### PR TITLE
Softfail "create_dirs_from_rpmdb" issue in MicroOS

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -180,7 +180,8 @@
     "bsc#1188215": {
         "description": "Failed to start Create missing directories from rpmdb",
         "products": {
-            "sle-micro": [ "5.0", "5.1" ]
+            "sle-micro": [ "5.0", "5.1" ],
+            "microos":  ["Tumbleweed"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
- Verification run: [microos-Tumbleweed-MicroOS-Image](https://openqa.opensuse.org/t2531981)
