### PR TITLE
create-dirs-from-rpmdb.service fails for slem5.3

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -180,7 +180,7 @@
     "bsc#1188215": {
         "description": "Failed to start Create missing directories from rpmdb",
         "products": {
-            "sle-micro": [ "5.0", "5.1" ],
+            "sle-micro": [ "5.0", "5.1", "5.3" ],
             "microos":  ["Tumbleweed"]
         },
         "type": "bug"


### PR DESCRIPTION
- Verification run: [sle-micro-5.3-DVD-B-Staging-x86_64-Build32.1_13.4-sle-micro_installation+update@64bit](http://kepler.suse.cz/tests/18752#)
