### PR TITLE
Support installing TW with ipxe menu in O3

### DIFF
--- a/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
+++ b/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
@@ -1,4 +1,4 @@
-name:           virt-guest-installation
+name:           tumbleweed-virt-guest-install-tests
 description:    >
     Maintainer: jcao@suse.com
     Virtualization guest installation tests including extended feature tests schedule
@@ -16,7 +16,7 @@ conditional_schedule:
     install_and_bootup:
         DO_NOT_INSTALL_HOST:
             0:
-                - '{{bootup}}'
+                - installation/ipxe_install
                 - installation/welcome
                 - installation/online_repos
                 - installation/installation_mode
@@ -65,9 +65,3 @@ conditional_schedule:
         ENABLE_STORAGE:
             1:
                 - virtualization/universal/storage
-    bootup:
-        IPXE:
-            1:
-                - installation/ipxe_install
-            0:
-                - boot/boot_from_pxe


### PR DESCRIPTION
In O3, only iPXE is supported to install Tumbleweed. Meanwhile, dnsmasq + http in O3 does not allow asign an seperate iPXE bootloader for an machine in its VLAN. As a consequence, the iPXE menu has to be kept working in general so maybe more people can make use of it in the future if needed.

A static iPXE menu is supported in this PR. For virtualization tests in O3, typing 't' to enter the TW entry to start install. Check screens a few times to ensure the install process is ongoing.

- Related ticket: https://progress.opensuse.org/issues/92380 & https://progress.opensuse.org/issues/113246
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/780
- Verification run: http://10.67.129.102/tests/303 (the iPXE menu is not shown due to ipmi sol console issues of my HP machine)

Welcome comments and suggestions. 

@alice-suse @guoxuguang @waynechen55 @nanzhg @tbaev @tonyyuan1 @lemon-suse @RoyCai7 @mdoucha @czerw