### PR TITLE
Give more time to match needles on exit_firefox

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -717,7 +717,7 @@ sub exit_firefox_common {
     # Exit
     send_key 'ctrl-q';
     wait_still_screen 1, 2;
-    send_key_until_needlematch([qw(firefox-save-and-quit xterm-left-open xterm-without-focus)], "alt-f4", 3, 30);
+    send_key_until_needlematch([qw(firefox-save-and-quit xterm-left-open xterm-without-focus)], "alt-f4", 6, 30);
     if (match_has_tag 'firefox-save-and-quit') {
         # confirm "save&quit"
         send_key "ret";

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -716,14 +716,14 @@ sub firefox_preferences {
 sub exit_firefox_common {
     # Exit
     send_key 'ctrl-q';
-    wait_still_screen 1, 2;
+    wait_still_screen 3, 6;
     send_key_until_needlematch([qw(firefox-save-and-quit xterm-left-open xterm-without-focus)], "alt-f4", 6, 30);
     if (match_has_tag 'firefox-save-and-quit') {
         # confirm "save&quit"
         send_key "ret";
     }
     # wait a sec because xterm-without-focus can match while firefox is being closed
-    wait_still_screen 2;
+    wait_still_screen 3, 6;
     assert_screen [qw(xterm-left-open xterm-without-focus)];
     if (match_has_tag 'xterm-without-focus') {
         # focus it


### PR DESCRIPTION
Give more time to match needles on exit_firefox, to avoid sending too many alt-f4 and then failing because we can't find the open terminal

- Related ticket: https://progress.opensuse.org/issues/115472
- Needles: none
- Verification run:
  - reproducing issue: https://openqa.suse.de/tests/9358395#details
  - test fix: 15 sp4 https://openqa.suse.de/tests/9358396
  - test fix: 12sp2 https://openqa.suse.de/tests/9358840
  - test fix: 15ga  https://openqa.suse.de/tests/9358841
  - test fix: 15sp2 https://openqa.suse.de/tests/9358842 
