### PR TITLE
Extend and improve MU install test

### DIFF
--- a/data/virtualization/autoyast/guest_12.xml.ep
+++ b/data/virtualization/autoyast/guest_12.xml.ep
@@ -21,7 +21,7 @@
     <ask-list config:type="list"/>
     <mode>
       <confirm config:type="boolean">false</confirm>
-      <final_reboot config:type="boolean">true</final_reboot>
+      <!--final_reboot config:type="boolean">true</final_reboot-->
     </mode>
     <proposals config:type="list"/>
     <signature-handling>
@@ -67,11 +67,15 @@
       <listentry>
         <media_url>http://download.suse.de/ibs/SUSE:/CA/{{CA_STR}}/</media_url>
       </listentry>
+    % unless ($check_var->('PATCH_WITH_ZYPPER', '1')) {
+      % my $n =0;
       % for my $repo (@$repos) {
       <listentry>
         <media_url><%= $repo %></media_url>
+        <alias>TEST_<%= $n++ %></alias>
       </listentry>
       % }
+    % }
     </add_on_products>
   </add-on>
   <firewall>

--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -53,11 +53,15 @@
       <listentry>
         <media_url>http://download.suse.de/ibs/SUSE:/CA/{{CA_STR}}/</media_url>
       </listentry>
-    % for my $repo (@$repos) {
+    % unless ($check_var->('PATCH_WITH_ZYPPER', '1')) {
+     % my $n =0;
+     % for my $repo (@$repos) {
       <listentry>
         <media_url><%= $repo %></media_url>
+        <alias>TEST_<%= $n++ %></alias>
       </listentry>
-      % }
+     % }
+    % }
     </add_on_products>
   </add-on>
   <bootloader>
@@ -79,7 +83,7 @@
     <ask-list config:type="list"/>
     <mode>
       <confirm config:type="boolean">false</confirm>
-      <final_reboot config:type="boolean">true</final_reboot>
+      <!--final_reboot config:type="boolean">true</final_reboot-->
     </mode>
     <proposals config:type="list"/>
     <signature-handling>
@@ -254,7 +258,6 @@
     <patterns config:type="list">
       <pattern>base</pattern>
       <pattern>enhanced_base</pattern>
-      <pattern>apparmor</pattern>
     </patterns>
   </software>
   <ssh_import>

--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -74,15 +74,19 @@
     </addons>
     %}
   </suse_register>
+    % unless ($check_var->('PATCH_WITH_ZYPPER', '1')) {
   <add-on>
     <add_on_products config:type="list">
+      % my $n =0;
       % for my $repo (@$repos) {
       <listentry>
         <media_url><%= $repo %></media_url>
+        <alias>TEST_<%= $n++ %></alias>
       </listentry>
       % }
     </add_on_products>
   </add-on>
+    % }
   <firewall>
     <enable_firewall config:type="boolean">false</enable_firewall>
     <start_firewall config:type="boolean">false</start_firewall>
@@ -122,6 +126,9 @@
   </networking>
   <partitioning config:type="list">
     <drive>
+      % if ($check_var->('IPMI_HW', 'supermicro')) {
+      <device>/dev/sda</device>
+      % }
       <disklabel>msdos</disklabel>
       <enable_snapshots config:type="boolean">false</enable_snapshots>
       <initialize config:type="boolean">true</initialize>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -25,25 +25,29 @@
         % if ($key eq 'ltss') {
         <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
         % }
+        <release_type/>
       </addon>
       % }
     </addons>
     %}
   </suse_register>
+    % unless ($check_var->('PATCH_WITH_ZYPPER', '1')) {
   <add-on>
     <add_on_products config:type="list">
+      % my $n =0;
       % for my $repo (@$repos) {
       <listentry>
         <media_url><%= $repo %></media_url>
+        <alias>TEST_<%= $n++ %></alias>
       </listentry>
       % }
     </add_on_products>
   </add-on>
+      % }
   <bootloader>
     <global>
       <activate>true</activate>
       <boot_mbr>true</boot_mbr>
-      <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
@@ -64,6 +68,9 @@
     <ask-list config:type="list"/>
     <mode>
       <confirm config:type="boolean">false</confirm>
