### PR TITLE
Add --no-pager to some git commands used during make test

### DIFF
--- a/tools/check_code_style
+++ b/tools/check_code_style
@@ -31,5 +31,5 @@ fail() {
     exit 1
 }
 
-git grep -P 'check_screen.*00(?!.*nocheck:)' || exit 0
+git --no-pager grep -P 'check_screen.*00(?!.*nocheck:)' || exit 0
 fail "See https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/CONTRIBUTING.md#coding-style for more details"

--- a/tools/print_status_all_bugrefs
+++ b/tools/print_status_all_bugrefs
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-git grep -l '\(boo\|bsc\)#' | xargs sed -n 's/^.*\(bsc\|boo\)#\([0-9]\+\).*$/\2/gp' | grep -v '123456' | sort -n | uniq | sort -n | $(dirname $0)/check_bugrefs
+git --no-pager grep -l '\(boo\|bsc\)#' | xargs sed -n 's/^.*\(bsc\|boo\)#\([0-9]\+\).*$/\2/gp' | grep -v '123456' | sort -n | uniq | sort -n | $(dirname $0)/check_bugrefs


### PR DESCRIPTION
Running `make test` locally, with git version 2.36.1, sometime the execution stops on same pager that need to be manually closed with :q to proceed with the testing.

- Verification run: local manual execution of `make test`
