### PR TITLE
Increase TO for installing cockpit packages

### DIFF
--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -43,7 +43,7 @@ sub run {
 
     if (@pkgs) {
         record_info('TEST', 'Installing Cockpit\'s Modules...');
-        trup_call("pkg install @pkgs");
+        trup_call("pkg install @pkgs", timeout => 300);
         check_reboot_changes;
     }
 


### PR DESCRIPTION
Additional cockpit packages pull more dependencies, therefore
installation times out.

- failure: https://openqa.suse.de/tests/9358886#step/cockpit_service/17
- Verification run: [sle-micro-5.2-DVD-Updates-aarch64](https://openqa.suse.de/tests/9359073)
