### PR TITLE
Restar docker and firewalld for 15-SP3 and 15-SP4

### DIFF
--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -13,6 +13,9 @@ use power_action_utils 'power_action';
 use utils;
 
 sub run {
+    my $self = shift;
+    select_console('root-console');
+    script_run('systemctl list-timers --all');
     power_action('poweroff');
 }
 


### PR DESCRIPTION
Failures in 15-SP3 and 15-SP4 after running docker and podman in the same job.
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP1&build=_15-SP1_6.2.647&groupid=453

VRS:
https://openqa.suse.de/tests/overview?version=15-SP2&build=jlausuch%2Fos-autoinst-distri-opensuse%23docker_restart_15.3_15.4&distri=sle

https://openqa.opensuse.org/tests/2487812
https://openqa.opensuse.org/tests/2487813
