### PR TITLE
Check if the 'Finish setup' screen appears at boot in Win11

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -123,7 +123,10 @@ sub wait_boot_windows {
     send_key_until_needlematch 'windows-login', 'esc';
     type_password;
     send_key 'ret';    # press shutdown button
-    assert_screen 'windows-desktop', 240;
+    assert_screen ['finish-setting', 'windows-desktop'], 240;
+    if (match_has_tag 'finish-setting') {
+        assert_and_click 'finish-setting';
+    }
 }
 
 sub windows_server_login_Administrator {

--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -143,12 +143,6 @@ sub run {
           q{New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\UserProfileEngagement' -Name ScoobeSystemSettingEnabled -Value 0 -Type DWORD}
     );
 
-    # Disables "Let's finish setting up your device" screen in Windows 11, which
-    # pops up in boot every 3 days
-    $self->run_in_powershell(
-        cmd => 'reg add HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager /v SubscribedContent-310093Enabled /t REG_DWORD /d 0'
-    ) if check_var('WIN_VERSION', '11');
-
     # Disables web search in Start menu
     $self->run_in_powershell(
         cmd => 'reg add HKEY_CURRENT_USER\Policies\Microsoft\Windows\Explorer /v DisableSearchBoxSuggestions /t REG_DWORD /d 1'


### PR DESCRIPTION
In Windows 11, every 3 days, an annoying appears at boot asking to customize the install. I've tried to disable it but it keeps appearing, so a new needle has been added to click on the "postpone 3 days" if it shows.

- Related ticket: https://progress.opensuse.org/issues/115649
- Needles:
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/2a9109d7d86250a2c5742c98cbb9a66a9224ff55/finish-setting-20220825.png
- Verification runs:
  - http://openqa.suse.de/t9405819 --> installation
  - http://openqa.suse.de/t9386477
  - http://openqa.suse.de/t9386479
  - http://openqa.suse.de/t9386576
  - http://openqa.suse.de/t9386583
  - http://openqa.suse.de/t9386585
