### PR TITLE
[WIP]Enable libssh test in FIPS mode

### DIFF
--- a/schedule/security/libssh_fips.yaml
+++ b/schedule/security/libssh_fips.yaml
@@ -1,0 +1,15 @@
+name: libssh_fips
+description:    >
+    This is for libssh_fips test
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/test_repo_setup
+    - fips/fips_setup
+    - console/libssh
+conditional_schedule:
+    bootloader:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm


### PR DESCRIPTION
Enable libssh test in FIPS mode since the Maintenance job group has run the case in non-FIPS mode and passed already.

- Related ticket: https://progress.opensuse.org/issues/102254
- Needles: NA
- Verification run:
  https://openqa.suse.de/tests/8965828 (kernel mode) - passed
  https://openqa.suse.de/tests/8971686 (ENV mode) - hit the curve25519 bug.