### PR TITLE
Bump $count in calls to send_key_until_needlematch

### DIFF
--- a/lib/Installation/Partitioner/FormattingOptionsPage.pm
+++ b/lib/Installation/Partitioner/FormattingOptionsPage.pm
@@ -79,7 +79,7 @@ sub select_partition_id {
     }
     # poo#35134 Sporadic synchronization failure resulted in incorrect choice of partition type
     # add partition screen was not refreshing fast enough
-    send_key_until_needlematch($partition_id_needle, 'up', 20, 5);
+    send_key_until_needlematch($partition_id_needle, 'up', 21, 5);
 }
 
 sub select_filesystem {
@@ -88,7 +88,7 @@ sub select_filesystem {
     assert_screen(FORMATTING_OPTIONS_PAGE);
     send_key($self->{filesystem_shortcut});
     send_key 'end', wait_screen_change => 1;
-    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up', 20, 5);
+    send_key_until_needlematch((sprintf FILESYSTEM_TYPE, $filesystem), 'up', 21, 5);
 }
 
 # Mounting Options

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
@@ -36,7 +36,7 @@ sub select_tab {
 sub select_bond_slave_in_list {
     assert_screen(BOND_SLAVES_TAB);
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED, 'alt-f10', 9, 2);
+    send_key_until_needlematch(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED, 'alt-f10', 10, 2);
     assert_and_click(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
@@ -37,7 +37,7 @@ sub select_tab {
 sub select_bridged_device_in_list {
     assert_screen(BRIDGED_DEVICES_TAB);
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(BRIDGED_DEVICE_CHECKBOX_UNCHECKED, 'alt-f10', 9, 2);
+    send_key_until_needlematch(BRIDGED_DEVICE_CHECKBOX_UNCHECKED, 'alt-f10', 10, 2);
     assert_and_click(BRIDGED_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
@@ -27,7 +27,7 @@ sub select_device_type {
         vlan => 'alt-v'
     };
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(DEVICE_TYPE_DIALOG, 'alt-f10', 9, 2);
+    send_key_until_needlematch(DEVICE_TYPE_DIALOG, 'alt-f10', 10, 2);
     send_key $shortcut->{$device};
 }
 

--- a/lib/YaST/NetworkSettings/OverviewTab.pm
+++ b/lib/YaST/NetworkSettings/OverviewTab.pm
@@ -28,19 +28,19 @@ sub new {
 
 sub press_add {
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 9, 2);
+    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 10, 2);
     send_key('alt-a');
 }
 
 sub press_edit {
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 9, 2);
+    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 10, 2);
     send_key('alt-i');
 }
 
 sub press_delete {
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 9, 2);
+    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 10, 2);
     send_key('alt-t');
 }
 
@@ -64,12 +64,12 @@ sub select_device {
     else {
         die "\"$device\" device is not known.";
     }
-    send_key_until_needlematch $device_needle, 'down', 5;
+    send_key_until_needlematch $device_needle, 'down', 6;
 }
 
 sub press_ok {
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 9, 2);
+    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 10, 2);
     send_key('alt-o');
 }
 

