### PR TITLE
tests/installation/rollback_from_ro_snapshot: Don't assert systemctl poweroff

### DIFF
--- a/tests/installation/rollback_from_ro_snapshot.pm
+++ b/tests/installation/rollback_from_ro_snapshot.pm
@@ -48,7 +48,8 @@ sub run {
     reset_consoles;
     $self->wait_boot;
     select_console 'root-console';
-    assert_script_run("systemctl poweroff");
+    script_run("systemctl poweroff");
+    assert_shutdown;
 }
 
 sub test_flags {


### PR DESCRIPTION
The system might not reply with the return code during shutdown. Replace it
with assert_shutdown instead.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1202495
- Verification run: https://openqa.opensuse.org/tests/2526647
