### PR TITLE
Fix condition multipath schedule

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -894,7 +894,7 @@ sub load_inst_tests {
     if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
         loadtest "installation/encrypted_volume_activation";
     }
-    if (is_sle('<15-SP4') && get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
+    if (!is_sle('15-SP4+') && get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
         loadtest "installation/multipath";
     }
     if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {


### PR DESCRIPTION
I have messed up rebase in my previous PR
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15120

- Verification runs: 
  - [opensuse-Tumbleweed-DVD-x86_64-Build20220619-install_only@64bit-multipath](http://kepler.suse.cz/tests/17510#)
  - [opensuse-15.4-DVD-x86_64-Build243.2-install_only@64bit-multipath](http://kepler.suse.cz/tests/17509#)
  - [sle-15-SP4-Server-DVD-Updates-x86_64-Build20220619-1-mru-install-minimal-with-addons-multipath@64bit](http://kepler.suse.cz/tests/17508#)
  - [sle-15-SP4-Server-DVD-Updates-x86_64-Build20220619-1-mru-install-minimal-with-addons-multipath@64bit](http://kepler.suse.cz/tests/17507#)
