### PR TITLE
Skip coredump_collect on non-SLES hosts

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -198,5 +198,5 @@ sub load_container_tests {
         }
     }
 
-    loadtest 'console/coredump_collect' unless (is_public_cloud || is_jeos || is_sle_micro || is_microos || is_leap_micro || get_var('BCI_TESTS'));
+    loadtest 'console/coredump_collect' unless (is_public_cloud || is_jeos || is_sle_micro || is_microos || is_leap_micro || get_var('BCI_TESTS') || is_ubuntu_host || is_expanded_support_host);
 }


### PR DESCRIPTION
Don't schedule the coredump_collect test on Ubuntu or RHEL hosts
anymore.

- Related ticket: https://progress.opensuse.org/issues/112385
