### PR TITLE
Run slurm configuration merely against compute nodes

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -117,26 +117,26 @@ sub cluster_names {
 
 =head2 distribute_munge_key
 
-Distributes munge kyes across all cluster nodes
+Distributes munge keys across all compute nodes of the cluster
 
 =cut
 sub distribute_munge_key {
     my ($self) = @_;
-    my @cluster_nodes = cluster_names();
-    foreach (@cluster_nodes) {
+    my @compute_nodes = slave_node_names();
+    foreach (@compute_nodes) {
         script_run("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@$_:/etc/munge/munge.key");
     }
 }
 
 =head2 distribute_slurm_conf
 
-Distributes slurm config across all cluster nodes
+Distributes slurm config across all compute nodes of the cluster
 
 =cut
 sub distribute_slurm_conf {
     my ($self) = @_;
-    my @cluster_nodes = cluster_names();
-    foreach (@cluster_nodes) {
+    my @compute_nodes = slave_node_names();
+    foreach (@compute_nodes) {
         script_run("scp -o StrictHostKeyChecking=no /etc/slurm/slurm.conf root\@$_:/etc/slurm/slurm.conf");
     }
 }


### PR DESCRIPTION
The operations which try to copy the ssh keys and the slurm configuration
consider all the slave(compute) nodes including the master(management) one.
However i think this is not necessary. In this commit i change this to run
merely against the compute nodes.

For some reason the behavior of those operations started failing, when the
where trying to copy data from master to itself. I didnt dig into it but this
shouldnt be like that anyway IMO. Anyway merging this seems to resolve the
problem.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run:

before:  https://openqa.suse.de/tests/8946387#
after: http://aquarius.suse.cz/tests/10944#

https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2315071&distri=sle&version=15-SP2