### PR TITLE
WIP: Ready bsc#1165915 check for transactional systems

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: module loader of container tests

--- a/lib/publiccloud/instances.pm
+++ b/lib/publiccloud/instances.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Base class for the public cloud namespace
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+package publiccloud::instances;
+
+our @instances;    # Package variable containing all instanciated instances for global access without RunArgs
+
+sub set_instances {
+    @instances = @_;
+}
+
+sub get_instance {
+    return undef if (scalar @instances) < 1;
+    return $instances[0];
+}
+
+1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -11,6 +11,7 @@ package publiccloud::provider;
 use testapi qw(is_serial_terminal :DEFAULT);
 use Mojo::Base -base;
 use publiccloud::instance;
+use publiccloud::instances;
 use publiccloud::utils 'is_azure';
 use Carp;
 use List::Util qw(max);
@@ -479,6 +480,7 @@ sub terraform_apply {
     }
 
     # Return an ARRAY of objects 'instance'
+    publiccloud::instances::set_instances(@instances);
     return @instances;
 }
 

--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -77,20 +77,21 @@ sub select_host_console {
     if ($tunneled && check_var('_SSH_TUNNELS_INITIALIZED', 1)) {
         die("Called select_host_console but we are in TUNNELED mode") unless ($args{force});
 
-        opensusebasetest::select_serial_terminal();
-        ssh_interactive_leave();
-
         select_console('tunnel-console', await_console => 0);
+        sleep 30;
         send_key 'ctrl-c';
         send_key 'ret';
+
+        ssh_interactive_leave();
 
         set_var('_SSH_TUNNELS_INITIALIZED', 0);
         opensusebasetest::clear_and_verify_console();
         save_screenshot;
+    } else {
+        set_var('TUNNELED', 0) if $tunneled;
+        opensusebasetest::select_serial_terminal();
+        set_var('TUNNELED', $tunneled);
     }
-    set_var('TUNNELED', 0) if $tunneled;
-    opensusebasetest::select_serial_terminal();
-    set_var('TUNNELED', $tunneled) if $tunneled;
 }
 
 1;

--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -1,11 +1,11 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Class with helpers related to SSH Interactive mode
 #
-# Maintainer: Pavel Dostal <pdostal@suse.cz>
+# Maintainer: qa-c@suse.de
 
 package publiccloud::ssh_interactive;
 use base Exporter;
@@ -13,8 +13,17 @@ use testapi;
 use Utils::Backends qw(set_sshserial_dev unset_sshserial_dev);
 use strict;
 use warnings;
+use distribution;
 
 our @EXPORT = qw(ssh_interactive_tunnel ssh_interactive_leave select_host_console);
