### PR TITLE
Fix timeout issue in java test

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -157,7 +157,7 @@ sub trup_call {
 
     my $script = "transactional-update $cmd > /dev/$serialdev";
     # Only print trup-0- if it's reliably read later (see below)
-    $script .= "; echo trup-\$?- > /dev/$serialdev" unless $cmd =~ /reboot / && $args{exit_code} == 0;
+    $script .= "; echo trup-\$?- | tee -a /dev/$serialdev" unless $cmd =~ /reboot / && $args{exit_code} == 0;
     script_run $script, 0;
     if ($cmd =~ /pkg |ptf /) {
         if (wait_serial "Continue?") {


### PR DESCRIPTION
Due to poo#115931, print the expected
string in serial terminal as well.

- Related ticket: https://progress.opensuse.org/issues/115931
- Needles: n/a
- Verification run:https://openqa.suse.de/tests/9427012#next_previous
