### PR TITLE
install_klp_product: Refresh incident repos

### DIFF
--- a/tests/kernel/install_klp_product.pm
+++ b/tests/kernel/install_klp_product.pm
@@ -47,7 +47,11 @@ sub run {
         die "Failed to parse 'uname -r' output: '$output'";
     }
 
-    install_klp_product() unless get_var('KGRAFT');
+    unless (get_var('KGRAFT')) {
+        zypper_call('ref');
+        install_klp_product();
+    }
+
     my $klp_pkg = find_installed_klp_pkg($kver, $kflavor);
     if (!$klp_pkg) {
         die "No installed kernel livepatch package for current kernel found";


### PR DESCRIPTION
Kernel update incidents sometimes get created with misconfigured livepatch channel and the base livepatch gets added after OpenQA test image installation. Refresh incident repos in install_klp_product test module so that the test can be restarted after repo fix without running the whole installation job as well.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - PPC64LE: https://openqa.suse.de/tests/9254721
  - s390x: https://openqa.suse.de/tests/9254722
  - x86_64: https://openqa.suse.de/tests/9254738
