### PR TITLE
lib/x11utils: ensure_unlocked_screen: Avoid waiting after screen change

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -178,6 +178,7 @@ sub ensure_unlocked_desktop {
                 send_key 'esc';    # end screenlock
                 diag("Screen lock present");
             };
+            next;    # Go directly to assert_screen, skip wait_still_screen (and don't collect $200)
         }
         wait_still_screen 1;    # slow down loop
     }


### PR DESCRIPTION
Currently it presses Esc to show the lock screen, waits for the lock screen
to appear (through wait_screen_change) and then it does a wait_still_screen
which can take long enough for the lock screen to disappear again.

Avoid the latter by skipping straight to the next match after a screen change
was detected.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1200615
- Verification run: https://openqa.opensuse.org/tests/2430136
