### PR TITLE
Public Cloud: Fix download_repos.pm and whitelist new IP on AWS

### DIFF
--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -73,7 +73,7 @@ resource "aws_security_group" "basic_sg" {
         from_port   = 0
         to_port     = 0
         protocol    = "-1"
-        cidr_blocks = ["213.151.95.130/32", "195.135.220.0/22", "195.250.132.144/29"]
+        cidr_blocks = ["213.151.95.130/32", "195.135.220.0/22", "195.250.132.144/29", "193.86.92.180/32"]
     }
 
     egress {

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -86,7 +86,7 @@ sub run {
         die "Empty test repositories" if ($check_empty_repos && $size < 100);
     }
 
-    my $total_size = script_output("du -hs ~/repos");
+    my $total_size = script_output("du -hs ~/repos", proceed_on_failure => 1);
     record_info("Repo size", "Total repositories size: $total_size");
     my $rpm_list = script_output("find ./ -name '*.rpm' -exec du -h '{}' \\; | sort -h");
     record_info("RPM list", "RPM list: $rpm_list");


### PR DESCRIPTION
This contains two commits:
 * Fix `download_repos.pm` when `PUBLIC_CLOUD_SKIP_MU=1`
 * Allow new Prague office IP on AWS