### PR TITLE
Add more steps to match needle in disable_grub_timeout

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -31,7 +31,7 @@ sub run {
     }
     else {
         # Select section booting on Installation Settings overview (video mode)
-        send_key_until_needlematch 'booting-section-selected', 'tab';
+        send_key_until_needlematch 'booting-section-selected', 'tab', 25, 1;
         send_key 'ret';
     }
 


### PR DESCRIPTION
Due to poo#115577, on some SLE15SP5 setups, we may need
more steps to match a needle when we try to disable grub
timeout.

- Related ticket: https://progress.opensuse.org/issues/115577
- Needles: n/a
- Verification run: 
https://openqa.suse.de/tests/9367412
https://openqa.suse.de/tests/9367422
https://openqa.suse.de/tests/9367423
