### PR TITLE
Fix slow k3s start

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -14,7 +14,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use utils qw(zypper_call script_retry file_content_replace);
+use utils qw(zypper_call script_retry file_content_replace validate_script_output_retry);
 use Utils::Systemd qw(systemctl);
 use containers::utils 'registry_url';
 use version_utils qw(is_sle);
@@ -48,6 +48,7 @@ sub install_k3s {
     assert_script_run('k3s -v');
     assert_script_run('uname -a');
     assert_script_run("k3s kubectl get node");
+    validate_script_output_retry("k3s kubectl get node", qr/ Ready /, retry => 6, delay => 15, timeout => 90);
     script_run("mkdir -p ~/.kube");
     script_run("rm -f ~/.kube/config");
     assert_script_run("ln -s /etc/rancher/k3s/k3s.yaml ~/.kube/config");


### PR DESCRIPTION
The `k3` is starting for quite a some time so we need to check that at least one node of the k8s cluster is `Ready` before we continue with the testing.

```
kubectl get node
NAME       STATUS     ROLES    AGE   VERSION
susetest   NotReady   <none>   0s    v1.24.4+k3s1

k3s kubectl get node
NAME       STATUS   ROLES                  AGE   VERSION
susetest   Ready    control-plane,master   15s   v1.24.4+k3s1
```

As this is quite small fix I think that one reviewer should be enough to merge this.

- Related request: #15429
- Verification run: [pdostal-server.suse.cz/t535](https://pdostal-server.suse.cz/tests/535)
