### PR TITLE
Revert "Improve error message when using libyui REST below SLE-15-SP3"

### DIFF
--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 SUSE LLC
+# Copyright 2020-2021 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Module to set up the environment for using libyui REST API with the
@@ -13,10 +13,8 @@ use Utils::Backends;
 use Utils::Architectures;
 use testapi;
 use YuiRestClient;
-use version_utils 'is_sle';
 
 sub run {
-    die 'Leap 15.2 and below and SLE 15-SP2 and below do not have libyui-REST, exit now.' if (is_sle('<=15-SP2') || is_leap('<=15.2'));
     die 'Module requires YUI_REST_API variable to be set.', unless get_var('YUI_REST_API');
     my $app = YuiRestClient::get_app(installation => 1, timeout => 120, interval => 1);
     my $port = $app->get_port();


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#15207

Fails with:

`# Test died: Undefined subroutine &setup_libyui::is_leap called at opensuse/tests/installation/setup_libyui.pm line 19.`