### PR TITLE
Increase clean up time out before executing test cases

### DIFF
--- a/tests/systemd_testsuite/runner.pm
+++ b/tests/systemd_testsuite/runner.pm
@@ -34,7 +34,7 @@ sub run {
 
     $self->select_serial_terminal();
 
-    assert_script_run(build_cmd('clean', $args));
+    assert_script_run(build_cmd('clean', $args), timeout => 180);
     my $out = script_output(build_cmd('setup', $args), 240);
 
     if ($out =~ $logs) {


### PR DESCRIPTION
- TO failures:
  [TEST-67-INTEGRITY](https://openqa.opensuse.org/tests/2537117#step/TEST-67-INTEGRITY/4) && [TEST-31-DEVICE-ENUMERATION](https://openqa.opensuse.org/tests/2537117#step/TEST-31-DEVICE-ENUMERATION/4)
- Verification run: https://openqa.opensuse.org/tests/2538865#
