### PR TITLE
Docker: configure insecure registry only if REGISTRY var is set

### DIFF
--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -26,12 +26,12 @@ sub configure_insecure_registries {
     my $registry = registry_url();
     # The debug output is messing with terminal in migration tests
     my $debug = (get_var('UPGRADE')) ? 'false' : 'true';
-    # Allow our internal 'insecure' registry
-    assert_script_run(
-'echo "{ \"debug\": ' . $debug . ', \"insecure-registries\" : [\"localhost:5000\", \"registry.suse.de\", \"' . $registry . '\"] }" > /etc/docker/daemon.json');
-    assert_script_run('cat /etc/docker/daemon.json');
+    # Allow our internal 'insecure' registry only if REGISTRY variable is set
+    my $str = '{ \"debug\": ' . $debug;
+    $str .= get_var('REGISTRY') ? ', \"insecure-registries\" : [\"' . $registry . '\"] }' : '}';
+    my $config = script_output("echo $str | tee /etc/docker/daemon.json");
+    record_info('daemon.json', $config);
     systemctl('restart docker');
-    record_info "setup $self->runtime", "deamon.json ready";
 }
 
 1;


### PR DESCRIPTION
registry.suse.de does not need to be in insecure registries. Same for localhost.

https://progress.opensuse.org/issues/112382


Verification runs:
- [TW Host](https://openqa.opensuse.org/tests/2416804)
- [TW image](https://openqa.opensuse.org/t2416805)
- [SLE 15-SP4 Host](https://openqa.suse.de/tests/overview?distri=sle&build=jlausuch%2Fos-autoinst-distri-opensuse%23poo_112382&version=15-SP4)
- [BCI test with REGISTRY](http://openqa.suse.de/t8955855)
- [BCI test without REGISTRY var](http://openqa.suse.de/t8955854)