### PR TITLE
Modify autoyast profle for create_hdd in yast MU

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_maintenance.xml.ep
+++ b/data/autoyast_sle15/create_hdd/create_hdd_maintenance.xml.ep
@@ -31,16 +31,16 @@
         %}
     </suse_register>
     <add-on>
-        <add_on_products config:type="list">
+        <add_on_others config:type="list">
             % for my $repo (@$repos) {
             % my ($repo_id, $addon) = $repo =~ (/(\d+)\/(.*)\//);
-            <listentry>
-                <media_url><%= $repo %></media_url>
-		        <name><%= $addon . "_" . $repo_id %></name>
-		        <alias><%= $addon . "_" . $repo_id %></alias>
-            </listentry>
-            % }
-        </add_on_products>
+        <listentry>
+        <media_url><%= $repo %></media_url>
+            <name><%= $addon . "_" . $repo_id %></name>
+            <alias><%= $addon . "_" . $repo_id %></alias>
+        </listentry>
+        %}
+        </add_on_others>
     </add-on>
     <bootloader>
         <global>
@@ -135,14 +135,18 @@
         <products config:type="list">
             <product><%= uc $get_var->('SLE_PRODUCT') %></product>
         </products>
-        % if ($get_var->('SCC_ADDONS') =~ m/\brt\b/) {
-        <kernel>kernel-rt</kernel>
-        % }
         <patterns config:type="list">
             % for my $pattern (@$patterns) {
             <pattern><%= $pattern %></pattern>
             % }
         </patterns>
+        <!-- Workaround for bsc#1202234: [addon]-release packages are missing after autoyast installation. -->
+        <packages config:type="list">
+        % foreach (values %$addons) {
+            <package><%= $_->{name} %>-release</package>
+        % }
+        </packages>
+        <!-- end of workaround -->
     </software>
     <services-manager>
         % if ($check_var->('DESKTOP', 'gnome')) {


### PR DESCRIPTION
Adds a workaround for bsc#1202234, and minor fixes.

VRs
http://waaa-amazing.suse.cz/tests/17714

I did not add an add_on_products section in the end, as all addons in registration section get installed automatically anyway.