### PR TITLE
Add work around & soft fail for poo#116191

### DIFF
--- a/schedule/ha/bv/migration/migration_online_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_online_sles_ha.yaml
@@ -26,6 +26,7 @@ schedule:
   - migration/version_switch_origin_system
   - '{{bootloader}}'
   - migration/online_migration/online_migration_setup
+  - ha/stop_pacemaker
   - migration/online_migration/register_system
   - migration/online_migration/zypper_patch
   - '{{remove_ltss}}'

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -16,7 +16,7 @@ use Utils::Architectures;
 use lockapi;
 use hacluster;
 use version_utils qw(is_sles4sap);
-use utils qw(systemctl);
+use utils qw(systemctl file_content_replace);
 
 sub run {
     my $cluster_name = get_cluster_name;
@@ -94,6 +94,31 @@ sub run {
     # Barrier for fenced nodes to wait for start delay.
     barrier_wait("SBD_START_DELAY_$cluster_name");
 
+    # Verify if poo#116191 is impacting the job
+    my $mdadm_conf = '/etc/mdadm.conf';
+    # Get UUID from the devices. blkdid output for the UUID is different than
+    # the format in /etc/mdadm.conf, so strip all non hex characters from it and
+    # then, split in 4 parts and join with ':', which should produce the format
+    # in /etc/mdadm.conf
+    my $get_uuid_cmd = 'for bd in $(grep ^DEVICE ' . $mdadm_conf . '); do [[ "$bd" == "DEVICE" ]] && continue; ';
+    $get_uuid_cmd .= 'blkid --output export "$bd" | sed -n -e s/[\-:]//g -e /^UUID=/s/^UUID=//p; done | sort -u';
+    my $uuid = script_output $get_uuid_cmd;
+    $uuid = join(':', substr($uuid, 0, 8), substr($uuid, 8, 8), substr($uuid, 16, 8), substr($uuid, 24));
+    die 'MD RAID devices have different UUIDs!' if ($uuid =~ /\n/);
+    my $mdadm_uuid = script_output "sed -r -n -e '/ARRAY/s/.*UUID=([0-9a-z:]+).*/\\1/p' $mdadm_conf";
+    if ($uuid ne $mdadm_uuid) {
+        record_soft_failure 'poo#116191 -- MD RAID UUID is different in /etc/mdadm.conf and cluster_md devices';
+        record_info 'UUID on MD Devices', $uuid;
+        record_info 'mdadm.conf', script_output "cat $mdadm_conf";
+        # Apply workaround in node 1, sync with rest of the cluster and cleanup cluster_md resource
+        if (is_node(1)) {
+            file_content_replace($mdadm_conf, 'UUID=[a-z0-9:]+' => "UUID=$uuid");
+            exec_csync;
+            rsc_cleanup 'cluster_md';
+        }
+    }
+
+    # Record pacemaker status
     systemctl 'status pacemaker', timeout => $default_timeout;
 
     # Wait for resources to be started

--- a/tests/ha/stop_pacemaker.pm
+++ b/tests/ha/stop_pacemaker.pm
@@ -1,0 +1,19 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: ha-cluster-bootstrap
+# Summary: stop pacemaker
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use Utils::Systemd qw(systemctl);
+
+sub run {
+    systemctl 'stop pacemaker';
+}
+
+1;


### PR DESCRIPTION
SLES+HA migrations from 15-SP3 to 15-SP4 & 15-SP5 on ppc64le fail on the `ha/check_after_reboot` test module because the UUID configured for the `cluster_md` MD RAID device in `/etc/mdadm.conf` in the qcow2 images from the 15-SP3 installations is different than the actual block devices UUIDs after the migration. This commit works around the issue and soft fail the test when the issue is detected.

- Related ticket: https://progress.opensuse.org/issues/116191
- Needles: N/A
- Verification runs: [support server](https://openqa.suse.de/tests/9458942), [node 1](https://openqa.suse.de/tests/9458943), [node 2](https://openqa.suse.de/tests/9458941)
- Verification run (regression): Alpha Cluster: [node 1](http://mango.qa.suse.de/tests/4945), [node 2](http://mango.qa.suse.de/tests/4946) & [support server](http://mango.qa.suse.de/tests/4946); 15-SP3 to 15-SP5 Migrations on x86_64: [node 1](http://mango.qa.suse.de/tests/4948), [node 2](http://mango.qa.suse.de/tests/4949) & [support server](http://mango.qa.suse.de/tests/4947)
