### PR TITLE
Add Internal CA certificates to SLEM

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -11,7 +11,7 @@ use warnings;
 use testapi qw(is_serial_terminal :DEFAULT);
 use lockapi 'mutex_wait';
 use mm_network;
-use version_utils qw(is_microos is_leap is_public_cloud is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos package_version_cmp);
+use version_utils qw(is_sle_micro is_microos is_leap is_public_cloud is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos package_version_cmp);
 use Utils::Architectures;
 use Utils::Systemd qw(systemctl disable_and_stop_service);
 use Utils::Backends;
@@ -2031,12 +2031,16 @@ This functions checks if ca-certificates-suse is installed and if it is not it a
 =cut
 
 sub ensure_ca_certificates_suse_installed {
-    return unless is_sle;
+    return unless is_sle || is_sle_micro;
     if (script_run('rpm -qi ca-certificates-suse') == 1) {
         my $host_version = get_var("HOST_VERSION") ? 'HOST_VERSION' : 'VERSION';
         my $distversion = get_required_var($host_version) =~ s/-SP/_SP/r;    # 15 -> 15, 15-SP1 -> 15_SP1
         zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_$distversion/SUSE:CA.repo");
-        zypper_call("in ca-certificates-suse");
+        if (is_sle_micro) {
+            transactional::trup_call('--continue pkg install ca-certificates-suse');
+        } else {
+            zypper_call("in ca-certificates-suse");
+        }
     }
 }
 

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -16,7 +16,7 @@ use testapi;
 use transactional qw(process_reboot trup_call check_reboot_changes);
 use bootloader_setup qw(change_grub_config);
 use version_utils qw(is_alp is_transactional);
-use utils qw(zypper_call);
+use utils qw(zypper_call ensure_ca_certificates_suse_installed);
 
 sub run {
     select_console 'root-console';
@@ -30,6 +30,7 @@ sub run {
     if (!$keep_grub_timeout or $extrabootparams) {
         record_info('GRUB', script_output('cat /etc/default/grub'));
         assert_script_run('transactional-update grub.cfg');
+        ensure_ca_certificates_suse_installed if get_var('HOST_VERSION');
         process_reboot(trigger => 1);
     }
     if (is_alp) {


### PR DESCRIPTION
Missing Internal CA certificates on the host, causing problems when
pulling toolbox container from internal registry.

- ticket: [toolbox test fails due to internal CA certificate missing](https://progress.opensuse.org/issues/115304)
- VR: [sle-micro-5.3-Container-Image-Updates-x86_64-Build5.3_4.2.6-sle_micro_toolbox_image@64bit](http://kepler.suse.cz/tests/18510#step/toolbox/91)