### PR TITLE
Wait for still screen after pressing ok 

### DIFF
--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -50,6 +50,7 @@ sub run {
     wait_still_screen 1;
     wait_screen_change { type_string "5" };
     wait_screen_change { send_key "alt-o" };
+    wait_still_screen 3;
 
     # Check previously set values + Miscellaneous Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);


### PR DESCRIPTION
yast2_security test module fills in login settings and press ok, then immediately launch another YaST modules, while the system is still applying the configuration. 

This change introduces a small delay so the screen has time to stabilize before opening the next configuration item.

- Verification run: https://openqa.suse.de/tests/9392980#
