### PR TITLE
fix: add console select

### DIFF
--- a/tests/microos/libzypp_config.pm
+++ b/tests/microos/libzypp_config.pm
@@ -14,6 +14,7 @@ use testapi;
 use version_utils qw(is_jeos);
 
 sub run {
+    shift->select_serial_terminal();
     unless (check_var('FLAVOR', 'JeOS-for-AArch64') || check_var('FLAVOR', 'JeOS-for-RPi')) {
         assert_script_run 'egrep -x "^solver.onlyRequires ?= ?true" /etc/zypp/zypp.conf';
         assert_script_run 'egrep -x "^rpm.install.excludedocs ?= ?yes" /etc/zypp/zypp.conf';


### PR DESCRIPTION
[failure](https://openqa.suse.de/tests/9180392#step/libzypp_config/2)

- Verification run: [sle-15-SP3-JeOS-for-kvm-and-xen-QR-aarch64-Build4.10.26-jeos-ltp-commands@aarch64](https://openqa.suse.de/t9180611)
