### PR TITLE
Fix script_retry times for guest install low and ip files empty

### DIFF
--- a/data/virtualization/autoyast/guest_12.xml.ep
+++ b/data/virtualization/autoyast/guest_12.xml.ep
@@ -331,10 +331,14 @@
 mkdir -p -m 700 /root/.ssh
 echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_key
-touch /etc/init.d/after.local && chmod +x /etc/init.d/after.local
-echo "#!/bin/bash
-ip -br a | grep eth0 | awk '{print /$3}' | cut -d'/' -f1  > /root/$(hostname)
-curl -k -u root:{{PASS}} -T /root/$(hostname) sftp://{{SUT_IP}}/root/guests_ip/ --ftp-create-dirs" > /etc/init.d/after.local
+cat > /etc/init.d/after.local<< EOF
+#!/bin/sh
+ip a | grep eth0 | grep -Po '(?<=inet )[\d.]+' > /root/$(hostname)
+logger "IP is written into file"
+curl -k -u root:{{PASS}} -T /root/$(hostname) sftp://{{SUT_IP}}/tmp/guests_ip/ --ftp-create-dirs
+exit 0
+EOF
+chmod u+x /etc/init.d/after.local
 ]]></source>
 </script>
 </post-scripts>

--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -320,10 +320,14 @@
 mkdir -p -m 700 /root/.ssh
 echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_key
-touch /etc/init.d/after.local && chmod +x /etc/init.d/after.local
-echo "#!/bin/bash
-ip -br a | grep eth0 | awk '{print /$3}' | cut -d'/' -f1  > /root/$(hostname)
-curl -k -u root:{{PASS}} -T /root/$(hostname) sftp://{{SUT_IP}}/root/guests_ip/ --ftp-create-dirs" > /etc/init.d/after.local
+cat > /etc/init.d/after.local<< EOF
+#!/bin/sh
+ip a | grep eth0 | grep -Po '(?<=inet )[\d.]+' > /root/$(hostname)
+logger "IP is written into file"
+curl -k -u root:{{PASS}} -T /root/$(hostname) sftp://{{SUT_IP}}/tmp/guests_ip/ --ftp-create-dirs
+exit 0
+EOF
+chmod u+x /etc/init.d/after.local
 ]]></source>
 </script>
 </post-scripts>

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -69,7 +69,7 @@ sub run {
     assert_script_run('for i in $(virsh list --name|grep sles);do virsh destroy $i;done');
     assert_script_run('for i in $(virsh list --name --inactive); do virsh undefine $i --remove-all-storage;done');
     script_run("[ -f /root/.ssh/known_hosts ] && > /root/.ssh/known_hosts");
-    script_run 'rm -rf guests_ip';
+    script_run 'rm -rf /tmp/guests_ip';
 
 
     # Ensure additional package is installed

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -101,9 +101,9 @@ sub run {
     assert_script_run "cat /etc/hosts";
 
     # Wait for guests to announce that installation is complete
-    script_retry("test -d guests_ip", retry => 30, delay => 60);
+    script_retry("test -d /tmp/guests_ip", retry => 15, delay => 120);
     foreach my $guest (keys %virt_autotest::common::guests) {
-        script_retry("test -f guests_ip/$guest", retry => 10, delay => 60);
+        script_retry("test -f /tmp/guests_ip/$guest", retry => 20, delay => 120);
         record_info("$guest installed", "Guest installation completed");
     }
     record_info("All guests installed", "Guest installation completed");


### PR DESCRIPTION
Fix script_retry and ip files empty issues. Improve some code.

See https://progress.opensuse.org/issues/114613

- Related ticket: https://progress.opensuse.org/issues/114613
- Needles: no
- Verification run: 
- sle15SP3: http://openqa.qam.suse.cz/tests/44968
- sle15SP4: http://openqa.qam.suse.cz/tests/44865
- sle12SP4: http://openqa.qam.suse.cz/tests/44777
