### PR TITLE
Get "mr test" running on openqaworker15 for 15 SP4

### DIFF
--- a/lib/mr_test_lib.pm
+++ b/lib/mr_test_lib.pm
@@ -1,0 +1,52 @@
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Base module for saptune "mr_test" test cases.
+#          It dynamically generates test modules (*.pm) according to 'MR_TEST'.
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: jsc#TEAM-6726
+
+package mr_test_lib;
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+use autotest;
+
+use base 'consoletest';
+use LTP::TestInfo 'testinfo';
+use mr_test_run qw(get_notes get_solutions);
+
+our @EXPORT = qw(
+  load_mr_tests
+);
+
+sub loadtest_mr_test {
+    my ($test, %args) = @_;
+    autotest::loadtest("lib/$test.pm", %args);
+}
+
+sub load_mr_tests {
+    my ($test_list) = @_;
+    my $i = 1;
+    my $note_solution = '';
+
+    # The main script which dynamically generates test modules (*.pm) according to 'MR_TEST' value
+    my $script = 'mr_test_run';
+    my $tinfo = testinfo({}, test => $script);
+    for my $test (split(/,/, $test_list)) {
+        $note_solution = '';
+        if (grep { /^${test}$/ } mr_test_run::get_solutions()) {
+            $note_solution = 'solution_';
+        }
+        elsif (grep { /^${test}$/ } mr_test_run::get_notes()) {
+            $note_solution = 'note_';
+        }
+        $tinfo = testinfo({}, test => $test);
+        loadtest_mr_test("$script", name => $i . '_saptune_' . $note_solution . $test, run_args => $tinfo);
+        $i++;
+    }
+}
+
+1;

