### PR TITLE
Fix wrong usages of signatures

### DIFF
--- a/lib/Tomcat/JspTest.pm
+++ b/lib/Tomcat/JspTest.pm
@@ -259,7 +259,7 @@ sub form() {
     for (1 .. 2) { send_key('ret'); }
 
     if (check_screen('tomcat-click-save-login', 60)) {
-        assert_and_click('tomcat-click-save-login', TIMEOUT);
+        assert_and_click('tomcat-click-save-login', timeout => TIMEOUT);
     }
 
     send_key('tab');

--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -45,7 +45,7 @@ our %EXPORT_TAGS = (
 
  is_s390x();
 
-Returns C<check_var('s390x')>.
+Returns C<check_var('ARCH', 's390x')>.
 
 =cut
 sub is_s390x {
@@ -56,7 +56,7 @@ sub is_s390x {
 
  is_i586();
 
-Returns C<check_var('is_i586')>.
+Returns C<check_var('ARCH', 'is_i586')>.
 
 =cut
 sub is_i586 {
@@ -67,7 +67,7 @@ sub is_i586 {
 
  is_i686();
 
-Returns C<check_var('is_i686')>.
+Returns C<check_var('ARCH', 'is_i686')>.
 
 =cut
 sub is_i686 {
@@ -78,7 +78,7 @@ sub is_i686 {
 
  is_x86_64();
 
-Returns C<check_var('x86_64')>.
+Returns C<check_var('ARCH', 'x86_64')>.
 
 =cut
 sub is_x86_64 {
@@ -89,7 +89,7 @@ sub is_x86_64 {
 
  is_x86_64_v2();
 
-Returns C<check_var('is_x86_64_v2')>.
+Returns C<check_var('ARCH', 'is_x86_64_v2')>.
 
 =cut
 sub is_x86_64_v2 {
@@ -105,7 +105,7 @@ sub is_x86_64_v2 {
 
  is_aarch64();
 
-Returns C<check_var('aarch64')>.
+Returns C<check_var('ARCH', 'aarch64')>.
 
 =cut
 sub is_aarch64 {
@@ -127,7 +127,7 @@ sub is_arm {
 
  is_ppc64le();
 
-Returns C<check_var('ppc64le')>.
+Returns C<check_var('ARCH', 'ppc64le')>.
 
 =cut
 sub is_ppc64le {
@@ -138,7 +138,7 @@ sub is_ppc64le {
 
  is_ppc64();
 
- Returns C<check_var('ppc64')>.
+ Returns C<check_var('ARCH', 'ppc64')>.
 
 =cut
 sub is_ppc64 {

--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -663,7 +663,7 @@ sub select_guest {
     sleep 5;
     if (check_screen 'virt-manager_notrunning') {
         record_info("The Guest was powered off and that should not happen");
-        assert_and_click 'virt-manager_poweron', 'left', 90;
+        assert_and_click 'virt-manager_poweron', button => 'left', timeout => 90;
         sleep 30;    # The boot would not be faster
     }
     if (check_screen('virt-manager_no-graphical-device')) {
@@ -690,7 +690,7 @@ sub powercycle {
             assert_and_click "virt-manager_shutdown_sure";
         }
     }
-    assert_and_click 'virt-manager_poweron', 'left', 90;
+    assert_and_click 'virt-manager_poweron', button => 'left', timeout => 90;
 }
 
 sub establish_connection {

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -170,7 +170,7 @@ sub run {
 
         # Add max_interval while type password and extend time of click needle match
         type_string($fips_password, max_interval => 2);
-        assert_and_click("firefox-enter-password-OK" => 120);
+        assert_and_click('firefox-enter-password-OK', timeout => 120);
         wait_still_screen 10;
 
         # Add a condition to avoid the password missed input

--- a/tests/security/apparmor_profile/apache2_changehat.pm
+++ b/tests/security/apparmor_profile/apache2_changehat.pm
@@ -158,7 +158,7 @@ sub run {
                 $self->result('fail');
             }
             else {
-                record_soft_failure('bsc#1191684', 'Apparmor profile test case "apache2_changehat" found some "DENIED" audit records');
+                record_soft_failure('bsc#1191684 - Apparmor profile test case "apache2_changehat" found some "DENIED" audit records');
             }
         }
     }

--- a/tests/sles4sap/grafana_dashboards.pm
+++ b/tests/sles4sap/grafana_dashboards.pm
@@ -53,8 +53,8 @@ sub run {
     type_password;
     send_key 'tab';
     send_key 'ret';
-    assert_and_click "grafana-home", $timeout;
-    assert_and_click "select_suse-dashboard", $timeout;
+    assert_and_click "grafana-home", timeout => $timeout;
+    assert_and_click "select_suse-dashboard", timeout => $timeout;
     assert_screen "check_suse-dashboard", $timeout;
 
     # Close the browser and back to the desktop

--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -61,7 +61,7 @@ sub run {
     assert_script_run "host www.suse.com";
     select_console 'x11', await_console => 0;
     wait_still_screen 2;
-    assert_and_click("wireshark-dns-response-list", TIMEOUT);
+    assert_and_click("wireshark-dns-response-list", timeout => TIMEOUT);
     assert_and_click "wireshark-dns-response-details";
     send_key "right";
     send_key_until_needlematch "wireshark-dns-response-details-answers", "down";


### PR DESCRIPTION
Found in daily openQA test review of tests failing. Caused by
https://github.com/os-autoinst/os-autoinst/pull/2078

Someone must have been really resilient ignoring all the Perl warnings
about "Odd name/value argument for subroutine" and such :)

Verification runs:

```
for i in https://openqa.suse.de/tests/8945482 https://openqa.suse.de/tests/8945569 https://openqa.suse.de/tests/8944691; do MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15061 $i; done
```

* [sle-12-SP4-Server-DVD-Updates-x86_64-Build20220612-1-mau-apparmor_profile@64bit](https://openqa.suse.de/t8945915)
Github oauth token provided, performing authenticated requests
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20220612-1-mau-extratests-security-fips@64bit](https://openqa.suse.de/t8945916)
Github oauth token provided, performing authenticated requests
* [sle-12-SP4-Server-DVD-Updates-x86_64-Build20220612-1-filesystem_autoyast_withouthome@64bit](https://openqa.suse.de/t8945917)
