### PR TITLE
Fix duplicate docker.io registry

### DIFF
--- a/data/containers/registries.conf
+++ b/data/containers/registries.conf
@@ -16,8 +16,3 @@ insecure = true
 [[registry]]
 location = "registry.suse.de"
 insecure = true
-
-# Note: REGISTRY will be replaced by the registry URL of the according test run.
-[[registry]]
-location = "REGISTRY"
-insecure = true

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -23,11 +23,11 @@ sub init {
 
 sub configure_insecure_registries {
     my ($self) = shift;
-    my $registry = registry_url();
 
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
-    file_content_replace("/etc/containers/registries.conf", REGISTRY => $registry);
+    # Add custom registry only if set by the REGISTRY variable
+    assert_script_run('echo -e \'[[registry]]\nlocation = "' . registry_url() . '"\ninsecure = true\' >> /etc/containers/registries.conf') if get_var('REGISTRY');
 }
 
 1;


### PR DESCRIPTION
docker.io will not be added to registries.conf if defined via the
REGISTRY variable because it's already present there with conflicting
insecure settings. This makes test runs succeed, also if no REGISTRY is
defined.

- Related ticket: https://progress.opensuse.org/issues/112370
- Verification run: https://duck-norris.qam.suse.de/t8935
