### PR TITLE
kernel: Use ltp-stable instead of qa_test_ltp package for all SLE ver…

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -262,9 +262,8 @@ sub get_default_pkg {
     my @packages;
 
     if (is_sle && is_released) {
-        push @packages, is_sle('15-SP4+') ? 'ltp-stable' : 'qa_test_ltp';
-        # temporarily disabled due to package conflict with qa_test_ltp
-        #push @packages, 'qa_test_ltp-32bit' if is_x86_64;
+        push @packages, 'ltp-stable';
+        push @packages, 'ltp-stable-32bit' if is_x86_64;
     } else {
         push @packages, 'ltp';
         push @packages, 'ltp-32bit' if is_x86_64 && !is_jeos;


### PR DESCRIPTION
Fix poo#112532: We will use ltp-stable for all SLE versions. Support
for 32bit was re-enabled.

- Related ticket: https://progress.opensuse.org/issues/112532
- Needles: none
- Verification run:
15-SP4: https://openqa.suse.de/tests/9009378
15-SP3: https://openqa.suse.de/tests/9009379
15-SP2: https://openqa.suse.de/tests/9009380
15-SP1: https://openqa.suse.de/tests/9009381
15: https://openqa.suse.de/tests/9009392
12-SP5: https://openqa.suse.de/tests/9009383
12-SP4: https://openqa.suse.de/tests/9009384
12-SP3: https://openqa.suse.de/tests/9009385
12-SP2: https://openqa.suse.de/tests/9009386

