### PR TITLE
BCI repo: check for dracut-fips package

### DIFF
--- a/tests/containers/bci_repo.pm
+++ b/tests/containers/bci_repo.pm
@@ -38,7 +38,7 @@ my $tdata = [
     },
     {
         patterns => [qw(apparmor base devel_basis documentation enhanced_base fips ofed sw_management)],
-        packages => [qw(apparmor-parser kbd gcc e2fsprogs openssh-fips rdma-core zypper)]
+        packages => [qw(apparmor-parser kbd gcc e2fsprogs dracut-fips rdma-core zypper)]
     }
 ];
 


### PR DESCRIPTION
`openssh-fips` is part of enhanced_base pattern in 15-SP3, nut not in 15-SP4.
Instead, a good check for fips pattern is `dracut-fips` package.

Ticket: https://progress.opensuse.org/issues/112778
Failed test: https://openqa.suse.de/tests/9077999#step/bci_repo/273
VR: https://openqa.suse.de/tests/overview?version=15-SP4&distri=sle&build=jlausuch%2Fos-autoinst-distri-opensuse%23fix_bci_repo_test
