### PR TITLE
Integrate 'Accessible network interface' into openQA

### DIFF
--- a/schedule/security/atsec_tests.yaml
+++ b/schedule/security/atsec_tests.yaml
@@ -6,6 +6,7 @@ schedule:
     - boot/boot_to_desktop
     - security/atsec/setup_atsec_env
     - '{{disable_root_ssh}}'
+    - security/atsec/accessible_network_interface
     - security/atsec/kvm_check
     - security/atsec/drng_test_preparation
     - security/atsec/dbus_services_exposure

--- a/tests/security/atsec/accessible_network_interface.pm
+++ b/tests/security/atsec/accessible_network_interface.pm
@@ -1,0 +1,52 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run 'Accessible network interface' test case of ATSec test suite
+# Maintainer: xiaojing.liu <xiaojing.liu@suse.com>
+# Tags: poo#111899
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use atsec_test;
+use Data::Dumper;
+
+sub run {
+    my ($self) = shift;
+
+    select_console 'root-console';
+
+    # The result of 'lsof -i -P' likes:
+    #   COMMAND    PID     USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
+    #   wickedd-d  890     root    8u  IPv4  16913      0t0  UDP *:68
+    # So we put the expected listen ports to a array
+    my @expected_listen_ports = (
+        '(wickedd-d.*IPv4.*\*:68)',    # wickedddhcp4, the dhcp server.
+        '(wickedd-d.*IPv6.*:\d+)',    # wickedd-dhcp6
+        '(sshd.*:22 \(LISTEN\))',    # The ssh server
+        '(master.*localhost:25 \(LISTEN\))',    # /usr/lib/postfix/bin//master
+        '(sshd.*\(ESTABLISHED\))');    # ssh connection to test system
+
+    my $regex = join('|', @expected_listen_ports);
+    my $output = script_output('lsof -i -P');
+    my @lines = split(/\n/, $output);
+    foreach my $port (@lines) {
+        if ($port =~ /^COMMAND/) {
+            # Skip title
+            next;
+        }
+        elsif ($port =~ /$regex/) {
+            record_info($port, 'This is an expected listening port');
+        }
+        else {
+            record_info($port, 'This is not an expected listening port', result => 'fail');
+            $self->result('fail');
+        }
+    }
+}
+
+1;


### PR DESCRIPTION
Related: https://progress.opensuse.org/issues/111899

Verification run:
https://openqa.suse.de/tests/9009236#  (aarch64)
https://openqa.suse.de/tests/9009237#  (s390x)
https://openqa.suse.de/tests/9009238#  (x86_64)