### PR TITLE
[PROPOSAL]Schedule systemd upstream tests dynamically 

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -43,6 +43,7 @@ our @EXPORT = qw(
   is_desktop
   is_kernel_test
   is_ltp_test
+  is_systemd_test
   is_livesystem
   is_memtest
   is_memtest
@@ -119,6 +120,7 @@ our @EXPORT = qw(
   load_extra_tests_kernel
   load_wicked_create_hdd
   load_jeos_openstack_tests
+  load_upstream_systemd_tests
 );
 
 sub init_main {
@@ -270,6 +272,10 @@ sub is_kernel_test {
         || get_var('TRINITY')
         || get_var('NUMA_IRQBALANCE')
         || get_var('TUNED'));
+}
+
+sub is_systemd_test {
+    return get_var('SYSTEMD_TESTSUITE');
 }
 
 # Isolate the loading of LTP tests because they often rely on newer features
@@ -617,9 +623,8 @@ sub load_jeos_tests {
     loadtest "jeos/firstrun";
     loadtest "jeos/image_info";
     loadtest "jeos/record_machine_id";
-    loadtest "console/system_prepare" if is_sle;
     loadtest "console/force_scheduled_tasks";
-    unless (get_var('INSTALL_LTP')) {
+    unless (get_var('INSTALL_LTP') || get_var('SYSTEMD_TESTSUITE')) {
         loadtest "jeos/grub2_gfxmode";
         loadtest "jeos/diskusage" unless is_openstack;
         loadtest "jeos/build_key";
@@ -3275,6 +3280,10 @@ sub load_nfs_tests {
     loadtest "nfs/install";
     loadtest "nfs/run";
     loadtest "nfs/generate_report";
+}
+
+sub load_upstream_systemd_tests {
+    loadtest 'systemd_testsuite/prepare_systemd_and_testsuite';
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -262,7 +262,6 @@ if (is_jeos) {
     load_jeos_tests();
 }
 
-
 if (is_kernel_test()) {
     load_kernel_tests();
 }
@@ -374,12 +373,17 @@ else {
         return 1 if load_default_tests;
     }
 
+    if (is_systemd_test()) {
+        load_upstream_systemd_tests();
+    }
+
     unless (install_online_updates()
         || load_qam_install_tests()
         || load_extra_tests()
         || load_virtualization_tests()
         || load_otherDE_tests()
-        || load_slenkins_tests())
+        || load_slenkins_tests()
+        || is_systemd_test())
     {
         loadtest "console/system_prepare";
         load_system_update_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -674,6 +674,12 @@ if (is_jeos) {
 if (is_kernel_test()) {
     load_kernel_tests();
 }
+if (is_systemd_test()) {
+    unless (is_jeos()) {
+        boot_hdd_image;
+    }
+    load_upstream_systemd_tests();
+}
 elsif (is_public_cloud) {
     load_publiccloud_tests();
 }

--- a/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
+++ b/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
@@ -6,20 +6,84 @@
 # Summary: Prepare systemd and testsuite.
 # Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
 
-use base 'systemd_testsuite_test';
-use warnings;
-use strict;
+use Mojo::Base qw(systemd_testsuite_test);
 use testapi;
+use utils;
+use version_utils qw(is_sle);
+use registration qw(add_suseconnect_product);
 
 sub run {
     my ($self) = @_;
-    $self->testsuiteinstall;
-    assert_script_run('cd /usr/lib/systemd/tests');
-    assert_script_run('./run-tests.sh --prepare', 600);
+    my $test_opts = {
+        NO_BUILD => get_var('SYSTEMD_NO_BUILD', 1),
+        TEST_PREFER_NSPAWN => get_var('SYSTEMD_NSPAWN', 1),
+        UNIFIED_CGROUP_HIERARCHY => get_var('SYSTEMD_UNIFIED_CGROUP', 'yes')
+    };
+    my $testdir = '/usr/lib/systemd/tests/test/';
+    my @pkgs = qw(
+      lz4
+      busybox
+      qemu
+      dhcp-client
+      python3
+      plymouth
+      binutils
+      netcat-openbsd
+      cryptsetup
+      less
+      device-mapper
+      strace
+      e2fsprogs
+      hostname
+      net-tools-deprecated
+      systemd-testsuite
+    );
+
+    $self->select_serial_terminal();
+
+    if (is_sle) {
+        add_suseconnect_product('sle-module-legacy');
+        add_suseconnect_product('sle-module-desktop-applications');
+        add_suseconnect_product('sle-module-development-tools');
+        my $repo = sprintf('http://download.suse.de/download/ibs/SUSE:/SLE-%s:/GA/standard/',
+            get_var('VERSION'));
+        zypper_call("ar $repo systemd-tests");
+    }
+
+    #install testsuite and dependecies
+    zypper_call('ref');
+    zypper_call("in @pkgs");
+
+    # navigate to test case directory
+    # extract all available test cases
+    assert_script_run("cd $testdir");
+    my @schedule = ();
+    my $exclude = get_var('SYSTEMD_EXCLUDE');
+
+    if (my $include = get_var('SYSTEMD_INCLUDE')) {
+        @schedule = split(',', $include);
+    } else {
+        my @tests = split(/\n/, script_output(qq(find . -maxdepth 1 -type d -name "TEST-*")));
+        foreach my $test (@tests) {
+            # trim folder prefix
+            $test =~ s/\.\///;
+            if (defined($exclude) && $test =~ m/$exclude/) {
+                next;
+            }
+            push @schedule, $test;
+        }
+    }
+
+    # execute generic openQA's systemd runner for each test case directory found within the *systemd-tests* package
+    # test case options are passed to each scheduled module separately
+    foreach my $test (@schedule) {
+        my $args = OpenQA::Test::RunArgs->new(test => $test, dir => $testdir, make_opts => $test_opts);
+        autotest::loadtest('tests/systemd_testsuite/runner.pm', name => $test, run_args => $args);
+    }
 }
 
 sub test_flags {
-    return {fatal => 1, milestone => 1};
+    return {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/systemd_testsuite/runner.pm
+++ b/tests/systemd_testsuite/runner.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Copyright 2019-2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run systemd upstream test cases
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use Mojo::Base qw(systemd_testsuite_test);
+use testapi;
+
+my $test_hash;
+
+sub build_cmd {
+    my ($target, $args) = @_;
+    my @opts = ();
+    my $test = $args->{test};
+    my $dir = $args->{dir};
+
+    foreach my $k (keys %{$args->{make_opts}}) {
+        if ($args->{make_opts}->{$k}) {
+            push @opts, "$k=$args->{make_opts}->{$k}";
+        }
+    }
+
+    return sprintf('%s make -C %s%s %s', join(" ", @opts), $dir, $test, $target);
+}
+
+sub run {
+    my ($self, $args) = @_;
+    my $timeout = 900;
+    my $marker = " systemd test runner: >>> $args->{test} has finished <<<";
+    my $logs = qr[\/var\/tmp\/systemd-test.(\w+)\/];
+
+    $self->select_serial_terminal();
+
+    assert_script_run(build_cmd('clean', $args));
+    my $out = script_output(build_cmd('setup', $args), 240);
+
+    if ($out =~ $logs) {
+        $test_hash = $1;
+        record_info("$test_hash", 'Test logs: /var/tmp/systemd-test.' . $test_hash);
+    } else {
+        bmwqemu::diag 'Cannot find the location for logs';
+    }
+
+    my $texec = sprintf('(%s;echo "%s [$?]")', build_cmd('run', $args), $marker);
+    my $test_log = script_output("$texec", $timeout);
+
+    if (defined($test_log) && $test_log =~ qr/$marker\s+\[(\d+)\]$/) {
+        if ($1 != 0) {
+            bmwqemu::diag "$args->{test} has failed with RC => $1!";
+            $self->{result} = 'fail';
+        }
+    } else {
+        bmwqemu::diag "$args->{test} has timed out!";
+        $self->{result} = 'fail';
+    }
+}
+
+sub post_fail_hook {
+    my $lpath = sprintf('/var/tmp/systemd-test.%s/system.journal', $test_hash);
+
+    select_console('log-console');
+    script_run("xz -9 $lpath");
+    upload_logs("$lpath" . '.xz', failok => 1);
+    shift->save_and_upload_log('journalctl -o short-precise --no-pager', "journalctl-host.txt");
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -163,6 +163,9 @@ SPLITUSR | boolean | false | Enables `installation/partitioning_splitusr` test m
 SUSEMIRROR | string | | Mirror url of the installation medium.
 SYSAUTHTEST | boolean | false | Enable system authentication test (`sysauth/sssd`)
 SYSCTL_IPV6_DISABLED | boolean | undef | Set automatically in samba_adcli tests when ipv6 is disabled
+SYSTEMD_NSPAWN | boolean | 1 | Run systemd upstream tests in nspawn container rather than qemu
+SYSTEMD_TESTSUITE | boolean | undef | Enable schedule of systemd upstream tests
+SYSTEMD_UNIFIED_CGROUP | string | "yes", "no", "hybrid", "default" | systemd currently supports 3 (unified,legacy,hybrid) cgroups configurations
 TEST | string | | Name of the test suite.
 TEST_CONTEXT | string | | Defines the class name to be used as the context instance of the test. This is used in the scheduler to pass the `run_args` into the loadtest function. If it is not given it will be undef.
 TOGGLEHOME | boolean | false | Changes the state of partitioning to have or not to have separate home partition in the proposal.


### PR DESCRIPTION
Tests provided by systemd upstream are packaged in *systemd-testsuite*.
Each test case is defined in folder with naming convention
`TEST-\d{2}-$testname`. The runner schedules all test cases that are
present in the provided package. Tests are preferably running in nswapn,
however some of them require qemu.
Users can override the default schedule either excluding certain test
cases provided by a regex. For debug purposes users can provide a list
of tests that will override the default schedule.