### PR TITLE
Facilicate features testing for SEV/SEV-ES guest

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -425,11 +425,23 @@ sub is_guest_online {
 }
 
 # wait_guest_online($guest, [$timeout]) waits until the given guests is online by probing for an open ssh port
+# If [$state_check] is not zero, guest state checking will be performed to ensure it is in running state and retry
 sub wait_guest_online {
     my $guest = shift;
     my $retries = shift // 300;
+    my $state_check = shift // 0;
     # Wait until guest is reachable via ssh
-    script_retry("nmap $guest -PN -p ssh | grep open", delay => 1, retry => $retries);
+    if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 1, retry => $retries, die => 0) != 0) {
+        # Ensure guest is running
+        if (($state_check != 0) and (script_run("virsh list --name --state-running | grep $guest") != 0)) {
+            script_run("virsh destroy $guest");
+            assert_script_run("virsh start $guest");
+            script_retry("nmap $guest -PN -p ssh | grep open", delay => 1, retry => $retries);
+        }
+        else {
+            die "Guest $guest ssh service is not up and running";
+        }
+    }
 }
 
 # Shutdown all guests and wait until they are shutdown
@@ -447,10 +459,10 @@ sub wait_guests_shutdown {
     # Note: Domain-0 is for xen only, but it does not hurt to exclude this also in kvm runs.
     # Firstly wait for guest shutdown for a while, turn it off forcibly using "virsh destroy" if timed-out.
     # Then wait for guest shutdown again with default "die => 1".
-    if (script_retry("! virsh list | grep -v Domain-0 | grep running", delay => 1, retry => $retries, die => 0) ne '0') {
+    if (script_retry("! virsh list | grep -v Domain-0 | grep running", timeout => 60, delay => 1, retry => $retries, die => 0) != 0) {
         script_run("virsh destroy $_") foreach (keys %virt_autotest::common::guests);
     }
-    script_retry("! virsh list | grep -v Domain-0 | grep running", delay => 1, retry => $retries);
+    script_retry("! virsh list | grep -v Domain-0 | grep running", timeout => 60, delay => 1, retry => $retries);
 }
 
 # Start all guests and wait until they are online

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -122,7 +122,7 @@ sub test_network_interface {
         # Wait until guest's primary interface is back up
         script_retry("ping -c3 $guest", delay => 6, retry => 30);
         # Activate guest's secondary (tested) interface
-        script_retry("ssh root\@$guest ifup $nic", delay => 5, retry => 4);
+        script_retry("ssh root\@$guest ifup $nic", delay => 10, retry => 20, timeout => 120);
     }
 
     # See obtained IP addresses
@@ -248,7 +248,7 @@ sub restore_guests {
     foreach (@vm_hostnames_array)
     {
         script_run("virsh destroy $_");
-        script_run("virsh undefine $_");
+        script_run("virsh undefine $_ || virsh undefine $_ --keep-nvram");
         script_run("virsh define /tmp/$_.xml");
     }
 }
@@ -319,7 +319,7 @@ sub get_active_pool_and_available_space {
     # get some debug info about storage pool
     script_run 'virsh pool-list --details';
     # ensure the available disk space size for active pool
-    my $active_pool = script_output("virsh pool-list --persistent | grep active | awk '{print \$1}'");
+    my $active_pool = script_output("virsh pool-list --persistent | grep -iv nvram | grep active | awk '{print \$1}'");
     my $available_size = script_output("virsh pool-info $active_pool | grep ^Available | awk '{print \$2}'");
     my $pool_unit = script_output("virsh pool-info $active_pool | grep ^Available | awk '{print \$3}'");
     # default available pool unit as GiB

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -48,8 +48,8 @@ sub run_test {
         #There will be two guests in two different routed networks so then the
         #host can route their traffic to confirm libvirt routed network
         assert_script_run("virsh dumpxml $guest > $guest.clone");
-        assert_script_run("virsh destroy $guest");
-        assert_script_run("virsh undefine $guest");
+        assert_script_run("virsh destroy $guest || (virsh list --state-shutoff | grep $guest)");
+        assert_script_run("virsh undefine $guest || virsh undefine $guest --keep-nvram");
         assert_script_run("virsh define $guest.clone");
         assert_script_run("rm -rf $guest.clone");
         assert_script_run("virt-clone -o $guest -n $guest.clone -f /var/lib/libvirt/images/$guest.clone");
@@ -96,7 +96,7 @@ sub run_test {
 
         script_run "sed -i '/ $guest.clone /d' /etc/hosts";
         assert_script_run("virsh destroy $guest.clone");
-        assert_script_run("virsh undefine $guest.clone");
+        assert_script_run("virsh undefine $guest.clone || virsh undefine $guest.clone --keep-nvram");
         assert_script_run("rm -rf /var/lib/libvirt/images/$guest.clone");
     }
     #Destroy ROUTED NETWORK

--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -38,6 +38,10 @@ sub run_test {
     my @vm_hostnames_inactive_array = split(/\n+/, $vm_hostnames_inactive);
 
     foreach my $guest (keys %virt_autotest::common::guests) {
+        if (virt_autotest::utils::is_sev_es_guest($guest) ne 'notsev') {
+            record_info "Skip external snapshot on $guest", "SEV/SEV-ES guest $guest does not support external snapshot";
+            next;
+        }
         my $type = check_guest_disk_type($guest);
         next if ($type == 1);
         record_info "virsh-snapshot", "Creating External Snapshot of guest's disk";

--- a/tests/virt_autotest/virsh_internal_snapshot.pm
+++ b/tests/virt_autotest/virsh_internal_snapshot.pm
@@ -22,6 +22,10 @@ sub run_test {
     return unless is_kvm_host;
 
     foreach my $guest (keys %virt_autotest::common::guests) {
+        if (virt_autotest::utils::is_sev_es_guest($guest) ne 'notsev') {
+            record_info "Skip internal snapshot on $guest", "SEV/SEV-ES guest $guest does not support internal snapshot";
+            next;
+        }
         my $type = check_guest_disk_type($guest);
         next if ($type == 1);
         record_info "virsh-snapshot", "Cleaning in case of rerun";

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -407,7 +407,7 @@ sub remove_vm {
         assert_script_run("virsh destroy $vm", 30);
     }
     if ($is_persistent_vm eq "yes") {
-        assert_script_run("virsh undefine $vm", 30);
+        assert_script_run("virsh undefine $vm || virsh undefine $vm --keep-nvram", 30);
     }
 }
 
@@ -653,7 +653,7 @@ sub recreate_guests {
     foreach (@vm_hostnames_array)
     {
         script_run("virsh destroy $_");
-        script_run("virsh undefine $_");
+        script_run("virsh undefine $_ || virsh undefine $_ --keep-nvram");
         script_run("virsh define /$based_guest_dir/$_.xml");
         script_run("virsh start $_");
     }

--- a/tests/virtualization/universal/hotplugging_memory.pm
+++ b/tests/virtualization/universal/hotplugging_memory.pm
@@ -41,7 +41,7 @@ sub run_test {
     my ($sles_running_version, $sles_running_sp) = get_os_release;
 
     record_info "SSH", "Check if guests are online with SSH";
-    wait_guest_online($_) foreach (keys %virt_autotest::common::guests);
+    wait_guest_online($_, 300, 1) foreach (keys %virt_autotest::common::guests);
 
     # Live memory change of guests
     record_info "Memory", "Changing the amount of memory available";

--- a/tests/virtualization/universal/hotplugging_network_interfaces.pm
+++ b/tests/virtualization/universal/hotplugging_network_interfaces.pm
@@ -38,7 +38,7 @@ sub add_virtual_network_interface {
         if (get_var('VIRT_AUTOTEST') && is_kvm_host) {
             $interface_model_option = '--model virtio';
         }
-        script_retry("ssh root\@$guest ip l | grep " . $virt_autotest::common::guests{$guest}->{macaddress}, delay => 60, retry => 3, timeout => 60);
+        script_retry("ssh root\@$guest ip l | grep " . $virt_autotest::common::guests{$guest}->{macaddress}, delay => 60, retry => 10, timeout => 60);
         assert_script_run("virsh domiflist $guest", 90);
         if (try_attach("virsh attach-interface --domain $guest --type bridge ${interface_model_option} --source br0 --mac " . $mac . " --live " . ${persistent_config_option})) {
             assert_script_run("virsh domiflist $guest | grep br0");


### PR DESCRIPTION
* **Power** on guest if it can not be reached for a while and redo ssh port detecting  if $state_check is given non-zero value explicitly in wait_guest_online in lib/virt_autotest/utils.pm

* **Adjust** timeout and retry values adjustment to some script_retry calls to make sure enough attempts

* **Keep** nvram when undefine uefi guest to ensure the guest can be redefined and then started up again

* **Ensure** guest is in shut-off state if it can not be destroyed and exclude nvram from "virsh pool-list

*  **Skip** SR-IVO/vCPU Hotplugging/Internal Snaphsot/External Snapshot tests for SEV/SEV-ES guests due to lacking of support

* **Verification runs:**
  * [sev-es 15sp3 on 15sp4](http://10.67.131.12/tests/438)
  * [sev-es 15sp4 on 15sp4](http://10.67.131.12/tests/439)
  * [uefi 12sp5 on 15sp4](https://openqa.suse.de/tests/9091409)
  * [uefi 15sp3 on 15sp4](https://openqa.suse.de/tests/9091411)
  * [uefi 15sp4 on 15sp4](https://openqa.suse.de/tests/9091414)
  * [uefi 15sp4 on 12sp5](https://openqa.suse.de/tests/9085532)
  * [uefi 15sp4 on 15sp3](https://openqa.suse.de/tests/9093206)
  * [non-uefi 15sp4 on 15sp3](https://openqa.suse.de/tests/9125705)
  * [non-uefi 15sp4 on 12sp5](https://openqa.suse.de/tests/9125745)
  * [non-uefi 12sp5 on 15sp4](http://10.67.131.12/tests/584)
  * [non-uefi 15sp3 on 15sp4](http://10.67.131.12/tests/587)
  * [non-uefi 15sp4 on 15sp4](http://10.67.131.12/tests/593)