### PR TITLE
Adjust hpc post_fail_hook for non-clustered nodes

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -88,8 +88,7 @@ sub destroy_test_barriers {
 sub post_run_hook {
     my ($self) = @_;
     select_console('log-console');
-    my $hname = get_required_var('HOSTNAME');
-    my $nodes = get_required_var('CLUSTER_NODES');
+    my $hname = get_var('HOSTNAME', 'susetest');
     foreach (keys %log_files) {
         $self->save_and_upload_log($log_files{$_}{cmd}, "/tmp/$hname-" . $log_files{$_}{logfile}, {screenshot => 1});
     }


### PR DESCRIPTION
Current commit introduced to collect logs from all nodes of a cluster. Logs
files would try to add the hostname of the node of each node. Clusters uses
`HOSTNAME` job variable which isnt assigned on a single machine jobs. Adjust
the post_fail_hook to use the default expected value.

Another solution would be to add `HOSTNAME` to each job which the variable is
missing such as the variable gives a meaningful name to the test logs.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/106829
- Verification run: http://aquarius.suse.cz/tests/11936
