### PR TITLE
Implement hpc modules to test dolly package in a cluster

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -57,6 +57,11 @@ sub destroy_test_barriers {
         barrier_destroy('SLAVE_MRLOGIN_STARTED');
         barrier_destroy('MRSH_MASTER_DONE');
     }
+    elsif (check_var('HPC', 'dolly_master') || check_var('HPC', 'dolly_slave')) {
+        barrier_destroy('DOLLY_INSTALLATION_FINISHED');
+        barrier_destroy('DOLLY_SERVER_READY');
+        barrier_destroy('DOLLY_DONE');
+    }
     elsif (check_var('HPC', 'munge_master') || check_var('HPC', 'munge_slave')) {
         barrier_destroy('MUNGE_INSTALLATION_FINISHED');
         barrier_destroy('MUNGE_KEY_COPIED');

--- a/schedule/hpc/multi_machine_test.yaml
+++ b/schedule/hpc/multi_machine_test.yaml
@@ -43,6 +43,10 @@ conditional_schedule:
         - hpc/pdsh_master
       pdsh_slave:
         - hpc/pdsh_slave
+      dolly_master:
+        - hpc/dolly_master
+      dolly_slave:
+        - hpc/dolly_slave
       hpc_master:
         - hpc/hpc_master
         - hpc/hpc_migration

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -44,6 +44,11 @@ sub run ($self) {
         barrier_create('MRSH_SOCKET_STARTED', $nodes);
         barrier_create('PDSH_SLAVE_DONE', $nodes);
     }
+    elsif (check_var('HPC', 'dolly')) {
+        barrier_create('DOLLY_INSTALLATION_FINISHED', $nodes);
+        barrier_create('DOLLY_SERVER_READY', $nodes);
+        barrier_create('DOLLY_DONE', $nodes);
+    }
     elsif (check_var('HPC', 'ganglia')) {
         barrier_create('GANGLIA_INSTALLED', $nodes);
         barrier_create('GANGLIA_SERVER_DONE', $nodes);

--- a/tests/hpc/dolly_master.pm
+++ b/tests/hpc/dolly_master.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright @ SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test Dolly package duplication block on all nodes, create sha256 for validation
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base 'hpcbase', -signatures;
+use testapi;
+use lockapi;
+use utils;
+
+our $test_dir = "/mnt/test";
+our $test_dev = "/dev/vdb";
+
+sub run ($self) {
+    my $nodes = get_required_var("CLUSTER_NODES");
+
+    zypper_call('in dolly');
+    barrier_wait("DOLLY_INSTALLATION_FINISHED");
+
+    assert_script_run("mkfs.ext4 -v $test_dev");
+    assert_script_run("mkdir -p $test_dir");
+    assert_script_run("mount $test_dev $test_dir");
+    assert_script_run("dd if=/dev/zero of=${test_dir}/data10Gb bs=1M count=1000");
+    assert_script_run("dd if=/dev/zero of=${test_dir}/data200M bs=1M count=200");
+    assert_script_run("sha256sum ${test_dir}/data* > ${test_dir}/hashes.sha256");
+    assert_script_run("umount $test_dir");
+    barrier_wait("DOLLY_SERVER_READY");
+    my $server_hostname = get_required_var("HOSTNAME");
+    my @slave_nodes = $self->slave_node_names();
+    my $client_hostnames = join(',', @slave_nodes);
+    assert_script_run("dolly -v -S $server_hostname -H $client_hostnames -I $test_dev -O $test_dev");
+    barrier_wait("DOLLY_DONE");
+}
+
+sub test_flags ($self) {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
+}
+
+1;

--- a/tests/hpc/dolly_slave.pm
+++ b/tests/hpc/dolly_slave.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright @ SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Operates as the client of the dolly server and checks final results
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base 'hpcbase', -signatures;
+use testapi;
+use lockapi;
+use utils;
+
+our $test_dir = "/mnt/test";
+our $test_dev = "/dev/vdb";
+
+sub run ($self) {
+    zypper_call("in dolly");
+    barrier_wait("DOLLY_INSTALLATION_FINISHED");
+    assert_script_run("mkfs.ext4 -v $test_dev");
+    barrier_wait("DOLLY_SERVER_READY");
+    assert_script_run("dolly -v");
+    barrier_wait("DOLLY_DONE");
+    assert_script_run("mkdir -p $test_dir");
+    assert_script_run("mount $test_dev $test_dir");
+    script_run("ls -la $test_dir");
+    my @data_files = split(/\n/, script_output("ls -1 ${test_dir}/data*"));
+    foreach my $file (@data_files) {
+        my $expected_hash = script_output("sha256sum $file");
+        record_info "hash $file", $expected_hash;
+        assert_script_run(qq@test "$expected_hash" = "\$(grep '$expected_hash' ${test_dir}/hashes.sha256)"@);
+        record_info "$file results", 'test pass successfully';
+    }
+}
+
+sub test_flags ($self) {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
+}
+
+1;


### PR DESCRIPTION
Implement hpc modules to test dolly package in a cluster
    
Create a couple of files and copy them to other nodes using dolly. For more
info take a look at the documentation
https://documentation.suse.com/sle-hpc/15-SP3/html/hpc-guide/cha-dolly.html#
Many options are not supported so we go with the very basic scenario.
    
Some other approach/test cases might be to do the same with a config file.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/113605
- Verification run: 
[master](http://aquarius.suse.cz/tests/12093)
[slave](http://aquarius.suse.cz/tests/12094)
