### PR TITLE
boot_from_pxe: Check for failure to load PXE kernel

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -166,6 +166,11 @@ sub run {
     send_key 'ret';
     save_screenshot;
 
+    # If the remote repo doesn't exist, the machine will silently boot
+    # from disk.
+    die 'PXE boot failed'
+      if (check_screen('pxe-kernel-not-found', timeout => 5));
+
     if (is_ipmi && !get_var('AUTOYAST')) {
         my $ssh_vnc_wait_time = 420;
         my $ssh_vnc_tag = eval { check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc' } . '-server-started';


### PR DESCRIPTION
SLE-15SP4 baremetal test installation is currently failing due to missing installation repository. However, the cause of the failure is not obvious because the test machines will boot from disk and a few more preparatory steps get executed before disk wipe gets stuck on busy device: http://openqa.qam.suse.cz/tests/44099#step/boot_from_pxe/7

Check for kernel load error after entering the PXE boot parameters and terminate the test instead of booting from disk.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1622
- Verification run:
  - SLE-15SP4: http://openqa.qam.suse.cz/tests/44257#step/boot_from_pxe/9 (expected failure)
  - SLE-15SP3: http://openqa.qam.suse.cz/tests/44258 (expected to pass)
