### PR TITLE
Install distribution-registry from Containers Module for 15-SP4

### DIFF
--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -4,10 +4,10 @@
 # Copyright 2012-2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: docker-distribution-registry
+# Package: docker-distribution-registry | distribution-registry
 # Summary: Test container registry package
-# - docker-distribution-registry package can be installed
-# - docker-distribution-registry daemon can be started
+# - distribution-registry package can be installed
+# - distribution-registry daemon can be started
 # - images can be pushed
 # - images can be searched
 # - images can be pulled
@@ -62,8 +62,16 @@ sub run {
     $self->select_serial_terminal;
 
     # Install and check that it's running
-    add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1) if is_sle(">=15");
-    my $pkg = is_tumbleweed ? 'distribution-registry' : 'docker-distribution-registry';
+    my $pkg = 'distribution-registry';
+    if (is_sle(">=15-SP4")) {
+        activate_containers_module;
+    } elsif (is_sle("<15-SP4")) {
+        add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
+        $pkg = 'docker-distribution-registry';
+    } elsif (is_leap("<15.4")) {
+        $pkg = 'docker-distribution-registry';
+    }
+
     zypper_call "se -v $pkg";
     zypper_call "in $pkg";
     systemctl '--now enable registry';


### PR DESCRIPTION
This package is intended to be moved out of PH for 15-SP4 and
renamed to distribution-registry

https://jira.suse.com/browse/SLE-24661

VR:

- [TW](https://openqa.opensuse.org/tests/2637165#step/registry/17)
- [Leap 15.3](https://openqa.opensuse.org/tests/2637167#step/registry/5)
- [Leap 15.4](https://openqa.opensuse.org/tests/2637837#step/registry/5)
- [15-SP3](https://openqa.suse.de/tests/9469551#step/registry/25)
- [15-SP4](https://openqa.suse.de/tests/9469550#step/registry/43)