### PR TITLE
wsl/prepare_wsl_feature: Close the serial port before installing the appx

### DIFF
--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -116,6 +116,12 @@ sub run {
         ) if (check_var("WIN_VERSION", "11"));
     }
 
+    record_info 'Port close', 'Closing serial port...';
+    $self->run_in_powershell(
+        cmd => q{$port.close()},
+        code => sub { }
+    );
+
     $self->run_in_powershell(
         cmd => qq{ii C:\\$wsl_appx_filename},
         code => sub {
@@ -123,12 +129,6 @@ sub run {
             assert_and_click 'install-linux-in-wsl-background' if (match_has_tag 'install-linux-in-wsl-background');
             assert_and_click 'install-linux-in-wsl';
         }
-    );
-
-    record_info 'Port close', 'Closing serial port...';
-    $self->run_in_powershell(
-        cmd => q{$port.close()},
-        code => sub { }
     );
 }
 


### PR DESCRIPTION
As part of the appx installation, the Tumbleweed initial setup is started
at the end. This opens a window which conflicts with the "run_in_powershell"
command for closing the serial port. As the serial port isn't needed for
appx installation, just close it earlier already.

- Related ticket: https://progress.opensuse.org/issues/111473#note-49 (yes, it's the right one)
- Verification run: https://openqa.opensuse.org/tests/2520424#live
