### PR TITLE
Test openJDK Supported Cipher Suites

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2258,6 +2258,15 @@ sub load_security_tests_crypt_firefox {
     loadtest "fips/mozilla_nss/firefox_nss" if get_var('FIPS_ENABLED');
 }
 
+sub load_security_tests_crypt_openjdk {
+    load_security_console_prepare;
+
+    if (get_var('FIPS_ENABLED')) {
+        loadtest "fips/openjdk/openjdk_fips";
+        loadtest "fips/openjdk/openjdk_ssh";
+    }
+}
+
 sub load_security_tests_crypt_tool {
     load_security_console_prepare;
 
@@ -2644,7 +2653,7 @@ sub load_mitigation_tests {
 
 sub load_security_tests {
     my @security_tests = qw(
-      fips_setup crypt_core crypt_web crypt_kernel crypt_x11 crypt_firefox crypt_tool
+      fips_setup crypt_core crypt_web crypt_kernel crypt_x11 crypt_firefox crypt_tool crypt_openjdk
       crypt_libtool crypt_krb5kdc crypt_krb5server crypt_krb5client
       ipsec mmtest
       apparmor apparmor_profile yast2_apparmor yast2_users selinux

--- a/tests/fips/openjdk/openjdk_fips.pm
+++ b/tests/fips/openjdk/openjdk_fips.pm
@@ -1,0 +1,69 @@
+# SUSE's openjdk fips tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: openjdk expect
+#
+# Summary: FIPS: openjdk
+#          Jira feature: SLE-21206
+#          FIPS 140-3: make OpenJDK be able to use the NSS certified crypto
+#          Test case GET "Supported Cipher Suites and list all crypto providers
+# Tags: poo#112034
+# Maintainer: Yutao Wang <yuwang@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = @_;
+
+    my $interactive_str = [
+        {
+            prompt => qr/Enter new password/m,
+            key => 'ret',
+        },
+        {
+            prompt => qr/Re-enter password/m,
+            key => 'ret',
+        },
+    ];
+
+    select_console "root-console";
+    zypper_call("in mozilla-nss-tools git-core");
+
+    # Configure nssdb
+    assert_script_run("mkdir /etc/pki/nssdb");
+    script_run_interactive("certutil -d /etc/pki/nssdb -N", $interactive_str, 30);
+    assert_script_run("chmod og+r /etc/pki/nssdb/*");
+
+    # Install openJDK
+    zypper_call("in java-11-openjdk java-11-openjdk-devel");
+
+    # Simple java crypto test
+    assert_script_run("cd ~;git clone -q https://github.com/ecki/JavaCryptoTest");
+    script_run("cd ~/JavaCryptoTest/src/main/java/");
+    script_run("javac net/eckenfels/test/jce/JCEProviderInfo.java");
+    my $crypto = script_output("java -cp ~/JavaCryptoTest/src/main/java/ net.eckenfels.test.jce.JCEProviderInfo");
+    record_info("FAIL", "Cannot list all crypto providers", result => 'fail') if ($crypto !~ /Listing all JCA Security Providers/);
+
+    # Prepare testing data
+    my $JDK_TCHECK = get_var("JDK_TCHECK", "https://gitlab.suse.de/QA-APAC-I/testing/-/raw/master/data/openjdk/Tcheck.java");
+    assert_script_run("cd ~;wget --quiet --no-check-certificate $JDK_TCHECK");
+    assert_script_run("chmod 777 Tcheck.java");
+    assert_script_run("javac Tcheck.java");
+    assert_script_run("java Tcheck > result.txt");
+    my $EX_TCHECK = get_var("EX_TCHECK", "https://gitlab.suse.de/QA-APAC-I/testing/-/raw/master/data/openjdk/Tcheck.txt");
+    assert_script_run("wget --quiet --no-check-certificate $EX_TCHECK");
+    my $out = script_output("diff -a Tcheck.txt result.txt");
+    record_info("FAIL", "Actually result VS Expected result: $out", result => 'fail') if ($out ne '');
+}
+
+sub test_flags {
+    return {no_rollback => 1};
+}
+
+1;

--- a/tests/fips/openjdk/openjdk_ssh.pm
+++ b/tests/fips/openjdk/openjdk_ssh.pm
@@ -1,0 +1,58 @@
+# SUSE's openjdk fips tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: openjdk expect
+#
+# Summary: FIPS: openjdk
+#          Jira feature: SLE-21206
+#          FIPS 140-3: make OpenJDK be able to use the NSS certified crypto
+#          Run Java SSH / Client http://www.jcraft.com/jsch/
+# Tags: poo#112034
+# Maintainer: Yutao Wang <yuwang@suse.com>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = @_;
+    select_console('x11');
+
+    # Start an xterm
+    x11_start_program("xterm");
+    # Wait before typing to avoid typos
+    wait_still_screen(5);
+
+    my $JSCH_JAR = get_var("JSCH_JAR", "https://gitlab.suse.de/QA-APAC-I/testing/-/raw/master/data/openjdk/jsch-0.1.55.jar");
+    assert_script_run("wget --quiet --no-check-certificate $JSCH_JAR");
+    assert_script_run("chmod 777 jsch-0.1.55.jar");
+
+    my $TEST_JAVA = get_var("TEST_JAVA", "https://gitlab.suse.de/QA-APAC-I/testing/-/raw/master/data/openjdk/Shell.java");
+    assert_script_run("wget --quiet --no-check-certificate $TEST_JAVA");
+    assert_script_run("chmod 777 Shell.java");
+
+    assert_script_run("javac -cp jsch-0.1.55.jar:. Shell.java");
+    script_run("java -cp jsch-0.1.55.jar:. Shell", timeout => 0);
+    assert_screen "openjdk-hostname";
+    for (1 .. 30) { send_key "backspace"; }
+    type_string get_var("OPENJDK_HN", 'bernhard@localhost');
+    save_screenshot;
+    send_key 'ret';
+    wait_still_screen 3;
+    send_key 'ret';
+    save_screenshot;
+    wait_still_screen 3;
+    send_key 'ret' if (check_screen("auth-key-connect", 10));
+    wait_still_screen 3;
+    record_info("FAIL", "java.security.ProviderException: Could not derive key", result => 'fail') if (check_screen("shell-not-derive-key", 10));
+    send_key 'ret';
+    save_screenshot;
+    wait_still_screen 3;
+    send_key 'alt-f4';
+}
+
+1;


### PR DESCRIPTION
Test openJDK Supported Cipher Suites, compared the expected result
with output information

- Related ticket:https://progress.opensuse.org/issues/112034
- Verification run: kernel: https://openqa.suse.de/tests/8985707
env:https://openqa.suse.de/tests/8994965