### PR TITLE
Containers: Create our own helm chart

### DIFF
--- a/data/containers/helm-test/Chart.yaml
+++ b/data/containers/helm-test/Chart.yaml
@@ -1,0 +1,3 @@
+version: 1.0.0
+name: "simple-job"
+appVersion: "1.16.0"

--- a/data/containers/helm-test/templates/NOTES.txt
+++ b/data/containers/helm-test/templates/NOTES.txt
@@ -1,0 +1,3 @@
+The job {{ .Release.Name }} has been successfully deployed in {{ .Release.Namespace }} namespace.
+Have a lot of fun...
+

--- a/data/containers/helm-test/templates/job.yaml
+++ b/data/containers/helm-test/templates/job.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-job"
+spec:
+  template:
+    spec:
+      containers:
+      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+        name: helm-test-{{ .Values.job_id }}
+        command: [ "cat", "/etc/os-release" ]
+        resources:
+          limits:
+            cpu: "0.5"
+            memory: 256Mi
+          requests:
+            cpu: "0.1"
+            memory: 128Mi
+      restartPolicy: Never
+  backoffLimit: 4

--- a/data/containers/helm-test/values.yaml
+++ b/data/containers/helm-test/values.yaml
@@ -1,0 +1,4 @@
+image:
+  repository: registry.suse.com/bci/bci-base
+  pullPolicy: Always
+  tag: latest

--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -35,6 +35,8 @@ sub install_k3s {
     sleep(20);    # Wait one iteration interval before checking because the server needs some time to boot-up
     script_retry("test -e /etc/rancher/k3s/k3s.yaml", delay => 20, retry => 10);
     assert_script_run('systemctl is-active k3s');
+    assert_script_run('k3s -v');
+    assert_script_run('uname -a');
     assert_script_run("k3s kubectl get node");
     script_run("mkdir -p ~/.kube");
     script_run("rm -f ~/.kube/config");


### PR DESCRIPTION
This adds our own helm chart. The chart right now deploys only a very simple job.
To test the 'helm repository' feature we would need to get a helm repository.

So please take this as a first alpha over which we should discuss how to proceed.

- Related ticket: [poo#112517](https://progress.opensuse.org/issues/112517)
- Verification run: [pdostal-server.suse.cz](https://pdostal-server.suse.cz/tests/416)
- Issues found: k3s-io/k3s#5946
