### PR TITLE
Ignore combustion|ignition device time outs

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -335,6 +335,8 @@
     "no-config-drive": {
         "description": "Timed out waiting for device (/dev/disk/by-label/ignition|/dev/combustion/config)",
         "products": {
+            "leap-micro": ["5.3"],
+            "sle-micro": ["5.3"],
             "microos":  ["Tumbleweed"]
         },
         "type": "ignore"


### PR DESCRIPTION
In case of testing sle|micro-without with `wizard` option tests should
ignore systemd device timeouts for related config drives.

- failure: https://openqa.suse.de/tests/9394768#step/journal_check/23
- Verification run: http://kepler.suse.cz/tests/19005#step/journal_check/20
