### PR TITLE
Remove stderr from json output

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -76,8 +76,8 @@ sub find_img {
 
 sub get_storage_account_keys {
     my ($self, $storage_account) = @_;
-    my $output = script_output("az storage account keys list --resource-group "
-          . $self->resource_group . " --account-name " . $storage_account);
+    my $cmd = "az storage account keys list --resource-group " . $self->resource_group . " --account-name " . $storage_account;
+    my $output = script_output("echo \"\n $cmd\" > /dev/$serialdev; " . $cmd . " 2>/dev/$serialdev");
     my $json = decode_azure_json($output);
     my $key = undef;
     if (@{$json} > 0) {


### PR DESCRIPTION
OpenQA PC 'upload_image' tests are failing because of some Azure tool 
commands are reading stderr info json output files. This PR redirects 
the stderr into /dev/null to sppress those messages.

- Needles: N/A
- Failing test: http://10.100.96.70/tests/5838#step/upload_image/104
- VR: http://mordor.suse.cz/tests/4179#