### PR TITLE
SLE Micro: skip installing a package in toolbox container

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -111,7 +111,7 @@ sub run {
         record_info('ISSUE', 'https://github.com/kubic-project/microos-toolbox/issues/23');
     }
     assert_script_run 'toolbox run -c devel -- zypper lr';
-    assert_script_run 'toolbox run -c devel -- zypper -n in python3', timeout => 180;
+    assert_script_run 'toolbox run -c devel -- zypper -n in python3', timeout => 180 unless is_sle_micro;
     assert_script_run 'podman rm devel';
 
     cleanup;


### PR DESCRIPTION
A regression happened with toolbox tests in SLE Micro 5.3 and it's
because the following pull request removed a condition:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15213

We can't install packages in toolbox container for non-released products
because it will try to get the repos from proxy scc which don't exist.

Failure: https://openqa.suse.de/tests/9214203#step/toolbox/87
VR: https://openqa.suse.de/tests/9215345#step/toolbox/1