### PR TITLE
Update trufflehog job description

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,4 +1,4 @@
-name: Leaked Secrets Scan
+name: WIP. Please Ignore this failure. Leaked Secrets Scan Test
 on:
   pull_request:
   push:


### PR DESCRIPTION
To make clear that this check can be ignored for the time being.

Still trying to understand why sometimes it scans the entire repo and sometimes only the PR delta.


