### PR TITLE
Trento deploy from unreleased version

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -321,7 +321,7 @@ sub cypress_exec {
         $self->result("fail");
     }
     if ($failok) {
-        record_soft_failure("Cypress exit code:$ret at $log_prefix");
+        record_soft_failure("Cypress exit code:$ret at $log_prefix") if ($ret);
         $ret = 0;
     }
     die "Cypress exec error at '$cmd'" unless ($ret == 0);

--- a/schedule/sles4sap/trento/trento.yml
+++ b/schedule/sles4sap/trento/trento.yml
@@ -13,6 +13,8 @@ vars:
     TRENTO_VM_IMAGE: 'SUSE:sles-sap-15-sp3-byos:gen2:latest'
     TRENTO_CYPRESS_VERSION: '4.4.0'
     PUBLIC_CLOUD_PROVIDER: 'AZURE'
+    PUBLIC_CLOUD_CREDENTIALS_URL: 'https://publiccloud-ng.qa.suse.de/secrets'
+    PUBLIC_CLOUD_NAMESPACE: 'sapha'
     TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
     - boot/boot_to_desktop

--- a/tests/sles4sap/trento/deploy_trento.pm
+++ b/tests/sles4sap/trento/deploy_trento.pm
@@ -20,13 +20,14 @@ sub run {
     my $machine_name = $self->get_vm_name;
     my $acr_name = $self->get_acr_name;
 
-    enter_cmd "cd /root/test";
+    my $basedir = '/root/test';
+    enter_cmd "cd $basedir";
 
+    my $script_run = ' ./';
     # Run the Trento deployment
     my $vm_image = get_var(TRENTO_VM_IMAGE => 'SUSE:sles-sap-15-sp3-byos:gen2:latest');
     my $deploy_script_log = 'script_00.040.txt';
-    my $deploy_script_run = './';
-    my $cmd_00_040 = 'set -o pipefail ; ' . $deploy_script_run . "00.040-trento_vm_server_deploy_azure.sh " .
+    my $cmd_00_040 = 'set -o pipefail ; ' . $script_run . "00.040-trento_vm_server_deploy_azure.sh " .
       " -g $resource_group" .
       " -s $machine_name" .
       " -i $vm_image" .
@@ -37,14 +38,48 @@ sub run {
     upload_logs($deploy_script_log);
 
     my $trento_registry_chart = get_var(TRENTO_REGISTRY_CHART => 'registry.suse.com/trento/trento-server');
+    my $cfg_json = 'config_images_gen.json';
+    my @imgs = qw(WEB RUNNER);
+    if (get_var("TRENTO_REGISTRY_IMAGE_$imgs[0]") || get_var("TRENTO_REGISTRY_IMAGE_$imgs[1]")) {
+        my $cfg_helper_cmd = './trento_deploy/config_helper.py' .
+          " -o $cfg_json" .
+          " --chart $trento_registry_chart";
+        if (get_var('TRENTO_REGISTRY_CHART_VERSION')) {
+            $cfg_helper_cmd .= ' --chart-version ' . get_var('TRENTO_REGISTRY_CHART_VERSION');
+        }
+        foreach my $img (@imgs) {
+            if (get_var("TRENTO_REGISTRY_IMAGE_$img")) {
+                $cfg_helper_cmd .= ' --' . lc($img) . ' ' . get_var("TRENTO_REGISTRY_IMAGE_$img") .
+                  ' --' . lc($img) . '-version ';
+                if (get_var("TRENTO_REGISTRY_IMAGE_${img}_VERSION")) {
+                    $cfg_helper_cmd .= get_var("TRENTO_REGISTRY_IMAGE_${img}_VERSION");
+                }
+                else {
+                    $cfg_helper_cmd .= 'latest';
+                }
+            }
+        }
+        assert_script_run($cfg_helper_cmd);
+        upload_logs($cfg_json);
+        $trento_registry_chart = $cfg_json;
+    }
     $deploy_script_log = 'script_trento_acr_azure.log.txt';
-    my $trento_acr_azure_cmd = 'set -o pipefail ; ' . $deploy_script_run . "trento_acr_azure.sh " .
-      "-g $resource_group " .
-      "-n $acr_name " .
-      "-r $trento_registry_chart " .
-      "-v 2>&1|tee $deploy_script_log";
-    assert_script_run($trento_acr_azure_cmd, 360);
+    my $trento_cluster_install = "${basedir}/trento_cluster_install.sh";
+    my $trento_acr_azure_timeout = 360;
+    my $trento_acr_azure_cmd = 'set -o pipefail ; ' . $script_run . "trento_acr_azure.sh" .
+      " -g $resource_group" .
+      " -n $acr_name" .
+      " -r $trento_registry_chart";
+    if (get_var("TRENTO_REGISTRY_IMAGE_$imgs[0]") || get_var("TRENTO_REGISTRY_IMAGE_$imgs[1]")) {
+        $trento_acr_azure_timeout += 240;
+        $trento_acr_azure_cmd .= " -o $basedir";
+    }
+    $trento_acr_azure_cmd .= " -v 2>&1|tee $deploy_script_log";
+    assert_script_run($trento_acr_azure_cmd, $trento_acr_azure_timeout);
     upload_logs($deploy_script_log);
+    if (get_var("TRENTO_REGISTRY_IMAGE_$imgs[0]") || get_var("TRENTO_REGISTRY_IMAGE_$imgs[1]")) {
+        upload_logs($trento_cluster_install);
+    }
 
     my $machine_ip = $self->az_get_vm_ip;
     my $acr_server = script_output("az acr list -g $resource_group --query \"[0].loginServer\" -o tsv");
@@ -55,12 +90,15 @@ sub run {
     assert_script_run("az acr repository list -n $acr_name");
 
     $deploy_script_log = 'script_1.010.log.txt';
-    my $cmd_01_010 = 'set -o pipefail ; ' . $deploy_script_run . '01.010-trento_server_installation_premium_v.sh ' .
+    my $cmd_01_010 = 'set -o pipefail ; ' . $script_run . '01.010-trento_server_installation_premium_v.sh ' .
       " -i $machine_ip " .
       ' -k ' . $self->SSH_KEY .
       ' -u ' . $self->VM_USER;
     if (get_var('TRENTO_REGISTRY_CHART_VERSION')) {
         $cmd_01_010 .= ' -c ' . get_var('TRENTO_REGISTRY_CHART_VERSION');
+    }
+    if (get_var("TRENTO_REGISTRY_IMAGE_$imgs[0]") || get_var("TRENTO_REGISTRY_IMAGE_$imgs[1]")) {
+        $cmd_01_010 .= " -x $trento_cluster_install";
     }
     $cmd_01_010 .= ' -p $(pwd) ' .
       " -r $acr_server/trento/trento-server " .


### PR DESCRIPTION
New variables added to allow the user to specify a registry and a
version for each deployment part: chart, runner and web.

- Verification run: http://1c242.qa.suse.de/tests/504/  http://1c242.qa.suse.de/tests/588