--- a/lib/mr_test_run.pm
+++ b/lib/mr_test_run.pm
@@ -1,0 +1,536 @@
+# SUSE's openQA tests
+#
+# Copyright 2019-2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: saptune testing with mr_test
+# Maintainer: QE-SAP <qe-sap@suse.de>, Ricardo Branco <rbranco@suse.de>, llzhao <llzhao@suse.com>
+
+package mr_test_run;
+
+use base "sles4sap";
+use testapi;
+use Utils::Backends;
+use utils;
+use version_utils 'is_sle';
+use Utils::Architectures;
+use Mojo::JSON 'encode_json';
+use strict;
+use warnings;
+
+our @EXPORT = qw(
+  $result_module
+  reboot_wait
+  get_notes
+  get_solutions
+);
+
+our $log_file = '/var/log.txt';
+our $results_file = '/var/results.txt';
+our $result;
+our $result_module;
+
+sub reboot_wait {
+    my ($self) = @_;
+    $self->reboot;
+}
+
+sub get_notes {
+    # Note: We ignore these as we're not testing on cloud:
+    # 1656250 - SAP on AWS: Support prerequisites - only Linux Operating System IO  recommendations
+    # 2993054 - Recommended settings for SAP systems on Linux running in Azure virtual machines
+    if (is_sle('>=15')) {
+        return qw(1410736 1680803 1771258 1805750 1980196 2161991 2382421 2534844 2578899 2684254 3024346 900929 941735 SAP_BOBJ);
+    }
+    else {
+        return qw(1410736 1680803 1771258 1805750 1980196 1984787 2161991 2205917 2382421 2534844 3024346 900929 941735 SAP_BOBJ);
+    }
+}
+
+sub get_solutions {
+    return qw(BOBJ HANA MAXDB NETWEAVER NETWEAVER+HANA S4HANA-APP+DB S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
+}
+
+sub tune_baseline {
+    my $filename = shift;
+    assert_script_run "sed -ri -e '/fs\\/file-max/s/:([0-9]*)\$/:~~\\1/' -e '/:scripts\\/shm_size/s/:([0-9]*)\$/:~~\\1/' $filename";
+}
+
+
+sub test_bsc1152598 {
+    my ($self) = @_;
+
+    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
+    $result = "ok";
+    $self->result("$result");
+    record_info "bsc1152598";
+
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_bsc1152598#1_1");
+    assert_script_run
+'echo -e "[version]\n# foobar-NOTE=foobar CATEGORY=foobar VERSION=0 DATE=foobar NAME=\" foobar \"\n[block]\nIO_SCHEDULER=noop, none, foobar\n" > /etc/saptune/extra/scheduler-test.conf';
+    $self->wrap_script_run("saptune note apply scheduler-test");
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_bsc1152598#1_2");
+    $self->wrap_script_run("saptune revert all");
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_bsc1152598#1_1");
+    assert_script_run
+'echo -e "[version]\n# foobar-NOTE=foobar CATEGORY=foobar VERSION=0 DATE=foobar NAME=\" foobar \"\n[block]\nIO_SCHEDULER=foobar, noop, none\n" > /etc/saptune/extra/scheduler-test.conf';
+    $self->wrap_script_run('saptune note apply scheduler-test');
+    $self->wrap_script_run("egrep -q '\[(noop|none)\]' /sys/block/sda/queue/scheduler");
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_bsc1152598#1_2");
+    $self->wrap_script_run("saptune revert all");
+
+    assert_script_run "echo Test test_bsc1152598: $result >> $log_file";
+    $self->result("$result");
+}
+
+sub test_delete {
+    my ($self) = @_;
+
+    my $dir = "Pattern/testpattern_saptune-delete+rename";
+    my $note = "2161991";
+
+    ### Deleting a shipped Note (without override/with override + not applied/applied)
+    $result = "ok";
+    $self->result("$result");
+    record_info "delete note $note";
+    $self->wrap_script_run("rm -f /etc/saptune/extra/* /etc/saptune/override/*");
+
+    # (not-applied, no override)
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_1");
+    $self->wrap_script_run("! saptune note delete ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_1");
+
+    # (applied, no override)
+    $self->wrap_script_run("saptune note apply ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_2");
+    $self->wrap_script_run("! saptune note delete ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_2");
+
+    # (applied, override)
+    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/override/${note}";
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_3");
+    $self->wrap_script_run("! saptune note delete ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_3");
+
+    # (not applied, override)
+    $self->wrap_script_run("saptune note revert ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_4");
+    $self->wrap_script_run("yes n | saptune note delete ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_4");
+    $self->wrap_script_run("yes | saptune note delete ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#1_1");
+
+    ### Deleting a created Note (without override/with override + not applied/applied)
+
+    $self->wrap_script_run("rm -f /etc/saptune/extra/* /etc/saptune/override/*");
+
+    # (applied, no override)
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_1");
+    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/extra/testnote.conf";
+    $self->wrap_script_run("saptune note apply testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_2");
+    $self->wrap_script_run("! saptune note delete testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_2");
+
+    # (applied, override)
+    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/override/testnote";
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_3");
+    $self->wrap_script_run("! saptune note delete testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_3");
+
+    # (not applied, override)
+    $self->wrap_script_run("saptune note revert testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_4");
+    $self->wrap_script_run("yes n | saptune note delete testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_4");
+    $self->wrap_script_run("yes | saptune note delete testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_1");
+
+    # (not-applied, no override)
+    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/extra/testnote.conf";
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_5");
+    $self->wrap_script_run("yes n | saptune note delete testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_5");
+    $self->wrap_script_run("yes | saptune note delete testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#2_1");
+
+    ### Deleting a non-existent Note
+
+    $self->wrap_script_run("rm -f /etc/saptune/extra/* /etc/saptune/override/*");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#3_1");
+    $self->wrap_script_run("! saptune note delete 999999");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-delete#3_1");
+
+    ### Renaming a shipped Note (without override/with override + not applied/applied)
+
+    $self->wrap_script_run("rm -f /etc/saptune/extra/* /etc/saptune/override/*");
+
+    assert_script_run "echo Test test_delete_$note: $result >> $log_file";
+    $self->result("$result");
+}
+
+sub test_rename {
+    my ($self) = @_;
+
+    my $dir = "Pattern/testpattern_saptune-delete+rename";
+    my $note = "2161991";
+
+    ### Renaming a shipped Note (without override/with override + not applied/applied)
+    $result = "ok";
+    $self->result("$result");
+    record_info "rename note $note";
+    $self->wrap_script_run("rm -f /etc/saptune/extra/* /etc/saptune/override/*");
+
+    # (not-applied, no override)
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#1_1");
+    $self->wrap_script_run("! saptune note rename ${note} newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#1_1");
+
+    # (applied, no override)
+    $self->wrap_script_run("saptune note apply ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#1_2");
+    $self->wrap_script_run("! saptune note rename ${note} newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#1_2");
+
+    # (applied, override)
+    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/override/${note}";
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#1_3");
+    $self->wrap_script_run("! saptune note rename ${note} newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#1_3");
+
+    # (not applied, override)
+    $self->wrap_script_run("saptune note revert ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#1_4");
+    $self->wrap_script_run("! saptune note rename ${note} newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#1_4");
+
+    ### Renaming a created Note (without override/with override + not applied/applied)
+
+    $self->wrap_script_run("rm -f /etc/saptune/extra/* /etc/saptune/override/*");
+
+    # (applied, no override)
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_1");
+    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/extra/testnote.conf";
+    $self->wrap_script_run("saptune note apply testnote");
+    $self->wrap_script_run("! saptune note rename testnote newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_2");
+
+    # (applied, override)
+    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/override/testnote";
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_3");
+    $self->wrap_script_run("! saptune note rename testnote newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_3");
+
+    # (not applied, override)
+    $self->wrap_script_run("saptune note revert testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_4");
+    $self->wrap_script_run("yes n | saptune note rename testnote newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_4");
+    $self->wrap_script_run("yes | saptune note rename testnote newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_5");
+
+    # (not-applied, no override)
+    $self->wrap_script_run("rm /etc/saptune/override/newnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_6");
+    $self->wrap_script_run("yes n | saptune note rename newnote testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_6");
+    $self->wrap_script_run("yes | saptune note rename newnote testnote");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#2_7");
+
+    ### Renaming a created Note to an existing note (not applied)
+
+    $self->wrap_script_run("rm -f /etc/saptune/extra/* /etc/saptune/override/*");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#3_1");
+    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/extra/testnote.conf";
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#3_2");
+    $self->wrap_script_run("! saptune note rename testnote ${note}");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#3_2");
+
+    ### Renaming a non-existent Note
+
+    $self->wrap_script_run("rm -f /etc/saptune/extra/* /etc/saptune/override/*");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#4_1");
+    $self->wrap_script_run("! saptune note rename 999999 999999");
+    $self->wrap_script_run("mr_test verify ${dir}/testpattern_saptune-rename#4_1");
+
+    assert_script_run "echo Test test_rename_$note: $result >> $log_file";
+    $self->result("$result");
+}
+
+sub test_note {
+    my ($self, $note) = @_;
+
+    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
+    my $extra = ($note eq "1771258") ? "-1" : "";
+
+    $result = "ok";
+    $self->result("$result");
+    record_info "note $note";
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_baseline_Cust");
+    $self->wrap_script_run("mr_test dump Pattern/${SLE}/testpattern_note_${note}${extra}_b > baseline_testpattern_note_${note}${extra}_b");
+    $self->wrap_script_run("saptune note apply $note");
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_note_${note}${extra}_a");
+    $self->wrap_script_run("mr_test verify baseline_testpattern_note_${note}${extra}_b");
+    tune_baseline("baseline_testpattern_note_${note}${extra}_b");
+    $self->reboot_wait;
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_note_${note}${extra}_a");
+    $self->wrap_script_run("mr_test verify baseline_testpattern_note_${note}${extra}_b");
+    $self->wrap_script_run("saptune note revert $note");
+    $self->reboot_wait;
+
+    assert_script_run "echo Test test_note_$note: $result >> $log_file";
+    $self->result("$result");
+}
+
+sub test_override {
+    my ($self, $note) = @_;
+
+    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
+
+    # With notes 1557506 & 1771258 we have to test 2 override files
+    my @overrides = ($note =~ m/^(1557506|1771258)$/) ? ("${note}-1", "${note}-2") : (${note});
+
+    $result = "ok";
+    $self->result("$result");
+    record_info "override $note";
+
+    if ($note eq "1680803") {
+        # Ignore the tests for the scheduler if we can't set "none" on /dev/sr0
+        assert_script_run("if [ -f /sys/block/sr0/queue/scheduler ] ; then "
+              . "grep -q none /sys/block/sr0/queue/scheduler || "
+              . "sed -i '/:scripts\\/nr_requests/s/^/#/' Pattern/$SLE/testpattern_note_${note}_a_override ; fi");
+    }
+    foreach my $override (@overrides) {
+        $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_baseline_Cust");
+        $self->wrap_script_run("mr_test dump Pattern/$SLE/testpattern_note_${override}_b > baseline_testpattern_note_${override}_b");
+        $self->wrap_script_run("cp Pattern/$SLE/override/$override /etc/saptune/override/$note");
+        $self->wrap_script_run("saptune note apply $note");
+        $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override");
+        $self->wrap_script_run("mr_test verify baseline_testpattern_note_${override}_b");
+        tune_baseline("baseline_testpattern_note_${override}_b");
+        $self->reboot_wait;
+        $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override");
+        $self->wrap_script_run("mr_test verify baseline_testpattern_note_${override}_b");
+        $self->wrap_script_run("saptune note revert $note");
+        $self->wrap_script_run("rm -f /etc/saptune/override/$note");
+        $self->reboot_wait;
+    }
+
+    assert_script_run "echo Test test_override_$note: $result >> $log_file";
+    $self->result("$result");
+}
+
+sub test_solution {
+    my ($self, $solution) = @_;
+
+    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
+
+    $result = "ok";
+    $self->result("$result");
+    record_info "solution $solution";
+
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_baseline_Cust");
+    $self->wrap_script_run("mr_test dump Pattern/${SLE}/testpattern_solution_${solution}_b > baseline_testpattern_solution_${solution}_b");
+    $self->wrap_script_run("saptune solution apply $solution");
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_solution_${solution}_a");
+    $self->wrap_script_run("mr_test verify baseline_testpattern_solution_${solution}_b");
+    tune_baseline("baseline_testpattern_solution_${solution}_b");
+    $self->reboot_wait;
+    $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_solution_${solution}_a");
+    $self->wrap_script_run("mr_test verify baseline_testpattern_solution_${solution}_b");
+    $self->wrap_script_run("saptune solution revert $solution");
+    $self->reboot_wait;
+
+    assert_script_run "echo Test test_solution_$solution: $result >> $log_file";
+    $self->result("$result");
+}
+
+sub test_notes {
+    my ($self) = @_;
+
+    foreach my $note (get_notes()) {
+        # Skip 1805750 (SYB: Usage of HugePages on Linux Systems with Sybase ASE)
+        # The ASE docs don't recommend any specific value or formula, so it must
+        # be tested with an override file in test_overrides()
+        next if ($note eq "1805750");
+        $self->test_note($note);
+    }
+}
+
+sub test_overrides {
+    my ($self) = @_;
+
+    foreach my $note (get_notes()) {
+        $self->test_override($note);
+    }
+}
+
+sub test_solutions {
+    my ($self) = @_;
+
+    foreach my $solution (get_solutions()) {
+        $self->test_solution($solution);
+    }
+}
+
+sub test_ppc64le {
+    my ($self) = @_;
+
+    die "This test cannot be run on QEMU" if (is_qemu);
+    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
+
+    record_info "ppc64le";
+    $result = "ok";
+    $self->result("$result");
+
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Power_1");
+    # Apply all notes except 1805750
+    foreach my $note (get_notes()) {
+        next if ($note eq "1805750");
+        $self->wrap_script_run("saptune note apply $note");
+    }
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Power_2");
+    $self->wrap_script_run("saptune revert all");
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Power_3");
+
+    assert_script_run "echo Test test_ppc64le: $result >> $log_file";
+    $self->result("$result");
+}
+
+
+sub test_x86_64 {
+    my ($self) = @_;
+
+    my $SLE;
+    my $note;
+
+    if (is_sle(">=15")) {
+        $SLE = "SLE15";
+        $note = "2684254";
+    }
+    else {
+        $SLE = "SLE12";
+        $note = "2205917";
+    }
+
+    record_info "x86_64";
+    $result = "ok";
+    $self->result("$result");
+
+    # energy_perf_bias=6
+    $self->wrap_script_run("cpupower set -b 6");
+    # governor=powersave
+    $self->wrap_script_run('cpupower frequency-set -g powersave');
+    # force_latency=max
+    $self->wrap_script_run('cpupower idle-set -E');
+    $self->reboot_wait;
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Intel_1");
+    $self->wrap_script_run("saptune note apply $note");
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Intel_2");
+    $self->wrap_script_run("saptune note revert $note");
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Intel_1");
+    assert_script_run "echo -e '[cpu]\\nenergy_perf_bias=powersave\\ngovernor=powersave\\nforce_latency=' > /etc/saptune/override/$note";
+    $self->wrap_script_run("saptune note apply $note");
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Intel_3");
+    $self->wrap_script_run("saptune note revert $note");
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Intel_1");
+    assert_script_run "echo -e '[cpu]\\nenergy_perf_bias=\\ngovernor=\\nforce_latency=\\n' > /etc/saptune/override/$note";
+    $self->wrap_script_run("saptune note apply $note");
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Intel_4");
+    $self->wrap_script_run("saptune note revert $note");
+    $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_Cust#Intel_1");
+
+    assert_script_run "echo Test test_x86_64_$note: $result >> $log_file";
+    $self->result("$result");
+}
+
+sub wrapup_log_file {
+    my %results;
+
+    $results{tests} = [];
+    my $output = script_output "cat $log_file";
+    foreach my $line (split("\n", $output)) {
+        my %aux = ();
+        next unless ($line =~ /Test ([^:]+)/);
+        $aux{name} = $1;
+        $line =~ /Test .*: ([a-zA-z]+)/;
+        if ($1 eq 'ok') {
+            $aux{outcome} = 'passed';
+        }
+        elsif ($1 eq 'fail') {
+            $aux{outcome} = 'failed';
+        }
+        $aux{test_index} = 0;
+        push @{$results{tests}}, \%aux;
+    }
+    my $json = encode_json \%results;
+    assert_script_run "echo '$json' > $results_file";
+}
+
+sub wrap_script_run {
+    my ($self, $args) = @_;
+    my $ret = '';
+
+    $ret = script_run "$args";
+    if ($ret) {
+        $result = 'fail';
+        record_soft_failure('Error found:jsc#TEAM-6726');
+        $result_module = $result;
+        $self->result("$result");
+    }
+}
+
+sub run {
+    my ($self, $tinfo) = @_;
+    my $test = $tinfo->test;
+
+    # Cleanup test log file before run test cases
+    assert_script_run "> $log_file";
+
+    # Set test module result to "ok"
+    $self->result("ok");
+    $result_module = "ok";
+
+    $test = quotemeta($test);
+    if ($test eq "solutions") {
+        $self->test_solutions;
+    }
+    elsif ($test eq "notes") {
+        $self->test_notes;
+    }
+    elsif ($test eq "overrides") {
+        $self->test_overrides;
+    }
+    elsif (grep { /^${test}$/ } get_solutions()) {
+        $self->test_solution($test);
+    }
+    elsif (grep { /^${test}$/ } get_notes()) {
+        # Skip 1805750 (SYB: Usage of HugePages on Linux Systems with Sybase ASE)
+        # The ASE docs don't recommend any specific value or formula, so it must
+        # be tested with an override file
+        $self->test_note($test) if ($test ne "1805750");
+        $self->test_override($test);
+    }
+    elsif ($test =~ m/^(x86_64|ppc64le)$/) {
+        $self->test_x86_64 if (is_ipmi);
+        $self->test_ppc64le if is_ppc64le();
+        $self->test_bsc1152598;
+    }
+    elsif ($test eq "delete_rename") {
+        $self->test_delete;
+        $self->test_rename;
+    }
+    else {
+        die "Invalid value for MR_TEST=$test";
+    }
+
+    # Reset test module result according to global test result flag
+    $self->result("$result_module");
+
+    # Do IPA parsing and upload log file
+    wrapup_log_file();
+    parse_extra_log(IPA => $results_file);
+    upload_logs $log_file;
+}
+
+1;

--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -1,10 +1,10 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: saptune testing with mr_test
-# Maintainer: QE-SAP <qe-sap@suse.de>, Ricardo Branco <rbranco@suse.de>
+# Maintainer: QE-SAP <qe-sap@suse.de>, Ricardo Branco <rbranco@suse.de>, llzhao <llzhao@suse.com>
 
 use base "sles4sap";
 use testapi;
@@ -14,6 +14,7 @@ use version_utils 'is_sle';
 use Utils::Architectures;
 use strict;
 use warnings;
+use mr_test_lib qw(load_mr_tests);
 
 sub reboot_wait {
     my ($self) = @_;
@@ -35,8 +36,13 @@ sub setup {
     quit_packagekit;
     # saptune is not installed by default on SLES4SAP 12 on ppc64le and in textmode profile
     zypper_call "-n in saptune" if ((is_ppc64le() and is_sle('<15')) or check_var('DESKTOP', 'textmode'));
+    zypper_call "in sapconf" if is_sle("<15");
     # Install mr_test dependencies
-    zypper_call "-n in python3-rpm";
+    # 'zypper_call "-n in python3-rpm"' returns error message:
+    #   "There are running programs which still use files and libraries deleted or updated by recent upgrades.
+    #   They should be restarted to benefit from the latest updates.
+    #   Run 'zypper ps -s' to list these programs."
+    zypper_call "in python3-rpm", exitcode => [0, 106];
     # Download mr_test and extract it to $HOME
     assert_script_run "curl -sk $tarball | tar zxf - --strip-components 1";
     # Add $HOME to $PATH
@@ -44,6 +50,7 @@ sub setup {
     # Remove any configuration set by sapconf
     assert_script_run "sed -i.bak '/^@/,\$d' /etc/security/limits.conf";
     script_run "mv /etc/systemd/logind.conf.d/sap.conf{,.bak}" unless check_var('DESKTOP', 'textmode');
+    systemctl '--now disable sapconf';
     assert_script_run 'saptune service enablestart';
     if (is_qemu) {
         # Ignore disk_elevator on VM's
@@ -54,391 +61,14 @@ sub setup {
     $self->reboot_wait;
 }
 
-sub get_notes {
-    # Note: We ignore these as we're not testing on cloud:
-    # 1656250 - SAP on AWS: Support prerequisites - only Linux Operating System IO  recommendations
-    # 2993054 - Recommended settings for SAP systems on Linux running in Azure virtual machines
-    if (is_sle('>=15')) {
-        return qw(1410736 1680803 1771258 1805750 1980196 2161991 2382421 2534844 2578899 2684254 3024346 900929 941735 SAP_BOBJ);
-    } else {
-        return qw(1410736 1680803 1771258 1805750 1980196 1984787 2161991 2205917 2382421 2534844 3024346 900929 941735 SAP_BOBJ);
-    }
-}
-
-sub get_solutions {
-    return qw(BOBJ HANA MAXDB NETWEAVER NETWEAVER+HANA S4HANA-APP+DB S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
-}
-
-sub tune_baseline {
-    my $filename = shift;
-    assert_script_run "sed -ri -e '/fs\\/file-max/s/:([0-9]*)\$/:~~\\1/' -e '/:scripts\\/shm_size/s/:([0-9]*)\$/:~~\\1/' $filename";
-}
-
-sub test_bsc1152598 {
-    my ($self) = @_;
-
-    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
-
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_bsc1152598#1_1";
-    assert_script_run 'echo -e "[version]\n# foobar-NOTE=foobar CATEGORY=foobar VERSION=0 DATE=foobar NAME=\" foobar \"\n[block]\nIO_SCHEDULER=noop, none, foobar\n" > /etc/saptune/extra/scheduler-test.conf';
-    assert_script_run "saptune note apply scheduler-test";
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_bsc1152598#1_2";
-    assert_script_run "saptune revert all";
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_bsc1152598#1_1";
-    assert_script_run 'echo -e "[version]\n# foobar-NOTE=foobar CATEGORY=foobar VERSION=0 DATE=foobar NAME=\" foobar \"\n[block]\nIO_SCHEDULER=foobar, noop, none\n" > /etc/saptune/extra/scheduler-test.conf';
-    assert_script_run 'saptune note apply scheduler-test';
-    assert_script_run "egrep -q '\[(noop|none)\]' /sys/block/sda/queue/scheduler";
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_bsc1152598#1_2";
-    assert_script_run "saptune revert all";
-}
-
-sub test_delete {
-    my ($self) = @_;
-
-    my $dir = "Pattern/testpattern_saptune-delete+rename";
-    my $note = "2161991";
-
-    ### Deleting a shipped Note (without override/with override + not applied/applied)
-
-    assert_script_run "rm -f /etc/saptune/extra/* /etc/saptune/override/*";
-
-    # (not-applied, no override)
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_1";
-    assert_script_run "! saptune note delete ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_1";
-
-    # (applied, no override)
-    assert_script_run "saptune note apply ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_2";
-    assert_script_run "! saptune note delete ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_2";
-
-    # (applied, override)
-    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/override/${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_3";
-    assert_script_run "! saptune note delete ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_3";
-
-    # (not applied, override)
-    assert_script_run "saptune note revert ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_4";
-    assert_script_run "yes n | saptune note delete ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_4";
-    assert_script_run "yes | saptune note delete ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#1_1";
-
-    ### Deleting a created Note (without override/with override + not applied/applied)
-
-    assert_script_run "rm -f /etc/saptune/extra/* /etc/saptune/override/*";
-
-    # (applied, no override)
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_1";
-    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/extra/testnote.conf";
-    assert_script_run "saptune note apply testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_2";
-    assert_script_run "! saptune note delete testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_2";
-
-    # (applied, override)
-    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/override/testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_3";
-    assert_script_run "! saptune note delete testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_3";
-
-    # (not applied, override)
-    assert_script_run "saptune note revert testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_4";
-    assert_script_run "yes n | saptune note delete testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_4";
-    assert_script_run "yes | saptune note delete testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_1";
-
-    # (not-applied, no override)
-    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/extra/testnote.conf";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_5";
-    assert_script_run "yes n | saptune note delete testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_5";
-    assert_script_run "yes | saptune note delete testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#2_1";
-
-    ### Deleting a non-existent Note
-
-    assert_script_run "rm -f /etc/saptune/extra/* /etc/saptune/override/*";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#3_1";
-    assert_script_run "! saptune note delete 999999";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-delete#3_1";
-
-    ### Renaming a shipped Note (without override/with override + not applied/applied)
-
-    assert_script_run "rm -f /etc/saptune/extra/* /etc/saptune/override/*";
-}
-
-sub test_rename {
-    my ($self) = @_;
-
-    my $dir = "Pattern/testpattern_saptune-delete+rename";
-    my $note = "2161991";
-
-    ### Renaming a shipped Note (without override/with override + not applied/applied)
-
-    assert_script_run "rm -f /etc/saptune/extra/* /etc/saptune/override/*";
-
-    # (not-applied, no override)
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#1_1";
-    assert_script_run "! saptune note rename ${note} newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#1_1";
-
-    # (applied, no override)
-    assert_script_run "saptune note apply ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#1_2";
-    assert_script_run "! saptune note rename ${note} newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#1_2";
-
-    # (applied, override)
-    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/override/${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#1_3";
-    assert_script_run "! saptune note rename ${note} newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#1_3";
-
-    # (not applied, override)
-    assert_script_run "saptune note revert ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#1_4";
-    assert_script_run "! saptune note rename ${note} newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#1_4";
-
-    ### Renaming a created Note (without override/with override + not applied/applied)
-
-    assert_script_run "rm -f /etc/saptune/extra/* /etc/saptune/override/*";
-
-    # (applied, no override)
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_1";
-    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/extra/testnote.conf";
-    assert_script_run "saptune note apply testnote";
-    assert_script_run "! saptune note rename testnote newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_2";
-
-    # (applied, override)
-    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/override/testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_3";
-    assert_script_run "! saptune note rename testnote newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_3";
-
-    # (not applied, override)
-    assert_script_run "saptune note revert testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_4";
-    assert_script_run "yes n | saptune note rename testnote newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_4";
-    assert_script_run "yes | saptune note rename testnote newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_5";
-
-    # (not-applied, no override)
-    assert_script_run "rm /etc/saptune/override/newnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_6";
-    assert_script_run "yes n | saptune note rename newnote testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_6";
-    assert_script_run "yes | saptune note rename newnote testnote";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#2_7";
-
-    ### Renaming a created Note to an existing note (not applied)
-
-    assert_script_run "rm -f /etc/saptune/extra/* /etc/saptune/override/*";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#3_1";
-    assert_script_run "echo -e '[version]\n# SAP-NOTE=testnote CATEGORY=test VERSION=0 DATE=01.01.1971 NAME=\"testnote\"' > /etc/saptune/extra/testnote.conf";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#3_2";
-    assert_script_run "! saptune note rename testnote ${note}";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#3_2";
-
-    ### Renaming a non-existent Note
-
-    assert_script_run "rm -f /etc/saptune/extra/* /etc/saptune/override/*";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#4_1";
-    assert_script_run "! saptune note rename 999999 999999";
-    assert_script_run "mr_test verify ${dir}/testpattern_saptune-rename#4_1";
-}
-
-sub test_note {
-    my ($self, $note) = @_;
-
-    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
-    my $extra = ($note eq "1771258") ? "-1" : "";
-
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_baseline_Cust";
-    assert_script_run "mr_test dump Pattern/${SLE}/testpattern_note_${note}${extra}_b > baseline_testpattern_note_${note}${extra}_b";
-    assert_script_run "saptune note apply $note";
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_note_${note}${extra}_a";
-    assert_script_run "mr_test verify baseline_testpattern_note_${note}${extra}_b";
-    tune_baseline("baseline_testpattern_note_${note}${extra}_b");
-    $self->reboot_wait;
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_note_${note}${extra}_a";
-    assert_script_run "mr_test verify baseline_testpattern_note_${note}${extra}_b";
-    assert_script_run "saptune note revert $note";
-    $self->reboot_wait;
-}
-
-sub test_override {
-    my ($self, $note) = @_;
-
-    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
-
-    # With notes 1557506 & 1771258 we have to test 2 override files
-    my @overrides = ($note =~ m/^(1557506|1771258)$/) ? ("${note}-1", "${note}-2") : (${note});
-
-    if ($note eq "1680803") {
-        # Ignore the tests for the scheduler if we can't set "none" on /dev/sr0
-        assert_script_run(
-            "if [ -f /sys/block/sr0/queue/scheduler ] ; then "
-              . "grep -q none /sys/block/sr0/queue/scheduler || "
-              . "sed -i '/:scripts\\/nr_requests/s/^/#/' Pattern/$SLE/testpattern_note_${note}_a_override ; fi"
-        );
-    }
-    foreach my $override (@overrides) {
-        assert_script_run "mr_test verify Pattern/${SLE}/testpattern_baseline_Cust";
-        assert_script_run "mr_test dump Pattern/$SLE/testpattern_note_${override}_b > baseline_testpattern_note_${override}_b";
-        assert_script_run "cp Pattern/$SLE/override/$override /etc/saptune/override/$note";
-        assert_script_run "saptune note apply $note";
-        assert_script_run "mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override";
-        assert_script_run "mr_test verify baseline_testpattern_note_${override}_b";
-        tune_baseline("baseline_testpattern_note_${override}_b");
-        $self->reboot_wait;
-        assert_script_run "mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override";
-        assert_script_run "mr_test verify baseline_testpattern_note_${override}_b";
-        assert_script_run "saptune note revert $note";
-        assert_script_run "rm -f /etc/saptune/override/$note";
-        $self->reboot_wait;
-    }
-}
-
-sub test_solution {
-    my ($self, $solution) = @_;
-
-    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
-
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_baseline_Cust";
-    assert_script_run "mr_test dump Pattern/${SLE}/testpattern_solution_${solution}_b > baseline_testpattern_solution_${solution}_b";
-    assert_script_run "saptune solution apply $solution";
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_solution_${solution}_a";
-    assert_script_run "mr_test verify baseline_testpattern_solution_${solution}_b";
-    tune_baseline("baseline_testpattern_solution_${solution}_b");
-    $self->reboot_wait;
-    assert_script_run "mr_test verify Pattern/${SLE}/testpattern_solution_${solution}_a";
-    assert_script_run "mr_test verify baseline_testpattern_solution_${solution}_b";
-    assert_script_run "saptune solution revert $solution";
-    $self->reboot_wait;
-}
-
-sub test_notes {
-    my ($self) = @_;
-
-    foreach my $note (get_notes()) {
-        # Skip 1805750 (SYB: Usage of HugePages on Linux Systems with Sybase ASE)
-        # The ASE docs don't recommend any specific value or formula, so it must
-        # be tested with an override file in test_overrides()
-        next if ($note eq "1805750");
-        $self->test_note($note);
-    }
-}
-
-sub test_overrides {
-    my ($self) = @_;
-
-    foreach my $note (get_notes()) {
-        $self->test_override($note);
-    }
-}
-
-sub test_solutions {
-    my ($self) = @_;
-
-    foreach my $solution (get_solutions()) {
-        $self->test_solution($solution);
-    }
-}
-
-sub test_ppc64le {
-    my ($self) = @_;
-
-    die "This test cannot be run on QEMU" if (is_qemu);
-    my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
-
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Power_1";
-    # Apply all notes except 1805750
-    foreach my $note (get_notes()) {
-        next if ($note eq "1805750");
-        assert_script_run "saptune note apply $note";
-    }
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Power_2";
-    assert_script_run "saptune revert all";
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Power_3";
-}
-
-sub test_x86_64 {
-    my ($self) = @_;
-
-    my $SLE;
-    my $note;
-
-    if (is_sle(">=15")) {
-        $SLE = "SLE15";
-        $note = "2684254";
-    } else {
-        $SLE = "SLE12";
-        $note = "2205917";
-    }
-
-    # energy_perf_bias=6
-    assert_script_run 'cpupower set -b 6';
-    # governor=powersave
-    assert_script_run 'cpupower frequency-set -g powersave';
-    # force_latency=max
-    assert_script_run 'cpupower idle-set -E';
-    $self->reboot_wait;
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Intel_1";
-    assert_script_run "saptune note apply $note";
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Intel_2";
-    assert_script_run "saptune note revert $note";
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Intel_1";
-    assert_script_run "echo -e '[cpu]\\nenergy_perf_bias=powersave\\ngovernor=powersave\\nforce_latency=' > /etc/saptune/override/$note";
-    assert_script_run "saptune note apply $note";
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Intel_3";
-    assert_script_run "saptune note revert $note";
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Intel_1";
-    assert_script_run "echo -e '[cpu]\\nenergy_perf_bias=\\ngovernor=\\nforce_latency=\\n' > /etc/saptune/override/$note";
-    assert_script_run "saptune note apply $note";
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Intel_4";
-    assert_script_run "saptune note revert $note";
-    assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Intel_1";
-}
-
 sub run {
     my ($self) = @_;
 
     $self->setup;
 
-    my $test = quotemeta(get_required_var("MR_TEST"));
-    if ($test eq "solutions") {
-        $self->test_solutions;
-    } elsif ($test eq "notes") {
-        $self->test_notes;
-    } elsif ($test eq "overrides") {
-        $self->test_overrides;
-    } elsif (grep { /^${test}$/ } get_solutions()) {
-        $self->test_solution($test);
-    } elsif (grep { /^${test}$/ } get_notes()) {
-        # Skip 1805750 (SYB: Usage of HugePages on Linux Systems with Sybase ASE)
-        # The ASE docs don't recommend any specific value or formula, so it must
-        # be tested with an override file
-        $self->test_note($test) if ($test ne "1805750");
-        $self->test_override($test);
-    } elsif ($test =~ m/^(x86_64|ppc64le)$/) {
-        $self->test_x86_64 if (is_ipmi);
-        $self->test_ppc64le if is_ppc64le();
-        $self->test_bsc1152598 if is_sle('>12-SP3');
-    } elsif ($test eq "delete_rename") {
-        $self->test_delete;
-        $self->test_rename;
-    } else {
-        die "Invalid value for MR_TEST";
-    }
+    my $test_list = get_required_var("MR_TEST");
+    record_info("MR_TEST=$test_list");
+    mr_test_lib::load_mr_tests("$test_list");
 }
 
 1;


### PR DESCRIPTION
Get "mr test" running on openqaworker15 for 15 SP4

jsc#TEAM-6726 - Get "mr test" running on openqaworker15 for 15 SP4 (intel on-premise)
(https://jira.suse.com/browse/TEAM-6726)

NOTE:
1. Test case "sles4sap_gnome_saptune_baremetal" is ignored as there is no ipmi backend in openqawork15.
2. all-in-one means set MR_TEST="1410736,1680803,1771258,1805750,1980196,2161991,2534844,2578899,2684254,3024346,900929,941735,SAP_BOBJ,BOBJ,S4HANA-APPSERVER,MAXDB,NETWEAVER,S4HANA-DBSERVER,solutions,2382421,notes,overrides,HANA,NETWEAVER+HANA,S4HANA-APP+DB,SAP-ASE,delete_rename"
3. If you think this all-in-one test case takes too long (8 hrs) we can separate it again via settings 'MR_TEST' without code change after the merging of this PR, for example MR_TEST="1410736,1680803,...".
4. 90+% of code in new file mr_test_run.pm is moved from original mr_test.pm

- Related ticket: https://jira.suse.com/browse/TEAM-6726
- Needles: NA
- job_templates
  https://openqaworker15.qa.suse.cz/admin/job_templates/21?  (added 4 new case: 'sles4sap_gnome_saptune_mr_test_*')
- Verification run:
  https://openqaworker15.qa.suse.cz/tests/29017 (mr_test: 27 modules/cases in total, all-in-one; dropped now as it takes about 10hrs)
  http://openqaworker15.qa.suse.cz/tests/29194 (notes, 01:55 hours)
  http://openqaworker15.qa.suse.cz/tests/29195 (solutions, 01:21 hours)
  http://openqaworker15.qa.suse.cz/tests/29196 (delete_rename, 43:51 minutes)
  http://openqaworker15.qa.suse.cz/tests/29197 (overrides, 02:12 hours)

IPA added (all test modules are passed):
https://openqaworker15.qa.suse.cz/tests/33945 (added IPA parsing for 'delete_rename')
http://openqaworker15.qa.suse.cz/tests/33946 (added IPA parsing for 'notes')
https://openqaworker15.qa.suse.cz/tests/33955 (added IPA parsing for 'solutions')
http://openqaworker15.qa.suse.cz/tests/33947 (added IPA parsing for 'overrides')

IPA added (make test module failed on note 1680803 but it does not block other notes' testing):
http://openqaworker15.qa.suse.cz/tests/35606#step/test_note_1680803/1
