### PR TITLE
Public Cloud: Add ability to redownload maintenance repositories

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -33,6 +33,10 @@ sub run {
         record_info('Skip download', 'Skipping maintenance update download (triggered by setting)');
         return;
     } else {
+        # Remove the ~/repos so they can be redownloaded
+        if (get_var('PUBLIC_CLOUD_REDOWNLOAD_MU')) {
+            script_run("rm -rf ~/repos");
+        }
         # Skip if we already downloaded the repos
         if (get_repo_status() == 1) {
             record_info("Downloaded", "Skipping download because the repositories have been already downloaded");

--- a/variables.md
+++ b/variables.md
@@ -272,6 +272,7 @@ PUBLIC_CLOUD_REGION | string | "" | The region to use. (default-azure: westeurop
 PUBLIC_CLOUD_RESOURCE_GROUP | string | "qashapopenqa" | Allows to specify resource group name on SLES4SAP PC tests.
 PUBLIC_CLOUD_RESOURCE_NAME | string | "openqa-vm" | The name we use when creating our VM.
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Debug variable used to run test without maintenance updates repository being applied.
+PUBLIC_CLOUD_REDOWNLOAD_MU | boolean | false | Debug variable used to redownload the maintenance repositories (as they might be downloaded by parent test)
 PUBLIC_CLOUD_GOOGLE_ACCOUNT | string | "" | GCE only, used to specify the account id.
 PUBLIC_CLOUD_GOOGLE_SERVICE_ACCOUNT | string | "" | GCE only, used to specify the service account.
 PUBLIC_CLOUD_AZURE_TENANT_ID | string | "" | Used to create the service account file together with `PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID`.


### PR DESCRIPTION
Currently, when we clone a test and modify the list of issues it gets ignored as repositories were downloaded by parent.

- Verification run: [PUBLIC_CLOUD_REDOWNLOAD_MU=](https://pdostal-server.suse.cz/tests/175), [PUBLIC_CLOUD_REDOWNLOAD_MU=1](https://pdostal-server.suse.cz/tests/174)