### PR TITLE
sync wait added to test_container_image

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -254,7 +254,7 @@ sub test_container_image {
     # Images from custom registry are listed with the '$registry/library/'
     $image =~ s/^docker\.io\/library\///;
 
-    my $smoketest = qq[/bin/sh -c '/bin/uname -r; /bin/echo "Heartbeat from $image"; ps'];
+    my $smoketest = qq[/bin/sh -c '/bin/uname -r; /bin/echo "Heartbeat from $image";ps'];
 
     $runtime->pull($image, timeout => 420);
     $runtime->check_image_in_host($image);


### PR DESCRIPTION
A wait time has been added after the container creation command, in order to have it completed, so that openqa could print the end of task marker, that resulted missing. 

- Related ticket: https://progress.opensuse.org/issues/112388
- Needles: none 
- Verification run: http://marvin5.arch.suse.cz/tests/379 
