### PR TITLE
update_kernel: Enable dmesg output to console

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -359,6 +359,8 @@ sub boot_to_console {
     select_console('sol', await_console => 0) if is_ipmi;
     $self->wait_boot;
     $self->select_serial_terminal;
+    assert_script_run('echo 1 >/sys/module/printk/parameters/ignore_loglevel')
+      unless is_sle('<12');
 }
 
 sub run {


### PR DESCRIPTION
Kernel does not print dmesg info to console by default. Enable dmesg output during kernel update mainly for livepatch installation and SecureBoot tests.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-11SP3TD: https://openqa.suse.de/tests/9173701
  - SLE-12SP2: https://openqa.suse.de/tests/9173647
  - SLE-12SP3TD: https://openqa.suse.de/tests/9173648
  - SLE-15GA aarch64: https://openqa.suse.de/tests/9173649
  - SLE-15GA PPC64LE: https://openqa.suse.de/tests/9173650
  - SLE-15GA s390x: https://openqa.suse.de/tests/9173710
