### PR TITLE
Fix yast2_keyboard failed case

### DIFF
--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -70,9 +70,7 @@ sub run {
     wait_still_screen 10;
     send_key "alt-k";
     wait_still_screen 2;
-    send_key "e";
-    send_key "n" if is_sle("15-SP2+");
-    send_key_until_needlematch("yast2_keyboard-layout-us", "down");
+    send_key_until_needlematch("yast2_keyboard-layout-us", "e");
     send_key $accept_keybind;
     assert_screen "generic-desktop", timeout => 90;
 


### PR DESCRIPTION
Fix yast2_keyboard failed case

- Related ticket: https://progress.opensuse.org/issues/115427
- Needles: na
- Verification run: 
15sp3
https://openqa.suse.de/tests/9350295   
12sp5
http://openqa.suse.de/t9350352

