### PR TITLE
Use systemctl helper instead of script_run

### DIFF
--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -13,6 +13,9 @@ use power_action_utils 'power_action';
 use utils;
 
 sub run {
+    my $self = shift;
+    select_console('root-console');
+    systemctl 'list-timers --all';
     power_action('poweroff');
 }
 


### PR DESCRIPTION
Use systemctl helper instead of script_run to "list-timers"



- Related ticket: https://progress.opensuse.org/issues/114433
- Needles: none 
- Verification run: https://openqa.suse.de/tests/9246636#live
