### PR TITLE
tests/network/firewalld_policy_objects: Contact the right openQA host

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -231,6 +231,8 @@ sub restart_networking {
     if ($is_nm) {
         assert_script_run 'nmcli networking off';
         assert_script_run 'nmcli networking on';
+        # Wait until the connections are configured
+        assert_script_run 'nmcli networking connectivity check';
     } else {
         assert_script_run 'rcnetwork restart';
     }

--- a/tests/network/firewalld_policy_objects.pm
+++ b/tests/network/firewalld_policy_objects.pm
@@ -70,6 +70,7 @@ sub configure_machines {
         configure_static_dns(get_host_resolv_conf(), is_nm => $is_nm);
         restart_networking(is_nm => $is_nm);
         assert_script_run("ip route add 10.0.3.0/24 via $FW_EXT_IP");
+        assert_script_run("ip route add 10.0.2.2 dev $net0");
         assert_script_run("ip route show");
     } elsif ($hostname eq "client") {
         record_info 'Setting up Client machine';
@@ -77,6 +78,7 @@ sub configure_machines {
         configure_static_dns(get_host_resolv_conf(), is_nm => $is_nm);
         restart_networking(is_nm => $is_nm);
         assert_script_run("ip route add default via $FW_INT_IP");
+        assert_script_run("ip route add 10.0.2.2 dev $net0");
         assert_script_run("ip route show");
     }
 }


### PR DESCRIPTION
The client and server VMs are possibly on other openQA workers than the
firewall, but they need to access their actual worker through 10.0.2.2 for
asset download and upload. Add an explicit route for that and rely on IP
rewriting done by OpenVSwitch.

Hopefully this fixes the remaining random firewalld test failures.

https://progress.opensuse.org/issues/115313#note-3

Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15371

Verification runs:

https://openqa.opensuse.org/tests/2517890
https://openqa.opensuse.org/tests/2517926