### PR TITLE
Correct profile for hpc/installation_autoyast

### DIFF
--- a/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
@@ -112,9 +112,7 @@
       <package>sle-module-hpc-release</package>
       % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
-      % } else {
-      <package>sle-module-python3-release</package>
-      }
+      % }
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>


### PR DESCRIPTION
Main problem seems to be the missing % on the profile which close the
_else_. However the else_statement is also wrong, so it's just removed.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/115199
