### PR TITLE
wicked: verify installation of wicked

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -115,12 +115,12 @@ sub run {
             zypper_call("in --from $repo_id $resolv_options --force -y --force-resolution  wicked wicked-service", log => 'zypper_in_wicked.log');
             my ($zypper_in_output) = script_output('cat /tmp/zypper_in_wicked.log');
             my @installed_packages;
-            for my $reg (('The following \d+ packages? (are|is) going to be upgraded:',
-                    'The following NEW packages? (are|is) going to be installed:',
-                    'The following \d+ packages? (are|is) going to be reinstalled:')) {
-                push(@installed_packages, split(/\s+/, $+{packages})) if ($zypper_in_output =~ m/(?s)($reg(?<packages>.*?))(?:\r*\n){2}/);
-            }
+            my $reg = 'The following (\d+|NEW) packages? (are|is) going to be (installed|reinstalled|upgraded|downgraded):';
+            push(@installed_packages, split(/\s+/, $+{packages})) if ($zypper_in_output =~ m/(?s)($reg(?<packages>.*?))(?:\r*\n){2}/);
             record_info('INSTALLED', join("\n", @installed_packages));
+            for my $pkg ('wicked', 'wicked-service') {
+                die("Missing installation of package $pkg!") unless grep { $_ eq $pkg } @installed_packages;
+            }
             my @zypper_ps_progs = split(/\s+/, script_output('zypper ps  --print "%s"', qr/^\s*$/));
             for my $ps_prog (@zypper_ps_progs) {
                 die("The following programm $ps_prog use deleted files") if grep { /$ps_prog/ } @installed_packages;


### PR DESCRIPTION
If WICKED_REPO is set, we will install wicked and
wicked-service from it. But this wasn't checked and thus we simple continue
but the version under test is something different!

- Verification run: 
  - http://openqa.wicked.suse.de/tests/76401#step/before_test/22 (successfull)
  - https://openqa.suse.de/t9342239 (error case)

