### PR TITLE
Revert #15268

### DIFF
--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -17,7 +17,6 @@ use testapi;
 sub run {
     my $self = shift;
     assert_script_run 'rm -f /root/autoinst.xml';
-    zypper_call('in autoyast2', 300);
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'clone_system', yast2_opts => '--ncurses');
     if (check_screen 'autoyast2-install-accept', 10) {
         send_key 'alt-i';    # confirm package installation


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15268 broke all of Factory with the following error

---
# Test died: Undefined subroutine &clone::zypper_call called at opensuse/tests/autoyast/clone.pm line 20.
	clone::run(clone=HASH(0x5611f78d25e8)) called at /usr/lib/os-autoinst/basetest.pm line 328
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 322
	basetest::runtest(clone=HASH(0x5611f78d25e8)) called at /usr/lib/os-autoinst/autotest.pm line 364
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 364
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 240
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 240
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 291
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x5611f9c34b38)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x5611f9c34b38), CODE(0x5611fa0847d0)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 488
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x5611f9c34b38)) called at /usr/lib/os-autoinst/autotest.pm line 293
	autotest::start_process() called at /usr/bin/isotovideo line 262
---

The PR clearly included no verification run

This PR will be merged ASAP to get Factory rolling again