### PR TITLE
Change softfailure to info for s390x shutdown

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -277,7 +277,7 @@ sub power_action {
         }
         elsif ($action eq 'poweroff') {
             if (is_backend_s390x) {
-                record_soft_failure('poo#58127 - Temporary workaround, because shutdown module is marked as failed on s390x backend when shutting down from GUI.');
+                record_info('poo#58127', 'Temporary workaround, because shutdown module is marked as failed on s390x backend when shutting down from GUI.');
                 select_console 'root-console';
                 enter_cmd "$action";
             }
@@ -430,5 +430,3 @@ sub assert_shutdown_with_soft_timeout {
     }
     assert_shutdown($args->{timeout} - $args->{soft_timeout});
 }
-
-


### PR DESCRIPTION
Backend does not implement is_shutdown so there is not much chance to detect a shutdown from the GUI. Nevertheless we can replace the softfailure with just an info.

- Related ticket: https://progress.opensuse.org/issues/110437
- Needles: -
- Verification run: https://openqa.suse.de/tests/9072280#