### PR TITLE
wicked-wlan: delay namespace setup of wlan device

### DIFF
--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -189,6 +189,8 @@ sub prepare_phys {
         die("Failed to get netns dummy pid") unless ($output =~ m/BACKGROUND_PROCESS:-(\d+)-/);
         $cmd_set_netns = 'iw phy ' . $self->ref_phy . ' set netns ' . $1;
     }
+    # Delay namespace setup of wlan device to avoid wickedd-nanny error message
+    sleep 3;
     assert_script_run($cmd_set_netns);
 
     assert_script_run('iw dev');


### PR DESCRIPTION
Give the system  some time to create the devices and throw all events.
This avoid a error message in wicked like
```
  Aug 25 02:35:16 install wickedd-nanny[646]: /org/opensuse/Network/Interface/4.getManagedObjects failed. Server responds:
  Aug 25 02:35:16 install wickedd-nanny[646]: org.freedesktop.DBus.Error.UnknownMethod: Method "GetManagedObjects" with signature "" on interface
```
which occur, because wickedd gets the NEWLINK and udev ADD event and emit a DEVICE_CREATED to nanny.
Nanny then tries to call the `getManagedObjects()` call, but the interface was already removed from wickedd again, because of the
move into the namespace.
Alternatively to `sleep` we could use a
```
   while ! dbus-send --system --print-reply --dest=org.opensuse.Network.Nanny /org/opensuse/Network/Nanny org.opensuse.Network.Nanny.getDevice string:"wlan0"; do sleep 1; done
```
but this would request `dbus-send` and wicked is running!

This is the error we see from time to time: http://openqa.wicked.suse.de/tests/77548#step/before_test/34

- Verification run: http://openqa.wicked.suse.de/tests/77590
