### PR TITLE
Create smoke test for HPC trilinos package

### DIFF
--- a/schedule/hpc/single_machine_test.yaml
+++ b/schedule/hpc/single_machine_test.yaml
@@ -22,6 +22,8 @@ conditional_schedule:
         - hpc/genders
       rasdaemon:
         - hpc/rasdaemon
+      trilinos:
+        - hpc/trilinos
       hpc_migration:
         - hpc/hpc_migration
 schedule:

--- a/tests/hpc/trilinos.pm
+++ b/tests/hpc/trilinos.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright @ SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: Trilinos smoke test
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base qw(hpcbase hpc::utils), -signatures;
+use testapi;
+use utils;
+
+sub run ($self) {
+    zypper_call('in libtrilinos-gnu-openmpi3-hpc trilinos-gnu-openmpi3-hpc-devel');
+    $self->relogin_root;
+
+    if (script_run('module load gnu openmpi trilinos') != 0) {
+        my $out_text = script_output('module load trilinos', proceed_on_failure => 1);
+        if ($out_text =~ /Lmod has detected the following error/) {
+            force_soft_failure "bsc#1200376: lmod cant load trilinos";
+        }
+    }
+    script_run "module av";
+    if (!script_run qq{IFS=\": \"; for i in \$LD_LIBRARY_PATH; do for j in \$i/*.so.*; do ldd \$j; done; done | grep \"not found\"}) {
+        force_soft_failure "bsc#1200376: missing libs in \$LD_LIBRARY_PATH";
+    }
+}
+
+1;


### PR DESCRIPTION
As per comment https://progress.opensuse.org/issues/112790#note-3 the only
requirement is a smoke test for trilinos. I quote the comment also here for
future reference:
Trilinos has been removed from SLE15 SP4. There are no new products which will
have this package. It may still appear in maintenance cases, but for this, we
will only need a smoke test - ie an installation test. Trilinos itself would
be extremely cumbersome to test as it consists of a wide range of individual
libraries - each of which would have to be tested.

So this test would be enable for maintainance prior to SLE15 SP4 just for the
rare updating cases.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/112790
- Verification run: http://aquarius.suse.cz/tests/11297