+      % if ($check_var->('VERSION', '15-SP4')) {
+      <final_reboot config:type="boolean">true</final_reboot>
+      % }
     </mode>
     <proposals config:type="list"/>
     <signature-handling>
@@ -128,7 +135,9 @@
   </ntp-client>
   <partitioning config:type="list">
     <drive>
-      <!--device>/dev/sda</device-->
+      % if ($check_var->('IPMI_HW', 'supermicro')) {
+      <device>/dev/sda</device>
+      % }
       <disklabel>msdos</disklabel>
       <enable_snapshots config:type="boolean">false</enable_snapshots>
       <initialize config:type="boolean">true</initialize>
@@ -192,7 +201,6 @@
       <enable config:type="list">
         <service>sshd</service>
       </enable>
-      <on_demand config:type="list"/>
     </services>
   </services-manager>
   <software>
@@ -200,6 +208,7 @@
     <instsource/>
     <packages config:type="list">
       <package>dhcp-client</package>
+      <package>guestfs-tools</package>
     </packages>
     <products config:type="list">
       <product><%= uc $get_var->('SLE_PRODUCT') %></product>
@@ -225,7 +234,6 @@
       <fullname>bernhard</fullname>
       <gid>100</gid>
       <home>/home/bernhard</home>
-      <home_btrfs_subvolume config:type="boolean">false</home_btrfs_subvolume>
       <password_settings>
         <expire/>
         <flag/>
@@ -245,7 +253,6 @@
       <fullname>root</fullname>
       <gid>0</gid>
       <home>/root</home>
-      <home_btrfs_subvolume config:type="boolean">false</home_btrfs_subvolume>
       <password_settings>
         <expire/>
         <flag/>

--- a/schedule/qam/common/virt/qam_virt_install_guest.yaml
+++ b/schedule/qam/common/virt/qam_virt_install_guest.yaml
@@ -6,5 +6,24 @@ schedule:
   - virt_autotest/login_console
   - virtualization/universal/prepare_guests
   - virtualization/universal/waitfor_guests
+  - '{{patch_host_guest_zypper}}'
   - virtualization/universal/kernel
   - virtualization/universal/finish
+conditional_schedule:
+  patch_host_guest_zypper:
+    PATCH_WITH_ZYPPER:
+      '1':
+        - virtualization/universal/patch_and_reboot
+        - '{{after_restart_host_libvirtd}}'
+  after_restart_host_libvirtd:
+    UPDATE_PACKAGE:
+      'kernel-default':
+        - virt_autotest/login_console
+        - virtualization/universal/list_guests
+        - virtualization/universal/patch_guests
+      'xen':
+        - virt_autotest/login_console
+        - virtualization/universal/list_guests
+      'qemu':
+        - virt_autotest/login_console
+        - virtualization/universal/list_guests

--- a/tests/virtualization/universal/kernel.pm
+++ b/tests/virtualization/universal/kernel.pm
@@ -18,13 +18,21 @@ use qam;
 
 sub run {
     my $self = shift;
-    my $kernel_log = shift // '/tmp/virt_kernel.txt';
-
-    script_run "rpm -qa > /tmp/rpm-qa.txt";
-    upload_logs("/tmp/rpm-qa.txt");
-
-    check_virt_kernel(log_file => $kernel_log);
-    upload_logs($kernel_log);
+    select_console('root-console');
+    if (my $pkg = get_var("UPDATE_PACKAGE")) {
+        validate_script_output("zypper if $pkg", sub { m/(?=.*TEST_\d+)(?=.*up-to-date)/s });
+    }
+    if (check_var('PATCH_WITH_ZYPPER', '1')) {
+        assert_script_run("dmesg --level=emerg,crit,alert,err -tx |sort |comm -23 - /tmp/dmesg_err_before.txt > /tmp/dmesg_err.txt");
+    } else {
+        assert_script_run("dmesg --level=emerg,crit,alert,err -x > /tmp/dmesg_err.txt");
+    }
+    if (script_run("[[ -s /tmp/dmesg_err.txt ]]") == 0) {
+        upload_logs('/tmp/dmesg_err.txt');
+        upload_logs('/tmp/dmesg_err_before.txt') if (script_run("[[ -s /tmp/dmesg_err_before.txt ]]") == 0);
+        record_soft_failure "The dmesg_err.txt needs to be checked manually! poo#55555";
+        script_run("cat /tmp/dmesg_err.txt");
+    }
 }
 
 sub post_run_hook {

--- a/tests/virtualization/universal/patch_and_reboot.pm
+++ b/tests/virtualization/universal/patch_and_reboot.pm
@@ -21,38 +21,26 @@ use qam;
 
 sub run {
     my $self = shift;
-    my $kernel_log = shift // '/tmp/virt_kernel.txt';
-    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
-    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
-
+    select_console('root-console');
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));
-
-    script_run "rpm -qa > /tmp/rpm-qa.txt";
-    upload_logs("/tmp/rpm-qa.txt");
-
-    check_virt_kernel(log_file => $kernel_log);
-    upload_logs($kernel_log);
-
+    assert_script_run("dmesg --level=emerg,crit,alert,err -tx|sort -o /tmp/dmesg_err_before.txt") if check_var("PATCH_WITH_ZYPPER", "1");
+    assert_script_run "rm -rf /etc/zypp/repos.d/TEST*";
     add_test_repositories;
     fully_patch_system;
 
