### PR TITLE
Check whether testfile is a binary file

### DIFF
--- a/tests/security/ecryptfs/ecryptfs.pm
+++ b/tests/security/ecryptfs/ecryptfs.pm
@@ -45,8 +45,9 @@ sub ecryptfs_mount {
     validate_script_output('mount | grep -m 1 ecryptfs', sub { m/\/root\/private/ });
     # The testfile should be readable and writable
     assert_script_run('cd private && touch testfile && echo Hello > testfile && grep Hello testfile && cd ..');
-    # The testfile should be an encrypted file
-    validate_script_output('file .private/testfile', sub { m/data/ });
+    # Check that testfile is a binary. This fails if file is plain-text (therefore decrypted)
+    assert_script_run("perl -E 'exit((-B \$ARGV[0])?0:1);' .private/testfile");
+
     assert_script_run('umount -l private');
     validate_script_output('ls -1 private/ | wc -l', sub { m/0/ });
 


### PR DESCRIPTION
As per bsc#1200893, using `file` to check if a file is encrypted is neither correct nor reliable. This commit replaces `file` with a perl check.

VR: https://openqa.opensuse.org/tests/2471554