### PR TITLE
Use yast2 registration instead of SUSEConnect

### DIFF
--- a/schedule/qam/common/qam-scc.yaml
+++ b/schedule/qam/common/qam-scc.yaml
@@ -14,5 +14,4 @@ schedule:
     - console/consoletest_setup
     - qa_automation/patch_and_reboot
     - console/yast2_registration
-    - console/suseconnect
 ...


### PR DESCRIPTION
Instead of using the SUSEConnect command line tool to cleanup the registration and also checking registration status, we should use the YaST registration module option 'Register again'.

- Related ticket: https://progress.opensuse.org/issues/112151
- Needles: -
- Verification run: https://openqa.suse.de/tests/overview?build=ge0r%2Fos-autoinst-distri-opensuse%23poo-112151&distri=sle
