### PR TITLE
lib/mm_network: Configure MTU with NetworkManager as well

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -60,9 +60,9 @@ sub configure_static_ip {
         my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep '$device' | head -n1");
         ($device, $nm_id) = split(':', $nm_list);
 
-        record_info('set_ip', "Device: $device\n NM ID: $nm_id\nIP: $ip");
+        record_info('set_ip', "Device: $device\n NM ID: $nm_id\nIP: $ip\nMTU: $mtu");
 
-        assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip4 $ip ipv4.method manual ";
+        assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip4 $ip ipv4.method manual 802-3-ethernet.mtu $mtu";
     } else {
         # Get MAC address
         my $net_conf = parse_network_configuration();


### PR DESCRIPTION
Setting the MTU properly is important if GRE tunneling is used.

- Related ticket: https://progress.opensuse.org/issues/64700
- Verification run: https://openqa.opensuse.org/tests/2495862 (ow1) + https://openqa.opensuse.org/tests/2495863 (ow7)
