### PR TITLE
fix zypper refresh timeout in zypper_lifecycle

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -63,12 +63,7 @@ sub run {
     # 0755 and all files have 0644 pemmission.
     # For some reason the system will change the permission on /var/cache/zypp/{solv,raw}
     # files. this cause the zypper lifecycle failed when building cache for non-root user.
-    script_run('rm -fr /var/cache/zypp/solv /var/cache/zypp/solv');
-    script_run('rm -fr /var/cache/zypp/raw /var/cache/zypp/raw');
-
-    # We add 'zypper ref' here to download and preparse the metadata of packages,
-    # which will make the following 'zypper lifecycle' runs faster.
-    script_run('zypper refresh', 300);
+    assert_script_run('chmod -R u+rwX,og+rX /var/cache/zypp');
 
     select_console 'user-console';
     my $overview = script_output('zypper lifecycle', 600);


### PR DESCRIPTION
Enhance the current logic not to remove the zypper cache.

- Related ticket: https://progress.opensuse.org/issues/115292
- Needles: n/a
- Verification run: 
x86_64:
https://openqa.suse.de/tests/9354276
https://openqa.suse.de/tests/9357992
aarch64:
https://openqa.suse.de/tests/9357971
s390x:
https://openqa.suse.de/tests/9357991