### PR TITLE
Generate osinfo parameters for virt-install

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -209,6 +209,7 @@ sub ssh_copy_id {
 
 sub create_guest {
     my ($guest, $method) = @_;
+    my $v_type = $guest->{name} =~ /HVM/ ? "-v" : "";
 
     my $name = $guest->{name};
     my $location = $guest->{location};
@@ -238,7 +239,7 @@ sub create_guest {
 
         $extra_args = "$linuxrc autoyast=$autoyastURL $extra_args";
         $extra_args = trim($extra_args);
-        $virtinstall = "virt-install $extra_params --name $name --vcpus=$vcpus,maxvcpus=$maxvcpus --memory=$memory,maxmemory=$maxmemory --vnc";
+        $virtinstall = "virt-install $v_type $guest->{osinfo} --name $name --vcpus=$vcpus,maxvcpus=$maxvcpus --memory=$memory,maxmemory=$maxmemory --vnc";
         $virtinstall .= " --disk /var/lib/libvirt/images/xen/$name.$diskformat --noautoconsole";
         $virtinstall .= " --network network=default,mac=$macaddress --autostart --location=$location --wait -1";
         $virtinstall .= " --events on_reboot=$on_reboot" unless ($on_reboot eq '');


### PR DESCRIPTION
os-variant is obsoleted and will be replaced with osinfo? base on the actual status for the --osinfo, we generate osinfo parameters for guest installation.

- Related ticket: https://progress.opensuse.org/issues/111806
- Needles: N/A
- Verification run: 
  http://openqa.qam.suse.cz/tests/44581  #sles15
  http://openqa.qam.suse.cz/tests/44988   #sles15SP1
http://openqa.qam.suse.cz/tests/44737#  #sles15SP2
http://openqa.qam.suse.cz/tests/44739   #sles15SP3
http://openqa.qam.suse.cz/tests/44865  #sles15SP4
http://openqa.qam.suse.cz/tests/44717#step/waitfor_guests/688    #sles12SP3
http://openqa.qam.suse.cz/tests/44719#details  #sles12SP4
http://openqa.qam.suse.cz/tests/44721#details  #sles12SP5

http://10.67.97.243/tests/70/logfile?filename=autoinst-log.txt   #full input test for function gen_osinfo on local env.

