### PR TITLE
Fix DNS SRV records issue for samba test

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -44,6 +44,9 @@ sub samba_sssd_install {
     script_run('echo NETCONFIG_DNS_STATIC_SERVERS="' . $AD_ip . '" >> /etc/sysconfig/network/config');
     assert_script_run('netconfig update -f');
 
+    record_info('Check the DNS config file');
+    script_run('cat /etc/resolv.conf');
+
     script_run('dig srv _kerberos._tcp.geeko.com');
     script_run('dig srv _ldap._tcp.geeko.com');
 }
@@ -118,7 +121,7 @@ sub run {
     samba_sssd_install;
 
     #Join the Active Directory
-    assert_script_run "expect kinit.exp";
+    script_retry("expect kinit.exp", retry => 3, timeout => 120, die => 1);
 
     # Retrying the adcli join is needed, probably due to https://bugs.freedesktop.org/show_bug.cgi?id=55487
     if (script_retry('adcli join -v -W --domain geeko.com -U Administrator -C', delay => 10, retry => 15, timeout => 60, die => 0) != 0) {


### PR DESCRIPTION
As per poo#114718, join the Active Directory may fail sporadically
duo to occasional DNS resolve issue. so add more retries.

- Related ticket: https://progress.opensuse.org/issues/114718
- Verification run: https://openqa.suse.de/tests/9229171
