### PR TITLE
chromium: Re-introduce urlbar update checks

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -14,6 +14,8 @@ use utils;
 
 sub type_address ($string) {
     send_key 'ctrl-l';    # select text in address bar
+                          # wait for the urlbar to be in a consistent state
+    assert_screen 'chromium-highlighted-urlbar';
     enter_cmd($string);
 }
 
@@ -25,6 +27,7 @@ sub run {
     # avoid async keyring popups
     # allow key input before rendering is done, see poo#109737 for details
     x11_start_program('chromium --password-store=basic --allow-pre-commit-input', target_match => 'chromium-main-window', match_timeout => 50);
+    wait_screen_change { send_key 'esc' };    # get rid of popup (or abort loading)
 
     type_address('chrome://version');
     assert_screen 'chromium-about';


### PR DESCRIPTION
- Cancel the popup via esc
- Check that the urlbar is highlighted after ^L

The popup still comes up while chrome://version is being typed at least as part of the full job with installation and other modules.

The urlbar highlight was also checked before and removed since it was not necessary in the simplified scenario.

See: https://progress.opensuse.org/issues/109737