### PR TITLE
Add known bugs to leap-micro 5.3

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -58,7 +58,7 @@
         "description": "Failed unmounting \/\\S+\\.|-- Reboot --|pam_systemd.*Failed to release session",
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
-            "leap-micro": [ "5.2" ],
+            "leap-micro": [ "5.2", "5.3" ],
             "microos":  ["Tumbleweed"],
             "alp":  ["0.1"]
         },
@@ -68,7 +68,7 @@
         "description": ".*rpcbind.*cannot(.*open file.*rpcbind.xdr.*|.*open file.*portmap.xdr.*|.*save any registration.*)",
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
-            "leap-micro": ["5.2"],
+            "leap-micro": ["5.2", "5.3"],
             "microos":  ["Tumbleweed"]
         },
         "type": "bug"
@@ -305,7 +305,7 @@
         "description": "health-checker/fail.sh check\" failed|Machine didn't come up correct, do a rollback",
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
-            "leap-micro": ["5.2"],
+            "leap-micro": ["5.2", "5.3"],
             "microos":  ["Tumbleweed"],
             "alp":  ["0.1"]
         },
@@ -378,7 +378,8 @@
     "bsc#1200490": {
         "description": "Unable to open /dev/kvm: No such file or directory",
         "products": {
-            "sle-micro": [ "5.3" ]
+            "sle-micro": [ "5.3" ],
+            "leap-micro": ["5.3"]
         },
         "type": "ignore"
     },


### PR DESCRIPTION
Add leap-micro 5.3 to known bugs list

- Verification run: [leap-micro-5.3-MicroOS-Image-x86_64-Build2.23-microos_image_default@64bit](http://kepler.suse.cz/tests/18476#)
