### PR TITLE
Remove workaround

### DIFF
--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -21,17 +21,18 @@ sub run {
     is_s390x() ? select_console 'root-console' : $self->select_serial_terminal;
 
     # Using packages from gitlab
-    my $repo_link = 'https://gitlab.suse.de/QA-APAC-I/testing/-/raw/master/data/selinux';
+    my $repo_link = 'https://gitlab.suse.de/qe-security/testing/-/raw/main/data/selinux';
     my $policy_pkg_20220124 = 'selinux-20220124.tgz';
     my $policy_pkg_20200219 = 'selinux-20200219.tgz';
 
-    # Program 'sestatus' can be found in policycoreutils pkgs
+    # Program 'sestatus' can be found in policycoreutils
     zypper_call("in policycoreutils");
-    # Program 'semanage' is in policycoreutils-python-utils pkgs on TW and SLES 15-SP4
+    # Program 'semanage' is found in:
+    #  - policycoreutils-python-utils pkgs on TW and SLES 15-SP4
+    #  - policycoreutils for 15-SP{0,3}
+    #  - policycoreutils-python for <= 12-SP5
     if (is_tumbleweed || is_sle('>=15-SP4')) {
-        record_soft_failure 'bsc#1200649' if is_sle('=15-SP4');
-        my $solver = is_sle('=15-SP4') ? '--force-resolution --solver-focus Update' : '';
-        zypper_call("in $solver policycoreutils-python-utils");
+        zypper_call("in policycoreutils-python-utils");
     }
     if (!is_sle('>=15')) {
         assert_script_run('zypper -n in policycoreutils-python');


### PR DESCRIPTION
Since the fix has been released, we can now remove the workaround (bsc#1200649).

Verification runs:
- 15-SP4: https://openqa.suse.de/tests/9458270
- 15-SP3: https://openqa.suse.de/tests/9458269