### PR TITLE
Add sle15sp5 in conditional settings of yml for hpc installations

### DIFF
--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -18,6 +18,8 @@ conditional_schedule:
         - installation/bootloader
   user_settings_root:
     VERSION:
+      15-SP5:
+        - installation/user_settings_root
       15-SP4:
         - installation/user_settings_root
       15-SP2:

--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -22,6 +22,8 @@ conditional_schedule:
         - installation/user_settings_root
       15-SP4:
         - installation/user_settings_root
+      15-SP5:
+        - installation/user_settings_root
   add_update_test_repo:
     FLAVOR:
       Server-DVD-HPC-Incidents:


### PR DESCRIPTION
Some jobs are missing `user_settings_root` before the
`resolve_dependency_issues` as it happens from sle15sp4 and above

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/115202
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2315355