### PR TITLE
Add a test suite for migration over maintenance updates

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -29,6 +29,7 @@ our @EXPORT = qw(
   reset_consoles_tty
   set_scc_proxy_url
   set_zypp_single_rpmtrans
+  remove_dropped_modules_packages
 );
 
 sub setup_sle {
@@ -129,6 +130,17 @@ sub deregister_dropped_modules {
         @all_addons = grep { $_ ne $name } @all_addons;
     }
     set_var('SCC_ADDONS', join(',', @all_addons));
+}
+
+# This function removes the packages specified with variable DROPPED_MODULES instead of un-registering the modules
+# before migrating: it is enough to just remove the -release package to avoid warnings like "the module
+# cannot be updated".
+sub remove_dropped_modules_packages {
+    my $droplist = get_var('DROPPED_MODULES', '');
+    for my $name (split(/,/, $droplist)) {
+        my $release_package = get_addon_fullname($name) . "-release";
+        zypper_call("rm $release_package");
+    }
 }
 
 # Disable installation repos before online migration

--- a/schedule/yast/maintenance/autoupgrade_sle15sp3+1_scc_we_sdk_basesys_wsm_srv_desk_lgm_contm_pcm_def_full.yaml
+++ b/schedule/yast/maintenance/autoupgrade_sle15sp3+1_scc_we_sdk_basesys_wsm_srv_desk_lgm_contm_pcm_def_full.yaml
@@ -1,0 +1,26 @@
+---
+name: autoupgrade_sle15sp3+1_scc_we_sdk_basesys_wsm_srv_desk_lgm_contm_pcm_def_full
+description: >
+  Performs a migration between installed system with unreleased maintenance updates installed, and next release, eg sle15 sp3>sp4
+schedule:
+  - autoyast/prepare_profile
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - console/check_system_info
+  - migration/remove_dropped_modules_packages
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - installation/bootloader
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - boot/grub_test_snapshot
+  - migration/version_switch_origin_system
+  - boot/snapper_rollback

--- a/tests/migration/remove_dropped_modules_packages.pm
+++ b/tests/migration/remove_dropped_modules_packages.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Register again is system is un-registered on SCC side, then
+# remove -release packages from dropped modules before installation to avoid related warnings.
+
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use migration;    #
+
+sub run {
+    select_console 'root-console';
+    remove_dropped_modules_packages if (get_var('DROPPED_MODULES'));
+}
+
+1;


### PR DESCRIPTION
See https://progress.opensuse.org/issues/113647
related MR https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/364

There is an issue that system gets de-registered the next day in the afternoon, and we cannot register it again. I tried many different hacks to work around it but none works. I don't think it is worth the effort as anyway, the test suite works otherwise. Just like all other maintenance update test suites, this one cannot be re-launched too long after the build.

VRs
https://openqa.suse.de/tests/9475427