### PR TITLE
Add workaround for 12SP5 livepatch installation issue

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -221,6 +221,10 @@ sub install_lock_kernel {
         $package .= '-' . ($packver{$package} // $kernel_version);
     }
 
+    # Workaround for kgraft installation issue due to Retbleed mitigations
+    push @packages, 'crash-kmp-default-7.2.1_k4.12.14_122.124'
+      if is_sle('=12-SP5');
+
     # install and lock needed kernel
     zypper_call("in " . join(' ', @packages), exitcode => [0, 102, 103, 104], timeout => 1400);
     zypper_call("al " . join(' ', @lpackages));


### PR DESCRIPTION
SLE-12SP5 livepatches for kernels without Retbleed mitigations fail to install due to dependency issue with crash-kmp-default package. Install an older version of that package to work around the issue.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - 12-SP4: https://openqa.suse.de/tests/9293920
  - 12-SP5: https://openqa.suse.de/tests/9293896
  - 15GA: https://openqa.suse.de/tests/9293921
  - 15-SP4: https://openqa.suse.de/tests/9293922
