### PR TITLE
Replace `sysauth/sssd` by newer test cases

### DIFF
--- a/schedule/qam/12-SP1/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP1/mau-extratests-phub.yaml
@@ -8,6 +8,6 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/12-SP2/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP2/mau-extratests-phub.yaml
@@ -8,6 +8,6 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/12-SP3/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP3/mau-extratests-phub.yaml
@@ -8,6 +8,6 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/12-SP4/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP4/mau-extratests-phub.yaml
@@ -8,6 +8,6 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/12-SP5/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP5/mau-extratests-phub.yaml
@@ -8,6 +8,6 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/15-SP1/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP1/mau-extratests-phub.yaml
@@ -10,7 +10,7 @@ schedule:
   - '{{sle15_x86_64}}'
   - console/python_flake8
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_openldap_functional
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:

--- a/schedule/qam/15-SP2/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP2/mau-extratests-phub.yaml
@@ -10,7 +10,7 @@ schedule:
   - '{{sle15_x86_64}}'
   - console/python_flake8
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_openldap_functional
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:

--- a/schedule/qam/15-SP3/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP3/mau-extratests-phub.yaml
@@ -10,7 +10,7 @@ schedule:
   - '{{sle15_x86_64}}'
   - console/python_flake8
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_389ds_functional
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:

--- a/schedule/qam/15-SP4/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP4/mau-extratests-phub.yaml
@@ -10,7 +10,7 @@ schedule:
   - '{{sle15_x86_64}}'
   # - console/python_flake8 Removed because of bsc#1198893
   - console/vmstat
-  # - sysauth/sssd Remove because of poo#113279
+  - console/sssd_389ds_functional
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:

--- a/schedule/qam/15/mau-extratests-phub.yaml
+++ b/schedule/qam/15/mau-extratests-phub.yaml
@@ -10,7 +10,7 @@ schedule:
   - '{{sle15_x86_64}}'
   - console/python_flake8
   - console/vmstat
-  - sysauth/sssd
+  - console/sssd_openldap_functional
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:


### PR DESCRIPTION
Replace `sysauth/sssd` either by `console/sssd_389ds_functional` for
15-SP3+ or folder older version by `console/sssd_openldap_functional`.

- ticket: [[qe-core]test fails in sssd. Depedency no longer shipped - replace with 389-ds](https://progress.opensuse.org/issues/113279)
- VRs: 
  * [sle-15-Server-DVD-Updates-x86_64-Build20220711-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/17663#step/sssd_openldap_functional/1)
  * [sle-15-SP1-Server-DVD-Updates-x86_64-Build20220711-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/17664#step/sssd_openldap_functional/1)
  * [sle-15-SP2-Server-DVD-Updates-x86_64-Build20220711-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/17671#step/sssd_openldap_functional/1)
  * [sle-15-SP3-Server-DVD-Updates-x86_64-Build20220711-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/17672#step/sssd_389ds_functional/1)
  * [sle-15-SP4-Server-DVD-Updates-x86_64-Build20220710-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/17667)
  * [sle-12-SP2-Server-DVD-Updates-x86_64-Build20220711-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/17668#step/sssd_openldap_functional/1)
  * [sle-12-SP4-Server-DVD-Updates-x86_64-Build20220711-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/17669#step/sssd_openldap_functional/1)
  * [sle-12-SP5-Server-DVD-Updates-x86_64-Build20220711-1-mau-extratests-phub@64bit](http://kepler.suse.cz/tests/17670#step/sssd_openldap_functional/1)