### PR TITLE
Fix hotkey for sle15sp4

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -73,6 +73,7 @@ sub get_product_shortcuts {
         return (
             sles => (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'
+            : (is_sle '15-SP4+') ? 's'
             : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
In textmode the hotkey for selecting sles 15sp4 product via yast is now alt-s instead of alt-i

- Related ticket: https://progress.opensuse.org/issues/112685
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1612
- Verification run: http://10.161.229.247/tests/67#step/scc_registration/116
