### PR TITLE
update_kernel: Check for retracted kernel packages

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -261,10 +261,8 @@ sub prepare_kgraft {
 
     fully_patch_system;
 
-    my $verlist = zypper_search(q(-s -x kernel-default));
-    my $kernel_version = right_kversion($verlist, $incident_klp_pkg);
-    $verlist = zypper_search(q(-s -x kernel-source));
-    my $src_version = right_kversion($verlist, $incident_klp_pkg);
+    my $kernel_version = find_version('kernel-default', $$incident_klp_pkg{kver});
+    my $src_version = find_version('kernel-source', $$incident_klp_pkg{kver});
     install_lock_kernel($kernel_version, $src_version);
 
     install_klp_product;
@@ -279,16 +277,18 @@ sub prepare_kgraft {
     return $incident_klp_pkg;
 }
 
-sub right_kversion {
-    my ($kversion, $incident_klp_pkg) = @_;
-    my $kver_fragment = $$incident_klp_pkg{kver};
-    $kver_fragment =~ s/\./\\./g;
+sub find_version {
+    my ($packname, $version_fragment) = @_;
+    my $verlist = zypper_search("-s -x -t package $packname");
+    my $version_arg = $version_fragment;
 
-    for my $item (@$kversion) {
-        return $$item{version} if $$item{version} =~ qr/^$kver_fragment\./;
+    $version_fragment =~ s/\./\\./g;
+
+    for my $item (@$verlist) {
+        return $$item{version} if $$item{version} =~ qr/^$version_fragment\./;
     }
 
-    die "Kernel $kver_fragment not found in repositories.";
+    die "$packname-$version_arg not found in repositories.";
 }
 
 sub update_kgraft {

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -285,7 +285,11 @@ sub find_version {
     $version_fragment =~ s/\./\\./g;
 
     for my $item (@$verlist) {
-        return $$item{version} if $$item{version} =~ qr/^$version_fragment\./;
+        if ($$item{version} =~ qr/^$version_fragment\./) {
+            die "$packname-$version_arg is retracted."
+              if $$item{status} =~ m/^.R/;
+            return $$item{version};
+        }
     }
 
     die "$packname-$version_arg not found in repositories.";


### PR DESCRIPTION
Retracted kernels should not receive any new livepatches. However, if a livepatch incident get accidentally created for a retracted kernel, installation test job will fail with rather ambiguous message that "patch is not needed". Check for retracted kernels during livepatch installation and fail with a clear error message.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - SLE-12SP4 (success): https://openqa.suse.de/tests/9293335
  - SLE-15SP3 (success): https://openqa.suse.de/tests/9293334
  - unfortunately, there are currently no open incidents for retracted kernels to test the failure code path