### PR TITLE
Add aarch64 support for swtpm test

### DIFF
--- a/data/swtpm/ssh_port_chk_script
+++ b/data/swtpm/ssh_port_chk_script
@@ -3,10 +3,11 @@ set -euo pipefail
 
 ip_addr=""
 for (( i = 0; i < 200; i++ )); do
-    ip_addr=`ip n | awk ' /192\\.168/ {print $1}'`
+    # The default network of libvirt is 192.168.122.*
+    ip_addr=`ip n | awk ' /192\\.168\\.122/ {print $1}'`
     if [[ -n "$ip_addr" ]] && nc -zvw2 $ip_addr 22 2>/dev/null; then
-         echo "the vm's ssh port is online"
-         exit 0
+        echo "the vm's ssh port is online"
+        exit 0
     else
         echo "the vm's ssh service is offline, loop to check"
         sleep 1

--- a/data/swtpm/swtpm_uefi_aarch64.xml
+++ b/data/swtpm/swtpm_uefi_aarch64.xml
@@ -1,0 +1,60 @@
+<domain type='kvm'>
+  <name>vm-swtpm-uefi</name>
+  <uuid>b5049116-80e1-4c6a-9a68-d48e6528c687</uuid>
+  <metadata>
+  </metadata>
+  <memory unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='aarch64' machine='virt-5.2'>hvm</type>
+    <loader readonly='yes' type='pflash'>/usr/share/qemu/aavmf-aarch64-code.bin</loader>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+  </features>
+  <cpu mode='host-passthrough' check='none'/>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-aarch64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/swtpm_uefi@64bit.qcow2'/>
+      <backingStore/>
+      <target dev='vda' bus='virtio'/>
+      <alias name='virtio-disk0'/>
+      <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
+    </disk>
+    <interface type='network'>
+      <mac address='52:54:00:95:27:54'/>
+      <source network='default'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <source path='/dev/pts/2'/>
+      <target type='system-serial' port='0'>
+        <model name='pl011'/>
+      </target>
+      <alias name='serial0'/>
+    </serial>
+    <console type='pty' tty='/dev/pts/2'>
+      <source path='/dev/pts/2'/>
+      <target type='serial' port='0'/>
+      <alias name='serial0'/>
+    </console>
+    <memballoon model='virtio'>
+      <alias name='balloon0'/>
+      <address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <alias name='rng0'/>
+      <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
+    </rng>
+  </devices>
+</domain>

--- a/lib/swtpmtest.pm
+++ b/lib/swtpmtest.pm
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Base module for swtpm test cases
-# Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81256, tc#1768671, poo#102849, poo#108386
+# Maintainer: rfan1 <richard.fan@suse.com> Starry Wang <starry.wang@suse.com>
+# Tags: poo#81256, tc#1768671, poo#102849, poo#108386, poo#100512
 
 package swtpmtest;
 
