### PR TITLE
script_retry: Adjust timeout with TIMEOUT_SCALE value

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1600,6 +1600,9 @@ sub script_retry {
 
     my $ret;
 
+    # Adjust timeout with TIMEOUT_SCALE value
+    $timeout = $timeout * get_var('TIMEOUT_SCALE', 1);
+
     my $exec = "timeout $timeout $cmd";
     # Exclamation mark needs to be moved before the timeout command, if present
     if (substr($cmd, 0, 1) eq "!") {


### PR DESCRIPTION
Currently, `script_retry` does not handle `TIMEOUT_SCALE` which is inconsistent.

Adding support of `TIMEOUT_SCALE` to `script_retry`  should fix some tests run on slower workers, such as `helm_K3S` run on aarch64.

- Verification run: 
