### PR TITLE
gnomeapps: gnome-todo has been replaced by Endeavour

### DIFF
--- a/tests/x11/gnomeapps/endeavour.pm
+++ b/tests/x11/gnomeapps/endeavour.pm
@@ -3,8 +3,8 @@
 # Copyright 2017 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: gnome-todo
-# Summary: GNOME Todo - Minimal Test
+# Package: endeavour
+# Summary: Endeavour - Minimal Test
 # Maintainer: Dominique Leuenberger <dimstar@suse.de>>
 
 use base "x11test";
@@ -14,7 +14,7 @@ use testapi;
 use utils;
 
 sub run {
-    assert_gui_app('gnome-todo');
+    assert_gui_app('endeavour');
 }
 
 1;


### PR DESCRIPTION

- Related ticket: N/A
- Needles: Will be created once merged
- Verification run: N/A
