### PR TITLE
Revert "Run list-timers before shutdown"

### DIFF
--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -13,9 +13,6 @@ use power_action_utils 'power_action';
 use utils;
 
 sub run {
-    my $self = shift;
-    select_console('root-console');
-    script_run('systemctl list-timers --all');
     power_action('poweroff');
 }
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#15294

This breaks Factory

# Test died: command 'systemctl list-timers --all' timed out at /usr/lib/os-autoinst/testapi.pm line 1008.

eg. https://openqa.opensuse.org/tests/2490184#step/shutdown/4