### PR TITLE
Improve error msg when using libyui REST in product version <15SP3

### DIFF
--- a/tests/installation/setup_libyui.pm
+++ b/tests/installation/setup_libyui.pm
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 SUSE LLC
+# Copyright 2020-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Module to set up the environment for using libyui REST API with the
@@ -13,8 +13,10 @@ use Utils::Backends;
 use Utils::Architectures;
 use testapi;
 use YuiRestClient;
+use version_utils qw(is_sle is_leap);
 
 sub run {
+    die 'Leap 15.2 and below and SLE 15-SP2 and below do not have libyui-REST, exit now.' if (is_leap('<=15.2') || is_sle('<=15-SP2'));
     die 'Module requires YUI_REST_API variable to be set.', unless get_var('YUI_REST_API');
     my $app = YuiRestClient::get_app(installation => 1, timeout => 120, interval => 1);
     my $port = $app->get_port();


### PR DESCRIPTION
Improve libyui REST error message.

- Related ticket: https://progress.opensuse.org/issues/112832
- Needles: -
- Verification run:
SLE15SP2: http://d218.qam.suse.de/tests/55
SLE15SP4: http://d218.qam.suse.de/tests/56
openSUSE15.3: http://d218.qam.suse.de/tests/57
openSUSE15.4: http://d218.qam.suse.de/tests/58