### PR TITLE
Revert "Install WSL from MSStore in Win11"

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -62,14 +62,12 @@ sub open_powershell_as_admin {
         assert_and_click "windows-user-acount-ctl-yes";
         mouse_hide();
         wait_still_screen stilltime => 2, timeout => 15;
-        if (check_var("WIN_VERSION", "11")) {
+        if (check_var('VERSION', '11')) {
             # Screen resolution differs in Win11 and the max. button is out of
-            # sight, so we right-click on the window bar to maximize
-            assert_and_click 'powershell-as-admin-window', button => 'right', timeout => 240;
-            save_screenshot;
-            assert_and_click 'powershell-max-window-right-click';
+            # sight, so we dclick on the window bar to maximize
+            assert_and_dclick 'powershell-as-admin-window';
         } else {
-            assert_screen 'powershell-as-admin-window', timeout => 240;
+            assert_screen 'powershell-as-admin-window', 240;
             assert_and_click 'window-max';
         }
         sleep 3;
@@ -162,9 +160,6 @@ sub install_wsl2_kernel {
             assert_and_click 'wsl2-install-kernel-start', timeout => 60;
             assert_and_click 'wsl2-install-kernel-finished', timeout => 60;
         }
-    );
-    $self->run_in_powershell(
-        cmd => q{wsl --set-default-version 2}
     );
 }
 

