### PR TITLE
Add libsamba-errors0 to conflict list

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -54,7 +54,8 @@ sub has_conflict {
         libiterm1 => 'terminfo-iterm',
         rust => 'rls',
         'rust-gdb' => 'cargo',
-        'openssl-1_0_0' => 'openssl-1_1'
+        'openssl-1_0_0' => 'openssl-1_1',
+        'libsamba-errors0' => 'samba-client-libs'
 
     );
     return $conflict{$binary};


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/113306
- Needles: none
- Verification run: https://openqa.suse.de/tests/9077925#

context: https://suse.slack.com/archives/C02D16TCP99/p1657094726166919
