### PR TITLE
Introduce PUBLIC_CLOUD_STORAGE_ACCOUNT variable

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -56,6 +56,10 @@ variable "create-extra-disk" {
 }
 
 variable "storage-account" {
+    # Note: Don't delete the default value!!!
+    # Not all of our `terraform destroy` calls pass this variable and neither is it necessary.
+    # However removing the default value might cause `terraform destroy` to fail in corner cases,
+    # resulting effectively in leaking resources due to failed cleanups.
     default="openqa"
 }
 
@@ -152,7 +156,7 @@ resource "azurerm_image" "image" {
     os_disk {
         os_type = "Linux"
         os_state = "Generalized"
-        blob_uri = "https://openqa.blob.core.windows.net/sle-images/${var.image_id}"
+        blob_uri = "https://${var.storage-account}.blob.core.windows.net/sle-images/${var.image_id}"
         size_gb = 30
     }
 }

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -17,8 +17,8 @@ use utils qw(script_output_retry);
 use publiccloud::azure_client;
 
 has resource_group => 'openqa-upload';
-# TODO: Remote 'openqa' once the deprecated Azure account is removed
-has storage_account => get_var('PUBLIC_CLOUD_CREDENTIALS_URL') ? 'eisleqaopenqa' : 'openqa';
+# Note: Remove the default 'openqa' once the deprecated account will be removed.
+has storage_account => get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT', 'openqa');
 has container => 'sle-images';
 has lease_id => undef;
 has vault => undef;

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -20,7 +20,7 @@ use mmapi 'get_current_job_id';
 
 use constant CREDENTIALS_FILE => '/root/google_credentials.json';
 
-has storage_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_STORAGE', 'openqa-storage') };
+has storage_name => sub { get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT', 'openqa-storage') };
 has project_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID') };
 has account => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
 has service_acount_name => sub { get_var('PUBLIC_CLOUD_GOOGLE_SERVICE_ACCOUNT') };

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -387,6 +387,12 @@ sub terraform_apply {
             $cmd .= sprintf(q(-var '%s=%s' ), $key, escape_single_quote($value));
         }
         $cmd .= "-var 'image_id=" . $image . "' " if ($image);
+        if (is_azure) {
+            # `storage-account` is only present in our Azure terraform profile
+            # Note: Remove the default 'openqa' once the deprecated account will be removed.
+            my $storage_account = get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT', 'openqa');
+            $cmd .= "-var 'storage-account=$storage_account' " if ($storage_account);
+        }
         $cmd .= "-var 'instance_count=" . $args{count} . "' ";
         $cmd .= "-var 'type=" . $instance_type . "' ";
         $cmd .= "-var 'region=" . $self->provider_client->region . "' ";
@@ -485,9 +491,11 @@ sub terraform_destroy {
             my $image = $self->get_image_id();
             my $offer = get_var('PUBLIC_CLOUD_AZURE_OFFER');
             my $sku = get_var('PUBLIC_CLOUD_AZURE_SKU');
+            my $storage_account = get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT');
             $cmd .= " -var 'image_id=$image'" if ($image);
             $cmd .= " -var 'offer=$offer'" if ($offer);
             $cmd .= " -var 'sku=$sku'" if ($sku);
+            $cmd .= " -var 'storage-account=$storage_account'" if ($storage_account);
         }
     }
     # Retry 3 times with considerable delay. This has been introduced due to poo#95932 (RetryableError)

--- a/variables.md
+++ b/variables.md
@@ -265,7 +265,6 @@ PUBLIC_CLOUD_AZURE_TENANT_ID | string | "" | Used to create the service account 
 PUBLIC_CLOUD_TOOLS_REPO | string | false | The URL to the cloud:tools repo (optional). (e.g. http://download.opensuse.org/repositories/Cloud:/Tools/openSUSE_Tumbleweed/Cloud:Tools.repo).
 PUBLIC_CLOUD_TTL_OFFSET | integer | 300 | This number + MAX_JOB_TIME equals the TTL of created VM.
 PUBLIC_CLOUD_SLES4SAP | boolean | false | If set, sles4sap test module is added to the job.
-PUBLIC_CLOUD_GOOGLE_STORAGE | string | "openqa-storage" | GCP only, Name of storage where we load the system image from.
 PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID | string | "" | Used to create the service account file together with `PUBLIC_CLOUD_AZURE_TENANT_ID`.
 PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY | string | "" | Name for public cloud registry for the container images used on kubernetes tests.
 PUBLIC_CLOUD_K8S_CLUSTER | string | "" | Name for the kubernetes cluster.
@@ -277,5 +276,6 @@ PUBLIC_CLOUD_CREDENTIALS_URL | string | "" | Base URL where to get the credentia
 PUBLIC_CLOUD_NAMESPACE | string | "" | The Public Cloud Namespace name that will be used to compose the full credentials URL together with `PUBLIC_CLOUD_CREDENTIALS_URL`.
 PUBLIC_CLOUD_USER | string | "" | The public cloud instance system user.
 PUBLIC_CLOUD_XEN | boolean | false | Indicates if this is a Xen test run.
+PUBLIC_CLOUD_STORAGE_ACCOUNT | string | "" | Storage account used e.g. for custom disk and container images
 PUBLIC_CLOUD_TERRAFORM_FILE | string | "" | If defined, use this terraform file (from the `data/` directory) instead the CSP default
 TERRAFORM_TIMEOUT | integer | 1800 | Set timeout for terraform actions


### PR DESCRIPTION
Introduce the `PUBLIC_CLOUD_STORAGE_ACCOUNT` variable to allow
customization of the CSP storage account being used.

- Related ticket: https://progress.opensuse.org/issues/112481
- Verification run: [SLE Micro](https://duck-norris.qam.suse.de/tests/8947) | [Old credential handling](https://duck-norris.qam.suse.de/tests/8963#dependencies) | [New credentials](https://duck-norris.qam.suse.de/tests/8961#dependencies)
