### PR TITLE
Update preparation of pr's (but really update github pages workflow)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
-name: Deploy
+name: Deploy documentation
+permissions:
+  pages: write
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,8 +129,9 @@ if (match_has_tag('yast2_missing_package')) {
 
 ### Preparing a new Pull Request
 * All code needs to be tidy, for this use `make prepare` the first time you
-  set up your local environment, use `make tidy` or `tools/tidy` locally to
-  ensure your new code adheres to our coding style.
+  set up your local environment, use `make tidy` before commiting your changes,
+  ensure your new code adheres to our coding style or use `make tidy-full` if
+  you have already few commits.
 * Every pull request is tested by our CI system for different perl versions,
   if something fails, run `make test` (don't forget to `make prepare` if your setup is new)
   but the CI results are available too, in case they need to be investigated further


### PR DESCRIPTION
I mostly want to test that explicitly changing workflow permissions, won't break anything, while avoiding privilege escalation - just in case - 

<img width="903" alt="Screenshot 2022-07-21 at 13 49 52" src="https://user-images.githubusercontent.com/229240/180207888-72150076-f2a6-4860-ad7d-8eed3167b01f.png">

follow up to: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15245
 