### PR TITLE
Force resolution of policycoreutils-python-utils

### DIFF
--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -29,7 +29,9 @@ sub run {
     zypper_call("in policycoreutils");
     # Program 'semanage' is in policycoreutils-python-utils pkgs on TW and SLES 15-SP4
     if (is_tumbleweed || is_sle('>=15-SP4')) {
-        zypper_call('in policycoreutils-python-utils');
+        record_soft_failure 'bsc#1200649' if is_sle('=15-SP4');
+        my $solver = is_sle('=15-SP4') ? '--force-resolution --solver-focus Update' : '';
+        zypper_call("in $solver policycoreutils-python-utils");
     }
     if (!is_sle('>=15')) {
         assert_script_run('zypper -n in policycoreutils-python');


### PR DESCRIPTION
Software packages depend on each other in various ways. Packages usually require
or recommend other packages, but they can also conflict with them. Packages may
support specific hardware or language settings. Zypper uses a dependency solver
to find out which packages need to be installed to satisfy the user’s request.

In Focus on Update mode the solver focuses on updating the requested package
and all its dependencies as much as possible. Beware, installing a single package
in this mode may easily lead to a mini system update.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1200649
- Verification run: https://openqa.suse.de/tests/9048309