### PR TITLE
Add unit tests for YAML schedule with reusable flows

### DIFF
--- a/t/02_yaml_schedule.t
+++ b/t/02_yaml_schedule.t
@@ -87,4 +87,32 @@ subtest 'parse_yaml_test_schedule_recursive_conditional' => sub {
     ok $modules[3] eq 'bar/test3', "Basic scheduling";
 };
 
+subtest 'merge default schedules with flows and individual schedules' => sub {
+    use scheduler;
+    use testapi 'set_var';
+
+    # positive unit tests
+
+    my $schedule = $ypp->load_file(dirname(__FILE__) . '/data/test_schedule_based_on_default.yaml');
+    my @modules;
+    set_var('YAML_SCHEDULE_DEFAULT', '/t/data/flows/default.yaml');
+    set_var('YAML_SCHEDULE_FLOWS', 'flow_a');
+    @modules = scheduler::parse_schedule($schedule);
+    my @expected = ('flow_a_foo', 'flow_a_bar', 'individual_step_3');
+    ok(eq_array(\@modules, \@expected), "Merge default with flows and schedule");
+    set_var('YAML_SCHEDULE_FLOWS', 'flow_b');
+    @modules = scheduler::parse_schedule($schedule);
+    @expected = ('flow_b_foo', 'flow_b_bar', 'individual_step_3');
+    ok(eq_array(\@modules, \@expected), "Merge default with flows and schedule");
+    set_var('YAML_SCHEDULE_FLOWS', 'flow_a,flow_b');    # flow_b should win
+    @modules = scheduler::parse_schedule($schedule);
+    ok(eq_array(\@modules, \@expected), "Merge default with flows and schedule");
+    set_var('YAML_SCHEDULE_FLOWS', 'flow_b,flow_a');    # flow_a should win
+    @modules = scheduler::parse_schedule($schedule);
+    @expected = ('flow_a_foo', 'flow_a_bar', 'individual_step_3');
+    ok(eq_array(\@modules, \@expected), "Merge default with flows and schedule");
+
+
+};
+
 done_testing;

--- a/t/data/flows/default.yaml
+++ b/t/data/flows/default.yaml
@@ -1,0 +1,7 @@
+---
+# minimal default file
+phase_1:
+  - step_1
+phase_2: []
+phase_3:
+  - step_3

--- a/t/data/flows/flow_a.yaml
+++ b/t/data/flows/flow_a.yaml
@@ -1,0 +1,6 @@
+---
+# example flow a
+phase_1:
+  - flow_a_foo
+phase_2: 
+  - flow_a_bar

--- a/t/data/flows/flow_b.yaml
+++ b/t/data/flows/flow_b.yaml
@@ -1,0 +1,6 @@
+---
+# example flow b
+phase_1: 
+  - flow_b_foo
+phase_2:
+  - flow_b_bar

--- a/t/data/test_schedule_based_on_default.yaml
+++ b/t/data/test_schedule_based_on_default.yaml
@@ -1,0 +1,6 @@
+---
+name: test_data_mini_default_flows
+description: Minimal file to merge with default and flows.
+schedule:
+  phase_3:
+    - individual_step_3


### PR DESCRIPTION
### Links to Progress, etc:

- Related ticket: https://progress.opensuse.org/issues/110236
- Needles: -
- Verification run: -

### Positve tests
- Supply YAML_SCHEDULE_DEFAULT, one YAML_SCHEDULE_FLOWS entry and individual schedule, check if expected schedule is created (2 tests)
-  Supply YAML_SCHEDULE_DEFAULT, two YAML_SCHEDULE_FLOWS entries and individual_schedule, check if the last flow "wins" by writing the final schedule. (2 tests)

### Negative tests
- Supply invalid YAML_SCHEDULE_DEFAULT and check if scheduler dies
- Supply wron flow name in YAML_SCHEDULE_FLOWS and check if scheduler dies