### PR TITLE
sles4sap: Add FENCING_MECHANISM variable (sbd|native)

### DIFF
--- a/data/publiccloud/terraform/sap/azure.tfvars
+++ b/data/publiccloud/terraform/sap/azure.tfvars
@@ -265,6 +265,9 @@ hana_master_password = "Linux1234"
 # Cost optimized scenario
 #scenario_type = "cost-optimized"
 
+# fencing mechanism for HANA cluster (Options: sbd [default], native)
+hana_cluster_fencing_mechanism = "%FENCING_MECHANISM%"
+
 #######################
 # SBD related variables
 #######################

--- a/data/publiccloud/terraform/sap/ec2.tfvars
+++ b/data/publiccloud/terraform/sap/ec2.tfvars
@@ -208,7 +208,7 @@ hana_cluster_vip = "192.168.1.10"
 
 # Select HANA cluster fencing mechanism. 'native' by default
 # Find more information in `doc/fencing.md` documentation page
-#hana_cluster_fencing_mechanism = "sbd"
+hana_cluster_fencing_mechanism = "%FENCING_MECHANISM%"
 
 # Enable Active/Active HANA setup (read-only access in the secondary instance)
 #hana_active_active = true

--- a/data/publiccloud/terraform/sap/gce.tfvars
+++ b/data/publiccloud/terraform/sap/gce.tfvars
@@ -193,7 +193,7 @@ hana_cluster_vip = "10.0.1.200"
 
 # Select HANA cluster fencing mechanism. 'native' by default
 # Find more information in `doc/fencing.md` documentation page
-#hana_cluster_fencing_mechanism = "sbd"
+hana_cluster_fencing_mechanism = "%FENCING_MECHANISM%"
 
 # Enable Active/Active HANA setup (read-only access in the secondary instance)
 #hana_active_active = true

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -374,6 +374,7 @@ sub terraform_apply {
         $sle_version =~ s/-/_/g;
         my $ha_sap_repo = get_var('HA_SAP_REPO') ? get_var('HA_SAP_REPO') . '/SLE_' . $sle_version : '';
         my $suffix = sprintf("%04x", rand(0xffff));
+        my $fencing_mechanism = get_var('FENCING_MECHANISM', 'sbd');
         file_content_replace('terraform.tfvars',
             q(%MACHINE_TYPE%) => $instance_type,
             q(%REGION%) => $self->provider_client->region,
@@ -383,7 +384,8 @@ sub terraform_apply {
             q(%STORAGE_ACCOUNT_NAME%) => $storage_account_name,
             q(%STORAGE_ACCOUNT_KEY%) => $storage_account_key,
             q(%HA_SAP_REPO%) => $ha_sap_repo,
-            q(%SLE_VERSION%) => $sle_version
+            q(%SLE_VERSION%) => $sle_version,
+            q(%FENCING_MECHANISM%) => $fencing_mechanism
         );
         upload_logs(TERRAFORM_DIR . "/$cloud_name/terraform.tfvars", failok => 1);
         script_retry('terraform init -no-color', timeout => $terraform_timeout, delay => 3, retry => 6);


### PR DESCRIPTION
This PR adds the `FENCING_MECHANISM` variable to test diferent fencing mechanisms: sbd or native.

According to [this document](https://github.com/SUSE/ha-sap-terraform-deployments/blob/main/doc/fencing.md#cloud-native-fencing), the native option is only available for AWS & GCP for now, so the verification run is only for GCP with `FENCING_MECHANISM` set to `sbd` (as `native` is the default for that provider).

- Verification run: http://1b124.qa.suse.de/tests/95