### PR TITLE
For zdup, ensure the nvram kernel module is loaded

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2009-2013 Bernhard M. Wiedemann
+# Copyright 2009-2022 Bernhard M. Wiedemann
 # Copyright 2012-2020 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(OPENQA_FTP_URL zypper_call);
+use Utils::Backends 'is_pvm';
 
 sub run {
     my $self = shift;
@@ -34,6 +35,7 @@ sub run {
     # This is just for reference to know how the network was configured prior to the update
     script_run "ip addr show";
     save_screenshot;
+    assert_script_run('modprobe nvram') if is_pvm;
 
     # Disable all repos, so we do not need to remove one by one
     # beware PackageKit!


### PR DESCRIPTION
Refer bsc#1192968 - Make sure the "nvram" kernel module is loaded
before attempting to install or update a kernel.

- Related ticket: https://progress.opensuse.org/issues/113453
- Verification run: https://openqa.suse.de/tests/9125754#step/zdup/4
