### PR TITLE
tests/installation/boot_into_snapshot: Wait until the snapshot menu is shown

### DIFF
--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -28,6 +28,8 @@ sub run {
         send_key 'ret';
         send_key_until_needlematch('snapshot-before-upgrade', 'down', 40, 5);
         send_key 'ret';
+        # Wait until the menu for that snapshot is shown
+        assert_screen('snapshot-help');
         send_key_until_needlematch('opensuse-leap', 'down', 10, 5);
         send_key 'ret';
         save_screenshot;


### PR DESCRIPTION
Otherwise it will try to select the entry before the menu is visible.

- Verification run: https://openqa.opensuse.org/tests/2508793