### PR TITLE
sles4sap: Adapt code to ha-sap-terraform-deployments 9.0.0

### DIFF
--- a/data/publiccloud/terraform/sap/azure.tfvars
+++ b/data/publiccloud/terraform/sap/azure.tfvars
@@ -255,12 +255,11 @@ hana_cluster_vip = "10.74.1.13"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
 # HANA instance master password. It must follow the SAP Password policies
-#hana_master_password = "YourPassword1234"
+hana_master_password = "YourPass1234!"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_primary_site = "Site1"
 # HANA secondary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_secondary_site = "Site2"
-hana_master_password = "Linux1234"
 
 # Cost optimized scenario
 #scenario_type = "cost-optimized"

--- a/data/publiccloud/terraform/sap/ec2.tfvars
+++ b/data/publiccloud/terraform/sap/ec2.tfvars
@@ -227,12 +227,11 @@ hana_ips = ["10.0.1.5", "10.0.2.6"]
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
 # HANA instance master password. It must follow the SAP Password policies
-#hana_master_password = "YourPassword1234"
+hana_master_password = "YourPass1234!"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_primary_site = "Site1"
 # HANA secondary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_secondary_site = "Site2"
-hana_master_password = "Linux1234"
 
 # Cost optimized scenario
 #scenario_type = "cost-optimized"

--- a/data/publiccloud/terraform/sap/gce.tfvars
+++ b/data/publiccloud/terraform/sap/gce.tfvars
@@ -259,12 +259,11 @@ hana_ips = ["10.0.0.2", "10.0.0.3"]
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
 # HANA instance master password. It must follow the SAP Password policies
-#hana_master_password = "YourPassword1234"
+hana_master_password = "YourPass1234!"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_primary_site = "Site1"
 # HANA secondary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_secondary_site = "Site2"
-hana_master_password = "Linux1234"
 
 # Cost optimized scenario
 #scenario_type = "cost-optimized"

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -452,14 +452,9 @@ sub terraform_apply {
     my $ips;
     my $resource_id;
     if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
-        foreach my $vm_type ('cluster_nodes', 'drbd', 'netweaver') {
-            if (is_azure && $vm_type eq 'cluster_nodes') {
-                push @{$vms}, @{$output->{$vm_type . '_name'}->{value}[0]};
-                push @{$ips}, @{$output->{$vm_type . '_public_ip'}->{value}[0]};
-            } else {
-                push @{$vms}, @{$output->{$vm_type . '_name'}->{value}};
-                push @{$ips}, @{$output->{$vm_type . '_public_ip'}->{value}};
-            }
+        foreach my $vm_type ('hana', 'drbd', 'netweaver') {
+            push @{$vms}, @{$output->{$vm_type . '_name'}->{value}};
+            push @{$ips}, @{$output->{$vm_type . '_public_ip'}->{value}};
         }
     } else {
         $vms = $output->{vm_name}->{value};


### PR DESCRIPTION
The [latest release for ha-sap-terraform-deployments](https://github.com/SUSE/ha-sap-terraform-deployments/releases/tag/9.0.0) changed the name and normalized the output type for the HANA cluster nodes & enforces a [new password policy](https://github.com/SUSE/ha-sap-terraform-deployments/blob/main/doc/sap_passwords.md)

Verification runs:
- Azure: http://1b124.qa.suse.de/tests/180
- GCP: http://1b124.qa.suse.de/tests/176

Related MR:
https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/932