### PR TITLE
klp: Update live patching tag for SLE 15-SP4+ in boot_ltp

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -14,7 +14,7 @@ use base 'opensusebasetest';
 use testapi;
 use Utils::Backends;
 use LTP::utils;
-use version_utils 'is_jeos';
+use version_utils qw(is_jeos is_sle);
 use utils 'assert_secureboot_status';
 
 sub run {
@@ -48,7 +48,8 @@ sub run {
 
     # check kGraft patch if KGRAFT=1
     if (check_var('KGRAFT', '1') && !check_var('REMOVE_KGRAFT', '1')) {
-        assert_script_run("uname -v| grep -E '(/kGraft-|/lp-)'");
+        my $lp_tag = is_sle('>=15-sp4') ? 'lp' : 'lp-';
+        assert_script_run("uname -v | grep -E '(/kGraft-|/${lp_tag})'");
     }
 
     prepare_ltp_env;


### PR DESCRIPTION
Fix poo@113072:  There was removed the hash pointing to the live
patching repository from the uname for 15-SP4 and newer.

- Related ticket: https://progress.opensuse.org/issues/113072
- Needles: none
- Verification run: 
15-SP4: http://10.100.12.105/tests/1635 http://10.100.12.105/tests/1634
15-SP3: http://10.100.12.105/tests/1636 http://10.100.12.105/tests/1633
