### PR TITLE
Record soft failure if language isn't tranlated

### DIFF
--- a/tests/installation/licensing/verify_license_translations.pm
+++ b/tests/installation/licensing/verify_license_translations.pm
@@ -55,7 +55,7 @@ sub run {
         $license_agreement->select_language($translation->{language});
         $license_agreement_info = $license_agreement->collect_current_license_agreement_info();
         if ($license_agreement_info->{text} !~ /$translation->{text}/) {
-            $errors .= "EULA content for the language: '$translation->{language}' didn't validate. Please, see autoints-log for the detailed content of EULA\n";
+            record_soft_failure("EULA content for the language: '$translation->{language}' didn't validate. See bsc#1203004 for details.\n");
             diag("EULA validation failed:\nExpected:\n$translation->{text}\nActual:\n$license_agreement_info->{text}\n\n");
         }
     }


### PR DESCRIPTION
### Links to tickets, needles and VRs

- Related ticket: https://progress.opensuse.org/issues/115358
- Needles: -
- Verification run: [SLE 15 SP5](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=softfail_license_translations&groupid=96) (note that the modified test softfails, but the whole test suite fails later)

### Additional info 

- in case of not validating EULA translations we now just record a soft
  failure instead of letting the test die.
- other problems like wrong preselected default language or
  langauage is not available will still lead to errors.
- So in the beginning of the product lifecycle we won't fail
  anymore, just record soft failures. At the end, close to GM,
   those soft failures should not happen anymore.

