### PR TITLE
Fix autoyast user configuration for sle rt

### DIFF
--- a/data/autoyast_sle15/autoyast_rt_textmode.xml
+++ b/data/autoyast_sle15/autoyast_rt_textmode.xml
@@ -128,7 +128,7 @@
   </networking>
   <users config:type="list">
     <user>
-      <encrypted config:type="boolean">false</encrypted>
+      <encrypted config:type="boolean">true</encrypted>
       <fullname>Bernhard M. Wiedemann</fullname>
       <gid>100</gid>
       <home>/home/bernhard</home>
@@ -144,7 +144,7 @@
       <username>bernhard</username>
     </user>
     <user>
-      <encrypted config:type="boolean">false</encrypted>
+      <encrypted config:type="boolean">true</encrypted>
       <fullname>root</fullname>
       <gid>0</gid>
       <home>/root</home>
@@ -156,7 +156,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA</user_password>
+      <user_password>$6$gdDHoMtVLjs4CCzf$2tSvAdgvqrKo84pA59bEjZRh7IGMfv4u0Yl4hrRzPgFPWLd8RXWdn/boT7yM3K3BlTk57qyR0TZ/nMb9rlpzx1</user_password>
       <username>root</username>
     </user>
   </users>


### PR DESCRIPTION
This will fix the login after autoyast installatiion for sle RT. The login
fails because it takes the hashed string as the actual password.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: http://aquarius.suse.cz/tests/11358
https://openqa.suse.de/t9177828