### PR TITLE
Run list-timers before shutdown

### DIFF
--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -13,6 +13,9 @@ use power_action_utils 'power_action';
 use utils;
 
 sub run {
+    my $self = shift;
+    select_console('root-console');
+    script_run('systemctl list-timers --all');
     power_action('poweroff');
 }
 


### PR DESCRIPTION
Run list-timers before shutdown and print the result to the console

- Related ticket: https://progress.opensuse.org/issues/114433
- Needles: none
- Verification run:
  - https://openqa.suse.de/t9231576
  - https://openqa.suse.de/tests/9231577
  - https://openqa.suse.de/tests/9231578
