### PR TITLE
Add kubectl test run

### DIFF
--- a/data/containers/kubectl/deployment.yml
+++ b/data/containers/kubectl/deployment.yml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: "0.5"
+            memory: 256Mi
+          requests:
+            cpu: "0.1"
+            memory: 128Mi
+        volumeMounts:
+          - name: www
+            mountPath: /usr/share/nginx/html
+      volumes:
+        - name: www
+          hostPath:
+            path: /srv/www/kubectl
+            type: Directory
+

--- a/data/containers/kubectl/service.yml
+++ b/data/containers/kubectl/service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-load-balancer
+  labels:
+    app: nginx
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx
+  ports:
+    - name: port-http
+      port: 8080            # (exposed) service port
+      targetPort: 80        # container port
+

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -200,13 +200,13 @@ sub load_container_tests {
         } elsif (get_var('REPO_BCI')) {
             loadtest 'containers/host_configuration';
             loadtest 'containers/bci_repo';
-        }
-        else {
+        } else {
             # Container Host tests
             load_host_tests_podman($run_args) if (/podman/i);
             load_host_tests_docker($run_args) if (/docker/i);
             load_host_tests_containerd_crictl() if (/containerd_crictl/i);
             load_host_tests_containerd_nerdctl() if (/containerd_nerdctl/i);
+            loadtest('containers/kubectl') if (/kubectl/i);
             load_host_tests_helm($run_args) if (/helm/i);
         }
     }

