### PR TITLE
Remove grub timeout for baremetal install of sles4sap

### DIFF
--- a/schedule/kernel/sles4sap/install_sles4sap_baremetal.yaml
+++ b/schedule/kernel/sles4sap/install_sles4sap_baremetal.yaml
@@ -27,6 +27,7 @@ schedule:
   - installation/user_settings_root
   - installation/resolve_dependency_issues
   - installation/installation_overview
+  - installation/disable_grub_timeout
   - installation/disable_kdump
   - installation/start_install
   - installation/await_install


### PR DESCRIPTION
This fixes a timeout where grub cannot be seen on ipmi console and thus a needle won't match. Plus, it helps to ensure we are actually rebooting by checking the bootloader prompt.
This change is already present and required for other baremetal jobs

- Verification run: http://baremetal-support.qa.suse.de/tests/2336#
