### PR TITLE
Check default selection for yast2_keyboard.pm

### DIFF
--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -45,7 +45,7 @@ sub run {
     send_key "g";
 
     # 2. Switch keymap from us to german
-    send_key_until_needlematch("yast2_keyboard-layout-german", "down");
+    send_key_until_needlematch("yast2_keyboard-layout-german", "down") unless check_screen("yast2_keyboard-layout-german", 30);
     wait_screen_change { send_key $accept_keybind };
     assert_screen "generic-desktop", timeout => 90;
 


### PR DESCRIPTION
We need check screen before sent down key on yast2_keyboard layout setting.

- Related ticket: https://progress.opensuse.org/issues/115220
- Needles: na
- Verification run: http://10.162.2.137/tests/374#step/yast2_keyboard/9
