### PR TITLE
BCI: Unify k8s tests in one only test for all providers

### DIFF
--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -20,7 +20,7 @@ has tenantid => undef;
 has region => sub { get_var('PUBLIC_CLOUD_REGION', 'westeurope') };
 has username => sub { get_var('PUBLIC_CLOUD_USER', 'azureuser') };
 has service => undef;
-has container_registry => sub { get_required_var('PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY') };
+has container_registry => sub { get_var('PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY', 'suseqectesting') };
 
 sub init {
     my ($self) = @_;

--- a/lib/publiccloud/ecr.pm
+++ b/lib/publiccloud/ecr.pm
@@ -33,7 +33,7 @@ Delete a ECR image
 sub delete_image {
     my ($self, $tag) = @_;
     assert_script_run(
-        "aws ecr batch-delete-image --repository-name " . $self->container_registry . " --image-ids imageTag=" . $tag);
+        "aws ecr batch-delete-image --repository-name " . $self->provider_client->container_registry . " --image-ids imageTag=" . $tag);
     return;
 }
 

--- a/lib/publiccloud/eks.pm
+++ b/lib/publiccloud/eks.pm
@@ -22,6 +22,7 @@ sub init {
     my $cluster = get_var("PUBLIC_CLOUD_K8S_CLUSTER", "qe-c-openqa");
     my $region = get_var("PUBLIC_CLOUD_ZONE", "eu-central-1");
     assert_script_run("aws eks update-kubeconfig --name $cluster --region $region", 120);
+    script_run("kubectl config get-contexts");
     assert_script_run("kubectl get nodes");
 }
 

--- a/tests/containers/push_container_image_to_pc.pm
+++ b/tests/containers/push_container_image_to_pc.pm
@@ -1,0 +1,66 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Push a container image to the Public Cloud Registry
+#
+# Maintainer: Ivan Lausuch <ilausuch@suse.com>, qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::k8sbasetest';
+use testapi;
+use containers::urls 'get_image_uri';
+
+sub run {
+    my ($self, $run_args) = @_;
+    my $provider = undef;
+    my $container_registry_service = undef;
+
+    $self->select_serial_terminal;
+
+    if (defined $run_args->{provider}) {
+        my $public_cloud_provider = shift(@{$run_args->{provider}});
+        $container_registry_service = $self->get_container_registry_service_name($public_cloud_provider);
+        $provider = $self->provider_factory(provider => $public_cloud_provider, service => $container_registry_service);
+    }
+    else {
+        $container_registry_service = $self->get_container_registry_service_name();
+        $provider = $self->provider_factory(service => $container_registry_service);
+    }
+
+    my $image = get_image_uri();
+    my $tag = $provider->get_default_tag();
+    $self->{image_tag} = $tag;
+
+    record_info('Pull', "Pulling $image");
+    assert_script_run("podman pull $image", 360);
+
+    my $image_build_format = '{{ index .Config.Labels "org.opencontainers.image.version" }}';
+    my $image_build = script_output("podman image inspect $image --format='$image_build_format'");
+    record_info('Img version', $image_build);
+
+    my $image_name = $provider->push_container_image($image, $tag);
+    record_info('Registry',
+        "Image successfully uploaded to $container_registry_service:\n$image_name\ntag:$tag\n\n\n" . script_output("podman inspect $image_name"));
+}
+
+sub cleanup {
+    my ($self) = @_;
+    record_info('INFO', "Deleting image $self->{image_tag}");
+    $self->{provider}->delete_image($self->{image_tag});
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->cleanup();
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/containers/run_container_in_k8s.pm
+++ b/tests/containers/run_container_in_k8s.pm
@@ -1,11 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright 2021 SUSE LLC
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-License-Identifier: FSFAP
 
 # Summary: Push a container image to the public cloud container registry
 #
@@ -15,8 +11,15 @@ use Mojo::Base 'publiccloud::k8sbasetest';
 use testapi;
 
 sub run {
-    my ($self) = @_;
-    $self->SUPER::init();
+    my ($self, $run_args) = @_;
+    if ($run_args->{provider}) {
+        my $provider = shift(@{$run_args->{provider}});
+        my $service = $self->get_k8s_service_name($provider);
+        $self->SUPER::init(provider => $provider, service => $service);
+    }
+    else {
+        $self->SUPER::init();
+    }
 
     my $cmd = '"cat", "/etc/os-release"';
 
@@ -74,6 +77,10 @@ sub post_fail_hook {
 sub post_run_hook {
     my ($self) = @_;
     $self->cleanup();
+}
+
+sub test_flags {
+    return {fatal => 0};
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/112754
- Verification run: 
- http://marvin5.arch.suse.cz/tests/1089 (Build_15-SP1_6.2.647-sle-15-SP1_image)
- http://marvin5.arch.suse.cz/tests/1091 (nodejs-14-image-lang_image)
- Compatible backwards: 
	-http://marvin5.arch.suse.cz/tests/1095

Merge with: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/917