--- a/tests/containers/kubectl.pm
+++ b/tests/containers/kubectl.pm
@@ -1,0 +1,140 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Test the kubectl utility
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils;
+use publiccloud::utils;
+use containers::k8s;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    install_kubectl();
+    # Record kubectl version and check if the tool itself is healthy
+    record_info("kubectl", script_output("kubectl version --client --output=json"));
+
+    # Prepare the webserver testdata
+    assert_script_run('mkdir -p /srv/www/kubectl');
+    assert_script_run("echo 'I am Groot' > /srv/www/kubectl/index.html");
+
+    # Configure CSP/k3s. Only one CSP at a time is possible due to the conflicting configuration in .kube/config
+    assert_script_run('mkdir -p ~/.kube');
+    my $provider = get_var("KUBECTL_CLUSTER", "k3s");
+    if ($provider eq "k3s") {
+        install_k3s();
+
+        # Ensure k3s has not installed its own kubectl
+        assert_script_run("! stat /usr/local/bin/kubectl");
+        validate_script_output("whereis kubectl", sub { $_ !~ m/\/usr\/local\/bin/ });
+    } else {
+        die "Invalid or unsupported KUBECTL_CLUSTER";
+    }
+
+    # Function to check if the output either has no resources or has at least two lines
+    # Two lines because one line is the header and the following lines are the data rows
+    validate_script_output("kubectl cluster-info", qr/Kubernetes control plane/);
+    record_info('Testing: get/smoketest', 'State tests (get commands)');
+    # Check for default namespaces to be present
+    validate_script_output("kubectl get namespaces", qr/default/);
+    validate_script_output("kubectl get namespaces", qr/system/);
+    # Check service output
+    validate_script_output("kubectl get service --all-namespaces", sub { $_ =~ m/No resources found/ || split(/\n/, $_) > 1; });
+    # At least the coredns pod must be present
+    validate_script_output("kubectl get pods --all-namespaces", sub { $_ =~ m/coredns/ });
+    # There must be at least one endpoint present
+    validate_script_output("kubectl get endpoints", sub { split(/\n/, $_) > 1; });
+    # There must be at least the coredns deployment present
+    validate_script_output("kubectl get deployments --all-namespaces", sub { $_ =~ m/coredns/ });
+    # Check if more than 1 replicasets are present
+    validate_script_output("kubectl get replicasets --all-namespaces --no-headers", sub { split(/\n/, $_) > 1; });
+    # Check ingresses, those are empty by default
+    validate_script_output("kubectl get ingresses --all-namespaces --no-headers", sub { $_ =~ m/No resources found/ });
+
+    ## Test the configuration
+    record_info('Testing: config', 'Configugration tests');
+    assert_script_run("kubectl config view");
+    validate_script_output("kubectl config view -o jsonpath={.clusters[].name}", qr/default/);
+    validate_script_output("kubectl config view -o jsonpath={.contexts[].name}", qr/default/);
+
+    ## Test the context configuration
+    assert_script_run("kubectl config get-contexts");
+    validate_script_output("kubectl config get-contexts", sub { $_ =~ m/default/ });
+    validate_script_output("kubectl config current-context", sub { $_ =~ m/default/ });
+    assert_script_run("kubectl config use-context default");
+    assert_script_run("kubectl config set-context --current --namespace=default");
+    assert_script_run("kubectl config set-context localhost --user=root --namespace=default");
+    assert_script_run("kubectl config use-context localhost");
+    assert_script_run("kubectl config use-context default");
+    assert_script_run("kubectl config unset contexts.localhost");
+
+    ## Test jobs
+    record_info('Testing: jobs and pods', 'job and pod test runs');
+    assert_script_run('kubectl create job sayhello --image=busybox:1.28 -- echo "Hello World"');
+    assert_script_run('kubectl create job gimme-date --image=busybox -- date');
+    validate_script_output("kubectl get jobs --no-headers", qr/sayhello/);
+    validate_script_output("kubectl get jobs --no-headers", qr/gimme-date/);
+    assert_script_run('kubectl wait jobs/sayhello --for=condition=complete --timeout=300s', timeout => 330);
+    assert_script_run('kubectl wait jobs/gimme-date --for=condition=complete --timeout=300s', timeout => 330);
+    # Check job output. First get the pod name
+    my $pod = script_output('kubectl get pods -o name --no-headers=true | grep sayhello');
+    script_retry("kubectl logs $pod | grep 'Hello World'", retry => 5, delay => 10);    # collection of the log can sometime take some time
+    ## Apply a custom Deployment, test scaling
+    record_info('Testing: deployment', 'deployment test');
+    assert_script_run('curl -o deployment.yml ' . data_url('containers/kubectl/deployment.yml'));
+    assert_script_run('kubectl apply -f deployment.yml');
+    assert_script_run('kubectl wait deployment nginx-deployment --for condition=available --timeout=300s', timeout => 330);
+    validate_script_output('kubectl describe deployments/nginx-deployment | grep Replicas', sub { $_ =~ m/2 desired.*2 total/ });
+    assert_script_run('kubectl describe deployments/nginx-deployment');
+    # Scale out
+    assert_script_run('kubectl scale --replicas=5 deployments/nginx-deployment');
+    assert_script_run('kubectl wait deployment nginx-deployment --for condition=available --timeout=300s', timeout => 330);
+    validate_script_output('kubectl describe deployments/nginx-deployment | grep Replicas', sub { $_ =~ m/5 desired.*5 total/ });
+    # Scale in
+    assert_script_run('kubectl scale --replicas=2 deployments/nginx-deployment');
+    assert_script_run('kubectl wait deployment nginx-deployment --for condition=available --timeout=300s', timeout => 330);
+    validate_script_output('kubectl describe deployments/nginx-deployment | grep Replicas', sub { $_ =~ m/2 desired.*2 total/ });
+    # Test the port-forwarding and the webserver
+    my $pid = background_script_run('kubectl port-forward deploy/nginx-deployment 8008:80');
+    validate_script_output_retry("curl http://localhost:8008/index.html", qr/I am Groot/, retry => 6, delay => 20, timeout => 10);
+    assert_script_run("kill $pid");    # terminate port-forwarding
+
+    ## Test service
+    # Create predefined service, and check if it appears as desired
+    record_info('Testing: services', 'service test');
+    assert_script_run('curl -o service.yml ' . data_url('containers/kubectl/service.yml'));
+    assert_script_run('kubectl apply -f service.yml');
+    validate_script_output('kubectl get services', qr/web-load-balancer/);
+    validate_script_output('kubectl describe services/web-load-balancer', sub { $_ =~ m/.*Name:.*web-load-balancer.*/ });
+    validate_script_output('kubectl describe services/web-load-balancer', sub { $_ =~ m/.*Port:.*8080\/TCP.*/ });
+    validate_script_output('kubectl describe services/web-load-balancer', sub { $_ =~ m/.*TargetPort:.*80\/TCP.*/ });
+    validate_script_output('kubectl describe services/web-load-balancer', sub { $_ =~ m/.*Endpoints:.*10.*/ });
+    validate_script_output_retry("curl http://localhost:8080/index.html", qr/I am Groot/, retry => 6, delay => 20, timeout => 10);
+    assert_script_run('kubectl delete -f service.yml');
+
+    assert_script_run('kubectl delete -f deployment.yml');
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    # Try to collect as much information about kubernetes as possible
+    script_run('kubectl describe deployments');
+    script_run('kubectl describe services');
+    script_run('kubectl describe pods');
+    # Cleanup
+    script_run('kubectl delete -f service.yml');
+    script_run('kubectl delete -f deployment.yml');
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -37,7 +37,8 @@ CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test mo
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
 CLUSTER_TYPES | string | false | Set the type of cluster that have to be analyzed (example: "drbd hana"). This variable belongs to PUBLIC_CLOUD_.
