### PR TITLE
Fix apache2_changehat

### DIFF
--- a/tests/security/apparmor_profile/apache2_changehat.pm
+++ b/tests/security/apparmor_profile/apache2_changehat.pm
@@ -153,7 +153,7 @@ sub run {
     my @check_list = ('file_receive', 'open', 'signal', 'mknod');
     foreach my $check_point (@check_list) {
         if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* operation=.*$check_point.* profile=.*httpd-prefork.*/sx) {
-            if (!is_sle('<=15-SP3')) {
+            if (!is_sle('<=15-SP4')) {
                 record_info("ERROR", "There are denied $check_point records found in $audit_log", result => 'fail');
                 $self->result('fail');
             }


### PR DESCRIPTION
Due to bsc#1191684, the case apache2_changehat may fail on sles15sp4- version as well, so we need add a workaround until the underlying issue is fixed.

Related ticket: https://progress.opensuse.org/issues/112909
Previous commit for <=15-SP3: https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/ef9242bd973ebdfa23bf1a7910418bfdb0c26eb5

Verification runs:
- 15-SP4: https://openqa.suse.de/tests/9011047#step/apache2_changehat/1
- 15-SP3: https://openqa.suse.de/tests/9011046#step/apache2_changehat/1