### PR TITLE
Fix textmode product shortcuts on 15-SP4

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -73,7 +73,7 @@ sub get_product_shortcuts {
         return (
             sles => (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'
-            : (is_sle '15-SP4+') ? 's'
+            : ((is_sle '15-SP4+') && (get_var('ISO') =~ /Full/)) ? 's'
             : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/112877
- Verification run:
https://openqa.suse.de/tests/9004868#step/welcome/5 qam-textmode+sle15
https://openqa.suse.de/tests/9004876#step/welcome/6 qam_create_hdd_ha_textmode
