### PR TITLE
Add test to set resolution in bootloader

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -44,6 +44,7 @@ our @EXPORT = qw(
   select_bootmenu_language
   tianocore_enter_menu
   tianocore_select_bootloader
+  tianocore_set_svga_resolution
   tianocore_http_boot
   zkvm_add_disk
   zkvm_add_interface
@@ -964,7 +965,7 @@ sub tianocore_disable_secureboot {
     $basetest->wait_grub;
 }
 
-sub tianocore_ensure_xga_resolution {
+sub tianocore_ensure_svga_resolution {
     assert_screen 'tianocore-mainmenu';
     send_key_until_needlematch 'tianocore-devicemanager', 'down';
     send_key 'ret';
@@ -995,10 +996,15 @@ sub tianocore_ensure_xga_resolution {
 
 sub tianocore_select_bootloader {
     tianocore_enter_menu;
-    tianocore_ensure_xga_resolution if check_var('QEMUVGA', 'qxl');
+    tianocore_ensure_svga_resolution if check_var('QEMUVGA', 'qxl');
     tianocore_enter_menu;
     send_key_until_needlematch('tianocore-bootmanager', 'down', 6, 5);
     send_key 'ret';
+}
+
+sub tianocore_set_svga_resolution {
+    tianocore_enter_menu;
+    tianocore_ensure_svga_resolution;
 }
 
 sub tianocore_http_boot {

--- a/schedule/install/generate_pflash.yaml
+++ b/schedule/install/generate_pflash.yaml
@@ -1,0 +1,11 @@
+name:           generate_pflash
+description:    >
+  This sets the resolution in Tianocore boot menu
+schedule:
+  - boot/tianocore_set_resolution
+vars:
+  PUBLISH_PFLASH_VARS: ovmf-x86_64-ms-vars-800x600.qcow2
+  QEMUVGA: qxl
+  UEFI: 1
+  UEFI_PFLASH_CODE: /usr/share/qemu/ovmf-x86_64-ms-code.bin
+  UEFI_PFLASH_VARS: /usr/share/qemu/ovmf-x86_64-ms-vars.bin

--- a/tests/boot/tianocore_set_resolution.pm
+++ b/tests/boot/tianocore_set_resolution.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Select resolution in bootloader and halt
+# - This is a simple test for saving a modified ovmf-x86_64-ms-vars.bin
+#   as a public asset
+# - Example settings:
+#   UEFI_PFLASH_CODE=/usr/share/qemu/ovmf-x86_64-ms-code.bin UEFI_PFLASH_VARS=/usr/share/qemu/ovmf-x86_64-ms-vars.bin PUBLISH_PFLASH_VARS=ovmf-x86_64-ms-vars-800x600.qcow2
+# Maintainer: Tina <tina.mueller@suse.com>
+
+use Mojo::Base 'bootbasetest', -signatures;
+use testapi;
+use Utils::Architectures;
+use bootloader_setup;
+
+sub run ($self) {
+    tianocore_set_svga_resolution();
+    my $bootloader_timeout = is_aarch64 ? 90 : 15;
+    assert_screen "bootloader-grub2", $bootloader_timeout;
+    send_key 'c';
+    assert_screen "bootloader-grub2-cmd";
+    enter_cmd("halt");
+}
+
+1;


### PR DESCRIPTION
This test enters the tianocore bootloader, selects 800x600 resolution and halts. It can be used to publish modified pflash vars.

- Related ticket: https://progress.opensuse.org/issues/113794
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/782
- Verification run: https://openqa.opensuse.org/tests/2600931

```
openqa-cli api -X POST jobs --host https://openqa.opensuse.org TEST=ovmf-resolution
 QEMUVGA=qxl UEFI=1 UEFI_PFLASH_CODE=/usr/share/qemu/ovmf-x86_64-ms-code.bin
 UEFI_PFLASH_VARS=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
 SCHEDULE=tests/boot/tianocore_set_resolution
 ISO=openSUSE-Tumbleweed-NET-x86_64-Snapshot20220829-Media.iso
 PUBLISH_PFLASH_VARS=ovmf-x86_64-ms-vars-800x600.qcow2
 "CASEDIR=https://github.com/perlpunk/os-autoinst-distri-opensuse.git#tianocore-pflash"
 "NEEDLES_DIR=https://github.com/perlpunk/os-autoinst-needles-opensuse.git#tianocore-pflash"
```