### PR TITLE
Install guest on SLE Micro KVM Host

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/slem_5_3_64_kvm_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/slem_5_3_64_kvm_hvm_x86_64.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <guest>
-    <guest_os_name>sles</guest_os_name>
-    <guest_version>15-sp4</guest_version>
-    <guest_version_major>15</guest_version_major>
-    <guest_version_minor>4</guest_version_minor>
+    <guest_os_name>slem</guest_os_name>
+    <guest_version>5.3</guest_version>
+    <guest_version_major>5</guest_version_major>
+    <guest_version_minor>3</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build>gm</guest_build>
+    <guest_build></guest_build>
     <host_hypervisor_uri></host_hypervisor_uri>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
@@ -17,18 +17,18 @@
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
     <guest_cpumodel></guest_cpumodel>
     <guest_metadata></guest_metadata>
-    <guest_xpath>./os/boot[@dev='hd']/@order=1#./os/boot[@dev='network']/@order=2</guest_xpath>
+    <guest_xpath></guest_xpath>
     <guest_installation_automation>autoyast</guest_installation_automation>
-    <guest_installation_automation_file>sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml</guest_installation_automation_file>
+    <guest_installation_automation_file>slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1/</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-5.3-Micro-POOL-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin</guest_boot_settings>
-    <guest_secure_boot>true</guest_secure_boot>
-    <guest_os_variant></guest_os_variant>
+    <guest_boot_settings></guest_boot_settings>
+    <guest_secure_boot></guest_secure_boot>
+    <guest_os_variant>slem5.1</guest_os_variant>
     <guest_storage_path></guest_storage_path>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>
@@ -72,12 +72,12 @@
     <guest_memorybacking></guest_memorybacking>
     <guest_features></guest_features>
     <guest_clock></guest_clock>
-    <guest_power_management>suspend_to_mem.enabled=yes,suspend_to_disk.enabled=yes</guest_power_management>
+    <guest_power_management></guest_power_management>
     <guest_events></guest_events>
     <guest_resource></guest_resource>
     <guest_sysinfo></guest_sysinfo>
     <guest_qemu_command></guest_qemu_command>
-    <guest_launchSecurity></guest_launchSecurity>
+    <guest_launchsecurity></guest_launchsecurity>
     <guest_autostart></guest_autostart>
     <guest_transient></guest_transient>
     <guest_destroy_on_exit></guest_destroy_on_exit>
@@ -90,4 +90,3 @@
     <guest_registration_password></guest_registration_password>
     <guest_registration_extensions></guest_registration_extensions>
 </guest>
-

--- a/data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on t="map">
+    <add_on_products t="list">
+    </add_on_products>
+  </add-on>
+  <general t="map">
+    <mode t="map">
+      <confirm t="boolean">false</confirm>
+      <second_stage t="boolean">false</second_stage>
+      <final_reboot t="boolean">true</final_reboot>
+      <final_halt t="boolean">false</final_halt>
+      <final_restart_services t="boolean">true</final_restart_services>
+    </mode>
+    <signature-handling>
+      <accept_file_without_checksum t="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key t="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key t="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file t="boolean">true</accept_unsigned_file>
+      <accept_verification_failed t="boolean">true</accept_verification_failed>
+      <import_gpg_key t="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <start_multipath t="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <suse_register>
+    <do_registration config:type="boolean">##Do-Registration##</do_registration>
+    <email>##Registration-UserName##</email>
+    <reg_code>##Registration-Code##</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <addons config:type="list">
+    </addons>
+  </suse_register>
+  <bootloader t="map">
+    <global t="map">
+      <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>
+      <cpu_mitigations>auto</cpu_mitigations>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <secure_boot>##Secure-Boot##</secure_boot>
+      <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
+      <terminal>gfxterm serial</terminal>
+      <timeout t="integer">3</timeout>
+      <update_nvram>true</update_nvram>
+    </global>
+    <loader_type>##Boot-Loader-Type##</loader_type>
+  </bootloader>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps t="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <drive t="map">
+    <device>/dev/vda</device>
+    <disklabel>##Disk-Label##</disklabel>
+    <use>all</use>
+  </drive>
+  <networking t="map">
+    <dns t="map">
+      <dhcp_hostname t="boolean">true</dhcp_hostname>
+      <domain>##Domain-Name##</domain>
+      <hostname>##Host-Name##</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+    </dns>
+    <interfaces t="list">
+      <interface t="map">
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>auto</startmode>
+      </interface>
+      <interface t="map">
+        <bootproto>static</bootproto>
+        <broadcast>127.255.255.255</broadcast>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+    <ipv6 t="boolean">true</ipv6>
+    <keep_install_network t="boolean">true</keep_install_network>
+    <managed t="boolean">false</managed>
+     <routing t="map">
+      <ipv4_forward t="boolean">true</ipv4_forward>
+      <ipv6_forward t="boolean">true</ipv6_forward>
+    </routing>
+  </networking>
+  <ssh_import t="map">
+    <import t="boolean">false</import>
+    <copy_config t="boolean">false</copy_config>
+  </ssh_import>
+  <report>
+    <errors>
+      <log t="boolean">true</log>
+      <show t="boolean">true</show>
+      <timeout t="integer">30</timeout>
+    </errors>
+    <messages>
+      <log t="boolean">true</log>
+      <show t="boolean">true</show>
+      <timeout t="integer">30</timeout>
+    </messages>
+    <warnings>
+      <log t="boolean">true</log>
+      <show t="boolean">true</show>
+      <timeout t="integer">30</timeout>
+    </warnings>
+    <yesno_messages>
+      <log t="boolean">true</log>
+      <show t="boolean">true</show>
+      <timeout t="integer">30</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager t="map">
+    <default_target>graphical</default_target>
+    <services t="map">
+      <enable t="list">
+        <service>NetworkManager</service>
+        <service>sshd</service>
+      </enable>
+      <disable config:type="list">
+        <service>firewalld</service>
+        <service>apparmor</service>
+        <service>rebootmgr</service>
+      </disable>
+    </services>
+  </services-manager>
+  <software t="map">
+    <install_recommended t="boolean">true</install_recommended>
+    <instsource/>
+    <packages t="list">
+      <package>snapper</package>
+      <package>openssh</package>
+      <package>kexec-tools</package>
+      <package>glibc</package>
+      <package>btrfsprogs</package>
+      <package>yast2-schema-micro</package>
+      <package>zypper</package>
+    </packages>
+    <patterns t="list">
+      <pattern>microos-base</pattern>
+      <pattern>microos-container_runtime</pattern>
+      <pattern>microos-hardware</pattern>
+      <pattern>microos-selinux</pattern>
+    </patterns>
+  </software>
+  <timezone t="map">
+    <hwclock>UTC</hwclock>
+    <timezone>America/Denver</timezone>
+  </timezone>
+  <user_defaults t="map">
+    <expire/>
+    <group>100</group>
+    <groups/>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <no_groups t="boolean">true</no_groups>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users t="list">
+    <user t="map">
+      <encrypted t="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <authorized_keys t="list">
+        <listentry>##Authorized-Keys##</listentry>
+      </authorized_keys>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- /etc/ssh/sshd_config/sshd_config is the default sshd config file in sles  -->
+    <init-scripts config:type="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config"
+if [ ! -f $sshd_config_file ]; then
+    mkdir -p `dirname $sshd_config_file`
+    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+else
+    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
+    for key in $keys; do
+        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
+    done
+fi
+[ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
+touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
+echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
+</profile>

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -47,6 +47,8 @@ use constant {
           unset_sshserial_dev
           use_ssh_serial_console
           set_ssh_console_timeout
+          save_serial_console
+          get_serial_console
         )
     ]
 };
