### PR TITLE
Allow installing LTP from Git in livepatch incidents

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -147,7 +147,14 @@ sub install_build_dependencies {
       libopenssl-devel
       make
     );
-    push @deps, is_rt ? 'kernel-rt-devel' : 'kernel-default-devel';
+
+    if (is_rt) {
+        push @deps, 'kernel-rt-devel';
+    }
+    elsif (!get_var('KGRAFT')) {
+        push @deps, 'kernel-default-devel';
+    }
+
     zypper_call('-t in ' . join(' ', @deps));
 
     my @maybe_deps = qw(


### PR DESCRIPTION
Livepatch installation installs old kernel-default-devel and locks the package version. This conflicts with install_ltp which also tries to install kernel-default-devel but fails due to the version lock. Skip installing kernel-default-devel in install_ltp for livepatch incidents.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - livepatch: https://openqa.suse.de/tests/9186687
  - kernel update: https://openqa.suse.de/tests/9186689
  - KOTD: https://openqa.suse.de/tests/9186688
