### PR TITLE
lib/y2_installbase: Allow more time for package searching

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -372,16 +372,16 @@ sub switch_selection {
     assert_screen $needles, 8;
 }
 
-=head2 toogle_package
+=head2 toggle_package
 
-    toogle_package($package_name, $operation);
+    toggle_package($package_name, $operation);
 
 Being in the "search package" screen, and showing a list of found packages,
-performs steps needed to toogle the checkbox of C<$package_name>.
+performs steps needed to toggle the checkbox of C<$package_name>.
 The C<$operation> can be '+' or 'minus'.
 =cut
 
-sub toogle_package {
+sub toggle_package {
     my ($self, $package_name, $operation) = @_;
     send_key_until_needlematch "packages-$package_name-selected", 'down', 60;
     wait_screen_change { send_key "$operation" };

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -383,6 +383,9 @@ The C<$operation> can be '+' or 'minus'.
 
 sub toggle_package {
     my ($self, $package_name, $operation) = @_;
+    # When coming from search_packages, the search might not be completed yet,
+    # give it some time.
+    check_screen "packages-$package_name-selected", 60;
     send_key_until_needlematch "packages-$package_name-selected", 'down', 60;
     wait_screen_change { send_key "$operation" };
     wait_still_screen 2;

--- a/tests/installation/select_packages.pm
+++ b/tests/installation/select_packages.pm
@@ -35,7 +35,7 @@ sub run {
             $operation = '+';
         }
         $self->search_package($package_name);
-        $self->toogle_package($package_name, $operation);
+        $self->toggle_package($package_name, $operation);
     }
     $self->back_to_overview_from_packages();
 
@@ -45,7 +45,7 @@ sub run {
         $self->go_to_search_packages();
         # this will only work for one blocker package: grub2
         $self->search_package('grub2');
-        $self->toogle_package('grub2', 'minus');
+        $self->toggle_package('grub2', 'minus');
         wait_screen_change { send_key 'alt-a' };    # accept
         assert_screen('automatic-changes');
         send_key 'alt-o';
@@ -65,7 +65,7 @@ sub run {
         $self->go_to_search_packages();
         for my $package_name (split(/,/, $blocker_packages)) {
             $self->search_package($package_name);
-            $self->toogle_package($package_name, '+');
+            $self->toggle_package($package_name, '+');
         }
         $self->back_to_overview_from_packages();
 


### PR DESCRIPTION
The select_packages test starts a search and then immediately calls
toggle_package. This leads to the issue that before the search is completed
it already presses the down key to move through the result list. Previously,
send_key_until_needlematch passed the timeout to the initial check_screen
call, which effectively gave it more time for the search to complete.

While this could probably be optimized by combining wait_still_screen with
a shorter check_screen, just reintroduce the previous behaviour for now.

Verification run: https://openqa.opensuse.org/tests/2507216