### PR TITLE
Fix KLP installation test on SLE beta builds

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -45,12 +45,14 @@ sub install_klp_product {
     if ($livepatch_repo) {
         zypper_ar("$utils::OPENQA_FTP_URL/$livepatch_repo", name => "repo-live-patching");
     }
+    else {
+        zypper_ar("http://download.suse.de/ibs/SUSE/Products/$lp_module/$version/$arch/product/", name => "kgraft-pool");
+        zypper_ar("$release_override http://download.suse.de/ibs/SUSE/Updates/$lp_module/$version/$arch/update/", name => "kgraft-update");
+    }
 
     # install kgraft product
-    zypper_ar("http://download.suse.de/ibs/SUSE/Products/$lp_module/$version/$arch/product/", name => "kgraft-pool");
-    zypper_ar("$release_override http://download.suse.de/ibs/SUSE/Updates/$lp_module/$version/$arch/update/", name => "kgraft-update");
     zypper_call("in -l -t product $lp_product", exitcode => [0, 102, 103]);
-    zypper_call("mr -e kgraft-update");
+    zypper_call("mr -e kgraft-update") unless $livepatch_repo;
 }
 
 sub is_klp_pkg {


### PR DESCRIPTION
Beta builds don't have product and update repos on our mirror servers.

- Related ticket: https://progress.opensuse.org/issues/115475
- Needles: N/A
- Verification run:
  - SLE-15SP4: https://openqa.suse.de/tests/9355026
  - SLE-15SP5: https://openqa.suse.de/tests/9355025
