### PR TITLE
Add PUBLIC_CLOUD_TERRAFORM_DIR variable

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -19,7 +19,7 @@ use Mojo::JSON qw(decode_json encode_json);
 use utils qw(file_content_replace script_retry);
 use mmapi;
 
-use constant TERRAFORM_DIR => '/root/terraform';
+use constant TERRAFORM_DIR => get_var('PUBLIC_CLOUD_TERRAFORM_DIR', '/root/terraform');
 use constant TERRAFORM_TIMEOUT => 30 * 60;
 
 has prefix => 'openqa';

--- a/variables.md
+++ b/variables.md
@@ -298,3 +298,4 @@ PUBLIC_CLOUD_TERRAFORM_FILE | string | "" | If defined, use this terraform file 
 TERRAFORM_TIMEOUT | integer | 1800 | Set timeout for terraform actions
 PUBLIC_CLOUD_INSTANCE_IP | string | "" | If defined, no instance will be created and this IP will be used to connect to
 _SECRET_PUBLIC_CLOUD_INSTANCE_SSH_KEY | string | "" | The `~/.ssh/id_rsa` existing key allowed by `PUBLIC_CLOUD_INSTANCE_IP` instance
+PUBLIC_CLOUD_TERRAFORM_DIR | string | "/root/terraform" | Override default root path to terraform directory


### PR DESCRIPTION
Currently public cloud library contains only static value for root 
terraform directory '/root/terraform'. This is problematic for 
projects having different directory structure. This PR adds OpenQA 
variable which will allow to override TERRAFORM_DIR value.

- Related ticket: https://jira.suse.com/browse/TEAM-6642
- Needles: None
- Verification run: 
  Using default value: https://mordor.suse.cz/tests/4286#step/sles4sap/49
  Variable set to "/root/qesap/terraform": https://mordor.suse.cz/tests/4283#step/sles4sap/49

* VRs are failing because of unrelated issue, terraform apply triggered from correct directories.