### PR TITLE
Odd number of arguments in java

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -53,10 +53,10 @@ sub run {
 
     if (is_transactional) {
         select_console 'root-console';
-        trup_call("--continue pkg $cmd", 2000);
+        trup_call("--continue pkg $cmd", timeout => 2000);
         check_reboot_changes;
         reset_consoles;
-        select_console('root-console', 200);
+        select_console 'root-console';
     }
     else {
         zypper_call($cmd, timeout => 2000);


### PR DESCRIPTION
Regression caused by PR#15255

```
Odd number of elements in hash assignment at
opensuse/lib/transactional.pm line 151.
    transactional::trup_call("--continue pkg install
--auto-agree-with-licenses java-*", 2000) called at
opensuse/tests/console/java.pm line 56"")
```

VR: [opensuse-Tumbleweed-DVD-x86_64-Build20220726-extra_tests_transactional_server@64bit](https://openqa.opensuse.org/tests/2484725#step/java/45)
