### PR TITLE
Fix timeout issue in the test rust

### DIFF
--- a/tests/console/rust.pm
+++ b/tests/console/rust.pm
@@ -21,7 +21,8 @@ sub run {
     select_console('user-console');
     assert_script_run('cargo new testproject');
     assert_script_run(qq(echo 'uuid = "0.8"' >> testproject/Cargo.toml));
-    assert_script_run('cargo run --manifest-path testproject/Cargo.toml');
+    validate_script_output("cargo run --manifest-path testproject/Cargo.toml",
+        sub { m/Hello, world!/ }, timeout => 300);
 }
 
 1;


### PR DESCRIPTION
Fixed timeout issue in the command  "cargo run" execution  and verified output in the rust test.

- Related ticket: https://progress.opensuse.org/issues/112244
- Needles:NO
- Verification run: 
 opensuse-15.4 - https://openqa.opensuse.org/tests/2416116#step/rust/9
 Tumbleweed - https://openqa.opensuse.org/tests/2416115#step/rust/9