### PR TITLE
Skip ha/drbd_passive test when not in TWO_NODES scenario

### DIFF
--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -44,7 +44,11 @@ sub run {
 
     # At this time, we only test DRBD on a 2 nodes cluster
     # And if the cluster has more than 2 nodes, we only use the first 2 nodes
-    return if (!is_node(1) && !is_node(2));
+    if ((!is_node(1) && !is_node(2)) || check_var('TWO_NODES', 'no')) {
+        write_tag('skip_fs_test');
+        record_info 'Skipped - Scenario', 'Test skipped because this job is not running in a two nodes scenario';
+        return;
+    }
 
     # Wait until DRBD test is initialized
     barrier_wait("DRBD_INIT_$cluster_name");

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -17,7 +17,8 @@ use hacluster;
 
 sub run {
     # Exit of this module if 'tag=drbd_passive' and if we are in a maintenance update not related to drbd
-    return 1 if (read_tag eq 'drbd_passive' and is_not_maintenance_update('drbd'));
+    my $tag = read_tag;
+    return 1 if (($tag eq 'drbd_passive' and is_not_maintenance_update('drbd')) or $tag eq 'skip_fs_test');
 
     my $cluster_name = get_cluster_name;
     my $node = get_hostname;
@@ -28,16 +29,16 @@ sub run {
     my $fs_opts = '-F -N 16';    # Force the filesystem creation and allows 16 nodes
 
     # This Filesystem test can be called multiple time
-    if (read_tag eq 'cluster_md') {
+    if ($tag eq 'cluster_md') {
         $resource = 'cluster_md';
     }
-    elsif (read_tag eq 'drbd_passive') {
+    elsif ($tag eq 'drbd_passive') {
         $resource = 'drbd_passive';
         $fs_lun = '/dev/drbd_passive' if is_node(1);
         $fs_type = 'xfs';
         $fs_opts = '-f';
     }
-    elsif (read_tag eq 'drbd_active') {
+    elsif ($tag eq 'drbd_active') {
         $resource = 'drbd_active';
     }
     else {

--- a/tests/ha/vg.pm
+++ b/tests/ha/vg.pm
@@ -26,20 +26,21 @@ sub run {
     my $vg_luns = undef;
 
     # This test can be called multiple time
-    if (read_tag eq 'cluster_md') {
+    my $tag = read_tag;
+    if ($tag eq 'cluster_md') {
         $resource = 'cluster_md';
         $vg_luns = '/dev/md*' if is_node(1);
 
         # Use a named RAID in SLE15
         $vg_luns = "/dev/md/$resource" if (is_sle('15+') && is_node(1));
     }
-    elsif (read_tag eq 'drbd_passive') {
+    elsif ($tag eq 'drbd_passive') {
         $resource = 'drbd_passive';
         $vg_luns = "/dev/$resource" if is_node(1);
         $vg_exclusive = 'true';
         $vg_type = '--clustered n';
     }
-    elsif (read_tag eq 'drbd_active') {
+    elsif ($tag eq 'drbd_active') {
         $resource = 'drbd_active';
         $vg_luns = "/dev/$resource" if is_node(1);
     }


### PR DESCRIPTION
Currently the 3 cluster node scenario tested for Maintenance jobs is [always scheduling](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/schedule/ha/qam/common/qam_cluster_node.yaml#L60-L61) the `ha/drbd_passive` test module, even when this particular test module is not designed to work in cluster scenarios with more than 2 nodes.

As a result, whenever a MU job is triggered with a package that requires a drbd test, the 3 node scenario job will fail as it is skipped in the third node before any of the `barrier_wait()` calls. This means the other nodes, remain blocked in a `barrier_wait()` call until they reach **MAX_JOB_TIME** and fail the whole scenario.

One possible solution would be to create a different schedule for the 3 cluster node scenario, but this implies a PR to this repo, as well as a change to the job settings.

This PR instead modifies `ha/drbd_passive` so it is skipped when running in scenarios with the setting **TWO_NODES=no**. It will also skip the test module `ha/filesystem` that is usually scheduled right after `ha/drbd_passive`, as there would be no block device on which to test the filesystem creation.

- Related ticket: https://progress.opensuse.org/issues/114727
- Needles: N/A
- Failing job: https://openqa.suse.de/tests/9247409#step/drbd_passive/5
- Verification runs:
+ QAM jobs (3 nodes): [node1](http://mango.qa.suse.de/tests/4871), [node 2](http://mango.qa.suse.de/tests/4872), [node 3](http://mango.qa.suse.de/tests/4873) & [support server](http://mango.qa.suse.de/tests/4870)
+ QAM jobs (2 nodes): [node 1](http://mango.qa.suse.de/tests/4875), [node 2](http://mango.qa.suse.de/tests/4876), [client](http://mango.qa.suse.de/tests/4877) & [support server](http://mango.qa.suse.de/tests/4874)
+ Alpha Cluster on Milestone Build Validation: [node 1](http://mango.qa.suse.de/tests/4860), [node 2](http://mango.qa.suse.de/tests/4861) & [support server](http://mango.qa.suse.de/tests/4859)

P.S.: I also include here a small optimization in `ha/vg` test module to avoid having multiple calls to `hacluster::read_tag` which sends commands to SUT.