### PR TITLE
Delete drawboard function from WebSocketsTest

### DIFF
--- a/lib/Tomcat/JspTest.pm
+++ b/lib/Tomcat/JspTest.pm
@@ -16,7 +16,7 @@ use Tomcat::Utils;
 use version_utils 'is_sle';
 
 # allow a 60 second timeout for asserting needles
-use constant TIMEOUT => 60;
+use constant TIMEOUT => 90;
 
 # test all JSP examples
 sub test_all_examples() {

--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -17,7 +17,7 @@ use version_utils 'is_sle';
 use registration;
 
 # allow a 60 second timeout for asserting needles
-use constant TIMEOUT => 60;
+use constant TIMEOUT => 90;
 
 # Use keyboard to browse the examples faster
 sub browse_with_keyboard {

--- a/lib/Tomcat/WebSocketsTest.pm
+++ b/lib/Tomcat/WebSocketsTest.pm
@@ -15,14 +15,14 @@ use utils;
 use Tomcat::Utils;
 
 # allow a 60 second timeout for asserting needles
-use constant TIMEOUT => 60;
+use constant TIMEOUT => 90;
 
 # test all WebSocket examples
 sub test_all_examples() {
     my ($self) = shift;
 
     # array with example test function and number of tabs required to select the example
-    my @websocket_examples = ([\&echo, 1], [\&chat, 1], [\&snake, 1], [\&drawboard, 1]);
+    my @websocket_examples = ([\&echo, 1], [\&chat, 1], [\&snake, 1]);
 
     # access the tomcat websocket examples page
     $self->firefox_open_url('localhost:8080/examples/websocket');
@@ -59,17 +59,6 @@ sub snake() {
     send_key('right');
     send_key('down');
     assert_screen('tomcat-snake-example', TIMEOUT);
-}
-
-# test multiplayer drawboard example
-sub drawboard() {
-    assert_screen('tomcat-multiplayer-drawboard-example', TIMEOUT);
-    assert_and_click('tomcat-multiplayer-drawboard-example-focus');
-    send_key('pgdn');
-    assert_and_click('tomcat-multiplayer-drawboard-example-thickness');
-    send_key('pgup');
-    assert_and_click('tomcat-multiplayer-drawboard-example-draw');
-    assert_screen('tomcat-multiplayer-drawboard-example-result', TIMEOUT);
 }
 
 1;


### PR DESCRIPTION
Due to poo#114532, in the sake of stability, that we can safely
delete the function that tests the drawboard example.
We already cover the rest of Tomcat's WebSocket examples,
and, in reality, this drawboard example is not really tested
with multiple connections as it would ideally be the case.

At the same time, increase the timeout value for some tomcat
test modules to reduce the impact by performance.

- Related ticket: https://progress.opensuse.org/issues/114532
- Needles:n/a
- Verification run: http://openqa.suse.de/tests/9208849