+
+sub active_console {
+    my $console = $_[0];
+    select_console("$console");
+    record_info("activating $console", "Activating the '$console' console");
+    script_run('ssh -t sut', timeout => 0);
+    save_screenshot;
+}
 
 sub ssh_interactive_tunnel {
     # Establish the ssh interarctive tunnel to the publiccloud instance.
@@ -28,40 +37,73 @@ sub ssh_interactive_tunnel {
     die '$serialdev is not set' if (!defined $serialdev || $serialdev eq '');
     return if ($args{force} != 1 && get_var('_SSH_TUNNELS_INITIALIZED', 0) == 1);
 
+    my $prev_console = current_console();
+    select_console('tunnel-console') unless ($prev_console =~ /tunnel-console/);
+
     # Prepare the environment for the SSH tunnel
     my $upload_port = get_required_var('QEMUPORT') + 1;
     my $upload_host = testapi::host_ip();
 
-    $instance->ssh_script_run(
-        # Create /dev/sshserial fifo on remote and tail|tee it to /dev/$serialdev on local
-        #   timeout => switches to script_run instead of script_output to be used so the test will not wait for the command to end
-        #   tunnel the worker port (for downloading from data/ and uploading assets / logs
-        cmd => "'rm -rf /dev/sshserial; mkfifo -m a=rwx /dev/sshserial; tail -fn +1 /dev/sshserial' 2>&1 | tee /dev/$serialdev; clear",
-        timeout => 0,
-        no_quote => 1,
-        ssh_opts => "-yt -R $upload_port:$upload_host:$upload_port",
-        username => 'root',
-    );
-    sleep 3;
-    save_screenshot;
+    if (get_var("TUNNEL_AUTO_SSH")) {
+        ## TODO: Use autossh -f to run in background
+        # Pipe the output of the device fifo to the local serial terminal
+        my $tunnel_pid = background_script_run("autossh -M 20000 sut 'rm -f /dev/sshserial && mkfifo -m a=rwx /dev/sshserial && tail -fn +1 /dev/sshserial' 2>&1 >/dev/$serialdev", quiet => 1);
+        sleep 3;
+        save_screenshot;
+        record_info("autossh", "ssh tunnel started as process $tunnel_pid");
+        # When re-activing the consoles we also need to setup the underlying ssh connections again
+        if (get_var('_SSH_TUNNELS_INITIALIZED')) {
+            active_console("root-console");
+            active_console("user-console");
+            active_console("user-virtio-terminal");
+            active_console("root-virtio-terminal");
+        }
+    } else {
+        $instance->ssh_script_run(
+            # Create /dev/sshserial fifo on remote and tail|tee it to /dev/$serialdev on local
+            #   timeout => switches to script_run instead of script_output to be used so the test will not wait for the command to end
+            #   tunnel the worker port (for downloading from data/ and uploading assets / logs
+            cmd => "'rm -rf /dev/sshserial; mkfifo -m a=rwx /dev/sshserial; tail -fn +1 /dev/sshserial' 2>&1 | tee /dev/$serialdev; clear",
+            timeout => 0,
+            no_quote => 1,
+            ssh_opts => "-yt -R $upload_port:$upload_host:$upload_port",
+            username => 'root',
+        );
+        sleep 3;
+        save_screenshot;
+    }
 
     set_var('SERIALDEV_', $serialdev);
     set_var('_SSH_TUNNELS_INITIALIZED', 1);
 
     set_var('AUTOINST_URL_HOSTNAME', 'localhost');
     set_sshserial_dev();
+
+    select_console($prev_console) if ($prev_console !~ /tunnel-console/);
 }
 
 sub ssh_interactive_leave {
-    # Check if the SSH tunnel is still up and leave the SSH interactive session
-    script_run("test -p /dev/sshserial && exit", timeout => 0);
+    if (get_var("TUNNEL_AUTO_SSH")) {
+        my $prev_console = current_console();
+        select_console('tunnel-console') unless ($prev_console !~ /tunnel-console/);
+        script_run("killall -q autossh");
+        set_var('AUTOINST_URL_HOSTNAME', testapi::host_ip());
+        unset_sshserial_dev();
+        $testapi::distri->set_standard_prompt('root');
+        assert_script_run("hostname");
+        assert_script_run("whoami");
+        select_console($prev_console) if ($prev_console !~ /tunnel-console/);
+    } else {
+        # Check if the SSH tunnel is still up and leave the SSH interactive session
+        script_run("test -p /dev/sshserial && exit", timeout => 0);
 
-    # Restore the environment to not use the SSH tunnel for upload/download from the worker
-    #set_var('SUT_HOSTNAME',          testapi::host_ip());
-    set_var('AUTOINST_URL_HOSTNAME', testapi::host_ip());
-    unset_sshserial_dev();
+        # Restore the environment to not use the SSH tunnel for upload/download from the worker
+        #set_var('SUT_HOSTNAME',          testapi::host_ip());
+        set_var('AUTOINST_URL_HOSTNAME', testapi::host_ip());
+        unset_sshserial_dev();
 
-    $testapi::distri->set_standard_prompt('root');
+        $testapi::distri->set_standard_prompt('root');
+    }
 }
 
 # Select console on the test host, if force is set, the interactive session will
@@ -74,9 +116,16 @@ sub select_host_console {
     $args{force} //= 0;
     my $tunneled = get_var('TUNNELED');
 
-    if ($tunneled && check_var('_SSH_TUNNELS_INITIALIZED', 1)) {
+    # In autossh mode, the tunnel console is not blocked.
+    if ($tunneled && check_var("TUNNEL_AUTO_SSH", 1)) {
+        select_console('tunnel-console');
+        opensusebasetest::clear_and_verify_console();
+        sleep 30;
+        save_screenshot;
+    } elsif ($tunneled && check_var('_SSH_TUNNELS_INITIALIZED', 1)) {
         die("Called select_host_console but we are in TUNNELED mode") unless ($args{force});
 
+        # Note: The console is blocked by the ssh tunnel, so don't await_console
         select_console('tunnel-console', await_console => 0);
         sleep 30;
         send_key 'ctrl-c';

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(
   is_azure
   is_gce
   is_container_host
+  is_slem_on_pc
   registercloudguest
   register_addon
   register_openstack
@@ -174,6 +175,10 @@ sub is_gce() {
 
 sub is_container_host() {
     return is_public_cloud && get_var('FLAVOR') =~ 'CHOST';
+}
+
+sub is_slem_on_pc() {
+    return is_public_cloud && get_var('FLAVOR') =~ 'Micro';
 }
 
 sub define_secret_variable {

--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -18,8 +18,6 @@ use version_utils qw(is_microos is_sle_micro is_leap_micro);
 sub run {
     my ($self) = @_;
 
-    select_console 'root-console';
-
     # Install cockpit if needed, this is needed for DVD flavor where
     # Cockpit pattern is not selected during install
     my @pkgs = ();

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -34,7 +34,12 @@ sub run {
 
     select_host_console();    # select console on the host, not the PC instance
 
-    if (is_container_host()) {
+    if (is_slem_on_pc) {
+        # SLEM on PublicCloud is still using SUSEConnect
+        $instance->ssh_assert_script_run("sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'));
+        $instance->ssh_assert_script_run("sudo zypper lr");
+        return;
+    } elsif (is_container_host()) {
         # CHOST images don't have registercloudguest pre-installed. To install it we need to register which make it impossible to do
         # all BYOS related checks. So we just regestering system and going further
         registercloudguest($instance);

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -44,8 +44,8 @@ sub run {
 
     assert_script_run("lsblk");
 
-    # Install bzip2 to check for bsc#1165915
-    zypper_call("in bzip2");
+    # Check for bsc#1165915
+    zypper_call("ref");
 
     assert_script_run("SUSEConnect --status-text", 300);
     zypper_call("lr -d");

--- a/tests/publiccloud/prepare_slem.pm
+++ b/tests/publiccloud/prepare_slem.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Prepare SLEM on PublicCloud
+#          This test run installs the required tools for the subsequent test runs.
+#          If you need packages please add them in here to avoid unnecessary reboots during the test runs.
+#
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::ssh_interactive 'select_host_console';
+
+sub run {
+    my ($self, $args) = @_;
+    my $instance = $args->{my_instance};
+    select_host_console();    # select console on the openQA VM, not the PC instance
+
+    # Not needed atm
+    return;
+
+    # Install all necessary packages at once because we have a transactional system that requires rebooting
+    my @pkgs = qw(podman);
+
+    $instance->ssh_assert_script_run("sudo transactional-update -n pkg in @pkgs");
+    $instance->softreboot();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -7,14 +7,14 @@
 # python3-img-proof azure-cli
 # Summary: Install IPA tool
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: qa-c team <qa-c@suse.de>
 
 use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
 use utils;
-use registration 'add_suseconnect_product';
+use registration;
 use version_utils qw(is_sle is_opensuse);
 use repo_tools 'generate_version';
 
@@ -71,6 +71,9 @@ sub run {
     ensure_ca_certificates_suse_installed();
 
     # Install prerequesite packages test
+    add_suseconnect_product(get_addon_fullname('phub')) if is_sle();
+    zypper_call('-q in autossh');
+
     zypper_call('-q in python3-pip python3-devel python3-virtualenv python3-img-proof python3-img-proof-tests podman docker jq rsync');
     record_info('python', script_output('python --version'));
     systemctl('enable --now docker');

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -25,11 +25,20 @@ sub run {
     # Preserve args for post_fail_hook
     $self->{provider} = $args->{my_provider};    # required for cleanup
     $self->{instance} = $args->{my_instance};
+    my $instance = $args->{my_instance};
 
     select_host_console();    # select console on the host, not the PC instance
 
-    registercloudguest($args->{my_instance});
-    register_addons_in_pc($args->{my_instance});
+
+    if (is_slem_on_pc) {
+        # SLEM on PublicCloud is still using SUSEConnect
+        $instance->ssh_assert_script_run("sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'));
+        $instance->ssh_assert_script_run("sudo zypper lr");
+        return;
+    } else {
+        registercloudguest($args->{my_instance});
+        register_addons_in_pc($args->{my_instance});
+    }
 }
 
 sub post_fail_hook {

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -1,12 +1,12 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: openssh
 # Summary: This tests will establish the tunnel and enable the SSH interactive console
 #
-# Maintainer: Pavel Dostal <pdostal@suse.cz>
+# Maintainer: qa-c@suse.de
 
 use Mojo::Base 'consoletest';
 use testapi;
@@ -34,7 +34,11 @@ sub run {
             select_console($setup_console);
             # The verbose output is visible only at the tunnel-console -
             #   it doesn't interfere with tests as it isn't piped to /dev/sshserial
-            script_run('ssh -E /var/tmp/ssh_sut.log -vt sut', timeout => 0);
+            if (get_var("TUNNEL_AUTO_SSH")) {
+                script_run('autossh -M 20002 sut', timeout => 0);
+            } else {
+                script_run('ssh -E /var/tmp/ssh_sut.log -vt sut', timeout => 0);
+            }
         }
     }
     die("expect ssh serial") unless (get_var('SERIALDEV') =~ /ssh/);

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -33,7 +33,7 @@ sub run {
     }
 
     # Download the given image via wget. Note that by default wget retries 20 times before giving up
-    my $cmd = "wget --no-check-certificate --retry-connrefused --retry-on-host-error $img_url -O $img_name";
+    my $cmd = "wget -q --no-check-certificate --retry-connrefused --retry-on-host-error $img_url -O $img_name";
     # A generious timeout is required because downloading up to 30 GB (Azure images) can take more than an hour.
     my $rc = script_run("$cmd 2>&1 | tee download.txt", timeout => 120 * 60);
     if ($rc != 0) {


### PR DESCRIPTION
Replace the check for bsc#1165915 with a zypper call that will also work
on transactional systems, e.g. SLE Micro on Public Cloud.

- Related ticket: https://progress.opensuse.org/issues/110791
- Verification run: https://duck-norris.qam.suse.de/tests/10540
