### PR TITLE
install_ltp: Add missing prepare_ltp_env for sle < 12

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -421,6 +421,7 @@ sub run {
         loadtest_kernel 'boot_ltp';
     } elsif ($cmd_file) {
         assert_secureboot_status(1) if get_var('SECUREBOOT');
+        prepare_ltp_env() if (is_sle('<12'));
         init_ltp_tests($cmd_file);
         schedule_tests($cmd_file);
     }


### PR DESCRIPTION
Fixes: fe8b2f909 ("Allow installing and running LTP tests without reboot in between")