### PR TITLE
Add new zfcp devices on channel fc00

### DIFF
--- a/tests/installation/disk_activation/configure_zfcp_device.pm
+++ b/tests/installation/disk_activation/configure_zfcp_device.pm
@@ -11,10 +11,17 @@
 use strict;
 use warnings;
 use base 'y2_installbase';
+use testapi;
 
 sub run {
-    my $zfcp_add_disk = $testapi::distri->get_add_new_zfcp_device();
-    $zfcp_add_disk->configure({channel => '0.0.fa00'});
+    my $add_new_zfcp_device = $testapi::distri->get_add_new_zfcp_device();
+    # configure first device
+    $add_new_zfcp_device->configure({channel => '0.0.fa00'});
+    save_screenshot;
+    # press "Add" button to add another device
+    $testapi::distri->get_configured_zfcp_devices()->add();
+    # configure second device
+    $add_new_zfcp_device->configure({channel => '0.0.fc00'});
 }
 
 1;


### PR DESCRIPTION
S390x infrastructure was updated with a new Host Bus Adapter (with channel ID 0.0.fc00)

- Related ticket: https://progress.opensuse.org/issues/105440
- VR: https://openqa.suse.de/tests/9247719#step/accept_configured_zfcp_devices/1