### PR TITLE
Revert "Workaround license insert disc issue"

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -107,10 +107,6 @@ sub is_module {
 sub accept_addons_license {
     my (@scc_addons) = @_;
 
-    # Trap the 'missing license file on media' issue
-    # Needle is configured as a workaround, so a soft-fail will be shown
-    send_key 'alt-s' if check_screen('license-insert-disc-issue', 30);
-
     # To check the current state of licenses in the product one can conduct
     # the following steps, e.g. for SLE15:
     #   isc co SUSE:SLE-15:GA 000product

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -151,9 +151,6 @@ sub run {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
-    # Trap the 'missing license file on media' issue
-    # Needle is configured as a workaround, so a soft-fail will be shown
-    send_key 'alt-s' if check_screen('license-insert-disc-issue', 30);
     # Wait for the addon products screen if needed
     unless (is_sle('15-SP2+') && get_var('MEDIA_UPGRADE')) {
         if ($self->process_unsigned_files([qw(inst-addon addon-products)])) {


### PR DESCRIPTION
This reverts commit a6ffe9569133236e848a9ea0a6a3a63424c4bbde.

Remove old workaround for bsc#1153326. The issue has been fixed in YaST a long time ago and the workaround needles have last matched 3 years ago.

If the issue appears again in the future, the tests should fail so that reviewers can file a new bug report. The needle check is done twice during installation and it adds unnecessary 30 second delay each time.

- Related ticket: https://progress.opensuse.org/issues/112343
- Needles: N/A
- Verification run: https://openqa.suse.de/t8947255