-CONTAINER_RUNTIME | string | | Container runtime to be used, e.g.  `docker`, `podman`, or both `podman,docker`.
+CONTAINER_RUNTIME | string | | Container runtime to be used, e.g.  `docker`, `podman`, or both `podman,docker`. In addition, it is also used for other container tests, like  `kubectl`, `helm`, etc.
+CONTAINERS_K3S_VERSION | string |  | If defined, install the provided version of k3s
 CONTAINERS_NO_SUSE_OS | boolean | false | Used by main_containers to see if the host is different than SLE or openSUSE.
 CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.
 CONTAINERS_CRICTL_VERSION | string | v1.23.0 | The version of CriCtl tool.
@@ -88,6 +89,10 @@ INSTLANG | string | en_US | Installation locale settings.
 IPXE | boolean | false | Indicates ipxe boot.
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
+K3S_SYMLINK | string | | Can be 'skip' or 'force'. Skips the installation of k3s symlinks to tools like kubectl or forces the creation of symlinks 
+K3S_BIN_DIR | string | | If defined, install k3s to this provided directory instead of `/usr/local/bin/`
+K3S_CHANNEL | string | | Set the release channel to pick the k3s version from. Options include "stable", "latest" and "testing"
+KUBECTL_CLUSTER | string | | Defines the cluster used to test `kubectl`. Currently only `k3s` is supported.
 KEEP_DISKS | boolean | false | Prevents disks wiping for remote backends without snaphots support, e.g. ipmi, powerVM, zVM
 KEEP_ONLINE_REPOS | boolean | false | openSUSE specific variable, not to replace original repos in the installed system with snapshot mirrors which are not yet published.
 KEEP_PERSISTENT_NET_RULES | boolean | false | Keep udev rules 70-persistent-net.rules, which are deleted on backends with image support (qemu, svirt) by default.


### PR DESCRIPTION
Add a test for `kubectl` on Tumbleweed. This PR adds the test code. The modifications to the job groups on O3 will be done after merging.

It also adds new variables to the `install_k3s` library function that are required for this test run to function properly.

Related ticket: https://progress.opensuse.org/issues/112457  
Verification run: [TW kubectl](https://duck-norris.qam.suse.de/tests/10059) | [TW helm](https://duck-norris.qam.suse.de/tests/10055)