### PR TITLE
[virt_autotest] Add Extend LVM Storage pool / volume test

### DIFF
--- a/lib/virt_autotest/virtual_storage_utils.pm
+++ b/lib/virt_autotest/virtual_storage_utils.pm
@@ -1,0 +1,100 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: virtual_storage_utils:
+#          This file provides fundamental utilities for virtual storage.
+# Maintainer: Leon Guo <xguo@suse.com>
+
+package virt_autotest::virtual_storage_utils;
+
+use base Exporter;
+use Exporter;
+
+use utils;
+use strict;
+use warnings;
+use File::Basename;
+use testapi;
+use Data::Dumper;
+use XML::Writer;
+use IO::File;
+use proxymode;
+use version_utils 'is_sle';
+use virt_autotest_base;
+use virt_autotest::utils;
+use virt_utils;
+
+our @EXPORT
+  = qw(virt_storage_management destroy_virt_storage_pool delete_physical_volume);
+
+
+# Basic Virtualization Storage Management
+sub virt_storage_management {
+    my ($vstorage_pool_name, %args) = @_;
+    my $vol_size = $args{size};
+    my $timeout = $args{timeout} // 120;
+    my $dir = $args{dir} // 0;
+    my $vol_resize = $args{resize} // 0;
+    ## Basic Virtualization Storage Pool Management
+    record_info "Storage Pool list";
+    assert_script_run "virsh pool-list --all | grep $vstorage_pool_name";
+    record_info "Storage Pool start";
+    assert_script_run "virsh pool-start $vstorage_pool_name";
+    record_info "Storage Pool autostart";
+    assert_script_run "virsh pool-autostart $vstorage_pool_name";
+    record_info "Storage Pool info";
+    assert_script_run "virsh pool-info $vstorage_pool_name";
+
+    ## Basic Virtualization Storage Volume Management
+    # Create a Storage Volume
+    record_info "Create a Storage Volume";
+    assert_script_run("virsh vol-create-as $vstorage_pool_name $_-storage $vol_size", $timeout) foreach (keys %virt_autotest::common::guests);
+    record_info "List Storage Volumes";
+    assert_script_run("virsh vol-list $vstorage_pool_name | grep $_-storage", $timeout) foreach (keys %virt_autotest::common::guests);
+    record_info "Dump Storage Volumes in XML";
+    assert_script_run("virsh vol-dumpxml --pool $vstorage_pool_name $_-storage", $timeout) foreach (keys %virt_autotest::common::guests);
+    if ($dir == 1) {
+        record_info "Resize";
+        assert_script_run("virsh vol-resize --pool testing $_-storage $vol_resize", $timeout) foreach (keys %virt_autotest::common::guests);
+    }
+    # Attach a Storage Volume to guest system
+    record_info "Attached";
+    my $target = (is_xen_host) ? "xvdx" : "vdx";
+    assert_script_run("virsh attach-disk --domain $_ --source `virsh vol-path --pool $vstorage_pool_name $_-storage` --target $target", $timeout) foreach (keys %virt_autotest::common::guests);
+    # Detach a Storage Volume from guest system
+    record_info "Detached";
+    assert_script_run("virsh detach-disk $_ $target", $timeout) foreach (keys %virt_autotest::common::guests);
+    record_info "Clone";
+    assert_script_run("virsh vol-clone --pool $vstorage_pool_name $_-storage $_-clone", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh vol-info --pool $vstorage_pool_name $_-clone", $timeout) foreach (keys %virt_autotest::common::guests);
+    # Delete and Remove a Storage Volume from storage pool
+    record_info "Remove";
+    assert_script_run("virsh vol-delete --pool $vstorage_pool_name $_-clone", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh vol-delete --pool $vstorage_pool_name $_-storage", $timeout) foreach (keys %virt_autotest::common::guests);
+}
+
+# Destroy Virtualization Storage Pool
+sub destroy_virt_storage_pool {
+    my ($vstorage_pool_name, %args) = @_;
+    my $lvm = $args{lvm} // 0;
+    my $lvmdisk = $args{lvmdisk} // 0;
+    record_info "Storage Pool destroy";
+    assert_script_run "virsh pool-destroy $vstorage_pool_name";
+    assert_script_run "virsh pool-delete $vstorage_pool_name";
+    assert_script_run "virsh pool-undefine $vstorage_pool_name";
+    # Delete a Physical Volume (PV) with LVM
+    delete_physical_volume($lvmdisk) if ($lvm == 1);
+}
+
+# Delete a Physical Volume (PV) with LVM
+sub delete_physical_volume {
+    my $lvm_disk_name = shift;
+    my $timeout = 180;
+    validate_script_output("pvremove -y ${lvm_disk_name}1", sub { m/successfully wiped/ }, $timeout);
+    assert_script_run 'pvdisplay';
+    save_screenshot;
+}
+
+1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -626,7 +626,10 @@ sub load_virt_feature_tests {
         loadtest 'virtualization/universal/hotplugging_memory';
         loadtest 'virtualization/universal/hotplugging_cleanup';
     }
-    loadtest "virtualization/universal/storage" if get_var("ENABLE_STORAGE");
+    if (get_var("ENABLE_STORAGE")) {
+        loadtest "virtualization/universal/storage";
+        loadtest "virt_autotest/libvirt_extend_storage_lvm";
+    }
     if (get_var("ENABLE_SNAPSHOT")) {
         loadtest "virt_autotest/virsh_internal_snapshot";
         loadtest "virt_autotest/virsh_external_snapshot";

--- a/tests/virt_autotest/libvirt_extend_storage_lvm.pm
+++ b/tests/virt_autotest/libvirt_extend_storage_lvm.pm
@@ -1,0 +1,110 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Virtualization Extend LVM Storage pool / volume test
+#
+# Test flow:
+# - Check a additional free hard disk
+# - Wipe hard disk clean
+# - Partition test disk
+# - Create a pv and display result
+# - Create a vg named 'lvm_vg' and display result
+# - Create a storage pool (lv) named 'guest_image_lvm'
+# - Create a logical volume (lv) size 1G
+# - Attach a logical volume (lv) to guest systems
+# - Clone a logical volume (lv)
+# - Cleanup
+# Maintainer: Leon Guo <xguo@suse.com>
+
+use base "virt_feature_test_base";
+use virt_autotest::virtual_storage_utils;
+use virt_autotest::utils;
+use virt_autotest::common;
+use strict;
+use warnings;
+use testapi;
+use utils;
+use virt_utils;
+use version_utils 'is_sle';
+
+our $lvm_vg_name = 'lvm_vg';
+our $lvm_pool_name = 'guest_image_lvm';
+sub run_test {
+    my ($self) = @_;
+
+    record_info "Prepare Guest Systems";
+    foreach (keys %virt_autotest::common::guests) {
+        start_guests() unless is_guest_online($_);
+    }
+    ## Prepare Virtualization LVM Storage Pool Source
+    my $lvm_disk = $self->prepare_lvm_storage_pool_source();
+
+    ## About LVM volume group storage pool management
+    # Use an LVM Volume Group (VG) as a storage pool named 'guest_image_lvm'
+    record_info "LVM Storage Pool define";
+    assert_script_run "virsh pool-define-as $lvm_pool_name logical --source-name $lvm_vg_name --target /dev/lvm_vg";
+    # Basic Virtualization LVM Storage Management
+    my $lvm_vol_size = '1G';
+    virt_storage_management($lvm_pool_name, size => $lvm_vol_size);
+
+    ## Cleanup
+    # Destroy the LVM volume group storage pool
+    destroy_virt_storage_pool($lvm_pool_name, lvm => 1, lvmdisk => $lvm_disk);
+}
+
+# Prepare Virtualization LVM Storage Pool source
+sub prepare_lvm_storage_pool_source {
+    ## Physical Hard Disk preparation
+    # Check with all existed Hard disks
+    my ($dev, $lvm_disk_name);
+    my @disks = split(/\n/, script_output("lsblk -n -l -o NAME -d -e 7,11"));
+    my $scalar = @disks;
+    #NOTE: Requires at least 2 physical hard disks for LVM Storage test
+    if (($scalar eq 1) || get_var('KEEP_DISKS')) {
+        record_info("WARNING", "Requires at least 2 physical hard disks for LVM Storage test\n", result => 'softfail');
+        return;
+    }
+    # Use a unused hard disk for LVM volumes
+    $dev = "/dev/";
+    foreach my $disk (@disks) {
+        if (script_run("set -o pipefail;lsblk -rnoPKNAME,MOUNTPOINT | grep -i $disk | awk \'{print \$2}\'") ne '0') {
+            $lvm_disk_name = $dev . $disk;
+            last;
+        }
+    }
+    record_info "Assign a New Disk:", "$lvm_disk_name";
+    # Wipe Hard Disk Clean via dd for assigned a new full disk
+    wipe_hard_disk($lvm_disk_name);
+    ## About LVM volumes management
+    # Create a Volume Group (VG) with LVM named 'lvm_vg'
+    create_volume_group($lvm_disk_name);
+    return ($lvm_disk_name);
+}
+
+# Wipe Hard Disk Clean via dd
+sub wipe_hard_disk {
+    my $hard_disk_name = shift;
+    assert_script_run("dd if=/dev/zero of=$hard_disk_name count=1M", timeout => 1500, fail_message => "Failed to wipe hard disk clean on $hard_disk_name");
+}
+
+# Create a Volume Group with LVM
+sub create_volume_group {
+    my $lvm_disk_name = shift;
+    my $timeout = 180;
+    # Create new disk partition for LVM volumes
+    record_info "Create new disk partition for LVM volumes";
+    assert_script_run 'echo -e "g\nn\n\n\n+20G\nt\n8e\np\nw" | fdisk ' . $lvm_disk_name;
+    # Create a Physical Volume (PV) with LVM
+    record_info "Create a Physical Volume";
+    validate_script_output("pvcreate ${lvm_disk_name}1", sub { m/successfully created/ }, $timeout);
+    validate_script_output("pvdisplay", sub { m/${lvm_disk_name}1/ }, $timeout);
+    # Create a Volume Group (VG) with LVM named 'lvm_vg'
+    record_info "Create a Volume Group";
+    validate_script_output("vgcreate $lvm_vg_name ${lvm_disk_name}1", sub { m/successfully created/ }, $timeout);
+    validate_script_output("vgdisplay ${lvm_vg_name}", sub { m/${lvm_vg_name}/ }, $timeout);
+    save_screenshot;
+}
+
+1;


### PR DESCRIPTION
Add Extend Virtualization LVM Storage pool / volume test

- Test flow:
Hard Disk
Check a additional free hard disk
Wipe hard disk clean
LVM volumes management
Create new disk partition for LVM volumes
Create a pv and display result
Create a vg named 'lvm_vg' and display result
LVM Storage pool management
Create a storage pool (lv) named 'guest_image_lvm'
LVM Storage volume management
Create a logical volume (lv) size 1G
Attach|Detach a logical volume (lv) to guest systems
Clone a logical volume (lv) 
Cleanup
Destroy the LVM volume group storage pool
Delete a Physical Volume (PV) with LVM
Wipe Hard Disk Clean via dd
- New functions
Hard Disk
`prepare_lvm_storage_pool_source`
Prepare Virtualization LVM Storage Pool source, make sure that there is at least two hard disk on testing environment and figure out a unused hard disk to create a Volume Group with LVM on SLE vm host, and included `wipe_hard_disk` and `create_volume_group` - LVM volumes management together. 
`wipe_hard_disk`
Wipe Hard Disk Clean via dd before create a Volume Group with LVM on a unused hard disk. 
LVM volumes management
`create_volume_group`
Create a Volume Group with LVM as basic LVM volumes management
`delete_physical_volume`
Delete a Physical Volume (PV) with LVM as basic LVM volumes management
Basic Virtualization Storage management
included basic Virtualization Storage Pool and Volume management 
`virt_storage_management`
Basic Virtualization Storage Pool management, such as, Basic Virtualization Storage Pool management, such as Storage Pool list, Storage Pool start, Storage Pool autostart and Storage Pool info. 
and Basic Virtualization Storage Volume management, such as Create a Storage Volume, List Storage Volumes, Dump Storage Volumes in XML, Resize Storage Volumes, Attach & Detach Storage Volumes, Clone Storage Volumes, and Remove Storage Volumes and so on. 
`destroy_virt_storage_pool`
Destroy Virtualization Storage Pool 

- Related ticket: https://progress.opensuse.org/issues/88151
- OSD Verification run: 
only [libvirt_extend_storage_lvm on host sles12sp5] (https://openqa.suse.de/tests/9291289#)
only [libvirt_extend_storage_lvm on host sles15sp3] (https://openqa.suse.de/tests/9291288#)
[storage and libvirt_extend_storage_lvm on host sles12sp5] (https://openqa.suse.de/tests/9291404#)
[storage and libvirt_extend_storage_lvm on host sles15sp3] (https://openqa.suse.de/tests/9291403#)

- full run
[gi-guest_developing-on-host_developing-kvm](http://10.67.129.218/tests/221)
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/9171211)
[gi-guest_sles12sp5-on-host_developing-kvm](https://openqa.suse.de/tests/9342590)
[gi-guest_sles12sp5-on-host_developing-xen](https://openqa.suse.de/tests/9180996)
[gi-guest_sles15sp3-on-host_developing-kvm](https://openqa.suse.de/tests/9342589)
[gi-guest_sles15sp3-on-host_developing-xen](https://openqa.suse.de/tests/9180998)
[gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.suse.de/tests/9185602)
[gi-guest_developing-on-host_sles12sp5-xen](https://openqa.suse.de/tests/9185002)
[gi-guest_developing-on-host_sles15sp3-kvm](https://openqa.suse.de/tests/9185004)
[gi-guest_developing-on-host_sles15sp3-xen](https://openqa.suse.de/tests/9185601)
- QAM OSD Verification run: 
[storage and libvirt_extend_storage_lvm on host sles12sp5](http://openqa.qam.suse.cz/tests/45882)
[storage and libvirt_extend_storage_lvm on host sles12sp4](http://openqa.qam.suse.cz/tests/45885)
[storage and libvirt_extend_storage_lvm on host sles12sp3](http://openqa.qam.suse.cz/tests/45888)
[storage and libvirt_extend_storage_lvm on host sles15sp4](http://openqa.qam.suse.cz/tests/45833#)