### PR TITLE
Install kdumptool where needed and fix synchronization failure in yast kdump module

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -192,13 +192,15 @@ sub activate_kdump {
         $expect_restart_info = 1;
     }
     send_key('alt-o');
+    # Expect yast2-kdump-restart-info on s390x
+    $expect_restart_info = 1 if (is_s390x && is_sle('15-SP5+'));
     if ($expect_restart_info == 1) {
-        my @tags = qw(yast2-kdump-restart-info os-prober-warning);
+        my @tags = qw(yast2-kdump-restart-info os-prober-warning yast2-kdump-no-restart-info);
         do {
             assert_screen(\@tags, timeout => 180);
             handle_warning_install_os_prober() if match_has_tag('os-prober-warning');
-        } until (match_has_tag('yast2-kdump-restart-info'));
-        send_key('alt-o');
+        } until (match_has_tag('yast2-kdump-restart-info') || match_has_tag('yast2-kdump-no-restart-info'));
+        send_key('alt-o') if match_has_tag('yast2-kdump-restart-info');
     }
     wait_serial("$module_name-0", 240) || die "'yast2 kdump' didn't finish";
 }

--- a/tests/console/yast2_kdump.pm
+++ b/tests/console/yast2_kdump.pm
@@ -17,6 +17,7 @@ use registration;
 use scheduler 'get_test_suite_data';
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     select_console('root-console');
@@ -24,6 +25,7 @@ sub run {
     # install kdump by adding additional modules
     add_suseconnect_product('sle-module-desktop-applications');
     add_suseconnect_product('sle-module-development-tools');
+    zypper_call('in kdump') if is_sle('15-SP5+');
     zypper_call('in yast2-kdump');
 
     # Kdump configuration with YaST module


### PR DESCRIPTION
Need install kdump which is not dependency of yast2-kdump module in SLE15-SP5 and is no longer installed when yast2-kdump is installed. And reboot requirement warning message need to be deal with on s390x. Use multi-tag to deal with the different behavior for reboot popup message.

- Related ticket: https://progress.opensuse.org/issues/115622
- Needles:  yast2-kdump-no-restart-info:  already merged to OSD.
- Verification run: 
   https://openqa.nue.suse.com/tests/9514874#  x86_64
   https://openqa.nue.suse.com/tests/9514876#   s390x
   http://openqa.nue.suse.com/tests/9514822#    aarch64  failed for bsc#1202738
   http://openqa.nue.suse.com/tests/9514821#    ppc64le
