### PR TITLE
Migrate first steps in qam-yast_self_update+15 to libyui REST

### DIFF
--- a/lib/Distribution/Sle/15_current.pm
+++ b/lib/Distribution/Sle/15_current.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2021 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: The class represents current (i.e. latest) Sle15 distribution and
@@ -26,6 +26,7 @@ use Installation::AddOnProduct::AddOnProductController;
 use Installation::RepositoryURL::RepositoryURLController;
 use Installation::AddOnProductInstallation::AddOnProductInstallationController;
 use Installation::SystemRole::Sle::SystemRoleController;
+use Installation::ModuleRegistration::ModuleRegCodeController;
 
 =head2 get_license_agreement
 
@@ -52,6 +53,10 @@ sub get_registration {
 
 sub get_module_registration {
     return Installation::ModuleRegistration::ModuleRegistrationController->new();
+}
+
+sub get_module_regcode {
+    return Installation::ModuleRegistration::ModuleRegCodeController->new();
 }
 
 sub get_module_selection {

--- a/lib/Installation/ModuleRegistration/ModuleRegCodeController.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegCodeController.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces business actions for Module Registration Code dialog.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::ModuleRegistration::ModuleRegCodeController;
+use strict;
+use warnings;
+use Installation::ModuleRegistration::ModuleRegCodePage;
+use Installation::Popups::ImportUntrustedGnuPGKey;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{ModuleRegCodePage} = Installation::ModuleRegistration::ModuleRegCodePage->new({app => YuiRestClient::get_app()});
+    $self->{ImportUntrustedGnuPGKey} = Installation::Popups::ImportUntrustedGnuPGKey->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_module_regcode_page {
+    my ($self) = @_;
+    die "Extension and Module Registration Codes page" unless $self->{ModuleRegCodePage}->is_shown();
+    return $self->{ModuleRegCodePage};
+}
+
+sub get_untrusted_GPG_popup {
+    my ($self) = @_;
+    die "Untrusted GPG key popup is not displayed" unless $self->{ImportUntrustedGnuPGKey}->is_shown();
+    return $self->{ImportUntrustedGnuPGKey};
+}
+
+sub wait_regcode_page {
+    my ($self, $args) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->{ModuleRegCodePage}->is_shown({timeout => 0});
+    }, %$args);
+}
+
+sub add_separate_registration_code {
+    my ($self, $regcode, $timeout) = @_;
+    $self->wait_regcode_page({timeout => $timeout, interval => 2,
+            message => 'Page to insert module registration code did not appear'});
+    $self->get_module_regcode_page()->set_regcode($regcode);
+    $self->get_module_regcode_page()->press_next();
+}
+
+sub trust_gnupg_key {
+    my ($self) = @_;
+    $self->get_untrusted_GPG_popup()->press_trust();
+}
+
+1;

