### PR TITLE
Fix yast2_storage_ng in sp4

### DIFF
--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -50,6 +50,7 @@ sub add_logical_volume {
     send_key("alt-t");
     wait_still_screen 1;
     send_key "alt-s";
+    send_key "ctrl-a";
     wait_screen_change { type_string "400MiB" };
     wait_screen_change { send_key "alt-n" };
     send_key "$role";


### PR DESCRIPTION
In sp4 a default value is present for volume size, we need to select the
text before.

Fixes https://openqa.suse.de/tests/8973107#step/yast2_storage_ng/60

VR (this module is not in O3, and only in sle 15+)
[Build20220616-1](http://waaa-amazing.suse.cz/tests/overview?build=20220616-1&distri=sle&version=15-SP2) of sle-15-SP2-Server-DVD-Updates.x86_64	[mau-extratests-yast2ui@64bit](http://waaa-amazing.suse.cz/tests/17171)	[4 1](http://waaa-amazing.suse.cz/tests/17171)
[Build20220616-1](http://waaa-amazing.suse.cz/tests/overview?build=20220616-1&distri=sle&version=15-SP1) of sle-15-SP1-Server-DVD-Updates.x86_64	[mau-extratests-yast2ui@64bit](http://waaa-amazing.suse.cz/tests/17170)	[5](http://waaa-amazing.suse.cz/tests/17170)
[Build20220616-1](http://waaa-amazing.suse.cz/tests/overview?build=20220616-1&distri=sle&version=15) of sle-15-Server-DVD-Updates.x86_64	[mau-extratests-yast2ui@64bit](http://waaa-amazing.suse.cz/tests/17174)	[5](http://waaa-amazing.suse.cz/tests/17174)
[Build20220616-1](http://waaa-amazing.suse.cz/tests/overview?build=20220616-1&distri=sle&version=15-SP3) of sle-15-SP3-Server-DVD-Updates.x86_64	[mau-extratests-yast2ui@64bit](http://waaa-amazing.suse.cz/tests/17172)
