### PR TITLE
Setup image data pushing for (sle|leap)-micro

### DIFF
--- a/tests/jeos/image_info.pm
+++ b/tests/jeos/image_info.pm
@@ -39,7 +39,7 @@ sub check_db {
     }
 
     # CASEDIR var is always set, and if when no specified, the value is "sle" for OSD and "opensuse" for O3
-    return 0 if (get_required_var('CASEDIR') !~ m/^sle$|^opensuse$/);
+    return 0 if (get_required_var('CASEDIR') !~ m/^sle$|^opensuse$|^(sle|leap)-micro$/);
 
     my $openqa_host = get_required_var('OPENQA_HOSTNAME');
     if ($openqa_host =~ /openqa1-opensuse|openqa.opensuse.org/) {    # O3 hostname


### PR DESCRIPTION
Allow pushing image data for other distris as it is for JeOS.

Data sample:
```
1662123225468332555 x86_64  33.1_17.2 sle-micro Default SLE-Micro.x86_64-5.3.0-Default-Build17.2.raw test uncompressed 2249 5.3
```

- ticket: [Add sle-micro to size monitoring process](https://progress.opensuse.org/issues/115556)