-    # useful for debugging
-    script_run("virsh list --all | grep -v Domain-0");
-
-    # Check that all guests are still running
-    script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
-
-    if (is_xen_host) {
-        # Shut all guests down so the reboot will be easier
-        script_run "virsh shutdown $_" foreach (keys %virt_autotest::common::guests);
-        script_retry "virsh list --all | grep -v Domain-0 | grep running", delay => 3, retry => 30, expect => 1;
+    if (get_var("UPDATE_PACKAGE") =~ /xen|kernel-default|qemu/) {
+        script_run("virsh list --all | grep -v Domain-0");
+        script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
+        script_run '( sleep 15 && reboot & )';
+        save_screenshot;
+        switch_from_ssh_to_sol_console(reset_console_flag => 'on');
+    } else {
+        systemctl("restart libvirtd");
+        script_run("virsh list --all | grep -v Domain-0");
+        # Check that all guests are still running
+        script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
     }
-
-    script_run '( sleep 15 && reboot & )';
-    save_screenshot;
-    switch_from_ssh_to_sol_console(reset_console_flag => 'on');
 }
-
 sub post_run_hook {
 }
 

--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -14,68 +14,41 @@ use testapi;
 use qam 'ssh_add_test_repositories';
 use utils;
 use virt_autotest::common;
