### PR TITLE
Fix yast_user by adding the IP of the NIS server

### DIFF
--- a/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12.yaml
+++ b/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12.yaml
@@ -9,6 +9,7 @@ schedule:
   - yast2_cmd/yast_timezone
   - yast2_cmd/yast_tftp_server
   - yast2_cmd/yast_ftp_server
+  - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
   - yast2_cmd/yast_keyboard
   - yast2_cmd/yast_nfs_server

--- a/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12_SP2.yaml
+++ b/schedule/yast/maintenance/mau_extratest_yast_cmd_SLE12_SP2.yaml
@@ -9,6 +9,7 @@ schedule:
   - yast2_cmd/yast_timezone
   - yast2_cmd/yast_tftp_server
   - yast2_cmd/yast_ftp_server
+  - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
   - yast2_cmd/yast_nfs_server
   - yast2_cmd/yast_nfs_client

--- a/schedule/yast/maintenance/mau_extratests_yast_cmd.yaml
+++ b/schedule/yast/maintenance/mau_extratests_yast_cmd.yaml
@@ -10,6 +10,7 @@ schedule:
   - yast2_cmd/yast_tftp_server
   - yast2_cmd/yast_ftp_server
   - yast2_cmd/yast_rdp
+  - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
   - yast2_cmd/yast_keyboard
   - yast2_cmd/yast_nfs_server

--- a/tests/yast2_cmd/yast_users.pm
+++ b/tests/yast2_cmd/yast_users.pm
@@ -41,7 +41,8 @@ sub run {
 
     # binds a nis server and start ypbind service, and then list all users from NIS server
     assert_script_run("yast nis enable domain=suse.de server=wotan.suse.de");
-    validate_script_output("ypwhich 2>&1", sub { m/(wotan|dns2).suse.de/ });
+    my $nis_server = get_var('NAMESERVER');
+    validate_script_output("ypwhich 2>&1", sub { m/((wotan|dns2).suse.de|$nis_server)/ });
     validate_script_output("yast users list nis 2>&1 | wc -l", sub { m/^(\d+)$/m and $1 > 20 }, timeout => 180, proceed_on_failure => 1);
     assert_script_run("yast nis disable");
 }

--- a/variables.md
+++ b/variables.md
@@ -58,10 +58,8 @@ DVD |||
 ENCRYPT | boolean | false | Enables or indicates encryption of the disks. Can be combined with `FULL_LVM_ENCRYPT`, `ENCRYPT_CANCEL_EXISTING`, `ENCRYPT_ACTIVATE_EXISTING` and `UNENCRYPTED_BOOT`.
 ENCRYPT_CANCEL_EXISTING | boolean | false | Used to cancel activation of the encrypted partitions |
 SOFTLOCKUP_PANIC_DISABLED | boolean | false | Disables panicking on softlockup, provides a stack trace once a softlockup has been detected (see POO#50345)
-ETC_PASSWD | string | | Sets content for /etc/passwd, can be used to mimic existing users. Is used to test import of existing users on backends which
-have no shapshoting support (powerVM, zVM). Should be used together with `ENCRYPT_ACTIVATE_EXISTING` and `ETC_SHADOW`.
-ETC_SHADOW | string | | Sets content for /etc/shadow, can be used to mimic existing users. Is used to test import of existing users on backends which
-have no shapshoting support (powerVM, zVM). Should be used together with `ENCRYPT_ACTIVATE_EXISTING` and `ETC_PASSWD`.
+ETC_PASSWD | string | | Sets content for /etc/passwd, can be used to mimic existing users. Is used to test import of existing users on backends which have no shapshoting support (powerVM, zVM). Should be used together with `ENCRYPT_ACTIVATE_EXISTING` and `ETC_SHADOW`.
+ETC_SHADOW | string | | Sets content for /etc/shadow, can be used to mimic existing users. Is used to test import of existing users on backends which have no shapshoting support (powerVM, zVM). Should be used together with `ENCRYPT_ACTIVATE_EXISTING` and `ETC_PASSWD`.
 EVERGREEN |||
 EXIT_AFTER_START_INSTALL | boolean | false | Indicates that test suite will be finished after `installation/start_install` test module. So that all the test modules after this one will not be scheduled and executed.
 EXPECTED_INSTALL_HOSTNAME | string | | Contains expected hostname YaST installer got from the environment (DHCP, 'hostname=', as a kernel cmd line argument)
@@ -115,6 +113,7 @@ MIRROR_{protocol} | string | | Specify source address
 MOK_VERBOSITY | boolean | false | Enable verbosity feature of shim. Requires preinstalled `mokutil`.
 MOZILLATEST |||
 NAME | string | | Name of the test run including distribution, build, machine name and job id.
+NAMESERVER | string | | Can be used to specify a name server's IP or FQDN.
 NET | boolean | false | Indicates net installation.
 NETBOOT | boolean | false | Indicates net boot.
 NETDEV | string | | Network device to be used when adding interface on zKVM.


### PR DESCRIPTION
yast_user failed because if ypwhich returning an IP.
This change adds IP of the nis server through a variable.
ypwhich is a tool that "return[s] name of NIS server or map master".
but it sometimes returns the IP address instead of the hostname, so the test failed
because of this.
The change also re-enables yast_user, introduces the variable
"NAMESERVER", and fixes wrong formatting in variable.md

See https://progress.opensuse.org/issues/112271

Please also merge https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/265 if you merge this one.

VR:
http://waaa-amazing.suse.cz/tests/17006
debug output with IP: http://waaa-amazing.suse.cz/tests/17005#step/yast_users/54


