### PR TITLE
Run BCI-tests also for Base Images

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -185,6 +185,7 @@ sub load_container_tests {
     if (is_container_image_test() && !(is_jeos || is_sle_micro || is_microos || is_leap_micro)) {
         # Container Image tests common
         loadtest 'containers/host_configuration';
+        loadtest 'containers/bci_prepare' if (get_var('BCI_TESTS'));
     }
 
     foreach (split(',\s*', $runtime)) {
@@ -192,9 +193,9 @@ sub load_container_tests {
         $run_args->{runtime} = $_;
         if (is_container_image_test()) {
             if (get_var('BCI_TESTS')) {
-                # External bci-tests pytest suite
-                loadtest 'containers/bci_prepare';
                 loadtest 'containers/bci_test';
+                # For Base image we also run traditional image.pm test
+                load_image_test($run_args) if (is_sle(">=15-SP3") && check_var('BCI_TEST_ENVS', 'base'));
             } elsif (is_sle_micro) {
                 # Test toolbox image updates
                 loadtest 'microos/toolbox';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/113501
VRs: 
- [15-SP3](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=17.17.24_base-image&groupid=442)
- [15-SP4](https://openqa.suse.de/tests/overview?build=27.8.5_base-image&distri=sle&version=15-SP4&groupid=443)

Needed fixes in BCI-repo to make all tests green:
- https://github.com/SUSE/BCI-tests/pull/161
- https://github.com/SUSE/BCI-tests/pull/160