### PR TITLE
Update hpc yaml scheduling to include maint modules

### DIFF
--- a/schedule/hpc/create_hdd_hpc_textmode.yaml
+++ b/schedule/hpc/create_hdd_hpc_textmode.yaml
@@ -1,7 +1,7 @@
 ---
 name: create_hdd_hpc_textmode
 description:    >
-     Maintainer: schlad
+     Maintainer: qe-kernel
      Rudimentary installation scenario for creating qcow2
      required by other HPC tests
 vars:
@@ -17,10 +17,19 @@ conditional_schedule:
         - installation/bootloader_uefi
       x86_64:
         - installation/bootloader
+  add_update_test_repo:
+    FLAVOR:
+      Server-DVD-HPC-Incidents:
+        - installation/add_update_test_repo
+  patch_and_reboot_inci:
+    FLAVOR:
+      Server-DVD-HPC-Incidents:
+        - qa_automation/patch_and_reboot
 schedule:
   - '{{bootloader}}'
   - installation/welcome
   - installation/scc_registration
+  - '{{add_update_test_repo}}'
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -42,6 +51,7 @@ schedule:
   - installation/first_boot
   - console/hostname
   - console/system_prepare
+  - '{{patch_and_reboot_inci}}'
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown

--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -1,7 +1,7 @@
 ---
 name: hpc_installation_node_dev
 description:    >
-     Maintainer: schlad
+     Maintainer: qe-kernel
      Installation scenario with HPC system role hpc-node and hpc-dev
 vars:
   DESKTOP: textmode
@@ -26,11 +26,20 @@ conditional_schedule:
     HPC:
       installation_dev:
         - installation/user_settings
+  add_update_test_repo:
+    FLAVOR:
+      Server-DVD-HPC-Incidents:
+        - installation/add_update_test_repo
+  patch_and_reboot_inci:
+    FLAVOR:
+      Server-DVD-HPC-Incidents:
+        - qa_automation/patch_and_reboot
 schedule:
   - installation/isosize
   - '{{bootloader}}'
   - installation/welcome
   - installation/scc_registration
+  - '{{add_update_test_repo}}'
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -50,6 +59,7 @@ schedule:
   - installation/first_boot
   - console/hostname
   - console/system_prepare
+  - '{{patch_and_reboot_inci}}'
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown

--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -1,7 +1,7 @@
 ---
 name: hpc_installation_server
 description:    >
-     Maintainer: schlad
+     Maintainer: qe-kernel
      Installation scenario with HPC system role hpc-server.
 vars:
   DESKTOP: textmode
@@ -22,11 +22,20 @@ conditional_schedule:
         - installation/user_settings_root
       15-SP4:
         - installation/user_settings_root
+  add_update_test_repo:
+    FLAVOR:
+      Server-DVD-HPC-Incidents:
+        - installation/add_update_test_repo
+  patch_and_reboot_inci:
+    FLAVOR:
+      Server-DVD-HPC-Incidents:
+        - qa_automation/patch_and_reboot
 schedule:
   - installation/isosize
   - '{{bootloader}}'
   - installation/welcome
   - installation/scc_registration
+  - '{{add_update_test_repo}}'
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
@@ -47,6 +56,7 @@ schedule:
   - installation/first_boot
   - console/hostname
   - console/system_prepare
+  - '{{patch_and_reboot_inci}}'
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown


### PR DESCRIPTION
Add conditional arguments in the HPC yaml to include the required modules for
the maintainance jobs. With that way we dont need to update the yaml for those
jobs but we have just to add a job variable. The yaml files will remain the
same for all the coresponding jobs. The variable `QAM_INCI` is already used in
other scheduler, so i thought that it is more convenience to adapt the same
approach.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/113653
- Verification run: TBD
