### PR TITLE
Add TRENTO_VERSION variable

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -203,6 +203,7 @@ sub k8s_logs {
             }
         }
     }
+    $self->az_vm_ssh_cmd('kubectl exec --stdin --tty deploy/trento-server-runner /usr/bin/trento-runner version', $machine_ip);
     script_run('ls -lai *.txt', 180);
 }
 

--- a/tests/sles4sap/trento/deploy_trento.pm
+++ b/tests/sles4sap/trento/deploy_trento.pm
@@ -40,6 +40,7 @@ sub run {
     my $trento_registry_chart = get_var(TRENTO_REGISTRY_CHART => 'registry.suse.com/trento/trento-server');
     my $cfg_json = 'config_images_gen.json';
     my @imgs = qw(WEB RUNNER);
+    # take care of TRENTO_VERSION variable too
     if (get_var("TRENTO_REGISTRY_IMAGE_$imgs[0]") || get_var("TRENTO_REGISTRY_IMAGE_$imgs[1]")) {
         my $cfg_helper_cmd = './trento_deploy/config_helper.py' .
           " -o $cfg_json" .

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -27,9 +27,16 @@ sub run {
 
     my $cypress_test_dir = "/root/test/test";
     enter_cmd "cd " . $cypress_test_dir;
-    assert_script_run("./cypress.env.py -u http://" . $machine_ip . " -p " . $trento_web_password . " -f Premium");
+    my $cypress_env_cmd = './cypress.env.py' .
+      " -u http://$machine_ip" .
+      " -p $trento_web_password" .
+      ' -f Premium';
+    if (get_var("TRENTO_VERSION")) {
+        $cypress_env_cmd .= ' --trento-version ' . get_var("TRENTO_VERSION");
+    }
+    assert_script_run($cypress_env_cmd);
     assert_script_run('cat cypress.env.json');
-
+    upload_logs('cypress.env.json');
     assert_script_run "mkdir " . $self->CYPRESS_LOG_DIR;
 
     #  Cypress verify: cypress.io self check about the framework installation

--- a/variables.md
+++ b/variables.md
@@ -202,6 +202,19 @@ ZYPPER_WHITELISTED_ORPHANS | string | empty | Whitelist expected orphaned packag
 PUBLIC_CLOUD_CONTAINER_IMAGES_REPO | string | | The Container images repository in CSP
 PREPARE_TEST_DATA_TIMEOUT | integer | 300 | Download assets in the prepare_test_data module timeout
 ZFS_REPOSITORY | string | | Optional repository used to test zfs from
+TRENTO_HELM_VERSION | string | 3.8.2 | Helm version of the JumpHost
+TRENTO_CYPRESS_VERSION | string | 4.4.0 | used as tag for the docker.io/cypress/included registry
+TRENTO_VM_IMAGE | string | SUSE:sles-sap-15-sp3-byos:gen2:latest | used as --image parameter during the Azure VM creation
+TRENTO_VERSION | string | (implicit 1.0.0) | Optional. Used as reference version string for the installed Trento
+TRENTO_REGISTRY_CHART | string | registry.suse.com/trento/trento-server | Helm chart registry
+TRENTO_REGISTRY_CHART_VERSION | string |  | Optional. Tag for the chart image
+TRENTO_REGISTRY_IMAGE_RUNNER | string |  | Optional. Overwrite the trento-runner image in the helm chart
+TRENTO_REGISTRY_IMAGE_RUNNER_VERSION | string |  | Optional. Version tag for the trento-runner image
+TRENTO_REGISTRY_IMAGE_WEB | string |  | Optional. Overwrite the trento-web image in the helm chart
+TRENTO_REGISTRY_IMAGE_WEB_VERSION | string |  | Optional. Version tag for the trento-web image
+TRENTO_GITLAB_REPO | string | gitlab.suse.de/qa-css/trento | Repository for the deployment scripts
+TRENTO_GITLAB_BRANCH | string | master | Branch to use in the deployment script repository
+
 
 ### Publiccloud specific variables
 


### PR DESCRIPTION
Add TRENTO_VERSION variable to set the expected version tag on the web
interface.Add some documentation for all the TRENTO variables.

- Verification run: http://1c242.qa.suse.de/tests/641  The key point there is in http://1c242.qa.suse.de/tests/641#settings where TRENTO_VERSION is visible and http://1c242.qa.suse.de/tests/641/file/test_trento_web-cypress.env.json that has the version to from that variable. This file is the expectation file provided as input to the  cypress test engine