### PR TITLE
Set windows focus to strict in GNOME

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   untick_welcome_on_next_startup
   start_root_shell_in_xterm
   handle_gnome_activities
+  set_gnome_strict_focus_window
 );
 
 =head1 X11_UTILS
@@ -489,6 +490,18 @@ sub turn_off_screensaver {
 # turn off the gnome deskop's notification
 sub turn_off_gnome_show_banner {
     script_run 'gsettings set org.gnome.desktop.notifications show-banners false';
+}
+
+=head2 set_gnome_strict_focus_window
+
+ set_gnome_strict_focus_window();
+
+Change the default focus of windows from smart to strict in GNOME
+
+=cut
+
+sub set_gnome_strict_focus_window {
+    script_run "sudo -u $testapi::username gsettings set org.gnome.desktop.wm.preferences focus-new-windows 'strict'";
 }
 
 =head2 untick_welcome_on_next_startup

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -16,7 +16,7 @@ use base 'consoletest';
 use testapi;
 use utils;
 use zypper;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_leap);
 use serial_terminal 'prepare_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use registration;
@@ -25,12 +25,18 @@ use List::MoreUtils 'uniq';
 use migration 'disable_kernel_multiversion';
 use strict;
 use warnings;
+use x11utils qw(set_gnome_strict_focus_window);
 
 sub run {
     my ($self) = @_;
     select_console 'root-console';
 
     ensure_serialdev_permissions;
+
+    if (is_leap && check_var('DESKTOP', 'gnome')) {
+        record_soft_failure 'boo#1202103 GNOME: lost window focus';
+        set_gnome_strict_focus_window;
+    }
 
     prepare_serial_console;
 


### PR DESCRIPTION
Default setting of windows focus is *smart*, which can lead to focus
stealing mainly when a test starts a program right after system start
up as it is in [updates_packagekit_gpk](https://openqa.opensuse.org/tests/2489474#step/updates_packagekit_gpk/31).

- ticket:  [[leap][qe-core] test fails in xterm - mistyping test string due to lost focus](https://progress.opensuse.org/issues/111752)
- VRs:
  - [gnome@64bit-2G](http://kepler.suse.cz/tests/18232#step/updates_packagekit_gpk/33) - [opensuse-15.4-DVD-Updates-x86_64-Build20220729-5-gnome@64bit-2G](http://kepler.suse.cz/tests/18281#step/updates_packagekit_gpk/33)
  - [upgrade_Leap_15.2_gnome@64bit](http://kepler.suse.cz/tests/18182#step/system_prepare/16) - [upgrade_Leap_15.2_gnome@64bit](http://kepler.suse.cz/tests/18230#step/updates_packagekit_gpk/36)
  - [full test suite](http://kepler.suse.cz/tests/18332#)