### PR TITLE
Fix failing download_repos with SKIP_MU=1

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -27,12 +27,11 @@ sub run {
     my ($self, $args) = @_;
     select_host_console();    # select console on the host, not the PC instance
 
-    # Skip maintenance updates. This is useful for debug runs
-    my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);
 
-    # Trigger to skip the download to speed up verification runs
-    if ($skip_mu) {
+    if (get_var('PUBLIC_CLOUD_SKIP_MU')) {
+        # Skip maintenance updates. This is useful for debug runs
         record_info('Skip download', 'Skipping maintenance update download (triggered by setting)');
+        return;
     } else {
         # Skip if we already downloaded the repos
         if (get_repo_status() == 1) {


### PR DESCRIPTION
When SKIP_MU=1 is set, the `~/repos` directory is not created but
required in other test runs. This commit ensures, this directory is
created regardless if the actual download is skipped or not.

- Verification run: [without SKIP_MU=1](https://duck-norris.qam.suse.de/tests/8974#step/download_repos/95) and [with SKIP_MU=1](https://duck-norris.qam.suse.de/tests/8975#step/download_repos/13)
