### PR TITLE
Collect logs from parallel jobs when one node is failing

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -95,7 +95,8 @@ Afterwards a screenshot will be created if C<$screenshot> is set.
 sub save_and_upload_log {
     my ($self, $cmd, $file, $args) = @_;
     script_run("$cmd | tee $file", $args->{timeout});
-    upload_logs($file, failok => 1) unless $args->{noupload};
+    my $lname = $args->{logname} ? $args->{logname} : '';
+    upload_logs($file, failok => 1, log_name => $lname) unless $args->{noupload};
     save_screenshot if $args->{screenshot};
 }
 

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -14,7 +14,7 @@ use utils;
 sub run ($self) {
     # Get number of nodes
     my $nodes = get_required_var('CLUSTER_NODES');
-
+    record_info("#barriers", $nodes);
     # Initialize barriers
     if (check_var('HPC', 'slurm')) {
         barrier_create('CLUSTER_PROVISIONED', $nodes);

--- a/tests/hpc/before_test.pm
+++ b/tests/hpc/before_test.pm
@@ -38,5 +38,6 @@ sub run ($self) {
 sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
+sub post_run_hook ($self) { }
 
 1;

--- a/tests/hpc/ganglia_client.pm
+++ b/tests/hpc/ganglia_client.pm
@@ -64,6 +64,7 @@ sub run ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('gmond');
 }

--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -67,6 +67,7 @@ sub run ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('apache2');
     $self->upload_service_log('gmond');

--- a/tests/hpc/hpc_master.pm
+++ b/tests/hpc/hpc_master.pm
@@ -82,6 +82,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/hpc_master_backup.pm
+++ b/tests/hpc/hpc_master_backup.pm
@@ -57,6 +57,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -26,6 +26,7 @@ sub run ($self) {
         bin => '/home/bernhard/bin',
         hpc_lib => '/usr/lib/hpc',
     );
+
     zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel python3-devel");
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
@@ -64,7 +65,6 @@ sub run ($self) {
     # python code is not compiled. *mpi_bin* is expected as a compiled binary. if compilation was not
     # invoked return source code (ex: sample_scipy.py).
     $mpi_bin = ($mpi_compiler) ? $mpi_bin : $mpi_c;
-
     barrier_wait('MPI_BINARIES_READY');
     my $mpirun_s = hpc::formatter->new();
 
@@ -103,7 +103,6 @@ sub run ($self) {
     } else {
         assert_script_run($mpirun_s->all_nodes("$exports_path{'bin'}/$mpi_bin"), timeout => 120);
     }
-
     barrier_wait('MPI_RUN_TEST');
 }
 
@@ -112,7 +111,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
-    upload_logs('/tmp/mpi_bin.log');
+    $self->destroy_test_barriers();
     $self->export_logs();
 }
 

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -31,6 +31,9 @@ sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook ($self) { }
+sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
+    $self->export_logs();
+}
 
 1;

--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -62,6 +62,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('munge');
 }

--- a/tests/hpc/mrsh_slave.pm
+++ b/tests/hpc/mrsh_slave.pm
@@ -38,6 +38,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('munge');
     $self->upload_service_log('mrshd');

--- a/tests/hpc/munge_master.pm
+++ b/tests/hpc/munge_master.pm
@@ -43,6 +43,7 @@ sub run ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('munge');
 }

--- a/tests/hpc/munge_slave.pm
+++ b/tests/hpc/munge_slave.pm
@@ -27,6 +27,7 @@ sub run ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('munge');
 }

--- a/tests/hpc/pdsh_master.pm
+++ b/tests/hpc/pdsh_master.pm
@@ -43,6 +43,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('mrshd');
     $self->upload_service_log('munge');

--- a/tests/hpc/pdsh_slave.pm
+++ b/tests/hpc/pdsh_slave.pm
@@ -45,6 +45,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     upload_logs '/tmp/pdsh.log';
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -88,6 +88,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -524,6 +524,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -48,6 +48,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -46,6 +46,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -48,6 +48,7 @@ sub test_flags ($self) {
 }
 
 sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
     $self->select_serial_terminal;
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');


### PR DESCRIPTION
The solution to make multi-machine jobs to collect logs was prevented mainly
by the fact of the barrier's usage. When the parent failed the barriers
following the failed command is never released.

In this patch this is what is changing:
- Collect some basic logs after main tests are done. This is for keeping track
of previous logs and comparison in case of failure. Logs are collecting from
all the nodes in the cluster.
- The `post_fail_hook` will destroy all the defined barrier before collect any
logs. This action needs to occur in either of the modules, in order to make
the depended nodes available for log collection despite of which node is
failing and triggering the `post_fail_hook`.
- Provide option to pass `log_name` parameter via `upload_service_log` to
change the log file

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Related ticket: https://progress.opensuse.org/issues/106829
- Verification run:

https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2315316&version=15-SP1

[master failing](http://aquarius.suse.cz/tests/11865) + [slave logs](http://aquarius.suse.cz/tests/11867#downloads) (dont confused with _fail_ status)
[slave failing](http://aquarius.suse.cz/tests/11875) + [master logs](http://aquarius.suse.cz/tests/11873#downloads)