### PR TITLE
Fix update_install test

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -53,7 +53,8 @@ sub has_conflict {
         libGLwM1 => 'libGLw1',
         libiterm1 => 'terminfo-iterm',
         rust => 'rls',
-        'rust-gdb' => 'cargo'
+        'rust-gdb' => 'cargo',
+        'openssl-1_0_0' => 'openssl-1_1'
 
     );
     return $conflict{$binary};

--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -51,7 +51,10 @@ sub has_conflict {
         'python3-ldb' => 'python-ldb',
         'chrony-pool-suse' => 'chrony-pool-empty',
         libGLwM1 => 'libGLw1',
-        libiterm1 => 'terminfo-iterm'
+        libiterm1 => 'terminfo-iterm',
+        rust => 'rls',
+        'rust-gdb' => 'cargo'
+
     );
     return $conflict{$binary};
 }


### PR DESCRIPTION
1. The test installs "cargo" and "rls" even though it should not  .  I modified the test to install only rust package and avoiding the installation of cago/rls.
Test is now failing in the rust installation due to issue : https://bugzilla.suse.com/show_bug.cgi?id=1200499

2.  Added openssl-1_1 and openssl-1_0_0 to the conflicts list.

- Related ticket:
    1. https://progress.opensuse.org/issues/112277
    2. https://progress.opensuse.org/issues/112376
- Needles: NO
- Verification run:  
 1. rust test - http://10.161.229.147/tests/3632#step/update_install/43 
 2. openssl  - http://10.161.229.147/tests/3638#step/update_install/38
