### PR TITLE
Move toolbox module to main_containers

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -203,6 +203,7 @@ sub load_container_tests {
         }
         else {
             # Container Host tests
+            loadtest 'microos/toolbox' if (/podman/i && (is_sle_micro || is_microos || is_leap_micro));
             load_host_tests_podman($run_args) if (/podman/i);
             load_host_tests_docker($run_args) if (/docker/i);
             load_host_tests_containerd_crictl() if (/containerd_crictl/i);

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -68,7 +68,6 @@ sub load_feature_tests {
         loadtest 'console/kubeadm';
     }
     elsif (check_var 'SYSTEM_ROLE', 'container-host') {
-        loadtest 'microos/toolbox';
         load_container_tests();
     }
 }

--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -50,7 +50,6 @@ sub load_boot_from_disk_tests {
     loadtest 'console/suseconnect_scc' if check_var('SCC_REGISTER', 'installation');
     loadtest 'transactional/enable_selinux' if get_var('ENABLE_SELINUX');
     loadtest 'transactional/install_updates' if is_released;
-    loadtest 'microos/toolbox';
 }
 
 # Handle updates from repos defined in OS_TEST_TEMPLATE combined with the list


### PR DESCRIPTION
Instead of loading this module individually in each product main.pm
I'd like to move it to the main container schedule logic.
This will help unifying the schedules later on and not execute it
when it's not needed.

VR: 
http://openqa.suse.de/t9115674
https://openqa.suse.de/tests/9115697