### PR TITLE
Increase wget timeout for larger images

### DIFF
--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -19,7 +19,8 @@ use publiccloud::openstack;
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
+    # Better use the root-console here so that the download progress can be monitored in openQA
+    select_console("root-console");
 
     my $provider = $self->provider_factory();
 
@@ -31,14 +32,18 @@ sub run {
         return;
     }
 
-    # Download the given image. Check for 404 errors and make them better visible
-    my $cmd = "wget --no-check-certificate $img_url -O $img_name";
-    my $rc = script_run("$cmd 2>download.txt", timeout => 60 * 10);
+    # Download the given image via wget. Note that by default wget retries 20 times before giving up
+    my $cmd = "wget --no-check-certificate --retry-connrefused --retry-on-host-error $img_url -O $img_name";
+    # A generious timeout is required because downloading up to 30 GB (Azure images) can take more than an hour.
+    my $rc = script_run("$cmd 2>&1 | tee download.txt", timeout => 120 * 60);
     if ($rc != 0) {
+        # Check for 404 errors and make them better visible
         upload_logs("download.txt");
-        script_run("cat download.txt");
-        die "404 - Image not found" if (script_run("grep '404' download.txt") == 0);
-        die "command '$cmd' failed with rc=$rc";
+        # The log contains mostly the download progress bar. Crop the last 10 lines for better visibility
+        my $output = script_output("tail -n 10 download.txt");
+        record_info("wget failed with status code $rc", "$cmd\n\n$output");
+        die "404 - Image not found" if ($output =~ "ERROR 404: Not Found");
+        die "wget failed with return code $rc";
     }
     $provider->upload_img($img_name);
 }


### PR DESCRIPTION
To account for the increased size of Azure images (30GB) we need to
increase the timeout for `wget` downloads, which can take now more than an hour.

- Related ticket: https://progress.opensuse.org/issues/112883
- Verification run: https://duck-norris.qam.suse.de/tests/10487 and https://duck-norris.qam.suse.de/tests/10488
