### PR TITLE
Test adaptations for ALP

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -59,7 +59,8 @@
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
             "leap-micro": [ "5.2" ],
-            "microos":  ["Tumbleweed"]
+            "microos":  ["Tumbleweed"],
+            "alp":  ["0.1"]
         },
         "type": "ignore"
     },
@@ -86,7 +87,8 @@
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
             "leap-micro": [ "5.2" ],
-            "microos":  ["Tumbleweed"]
+            "microos":  ["Tumbleweed"],
+            "alp":  ["0.1"]
         },
         "type": "bug"
     },
@@ -296,7 +298,8 @@
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
             "leap-micro": ["5.2"],
-            "microos":  ["Tumbleweed"]
+            "microos":  ["Tumbleweed"],
+            "alp":  ["0.1"]
         },
         "type": "ignore"
     },

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -17,7 +17,7 @@ use warnings;
 use testapi;
 use microos 'microos_reboot';
 use power_action_utils qw(power_action prepare_system_shutdown);
-use version_utils qw(is_opensuse is_microos is_sle_micro is_leap_micro is_sle);
+use version_utils;
 use utils 'reconnect_mgmt_console';
 use Utils::Backends;
 use Utils::Architectures;
@@ -37,7 +37,7 @@ sub get_utt_packages {
     # SLE and SUSE MicroOS need an additional repo for testing
     if (is_sle || is_sle_micro) {
         assert_script_run 'curl -O ' . data_url("microos/utt.repo");
-    } elsif (is_leap_micro) {
+    } elsif (is_leap_micro || is_alp) {
         assert_script_run 'curl -o utt.repo ' . data_url("microos/utt-leap.repo");
     }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -21,6 +21,7 @@ use constant {
           is_microos
           is_leap_micro
           is_sle_micro
+          is_alp
           is_selfinstall
           is_gnome_next
           is_jeos
@@ -257,6 +258,21 @@ sub is_sle_micro {
     return check_version($query, $version, qr/\d{1,}\.\d/);
 }
 
+=head2 is_alp
+
+Check if distribution is ALP
+=cut
+sub is_alp {
+    my $query = shift;
+    my $version = shift // get_var('VERSION');
+
+    return 0 unless check_var('DISTRI', 'alp');
+    return 1 unless $query;
+
+    # Version check
+    return check_version($query, $version, qr/\d{1,}\.\d/);
+}
+
 =head2 is_selfinstall
 
 Check if SLEM is in flavor of self installable iso
@@ -311,6 +327,7 @@ sub is_opensuse {
     return 1 if check_var('DISTRI', 'opensuse');
     return 1 if check_var('DISTRI', 'microos');
     return 1 if check_var('DISTRI', 'leap-micro');
+    return 1 if check_var('DISTRI', 'alp');
     return 0;
 }
 
@@ -336,6 +353,7 @@ Returns true if called on a transactional server
 =cut
 sub is_transactional {
     return 1 if (is_microos || is_sle_micro || is_leap_micro);
+    return 1 if (is_alp && get_var('FLAVOR') !~ /NonTransactional/);
     return check_var('SYSTEM_ROLE', 'serverro') || get_var('TRANSACTIONAL_SERVER');
 }
 

--- a/products/alp/main.pm
+++ b/products/alp/main.pm
@@ -45,7 +45,7 @@ sub load_common_tests {
 
 sub load_transactional_tests {
     loadtest 'transactional/host_config';
-    loadtest 'transactional/enable_selinux' if get_var('ENABLE_SELINUX');
+    loadtest 'transactional/enable_selinux';
     loadtest 'transactional/trup_smoke';
     loadtest 'transactional/filesystem_ro' if is_transactional;
     loadtest 'transactional/transactional_update';

--- a/products/alp/main.pm
+++ b/products/alp/main.pm
@@ -35,6 +35,8 @@ sub load_selfinstall_boot_tests {
 }
 
 sub load_common_tests {
+    loadtest 'transactional/host_config';
+    loadtest 'transactional/enable_selinux';
     loadtest 'microos/networking';
     loadtest 'microos/libzypp_config';
     loadtest 'microos/image_checks';
@@ -44,8 +46,6 @@ sub load_common_tests {
 }
 
 sub load_transactional_tests {
-    loadtest 'transactional/host_config';
-    loadtest 'transactional/enable_selinux';
     loadtest 'transactional/trup_smoke';
     loadtest 'transactional/filesystem_ro' if is_transactional;
     loadtest 'transactional/transactional_update';

--- a/products/alp/main.pm
+++ b/products/alp/main.pm
@@ -10,7 +10,7 @@ use utils;
 use testapi;
 use main_common;
 use main_containers qw(load_container_tests is_container_test);
-use version_utils qw(is_released);
+use version_utils qw(is_transactional);
 use Utils::Architectures qw(is_s390x);
 
 init_main();
@@ -47,7 +47,7 @@ sub load_transactional_tests {
     loadtest 'transactional/host_config';
     loadtest 'transactional/enable_selinux' if get_var('ENABLE_SELINUX');
     loadtest 'transactional/trup_smoke';
-    loadtest 'transactional/filesystem_ro';
+    loadtest 'transactional/filesystem_ro' if is_transactional;
     loadtest 'transactional/transactional_update';
     loadtest 'transactional/rebootmgr';
     loadtest 'transactional/health_check';

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -13,8 +13,10 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use transactional qw(process_reboot);
+use transactional qw(process_reboot trup_call check_reboot_changes);
 use bootloader_setup qw(change_grub_config);
+use version_utils qw(is_alp is_transactional);
+use utils qw(zypper_call);
 
 sub run {
     select_console 'root-console';
@@ -30,8 +32,15 @@ sub run {
         assert_script_run('transactional-update grub.cfg');
         process_reboot(trigger => 1);
     }
-
-    # Placeholder for other configurations we might need (not related to grub)
+    if (is_alp) {
+        record_info('Packages', 'Install needed packages to run the tests');
+        if (is_transactional) {
+            trup_call('pkg install tar', timeout => 300);
+            check_reboot_changes;
+        } else {
+            zypper_call('in tar');
+        }
+    }
 }
 
 sub test_flags {

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use version_utils qw(is_staging is_opensuse is_leap is_sle is_sle_micro is_leap_micro);
+use version_utils qw(is_staging is_opensuse is_leap is_sle is_sle_micro is_leap_micro is_alp);
 use transactional;
 use utils;
 
@@ -77,8 +77,8 @@ sub run {
     unless (is_opensuse && is_staging) {
         record_info 'Update #1', 'Add repository and update - snapshot #2';
         # Leap Micro misses the gpg key for openSUSE:Maintenance space
-        my $no_gpg_check = is_leap_micro ? '-G' : '';
-        zypper_call "ar $no_gpg_check utt.repo" if (is_sle || is_sle_micro || is_leap_micro);
+        my $no_gpg_check = (is_leap_micro || is_alp) ? '-G' : '';
+        zypper_call "ar $no_gpg_check utt.repo" if (is_sle || is_sle_micro || is_leap_micro || is_alp);
         # openSUSE MicroOS does not need additional repo as UTT package is already available
         trup_call 'cleanup up', timeout => 300;
         check_reboot_changes;


### PR DESCRIPTION
This is combination of several commits:
- Create new util function is_alp
- Execute filesystem_ro test only for transactional ALP
- Execute enable_selinux on ALP always
- Execute enable_selinux on ALP always
- Add some bugs in ALP to journal whitelist


Related ticket: https://progress.opensuse.org/issues/112427

VR:
- https://openqa.opensuse.org/tests/2425554
- https://openqa.opensuse.org/tests/2425553
