### PR TITLE
Add dracut testsuite

### DIFF
--- a/lib/dracut_testsuite_test.pm
+++ b/lib/dracut_testsuite_test.pm
@@ -35,7 +35,7 @@ sub testsuiteinstall {
     zypper_call "ar https://download.suse.de/install/SLP/SLE-15-SP4-Module-Development-Tools-LATEST/x86_64/DVD1/?ssl_verify=no git-repo";
     zypper_call "ar https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.4/?ssl_verify=no kiwi-repo";
     zypper_call "ar https://download.opensuse.org/repositories/devel:/languages:/python:/backports/15.4/?ssl_verify=no kiwi-overlay-repo";
-    
+
     zypper_call "--gpg-auto-import-keys ref";
 
     # use dracut from the repo of the qa package
@@ -53,8 +53,8 @@ sub testsuiteinstall {
         }
 
         if (!check_var('DESKTOP', 'textmode')) {
-	   assert_screen( "displaymanager", 500);
-           send_key "ctrl-alt-f1";
+            assert_screen("displaymanager", 500);
+            send_key "ctrl-alt-f1";
         }
 
         assert_screen('linux-login', 30);
@@ -67,31 +67,31 @@ sub testsuiteinstall {
 sub testsuiterun {
     my ($self, $test_name, $option) = @_;
     my $timeout = get_var('DRACUT_TEST_DEFAULT_TIMEOUT') || 300;
-    
+
     select_console 'root-console';
     assert_script_run "mkdir -p $logs_dir";
     assert_script_run "cd /usr/lib/dracut/test/$test_name";
-  
-    my $NMPREFIX; 
 
-    if ( substr($test_name, -3, 3) eq "-NM" )
-    	{
-		my @test_data = split /-/, $test_name;
-		@test_data[1] = '*';
-		my $test_name_no_numb = join '-', @test_data;
-		$NMPREFIX=substr($test_name_no_numb, 0, -3);    
-	}
- 
-    if ( defined($NMPREFIX) )
+    my $NMPREFIX;
+
+    if (substr($test_name, -3, 3) eq "-NM")
     {
-	    assert_script_run "cd /usr/lib/dracut/test/$NMPREFIX";
-	    assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && export NM=1 && ./test.sh --setup 2>&1 > $logs_dir/$test_name-setup.log", $timeout;
-	    assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && export NM=1 && ./test.sh --run 2>&1 > $logs_dir/$test_name-run.log", $timeout;
+        my @test_data = split /-/, $test_name;
+        @test_data[1] = '*';
+        my $test_name_no_numb = join '-', @test_data;
+        $NMPREFIX = substr($test_name_no_numb, 0, -3);
     }
-    else 
+
+    if (defined($NMPREFIX))
     {
-	    assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && ./test.sh --setup 2>&1 > $logs_dir/$test_name-setup.log", $timeout;
-	    assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && ./test.sh --run 2>&1 > $logs_dir/$test_name-run.log", $timeout;
+        assert_script_run "cd /usr/lib/dracut/test/$NMPREFIX";
+        assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && export NM=1 && ./test.sh --setup 2>&1 > $logs_dir/$test_name-setup.log", $timeout;
+        assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && export NM=1 && ./test.sh --run 2>&1 > $logs_dir/$test_name-run.log", $timeout;
+    }
+    else
+    {
+        assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && ./test.sh --setup 2>&1 > $logs_dir/$test_name-setup.log", $timeout;
+        assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && ./test.sh --run 2>&1 > $logs_dir/$test_name-run.log", $timeout;
     }
 
     # Check dracut generation errors
@@ -99,7 +99,7 @@ sub testsuiterun {
     power_action('reboot', textmode => 1);
     wait_still_screen(10, 60);
     if (!check_var('DESKTOP', 'textmode')) {
-        assert_screen( "displaymanager", 500);
+        assert_screen("displaymanager", 500);
         send_key "ctrl-alt-f1";
     }
 
@@ -109,13 +109,13 @@ sub testsuiterun {
     type_password;
     wait_still_screen 3;
     send_key 'ret';
-    
+
     # Clean
     assert_script_run "cd /usr/lib/dracut/test/$test_name";
 
-    if ( defined($NMPREFIX) )
+    if (defined($NMPREFIX))
     {
-	assert_script_run "cd /usr/lib/dracut/test/$NMPREFIX";
+        assert_script_run "cd /usr/lib/dracut/test/$NMPREFIX";
     }
     assert_script_run 'export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && ./test.sh --clean';
 }

--- a/lib/dracut_testsuite_test.pm
+++ b/lib/dracut_testsuite_test.pm
@@ -1,0 +1,72 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: library functions for setting up the tests and uploading logs in case of error.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+package dracut_testsuite_test;
+use warnings;
+use strict;
+use testapi;
+use base "consoletest";
+use utils 'zypper_call';
+use power_action_utils 'power_action';
+
+my $logs_dir = '/tmp/dracut-testsuite-logs';
+
+sub testsuiteinstall {
+    my $dracut_testsuite_repo = get_var('DRACUT_TESTSUITE_REPO', '');
+
+    select_console 'root-console';
+
+    my $from_repo = '';
+    if ($dracut_testsuite_repo) {
+        zypper_call "ar $dracut_testsuite_repo dracut-testrepo";
+        zypper_call "--gpg-auto-import-keys ref dracut-testrepo";
+        $from_repo = "--from dracut-testrepo";
+    }
+    zypper_call "in $from_repo dracut dracut-mkinitrd-deprecated dracut-qa-testsuite";
+}
+
+sub testsuiterun {
+    my ($self, $test_name, $option) = @_;
+    my $timeout = get_var('DRACUT_TEST_DEFAULT_TIMEOUT') || 300;
+    
+    select_console 'root-console';
+    
+    assert_script_run "mkdir -p $logs_dir";
+    assert_script_run "cd /usr/lib/dracut/test/$test_name";
+    assert_script_run "./test.sh --setup 2>&1 | tee $logs_dir/$test_name-setup.log", $timeout;
+    # Check that dracut and grub2-mkconfig return 0
+    assert_script_run "grep -q dracut-root-block-created $logs_dir/$test_name-setup.log";
+    # Check dracut generation errors
+    assert_script_run "! grep -e ERROR -e FAIL $logs_dir/$test_name-setup.log";
+
+    power_action('reboot', textmode => 1);
+    wait_still_screen(10, 60);
+    assert_screen("linux-login", 600);
+    enter_cmd "root";
+    wait_still_screen 3;
+    type_password;
+    wait_still_screen 3;
+    send_key 'ret';
+
+    # Clean
+    assert_script_run "cd /usr/lib/dracut/test/$test_name";
+    assert_script_run './test.sh --clean';
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->SUPER::post_fail_hook;
+    assert_script_run("tar -czf dracut-testsuite-logs.tar.gz $logs_dir", 600);
+    upload_logs('dracut-testsuite-logs.tar.gz');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/lib/dracut_testsuite_test.pm
+++ b/lib/dracut_testsuite_test.pm
@@ -10,6 +10,9 @@ package dracut_testsuite_test;
 use warnings;
 use strict;
 use testapi;
+use Utils::Architectures qw(is_aarch64);
+use Utils::Architectures 'is_s390x';
+use bootloader_setup qw(change_grub_config grub_mkconfig);
 use base "consoletest";
 use utils 'zypper_call';
 use power_action_utils 'power_action';
@@ -17,6 +20,7 @@ use power_action_utils 'power_action';
 my $logs_dir = '/tmp/dracut-testsuite-logs';
 
 sub testsuiteinstall {
+    my ($self) = @_;
     my $dracut_testsuite_repo = get_var('DRACUT_TESTSUITE_REPO', '');
 
     select_console 'root-console';
@@ -24,10 +28,40 @@ sub testsuiteinstall {
     my $from_repo = '';
     if ($dracut_testsuite_repo) {
         zypper_call "ar $dracut_testsuite_repo dracut-testrepo";
-        zypper_call "--gpg-auto-import-keys ref dracut-testrepo";
         $from_repo = "--from dracut-testrepo";
     }
-    zypper_call "in $from_repo dracut dracut-mkinitrd-deprecated dracut-qa-testsuite";
+    #repos necessary for test 16 (dmsquash)
+    zypper_call "ar https://updates.suse.de/download/SUSE/Backports/SLE-15-SP3_x86_64/standard/?ssl_verify=no devel-repo";
+    zypper_call "ar https://download.suse.de/install/SLP/SLE-15-SP4-Module-Development-Tools-LATEST/x86_64/DVD1/?ssl_verify=no git-repo";
+    zypper_call "ar https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/openSUSE_Leap_15.4/?ssl_verify=no kiwi-repo";
+    zypper_call "ar https://download.opensuse.org/repositories/devel:/languages:/python:/backports/15.4/?ssl_verify=no kiwi-overlay-repo";
+    
+    zypper_call "--gpg-auto-import-keys ref";
+
+    # use dracut from the repo of the qa package
+    if (get_var('DRACUT_FROM_TESTREPO')) {
+        zypper_call "in --force $from_repo dracut dracut-mkinitrd-deprecated";
+        change_grub_config('=.*', '=9', 'GRUB_TIMEOUT');
+        grub_mkconfig;
+        wait_screen_change { enter_cmd "shutdown -r now" };
+        if (is_s390x) {
+            $self->wait_boot(bootloader_time => 180);
+        } else {
+            $self->handle_uefi_boot_disk_workaround if (is_aarch64);
+            wait_still_screen 10;
+            wait_serial('Welcome to', 300) || die "System did not boot in 300 seconds.";
+        }
+
+        if (!check_var('DESKTOP', 'textmode')) {
+	   assert_screen( "displaymanager", 500);
+           send_key "ctrl-alt-f1";
+        }
+
+        assert_screen('linux-login', 30);
+        reset_consoles;
+        select_console('root-console');
+    }
+    zypper_call 'in dracut-kiwi-overlay python3-kiwi git tree dracut-kiwi-live dracut-qa-testsuite NetworkManager nbd nfs-kernel-server dhcp-server tcpdump tgt';
 }
 
 sub testsuiterun {
@@ -35,27 +69,55 @@ sub testsuiterun {
     my $timeout = get_var('DRACUT_TEST_DEFAULT_TIMEOUT') || 300;
     
     select_console 'root-console';
-    
     assert_script_run "mkdir -p $logs_dir";
     assert_script_run "cd /usr/lib/dracut/test/$test_name";
-    assert_script_run "./test.sh --setup 2>&1 | tee $logs_dir/$test_name-setup.log", $timeout;
-    # Check that dracut and grub2-mkconfig return 0
-    assert_script_run "grep -q dracut-root-block-created $logs_dir/$test_name-setup.log";
+  
+    my $NMPREFIX; 
+
+    if ( substr($test_name, -3, 3) eq "-NM" )
+    	{
+		my @test_data = split /-/, $test_name;
+		@test_data[1] = '*';
+		my $test_name_no_numb = join '-', @test_data;
+		$NMPREFIX=substr($test_name_no_numb, 0, -3);    
+	}
+ 
+    if ( defined($NMPREFIX) )
+    {
+	    assert_script_run "cd /usr/lib/dracut/test/$NMPREFIX";
+	    assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && export NM=1 && ./test.sh --setup 2>&1 > $logs_dir/$test_name-setup.log", $timeout;
+	    assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && export NM=1 && ./test.sh --run 2>&1 > $logs_dir/$test_name-run.log", $timeout;
+    }
+    else 
+    {
+	    assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && ./test.sh --setup 2>&1 > $logs_dir/$test_name-setup.log", $timeout;
+	    assert_script_run "export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && ./test.sh --run 2>&1 > $logs_dir/$test_name-run.log", $timeout;
+    }
+
     # Check dracut generation errors
     assert_script_run "! grep -e ERROR -e FAIL $logs_dir/$test_name-setup.log";
-
     power_action('reboot', textmode => 1);
     wait_still_screen(10, 60);
-    assert_screen("linux-login", 600);
+    if (!check_var('DESKTOP', 'textmode')) {
+        assert_screen( "displaymanager", 500);
+        send_key "ctrl-alt-f1";
+    }
+
+    assert_screen('linux-login', 30);
     enter_cmd "root";
     wait_still_screen 3;
     type_password;
     wait_still_screen 3;
     send_key 'ret';
-
+    
     # Clean
     assert_script_run "cd /usr/lib/dracut/test/$test_name";
-    assert_script_run './test.sh --clean';
+
+    if ( defined($NMPREFIX) )
+    {
+	assert_script_run "cd /usr/lib/dracut/test/$NMPREFIX";
+    }
+    assert_script_run 'export basedir=/usr/lib/dracut && export testdir=/usr/lib/dracut/test/ && ./test.sh --clean';
 }
 
 sub post_fail_hook {

--- a/schedule/qam/common/mau-dracut.yaml
+++ b/schedule/qam/common/mau-dracut.yaml
@@ -1,0 +1,12 @@
+---
+name: mau-systemd
+schedule:
+- '{{zkvm_boot}}'
+- boot/boot_to_desktop
+- dracut_testsuite/prepare_dracut_and_testsuite
+conditional_schedule:
+  zkvm_boot:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
+...

--- a/schedule/qam/common/mau-dracut.yaml
+++ b/schedule/qam/common/mau-dracut.yaml
@@ -4,6 +4,7 @@ schedule:
 - '{{zkvm_boot}}'
 - boot/boot_to_desktop
 - dracut_testsuite/prepare_dracut_and_testsuite
+- dracut_testsuite/test_03_usr_mount
 conditional_schedule:
   zkvm_boot:
     ARCH:

--- a/schedule/qam/common/mau-dracut.yaml
+++ b/schedule/qam/common/mau-dracut.yaml
@@ -1,10 +1,38 @@
 ---
-name: mau-systemd
+name: mau-dracut
 schedule:
 - '{{zkvm_boot}}'
 - boot/boot_to_desktop
 - dracut_testsuite/prepare_dracut_and_testsuite
+- dracut_testsuite/test_01_basic
+- dracut_testsuite/test_02_systemd
 - dracut_testsuite/test_03_usr_mount
+- dracut_testsuite/test_04_full_systemd
+- dracut_testsuite/test_10_raid
+- dracut_testsuite/test_11_lvm
+- dracut_testsuite/test_12_raid_deg
+- dracut_testsuite/test_13_enc_raid_lvm
+# - dracut_testsuite/test_14_imsm
+- dracut_testsuite/test_15_btrfsraid
+# - dracut_testsuite/test_16_dmsquash
+- dracut_testsuite/test_17_lvm_thin
+- dracut_testsuite/test_20_nfs
+- dracut_testsuite/test_21_nfs_nm
+- dracut_testsuite/test_30_iscsi
+- dracut_testsuite/test_31_iscsi_nm
+- dracut_testsuite/test_35_iscsi_multi
+- dracut_testsuite/test_36_iscsi_multi_nm
+# - dracut_testsuite/test_40_nbd
+# - dracut_testsuite/test_41_nbd_nm
+- dracut_testsuite/test_50_multinic
+- dracut_testsuite/test_51_multinic_nm
+- dracut_testsuite/test_60_bondbridgevlanifcfg
+# - dracut_testsuite/test_61_bondbridgevlanifcfg_nm
+- dracut_testsuite/test_62_skipcpio
+- dracut_testsuite/test_63_dracut_cpio
+- dracut_testsuite/test_98_getarg
+# - dracut_testsuite/test_99_rpm
+- shutdown/shutdown
 conditional_schedule:
   zkvm_boot:
     ARCH:

--- a/tests/dracut_testsuite/prepare_dracut_and_testsuite.pm
+++ b/tests/dracut_testsuite/prepare_dracut_and_testsuite.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Prepare dracut and testsuite.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base 'dracut_testsuite_test';
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiteinstall;
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_01_basic.pm
+++ b/tests/dracut_testsuite/test_01_basic.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-01-BASIC after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-01-BASIC');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_02_systemd.pm
+++ b/tests/dracut_testsuite/test_02_systemd.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-02-SYSTEMD after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-02-SYSTEMD');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_03_usr_mount.pm
+++ b/tests/dracut_testsuite/test_03_usr_mount.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-03-USR-MOUNT after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-03-USR-MOUNT');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_04_full_systemd.pm
+++ b/tests/dracut_testsuite/test_04_full_systemd.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-04-FULL-SYSTEMD after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-04-FULL-SYSTEMD');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_10_raid.pm
+++ b/tests/dracut_testsuite/test_10_raid.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-10-RAID after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-10-RAID');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_11_lvm.pm
+++ b/tests/dracut_testsuite/test_11_lvm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-11-LVM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-11-LVM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_12_raid_deg.pm
+++ b/tests/dracut_testsuite/test_12_raid_deg.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-12-RAID-DEG after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-12-RAID-DEG');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_13_enc_raid_lvm.pm
+++ b/tests/dracut_testsuite/test_13_enc_raid_lvm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-13-ENC-RAID-LVM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-13-ENC-RAID-LVM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_14_imsm.pm
+++ b/tests/dracut_testsuite/test_14_imsm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-14-IMSM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-14-IMSM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_15_btrfsraid.pm
+++ b/tests/dracut_testsuite/test_15_btrfsraid.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-15-BTRFSRAID after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-15-BTRFSRAID');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_16_dmsquash.pm
+++ b/tests/dracut_testsuite/test_16_dmsquash.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-16-DMSQUASH after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-16-DMSQUASH');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_17_lvm_thin.pm
+++ b/tests/dracut_testsuite/test_17_lvm_thin.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-17-LVM-THIN after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-17-LVM-THIN');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_20_nfs.pm
+++ b/tests/dracut_testsuite/test_20_nfs.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-20-NFS after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-20-NFS');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+
+1;

--- a/tests/dracut_testsuite/test_21_nfs_nm.pm
+++ b/tests/dracut_testsuite/test_21_nfs_nm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-21-NFS-NM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-21-NFS-NM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_30_iscsi.pm
+++ b/tests/dracut_testsuite/test_30_iscsi.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-30-ISCSI after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-30-ISCSI');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_31_iscsi_nm.pm
+++ b/tests/dracut_testsuite/test_31_iscsi_nm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-31-ISCSI_NM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-31-ISCSI-NM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_35_iscsi_multi.pm
+++ b/tests/dracut_testsuite/test_35_iscsi_multi.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-35-ISCSI-MULTI after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-35-ISCSI-MULTI');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_36_iscsi_multi_nm.pm
+++ b/tests/dracut_testsuite/test_36_iscsi_multi_nm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-36-ISCSI-MULTI-NM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-36-ISCSI-MULTI-NM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_40_nbd.pm
+++ b/tests/dracut_testsuite/test_40_nbd.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-40-NBD after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-40-NBD');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_41_nbd_nm.pm
+++ b/tests/dracut_testsuite/test_41_nbd_nm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-41-NBD-NM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-41-NBD-NM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_50_multinic.pm
+++ b/tests/dracut_testsuite/test_50_multinic.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-50-MULTINIC after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-50-MULTINIC');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_51_multinic_nm.pm
+++ b/tests/dracut_testsuite/test_51_multinic_nm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-51-MULTINIC-NM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-51-MULTINIC-NM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_60_bondbridgevlanifcfg.pm
+++ b/tests/dracut_testsuite/test_60_bondbridgevlanifcfg.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-60-BONDBRIDGEVLANIFCFG after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-60-BONDBRIDGEVLANIFCFG');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_61_bondbridgevlanifcfg_nm.pm
+++ b/tests/dracut_testsuite/test_61_bondbridgevlanifcfg_nm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-61-BONDBRIDGEVLANIFCFG_NM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-61-BONDBRIDGEVLANIFCFG-NM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_62_skipcpio.pm
+++ b/tests/dracut_testsuite/test_62_skipcpio.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-62-SKIPCPIO after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-62-SKIPCPIO');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_63_dracut_cpio.pm
+++ b/tests/dracut_testsuite/test_63_dracut_cpio.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-63-DRACUT-CPIO after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-63-DRACUT-CPIO');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_98_getarg.pm
+++ b/tests/dracut_testsuite/test_98_getarg.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-98-GETARG after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-98-GETARG');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/dracut_testsuite/test_99_rpm.pm
+++ b/tests/dracut_testsuite/test_99_rpm.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Run upstream test TEST-99-RPM after applying SUSE patches.
+# Maintainer: dracut maintainers <dracut-maintainers@suse.de>
+
+use base "dracut_testsuite_test";
+use warnings;
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->testsuiterun('TEST-99-RPM');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
These changes allow most tests from the dracut testsuite to run on SLES.

Dracuts test shell files must be patched beforehand. The neccessary patches are available here:
https://github.com/r-richardson/dracut/tree/add_tests/suse
(NM tests are patched along with their parent -> to run test 21 NFS NM, apply Patch 20 NFS)

for some tests, such as nfs and multinic higher timout values are neccessary
(see command below)

compatible Tests:
- 01 basic
- 02 systemd
- 03 usr mount
- 04 full systemd
- 10 raid
- 11 lvm
- 12 raid deg
- 13 enc raid lvm
- 15 btrfsraid
- 17lvm thin
- 20 nfs
- 21 nfs nm
- 30 iscsi
- 31 iscsi nm
- 35 iscsi multi
- 36 iscsi multi nm
- 50 multinic
- 51 multinic nm
- 60 bondbridgevlanifcfg
- 62 skipcpio
- 63 dracut cpio
- 98 getarg

incompatible Tests:
- 14 imsm
- 16 dmsquash
- 40 nbd
- 41 nbd nm
- 61 bondbridgevlanifcfg nm
- 99 rpm

tested using: SLES-15-SP4-x86_64-Build151.1@64bit-gnome
Verification run: http://mercury.arch.suse.de/tests/803#
command: `openqa-clone-job --from http://openqa.suse.de 8752474 SCC_URL=http://hydra.scc.suse.de TESTSUITE_NAME=dracut-testsuite-robert YAML_SCHEDULE=schedule/qam/common/mau-dracut.yaml HDD_1=SLES-15-SP4-x86_64-Build151.1@64bit-gnome.qcow2 PUBLISH_HDD_1="" PUBLISH_HDD_2="" DRACUT_TESTSUITE_REPO=https://download.suse.de/ibs/home:/robert.richardson:/branches:/SUSE:/SLE-15-SP4:/Update/standard/?ssl_verify=no DRACUT_FROM_TESTREPO=1 DRACUT_TEST_DEFAULT_TIMEOUT=3000 MAX_JOB_TIME=14400`