@@ -14,6 +14,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils 'is_sle';
+use Utils::Architectures;
 
 our @EXPORT = qw(
   start_swtpm_vm
@@ -36,11 +37,11 @@ my $guestvm_cfg = {
 };
 
 my $sample_cfg = {
-    uefi => {vm_name => 'vm-swtpm-uefi', sample_file => 'swtpm_uefi.xml'},
-    legacy => {vm_name => 'vm-swtpm-legacy', sample_file => 'swtpm_legacy.xml'},
+    uefi => {vm_name => 'vm-swtpm-uefi', sample_file => 'swtpm_uefi'},
+    legacy => {vm_name => 'vm-swtpm-legacy', sample_file => 'swtpm_legacy'},
 };
 
-# Function "start_swtpm_vm" starts a vm via libvirt "virsh" commands,
+# Function "start_swtpm_vm" starts a vm via libvirt "virsh" commands
 # sample xml file and vm image file are pre-configured
 sub start_swtpm_vm {
     my ($swtpm_ver, $swtpm_vm_type) = @_;
@@ -54,6 +55,7 @@ sub start_swtpm_vm {
     my $sample_xml = $guest_mode->{sample_file};
     my $guest_xml = $guest_swtpm_ver->{xml_file};
     my $swtpm_type = $guest_swtpm_ver->{version};
+    $sample_xml .= is_aarch64 ? '_aarch64.xml' : '.xml';
     assert_script_run("cd $image_path");
     assert_script_run("cp $sample_xml $guest_xml->{$swtpm_vm_type}");
     assert_script_run(
@@ -92,8 +94,8 @@ sub swtpm_verify {
 
     # Login to the vm and run the commands to check tpm device
     my $user = 'root';
-    my $passwd = $testapi::password;
-    my $ip_addr = script_output("ip n | awk '/192\\.168/ {print \$1}'");
+    my $passwd = 'nots3cr3t';
+    my $ip_addr = script_output("ip n | awk '/192\\.168\\.122/ {print \$1}'");
     my $guest_swtpm_ver = $guestvm_cfg->{$para};
     my $result_file = "/tmp/$para";
     my $ssh_script = "$image_path/ssh_script";

--- a/schedule/security/swtpm_jeos_rpi4.yaml
+++ b/schedule/security/swtpm_jeos_rpi4.yaml
@@ -1,0 +1,12 @@
+name: swtpm_jeos_rpi4
+description:    >
+    Test swtpm on RPi4 with JeOS
+schedule:
+    - jeos/prepare_firstboot
+    - jeos/firstrun
+    - console/consoletest_setup
+    - update/zypper_clear_repos
+    - console/zypper_ar
+    - console/zypper_ref
+    - security/swtpm/swtpm_env_setup
+    - security/swtpm/swtpm_verify

--- a/tests/security/swtpm/swtpm_env_setup.pm
+++ b/tests/security/swtpm/swtpm_env_setup.pm
@@ -5,18 +5,38 @@
 #          install required packages and download the pre-installed
 #          OS images for later tests, prepare a script for remote
 #          ssh login and execution
-# Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81256, tc#1768671
+# Maintainer: rfan1 <richard.fan@suse.com> Starry Wang <starry.wang@suse.com>
+# Tags: poo#81256, tc#1768671, poo#100512
 
 use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
+use Utils::Architectures;
+use power_action_utils qw(power_action);
 
 sub run {
     my $self = shift;
-    $self->select_serial_terminal;
+    $self->select_serial_terminal if !(get_var('MACHINE') =~ /RPi4/);
+
+    # Enable TPM on Raspberry Pi 4
+    # Refer: https://en.opensuse.org/HCL:Raspberry_Pi3_TPM
+    if (get_var('MACHINE') =~ /RPi4/) {
+        assert_script_run('echo -e "dtparam=spi=on\ndtoverlay=tpm-slb9670" >> /boot/efi/extraconfig.txt');
+        assert_script_run('cat /boot/efi/extraconfig.txt');
+        assert_script_run('echo "tpm_tis_spi" > /etc/modules-load.d/tpm.conf');
+        power_action('reboot', textmode => 1);
+
+        # Add some timeout to wait for reboot
+        sleep(60);
+        # Restore SSH connection
+        reset_consoles;
+        select_console('root-ssh');
+
+        assert_script_run('dmesg | grep tpm');
+        record_info('RPi4 TPM', 'Enabled TPM on Rasperry Pi 4');
+    }
 
     # Install the required packages for libvirt environment setup,
     # "expect" is used for later remote login test, so install here as well
@@ -28,21 +48,52 @@ sub run {
     assert_script_run("systemctl is-active libvirtd");
     assert_script_run("virsh net-list | grep default | grep active");
 
+    # Since machine:RPi4 and machine:aarch64 are using different flavors,
+    # and we can not add `START_AFTER_TEST` dependencies between jobs in
+    # different flavors, so we need to wait create_swtpm_hdd job finished
+    # here if this test is running on machine:RPi4
+    my $openqa_url = get_var('OPENQA_URL', autoinst_url);
+    if (get_var('MACHINE') =~ /RPi4/) {
+        if (!get_var('CREATE_SWTPM_HDD_TEST')) {
+            die 'CREATE_SWTPM_HDD_TEST settings are needed';
+        }
+        my $build = get_var('BUILD');
+        my $create_swtpm_test = get_var('CREATE_SWTPM_HDD_TEST');
+        my $counter = 100;
+        record_info('check status', "start checking job status of $create_swtpm_test");
+        while ($counter--) {
+            my $result = script_output(
+                "curl -s \"$openqa_url/api/v1/jobs?build=$build&machine=aarch64&flavor=DVD&latest=1&test=$create_swtpm_test&state=done&page=1&limit=3\""
+            );
+            if ($result =~ m/\"state\":\"done\"/) {
+                record_info('check status finished', "$create_swtpm_test job done");
+                last;
+            }
+            sleep(60);
+        }
+        if (!$counter) {
+            die "waiting for test $create_swtpm_test finished timeout";
+        }
+    }
+
     # Download the pre-installed guest images and sample xml files
     my $image_path = '/var/lib/libvirt/images';
     my $legacy_image = 'swtpm_legacy@64bit.qcow2';
     my $uefi_image = 'swtpm_uefi@64bit.qcow2';
     if (get_var('HDD_SWTPM_LEGACY')) {
         my $hdd_swtpm_legacy = get_required_var('HDD_SWTPM_LEGACY');
-        assert_script_run("wget -c -P $image_path " . autoinst_url("/assets/hdd/$hdd_swtpm_legacy"), 900);
+        my $sample_file = 'swtpm/swtpm_legacy.xml';
+        assert_script_run("wget -c -P $image_path $openqa_url/assets/hdd/$hdd_swtpm_legacy", 900);
         assert_script_run("mv $image_path/$hdd_swtpm_legacy $image_path/$legacy_image");
-        assert_script_run("wget --quiet " . data_url("swtpm/swtpm_legacy.xml") . " -P $image_path");
+        assert_script_run("wget --quiet " . data_url($sample_file) . " -P $image_path");
     }
     elsif (get_var('HDD_SWTPM_UEFI')) {
         my $hdd_swtpm_uefi = get_required_var('HDD_SWTPM_UEFI');
-        assert_script_run("wget -c -P $image_path " . autoinst_url("/assets/hdd/$hdd_swtpm_uefi"), 900);
+        my $sample_file = 'swtpm/swtpm_uefi';
+        $sample_file .= is_aarch64 ? '_aarch64.xml' : '.xml';
+        assert_script_run("wget -c -P $image_path $openqa_url/assets/hdd/$hdd_swtpm_uefi", 900);
         assert_script_run("mv $image_path/$hdd_swtpm_uefi $image_path/$uefi_image");
-        assert_script_run("wget --quiet " . data_url("swtpm/swtpm_uefi.xml") . " -P $image_path");
+        assert_script_run("wget --quiet " . data_url($sample_file) . " -P $image_path");
     }
 
     # Write expect script to implement ssh access into remote host and run some commands

--- a/tests/security/swtpm/swtpm_verify.pm
+++ b/tests/security/swtpm/swtpm_verify.pm
@@ -4,21 +4,25 @@
 # Summary: Ship the "swtpm" software TPM emulator for QEMU,
 #          test Legacy guest OS under libvirt, cover both
 #          TPM 1.2 and TPM 2.0
-# Maintainer: rfan1 <richard.fan@suse.com>
-# Tags: poo#81256, tc#1768671
+# Maintainer: rfan1 <richard.fan@suse.com> Starry Wang <starry.wang@suse.com>
+# Tags: poo#81256, tc#1768671, poo#100512
 
 use base 'opensusebasetest';
 use swtpmtest;
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures;
 
 sub run {
     my $self = shift;
-    $self->select_serial_terminal;
+    $self->select_serial_terminal if !(get_var('MACHINE') =~ /RPi4/);
     my $vm_type = 'legacy';
     $vm_type = 'uefi' if get_var('HDD_SWTPM_UEFI');
-    foreach my $i ("swtpm_1", "swtpm_2") {
+    # aarch64 does not support tpm1.2
+    my @swtpm_versions = qw(swtpm_2);
+    push @swtpm_versions, qw(swtpm_1) if !is_aarch64;
+    foreach my $i (@swtpm_versions) {
         start_swtpm_vm($i, "$vm_type");
         swtpm_verify($i);
         stop_swtpm_vm("$vm_type");


### PR DESCRIPTION
Updated test code to add aarch64 support of swtpm tests by running tests on Raspberry Pi4.

> The flavor of `create_swtpm_hdd_aarch` is `DVD`, and the flavor of `security_swtpm_jeos_rpi4` is `JeOS-for-RPi`,
> I can not add `START_AFTER_TEST` dependencies between these two tests since they use different flavors,
> and I also can not set the flavor of `create_swtpm_hdd_aarch` to `JeOS-for-RPi` since it needs to start 
> after `create_hdd_textmode@aarch64`.
> So I updated the test code in `swtpm_env_setup.pm` to check the status of `create_swtpm_hdd_aarch` by using openQA API.

- Related ticket: https://progress.opensuse.org/issues/100512
- Needles: N/A
- Verification run: 
  aarch64:
    - create_swtpm_hdd_aarch: https://openqa.opensuse.org/tests/2432209#
    - security_swtpm_jeos_rpi4: https://openqa.opensuse.org/tests/2433943#
  
  x86_64:
    - create_swtpm_hdd: https://openqa.opensuse.org/tests/2433945#
    - create_swtpm_hdd_uefi: https://openqa.opensuse.org/tests/2433947#
    - security_swtpm: https://openqa.opensuse.org/tests/2433946#
    - security_swtpm_uefi: https://openqa.opensuse.org/tests/2433948#
 