### PR TITLE
Leave an empty line between pod and code to all the files under lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ test-compile: check-links
 test-compile-changed: os-autoinst/
 	export PERL5LIB=${PERL5LIB_} ; for f in `git diff --name-only | grep '.pm'` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
 
+.PHONY: test_pod_whitespace_rule
+test_pod_whitespace_rule:
+	tools/check_pod_whitespace_rule
+
 .PHONY: test-yaml-valid
 test-yaml-valid:
 	$(eval YAMLS=$(shell sh -c "git ls-files schedule/ test_data/ | grep '\\.ya\?ml$$'"))
@@ -107,7 +111,7 @@ test-spec:
 	tools/update_spec --check
 
 .PHONY: test-static
-test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax test-code-style test-metadata
+test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax test-code-style test-metadata test_pod_whitespace_rule
 
 .PHONY: test
 ifeq ($(TESTS),compile)

--- a/lib/Distribution/Opensuse/Leap/15.pm
+++ b/lib/Distribution/Opensuse/Leap/15.pm
@@ -24,6 +24,7 @@ Returns controller for license agreement which differs from SLE due to
 openSUSE use a different UI flow to accept the default license.
 
 =cut
+
 sub get_firstboot_license_agreement {
     return Installation::License::Opensuse::Firstboot::LicenseAgreementController->new();
 }

--- a/lib/DistributionProvider.pm
+++ b/lib/DistributionProvider.pm
@@ -30,6 +30,7 @@ Returns the certain distribution depending on the version of the product.
 If there is no matched version, then returns Tumbleweed as the default one.
 
 =cut