-use version_utils;
-use virt_autotest::kernel;
+#use version_utils;
+#use virt_autotest::kernel;
 use virt_autotest::utils;
 
 sub run {
     my ($self) = @_;
-    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
-    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
-
-    my $kernel_log = '/tmp/guests_kernel_results.txt';
-    my ($host_running_version, $host_running_sp) = get_os_release();
+    select_console('root-console');
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));
-
-    my $found_guest = 0;    # guest where update needs to be installed has been found
-    assert_script_run qq(echo -e "Guests before and after patching:" > $kernel_log);
-    assert_script_run qq(echo -e "\\n\\nBefore:" >> $kernel_log);
-    record_info "BEFORE", "This phase is BEFORE the patching";
+    my $host_os_version = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
     foreach my $guest (keys %virt_autotest::common::guests) {
-        record_info "$guest", "Probing the guest, adding test repositories and patching the system";
-        ensure_online($guest, skip_ping => (is_hyperv_virtualization || is_vmware_virtualization));
+        if ($guest =~ /$host_os_version/) {
+            if (check_var('PATCH_WITH_ZYPPER', '1')) {
+                assert_script_run("ssh root\@$guest dmesg --level=emerg,crit,alert,err -tx|sort -o /tmp/${guest}_dmesg_err_before.txt");
+                record_info("Patching $guest");
+                ssh_add_test_repositories "$guest";
+                ssh_fully_patch_system "$guest";
 
-        my ($guest_running_version, $guest_running_sp) = get_os_release("ssh root\@$guest");
-
-        # If we're on support server we have available only guests for upgrade
-        # If we test also the hypervizor we upgrade only guests with matching version
-        if (get_var('SUPPORT_SERVER') || ($host_running_version == $guest_running_version && $host_running_sp == $guest_running_sp)) {
-            ssh_add_test_repositories "$guest";
-
-            assert_script_run "ssh root\@$guest rpm -qa > /tmp/rpm-qa-$guest-before.txt", 600;
-            upload_logs("/tmp/rpm-qa-$guest-before.txt");
-
-            check_virt_kernel(target => $guest, suffix => '-before', log_file => $kernel_log);
-
-            ssh_fully_patch_system "$guest";
-            $found_guest = 1;
-        }
-
-        record_info("REBOOT", "Rebooting $guest");
-        script_run("ssh root\@$guest reboot || true", timeout => 10);
-        wait_guest_online($guest);
-    }
-
-    # Warning, if guest which should be updated has not been found
-    record_soft_failure("Didn't found matching guest for update install:\n$host_running_version $host_running_sp") unless ($found_guest);
-    wait_guest_online($_) foreach (keys %virt_autotest::common::guests);
-
-    assert_script_run qq(echo -e "\\n\\nAfter:" >> $kernel_log);
-    record_info "AFTER", "This phase is AFTER the patching";
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 12, die => 0) != 0) {
-            record_soft_failure "Reboot on $guest failed";
-            unless (is_vmware_virtualization || is_hyperv_virtualization) {
-                script_run "virsh destroy $guest", 90;
-                assert_script_run "virsh start $guest", 60;
+                record_info("Rebooting $guest");
+                script_run("ssh root\@$guest reboot || true", timeout => 10);
+                wait_guest_online($guest);
+                assert_script_run("ssh root\@$guest dmesg --level=emerg,crit,alert,err -tx|sort|comm -23 - /tmp/${guest}_dmesg_err_before.txt > /tmp/${guest}_dmesg_err.txt");
+            } else {
+                assert_script_run("ssh root\@$guest dmesg --level=emerg,crit,alert,err > /tmp/${guest}_dmesg_err.txt");
             }
-        }
-        wait_guest_online($guest);
+            if (my $pkg = get_var("UPDATE_PACKAGE")) {
+                validate_script_output("ssh root\@$guest zypper if $pkg", sub { m/(?=.*TEST_\d+)(?=.*up-to-date)/s });
+            }
+            if (script_run("[[ -s /tmp/${guest}_dmesg_err.txt ]]") == 0) {
+                upload_logs("/tmp/${guest}_dmesg_err_before.txt") if (script_run("[[ -s /tmp/${guest}_dmesg_err_before.txt ]]") == 0); #in case err can't filtered out automatically
+                upload_logs("/tmp/${guest}_dmesg_err.txt");
+                record_soft_failure "The /tmp/${guest}_dmesg_err.txt needs to be checked manually! poo#55555";
+                assert_script_run("cat /tmp/${guest}_dmesg_err.txt");
+            }
 
-        check_virt_kernel(target => $guest, suffix => '-after', log_file => $kernel_log);
-        upload_logs($kernel_log);
-        assert_script_run "ssh root\@$guest rpm -qa > /tmp/rpm-qa-$guest-after.txt", 600;
-        upload_logs("/tmp/rpm-qa-$guest-after.txt");
+        }
     }
 }
 

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -94,9 +94,7 @@ sub upload_machine_definitions {
 
 sub run {
     my $self = shift;
-    # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
-    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
-
+    select_console('root-console');
     # Fill the current pairs of hostname & address into /etc/hosts file
     assert_script_run 'virsh list --all';
     add_guest_to_hosts $_, $virt_autotest::common::guests{$_}->{ip} foreach (keys %virt_autotest::common::guests);


### PR DESCRIPTION
Add maintenance update with zypper install and check the MU installed
from the testing repo.
See more in https://progress.opensuse.org/issues/111515


- Related ticket: https://progress.opensuse.org/issues/111515
- Needles: no
- Verification run:
- zypper:
sles15sp4:   http://openqa.qam.suse.cz/tests/44300
sles15sp1: http://openqa.qam.suse.cz/tests/44294
sles12sp5: http://openqa.qam.suse.cz/tests/44115
- autoyast : 
http://openqa.qam.suse.cz/tests/44016
- hyperv : 
https://openqa.suse.de/tests/9126294
- vmware: 
https://openqa.suse.de/tests/9126906