### PR TITLE
Helper script to compose  default based YAML schedules

### DIFF
--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -73,7 +73,6 @@ sub parse_schedule {
               $additional_flows->{$k}->@*
               : $default_flow->{$k}->@*;
         }
-        diag($ypp->dump_string(\@scheduled));
     }
     # schedule contains a list of test modules
     else {

--- a/script/helper_default_based_schedule.pl
+++ b/script/helper_default_based_schedule.pl
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+
+# Tool to merge YAML_SCHEDULE_DEFAULT  with YAML_SCHEDULE_FLOWS
+# and YAML_SCHEDULE.
+
+use strict;
+use warnings;
+use File::Basename;
+
+use Cwd;
+
+use YAML::PP;
+use YAML::PP::Schema::Include;
+use YAML::PP::Common 'PRESERVE_ORDER';
+
+my $test_suite_data;
+my $root_project_dir = getcwd;
+my $include = YAML::PP::Schema::Include->new(paths => ($root_project_dir));
+my $ypp = YAML::PP->new(
+    schema => ['Core', 'Merge'],
+    preserve => PRESERVE_ORDER
+);
+$include->yp($ypp);
+
+
+my $yamlfile = $ENV{YAML_SCHEDULE};
+my $schedule_file = $ypp->load_file($yamlfile);
+parse_schedule($schedule_file);
+
+
+sub parse_schedule {
+    my ($schedule) = shift;
+    my @scheduled;
+
+    # schedule contains keys and is based on a list of files representing schedule flows
+    if (ref $schedule->{schedule} eq 'HASH') {
+        my $default_path = $ENV{YAML_SCHEDULE_DEFAULT};
+        die "You need to provide'YAML_SCHEDULE_DEFAULT' when using this script." unless $default_path;
+        my $default_flow = $ypp->load_file($default_path);
+
+        my $additional_flows = {};
+        if (my @flows = split(/,/, ($ENV{YAML_SCHEDULE_FLOWS}))) {
+            # all flows are expected to be in the same path than the default.yaml
+            my (undef, $flows_path, undef) = fileparse($default_path, '.yaml');
+
+            # merge flows
+            for my $flow (@flows) {
+                # latest flow has priority over previous processed flows
+                $additional_flows = {
+                    %{$additional_flows},
+                    %{$ypp->load_file($flows_path . $flow . '.yaml')}
+                };
+            }
+        }
+        # schedule flow has priority over previous processed flows
+        $additional_flows = {%{$additional_flows}, %{$schedule->{schedule}}};
+
+        # create the final list of test modules
+        for my $k (keys %$default_flow) {
+            push @scheduled, exists $additional_flows->{$k} ?
+              $additional_flows->{$k}->@*
+              : $default_flow->{$k}->@*;
+        }
+    }
+    # schedule contains a list of test modules
+    else {
+        die "You're trying to apply this script to a list of test modules instead " .
+          "to a default based schedule.";
+    }
+    print($ypp->dump_string(\@scheduled));
+    return @scheduled;
+}
+
+=head1 helper_default_based_schedule
+
+Tool to merge YAML schedules for openQA based on defaults, flows
+and an individual YAML schedule.
+
+=head2 USAGE
+
+  YAML_SCHEDULE_DEFAULT=<path to default schedule> \\
+  YAML_SCHEDULE_FLOWS=<comma-separated list of flows> \\
+  YAML_SCHEDULE=<path to individual schedule> \\
+  tools/helper_default_based_schedule
+
+This makes use of the openQA YAML scheduler. The resulting vars and schedule
+are printed out as diag information on STDERR.
+
+=cut


### PR DESCRIPTION
- This script is for a quick verfificaton of the new YAML scheudler
  using YAML_SCHEDULE_DEFAULT and YAML_SCHEDULE_FLOWS together with
  YAML_SCHEDULE.
- Related ticket: https://progress.opensuse.org/issues/110239
- The script uses as much as possible from the real scheduler code,
  so future changes in the scheduler won't harm the integrity.
- Small bugfix in the scheduler to avoid double diag output
  of schedule applied.

- Verification run:

```
$ YAML_SCHEDULE=schedule/yast/sle/guided_ext4/guided_ext4.yaml YAML_SCHEDULE_DEFAULT=schedule/yast/sle/flows/default.yaml YAML_SCHEDULE_FLOWS=desktop,guided tools/merge_schedule
[2022-08-04T10:44:52.647923+02:00] [debug] parse_vars (variables parsed from YAML schedule):
[2022-08-04T10:44:52.648423+02:00] [debug] ---
  FILESYSTEM: ext4
  YUI_REST_API: 1
  
[2022-08-04T10:44:52.660373+02:00] [debug] ---
  - installation/bootloader_start
  - installation/setup_libyui
  - installation/product_selection/install_SLES
  - installation/licensing/accept_license
  - installation/registration/register_via_scc
  - installation/module_registration/register_module_desktop
  - installation/add_on_product/skip_install_addons
  - installation/system_role/accept_selected_role_SLES_with_GNOME
  - installation/partitioning/select_guided_setup
  - installation/partitioning/guided_setup/accept_default_part_scheme
  - installation/partitioning/guided_setup/select_filesystem_option_ext4
  - installation/partitioning/accept_proposed_layout
  - installation/clock_and_timezone/accept_timezone_configuration
  - installation/authentication/use_same_password_for_root
  - installation/authentication/default_user_simple_pwd
  - installation/bootloader_settings/disable_boot_menu_timeout
  - installation/installation_settings/validate_default_target
  - installation/launch_installation
  - installation/confirm_installation
  - installation/performing_installation/perform_installation
  - installation/logs_from_installation_system
  - installation/performing_installation/confirm_reboot
  - installation/grub_test
  - installation/first_boot
  - console/validate_partition_table_via_blkid
  - console/validate_blockdevices
  - console/validate_free_space
```


