### PR TITLE
Unschedule sssd_openldap_functional in aarch64

### DIFF
--- a/schedule/qam/12-SP5/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP5/mau-extratests-phub.yaml
@@ -8,6 +8,13 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - console/sssd_openldap_functional
+  - '{{sssd_openldap_functional}}'
   - console/coredump_collect
+conditional_schedule:
+  sssd_openldap_functional:
+    ARCH:
+      x86_64:
+        - console/sssd_openldap_functional
+      s390x:
+        - console/sssd_openldap_functional
 ...

--- a/schedule/qam/15/mau-extratests-phub.yaml
+++ b/schedule/qam/15/mau-extratests-phub.yaml
@@ -10,11 +10,17 @@ schedule:
   - '{{sle15_x86_64}}'
   - console/python_flake8
   - console/vmstat
-  - console/sssd_openldap_functional
+  - '{{sssd_openldap_functional}}'
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:
     ARCH:
       x86_64:
         - console/wpa_supplicant
+  sssd_openldap_functional:
+    ARCH:
+      x86_64:
+        - console/sssd_openldap_functional
+      s390x:
+        - console/sssd_openldap_functional
 ...


### PR DESCRIPTION
It seems that there is no support in sle12 and sle15 for sle-module-containers
for aarch64 and the test can be removed from sle12sp5 and sle15, aarch64.

- Related ticket: https://progress.opensuse.org/issues/113695
- Needles: N/A
- Verification run: [sle15](https://openqa.suse.de/tests/9158991) | [sle12sp5](https://openqa.suse.de/tests/9158992)