### PR TITLE
helm GKE added and gcloud_install() defined

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -142,7 +142,7 @@ sub load_host_tests_helm {
     my $backends = undef;
 
     if (is_sle('15-sp3+')) {
-        $backends = get_var("HELM_K8S_BACKEND", "EKS,AKS,K3S");
+        $backends = get_var("HELM_K8S_BACKEND", "GKE,EKS,AKS,K3S");
     } elsif (is_opensuse) {
         $backends = get_var("HELM_K8S_BACKEND", "K3S");
     } else {

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   register_openstack
   register_addons_in_pc
   select_host_console
+  gcloud_install
 );
 
 # Select console on the test host, if force is set, the interactive session will
@@ -236,6 +237,36 @@ sub get_credentials {
         assert_script_run('curl ' . autoinst_url . '/files/creds.json -o ' . $output_json);
     }
     return $data_structure;
+}
+
+=head2 gcloud_install
+    gcloud_install($url, $dir, $timeout)
+
+This function is used to install the gcloud CLI 
+for the GKE Google Cloud.
+
+From $url we get the full package and install it
+in $dir local folder as a subdir of /root.
+Defaults are available for a simple call without parameters:
+    gcloud_install()
+
+=cut
+
+sub gcloud_install {
+    my %args = @_;
+    my $url = $args{url} || 'sdk.cloud.google.com';
+    my $dir = $args{dir} || 'google-cloud-sdk';
+    my $timeout = $args{timeout} || 700;
+
+    zypper_call("in curl tar gzip", $timeout);
+
+    assert_script_run("export CLOUDSDK_CORE_DISABLE_PROMPTS=1");
+    assert_script_run("curl $url | bash", $timeout);
+    assert_script_run("echo . /root/$dir/completion.bash.inc >> ~/.bashrc");
+    assert_script_run("echo . /root/$dir/path.bash.inc >> ~/.bashrc");
+    assert_script_run("source ~/.bashrc");
+
+    record_info('GCE', script_output('gcloud version'));
 }
 
 1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -94,7 +94,6 @@ our @EXPORT = qw(
   permit_root_ssh_in_sol
   cleanup_disk_space
   package_upgrade_check
-  gcloud_install
 );
 
 =head1 SYNOPSIS
@@ -2232,33 +2231,5 @@ sub package_upgrade_check {
         }
     }
 }
-
-=head2 gcloud_install
-    gcloud_install();
-
-This function is used to install the gcloud CLI 
-for the GKE Google Cloud.
-
-From $url we get the full package and install in $dir local folder,
-that is supposed to be a subdir of the root user home /root.
-The Defaults are availeble for a simple call without parameters.
-
-=cut
-
-sub gcloud_install {
-    my %args = @_;
-    my $url = $args{url} || 'sdk.cloud.google.com';
-    my $dir = $args{dir} || 'google-cloud-sdk';
-    my $timeout = $args{timeout} || 700;
-
-    zypper_call("in curl tar gzip", $timeout);
-    assert_script_run("export CLOUDSDK_CORE_DISABLE_PROMPTS=1");
-    assert_script_run("curl $url | bash", $timeout);
-
-    assert_script_run("echo . /root/$dir/completion.bash.inc >> ~/.bashrc");
-    assert_script_run("echo . /root/$dir/path.bash.inc >> ~/.bashrc");
-    record_info('GCE', script_output('source ~/.bashrc && gcloud version'));
-}
-
 
 1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2251,7 +2251,7 @@ sub gcloud_install {
     my $dir = $args{dir} || 'google-cloud-sdk';
     my $timeout = $args{timeout} || 700;
 
-    assert_script_run("zypper -n in curl tar gzip", $timeout);
+    zypper_call("in curl tar gzip", $timeout);
     assert_script_run("export CLOUDSDK_CORE_DISABLE_PROMPTS=1");
     assert_script_run("curl $url | bash", $timeout);
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -94,6 +94,7 @@ our @EXPORT = qw(
   permit_root_ssh_in_sol
   cleanup_disk_space
   package_upgrade_check
+  gcloud_install
 );
 
 =head1 SYNOPSIS
@@ -2231,5 +2232,33 @@ sub package_upgrade_check {
         }
     }
 }
