### PR TITLE
Add variable version in repo-main

### DIFF
--- a/data/autoyast_opensuse/autoyast_leap-micro.xml.ep
+++ b/data/autoyast_opensuse/autoyast_leap-micro.xml.ep
@@ -5,7 +5,7 @@
     <add_on_products config:type="list">
       <listentry>
         <alias>repo-main</alias>
-        <media_url><![CDATA[https://download.opensuse.org/distribution/leap-micro/5.2/product/repo/Leap-Micro-<%= $get_var->('VERSION') %>-<%= $get_var->('ARCH') %>-Media/]]></media_url>
+        <media_url><![CDATA[https://download.opensuse.org/distribution/leap-micro/<%= $get_var->('VERSION') %>/product/repo/Leap-Micro-<%= $get_var->('VERSION') %>-<%= $get_var->('ARCH') %>-Media/]]></media_url>
         <name>Leap Micro Main Repository</name>
       </listentry>
     </add_on_products>


### PR DESCRIPTION
Hard coded [5.2](https://openqa.opensuse.org/tests/2506817#step/installation/44) version in URL path has to be replaced by a variable

- Verification runs:
  * [leap-micro-5.2-DVD-x86_64-Build41.9-microos_installation_autoyast@64bit](http://kepler.suse.cz/tests/18480#step/installation/4)
  * [leap-micro-5.3-DVD-x86_64-Build9.5-microos_installation_autoyast@64bit](http://kepler.suse.cz/tests/18479#live)
