### PR TITLE
Prevent kernel taint during livepatch installation

### DIFF
--- a/data/qam/heavy_load.sh
+++ b/data/qam/heavy_load.sh
@@ -10,11 +10,9 @@ if ! rpm -q "ltp-stable" ; then
 fi
 
 # Copy syscalls runtest file and use only new file
-cp /opt/ltp/runtest/syscalls /opt/ltp/runtest/syscalls.klp
-# disable add_key02 test - on most kernels causes panic
-sed  -i '/\n/!N;/\n.*\n/!N;/\n.*\n.*add_key02/{$d;N;N;d};P;D' /opt/ltp/runtest/syscalls.klp
-# kernel 4.4.92 ppc64le panicked with this tes
-sed  -i '/\n/!N;/\n.*\n/!N;/\n.*\n.*add_key04/{$d;N;N;d};P;D' /opt/ltp/runtest/syscalls.klp
+# Disable add_key* tests (may cause crashes on older kernels)
+# Disable tests which load custom kernel modules
+grep -v 'module\|add_key' /opt/ltp/runtest/syscalls >/opt/ltp/runtest/syscalls.klp
 
 # LTP: the syscalls tests
 screen -S LTP_syscalls     -L -d -m  sh -c 'yes | /opt/ltp/runltp  -f syscalls.klp'


### PR DESCRIPTION
Livepatch installation runs LTP tests in the background to create some system load while the livepatch is being applied. A few syscalls tests load custom kernel modules which taints the running kernel and causes the livepatch installation to fail. Skip those tests during livepatch setup.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/9173921
