### PR TITLE
Remove swap partition

### DIFF
--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -119,12 +119,6 @@
           <filesystem config:type="symbol">ext4</filesystem>
           <mount>/</mount>
         </partition>
-        <partition>
-          <mountby config:type="symbol">device</mountby>
-          <filesystem config:type="symbol">swap</filesystem>
-          <mount>swap</mount>
-          <size>2G</size>
-        </partition>
       </partitions>
       <use>all</use>
     </drive>


### PR DESCRIPTION
Completely remove the swap partition from the PC tools image, since it
is not needed.

- Related ticket: https://progress.opensuse.org/issues/112883
- Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15415
- Verification run: https://duck-norris.qam.suse.de/tests/10483
