### PR TITLE
Fix redis test

### DIFF
--- a/data/console/redis_cli.sh
+++ b/data/console/redis_cli.sh
@@ -1,0 +1,80 @@
+#!/bin/bash 
+
+function connect() {
+        port=$1
+        a=$(redis-cli -p $port ping) # Connects to the redis server at the address 127.0.0.1 with $port.
+        if [ "$a" = "PONG" ]
+        then
+                echo 'redis-server is running'
+        else
+                echo 'Failed: redis-server is not started'
+                exit 1
+        fi
+}
+
+function exec_redis() {
+        cmd=$1
+        expec_res=$2
+        res=$($cmd)
+        if [ "$res" = "$expec_res" ]
+        then
+                echo "$cmd: $expec_res"
+        else
+                echo 'Failed: redis-cli command '"$cmd"' execution'
+                exit 1
+        fi
+}
+
+## ==== Prepare environment ================================================= ##
+set -o pipefail
+connect 6379
+# Execute redis-cli commands  
+exec_redis 'redis-cli set foo bar' 'OK'
+exec_redis 'redis-cli get foo'  'bar'
+exec_redis 'redis-cli pfselftest' 'OK'
+exec_redis 'redis-cli flushdb' 'OK'
+out=$(redis-cli -p 6379 get foo)
+if [ "$out" = "" ] || [ $out = "(nil)" ]
+then
+        echo "redis-cli -p 6379 get foo: $out"
+else
+        echo 'Failed: redis-cli command 'redis-cli get foo' failed to execute'
+        exit 1
+fi
+
+# Load a test db from the data directory
+out=$(redis-cli -h localhost -p 6379 < ./movies.redis)
+exec_redis 'redis-cli HMGET movie:343 title' 'Spider-Man'
+
+# Connect to the new instance of redis-server with port 6380 and make 6380 instance a 
+# replica of redis instance running on port 6379 and verify the result
+connect 6380
+exec_redis 'redis-cli -p 6380 replicaof 127.0.0.1 6379' 'OK'
+sleep 10 
+
+out=$(redis-cli info replication)
+
+if [[ "$out" =~ "connected_slaves:1" ]]
+then
+        echo "redis-cli info replication on master"
+else
+        echo "Failed: redis-cli info replication on master, slave took longer than 10 seconds to show up"
+        exit 1
+fi
+out=$(redis-cli -p 6380 info replication)
+
+if [[ "$out" =~ "role:slave" ]]
+then
+        echo "Role:slave in redis-cli on replica"
+else
+        echo "Failed: redis-cli info replication on replica"
+        exit 1 
+fi
+out=$(redis-cli -p 6380 HMGET "movie:343" title)
+if [ "$out" = "Spider-Man" ]
+then 
+	echo "redis-cli replicaof done" 
+else	
+	echo "Failed: redis-cli replication on replica "
+        exit 1
+fi

--- a/tests/console/redis.pm
+++ b/tests/console/redis.pm
@@ -17,15 +17,8 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
-
-sub wait_serial_or_die {
-    my ($feedback, %args) = @_;
-    $args{timeout} //= 10;
-
-    my $e = wait_serial($feedback, %args);
-
-    die('Unexpected serial output') unless (defined $e);
-}
+use version_utils;
+use registration qw(add_suseconnect_product get_addon_fullname);
 
 sub run {
     my $self = shift;
@@ -34,46 +27,21 @@ sub run {
     # install redis package
     zypper_call 'in redis';
 
-    # start redis server
+    # start redis server on port 6379 and 6380
     background_script_run('redis-server');
     wait_still_screen(5);
-
-    # test if redis cli is working
-    enter_cmd('redis-cli');
-    wait_serial_or_die('127.0.0.1:6379');
-    enter_cmd('quit');
-
-    # test some redis cli commands
-    validate_script_output('redis-cli ping', sub { m/PONG/ });
-    validate_script_output('redis-cli set foo bar', sub { m/OK/ });
-    validate_script_output('redis-cli get foo', sub { m/bar/ });
-    validate_script_output('redis-cli pfselftest', sub { m/OK/ });
-    validate_script_output('redis-cli flushdb', sub { m/OK/ });
-    validate_script_output('redis-cli get foo', sub { m/(nil)/ });
-
-    assert_script_run 'curl -O ' . data_url('console/movies.redis');
-    assert_script_run('redis-cli -h localhost -p 6379 < ./movies.redis');
-    wait_still_screen(5);
-
-    validate_script_output('redis-cli HMGET "movie:343" title', sub { m/Spider-Man/ });
-
-    # start another redis instance with a different port
     background_script_run('redis-server --port 6380');
     wait_still_screen(5);
+    assert_script_run 'curl -O ' . data_url('console/movies.redis');
+    run_script('redis_cli.sh');
+}
 
-    # get redis cli prompt of new instance
-    enter_cmd('redis-cli -p 6380');
-    wait_serial_or_die('127.0.0.1:6380');
-    enter_cmd('quit');
-
-    # make 6380 instance a replica of redis instance running on port 6379
-    assert_script_run('redis-cli -p 6380 replicaof localhost 6379');
-    wait_still_screen(5);
-
-    # test replication
-    validate_script_output('redis-cli info replication', sub { m/connected_slaves:1/ });
-    validate_script_output('redis-cli -p 6380 info replication', sub { m/role:slave/ });
-    validate_script_output('redis-cli -p 6380 HMGET "movie:343" title', sub { m/Spider-Man/ });
+sub run_script {
+    my $script = shift;
+    record_info($script, "Running shell script: $script");
+    assert_script_run("curl " . data_url("console/$script") . " -o '$script'");
+    assert_script_run("chmod a+rx '$script'");
+    assert_script_run("./$script");
 }
 
 sub post_fail_hook {
@@ -94,6 +62,8 @@ sub cleanup {
     script_run('killall redis-server');
     wait_still_screen(5);
     script_run('rm -f movies.redis');
+    wait_still_screen(5);
+    script_run('rm -f redis_cli.sh');
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/111128
- Needles: NO
- Verification run: 
 SLE 15 SP3 - [x86_64](https://openqa.suse.de/tests/9274968#step/redis/22) | [s390x|](https://openqa.suse.de/tests/9274969#step/redis/22) | [aarch64](https://openqa.suse.de/tests/9274970#step/redis/22)
SLE 15 SP2 -  [x86_64](https://openqa.suse.de/tests/9274974#step/redis/22) | [s390x|](https://openqa.suse.de/tests/9274972#step/redis/22) | [aarch64](https://openqa.suse.de/tests/9274971#step/redis/22)
SLE 15 SP4 -  [x86_64](https://openqa.suse.de/tests/9274979#step/redis/22) | [ppc64le|](https://openqa.suse.de/tests/9274978#step/redis/22) | [aarch64](https://openqa.suse.de/tests/9274976#step/redis/22) | [svirt-xen-hvm](https://openqa.suse.de/tests/9274980#step/redis/17) | [svirt-xen-pv](https://openqa.suse.de/tests/9274981#step/redis/17) | [s390x](https://openqa.suse.de/tests/9274998#step/redis/22)
LEAP: [x86_64](http://10.161.229.147/tests/3801#step/redis/22)
Tumbleweed: [x86_64](http://10.161.229.147/tests/3800#step/redis/22)
