### PR TITLE
Containers BCI: Workaround issues on RHEL host #1

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -14,6 +14,7 @@ use testapi;
 use utils;
 use version_utils qw(check_os_release get_os_release is_sle);
 use containers::common;
+use power_action_utils 'power_action';
 
 sub run {
     my ($self) = @_;
@@ -39,6 +40,11 @@ sub run {
             script_retry("yum update -q -y --nobest", timeout => $update_timeout);
         } elsif ($host_distri eq 'rhel') {
             script_retry("yum update -q -y", timeout => $update_timeout);
+
+            # This is just a workaround and should be removed after we upgrade the RHEL image
+            power_action('reboot');
+            sleep 180;
+            $self->select_serial_terminal;
         }
     }
 


### PR DESCRIPTION
- Failed test: https://openqa.suse.de/tests/9005010#step/bci_prepare/78
- Verification run: https://pdostal-server.suse.cz/tests/154#
