### PR TITLE
Add test to add maintenance test repos

### DIFF
--- a/schedule/yast/qam-yast_self_update_libyui.yaml
+++ b/schedule/yast/qam-yast_self_update_libyui.yaml
@@ -1,0 +1,37 @@
+---
+name: qam-yast_self_update_libyui
+description: installation using self_update as boot parameter
+vars:
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/validate_self_update
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_extensions_and_modules
+  - installation/add_on_product/add_maintenance_repos
+  - installation/addon_products_sle
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{efi}}'
+conditional_schedule:
+  efi:
+    MACHINE:
+      uefi:
+        - console/consoletest_setup
+        - console/verify_efi_mok

--- a/tests/installation/add_on_product/add_maintenance_repos.pm
+++ b/tests/installation/add_on_product/add_maintenance_repos.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Add new add-ons using maintenance test repo URLs.
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+
+sub create_repo_name {
+    my ($repo_id, $addon) = $_[0] =~ (/(\d+)\/(.*)\//);
+    my $name = $addon . "_" . $repo_id;
+    return $name;
+}
+
+sub run {
+    my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
+
+    $testapi::distri->get_add_on_product()->confirm_like_additional_add_on();
+
+    my $maintrepo = shift @repos;
+    my $reponame = create_repo_name($maintrepo);
+    $testapi::distri->get_add_on_product()->accept_current_media_type_selection();
+    save_screenshot;
+    $testapi::distri->get_repository_url()->add_repo({url => $maintrepo, name => $reponame});
+    save_screenshot;
+
+    for my $repo (@repos) {
+        $testapi::distri->get_add_on_product_installation()->add_add_on_product();
+        $testapi::distri->get_add_on_product()->accept_current_media_type_selection();
+        my $name = create_repo_name($repo);
+        $testapi::distri->get_repository_url()->add_repo({url => $repo, name => $name});
+        save_screenshot;
+    }
+    $testapi::distri->get_add_on_product_installation()->accept_add_on_products();
+}
+
+1;


### PR DESCRIPTION
Create a test module to add maintenance test repos using libyui instead of needles, the libyui equivalent of [add_update_test_repo.pm](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/installation/add_update_test_repo.pm).

- Related ticket: https://openqa.suse.de/tests/9406283
- Verification run: https://openqa.suse.de/tests/9418773

gitlab mr: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/369