### PR TITLE
Make sure that autoyast2 is installed before clone_system

### DIFF
--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -17,6 +17,7 @@ use testapi;
 sub run {
     my $self = shift;
     assert_script_run 'rm -f /root/autoinst.xml';
+    zypper_call('in autoyast2', 300);
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'clone_system', yast2_opts => '--ncurses');
     if (check_screen 'autoyast2-install-accept', 10) {
         send_key 'alt-i';    # confirm package installation


### PR DESCRIPTION
Call `zypper in` on /autoyast2/ package which provides the clone_system yast
feature. This makes the module autonomous and self-contained. In case the
package is already installed, this addition would not cause any destructions
and the flow will continue as expected. I added a timeout because i encounter
some issues on aarch64. no needed for x86_64.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>
