### PR TITLE
Increase screen time for flatpak

### DIFF
--- a/tests/x11/flatpak.pm
+++ b/tests/x11/flatpak.pm
@@ -35,9 +35,9 @@ sub run {
     select_console 'x11';
     ensure_unlocked_desktop;
     x11_start_program('flatpak run org.gimp.GIMP', target_match => 'flatpak-gimp');
-    wait_still_screen(3);
+    wait_still_screen(10);
     assert_and_click('flatpak-gimp');
-    wait_still_screen(3);
+    wait_still_screen(10);
 }
 
 1;


### PR DESCRIPTION
Fix occasional test failures due to a too low timeout of
wait_still_screen.

- Related test failure: e.g. https://openqa.opensuse.org/tests/2458032#step/flatpak/40
- Verification run: https://openqa.opensuse.org/tests/2458558
