### PR TITLE
klp: Update live patching tag for SLE 15-SP4

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -357,7 +357,8 @@ sub run {
 
     # check kGraft if KGRAFT=1
     if (check_var("KGRAFT", '1') && !check_var('REMOVE_KGRAFT', '1')) {
-        assert_script_run("uname -v | grep -E '(/kGraft-|/lp-)'");
+        my $lp_tag = is_sle('>=15-sp4') ? 'lp' : 'lp-';
+        assert_script_run("uname -v | grep -E '(/kGraft-|/${lp_tag})'");
     }
 
     upload_logs('/boot/config-$(uname -r)', failok => 1);


### PR DESCRIPTION
Fix poo@113072:  There was removed the hash pointing to the live
patching repository from the uname for 15-SP4 and newer.

- Related ticket: https://progress.opensuse.org/issues/113072
- Needles:
- Verification run: 
15-SP4: http://10.100.12.105/tests/1629#step/install_ltp/11
15-SP3: http://10.100.12.105/tests/1628#step/install_ltp/11
