### PR TITLE
[WIP]Set flag to run install_service

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -477,7 +477,7 @@ sub load_online_migration_tests {
     if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE'))) {
         loadtest "console/check_system_info";
     }
-    loadtest 'installation/install_service' if (is_sle && !is_desktop && !get_var('INSTALLONLY'));
+    loadtest 'installation/install_service' if (get_var('FORCE_INSTALL_SERVICE') || (is_sle && !is_desktop && !get_var('INSTALLONLY')));
     loadtest "migration/version_switch_upgrade_target";
     loadtest "migration/online_migration/pre_migration";
     if (get_var("LOCK_PACKAGE")) {

--- a/tests/installation/install_service.pm
+++ b/tests/installation/install_service.pm
@@ -24,13 +24,13 @@ sub run {
     }
 
     install_services($default_services)
-      if is_sle
-      && !is_desktop
-      && !is_sles4sap
-      && !is_hyperv
-      && !get_var('MEDIA_UPGRADE')
-      && !get_var('ZDUP')
-      && !get_var('INSTALLONLY');
+      if get_var('FORCE_INSTALL_SERVICE') || (is_sle
+        && !is_desktop
+        && !is_sles4sap
+        && !is_hyperv
+        && !get_var('MEDIA_UPGRADE')
+        && !get_var('ZDUP')
+        && !get_var('INSTALLONLY'));
 
     if ($srv_check_results{'before_migration'} eq 'FAIL') {
         record_info("Summary", "failed", result => 'fail');

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -13,6 +13,9 @@ use power_action_utils 'power_action';
 use utils;
 
 sub run {
+    select_console 'root-console';
+    script_run('cat /etc/os-release');
+    select_console 'x11';
     power_action('poweroff');
 }
 


### PR DESCRIPTION
For the new regression tests, we need to set INSTALL_ONLY=1 to
generate the qcow file and then run the regression tests. and
We want to load install_service in the installation part.

- Related ticket: https://progress.opensuse.org/issues/110875
- Needles: N/A
- Verification run:  
https://openqa.nue.suse.com/tests/8965952 with FORCE_INSTALL_SERVICE=1
https://openqa.nue.suse.com/t8965961 w/o FORCE_INSTALL_SERVICE