### PR TITLE
Trim whitespaces repolinks provided in ZDUPREPOS

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -94,6 +94,7 @@ sub run {
 
     my $nr = 1;
     foreach my $r (split(/,/, get_var('ZDUPREPOS', $defaultrepo))) {
+        $r =~ s/^\s+|\s+$//g;
         zypper_call("--no-gpg-checks ar \"$r\" repo$nr");
         $nr++;
     }


### PR DESCRIPTION
Folded multiline [ZDUPREPOS](https://github.com/os-autoinst/opensuse-jobgroups/blob/master/job_groups/opensuse_leap_15.4_updates.yaml#L14) leaves trailing
white spaces in the repo links. This causes issues in [repo path](https://openqa.opensuse.org/tests/2417040#step/zdup/22).

- Verification runs: 
  * [zdup-Leap-15.2-kde](https://openqa.opensuse.org/tests/2417068#)
  * [zdup-Leap-15.3-kde](https://openqa.opensuse.org/tests/2417069#)
  * [zdup-Leap-15.2-gnome](https://openqa.opensuse.org/tests/2417067#step/zdup/24)
  * [zdup-Leap-15.3-gnome](https://openqa.opensuse.org/tests/2417070#step/zdup/24)
