### PR TITLE
Containers, Public Cloud: Get rid of multiple arguments in record_soft_failure

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -111,7 +111,7 @@ sub install_docker_when_needed {
         # Check for docker start timeout, bsc#1187479
         if (script_run('journalctl -e | grep "timeout waiting for containerd to start"') == 0) {
             # Retry one more time
-            record_soft_failure("bsc#1187479");
+            record_soft_failure("bsc#1187479 - docker start infrequently times out waiting for containerd");
             sleep(120);    # give background services time to complete to prevent another failure
             systemctl('start docker');
         } else {

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -47,8 +47,7 @@ sub registry_push_pull {
     if (script_run($engine->runtime . " images | grep '$image'") == 0) {
         assert_script_run $engine->runtime . " image rm -f $image", 90;
     } else {
-        record_soft_failure("containers/podman#10685",
-            "Known issue - containers/podman#10685: podman image rm --force also untags other images (3.2.0 regression)");
+        record_soft_failure("Known issue - containers/podman#10685: podman image rm --force also untags other images (3.2.0 regression)");
     }
     assert_script_run "! " . $engine->runtime . " images | grep '$image'", 60;
     assert_script_run "! " . $engine->runtime . " images | grep 'localhost:5000/$image'", 60;

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -43,12 +43,12 @@ sub run {
         }
 
         if ($instance->run_ssh_command(cmd => 'sudo systemctl is-enabled guestregister.service', proceed_on_failure => 1) !~ /disabled/) {
-            (is_sle('=12-SP4') || is_sle('=15-sp1')) ? record_soft_failure('bsc#1199311', 'bsc#1199311 - guestregister.service is not disabled') : die('guestregister.service is not disabled');
+            (is_sle('=12-SP4') || is_sle('=15-sp1')) ? record_soft_failure('bsc#1199311 - guestregister.service is not disabled') : die('guestregister.service is not disabled');
         }
 
         if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l', proceed_on_failure => 1) != 0) {
             $instance->run_ssh_command(cmd => 'sudo ls -la /etc/zypp/credentials.d/', proceed_on_failure => 1);
-            (is_sle('=12-SP4') || is_sle('=15-sp1')) ? record_soft_failure('bsc#1199311', 'bsc#1199311 - guestregister.service is not disabled') : die('/etc/zypp/credentials.d/ is not empty');
+            (is_sle('=12-SP4') || is_sle('=15-sp1')) ? record_soft_failure('bsc#1199311 - guestregister.service is not disabled') : die('/etc/zypp/credentials.d/ is not empty');
         }
 
         if (is_azure() && $instance->run_ssh_command(cmd => 'sudo systemctl is-enabled regionsrv-enabler-azure.timer', proceed_on_failure => 1) !~ /enabled/) {
@@ -56,7 +56,7 @@ sub run {
         }
 
         if ($instance->run_ssh_command(cmd => 'sudo stat --printf="%s" /var/log/cloudregister', proceed_on_failure => 1) != 0) {
-            (is_sle('=12-SP4') || is_sle('=15-sp1')) ? record_soft_failure('bsc#1199311', 'bsc#1199311 - guestregister.service is not disabled') : die('/var/log/cloudregister is not empty');
+            (is_sle('=12-SP4') || is_sle('=15-sp1')) ? record_soft_failure('bsc#1199311 - guestregister.service is not disabled') : die('/var/log/cloudregister is not empty');
         }
         # The `sudo SUSEConnect -d` is not supported on BYOS and should fail.
         $instance->run_ssh_command(cmd => '! sudo SUSEConnect -d');
@@ -80,7 +80,7 @@ sub run {
 
     # Test re-registration. Assuming the system has been registered before
     if (script_run('which registercloudguest') != 0 && (is_sle('=12-SP4') || is_sle('=15-sp1'))) {
-        record_soft_failure('bsc#1198815', 'bsc#1198815 - Package cloud-regionsrv-client is not installed');
+        record_soft_failure('bsc#1198815 - Package cloud-regionsrv-client is not installed');
         registercloudguest($instance);
     } else {
         $instance->run_ssh_command(cmd => 'sudo registercloudguest --clean');


### PR DESCRIPTION
The `testapi::record_soft_failure()` takes only one argument (`$reason`) and fails if multiple are provided.

- Related documentation: http://open.qa/api/testapi/#_record_soft_failure
- Related issue: https://openqa.suse.de/tests/8945622#step/check_registercloudguest/4