### PR TITLE
lib/main_common: Run autoyast/wicked only on SLE+Leap

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -498,7 +498,8 @@ sub load_autoyast_tests {
     return loadtest "locale/keymap_or_locale" if get_var('INSTALL_KEYBOARD_LAYOUT');
     loadtest("autoyast/console");
     loadtest("autoyast/login");
-    loadtest("autoyast/wicked");
+    # Wicked is the default on Leap and SLE < 16 only
+    loadtest("autoyast/wicked") if (is_sle("<16") || is_leap("<16.0"));
     loadtest('autoyast/' . get_var("AUTOYAST_VERIFY_MODULE")) if get_var("AUTOYAST_VERIFY_MODULE");
     if (get_var("SUPPORT_SERVER_GENERATOR")) {
         loadtest("support_server/configure");


### PR DESCRIPTION
Tumbleweed uses NetworkManager by default, where this module is useless.

- Verification run: https://openqa.opensuse.org/tests/2470568#live
