### PR TITLE
Add yaml file to schedule mau-extratests-desktop testsuite

### DIFF
--- a/schedule/qam/common/mau-extratests-desktop.yaml
+++ b/schedule/qam/common/mau-extratests-desktop.yaml
@@ -1,0 +1,31 @@
+---
+name: mau-extratests-desktop
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - x11/disable_screensaver
+  - x11/vnc_two_passwords
+  - x11/user_defined_snapshot
+  - x11/remote_desktop/screensharing_available
+  - x11/libqt5_qtbase
+  - x11/rrdtool_x11
+  - x11/yast2_lan_restart
+  - console/yast2_lan_device_settings
+  - '{{version_specific}}'
+  - console/coredump_collect
+conditional_schedule:
+  version_specific:
+    VERSION:
+      15-SP4:
+        - texlive/latexdiff
+      15-SP3:
+        - texlive/latexdiff
+      15-SP2:
+        - texlive/latexdiff
+      15-SP1:
+        - texlive/latexdiff
+      15:
+        - texlive/latexdiff
+...


### PR DESCRIPTION
Scheduling mau-extratests-desktop testsuite via yaml file instead of main_common.pm and also updated mau-extratests-desktop.json to schedule the tests - https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/358/

- Related ticket: https://progress.opensuse.org/issues/109373
- Needles:NO
- Verification run:
  [15-SP4](https://openqa.suse.de/tests/9378836#) | [15-SP3](https://openqa.suse.de/tests/9378846#) | [15-SP2](https://openqa.suse.de/tests/9378825#) | [15-SP1](https://openqa.suse.de/tests/9378808#) |[15](https://openqa.suse.de/tests/9378838#)
[12-SP3](https://openqa.suse.de/tests/9378794#) | [12-SP4](https://openqa.suse.de/tests/9378802#) | [12-SP5](https://openqa.suse.de/tests/9378842#)