### PR TITLE
opensusebasetest: Prevent sporadic timeout on 'coredumpctl'

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1343,7 +1343,7 @@ post_fail_hook calls.
 
 sub upload_coredumps {
     my ($self, %args) = @_;
-    my $res = script_run("coredumpctl --no-pager", timeout => 10);
+    my $res = script_run('coredumpctl --no-pager');
     if (!$res) {
         record_info("COREDUMPS found", "we found coredumps on SUT, attemp to upload");
         script_run("coredumpctl info --no-pager | tee coredump-info.log");


### PR DESCRIPTION
Observed in
https://openqa.suse.de/tests/9099492#step/coredump_collect/4 the call to
"coredumpctl --no-pager" which normally is quick enough failed on an
aarch64 virtual machine.
https://openqa.suse.de/tests/9099492#comment-565013 showed that this is
a sporadic issue so likely the tiimeout is just a bit too aggressive.
The timeout of 10s was introduced initially in 093b5acbc with no
reasoning about the timeout so likely an arbitrary choice and should be
avoided. We can just rely on the default timeout here.