### PR TITLE
Fix the SAP zypper migration

### DIFF
--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -35,7 +35,10 @@ sub check_or_install_packages {
         } else {
             # if system is fully updated or even minimal patch applied,
             # all necessary packages for online migration should be installed
-            assert_script_run("rpm -q $_") foreach qw(yast2-migration zypper-migration-plugin rollback-helper);
+            # and zypper-migration-plugin was obsoleted since 15sp4.
+            my @pkgs = qw(yast2-migration rollback-helper);
+            push @pkgs, "zypper-migration-plugin" if is_sle('<15-SP4', get_var('ORIGIN_SYSTEM_VERSION'));
+            assert_script_run("rpm -q $_") foreach @pkgs;
         }
     } else {
         # install necessary packages for online migration if system is not updated


### PR DESCRIPTION
In SAP zypper migration for 15sp4, It has no zypper-migration-plugin
package. We need to skip the check before 'zypper migration'.

- Related ticket: https://progress.opensuse.org/issues/113465
- Needles: N/A
- Verification run: 
  https://openqa.nue.suse.com/t9109274
  regression:
 https://openqa.nue.suse.com/t9109275