### PR TITLE
Use script_retry in zypper_docker

### DIFF
--- a/tests/containers/zypper_docker.pm
+++ b/tests/containers/zypper_docker.pm
@@ -35,15 +35,15 @@ sub run {
     my $local_images_list = script_output('docker images');
     die("docker image $testing_image not found") unless ($local_images_list =~ /opensuse\s*/);
     validate_script_output("zypper-docker images ls", sub { m/opensuse/ }, 180);
-    assert_script_run("zypper-docker list-updates $testing_image", timeout => 1200);
-    assert_script_run("zypper-docker list-patches $testing_image", timeout => 1200);
+    script_retry("zypper-docker list-updates $testing_image", timeout => 600, retry => 5, delay => 60);
+    script_retry("zypper-docker list-patches $testing_image", timeout => 600, retry => 5, delay => 60);
     # run a container and check zypper-docker's containers funcionalities
     assert_script_run("docker container run -d --name tmp_container $testing_image tail -f /dev/null");
     assert_script_run("zypper-docker ps", timeout => 600);
-    assert_script_run("zypper-docker list-updates-container tmp_container", timeout => 1200);
-    assert_script_run("zypper-docker list-patches-container tmp_container", timeout => 600);
+    script_retry("zypper-docker list-updates-container tmp_container", timeout => 600, retry => 5, delay => 60);
+    script_retry("zypper-docker list-patches-container tmp_container", timeout => 600, retry => 5, delay => 60);
     # apply all the updates to a new_image
-    assert_script_run("zypper-docker update --auto-agree-with-licenses $testing_image new_image", timeout => 900);
+    script_retry("zypper-docker update --auto-agree-with-licenses $testing_image new_image", timeout => 900, retry => 5, delay => 60);
     $docker->cleanup_system_host();
 }
 


### PR DESCRIPTION
To make things a bit more robust when things like this happen:
https://openqa.suse.de/tests/9149414#step/zypper_docker/50
https://openqa.suse.de/tests/9105548#step/zypper_docker/60
https://openqa.suse.de/tests/9156098#step/zypper_docker/54

VR:  http://openqa.suse.de/t9159007