### PR TITLE
kernel: Use ltp-stable instead of qa_test_ltp package for SLE 15-SP4

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -262,7 +262,7 @@ sub get_default_pkg {
     my @packages;
 
     if (is_sle && is_released) {
-        push @packages, 'qa_test_ltp';
+        push @packages, is_sle('15-SP4+') ? 'ltp-stable' : 'qa_test_ltp';
         # temporarily disabled due to package conflict with qa_test_ltp
         #push @packages, 'qa_test_ltp-32bit' if is_x86_64;
     } else {


### PR DESCRIPTION
Fix poo#112532: We will stop using qa_test_ltp package with 15-SP4 and
will use only ltp-stable package.

- Related ticket: https://progress.opensuse.org/issues/112532
- Needles: none
- Verification run:
15-SP3: http://10.100.12.105/tests/1599#step/install_ltp/54
15-SP4: http://10.100.12.105/tests/1602#step/install_ltp/54
15-SP4: ltp_cve: http://10.100.12.105/tests/1605