### PR TITLE
Fix HA yast2_ntpclient needle mismatch error

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2020 SUSE LLC
+# Copyright 2016-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Functions for HA Cluster tests
@@ -88,10 +88,10 @@ Extension (HA or HAE) tests.
 
 =cut
 our $crm_mon_cmd = 'crm_mon -R -r -n -N -1';
-our $softdog_timeout = bmwqemu::scale_timeout(60);
+our $softdog_timeout = bmwqemu::scale_timeout(120);
 our $prev_console;
-our $join_timeout = bmwqemu::scale_timeout(60);
-our $default_timeout = bmwqemu::scale_timeout(30);
+our $join_timeout = bmwqemu::scale_timeout(120);
+our $default_timeout = bmwqemu::scale_timeout(90);
 
 # Private functions
 sub _just_the_ip {
@@ -416,7 +416,7 @@ sub ensure_resource_running {
     my $starttime = time;
     my $ret = undef;
 
-    while ($ret = script_run("grep -E -q '$regex' <(crm resource status $rsc)", $default_timeout)) {
+    while ($ret = script_run("grep -E -q '$regex' <(crm resource status $rsc)", $join_timeout)) {
         my $timerun = time - $starttime;
         if ($timerun < $default_timeout) {
             sleep 5;

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -20,6 +20,11 @@ use version_utils qw(is_upgrade is_sles4sap is_sle);
 
 sub run {
     my ($self) = @_;
+
+    # sleep 300;
+    #record_info "sleep 300";
+
+
     $self->{in_boot_desktop} = 1;
     # We have tests that boot from HDD and wait for DVD boot menu's timeout, so
     # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
@@ -51,6 +56,11 @@ sub run {
     else {
         $self->wait_boot(bootloader_time => $timeout, nologin => $nologin, ready_time => $ready_time);
     }
+    select_console 'root-console';
+    my $ip = get_var('IP');
+     my $netdev = get_var('NETDEV', 'eth0');
+     assert_script_run("ip addr add $ip/24 dev $netdev");
+     assert_script_run("systemctl restart pacemaker");
 }
 
 sub test_flags {

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -27,6 +27,9 @@ sub run {
     $timeout_scale = 2 if ($timeout_scale < 2);
     set_var('TIMEOUT_SCALE', $timeout_scale) unless (is_x86_64);
 
+    #sleep 120;
+    #record_info "sleep 120";
+
     # Check cluster state *after* reboot
     barrier_wait("CHECK_AFTER_REBOOT_BEGIN_${cluster_name}_NODE${node_index}");
 
@@ -40,6 +43,11 @@ sub run {
     # in that case
     select_console 'root-console' if (get_var('HDDVERSION'));
 
+    #     my $ip = get_var('IP');
+    # my $netdev = get_var('NETDEV', 'eth0');
+    # assert_script_run("ip addr add $ip/24 dev $netdev");
+    #assert_script_run("ip addr");
+ 
     # Remove iptable rules in node 1 when testing qnetd/qdevice in multicast
     assert_script_run "iptables -F && iptables -X" if (is_node(1) && check_var('QDEVICE_TEST_ROLE', 'client') && !get_var('HA_UNICAST'));
 

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -74,7 +74,7 @@ sub run {
 
     # Format the Filesystem device
     if (is_node(1)) {
-        assert_script_run "mkfs -t $fs_type $fs_opts \"$fs_lun\"", $default_timeout;
+        assert_script_run "mkfs -t $fs_type $fs_opts \"$fs_lun\"", timeout => $join_timeout;
     }
     else {
         diag 'Wait until Filesystem device is formatted...';

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2018 SUSE LLC
+# Copyright 2016-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: chrony ntp corosync-qdevice ha-cluster-bootstrap
@@ -52,7 +52,7 @@ sub run {
     assert_script_run "ping -c1 $node_to_join";
     # Status redirection is not needed if running on serial terminal
     my $redirection = is_serial_terminal() ? '' : "> /dev/$serialdev";
-    enter_cmd "ha-cluster-join -yc $node_to_join ; echo ha-cluster-join-finished-\$? $redirection";
+    enter_cmd "ha-cluster-join -yc $node_to_join ; echo ha-cluster-join-finished-\$? $redirection", timeout => $join_timeout;
     wait_for_password_prompt(needle => 'ha-cluster-join-password', timeout => $join_timeout);
     type_password;
     send_key 'ret';
@@ -66,7 +66,7 @@ sub run {
         sleep bmwqemu::scale_timeout(3);
         # Attempt to start pacemaker in case this was what failed during join
         # This is needed so ha-cluster-remove works
-        assert_script_run 'systemctl start pacemaker';
+        assert_script_run 'systemctl start pacemaker', $join_timeout;
         assert_script_run 'ha-cluster-remove -F -y -c $(hostname)';
         assert_script_run "ha-cluster-join -yc $node_to_join", $join_timeout;
     }

--- a/tests/support_server/login.pm
+++ b/tests/support_server/login.pm
@@ -15,6 +15,9 @@ use version_utils qw(is_desktop_installed is_tumbleweed);
 sub run {
     my ($self) = @_;
     my $timeout = (is_tumbleweed) ? 180 : 80;
+
+    #resume_vm() if (get_var('DELAYED_START'));
+
     # we have some tests that waits for dvd boot menu timeout and boot from hdd
     # - the timeout here must cover it
     $self->wait_boot(bootloader_time => $timeout, textmode => !is_desktop_installed);


### PR DESCRIPTION
Fix HA yast2_ntpclient “yast2_ntp-client_support_server_ntp_server_added“ needle mismatch error.

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