+
 sub provide {
     return Distribution::Sle::15_current->new() if is_sle('>=15-sp3');
     return Distribution::Sle::15sp2->new() if is_sle('>15');

--- a/lib/Installation/Partitioner/AbstractExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/AbstractExpertPartitionerController.pm
@@ -22,6 +22,7 @@ see C<_add_partition>.
 $args->{raid_level} defines wanted raid level.
 
 =cut
+
 sub add_raid();
 
 =head2 accept_changes_and_press_next
@@ -31,6 +32,7 @@ sub add_raid();
 Accept partitioning setup and proceed to the next page.
 
 =cut
+
 sub accept_changes_and_press_next();
 
 =head2 run_expert_partitioner
@@ -40,6 +42,7 @@ sub accept_changes_and_press_next();
 Open Expert Partitioner with existing partitions.
 
 =cut
+
 sub run_expert_partitioner();
 
 =head2 add_partition_on_gpt_disk
@@ -52,6 +55,7 @@ $args->{partition}`contains hash reference with parameters for the partition,
 see C<_add_partition>.
 
 =cut
+
 sub add_partition_on_gpt_disk();
 
 =head2 _finish_partition_creation
@@ -62,6 +66,7 @@ Method finished partitioning, has different implementation in libstorage and
 libstorage-ng
 
 =cut
+
 sub _finish_partition_creation();
 
 sub _set_partition_size {

--- a/lib/Installation/Partitioner/LibstorageNG/v3/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v3/ExpertPartitionerController.pm
@@ -49,6 +49,7 @@ Expected values are [existing|current].
 if none is given the existing partiotion is used as deault.
 
 =cut
+
 sub run_expert_partitioner {
     my ($self, $option) = @_;
     $option //= 'existing';

--- a/lib/Mitigation.pm
+++ b/lib/Mitigation.pm
@@ -78,6 +78,7 @@ To reboot and waiting system back and login it.
 This could support IPMI and QEMU backend.
 C<$timeout> in seconds.
 =cut
+
 sub reboot_and_wait {
     my ($self, $timeout) = @_;
     if (is_ipmi) {

--- a/lib/Remote/Lab.pm
+++ b/lib/Remote/Lab.pm
@@ -59,6 +59,7 @@ Setup tunnel(s) over SSH based on an openSSH configuration configuring a
 "jumpbox" including forwarding a port for remote log uploading.
 
 =cut
+
 sub setup_ssh_tunnels {
     my ($self) = @_;
     return if get_var('_SSH_TUNNELS_INITIALIZED');

--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -48,6 +48,7 @@ our %EXPORT_TAGS = (
 Returns C<check_var('ARCH', 's390x')>.
 
 =cut
+
 sub is_s390x {
     return check_var('ARCH', 's390x');
 }
@@ -59,6 +60,7 @@ sub is_s390x {
 Returns C<check_var('ARCH', 'is_i586')>.
 
 =cut
+
 sub is_i586 {
     return check_var('ARCH', 'i586');
 }
@@ -70,6 +72,7 @@ sub is_i586 {
 Returns C<check_var('ARCH', 'is_i686')>.
 
 =cut
+
 sub is_i686 {
     return check_var('ARCH', 'i686');
 }
@@ -81,6 +84,7 @@ sub is_i686 {
 Returns C<check_var('ARCH', 'x86_64')>.
 
 =cut
+
 sub is_x86_64 {
     return check_var('ARCH', 'x86_64');
 }
@@ -92,6 +96,7 @@ sub is_x86_64 {
 Returns C<check_var('ARCH', 'is_x86_64_v2')>.
 
 =cut
+
 sub is_x86_64_v2 {
     return 0 unless is_x86_64;
     my $cpu_flags = script_output('lscpu | grep -i flags');
@@ -108,6 +113,7 @@ sub is_x86_64_v2 {
 Returns C<check_var('ARCH', 'aarch64')>.
 
 =cut
+
 sub is_aarch64 {
     return check_var('ARCH', 'aarch64');
 }
@@ -119,6 +125,7 @@ sub is_aarch64 {
 Returns C<get_var('ARCH') =~ /arm/>.
 
 =cut
+
 sub is_arm {
     return (get_var('ARCH') =~ /arm/);    # Can match arm, armv7, armv7l, armv7hl, ...
 }
@@ -130,6 +137,7 @@ sub is_arm {
 Returns C<check_var('ARCH', 'ppc64le')>.
 
 =cut
+
 sub is_ppc64le {
     return check_var('ARCH', 'ppc64le');
 }
@@ -141,6 +149,7 @@ sub is_ppc64le {
  Returns C<check_var('ARCH', 'ppc64')>.
 
 =cut
+
 sub is_ppc64 {
     return check_var('ARCH', 'ppc64');
 }
@@ -152,6 +161,7 @@ sub is_ppc64 {
 Returns C<true if machine FQDN has arch.suse.de suffix>.
 
 =cut
+
 sub is_orthos_machine {
     my $sut_fqdn = get_var('SUT_IP', 'nosutip');
     return 1 if $sut_fqdn =~ /(arch\.suse\.de)/im;
@@ -165,6 +175,7 @@ sub is_orthos_machine {
 Returns C<true if machine FQDN has qa.suse.de, qa2.suse.asia or arch.suse.de suffix>.
 
 =cut
+
 sub is_supported_suse_domain {
     my $sut_fqdn = get_var('SUT_IP', 'nosutip');
     return 1 if $sut_fqdn =~ /(arch\.suse\.de|qa2\.suse\.asia|qa\.suse\.de)/im;

--- a/lib/Utils/Firewalld.pm
+++ b/lib/Utils/Firewalld.pm
@@ -21,6 +21,7 @@ Adds tcp C<$port> to C<$zone> of permanent configuration. Port can be a single p
 number or a range of ports e.g. 3000-5000
 
 =cut
+
 sub add_port_to_zone {
     my ($args) = @_;
     assert_script_run("firewall-cmd --zone=$args->{zone} --add-port=$args->{port}/tcp --permanent");

--- a/lib/Utils/Systemd.pm
+++ b/lib/Utils/Systemd.pm
@@ -35,6 +35,7 @@ Mask it if I<$mask_service> evaluates to true. Default: false
 Raise a failure if I<$ignore_failure> evaluates to true. Default: false
 
 =cut
+
 sub disable_and_stop_service {
     my ($service_name, %args) = @_;
     die "disable_and_stop_service(): no service name given" if ($service_name =~ /^ *$/);
@@ -53,6 +54,7 @@ Wrapper around systemctl call to be able to add some useful options.
 Please note that return code of this function is handle by 'script_run' or
 'assert_script_run' function, and as such, can be different.
 =cut
+
 sub systemctl {
     my ($command, %args) = @_;
     croak "systemctl(): no command specified" if ($command =~ /^ *$/);
@@ -74,6 +76,7 @@ sub systemctl {
 Return list of started systemd services
 
 =cut
+
 sub get_started_systemd_services {
     return keys(%started_systemd_services);
 }
@@ -83,6 +86,7 @@ sub get_started_systemd_services {
 Clear the list of started systemd services
 
 =cut
+
 sub clear_started_systemd_services {
     %started_systemd_services = ();
 }

--- a/lib/YaST/NetworkSettings/AbstractNetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/AbstractNetworkSettingsController.pm
@@ -60,6 +60,7 @@ The function just adds the device, but does not save the changes by closing
 Network Settings Dialog.
 
 =cut
+
 sub add_bridged_device();
 
 =head2 add_bond_slave
@@ -72,6 +73,7 @@ The function just adds the device, but does not save the changes by closing
 Network Settings Dialog.
 
 =cut
+
 sub add_bond_slave();
 
 =head2 add_vlan_device
@@ -84,6 +86,7 @@ The function just adds the device, but does not save the changes by closing
 Network Settings Dialog.
 
 =cut
+
 sub add_vlan_device();
 
 =head2 view_bridged_device_without_editing
@@ -94,6 +97,7 @@ Open already created Bridged Device for editing, view its settings, do not
 change any settings and close the Edit Dialog.
 
 =cut
+
 sub view_bridged_device_without_editing();
 
 =head2 view_bond_slave_without_editing
@@ -104,6 +108,7 @@ Open already created Bond Slave Device for editing, view its settings, do not
 change any settings and close the Edit Dialog.
 
 =cut
+
 sub view_bond_slave_without_editing();
 
 sub delete_bridged_device {

--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -33,6 +33,7 @@ Possible values for C<$mode> are: SSL, NSS, NSSFIPS, PHP7 and PHP8
  setup_apache2(mode => 'SSL');
 
 =cut
+
 sub setup_apache2 {
     my %args = @_;
     my $mode = uc $args{mode} || "";
@@ -163,6 +164,7 @@ sub setup_apache2 {
 Set up a postgres data base
 
 =cut
+
 sub setup_pgsqldb {
     # without changing current working directory we get:
     # 'could not change directory to "/root": Permission denied'
@@ -183,6 +185,7 @@ sub setup_pgsqldb {
 Destroy a postgres data base
 
 =cut
+
 sub destroy_pgsqldb {
     assert_script_run 'pushd /tmp';
 
@@ -221,6 +224,7 @@ Set up a postgres database and configure for:
 =back
 
 =cut
+
 sub test_pgsql {
     # configuration so that PHP can access PostgreSQL
     # setup password
@@ -365,6 +369,7 @@ EOF
 Create the 'openQAdb' database with table 'test' and insert one element
 
 =cut
+
 sub test_mysql {
     # create the 'openQAdb' database with table 'test' and insert one element 'can php read this?'
     my $setup_openQAdb = "CREATE DATABASE openQAdb; USE openQAdb; " .

--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -107,6 +107,7 @@ sub aa_tmp_prof_prepare {
 Verify that program can start with temporary profiles and then restore to the enforce status with normal profiles
 
 =cut
+
 sub aa_tmp_prof_verify {
     my ($self, $prof_dir_tmp, $prog) = @_;
 
@@ -127,6 +128,7 @@ sub aa_tmp_prof_verify {
 Remove appamor temporary profiles
 
 =cut
+
 sub aa_tmp_prof_clean {
     my ($self, $prof_dir_tmp) = @_;
 
@@ -142,6 +144,7 @@ sub aa_tmp_prof_clean {
 Get the named profile for an executable program
 
 =cut
+
 sub get_named_profile {
     my ($self, $profile_name) = @_;
 
@@ -158,6 +161,7 @@ sub get_named_profile {
 
 Check the output of aa-status: if a given profile belongs to a given mode
 =cut
+
 sub aa_status_stdout_check {
     my ($self, $profile_name, $profile_mode) = @_;
 
@@ -175,6 +179,7 @@ sub aa_status_stdout_check {
 Fetch ip details
 
 =cut
+
 sub ip_fetch {
     # "# hostname -i/-I" can not work in some cases
     my $ip = script_output("ip -4 -f inet -o a | grep -E \'eth0|ens\' | sed -n 's/\.*inet \\([0-9.]\\+\\)\.*/\\1/p'");
@@ -204,6 +209,7 @@ Set up mail server with Postfix and Dovecot:
 =back
 
 =cut
+
 sub setup_mail_server_postfix_dovecot {
     my ($self) = @_;
     my $ip = "";
@@ -754,6 +760,7 @@ sub create_log_content_is_special {
 Upload mail warn, err and info logs for reference
 
 =cut
+
 sub upload_logs_mail {
     # Upload mail warn, err and info logs for reference
     if (script_run("! [[ -e $mail_err_log ]]")) {
@@ -774,6 +781,7 @@ sub upload_logs_mail {
 Restart auditd and apparmor in root-console
 
 =cut
+
 sub pre_run_hook {
     my ($self) = @_;
 
@@ -790,6 +798,7 @@ sub pre_run_hook {
 Run post_fail_hook and upload audit logs
 
 =cut
+
 sub post_fail_hook {
     my ($self) = shift;
 

--- a/lib/autofs_utils.pm
+++ b/lib/autofs_utils.pm
@@ -32,6 +32,7 @@ my $autofs_sys_conf_file = '/etc/sysconfig/autofs';
 Set up an autofs server by using scripts
 
 =cut
+
 sub setup_autofs_server {
     my (%args) = @_;
     my $grep_output = script_output("grep '#+dir' $args{autofs_conf_file}");
@@ -53,6 +54,7 @@ sub setup_autofs_server {
 Check autofs service by starting and stopping service
 
 =cut
+
 sub check_autofs_service {
     common_service_action 'autofs', $service_type, 'start';
     common_service_action 'autofs', $service_type, 'is-active';
@@ -67,6 +69,7 @@ sub check_autofs_service {
 
 Install autofs package
 =cut
+
 sub install_service {
     zypper_call 'in autofs';
 }
@@ -77,6 +80,7 @@ sub install_service {
 
 Enable service autofs
 =cut
+
 sub enable_service {
     common_service_action 'autofs', $service_type, 'enable';
 }
@@ -87,6 +91,7 @@ sub enable_service {
 
 Start service autofs
 =cut
+
 sub start_service {
     common_service_action 'autofs', $service_type, 'start';
 }
@@ -97,6 +102,7 @@ sub start_service {
 
 Check service autofs
 =cut
+
 sub check_service {
     common_service_action 'autofs', $service_type, 'is-enabled';
     common_service_action 'autofs', $service_type, 'is-active';
@@ -112,6 +118,7 @@ The argument C<$stage> has the value C<function>, some iso and autofs related rp
 Also C<check_autofs_service()> will be called.
 
 =cut
+
 sub configure_service {
     my ($stage) = @_;
     $stage //= '';
@@ -146,6 +153,7 @@ sub configure_service {
 
 Check iso which is mounted to test directory
 =cut
+
 sub check_function {
     # We don't check autofs function for sles11sp4
     return if ($service_type eq 'SystemV');
@@ -197,6 +205,7 @@ Run checks of autofs by call following functions:
 =back
 
 =cut
+
 sub full_autofs_check {
     my (%hash) = @_;
     my ($stage, $type) = ($hash{stage}, $hash{service_type});

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -53,6 +53,7 @@ Expand patterns for sle12 and sle15.
 Returns a list of patterns to be installed.
 
 =cut
+
 sub expand_patterns {
     if (get_var('PATTERNS', '') =~ m/^\s*$/) {
         if (is_sle('15+')) {
@@ -134,6 +135,7 @@ my @unversioned_products = qw(asmm contm lgm tcm wsm);
 Return product version from SCC and product name, so-called unversioned products like asmm, contm, lgm, tcm, wsm if product version number lower than 15
 
 =cut
+
 sub get_product_version {
     my ($name) = @_;
     my $version = scc_version(get_var('VERSION', ''));
@@ -147,6 +149,7 @@ sub get_product_version {
 
 Returns hash of all C<SCC_ADDONS> with name, version and architecture.
 =cut
+
 sub expand_addons {
     my %addons;
     my @addons = grep { defined $_ && $_ } split(/,/, get_var('SCC_ADDONS', ''));
@@ -169,6 +172,7 @@ Expand and returns template including autoyast profile and it's varialbes like a
 $profile is the autoyast profile 'autoinst.xml'.
 
 =cut
+
 sub expand_template {
     my ($profile) = @_;
     my $template = Mojo::Template->new(vars => 1);
@@ -194,6 +198,7 @@ sub expand_template {
 Initialize or create a new autoyast profile by 'yast2 clone_system' if doesn't exist and returns the path of autoyast profile
 
 =cut
+
 sub init_autoyast_profile {
     select_console('root-console');
     my $profile_path = '/root/autoinst.xml';
@@ -256,6 +261,7 @@ profile:
 
 
 =cut
+
 sub validate_autoyast_profile {
     my $profile = shift;
 
@@ -283,6 +289,7 @@ sub validate_autoyast_profile {
   In other words, a node is not processable when just needs to be traversed in the YAML.
 
 =cut
+
 sub is_processable {
     my $node = shift;
     return (!ref $node ||
@@ -344,6 +351,7 @@ sub is_processable {
                     label: test_multi_btrfs
 
 =cut
+
 sub has_properties {
     my $node = shift;
     return 0 unless ref $node;
@@ -362,6 +370,7 @@ sub has_properties {
 Based on the properties of the node will create a predicate for the XPATH expression.
 
 =cut
+
 sub create_xpath_predicate {
     my $node = shift;
     my @predicates = ();
@@ -386,6 +395,7 @@ sub create_xpath_predicate {
 Joins a list of intermediate predicates and closes it to create one XPATH predicate.
 
 =cut
+
 sub close_predicate {
     my @predicates = @_;
     return '[' . join(' and ', @predicates) . ']';
@@ -399,6 +409,7 @@ Add XML namespace to the node declared in YAML file to be able to build
 the correct XPATH expression with namespaces.
 
 =cut
+
 sub ns {
     my $node = shift;
     return "ns:$node";
@@ -419,6 +430,7 @@ YAML:  subvolumes:
            - path: var
 
 =cut
+
 sub get_traversable {
     my $node = shift;
     if ((ref $node eq 'HASH')) {
@@ -436,6 +448,7 @@ It will apply the right separator in case direct children nodes (default)
 or any descendant is applied ('' also means ./ for direct children)
 
 =cut
+
 sub get_descendant {
     my $node = shift;
     return ".//" if (ref $node eq 'HASH' && $node->{_descendant});
@@ -449,6 +462,7 @@ sub get_descendant {
 Recursive algorithm to traverse YAML file and create a list of XPATH expressions.
 
 =cut
+
 sub generate_expressions {
     my ($node) = shift;
     # accumulate expressions
@@ -525,6 +539,7 @@ sub generate_expressions {
 Run XPATH expressions. Errors handled are 'no node found' and 'more than one node found'
 
 =cut
+
 sub run_expressions {
     my (%args) = @_;
 
@@ -551,6 +566,7 @@ sub run_expressions {
 Create a report with the errors found and listing all the XPATH expressions executed.
 
 =cut
+
 sub create_report {
     my %args = @_;
 
@@ -573,6 +589,7 @@ sub create_report {
  $path is AutoYaST profile path
 
 =cut
+
 sub detect_profile_directory {
     my (%args) = @_;
     my $profile = $args{profile};
@@ -604,6 +621,7 @@ sub detect_profile_directory {
  $profile is the autoyast profile 'autoinst.xml'.
 
 =cut
+
 sub expand_version {
     my ($profile) = @_;
     if (my $version = scc_version(get_var('VERSION', ''))) {
@@ -621,6 +639,7 @@ sub expand_version {
  $profile is the autoyast profile 'autoinst.xml'.
 
 =cut
+
 sub adjust_network_conf {
     my ($profile) = @_;
     my $hostip;
@@ -644,6 +663,7 @@ sub adjust_network_conf {
  $profile is the autoyast profile 'autoinst.xml'.
 
 =cut
+
 sub expand_variables {
     my ($profile) = @_;
     # Expand other variables
@@ -677,6 +697,7 @@ sub expand_variables {
  using rules and classes.
 
 =cut
+
 sub upload_profile {
     my (%args) = @_;
     my $profile = $args{profile};
@@ -704,6 +725,7 @@ sub upload_profile {
  $profile is the autoyast profile 'autoinst.xml'.
 
 =cut
+
 sub inject_registration {
     my ($profile) = @_;
 
@@ -730,6 +752,7 @@ EOF
  Test if the autoyast profile url is reachable, before the autoyast installation begins.
 
 =cut
+
 sub test_ayp_url {
     my $ayp_url = get_var('AUTOYAST');
     if ($ayp_url =~ /^http/) {
@@ -768,6 +791,7 @@ This could return a reference to an array with content:
   - autoyast_sle15/rule-based_example/classes/general/users.xml
 
 =cut
+
 sub get_test_data_files {
     my ($path) = @_;
     my $casedir_data = get_var('CASEDIR') . '/data/';
@@ -795,6 +819,7 @@ Return new path in case of using AutoYaST templates
  using rules and classes.
 
 =cut
+
 sub prepare_ay_file {
     my ($path) = @_;
 

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
 Get into SMS menu for booting from net.
 
 =cut
+
 sub get_into_net_boot {
     assert_screen 'pvm-bootmenu';
 
@@ -74,6 +75,7 @@ sub get_into_net_boot {
 Handle the boot and installation preperation process of PVM LPARs after the hypervisor specific actions to power them on is done
 
 =cut
+
 sub prepare_pvm_installation {
     my ($boot_attempt) = @_;
     $boot_attempt //= 1;
@@ -198,6 +200,7 @@ sub boot_hmc_pvm {
 Boot from spvm backend via novalink and switch to installation console (ssh or vnc).
 
 =cut
+
 sub boot_spvm {
     my $lpar_id = get_required_var('NOVALINK_LPAR_ID');
     my $novalink = select_console 'novalink-ssh';

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -104,6 +104,7 @@ grub entries with C<GRUB_PARAM='ima_policy=tcb'> and calling add_custom_grub_ent
 And of course the new entries have C<ima_policy=tcb> added to kernel parameters.
 
 =cut
+
 sub add_custom_grub_entries {
     my @grub_params = split(/\s*;\s*/, trim(get_var('GRUB_PARAM', '')));
     return unless $#grub_params >= 0;
@@ -207,6 +208,7 @@ Boot the default kernel recovery mode (selected in the "Advanced options ..."):
     boot_grub_item(2, 2);
 
 =cut
+
 sub boot_grub_item {
     my ($menu1, $menu2) = @_;
     $menu1 //= 3;
@@ -442,6 +444,7 @@ Returns array of strings C<@params> with linurc boot options to enable logging t
 console, enable core dumps and set debug level for logging.
 
 =cut
+
 sub get_linuxrc_boot_params {
     my @params;
     push @params, "linuxrc.log=/dev/$serialdev";
@@ -1138,6 +1141,7 @@ sub ensure_shim_import {
 
 Search for C<$pattern> in /etc/default/grub, return 1 if found.
 =cut
+
 sub grep_grub_settings {
     die((caller(0))[3] . ' expects 1 arguments') unless @_ == 1;
     my $pattern = shift;
@@ -1151,6 +1155,7 @@ sub grep_grub_settings {
 Search for C<$pattern> in grub cmdline variable (usually
 GRUB_CMDLINE_LINUX_DEFAULT) in /etc/default/grub, return 1 if found.
 =cut
+
 sub grep_grub_cmdline_settings {
     my ($pattern, $search) = @_;
     $search //= get_cmdline_var();
@@ -1167,6 +1172,7 @@ C<$search> meant to be for changing only particular line for sed,
 C<$modifiers> for sed replacement, e.g. "g".
 C<$update_grub> if set, regenerate /boot/grub2/grub.cfg with grub2-mkconfig and upload configuration.
 =cut
+
 sub change_grub_config {
     die((caller(0))[3] . ' expects from 3 to 5 arguments') unless (@_ >= 3 && @_ <= 5);
     my ($old, $new, $search, $modifiers, $update_grub) = @_;
@@ -1192,6 +1198,7 @@ Add C<$add> into /etc/default/grub, using sed.
 C<$update_grub> if set, regenerate /boot/grub2/grub.cfg with grub2-mkconfig and upload configuration.
 C<$search> if set, bypass default grub cmdline variable.
 =cut
+
 sub add_grub_cmdline_settings {
     my $add = shift;
     my %args = testapi::compat_args(
@@ -1214,6 +1221,7 @@ sub add_grub_cmdline_settings {
 Add C<$add> into /etc/default/grub, using sed.
 C<$update_grub> if set, regenerate /boot/grub2/grub.cfg with grub2-mkconfig and upload configuration.
 =cut
+
 sub add_grub_xen_cmdline_settings {
     my ($add, $update_grub) = @_;
     add_grub_cmdline_settings($add, $update_grub, "GRUB_CMDLINE_XEN_DEFAULT");
@@ -1227,6 +1235,7 @@ Replace C<$old> with C<$new> in /etc/default/grub, using sed.
 C<$update_grub> if set, regenerate /boot/grub2/grub.cfg with grub2-mkconfig and upload configuration.
 C<$search> if set, bypass default grub cmdline variable.
 =cut
+
 sub replace_grub_cmdline_settings {
     my $old = shift;
     my $new = shift;
@@ -1250,6 +1259,7 @@ sub replace_grub_cmdline_settings {
 Replace C<$old> with C<$new> in /etc/default/grub, using sed.
 C<$update_grub> if set, regenerate /boot/grub2/grub.cfg with grub2-mkconfig and upload configuration.
 =cut
+
 sub replace_grub_xen_cmdline_settings {
     my ($old, $new, $update_grub) = @_;
     replace_grub_cmdline_settings($old, $new, $update_grub, "GRUB_CMDLINE_XEN_DEFAULT");
@@ -1262,6 +1272,7 @@ sub replace_grub_xen_cmdline_settings {
 Remove C<$remove> from /etc/default/grub (using sed) and regenerate /boot/grub2/grub.cfg.
 Search line C<$search> from /etc/default/grub (use for sed).
 =cut
+
 sub remove_grub_cmdline_settings {
     my ($remove, $search) = @_;
     replace_grub_cmdline_settings('[[:blank:]]*' . $remove . '[[:blank:]]*', " ", "g", $search);
@@ -1273,6 +1284,7 @@ sub remove_grub_cmdline_settings {
 
 Remove C<$remove> from /etc/default/grub (using sed) and regenerate /boot/grub2/grub.cfg.
 =cut
+
 sub remove_grub_xen_cmdline_settings {
     my $remove = shift;
     remove_grub_cmdline_settings($remove, "GRUB_CMDLINE_XEN_DEFAULT");
@@ -1285,6 +1297,7 @@ sub remove_grub_xen_cmdline_settings {
 
 Regenerate /boot/grub2/grub.cfg with grub2-mkconfig.
 =cut
+
 sub grub_mkconfig {
     my $config = shift;
     $config //= GRUB_CFG_FILE;
@@ -1298,6 +1311,7 @@ sub grub_mkconfig {
 Get default grub cmdline variable:
 GRUB_CMDLINE_LINUX for JeOS, GRUB_CMDLINE_LINUX_DEFAULT for the rest.
 =cut
+
 sub get_cmdline_var {
     my $label = is_jeos() ? 'GRUB_CMDLINE_LINUX' : 'GRUB_CMDLINE_LINUX_DEFAULT';
     return "^${label}=";
@@ -1375,6 +1389,7 @@ Method accepts C<disk> to define the device to work with, C<passwd> and C<shadow
 store content of the /etc/passwd and /etc/shadow files accordingly.
 
 =cut
+
 sub mimic_user_to_import {
     my (%args) = @_;
     my $disk = $args{disk};
@@ -1411,6 +1426,7 @@ Is handy for the bare metal setups and LPARs where we can have traces of
 previous installation.
 
 =cut
+
 sub prepare_disks {
     # Delete partition table before starting installation
     select_console('install-shell');
@@ -1444,6 +1460,7 @@ sub prepare_disks {
 Sync system time, time offset can cause problems e.g. certificate is not yet valid
 
 =cut
+
 sub sync_time {
     # sync system time before installation
     select_console('install-shell');

--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -21,6 +21,7 @@ Returns disk without a partition table for filesystem experiments.
 Sets the test variable C<PLAYGROUNDDISK>, on first invocation of
 the function.
 =cut
+
 sub set_playground_disk {
     unless (get_var('PLAYGROUNDDISK')) {
         my $vd = 'vd';    # KVM
@@ -48,6 +49,7 @@ In `snapper --no-dbus` test we need DBus to be disabled on SLES12SP3 and Leap 42
 systemd allows DBus to be disabled. On Tumbleweed this is not possible and the simplest
 way to get DBus-less environment is to enter rescue.target via systemctl.
 =cut
+
 sub snapper_nodbus_setup {
     my ($self) = @_;
     if (script_run('! systemctl is-active dbus')) {
@@ -69,6 +71,7 @@ Restore environment to default.target. Console root-console has to be reset, bec
 move from rescue to default target, logs us out. Die if DBus is active at this point,
 it means that DBus got activated somehow, thus invalidated `snapper --no-dbus` testing.
 =cut
+
 sub snapper_nodbus_restore {
     my $ret = script_run('systemctl is-active dbus', timeout => 300, die_on_timeout => 1);
     die 'DBus service should be inactive, but it is active' if ($ret == 0);
@@ -97,6 +100,7 @@ to be executed. The info about last run is stored in /var/spool/cron/lastrun
 By updating the lastrun files timestamps, we make sure those routines won't be executed
 while tests are running.
 =cut
+
 sub cron_mock_lastrun {
     my $tries = 5;
     while (script_run(q/ps aux | grep '[s]napper'/) == 0 && $tries > 0) {

--- a/lib/bugzilla.pm
+++ b/lib/bugzilla.pm
@@ -53,6 +53,7 @@ contain only two entries: C<bug_id> and C<error>. It is up to you to handle
 this possibility.
 
 =cut
+
 sub bugzilla_buginfo {
     my $bugid = shift;
     my $url = get_var('BUGZILLA_URL');

--- a/lib/console/vmstat_utils.pm
+++ b/lib/console/vmstat_utils.pm
@@ -23,6 +23,7 @@ our @EXPORT = qw(read_memory_cpu average);
  Returns a list with two array references which maps to amount of idle memory and CPU usage from the vmstat output log file.
 
 =cut
+
 sub read_memory_cpu {
 
     my $file_name = shift;
@@ -39,6 +40,7 @@ sub read_memory_cpu {
  Returns the average of numbers.
 
 =cut
+
 sub average {
     my @a = @_;
     my $size = @a;

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -22,6 +22,7 @@ C<consoletest> - Base class for all console tests
 Method executed when run() finishes.
 
 =cut
+
 sub post_run_hook {
     my ($self) = @_;
 
@@ -37,6 +38,7 @@ sub post_run_hook {
 Method executed when run() finishes and the module has result => 'fail'
 
 =cut
+
 sub post_fail_hook {
     my ($self) = @_;
     $self->SUPER::post_fail_hook;
@@ -56,6 +58,7 @@ sub post_fail_hook {
 switch network manager to wicked.
 
 =cut
+
 sub use_wicked_network_manager {
     assert_script_run "systemctl disable NetworkManager --now";
     assert_script_run "systemctl enable --force wicked --now";

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -40,6 +40,7 @@ The main container runtimes do not need C<buildah> variable in general, unless
 you want to build the image with buildah but run it with $<runtime>
 
 =cut
+
 sub build_and_run_image {
     my %args = @_;
     my $runtime = $args{runtime};

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -59,6 +59,7 @@ C<cmd> can be anything you want to run in the container, similar to C<run>. for
 instance: C<docker create -it tumbleweed bash>
 
 =cut
+
 sub create_container {
     my ($self) = shift;
     my %args = (
@@ -77,6 +78,7 @@ sub create_container {
 Starts container named C<image_name>.
 
 =cut
+
 sub start_container {
     my ($self, $image_name) = @_;
     $self->_engine_assert_script_run("container start $image_name");
@@ -90,6 +92,7 @@ C<container_name> which runs.
 https://docs.docker.com/engine/reference/commandline/wait/
 
 =cut
+
 sub halt_container {
     my ($self, $container_name) = @_;
     $self->_engine_assert_script_run("wait $container_name");
@@ -105,6 +108,7 @@ C<container_tag> will be the name of the container.
 Give C<timeout> if you want to change the timeout passed to C<assert_script_run>. Default for containers is 300.
 
 =cut
+
 sub build {
     my ($self, $dockerfile_path, $image_tag, %args) = @_;
     die 'wrong number of arguments' if @_ < 3;
@@ -130,6 +134,7 @@ if C<retry> is given, the command is being repeated the given amount of times on
 If C<delay> is given, this defines the number of seconds between retries
 
 =cut
+
 sub run_container {
     my ($self, $image_name, %args) = @_;
     die 'image name or id is required' unless $image_name;
@@ -162,6 +167,7 @@ where C<image_name> can be the name or id of the image.
 C<args> passes parameters to C<script_run>
 
 =cut
+
 sub pull {
     my ($self, $image_name, %args) = @_;
     if (my $rc = $self->_engine_script_run("image inspect --format='{{.RepoTags}}' $image_name | grep '$image_name'") == 0) {
@@ -177,6 +183,7 @@ sub pull {
 Save a existing container as a new image in the local registry
 
 =cut
+
 sub commit {
     my ($self, $mycontainer, $new_image_name, %args) = @_;
     $self->_engine_assert_script_run("commit $mycontainer $new_image_name", timeout => $args{timeout});
@@ -187,6 +194,7 @@ sub commit {
 Return an array ref of the images
 
 =cut
+
 sub enum_images {
     my ($self) = shift;
     my $images_s = $self->_engine_script_output("images -q");
@@ -200,6 +208,7 @@ sub enum_images {
 Return an array ref of the containers
 
 =cut
+
 sub enum_containers {
     my ($self) = shift;
     my $containers_s = $self->_engine_script_output("container ls -q");
@@ -213,6 +222,7 @@ sub enum_containers {
 Returns an array ref with the names of the images.
 
 =cut
+
 sub get_images_by_repo_name {
     my ($self) = @_;
     my $repo_images = $self->_engine_script_output("images --format '{{.Repository}}'", timeout => 120);
@@ -226,6 +236,7 @@ Assert a C<property> against given expected C<value> if C<value> is given.
 Otherwise it prints the output of info.
 
 =cut
+
 sub info {
     my ($self, %args) = shift;
     my $property = $args{property} ? qq(--format '{{.$args{property}}}') : '';
@@ -240,6 +251,7 @@ C<container> the running container.
 C<filename> file the logs are written to.
 
 =cut
+
 sub get_container_logs {
     my ($self, $container, $filename) = @_;
     $self->_engine_assert_script_run("container logs $container | tee $filename");
@@ -250,6 +262,7 @@ sub get_container_logs {
 Remove a image from the pool.
 
 =cut
+
 sub remove_image {
     my ($self, $image_name) = @_;
     $self->_engine_assert_script_run("rmi -f $image_name");
@@ -262,6 +275,7 @@ C<container_name> is the container name to be removed. Required argument.
 C<assert> Is an optional boolean for asserting that the call is successful. If false the method returns the return value of the call.
 
 =cut
+
 sub remove_container {
     my ($self, $container_name, %args) = @_;
     my $assert = $args{assert} // 1;
@@ -277,6 +291,7 @@ sub remove_container {
 Returns true if host contains C<img> or false.
 
 =cut
+
 sub check_image_in_host {
     my ($self, $img) = @_;
     grep { $img eq $_ } @{$self->enum_images()};
@@ -290,6 +305,7 @@ insecure registries.
 Implementation is subject to the subclass.
 
 =cut
+
 sub configure_insecure_registries {
     return;
 }
@@ -300,6 +316,7 @@ Remove containers and then all the images respectively.
 Asserts that everything was cleaned up unless c<assert> is set to 0.
 
 =cut
+
 sub cleanup_system_host {
     my ($self, $assert) = @_;
     $assert //= 1;

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -230,6 +230,7 @@ In this case the build of the base image is not going to work as it lacks the re
 The call should return false if the test is run on a non-sle host.
 
 =cut
+
 sub can_build_sle_base {
     # script_run returns 0 if true, but true is 1 on perl
     my $has_sle_registration = !script_run("test -e /etc/zypp/credentials.d/SCCcredentials");

--- a/lib/data_integrity_utils.pm
+++ b/lib/data_integrity_utils.pm
@@ -33,6 +33,7 @@ Returns image digest. Image path C<$image_path> is the parameter which is used t
 Digest retrieval is platform-specific depends.
 
 =cut
+
 sub get_image_digest {
     my ($image_path) = shift;
 
@@ -59,6 +60,7 @@ Directory path C<$dir_path> is the parameter which is a part of image path '$ima
 Returns error message in case of failure, empty string in case of success.
 
 =cut
+
 sub verify_checksum {
     my ($dir_path) = shift;
     my $error = '';

--- a/lib/db_utils.pm
+++ b/lib/db_utils.pm
@@ -52,6 +52,7 @@ Example of data:
         values => { io_reads' => 1337, io_writes => 1338 }
     }
 =cut
+
 sub influxdb_push_data {
     my ($url, $db, $data, %args) = @_;
     $args{quiet} //= 1;
@@ -72,6 +73,7 @@ SELECT query for given DB.
 returns json with results of SELECT query.
 
 =cut
+
 sub influxdb_read_data {
     my ($url_base, $db, $query) = @_;
     my $ua = Mojo::UserAgent->new();

--- a/lib/filesystem_utils.pm
+++ b/lib/filesystem_utils.pm
@@ -41,6 +41,7 @@ our @EXPORT = qw(
 Format number and unit from KB, MB, GB, TB to MB
 
 =cut
+
 sub str_to_mb {
     my $str = shift;
     if ($str =~ /(\d+(\.\d+)?)K/) {
@@ -68,6 +69,7 @@ Print partition  of device B<dev> in unit B<unit>.
 By default B<unit> is expressed in MB.
 
 =cut
+
 sub parted_print {
     my (%args) = @_;
     my $dev = $args{dev};
@@ -83,6 +85,7 @@ sub parted_print {
 Get partition number by given device partition start and end
 
 =cut
+
 sub partition_num_by_start_end {
     my ($dev, $start, $end) = @_;
     my $output = parted_print(dev => $dev);
@@ -99,6 +102,7 @@ Get the first parition number by given device and partition/FS type. e.g. extend
 Return -1 when not find
 
 =cut
+
 sub partition_num_by_type {
     my ($dev, $type) = @_;
     my $output = parted_print(dev => $dev);
@@ -119,6 +123,7 @@ perform the operation, get all information (start, end, size) about the bigest f
 Return a hash containing start, end and size
 
 =cut
+
 sub free_space {
     my (%args) = @_;
     my $dev = $args{dev};
@@ -147,6 +152,7 @@ sub free_space {
 Get partition by mountpoint, e.g. give /home get /dev/sda3
 
 =cut
+
 sub mountpoint_to_partition {
     my $mountpoint = shift;
     my $output = script_output('mount');
@@ -165,6 +171,7 @@ sub mountpoint_to_partition {
 Get partition table information by giving device
 
 =cut
+
 sub partition_table {
     my $dev = shift;
     my $output = parted_print(dev => $dev);
@@ -183,6 +190,7 @@ Get partition table information of giving device using blkid
 (for example, minimal role does not install parted)
 
 =cut
+
 sub get_partition_table_via_blkid {
     my $dev = shift;
     return (split(/\"/, script_output("blkid $dev")))[-1];
@@ -194,6 +202,7 @@ Create a new partition by giving device, partition type and partition size
 part_type (extended|logical|primary)
 
 =cut
+
 sub create_partition {
     my ($dev, $part_type, $size) = @_;
     my ($part_start, $part_end);
@@ -234,6 +243,7 @@ sub create_partition {
 Remove a partition by given partition name, e.g /dev/sdb5
 
 =cut
+
 sub remove_partition {
     my $part = shift;
     my ($dev, $num);
@@ -258,6 +268,7 @@ sub remove_partition {
 Format partition to target filesystem. The optional value C<$options> is '-f' as default.
 
 =cut
+
 sub format_partition {
     my ($part, $filesystem, %args) = @_;
     my $options;
@@ -279,6 +290,7 @@ Returns the value of the "df -h" output in given column, for a given partition
   df_command([partition=>$partition , column=> $column])
 
 =cut
+
 sub df_command {
     my $args = shift;
     return script_output("df -h $args->{partition} | awk \'NR==2 {print \$$args->{column}}\'");
@@ -291,6 +303,7 @@ Return the value of the defined partition size
   get_partition_size($partition)
 
 =cut
+
 sub get_partition_size {
     my $partition = shift;
     return df_command({partition => $partition, column => '2'});
@@ -303,6 +316,7 @@ Returns the value of used space of the defined partition
   get_used_partition_space($partition)
 
 =cut
+
 sub get_used_partition_space {
     my $partition = shift;
     return df_command({partition => $partition, column => '5'});
@@ -442,6 +456,7 @@ used contains new MOUNTPOINTS column including all subvolumes mountpoints or not
 Returns string with all found errors.
 
 =cut
+
 sub validate_lsblk {
     my (%args) = @_;
     my $dev = $args{device};

--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -27,6 +27,7 @@ Handle grub menu after reboot
     - Enable plymouth debug if product if GRUB_KERNEL_OPTION_APPEND is set,
       or product is sle, aarch64 and PLYMOUTH_DEBUG is set
 =cut
+
 sub grub_test {
     my $timeout = get_var('GRUB_TIMEOUT', 200);
 
@@ -55,6 +56,7 @@ sub grub_test {
 
 Due to pre-installation setup, qemu boot order is always booting from CD-ROM.
 =cut
+
 sub handle_installer_medium_bootup {
     return unless (check_var("BOOTFROM", "d") || (get_var('UEFI') && get_var('USBBOOT')));
     assert_screen 'inst-bootmenu', 180;

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -950,6 +950,7 @@ or calculated:
 "corosync_token + corosync_consensus + SBD_WATCHDOG_TIMEOUT * 2"
 Variables 'corosync_token' and 'corosync_consensus' are converted to seconds.
 =cut
+
 sub calculate_sbd_start_delay {
     my %params;
     my $default_wait = 35 * get_var('TIMEOUT_SCALE', 1);

--- a/lib/hpc/configs.pm
+++ b/lib/hpc/configs.pm
@@ -140,6 +140,7 @@ should usually be called from the master node and then get distributed
 among the nodes of the cluster.
 
 =cut
+
 sub prepare_slurm_conf ($self) {
     my $slurm_conf = get_required_var('SLURM_CONF');
 
@@ -219,6 +220,7 @@ sub prepare_slurm_conf ($self) {
 Prepare slurmdbd.conf based on test requirements and settings
 
 =cut
+
 sub prepare_slurmdb_conf ($self) {
     my @cluster_compute_nodes = $self->slave_node_names();
 

--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -33,6 +33,7 @@ C<bin> is required. C<need_interpreter> boolean will tell if the C<bin>
 is actually a source code where needs invoke _python_ interpreter.
 
 =cut
+
 sub single_node ($self, $bin) {
     #my ($self, $bin) = @_;
     die unless $bin;
@@ -52,6 +53,7 @@ a source code where needs invoke _python_ interpreter.
 TODO: improve the identification of the C<bin>
 
 =cut
+
 sub all_nodes ($self, $bin) {
     #my ($self, $bin) = @_;
     die unless $bin;

--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -38,6 +38,7 @@ will be used(mpich, openmpi, mvapich2).
 Returns an array with the mpi compiler and the source code located in /data/hpc
 
 =cut
+
 sub get_mpi_src {
     return ('mpicc', 'simple_mpi.c') unless get_var('HPC_LIB', '');
     # not a boost lib. but using it we can distiguish between `.c` and `.cpp` source code
@@ -53,6 +54,7 @@ This sub logouts the root user and relogins him from terminal.
 Useful to rerun configuration scripts after some changes
 
 =cut
+
 sub relogin_root {
     my $self = shift;
     record_info 'relogin', 'user needs to logout and login back to trigger scripts which set env variales and others';
@@ -75,6 +77,7 @@ L<https://documentation.suse.com/sle-hpc/15-SP3/single-html/hpc-guide/#sec-compu
 When subroutine returns immediately returns 1 to indicate that no relogin has occurred.
 
 =cut
+
 sub setup_scientific_module {
     my ($self) = @_;
     return 1 unless get_var('HPC_LIB', '');

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -18,6 +18,7 @@ use version_utils 'is_sle';
 Enables and starts given systemd service
 
 =cut
+
 sub enable_and_start {
     my ($self, $arg) = @_;
     systemctl("enable $arg");
@@ -62,6 +63,7 @@ in config preparation, munge key distribution, etc.
 The naming follows general pattern of master-slave
 
 =cut
+
 sub master_node_names {
     my ($self) = @_;
     my $master_nodes = get_required_var("MASTER_NODES");
@@ -82,6 +84,7 @@ instance in config preparation, munge key distribution, etc.
 The naming follows general pattern of master-slave
 
 =cut
+
 sub slave_node_names {
     my ($self) = @_;
     my $master_nodes = get_required_var("MASTER_NODES");
@@ -102,6 +105,7 @@ sub slave_node_names {
 Prepare all node names, so those names could be reused
 
 =cut
+
 sub cluster_names {
     my ($self) = @_;
     my @cluster_names;
@@ -122,6 +126,7 @@ This should usually be called from the master node. If a replica
 master node is expected, key should be also be copied in it too.
 
 =cut
+
 sub distribute_munge_key {
     my ($self) = @_;
     my @cluster_nodes = slave_node_names();
@@ -142,6 +147,7 @@ This should usually be called from the master node. If a replica
 master node is expected, config file should be also be copied in it too.
 
 =cut
+
 sub distribute_slurm_conf {
     my ($self) = @_;
     my @cluster_nodes = slave_node_names();
@@ -166,6 +172,7 @@ be copied. This should usually be called from the master node. If a replica
 master node is expected, the ssh keys should be also be distributed in it too.
 
 =cut
+
 sub generate_and_distribute_ssh {
     my ($self, $user) = @_;
     $user //= 'root';
@@ -186,6 +193,7 @@ sub generate_and_distribute_ssh {
 Checks if all listed HPC cluster nodes are available (ping)
 
 =cut
+
 sub check_nodes_availability {
     my ($self) = @_;
     my @cluster_nodes = cluster_names();
@@ -199,6 +207,7 @@ sub check_nodes_availability {
 Ensure correct dir is created, and correct NFS dir is mounted on SUT
 
 =cut
+
 sub mount_nfs {
     my ($self) = @_;
     zypper_call('in nfs-client rpcbind');
@@ -215,6 +224,7 @@ sub mount_nfs {
 Check the IP of the master node
 
 =cut
+
 sub get_master_ip {
     my ($self) = @_;
 
@@ -228,6 +238,7 @@ sub get_master_ip {
 Check the IP of the slave node
 
 =cut
+
 sub get_slave_ip {
     my ($self) = @_;
 
@@ -241,6 +252,7 @@ sub get_slave_ip {
 Creating slurm user and group with some pre-defined ID
 
 =cut
+
 sub prepare_user_and_group {
     my ($self) = @_;
     assert_script_run('groupadd slurm -g 7777');
@@ -258,6 +270,7 @@ from the rest and can be exported via a network file system.
 After C<prepare_spack_env> run, C<spack> should be ready to build entire tool stack,
 downloading and installing all bits required for whatever package or compiler.
 =cut
+
 sub prepare_spack_env {
     my ($self, $mpi) = @_;
     $mpi //= 'mpich';
@@ -278,6 +291,7 @@ sub prepare_spack_env {
 
 Unload and uninstall C<module> from spack stack
 =cut
+
 sub uninstall_spack_module {
     my ($self, $module) = @_;
     die 'uninstall_spack_module requires a module name' unless $module;
@@ -295,6 +309,7 @@ This function is used to select dependencies packages which are required to be i
 on HPC compute nodes in order to run code against particular C<mpi> implementation.
 C<get_compute_nodes_deps> returns an array of packages
 =cut
+
 sub get_compute_nodes_deps {
     my ($self, $mpi) = @_;
     die "missing C<mpi> parameter" unless $mpi;
@@ -320,6 +335,7 @@ of *-gnu-hpc installed libraries and the directory with the binaries.
 C<exports> takes a hash reference with the paths which NFS should make
 available to the compute nodes in order to run MPI software.
 =cut
+
 sub setup_nfs_server {
     my ($self, $exports) = @_;
     zypper_call 'in nfs-kernel-server';
@@ -337,6 +353,7 @@ compute nodes, from the management one.
 C<exports> takes a hash reference with the paths which the management node share in order to
 run the MPI binaries
 =cut
+
 sub mount_nfs_exports {
     my ($self, $exports) = @_;
     zypper_call 'in nfs-client';

--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -42,6 +42,7 @@ To add a known bug simply copy and adapt the following line:
 C<push @$serial_failures, {type => soft/hard, message => 'Errormsg', pattern => quotemeta 'ErrorPattern' }>
 
 =cut
+
 sub create_list_of_serial_failures {
     my $serial_failures = [];
 
@@ -86,6 +87,7 @@ type=hard will just emit a soft fail message but the module will do a normal fai
 type=info will message the user but the module will not fail
 
 =cut
+
 sub create_list_of_autoinst_failures {
     my $autoinst_failures = [];
 
@@ -100,6 +102,7 @@ type=soft will force the testmodule result to softfail
 type=hard will just emit a soft fail message but the module will do a normal fail
 
 =cut
+
 sub create_list_of_journal_failures {
     my $journal_failures = [];
 
@@ -112,6 +115,7 @@ Checks the journal for known patterns defined in $journal_failures
 Do not touch unless you know what you're doing
 
 =cut
+
 sub upload_journal {
     my ($file) = @_;
 

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -31,6 +31,7 @@ Also doing test ping to 10.0.2.2 to check that network is alive
 Set DNS server defined via required variable C<STATIC_DNS_SERVER>
 
 =cut
+
 sub setup_static_network {
     my (%args) = @_;
     # Set default values
@@ -54,6 +55,7 @@ sub setup_static_network {
 Return first NIC which is not loopback
 
 =cut
+
 sub iface {
     my ($quantity) = @_;
     $quantity ||= 1;
@@ -66,6 +68,7 @@ sub iface {
 
 Returns if can ping worker host gateway
 =cut
+
 sub can_upload_logs {
     my ($gw) = @_;
     $gw ||= testapi::host_ip();
@@ -87,6 +90,7 @@ in case skiped '10.0.2.15/24' will be used as fallback.
 
 C<gw> => allowing to specify default gateway. Fallback to worker IP in case nothing specified.
 =cut
+
 sub recover_network {
     my (%args) = @_;
 
@@ -116,6 +120,7 @@ sub recover_network {
 Return if ifconfig exists.
 
 =cut
+
 sub ifc_exists {
     my ($ifc) = @_;
     return !script_run('ip link show dev ' . $ifc);
@@ -128,6 +133,7 @@ sub ifc_exists {
 Return only if network status is UP.
 
 =cut
+
 sub ifc_is_up {
     my ($ifc) = @_;
     return !script_run("ip link show dev $ifc | grep 'state UP'");

--- a/lib/networkdbase.pm
+++ b/lib/networkdbase.pm
@@ -22,6 +22,7 @@ use base 'consoletest';
 Run C<$script> in the systemd-nspawn container called C<$machine>.
 
 =cut
+
 sub assert_script_run_container {
     my ($self, $machine, $script) = @_;
     assert_script_run("systemd-run -tM $machine /bin/bash -c \"$script\"");
@@ -34,6 +35,7 @@ sub assert_script_run_container {
 Run C<$script> in the systemd-nspawn container called C<$machine>.
 
 =cut
+
 sub script_run_container {
     my ($self, $machine, $script) = @_;
     return script_run("systemd-run -tM $machine /bin/bash -c \"$script\"");
@@ -46,6 +48,7 @@ sub script_run_container {
 Start the systemd-nspawn container called C<$machine>.
 
 =cut
+
 sub start_nspawn_container {
     my ($self, $machine) = @_;
     assert_script_run("systemctl start systemd-nspawn@" . $machine);
@@ -58,6 +61,7 @@ sub start_nspawn_container {
 Restart the systemd-nspawn container called C<$machine>.
 
 =cut
+
 sub restart_nspawn_container {
     my ($self, $machine) = @_;
     assert_script_run("systemctl stop systemd-nspawn@" . $machine);
@@ -73,6 +77,7 @@ Use C<zypper> to add a repo to the chroot and install (with C<--no-recommends>)
 the packages listed in C<$packages>.
 
 =cut
+
 sub setup_nspawn_container {
     my ($self, $machine, $repo, $packages) = @_;
     my $systemd_nspawn_file = "
@@ -105,6 +110,7 @@ Create a file at path (including filename) C<$file> within the container called 
 with the content C<$content>.
 
 =cut
+
 sub write_container_file {
     my ($self, $machine, $file, $content) = @_;
     my $path = "/var/lib/machines/$machine/$file";
@@ -118,6 +124,7 @@ sub write_container_file {
 Helper function to write a file at path (including filename) C<$file> with the content C<$content>.
 
 =cut
+
 sub write_file {
     my ($self, $file, $content) = @_;
     enter_cmd("cat > $file <<EOF\n$content\nEOF");
@@ -131,6 +138,7 @@ sub write_file {
 Wait until networkd in the container C<$machine> has configured the network interface C<$netif>.
 
 =cut
+
 sub wait_for_networkd {
     my ($self, $machine, $netif) = @_;
     $self->assert_script_run_container($machine, "ip a");
@@ -151,6 +159,7 @@ This works without interacting with the container as logs are
 redirected to the host system journal.
 
 =cut
+
 sub export_container_journal {
     my ($self, $machine) = @_;
 
@@ -165,6 +174,7 @@ sub export_container_journal {
 Upload the logs of all known containers.
 
 =cut
+
 sub post_fail_hook {
     my ($self) = shift;
     select_console('log-console');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -43,6 +43,7 @@ Clear the console and ensure that it really got cleared
 using a needle.
 
 =cut
+
 sub clear_and_verify_console {
     my ($self) = @_;
 
@@ -59,6 +60,7 @@ Test modules (or their intermediate base classes) may overwrite
 this method, must call this baseclass method from the overwriting method.
 
 =cut
+
 sub pre_run_hook {
     my ($self) = @_;
     clear_started_systemd_services();
@@ -74,6 +76,7 @@ Test modules (or their intermediate base classes) may overwrite
 this method.
 
 =cut
+
 sub post_run_hook {
     my ($self) = @_;
     # overloaded in x11 and console
@@ -88,6 +91,7 @@ The C<$timeout> parameter specifies how long C<$cmd> may run.
 When C<$cmd> returns, the output file will be uploaded to openQA unless C<$noupload> is set.
 Afterwards a screenshot will be created if C<$screenshot> is set.
 =cut
+
 sub save_and_upload_log {
     my ($self, $cmd, $file, $args) = @_;
     script_run("$cmd | tee $file", $args->{timeout});
@@ -106,6 +110,7 @@ When C<tar> returns, the output file will be uploaded to openQA unless C<$nouplo
 Afterwards a screenshot will be created if C<$screenshot> is set.
 
 =cut
+
 sub tar_and_upload_log {
     my ($self, $sources, $dest, $args) = @_;
     script_run("tar -jcv -f $dest $sources", $args->{timeout});
@@ -120,6 +125,7 @@ sub tar_and_upload_log {
 Saves the journal of the systemd unit C<$unit> to C<journal_$unit.log> and uploads it to openQA.
 
 =cut
+
 sub save_and_upload_systemd_unit_log {
     my ($self, $unit) = @_;
     $self->save_and_upload_log("journalctl --no-pager -u $unit -o short-precise", "journal_$unit.log");
@@ -135,6 +141,7 @@ if such jobs are running, providing a hint why test timed out.
 This method will create a softfail if such a problem is detected.
 
 =cut
+
 sub detect_bsc_1063638 {
     # Detect bsc#1063638
     record_soft_failure 'bsc#1063638' if (script_run('ps x | grep "btrfs-\(scrub\|balance\|trim\)"') == 0);
@@ -150,6 +157,7 @@ output of rpmverify.
 The files will be uploaded as a single tarball called C<problem_detection_logs.tar.xz>.
 
 =cut
+
 sub problem_detection {
     my $self = shift;
 
@@ -232,6 +240,7 @@ Inspect the YaST2 logfile checking for known issues. logs_path can be a director
 e.g. /tmp. In that case the function will parse /tmp/var/log/YaST2/y2logs* files.
 
 =cut
+
 sub investigate_yast2_failure {
     my ($self, %args) = @_;
     my $logs_path = $args{logs_path} . '/var/log/YaST2';
@@ -421,6 +430,7 @@ Upload healthcheck logs that make sense for any failure.
 This includes C<cpu>, C<memory> and C<fdisk>.
 
 =cut
+
 sub export_healthcheck_basic {
 
     my $cmd = <<'EOF';
@@ -455,6 +465,7 @@ Upload logs that make sense for any failure.
 This includes C</proc/loadavg>, C<ps axf>, complete journal since last boot, C<dmesg> and C</etc/sysconfig>.
 
 =cut
+
 sub export_logs_basic {
     my ($self) = @_;
     $self->save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg.txt', {screenshot => 1});
@@ -477,6 +488,7 @@ that react very slow due to high background load or high memory consumption.
 This should be especially useful in C<post_fail_hook> implementations.
 
 =cut
+
 sub select_log_console { select_console('log-console', timeout => 180, @_) }
 
 =head2 export_logs
@@ -486,6 +498,7 @@ sub select_log_console { select_console('log-console', timeout => 180, @_) }
 This method will call several other log gathering methods from this class.
 
 =cut
+
 sub export_logs {
     my ($self) = shift;
     select_log_console;
@@ -520,6 +533,7 @@ Upload logs related to system locale settings.
 This includes C<locale>, C<localectl> and C</etc/vconsole.conf>.
 
 =cut
+
 sub export_logs_locale {
     my ($self) = shift;
     $self->save_and_upload_log('locale', '/tmp/locale.log');
@@ -534,6 +548,7 @@ sub export_logs_locale {
 Upload C</var/log/pk_backend_zypp>.
 
 =cut
+
 sub upload_packagekit_logs {
     my ($self) = @_;
     upload_logs '/var/log/pk_backend_zypp';
@@ -546,6 +561,7 @@ sub upload_packagekit_logs {
 Upload C</tmp/solverTestCase.tar.bz2>.
 
 =cut
+
 sub upload_solvertestcase_logs {
     my $ret = script_run("zypper -n patch --debug-solver --with-interactive -l");
     # if zypper was not found, we just skip upload solverTestCase.tar.bz2
@@ -561,6 +577,7 @@ sub upload_solvertestcase_logs {
 Set a simple reproducible prompt for easier needle matching without hostname.
 
 =cut
+
 sub set_standard_prompt {
     my ($self, $user) = @_;
     $testapi::distri->set_standard_prompt($user);
@@ -573,6 +590,7 @@ sub set_standard_prompt {
 Upload several KDE, GNOME, X11, GDM and SDDM related logs and configs.
 
 =cut
+
 sub export_logs_desktop {
     my ($self) = @_;
     select_log_console;
@@ -620,6 +638,7 @@ Our aarch64 setup fails to boot properly from an installed hard disk so
 point the firmware boot manager to the right file.
 
 =cut
+
 sub handle_uefi_boot_disk_workaround {
     my ($self) = @_;
     record_info 'workaround', 'Manually selecting boot entry, see bsc#1022064 for details';
@@ -668,6 +687,7 @@ Makes sure the bootloader appears. Returns successfully when reached the bootloa
 C<$bootloader_time> in seconds. Set C<$in_grub> to 1 when the
 SUT is already expected to be within the grub menu.
 =cut
+
 sub wait_grub {
     my ($self, %args) = @_;
     my $bootloader_time = $args{bootloader_time} // 100;
@@ -762,6 +782,7 @@ sub wait_grub {
 
 When bootloader appears, make sure to boot from local disk when it is on aarch64.
 =cut
+
 sub wait_grub_to_boot_on_local_disk {
     # assuming the cursor is on 'installation' by default and 'boot from
     # harddisk' is above
@@ -890,6 +911,7 @@ Handle a textmode PXE bootloader menu by means of two needle tags:
 C<$pxemenu> to match the initial menu, C<$pxeselect> to match the
 menu with the desired entry selected.
 =cut
+
 sub handle_pxeboot {
     my ($self, %args) = @_;
     my $bootloader_time = $args{bootloader_time};
@@ -1017,6 +1039,7 @@ before.  The time waiting for the system to be fully booted can be configured
 with C<$ready_time> in seconds. C<$forcenologin> makes this function
 behave as if the env var NOAUTOLOGIN was set.
 =cut
+
 sub wait_boot_past_bootloader {
     my ($self, %args) = @_;
     my $textmode = $args{textmode};
@@ -1113,6 +1136,7 @@ SUT is already expected to be within the grub menu. C<wait_boot> continues
 from there. C<$forcenologin> makes this function behave as if
 the env var NOAUTOLOGIN was set.
 =cut
+
 sub wait_boot {
     my ($self, %args) = @_;
     my $bootloader_time = $args{bootloader_time} // ((is_pvm || is_ipmi) ? 300 : 100);
@@ -1182,6 +1206,7 @@ If C<$slow> is set, the typing will be very slow.
 If C<$cmd> is set, the text will be prefixed by an C<echo> command.
 
 =cut
+
 sub enter_test_text {
     my ($self, $name, %args) = @_;
     $name //= 'your program';
@@ -1207,6 +1232,7 @@ Return the default expected firewall implementation depending on the product
 under test, the version and if the SUT is an upgrade.
 
 =cut
+
 sub firewall {
     my $old_product_versions = is_sle('<15') || is_leap('<15.0');
     my $upgrade_from_susefirewall = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
@@ -1221,6 +1247,7 @@ Mounts /tmp to shared memory if not possible to write to tmp.
 For example, save_y2logs creates temporary files there.
 
 =cut
+
 sub remount_tmp_if_ro {
     script_run 'touch /tmp/test_ro || mount -t tmpfs /dev/shm /tmp';
 }
@@ -1261,6 +1288,7 @@ On ikvm|ipmi|spvm|pvm_hmc it's expected, that use_ssh_serial_console() has been 
 (done via activate_console()) therefore SERIALDEV has been set and we can
 use root-ssh console directly.
 =cut
+
 sub select_serial_terminal {
     my ($self, $root) = @_;
     $root //= 1;
@@ -1299,6 +1327,7 @@ sub select_serial_terminal {
 Select most suitable text console with non-root user.
 The choice is made by BACKEND and other variables.
 =cut
+
 sub select_user_serial_terminal {
     select_serial_terminal(0);
 }
@@ -1311,6 +1340,7 @@ Upload all coredumps to logs. In case `proceed_on_failure` key is set to true,
 errors during logs collection will be ignored, which is usefull for the
 post_fail_hook calls.
 =cut
+
 sub upload_coredumps {
     my ($self, %args) = @_;
     my $res = script_run("coredumpctl --no-pager", timeout => 10);
@@ -1337,6 +1367,7 @@ this method to export certain specific logfiles and call the
 base method using C<$self-E<gt>SUPER::post_fail_hook;> at the end.
 
 =cut
+
 sub post_fail_hook {
     my ($self) = @_;
     return if is_serial_terminal();    # unless VIRTIO_CONSOLE=0 nothing below make sense

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -54,6 +54,7 @@ Returns true if running on a scenario that expects storage-ng.
 We got changes to the storage-ng UI in SLE 15 SP1, Leap 15.1 and TW
 
 =cut
+
 sub is_storage_ng_newui {
     return is_storage_ng && (
         is_sle('15-SP1+')
@@ -71,6 +72,7 @@ Despite the name it does not check if it is run on a storage ng system,
 so be careful here
 
 =cut
+
 sub wipe_existing_partitions_storage_ng {
     send_key_until_needlematch "expert-partitioner-hard-disks", 'right';
     wait_still_screen 2;
@@ -93,6 +95,7 @@ C<$table_type> can be 'GPT' or 'MSDOS' and is optional.
 This function creates a new partitioning setup from scratch.
 
 =cut
+
 sub create_new_partition_table {
     my ($table_type) = shift // (is_storage_ng) ? 'GPT' : 'MSDOS';
     my %table_type_hotkey = (
@@ -156,6 +159,7 @@ sub create_new_partition_table {
 Set mount point and volume label. C<$mount> is mount point.
 
 =cut
+
 sub mount_device {
     my ($mount) = shift;
     send_key 'alt-o';
@@ -187,6 +191,7 @@ Example:
  set_patition_size(size => '100')
 
 =cut
+
 sub set_partition_size {
     my (%args) = @_;
     assert_screen 'partition-size';
@@ -212,6 +217,7 @@ Method assumes that correct disk is already selected.
 Select Maximum size by default
 
 =cut
+
 sub resize_partition {
     my (%args) = @_;
     if (is_storage_ng_newui) {
@@ -236,6 +242,7 @@ sub resize_partition {
 Adds a partition with the given parameters to the partitioning table.
 
 =cut
+
 sub addpart {
     my (%args) = @_;
     assert_screen 'expert-partitioner';
@@ -305,6 +312,7 @@ Example:
  addvg(name => 'vg-system', add_all_pvs => 1);
 
 =cut
+
 sub addvg {
     my (%args) = @_;
 
@@ -341,6 +349,7 @@ sub addvg {
 Add a LVM logical volume.
 
 =cut
+
 sub addlv {
     my (%args) = @_;
 
@@ -405,6 +414,7 @@ Add a boot partition based on architecture.
 C<$part_size> is the size of partition.
 
 =cut
+
 sub addboot {
     my $part_size = shift;
     my %default_boot_sizes = (
@@ -445,6 +455,7 @@ The device should be [sv]da, other devices will be unselected. [sv]da device wil
 force-selected at the end if needed (in some cases [sv]da is at the end of the list).
 
 =cut
+
 sub select_first_hard_disk {
     # Try to handle most of the device type
     my @tags = 'existing-partitions';
@@ -489,6 +500,7 @@ sub select_first_hard_disk {
 Enable encryption in guided setup during installation.
 
 =cut
+
 sub enable_encryption_guided_setup {
     my $self = shift;
     send_key $cmd{encryptdisk};
@@ -512,6 +524,7 @@ sub enable_encryption_guided_setup {
 Only works on storage-ng and is being called by C<take_first_disk>.
 
 =cut
+
 sub take_first_disk_storage_ng {
     my (%args) = @_;
     return unless is_storage_ng;
@@ -574,6 +587,7 @@ Example:
  take_first_disk(iscsi => 1);
 
 =cut
+
 sub take_first_disk
 {
     my (%args) = @_;

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -45,6 +45,7 @@ and assign console('svirt') with C<stop_serial_grab>.
 $vnc_console get required variable 'SVIRT_VNC_CONSOLE' before assignment.
 
 =cut
+
 sub prepare_system_shutdown {
     # kill the ssh connection before triggering reboot
     console('root-ssh')->kill_ssh if get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/;
@@ -75,6 +76,7 @@ Reboot from Gnome Desktop and handle authentification scenarios during shutdown.
 Run C<prepare_system_shutdown> if shutdown needs authentification.
 
 =cut
+
 sub reboot_x11 {
     my ($self) = @_;
     wait_still_screen;
@@ -125,6 +127,7 @@ Handle each desktop differently for kde, gnome, xfce, lxde, lxqt, enlightenment,
 Work around issue with CD-ROM pop-up: bsc#1137230 and make sure that s390 SUT shutdown correctly.
 
 =cut
+
 sub poweroff_x11 {
     my ($self) = @_;
     wait_still_screen;
@@ -222,6 +225,7 @@ Handle a potential failure on a live CD related to boo#993885 that the reboot
 action from a desktop session does not work and we are stuck on the desktop.
 
 =cut
+
 sub handle_livecd_reboot_failure {
     mouse_hide;
     wait_still_screen;
@@ -249,6 +253,7 @@ console, that is 'root-console' for textmode, 'x11' otherwise. The actual execut
 for textmode or with GUI commands otherwise unless explicitly overridden by setting C<$textmode> to either 0 or 1.
 
 =cut
+
 sub power_action {
     my ($action, %args) = @_;
     $args{observe} //= 0;
@@ -409,6 +414,7 @@ Example:
  assert_shutdown_with_soft_timeout({timeout => 300, soft_timeout => 60, bugref => 'bsc#123456'});
 
 =cut
+
 sub assert_shutdown_with_soft_timeout {
     my ($args) = @_;
     $args->{timeout} //= is_s390x ? 600 : get_var('DEBUG_SHUTDOWN') ? 180 : 60;

--- a/lib/publiccloud/acr.pm
+++ b/lib/publiccloud/acr.pm
@@ -32,6 +32,7 @@ sub init {
 =head2 delete_image
 Delete a ACR image
 =cut
+
 sub delete_image {
     my ($self, $tag) = @_;
     $tag //= $self->get_default_tag();

--- a/lib/publiccloud/aks.pm
+++ b/lib/publiccloud/aks.pm
@@ -30,6 +30,7 @@ sub init {
 
 Clean a container image from the ACR
 =cut
+
 sub delete_container_image {
     my ($self, $tag) = @_;
 

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -37,6 +37,7 @@ object.
 Due to https://github.com/Azure/azure-cli/issues/9903 we need to strip all
 color codes from that string first.
 =cut
+
 sub decode_azure_json {
     return decode_json(colorstrip(shift));
 }
@@ -282,6 +283,7 @@ sub start_instance
 Extract resource group and vm name from full instance id which looks like
 C</subscriptions/c011786b-59d7-4817-880c-7cd8a6ca4b19/resourceGroups/openqa-suse-de-1ec3f5a05b7c0712/providers/Microsoft.Compute/virtualMachines/openqa-suse-de-1ec3f5a05b7c0712>
 =cut
+
 sub parse_instance_id
 {
     my ($self, $instance) = @_;

--- a/lib/publiccloud/ecr.pm
+++ b/lib/publiccloud/ecr.pm
@@ -29,6 +29,7 @@ sub init {
 =head2 delete_image
 Delete a ECR image
 =cut
+
 sub delete_image {
     my ($self, $tag) = @_;
     assert_script_run(

--- a/lib/publiccloud/eks.pm
+++ b/lib/publiccloud/eks.pm
@@ -29,6 +29,7 @@ sub init {
 
 Clean a container image from the ECR
 =cut
+
 sub delete_container_image {
     my ($self, $tag) = @_;
 

--- a/lib/publiccloud/gke.pm
+++ b/lib/publiccloud/gke.pm
@@ -30,6 +30,7 @@ sub init {
 
 Clean a container image from the GCR
 =cut
+
 sub delete_container_image {
     my ($self, $tag) = @_;
 

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -46,6 +46,7 @@ Use argument C<username> to specify a different username then
 C<<$instance->username()>>.
 Use argument C<rc_only> to only check for the return code of the command.
 =cut
+
 sub run_ssh_command {
     my $self = shift;
     my %args = testapi::compat_args({cmd => undef}, ['cmd'], @_);
@@ -103,6 +104,7 @@ C<<$instance->ssh_opts>>.
 Use argument C<username> to specify a different username then
 C<<$instance->username()>>.
 =cut
+
 sub retry_ssh_command {
     my $self = shift;
     my %args = testapi::compat_args({cmd => undef}, ['cmd'], @_);
@@ -129,6 +131,7 @@ C<remote:> is replaced with the IP from this instance. E.g. a call to copy
 the file I</var/log/cloudregister> to I</tmp> looks like:
 C<<<$instance->scp('remote:/var/log/cloudregister', '/tmp');>>>
 =cut
+
 sub scp {
     my ($self, $from, $to, %args) = @_;
     $args{timeout} //= SSH_TIMEOUT;
@@ -150,6 +153,7 @@ sub scp {
 Upload a file from this instance to openqa using L<upload_logs()>.
 If the file doesn't exists on the instance, B<no> error is thrown.
 =cut
+
 sub upload_log {
     my ($self, $remote_file, %args) = @_;
 
@@ -171,6 +175,7 @@ If guestregister will not finish within C<timeout> seconds, job dies.
 In case of BYOS images we checking that service is inactive and quit
 Returns the time needed to wait for the guestregister to complete.
 =cut
+
 sub wait_for_guestregister
 {
     my ($self, %args) = @_;
@@ -215,6 +220,7 @@ sub wait_for_guestregister
 
 Check if the SSH port of the instance is reachable and open.
 =cut
+
 sub wait_for_ssh
 {
     my ($self, %args) = @_;
@@ -268,6 +274,7 @@ Does a softreboot of the instance by running the command C<shutdown -r>.
 Return an array of two values, first one is the time till the instance isn't
 reachable anymore. The second one is the estimated bootup time.
 =cut
+
 sub softreboot
 {
     my ($self, %args) = @_;
@@ -313,6 +320,7 @@ sub softreboot
 
 Stop the instance using the CSP api calls.
 =cut
+
 sub stop
 {
     my $self = shift;
@@ -326,6 +334,7 @@ sub stop
 Start the instance and check SSH connectivity. Return the number of seconds
 till the SSH port was available.
 =cut
+
 sub start
 {
     my ($self, %args) = @_;
@@ -339,6 +348,7 @@ sub start
 
 Get the status of the instance using the CSP api calls.
 =cut
+
 sub get_state
 {
     my $self = shift;
@@ -351,6 +361,7 @@ sub get_state
 
 Test the network speed.
 =cut
+
 sub network_speed_test() {
     my ($self, %args) = @_;
     # Curl stats output format

--- a/lib/publiccloud/k8s_provider.pm
+++ b/lib/publiccloud/k8s_provider.pm
@@ -96,6 +96,7 @@ in the local registry. And the tag (name) in the public cloud
 containers repository Retrieves the full name of the uploaded 
 image or die.
 =cut
+
 sub push_container_image {
     my ($self, $image, $tag) = @_;
 

--- a/lib/publiccloud/k8sbasetest.pm
+++ b/lib/publiccloud/k8sbasetest.pm
@@ -20,6 +20,7 @@ use containers::k8s qw(install_kubectl);
 
 Prepare the provider and install kubectl
 =cut
+
 sub init {
     my ($self) = @_;
 
@@ -34,6 +35,7 @@ sub init {
 
 Apply a kubernetes manifest
 =cut
+
 sub apply_manifest {
     my ($self, $manifest) = @_;
 
@@ -49,6 +51,7 @@ sub apply_manifest {
 
 Find pods using kubectl queries
 =cut
+
 sub find_pods {
     my ($self, $query) = @_;
     return script_output("kubectl get pods --no-headers -l $query -o custom-columns=':metadata.name'");
@@ -58,6 +61,7 @@ sub find_pods {
 
 Wait until the job is complete
 =cut
+
 sub wait_for_job_complete {
     my ($self, $job) = @_;
     assert_script_run("kubectl wait --for=condition=complete --timeout=300s job/$job");
@@ -67,6 +71,7 @@ sub wait_for_job_complete {
 
 Validates that the logs contains a text
 =cut
+
 sub validate_log {
     my ($self, $pod, $text) = @_;
     validate_script_output("kubectl logs $pod 2>&1", qr/$text/);
@@ -77,6 +82,7 @@ sub validate_log {
 
 Returns the name for the kubernetes service
 =cut
+
 sub get_k8s_service_name {
     my ($self) = @_;
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -35,6 +35,7 @@ has provider_client => undef;
 Needs provider specific credentials, e.g. key_id, key_secret, region.
 
 =cut
+
 sub init {
     my ($self) = @_;
     $self->create_ssh_key();
@@ -45,6 +46,7 @@ sub init {
 Does the conversion between C<PUBLIC_CLOUD_PROVIDER> and Terraform providers name.
 
 =cut
+
 sub conv_openqa_tf_name {
     # Check https://github.com/SUSE/ha-sap-terraform-deployments/issues/177 for more information
     my $cloud_provider = lc get_var('PUBLIC_CLOUD_PROVIDER');
@@ -58,6 +60,7 @@ sub conv_openqa_tf_name {
 Retrieves the image-id by given image C<name>.
 
 =cut
+
 sub find_img {
     die('find_image() isn\'t implemented');
 }
@@ -73,6 +76,7 @@ on GCE at the momment.
 Retrieves the image-id after upload or die.
 
 =cut
+
 sub upload_image {
     die('find_image() isn\'t implemented');
 }
@@ -95,6 +99,7 @@ Call img-proof tool and retrieves a hashref as result. Do not die if img-proof c
   };
 
 =cut
+
 sub img_proof {
     die('img_proof() isn\'t implemented');
 }
@@ -104,6 +109,7 @@ sub img_proof {
 Parse the output from img-proof command and retrieves instance-id, ip and logfile names.
 
 =cut
+
 sub parse_img_proof_output {
     my ($self, $output) = @_;
     my $ret = {};
@@ -146,6 +152,7 @@ sub parse_img_proof_output {
 Creates an ssh keypair in a given file path by $args{ssh_private_key_file}
 
 =cut
+
 sub create_ssh_key {
     my ($self, %args) = @_;
     $args{ssh_private_key_file} //= '/root/.ssh/id_rsa';
@@ -160,6 +167,7 @@ sub create_ssh_key {
 called by childs within img-proof function
 
 =cut
+
 sub run_img_proof {
     my ($self, %args) = @_;
     die('Must provide an instance object') if (!$args{instance});
@@ -213,6 +221,7 @@ The given C<$img_url> is optional, if not present it retrieves from
 PUBLIC_CLOUD_IMAGE_LOCATION.
 If PUBLIC_CLOUD_IMAGE_ID is set, then this value will be used
 =cut
+
 sub get_image_id {
     my ($self, $img_url) = @_;
     my $predefined_id = get_var('PUBLIC_CLOUD_IMAGE_ID');
@@ -237,6 +246,7 @@ C<instance_type> defines the flavor of the instance. If not specified, it will l
                      from PUBLIC_CLOUD_INSTANCE_TYPE.
 
 =cut
+
 sub create_instance {
     return (shift->create_instances(@_))[0];
 }
@@ -251,6 +261,7 @@ C<instance_type> defines the flavor of the instance. If not specified, it will l
                      from PUBLIC_CLOUD_INSTANCE_TYPE.
 
 =cut
+
 sub create_instances {
     my ($self, %args) = @_;
     $args{check_connectivity} //= 1;
@@ -277,6 +288,7 @@ The working directory is always the terraform directory, where the statefile
 and the *.tf is placed.
 
 =cut
+
 sub on_terraform_apply_timeout {
 }
 
@@ -290,6 +302,7 @@ The working directory is always the terraform directory, where the statefile
 and the *.tf is placed.
 
 =cut
+
 sub on_terraform_destroy_timeout {
 }
 
@@ -298,6 +311,7 @@ sub on_terraform_destroy_timeout {
 This method is used to initialize the terraform environment.
 it is executed only once, guareded by `terraform_env_prepared` member.
 =cut
+
 sub terraform_prepare_env {
     my ($self) = @_;
     return if $self->terraform_env_prepared;
@@ -329,6 +343,7 @@ sub terraform_prepare_env {
 Calls terraform tool and applies the corresponding configuration .tf file
 
 =cut
+
 sub terraform_apply {
     my ($self, %args) = @_;
     my @instances;
@@ -470,6 +485,7 @@ sub terraform_apply {
 Destroys the current terraform deployment
 
 =cut
+
 sub terraform_destroy {
     my ($self) = @_;
     # Do not destroy if terraform has not been applied or the environment doesn't exist
@@ -524,6 +540,7 @@ sub terraform_destroy {
 Build the tags parameter for terraform. It is a single depth json like
 c<{"key": "value"}> where c<value> must be a string.
 =cut
+
 sub terraform_param_tags
 {
     my ($self) = @_;
@@ -547,6 +564,7 @@ sub escape_single_quote {
 This method is called called after each test on failure or success.
 
 =cut
+
 sub cleanup {
     my ($self) = @_;
     $self->terraform_destroy();
@@ -558,6 +576,7 @@ sub cleanup {
 This function implements a provider specifc stop call for a given instance.
 
 =cut
+
 sub stop_instance
 {
     die('stop_instance() isn\'t implemented');
@@ -568,6 +587,7 @@ sub stop_instance
 This function implements a provider specifc start call for a given instance.
 
 =cut
+
 sub start_instance
 {
     die('start_instance() isn\'t implemented');
@@ -578,6 +598,7 @@ sub start_instance
 This function implements a provider specifc get_state call for a given instance.
 
 =cut
+
 sub get_state_from_instance
 {
     die('get_state_from_instance() isn\'t implemented');

--- a/lib/publiccloud/vault.pm
+++ b/lib/publiccloud/vault.pm
@@ -19,6 +19,7 @@ has lease_id => undef;
 
 Retry n times the execution of a function.
 =cut
+
 sub retry {
     my ($self, $code, %args) = @_;
     my $max_tries = max(1, get_var('PUBLIC_CLOUD_VAULT_TRIES', $args{max_tries} // 3));
@@ -42,6 +43,7 @@ Login to vault using C<_SECRET_PUBLIC_CLOUD_REST_USER> and
 C<_SECRET_PUBLIC_CLOUD_REST_PW>. The retrieved TOKEN is stored in this
 instance and used for further C<publiccloud::provider::api()> calls.
 =cut
+
 sub __login {
     my ($self) = @_;
     my $url = get_required_var('_SECRET_PUBLIC_CLOUD_REST_URL');
@@ -66,6 +68,7 @@ sub __login {
 
 Wrapper arround C<<$self->login()>> to have retry capability.
 =cut
+
 sub login {
     my $self = shift;
     return $self->retry(
@@ -81,6 +84,7 @@ Invoke a vault API call. It use _SECRET_PUBLIC_CLOUD_REST_URL as base
 url.
 Depending on the method (get|post) you can pass additional data as json.
 =cut
+
 sub __api {
     my ($self, $path, %args) = @_;
     my $method = $args{method} // 'get';
@@ -119,6 +123,7 @@ sub __api {
 
 Wrapper around C<<$self->api()>> to get retry capability.
 =cut
+
 sub api {
     my ($self, $path, %args) = @_;
     my $max_tries = delete($args{max_tries}) // 3;
@@ -141,6 +146,7 @@ azure secret engine.
 It prepend C<'/v1/' + $NAMESPACE> to the given path before sending the request.
 It stores lease_id and also adjust the token-live-time.
 =cut
+
 sub get_secrets {
     my ($self, $path, %args) = @_;
     my $res = $self->api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . $path, method => 'get', %args);
@@ -158,6 +164,7 @@ sub get_secrets {
 
 Revoke a previous retrieved credential
 =cut
+
 sub revoke {
     my ($self) = @_;
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -153,6 +153,7 @@ sub accept_addons_license {
 Helper for parsing SLE RC version into integer. It replaces SLE version
 in format X-SPY into X.Y.
 =cut
+
 sub scc_version {
     my $version = shift;
     $version //= get_required_var('VERSION');
@@ -165,6 +166,7 @@ sub scc_version {
 
 Wrapper for SUSEConnect -p $name.
 =cut
+
 sub add_suseconnect_product {
     my ($name, $version, $arch, $params, $timeout, $retry) = @_;
     assert_script_run 'source /etc/os-release';
@@ -202,6 +204,7 @@ sub add_suseconnect_product {
 
 Wrapper for SUSEConnect -p $name  over ssh.
 =cut
+
 sub ssh_add_suseconnect_product {
     my ($remote, $name, $version, $arch, $params, $timeout, $retries, $delay) = @_;
     assert_script_run "sftp $remote:/etc/os-release /tmp/os-release";
@@ -222,6 +225,7 @@ sub ssh_add_suseconnect_product {
 
 Wrapper for SUSEConnect -d $name.
 =cut
+
 sub remove_suseconnect_product {
     my ($name, $version, $arch, $params) = @_;
     $version //= scc_version();
@@ -236,6 +240,7 @@ sub remove_suseconnect_product {
 
 Wrapper for SUSEConnect -d $name over ssh.
 =cut
+
 sub ssh_remove_suseconnect_product {
     my ($remote, $name, $version, $arch, $params) = @_;
     assert_script_run "sftp $remote:/etc/os-release /tmp/os-release";
@@ -253,6 +258,7 @@ sub ssh_remove_suseconnect_product {
 Wrapper for SUSEConnect --cleanup. Resets proxy SCC url if job has SCC_URL
 variable set.
 =cut
+
 sub cleanup_registration {
     # Remove registration from the system
     assert_script_run 'SUSEConnect --cleanup';
@@ -268,6 +274,7 @@ sub cleanup_registration {
 Wrapper for SUSEConnect -r <regcode>. Requires SCC_REGCODE variable.
 SUSEConnect --url with SMT/RMT server.
 =cut
+
 sub register_product {
     if (get_var('SMT_URL')) {
         assert_script_run('SUSEConnect --url ' . get_var('SMT_URL') . ' ' . uc(get_var('SLE_PRODUCT')) . '/' . scc_version(get_var('HDDVERSION')) . '/' . get_var('ARCH'), 200);

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -107,6 +107,7 @@ Helper to add QA:HEAD repository repository (usually from IBS).
 This repository *is* mandatory.
 
 =cut
+
 sub add_qa_head_repo {
     my (%args) = @_;
     my $priority = $args{priority} // 0;
@@ -122,6 +123,7 @@ Helper to add QA web repository repository.
 This repository is *not* mandatory.
 
 =cut
+
 sub add_qa_web_repo {
     my $repo = get_var('QA_WEB_REPO');
     zypper_ar($repo, name => 'qa-web', no_gpg_check => is_sle("<12") ? 0 : 1) if ($repo);
@@ -137,6 +139,7 @@ Then the names of patterns are parsed from the XML.
 Returns array containing all installed patterns in the system.
 
 =cut
+
 sub get_installed_patterns {
     my $xml = script_output q[zypper -n -q -x se -i -t pattern];
     map { $_->to_literal() } find_nodes(xpc => get_xpc($xml), xpath => '//solvable[@kind="pattern"]/@name');
@@ -150,6 +153,7 @@ This takes something like "MODULE_BASESYSTEM_SOURCE" as parameter C<$repo_name>
 and returns "REPO_SLE15_SP1_MODULE_BASESYSTEM_SOURCE" when being called on SLE15-SP1.
 
 =cut
+
 sub get_repo_var_name {
     my ($repo_name) = @_;
     my $distri = uc get_required_var("DISTRI");
@@ -163,6 +167,7 @@ sub get_repo_var_name {
 Run smt wizard workflow and to get repository synced with smt server
 
 =cut
+
 sub smt_wizard {
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'smt-wizard');
     assert_screen 'smt-wizard-1';
@@ -226,6 +231,7 @@ sub smt_mirror_repo {
 Type password, TAB, password, ALT+o. This is for use within YaST.
 
 =cut
+
 sub type_password_twice {
     type_password;
     send_key "tab";
@@ -241,6 +247,7 @@ rmt_wizard();
 Install Repository Mirroring Tool and mariadb database
 
 =cut
+
 sub rmt_wizard {
     # add develop version of rmt repo
     if (get_var("DEV_PATH")) {
@@ -318,6 +325,7 @@ sub rmt_wizard {
 Function to sync rmt server
 
 =cut
+
 sub rmt_sync {
     script_retry 'rmt-cli sync', delay => 60, retry => 6, timeout => 1800;
 }
@@ -329,6 +337,7 @@ sub rmt_sync {
 Function to enable products
 
 =cut
+
 sub rmt_enable_pro {
     my $pro_ls = get_var('RMT_PRO') || 'sle-module-legacy/15/x86_64';
     assert_script_run "rmt-cli products enable $pro_ls", 600;
@@ -341,6 +350,7 @@ sub rmt_enable_pro {
 Function to mirror the enabled repository
 
 =cut
+
 sub rmt_mirror_repo {
     assert_script_run 'rmt-cli mirror', 1800;
 }
@@ -352,6 +362,7 @@ sub rmt_mirror_repo {
 Function to list products
 
 =cut
+
 sub rmt_list_pro {
     assert_script_run 'rmt-cli product list', 600;
 }
@@ -365,6 +376,7 @@ available repositories and the mirrored packages
 C<$datafile> is repository source.
 
 =cut
+
 sub rmt_import_data {
     my ($datapath) = @_;
     # Check import data resource exsited
@@ -382,6 +394,7 @@ sub rmt_import_data {
 RMT server export data about available repositories and the mirrored packages
 
 =cut
+
 sub rmt_export_data {
     my $datapath = "/rmtdata/";
     assert_script_run("mkdir -p $datapath");
@@ -400,6 +413,7 @@ sub rmt_export_data {
 Prepare SLES or OSS souce repositories
 
 =cut
+
 sub prepare_source_repo {
     my $cmd;
     if (is_sle) {
@@ -453,6 +467,7 @@ sub prepare_source_repo {
 Disable source repositories
 
 =cut
+
 sub disable_source_repo {
     if (is_sle && get_var('FLAVOR') =~ /-Updates$|-Incidents$/) {
         zypper_call(q{mr -d $(zypper -n lr | awk '/-Source/ {print $1}')});
@@ -470,6 +485,7 @@ sub disable_source_repo {
 Generate SLE or openSUSE versions. C<$separator> is separator used for version number, it will be default to _ if omitted. Example: SLES-12-4, openSUSE_Leap
 
 =cut
+
 sub generate_version {
     my ($separator) = @_;
     my $dist = get_required_var('DISTRI');
@@ -505,6 +521,7 @@ C<$args> should have following keys defined:
 - C<URI>: repository uri, used as a search criteria if no C<Filter> provided.
 
 =cut
+
 sub validate_repo_properties {
     my ($args) = @_;
     my $search_criteria = $args->{Filter} // $args->{URI};
@@ -551,6 +568,7 @@ Returns Hash reference with all the parsed properties and their values, for exam
 {Alias => 'repo-oss', Name => 'openSUSE-Tumbleweed-Oss', Enabled => 'Yes', ...}
 
 =cut
+
 sub parse_repo_data {
     my ($repo_identifier) = @_;
     my @lines = split(/\n/, script_output("zypper lr $repo_identifier"));

--- a/lib/rescuecdstep.pm
+++ b/lib/rescuecdstep.pm
@@ -16,6 +16,7 @@ use warnings;
 Return test flag fatal => 1
 
 =cut
+
 sub test_flags {
     return {fatal => 1};
 }

--- a/lib/s390base.pm
+++ b/lib/s390base.pm
@@ -25,6 +25,7 @@ use warnings;
 Execute C<$script> with arguments C<$scriptargs> and upload STDERR and STDOUT as script logs.
 The maximum execution time of the script is defined by C<$timeout>.
 =cut
+
 sub execute_script {
     my ($self, $script, $scriptargs, $timeout) = @_;
     assert_script_run("./$script $scriptargs 2>&1 | tee --append logs/$script.log", timeout => $timeout);
@@ -38,6 +39,7 @@ sub execute_script {
 Collect and upload logs for investigation. cleanup test suite files.
 
 =cut
+
 sub upload_logs_and_cleanup {
     my ($self) = @_;
     $self->export_logs();
@@ -53,6 +55,7 @@ sub upload_logs_and_cleanup {
 Executed when a module fails.
 
 =cut
+
 sub post_fail_hook {
     my ($self) = @_;
     $self->upload_logs_and_cleanup();
@@ -65,6 +68,7 @@ sub post_fail_hook {
 Executed when a module finishes.
 
 =cut
+
 sub post_run_hook {
     my ($self) = @_;
     $self->upload_logs_and_cleanup();
@@ -78,6 +82,7 @@ Executed before method run.
 Fetch the testcase and common libraries from openQA server.
 
 =cut
+
 sub pre_run_hook {
     my ($self) = @_;
     my $path = data_url("s390x");

--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -101,6 +101,7 @@ sub logs_from_salt {
 Method executed when run() finishes.
 
 =cut
+
 sub post_run_hook {
     my ($self) = @_;
 
@@ -122,6 +123,7 @@ sub post_run_hook {
 Method executed when run() finishes and the module has result => 'fail'
 
 =cut
+
 sub post_fail_hook {
     my ($self) = shift;
     select_console('log-console');

--- a/lib/selenium.pm
+++ b/lib/selenium.pm
@@ -58,6 +58,7 @@ Usage:
   my $driver = selenium_driver;
   ...
 =cut
+
 sub add_chromium_repos {
     my $ret = zypper_call("se chromedriver", exitcode => [0, 104]);
     if ($ret == 104) {

--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -43,6 +43,7 @@ our $serial_term_prompt;
 Adds $console to /etc/securetty (unless already in file), enables systemd
 service and start it. It requires selecting root console before.
 =cut
+
 sub add_serial_console {
     my ($console) = @_;
     my $service = 'serial-getty@' . $console;
@@ -80,6 +81,7 @@ Suitable for testing whether boot has been finished:
 
 wait_serial(get_login_message(), 300);
 =cut
+
 sub get_login_message {
     my $arch = get_required_var("ARCH");
     return is_sle() ? qr/Welcome to SUSE Linux Enterprise .*\($arch\)/
@@ -95,6 +97,7 @@ sub get_login_message {
 Set serial terminal prompt to given string.
 
 =cut
+
 sub set_serial_prompt {
     $serial_term_prompt = shift // '';
 
@@ -112,6 +115,7 @@ Enters root's name and password to login. Also sets the prompt to something stat
 escape sequences (i.e. a single #) and changes the terminal width.
 
 =cut
+
 sub login {
     die 'Login expects two arguments' unless @_ == 2;
     my $user = shift;
@@ -168,6 +172,7 @@ times, before giving up.
 To overwrite destination use C<force>.
 This function die on any failure.
 =cut
+
 sub download_file {
     my ($src, $dst, %opts) = @_;
     $opts{chunk_size} //= 1024 * 2;
@@ -221,6 +226,7 @@ The file is placed in the C<ulogs/> directory of the worker.
 
 This function die on any failure.
 =cut
+
 sub upload_file {
     my ($src, $dst, %opts) = @_;
     my $chunk_size = $opts{chunk_size} //= 1024 * 2;

--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -256,6 +256,7 @@ registered_addons, susefirewall, ntp, chrony, postfix, apache, dhcpd, bind, snmp
 Check service before migration, zypper install service package, enable, start and check service status
 
 =cut
+
 sub install_services {
     my ($service) = @_;
     opensusebasetest::select_serial_terminal() if (get_var('SEL_SERIAL_CONSOLE'));
@@ -327,6 +328,7 @@ sub install_services {
 check service status after migration
 
 =cut
+
 sub check_services {
     my ($service) = @_;
     foreach my $s (sort keys %$service) {

--- a/lib/suseconnect_register.pm
+++ b/lib/suseconnect_register.pm
@@ -32,6 +32,7 @@ our @EXPORT = qw(suseconnect_registration command_register is_module assert_modu
 Register base prodcut and extensions without reg code
 
 =cut
+
 sub suseconnect_registration {
     my $product_version = get_required_var('VERSION');
 
@@ -57,6 +58,7 @@ The variables used for registion are product version C<$version>, extension name
 Precompile regexes, handle zdup migration and resolve potential conflict by zypper for extension or just register a bare system
 
 =cut
+
 sub command_register {
     my ($version, $addon, $addon_regcode) = @_;
     my $arch = get_required_var("ARCH");

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -40,6 +40,7 @@ use testapi qw(send_key %cmd assert_screen check_screen check_var click_lastmatc
 
 Class constructor
 =cut
+
 sub new {
     my ($class) = @_;
     my $self = $class->SUPER::new(@_);
@@ -52,6 +53,7 @@ sub new {
 
 Types the password in a password prompt
 =cut
+
 sub handle_password_prompt {
     my ($console) = @_;
     $console //= '';
@@ -74,6 +76,7 @@ sub handle_password_prompt {
 
 TODO needs to be documented
 =cut
+
 sub init {
     my ($self) = @_;
 
@@ -86,6 +89,7 @@ sub init {
 
 TODO needs to be documented
 =cut
+
 sub init_cmd {
     my ($self) = @_;
 
@@ -181,6 +185,7 @@ sub init_cmd {
 
 Starts the desktop runner for C<x11_start_program>
 =cut
+
 sub init_desktop_runner {
     my ($program, $timeout) = @_;
     $timeout //= 30;
@@ -264,6 +269,7 @@ we keep the old check for the runner border.
 
 This method is overwriting the base method in os-autoinst.
 =cut
+
 sub x11_start_program {
     my ($self, $program, %args) = @_;
     my $timeout = $args{timeout};
@@ -315,6 +321,7 @@ sub _ensure_installed_zypper_fallback {
 
 Ensure that a package is installed
 =cut
+
 sub ensure_installed {
     my ($self, $pkgs, %args) = @_;
     my $pkglist = ref $pkgs eq 'ARRAY' ? join ' ', @$pkgs : $pkgs;
@@ -334,6 +341,7 @@ sub ensure_installed {
 
 Execute the given command as sudo
 =cut
+
 sub script_sudo {
     my ($self, $prog, $wait) = @_;
 
@@ -362,6 +370,7 @@ sub script_sudo {
 C<$user> and C<os_type> affect prompt sign. C<skip_set_standard_prompt> options
 skip the entire routine.
 =cut
+
 sub set_standard_prompt {
     my ($self, $user, %args) = @_;
     return if $args{skip_set_standard_prompt} || !get_var('SET_CUSTOM_PROMPT');
@@ -382,6 +391,7 @@ sub set_standard_prompt {
 
 Log in as root in the current console
 =cut
+
 sub become_root {
     my ($self) = @_;
 
@@ -399,6 +409,7 @@ sub become_root {
 
 Initialize the consoles needed during our tests
 =cut
+
 sub init_consoles {
     my ($self) = @_;
 
@@ -641,6 +652,7 @@ sub init_consoles {
 
 Make sure the right user is logged in, e.g. when using remote shells
 =cut
+
 sub ensure_user {
     my ($user) = @_;
     enter_cmd(sprintf('test "$(id -un)" == "%s" || su - "%s"', $user, $user)) if $user ne 'root';
@@ -661,6 +673,7 @@ test variable C<CONSOLE_JUST_ACTIVATED> works as a mutually exclusive lock.
 
 Requires C<console> name, an actual VT number C<nr> is optional.
 =cut
+
 sub hyperv_console_switch {
     my ($self, $console, $nr) = @_;
 
@@ -692,6 +705,7 @@ sub hyperv_console_switch {
 
 Return console VT number with regards to it's name.
 =cut
+
 sub console_nr {
     my ($console) = @_;
     $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell)/;
@@ -719,6 +733,7 @@ Option C<ensure_tty_selected> ensures TTY is selected.
 C<timeout> is set on the internal C<assert_screen> call and can be set to
 configure a timeout value different than default.
 =cut
+
 sub activate_console {
     my ($self, $console, %args) = @_;
 
@@ -882,6 +897,7 @@ known uncheckable consoles are already ignored.
 C<timeout> is set on the internal C<assert_screen> call and can be set to
 configure a timeout value different than default.
 =cut
+
 sub console_selected {
     my ($self, $console, %args) = @_;
     if ((exists $testapi::testapi_console_proxies{'root-ssh'}) && $console =~ m/^(root-console|install-shell|log-console)$/) {

--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -28,6 +28,7 @@ Create an email account in Thunderbird.
 C<$proto> can be C<pop> or C<imap>.
 C<$account> can be C<internal_account_A> or C<internal_account_B> or C<internal_account_C> or C<internal_account_D>.
 =cut
+
 sub tb_setup_account {
     my $hostname = get_var('HOSTNAME') // '';
     my ($self, $proto, $account) = @_;
@@ -189,6 +190,7 @@ C<$proto> can be C<pop> or C<imap>.
 C<$account> can be C<internal_account_A> or C<internal_account_B> or C<internal_account_C> or C<internal_account_D>.
 Returns email subject.
 =cut
+
 sub tb_send_message {
     my $hostname = get_var('HOSTNAME') // '';
     my ($self, $proto, $account) = @_;
@@ -235,6 +237,7 @@ sub tb_send_message {
 Check for new emails.
 C<$mail_search> may be an email subject to search for.
 =cut
+
 sub tb_check_email {
     my ($self, $mail_search) = @_;
 

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -75,6 +75,7 @@ Package with common methods and default or constant  values for Trento tests
 Return a string to be used as cloud resource group.
 It contains the JobId
 =cut
+
 sub get_resource_group {
     my $job_id = get_current_job_id();
     return TRENTO_AZ_PREFIX . "-rg-$job_id";
@@ -85,6 +86,7 @@ sub get_resource_group {
 Return a string to be used as cloud VM name.
 It contains the JobId
 =cut
+
 sub get_vm_name {
     my $job_id = get_current_job_id();
     return TRENTO_AZ_PREFIX . "-vm-$job_id";
@@ -95,6 +97,7 @@ sub get_vm_name {
 Return a string to be used as cloud ACR name.
 It contains the JobId
 =cut
+
 sub get_acr_name {
     return TRENTO_AZ_ACR_PREFIX . get_current_job_id();
 }
@@ -103,6 +106,7 @@ sub get_acr_name {
 
 Return the running VM public IP
 =cut
+
 sub az_get_vm_ip {
     my $az_cmd = 'az vm show -d ' .
       '-g ' . get_resource_group() . ' ' .
@@ -116,6 +120,7 @@ sub az_get_vm_ip {
 
 Delete the resource group associated to this JobID and all its content
 =cut
+
 sub az_delete_group {
     script_run('echo "Delete all resources"');
     my $az_cmd = 'az group delete ' .
@@ -139,6 +144,7 @@ take care that is a time consuming I<az> query.
 
 =back
 =cut
+
 sub az_vm_ssh_cmd {
     my ($self, $cmd_arg, $vm_ip_arg) = @_;
     record_info('REMOTE', "cmd:$cmd_arg");
@@ -164,6 +170,7 @@ Get all relevant info out from the cluster
 
 =back
 =cut
+
 sub k8s_logs {
     my $self = shift;
     my (@pods_list) = @_;
@@ -204,6 +211,7 @@ sub k8s_logs {
 Perform some generic checks related to the podman installation itself
 and the relevant parameters of the current machine environment.
 =cut
+
 sub podman_self_check {
     record_info('PODMAN', 'Check podman');
     assert_script_run('which podman');
@@ -224,6 +232,7 @@ Prepare whatever is needed to run cypress tests using container
 
 =back
 =cut
+
 sub cypress_install_container {
     my ($self, $cypress_ver) = @_;
     podman_self_check();
@@ -254,6 +263,7 @@ Upload to openQA the relevant logs
 
 =back
 =cut
+
 sub cypress_log_upload {
     my ($self, @log_filter) = @_;
     my $find_cmd = 'find ' . CYPRESS_LOG_DIR . ' -type f \( -iname \*' . join(' -o -iname \*', @log_filter) . ' \)';
@@ -282,6 +292,7 @@ return not 0 exit code. 1:all not 0 podman/cypress exit code are ignored. SoftFa
 
 =back
 =cut
+
 sub cypress_exec {
     my ($self, $cypress_test_dir, $cmd, $timeout, $log_prefix, $failok) = @_;
     my $ret = 0;
@@ -333,6 +344,7 @@ Also used as tag for each test result file
 
 =back
 =cut
+
 sub cypress_test_exec {
     my ($self, $cypress_test_dir, $test_tag, $timeout) = @_;
     my $ret = 0;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -128,6 +128,7 @@ partitions and rewriting the network definition of zKVM instances.
 
 Does B<not> work on B<Hyper-V>.
 =cut
+
 sub save_svirt_pty {
     return if check_var('VIRSH_VMM_FAMILY', 'hyperv');
     my $name = console('svirt')->name;
@@ -144,6 +145,7 @@ and expects C<$expect> to be returned on the terminal if C<$expect> is set.
 If the expected text is not found, it will fail with C<$fail_message>.
 
 =cut
+
 sub type_line_svirt {
     my ($string, %args) = @_;
     enter_cmd "echo $string > \$pty";
@@ -161,6 +163,7 @@ C<$console> should be set to C<console('x3270')>.
 C<$testapi::password> will be used as password.
 
 =cut
+
 sub unlock_zvm_disk {
     my ($console) = @_;
     eval { $console->expect_3270(output_delim => 'Please enter passphrase', timeout => 30) };
@@ -184,6 +187,7 @@ C<$console> should be set to C<console('x3270')>.
 TODO: Add support for GRUB_BOOT_NONDEFAULT, GRUB_SELECT_FIRST_MENU, GRUB_SELECT_SECOND_MENU,
 see boot_grub_item()
 =cut
+
 sub handle_grub_zvm {
     my ($console) = @_;
     eval { $console->expect_3270(output_delim => 'GNU GRUB', timeout => 60); };
@@ -204,6 +208,7 @@ Check if a previous needle match included the tag C<import-known-untrusted-gpg-k
 If yes, import the key, otherwise don't.
 
 =cut
+
 sub handle_untrusted_gpg_key {
     if (match_has_tag('import-known-untrusted-gpg-key')) {
         record_info('Import', 'Known untrusted gpg key is imported');
@@ -223,6 +228,7 @@ Check that guest IP address that host and guest see is the same.
 Die, if this is not the case.
 
 =cut
+
 sub integration_services_check_ip {
     # Host-side of Integration Services
     my $vmname = console('svirt')->name;
@@ -255,6 +261,7 @@ Make sure integration services (e.g. kernel modules, utilities, services)
 are present and in working condition.
 
 =cut
+
 sub integration_services_check {
     integration_services_check_ip();
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
@@ -291,6 +298,7 @@ Check whether the system under test has an encrypted partition and attempts to u
 C<$check_typed_password> will default to C<0>.
 
 =cut
+
 sub unlock_if_encrypted {
     my (%args) = @_;
     $args{check_typed_password} //= 0;
@@ -344,6 +352,7 @@ If this happens to fast, the screen would not be cleared.
 So this function will simply type C<clear\n>.
 
 =cut
+
 sub clear_console {
     enter_cmd "clear";
 }
@@ -373,6 +382,7 @@ Optional parameters are:
      running. This can be used if the application shall be tested further.
 
 =cut
+
 sub assert_gui_app {
     my ($application, %args) = @_;
     ensure_installed($application) if $args{install};
@@ -392,6 +402,7 @@ console font, we need to call systemd-vconsole-setup to workaround
 that.
 
 =cut
+
 sub check_console_font {
     # Does not make sense on ssh-based consoles
     return if get_var('BACKEND', '') =~ /ipmi|spvm|pvm_hmc/;
@@ -418,6 +429,7 @@ sub check_console_font {
 Enable additional arguments for nested calls of C<wait_still_screen>.
 
 =cut
+
 sub type_string_slow_extended {
     my ($string) = @_;
     type_string($string, max_interval => SLOW_TYPING_SPEED, wait_still_screen => 0.05, timeout => 5, similarity_level => 38);
@@ -430,6 +442,7 @@ sub type_string_slow_extended {
 Typing a string with C<SLOW_TYPING_SPEED> to avoid losing keys.
 
 =cut
+
 sub type_string_slow {
     my ($string) = @_;
 
@@ -454,6 +467,7 @@ C<wait_still_screen> to timeout, especially because C<wait_still_screen> is
 also scaled by C<TIMEOUT_SCALE> which we do not need here.
 
 =cut
+
 sub type_string_very_slow {
     my ($string) = @_;
 
@@ -474,6 +488,7 @@ sub type_string_very_slow {
 Enter a command with C<SLOW_TYPING_SPEED> to avoid losing keys.
 
 =cut
+
 sub enter_cmd_slow {
     my ($cmd) = @_;
 
@@ -488,6 +503,7 @@ Enter a command even slower with C<VERY_SLOW_TYPING_SPEED>. Compare to
 C<type_string_very_slow>.
 
 =cut
+
 sub enter_cmd_very_slow {
     my ($cmd) = @_;
 
@@ -503,6 +519,7 @@ sub enter_cmd_very_slow {
 Return the mirror URL eg from the C<MIRROR_HTTP> var if C<INSTALL_SOURCE> is set to C<http>.
 
 =cut
+
 sub get_netboot_mirror {
     my $m_protocol = get_var('INSTALL_SOURCE', 'http');
     return get_var('MIRROR_' . uc($m_protocol));
@@ -526,6 +543,7 @@ for example:
 
 C<dumb_term> will default to C<is_serial_terminal()>.
 =cut
+
 sub zypper_call {
     my $command = shift;
     my %args = @_;
@@ -604,6 +622,7 @@ sub zypper_call {
 Enables the install DVDs if they were used during the installation.
 
 =cut
+
 sub zypper_enable_install_dvd {
     # If DVD Packages is used we need to (re-)enable the local repos
     # see FATE#325541
@@ -637,6 +656,7 @@ Examples:
  zypper_ar('https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Tumbleweed/devel:kubic.repo', no_gpg_check => 1, priority => 90);
 
 =cut
+
 sub zypper_ar {
     my ($url, %args) = @_;
     my $name = $args{name} // '';
@@ -674,6 +694,7 @@ Run C<zypper patch> twice. The first run will update the package manager,
 the second run will update the system.
 
 =cut
+
 sub fully_patch_system {
     # special handle for 11-SP4 s390 install
     if (is_sle('=11-SP4') && is_s390x && is_backend_s390x) {
@@ -710,6 +731,7 @@ running C<zypper patch> twice. The first run will update the package manager,
 the second run will update the system.
 
 =cut
+
 sub ssh_fully_patch_system {
     my $remote = shift;
 
@@ -732,6 +754,7 @@ sub ssh_fully_patch_system {
 
 zypper doesn't offer --updatestack-only option before 12-SP1, use patch for sp0 to update packager
 =cut
+
 sub minimal_patch_system {
     my (%args) = @_;
     $args{version_variable} //= 'VERSION';
@@ -785,6 +808,7 @@ the system lock. If this function is called without arguments, it'll set
 timeout to 300 seconds.
 
 =cut
+
 sub set_zypper_lock_timeout {
     my $timeout = shift // 300;
 
@@ -804,6 +828,7 @@ already doing the same by default also in the case of pre-storage-ng but not
 anymore for storage-ng.
 
 =cut
+
 sub workaround_type_encrypted_passphrase {
     # nothing to do if the boot partition is not encrypted in FULL_LVM_ENCRYPT
     return unless is_boot_encrypted();
@@ -822,6 +847,7 @@ This will return C<1> if the env variables suggest
 that the boot partition is encrypted.
 
 =cut
+
 sub is_boot_encrypted {
     return 0 if get_var('UNENCRYPTED_BOOT');
     return 0 if !get_var('ENCRYPT') && !get_var('FULL_LVM_ENCRYPT');
@@ -848,6 +874,7 @@ sub is_boot_encrypted {
 returns C<BRIDGED_NETWORKING>.
 
 =cut
+
 sub is_bridged_networking {
     return get_var('BRIDGED_NETWORKING');
 }
@@ -859,6 +886,7 @@ sub is_bridged_networking {
 Sets C<BRIDGED_NETWORKING> to C<1> if applicable.
 
 =cut
+
 sub set_bridged_networking {
     my $ret = 0;
     if (is_svirt and !is_s390x) {
@@ -885,6 +913,7 @@ C<NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh>
 if hostname is changed via C<yast2 lan>.
 
 =cut
+
 sub set_hostname {
     my ($hostname) = @_;
     assert_script_run "hostnamectl set-hostname $hostname";
@@ -908,6 +937,7 @@ You can check if the screen changed by using an explicit repeat and comparing it
 to the returned number of attempts. If the value equals repeat the screen didn't change.
 
 =cut
+
 sub assert_and_click_until_screen_change {
     my ($mustmatch, $wait_change, $repeat) = @_;
     $wait_change //= 2;
@@ -932,6 +962,7 @@ Handle a potential failure on a live CD related to boo#993885 that the reboot
 action from a desktop session does not work and we are stuck on the desktop.
 
 =cut
+
 sub handle_livecd_reboot_failure {
     mouse_hide;
     wait_still_screen;
@@ -963,6 +994,7 @@ Example:
  assert_screen_with_soft_timeout('registration-found', timeout => 300, soft_timeout => 60, bugref => 'bsc#123456');
 
 =cut
+
 sub assert_screen_with_soft_timeout {
     my ($mustmatch, %args) = @_;
     # as in assert_screen
@@ -988,6 +1020,7 @@ Stop and mask packagekit service and wait until it is really dead.
 This is needed to prevent access conflicts to the RPM database.
 
 =cut
+
 sub quit_packagekit {
     script_run("systemctl mask packagekit; systemctl stop packagekit; while pgrep packagekitd; do sleep 1; done");
 }
@@ -1000,6 +1033,7 @@ Wait until purge-kernels is done
 Prevent RPM lock e.g. SUSEConnect fail
 
 =cut
+
 sub wait_for_purge_kernels {
     script_run('while pgrep purge-kernels; do sleep 1; done');
 }
@@ -1010,6 +1044,7 @@ sub wait_for_purge_kernels {
 
 TODO someone should document this
 =cut
+
 sub addon_decline_license {
     if (get_var("HASLICENSE")) {
         if (check_screen 'next-button-is-active', 5) {
@@ -1032,6 +1067,7 @@ sub addon_decline_license {
 
 TODO someone should document this
 =cut
+
 sub addon_license {
     my ($addon) = @_;
     my $uc_addon = uc $addon;    # variable name is upper case
@@ -1068,6 +1104,7 @@ sub addon_license {
 Return C<1> if C<ADDONURL> is set and C<LIVECD> is unset.
 
 =cut
+
 sub addon_products_is_applicable {
     return !get_var('LIVECD') && get_var('ADDONURL');
 }
@@ -1079,6 +1116,7 @@ sub addon_products_is_applicable {
 Return C<1> if neither C<UPGRADE> nor C<LIVE_UPGRADE> is set.
 
 =cut
+
 sub noupdatestep_is_applicable {
     return !get_var("UPGRADE") && !get_var("LIVE_UPGRADE");
 }
@@ -1091,6 +1129,7 @@ Return C<1> if installation should be done with addon repos
 based on ENV variables.
 
 =cut
+
 sub installwithaddonrepos_is_applicable {
     return get_var("HAVE_ADDON_REPOS") && !get_var("UPGRADE") && !get_var("NET");
 }
@@ -1103,6 +1142,7 @@ Returns a random string with length C<$length> (default: 4)
 containing alphanumerical characters.
 
 =cut
+
 sub random_string {
     my ($self, $length) = @_;
     $length //= 4;
@@ -1118,6 +1158,7 @@ Handle emergency shell or (systemd) emergency mode and dump
 some basic logging information to the serial output.
 
 =cut
+
 sub handle_emergency {
     if (match_has_tag('emergency-shell')) {
         # get emergency shell logs for bug, scp doesn't work
@@ -1148,6 +1189,7 @@ Example:
  service_action('dbus', {type => ['socket', 'service'], action => ['unmask', 'start']});
 
 =cut
+
 sub service_action {
     my ($name, $args) = @_;
 
@@ -1171,6 +1213,7 @@ Since SLE 15 gdm is running on tty2, so we change behaviour for it and
 openSUSE distris, except for Xen PV (bsc#1086243).
 
 =cut
+
 sub get_root_console_tty {
     return (!is_sle('<15') && !is_microos && !check_var('VIRSH_VMM_TYPE', 'linux')) ? 6 : 2;
 }
@@ -1185,6 +1228,7 @@ is running on tty2 by default, except for Xen PV and Hyper-V (bsc#1086243).
 See also: bsc#1054782
 
 =cut
+
 sub get_x11_console_tty {
     my $new_gdm
       = !is_sle('<15')
@@ -1209,6 +1253,7 @@ sub get_x11_console_tty {
 Comparing two arrays passed by reference. Return 1 if arrays has symmetric difference
 and 0 otherwise.
 =cut
+
 sub arrays_differ {
     my ($array1_ref, $array2_ref) = @_;
     my @array1 = @{$array1_ref};
@@ -1232,6 +1277,7 @@ If all the items of array1 exist in array2, returns an empty array (which means
 array1 is a subset of array2).
 
 =cut
+
 sub arrays_subset {
     my ($array1_ref, $array2_ref) = @_;
     my @result;
@@ -1250,6 +1296,7 @@ over reboots. Used to ensure that testapi calls like script_run work for the
 test user as well as root.
 
 =cut
+
 sub ensure_serialdev_permissions {
     my ($self) = @_;
     return if get_var('ROOTONLY');
@@ -1278,6 +1325,7 @@ identify that system has been booted, so do not mask on non-qemu backends.
 This is only necessary for Linux < 4.20.4 so skipped on more recent versions.
 
 =cut
+
 sub disable_serial_getty {
     my ($self) = @_;
     my $service_name = "serial-getty\@$testapi::serialdev";
@@ -1305,6 +1353,7 @@ sub disable_serial_getty {
 3. Insert password and hits enter
 
 =cut
+
 sub exec_and_insert_password {
     my ($cmd) = @_;
     my $hashed_cmd = hashed_string("SR$cmd");
@@ -1346,6 +1395,7 @@ This is mainly used for autoyast url shorten to avoid limit of x3270 xedit.
 C<$url> is the url to short. C<$wishid> is the prefered short url id.
 
 =cut
+
 sub shorten_url {
     my ($url, %args) = @_;
     $args{wishid} //= '';
@@ -1365,6 +1415,7 @@ sub shorten_url {
 Internal helper function used by C<reconnect_mgmt_console>.
 
 =cut
+
 sub _handle_login_not_found {
     my ($str) = @_;
     record_info 'Investigation', 'Expected welcome message not found, investigating bootup log content: ' . $str;
@@ -1400,6 +1451,7 @@ sub _handle_login_not_found {
 Internal helper function used by C<reconnect_mgmt_console>.
 
 =cut
+
 sub _handle_firewall {
     select_console 'root-console';
     return if script_run("iptables -S | grep 'A input_ext.*tcp.*dport 59.*-j ACCEPT'", 30) == 0;
@@ -1429,6 +1481,7 @@ C<$timeout> can be set to some specific time and if during reboot GRUB is shown 
 can be set to 1.
 
 =cut
+
 sub reconnect_mgmt_console {
     my (%args) = @_;
     $args{timeout} //= 300;
@@ -1523,6 +1576,7 @@ of dump.
 See L<https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/sysrq.rst>.
 
 =cut
+
 sub show_tasks_in_blocked_state {
     # sending sysrqs doesn't work for svirt
     if (has_ttys) {
@@ -1545,6 +1599,7 @@ sub show_tasks_in_blocked_state {
 Show logs about an out of memory process kill.
 
 =cut
+
 sub show_oom_info {
     if (script_run('dmesg | grep "Out of memory"') == 0) {
         my $oom = script_output('dmesg | grep "Out of memory"', proceed_on_failure => 1);
@@ -1564,6 +1619,7 @@ sub show_oom_info {
 Return C<VIRSH_OPENQA_BASEDIR> or fall back to C</var/lib>.
 
 =cut
+
 sub svirt_host_basedir {
     return get_var('VIRSH_OPENQA_BASEDIR', '/var/lib');
 }
@@ -1590,6 +1646,7 @@ Example:
  script_retry('ping -c1 -W1 machine', retry => 5);
 
 =cut
+
 sub script_retry {
     my ($cmd, %args) = @_;
     my $ecode = $args{expect} // 0;
@@ -1641,6 +1698,7 @@ Example:
  script_output_retry('ping -c1 -W1 machine', retry => 5);
 
 =cut
+
 sub script_output_retry {
     my ($cmd, %args) = @_;
     my $retry = $args{retry} // 10;
@@ -1677,6 +1735,7 @@ Example:
  validate_script_output_retry('ping -c1 -W1 machine', m/1 packets transmitted/, retry => 5, delay => 60);
 
 =cut
+
 sub validate_script_output_retry {
     my ($cmd, $check, %args) = @_;
     $args{retry} //= 10;
@@ -1733,6 +1792,7 @@ be processed - to run the command without interaction with terminal output.
 This is useful for some situation when you want to do more between inputing
 command and the following interaction, eg. switch TTYs or detach the screen.
 =cut
+
 sub script_run_interactive {
     my ($cmd, $scan, $timeout) = @_;
     my $output;
@@ -1791,6 +1851,7 @@ Create btrfs subvolume for C</boot/grub2/arm64-efi> before migration.
 ref:bsc#1122591
 
 =cut
+
 sub create_btrfs_subvolume {
     my $fstype;
     $fstype = script_output("df -PT /boot/grub2/arm64-efi/ | grep -v \"Filesystem\" | awk '{print \$2}'", 120);
@@ -1820,6 +1881,7 @@ Example to create a RAID C<5> array over C<3> loop devices, C<200> Mb each:
     create_raid_loop_device(raid_type => 5, device_num => 3, file_size => 200)
 
 =cut
+
 sub create_raid_loop_device {
     my %args = @_;
     my $raid_type = $args{raid_type} // 1;
@@ -1857,6 +1919,7 @@ Special key C<--debug> allow to output full file content into serial.
 Disabled by default.
 
 =cut
+
 sub file_content_replace {
     my ($filename, %to_replace) = @_;
     $to_replace{'--sed-modifier'} //= '';

--- a/lib/validate_encrypt_utils.pm
+++ b/lib/validate_encrypt_utils.pm
@@ -35,6 +35,7 @@ our @EXPORT = qw(
 This sub reads the output of F</etc/crypttab> and returns C<%crypttab> reference with its data.
 Check https://www.freedesktop.org/software/systemd/man/crypttab.html for more info about parsing 
 =cut
+
 sub parse_devices_in_crypttab {
     my @lines = split(/\n/, script_output("cat /etc/crypttab"));
     my $crypttab = {};
@@ -63,6 +64,7 @@ sub parse_devices_in_crypttab {
 
 returns the C<$status> of the encrypted device. If no encrypted device found it returns a reference to an empty anonymous hash.
 =cut
+
 sub parse_cryptsetup_status {
     my ($dev) = @_;
     my @lines = split(/\n/, script_output("cryptsetup status $dev", proceed_on_failure => 1));
@@ -86,6 +88,7 @@ sub parse_cryptsetup_status {
 
 Verify the existence of F</etc/crypttab> file.
 =cut
+
 sub verify_crypttab_file_existence {
     record_info("crypttab file", "Verify the existence of /etc/crypttab file");
     assert_script_run("test -f /etc/crypttab", fail_message => "No /etc/crypttab found");
@@ -106,6 +109,7 @@ sub verify_crypttab_file_existence {
 =back
 
 =cut
+
 sub verify_number_of_encrypted_devices {
     my ($expected_number, $actual_number) = @_;
     record_info("devices number", "Verify number of encrypted devices");
@@ -129,6 +133,7 @@ sub verify_number_of_encrypted_devices {
 =back
 
 =cut
+
 sub verify_cryptsetup_message {
     my ($expected_message, $actual_message) = @_;
     record_info("Assert volumes status", "Verify crypted volume status based on test_data expectations");
@@ -150,6 +155,7 @@ sub verify_cryptsetup_message {
 
 =back
 =cut
+
 sub verify_cryptsetup_properties {
     my ($expected_properties, $actual_properties) = @_;
     record_info("params", "Verify parameters, that are set for crypted volumes");
@@ -181,6 +187,7 @@ Where C<%args> expects the following parameters:
 
 Validates that the device is an encrypted one and tests the backup of the keyslot info.
 =cut
+
 sub verify_restoring_luks_backups {
     my (%args) = @_;
     my $mapped_dev_path = $args{encrypted_device_path};
@@ -210,6 +217,7 @@ sub verify_restoring_luks_backups {
 =back
 
 =cut
+
 sub verify_locked_encrypted_partition {
     my $enc_disk_part = shift;
     my @lines = split(/\n/, script_output("lsblk -l -n /dev/$enc_disk_part"));

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -99,6 +99,7 @@ our %EXPORT_TAGS = (
 
 Returns true if called on jeos
 =cut
+
 sub is_jeos {
     return get_var('FLAVOR', '') =~ /^JeOS/;
 }
@@ -107,6 +108,7 @@ sub is_jeos {
 
 Returns true if called on vmware
 =cut
+
 sub is_vmware {
     return check_var('VIRSH_VMM_FAMILY', 'vmware');
 }
@@ -115,6 +117,7 @@ sub is_vmware {
 
 Returns true if called on krypton or argon
 =cut
+
 sub is_krypton_argon {
     return get_var('FLAVOR', '') =~ /(Krypton|Argon)/;
 }
@@ -123,6 +126,7 @@ sub is_krypton_argon {
 
 Returns true if called on Gnome-Live
 =cut
+
 sub is_gnome_next {
     return get_var('FLAVOR', '') =~ /Gnome-Live/;
 }
@@ -131,6 +135,7 @@ sub is_gnome_next {
 
 Returns true if 'INSTALLCHECK' is set
 =cut
+
 sub is_installcheck {
     return get_var('INSTALLCHECK');
 }
@@ -139,6 +144,7 @@ sub is_installcheck {
 
 Returns true if called on a rescue system
 =cut
+
 sub is_rescuesystem {
     return get_var('RESCUESYSTEM');
 }
@@ -147,6 +153,7 @@ sub is_rescuesystem {
 
 Returns true if called on a virutalization server
 =cut
+
 sub is_virtualization_server {
     return get_var('SYSTEM_ROLE', '') =~ /(kvm|xen)/;
 }
@@ -155,6 +162,7 @@ sub is_virtualization_server {
 
 Returns true if executed on a live cd
 =cut
+
 sub is_livecd {
     return get_var("LIVECD");
 }
@@ -166,6 +174,7 @@ Query format: [= > < >= <=] version [+] (Example: <=12-sp3 =12-sp1 <4.0 >=15 3.0
 Check agains: product version to check against - probably get_var('VERSION')
 Regex format: checks query version format (Example: /\d{2}\.\d/)#
 =cut
+
 sub check_version {
     my $query = lc shift;
     my $pv = lc shift;
@@ -197,6 +206,7 @@ Media type: DVD (iso) or VMX (all disk images)
 Version: Tumbleweed | 15.2 (Leap)
 Flavor: DVD | MS-HyperV | XEN | KVM-and-Xen | ..
 =cut
+
 sub is_microos {
     my $filter = shift;
     my $distri = get_var('DISTRI');
@@ -230,6 +240,7 @@ sub is_microos {
 
 Check if distribution is openSUSE Leap Micro
 =cut
+
 sub is_leap_micro {
     my $query = shift;
     my $version = shift // get_var('VERSION');
@@ -245,6 +256,7 @@ sub is_leap_micro {
 
 Check if distribution is SUSE Linux Enterprise Micro
 =cut
+
 sub is_sle_micro {
     my $query = shift;
     my $version = shift // get_var('VERSION');
@@ -260,6 +272,7 @@ sub is_sle_micro {
 
 Check if distribution is ALP
 =cut
+
 sub is_alp {
     my $query = shift;
     my $version = shift // get_var('VERSION');
@@ -275,6 +288,7 @@ sub is_alp {
 
 Check if SLEM is in flavor of self installable iso
 =cut
+
 sub is_selfinstall {
     return get_var('FLAVOR') =~ /selfinstall/i;
 }
@@ -283,6 +297,7 @@ sub is_selfinstall {
 
 Returns true if called on tumbleweed
 =cut
+
 sub is_tumbleweed {
     # Tumbleweed and its stagings
     return 0 unless check_var('DISTRI', 'opensuse');
@@ -296,6 +311,7 @@ sub is_tumbleweed {
 Check if distribution is Leap with optional filter for:
 Version: <=42.2 =15.0 >15.0 >=42.3 15.0+
 =cut
+
 sub is_leap {
     my $query = shift;
     my $version = get_var('VERSION', '');
@@ -321,6 +337,7 @@ sub is_leap {
 
 Returns true if called on opensuse
 =cut
+
 sub is_opensuse {
     return 1 if check_var('DISTRI', 'opensuse');
     return 1 if check_var('DISTRI', 'microos');
@@ -334,6 +351,7 @@ sub is_opensuse {
 Check if distribution is SLE with optional filter for:
 Version: <=12-sp3 =12-sp1 >11-sp1 >=15 15+ (>=15 and 15+ are equivalent)
 =cut
+
 sub is_sle {
     my $query = shift;
     my $version = shift // get_var('VERSION');
@@ -349,6 +367,7 @@ sub is_sle {
 
 Returns true if called on a transactional server
 =cut
+
 sub is_transactional {
     return 1 if (is_microos || is_sle_micro || is_leap_micro);
     return 1 if (is_alp && get_var('FLAVOR') !~ /NonTransactional/);
@@ -359,6 +378,7 @@ sub is_transactional {
 
 Returns true if called in a migration scenario
 =cut
+
 sub is_sles4migration {
     return get_var('FLAVOR', '') =~ /Migration|migrated/ && check_var('SLE_PRODUCT', 'sles');
 }
@@ -367,6 +387,7 @@ sub is_sles4migration {
 
 Returns true if called in a SAP test
 =cut
+
 sub is_sles4sap {
     return get_var('FLAVOR', '') =~ /SAP/ || check_var('SLE_PRODUCT', 'sles4sap');
 }
@@ -375,6 +396,7 @@ sub is_sles4sap {
 
 Returns true if called in an SAP standard test
 =cut
+
 sub is_sles4sap_standard {
     return is_sles4sap && check_var('SLES4SAP_MODE', 'sles');
 }
@@ -383,6 +405,7 @@ sub is_sles4sap_standard {
 
 Returns true if called on a real time system
 =cut
+
 sub is_rt {
     return (check_var('SLE_PRODUCT', 'rt') || get_var('FLAVOR') =~ /rt/i);
 }
@@ -391,6 +414,7 @@ sub is_rt {
 
 Returns true if called in an HPC test
 =cut
+
 sub is_hpc {
     return check_var('SLE_PRODUCT', 'hpc');
 }
@@ -399,6 +423,7 @@ sub is_hpc {
 
 Returns true if called on a released build
 =cut
+
 sub is_released {
     return get_var('FLAVOR') =~ /Incidents|Updates|QR/;
 }
@@ -408,6 +433,7 @@ sub is_released {
 
 Returns true if called in staging
 =cut
+
 sub is_staging {
     return get_var('STAGING');
 }
@@ -416,6 +442,7 @@ sub is_staging {
 
 Returns true if storage_ng is used
 =cut
+
 sub is_storage_ng {
     return get_var('STORAGE_NG') || is_sle('15+');
 }
@@ -424,6 +451,7 @@ sub is_storage_ng {
 
 Returns true in upgrade scenarios
 =cut
+
 sub is_upgrade {
     return get_var('UPGRADE') || get_var('ONLINE_MIGRATION') || get_var('ZDUP') || get_var('AUTOUPGRADE') || get_var('LIVE_UPGRADE');
 }
@@ -432,6 +460,7 @@ sub is_upgrade {
 
 Returns true if called in SLES12 upgrade scenario
 =cut
+
 sub is_sle12_hdd_in_upgrade {
     return is_upgrade && is_sle('<15', get_var('HDDVERSION'));
 }
@@ -440,6 +469,7 @@ sub is_sle12_hdd_in_upgrade {
 
 Returns true if a desktop is installed
 =cut
+
 sub is_desktop_installed {
     return get_var("DESKTOP") !~ /textmode|minimalx/;
 }
@@ -448,6 +478,7 @@ sub is_desktop_installed {
 
 #TODO this should be documented
 =cut
+
 sub is_system_upgrading {
     # If PATCH=1, make sure patch action is finished
     return is_upgrade && (!get_var('PATCH') || (get_var('PATCH') && get_var('SYSTEM_PATCHED')));
@@ -457,6 +488,7 @@ sub is_system_upgrading {
 
 Returns if system is older than SLE or Leap 15
 =cut
+
 sub is_pre_15 {
     return (is_sle('<15') || is_leap('<15.0')) && !is_tumbleweed;
 }
@@ -465,6 +497,7 @@ sub is_pre_15 {
 
 Returns true if system is aarch64 with uefi and shall boot an hdd image
 =cut
+
 sub is_aarch64_uefi_boot_hdd {
     return get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE');
 }
@@ -473,6 +506,7 @@ sub is_aarch64_uefi_boot_hdd {
 
 Returns true if executed on a server pattern, SLES4SAP or SLES4MIGRATION
 =cut
+
 sub is_server {
     return 1 if is_sles4sap();
     return 1 if is_sles4migration();
@@ -487,6 +521,7 @@ sub is_server {
 
 Returns true if INSTALL_TO_OTHERS is not set
 =cut
+
 sub install_this_version {
     return !check_var('INSTALL_TO_OTHERS', 1);
 }
@@ -496,6 +531,7 @@ sub install_this_version {
 Check the real version of the test machine is at least some value, rather than the VERSION variable
 It is for version checking for tests with variable "INSTALL_TO_OTHERS".
 =cut
+
 sub install_to_other_at_least {
     my $version = shift;
 
@@ -524,6 +560,7 @@ SLE 15 SP1:
     * RT Product has only one (minimal) role.
 On microos, leap 15.1+, TW we have it instead of desktop selection screen
 =cut
+
 sub is_using_system_role {
     return is_sle('>=12-SP2') && is_sle('<15')
       && is_x86_64
@@ -541,6 +578,7 @@ sub is_using_system_role {
 
 On leap 15.0 we have desktop selection first, and everywhere, where we have system roles
 =cut
+
 sub is_using_system_role_first_flow {
     return is_leap('=15.0') || is_using_system_role;
 }
@@ -549,15 +587,82 @@ sub is_using_system_role_first_flow {
 
 If there is only one role, there is no selection offered
 =cut
+
 sub requires_role_selection {
     # Applies to Krypton and Argon based on Leap 15.1+
     return !is_krypton_argon;
+}
+
+=head2 has_product_selection
+
+    has_product_selection;
+
+Identify cases when Installer has to show Product Selection screen.
+
+Starting with SLE 15, all products are distributed using one medium, and Product
+to install has to be chosen explicitly.
+
+Though, there are some exceptions (like s390x on Sle15 SP0) when there is only
+one Product, so that License agreement is shown directly, skipping the Product
+selection step. Also, Product Selection screen is not shown during upgrade.
+on SLE 15+, zVM preparation test shouldn't show Product Selection screen.
+
+Returns true (1) if Product Selection step has to be shown for the certain
+configuration, otherwise returns false (0).
+=cut
+
+sub has_product_selection {
+    # Product selection behavior changed for s390 on 15-SP4, so now there's only a single product
+    # and there's no need for the installer to request anything, however for QU this might change
+    # following PR should be used as a reference for when product selection changes again in the
+    # future
+    # https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13880
+    my $does_not_have = is_sle('>=15-SP4') && check_var('FLAVOR', 'Full') && is_s390x();
+    if (is_sle('15+') && !get_var('UPGRADE')) {
+        return 0 if $does_not_have;
+        return (is_sle('>=15-SP1') || !is_s390x()) && !get_var('BASE_VERSION');
+    }
+}
+
+=head2 has_license_on_welcome_screen
+
+    has_license_on_welcome_screen;
+
+Identify cases when License Agreement has to be shown on Welcome screen and should be accepted there.
+
+Returns true (1) if License Agreement has to be shown on Welcome screen for the certain
+configuration, otherwise returns false (0).
+
+=cut
+
+sub has_license_on_welcome_screen {
+    return 1 if is_sle_micro;
+    if (get_var('HASLICENSE')) {
+        return 1 if (
+            ((is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x())
+            || is_sle('<15')
+            || (is_sle('=15') && is_s390x())
+            || (is_sle('>=15-SP4') && check_var('FLAVOR', 'Full') && is_s390x() && !get_var('UPGRADE'))
+        );
+    }
+
+    return 0;
+}
+
+=head2 has_license_to_accept
+
+Returns true if the system has a license that needs to be accepted
+=cut
+
+sub has_license_to_accept {
+    return has_license_on_welcome_screen || has_product_selection;
 }
 
 =head2 uses_qa_net_hardware
 
 Returns true if the SUT uses qa net hardware
 =cut
+
 sub uses_qa_net_hardware {
     return !check_var("IPXE", "1") && is_ipmi || check_var("BACKEND", "generalhw");
 }
@@ -572,6 +677,7 @@ At the same time, connection method to the entity in which the file reside shoul
 firt argument go_to_target, for example, "ssh root at name or ip address" or "way to download the file"
 For use only on locahost, no argument needs to be specified
 =cut
+
 sub get_os_release {
     my ($go_to_target, $os_release_file) = @_;
     $go_to_target //= '';
@@ -608,6 +714,7 @@ Default to I</etc/os-release>.
 Returns 1 (true) if the ID_LIKE variable contains C<distri_name>.
 
 =cut
+
 sub check_os_release {
     my ($distri_name, $line, $go_to_target, $os_release_file) = @_;
     die '$distri_name is not given' unless $distri_name;
@@ -641,6 +748,7 @@ sub is_openstack {
 
 Returns true if called in a leap to sle migration scenario
 =cut
+
 sub is_leap_migration {
     return is_upgrade && get_var('ORIGIN_SYSTEM_VERSION') =~ /leap/;
 }
@@ -712,6 +820,7 @@ sub package_version_cmp {
 
 Returns true if called in quaterly iso testing
 =cut
+
 sub is_quarterly_iso {
     return 1 if get_var('FLAVOR', '') =~ /QR/;
 }
@@ -726,6 +835,7 @@ fqdn text of the remote machine. The default location that contains VERSION_ID i
 file /etc/os-release if nothing else is passed in to argument verid_file.
 
 =cut
+
 sub get_version_id {
     my (%args) = @_;
     $args{dst_machine} //= 'localhost';

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -583,6 +583,7 @@ without being passed value to dst_machine or dst_port.The subroutine will return
 return 0.
 
 =cut
+
 sub check_port_state {
     my ($dst_machine, $dst_port, $retries, $delay) = @_;
     $dst_machine //= "";
@@ -621,6 +622,7 @@ to a remote machine. Deactivation is also supported if argument activate is give
 separated by space to argument reg_exts to be subscribed one by one.
 
 =cut
+
 sub subscribe_extensions_and_modules {
     my (%args) = @_;
     $args{dst_machine} //= 'localhost';

--- a/lib/vt_perf_libs.pm
+++ b/lib/vt_perf_libs.pm
@@ -24,6 +24,7 @@ Downlaod git repo.
 C<$git_branch_name> Branch name in string.
 C<$git_repo_url> URL in string.
 =cut
+
 sub prepare_git_repo {
     my ($git_branch_name, $git_repo_url) = @_;
     #Prepare mitigations-testsuite.git
@@ -45,6 +46,7 @@ It would be used in Dom0, kvm hypervisor, baremetal.
 C<$git_branch_name> Branch name in string.
 C<$git_repo_url> URL in string.
 =cut
+
 sub switch_to_linux_default_enable {
     my $self = shift;
     my $ret = script_run("grep \"mitigations=off\" /proc/cmdline");
@@ -77,6 +79,7 @@ It would be used in Dom0, kvm hypervisor, baremetal.
 C<$git_branch_name> Branch name in string.
 C<$git_repo_url> URL in string.
 =cut
+
 sub switch_to_xen_default_enable {
     my $self = shift;
     my $reboot = 0;

--- a/lib/web_browser.pm
+++ b/lib/web_browser.pm
@@ -35,6 +35,7 @@ our @EXPORT = qw(
 Setup test envs: register PackageHub and check FIPS pattern installed
 
 =cut
+
 sub setup_web_browser_env {
     my $ret = 0;
 
@@ -64,6 +65,7 @@ $browser: The name of text based web browser: w3m/links/lynx
 $options: command line options
 
 =cut
+
 sub run_web_browser_text_based {
     my ($browser, $options) = @_;
 

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -40,6 +40,7 @@ The mandatory parameter C<iface> specifies the interface which action will be ex
 This function saves the command and the stdout and stderr to a file to be uploaded later.
 
 =cut
+
 sub wicked_command {
     my ($self, $action, $iface) = @_;
     my $serial_log = '/tmp/wicked_serial.log';
@@ -59,6 +60,7 @@ sub wicked_command {
 
 Return the current installed wicked version
 =cut
+
 sub get_wicked_version {
     my $v = script_output(q(rpm -qa 'wicked' --qf '%{VERSION}\n'));
     die("Unable to get wicked version '$v'") unless $v =~ /^\d+\.\d+\.\d+$/;
@@ -70,6 +72,7 @@ sub get_wicked_version {
     check_wicked_version('>=0.6.66')
 
 =cut
+
 sub check_wicked_version {
     my ($self, $query) = @_;
     return 1 if get_var('WICKED_SKIP_VERSION_CHECK', 0);
@@ -104,6 +107,7 @@ The optinal argument C<iface> allows to print the output of the command 'ip addr
 With no arguments, it will check that wicked.service and wickedd.service are up.
 
 =cut
+
 sub assert_wicked_state {
     my ($self, %args) = @_;
     systemctl('is-active wicked.service', expect_false => $args{wicked_client_down});
@@ -216,6 +220,7 @@ Gets the IP of a given interface by C<ifc>.
 The parameter C<ip_version> chould be one of the values 'v4' or 'v6'.
 
 =cut
+
 sub get_current_ip {
     my ($self, $ifc, %args) = @_;
     $args{ip_version} //= 'v4';
@@ -233,6 +238,7 @@ sub get_current_ip {
 Download all files from data/wicked into WICKED_DATA_DIR.
 This method is used by before_test.pm.
 =cut
+
 sub download_data_dir {
     assert_script_run("mkdir -p '" . WICKED_DATA_DIR . "'");
     assert_script_run("(cd '" . WICKED_DATA_DIR . "'; curl -L -v " . autoinst_url . "/data/wicked > wicked.data && cpio -id < wicked.data && mv data wicked && rm wicked.data)");
@@ -248,6 +254,7 @@ If the parameter C<add_suffix> is set to 1, it will append 'ref' or 'sut' at the
 If the parameter C<executable> is set to 1, it will grant execution permissions to the file.
 
 =cut
+
 sub get_from_data {
     my ($self, $source, $target, %args) = @_;
 
@@ -267,6 +274,7 @@ IP could be specified directly via C<ip> or using C<type> variable. In case of C
 it will be bypassed to C<get_remote_ip> function to get IP by label.
 If ping fails, command die unless you specify C<proceed_on_failure>.
 =cut
+
 sub ping_with_timeout {
     my ($self, %args) = @_;
     $args{ip_version} //= 'v4';
@@ -316,6 +324,7 @@ The mandatory parameter C<type> determines if it will configure a TUN device or 
 The interface will be brought up using a wicked command.
 
 =cut
+
 sub setup_tuntap {
     my ($self, $config, $type, $iface) = @_;
     my $local_ip = $self->get_ip(type => $type);
@@ -334,6 +343,7 @@ will be replaced with the corresponding IPs. The mandatory parameter C<type> sho
 The interface will be brought up using a wicked command.
 
 =cut
+
 sub setup_tunnel {
     my ($self, $config, $type, $iface) = @_;
     my $local_ip = $self->get_ip(type => 'host');
@@ -352,6 +362,7 @@ The parameter C<type> determines the interface to be configured and C<mode> the 
 Supported tunnels in this function are GRE, SIT, IPIP, TUN.
 
 =cut
+
 sub create_tunnel_with_commands {
     my ($self, $type, $mode, $sub_mask) = @_;
     my $local_ip = $self->get_ip(type => 'host');
@@ -393,6 +404,7 @@ dummy interface using the config file given by this parameter.
 C<command> determines the wicked command to bring up/down the interface
 
 =cut
+
 sub setup_bridge {
     my ($self, $config, $dummy, $command) = @_;
     my $local_ip = $self->get_ip(type => 'host');
@@ -414,6 +426,7 @@ sub setup_bridge {
 Setups the openvpn client using the interface given by C<device>
 
 =cut
+
 sub setup_openvpn_client {
     my ($self, $device) = @_;
     my $openvpn_client = '/etc/openvpn/client.conf';
@@ -430,6 +443,7 @@ It returns FAILED or PASSED if the ping to the remote IP of a certain interface 
 The parameter C<ip_version> chould be one of the values 'v4' or 'v6'.
 
 =cut
+
 sub get_test_result {
     my ($self, $type, $ip_version) = @_;
     my $timeout = "60";
@@ -451,6 +465,7 @@ not throw and error. On failing we only put a C<<record_info(result => fail)>>
 
     $self->upload_log_file($src [, $dst]);
 =cut
+
 sub upload_log_file {
     my ($self, $src, $dst) = @_;
     $dst //= basename($src);
@@ -481,6 +496,7 @@ This function is normally called before and after a test is executed, the parame
 to the file name to be uploaded. Normally 'pre' or 'post', but could be any string.
 
 =cut
+
 sub upload_wicked_logs {
     my ($self, $prefix) = @_;
     my $dir_name = $self->{name} . '_' . $prefix;
@@ -514,6 +530,7 @@ sub upload_wicked_logs {
 Used to syncronize the wicked tests for SUT and REF creating the corresponding mutex locks.
 
 =cut
+
 sub do_barrier {
     my ($self, $type) = @_;
     my $barrier_name = 'test_' . $self->{name} . '_' . $type;
@@ -528,6 +545,7 @@ Creating VLAN using only ip commands. Getting ip alias name for wickedbase::get_
 function
 
 =cut
+
 sub setup_vlan {
     my ($self, $ip_type) = @_;
     my $iface = iface();
@@ -653,6 +671,7 @@ After succesfully service start will create mutex with C<$mutex>
 which can be used by parallel test to catch this event
 
 =cut
+
 sub sync_start_of {
     my ($self, $service, $mutex, $tries) = @_;
     $tries //= 12;
@@ -776,6 +795,7 @@ it try to lookup a member function with the given c<name> and replace the string
 with return value
 
 =cut
+
 sub write_cfg {
     my ($self, $filename, $content, %args) = @_;
     my ($filename_orig, $content_orig);

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -54,6 +54,7 @@ Returns the hotkey for the desktop runner according to the used
 desktop
 
 =cut
+
 sub desktop_runner_hotkey { check_var('DESKTOP', 'minimalx') ? 'super-spc' : 'alt-f2' }
 
 
@@ -66,6 +67,7 @@ screen lock is necessary when switch back to x11
 all possible options should be handled within loop to get unlocked desktop
 
 =cut
+
 sub ensure_unlocked_desktop {
     my $counter = 10;
 
@@ -191,6 +193,7 @@ sub ensure_unlocked_desktop {
 C<tag> can contain a needle name and is optional, it defaults to yast2-windowborder
 
 =cut
+
 sub ensure_fullscreen {
     my (%args) = @_;
     $args{tag} //= 'yast2-windowborder';
@@ -249,6 +252,7 @@ Example:
   handle_login('user1', 1);
 
 =cut
+
 sub handle_login {
     my ($myuser, $user_selected, $mypwd) = @_;
     $myuser //= $username;
@@ -304,6 +308,7 @@ sub handle_login {
 Handles the logout from the desktop
 
 =cut
+
 sub handle_logout {
     # hide mouse for clean logout needles
     mouse_hide();
@@ -327,6 +332,7 @@ sub handle_logout {
 First logs out and the log in via C<handle_logout()> and C<handle_login()>
 
 =cut
+
 sub handle_relogin {
     handle_logout;
     handle_login;
@@ -341,6 +347,7 @@ C<$myuser> specifies the username to switch to.
 If not set, it will default to C<$username>.
 
 =cut
+
 sub select_user_gnome {
     my ($myuser) = @_;
     $myuser //= $username;
@@ -371,6 +378,7 @@ sub select_user_gnome {
 Turns off the Plasma desktop screen energy saving.
 
 =cut
+
 sub turn_off_plasma_screen_energysaver {
     x11_start_program('kcmshell5 powerdevilprofilesconfig', target_match => [qw(kde-energysaver-enabled energysaver-disabled)]);
     assert_and_click 'kde-disable-energysaver' if match_has_tag('kde-energysaver-enabled');
@@ -387,6 +395,7 @@ sub turn_off_plasma_screen_energysaver {
 Turns off the Plasma desktop screenlocker.
 
 =cut
+
 sub turn_off_plasma_screenlocker {
     x11_start_program('kcmshell5 screenlocker', target_match => [qw(kde-screenlock-enabled screenlock-disabled)]);
     assert_and_click 'kde-disable-screenlock' if match_has_tag('kde-screenlock-enabled');
@@ -405,6 +414,7 @@ desktop. Call before tests that are not providing input for a long time, to
 prevent needles from failing.
 
 =cut
+
 sub turn_off_kde_screensaver {
     turn_off_plasma_screenlocker;
     turn_off_plasma_screen_energysaver;
@@ -417,6 +427,7 @@ sub turn_off_kde_screensaver {
 Disable screensaver in gnome. To be called from a command prompt, for example an xterm window.
 
 =cut
+
 sub turn_off_gnome_screensaver {
     script_run 'gsettings set org.gnome.desktop.session idle-delay 0', die_on_timeout => 0, timeout => 90;
 }
@@ -429,6 +440,7 @@ Disable screensaver in gnome for gdm. The function should be run under root. To 
 a command prompt, for example an xterm window.
 
 =cut
+
 sub turn_off_gnome_screensaver_for_gdm {
     script_run 'sudo -u gdm dbus-launch gsettings set org.gnome.desktop.session idle-delay 0';
 }
@@ -441,6 +453,7 @@ Disable screensaver in gnome for running gdm. The function should be run under r
 from a command prompt, for example an xterm window.
 
 =cut
+
 sub turn_off_gnome_screensaver_for_running_gdm {
     script_run 'su gdm -s /bin/bash -c "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u gdm)/bus gsettings set org.gnome.desktop.session idle-delay 0"';
 }
@@ -452,6 +465,7 @@ sub turn_off_gnome_screensaver_for_running_gdm {
 Disable suspend in gnome. To be called from a command prompt, for example an xterm window.
 
 =cut
+
 sub turn_off_gnome_suspend {
     script_run 'gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type \'nothing\'';
 }
@@ -463,6 +477,7 @@ sub turn_off_gnome_suspend {
 Turns off the screensaver depending on desktop environment
 
 =cut
+
 sub turn_off_screensaver {
     return turn_off_kde_screensaver if check_var('DESKTOP', 'kde');
     die "Unsupported desktop '" . get_var('DESKTOP', '') . "'" unless check_var('DESKTOP', 'gnome');
@@ -483,6 +498,7 @@ sub turn_off_gnome_show_banner {
 untick welcome page on next startup.
 
 =cut
+
 sub untick_welcome_on_next_startup {
     # Untick box - (Retries may be needed: poo#56024)
     for my $retry (1 .. 5) {
@@ -508,6 +524,7 @@ Disable auto-launch on next boot and close application.
 Also handle workarounds when needed.
 
 =cut
+
 sub handle_welcome_screen {
     my (%args) = @_;
     assert_screen([qw(opensuse-welcome opensuse-welcome-gnome40-activities)], $args{timeout});
@@ -522,6 +539,7 @@ sub handle_welcome_screen {
 Start a root shell in xterm.
 
 =cut
+
 sub start_root_shell_in_xterm {
     select_console 'x11';
     x11_start_program("xterm -geometry 155x50+5+5", target_match => 'xterm');
@@ -538,6 +556,7 @@ sub start_root_shell_in_xterm {
 
 handle_gnome_activities
 =cut
+
 sub handle_gnome_activities {
     my @tags = 'generic-desktop';
     my $timeout = 600;

--- a/lib/xml_utils.pm
+++ b/lib/xml_utils.pm
@@ -79,6 +79,7 @@ C<xpc> - XPathContext object for the parsed xml,
 C<xpath> - XPath to the target node
 
 =cut
+
 sub find_nodes {
     my (%args) = @_;
     my $nodeset = $args{xpc}->findnodes($args{xpath});

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -32,6 +32,7 @@ C<y2_installbase> - Base class for Yast installer related functionality
 After making changes in the "software selection" screen, accepts any 3rd party
 license.
 =cut
+
 sub accept3rdparty {
     my ($self) = @_;
     #Third party licenses sometimes appear
@@ -52,6 +53,7 @@ sub accept3rdparty {
 
 After making changes in the "pattern selection" screen, accepts changes.
 =cut
+
 sub accept_changes {
     my ($self) = @_;
     if (check_var('VIDEOMODE', 'text')) {
@@ -72,6 +74,7 @@ The function compares the actual systemd target with the expected one
 
 C<$expected_target> - systemd target that is expected and need to be validated.
 =cut
+
 sub validate_default_target {
     my ($self, $expected_target) = @_;
     select_console 'install-shell';
@@ -94,6 +97,7 @@ sub validate_default_target {
 Being in the "search packages" screen, performs steps needed to go back to
 overview page accepting automatic changes changes and 3rd party licenses.
 =cut
+
 sub back_to_overview_from_packages {
     my ($self) = @_;
     wait_screen_change { send_key 'alt-a' };    # accept
@@ -109,6 +113,7 @@ sub back_to_overview_from_packages {
 
 Being in the "select pattern" screen, workaround a known bug of Yast using QT.
 =cut
+
 sub check12qtbug {
     if (check_screen('pattern-too-low', 5)) {
         assert_and_click('pattern-too-low', timeout => 1);
@@ -122,6 +127,7 @@ sub check12qtbug {
 Performs steps needed to go from the "installation overview" screen to the
 "pattern selection" screen.
 =cut
+
 sub go_to_patterns {
     my ($self) = @_;
     $self->deal_with_dependency_issues();
@@ -159,6 +165,7 @@ sub go_to_patterns {
 Performs steps needed to go from the "pattern selection" screen to
 "search packages" screen.
 =cut
+
 sub go_to_search_packages {
     my ($self) = @_;
     send_key 'alt-d';    # details button
@@ -174,6 +181,7 @@ sub go_to_search_packages {
 Being in the "select pattern" screen, performs steps needed to move the
 highlight cursor one item down.
 =cut
+
 sub move_down {
     my $ret = wait_screen_change { send_key 'down' };
     workaround_bsc1189550() if (!$workaround_bsc1189550_done && is_sle('>=15-sp3'));
@@ -191,6 +199,7 @@ Possible values for PATTERNS
   PATTERNS=all (to select all of them)
   PATTERNS=default,web,-x11,-gnome (to keep the default but add web and remove x11 and gnome)
 =cut
+
 sub process_patterns {
     my ($self) = @_;
     if (get_required_var('PATTERNS')) {
@@ -211,6 +220,7 @@ sub process_patterns {
 Being in the "search package" screen, performs steps needed to search for
 C<$package_name>
 =cut
+
 sub search_package {
     my ($self, $package_name) = @_;
     assert_and_click 'packages-search-field-selected';
@@ -227,6 +237,7 @@ sub search_package {
 Being in the "select pattern" screen, performs steps needed to select all
 available patterns.
 =cut
+
 sub select_all_patterns_by_menu {
     my ($self) = @_;
     # Ensure mouse on certain pattern then right click
@@ -250,6 +261,7 @@ sub select_all_patterns_by_menu {
 
 Deselect patterns from already selected ones.
 =cut
+
 sub deselect_pattern {
     my ($self) = @_;
     my %patterns;    # set of patterns to be processed
@@ -275,6 +287,7 @@ You can pass
   PATTERNS=default,web,-x11,-gnome to keep the default but add web and remove
   x11 and gnome
 =cut
+
 sub select_specific_patterns_by_iteration {
     my %patterns;    # set of patterns to be processed
                      # fill with variable values
@@ -347,6 +360,7 @@ checkbox (C<$action>) of the pattern matching one of the given C<$needles>.
 Example
   switch_selection(action => 'select', needles => ['current-pattern-selected']);
 =cut
+
 sub switch_selection {
     my (%args) = @_;
     my $action = $args{action};
@@ -366,6 +380,7 @@ Being in the "search package" screen, and showing a list of found packages,
 performs steps needed to toogle the checkbox of C<$package_name>.
 The C<$operation> can be '+' or 'minus'.
 =cut
+
 sub toogle_package {
     my ($self, $package_name, $operation) = @_;
     send_key_until_needlematch "packages-$package_name-selected", 'down', 60;

--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -154,6 +154,7 @@ Uploads autoyast profile used for the installation, as well as modified profile,
 in case feature to modify the profile dynamically was used.
 Non existing files will be ignored.
 =cut
+
 sub upload_autoyast_profile {
     # Upload autoyast profile if file exists
     if (script_run('test -e /tmp/profile/autoinst.xml') == 0) {
@@ -177,6 +178,7 @@ sub upload_autoyast_profile {
 Uploads autoyast schema files shipped in the distribution as a tarball.
 If expected directory doesn't exist, no attempt to upload logs occurs.
 =cut
+
 sub upload_autoyast_schema {
     my ($self) = @_;
     my $xml_schema_path = "/usr/share/YaST2/schema/autoyast/rng";

--- a/lib/y2_mm_common.pm
+++ b/lib/y2_mm_common.pm
@@ -23,6 +23,7 @@ Then setup a static network by C<configure_static_network(%args{ip})>.
 C<%args> is a list with possible keys like {message} or {ip}.
 
 =cut
+
 sub prepare_xterm_and_setup_static_network {
     my %args = @_;
     die "Static network configuration failed, no IP specified!\n" unless defined($args{ip});

--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -38,6 +38,7 @@ C<extra_vars> extends the variables that can be used. C<extra_vars> expects a st
 ex: with_yast_env_variables("foo=bar");
 
 =cut
+
 sub with_yast_env_variables {
     my ($extra_vars) = shift // '';
     return "Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 Y2STRICTTEXTDOMAIN=1 $extra_vars";
@@ -50,6 +51,7 @@ sub with_yast_env_variables {
 openSUSE desktop roles have network manager as default except for older Leap versions.
 
 =cut
+
 sub is_network_manager_default {
     return 0 if !is_opensuse;
     return 0 if is_leap('<=15.0');
@@ -63,6 +65,7 @@ sub is_network_manager_default {
 Click on Continue when appears info indicating that network interfaces are controlled by Network Manager
 
 =cut
+
 sub continue_info_network_manager_default {
     if (is_network_manager_default) {
         assert_screen 'yast2-lan-warning-network-manager';
@@ -77,6 +80,7 @@ sub continue_info_network_manager_default {
 Click on OK when appears a warning indicating that network interfaces are controlled by Network Manager.
 
 =cut
+
 sub accept_warning_network_manager_default {
     assert_screen 'yast2-lan-warning-network-manager';
     send_key $cmd{ok};
@@ -96,6 +100,7 @@ C<module> module to wait for exit.
 C<timeout> timeout to wait on the serial.
 
 =cut
+
 sub wait_for_exit {
     my %args = @_;
     $args{timeout} //= 60;

--- a/lib/y2_module_guitest.pm
+++ b/lib/y2_module_guitest.pm
@@ -37,6 +37,7 @@ Optional C<$match_timeout> can be specified as a timeout on the C<assert_screen>
 C<$maximize_window> option allows to maximize application window using shortcut.
 
 =cut
+
 sub launch_yast2_module_x11 {
     my ($module, %args) = @_;
     $module //= '';

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -54,6 +54,7 @@ my $query_pattern_for_restart = "shutting down|ifdown all|Stopping wicked";
 Initialize yast2 lan. Stop firewalld. Ensure firewalld is stopped. Enable DEBUG. Clear journal.
 
 =cut
+
 sub initialize_y2lan
 {
     start_root_shell_in_xterm();
@@ -82,6 +83,7 @@ Open yast2 lan module, expecting Overview tab and select first device.
 Accept warning for Networkmanager controls network device.
 
 =cut
+
 sub open_network_settings {
     $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'lan', extra_vars => get_var('YUI_PARAMS'));
     # 'Global Options' tab is opened after accepting the warning on the systems
@@ -105,6 +107,7 @@ sub open_network_settings {
 Close network settings checking for return code 0 on serial line.
 
 =cut
+
 sub close_network_settings {
     wait_still_screen 1, 1;
     send_key 'alt-o';
@@ -134,6 +137,7 @@ sub close_network_settings {
 Check network status for device, test connection and DNS. Print journal.log on screen if C<$expected_status> is restart.
 
 =cut
+
 sub check_network_status {
     my ($expected_status, $device) = @_;
     $expected_status //= 'no_restart_or_reload';
@@ -173,6 +177,7 @@ Checks state of the device using ip command, receives keys C<device> which conta
 device name and C<state> which contains expected state of the device.
 
 =cut
+
 sub check_device_state {
     my ($args) = @_;
     assert_script_run "ip -s link show @{ [ $args->{device} ] } | grep -i 'state @{ [ $args->{state} ] }'";    # check if provided device is up and running
@@ -197,6 +202,7 @@ Verify network configurations for: device name, network status, workaround or no
 Check network status C<$expected_status>, C<$workaround> if C<$no_network_check> is defined
 
 =cut
+
 sub verify_network_configuration {
     my ($fn, $expected_status, $dev_name, $workaround, $no_network_check) = @_;
     open_network_settings;
@@ -217,6 +223,7 @@ Validate /etc/hosts entries for ip, fqdn, host.
 Run record_soft_failure for bsc#1115644 if C<$args> has not been found in /etc/hosts and print /etc/hosts.
 
 =cut
+
 sub validate_etc_hosts_entry {
     my (%args) = @_;
 
@@ -232,6 +239,7 @@ sub validate_etc_hosts_entry {
 Manually configure network settings or set it to DHCP. C<$args> can be static, ip, mask, fqdn
 
 =cut
+
 sub set_network {
     my (%args) = @_;
 
@@ -286,6 +294,7 @@ Check update of /etc/hosts. In order to target bugs bsc#1115644 and bsc#1052042,
 =back
 
 =cut
+
 sub check_etc_hosts_update {
 
     my $ip = '192.168.122.10';
@@ -325,6 +334,7 @@ Handle Networkmanager controls the network configurations.
 Confirm if a warning popup for Networkmanager controls networking.
 
 =cut
+
 sub handle_Networkmanager_controlled {
     assert_screen 'Networkmanager_controlled', 300;
     send_key "ret";    # confirm networkmanager popup
@@ -344,6 +354,7 @@ sub handle_Networkmanager_controlled {
 Handle DHCP popup, confirm for DHCP popup.
 
 =cut
+
 sub handle_dhcp_popup {
     if (match_has_tag('dhcp-popup')) {
         wait_screen_change { send_key 'alt-o' };
@@ -357,6 +368,7 @@ sub handle_dhcp_popup {
 Open yast2 routing
 
 =cut
+
 sub open_yast2_routing {
     $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'routing');
     assert_screen "yast2_routing", 120;
@@ -372,6 +384,7 @@ C<$should_conflict> 1 means conflict is expected or 0 otherwise
 Open routing module and enable or disable ip_forwarding
 
 =cut
+
 sub change_ipforward {
     my %options = @_;
     open_yast2_routing();
@@ -392,6 +405,7 @@ Open yast2 lan, run handle_dhcp_popup() and install and check firewalld
 If network is controlled by Networkmanager, don't change any network settings.
 
 =cut
+
 sub open_yast2_lan {
     my $is_nm = !script_run('systemctl is-active NetworkManager');    # Revert boolean because of bash vs perl's return code.
 
@@ -420,6 +434,7 @@ sub open_yast2_lan {
 Close yast2 lan configuration and check that it is closed successfully
 
 =cut
+
 sub close_yast2_lan {
     my ($tag) = @_;
     if ($tag eq '') {
@@ -438,6 +453,7 @@ Makes space for better readability of the console and clears journal.log,
 so that the existing logs will not interfere with the new ones.
 
 =cut
+
 sub clear_journal_log {
     enter_cmd "\n";
     assert_script_run '> journal.log';
@@ -455,6 +471,7 @@ It is used to be sure, that all the yast2 lan windows are closed, so that all
 further actions in xterm can be made.
 
 =cut
+
 sub wait_for_xterm_to_be_visible {
     assert_screen 'yast2_closed_xterm_visible', 120;
 }
@@ -467,6 +484,7 @@ The function kills all the instances of xterm terminal to clear desktop for
 further tests.
 
 =cut
+
 sub close_xterm {
     enter_cmd "killall xterm";
 }

--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -19,6 +19,7 @@ Select Current Configuration on Snapshots screen
 C<$ncurses> is used to check if it is ncurses.
 
 =cut
+
 sub y2snapper_select_current_conf {
     my ($self, $ncurses) = @_;
     $ncurses //= 0;
@@ -43,6 +44,7 @@ Close snapper module
 C<$ncurses> is used to check if it is ncurses.
 
 =cut
+
 sub y2snapper_close_snapper_module {
     my ($self, $ncurses) = @_;
     $ncurses //= 0;
@@ -64,6 +66,7 @@ Setup another snapper config for /test (creating previously a subvolume for it)
 It allows to have more control over diffs amongs snapshots.
 
 =cut
+
 sub y2snapper_adding_new_snapper_conf {
     assert_script_run("btrfs subvolume create /test");
     assert_script_run("snapper -c test create-config /test");
@@ -79,6 +82,7 @@ sub y2snapper_adding_new_snapper_conf {
 Helper to create a snapper snapshot. C<$name> is the name of snapshot.
 
 =cut
+
 sub y2snapper_create_snapshot {
     my $self = shift;
     my $name = shift || "Awesome Snapshot";
@@ -102,6 +106,7 @@ Create a new snapshot.
 C<$ncurses> is used to check if it is ncurses. In ncurses it needs to focus to snapshots list manually.
 
 =cut
+
 sub y2snapper_new_snapshot {
     my ($self, $ncurses) = @_;
     $ncurses //= 0;
@@ -134,6 +139,7 @@ Performs any modification in filesystem and at least include some change
 under /test, which is the subvolume for testing.
 
 =cut
+
 sub y2snapper_apply_filesystem_changes {
     assert_script_run('echo "hello world in snapper conf /root" > /hello_root.txt');
     assert_script_run('echo "hello world in snapper conf /test" > /test/hello_test.txt');
@@ -148,6 +154,7 @@ Show changes of snapshot and delete it.
 Use C<$ncurses> to check if it is ncurses. Select in ncurses the first subvolume (root) in the tree and expand it.
 
 =cut
+
 sub y2snapper_show_changes_and_delete {
     my ($self, $ncurses) = @_;
     $ncurses //= 0;
@@ -193,6 +200,7 @@ C<$module_name> is YaST2 module yast2-snapper.
 Quit yast2-snapper and clean up the test data.
 
 =cut
+
 sub y2snapper_clean_and_quit {
     my ($self, $module_name, $ncurses) = @_;
 
@@ -228,6 +236,7 @@ sub y2snapper_clean_and_quit {
 Analyse failure and upload logs.
 
 =cut
+
 sub y2snapper_failure_analysis {
     my ($self) = @_;
     # snapper actions can put the system under quite some load so we want to

--- a/lib/yast2_widget_utils.pm
+++ b/lib/yast2_widget_utils.pm
@@ -29,6 +29,7 @@ our @EXPORT = qw(change_service_configuration verify_service_configuration);
 Verify service configuration: status. This will just verify C<assert_screen> for C<yast2_ncurses_service_$status>.
 
 =cut
+
 sub verify_service_configuration {
     my (%args) = @_;
     my $status = $args{status};
@@ -42,6 +43,7 @@ sub verify_service_configuration {
 Modify service configuration: "after writing" and/or "after reboot" steps
 
 =cut
+
 sub change_service_configuration {
     my (%args) = @_;
     my $after_writing_ref = $args{after_writing};
@@ -63,6 +65,7 @@ C<$step_conf_ref> is used together with 'keys' as a reference for C<$action>. It
 C<$action> is a part of C<needle_selection> which is used for needle match.
 
 =cut
+
 sub change_service_configuration_step {
     my ($step_name, $step_conf_ref) = @_;
     my ($action) = keys %$step_conf_ref;

--- a/lib/zypper.pm
+++ b/lib/zypper.pm
@@ -28,6 +28,7 @@ so we need wait the zypper processes in background to finish and release the
 lock so that we can run a new zypper for our test.
 
 =cut
+
 sub wait_quit_zypper {
     # sometimes the zypper processes already in quit process but can't pgrep, we
     # need wait several seconds for them to finish deactivate.

--- a/tools/check_pod_whitespace_rule
+++ b/tools/check_pod_whitespace_rule
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+<< 'heredoc_pod_whitespace_rule'
+As a convention the POD and the code needs to have an empty line in between.
+The script checks all the files rather the commit files in the lib directory.
+heredoc_pod_whitespace_rule
+
+
+grep -Pzo "=cut\nsub" -rn lib || exit 0
+echo -e '\033[0;31mCheck for whitespace after end of POD failed.\nAdd a empty line between =cut and code.'
+exit 1


### PR DESCRIPTION
Following the recommendation all the perl POD documentation should have a
empty line before the beginning of the code as a good practice. In this PR all
the files which found under lib directory and its subdirectories are adding a
new line from all the cases which matched `=cut\nsub`

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/112544

