### PR TITLE
Restart cups service after configuration changes

### DIFF
--- a/lib/services/cups.pm
+++ b/lib/services/cups.pm
@@ -21,22 +21,26 @@ sub install_service {
 }
 
 sub config_service {
+    my $conf = '/etc/cups/cups-files.conf';
     if ($service_type eq 'Systemd') {
-        script_run 'echo FileDevice Yes >> /etc/cups/cups-files.conf';
+        script_run "echo FileDevice Yes >> $conf";
         validate_script_output 'cupsd -t', sub { m/is OK/ };
     } else {
+        $conf = '/etc/cups/cupsd.conf';
         # Allow new printers to be added using device URIs "file:/filename"
-        script_run 'echo FileDevice Yes >> /etc/cups/cupsd.conf';
+        script_run "echo FileDevice Yes >> $conf";
         assert_script_run 'cupsd';
     }
+
+    record_info('cups-files', script_output("cat $conf"));
 }
 
 sub enable_service {
     common_service_action 'cups', $service_type, 'enable';
 }
 
-sub start_service {
-    common_service_action 'cups', $service_type, 'start';
+sub restart_service {
+    common_service_action 'cups', $service_type, 'restart';
 }
 
 # check service is running and enabled
@@ -119,7 +123,7 @@ sub full_cups_check {
         install_service();
         config_service();
         enable_service();
-        start_service();
+        restart_service();
     }
     check_service();
     check_function();

--- a/tests/console/cups.pm
+++ b/tests/console/cups.pm
@@ -34,7 +34,7 @@ sub run {
     services::cups::install_service();
     services::cups::config_service();
     services::cups::enable_service();
-    services::cups::start_service();
+    services::cups::restart_service();
     services::cups::check_service();
     services::cups::check_function();
 


### PR DESCRIPTION
As long as cups daemon is running prior to this test case, starting the
service becomes a noop therefore configuration changes are not applied.

Warning message: `lpadmin: Raw queues are deprecated and will stop
working in a future version of CUPS.` is not handled in this PR as it is
harmless in the current version of `cups`.

- Related ticket: https://progress.opensuse.org/issues/xyz
- Verification runs: 
  - [opensuse-15.4-DVD-x86_64-Build243.2-extra_tests_textmode@64bit](http://kepler.suse.cz/tests/17513#step/cups/64)
  - [Build20220619 of opensuse-Tumbleweed-DVD.x86_64](http://kepler.suse.cz/tests/17514#step/cups/64)
