### PR TITLE
Adjust autoyast variables on HPC profiles

### DIFF
--- a/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
@@ -75,7 +75,7 @@
     % } else {
     <install_updates t="boolean">false</install_updates>
     % }
-    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
     <reg_server>{{SCC_URL}}</reg_server>
     <slp_discovery t="boolean">false</slp_discovery>
   </suse_register>
@@ -408,7 +408,7 @@
       <package>sle-module-development-tools-release</package>
       <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
-      % unless ($check_var->('VERSION', '15-SP4')) {
+      % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
       % } else {
       <package>sle-module-python3-release</package>

--- a/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
@@ -75,7 +75,7 @@
     % } else {
     <install_updates t="boolean">false</install_updates>
     % }
-    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
     <reg_server>{{SCC_URL}}</reg_server>
     <slp_discovery t="boolean">false</slp_discovery>
   </suse_register>
@@ -448,7 +448,7 @@
       <package>sle-module-development-tools-release</package>
       <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
-      % unless ($check_var->('VERSION', '15-SP4')) {
+      % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
       % } else {
       <package>sle-module-python3-release</package>


### PR DESCRIPTION
Main changes is:
- use of SCC_REGCODE_HPC in place of SCC_REGCODE
- do not install unavailable module python2 in sle15sp5

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/113593
- Verification run: 
❯ openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15460 https://openqa.suse.de/tests/9426855
Github oauth token provided, performing authenticated requests
Created job #9427406: sle-15-SP5-Online-x86_64-Build19.1-create_hdd_hpc_textmode@64bit -> https://openqa.suse.de/t9427406
❯ openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15460 https://openqa.suse.de/tests/9426848
Github oauth token provided, performing authenticated requests
Created job #9427407: sle-15-SP5-Online-aarch64-Build19.1-create_hdd_hpc_textmode@aarch64 -> https://openqa.suse.de/t9427407
