### PR TITLE
Capture installed and uninstalled packages during test (PR v2)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1317,6 +1317,7 @@ sub load_consoletests {
     }
     loadtest "console/nginx" if ((is_opensuse && !is_staging) || (is_sle('15+') && !is_desktop));
     loadtest 'console/orphaned_packages_check' if is_jeos || get_var('UPGRADE') || get_var('ZDUP') || !is_sle('<12-SP4');
+    loadtest "console/zypper_log_packages" unless x11tests_is_applicable();
     loadtest "console/consoletest_finish";
 }
 
@@ -1469,6 +1470,7 @@ sub load_x11tests {
             loadtest "x11/reboot_lxde";
         }
     }
+    loadtest "console/zypper_log_packages";
     # Need to skip shutdown to keep backend alive if running rollback tests after migration
     unless (get_var('ROLLBACK_AFTER_MIGRATION')) {
         load_shutdown_tests;

--- a/schedule/functional/extra_tests_clamav.yaml
+++ b/schedule/functional/extra_tests_clamav.yaml
@@ -7,3 +7,4 @@ schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
     - console/clamav
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_dracut.yaml
+++ b/schedule/functional/extra_tests_dracut.yaml
@@ -7,3 +7,4 @@ schedule:
     - boot/boot_to_desktop
     - console/dracut
     - console/coredump_collect
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_gnome.yaml
+++ b/schedule/functional/extra_tests_gnome.yaml
@@ -68,3 +68,4 @@ schedule:
     - console/check_default_network_manager
     - '{{python_liblouis}}'
     - console/coredump_collect
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_gnome_sdk.yaml
+++ b/schedule/functional/extra_tests_gnome_sdk.yaml
@@ -9,3 +9,4 @@ schedule:
     - console/consoletest_setup
     - x11/libqt5_qtbase
     - console/coredump_collect
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_gnuhealth.yaml
+++ b/schedule/functional/extra_tests_gnuhealth.yaml
@@ -9,3 +9,4 @@ schedule:
     - gnuhealth/gnuhealth_client_install
     - gnuhealth/gnuhealth_client_preconfigure
     - gnuhealth/gnuhealth_client_first_time
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_misc.yaml
+++ b/schedule/functional/extra_tests_misc.yaml
@@ -21,3 +21,4 @@ schedule:
     - console/journalctlLevels
     - console/perf
     - '{{tw_tests}}'
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_networkd.yaml
+++ b/schedule/functional/extra_tests_networkd.yaml
@@ -9,3 +9,4 @@ schedule:
     - networkd/networkd_vlan
     - networkd/networkd_bridge
     - console/coredump_collect
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_ovs.yaml
+++ b/schedule/functional/extra_tests_ovs.yaml
@@ -14,3 +14,4 @@ schedule:
     - installation/bootloader_start
     - network/setup_multimachine
     - '{{ovs}}'
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_qemu.yaml
+++ b/schedule/functional/extra_tests_qemu.yaml
@@ -21,3 +21,4 @@ schedule:
     - qemu/qemu
     - '{{kvm}}'
     - '{{user}}'
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -170,3 +170,4 @@ schedule:
     - '{{tumbleweed_tests}}'
     - console/tar
     - console/coredump_collect
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_textmode_mod_desktop.yaml
+++ b/schedule/functional/extra_tests_textmode_mod_desktop.yaml
@@ -19,3 +19,4 @@ schedule:
     - console/consoletest_setup
     - '{{tests_requiring_soundcard}}'
     - console/libvorbis
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -12,6 +12,7 @@ schedule:
     - console/vmstat
     - console/sssd_389ds_functional
     - console/coredump_collect
+    - console/zypper_log_packages
 conditional_schedule:
     wpa_supplicant:
         ARCH:

--- a/schedule/functional/extra_tests_textmode_sdk.yaml
+++ b/schedule/functional/extra_tests_textmode_sdk.yaml
@@ -7,3 +7,4 @@ schedule:
     - boot/boot_to_desktop
     - console/gdb
     - console/coredump_collect
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_toolkits.yaml
+++ b/schedule/functional/extra_tests_toolkits.yaml
@@ -17,3 +17,4 @@ schedule:
     - x11/toolkits/qt5
     - x11/toolkits/swing
     - console/coredump_collect
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_transactional_server.yaml
+++ b/schedule/functional/extra_tests_transactional_server.yaml
@@ -13,3 +13,4 @@ schedule:
     - transactional/transactional_update
     - transactional/rebootmgr
     - transactional/health_check
+    - console/zypper_log_packages

--- a/schedule/functional/extra_tests_webframeworks.yaml
+++ b/schedule/functional/extra_tests_webframeworks.yaml
@@ -8,3 +8,4 @@ schedule:
     - console/prepare_test_data
     - console/django
     - console/flask
+    - console/zypper_log_packages

--- a/t/data/test_schedule.out
+++ b/t/data/test_schedule.out
@@ -61,4 +61,5 @@ tests/x11/kate.pm
 tests/x11/amarok.pm
 tests/x11/kontact.pm
 tests/x11/reboot_plasma5.pm
+tests/console/zypper_log_packages.pm
 tests/shutdown/shutdown.pm

--- a/tests/console/zypper_log_packages.pm
+++ b/tests/console/zypper_log_packages.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: zypper
+# Summary: gather info about installed/removed packages during the test
+# Maintainer: Dominik Heidler <dheidler@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+use Utils::Logging;
+use Mojo::JSON qw(to_json);
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    my $zypper_packages = {};
+    $zypper_packages->{commands} = $testapi::distri->{zypper_packages} // [];
+    my $individual_pkgs = script_output('grep "|\(Installing:\|Removing\) .*} END" /var/log/zypper.log', proceed_on_failure => 1);
+    # this looks like this:
+    # 2022-08-05 12:18:55 <1> athene(13626) [Progress++] progressdata.cc(report):89 {#24|Installing: xosview-1.22-1.10.x86_64} END
+    # 2022-08-05 12:19:48 <1> athene(13993) [Progress++] progressdata.cc(report):89 {#21|Removing xosview-1.22-1.10.x86_64} END
+    $zypper_packages->{individual_pkgs} = [];
+    while ($individual_pkgs =~ m/\|([A-Z][a-z]*):? ([^}]*)}/g) {
+        my $action;
+        if ($1 eq "Installing") { $action = "install"; }
+        elsif ($1 eq "Removing") { $action = "remove"; }
+        $2 =~ m/(.+)-([^-]+)-([^-]+)\.([^.]+)/;
+        push(@{$zypper_packages->{individual_pkgs}}, {
+                action => $action,
+                package => $1,
+                version => $2,
+                release => $3,
+                arch => $4,
+        });
+    }
+
+    save_ulog(to_json($zypper_packages), "zypper_packages.json");
+    record_info('zypper_packages.json', "zypper_packages.json was saved via worker", result => 'ok');
+}
+
+1;


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/115478
VR: http://kazhua.qa.suse.de/tests/149

As suggested in the ticket this uses `save_ulog` to directly save
the asset into the right folder on the worker filesystem.

This reapplies the changes reverted in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15439 with stated fix.
This version of the code doesn't rely on https://github.com/os-autoinst/os-autoinst/pull/2149 anymore.