### PR TITLE
console: Add very basic ping IPv6 test

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -103,6 +103,7 @@ schedule:
     - console/prepare_test_data
     - console/consoletest_setup
     - '{{update_repos}}'
+    - console/ping
     - console/orphaned_packages_check
     - console/zypper_lr_validate
     - console/zypper_ref

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -52,6 +52,7 @@ schedule:
     - console/consoletest_setup
     - '{{udev_dep}}'
     - locale/keymap_or_locale
+    - console/ping
     - console/apache
     - console/dns_srv
     - console/postgresql_server

--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -7,6 +7,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/check_os_release
+  - console/ping
   - console/openvswitch
   - console/pam
   - console/sshd

--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -1,0 +1,62 @@
+# SUSE's ping tests in openQA
+#
+# Copyright 2016-2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Very basic ping test.
+# Tests pinging site-local IPv6, which had problems on ICMP datagram socket,
+# there were also problems with sysctl setup (bsc#1200617).
+#
+# Maintainer: Petr Vorel <pvorel@suse.cz>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use version_utils qw(is_jeos is_sle);
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+
+    record_info('net.ipv4.ping_group_range', script_output('sysctl net.ipv4.ping_group_range'));
+    record_info('aaa_base', script_output('rpm -qi aaa_base'));
+    record_info('KERNEL VERSION', script_output('uname -a'));
+    record_info('sysctl', script_output('sysctl -V'));
+    record_info('procps', script_output('rpm -qi procps'));
+
+    my $kernel_pkg = is_jeos ? 'kernel-default-base' : 'kernel-default';
+    record_info('KERNEL DEFAULT PKG', script_output("rpm -qi $kernel_pkg", proceed_on_failure => 1));
+
+    my $ifname = script_output('ip -6 link |grep "^[0-9]:" |grep -v lo: | head -1 | awk "{print \$2}" | sed s/://');
+    my $addr = script_output("ip -6 addr show $ifname | grep 'scope link' | head -1 | awk '{ print \$2 }' | cut -d/ -f1");
+
+    my $cmd = "ping6 -c2 $addr%$ifname";
+    record_info('ping %');
+    assert_script_run($cmd);
+
+    $cmd = "ping6 -c2 $addr -I$ifname";
+    record_info('ping -I');
+    my $rc = script_run($cmd);
+
+    if ($rc) {
+        my $bug;
+        $bug = "bsc#1195826 or bsc#1200617" if is_sle('=15-SP4');
+        $bug = "bsc#1196840 or bsc#1200617" if is_sle('=15-SP3');
+        $bug = "bsc#1199918 or bsc#1200617" if is_sle('=15-SP2');
+        $bug = "bsc#1199926" if is_sle('=15-SP1');
+        $bug = "bsc#1199927" if is_sle('=15');
+
+        if (defined($bug)) {
+            record_soft_failure $bug;
+        } else {
+            $self->result("fail");
+            record_info("Unknown failure, maybe related to: bsc#1200617, bsc#1195826, bsc#1196840, bsc#1199918, bsc#1199926, bsc#1199927");
+        }
+    }
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;


### PR DESCRIPTION
I plan to create testsuite in iputils upstream, but meanwhile let's add just this.
    
Test added to mau-extratests1 (SLES QAM), jeos-main (SLES) and extra_tests_textmode (Tumbleweed).

Related bugs: bsc#1200617, bsc#1195826, bsc#1196840, bsc#1199918, bsc#1199926, bsc#1199927
Due to these bugs test is going to temporarily fail on SLE15-SP0 to SP3, I guess I should mark it as know issue.
Test should work out of box on SLE12 (where ping uses RAW socket)

NOTE: I put ping test to the top for faster validation. I can move it down if required.

Verification run:
- sle-15-SP1-Server-DVD-Incidents-x86_64-Build:24702:mdadm-mau-extratests1@64bit
http://quasar.suse.cz/tests/106#step/ping/61

old verifications:
- sle-15-SP3-JeOS-for-kvm-and-xen-QR-x86_64-Build4.10.18-jeos-main@uefi-virtio-vga
http://quasar.suse.cz/tests/83#step/ping/33 (expected failure due bsc#1196840)
- sle-15-SP1-Server-DVD-Incidents-x86_64-Build:24702:mdadm-mau-extratests1@64bit
http://quasar.suse.cz/tests/86#step/ping/9 (expected failure due bsc#1199926)
- sle-15-SP2-Server-DVD-Incidents-x86_64-Build:24702:mdadm-mau-extratests1@64bit
http://quasar.suse.cz/tests/87#step/ping/33 (expected failure due bsc#1199918)
- sle-15-SP3-Server-DVD-Updates-x86_64-Build20220616-1-mau-extratests1@64bit
http://quasar.suse.cz/tests/82#step/ping/33
- opensuse-Tumbleweed-DVD-x86_64-Build20220614-extra_tests_textmode@64bit
http://quasar.suse.cz/tests/81#step/ping/33

- sle-12-SP5-Server-DVD-Incidents-x86_64-Build:24701:mdadm-mau-extratests1@64bit
http://quasar.suse.cz/tests/84#step/ping/33
- sle-12-SP5-Server-DVD-Incidents-x86_64-Build:24701:mdadm-mau-extratests1@64bit
http://quasar.suse.cz/tests/85#step/ping/33

