### PR TITLE
rt: Add cleanup and shutdow to prepare migration

### DIFF
--- a/schedule/rt/prepare_migration.yaml
+++ b/schedule/rt/prepare_migration.yaml
@@ -5,3 +5,5 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - rt/prepare_migration
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
We need to publish hdd after migration. Image have to be cleaned and
system have to be shutdown.

- Related ticket: none
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: http://10.100.12.105/tests/1704
