### PR TITLE
Fix some more send_key_until_needlematch races

### DIFF
--- a/tests/boot/grub2_test.pm
+++ b/tests/boot/grub2_test.pm
@@ -29,7 +29,7 @@ sub reboot {
 
 sub edit_cmdline {
     send_key 'e';
-    for (1 .. 13) { send_key 'down'; }
+    for (1 .. 12) { send_key 'down'; }
     send_key_until_needlematch 'grub2-edit-linux-line', 'down';
     send_key 'end';
 }

--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -43,7 +43,10 @@ sub change_desktop {
         }
         send_key 'ret';
     }
-    send_key_until_needlematch 'patterns-list-selected', 'tab', 10, 2;
+    # Give it some time to process the 'ret'
+    if (!check_screen('patterns-list-selected', 10)) {
+        send_key_until_needlematch 'patterns-list-selected', 'tab', 10, 2;
+    }
 
     if (is_sle('<=12-SP1') && get_var("REGRESSION", '') =~ /xen|kvm|qemu/) {
         assert_and_click 'gnome_logo';


### PR DESCRIPTION
`send_key_until_needlematch` expects that it can get straight to work, but the
previous keypress might not be processed yet.

- Verification runs:
change_desktop: http://10.168.4.168/tests/1238
grub2_test: http://10.168.4.168/tests/1240