--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -22,7 +22,7 @@ sub run {
 
     # Win11 checks for updates and reboots here so there's need for timeout
     assert_and_click('windows-device-name', timeout => 300)
-      if (check_var("WIN_VERSION", "11"));
+      if (check_var('VERSION', '11'));
 
     # Network setup takes ages
     assert_screen 'windows-account-setup', 360;
@@ -31,7 +31,7 @@ sub run {
     assert_and_click 'windows-next';
 
     # To select an offline account in Win11 requires an intermediate step
-    if (check_var "WIN_VERSION", "11") {
+    if (check_var 'VERSION', '11') {
         assert_and_click('windows-signin-options', timeout => 300);
     }
     else {
@@ -69,7 +69,7 @@ sub run {
     my @privacy_menu =
       split(',', get_required_var('WIN_INSTALL_PRIVACY_NEEDLES'));
     foreach my $tag (@privacy_menu) {
-        my $version_privacy_needles_scroll = (check_var("WIN_VERSION", "11")) ? 3 : 4;
+        my $version_privacy_needles_scroll = (check_var('VERSION', '11')) ? 3 : 4;
         send_key('pgdn') if (++$count % $version_privacy_needles_scroll == 0);
         assert_and_click $tag;
         wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;

--- a/tests/wsl/install/ms_win_installation.pm
+++ b/tests/wsl/install/ms_win_installation.pm
@@ -33,7 +33,7 @@ sub run {
     # This test works onlywith CDMODEL=ide-cd due to windows missing scsi drivers which are installed via scsi iso
     assert_screen 'windows-setup', 300;
     send_key 'alt-n';    # next
-    prepare_win11 if (check_var('WIN_VERSION', '11'));
+    prepare_win11 if (get_var('VERSION') == '11');
 
     save_screenshot;
     send_key 'alt-i';    # install Now

--- a/tests/wsl/install_from_MSStore.pm
+++ b/tests/wsl/install_from_MSStore.pm
@@ -13,14 +13,11 @@ use version_utils "is_sle";
 sub run {
     my ($self) = @_;
     my $winget_version = 'v.1.3.1611';
-    my $winget_url = "https://github.com/microsoft/winget-cli/releases/download/$winget_version/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle";
+    my $winget_url = 'https://github.com/microsoft/winget-cli/releases/download/' . $winget_version . '/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle';
     my $WSL_version = get_required_var "WSL_VERSION";
     assert_screen 'windows-desktop';
     $self->open_powershell_as_admin;
     # Enable Windows features WSL and VM platform
-    $self->run_in_powershell(
-        cmd => 'New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -Name AllowDevelopmentWithoutDevLicense -PropertyType DWORD -Value 1'
-    );
     $self->run_in_powershell(
         cmd => "Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart",
         timeout => 300
@@ -29,46 +26,27 @@ sub run {
         cmd => "Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -NoRestart",
         timeout => 300
     );
-    $self->run_in_powershell(
-        cmd => 'Disable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V-Hypervisor -NoRestart'
-    ) if (get_var('WSL2'));
 
     # Reboot and wait for it
     $self->reboot_or_shutdown(1);
     $self->wait_boot_windows;
     $self->open_powershell_as_admin;
 
-    if (get_var('WSL2')) {
-        $self->install_wsl2_kernel;
-    }
-    else {
-        $self->run_in_powershell(
-            cmd => "wsl --set-default-version 1"
-        ) if (check_var("WIN_VERSION", "11"));
-    }
-
+    # $self->install_wsl2_kernel;
 
     # Download 'winget v1.3.1251-preview' for installing packages from the MS Store
     # with no need for credentials.
     $self->run_in_powershell(
-        cmd => "Invoke-WebRequest -Uri \"$winget_url\" -OutFile \"C:\\winget.msixbundle\"",
+        cmd => "Invoke-WebRequest -Uri '" . $winget_url . "' -OutFile 'C:\\winget.msixbundle'",
         timeout => 300
     );
     # Install 'winget v1.3.1251-preview'
     $self->run_in_powershell(
         cmd => 'ii C:\\winget.msixbundle',
         code => sub {
-            send_key 'alt-tab' if (check_var("WIN_VERSION", "11"));
-            assert_screen [('install-winget-wsl', 'install-winget-background-wsl')];
-            assert_and_click 'install-winget-background-wsl' if (match_has_tag('install-winget-background-wsl'));
             assert_and_click 'install-winget-wsl';
             assert_screen 'install-winget-wsl-finish', timeout => 600;
-            assert_screen(['background-winget-install', 'foreground-winget-install']);
-            if (match_has_tag 'foreground-winget-install') {
-                assert_and_click 'foreground-winget-install';
-            } else {
-                assert_and_click 'background-winget-install';
-            }
+            assert_and_click 'foreground-winget-install';
             assert_and_click 'close-winget-install';
             send_key 'alt-tab';
         }
@@ -78,12 +56,17 @@ sub run {
     $self->run_in_powershell(
         cmd => 'winget install --accept-package-agreements --accept-source-agreements "' . $WSL_version . '"',
         code => sub {
-            assert_screen 'install-SUSE-WSL-finish', timeout => 600;
+            assert_and_click 'install-SUSE-WSL-finish', timeout => 600;
         }
     );
 
-    $self->use_search_feature(get_var('WSL_VERSION'));
-    send_key 'ret';
+    record_info 'Port close', 'Closing serial port...';
+    $self->run_in_powershell(
+        cmd => q{$port.close()},
+        code => sub { }
+    );
+
+    assert_and_click 'foreground-SUSE-WSL';
 }
 
 1;

--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -108,20 +108,21 @@ sub run {
     if (get_var('WSL2')) {
         $self->open_powershell_as_admin;
         $self->install_wsl2_kernel;
+        $self->run_in_powershell(
+            cmd => q{wsl --set-default-version 2}
+        );
+        $self->run_in_powershell(
+            cmd => q{$port.close()},
+            code => sub { }
+        );
     } else {
         $self->open_powershell_as_admin(no_serial => 1);
-        $self->run_in_powershell(
-            cmd => "wsl --set-default-version 1",
-            code => sub { }
-        ) if (check_var("WIN_VERSION", "11"));
     }
 
     $self->run_in_powershell(
         cmd => qq{ii C:\\$wsl_appx_filename},
         code => sub {
-            assert_screen(['install-linux-in-wsl', 'install-linux-in-wsl-background'], timeout => 120);
-            assert_and_click 'install-linux-in-wsl-background' if (match_has_tag 'install-linux-in-wsl-background');
-            assert_and_click 'install-linux-in-wsl';
+            assert_and_click 'install-linux-in-wsl', timeout => 120;
         }
     );
 }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#15243

This broke the wsl-install-MSStore-TW test on TW: https://openqa.opensuse.org/tests/2479903
From a quick look this might be caused by no longer closing the serial port.

Verification run: https://openqa.opensuse.org/tests/2479929#live

CC @pablo-herranz 