### PR TITLE
wait for the screen to be still after tab key press

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -80,6 +80,7 @@ sub run {
             # It takes longer time to show multilple release notes for addons
             assert_screen([qw(release-notes-sle-ok-button release-notes-sle-close-button)], 300);
         }
+        wait_still_screen(2);
         for my $i (@addons) {
             next if grep { $i eq $_ } @no_relnotes;
             send_key_until_needlematch("release-notes-$i", 'right', 4, 60);


### PR DESCRIPTION
To avoid pressing the _right_ key before the previous _tab_ has been taken effect wait for a still screen for 2 seconds.

- Related: https://github.com/os-autoinst/os-autoinst/pull/2123#issuecomment-1219366078
- Verification run: https://openqa.suse.de/tests/9387550#step/releasenotes/3
