### PR TITLE
Apply workaround for yast content not being loaded for MU sp4

### DIFF
--- a/schedule/yast/maintenance/mau_extratests_yast2ui_restapi.yaml
+++ b/schedule/yast/maintenance/mau_extratests_yast2ui_restapi.yaml
@@ -10,6 +10,7 @@ schedule:
   - console/system_prepare
   - console/prepare_test_data
   - console/consoletest_setup
+  - update/zypper_ref_auto_import_keys
   - yast2_gui/yast2_bootloader
   - yast2_gui/yast2_security
   - yast2_gui/yast2_keyboard

--- a/tests/update/zypper_ref_auto_import_keys.pm
+++ b/tests/update/zypper_ref_auto_import_keys.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: zypper
+# Summary: auto import gpg keys
+# Auto import gpg keys, useful when we re-launch the test suite after the gpg key for maintenance repositories have expired (eg next day after initial run).
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+    zypper_call('--gpg-auto-import-keys ref');
+}
+
+1;

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2021 SUSE LLC
+# Copyright 2012-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: yast2-bootloader
@@ -45,8 +45,10 @@ sub run {
     type_string '16';
 
     #	default boot section
+    for (1 .. 2) { send_key 'alt-f10' }
     assert_and_click 'yast2-bootloader_default-boot-section';
-    assert_screen 'yast2-bootloader_default-boot-section_tw';
+    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2-bootloader_default-boot-section_tw', 'alt-f10', 9, 2);
     send_key 'esc';    # Close drop down
 
     #	proctect boot loader with password

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: nfs-client yast2-instserver lftp xinetd vsftpd openslp-server yast2-nfs-server nfs-client apache2
@@ -110,7 +110,8 @@ sub test_http_instserver {
     wait_still_screen 2, 2;
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-a", 2);
-    assert_screen('yast2-instserver-repository-conf');
+    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+    send_key_until_needlematch('yast2-instserver-repository-conf', 'alt-f10', 9, 2);
     send_key_and_wait("alt-p", 2);
     type_string "instserver";
     wait_still_screen 2, 2;
@@ -121,7 +122,7 @@ sub test_http_instserver {
     send_key_until_needlematch("yast2-instserver_sr0dev", "down", 3);
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
-    assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 300);
+    send_key_until_needlematch([qw(yast2-instserver-ui yast2-instserver-change-media)], 'alt-f10', 21, 30);
     # skip "insert next cd" on SLE 12.x
     send_key_and_wait("alt-s", 2) if is_sle("<=12-SP5") && match_has_tag('yast2-instserver-change-media');
     assert_screen('yast2-instserver-ui');
@@ -168,5 +169,5 @@ sub run {
     clean_env;
 
 }
-1;
 
+1;


### PR DESCRIPTION
Apply workaround for yast content not being loaded for MU sp4

- Related ticket: https://progress.opensuse.org/issues/112577
- Needles: -
- Verification run: http://d218.qam.suse.de/tests/156