### PR TITLE
[wip]Enhance wait_countdown_stop logic to retry more

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -194,7 +194,7 @@ sub run {
         # A single changing digit is only a minor change, overide default
         # similarity level considered a screen change
         my $minor_change_similarity = 55;
-        while ($counter-- and wait_countdown_stop(3, $minor_change_similarity)) {
+        while ($counter-- and wait_countdown_stop(1, $minor_change_similarity)) {
             record_info('workaround', "While trying to stop countdown we saw a screen change, retrying up to $counter times more");
         }
     }


### PR DESCRIPTION
The system will auto-reboot after installation
within 10s, current logic is send 'alt-s' key
to stop it every 3s. set it to 1s then we can
retry more times on low performance setups.

- Related ticket: https://progress.opensuse.org/issues/113396
- Verification run:  [run the same job for 5 times]
http://openqa.suse.de/t9101633
http://openqa.suse.de/t9101634
http://openqa.suse.de/t9101635
http://openqa.suse.de/t9101636
http://openqa.suse.de/t9101637