### PR TITLE
Add library for RPI

### DIFF
--- a/lib/rpi.pm
+++ b/lib/rpi.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+package rpi;
+
+use warnings;
+use strict;
+
+use Exporter 'import';
+use testapi;
+use power_action_utils 'power_action';
+
+our @EXPORT = 'enable_tpm_slb9670';
+
+# Enable TPM on Raspberry Pi
+# https://en.opensuse.org/HCL:Raspberry_Pi3_TPM
+sub enable_tpm_slb9670 {
+    my $module = "tpm_tis_spi";
+
+    assert_script_run('echo -e "dtparam=spi=on\ndtoverlay=tpm-slb9670" >> /boot/efi/extraconfig.txt');
+    assert_script_run('cat /boot/efi/extraconfig.txt');
+    assert_script_run("echo '$module' > /etc/modules-load.d/tpm.conf");
+    power_action('reboot', textmode => 1);
+
+    # Add some timeout to wait for reboot
+    sleep(60);
+
+    # Restore SSH connection
+    reset_consoles;
+    select_console('root-ssh');
+
+    record_info('RPi TPM', script_output("dmesg | grep '$module.*2.0 TPM.*device-id.*rev-id'"));
+}
+
+1;

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -23,6 +23,7 @@ use version_utils qw(is_jeos is_opensuse is_released is_sle is_leap is_tumblewee
 use Utils::Architectures;
 use Utils::Systemd qw(systemctl disable_and_stop_service);
 use LTP::utils;
+use rpi 'enable_tpm_slb9670';
 
 sub add_we_repo_if_available {
     # opensuse doesn't have extensions
@@ -356,6 +357,8 @@ sub run {
     if (!get_var('KGRAFT') && !get_var('LTP_BAREMETAL') && !is_jeos) {
         $self->wait_boot;
     }
+
+    enable_tpm_slb9670 if (get_var('MACHINE') =~ /RPi/);
 
     $self->select_serial_terminal;
 


### PR DESCRIPTION
ATM containing only single method.

Verification run:
* **https://openqa.opensuse.org/tests/2584395 opensuse-Tumbleweed-JeOS-for-RPi-aarch64-Buildpevik_os-autoinst-distri-opensuse_lib-rpi-jeos-ltp-ima@pevik_os-autoinst-distri-opensuse_lib-rpi@RPi4**
NOTE: error on https://openqa.opensuse.org/tests/2584395#step/ima_tpm/8 is bug found by LTP test, which is visible due this change (good we found a problem in OS => no need to hide that)

Verifications non-RPI tests still work:
* https://openqa.opensuse.org/tests/2580422 opensuse-Tumbleweed-DVD-x86_64-Buildpevik_os-autoinst-distri-opensuse_lib-rpi-security_swtpm@pevik_os-autoinst-distri-opensuse_lib-rpi@64bit
* https://openqa.opensuse.org/tests/2580421 opensuse-Tumbleweed-DVD-x86_64-Buildpevik_os-autoinst-distri-opensuse_lib-rpi-security_swtpm_uefi@pevik_os-autoinst-distri-opensuse_lib-rpi@64bit

@STARRY-S do we run on o3?
@ggardet FYI
