### PR TITLE
chromium: Ensure each character is typed in the address bar without waiting too long

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -16,7 +16,7 @@ sub type_address ($string) {
     send_key 'ctrl-l';    # select text in address bar
                           # wait for the urlbar to be in a consistent state
     assert_screen 'chromium-highlighted-urlbar';
-    enter_cmd($string);
+    enter_cmd($string, wait_screen_change => 1, no_wait => 1);
 }
 
 sub run {


### PR DESCRIPTION
Needs https://github.com/os-autoinst/os-autoinst/pull/2109

Related progress issue: https://progress.opensuse.org/issues/109737