--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -566,7 +566,7 @@ sub adminer_setup {
         check_screen([qw(adminer-login unresponsive-script)], timeout => 300);    # nocheck: old code, should be updated
     }
     if (match_has_tag("unresponsive-script")) {
-        send_key_until_needlematch("adminer-login", 'ret', 5, 5);
+        send_key_until_needlematch("adminer-login", 'ret', 6, 5);
     }
     elsif (match_has_tag("adminer-login")) {
         record_info("Firefox is loading adminer", "adminer login page shows up");
@@ -583,16 +583,16 @@ sub adminer_setup {
     $ret = check_screen("quit-and-close-tabs", timeout => 30);
     if (defined($ret)) {
         # Click the "quit and close tabs" button
-        send_key_until_needlematch("close-button-selected", 'tab', 5, 5);
+        send_key_until_needlematch("close-button-selected", 'tab', 6, 5);
         send_key "ret";
     }
     wait_still_screen(stilltime => 3, timeout => 30);
     # Exit xterm
     if (is_tumbleweed()) {
-        send_key_until_needlematch("generic-desktop", 'alt-f4', 5, 5);
+        send_key_until_needlematch("generic-desktop", 'alt-f4', 6, 5);
     }
     # Send "ret" key in case of any pop up message
-    send_key_until_needlematch("generic-desktop", 'ret', 5, 5);
+    send_key_until_needlematch("generic-desktop", 'ret', 6, 5);
     select_console("root-console");
     send_key "ctrl-c";
     clear_console;
@@ -631,7 +631,7 @@ sub adminer_database_delete {
     assert_and_click("adminer-click-database-test");
     assert_and_click("adminer-click-drop-database-test");
     # Confirm drop
-    send_key_until_needlematch("adminer-database-dropped", 'ret', 10, 1);
+    send_key_until_needlematch("adminer-database-dropped", 'ret', 11, 1);
     # Exit x11 and turn to console
     send_key "alt-f4";
     # Handle exceptions when "Quit and close tabs" in Firefox, the warning FYI:

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -92,7 +92,7 @@ sub prepare_pvm_installation {
     }
     # try 3 times but wait a long time in between - if we're too eager
     # we end with ccc in the prompt
-    send_key_until_needlematch('pvm-grub-command-line', 'c', 3, 5);
+    send_key_until_needlematch('pvm-grub-command-line', 'c', 4, 5);
 
     # clear the prompt (and create an error) in case the above went wrong
     send_key 'ret';

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -283,21 +283,21 @@ sub boot_local_disk {
 }
 
 sub boot_into_snapshot {
-    send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
+    send_key_until_needlematch('boot-menu-snapshot', 'down', 11, 5);
     send_key 'ret';
     # assert needle to make sure grub2 page show up
     assert_screen('grub2-page', 60);
     # assert needle to avoid send down key early in grub_test_snapshot.
     if (get_var('OFW') || is_pvm || check_var('SLE_PRODUCT', 'hpc')) {
-        send_key_until_needlematch('snap-default', 'down', 60, 5);
+        send_key_until_needlematch('snap-default', 'down', 61, 5);
     }
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
-        send_key_until_needlematch('snap-before-update', 'down', 60, 5);
+        send_key_until_needlematch('snap-before-update', 'down', 61, 5);
         save_screenshot;
     }
     # in an online migration
-    send_key_until_needlematch('snap-before-migration', 'down', 60, 5) if (get_var('ONLINE_MIGRATION'));
+    send_key_until_needlematch('snap-before-migration', 'down', 61, 5) if (get_var('ONLINE_MIGRATION'));
     save_screenshot;
     send_key 'ret';
     # avoid timeout for booting to HDD
@@ -322,17 +322,17 @@ sub select_bootmenu_option {
 
     if (get_var('UPGRADE')) {
         # OFW has contralily oriented menu behavior
-        send_key_until_needlematch 'inst-onupgrade', get_var('OFW') ? 'up' : 'down', 10, 5;
+        send_key_until_needlematch 'inst-onupgrade', get_var('OFW') ? 'up' : 'down', 11, 5;
     }
     else {
         if (get_var('PROMO') || get_var('LIVETEST') || get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {
-            send_key_until_needlematch 'boot-live-' . get_var('DESKTOP'), 'down', 10, 5;
+            send_key_until_needlematch 'boot-live-' . get_var('DESKTOP'), 'down', 11, 5;
         }
         elsif (get_var('OFW')) {
-            send_key_until_needlematch 'inst-oninstallation', 'up', 10, 5;
+            send_key_until_needlematch 'inst-oninstallation', 'up', 11, 5;
         }
         elsif (!get_var('JEOS')) {
-            send_key_until_needlematch 'inst-oninstallation', 'down', 10, 5;
+            send_key_until_needlematch 'inst-oninstallation', 'down', 11, 5;
         }
     }
     return 0;
@@ -359,9 +359,9 @@ sub get_bootmenu_console_params {
 sub uefi_bootmenu_params {
     # assume bios+grub+anim already waited in start.sh
     # in grub2 it's tricky to set the screen resolution
-    #send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5);
+    #send_key_until_needlematch('grub2-enter-edit-mode', 'e', 6, 0.5);
     (is_jeos)
-      ? send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5)
+      ? send_key_until_needlematch('grub2-enter-edit-mode', 'e', 6, 0.5)
       : send_key 'e';
     # Kiwi in TW uses grub2-mkconfig instead of the custom kiwi config
     # Locate gfxpayload parameter and update it
@@ -634,10 +634,10 @@ sub select_bootmenu_more {
 
     # after installation-images 14.210 added a submenu
     if ($more && check_screen 'inst-submenu-more', 0) {
-        send_key_until_needlematch('inst-onmore', get_var('OFW') ? 'up' : 'down', 10, 5);
+        send_key_until_needlematch('inst-onmore', get_var('OFW') ? 'up' : 'down', 11, 5);
         send_key "ret";
     }
-    send_key_until_needlematch($tag, get_var('OFW') ? 'up' : 'down', 10, 3);
+    send_key_until_needlematch($tag, get_var('OFW') ? 'up' : 'down', 11, 3);
     # Redirect linuxrc logs to console when booting from menu: "boot linux system"
     push @params, get_linuxrc_boot_params if get_var('LINUXRC_BOOT');
     # Make sure to use the correct repo for testing
@@ -823,7 +823,7 @@ sub remote_install_bootmenu_params {
 sub select_bootmenu_video_mode {
     if (check_var("VIDEOMODE", "text")) {
         send_key "f3";
-        send_key_until_needlematch("inst-textselected", "up", 5);
+        send_key_until_needlematch("inst-textselected", "up", 6);
         send_key "ret";
         if (match_has_tag("inst-textselected-with_colormenu")) {
             # The video mode menu was enhanced to support various color profiles
@@ -945,11 +945,11 @@ sub tianocore_disable_secureboot {
     enter_cmd "exit";
     assert_screen 'tianocore-mainmenu';
     # Select 'Boot manager' entry
-    send_key_until_needlematch('tianocore-devicemanager', 'down', 5, 5);
+    send_key_until_needlematch('tianocore-devicemanager', 'down', 6, 5);
     send_key 'ret';
-    send_key_until_needlematch('tianocore-devicemanager-sb-conf', 'down', 5, 5);
+    send_key_until_needlematch('tianocore-devicemanager-sb-conf', 'down', 6, 5);
     send_key 'ret';
-    send_key_until_needlematch($neelle_sb_conf_attempt, 'down', 5, 5);
+    send_key_until_needlematch($neelle_sb_conf_attempt, 'down', 6, 5);
     send_key 'spc';
     assert_screen 'tianocore-devicemanager-sb-conf-changed';
     send_key 'ret';
@@ -992,25 +992,25 @@ sub tianocore_select_bootloader {
     tianocore_enter_menu;
     tianocore_ensure_xga_resolution if check_var('QEMUVGA', 'qxl');
     tianocore_enter_menu;
-    send_key_until_needlematch('tianocore-bootmanager', 'down', 5, 5);
+    send_key_until_needlematch('tianocore-bootmanager', 'down', 6, 5);
     send_key 'ret';
 }
 
 sub tianocore_http_boot {
     tianocore_enter_menu;
     # Go to Device manager
-    send_key_until_needlematch('tianocore-devicemanager', 'down', 5, 5);
+    send_key_until_needlematch('tianocore-devicemanager', 'down', 6, 5);
     send_key 'ret';
     # In device manager, go to 'Network Device List'
-    send_key_until_needlematch('tianocore-devicemanager-networkdevicelist', 'up', 5, 5);
+    send_key_until_needlematch('tianocore-devicemanager-networkdevicelist', 'up', 6, 5);
     send_key 'ret';
     # In 'Network Device List', go to first MAC addr
     send_key 'ret';
     # Go to 'HTTP Boot Configuration'
-    send_key_until_needlematch('tianocore-devicemanager-networkdevicelist-mac-httpbootconfig', 'up', 5, 5);
+    send_key_until_needlematch('tianocore-devicemanager-networkdevicelist-mac-httpbootconfig', 'up', 6, 5);
     send_key 'ret';
     # Select 'Boot URI'
-    send_key_until_needlematch('tianocore-devicemanager-networkdevicelist-mac-httpbootconfig-booturi', 'up', 5, 5);
+    send_key_until_needlematch('tianocore-devicemanager-networkdevicelist-mac-httpbootconfig-booturi', 'up', 6, 5);
     send_key 'ret';
     # Enter URI (full URI to EFI file)
     my $arch = get_var("ARCH");
@@ -1041,10 +1041,10 @@ sub tianocore_http_boot {
     send_key 'esc';
     send_key 'esc';
     # Select 'Boot manager' entry
-    send_key_until_needlematch('tianocore-bootmanager', 'down', 5, 5);
+    send_key_until_needlematch('tianocore-bootmanager', 'down', 6, 5);
     send_key 'ret';
     # Select 'UEFI Http' entry
-    send_key_until_needlematch('tianocore-bootmanager-uefihttp', 'up', 5, 5);
+    send_key_until_needlematch('tianocore-bootmanager-uefihttp', 'up', 6, 5);
     send_key 'ret';
 }
 

--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -38,7 +38,7 @@ sub grub_test {
     assert_screen('grub2', $timeout);
     stop_grub_timeout;
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
-    send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');
+    send_key_until_needlematch("bootmenu-xen-kernel", 'down', 11, 5) if get_var('XEN');
     if ((is_aarch64 && is_sle && get_var('PLYMOUTH_DEBUG'))
         || get_var('GRUB_KERNEL_OPTION_APPEND'))
     {
@@ -78,7 +78,7 @@ sub bug_workaround_bsc1005313 {
     record_soft_failure "Running with plymouth:debug to catch bsc#1005313" if get_var('PLYMOUTH_DEBUG');
     send_key 'e';
     # Move to end of kernel boot parameters line
-    send_key_until_needlematch "linux-line-selected", "down", 25;
+    send_key_until_needlematch "linux-line-selected", "down", 26;
     send_key "end";
 
     assert_screen "linux-line-matched";

--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -26,7 +26,7 @@ sub microos_login {
         # FreeRDP is not sending 'Ctrl' as part of 'Ctrl-Alt-Fx', 'Alt-Fx' is fine though.
         my $key = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f2' : 'ctrl-alt-f2';
         # First attempts to select tty2 are ignored - bsc#1035968
-        send_key_until_needlematch 'tty2-selected', $key, 10, 30;
+        send_key_until_needlematch 'tty2-selected', $key, 11, 30;
     }
 
     select_console 'root-console';

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -645,7 +645,7 @@ sub handle_uefi_boot_disk_workaround {
     my ($self) = @_;
     record_info 'workaround', 'Manually selecting boot entry, see bsc#1022064 for details';
     tianocore_enter_menu;
-    send_key_until_needlematch 'tianocore-boot_maintenance_manager', 'down', 5, 5;
+    send_key_until_needlematch 'tianocore-boot_maintenance_manager', 'down', 6, 5;
     wait_screen_change { send_key 'ret' };
     send_key_until_needlematch 'tianocore-boot_from_file', 'down';
     wait_screen_change { send_key 'ret' };
@@ -764,7 +764,7 @@ sub wait_grub {
     elsif (get_var("LIVETEST")) {
         # prevent if one day booting livesystem is not the first entry of the boot list
         if (!match_has_tag("boot-live-" . get_var("DESKTOP"))) {
-            send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 5);
+            send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 11, 5);
         }
     }
     elsif (match_has_tag('inst-bootmenu')) {
@@ -802,7 +802,7 @@ sub wait_grub_to_boot_on_local_disk {
             type_string "exit";
             wait_screen_change { send_key 'ret' };
             tianocore_select_bootloader;
-            send_key_until_needlematch("ovmf-boot-HDD", 'down', 5, 1);
+            send_key_until_needlematch("ovmf-boot-HDD", 'down', 6, 1);
             send_key "ret";
             return;
         }

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -223,7 +223,7 @@ sub resize_partition {
     if (is_storage_ng_newui) {
         send_key 'alt-m';
         # start with preconfigured partitions
-        send_key_until_needlematch 'modify-partition-resize', 'down', 5, 3;
+        send_key_until_needlematch 'modify-partition-resize', 'down', 6, 3;
         send_key 'ret';
     }
     else {
@@ -268,7 +268,7 @@ sub addpart {
             send_key((is_storage_ng) ? 'alt-f' : 'alt-s');
             wait_screen_change { send_key 'home' };    # start from the top of the list
             assert_screen(((is_storage_ng) ? 'partition-selected-ext2-type' : 'partition-selected-btrfs-type'), timeout => 10);
-            send_key_until_needlematch "partition-selected-$args{format}-type", 'down', 10, 5;
+            send_key_until_needlematch "partition-selected-$args{format}-type", 'down', 11, 5;
         }
     }
     # Enable snapshots option works only with btrfs
@@ -284,7 +284,7 @@ sub addpart {
             record_soft_failure('bsc#1079399 - Combobox is writable');
             for (1 .. 10) { send_key 'up'; }
         }
-        send_key_until_needlematch "partition-selected-$args{fsid}-type", 'down', 10, 5;
+        send_key_until_needlematch "partition-selected-$args{fsid}-type", 'down', 11, 5;
     }
 
     mount_device $args{mount} if $args{mount};
@@ -546,7 +546,7 @@ sub take_first_disk_storage_ng {
                 send_key 'tab';
             }
             save_screenshot;
-            send_key_until_needlematch 'after-partitioning', $cmd{next}, 10, 3;
+            send_key_until_needlematch 'after-partitioning', $cmd{next}, 11, 3;
             return;
         }
 
@@ -554,7 +554,7 @@ sub take_first_disk_storage_ng {
         assert_screen 'partition-scheme';
     }
     elsif (is_ipmi) {
-        send_key_until_needlematch 'after-partitioning', $cmd{next}, 10, 3;
+        send_key_until_needlematch 'after-partitioning', $cmd{next}, 11, 3;
         return;
     }
 
@@ -564,7 +564,7 @@ sub take_first_disk_storage_ng {
     if (check_var('VIDEOMODE', 'text')) {
         assert_screen 'select-root-filesystem';
         send_key 'alt-f';
-        send_key_until_needlematch 'filesystem-btrfs', 'down', 10, 3;
+        send_key_until_needlematch 'filesystem-btrfs', 'down', 11, 3;
         send_key 'ret';
     }
     else {

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -87,7 +87,7 @@ sub reboot_x11 {
             assert_and_click('reboot-power-menu');
             assert_and_click('reboot-click-restart');
         } else {
-            send_key_until_needlematch 'logoutdialog', 'ctrl-alt-delete', 7, 10;    # reboot
+            send_key_until_needlematch 'logoutdialog', 'ctrl-alt-delete', 8, 10;    # reboot
         }
         my $repetitions = assert_and_click_until_screen_change 'logoutdialog-reboot-highlighted';
         record_soft_failure 'poo#19082' if ($repetitions > 0);

--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -148,7 +148,7 @@ sub advance_installer_window {
     }
     unless (check_screen "$screenName", 60) {
         my $key = check_screen('cannot-access-installation-media') ? "alt-y" : "$cmd{next}";
-        send_key_until_needlematch $screenName, $key, 5, 60;
+        send_key_until_needlematch $screenName, $key, 6, 60;
         record_soft_failure 'Retry most probably due to network problems poo#52319 or failed next click';
     }
 }

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -333,7 +333,7 @@ sub register_addons {
             # skip addons which doesn't need to input scc code
             next unless grep { $addon eq $_ } @addons_with_code;
             if (check_var('VIDEOMODE', 'text')) {
-                send_key_until_needlematch("scc-code-field-$addon", 'tab', 60, 3);
+                send_key_until_needlematch("scc-code-field-$addon", 'tab', 61, 3);
             }
             else {
                 assert_and_click("scc-code-field-$addon", timeout => 240);
@@ -445,7 +445,7 @@ sub process_scc_register_addons {
                 # Uncheck 'Hide Beta Versions'
                 # The workaround with send_key_until_needlematch is added,
                 # because on ppc64le the shortcut key does not reach VM sporadically.
-                send_key_until_needlematch('scc-beta-filter-unchecked', 'alt-i', 3, 5);
+                send_key_until_needlematch('scc-beta-filter-unchecked', 'alt-i', 4, 5);
             }
             else {
                 send_key 'alt-f';    # uncheck 'Filter Out Beta Version'
@@ -696,7 +696,7 @@ sub select_addons_in_textmode {
     my ($addon, $flag) = @_;
     if ($flag) {
         send_key_until_needlematch 'scc-module-area-selected', 'tab';
-        send_key_until_needlematch ["scc-module-$addon", "scc-module-$addon-selected"], 'down', 30, 5;
+        send_key_until_needlematch ["scc-module-$addon", "scc-module-$addon-selected"], 'down', 31, 5;
         if (match_has_tag("scc-module-$addon")) {
             send_key 'spc';
             # After selected/deselected an addon, yast scc would automatically

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -313,7 +313,7 @@ sub rmt_wizard {
     wait_still_screen;
     send_key 'alt-n';
     assert_screen 'yast2_rmt_service_status', 90;
-    send_key_until_needlematch('yast2_rmt_config_summary', 'alt-n', 3, 10);
+    send_key_until_needlematch('yast2_rmt_config_summary', 'alt-n', 4, 10);
     send_key 'alt-f';
     wait_serial("yast2-rmt-wizard-0", 800) || die 'rmt wizard failed, it can be connection issue or credential issue';
 }

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -34,7 +34,7 @@ our $pwd4newUser = "helloWORLD-0";
 sub lock_screen {
     assert_and_click "system-indicator";
     assert_and_click "lock-system";
-    send_key_until_needlematch 'gnome-screenlock-password', 'esc', 5, 10;
+    send_key_until_needlematch 'gnome-screenlock-password', 'esc', 6, 10;
     type_password "$newpwd\n";
     assert_screen "generic-desktop";
 }

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -197,7 +197,7 @@ sub init_desktop_runner {
     if (!check_screen('desktop-runner', $timeout)) {
         record_info('workaround', "desktop-runner does not show up on $hotkey, retrying up to three times (see bsc#978027)");
         send_key 'esc';    # To avoid failing needle on missing 'alt' key - poo#20608
-        send_key_until_needlematch 'desktop-runner', $hotkey, 3, 10;
+        send_key_until_needlematch 'desktop-runner', $hotkey, 4, 10;
     }
     wait_still_screen(2);
     for (my $retries = 10; $retries > 0; $retries--) {
@@ -226,7 +226,7 @@ sub init_desktop_runner {
             # Prepare for next attempt
             send_key 'esc';    # Escape from desktop-runner
             sleep(5);    # Leave some time for the system to recover
-            send_key_until_needlematch 'desktop-runner', $hotkey, 3, 10;
+            send_key_until_needlematch 'desktop-runner', $hotkey, 4, 10;
         } else {
             last;
         }

--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -111,7 +111,7 @@ sub tb_setup_account {
                 type_string 'admin';
             }
             assert_and_click 'thunderbird_wizard-retest';
-            send_key_until_needlematch 'thunderbird_wizard-done', 'tab', 15, 1;
+            send_key_until_needlematch 'thunderbird_wizard-done', 'tab', 16, 1;
             assert_and_click 'thunderbird_wizard-done';
             wait_still_screen(2, 4);
             assert_and_click 'thunderbird_SSL_done_config' unless check_screen('thunderbird_confirm_security_exception');
@@ -137,7 +137,7 @@ sub tb_setup_account {
                 type_string 'admin';
             }
             assert_and_click 'thunderbird_wizard-retest';
-            send_key_until_needlematch 'thunderbird_wizard-done', 'tab', 15, 1;
+            send_key_until_needlematch 'thunderbird_wizard-done', 'tab', 16, 1;
             assert_and_click 'thunderbird_wizard-done';
             wait_still_screen(2);
             send_key 'end';    # go to the bottom to see whole button and checkbox
@@ -155,7 +155,7 @@ sub tb_setup_account {
     else {
         # If use multimachine, select correct needles to configure thunderbird.
         if ($hostname eq 'client') {
-            send_key_until_needlematch 'thunderbird_SSL_done_config', 'alt-t', 4, 2;
+            send_key_until_needlematch 'thunderbird_SSL_done_config', 'alt-t', 5, 2;
             wait_still_screen(2);
             assert_and_click "thunderbird_SSL_done_config";
             wait_still_screen(3);
@@ -248,7 +248,7 @@ sub tb_check_email {
     wait_still_screen 2, 3;
     type_string "$mail_search";
     wait_still_screen 2, 3;
-    send_key_until_needlematch "thunderbird_sent-message-received", 'shift-f5', 4, 30;
+    send_key_until_needlematch "thunderbird_sent-message-received", 'shift-f5', 5, 30;
 
     # delete the message
     assert_and_click "thunderbird_select-message";

--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -656,7 +656,7 @@ sub select_guest {
         } else {
             assert_and_click("virt-manager_list-arrowdown", clicktime => 10) for (1 .. 5);    # Go down so we will see every guest unselected on the way up
         }
-        send_key_until_needlematch("virt-manager_list-$guest", 'up', 20, 3);
+        send_key_until_needlematch("virt-manager_list-$guest", 'up', 21, 3);
     }
     assert_and_click "virt-manager_list-$guest";
     send_key 'ret';

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -251,12 +251,12 @@ sub check_new_mail_evolution {
     send_key "alt-w";
     send_key "ret";
     wait_still_screen 2;
-    send_key_until_needlematch "evolution_mail_show-all", "down", 5, 1;
+    send_key_until_needlematch "evolution_mail_show-all", "down", 6, 1;
     send_key "ret";
     wait_still_screen(2);
     send_key "alt-n";
     send_key "ret";
-    send_key_until_needlematch "evolution_mail_show-allcount", "down", 5, 1;
+    send_key_until_needlematch "evolution_mail_show-allcount", "down", 6, 1;
     send_key "ret";
     send_key "alt-c";
     type_string "$mail_search";
@@ -432,7 +432,7 @@ sub setup_mail_account {
     # Open Server Type screen.
     send_key "alt-t";
     wait_still_screen(1);
-    send_key_until_needlematch "evolution_wizard-receiving-$proto", "down", 10, 1;
+    send_key_until_needlematch "evolution_wizard-receiving-$proto", "down", 11, 1;
     send_key "alt-s";
     wait_still_screen(1);
     type_string "$mail_recvServer";
@@ -452,7 +452,7 @@ sub setup_mail_account {
     type_string "$mail_user";
     send_key "alt-m";
     wait_still_screen(1);
-    send_key_until_needlematch "evolution_wizard-receiving-ssl", "down", 5, 1;
+    send_key_until_needlematch "evolution_wizard-receiving-ssl", "down", 6, 1;
     $self->evolution_add_self_signed_ca($account);
     assert_screen [qw(evolution_wizard-receiving-opts evolution_wizard-receiving-not-focused)];
     if (match_has_tag 'evolution_wizard-receiving-not-focused') {
@@ -474,7 +474,7 @@ sub setup_mail_account {
     wait_still_screen(2);
     send_key "home";
     wait_still_screen(2);
-    send_key_until_needlematch "evolution_wizard-sending-smtp", "down", 5, 1;
+    send_key_until_needlematch "evolution_wizard-sending-smtp", "down", 6, 1;
     send_key "alt-s";
     type_string "$mail_sendServer";
     wait_still_screen(2, 2);
@@ -488,7 +488,7 @@ sub setup_mail_account {
     send_key "home";
     #change to use mail-server and SSL
     my $encrypt = get_var('QAM_MAIL_EVOLUTION') ? 'TLS' : 'STARTTLS';
-    send_key_until_needlematch "evolution_SSL_wizard-sending-$encrypt", "down", 5, 1;
+    send_key_until_needlematch "evolution_SSL_wizard-sending-$encrypt", "down", 6, 1;
     assert_and_click "evolution_wizard-sending-setauthtype";
     assert_and_click "evolution_wizard-sending-setauthtype_login";
     wait_screen_change { send_key 'alt-n' };
@@ -513,7 +513,7 @@ sub setup_mail_account {
         send_key "ret";
     }
     # Μake sure the welcome window is maximized
-    send_key_until_needlematch 'evolution_mail-max-window', 'super-up', 3, 3;
+    send_key_until_needlematch 'evolution_mail-max-window', 'super-up', 4, 3;
 }
 
 # Use AutoConfig file for firefox to predefine some user values
@@ -705,19 +705,19 @@ sub firefox_open_url {
     }
     enter_cmd_slow "$url";
     wait_still_screen 2, 4;
-    send_key_until_needlematch 'firefox-url-loaded', 'f5', 3, 90;
+    send_key_until_needlematch 'firefox-url-loaded', 'f5', 4, 90;
 }
 
 sub firefox_preferences {
-    send_key_until_needlematch 'firefox-edit-menu', 'alt-e', 5, 5;
-    send_key_until_needlematch 'firefox-preferences', 'n', 5, 5;
+    send_key_until_needlematch 'firefox-edit-menu', 'alt-e', 6, 5;
+    send_key_until_needlematch 'firefox-preferences', 'n', 6, 5;
 }
 
 sub exit_firefox_common {
     # Exit
     send_key 'ctrl-q';
     wait_still_screen 3, 6;
-    send_key_until_needlematch([qw(firefox-save-and-quit xterm-left-open xterm-without-focus)], "alt-f4", 6, 30);
+    send_key_until_needlematch([qw(firefox-save-and-quit xterm-left-open xterm-without-focus)], "alt-f4", 7, 30);
     if (match_has_tag 'firefox-save-and-quit') {
         # confirm "save&quit"
         send_key "ret";
@@ -802,7 +802,7 @@ sub setup_evolution_for_ews {
     assert_screen "test-evolution-1";
     send_key "alt-o";
     assert_screen "evolution_wizard-restore-backup";
-    send_key_until_needlematch("evolution_wizard-identity", "alt-o", 10);
+    send_key_until_needlematch("evolution_wizard-identity", "alt-o", 11);
     wait_screen_change {
         send_key "alt-e";
     };
@@ -824,7 +824,7 @@ sub setup_evolution_for_ews {
     send_key "alt-t";
     wait_still_screen(1);
     send_key "ret";
-    send_key_until_needlematch "evolution_wizard-receiving-ews", "up", 10, 3;
+    send_key_until_needlematch "evolution_wizard-receiving-ews", "up", 11, 3;
     send_key "ret";
     assert_screen "evolution_wizard-ews-prefill";
     send_key "alt-u";
@@ -927,7 +927,7 @@ sub tomboy_logout_and_login {
 
 sub gnote_launch {
     x11_start_program('gnote');
-    send_key_until_needlematch 'gnote-start-here-matched', 'down', 5;
+    send_key_until_needlematch 'gnote-start-here-matched', 'down', 6;
 }
 
 sub gnote_search_and_close {

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -264,7 +264,7 @@ sub handle_login {
     # Previously this pressed esc, but that makes the text field in SDDM lose focus
     # we need send key 'esc' to quit screen saver when desktop is gnome
     my $mykey = check_var('DESKTOP', 'gnome') ? 'esc' : 'shift';
-    send_key_until_needlematch('displaymanager', $mykey, 30, 3);
+    send_key_until_needlematch('displaymanager', $mykey, 31, 3);
     if (get_var('ROOTONLY')) {
         # we now use this tag to support login as root
         if (check_screen 'displaymanager-username-notlisted', 10) {

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -386,7 +386,7 @@ sub toggle_package {
     # When coming from search_packages, the search might not be completed yet,
     # give it some time.
     check_screen "packages-$package_name-selected", 60;
-    send_key_until_needlematch "packages-$package_name-selected", 'down', 60;
+    send_key_until_needlematch "packages-$package_name-selected", 'down', 61;
     wait_screen_change { send_key "$operation" };
     wait_still_screen 2;
     save_screenshot;

--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -118,14 +118,14 @@ sub verify_license_translations {
         wait_screen_change { send_key 'alt-l' };
         # in textmode only arrow navigation is possible
         if (get_var('VIDEOMODE') =~ 'text') {
-            send_key_until_needlematch("license-language-selected-english-us", 'up', 60);
+            send_key_until_needlematch("license-language-selected-english-us", 'up', 61);
             send_key 'ret';
         }
         else {
             assert_and_click "license-language-selected-$current_lang";
         }
         wait_screen_change { type_string(substr($lang, 0, 1)) } unless (check_var('VIDEOMODE', 'text'));
-        send_key_until_needlematch("license-language-selected-dropbox-$lang", 'down', 60);
+        send_key_until_needlematch("license-language-selected-dropbox-$lang", 'down', 61);
         if (is_s390x()) {
             record_soft_failure('bsc#1172738 - "Next" button is triggered, even though it is not in focus while selecting language on License Agreement screen on s390x');
             assert_and_click("license-language-selected-dropbox-$lang");

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -260,7 +260,7 @@ sub set_network {
             type_string $args{mask};
         }
         send_key 'tab';
-        send_key_until_needlematch('hostname_textfield_empty', 'backspace', 30, 1);
+        send_key_until_needlematch('hostname_textfield_empty', 'backspace', 31, 1);
         type_string $args{fqdn};
         assert_screen 'yast2_lan_static_ip_set';
     }
@@ -440,7 +440,7 @@ sub close_yast2_lan {
     if ($tag eq '') {
         send_key 'alt-o';
     } else {
-        send_key_until_needlematch($tag, 'alt-o', 5, 5);
+        send_key_until_needlematch($tag, 'alt-o', 6, 5);
     }
     wait_serial("$module_name-0", 180) || die "'yast2 lan' didn't finish";
 }

--- a/lib/yast2_widget_utils.pm
+++ b/lib/yast2_widget_utils.pm
@@ -75,7 +75,7 @@ sub change_service_configuration_step {
 
     send_key $shortcut;
     send_key 'end';
-    send_key_until_needlematch $needle_selection, 'up', 5, 1;
+    send_key_until_needlematch $needle_selection, 'up', 6, 1;
     if (check_var_array('EXTRATEST', 'y2uitest_ncurses')) {
         send_key 'ret';
         assert_screen $needle_check;

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -56,7 +56,7 @@ sub run {
     if (match_has_tag("virttest-pxe-menu")) {
         #BeiJing
         # Login to command line of pxe management
-        send_key_until_needlematch "virttest-pxe-edit-prompt", "esc", 60, 1;
+        send_key_until_needlematch "virttest-pxe-edit-prompt", "esc", 61, 1;
 
         $image_path = get_var("HOST_IMG_URL");
     }
@@ -80,7 +80,7 @@ sub run {
             $key_used = 'esc';
         }
         #Detect orthos-grub-boot and qa-net-grub-boot for aarch64 in orthos and openQA networks respectively, and qa-net-boot for x86_64 in openQA network
-        send_key_until_needlematch [qw(qa-net-boot orthos-grub-boot qa-net-grub-boot)], $key_used, 8, 3;
+        send_key_until_needlematch [qw(qa-net-boot orthos-grub-boot qa-net-grub-boot)], $key_used, 9, 3;
         if (match_has_tag("qa-net-boot")) {
             #Nuremberg
             my $path_prefix = "/mnt/openqa/repo";
@@ -100,7 +100,7 @@ sub run {
         $image_path .= "?device=$interface " if (is_ipmi && !get_var('SUT_NETDEVICE_SKIPPED'));
     }
     elsif (match_has_tag('prague-pxe-menu')) {
-        send_key_until_needlematch 'qa-net-boot', 'esc', 8, 3;
+        send_key_until_needlematch 'qa-net-boot', 'esc', 9, 3;
         if (get_var('PXE_ENTRY')) {
             my $entry = get_var('PXE_ENTRY');
             send_key_until_needlematch "pxe-$entry-entry", 'down';

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -70,7 +70,7 @@ sub run {
                                           # Sometimes we don't get to the next page after first key press
                                           # As part of poo#20668 we introduce this workaround to have reliable tests
                                           # Go to http server wizard (4/5)--virtual hosts and check page (4/5 )is open
-    send_key_until_needlematch 'http_add_host', $cmd{next}, 2, 3;
+    send_key_until_needlematch 'http_add_host', $cmd{next}, 3, 3;
     wait_still_screen 1;
     send_key 'alt-a';
     assert_screen 'http_new_host_info';    # check new host information page got open to edit

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -82,7 +82,7 @@ sub run {
     # Check disk usage widget for not showing subvolumes (bsc#949945)
     # on SLE12SP0 hidden subvolume isn't supported
     if (!check_var('VERSION', '12')) {
-        send_key_until_needlematch('yast2-sw_single-extras-open', 'alt-e', 5, 3);
+        send_key_until_needlematch('yast2-sw_single-extras-open', 'alt-e', 6, 3);
         wait_screen_change { send_key 'alt-s' };
         assert_screen 'yast2-sw_single-disk_usage';
         wait_screen_change { send_key 'alt-o' };

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -69,7 +69,7 @@ sub run {
         send_key "tab";
         assert_screen 'yast2_lan-set-hostname-via-dhcp-selected';
         send_key 'down';
-        send_key_until_needlematch("yast2_lan-set-hostname-via-dhcp-NO-selected", "up", 5);
+        send_key_until_needlematch("yast2_lan-set-hostname-via-dhcp-NO-selected", "up", 6);
         send_key "ret";
     }
 

--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -140,7 +140,7 @@ sub run {
     open_yast2_lan();
 
     for (1 .. 2) { send_key "tab" }    # move to device list
-    send_key_until_needlematch 'vlan-selected', 'down', 5, 5;    # move to vlan
+    send_key_until_needlematch 'vlan-selected', 'down', 6, 5;    # move to vlan
     send_key "alt-t";    # remove vlan
     assert_screen 'vlan-deleted';
     close_yast2_lan();

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -123,7 +123,7 @@ sub run {
 
     # close it with OK
     my $ntp_client_needle = check_var('USE_SUPPORT_SERVER', 1) ? 'support_server' : 'public';
-    send_key_until_needlematch "yast2_ntp-client_${ntp_client_needle}_ntp_server_added", "alt-o", 3, 5;
+    send_key_until_needlematch "yast2_ntp-client_${ntp_client_needle}_ntp_server_added", "alt-o", 4, 5;
 
     if (!$is_chronyd) {
         # now check display log and save log

--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -106,7 +106,7 @@ sub run {
     # check network interfaces with open port in firewall
     # repeat action as sometimes keys are not triggering action on leap if workers are slow
     if (is_sle('<15') || is_leap('<15.0')) {
-        send_key_until_needlematch 'yast2_proxy_network_interfaces', 'alt-d', 2, 5;
+        send_key_until_needlematch 'yast2_proxy_network_interfaces', 'alt-d', 3, 5;
         wait_still_screen 1;
         send_key 'alt-n';
         wait_still_screen 1;

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -209,7 +209,7 @@ sub setup_samba_share {
 
     # Identification
     assert_screen 'yast2_samba-server_new-share';
-    send_key_until_needlematch 'yast2_samba-share-name-focused', $actions{name}->{shortcut}, 5;    # ensure responsive
+    send_key_until_needlematch 'yast2_samba-share-name-focused', $actions{name}->{shortcut}, 6;    # ensure responsive
     type_string $actions{name}->{value};
     wait_screen_change { send_key $actions{description}->{shortcut} };
     type_string $actions{description}->{value};

--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -38,7 +38,7 @@ sub run() {
         type_string $maintrepo;
         advance_installer_window('addon-products');
         # if more repos to come, add more
-        send_key_until_needlematch('addon-menu-active', 'alt-a', 10, 2) if @repos;
+        send_key_until_needlematch('addon-menu-active', 'alt-a', 11, 2) if @repos;
     }
 }
 

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -76,7 +76,7 @@ sub handle_all_packages_medium {
         next if (skip_package_hub_if_necessary($i));
         push @addons_license_tags, "addon-license-$i" if grep(/^$i$/, @addons_with_license);
         send_key 'home';
-        send_key_until_needlematch ["addon-products-all_packages-$i-highlighted", "addon-products-all_packages-$i-selected"], "down", 30;
+        send_key_until_needlematch ["addon-products-all_packages-$i-highlighted", "addon-products-all_packages-$i-selected"], "down", 31;
         if (match_has_tag("addon-products-all_packages-$i-highlighted")) {
             send_key 'spc';
         } else {
@@ -129,7 +129,7 @@ sub handle_addon {
     }
     send_key 'pgup';
     wait_still_screen 2;
-    send_key_until_needlematch "addon-products-$addon", 'down', 30;
+    send_key_until_needlematch "addon-products-$addon", 'down', 31;
     # modules like SES or RT that are not part of Packages ISO don't have this step
     send_key 'spc' if (is_sle('15+') && $addon !~ /^ses$|^rt$/);
     # Return to top of the list
@@ -175,8 +175,8 @@ sub run {
                 wait_screen_change { send_key 'alt-d' };    # DVD
                 send_key $cmd{next};
                 assert_screen 'dvd-selector';
-                send_key_until_needlematch 'addon-dvd-list', 'tab', 5;    # jump into addon list
-                send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 10;    # select addon in list
+                send_key_until_needlematch 'addon-dvd-list', 'tab', 6;    # jump into addon list
+                send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 11;    # select addon in list
                 send_key 'alt-o';    # continue
             }
             handle_addon($addon);

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -66,8 +66,8 @@ sub run {
                 wait_screen_change { send_key 'alt-v' };    # DVD
                 send_key $cmd{next};
                 assert_screen 'dvd-selector', 3;
-                send_key_until_needlematch 'addon-dvd-list', 'tab', 5;    # jump into addon list
-                send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 10;    # select addon in list
+                send_key_until_needlematch 'addon-dvd-list', 'tab', 6;    # jump into addon list
+                send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 11;    # select addon in list
                 send_key 'alt-o';    # continue
             }
             if (check_screen('import-untrusted-gpg-key', 10)) {    # workaround untrusted key pop-up, record soft fail and trust it
@@ -86,7 +86,7 @@ sub run {
             wait_screen_change { send_key 'alt-a' };    # yes, agree
             send_key $cmd{next};
             assert_screen 'addon-yast2-patterns';
-            send_key_until_needlematch 'addon-yast2-view-selected', 'alt-v', 10;
+            send_key_until_needlematch 'addon-yast2-view-selected', 'alt-v', 11;
             send_key 'spc';    # open view menu
             wait_screen_change { send_key 'alt-r' };
             wait_screen_change { send_key 'alt-r' };    # go to repositories

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -24,13 +24,13 @@ sub run {
         assert_screen('bootloader', 200);
         send_key 'ret';
         # boot into leap snapshot
-        send_key_until_needlematch('start-bootloader-from-snapshot', 'down', 10, 5);
+        send_key_until_needlematch('start-bootloader-from-snapshot', 'down', 11, 5);
         send_key 'ret';
-        send_key_until_needlematch('snapshot-before-upgrade', 'down', 40, 5);
+        send_key_until_needlematch('snapshot-before-upgrade', 'down', 41, 5);
         send_key 'ret';
         # Wait until the menu for that snapshot is shown
         assert_screen('snapshot-help');
-        send_key_until_needlematch('opensuse-leap', 'down', 10, 5);
+        send_key_until_needlematch('opensuse-leap', 'down', 11, 5);
         send_key 'ret';
         save_screenshot;
         reset_consoles;
@@ -59,4 +59,3 @@ sub post_fail_hook {
 }
 
 1;
-

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -28,9 +28,9 @@ sub vmware_set_permanent_boot_device {
     send_key 'ret' && return unless $boot_device;
     # Enter menu with available boot devices
     send_key 'f2';
-    send_key_until_needlematch('vmware_bios_boot_tab', 'right', 10, 2);
-    send_key_until_needlematch("vmware_bios_boot_${boot_device}", 'down', 5);
-    send_key_until_needlematch("vmware_bios_boot_top_${boot_device}", '+', 5);
+    send_key_until_needlematch('vmware_bios_boot_tab', 'right', 11, 2);
+    send_key_until_needlematch("vmware_bios_boot_${boot_device}", 'down', 6);
+    send_key_until_needlematch("vmware_bios_boot_top_${boot_device}", '+', 6);
     send_key 'f10';
     assert_screen('vmware_bios_boot_confirm');
     send_key 'ret';

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -58,7 +58,7 @@ sub run {
         # Skip workaround on specific scenaio which call this module after migration
         if (!check_screen('bootloader-grub2', 0, no_wait => 1)) {
             tianocore_select_bootloader;
-            send_key_until_needlematch("ovmf-boot-HDD", 'down', 5, 1);
+            send_key_until_needlematch("ovmf-boot-HDD", 'down', 6, 1);
             send_key "ret";
             return;
         }
@@ -71,7 +71,7 @@ sub run {
 
     if (get_var('DUALBOOT')) {
         tianocore_select_bootloader;
-        send_key_until_needlematch('tianocore-bootmanager-dvd', 'down', 5, 5);
+        send_key_until_needlematch('tianocore-bootmanager-dvd', 'down', 6, 5);
         send_key "ret";
     }
 
@@ -110,14 +110,14 @@ sub run {
 
     if (get_var("UPGRADE")) {
         # random magic numbers
-        send_key_until_needlematch('inst-onupgrade', 'down', 10, 3);
+        send_key_until_needlematch('inst-onupgrade', 'down', 11, 3);
     }
     else {
         if (get_var("PROMO") || get_var('LIVETEST') || get_var('LIVECD')) {
-            send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 3);
+            send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 11, 3);
         }
         elsif (!is_jeos && !is_microos('VMX')) {
-            send_key_until_needlematch('inst-oninstallation', 'down', 10, 0.5);
+            send_key_until_needlematch('inst-oninstallation', 'down', 11, 0.5);
         }
     }
 

--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -24,7 +24,7 @@ sub change_desktop {
         wait_screen_change { send_key 'alt-s'; };
     }
     else {
-        send_key_until_needlematch 'packages-section-selected', 'tab', 10;
+        send_key_until_needlematch 'packages-section-selected', 'tab', 11;
         wait_screen_change { send_key 'ret'; };
     }
 
@@ -44,7 +44,7 @@ sub change_desktop {
         wait_screen_change { send_key 'ret'; };
     }
 
-    send_key_until_needlematch 'patterns-list-selected', 'tab', 10, 2;
+    send_key_until_needlematch 'patterns-list-selected', 'tab', 11, 2;
 
     if (is_sle('<=12-SP1') && get_var("REGRESSION", '') =~ /xen|kvm|qemu/) {
         assert_and_click 'gnome_logo';

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -31,7 +31,7 @@ sub run {
     }
     else {
         # Select section booting on Installation Settings overview (video mode)
-        send_key_until_needlematch 'booting-section-selected', 'tab', 25, 1;
+        send_key_until_needlematch 'booting-section-selected', 'tab', 26, 1;
         send_key 'ret';
     }
 

--- a/tests/installation/disk_space_release.pm
+++ b/tests/installation/disk_space_release.pm
@@ -44,7 +44,7 @@ sub run {
     select_console('installation');
     send_key "alt-b";
     wait_still_screen;
-    send_key_until_needlematch "inst-overview", "alt-n", 3, 30;
+    send_key_until_needlematch "inst-overview", "alt-n", 4, 30;
     assert_screen "no-packages-warning";
 }
 

--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -25,7 +25,7 @@ sub run {
     }
     else {
         # Select section booting on Installation Settings overview (video mode)
-        send_key_until_needlematch 'security-section-selected', 'tab', 30, 2;
+        send_key_until_needlematch 'security-section-selected', 'tab', 31, 2;
         send_key 'ret';
     }
 

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -23,7 +23,7 @@ use Test::Assert ':all';
 sub ensure_ssh_unblocked {
     if (!get_var('UPGRADE') && is_remote_backend) {
 
-        send_key_until_needlematch [qw(ssh-blocked ssh-open)], 'tab', 25;
+        send_key_until_needlematch [qw(ssh-blocked ssh-open)], 'tab', 26;
         if (match_has_tag 'ssh-blocked') {
             if (check_var('VIDEOMODE', 'text')) {
                 send_key 'alt-c';
@@ -35,7 +35,7 @@ sub ensure_ssh_unblocked {
                 send_key 'alt-o';
             }
             else {
-                send_key_until_needlematch 'ssh-blocked-selected', 'tab', 25;
+                send_key_until_needlematch 'ssh-blocked-selected', 'tab', 26;
                 send_key 'ret';
                 send_key_until_needlematch 'ssh-open', 'tab';
             }
@@ -74,7 +74,7 @@ sub check_default_target {
 }
 
 sub set_linux_security_to_none {
-    send_key_until_needlematch 'security-section-selected', 'tab', 25;
+    send_key_until_needlematch 'security-section-selected', 'tab', 26;
     send_key 'ret';
     assert_screen 'security-configuration', 120;
     send_key 'alt-s';

--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -67,7 +67,7 @@ sub run {
         # we need to introduce a reasonable number as the counter here. On the
         # Net installer we need 77 * 'down' to the last pattern including the
         # group title, use 85 to be the counter then we have 8 spare places.
-        send_key_until_needlematch "pattern-$de-selected", 'down', 85;
+        send_key_until_needlematch "pattern-$de-selected", 'down', 86;
         send_key 'spc';
         assert_screen "pattern-$de-checked";
         send_key $cmd{ok};

--- a/tests/installation/installer_timezone.pm
+++ b/tests/installation/installer_timezone.pm
@@ -21,14 +21,14 @@ sub run {
     assert_screen "inst-timezone", 125 || die 'no timezone';
     # performance ci need install with timezone Asia-beijing
     if (check_var('TIMEZONE', 'beijing')) {
-        send_key_until_needlematch("timezone-Asia", "up", 20, 1);
+        send_key_until_needlematch("timezone-Asia", "up", 21, 1);
         send_key 'tab';
-        send_key_until_needlematch("timezone-beijing", "down", 20, 1);
+        send_key_until_needlematch("timezone-beijing", "down", 21, 1);
     } elsif (check_var('TIMEZONE', 'shanghai')) {
-        send_key_until_needlematch("timezone-Asia", "up", 20, 1);
+        send_key_until_needlematch("timezone-Asia", "up", 21, 1);
         send_key 'tab';
         send_key "end";
-        send_key_until_needlematch("timezone-shanghai", "up", 100, 1);
+        send_key_until_needlematch("timezone-shanghai", "up", 101, 1);
     }
     # Unpredictable hotkey on kde live distri, click button. See bsc#1045798
     if (noupdatestep_is_applicable() && get_var("LIVECD")) {

--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -25,14 +25,14 @@ sub disable_online_repos_explicitly {
     # Disable repos
     if (is_leap) {
         # We have update non-oss repo on leap
-        send_key_until_needlematch 'main-update-nos-oss-repo-disabled', 'spc', 3, 1;
+        send_key_until_needlematch 'main-update-nos-oss-repo-disabled', 'spc', 4, 1;
         send_key 'down';
     }
-    send_key_until_needlematch 'main-update-repo-disabled', 'spc', 3, 1;
+    send_key_until_needlematch 'main-update-repo-disabled', 'spc', 4, 1;
     send_key 'down';
-    send_key_until_needlematch 'main-repo-oss-disabled', 'spc', 3, 1;
+    send_key_until_needlematch 'main-repo-oss-disabled', 'spc', 4, 1;
     send_key 'down';
-    send_key_until_needlematch 'main-repo-non-oss-disabled', 'spc', 3, 1;
+    send_key_until_needlematch 'main-repo-non-oss-disabled', 'spc', 4, 1;
     assert_screen 'online-repos-disabled';
     send_key $cmd{next};
 }

--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -41,7 +41,7 @@ sub run {
     my $fs = get_var('FILESYSTEM');
     # select filesystem
     send_key 'home';
-    send_key_until_needlematch("filesystem-$fs", 'down', 20, 3);
+    send_key_until_needlematch("filesystem-$fs", 'down', 21, 3);
     send_key 'ret' if check_var('VIDEOMODE', 'text');
 
     assert_screen "$fs-selected";

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -84,7 +84,7 @@ sub addpart {
     else {
         # poo#35134 Sporadic synchronization failure resulted in incorrect choice of partition type
         # add partition screen was not refreshing fast enough
-        send_key_until_needlematch 'partition-selected-raid-type', 'down', 20, 3;
+        send_key_until_needlematch 'partition-selected-raid-type', 'down', 21, 3;
     }
     send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
 }

--- a/tests/installation/partitioning_smalldisk_storageng.pm
+++ b/tests/installation/partitioning_smalldisk_storageng.pm
@@ -98,7 +98,7 @@ sub run {
             assert_screen 'partition-scheme';
         }
     }
-    send_key_until_needlematch 'after-partitioning', $cmd{next}, 10, 3;
+    send_key_until_needlematch 'after-partitioning', $cmd{next}, 11, 3;
 }
 
 1;

--- a/tests/installation/partitioning_specific_disk.pm
+++ b/tests/installation/partitioning_specific_disk.pm
@@ -35,7 +35,7 @@ sub select_partition {
     send_key 'tab';
     for (1 ... 100) {
         send_key 'down';
-        send_key_until_needlematch("expert-partitioner-label", "right", 50, 1);
+        send_key_until_needlematch("expert-partitioner-label", "right", 51, 1);
         if (check_screen $partition_needle_name, 2) {
             last;
         }
@@ -49,8 +49,7 @@ sub format_partition {
     wait_still_screen 3;
     send_key 'ret';
     send_key(is_storage_ng() ? 'alt-f' : 'alt-s');
-    send_key_until_needlematch("expert-partitioner-$filesystem",
-        "down", 20, 1);
+    send_key_until_needlematch("expert-partitioner-$filesystem", "down", 21, 1);
     send_key 'ret';
 }
 

--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -29,7 +29,7 @@ sub run {
     wait_screen_change { send_key "tab" };
     send_key "home";
     wait_still_screen(2);
-    send_key_until_needlematch 'root-partition-selected', 'down', 5, 2;    # Select root partition
+    send_key_until_needlematch 'root-partition-selected', 'down', 6, 2;    # Select root partition
 
     # Resize has been moved under drop down button Modify in storage-ng
     if (is_storage_ng) {

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -83,7 +83,7 @@ sub run {
         wait_still_screen(2);
         for my $i (@addons) {
             next if grep { $i eq $_ } @no_relnotes;
-            send_key_until_needlematch("release-notes-$i", 'right', 4, 60);
+            send_key_until_needlematch("release-notes-$i", 'right', 5, 60);
             send_key 'left';    # move back to first tab
             send_key 'left';
             send_key 'left';

--- a/tests/installation/ssh_key_setup.pm
+++ b/tests/installation/ssh_key_setup.pm
@@ -13,7 +13,7 @@ use warnings;
 use testapi;
 
 sub run {
-    send_key_until_needlematch 'ssh-key-import-selected', 'tab', 30, 1;
+    send_key_until_needlematch 'ssh-key-import-selected', 'tab', 31, 1;
     send_key 'ret';
     assert_screen "inst-import-ssh-key";
     if (get_var('SSH_KEY_IMPORT')) {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -34,7 +34,7 @@ sub switch_keyboard_layout {
     my $keyboard_layout = get_var('INSTALL_KEYBOARD_LAYOUT');
     # for instance, select france and test "querty"
     send_key 'alt-k';    # Keyboard Layout
-    send_key_until_needlematch("keyboard-layout-$keyboard_layout", 'down', 60);
+    send_key_until_needlematch("keyboard-layout-$keyboard_layout", 'down', 61);
     if (check_var('DESKTOP', 'textmode')) {
         send_key 'ret';
         assert_screen "keyboard-layout-$keyboard_layout-selected";
@@ -47,7 +47,7 @@ sub switch_keyboard_layout {
     assert_screen "keyboard-test-$keyboard_layout";
     # Select back default keyboard layout
     send_key 'alt-k';
-    send_key_until_needlematch("keyboard-layout", 'up', 60);
+    send_key_until_needlematch("keyboard-layout", 'up', 61);
     wait_screen_change { send_key 'ret' } if (check_var('DESKTOP', 'textmode'));
 }
 

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -63,7 +63,7 @@ sub initiator_discovered_targets_tab {
     my $target_ip_only = (split('/', $test_data->{target_conf}->{ip}))[0];
     type_string_slow_extended $target_ip_only;
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('iscsi-initiator-discovered-IP-adress', 'alt-f10', 9, 2);
+    send_key_until_needlematch('iscsi-initiator-discovered-IP-adress', 'alt-f10', 10, 2);
     # next and press connect button
     send_key "alt-n";
     assert_and_click 'iscsi-initiator-connect-button';
@@ -88,7 +88,7 @@ sub initiator_connected_targets_tab {
     # go to discovered targets tab
     send_key "alt-d";
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('iscsi-initiator-discovered-targets', 'alt-f10', 9, 2);
+    send_key_until_needlematch('iscsi-initiator-discovered-targets', 'alt-f10', 10, 2);
     # go to connected targets tab
     send_key "alt-n";
     assert_screen 'iscsi-initiator-connected-targets';

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -93,7 +93,7 @@ sub target_service_tab {
 
 sub config_2way_authentication {
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('iscsi-target-modify-acls', 'alt-f10', 9, 2);
+    send_key_until_needlematch('iscsi-target-modify-acls', 'alt-f10', 10, 2);
     send_key 'alt-a';
     assert_screen 'iscsi-target-modify-acls-initiator-popup';
     if (is_sle('>=15')) {

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -89,13 +89,13 @@ sub run {
         send_key 'ret';
     } elsif ((is_opensuse && !is_microos && !is_x86_64) || is_sle('=12-sp5')) {
         assert_screen 'jeos-locale', 300;
-        send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 50;
+        send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 51;
         send_key 'ret';
     }
 
     # Select keyboard layout
     assert_screen 'jeos-keylayout', 300;
-    send_key_until_needlematch "jeos-keylayout-$lang", $keylayout_key{$lang}, 30;
+    send_key_until_needlematch "jeos-keylayout-$lang", $keylayout_key{$lang}, 31;
     send_key 'ret';
 
     # Show license
@@ -109,7 +109,7 @@ sub run {
     }
 
     # Select timezone
-    send_key_until_needlematch "jeos-timezone-$lang", $tz_key{$lang}, 10;
+    send_key_until_needlematch "jeos-timezone-$lang", $tz_key{$lang}, 11;
     send_key 'ret';
 
     # Enter password & Confirm

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -194,7 +194,7 @@ sub run {
     assert_screen 'yast2-migration-target';
     send_key "alt-p";    # focus on the item of possible migration targets
     assert_screen 'yast2-migration-target-list-selected', 60;
-    send_key_until_needlematch 'migration-target-' . get_var("VERSION"), 'down', 20, 3;
+    send_key_until_needlematch 'migration-target-' . get_var("VERSION"), 'down', 21, 3;
     send_key "alt-n";
     # migration via smt will install packagehub and NVIDIA compute, we need click trust
     # gpg keys; Same with leap to sle migration, need to trust packagehub gpg key.

--- a/tests/security/aarch64_secure_boot/yast2_bootloader.pm
+++ b/tests/security/aarch64_secure_boot/yast2_bootloader.pm
@@ -33,10 +33,10 @@ sub run {
 
     enter_cmd("yast2 bootloader");
     assert_screen("yast2-bootloder-GRUB2-for-EFI");
-    send_key_until_needlematch("yast2_bootloader-Secureboot-Support", "tab", 6, 2);
+    send_key_until_needlematch("yast2_bootloader-Secureboot-Support", "tab", 7, 2);
     send_key("ret");
     assert_screen("yast2_bootloader-Secureboot-unselect");
-    send_key_until_needlematch("yast2_bootloader-Secureboot-unselect-ok", "tab", 5, 2);
+    send_key_until_needlematch("yast2_bootloader-Secureboot-unselect-ok", "tab", 6, 2);
     send_key("ret");
     reset_consoles;
 

--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -51,7 +51,7 @@ sub samba_server_setup {
     send_key "ctrl-a";
     send_key "delete";
     type_string("WORKGROUP");
-    send_key_until_needlematch("samba-server-configuration", 'alt-n', 10, 2);
+    send_key_until_needlematch("samba-server-configuration", 'alt-n', 11, 2);
     send_key "alt-s";
     assert_screen("samba-server-configuration-shares");
     send_key "alt-a";
@@ -96,20 +96,20 @@ sub samba_client_access {
 
     # Connect to samba server
     assert_and_click("nautilus-other-locations");
-    send_key_until_needlematch("nautilus-connect-to-server", 'tab', 20, 2);
+    send_key_until_needlematch("nautilus-connect-to-server", 'tab', 21, 2);
     type_string("smb://$ip");
     send_key "ret";
     wait_still_screen(2);
 
     # Search the shared dir
-    send_key_until_needlematch("nautilus-sharedir-search", 'ctrl-f', 5, 2);
+    send_key_until_needlematch("nautilus-sharedir-search", 'ctrl-f', 6, 2);
     type_string("$testdir");
     assert_screen("nautilus-sharedir-selected");
     send_key "ret";
 
     # Input password for samb user
     assert_screen("nautilus-selected-sharedir-access-passwd");
-    send_key_until_needlematch("nautilus-registered-user-login", 'down', 5, 2);
+    send_key_until_needlematch("nautilus-registered-user-login", 'down', 6, 2);
     send_key "tab";
     send_key "ctrl-a";
     send_key "delete";
@@ -131,7 +131,7 @@ sub samba_client_access {
     assert_screen("nautilus-folder-name-input-box");
     type_string("sub-testdir", wait_screen_change => 10);
     send_key "ret";
-    send_key_until_needlematch("nautilus-sharedir-delete", "delete", 5, 2);
+    send_key_until_needlematch("nautilus-sharedir-delete", "delete", 6, 2);
     send_key "ret";
     assert_screen("nautilus-sharedir-deleted");
 

--- a/tests/security/grub_auth/grub_authorization.pm
+++ b/tests/security/grub_auth/grub_authorization.pm
@@ -34,7 +34,7 @@ sub switch_boot_menu {
     # UEFI item is available only from 15-SP4
     if (get_var('UEFI') && (!is_sle('<15-SP4'))) {
         assert_screen("grub_uefi_firmware_menu_entry", timeout => 90);
-        send_key_until_needlematch("grub_auth_boot_menu_entry", "down", 5, 2) if $switch;
+        send_key_until_needlematch("grub_auth_boot_menu_entry", "down", 6, 2) if $switch;
     }
     else {
         assert_screen("grub_auth_boot_menu_entry", timeout => 90);
@@ -53,7 +53,7 @@ sub grub_auth_oper {
     }
     elsif ($para eq "maintainer") {
         switch_boot_menu();
-        send_key_until_needlematch("grub_auth_boot_menu_entry_maintainer", "down", 5, 2);
+        send_key_until_needlematch("grub_auth_boot_menu_entry_maintainer", "down", 6, 2);
         send_key("ret");
         assert_screen("grub_auth_maintain_user_login");
         enter_cmd("$maint_user");

--- a/tests/security/yast2_apparmor/manually_add_profile.pm
+++ b/tests/security/yast2_apparmor/manually_add_profile.pm
@@ -40,7 +40,7 @@ sub run {
     # it should be failed
     assert_and_click("AppArmor-Manually-Add-Profile", timeout => 90);
     assert_and_click("AppArmor-Launch", timeout => 60);
-    send_key_until_needlematch("AppArmor-Chose-a-program-to-generate-a-profile", "alt-n", 30, 3);
+    send_key_until_needlematch("AppArmor-Chose-a-program-to-generate-a-profile", "alt-n", 31, 3);
     type_string("$test_file");
     assert_and_click("AppArmor-Chose-a-program-to-generate-a-profile-Open", timeout => 60);
     wait_still_screen(5);
@@ -71,7 +71,7 @@ sub run {
         send_key "tab";
     }
 
-    send_key_until_needlematch("AppArmor-Scan-system-log", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Scan-system-log", "tab", 3, 2);
     # Scan systemlog
     send_key "alt-s";
     assert_screen("AppArmor-Scan-system-log");
@@ -95,14 +95,14 @@ sub run {
         record_soft_failure("bsc#1190295, add workaround to click 'Open' again");
         send_key "tab";
     }
-    send_key_until_needlematch("AppArmor-Inactive-local-profile", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Inactive-local-profile", "tab", 3, 2);
     send_key "tab";
 
     # Check "View Profile"
     assert_and_click("AppArmor-View-Profile-clickview");
-    send_key_until_needlematch("AppArmor-View-Profile", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-View-Profile", "tab", 3, 2);
     send_key "alt-o";
-    send_key_until_needlematch("AppArmor-Inactive-local-profile", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Inactive-local-profile", "tab", 3, 2);
     # Check "Use Profile"
     send_key "alt-u";
     assert_screen("AppArmor-Scan-system-log");

--- a/tests/security/yast2_apparmor/scan_audit_logs.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs.pm
@@ -76,27 +76,27 @@ sub run {
 
     # Audit the entry
     send_key "alt-u";
-    send_key_until_needlematch("AppArmor-Scan-Audit-logs-audit", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-audit", "tab", 3, 2);
     send_key "alt-u";
-    send_key_until_needlematch("AppArmor-Scan-Audit-logs-scan-records", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-scan-records", "tab", 3, 2);
 
     # Allow the entry
     send_key "alt-a";
-    send_key_until_needlematch("AppArmor-Scan-Audit-logs-allow", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-allow", "tab", 3, 2);
 
     # View changes
     send_key "alt-v";
-    send_key_until_needlematch("AppArmor-Scan-Audit-logs-view-changes", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-view-changes", "tab", 3, 2);
     send_key "alt-o";
 
     # View changes b/w clean profile
     send_key "alt-i";
-    send_key_until_needlematch("AppArmor-Scan-Audit-logs-view-changes-clean-profile", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-view-changes-clean-profile", "tab", 3, 2);
     send_key "alt-o";
 
     # Abort: no
     send_key "alt-a";
-    send_key_until_needlematch("AppArmor-Scan-Audit-logs-abort", "tab", 2, 2);
+    send_key_until_needlematch("AppArmor-Scan-Audit-logs-abort", "tab", 3, 2);
     send_key "alt-n";
     assert_screen("AppArmor-Scan-Audit-logs-allow");
 

--- a/tests/ses/openattic.pm
+++ b/tests/ses/openattic.pm
@@ -35,7 +35,7 @@ sub run {
         assert_and_click 'firefox-passwd-confirm_remember';
         send_key 'esc';    # get rid of unsecure connection pop-up
         assert_screen 'openattic-dashboard';
-        send_key_until_needlematch 'openattic-health-status-ok', 'f5', 10, 30;
+        send_key_until_needlematch 'openattic-health-status-ok', 'f5', 11, 30;
         barrier_wait {name => 'all_tests_done', check_dead_job => 1};
     }
     else {
@@ -44,4 +44,3 @@ sub run {
 }
 
 1;
-

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -60,7 +60,7 @@ sub run {
     send_key_until_needlematch 'sap-wizard-proto-' . $proto . '-selected', 'down';
     send_key 'ret' if check_var('DESKTOP', 'textmode');
     send_key 'alt-p';
-    send_key_until_needlematch 'sap-wizard-inst-master-empty', 'backspace', 30 if check_var('DESKTOP', 'textmode');
+    send_key_until_needlematch 'sap-wizard-inst-master-empty', 'backspace', 31 if check_var('DESKTOP', 'textmode');
     type_string_slow "$path", wait_still_screen => 1;
     save_screenshot;
     send_key $cmd{next};

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -401,7 +401,7 @@ sub setup_iscsi_server {
         send_key 'alt-a';
 
         # Send alt-p until LUN path is selected
-        send_key_until_needlematch 'iscsi-target-LUN-path-selected', 'alt-p', 5, 5;
+        send_key_until_needlematch 'iscsi-target-LUN-path-selected', 'alt-p', 6, 5;
         type_string "$hdd_lun$num_lun";
         assert_screen 'iscsi-target-LUN-support-server';
         send_key 'alt-o';

--- a/tests/virt_autotest/proxymode_init_pxe_install.pm
+++ b/tests/virt_autotest/proxymode_init_pxe_install.pm
@@ -24,7 +24,7 @@ sub run {
     $self->connect_slave($ipmi_machine);
     $self->restart_host($ipmi_machine);
     assert_screen "proxy_virttest-pxe", 300;
-    send_key_until_needlematch "proxy_virttest-pxe-edit-prompt", "esc", 10, 5;
+    send_key_until_needlematch "proxy_virttest-pxe-edit-prompt", "esc", 11, 5;
     wait_still_screen 5;
     # Execute installation command on pxe management cmd console
     my $type_speed = 20;

--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -85,7 +85,7 @@ sub run {
         assert_and_click 'finish-button-in-win10';
         assert_screen 'successful-certificate-import';
         # close all opened windows, including powershell
-        send_key_until_needlematch 'powershell-ready-prompt', 'alt-f4', 25, 2;
+        send_key_until_needlematch 'powershell-ready-prompt', 'alt-f4', 26, 2;
     }
 
     # enable WSL & VM platform (WSL2) features

--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -34,7 +34,7 @@ sub run {
         mouse_hide(1);
     }
     else {
-        send_key_until_needlematch 'test-desktop_mainmenu-1', 'alt-f1', 5, 10;
+        send_key_until_needlematch 'test-desktop_mainmenu-1', 'alt-f1', 6, 10;
     }
     assert_screen 'test-desktop_mainmenu-1', 20;
 

--- a/tests/x11/evolution/evolution_timezone_setup.pm
+++ b/tests/x11/evolution/evolution_timezone_setup.pm
@@ -48,10 +48,10 @@ sub run {
     # Change timezone to Shanghai
     send_key "alt-s";
     wait_still_screen(2);
-    send_key_until_needlematch('timezone-asia', 'ret', 10, 2);
+    send_key_until_needlematch('timezone-asia', 'ret', 11, 2);
     send_key "right";
     wait_still_screen(2);
-    send_key_until_needlematch("timezone-shanghai", "up", 20, 1);
+    send_key_until_needlematch("timezone-shanghai", "up", 21, 1);
     send_key "ret";
     assert_screen "asia-shanghai-timezone-setup";
     send_key "alt-o";

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -25,11 +25,11 @@ sub run() {
     $self->start_firefox;
     wait_still_screen;
     send_key('alt');
-    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt-h', 4, 10);
+    send_key_until_needlematch('firefox-top-bar-highlighted', 'alt-h', 5, 10);
     send_key('alt-h');
     wait_still_screen;
     assert_screen('firefox-help-menu');
-    send_key_until_needlematch('test-firefox-3', 'a', 9, 6);
+    send_key_until_needlematch('test-firefox-3', 'a', 10, 6);
 
     # close About
     send_key "alt-f4";
@@ -40,11 +40,11 @@ sub run() {
     if (match_has_tag 'not-responding') {
         record_soft_failure "firefox is not responding, see boo#1174857";
         # confirm "save&quit"
-        send_key_until_needlematch('generic-desktop', 'ret', 9, 6);
+        send_key_until_needlematch('generic-desktop', 'ret', 10, 6);
     }
     elsif (match_has_tag 'firefox-save-and-quit') {
         # confirm "save&quit"
-        send_key_until_needlematch('generic-desktop', 'ret', 9, 6);
+        send_key_until_needlematch('generic-desktop', 'ret', 10, 6);
     }
 }
 

--- a/tests/x11/firefox/firefox_downloading.pm
+++ b/tests/x11/firefox/firefox_downloading.pm
@@ -85,7 +85,7 @@ sub dl_menu {
     # sometimes menu does close due high load or some worker hickup, check & open menu again if not present
     for (1 .. 2) {
         wait_still_screen 3, 6;
-        send_key_until_needlematch 'firefox-downloading-menu', 'shift-f10', 3, 3;
+        send_key_until_needlematch 'firefox-downloading-menu', 'shift-f10', 4, 3;
     }
 }
 
@@ -148,7 +148,7 @@ sub run {
 
     dl_menu();
     # clear downloads, sometimes one d does not clear the list
-    send_key_until_needlematch 'firefox-downloading-blank_list', 'd', 3, 3;
+    send_key_until_needlematch 'firefox-downloading-blank_list', 'd', 4, 3;
 
     send_key "alt-f4";
     send_key "spc";

--- a/tests/x11/firefox/firefox_emaillink.pm
+++ b/tests/x11/firefox/firefox_emaillink.pm
@@ -31,7 +31,7 @@ sub run {
     $self->start_firefox_with_profile;
 
     # Email link
-    send_key_until_needlematch 'firefox-file-menu', 'alt-f', 3, 15;
+    send_key_until_needlematch 'firefox-file-menu', 'alt-f', 4, 15;
     send_key "e";
     assert_screen(['firefox-email_link-welcome', 'firefox-email-mutt', 'firefox-email_link-send'], 90);
     if (match_has_tag('firefox-email-mutt')) {

--- a/tests/x11/firefox/firefox_extensions.pm
+++ b/tests/x11/firefox/firefox_extensions.pm
@@ -45,7 +45,7 @@ sub run {
         assert_and_click_until_screen_change('firefox-extensions-add-to-firefox', 5, 5);
     }
     else {
-        send_key_until_needlematch 'firefox-extensions-flagfox', 'f5', 5, 5;
+        send_key_until_needlematch 'firefox-extensions-flagfox', 'f5', 6, 5;
         assert_and_click 'firefox-extensions-flagfox', timeout => 60;
         wait_still_screen 3;
         assert_and_click_until_screen_change('firefox-extensions-add-to-firefox', 5, 5);
@@ -55,9 +55,9 @@ sub run {
     assert_and_click 'firefox-extensions-added', timeout => 60;
     assert_and_click 'firefox-extensions-flagfox-tab', timeout => 60;
     # close the flagfox relase notes tab and flagfox search tab
-    send_key_until_needlematch 'firefox-addons-plugins', 'ctrl-w', 3, 3;
+    send_key_until_needlematch 'firefox-addons-plugins', 'ctrl-w', 4, 3;
     # refresh the page to see addon buttons
-    send_key_until_needlematch 'firefox-extensions-flagfox_installed', 'f5', 5, 5;
+    send_key_until_needlematch 'firefox-extensions-flagfox_installed', 'f5', 6, 5;
 
     send_key "alt-1";
     $self->firefox_open_url('opensuse.org');

--- a/tests/x11/firefox/firefox_pagesaving.pm
+++ b/tests/x11/firefox/firefox_pagesaving.pm
@@ -32,7 +32,7 @@ sub run {
     assert_screen 'firefox-pagesaving-saveas';
     wait_still_screen 3;
     # on sle15 just one alt-s does not work
-    send_key_until_needlematch 'firefox-downloading-saving_dialog', 'alt-s', 3, 3;
+    send_key_until_needlematch 'firefox-downloading-saving_dialog', 'alt-s', 4, 3;
 
     # Exit
     $self->exit_firefox;

--- a/tests/x11/firefox/firefox_passwd.pm
+++ b/tests/x11/firefox/firefox_passwd.pm
@@ -44,7 +44,7 @@ sub run {
 
     $self->firefox_preferences;
     assert_and_click('firefox-passwd-security');
-    send_key_until_needlematch('firefox-primary-passwd-selected', 'alt-shift-u', 3, 1);
+    send_key_until_needlematch('firefox-primary-passwd-selected', 'alt-shift-u', 4, 1);
     send_key 'spc';
     assert_screen('firefox-passwd-master_setting');
     type_string $masterpw, 150;
@@ -74,13 +74,13 @@ sub run {
 
     $self->firefox_preferences;
     assert_and_click('firefox-passwd-security');
-    send_key_until_needlematch 'firefox-saved-logins-button', 'alt-shift-l', 5, 1;
+    send_key_until_needlematch 'firefox-saved-logins-button', 'alt-shift-l', 6, 1;
     wait_still_screen 3;
     send_key 'spc';
     assert_screen('firefox-passwd-saved');
     assert_and_click('firefox-saved-logins-remove');
     send_key 'spc';
-    send_key_until_needlematch('firefox-passwd-auto_filled', 'ctrl-w', 3, 2);
+    send_key_until_needlematch('firefox-passwd-auto_filled', 'ctrl-w', 4, 2);
     send_key 'f5';
     assert_screen('firefox-passwd-removed');
 

--- a/tests/x11/firefox/firefox_ssl.pm
+++ b/tests/x11/firefox/firefox_ssl.pm
@@ -35,7 +35,7 @@ sub run {
     # go to advanced button and press it
     send_key "tab";
     send_key 'spc';
-    send_key_until_needlematch 'firefox-ssl-risk-accept-and-continue-button-selected', 'tab', 7, 1;
+    send_key_until_needlematch 'firefox-ssl-risk-accept-and-continue-button-selected', 'tab', 8, 1;
     assert_and_click('firefox-ssl-risk-accept-and-continue-button-selected');
     if (check_screen 'firefox-ssl-addexception', 10) {
         send_key 'alt-c';

--- a/tests/x11/gimp.pm
+++ b/tests/x11/gimp.pm
@@ -17,7 +17,7 @@ sub run {
     ensure_installed("gimp");
     x11_start_program('gimp', match_timeout => 60);
     # sometimes send_key "alt-f4" doesn't work reliable, so repeat it and exit
-    send_key_until_needlematch 'generic-desktop', "alt-f4", 5, 5;
+    send_key_until_needlematch 'generic-desktop', "alt-f4", 6, 5;
 }
 
 1;

--- a/tests/x11/gnome_music.pm
+++ b/tests/x11/gnome_music.pm
@@ -18,7 +18,7 @@ use utils;
 
 sub run {
     assert_gui_app('gnome-music', install => 1);
-    send_key_until_needlematch("generic-desktop", 'alt-f4', 5, 5);
+    send_key_until_needlematch("generic-desktop", 'alt-f4', 6, 5);
 }
 
 1;

--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -46,7 +46,7 @@ sub tweak_startupapp_menu {
 
     $self->start_gnome_tweak_tool;
     # increase the default timeout - the switching can be slow
-    send_key_until_needlematch "tweak-startapp", "down", 10, 2;
+    send_key_until_needlematch "tweak-startapp", "down", 11, 2;
 }
 
 sub start_dconf {

--- a/tests/x11/gnomecase/nautilus_permission.pm
+++ b/tests/x11/gnomecase/nautilus_permission.pm
@@ -26,7 +26,7 @@ use version_utils qw(is_sle is_leap is_tumbleweed);
 sub run {
     x11_start_program('touch newfile', valid => 0);
     x11_start_program('nautilus');
-    send_key_until_needlematch 'nautilus-newfile-matched', 'right', 15;
+    send_key_until_needlematch 'nautilus-newfile-matched', 'right', 16;
     if (is_sle('15+') || is_leap('15.0+') || is_tumbleweed) {
         assert_and_click('nautilus-newfile-matched', button => 'right');
         record_soft_failure 'boo#1074057 qemu can not properly capture some keys in nautilus under GNOME wayland';

--- a/tests/x11/ibus/ibus_test_cn.pm
+++ b/tests/x11/ibus/ibus_test_cn.pm
@@ -17,7 +17,7 @@ use utils;
 sub test_cn {
     x11_start_program('gedit');
     hold_key 'super';
-    send_key_until_needlematch 'ibus_switch_cn', 'spc', 6;
+    send_key_until_needlematch 'ibus_switch_cn', 'spc', 7;
     release_key 'super';
 
     wait_still_screen(3);
@@ -26,7 +26,7 @@ sub test_cn {
     assert_screen 'ibus_cn_nihao';
 
     hold_key 'super';
-    send_key_until_needlematch 'ibus_switch_en', 'spc', 6;
+    send_key_until_needlematch 'ibus_switch_en', 'spc', 7;
     release_key 'super';
 
     send_key 'alt-f4';

--- a/tests/x11/ibus/ibus_test_jp.pm
+++ b/tests/x11/ibus/ibus_test_jp.pm
@@ -17,7 +17,7 @@ use utils;
 sub test_jp {
     x11_start_program('gedit');
     hold_key('super');
-    send_key_until_needlematch 'ibus_switch_jp', 'spc', 6;
+    send_key_until_needlematch 'ibus_switch_jp', 'spc', 7;
     release_key('super');
 
     wait_still_screen(3);
@@ -26,7 +26,7 @@ sub test_jp {
     assert_screen 'ibus_jp_hi';
 
     hold_key 'super';
-    send_key_until_needlematch 'ibus_switch_en', 'spc', 6;
+    send_key_until_needlematch 'ibus_switch_en', 'spc', 7;
     release_key 'super';
 
     send_key 'alt-f4';

--- a/tests/x11/ibus/ibus_test_kr.pm
+++ b/tests/x11/ibus/ibus_test_kr.pm
@@ -17,7 +17,7 @@ use utils;
 sub test_kr {
     x11_start_program('gedit');
     hold_key 'super';
-    send_key_until_needlematch 'ibus_switch_kr', 'spc', 6;
+    send_key_until_needlematch 'ibus_switch_kr', 'spc', 7;
     release_key 'super';
 
     # turn on the hangul mode
@@ -28,7 +28,7 @@ sub test_kr {
     assert_screen 'ibus_kr_hi';
 
     hold_key('super');
-    send_key_until_needlematch 'ibus_switch_en', 'spc', 6;
+    send_key_until_needlematch 'ibus_switch_en', 'spc', 7;
     release_key('super');
 
     send_key 'alt-f4';

--- a/tests/x11/libreoffice/libreoffice_default_theme.pm
+++ b/tests/x11/libreoffice/libreoffice_default_theme.pm
@@ -35,7 +35,7 @@ sub check_lo_theme {
         send_key "o";
     }
     assert_screen 'ooffice-tools-options';
-    send_key_until_needlematch 'ooffice-tools-options-view', 'down', 5, 2;
+    send_key_until_needlematch 'ooffice-tools-options-view', 'down', 6, 2;
     send_key "esc";
     wait_still_screen 3;
     send_key "ctrl-q";    # Quit LO

--- a/tests/x11/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11/libreoffice/libreoffice_double_click_file.pm
@@ -31,7 +31,7 @@ sub run {
 
     # open test files of different formats
     for my $tag (qw(doc docx fodg fodp fods fodt odf odg odp ods odt pptx xlsx)) {
-        send_key_until_needlematch("libreoffice-specified-list-$tag", "right", 50, 1);
+        send_key_until_needlematch("libreoffice-specified-list-$tag", "right", 51, 1);
         assert_and_dclick("libreoffice-specified-list-$tag");
         assert_screen("libreoffice-test-$tag", 90);
         if (is_sle '15+') {

--- a/tests/x11/libreoffice/libreoffice_pyuno_bridge.pm
+++ b/tests/x11/libreoffice/libreoffice_pyuno_bridge.pm
@@ -30,7 +30,7 @@ sub run {
     send_key "alt-o";
     assert_screen('libreoffice-options-menu', 30);
     assert_and_dclick('liberoffice-options-menu-LiberOfficeWriter');
-    send_key_until_needlematch "liberoffice-mail-Merge", "down", 20, 3;    #find Mail Merge E-mail
+    send_key_until_needlematch "liberoffice-mail-Merge", "down", 21, 3;    #find Mail Merge E-mail
 
     #fill the information and click test_setting button
     send_key "alt-y";

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -58,7 +58,7 @@ sub run {
     }
     elsif (check_var('DESKTOP', 'xfce')) {
         # select created user #01
-        send_key_until_needlematch(['user-01-selected', 'user-freetext-input-selected'], 'down', 1, 3);
+        send_key_until_needlematch(['user-01-selected', 'user-freetext-input-selected'], 'down', 2, 3);
         if (match_has_tag 'user-freetext-input-selected') {
             enter_cmd "$user";
         }

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -66,7 +66,7 @@ sub nis_server_configuration {
     send_key $cmd{next};
     # NIS Server Query Hosts
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('nis-server-query-hosts-setup', 'alt-f10', 9, 2);
+    send_key_until_needlematch('nis-server-query-hosts-setup', 'alt-f10', 10, 2);
     send_key 'alt-a';    # add
     assert_screen 'nis-server-network-conf-popup';
     type_string $setup_nis_nfs_x11{net_mask};

--- a/tests/x11/plasma_browser_integration.pm
+++ b/tests/x11/plasma_browser_integration.pm
@@ -65,7 +65,7 @@ sub run {
     assert_screen('plasma-mpris-playing');
 
     # Close firefox again. Can't use exit_firefox_common here as it expects xterm.
-    send_key_until_needlematch([qw(firefox-save-and-quit generic-desktop)], 'alt-f4', 3, 30);
+    send_key_until_needlematch([qw(firefox-save-and-quit generic-desktop)], 'alt-f4', 4, 30);
     if (match_has_tag('firefox-save-and-quit')) {
         # confirm "save&quit"
         send_key('ret');

--- a/tests/x11/rmt/rmt_chinese.pm
+++ b/tests/x11/rmt/rmt_chinese.pm
@@ -36,7 +36,7 @@ sub set_language_to_Chinese {
     become_root;
     script_run('yast2 language', die_on_timeout => 0);
     assert_screen 'yast2-language', 60;
-    send_key_until_needlematch 'yast2-lang-simplified-chinese', 'down', 180;
+    send_key_until_needlematch 'yast2-lang-simplified-chinese', 'down', 181;
     send_key 'alt-o';
 
     # Problem here is that sometimes installation takes longer than 10 minutes

--- a/tests/x11/seahorse.pm
+++ b/tests/x11/seahorse.pm
@@ -51,7 +51,7 @@ sub run {
     assert_screen [qw(seahorse-collecton-is-empty seahorse-default_keyring)];
     if (match_has_tag "seahorse-collecton-is-empty") {
         record_soft_failure 'Missing entries of Passwords, Keys, Certificates, see boo#1175513';
-        send_key_until_needlematch("generic-desktop", "alt-f4", 5, 5);
+        send_key_until_needlematch("generic-desktop", "alt-f4", 6, 5);
     }
     elsif (match_has_tag "seahorse-default_keyring") {
         assert_and_click('seahorse-default_keyring', button => 'right');    # right click the new keyring

--- a/tests/x11/tracker/tracker_search_in_nautilus.pm
+++ b/tests/x11/tracker/tracker_search_in_nautilus.pm
@@ -26,7 +26,7 @@ sub run {
     send_key 'ret';
     assert_screen 'gedit-launched';    # should open file newfile
     send_key 'alt-f4';
-    send_key_until_needlematch('generic-desktop', 'alt-f4', 3, 10);
+    send_key_until_needlematch('generic-desktop', 'alt-f4', 4, 10);
 }
 
 1;

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -66,13 +66,13 @@ sub run {
     record_info 'Snapshot created', 'booting the system into created snapshot';
     power_action('reboot', keepconsole => 1);
     $self->wait_grub(bootloader_time => 250);
-    send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
+    send_key_until_needlematch("boot-menu-snapshot", 'down', 11, 5);
     send_key 'ret';
     $self->{in_wait_boot} = 0;
     # On slow VMs we press down key before snapshots list is on screen
     wait_screen_change { assert_screen 'boot-menu-snapshots-list' };
 
-    send_key_until_needlematch("snap-bootloader-comment", 'down', 10, 5);
+    send_key_until_needlematch("snap-bootloader-comment", 'down', 11, 5);
     save_screenshot;
     wait_screen_change { send_key 'ret' };
 

--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -16,9 +16,9 @@ sub run {
     assert_and_click "vlc-first-time-wizard";
     assert_screen "vlc-main-window";
     send_key "ctrl-l";
-    send_key_until_needlematch("vlc-playlist-empty", "ctrl-l", 3, 60);
+    send_key_until_needlematch("vlc-playlist-empty", "ctrl-l", 4, 60);
     send_key "ctrl-n";
-    send_key_until_needlematch("vlc-network-window", "ctrl-n", 3, 60);
+    send_key_until_needlematch("vlc-network-window", "ctrl-n", 4, 60);
     send_key "backspace";
     type_string autoinst_url . "/data/Big_Buck_Bunny_8_seconds_bird_clip.ogv";
     assert_screen "url_check", 90;

--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -100,7 +100,7 @@ sub select_special_device_tab {
     send_key 'tab';
     send_key 'tab';
     send_key 'home';
-    send_key_until_needlematch ["yast2_lan_device_${device}_selected", "yast2_lan_device_bsc1111483"], 'down', 5;
+    send_key_until_needlematch ["yast2_lan_device_${device}_selected", "yast2_lan_device_bsc1111483"], 'down', 6;
     return if check_bsc1111483;
     send_key 'alt-i';    # Edit NIC
     assert_screen 'yast2_lan_network_card_setup';
@@ -129,7 +129,7 @@ sub delete_device {
     send_key 'tab';
     send_key 'tab';
     send_key 'home';
-    send_key_until_needlematch ["yast2_lan_device_${device}_selected", "yast2_lan_device_bsc1111483"], 'down', 5;
+    send_key_until_needlematch ["yast2_lan_device_${device}_selected", "yast2_lan_device_bsc1111483"], 'down', 6;
     return if check_bsc1111483;
     send_key 'alt-t';    # Delete NIC
     wait_still_screen;

--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -42,7 +42,7 @@ sub run {
 
     # Restore keyboard settings to english-us and verify(enter using german characters).
     enter_cmd("zast kezboard set lazout)english/us", wait_still_screen => 10, timeout => 180);
-    send_key_until_needlematch 'root-console', 'ret', 60, 5;
+    send_key_until_needlematch 'root-console', 'ret', 61, 5;
     validate_script_output("yast keyboard summary 2>&1", sub { m/english-us/ }, timeout => 180);
 }
 

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -205,7 +205,7 @@ sub start_vpn_gateway {
     search('vpn');
     assert_and_click 'yast2_control-center_vpn-gateway-client';
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2-vpn-gateway-client', 'alt-f10', 19, 9);
+    send_key_until_needlematch('yast2-vpn-gateway-client', 'alt-f10', 20, 9);
     send_key 'alt-c';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
@@ -246,7 +246,7 @@ sub start_add_system_extensions_or_modules {
     search 'system ext';
     assert_and_click 'yast2_control-center_add-system-extensions-or-modules';
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2_control-center_registration', 'alt-f10', 9, 2);
+    send_key_until_needlematch('yast2_control-center_registration', 'alt-f10', 10, 2);
     send_key 'alt-r';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
@@ -282,7 +282,7 @@ sub start_wake_on_lan {
     assert_screen 'yast2_control-center_wake-on-lan_install_wol';
     send_key $cmd{install};    # wol needs to be installed
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2_control-center_wake-on-lan_overview', 'alt-f10', 9, 2);
+    send_key_until_needlematch('yast2_control-center_wake-on-lan_overview', 'alt-f10', 10, 2);
     send_key 'alt-f';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -32,7 +32,7 @@ sub run {
     select_console 'x11';
     y2_module_guitest::launch_yast2_module_x11($module, match_timeout => 90);
     record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2_hostnames_added', 'alt-f10', 9, 2);
+    send_key_until_needlematch('yast2_hostnames_added', 'alt-f10', 10, 2);
     assert_and_click "yast2_hostnames_added";
     send_key 'alt-i';
     assert_screen 'yast2_hostnames_edit_popup';

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -119,7 +119,7 @@ sub test_http_instserver {
     # select sr0
     send_key_and_wait("alt-c", 2);
     send_key_and_wait("alt-s", 2);
-    send_key_until_needlematch("yast2-instserver_sr0dev", "down", 3);
+    send_key_until_needlematch("yast2-instserver_sr0dev", "down", 4);
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
     send_key_until_needlematch([qw(yast2-instserver-ui yast2-instserver-change-media)], 'alt-f10', 21, 30);

--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -62,7 +62,7 @@ sub run {
     send_key "alt-f2";
     assert_screen('desktop-runner');
     type_string("xdg/su /c |&sbin&zast2 kezboard|");
-    send_key_until_needlematch('root-auth-dialog', 'ret', 3, 3);
+    send_key_until_needlematch('root-auth-dialog', 'ret', 4, 3);
     wait_still_screen 2;
     type_password;
     send_key("ret");

--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -42,7 +42,7 @@ sub run {
     assert_and_click "yast2_security-pwd-settings";
     if (is_sle('15-SP4+')) {
         record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('yast2_security-check-min-pwd-len-and-exp-days', 'alt-f10', 9, 2);
+        send_key_until_needlematch('yast2_security-check-min-pwd-len-and-exp-days', 'alt-f10', 10, 2);
     }
     assert_screen "yast2_security-check-min-pwd-len-and-exp-days";
     assert_and_click "yast2_security-login-settings";
@@ -56,7 +56,7 @@ sub run {
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     if (is_sle('15-SP4+')) {
         record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('yast2_security-login-settings', 'alt-f10', 9, 2);
+        send_key_until_needlematch('yast2_security-login-settings', 'alt-f10', 10, 2);
     }
     assert_and_click "yast2_security-login-settings";
     assert_screen "yast2_security-login-attempts";
@@ -71,7 +71,7 @@ sub run {
     assert_and_click "yast2_security-misc-settings";
     if (is_sle('15-SP4+')) {
         record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('yast2_security-file-perms-secure', 'alt-f10', 9, 2);
+        send_key_until_needlematch('yast2_security-file-perms-secure', 'alt-f10', 10, 2);
     }
     assert_screen "yast2_security-file-perms-secure";
     wait_screen_change { send_key "alt-o" };


### PR DESCRIPTION
The function `send_key_until_needlematch()` had an off-by-one error.
This error has been [recently fixed](https://github.com/os-autoinst/os-autoinst/pull/2151), so we need to increment +1 the `$count` argument (3rd positional) in all test suites calling it.

- Related ticket: https://progress.opensuse.org/issues/115619
- Verification Runs:
  - http://d505.qam.suse.de/tests/109
  - http://d505.qam.suse.de/tests/116
  - http://d505.qam.suse.de/tests/117
  - http://d505.qam.suse.de/tests/123
  - http://d505.qam.suse.de/tests/124
  - http://d505.qam.suse.de/tests/138
  - http://d505.qam.suse.de/tests/144

