### PR TITLE
Add test on hpc for cpuid

### DIFF
--- a/schedule/hpc/multi_machine_test.yaml
+++ b/schedule/hpc/multi_machine_test.yaml
@@ -60,4 +60,5 @@ schedule:
   - '{{bootmenu}}'
   - boot/boot_to_desktop
   - hpc/before_test
+  - hpc/cpuid
   - '{{hpctest}}'

--- a/tests/hpc/cpuid.pm
+++ b/tests/hpc/cpuid.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright @ SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: smoke test for cpuid on HPC
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base 'hpcbase', -signatures;
+use testapi;
+use utils;
+
+sub run ($self) {
+    zypper_call('in cpuid');
+    assert_script_run("cpuid > /tmp/output.txt 2>&1");
+}
+
+sub post_run_hook ($self) {
+    upload_logs('/tmp/output.txt', failok => 1);
+    $self->SUPER::post_run_hook();
+}
+
+sub post_fail_hook ($self) {
+    upload_logs('/tmp/output.txt', failok => 1);
+    $self->SUPER::post_fail_hook();
+}
+
+1;


### PR DESCRIPTION
Just install and run it to see if it works as a basic validation.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/116170
- Verification run: 
http://aquarius.suse.cz/tests/12159