### PR TITLE
Exclude sle-module-python2 from hpc autoyast profile

### DIFF
--- a/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
@@ -43,7 +43,7 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
-      % unless ($check_var->('VERSION', '15-SP4')) {
+      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
       <addon>
         <name>sle-module-python2</name>
         <version>{{VERSION}}</version>
@@ -110,9 +110,11 @@
       <package>sle-module-basesystem-release</package>
       <package>sle-module-web-scripting-release</package>
       <package>sle-module-hpc-release</package>
-      % unless ($check_var->('VERSION', '15-SP4')) {
+      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
-      % }
+      % } else {
+      <package>sle-module-python3-release</package>
+      }
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
@@ -43,7 +43,7 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
-      % unless ($check_var->('VERSION', '15-SP4')) {
+      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
       <addon>
         <name>sle-module-python2</name>
         <version>{{VERSION}}</version>
@@ -96,7 +96,7 @@
       <package>sle-module-basesystem-release</package>
       <package>sle-module-web-scripting-release</package>
       <package>sle-module-hpc-release</package>
-      % unless ($check_var->('VERSION', '15-SP4')) {
+      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
       % }
     </packages>


### PR DESCRIPTION
As per sle15-sp4 python2 sle module needs to be exclude as well from sle15sp5.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/115199
- Verification run: http://aquarius.suse.cz/tests/11935
