### PR TITLE
Create qcow2 with virt-install

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -231,15 +231,10 @@ sub create_guest {
         my ($autoyastURL, $diskformat, $virtinstall);
         $autoyastURL = $autoyast;
         $diskformat = get_var("VIRT_QEMU_DISK_FORMAT") // "qcow2";
-
-        assert_script_run "qemu-img create -f $diskformat /var/lib/libvirt/images/xen/$name.$diskformat 20G", 180;
-        assert_script_run "sync", 180;
-        script_run "qemu-img info /var/lib/libvirt/images/xen/$name.$diskformat";
-
         $extra_args = "$linuxrc autoyast=$autoyastURL $extra_args";
         $extra_args = trim($extra_args);
         $virtinstall = "virt-install $v_type $guest->{osinfo} --name $name --vcpus=$vcpus,maxvcpus=$maxvcpus --memory=$memory,maxmemory=$maxmemory --vnc";
-        $virtinstall .= " --disk /var/lib/libvirt/images/xen/$name.$diskformat --noautoconsole";
+        $virtinstall .= " --disk path=/var/lib/libvirt/images/$name.$diskformat,size=20,format=$diskformat --noautoconsole";
         $virtinstall .= " --network network=default,mac=$macaddress --autostart --location=$location --wait -1";
         $virtinstall .= " --events on_reboot=$on_reboot" unless ($on_reboot eq '');
         $virtinstall .= " --extra-args '$extra_args'" unless ($extra_args eq '');

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -91,9 +91,6 @@ sub run {
 
     # Ensure additional package is installed
     zypper_call '-t in libvirt-client iputils nmap supportutils';
-
-    assert_script_run "mkdir -p /var/lib/libvirt/images/xen/";
-
     if (script_run("virsh net-list --all | grep default") != 0) {
         assert_script_run "curl " . data_url("virt_autotest/default_network.xml") . " -o ~/default_network.xml";
         assert_script_run "virsh net-define --file ~/default_network.xml";


### PR DESCRIPTION
POO: https://progress.opensuse.org/issues/109325
Create qcow2 with virt-install instead of qemu-img

- Related ticket: https://progress.opensuse.org/issues/109325
- Needles: NA
- Verification run: 
Format: raw: [sle-15-SP2-Server-DVD-Virt-XEN-Incidents](http://openqa.qam.suse.cz/tests/45667)
Format: qcow2:[sle-15-SP2-Server-DVD-Virt-XEN-Incidents](http://openqa.qam.suse.cz/tests/45910#)
Full test(qcow2):[SLE 15 SP4 Virt XEN Incidents](http://openqa.qam.suse.cz/tests/overview?distri=sle&version=15-SP4&build=roy_lvm%3Atest%3Ainara&groupid=163)