### PR TITLE
lib/mm_network: Wait for NetworkManager to configure the interfaces

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -231,6 +231,8 @@ sub restart_networking {
     if ($is_nm) {
         assert_script_run 'nmcli networking off';
         assert_script_run 'nmcli networking on';
+        # Wait until the connections are configured
+        assert_script_run 'nmcli networking connectivity check';
     } else {
         assert_script_run 'rcnetwork restart';
     }


### PR DESCRIPTION
Apparently there's a delay between "nmcli networking on" and the interface
getting the configuration assigned. Wait for that to happen.

- Related ticket: https://progress.opensuse.org/issues/115313
- Verification run: https://openqa.opensuse.org/tests/2517142
