### PR TITLE
Add bzip2 to the install profile

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
@@ -34,6 +34,7 @@
     <install_recommended config:type="boolean">true</install_recommended>
     <packages config:type="list">
       <package>grub2</package>
+      <package>bzip2</package>
     </packages>
     <patterns config:type="list">
       <pattern>basesystem</pattern>


### PR DESCRIPTION
Add the bzip2 package to the SLE Micro installation profile, required by
openQA's log collection.

- Related ticket: https://progress.opensuse.org/issues/115586
- Verification run: https://duck-norris.qam.suse.de/tests/10531#step/logs/3
