### PR TITLE
[WIP] Enable sssd_389ds_functional test in FIPS mode

### DIFF
--- a/schedule/security/sssd_389ds_functional_fips.yaml
+++ b/schedule/security/sssd_389ds_functional_fips.yaml
@@ -1,0 +1,15 @@
+name: sssd_389ds_functional_fips
+description:    >
+    This is for sssd_389ds_functional_fips test
+schedule:
+    - '{{bootloader}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/test_repo_setup
+    - fips/fips_setup
+    - console/sssd_389ds_functional
+conditional_schedule:
+    bootloader:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
