### PR TITLE
Allow up to 5 redirects when downloading LTP whitelist

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -38,7 +38,7 @@ sub _download_whitelist {
 
     my $res = Mojo::UserAgent->new(max_redirects => 5)->get($path)->result;
     unless ($res->is_success) {
-        record_info("File not downloaded!", $res->message, result => 'softfail');
+        record_info("$path not downloaded!", $res->message, result => 'softfail');
         set_var('LTP_KNOWN_ISSUES_LOCAL', '');
         return;
     }

--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -36,7 +36,7 @@ sub _download_whitelist {
     my $path = get_var('LTP_KNOWN_ISSUES');
     return undef unless defined($path);
 
-    my $res = Mojo::UserAgent->new->get($path)->result;
+    my $res = Mojo::UserAgent->new(max_redirects => 5)->get($path)->result;
     unless ($res->is_success) {
         record_info("File not downloaded!", $res->message, result => 'softfail');
         set_var('LTP_KNOWN_ISSUES_LOCAL', '');


### PR DESCRIPTION
Our server hosting the ltp_known_issues.yaml file now redirects to another address and LTP tests fail to download the file as a results: https://openqa.suse.de/tests/9322821#step/boot_ltp/222
Enable redirects when downloading ltp_known_issues.yaml.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/9322897
