### PR TITLE
Restart docker and firewalld for 15-SP3 and 15-SP4

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -47,8 +47,8 @@ sub run {
     install_podman_when_needed($host_distri) if ($engine =~ 'podman');
 
     # It has been observed that after system update, the ip forwarding doesn't work.
-    # In Leap 15.3 there is a need to restart the firewall and docker daemon.
-    if ($host_distri eq 'opensuse-leap' && $version eq '15' && $sp eq '3') {
+    # In 15.3/15.4 there is a need to restart the firewall and docker daemon.
+    if ($host_distri =~ /sles|opensuse-leap/ && $version eq '15' && $sp =~ /3|4/) {
         systemctl("restart docker") if ($engine =~ 'docker');
         systemctl("restart firewalld");
     }


### PR DESCRIPTION
Failures in 15-SP3 and 15-SP4 after running docker and podman in the same job.
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP1&build=_15-SP1_6.2.647&groupid=453

VRS:
https://openqa.suse.de/tests/overview?version=15-SP2&build=jlausuch%2Fos-autoinst-distri-opensuse%23docker_restart_15.3_15.4&distri=sle

https://openqa.opensuse.org/tests/2487812
https://openqa.opensuse.org/tests/2487813
