### PR TITLE
Double confirm 'apply changes' in kdump_and_crash test

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -195,6 +195,12 @@ sub activate_kdump {
         } until (match_has_tag('yast2-kdump-restart-info'));
         send_key('alt-o');
     }
+
+    if (check_screen('yast2-kdump-restart-info', 180)) {
+        record_info('bsc#1202629', 'yast2 kdump shows "To apply changes a reboot is necessary" even no changes there');
+        send_key('alt-o');
+    }
+
     wait_serial("$module_name-0", 240) || die "'yast2 kdump' didn't finish";
 }
 


### PR DESCRIPTION
poo#115589 & bsc#1202629

- Related ticket: https://progress.opensuse.org/issues/115589
- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1202629
- Needles: n/a
- Verification run: 
SLE- https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=kdump
TW - https://openqa.opensuse.org/tests/2634662
[Please omit the failed kdump_and_crash cases on aarch64+ sle and TW, they are known issues]