@@ -58,7 +60,20 @@ our %EXPORT_TAGS = (
     BACKEND => (BACKEND)
 );
 
+sub save_serial_console {
+    my $serialconsole = get_var('SERIALCONSOLE', '');
+    return if ($serialconsole ne '');
+    $serialconsole = get_var('SERIALDEV', 'ttyS1');
+    set_var('SERIALCONSOLE', $serialconsole);
+    bmwqemu::save_vars();
+}
+
+sub get_serial_console {
+    return get_var('SERIALCONSOLE', get_var('SERIALDEV', 'ttyS1'));
+}
+
 sub set_sshserial_dev {
+    save_serial_console();
     $serialdev = 'sshserial';
     set_var('SERIALDEV', $serialdev);
     bmwqemu::save_vars();

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -36,7 +36,8 @@ use utils;
 use virt_utils;
 use virt_autotest::utils;
 use version_utils;
-use Utils::Systemd 'disable_and_stop_service';
+use Utils::Systemd;
+use mm_network;
 
 #%guest_params contains all parameters will be used for virtual machine creation, installation and configuration.
 #All parameters before those end with 'options' can be included in guest params xml file and used as guest instance configuration file.
@@ -215,7 +216,7 @@ our %guest_params = (
 );
 
 our $AUTOLOAD;
-our $common_log_folder = '/tmp/guest_installation_and_configuration';
+our $common_log_folder = '/var/log/guest_installation_and_configuration';
 our $common_environment_prepared = 'false';
 
 #Any subroutine calls this subroutine announces its identity and it is being executed
@@ -367,17 +368,35 @@ sub prepare_common_environment {
         virt_autotest::utils::setup_common_ssh_config('/root/.ssh/config');
         script_run("sed -i -r -n \'s/^.*IdentityFile.*\$/#&/\' /etc/ssh/ssh_config");
         enable_debug_logging;
+        $self->prepare_non_transactional_environment;
+        $common_environment_prepared = 'true';
+        diag("Common environment preparation is done now.");
+    }
+    else {
+        diag("Common environment preparation had already been done.");
+    }
+    return $self;
+}
+
+=head2 prepare_non_transactional_environment
+
+  prepare_non_transactional_environment($self)
+
+Do preparation on non-transactional server.
+
+=cut
+
+sub prepare_non_transactional_environment {
+    my $self = shift;
+
+    $self->reveal_myself;
+    if (!is_transactional) {
         virt_autotest::utils::setup_rsyslog_host($common_log_folder);
         my $_packages_to_check = 'wget curl screen dnsmasq xmlstarlet yast2-schema python3 nmap';
         zypper_call("install -y $_packages_to_check");
         my $_patterns_to_check = 'kvm_server kvm_tools';
         $_patterns_to_check = 'xen_server xen_tools' if ($self->{host_virt_type} eq 'xen');
         zypper_call("install -y -t pattern $_patterns_to_check");
-        $common_environment_prepared = 'true';
-        diag("Common environment preparation is done now.");
-    }
-    else {
-        diag("Common environment preparation had already been done.");
     }
     return $self;
 }
@@ -850,42 +869,235 @@ sub config_guest_network_bridge {
     return $self;
 }
 
