### PR TITLE
Increase timeout for cockpit modules installation

### DIFF
--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -43,7 +43,7 @@ sub run {
 
     if (@pkgs) {
         record_info('TEST', 'Installing Cockpit\'s Modules...');
-        trup_call("pkg install @pkgs", timeout => 300);
+        trup_call("pkg install @pkgs", timeout => 360);
         check_reboot_changes;
     }
 


### PR DESCRIPTION
Failure on aarch64: https://openqa.suse.de/tests/9387387#step/cockpit_service/16

