### PR TITLE
Replace wrong assert_script_run function usage

### DIFF
--- a/tests/autoyast/verify_btrfs_quota.pm
+++ b/tests/autoyast/verify_btrfs_quota.pm
@@ -19,9 +19,9 @@ sub run {
     foreach my $disk (@{$test_data->{disks}}) {
         foreach my $partition (@{$disk->{partitions}}) {
             my $mount_point = $partition->{mounting_options}->{mount_point};
-            my $output_btrfs_subvolumes = assert_script_run("btrfs subvolume list $mount_point");
+            my $output_btrfs_subvolumes = script_output("btrfs subvolume list $mount_point");
             # Get 'qgroupid' and 'max_rfer' columns from the output. Other columns are not needed for this test.
-            my $output_btrfs_qgroups = assert_script_run("btrfs qgroup show -r $mount_point | awk '{print \$1,\$4}'");
+            my $output_btrfs_qgroups = script_output("btrfs qgroup show -r $mount_point | awk '{print \$1,\$4}'");
             foreach my $subvolume (@{$partition->{subvolumes}}) {
                 # Parse id for the subvolume path
                 (my $subvolume_id) = ($output_btrfs_subvolumes =~ /ID\s*([0-9]*).*?$subvolume->{path}/);


### PR DESCRIPTION
In `verify_btrfs_quota.pm`, `assert_script_run` was used to get the output of 2 commands. That function does not collect the output, but the test did not catch that and passed. Here, it was replaced with `script_output` which collects command output.

- Related ticket: https://progress.opensuse.org/issues/115985
- Verification run: https://openqa.suse.de/tests/9427431#step/verify_btrfs_quota/2

See the difference (under `Result`) with the previous, wrong case: https://openqa.suse.de/tests/9313739#step/verify_btrfs_quota/2
