### PR TITLE
Try to mitigate key repetition errors in X sessions

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1311,6 +1311,7 @@ sub load_x11tests {
     }
     # first module after login or startup to check prerequisites
     loadtest "x11/desktop_runner";
+    loadtest "x11/setup";
     if (xfcestep_is_applicable()) {
         loadtest "x11/xfce4_terminal";
     }

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -995,6 +995,10 @@ sub check_desktop_runner {
     x11_start_program('true', target_match => 'generic-desktop', no_wait => 1);
 }
 
+sub disable_key_repeat {
+    x11_start_program('xset -r', target_match => 'generic-desktop', no_wait => 1);
+}
+
 # Start one of the libreoffice components, close any first-run dialogs
 sub libreoffice_start_program {
     my ($self, $program) = @_;

--- a/schedule/functional/gnome.yaml
+++ b/schedule/functional/gnome.yaml
@@ -30,6 +30,7 @@ schedule:
     - console/prepare_test_data
     - console/consoletest_setup
     - x11/desktop_runner
+    - x11/setup
     - x11/xterm
     - x11/sshxterm
     - x11/gnome_control_center

--- a/schedule/functional/upgrade_Leap_15.1_gnome.yaml
+++ b/schedule/functional/upgrade_Leap_15.1_gnome.yaml
@@ -52,6 +52,7 @@ schedule:
     - console/consoletest_finish
     - x11/user_gui_login
     - x11/desktop_runner
+    - x11/setup
     - x11/xterm
     - locale/keymap_or_locale_x11
     - x11/sshxterm

--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -113,6 +113,7 @@ conditional_schedule:
       2:
         - console/consoletest_finish
         - x11/desktop_runner
+        - x11/setup
         - x11/xterm
         - locale/keymap_or_locale_x11
         - x11/sshxterm

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -101,6 +101,7 @@ conditional_schedule:
       2:
         - console/consoletest_finish
         - x11/desktop_runner
+        - x11/setup
         - x11/xterm
         - locale/keymap_or_locale_x11
         - x11/sshxterm

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -112,6 +112,7 @@ conditional_schedule:
       2:
         - console/consoletest_finish
         - x11/desktop_runner
+        - x11/setup
         - x11/xterm
         - locale/keymap_or_locale_x11
         - x11/sshxterm

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -105,6 +105,7 @@ conditional_schedule:
       2:
         - console/consoletest_finish
         - x11/desktop_runner
+        - x11/setup
         - x11/xterm
         - locale/keymap_or_locale_x11
         - x11/sshxterm

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -104,6 +104,7 @@ conditional_schedule:
       2:
         - console/consoletest_finish
         - x11/desktop_runner
+        - x11/setup
         - x11/xterm
         - locale/keymap_or_locale_x11
         - x11/sshxterm

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -98,6 +98,7 @@ conditional_schedule:
       2:
         - console/consoletest_finish
         - x11/desktop_runner
+        - x11/setup
         - x11/xterm
         - locale/keymap_or_locale_x11
         - x11/sshxterm

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -111,6 +111,7 @@ conditional_schedule:
       2:
         - console/consoletest_finish
         - x11/desktop_runner
+        - x11/setup
         - x11/xterm
         - locale/keymap_or_locale_x11
         - x11/sshxterm

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -101,6 +101,7 @@ conditional_schedule:
       2:
         - console/consoletest_finish
         - x11/desktop_runner
+        - x11/setup
         - x11/xterm
         - locale/keymap_or_locale_x11
         - x11/sshxterm

--- a/schedule/migration/zdup-Leap-42.3-gnome.yaml
+++ b/schedule/migration/zdup-Leap-42.3-gnome.yaml
@@ -42,6 +42,7 @@ schedule:
   - console/consoletest_finish
   - x11/user_gui_login
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/qam/12-SP1/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP1/qam-allpatterns.yaml
@@ -41,6 +41,7 @@ schedule:
 - console/mtab
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/qam/12-SP2/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP2/qam-allpatterns.yaml
@@ -42,6 +42,7 @@ schedule:
 - console/zypper_lifecycle
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/qam/12-SP3/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP3/qam-allpatterns.yaml
@@ -42,6 +42,7 @@ schedule:
 - console/zypper_lifecycle
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/qam/12-SP4/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP4/qam-allpatterns.yaml
@@ -43,6 +43,7 @@ schedule:
 - console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/qam/12-SP5/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP5/qam-allpatterns.yaml
@@ -43,6 +43,7 @@ schedule:
 - console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/qam/15-SP1/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP1/qam-allpatterns.yaml
@@ -44,6 +44,7 @@ schedule:
 - console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/qam/15-SP2/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP2/qam-allpatterns.yaml
@@ -44,6 +44,7 @@ schedule:
 - console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/qam/15-SP3/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP3/qam-allpatterns.yaml
@@ -44,6 +44,7 @@ schedule:
 - console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/qam/15/qam-allpatterns.yaml
+++ b/schedule/qam/15/qam-allpatterns.yaml
@@ -44,6 +44,7 @@ schedule:
 - console/orphaned_packages_check
 - console/consoletest_finish
 - x11/desktop_runner
+- x11/setup
 - x11/xterm
 - locale/keymap_or_locale_x11
 - x11/sshxterm

--- a/schedule/rt/migration_offline_sle12sp3+rt.yaml
+++ b/schedule/rt/migration_offline_sle12sp3+rt.yaml
@@ -54,6 +54,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/rt/online-migration-slertnext.yaml
+++ b/schedule/rt/online-migration-slertnext.yaml
@@ -52,6 +52,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/rt/sle12/migration_offline_sle12sp3+rt.yaml
+++ b/schedule/rt/sle12/migration_offline_sle12sp3+rt.yaml
@@ -54,6 +54,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/rt/sle12/rt+ha+geo.yaml
+++ b/schedule/rt/sle12/rt+ha+geo.yaml
@@ -57,6 +57,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/rt/sle12/rt+sdk.yaml
+++ b/schedule/rt/sle12/rt+sdk.yaml
@@ -58,6 +58,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/rt/sle12/rt.yaml
+++ b/schedule/rt/sle12/rt.yaml
@@ -40,6 +40,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/rt/sle12/sles+rt-net.yaml
+++ b/schedule/rt/sle12/sles+rt-net.yaml
@@ -40,6 +40,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/rt/sle12/sles+rt.yaml
+++ b/schedule/rt/sle12/sles+rt.yaml
@@ -38,6 +38,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/rt/sle15/rt-validation_extra_tests.yaml
+++ b/schedule/rt/sle15/rt-validation_extra_tests.yaml
@@ -40,6 +40,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/schedule/staging/gnome@64bit-staging.yaml
+++ b/schedule/staging/gnome@64bit-staging.yaml
@@ -53,6 +53,7 @@ schedule:
   - console/orphaned_packages_check
   - console/consoletest_finish
   - x11/desktop_runner
+  - x11/setup
   - x11/xterm
   - locale/keymap_or_locale_x11
   - x11/sshxterm

--- a/t/data/test_schedule.out
+++ b/t/data/test_schedule.out
@@ -43,6 +43,7 @@ tests/console/mtab.pm
 tests/console/orphaned_packages_check.pm
 tests/console/consoletest_finish.pm
 tests/x11/desktop_runner.pm
+tests/x11/setup.pm
 tests/x11/xterm.pm
 tests/locale/keymap_or_locale_x11.pm
 tests/x11/sshxterm.pm

--- a/tests/x11/reboot_plasma5.pm
+++ b/tests/x11/reboot_plasma5.pm
@@ -22,6 +22,8 @@ sub run {
     # modules
     # https://progress.opensuse.org/issues/30805
     $self->check_desktop_runner;
+    # also prevent key repetition errors
+    $self->disable_key_repeat;
 }
 
 sub test_flags {

--- a/tests/x11/setup.pm
+++ b/tests/x11/setup.pm
@@ -1,0 +1,14 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Generic setup of X11 session with stability improvements for
+#   automated tests
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use Mojo::Base 'x11test', -signatures;
+
+sub run ($self) { $self->disable_key_repeat }
+
+1;


### PR DESCRIPTION
* Add 'x11/setup' with disabled key repetition to schedules
* Try to mitigate "VNC typing issues" with disabled key repeat

Verification runs:
```
for i in https://openqa.opensuse.org/tests/2415152 https://openqa.opensuse.org/tests/2414998 https://openqa.opensuse.org/tests/2415293 https://openqa.opensuse.org/tests/2414950 https://openqa.opensuse.org/tests/2415061 https://openqa.opensuse.org/tests/2414941 https://openqa.opensuse.org/tests/2414947; do MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15095 $i; done
```

* [opensuse-Tumbleweed-NET-x86_64-Build20220613-zdup_tw2twnext_gnome@64bit](https://openqa.opensuse.org/t2417332)
* [opensuse-Tumbleweed-NET-x86_64-Build20220613-lxde@64bit](https://openqa.opensuse.org/t2417333)
* [opensuse-Tumbleweed-GNOME-Live-i686-Build20220613-gnome-live@32bit](https://openqa.opensuse.org/t2417334)
* [opensuse-Tumbleweed-DVD-x86_64-Build20220613-xfce@64bit](https://openqa.opensuse.org/t2417335)
* [opensuse-Tumbleweed-DVD-x86_64-Build20220613-upgrade_Leap_42.3_gnome@64bit](https://openqa.opensuse.org/tests/2417386)
* [opensuse-Tumbleweed-DVD-x86_64-Build20220613-kde@64bit](https://openqa.opensuse.org/t2417337)
* [opensuse-Tumbleweed-DVD-x86_64-Build20220613-gnome@64bit](https://openqa.opensuse.org/t2417338)
