### PR TITLE
Fix apache2_changehat on Tumbleweed too

### DIFF
--- a/tests/security/apparmor_profile/apache2_changehat.pm
+++ b/tests/security/apparmor_profile/apache2_changehat.pm
@@ -153,7 +153,7 @@ sub run {
     my @check_list = ('file_receive', 'open', 'signal', 'mknod');
     foreach my $check_point (@check_list) {
         if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* operation=.*$check_point.* profile=.*httpd-prefork.*/sx) {
-            if (!is_sle('<=15-SP4')) {
+            if (is_sle('>15-SP4')) {
                 record_info("ERROR", "There are denied $check_point records found in $audit_log", result => 'fail');
                 $self->result('fail');
             }


### PR DESCRIPTION
This fixes the failing test https://openqa.opensuse.org/tests/2477806 (bsc#1191684)

- Verification runs:
  - 15-SP4: https://openqa.suse.de/tests/9207429
  - openSUSE Tumbleweed: https://openqa.opensuse.org/tests/2479850