### PR TITLE
Add addon_dud with restapi in installer

### DIFF
--- a/lib/Installation/ProductSelection/AdditionalProductPage.pm
+++ b/lib/Installation/ProductSelection/AdditionalProductPage.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Additional Prodcuts page
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::ProductSelection::AdditionalProductPage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->{btn_add} = $self->{app}->button({id => 'ok'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{btn_add}->exist();
+}
+
+sub press_add {
+    my ($self) = @_;
+    return $self->{btn_add}->click();
+}
+
+1;

--- a/lib/Installation/ProductSelection/ProductSelectionController.pm
+++ b/lib/Installation/ProductSelection/ProductSelectionController.pm
@@ -12,6 +12,7 @@ use warnings;
 use YuiRestClient;
 use Installation::ProductSelection::ProductSelectionPage;
 use Installation::Popups::OKPopup;
+use Installation::ProductSelection::AdditionalProductPage;
 
 sub new {
     my ($class, $args) = @_;
@@ -22,6 +23,7 @@ sub new {
 sub init {
     my ($self) = @_;
     $self->{ProductSelectionPage} = Installation::ProductSelection::ProductSelectionPage->new({app => YuiRestClient::get_app()});
+    $self->{AdditionalProductPage} = Installation::ProductSelection::AdditionalProductPage->new({app => YuiRestClient::get_app()});
     $self->{AccessBetaDistributionPopup} = Installation::Popups::OKPopup->new({app => YuiRestClient::get_app()});
     return $self;
 }
@@ -30,6 +32,12 @@ sub get_product_selection_page {
     my ($self) = @_;
     die 'Product Selection page is not displayed' unless $self->{ProductSelectionPage}->is_shown();
     return $self->{ProductSelectionPage};
+}
+
+sub get_additional_product_page {
+    my ($self) = @_;
+    die 'Additional Product page is not displayed' unless $self->{AdditionalProductPage}->is_shown();
+    return $self->{AdditionalProductPage};
 }
 
 sub get_access_beta_distribution_popup {
@@ -47,6 +55,11 @@ sub install_product {
 sub access_beta_distribution {
     my ($self) = @_;
     $self->get_access_beta_distribution_popup()->press_ok();
+}
+
+sub add_selected_products {
+    my ($self) = @_;
+    $self->get_additional_product_page()->press_add();
 }
 
 1;

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -18,7 +18,7 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_module_desktop
-  - installation/dud_addon
+  - installation/addon_dud
   - installation/add_on_product_installation/accept_add_on_installation
   - installation/system_role/accept_selected_role_SLES_with_GNOME
   - installation/partitioning/accept_proposed_layout

--- a/tests/installation/addon_dud.pm
+++ b/tests/installation/addon_dud.pm
@@ -1,0 +1,18 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Add selected additional products
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    $testapi::distri->get_product_selection()->add_selected_products();
+}
+
+1;


### PR DESCRIPTION
Replaces the module dud_addon by one that uses libyui-rest-api.

- Related ticket: https://progress.opensuse.org/issues/113734
- Verification run: https://openqa.suse.de/tests/9235799#step/addon_dud/1
