### PR TITLE
Click install kdump when yast2 kdump module starts

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -254,6 +254,7 @@ sub start_add_system_extensions_or_modules {
 sub start_kernel_dump {
     search('dump');
     assert_and_click 'yast2_control-kernel-kdump';
+    assert_and_click 'yast2_control-install-kdump';
     assert_screen 'yast2_control-center_kernel-kdump-configuration', timeout => 180;
     send_key 'alt-o';    # Press ok
     assert_screen 'yast2-control-center-ui', timeout => 60;


### PR DESCRIPTION
Package kdump is no longer a dependency of yast2-kdump as seen in this [PR](https://github.com/yast/yast-kdump/pull/128).
This means that we now have to install kdump when we start the yast2 kdump module.

- Related ticket: No ticket, fails in https://openqa.suse.de/tests/9340981#step/yast2_control_center/93
- Needles: No
- Verification run:  https://openqa.suse.de/tests/9359006#step/yast2_control_center/92 (module `yast2_control_center` is not run anywhere else)
