### PR TITLE
Update test flow for sle15sp4 multipath test scenario

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -894,7 +894,7 @@ sub load_inst_tests {
     if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
         loadtest "installation/encrypted_volume_activation";
     }
-    if (get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
+    if (is_sle('<15-SP4') && get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
         loadtest "installation/multipath";
     }
     if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {
@@ -915,6 +915,9 @@ sub load_inst_tests {
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
         loadtest "installation/scc_registration";
+        if (is_sle('15-SP4+') && get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
+            loadtest "installation/multipath";
+        }
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }


### PR DESCRIPTION
Although that YaST correctly detects multipath feature, the test case
was misplaced in case of sle15sp4 test scenario. It should be executed
after the system is registered.

- ticket: [[qe-core] test fails in multipath - activation of multipath is expected](https://progress.opensuse.org/issues/112739)
- Verification run: 
  - [sle-15-SP4-Server-DVD-Updates-x86_64-Build20220619-1-mru-install-minimal-with-addons-multipath@64bit](http://kepler.suse.cz/tests/17475#)
  - [opensuse-15.4-DVD-x86_64-Build243.2-install_only@64bit-multipath](http://kepler.suse.cz/tests/17479#step/multipath/1)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20220619-install_only@64bit-multipath](http://kepler.suse.cz/tests/17478#step/multipath/1)
