### PR TITLE
yamllint: Disable truthy rule

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -11,3 +11,4 @@ rules:
   colons:
     # Ignore spaces after colons
     max-spaces-after: -1
+  truthy: disable


### PR DESCRIPTION
yamllint warns about things like 'yes' or 'on', sayin gthat they should be
changed to 'true'. But these are strings in YAML 1.2, they were only
booleans in 1.1.

