### PR TITLE
Validate output from pdsh

### DIFF
--- a/tests/hpc/pdsh_slave.pm
+++ b/tests/hpc/pdsh_slave.pm
@@ -36,6 +36,7 @@ sub run ($self) {
     $self->switch_user('nobody');
     my $genders_plugin = get_var('PDSH_GENDER_TEST') ? '-g type=genders-test' : '';
     assert_script_run("pdsh -R mrsh $genders_plugin -w $server_hostname ls / &> /tmp/pdsh.log");
+    assert_script_run("test -s /tmp/pdsh.log");
     upload_logs '/tmp/pdsh.log';
     barrier_wait("PDSH_SLAVE_DONE");
 }


### PR DESCRIPTION
Test doesnt validate whether the file contains any context or not. So this
patch perform a minimal validation that indicates that the file is not
empty. I dont add checks for the actual context as i am not of its impoirtance
in this case

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/115928
- Verification run: http://aquarius.suse.cz/tests/12102
