### PR TITLE
Use worker ip for zypper_log_packages autoinst_url

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -591,8 +591,27 @@ sub zypper_call {
 
     # log all install and remove actions for later use by tests/console/zypper_log_packages.pm
     my @packages = split(" ", $command);
+    my $dry_run = 0;
     for (my $i = 0; $i < scalar(@packages); $i++) {
         if ($packages[$i] eq "--root" || $packages[$i] eq "-R") {
+            splice(@packages, $i, 2);
+        }
+        elsif ($packages[$i] eq "--name" || $packages[$i] eq "-n") {
+            splice(@packages, $i, 2);
+        }
+        elsif ($packages[$i] eq "--from") {
+            splice(@packages, $i, 2);
+        }
+        elsif ($packages[$i] eq "--repo" || $packages[$i] eq "-r") {
+            splice(@packages, $i, 2);
+        }
+        elsif ($packages[$i] eq "--download") {
+            splice(@packages, $i, 2);
+        }
+        elsif ($packages[$i] eq "--dry-run" || $packages[$i] eq "--download-only" || $packages[$i] eq '-d') {
+            $dry_run = 1;
+        }
+        elsif ($packages[$i] eq "--solver-focus") {
             splice(@packages, $i, 2);
         }
     }
@@ -600,7 +619,7 @@ sub zypper_call {
     my $zypper_action = shift(@packages);
     $zypper_action = "install" if ($zypper_action eq "in");
     $zypper_action = "remove" if ($zypper_action eq "rm");
-    if ($zypper_action =~ m/^(install|remove)$/) {
+    if ($zypper_action =~ m/^(install|remove)$/ && !$dry_run) {
         push(@{$testapi::distri->{zypper_packages}}, {
                 raw_command => $command,
                 action => $zypper_action,

--- a/tests/console/zypper_log_packages.pm
+++ b/tests/console/zypper_log_packages.pm
@@ -40,11 +40,12 @@ sub run {
     }
 
     my $ua = Mojo::UserAgent->new;
-    my $res = $ua->post(autoinst_url("/uploadlog/zypper_packages.json") => form => {
+    my $url = autoinst_url("/uploadlog/zypper_packages.json", undef, {inside_sut => 0});
+    my $res = $ua->post($url => form => {
             upload => {content => to_json($zypper_packages)},
             uname => "zypper_packages.json"
     })->result;
-    record_info('zypper_packages.json', 'zypper_packages.json was uploaded via worker', result => ($res->is_success) ? 'ok' : 'fail');
+    record_info('zypper_packages.json', "zypper_packages.json was uploaded via worker to $url", result => ($res->is_success) ? 'ok' : 'fail');
 }
 
 1;


### PR DESCRIPTION
This is required as we are posting from worker.

Also Cover all parametrized zypper-in arguments for logging package installs

Ticket: https://progress.opensuse.org/issues/115478
Verification: http://kazhua.qa/tests/141#step/zypper_log_packages/23
Related: https://github.com/os-autoinst/os-autoinst/pull/2149