### PR TITLE
mariadb: change the order of the parameters to my_print_defaults

### DIFF
--- a/tests/console/mariadb_srv.pm
+++ b/tests/console/mariadb_srv.pm
@@ -54,7 +54,7 @@ sub run {
         systemctl 'start mariadb@node2.service';
 
         # Test a regression for broken multi instance
-        assert_script_run '/usr/bin/my_print_defaults mysqld mysqld_multi "node1" --defaults-extra-file=/etc/mynode1.cnf | grep datadir';
+        assert_script_run '/usr/bin/my_print_defaults --defaults-extra-file=/etc/mynode1.cnf mysqld mysqld_multi "node1" | grep datadir';
 
         # Stop the two instances
         cleanup();


### PR DESCRIPTION
Ensure to first pass all --extra config parameters before giving
named attributes

Fixes usage with mariadb 10.8, that otherwise fails with
/usr/bin/my_print_defaults: unknown variable 'defaults-extra-file=/etc/mynode1.cnf'

- Related ticket: N/A - identified on staging test runs
- Needles: N/A
- Verification run: [Staging with MariaDB 10.8](https://openqa.opensuse.org/tests/2597415) | [Tumbleweed with MariaDB 10.7](https://openqa.opensuse.org/t2597416)
