### PR TITLE
Fail the job when a lpar is not available

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -163,6 +163,9 @@ sub boot_hmc_pvm {
     record_info("Details", "See the next screen to get details on $hmc_machine_name");
     enter_cmd "lslic -m $hmc_machine_name -t syspower | sed 's/,/\\n/g'";
 
+    # Fail the job when a lpar is not available
+    die 'The managed system is not available' if check_screen('lpar_manage_status_unavailable', 3);
+
     # detach possibly attached terminals - might be left over
     enter_cmd "rmvterm -m $hmc_machine_name --id $lpar_id && echo 'DONE'";
     assert_screen 'pvm-vterm-closed';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/115118
- Needles: added new needle 'lpar_manage_status_unavailable'
- Verification run: https://openqa.nue.suse.com/tests/9311593#step/bootloader/7