--- a/lib/Installation/ModuleRegistration/ModuleRegCodePage.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegCodePage.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act with page that ask for module extra registration code
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::ModuleRegistration::ModuleRegCodePage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->{tb_we_code} = $self->{app}->textbox({id => '"sle-we"'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{tb_we_code}->exist();
+}
+
+sub set_regcode {
+    my ($self, $code) = @_;
+    $self->{tb_we_code}->set($code);
+}
+
+1;

--- a/lib/Installation/ModuleRegistration/ModuleRegistrationController.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegistrationController.pm
@@ -37,9 +37,9 @@ sub register_module {
     $self->get_module_registration_page()->press_next();
 }
 
-sub register_modules {
+sub register_extension_and_modules {
     my ($self, $modules) = @_;
-    $self->get_module_registration_page()->register_modules($modules);
+    $self->get_module_registration_page()->register_extension_and_modules($modules);
     $self->get_module_registration_page()->press_next();
 }
 

--- a/lib/Installation/ModuleRegistration/ModuleRegistrationPage.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegistrationPage.pm
@@ -25,12 +25,18 @@ sub init {
     $self->SUPER::init();
     $self->{chb_hide_dev_versions} = $self->{app}->checkbox({id => 'filter_devel'});
     $self->{rct_items} = $self->{app}->richtext({id => 'items'});
-    $self->{rct_item_containers} = 'sle-module-containers';
+    $self->{rct_item_we} = 'sle-we';
+    $self->{rct_item_base} = 'sle-module-basesystem';
+    $self->{rct_item_contm} = 'sle-module-containers';
     $self->{rct_item_desktop} = 'sle-module-desktop-applications';
-    $self->{rct_item_development} = 'sle-module-development-tools';
+    $self->{rct_item_sdk} = 'sle-module-development-tools';
     $self->{rct_item_legacy} = 'sle-module-legacy';
     $self->{rct_item_transactional} = 'sle-module-transactional-server';
-    $self->{rct_item_web} = 'sle-module-web-scripting';
+    $self->{rct_item_script} = 'sle-module-web-scripting';
+    $self->{rct_item_python2} = 'sle-module-python2';
+    $self->{rct_item_python3} = 'sle-module-python3';
+    $self->{rct_item_pcm} = 'sle-module-public-cloud';
+    $self->{rct_item_serverapp} = 'sle-module-server-applications';
     return $self;
 }
 
@@ -66,7 +72,7 @@ sub register_module {
     return $self->{rct_items}->activate_link($module_full_name);
 }
 
-sub register_modules {
+sub register_extension_and_modules {
     my ($self, $modules) = @_;
     $self->register_module($_) for ($modules->@*);
     return $self;

--- a/lib/Installation/Popups/ImportUntrustedGnuPGKey.pm
+++ b/lib/Installation/Popups/ImportUntrustedGnuPGKey.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces methods to handle
+# a Trust&Import popup.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::Popups::ImportUntrustedGnuPGKey;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_trust} = $self->{app}->button({id => 'trust'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    $self->{btn_trust}->exist();
+}
+
+sub press_trust {
+    my ($self) = @_;
+    $self->{btn_trust}->click();
+}
+
+1;

--- a/schedule/qam/common/qam-yast-self-update.yaml
+++ b/schedule/qam/common/qam-yast-self-update.yaml
@@ -30,4 +30,3 @@ conditional_schedule:
       uefi:
         - console/consoletest_setup
         - console/verify_efi_mok
-...

--- a/schedule/yast/qam-yast_self_update.yaml
+++ b/schedule/yast/qam-yast_self_update.yaml
@@ -1,0 +1,38 @@
+---
+name: qam-yast_self_update
+description: installation using self_update as boot parameter
+vars:
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/validate_self_update
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_extensions_and_modules
+  - installation/add_update_test_repo
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{efi}}'
+conditional_schedule:
+  efi:
+    MACHINE:
+      uefi:
+        - console/consoletest_setup
+        - console/verify_efi_mok

--- a/tests/installation/module_registration/register_extensions_and_modules.pm
+++ b/tests/installation/module_registration/register_extensions_and_modules.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Register Application module
+#          in "Extension and Module Selection" dialog
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi qw(save_screenshot get_var);
+
+sub run {
+    my @scc_addons = split ',', get_var('SCC_ADDONS');
+    $testapi::distri->get_module_registration()->register_extension_and_modules([@scc_addons]);
+    save_screenshot;
+
+    # when some module (e.g. workstation extension) requires registration, provide separate code
+    my $timeout = 60 * get_var('TIMEOUT_SCALE', 1);
+    my $regcode = get_var('SCC_REGCODE_WE');
+    $testapi::distri->get_module_regcode()->add_separate_registration_code($regcode, $timeout);
+    save_screenshot;
+
+    # confirm to trust the untrusted GPG key
+    $testapi::distri->get_module_regcode()->trust_gnupg_key();
+}
+
+1;

--- a/tests/installation/module_registration/register_nonconflicting_modules.pm
+++ b/tests/installation/module_registration/register_nonconflicting_modules.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Register non-conflicting modules along with preselected modules
@@ -22,8 +22,8 @@ use strict;
 use warnings;
 
 sub run {
-    $testapi::distri->get_module_registration()->register_modules(
-        [qw(containers desktop development legacy web)]);
+    $testapi::distri->get_module_registration()->register_extension_and_modules(
+        [qw(contm desktop sdk legacy script)]);
 }
 
 1;


### PR DESCRIPTION
Apply libyui-REST for yast qam self-update install tests. Intended to replace `qam-yast-self-update.yaml` only on >= 15SP3 

- Related ticket: https://progress.opensuse.org/issues/112574
- Verification runs: 
  - https://openqa.suse.de/tests/9359062 (15-SP3)
  - https://openqa.suse.de/tests/9359063 (15-SP3@uefi)
  - https://openqa.suse.de/tests/9359064 (15-SP4)
  - https://openqa.suse.de/tests/9359065 (15-SP4@uefi)
- merge request on gitlab: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/298