-#Write ethernet device config file to /etc/sysconfig/network/ifcfg-*.Please refer to https://github.com/openSUSE/sysconfig/blob/master/config/ifcfg.template for config file content.
-#If $_ipaddr given is empty, it means there is no associated specific ip address to this interface which might be attached to another bridge interface or will not be assigned one
-#ip address from dhcp, so set $_ipaddr to '0.0.0.0'.If $_ipaddr given is non-empty but not in ip address format,for example,'host-default',it means the interface will not use a ip
-#address from pre-defined subnet and will automically accept dhcp ip address from public facing host network.
+=head2 write_guest_network_bridge_device_config
+
+  write_guest_network_bridge_device_config($self, _name => $_name [, 
+  _ipaddr => $_ipaddr, _bootproto => $_bootproto, _startmode => $_startmode, 
+  _zone => $_zone, _bridge_type => $_bridge_type, _bridge_ports => $_bridge_ports, 
+  _bridge_stp => $_bridge_stp, _bridge_forwarddelay => $_bridge_forwarddelay])
+
+Write network device settings to conventional /etc/sysconfig/network/ifcfg-* or 
+/etc/NetworkManager/system-connections/*.nmconnection depends on whether system
+network is managed by NetworkManager or not. The supported arguments are listed
+out as below:
+$_ipaddr: IP address/mask length pair of the interface
+$_name: Identifier of the interface
+$_bootproto: DHCP automatic or manual configuration, 'static', 'dhcp' or 'none'
+$_startmode: Auto start up or connection: 'auto', 'manual' or 'off'
+$_zone: The trust level of this network connection
+$_bridge_type: 'master' or 'slave' to indicate master or slave interface
+$_bridge_port: Specify interface's master or slave interface name
+$_bridge_stp: 'on' or 'off' to turn stp on or off
+$_bridge_forwarddelay: The stp forwarding delay in seconds
+If $_ipaddr given is empty, it means there is no associated specific ip address 
+to this interface which might be attached to another bridge interface or will not 
+be assigned one ip address from dhcp, so set $_ipaddr to '0.0.0.0'.If $_ipaddr 
+given is non-empty but not in ip address format,for example, 'host-default',it 
+means the interface will not use a ip address from pre-defined subnet and will 
+automically accept dhcp ip address from public facing host network.
+
+=cut
+
 sub write_guest_network_bridge_device_config {
-    my ($self, $_ipaddr, $_name, $_bootproto, $_startmode, $_zone, $_bridge, $_bridge_ports, $_bridge_stp, $_bridge_forwarddelay) = @_;
+    my ($self, %args) = @_;
 
     $self->reveal_myself;
-    $_ipaddr //= '0.0.0.0';
-    $_name //= '';
-    $_bootproto //= 'dhcp';
-    $_startmode //= 'auto';
-    $_zone //= '';
-    $_bridge //= '';
-    $_bridge_ports //= '';
-    $_bridge_stp //= 'off';
-    $_bridge_forwarddelay //= '15';
-    script_run("cp /etc/sysconfig/network/ifcfg-$_name /etc/sysconfig/network/backup-ifcfg-$_name");
-    script_run("cp /etc/sysconfig/network/backup-ifcfg-$_name $common_log_folder");
-    my $_bridge_device_config_file = '/etc/sysconfig/network/ifcfg-' . $_name;
-    $_ipaddr = '0.0.0.0' if ($_ipaddr eq '');
-    $_ipaddr = '' if (!($_ipaddr =~ /\d+\.\d+\.\d+\.\d+/));
+    $args{_ipaddr} //= '0.0.0.0';
+    $args{_name} //= '';
+    $args{_bootproto} //= 'dhcp';
+    $args{_startmode} //= 'auto';
+    $args{_zone} //= '';
+    $args{_bridge_type} //= 'master';
+    $args{_bridge_port} //= '';
+    $args{_bridge_stp} //= 'off';
+    $args{_bridge_forwarddelay} //= '15';
+    croak("Interface name must be given otherwise network bridge device config can not be generated.") if ($args{_name} eq '');
+
+    $args{_ipaddr} = '0.0.0.0' if ($args{_ipaddr} eq '');
+    $args{_ipaddr} = '' if (!($args{_ipaddr} =~ /\d+\.\d+\.\d+\.\d+/));
+    if (is_networkmanager) {
+        $self->write_guest_network_bridge_device_nmconnection(%args);
+    }
+    else {
+        $self->write_guest_network_bridge_device_ifcfg(%args);
+    }
+    return $self;
+}
+
+=head2 write_guest_network_bridge_device_ifcfg
+
+  write_guest_network_bridge_device_ifcfg($self, _name => $_name [, 
+  _ipaddr => $_ipaddr, _name => $_name, _bootproto => $_bootproto, 
+  _startmode => $_startmode, _zone => $_zone, _bridge_type => $_bridge_type, 
+  _bridge_ports => $_bridge_ports, _bridge_stp => $_bridge_stp, 
+  _bridge_forwarddelay => $_bridge_forwarddelay])
+
+Write bridge device config file to /etc/sysconfig/network/ifcfg-*. Please refer 
+to https://github.com/openSUSE/sysconfig/blob/master/config/ifcfg.template for 
+config file content. 
+
+=cut
+
+sub write_guest_network_bridge_device_ifcfg {
+    my ($self, %args) = @_;
+
+    $self->reveal_myself;
+    script_run("cp /etc/sysconfig/network/ifcfg-$args{_name} /etc/sysconfig/network/backup-ifcfg-$args{_name}");
+    script_run("cp /etc/sysconfig/network/backup-ifcfg-$args{_name} $common_log_folder");
+    my $_bridge_device_config_file = '/etc/sysconfig/network/ifcfg-' . $args{_name};
+    my $_is_bridge = ($args{_bridge_type} eq 'master' ? 'yes' : 'no');
     type_string("cat > $_bridge_device_config_file <<EOF
-IPADDR=\'$_ipaddr\'
-NAME=\'$_name\'
-BOOTPROTO=\'$_bootproto\'
-STARTMODE=\'$_startmode\'
-ZONE=\'$_zone\'
-BRIDGE=\'$_bridge\'
-BRIDGE_PORTS=\'$_bridge_ports\'
-BRIDGE_STP=\'$_bridge_stp\'
-BRIDGE_FORWARDDELAY=\'$_bridge_forwarddelay\'
+IPADDR=\'$args{_ipaddr}\'
+NAME=\'$args{_name}\'
+BOOTPROTO=\'$args{_bootproto}\'
+STARTMODE=\'$args{_startmode}\'
+ZONE=\'$args{_zone}\'
+BRIDGE=\'$_is_bridge\'
+BRIDGE_PORTS=\'$args{_bridge_port}\'
+BRIDGE_STP=\'$args{_bridge_stp}\'
+BRIDGE_FORWARDDELAY=\'$args{_bridge_forwarddelay}\'
 EOF
 ");
     script_run("cp $_bridge_device_config_file $common_log_folder");
-    record_info("Network device $_name config $_bridge_device_config_file", script_output("cat $_bridge_device_config_file", proceed_on_failure => 0));
+    record_info("Network device $args{_name} config $_bridge_device_config_file", script_output("cat $_bridge_device_config_file", proceed_on_failure => 0));
+    return $self;
+}
+
+=head2 write_guest_network_bridge_device_nmconnection
+  
+  write_guest_network_bridge_device_nmconnection($self, _name => $_name [, 
+  _ipaddr => $_ipaddr, _name => $_name, _bootproto => $_bootproto, 
+  _startmode => $_startmode, _zone => $_zone, _bridge_type => $_bridge_type, 
+  _bridge_ports => $_bridge_ports, _bridge_stp => $_bridge_stp, 
+  _bridge_forwarddelay => $_bridge_forwarddelay])
+
+Write bridge device config file to /etc/NetworkManager/system-connections/*. NM
+settings are a little bit different from ifcfg settings, but there are definite
+mapping between them. So translation from well-known and default ifcfg settings
+to NM settings is necessary. Please refer to nm-settings explanation as below:
+https://developer-old.gnome.org/NetworkManager/stable/nm-settings-keyfile.html
+
+=cut
+
+sub write_guest_network_bridge_device_nmconnection {
+    my ($self, %args) = @_;
+
+    $self->reveal_myself;
+    my $_configmethod = ($args{_bootproto} eq 'dhcp' ? 'auto' : 'manual');
+    my $_autoconnect = ($args{_startmode} eq 'auto' ? 'true' : 'false');
+    $args{_bridge_stp} = ($args{_bridge_stp} eq 'on' ? 'true' : 'false');
+    script_run("cp /etc/NetworkManager/system-connections/$args{_name}.nmconnection /etc/NetworkManager/system-connections/backup-$args{_name}.nmconnection");
+    script_run("cp /etc/NetworkManager/system-connections/backup-$args{_name}.nmconnection $common_log_folder");
+    my $_bridge_device_config_file = '/etc/NetworkManager/system-connections/' . $args{_name} . ".nmconnection";
+
+    if ($args{_bridge_type} eq 'master') {
+        type_string("cat > $_bridge_device_config_file <<EOF
+[connection]
+autoconnect=$_autoconnect
+id=$args{_name}
+permissions=
+interface-name=$args{_name}
+type=bridge
+zone=$args{_zone}
+[ipv4]
+method=$_configmethod
+address1=$args{_ipaddr}
+[bridge]
+stp=$args{_bridge_stp}
+forward-delay=$args{_bridge_forwarddelay}
+EOF
+");
+    }
+    elsif ($args{_bridge_type} eq 'slave') {
+        my $_interfacetype = "";
+        if (script_run("nmcli connection show $args{_name}") == 0) {
+            $_interfacetype = script_output("nmcli connection show $args{_name} | grep connection.type | awk \'{print \$2}\'", proceed_on_failure => 0);
+        }
+        else {
+            my $_interfacename = script_output("nmcli -f NAME,DEVICE connection show | grep $args{_name}", proceed_on_failure => 0);
+            $_interfacename =~ s/\s*$args{_name}\s*$//;
+            $_interfacetype = script_output("nmcli connection show \"$_interfacename\" | grep connection.type | awk \'{print \$2}\'", proceed_on_failure => 0);
+        }
+        type_string("cat > $_bridge_device_config_file <<EOF
+[connection]
+autoconnect=$_autoconnect
+id=$args{_name}
+permissions=
+interface-name=$args{_name}
+type=$_interfacetype
+zone=$args{_zone}
+slave-type=bridge
+master=$args{_bridge_port}
+[ipv4]
+method=$_configmethod
+address1=$args{_ipaddr}
+EOF
+");
+    }
+    script_run("chmod 700 $_bridge_device_config_file && cp $_bridge_device_config_file $common_log_folder");
+    script_retry("nmcli connection load $_bridge_device_config_file", retry => 3, die => 0);
+    record_info("Network device $args{_name} config $_bridge_device_config_file", script_output("cat $_bridge_device_config_file", proceed_on_failure => 0));
+    return $self;
+}
+
+=head2 activate_guest_network_bridge_device
+
+  activate_guest_network_bridge_device($self, _bridge_name => $_bridge_name)
+
+Activate guest network bridge device by using wicked or NetworkManager depends on
+system configuration. And also validate whether activation is successful or not.
+
+=cut
+
+sub activate_guest_network_bridge_device {
+    my ($self, %args) = @_;
+
+    $self->reveal_myself;
+    $args{_host_device} //= '';
+    $args{_bridge_device} //= '';
+    croak("Bridge device name must be given otherwise activation can not be done.") if ($args{_bridge_device} eq '');
+    my $_detect_active_route = '';
+    my $_detect_inactive_route = '';
+    if ($self->{guest_netaddr} ne 'host-default') {
+        if (is_networkmanager) {
+            script_retry("nmcli connection up $args{_bridge_device}", retry => 3, die => 0);
+        }
+        else {
+            my $_bridge_device_config_file = '/etc/sysconfig/network/ifcfg-' . $args{_bridge_device};
+            if (is_opensuse) {
+                # NIC in openSUSE TW guest is unable to get the IP from its network configration file with 'wicked ifup' or 'ifup'
+                # Not sure if it is a bug yet. This is just a temporary solution.
+                my $_bridge_ipaddr = script_output("grep IPADDR $_bridge_device_config_file | cut -d \"'\" -f2");
+                script_retry("ip link add $args{_bridge_device} type bridge; ip addr flush dev $args{_bridge_device}", retry => 3, die => 0);
+                script_retry("ip addr add $_bridge_ipaddr dev $args{_bridge_device} && ip link set $args{_bridge_device} up", retry => 3, die => 0);
+            }
+            else {
+                script_retry("wicked ifup $_bridge_device_config_file $args{_bridge_device}", retry => 3, die => 0);
+            }
+        }
+        $_detect_active_route = script_output("ip route show | grep -i $args{_bridge_device}", proceed_on_failure => 1);
+    }
+    else {
+        if (is_networkmanager) {
+            script_retry("nmcli connection up $args{_bridge_device}", timeout => 60, delay => 15, retry => 3, die => 0);
+            script_retry("nmcli connection up $args{_host_device}", timeout => 60, delay => 15, retry => 3, die => 0);
+        }
+        else {
+            script_retry("systemctl restart network", timeout => 60, delay => 15, retry => 3, die => 0);
+        }
+        type_string("reset\n");
+        select_console('root-ssh') if (!(check_screen('text-logged-in-root')));
+        $_detect_active_route = script_output("ip route show default | grep -i $args{_bridge_device}", proceed_on_failure => 1);
+        $_detect_inactive_route = script_output("ip route show default | grep -i $args{_host_device}", proceed_on_failure => 1);
+    }
+
+    if (($_detect_active_route ne '') and ($_detect_inactive_route eq '')) {
+        record_info("Successfully setup bridge device $self->{guest_network_device} to be used by $self->{guest_name}.", script_output("ip addr show;ip route show"));
+    }
+    else {
+        record_info("Failed to setup bridge device $self->{guest_network_device} to be used by $self->{guest_name}.Mark guest $self->{guest_name} installation as FAILED", script_output("ip addr show;ip route show"));
+        $self->record_guest_installation_result('FAILED');
+    }
     return $self;
 }
 
@@ -903,35 +1115,14 @@ sub config_guest_network_bridge_device {
         my $_detect_active_route = '';
         my $_detect_inactive_route = '';
         if ($self->{guest_netaddr} ne 'host-default') {
-            $self->write_guest_network_bridge_device_config($_bridge_network, $_bridge_device, 'static', 'auto', '', 'yes');
-            my $_bridge_device_config_file = '/etc/sysconfig/network/ifcfg-' . $_bridge_device;
-            if (is_opensuse) {
-                #NIC in openSUSE TW guest is unable to get the IP from its network configration file with 'wicked ifup' or 'ifup'
-                #Not sure if it is a bug yet. This is just a temporary solution.
-                my $_bridge_ipaddr = script_output("grep IPADDR $_bridge_device_config_file | cut -d \"'\" -f2");
-                script_retry("ip link add $_bridge_device type bridge && ip addr add $_bridge_ipaddr dev $_bridge_device && ip link set $_bridge_device up", retry => 3, die => 0);
-            }
-            else {
-                script_retry("wicked ifup $_bridge_device_config_file $_bridge_device", retry => 3, die => 0);
-            }
-            $_detect_active_route = script_output("ip route show | grep -i $_bridge_device", proceed_on_failure => 1);
+            $self->write_guest_network_bridge_device_config(_ipaddr => $_bridge_network, _name => $_bridge_device, _bootproto => 'static', _bridge_type => 'master');
+            $self->activate_guest_network_bridge_device(_bridge_device => $_bridge_device);
         }
         else {
             my $_host_default_network_interface = script_output("ip route show default | grep -i dhcp | grep -vE br[[:digit:]]+ | head -1 | awk \'{print \$5}\'");
-            $self->write_guest_network_bridge_device_config($_bridge_network, $_bridge_device, 'dhcp', 'auto', '', 'yes', $_host_default_network_interface);
-            $self->write_guest_network_bridge_device_config('', $_host_default_network_interface, 'none');
-            script_retry("systemctl restart network", timeout => 60, delay => 15, retry => 3, die => 0);
-            type_string("reset\n");
-            select_console('root-ssh') if (!(check_screen('text-logged-in-root')));
-            $_detect_active_route = script_output("ip route show default | grep -i $_bridge_device", proceed_on_failure => 1);
-            $_detect_inactive_route = script_output("ip route show default | grep -i $_host_default_network_interface", proceed_on_failure => 1);
-        }
-        if (($_detect_active_route ne '') and ($_detect_inactive_route eq '')) {
-            record_info("Successfully setup bridge device $self->{guest_network_device} to be used by $self->{guest_name}.", script_output("ip addr show;ip route show"));
-        }
-        else {
-            record_info("Failed to setup bridge device $self->{guest_network_device} to be used by $self->{guest_name}.Mark guest $self->{guest_name} installation as FAILED", script_output("ip addr show;ip route show"));
-            $self->record_guest_installation_result('FAILED');
+            $self->write_guest_network_bridge_device_config(_ipaddr => $_bridge_network, _name => $_bridge_device, _bootproto => 'dhcp', _bridge_type => 'master', _bridge_port => $_host_default_network_interface);
+            $self->write_guest_network_bridge_device_config(_ipaddr => '', _name => $_host_default_network_interface, _bootproto => 'none', _bridge_type => 'slave', _bridge_port => $_bridge_device);
+            $self->activate_guest_network_bridge_device(_host_device => $_host_default_network_interface, _bridge_device => $_bridge_device);
         }
     }
     else {
@@ -991,13 +1182,7 @@ sub config_guest_network_bridge_services {
     }
     else {
         record_info("DHCP and DNS services had already been running on $self->{guest_network_device} which is ready for use", "The command used is ((nohup $_dnsmasq_command  &>$_dnsmasq_log) &)");
-        if (script_output("cat $common_log_folder/root_cron_job | grep -i \"$_dnsmasq_command\"", proceed_on_failure => 1) eq '') {
-            type_string("cat >> $common_log_folder/root_cron_job <<EOF
-\@reboot ((nohup $_dnsmasq_command  &>$_dnsmasq_log) &)
-EOF
-");
-            script_run("crontab $common_log_folder/root_cron_job;crontab -l");
-        }
+        $self->schedule_tasks_on_boot(_task => "(nohup $_dnsmasq_command  &>$_dnsmasq_log) &");
     }
     return $self;
 }
@@ -1011,7 +1196,7 @@ sub config_guest_network_bridge_policy {
     my @_default_route_devices = split(/\n/, script_output("ip route show default | grep -i dhcp | awk \'{print \$5}\'", proceed_on_failure => 0));
     my $_iptables_default_route_devices = '';
     $_iptables_default_route_devices = "iptables --table nat --append POSTROUTING --out-interface $_ -j MASQUERADE\n" . $_iptables_default_route_devices foreach (@_default_route_devices);
-    my $_network_policy_config_file = '/tmp/network_policy_bridge_device_' . $_guest_network_device . '_default_route_device';
+    my $_network_policy_config_file = "$common_log_folder/network_policy_bridge_device_" . $_guest_network_device . "_default_route_device";
     $_network_policy_config_file = $_network_policy_config_file . '_' . $_ foreach (@_default_route_devices);
     $_network_policy_config_file = $_network_policy_config_file . '.sh';
     type_string("cat > $_network_policy_config_file <<EOF
@@ -1029,6 +1214,7 @@ systemctl stop firewalld
 systemctl disable firewalld
 systemctl stop apparmor
 systemctl disable apparmor
+sed -i -r \'s/^SELINUX=.*\$/SELINUX=disabled/g\' /etc/selinux/config
 systemctl stop named
 systemctl disable named
 systemctl stop dhcpd
@@ -1042,6 +1228,7 @@ iptables -X
 $_iptables_default_route_devices
 iptables --append FORWARD --in-interface $_guest_network_device -j ACCEPT
 sysctl -w net.ipv4.ip_forward=1
+sysctl -w net.ipv4.conf.all.forwarding=1
 sysctl -w net.ipv6.conf.all.forwarding=1
 iptables-save > $self->{guest_log_folder}/iptables_after_modification_by_$self->{guest_name}
 EOF
@@ -1049,15 +1236,112 @@ EOF
     assert_script_run("chmod 777 $_network_policy_config_file");
     record_info("Network policy config file", script_output("cat $_network_policy_config_file", proceed_on_failure => 0));
     script_run("$_network_policy_config_file", timeout => 60);
-    if (script_output("cat $common_log_folder/root_cron_job | grep -i $_network_policy_config_file", proceed_on_failure => 1) eq '') {
+    $self->schedule_tasks_on_boot(_task => "$_network_policy_config_file");
+    return $self;
+}
+
+=head2 schedule_tasks_on_boot
+
+  schedule_tasks_on_boot($self, _task => $task)
+
+Schedule tasks to be executed on system boot up, please refer to these documents:
+https://docs.oracle.com/en/learn/oracle-linux-crontab/ for using crontab utility
+and https://linuxconfig.org/how-to-schedule-tasks-with-systemd-timers-in-linux for 
+for using systemd service and timer. In order to schedule a task successfully, the
+_task argument should not be empty.
+
+=cut
+
+sub schedule_tasks_on_boot {
+    my ($self, %args) = @_;
+
+    $self->reveal_myself;
+    $args{_task} //= '';
+
+    croak("Jobs to be scheduled should have _task arguments set.") if ($args{_task} eq '');
+    if (script_run('systemctl is-active cron.service') != 0) {
+        $self->schedule_tasks_on_boot_systemd(%args);
+    }
+    else {
+        $self->schedule_tasks_on_boot_crontab(%args);
+    }
+    return $self;
+}
+
+=head2 schedule_tasks_on_boot_crontab
+
+  schedule_tasks_on_boot_crontab($self, _task => $task)
+
+Schedule tasks on system boot up by using crontab utility.
+
+=cut
+
+sub schedule_tasks_on_boot_crontab {
+    my ($self, %args) = @_;
+
+    $self->reveal_myself;
+    $args{_task} = "($args{_task})" if $args{_task} =~ /\s*&\s*$/;
+    if (script_output("cat $common_log_folder/root_cron_job | grep -i \"$args{_task}\"", proceed_on_failure => 1) eq '') {
         type_string("cat >> $common_log_folder/root_cron_job <<EOF
-\@reboot $_network_policy_config_file
+\@reboot $args{_task}
 EOF
 ");
         script_run("crontab $common_log_folder/root_cron_job;crontab -l");
     }
     return $self;
 }
+
+
+
+=head2 schedule_tasks_on_boot_systemd
+
+  schedule_tasks_on_boot_systemd($self, _task => $task)
+
+Schedule tasks on system boot up by using systemd service and timer.
+
+=cut
+
+sub schedule_tasks_on_boot_systemd {
+    my ($self, %args) = @_;
+
+    $self->reveal_myself;
+    $args{_task} =~ s/\s*&\s*$//;
+    my $_systemd_unit_path = "/etc/systemd/system";
+    my $_systemd_unit_name = "stubnetwork";
+    if (script_output("cat $common_log_folder/root_systemd_job | grep -i \"$args{_task}\"", proceed_on_failure => 1) eq '') {
+        assert_script_run("echo -e \"$args{_task}\\n\$(cat $common_log_folder/root_systemd_job)\" > $common_log_folder/root_systemd_job");
+        assert_script_run("chmod 755 $common_log_folder/root_systemd_job");
+        if (script_output("systemctl list-timers | grep $_systemd_unit_name", proceed_on_failure => 1) eq '') {
+            type_string("cat > $_systemd_unit_path/$_systemd_unit_name.service <<EOF
+[Unit]
+Description=Bridge DHCP and DNS Services without Blockage
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash $common_log_folder/root_systemd_job
+EOF
+");
+            type_string("cat > $_systemd_unit_path/$_systemd_unit_name.timer <<EOF
+[Unit]
+Description=Bridge DHCP and DNS services without Blockage
+
+[Timer]
+Unit=stubnetwork.service
+OnBootSec=10
+
+[Install]
+WantedBy=timers.target
+EOF
+");
+            script_run("cp $_systemd_unit_path/$_systemd_unit_name* $common_log_folder");
+        }
+        disable_and_stop_service("$_systemd_unit_name.timer", ignore_failure => 1);
+        systemctl("enable $_systemd_unit_name.timer", ignore_failure => 1);
+        systemctl("status $_systemd_unit_name.timer", ignore_failure => 1);
+    }
+    return $self;
+}
+
 
 #Configure [guest_installation_method_options].User can still change [guest_installation_method],[guest_installation_media],[guest_build],[guest_version],[guest_version_major],
 #[guest_version_minor],[guest_installation_fine_grained] and [guest_autoconsole] by passing non-empty arguments using hash.Call config_guest_installation_media to set correct
@@ -1156,6 +1440,12 @@ sub config_guest_installation_extra_args {
         $self->{guest_installation_extra_args_options} = $self->{guest_installation_extra_args_options} . "--extra-args \"$_\" " foreach (@_guest_installation_extra_args);
         $self->{guest_installation_extra_args_options} = $self->{guest_installation_extra_args_options} . "--extra-args \"ip=$self->{guest_ipaddr}\"" if (($self->{guest_ipaddr_static} eq 'true') and ($self->{guest_ipaddr} ne ''));
     }
+
+    if (is_transactional and $self->{guest_os_name} eq 'slem') {
+        record_soft_failure("bsc#1202405 - SLE Micro 5.3 media can not be successfully loaded automatically for virtual machine installation");
+        $self->{guest_installation_extra_args_options} = $self->{guest_installation_extra_args_options} . "--extra-args \"install=$self->{guest_installation_media}\"";
+    }
+
     if (($self->{guest_installation_automation} ne '') and ($self->{guest_installation_automation_file} ne '')) {
         $self->config_guest_installation_automation;
         $self->{guest_installation_extra_args_options} = "$self->{guest_installation_extra_args_options} $self->{guest_installation_automation_options}" if ($self->{guest_installation_automation_options} ne '');
@@ -1163,6 +1453,7 @@ sub config_guest_installation_extra_args {
     else {
         record_info("Skip installation automation configuration for guest $self->{guest_name}", "It has no guest_installation_automation or no guest_installation_automation_file configured.Skip config_guest_installation_automation.");
     }
+
     return $self;
 }
 
@@ -1421,7 +1712,7 @@ sub get_guest_installation_session {
     my $installation_tty = script_output("tty | awk -F\"/\" 'BEGIN { OFS=\"-\" } {print \$3,\$4}\'", proceed_on_failure => 1);
     #Use grep instead of pgrep to avoid that the latter's case-insensitive search option might not be supported by some obsolete operating systems.
     my $installation_pid = script_output("ps ax | grep -i \"SCREEN -t $self->{guest_name}\" | grep -v grep | awk \'{print \$1}\'", proceed_on_failure => 1);
-    $self->{guest_installation_session} = ($installation_pid eq '' ? '' : $installation_pid . ".$installation_tty." . $self->{host_name});
+    $self->{guest_installation_session} = ($installation_pid eq '' ? '' : $installation_pid . ".$installation_tty." . (split(/\./, $self->{host_name}))[0]);
     record_info("Guest $self->{guest_name} installation screen process info", "$self->{guest_name} $self->{guest_installation_session}");
     return $self;
 }

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -679,11 +679,10 @@ sub subscribe_extensions_and_modules {
 
     $ret = 0;
     my @to_be_subscribed = split(/ /, $args{reg_exts});
-    my $version_id = version_utils::get_version_id(dst_machine => "$args{dst_machine}");
     foreach (@to_be_subscribed) {
-        $cmd = "-p $_/" . $version_id . "/" . get_required_var("ARCH");
+        $cmd = "-p " . "\$(SUSEConnect -l | grep -o \"\\b$_\\/.*\\/.*\\b\")";
         $cmd = ($args{activate} != 0 ? "SUSEConnect " : "SUSEConnect -d ") . $cmd;
-        $cmd = "ssh root\@$args{dst_machine} " . "\"$cmd\"" if ($args{dst_machine} ne 'localhost');
+        $cmd = "ssh root\@$args{dst_machine} " . "\'$cmd\'" if ($args{dst_machine} ne 'localhost');
         $ret |= script_run($cmd, timeout => 120);
         save_screenshot;
     }

--- a/schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml
+++ b/schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml
@@ -1,0 +1,51 @@
+---
+name: install_guest_on_slem_kvm_host.yaml
+description: |
+  Maintainer: Wayne Chen (wchen@suse.com) qe-virt@suse.de
+  Virtualization Guest Installation on SLE Micro KVM Host
+
+vars:
+  VIRT_AUTOTEST: 1
+  VIRT_PRJ1_GUEST_INSTALL: 1
+  VIRT_UNIFIED_GUEST_INSTALL: 1
+  VIDEOMODE: text
+  DO_NOT_INSTALL_HOST: 0
+  SKIP_GUEST_INSTALL: 0
+  SYSTEM_ROLE: kvm
+  HOST_HYPERVISOR: kvm
+  PATTERNS: default,kvm
+  IPXE: 0
+  MAX_JOB_TIME: 10800
+schedule:
+  - "{{bootup_and_install}}"
+  - virt_autotest/login_console
+  - virt_autotest/transactional/prepare_transactional_server
+  - "{{install_guest}}"
+conditional_schedule:
+  bootup_and_install:
+    DO_NOT_INSTALL_HOST:
+      0:
+        - "{{bootup}}"
+        - installation/welcome
+        - installation/scc_registration
+        - installation/ntp_config_settings
+        - installation/user_settings_root
+        - installation/resolve_dependency_issues
+        - installation/select_patterns
+        - installation/installation_overview
+        - installation/disable_grub_graphics
+        - installation/start_install
+        - installation/await_install
+        - installation/logs_from_installation_system
+        - installation/reboot_after_installation
+  install_guest:
+    SKIP_GUEST_INSTALL:
+      0:
+        - virt_autotest/unified_guest_installation
+  bootup:
+    IPXE:
+      1:
+        - installation/ipxe_install
+      0:
+        - boot/boot_from_pxe
+...

--- a/tests/virt_autotest/transactional/prepare_transactional_server.pm
+++ b/tests/virt_autotest/transactional/prepare_transactional_server.pm
@@ -1,0 +1,117 @@
+# PREPARE TRANSACTIONAL SERVER MODULE
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: This module do preparation work for virtual machine installation on
+# transactional server, including extensions registration, packages installation,
+# services toggle and other operations that are pertinent to transactonal server
+# only or which need to to performed by leveraging transactional-update command.
+#
+# Maintainer: Wayne Chen <wchen@suse.com> qe-virt@suse.de
+package prepare_transactional_server;
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use transactional;
+use utils;
+use version_utils;
+use Utils::Systemd;
+use Utils::Backends;
+use ipmi_backend_utils;
+use virt_autotest::utils;
+
+sub run {
+    my $self = shift;
+
+    $self->prepare_in_trup_shell;
+    $self->prepare_on_active_system;
+}
+
+sub prepare_in_trup_shell {
+    my $self = shift;
+
+    transactional::enter_trup_shell(global_options => '--drop-if-no-change');
+    $self->prepare_extensions;
+    $self->prepare_packages;
+    $self->prepare_bootloader;
+    transactional::exit_trup_shell_and_reboot();
+}
+
+sub prepare_on_active_system {
+    my $self = shift;
+
+    $self->prepare_services;
+}
+
+sub prepare_extensions {
+    my $self = shift;
+
+    #Subscribing packagehub that enables access to many useful software tools
+    virt_autotest::utils::subscribe_extensions_and_modules(reg_exts => 'PackageHub');
+}
+
+sub prepare_packages {
+    my $self = shift;
+
+    # Install necessary virtualization client packages
+    zypper_call("--non-interactive install --no-allow-downgrade --no-allow-name-change --no-allow-vendor-change virt-install libvirt-client libguestfs0 guestfs-tools yast2-schema-micro sshpass");
+
+    if (get_var("INSTALL_OTHER_REPOS")) {
+
+        # SLE Micro is a lightweight operating system purpose built for containerized
+        # and virtualized workloads. It does not provide equally abundant functionality
+        # compared with SLES, so it becomes necessary to install some useful utilities
+        # from SLES repos to facilitate test run. At the same time, ensure it will not
+        # alter SLEM and its features and characteristics. Althought operating system
+        # should not prevent user from installing legitimate tools and utilities, it
+        # is expected that use of additional packages should be limited to the minimum
+        # and their impact should be analyzed beforehand.
+        my @repos_to_install = split(/,/, get_var("INSTALL_OTHER_REPOS"));
+        my @repos_names = ();
+        my $repo_name = "";
+        foreach (@repos_to_install) {
+            $repo_name = (split(/\//, $_))[-1] . "-" . bmwqemu::random_string(8);
+            push(@repos_names, $repo_name);
+            zypper_call("--non-interactive --gpg-auto-import-keys ar --enable --refresh $_ $repo_name");
+            save_screenshot;
+        }
+        zypper_call("--non-interactive --gpg-auto-import-keys refresh");
+        save_screenshot;
+
+        my $cmd = "--non-interactive install --no-allow-downgrade --no-allow-name-change --no-allow-vendor-change";
+        $cmd = $cmd . " $_" foreach (split(/,/, get_required_var("INSTALL_OTHER_PACKAGES")));
+        zypper_call($cmd);
+        save_screenshot;
+
+        # Remove additional repos from SLEM after packages installation finishes.
+        $cmd = "--non-interactive rr";
+        $cmd = $cmd . " $_" foreach (@repos_names);
+        zypper_call($cmd);
+        save_screenshot;
+    }
+}
+
+sub prepare_bootloader {
+    my $self = shift;
+
+    my $serialconsole = get_serial_console();
+    ipmi_backend_utils::add_kernel_options(kernel_opts => "selinux=0 console=tty console=$serialconsole,115200");
+    ipmi_backend_utils::set_grub_terminal_and_timeout(terminals => "console serial", timeout => 30);
+}
+
+sub prepare_services {
+    my $self = shift;
+
+    #Disable rebootmgr service to prevent scheduled maitenance reboot.
+    disable_and_stop_service('rebootmgr.service');
+    systemctl('status rebootmgr.service', ignore_failure => 1);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
* **Changes** to lib/guest_installation_and_configuration_base.pm:
  * **Changed** $common_log_folder to /var/log because /tmp folder will be cleaned up on each reboot, including intended reboot, unexpected reboot or panic reboot.
  * **Wrap** preparation steps that are only pertinent to non-transactional server into subroutine prepare_non_transactional_environment.
  * **Introduced** functionality specific to NetworkManager and also re-organized networking configuration steps to make it clean and clear:
![network_config](https://user-images.githubusercontent.com/38779103/189257969-346d2898-5600-4b40-84c1-e244fed3040c.png)
  * **Schedule** tasks by using systemd on transactional server and re-organized configuration steps to make it clean and clear:
![schedule_tasks](https://user-images.githubusercontent.com/38779103/189257983-1746331c-0d7b-454f-a5fe-7dd57a04ccd5.png)
  * **Disable** selinux and enable ipv4.conf.all.forwarding in config_guest_network_bridge_policy.
  * **Strip** $self->{host_name} to make sure only the host part takes participation in forming guest installation session id.
  * **Add** automation workaround for bsc#1202405 


* **Changes** to module lib/transactional.pm:
  * **enter_trup_shell** handles entering into transactional update shell on transactional server.
  * **exit_trup_shell_and_reboot** handles leaving transactional update shell on transactional server.
  * **reboot_on_changes** handles reboot transactional server if new snapshot created.


* **New** module tests/virt_autotest/transactional/prepare_transactional_server.pm to do preparation work on transactional server, including extension registration, packages installation, services toggle, bootloader customization and etc:
![transactional_preparation](https://user-images.githubusercontent.com/38779103/189258020-c422978d-d2c4-476f-b092-c5287a27d4cd.png)
* **Changes** to lib/ipmi_backend_utils.pm:
  * **New** subroutine set_grub_terminal_and_timeout to handle terminal and corresponding timeout configuring.
  * **Use** more precise boundary match in subroutine add_kernel_options.

* **Changes** to lib/Utils/Backends.pm:
  * **Add** new subroutine save_serial_console to save SUT machine's serial console, otherwise this piece of information will be overwritten by set_sshserial_dev.
  * **Add** new subroutine get_serial_console to obtain SUT machine's serial console.


* **Updated** subroutine subscribe_extensions_and_modules in lib/virt_autotest/utils.pm to use the de-facto version and arch for the extension or module to be de-/registered instead of deriving them from test suite parameters.

* **Use** yaml scheduling file schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml for guest installation on SLE Micro test suite.

* **Profile** and autoyast files for SLE Micro: data/virt_autotest/guest_params_xml_files/slem_5_3_64_kvm_hvm_x86_64.xml and data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml.

* **Updated** SLE 15 SP4 profile data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64.xml to reflect GM and do registration.

* **Verification runs:**
  * [slem5.3 guest on slem5.3 host](http://10.67.131.12/tests/883)
  * [sles15sp4 guest on slem5.3 host](http://10.67.131.12/tests/872)
  * [guest install on slem5.3 host using br0](http://10.67.131.12/tests/834)
  * [oraclelinux on sles15sp4](http://10.67.131.12/tests/795)
  * [sles15sp4 guest on sles12sp5 host](http://10.67.131.12/tests/797)
  * [sles12sp5 guest on sles15sp4 host](http://10.67.131.12/tests/794)
  * [sles15sp4 guest on sles15sp4 host](http://10.67.131.12/tests/873)
  * [opensuseTW on opensuseTW using NetworkManager](http://10.67.131.12/tests/882)
  * [opensuseTW on opensuseTW using wicked](http://10.67.131.12/tests/890)