### PR TITLE
Add function to get qe-sap-deployment code in the test

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1,0 +1,97 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Functions to use qe-sap-deployment project
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+## no critic (RequireFilenameMatchesPackage);
+
+=encoding utf8
+
+=head1 NAME
+
+qe-sap-deployment test lib
+
+=head1 COPYRIGHT
+
+Copyright 2022 SUSE LLC
+SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+QE SAP <qe-sap@suse.de>
+
+=cut
+
+package qesapdeployment;
+
+use strict;
+use warnings;
+use testapi;
+use Exporter 'import';
+
+# Constants
+use constant DEPLOYMENT_DIR => get_var('DEPLOYMENT_DIR', '/root/qe-sap-deployment');
+use constant QESAP_GIT_CLONE_LOG => '/tmp/git_clone.log';
+
+my @log_files = ();
+
+our @EXPORT = qw(
+  qesap_create_folder_tree
+  qesap_get_deployment_code
+);
+
+
+=head1 DESCRIPTION
+
+Package with common methods and default or constant  values for qe-sap-deployment
+
+=head2 Methods
+=head3 qesap_create_folder_tree
+
+Create all needed folders
+
+=cut
+
+sub qesap_create_folder_tree {
+    assert_script_run('mkdir -p ' . DEPLOYMENT_DIR, quiet => 1);
+}
+
+
+=head3 qesap_get_deployment_code
+
+Get the qe-sap-deployment code
+=cut
+
+sub qesap_get_deployment_code {
+    record_info("QESAP repo", "Preparing qe-sap-deployment repository");
+
+    my $git_repo = get_var(QESAPDEPLOY_GITHUB_REPO => 'github.com/SUSE/qe-sap-deployment');
+    enter_cmd "cd " . DEPLOYMENT_DIR;
+
+    # Script from a release
+    if (get_var('QESAPDEPLOY_VER')) {
+        my $ver_artifact = 'v' . get_var('QESAPDEPLOY_VER') . '.tar.gz';
+
+        my $curl_cmd = "curl -v -L https://$git_repo/archive/refs/tags/$ver_artifact -o$ver_artifact";
+        assert_script_run("set -o pipefail ; $curl_cmd | tee " . QESAP_GIT_CLONE_LOG, quiet => 1);
+
+        my $tar_cmd = "tar xvf $ver_artifact --strip-components=1";
+        assert_script_run($tar_cmd);
+        enter_cmd 'ls -lai';
+    }
+    else {
+        # Get the code for the qe-sap-deployment by cloning its repository
+        assert_script_run('git config --global http.sslVerify false', quiet => 1) if get_var('QESAPDEPLOY_GIT_NO_VERIFY');
+        my $git_branch = get_var('QESAPDEPLOY_GITHUB_BRANCH', 'main');
+
+        my $git_clone_cmd = 'git clone --depth 1 --branch ' . $git_branch . ' https://' . $git_repo . ' ' . DEPLOYMENT_DIR;
+        push(@log_files, QESAP_GIT_CLONE_LOG);
+        assert_script_run("set -o pipefail ; $git_clone_cmd | tee " . QESAP_GIT_CLONE_LOG, quiet => 1);
+    }
+}
+
+
+1;

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2017-2020 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Functions for Trento tests
@@ -16,7 +16,7 @@ Trento test lib
 
 =head1 COPYRIGHT
 
-Copyright 2017-2020 SUSE LLC
+Copyright 2022 SUSE LLC
 SPDX-License-Identifier: FSFAP
 
 =head1 AUTHORS
@@ -319,8 +319,6 @@ sub k8s_logs {
             }
         }
     }
-    $self->az_vm_ssh_cmd('kubectl exec --stdin --tty deploy/trento-server-runner /usr/bin/trento-runner version', $machine_ip);
-    script_run('ls -lai *.txt', 180);
 }
 
 =head3 podman_self_check

--- a/schedule/sles4sap/trento/trento.yml
+++ b/schedule/sles4sap/trento/trento.yml
@@ -11,6 +11,7 @@ vars:
 schedule:
     - boot/boot_to_desktop
     - sles4sap/trento/init_jumphost
+    - sles4sap/trento/cluster_configure
     - sles4sap/trento/deploy_trento
     - sles4sap/trento/test_trento_deploy
     - sles4sap/trento/test_trento_web

--- a/tests/sles4sap/trento/cluster_configure.pm
+++ b/tests/sles4sap/trento/cluster_configure.pm
@@ -1,0 +1,28 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Configuration steps for qe-sap-deployment
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use qesapdeployment;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    # Get the code for the qe-sap-deployment
+    $self->qesap_create_folder_tree();
+    $self->qesap_get_deployment_code();
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->select_serial_terminal;
+    $self->SUPER::post_fail_hook;
+}
+
+1;


### PR DESCRIPTION
Create a library for the qe-sap-deployment project management
Add a Trento test step about deploying a SAP Landscape
Change the Trento scheduling to use this new test step

- Verification run with git clone of the qe-sap-deployment repo: http://openqaworker15.qa.suse.cz/tests/20849
- Verification run with QESAPDEPLOY_VER=0.2.0: http://openqaworker15.qa.suse.cz/tests/20850