### PR TITLE
Replace host reboot with console connection

### DIFF
--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -253,9 +253,6 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     );
 } elsif (get_var("REGRESSION", '') =~ /vmware/) {
     %guests = (
-        sles12sp2 => {
-            name => 'sles12sp2',
-        },
         sles12sp3 => {
             name => 'sles12sp3',
         },
@@ -295,10 +292,6 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles12sp3 => {
             name => 'sles12sp3',
             ip => 'win2k19-sle12-SP3.qa.suse.cz',
-        },
-        sles12sp2 => {
-            name => 'sles12sp2',
-            ip => 'win2k19-sle12-SP2.qa.suse.cz',
         },
         sles12sp4 => {
             name => 'sles12sp4',

--- a/schedule/qam/common/virt/qam_virt_tests.yaml
+++ b/schedule/qam/common/virt/qam_virt_tests.yaml
@@ -1,0 +1,54 @@
+---
+name: qam virtualization tests
+description:    >
+    Tests for virtualization tests
+schedule:
+  - console/login
+  - '{{qam_tests}}'
+  - virtualization/universal/finish
+conditional_schedule:
+  qam_tests:
+    VIRT_PART:
+      'save_and_restore':
+        - virtualization/universal/save_and_restore
+      'networking':
+        - virt_autotest/libvirt_host_bridge_virtual_network
+        - virt_autotest/libvirt_nated_virtual_network
+        - virt_autotest/libvirt_isolated_virtual_network
+      'guest_management':
+        - virtualization/universal/guest_management
+      'snapshots':
+        - virt_autotest/virsh_internal_snapshot
+        - virt_autotest/virsh_external_snapshot
+      'dom_metrics':
+        - virtualization/universal/virsh_stop
+        - virtualization/universal/xl_create
+        - virtualization/universal/dom_install
+        - virtualization/universal/dom_metrics
+        - virtualization/universal/xl_stop
+        - virtualization/universal/virsh_start
+      'final':
+        - virtualization/universal/ssh_final
+        - virtualization/universal/virtmanager_final
+        - virtualization/universal/smoketest
+        - virtualization/universal/stresstest
+        - console/perf
+      'hotplugging':
+        - virtualization/universal/hotplugging_guest_preparation
+        - virtualization/universal/hotplugging_network_interfaces
+        - virtualization/universal/hotplugging_HDD
+        - virtualization/universal/hotplugging_vCPUs
+        - virtualization/universal/hotplugging_memory
+        - virtualization/universal/hotplugging_cleanup
+      'storage':
+        - virtualization/universal/storage
+      'windows':
+        - virtualization/universal/download_image
+        - virtualization/universal/windows
+      'irqbalance':
+        - virt_autotest/xen_guest_irqbalance
+      'virtmanager':
+        - virtualization/universal/virtmanager_init
+        - virtualization/universal/virtmanager_offon
+        - virtualization/universal/virtmanager_add_devices
+        - virtualization/universal/virtmanager_rm_devices

--- a/tests/console/login.pm
+++ b/tests/console/login.pm
@@ -1,0 +1,23 @@
+package login;
+
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: login console
+# Maintainer: Tony Yuan <tyuan@suse.com>, qe-virt@suse.com
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use lib 'sle/tests/virt_autotest';
+use lib 'os-autoinst-distri-opensuse/tests/virt_autotest';
+
+sub run {
+    my $self = shift;
+    select_console 'root-ssh';
+    record_info("console logined");
+}
+1;

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -133,6 +133,7 @@ sub restore_xml_changed_guests {
     foreach my $guest (@changed_guests) {
         remove_vm($guest);
         restore_downloaded_guests($guest, $changed_xml_dir);
+        assert_script_run "virsh start $guest";
     }
 }
 

--- a/tests/virtualization/universal/hotplugging_cleanup.pm
+++ b/tests/virtualization/universal/hotplugging_cleanup.pm
@@ -26,6 +26,7 @@ sub run_test {
     # Ensure guests remain in a consistent state also
     shutdown_guests();
     reset_guest($_, $MAC_PREFIX) foreach (keys %virt_autotest::common::guests);
+    start_guests();
 }
 
 sub post_fail_hook {

--- a/tests/virtualization/universal/hotplugging_guest_preparation.pm
+++ b/tests/virtualization/universal/hotplugging_guest_preparation.pm
@@ -21,15 +21,6 @@ use hotplugging_utils;
 # Magic MAC prefix for temporary devices. Must be of the format 'XX:XX:XX:XX'
 my $MAC_PREFIX = '00:16:3f:32';
 
-sub increase_max_memory {
-    my $guest = shift;
-    my $increase = shift // 2048;
-    my $guest_instance = $virt_autotest::common::guests{$guest};
-    my $maxmemory = $guest_instance->{maxmemory} // "4096";
-    $maxmemory += $increase;
-    assert_script_run("virsh setmaxmem $guest $maxmemory" . "M --config");
-}
-
 sub run_test {
     my ($self) = @_;
     my ($sles_running_version, $sles_running_sp) = get_os_release;
@@ -45,10 +36,8 @@ sub run_test {
 
     # Guest preparation
     shutdown_guests();
-    # Increase maximum memory for this test run
-    increase_max_memory($_) foreach (keys %virt_autotest::common::guests);
+    reset_guest($_, $MAC_PREFIX) foreach (keys %virt_autotest::common::guests);
     start_guests();
-
 }
 
 sub post_fail_hook {

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -19,7 +19,6 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
 use File::Copy 'copy';
 use File::Path 'make_path';
 
@@ -83,8 +82,8 @@ sub run {
     #    $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
     select_console('root-console');
     systemctl("restart libvirtd");
-    assert_script_run('for i in $(virsh list --name|grep sles);do virsh destroy $i;done');
-    assert_script_run('for i in $(virsh list --name --inactive); do virsh undefine $i --remove-all-storage;done');
+    assert_script_run('for i in $(virsh list --name|grep -v Domain-0);do virsh destroy $i;done');
+    assert_script_run('for i in $(virsh list --name --inactive); do if [[ $i == win* ]]; then virsh undefine $i; else virsh undefine $i --remove-all-storage; fi; done');
     script_run("[ -f /root/.ssh/known_hosts ] && > /root/.ssh/known_hosts");
     script_run 'rm -rf /tmp/guests_ip';
 

--- a/tests/virtualization/universal/storage.pm
+++ b/tests/virtualization/universal/storage.pm
@@ -24,7 +24,7 @@ sub run_test {
 
     record_info "Prepare";
     foreach (keys %virt_autotest::common::guests) {
-        start_guests() unless is_guest_online($_);
+        script_run("virsh start '$_'") unless is_guest_online($_);
     }
     ## Prepare Virtualization Dir Storage Pool source
     prepare_dir_storage_pool_source($dir_pool_name);

--- a/tests/virtualization/universal/virtmanager_init.pm
+++ b/tests/virtualization/universal/virtmanager_init.pm
@@ -23,7 +23,6 @@ sub run_test {
     # Ensure additional devices are removed (if present).
     # This is necessary for restarting the virtmanager tests, as we assume the state is clear.
     foreach my $guest (keys %virt_autotest::common::guests) {
-        next if ($guest == "");
         remove_additional_nic($guest, "00:16:3e:32");
         remove_additional_disks($guest);
     }

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -14,119 +14,39 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-
-sub ensure_reboot_policy {
-    my $guest = shift;
-    my $xml = "$guest.xml";
-    assert_script_run("virsh dumpxml $guest > $xml");
-    assert_script_run("sed 's!.*<on_reboot>.*</on_reboot>!<on_reboot>restart</on_reboot>!' -i $xml");
-    assert_script_run("virt-xml-validate $xml");
-    assert_script_run("virsh define $xml");
-    # Check if the reboot policy is applied correctly
-    assert_script_run("virsh dumpxml $guest | grep on_reboot | grep restart");
-}
-
-sub add_pci_bridge {
-    my $guest = shift;
-    my $xml = "$guest.xml";
-
-    assert_script_run("virsh dumpxml $guest > $xml");
-
-    # There are two different approaches, one for q35 and one for i440fx machine type
-    if (script_run("grep machine '$xml' | grep 'i440fx'") == 0) {
-        # on i440fx add a pci-bridge:
-        # "<controller type='pci' model='pci-bridge'/>"
-
-        # Skip if a pci-bridge is already present
-        return if (script_run("cat $xml | grep 'controller' | grep 'pci-bridge'") == 0);
-
-        # add pci-bridge to xml settings
-        assert_script_run("virsh dumpxml $guest > $xml");
-        assert_script_run("sed -i '/.*<\\/devices>/i<controller type=\"pci\" model=\"pci-bridge\"/>' /root/$xml");
-        upload_logs("$xml");
-
-        # Check if settings are applied correctly in the new xml
-        assert_script_run("cat $xml | grep 'controller' | grep 'pci-root'");
-        assert_script_run("cat $xml | grep 'controller' | grep 'pci-bridge'");
-
-        # Apply xml settings to VM. Note: They will be applied after reboot.
-        assert_script_run("virt-xml-validate $xml");
-        assert_script_run("virsh define $xml");
-
-    } elsif (script_run("grep machine '$xml' | grep 'q35'") == 0) {
-        # On q35 add a pcie-root-port and a pcie-to-pci bridge
-
-        # Skip if a pcie-to-pci-bridge is already present
-        return if (script_run("cat $xml | grep 'controller' | grep 'pcie-to-pci-bridge'") == 0);
-
-        # Add 10 pcie-root-port devices and a pcie-to-pci brdige
-        assert_script_run("virsh dumpxml $guest > $xml");
-        for (1 .. 10) {
-            assert_script_run("sed -i '/.*<\\/devices>/i<controller type=\"pci\" model=\"pcie-root-port\"/>' /root/$xml");
-        }
-        assert_script_run("sed -i '/.*<\\/devices>/i<controller type=\"pci\" model=\"pcie-to-pci-bridge\"/>' /root/$xml");
-        upload_logs("$xml");
-
-        # Check if settings are applied correctly in the xml
-        assert_script_run("cat $xml | grep 'controller' | grep 'pcie-root-port'");
-        assert_script_run("cat $xml | grep 'controller' | grep 'pcie-to-pci-bridge'");
-
-        # Apply xml settings to VM. Note: They will be applied after reboot.
-        assert_script_run("virt-xml-validate $xml");
-        assert_script_run("virsh define $xml");
-
-    } elsif (is_xen_host()) {
-        # We're skipping to add an additional bridge on xen
-    } else {
-        my $msg = "Unknown machine type";
-        record_soft_failure($msg);
-    }
-}
-
-# Upload xml definitions of all guests
-sub upload_machine_definitions {
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        my $xml = "$guest.xml";
-        assert_script_run("virsh dumpxml $guest | tee $xml");
-        upload_logs("$xml");
-    }
-}
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
     select_console('root-console');
+    my @guests = keys %virt_autotest::common::guests;
     # Fill the current pairs of hostname & address into /etc/hosts file
     assert_script_run 'virsh list --all';
-    add_guest_to_hosts $_, $virt_autotest::common::guests{$_}->{ip} foreach (keys %virt_autotest::common::guests);
+    add_guest_to_hosts $_, $virt_autotest::common::guests{$_}->{ip} foreach (@guests);
     assert_script_run "cat /etc/hosts";
 
     # Wait for guests to announce that installation is complete
     script_retry("test -d /tmp/guests_ip", retry => 15, delay => 120);
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         script_retry("test -f /tmp/guests_ip/$guest", retry => 20, delay => 120);
         record_info("$guest installed", "Guest installation completed");
     }
     record_info("All guests installed", "Guest installation completed");
+    if (is_sle('>15') && get_var("KVM")) {
+        # Adding the PCI bridges requires the guests to be shutdown
+        record_info("shutdown guests", "Shutting down all guests");
+        shutdown_guests();
 
-    # Adding the PCI bridges requires the guests to be shutdown
-    record_info("shutdown guests", "Shutting down all guests");
-    shutdown_guests();
-
-    ## Add a PCIe root port and a PCIe to PCI bridge for hotplugging
-    add_pci_bridge("$_") foreach (keys %virt_autotest::common::guests);
-
-    ## Ensure the reboot policy is set to 'restart'. This needs to happen on shutdown guest
-    # Do a shutdown and start here because some guests might not reboot because of the on_reboot=destroy policy
-    ensure_reboot_policy("$_") foreach (keys %virt_autotest::common::guests);
-    upload_machine_definitions();
-
-    record_info("Starting guests", "Starting all guests");
-    start_guests();
-
-    # Check that guests are online so we can continue and setup them
-    ensure_online $_, skip_ssh => 1, ping_delay => 45 foreach (keys %virt_autotest::common::guests);
-
-    # All guests should be now installed and running
+        # Add a PCIe root port and a PCIe to PCI bridge for Q35 machine
+        if (is_sle('<15-SP4')) {
+            assert_script_run("virt-xml $_ --add-device --controller type=pci,index=11,model=pcie-to-pci-bridge") foreach (@guests);
+        } else {
+            assert_script_run("virt-xml $_ --add-device --controller type=pci,model=pcie-to-pci-bridge") foreach (@guests);
+        }
+        record_info("Starting guests", "Starting all guests");
+        start_guests();
+        ensure_online $_, skip_ssh => 1, ping_delay => 45 foreach (@guests);
+    }
     assert_script_run('virsh list --all');
     wait_still_screen 1;
 }

--- a/tests/virtualization/universal/windows.pm
+++ b/tests/virtualization/universal/windows.pm
@@ -30,7 +30,7 @@ sub run {
 
     # Remove already existing guests to ensure a fresh start (needed for restarting jobs)
     remove_guest $_ foreach (keys %virt_autotest::common::imports);
-    shutdown_guests();    # Shutdown SLES guests as they are not needed here
+    #    shutdown_guests();    # Shutdown SLES guests as they are not needed here
 
     import_guest $_, 'virt-install' foreach (values %virt_autotest::common::imports);
     add_guest_to_hosts $_, $virt_autotest::common::imports{$_}->{ip} foreach (keys %virt_autotest::common::imports);
@@ -53,9 +53,9 @@ sub post_fail_hook {
 }
 
 sub post_run_hook {
-    my $self = shift;
+    #    my $self = shift;
     remove_guest $_ foreach (keys %virt_autotest::common::imports);
-    $self->SUPER::post_run_hook;
+    #    $self->SUPER::post_run_hook;
 }
 
 1;


### PR DESCRIPTION
Remove host unnecessary reboot from tests. Use yaml file to schedule all tests instead of main.pm

- Related ticket: https://progress.opensuse.org/issues/113608
- Needles: no
- Verification run: 

 sles15sp3 kvm: http://openqa.qam.suse.cz/tests/overview?build=%3Atest%3Aboot%3Awitch&groupid=154&version=15-SP3&distri=sle
  sles15sp3 xen: http://openqa.qam.suse.cz/tests/overview?groupid=156&build=%3Atest%3Aboot02%3Ayoda&version=15-SP3&distri=sle
  sles15sp4 xen: http://openqa.qam.suse.cz/tests/overview?distri=sle&version=15-SP4&groupid=163&build=%3Atest%3Aboot%3Ajavor
