### PR TITLE
Remove 'sssd_openldap_functional' test from Core

### DIFF
--- a/schedule/qam/12-SP1/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP1/mau-extratests-phub.yaml
@@ -8,6 +8,5 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/12-SP2/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP2/mau-extratests-phub.yaml
@@ -8,6 +8,5 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/12-SP3/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP3/mau-extratests-phub.yaml
@@ -8,6 +8,5 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/12-SP4/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP4/mau-extratests-phub.yaml
@@ -8,6 +8,5 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - console/sssd_openldap_functional
   - console/coredump_collect
 ...

--- a/schedule/qam/12-SP5/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP5/mau-extratests-phub.yaml
@@ -8,13 +8,5 @@ schedule:
   - console/add_phub_extension
   - console/python_scientific
   - console/vmstat
-  - '{{sssd_openldap_functional}}'
   - console/coredump_collect
-conditional_schedule:
-  sssd_openldap_functional:
-    ARCH:
-      x86_64:
-        - console/sssd_openldap_functional
-      s390x:
-        - console/sssd_openldap_functional
 ...

--- a/schedule/qam/15/mau-extratests-phub.yaml
+++ b/schedule/qam/15/mau-extratests-phub.yaml
@@ -10,17 +10,10 @@ schedule:
   - '{{sle15_x86_64}}'
   - console/python_flake8
   - console/vmstat
-  - '{{sssd_openldap_functional}}'
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:
     ARCH:
       x86_64:
         - console/wpa_supplicant
-  sssd_openldap_functional:
-    ARCH:
-      x86_64:
-        - console/sssd_openldap_functional
-      s390x:
-        - console/sssd_openldap_functional
 ...


### PR DESCRIPTION
Due to poo#113638, the sssd_openldap_functional has been covered
in Security job group, so remove it from Core Maintenance Updates

- Related ticket: https://progress.opensuse.org/issues/113638

- Verification run:
I didn't carry out any VRs since I only deleted a single test module which didn't have dependence there. 
Anyway all cases passed in security dev job group:
https://openqa.suse.de/tests/overview?distri=sle&version=12-SP2&build=20220718-1&groupid=431
https://openqa.suse.de/tests/overview?distri=sle&version=12-SP4&build=20220718-1&groupid=431
https://openqa.suse.de/tests/overview?distri=sle&version=15&build=20220718-1&groupid=431

Tests on aarch64 platform is skipped due to poo#113695