### PR TITLE
data/journal_check/bug_refs.json: make health-check unique names

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -302,7 +302,7 @@
         },
         "type": "ignore"
     },
-    "health-check": {
+    "health-check-typo": {
         "description": "health-checker/fail.sh check\" failed|Machine didn't come up correct, do a rollback",
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],


### PR DESCRIPTION
Fix regression from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15481

The 'name' of the entries need to be unique

- Related ticket: N/A
- Needles: N/A
- Verification run: [health-check-typo](https://openqa.opensuse.org/t2639567) | [health-check (new string)](https://openqa.opensuse.org/t2639568)
