### PR TITLE
Limit swap space to 2GB in pc_tools image

### DIFF
--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -116,13 +116,14 @@
       <partitions config:type="list">
         <partition>
           <mountby config:type="symbol">device</mountby>
-          <filesystem config:type="symbol">swap</filesystem>
-          <mount>swap</mount>
+          <filesystem config:type="symbol">ext4</filesystem>
+          <mount>/</mount>
         </partition>
         <partition>
           <mountby config:type="symbol">device</mountby>
-          <filesystem config:type="symbol">ext4</filesystem>
-          <mount>/</mount>
+          <filesystem config:type="symbol">swap</filesystem>
+          <mount>swap</mount>
+          <size>2G</size>
         </partition>
       </partitions>
       <use>all</use>


### PR DESCRIPTION
Limit the swap partition to 2GB instead of using half of the available
disk space (currently 50GB) for swap.

- Related ticket: https://progress.opensuse.org/issues/112883
- Verification run: https://duck-norris.qam.suse.de/t10481
