### PR TITLE
Optimize installation/add_update_test_repo

### DIFF
--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -38,7 +38,10 @@ sub run() {
         type_string $maintrepo;
         advance_installer_window('addon-products');
         # if more repos to come, add more
-        send_key_until_needlematch('addon-menu-active', 'alt-a', 11, 2) if @repos;
+        if (@repos) {
+            send_key 'alt-a';
+            send_key_until_needlematch('addon-menu-active', 'alt-a', 11, 2);
+        }
     }
 }
 


### PR DESCRIPTION
Handle optional screens and pop-ups while adding custom repository URLs based on needle matches instead of needlessly waiting for optional screens which will not show up.

- Related ticket: https://progress.opensuse.org/issues/112343
- Needles: N/A
- Verification runs:
  - SLE-12SP5: https://openqa.suse.de/tests/10323009
  - SLE-15SP4: https://openqa.suse.de/tests/10323008