### PR TITLE
Fix multipath schedule

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -880,8 +880,10 @@ sub load_inst_tests {
     if (get_var('IBFT')) {
         loadtest "installation/iscsi_configuration";
     }
+    # specific case for mru-install-multipath-remote
     if (get_var('WITHISCSI')) {
         loadtest "installation/disk_activation_iscsi";
+        loadtest "installation/multipath";
     }
     if (is_s390x) {
         if (is_backend_s390x) {
@@ -894,7 +896,7 @@ sub load_inst_tests {
     if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
         loadtest "installation/encrypted_volume_activation";
     }
-    if (!is_sle('15-SP4+') && get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
+    if (!is_sle('15-SP4+') && !get_var('WITHISCSI') && (get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM'))) {
         loadtest "installation/multipath";
     }
     if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {
@@ -915,7 +917,7 @@ sub load_inst_tests {
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
         loadtest "installation/scc_registration";
-        if (is_sle('15-SP4+') && get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM')) {
+        if (is_sle('15-SP4+') && !get_var('WITHISCSI') && (get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM'))) {
             loadtest "installation/multipath";
         }
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {


### PR DESCRIPTION
Without parenthesis the multipath test case got scheduled [twice](https://openqa.suse.de/tests/9002971#step/multipath#1/2) when `MULTIPATH_CONFIRM` is set.
In case multipath is expected to be configured along with iscsi, the
installation flow changes again

- Related ticket: https://progress.opensuse.org/issues/112739
- Verification runs: 
  - [sle-15-SP4-Server-DVD-Updates-x86_64-Build20220621-1-mru-install-multipath-remote@64bit](http://kepler.suse.cz/tests/17550#step/multipath/1)
  - [sle-15-SP4-Server-DVD-Updates-x86_64-Build20220621-1-mru-install-minimal-with-addons-multipath@64bit](http://kepler.suse.cz/tests/17551#)
  - [sle-12-SP5-Server-DVD-Updates-x86_64-Build20220621-1-mru-install-minimal-with-addons-multipath@64bit](http://kepler.suse.cz/tests/17552#live)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20220621-install_only@64bit-multipath](http://kepler.suse.cz/tests/17554#live)
