### PR TITLE
Save logs directly on the worker for offline upload via ulogs

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -1,0 +1,41 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+=head1 Utils::Logging
+
+C<Utils::Logging> - Save logs directly on the worker for offline upload via ulogs 
+
+=cut
+
+package Utils::Logging;
+
+use base 'Exporter';
+use Exporter;
+use strict;
+use warnings;
+use testapi 'script_output';
+use Mojo::File qw(path);
+
+our @EXPORT = qw(save_ulog);
+
+=head2
+
+save_ulog($out $filename);
+
+Creates a file from a string, the file is then saved in the ulogs directory of the worker running isotovideo. 
+This is particularily useful when the SUT has no network connection.
+
+example: 
+
+$out = script_output('journalctl --no-pager -axb -o short-precise');
+$filename = "my-test.log";
+
+=cut
+
+sub save_ulog {
+    my ($out, $filename) = @_;
+    mkdir('ulogs') if (!-d 'ulogs');
+    path("ulogs/$filename")->spurt($out);    # save the logs to the ulogs directory on the worker directly
+}
+
+1;

--- a/tests/console/start_systemd_testkit_offline.pm
+++ b/tests/console/start_systemd_testkit_offline.pm
@@ -21,6 +21,7 @@ use Mojo::JSON qw(encode_json);
 use version_utils qw(is_sle);
 use strict;
 use warnings;
+use Utils::Logging;
 
 my $log = '/tmp/systemd_run.log';
 my $testdir = '/usr/lib/test/external/';
@@ -122,6 +123,8 @@ sub upload_systemdlib_tests_logs {
     my ($self) = @_;
     my $out = script_output('journalctl --no-pager -axb -o short-precise');
     record_info("JOURNAL", "$out");
+    my $filename = "start_external_testkit_offline.log";
+    save_ulog($out, $filename);
 }
 
 1;


### PR DESCRIPTION
see poo# https://progress.opensuse.org/issues/109792
sub routine: save_ulog - save logs directly on the worker for offline upload via ulog
see verification test run for start_systemd_testkit_offline