### PR TITLE
Softfail "bsc#1188215" in slem5.2

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -180,7 +180,7 @@
     "bsc#1188215": {
         "description": "Failed to start Create missing directories from rpmdb",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.3" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
             "microos":  ["Tumbleweed"]
         },
         "type": "bug"


### PR DESCRIPTION
Known bug that was currently fixed in slem5.3, but as of now we need to
softfail on slem5.2 in order to unblock updates

- fail: https://openqa.suse.de/tests/9403083
- Verification run: [ sle-micro-5.2-DVD-Updates-x86_64-Build20220828-1-slem_installation_autoyast@64bit](http://kepler.suse.cz/tests/18999)
