### PR TITLE
Boot from local disk for ipxe installation

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -1254,8 +1254,8 @@ sub config_guest_installation_automation {
         $self->{guest_installation_automation_options} = "--extra-args \"inst.ks=$self->{guest_installation_automation_file}\"";
         $self->{guest_installation_automation_options} = "--extra-args \"ks=$self->{guest_installation_automation_file}\"" if (($self->{guest_os_name} =~ /oraclelinux/im) and ($self->{guest_version_major} lt 7));
     }
-    if (script_run("curl -sSf $self->{guest_installation_automation_file} > /dev/null") ne 0) {
-        record_info("Guest $self->{guest_name} unattended installation file hosted on local host can not be reached", "Mark guest installation as FAILED. The unattended installation file url is $self->{guest_installation_automation_file}");
+    if (script_retry("curl -sSf $self->{guest_installation_automation_file} > /dev/null") ne 0) {
+        record_info("Guest $self->{guest_name} unattended installation file hosted on local host can not be reached", "Mark guest installation as FAILED. The unattended installation file url is $self->{guest_installation_automation_file}", result => 'softfail');
         $self->record_guest_installation_result('FAILED');
     }
     return $self;

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -43,40 +43,17 @@ sub switch_from_ssh_to_sol_console {
     save_screenshot;
 }
 
-my $grub_ver;
+my $grub_ver = "grub2";
 
 sub get_dom0_serialdev {
-    my $root_dir = shift;
-    $root_dir //= '/';
-
     my $dom0_serialdev;
-
-    script_run("clear");
-    script_run("cat ${root_dir}/etc/SuSE-release || cat ${root_dir}/etc/os-release");
-    save_screenshot;
-    assert_screen([qw(on_host_sles_12_sp2_or_above on_host_lower_than_sles_12_sp2)]);
-
     if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
-        if (match_has_tag("on_host_sles_12_sp2_or_above")) {
-            $dom0_serialdev = "hvc0";
-        }
-        elsif (match_has_tag("on_host_lower_than_sles_12_sp2")) {
-            $dom0_serialdev = "xvc0";
-        }
+        $dom0_serialdev = "hvc0";
     }
     else {
         $dom0_serialdev = get_var("LINUX_CONSOLE_OVERRIDE", "ttyS1");
     }
-
-    if (match_has_tag("grub1")) {
-        $grub_ver = "grub1";
-    }
-    else {
-        $grub_ver = "grub2";
-    }
-
-    enter_cmd("echo \"Debug info: hypervisor serial dev should be $dom0_serialdev. Grub version is $grub_ver.\"");
-
+    enter_cmd("echo \"Debug info: hypervisor serial dev should be $dom0_serialdev.\"");
     return $dom0_serialdev;
 }
 
@@ -364,7 +341,7 @@ sub set_grub_on_vh {
     }
 
     #set up xen serial console
-    my $ipmi_console = get_dom0_serialdev("$root_dir");
+    my $ipmi_console = get_dom0_serialdev();
     if (${virt_type} eq "xen" || ${virt_type} eq "kvm") { setup_console_in_grub($ipmi_console, $root_dir, $virt_type); }
     else { die "Host Hypervisor is not xen or kvm"; }
 

--- a/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
+++ b/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
@@ -32,8 +32,6 @@ conditional_schedule:
                 - installation/start_install
                 - installation/await_install
                 - installation/reboot_after_installation
-                - boot/reconnect_mgmt_console
-                - installation/first_boot
     reboot:
         DO_NOT_INSTALL_HOST:
             0:


### PR DESCRIPTION
we set 'boot from pxe' in ipxe_install module, so boot from local disk in other cases.

- Remove reconnect_mgmt_console and first_boot as pxe menu has not been shown any more during reboot.
- Remove version detection by needles which blocks openSUSE TumbleWeed login. It is obosolete as we have not sle12sp2 in our test any more.
- No intension to remove all obosolete functions for sles12sp2/grub1 in my pr
- Retry to check if the URL of autoyast file is accessible as there are a few failures(https://openqa.opensuse.org/tests/2516852#step/unified_guest_installation/276)

Related ticket: https://progress.opensuse.org/issues/103742
Needles: added in openqa webUI in O3
Verification run: 
[virt-guest-installation-kvm in my indevidual openqa server](http://10.67.129.102/tests/342)
[virt-guest-installation-kvm in O3](https://openqa.opensuse.org/tests/2517804)
[virt-guest-installation-xen in O3](https://openqa.opensuse.org/tests/2520263)
[uefi-gi-guest_developing-on-host_developing-kvm in OSD](https://openqa.suse.de/tests/9347321)

@alice-suse @xguo @waynechen55 @nanzhg @tbaev @tonyyuan1 @RoyCai7 @lemon-suse
