### PR TITLE
SLE Micro 5.3 wizard install tests

### DIFF
--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -44,7 +44,11 @@ sub load_boot_from_disk_tests {
         loadtest 'installation/bootloader_start';
         loadtest 'boot/boot_to_desktop';
     } else {
-        loadtest 'microos/disk_boot';
+        if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
+            loadtest 'jeos/firstrun';
+        } else {
+            loadtest 'microos/disk_boot';
+        }
     }
     loadtest 'transactional/host_config';
     loadtest 'console/suseconnect_scc' if check_var('SCC_REGISTER', 'installation');

--- a/schedule/sle-micro/raw_image.yaml
+++ b/schedule/sle-micro/raw_image.yaml
@@ -9,9 +9,9 @@ conditional_schedule:
         - installation/bootloader_start
         - boot/boot_to_desktop
       'x86_64':
-        - microos/disk_boot
+        - '{{wizard}}'
       'aarch64':
-        - microos/disk_boot
+        - '{{wizard}}'
   registration:
     SCC_REGISTER:
       'installation':
@@ -36,6 +36,16 @@ conditional_schedule:
     FLAVOR:
       'ECS-Anywhere':
         - containers/ecs_anywhere
+  wizard:
+    FIRST_BOOT_CONFIG:
+      'wizard':
+        - jeos/firstrun
+      'ignition':
+        - microos/disk_boot
+      'combustion':
+        - microos/disk_boot
+      'combustion+ignition':
+        - microos/disk_boot
 
 schedule:
   - '{{boot}}'

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -10,7 +10,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle is_tumbleweed is_leap is_opensuse is_microos);
+use version_utils qw(is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro);
 use Utils::Architectures;
 use Utils::Backends;
 use jeos qw(expect_mount_by_uuid);
@@ -119,7 +119,7 @@ sub run {
         send_key 'ret';
     }
 
-    if (is_sle) {
+    if (is_sle || is_sle_micro) {
         assert_screen 'jeos-please-register';
         send_key 'ret';
 

--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -23,7 +23,7 @@ sub cleanup {
 }
 
 sub create_user {
-    assert_script_run "useradd -m $user ";
+    assert_script_run "useradd -m $user " if (!check_var('FIRST_BOOT_CONFIG', 'wizard'));
     assert_script_run "echo '$user:$password' | chpasswd";
 
     # Make sure user has access to tty group


### PR DESCRIPTION
Add a new job to test the *'new'* installation wizard that pops up when no *ignition* neither *combustion* disk is present.

- Related ticket: https://progress.opensuse.org/issues/114938
- Needles: *not yet*
- Verification runs: 
  - [slem_image_default with ignition](https://openqa.suse.de/t9378781)
  - [slem_containers with ignition](https://openqa.suse.de/t9378779)
  - [slem_image_default with wizard](https://openqa.suse.de/t9378385)
  - [slem_containers with wizard](https://openqa.suse.de/t9378247)
