### PR TITLE
Increase timeout for SUSEConnect

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -43,16 +43,16 @@ sub packages_to_install {
         push @packages, 'python3-devel';
         if ($version eq "12.5") {
             # PackageHub is needed for jq
-            script_retry("SUSEConnect -p PackageHub/12.5/$arch", delay => 60, retry => 3);
+            script_retry("SUSEConnect -p PackageHub/12.5/$arch", delay => 60, retry => 3, timeout => 300);
             push @packages, 'python36-pip';
         } elsif ($version eq '15.0') {
             # On SLES15 go needs to be installed from packagehub. On later SLES it comes from the SDK module
-            script_retry("SUSEConnect -p PackageHub/15/$arch", delay => 60, retry => 3);
+            script_retry("SUSEConnect -p PackageHub/15/$arch", delay => 60, retry => 3, timeout => 300);
             push @packages, ('go1.10', 'skopeo');
         } else {
             # Desktop module is needed for SDK module, which is required for installing go
-            script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3);
-            script_retry("SUSEConnect -p sle-module-development-tools/$version/$arch", delay => 60, retry => 3);
+            script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3, timeout => 300);
+            script_retry("SUSEConnect -p sle-module-development-tools/$version/$arch", delay => 60, retry => 3, timeout => 300);
             push @packages, ('go', 'skopeo');
         }
     } elsif ($host_distri =~ /opensuse/) {


### PR DESCRIPTION
Avoid occasional timeout issues during SUSEConnect by increasing the
command timeout.

- Related ticket: https://progress.opensuse.org/issues/115481
- Verification run: https://duck-norris.qam.suse.de/tests/10426
