### PR TITLE
tests/installation/change_desktop: Replace delay with wait_screen_change

### DIFF
--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -41,12 +41,10 @@ sub change_desktop {
         for (1 .. 4) {
             wait_screen_change { send_key 'up'; };
         }
-        send_key 'ret';
+        wait_screen_change { send_key 'ret'; };
     }
-    # Give it some time to process the 'ret'
-    if (!check_screen('patterns-list-selected', 10)) {
-        send_key_until_needlematch 'patterns-list-selected', 'tab', 10, 2;
-    }
+
+    send_key_until_needlematch 'patterns-list-selected', 'tab', 10, 2;
 
     if (is_sle('<=12-SP1') && get_var("REGRESSION", '') =~ /xen|kvm|qemu/) {
         assert_and_click 'gnome_logo';


### PR DESCRIPTION
Instead of doing a check_screen which effectively just waits for the timeout in
the relevant case, use wait_screen_change to assure the 'ret' was processed.

Unlike a new `assert_screen`, this doesn't need new needles and is probably even quicker.

- Verification run: http://10.168.4.168/tests/1241
