### PR TITLE
Update repos and meta before invoke yast

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -221,6 +221,8 @@ sub activate_kdump_cli {
 
 # Deactivate kdump using yast command line interface
 sub deactivate_kdump_cli {
+    # Solution to poo113351. Avoid to use needles to solve this case.
+    zypper_call("--gpg-auto-import-keys ref");
     # Disable the crashkernel option from the kernel grub cmdline
     assert_script_run('yast kdump startup disable alloc_mem=0', 180);
     # Disable the kdump service at boot time


### PR DESCRIPTION
`deactivate_kdump_cli` breaks as once the YaST run for first time will prompt
to trust signing key from Basesystem-Update module. The simpliest solution is
to run `zypper ref` before `yast`. Other solutions would be to go through
needling or import the key directly with `rpm --import`. However i found
zypper convenience because i do not need to care about the specifics of the key.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/113351
- Verification run:
sle-15-SP4-Server-DVD-Incidents-x86_64-Build:24623:python3-mau-sles-sys-param-check@64bit-2gbram -> https://openqa.suse.de/t9094057