### PR TITLE
syscall_thrasher.pm: retry on trash failure

### DIFF
--- a/tests/security/atsec/syscall_thrasher.pm
+++ b/tests/security/atsec/syscall_thrasher.pm
@@ -38,7 +38,10 @@ sub run {
 
     # Run the test
     assert_script_run("cd $test_dir");
-    assert_script_run("./$exe_file", timeout => 1200);
+
+    # Since this randomly fails, we retry 10 times each time adding a delay before failing and exiting.
+    script_retry("./$exe_file", retry => 10, timeout => 1200, delay => 60);
+
     assert_script_run('ls');
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/115754 and https://progress.opensuse.org/issues/118360
- Verification run: https://openqa.suse.de/tests/9743022