### PR TITLE
Double confirm smt-mirror can pass

### DIFF
--- a/tests/smt/smt_server_install.pm
+++ b/tests/smt/smt_server_install.pm
@@ -160,10 +160,16 @@ sub run {
     validate_script_output "smt-repos -o", sub { m/SLES12-SP5-Updates/ };
     validate_script_output "smt-repos -o", sub { m/SLES12-SP5-Pool/ };
 
-    assert_script_run "smt-mirror", 16000;
+    assert_script_run "smt-mirror --logfile /var/log/smt/smt-mirror.log", 16000;
 
     assert_script_run "df -h";
     save_screenshot;
+
+    #We need double confirm the mirroring procedure succeeds without any error,
+    #please refer to bsc#1201738 for more detail information
+    assert_script_run "sync";
+    assert_script_run "tail -2 /var/log/smt/smt-mirror.log | grep 'Errors:                   : 0'";
+
     select_console "x11";
 }
 


### PR DESCRIPTION
Due to bsc#1201738, enhance current logic to double check
the log file to make sure smt-mirror passes without error

- Related ticket: https://progress.opensuse.org/issues/114403
- Verification run:
http://openqa.suse.de/t9207330
http://openqa.suse.de/t9207331
http://openqa.suse.de/t9207332
