### PR TITLE
installation/bootloader_uefi: Avoid sleeping during the grub timeout

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -95,9 +95,6 @@ sub run {
     if (get_var('DISABLE_SECUREBOOT') && (get_var('BACKEND') eq 'qemu')) {
         $self->tianocore_disable_secureboot;
     }
-    if (get_var("QEMUVGA") && get_var("QEMUVGA") ne "cirrus") {
-        sleep 5;
-    }
     if ((get_var("ZDUP") && !is_jeos) || (get_var('ONLINE_MIGRATION') && check_var('BOOTFROM', 'd'))) {
         # 'eject_cd' is broken ATM (at least on aarch64), so select HDD from menu - poo#47303
         # Check we are booting the ISO


### PR DESCRIPTION
This sleep makes it much more likely to miss the grub menu with its default
10s timeout. The reason why this was introduced is not clear, remove it.

Before: https://openqa.opensuse.org/tests/2485325 - >80% failure rate

After: https://openqa.opensuse.org/tests/2485579 - https://openqa.opensuse.org/tests/2485584 - all green