### PR TITLE
Add conflict for rpm-ndb

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -58,6 +58,8 @@ sub has_conflict {
         'openssl-1_0_0' => 'openssl-1_1',
         'libsamba-errors0' => 'samba-client-libs',
         rpm => 'rpm-ndb',
+        # rpm-ndb can't be installed, it will remove rpm and break rpmdb2solv -> zypper
+        'rpm-ndb' => 'rpm-ndb',
         'SAPHanaSR-ScaleOut' => 'SAPHanaSR',
         'SAPHanaSR-ScaleOut-doc' => 'SAPHanaSR-doc',
         'dapl-devel' => 'dapl-debug-devel',


### PR DESCRIPTION
```
The following NEW package is going to be installed:
  rpm-ndb

The following package is going to be REMOVED:
  rpm

1 new package to install, 1 to remove.
Overall download size: 989.8 KiB. Already cached: 0 B. After the operation, 2.1 MiB will be freed.
Continue? [y/n/p/...? shows all options] (y): y
Retrieving package rpm-ndb-4.14.1-22.7.1.ppc64le (1/1), 989.8 KiB (  4.3 MiB unpacked)
Retrieving: rpm-ndb-4.14.1-22.7.1.ppc64le.rpm [done]

Checking for file conflicts: [......done]
(1/2) Removing rpm-4.14.1-22.7.1.ppc64le [.....done]
(2/2) Installing: rpm-ndb-4.14.1-22.7.1.ppc64le [.Installation of rpm-ndb-4.14.1-22.7.1.ppc64le failed:
Error: Subprocess failed. Error: RPM failed: Command exited with status 129.
error]
Abort, retry, ignore? [a/r/i] (a): a
Problem occurred during or after installation or removal of packages:
Failed to cache rpm database (127).
History:
 - 'rpmdb2solv' '-r' '/' '-D' '/usr/lib/sysimage/rpm' '-X' '-p' '/etc/products.d' '/var/cache/zypp/solv/@System/solv' '-o' '/var/cache/zypp/solv/@System/solv0lluES'
   rpmdb2solv: error while loading shared libraries: librpmio.so.8: cannot open shared object file: No such file or directory

Please see the above error message for a hint.
```

- Fail: https://openqa.suse.de/tests/9469558#step/update_install/65
- Verification run:
https://dzedro.suse.cz/tests/409
https://openqa.suse.de/tests/9470568 x86_64
https://openqa.suse.de/tests/9470569 s390x
https://openqa.suse.de/tests/9470733 ppc64le
https://openqa.suse.de/tests/9470571 aarch64
