### PR TITLE
Switch yast2_nfs* console tests to serial terminal

### DIFF
--- a/tests/console/yast2_nfs4_client.pm
+++ b/tests/console/yast2_nfs4_client.pm
@@ -29,10 +29,8 @@ use mm_network;
 use nfs_common;
 
 sub run {
-    #
-    # Preparation
-    #
-    select_console 'root-console';
+    my $self = shift;
+    $self->select_serial_terminal;
 
     setup_static_mm_network('10.0.2.102/24');
 
@@ -44,6 +42,9 @@ sub run {
     # add comments into fstab and save current fstab bsc#429326
     assert_script_run 'sed -i \'5i# test comment\' /etc/fstab';
     assert_script_run 'cat /etc/fstab > fstab_before';
+
+    # Fron now we need needles
+    select_console 'root-console';
 
     #
     # YaST nfs-client execution
@@ -78,6 +79,9 @@ sub run {
     sleep 1;
     save_screenshot;
     yast2_client_exit($module_name);
+
+    # From now we can use serial terminal
+    $self->select_serial_terminal;
 
     mount_export();
 

--- a/tests/console/yast2_nfs4_server.pm
+++ b/tests/console/yast2_nfs4_server.pm
@@ -30,9 +30,10 @@ use nfs_common;
 
 sub run {
     my ($self) = @_;
+    $self->select_serial_terminal;
+
     my $rw = '/srv/nfs';
     my $ro = '/srv/nfs/ro';
-    select_console 'root-console';
 
     server_configure_network($self);
 
@@ -42,6 +43,9 @@ sub run {
     try_nfsv2();
 
     prepare_exports($rw, $ro);
+
+    # We need needles from now
+    select_console 'root-console';
 
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nfs-server');
 
@@ -65,6 +69,7 @@ sub run {
 
     # Back on the console, test mount locally
     clear_console;
+    select_console 'root-console';
 
     # Server is up and running, client can use it now!
     script_run "( journalctl -fu nfs-server > /dev/$serialdev & )";

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -27,10 +27,8 @@ use mm_network 'setup_static_mm_network';
 use nfs_common;
 
 sub run {
-    #
-    # Preparation
-    #
-    select_console 'root-console';
+    my ($self) = @_;
+    $self->select_serial_terminal;
 
     # NFSCLIENT defines if the test should be run on multi-machine setup.
     # Otherwise, configure server and client on the single machine.
@@ -58,6 +56,9 @@ sub run {
     # add comments into fstab and save current fstab bsc#429326
     assert_script_run 'sed -i \'5i# test comment\' /etc/fstab';
     assert_script_run 'cat /etc/fstab > fstab_before';
+
+    # From now we need needles
+    select_console 'root-console';
 
     #
     # YaST nfs-client execution
@@ -91,6 +92,9 @@ sub run {
     #
     # Check the result
     #
+
+    # From now we can use serial terminal
+    $self->select_serial_terminal;
 
     mount_export();
     if (get_var('NFSCLIENT')) {

--- a/tests/console/yast2_nfs_server.pm
+++ b/tests/console/yast2_nfs_server.pm
@@ -31,14 +31,22 @@ use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
-    select_console 'root-console';
+    $self->select_serial_terminal;
 
     if (get_var('NFSSERVER')) {
         server_configure_network($self);
     }
 
     install_service;
+
+    # From now we need needles
+    select_console 'root-console';
+
     config_service($rw, $ro);
+
+    # From now we can use serial terminal
+    $self->select_serial_terminal;
+
     start_service($rw, $ro);
 
     mutex_create('nfs_ready');


### PR DESCRIPTION
As the VNC console is slow and unstable I propose to switch NFS tests to serial terminal.

Please see attached screenshot with example error:
![image](https://user-images.githubusercontent.com/1254493/174331923-691d690a-5e4f-4f6d-adf4-46c21660c331.png)

- Related ticket: [poo#105295](https://progress.opensuse.org/issues/105295)
- Verification run: [yast2_nfs_v3](https://pdostal-server.suse.cz/tests/139), [yast2_nfs_v4](https://pdostal-server.suse.cz/tests/134)