+
+=head2 gcloud_install
+    gcloud_install();
+
+This function is used to install the gcloud CLI 
+for the GKE Google Cloud.
+
+From $url we get the full package and install in $dir local folder,
+that is supposed to be a subdir of the root user home /root.
+The Defaults are availeble for a simple call without parameters.
+
+=cut
+
+sub gcloud_install {
+    my %args = @_;
+    my $url = $args{url} || 'sdk.cloud.google.com';
+    my $dir = $args{dir} || 'google-cloud-sdk';
+    my $timeout = $args{timeout} || 700;
+
+    assert_script_run("zypper -n in curl tar gzip", $timeout);
+    assert_script_run("export CLOUDSDK_CORE_DISABLE_PROMPTS=1");
+    assert_script_run("curl $url | bash", $timeout);
+
+    assert_script_run("echo . /root/$dir/completion.bash.inc >> ~/.bashrc");
+    assert_script_run("echo . /root/$dir/path.bash.inc >> ~/.bashrc");
+    record_info('GCE', script_output('source ~/.bashrc && gcloud version'));
+}
+
 
 1;

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -69,8 +69,8 @@ sub run {
 
             # package needed by init():
             (is_sle('=15-SP4')) ? 
-               assert_script_run('zypper in -y chrony') : 
-               assert_script_run('zypper in -y ntp');
+               zypper_call("in chrony", timeout => 300): 
+               zypper_call("in ntp", timeout => 300);
 
             $provider = publiccloud::gke->new();
         }

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -16,11 +16,12 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use utils qw(zypper_call script_retry gcloud_install);
+use utils qw(zypper_call script_retry);
 use version_utils qw(is_sle);
 use mmapi 'get_current_job_id';
 use registration qw(add_suseconnect_product get_addon_fullname);
 use containers::k8s;
+use publiccloud::utils qw(gcloud_install);
 
 sub run {
     my ($self, $run_args) = @_;
@@ -68,9 +69,9 @@ sub run {
             gcloud_install();
 
             # package needed by init():
-            (is_sle('=15-SP4')) ? 
-               zypper_call("in chrony", timeout => 300): 
-               zypper_call("in ntp", timeout => 300);
+            (is_sle('=15-SP4'))
+              ? zypper_call("in chrony", timeout => 300)
+              : zypper_call("in ntp", timeout => 300);
 
             $provider = publiccloud::gke->new();
         }
@@ -84,7 +85,8 @@ sub run {
     install_helm();
 
     # Add repo, search and show values
-    assert_script_run("helm repo add bitnami https://charts.bitnami.com/bitnami", 180);
+    assert_script_run(
+        "helm repo add bitnami https://charts.bitnami.com/bitnami", 180);
     assert_script_run("helm repo update", 180);
     assert_script_run("helm search repo apache");
     assert_script_run("helm show all $chart");

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -69,9 +69,8 @@ sub run {
             gcloud_install();
 
             # package needed by init():
-            (is_sle('=15-SP4'))
-              ? zypper_call("in chrony", timeout => 300)
-              : zypper_call("in ntp", timeout => 300);
+            my $pkg = is_sle('=15-SP4') ? "in chrony" : "in ntp";
+            zypper_call($pkg, timeout => 300);
 
             $provider = publiccloud::gke->new();
         }


### PR DESCRIPTION
GKE publiccloud added in containers/helm.pm charts and _gcloud_install()_ defined in lib/utils.pm

- Related ticket: _[Test Helm command with a GKE kubernetes environment](https://progress.opensuse.org/issues/112247)_
- Needles: none
- Verification run: http://marvin5.arch.suse.cz/tests/440
