### PR TITLE
Fix timeout issue in the pkcon test

### DIFF
--- a/tests/console/pkcon.pm
+++ b/tests/console/pkcon.pm
@@ -34,7 +34,7 @@ sub run {
     foreach (@command) {
         script_run "pkcon $_";
     }
-    script_run("pkcon install $pkgname --allow-reinstall --allow-downgrade -y");
+    script_run("pkcon install $pkgname --allow-reinstall --allow-downgrade -y", 300);
 
     # restore previous state for packagekit service
     quit_packagekit;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/115886
- Needles: No
- Verification run:
  15-SP5 : [aarch64](https://openqa.suse.de/tests/9426814#step/pkcon/25) | [x86_64](https://openqa.suse.de/tests/9426508#step/pkcon/25) | [ppc64le](https://openqa.suse.de/tests/9426507#step/pkcon/25) | [svirt-xen-hvm ](https://openqa.suse.de/tests/9426509#step/pkcon/25)
Leap: [x86_64](https://openqa.suse.de/tests/9426509#step/pkcon/25) | [aarch54](https://openqa.opensuse.org/tests/2597308#step/pkcon/22)
Tumbleweed: [x86_64](https://openqa.opensuse.org/tests/2597306#step/pkcon/22)
