### PR TITLE
LXQt: use sddm as default configured display manager

### DIFF
--- a/tests/x11/lxqt_reconfigure_openqa.pm
+++ b/tests/x11/lxqt_reconfigure_openqa.pm
@@ -20,7 +20,7 @@ sub run {
 
     # LXQt uses sddm as window manager, which has the user preselected
     set_var('DISPLAYMANAGER', 'sddm');
-    # sddm asks straoght for PW with only one user; there is no need to type the username
+    # sddm asks straight for PW with only one user; there is no need to type the username
     set_var('DM_NEEDS_USERNAME', 0);
 
     $self->result('ok');

--- a/tests/x11/lxqt_reconfigure_openqa.pm
+++ b/tests/x11/lxqt_reconfigure_openqa.pm
@@ -18,9 +18,9 @@ sub run {
 
     set_var("DESKTOP", "lxqt");
 
-    # LXQt uses lightdm as window manager, which has the user preselected
-    set_var('DISPLAYMANAGER', 'lightdm');
-    # LightDM has the user in a drop-down preselected; there is no need to type the username
+    # LXQt uses sddm as window manager, which has the user preselected
+    set_var('DISPLAYMANAGER', 'sddm');
+    # sddm asks straoght for PW with only one user; there is no need to type the username
     set_var('DM_NEEDS_USERNAME', 0);
 
     $self->result('ok');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/115385
- Needles: 
- Verification run: https://openqa.opensuse.org/tests/2538863#live
