### PR TITLE
Generation of the xml for the DUD in maintenance

### DIFF
--- a/schedule/yast/lvm_thin_provisioning_dev.yaml
+++ b/schedule/yast/lvm_thin_provisioning_dev.yaml
@@ -1,0 +1,31 @@
+---
+name: lvm_thin_provisioning_dev
+vars:
+  DUD_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_module_desktop
+  - installation/add_on_product_installation/add_additional_products
+  - installation/add_on_product_installation/accept_add_on_installation
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/new_partitioning_gpt
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/handle_reboot
+  - installation/first_boot
+...

--- a/tests/console/generate_dud.pm
+++ b/tests/console/generate_dud.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: mkdud
@@ -13,8 +13,9 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
+use XML::Writer;
 use utils qw(zypper_call);
-use autoyast qw(expand_variables);
+use autoyast qw(expand_variables generate_xml);
 use registration qw(add_suseconnect_product get_addon_fullname);
 
 sub run {
@@ -23,7 +24,8 @@ sub run {
     my $xml = 'add_on_products.xml';
     my $dud = get_required_var('DUD');
 
-    my $content = expand_variables(get_test_data($xml));
+    my $repos = get_var('MAINT_TEST_REPO', '');
+    my $content = ($repos eq '') ? expand_variables(get_test_data($xml)) : generate_xml($repos);
     save_tmp_file($xml, $content);
     add_suseconnect_product(get_addon_fullname('phub'));
     zypper_call('in mkdud');
@@ -31,6 +33,7 @@ sub run {
     assert_script_run("mkdud --create $dud --dist sle15 " .
           "--install instsys,repo --obs-keys --name 'Update' inst-sys");
     upload_asset($dud);
+    upload_logs("inst-sys/$xml");
 }
 
 1;


### PR DESCRIPTION
Generation of the xml for the DUD in maintenance

- Related ticket: https://progress.opensuse.org/issues/113734
- Verification run: With test repos VR: https://openqa.suse.de/tests/9475436 and https://openqa.suse.de/tests/9475437#
   Original case VR: https://openqa.suse.de/tests/9405877
 MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/371