### PR TITLE
Fix InfiniBand tests

### DIFF
--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -45,4 +45,5 @@ schedule:
     - installation/first_boot
     - kernel/build_git_kernel
     - kernel/ibtests_prepare
+    - installation/handle_reboot
     - kernel/ibtests

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -42,4 +42,5 @@ schedule:
     - installation/handle_reboot
     - installation/first_boot
     - kernel/ibtests_prepare
+    - installation/handle_reboot
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -45,4 +45,5 @@ schedule:
     - installation/first_boot
     - kernel/build_git_kernel
     - kernel/ibtests_prepare
+    - installation/handle_reboot
     - kernel/ibtests

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -42,4 +42,5 @@ schedule:
     - installation/handle_reboot
     - installation/first_boot
     - kernel/ibtests_prepare
+    - installation/handle_reboot
     - kernel/ibtests

--- a/tests/kernel/ibtests.pm
+++ b/tests/kernel/ibtests.pm
@@ -77,12 +77,12 @@ sub ibtest_master {
 
 
     # pull in the testsuite
-    assert_script_run("git clone $hpc_testing --branch $hpc_testing_branch");
+    assert_script_run("git clone $hpc_testing --branch $hpc_testing_branch", timeout => $timeout);
 
     # wait until the two machines under test are ready setting up their local things
     assert_script_run('cd hpc-testing');
     barrier_wait('IBTEST_BEGIN');
-    script_run("./ib-test.sh $args $master $slave", $timeout);
+    script_run("./ib-test.sh $args $master $slave", timeout => $timeout);
     script_run('tr -cd \'\11\12\15\40-\176\' < results/TEST-ib-test.xml > /tmp/results.xml');
     parse_extra_log('XUnit', '/tmp/results.xml');
 

--- a/tests/kernel/ibtests_prepare.pm
+++ b/tests/kernel/ibtests_prepare.pm
@@ -17,19 +17,6 @@ use lockapi;
 use version_utils;
 use mmapi;
 
-
-sub permit_root_login {
-    my $self = shift;
-
-    select_console('sol', await_console => 1);
-    type_string "root";
-    wait_screen_change { type_string "\n" };
-    type_password;
-    wait_screen_change { type_string "\n" };
-    permit_root_ssh_in_sol;
-    wait_screen_change { type_string "\n" };
-}
-
 sub run {
     my $self = shift;
     my $master = get_required_var('IBTEST_IP1');
@@ -40,9 +27,9 @@ sub run {
     my $packages_master = $packages . " git-core twopence-shell-client bc";
 
 
-    $self->permit_root_login if is_ipmi;
-
     $self->select_serial_terminal;
+    permit_root_ssh_in_sol;
+
     # unload firewall. MPI- and libfabric-tests require too many open ports
     systemctl("disable --now " . opensusebasetest::firewall);
 


### PR DESCRIPTION
Make sure we have less flaky InfiniBand tests and fix the timeouts issue
before actual test execution (due to missing handle_reboot module).

Verification run: http://baremetal-support.qa.suse.de/tests/2302 and http://baremetal-support.qa.suse.de/tests/2303