### PR TITLE
Use new Azure storage account

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -17,7 +17,8 @@ use utils qw(script_output_retry);
 use publiccloud::azure_client;
 
 has resource_group => 'openqa-upload';
-has storage_account => 'openqa';
+# TODO: Remote 'openqa' once the deprecated Azure account is removed
+has storage_account => get_var('PUBLIC_CLOUD_CREDENTIALS_URL') ? 'eisleqaopenqa' : 'openqa';
 has container => 'sle-images';
 has lease_id => undef;
 has vault => undef;


### PR DESCRIPTION
In runs that use the new Azure credentials also use the new storage
account name.

- Related ticket: https://progress.opensuse.org/issues/112481
- Verification run: https://duck-norris.qam.suse.de/tests/8936#
