### PR TITLE
Migrate to libyui REST API yast2 scc

### DIFF
--- a/lib/Distribution/Sle/15_current.pm
+++ b/lib/Distribution/Sle/15_current.pm
@@ -21,6 +21,7 @@ use Installation::License::Sle::Firstboot::LicenseAgreementController;
 use Installation::ProductSelection::ProductSelectionController;
 use Installation::Registration::RegistrationController;
 use Installation::ModuleRegistration::ModuleRegistrationController;
+use Installation::ModuleRegistration::ModuleRegistrationInstallationReportController;
 use Installation::ModuleSelection::ModuleSelectionController;
 use Installation::AddOnProduct::AddOnProductController;
 use Installation::RepositoryURL::RepositoryURLController;
@@ -53,6 +54,10 @@ sub get_registration {
 
 sub get_module_registration {
     return Installation::ModuleRegistration::ModuleRegistrationController->new();
+}
+
+sub get_module_registration_installation_report {
+    return Installation::ModuleRegistration::ModuleRegistrationInstallationReportController->new();
 }
 
 sub get_module_regcode {

--- a/lib/Installation/ModuleRegistration/ModuleRegistrationInstallationReportController.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegistrationInstallationReportController.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces business actions for Module Registration dialog.
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::ModuleRegistration::ModuleRegistrationInstallationReportController;
+use strict;
+use warnings;
+use Installation::ModuleRegistration::ModuleRegistrationInstallationReportPage;
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{ModuleRegistrationInstallationReportPage} = Installation::ModuleRegistration::ModuleRegistrationInstallationReportPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_module_registration_installation_report_page {
+    my ($self) = @_;
+    die "Module Registration Installation Report page is not displayed" unless $self->{ModuleRegistrationInstallationReportPage}->is_shown();
+    return $self->{ModuleRegistrationInstallationReportPage};
+}
+
+sub press_finish {
+    my ($self) = @_;
+    $self->get_module_registration_installation_report_page->press_next();
+}
+
+1;

--- a/lib/Installation/ModuleRegistration/ModuleRegistrationInstallationReportPage.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegistrationInstallationReportPage.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act with page that give module registration installation report
+#
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package Installation::ModuleRegistration::ModuleRegistrationInstallationReportPage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub init {
+    my ($self) = @_;
+    $self->SUPER::init();
+    $self->{btn_finish} = $self->{app}->button({id => 'next'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{btn_finish}->exist();
+}
+
+1;

--- a/lib/Installation/Registration/RegistrationPage.pm
+++ b/lib/Installation/Registration/RegistrationPage.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: The module provides interface to act with Registration page
@@ -25,7 +25,7 @@ sub init {
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rdb_skip_registration}->exist();
+    return $self->{txb_reg_code}->exist();
 }
 
 sub enter_email {

--- a/lib/YaST/Module.pm
+++ b/lib/YaST/Module.pm
@@ -42,7 +42,7 @@ sub open {
         );
     }
     elsif ($ui eq 'qt') {
-        launch_yast2_module_x11($module, extra_vars => get_var('YUI_PARAMS'));
+        launch_yast2_module_x11($module, extra_vars => get_var('YUI_PARAMS'), maximize_window => get_var('MAXIMIZE_WINDOW'));
     }
     else {
         die "Unknown user interface: $ui";

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration.yaml
@@ -44,6 +44,11 @@ schedule:
   - shutdown/grub_set_bootargs
   - console/validate_installed_packages
   - console/validate_installed_patterns
-  - console/suseconnect_scc
+  - console/scc_cleanup_reregister
+  - console/install_packages_simple
+  - console/scc_deregistration
+  - console/firewalld_add_port
+  - console/setup_libyui_running_system
+  - x11/addon_products_via_SCC_yast2
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown

--- a/test_data/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
+++ b/test_data/yast/select_modules_and_patterns/select_modules_and_patterns.yaml
@@ -18,3 +18,7 @@ software:
 validate_subvolumes:
   - subvolume: home
     mount_point: /
+install_packages:
+  - libyui-rest-api
+port: 30000-50000
+zone: public

--- a/tests/console/firewalld_add_port.pm
+++ b/tests/console/firewalld_add_port.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Add ports to zone, as specified in test data, using firewall-cmd.
@@ -19,12 +19,13 @@ use base 'consoletest';
 use warnings;
 use testapi;
 use scheduler 'get_test_suite_data';
-use Utils::Firewalld 'add_port_to_zone';
+use Utils::Firewalld qw(add_port_to_zone reload_firewalld);
 
 sub run {
     my $test_data = get_test_suite_data();
     select_console 'root-console';
     add_port_to_zone({zone => $test_data->{zone}, port => $test_data->{port}});
+    reload_firewalld();
 }
 
 sub test_flags {

--- a/tests/x11/addon_products_via_SCC_yast2.pm
+++ b/tests/x11/addon_products_via_SCC_yast2.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: add addon to SLES via SCC
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base qw(y2_installbase y2_module_guitest);
+use strict;
+use warnings;
+use testapi;
+use registration;
+use version_utils qw(is_sle is_leap);
+use x11utils 'turn_off_gnome_screensaver';
+use YaST::Module;
+use utils;
+
+sub test_setup {
+    select_console "x11";
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver;
+}
+
+sub run {
+    my $self = shift;
+    test_setup;
+    YaST::Module::open(module => 'scc', ui => 'qt');
+    save_screenshot;
+
+    $testapi::distri->get_registration()->register_via_scc({
+            email => get_var('SCC_EMAIL'),
+            reg_code => get_var('SCC_REGCODE')});
+    save_screenshot;
+
+    my @scc_addons = split ',', get_var('SCC_ADDONS');
+    $testapi::distri->get_module_registration()->register_extension_and_modules([@scc_addons]);
+    save_screenshot;
+
+    # No libyui-rest-api for advance software selection
+    assert_screen("yast_scc-pkgtoinstall", 100);
+    wait_screen_change {
+        send_key 'alt-a';
+    };
+    assert_screen("yast_scc-installation-summary", 100);
+
+    $testapi::distri->get_module_registration_installation_report()->press_finish();
+    save_screenshot;
+
+    assert_screen("generic-desktop", 60);
+    # Check that repos actually work
+    $self->select_serial_terminal;
+    zypper_call 'refresh';
+    zypper_call 'repos --details';
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->SUPER::post_fail_hook;
+    $self->save_upload_y2logs;
+    verify_scc;
+    investigate_log_empty_license;
+}
+
+sub test_flags {
+    # add milestone flag to save setup in lastgood VM snapshot
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
Migrate to libyui REST API yast2 scc

- Related ticket:  https://progress.opensuse.org/issues/108227
- Needles: na
- Verification run:  https://openqa.suse.de/tests/9386243#step/addon_products_via_SCC_yast2/21

For select_modules_and_patterns+registration, run aarch64 and ppc64le result is ok.
s390 can't run since 151.1 repo already not exist(Pass case) and we have ticket blocked on latest build.
sle-15-SP5-Full-aarch64-Build15.2-select_modules_and_patterns+registration@aarch64 -> https://openqa.suse.de/t9411438
set priority for 9411438
sle-15-SP5-Full-ppc64le-Build15.2-select_modules_and_patterns+registration@ppc64le -> https://openqa.suse.de/t9411439
set priority for 9411439

