### PR TITLE
Do not expect license in factory images

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -98,12 +98,14 @@ sub run {
     send_key_until_needlematch "jeos-keylayout-$lang", $keylayout_key{$lang}, 30;
     send_key 'ret';
 
-    # Accept license
-    unless (is_leap('<15.2')) {
-        foreach my $license_needle (qw(jeos-license jeos-doyouaccept)) {
-            assert_screen $license_needle;
-            send_key 'ret';
-        }
+    # Show license
+    assert_screen 'jeos-license';
+    send_key 'ret';
+
+    # Accept EULA if required
+    unless (is_tumbleweed || is_microos) {
+        assert_screen 'jeos-doyouaccept';
+        send_key 'ret';
     }
 
     # Select timezone


### PR DESCRIPTION
License has to be shown but there is no need to accept it in openSUSE
images.

- Related ticket: https://progress.opensuse.org/issues/112700
- Verification run: 
  - [microos-Tumbleweed-MicroOS-Image-x86_64-Build20220617-microos-wizard@64bit](http://kepler.suse.cz/tests/17467#step/firstrun/4)
  - [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20220619-jeos@64bit_virtio](http://kepler.suse.cz/tests/17469#)
