### PR TITLE
containerd_nerdctl: Add support for aarch64

### DIFF
--- a/lib/containers/containerd_nerdctl.pm
+++ b/lib/containers/containerd_nerdctl.pm
@@ -11,6 +11,7 @@ use Mojo::Base 'containers::engine';
 use testapi;
 use containers::common 'install_containerd_when_needed';
 use containers::utils 'registry_url';
+use Utils::Architectures;
 has runtime => 'nerdctl';
 
 sub init {
@@ -18,8 +19,16 @@ sub init {
 
     # The nerdctl validation test suite is a plug-in required for this test and needs to be installed from an external source.
     my $version = get_var('CONTAINERS_NERDCTL_VERSION', '0.16.1');
-    my $url = "https://github.com/containerd/nerdctl/releases/download/v$version/nerdctl-$version-linux-amd64.tar.gz";
-    my $filename = "/tmp/nerdctl-$version-linux-amd64.tar.gz";
+    my $arch;
+    if (is_aarch64) {
+        $arch = 'arm64';
+    } elsif (is_x86_64) {
+        $arch = 'amd64';
+    } else {
+        die 'Architecture ' . get_required_var('ARCH') . ' is not supported';
+    }
+    my $url = "https://github.com/containerd/nerdctl/releases/download/v$version/nerdctl-$version-linux-$arch.tar.gz";
+    my $filename = "/tmp/nerdctl-$version-linux-$arch.tar.gz";
     assert_script_run("curl -L $url -o $filename");
     assert_script_run("tar zxvf $filename -C /usr/local/bin");
     assert_script_run("rm $filename");


### PR DESCRIPTION
- Verification run on TW: 
  - aarch64: https://openqa.opensuse.org/t2463204
  - x86_64: https://openqa.opensuse.org/t2463199
