### PR TITLE
Remove persistent net rules from pc_tools image

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -129,6 +129,9 @@ EOT
     assert_script_run('chmod +x /usr/bin/kubectl');
     record_info('kubectl', script_output('kubectl version --client=true'));
 
+    # Remove persistent net rules, necessary to boot the x86_64 image in the aarch64 test runs
+    assert_script_run('rm /etc/udev/rules.d/70-persistent-net.rules');
+
     select_console 'root-console';
 }
 


### PR DESCRIPTION
Remove the persistent-net.rules file from the PC tools image to allow it
to start the network also if the `ARCH` setting is set to non-x86_64.

This is required to establish a workflow for aarch64 where we will
continue to use the x86_64 helper VM.

- Related ticket: https://progress.opensuse.org/issues/115652
- Verification runs: [tools generation](https://duck-norris.qam.suse.de/tests/10454) | [test run using the generated image](https://duck-norris.qam.suse.de/tests/10455)