### PR TITLE
Link info on problems with S390 GUI shutdown to most recent ticket

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -277,7 +277,7 @@ sub power_action {
         }
         elsif ($action eq 'poweroff') {
             if (is_backend_s390x) {
-                record_info('poo#58127', 'Temporary workaround, because shutdown module is marked as failed on s390x backend when shutting down from GUI.');
+                record_info('poo#114439', 'Temporary workaround, because shutdown module is marked as failed on s390x backend when shutting down from GUI.');
                 select_console 'root-console';
                 enter_cmd "$action";
             }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/114439
- GUI shutdown is not working, so there is still the workaround
  and we log an info message there

- Verification run: https://openqa.suse.de/tests/9197390#step/shutdown/8