### PR TITLE
Fix generation of the gh pages docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy documentation
 permissions:
-  pages: write
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Permission was wrong in the first place, waiting for https://github.com/peaceiris/actions-gh-pages/pull/624 to be merged to update the version of the action.
