### PR TITLE
wicked: Adopt SAE tests for 0.6.70 final version

### DIFF
--- a/tests/wicked/wlan/sut/t14_sae_transition.pm
+++ b/tests/wicked/wlan/sut/t14_sae_transition.pm
@@ -24,20 +24,20 @@ has ssid => 'Virtual WiFi SAE Secured';
 has psk => 'TopSecretWifiPassphrase!';
 
 has hostapd_conf => q(
-		ctrl_interface=/var/run/hostapd
-		interface={{ref_ifc}}
-		driver=nl80211
-		country_code=DE
-		hw_mode=g
-		channel=5
-		ieee80211n=1
-		ssid={{ssid}}
-		ieee80211w=1
-		wpa=2
-		wpa_key_mgmt=SAE WPA-PSK
-		wpa_pairwise=CCMP
-		group_cipher=CCMP
-		wpa_passphrase={{psk}}
+        ctrl_interface=/var/run/hostapd
+        interface={{ref_ifc}}
+        driver=nl80211
+        country_code=DE
+        hw_mode=g
+        channel=5
+        ieee80211n=1
+        ssid={{ssid}}
+        ieee80211w=1
+        wpa=2
+        wpa_key_mgmt=SAE WPA-PSK
+        wpa_pairwise=CCMP
+        group_cipher=CCMP
+        wpa_passphrase={{psk}}
 );
 
 has ifcfg_wlan => sub { [
@@ -45,35 +45,48 @@ has ifcfg_wlan => sub { [
         BOOTPROTO='dhcp'
         STARTMODE='auto'
 
-		WIRELESS_AUTH_MODE='wpa2-personal'
-		WIRELESS_ESSID='{{ssid}}'
-		WIRELESS_WPA_PSK='{{psk}}'
+        WIRELESS_ESSID='{{ssid}}'
+        WIRELESS_WPA_PSK='{{psk}}'
     ),
         q(
         BOOTPROTO='dhcp'
         STARTMODE='auto'
 
-		WIRELESS_AUTH_MODE='wpa2-personal'
         WIRELESS_PMF=required
-		WIRELESS_ESSID='{{ssid}}'
-		WIRELESS_WPA_PSK='{{psk}}'
+        WIRELESS_ESSID='{{ssid}}'
+        WIRELESS_WPA_PSK='{{psk}}'
     ),
         q(
         BOOTPROTO='dhcp'
         STARTMODE='auto'
 
-		WIRELESS_AUTH_MODE='wpa3-personal'
         WIRELESS_PMF=disabled
-		WIRELESS_ESSID='{{ssid}}'
-		WIRELESS_WPA_PSK='{{psk}}'
+        WIRELESS_ESSID='{{ssid}}'
+        WIRELESS_WPA_PSK='{{psk}}'
     ),
         q(
         BOOTPROTO='dhcp'
         STARTMODE='auto'
 
-		WIRELESS_AUTH_MODE='wpa3-personal'
-		WIRELESS_ESSID='{{ssid}}'
-		WIRELESS_WPA_PSK='{{psk}}'
+        WIRELESS_KEY_MGMT=WPA-PSK
+        WIRELESS_ESSID='{{ssid}}'
+        WIRELESS_WPA_PSK='{{psk}}'
+    ),
+        q(
+        BOOTPROTO='dhcp'
+        STARTMODE='auto'
+
+        WIRELESS_KEY_MGMT=SAE
+        WIRELESS_ESSID='{{ssid}}'
+        WIRELESS_WPA_PSK='{{psk}}'
+    ),
+        q(
+        BOOTPROTO='dhcp'
+        STARTMODE='auto'
+
+        WIRELESS_KEY_MGMT='SAE WPA-PSK'
+        WIRELESS_ESSID='{{ssid}}'
+        WIRELESS_WPA_PSK='{{psk}}'
     )
 ] };
 

--- a/tests/wicked/wlan/sut/t15_wpa3_personal.pm
+++ b/tests/wicked/wlan/sut/t15_wpa3_personal.pm
@@ -40,14 +40,28 @@ has hostapd_conf => q(
         wpa_passphrase={{psk}}
 );
 
-has ifcfg_wlan => q(
+has ifcfg_wlan => sub { [
+        q(
+        # By default, 80211mac_hwsim has SAE capabilities, so autoselection should work
         BOOTPROTO='dhcp'
         STARTMODE='auto'
 
-        WIRELESS_AUTH_MODE='wpa3-personal'
         WIRELESS_ESSID='{{ssid}}'
         WIRELESS_WPA_PSK='{{psk}}'
-);
+    ),
+        q(
+        BOOTPROTO='dhcp'
+        STARTMODE='auto'
+
+        WIRELESS_KEY_MGMT=SAE
+        WIRELESS_CIPHER_GROUP=CCMP
+        WIRELESS_CIPHER_PAIRWISE=CCMP
+        WIRELESS_PMF=required
+        WIRELESS_ESSID='{{ssid}}'
+        WIRELESS_WPA_PSK='{{psk}}'
+    )
+] };
+
 
 
 1;

--- a/tests/wicked/wlan/sut/t16_wpa3_eap_ttls.pm
+++ b/tests/wicked/wlan/sut/t16_wpa3_eap_ttls.pm
@@ -36,7 +36,7 @@ has hostapd_conf => q(
     ieee80211n=1
     auth_algs=3
     wpa=2
-    wpa_key_mgmt=WPA-EAP-SUITE-B-192
+    wpa_key_mgmt=WPA-EAP-SUITE-B WPA-EAP-SUITE-B-192
     rsn_pairwise=CCMP
     group_cipher=CCMP
     ieee80211w=2
@@ -60,7 +60,20 @@ has ifcfg_wlan => sub { [
 
             # Network settings
             WIRELESS_ESSID='{{ssid}}'
-            WIRELESS_AUTH_MODE='wpa3-enterprise'
+            WIRELESS_KEY_MGMT='WPA-EAP-SUITE-B'
+            WIRELESS_EAP_AUTH='pap'
+            WIRELESS_EAP_MODE='TTLS'
+            WIRELESS_CA_CERT='{{ca_cert}}'
+            WIRELESS_WPA_IDENTITY='{{eap_user}}'
+            WIRELESS_WPA_PASSWORD='{{eap_password}}'
+        ),
+        q(
+            BOOTPROTO='dhcp'
+            STARTMODE='auto'
+
+            # Network settings
+            WIRELESS_ESSID='{{ssid}}'
+            WIRELESS_KEY_MGMT='WPA-EAP-SUITE-B-192'
             WIRELESS_EAP_AUTH='pap'
             WIRELESS_EAP_MODE='TTLS'
             WIRELESS_CA_CERT='{{ca_cert}}'


### PR DESCRIPTION
The tests where created during development, where we had
`WIRLESS_AUTH_MODE=wpa[123]-personal` and so on. This was replaces with `WIRELESS_KEY_MGMT` in the final PR.

The PR which merged wpa3 support for wicked is: https://github.com/openSUSE/wicked/pull/920

- Verification run: http://openqa.wicked.suse.de/tests/75408
