### PR TITLE
Add softfail for start_systemd_testkit_offline failure before Beta

### DIFF
--- a/tests/console/start_systemd_testkit_offline.pm
+++ b/tests/console/start_systemd_testkit_offline.pm
@@ -65,8 +65,7 @@ sub parse_results_from_output {
     my %results = (
         tests => [],
         info => {timestamp => 0, distro => $distro, results_file => $results_file},
-        summary => {duration => 0, passed => 0, num_tests => 0}
-    );
+        summary => {duration => 0, passed => 0, num_tests => 0});
 
     $out =~ s/\r//gs;
     foreach my $line (split(/\n/, $out)) {
@@ -92,14 +91,24 @@ sub parse_results_from_output {
                 #   $openQA_result = $self->record_testresult('softfail');
                 #   $softfail_result = 119565;
                 #} else {
-                my $openQA_result = $self->record_testresult('fail');
-                #$softfail_result = 0;
-                #}
+                my ($openQA_result, $softfail_result);
+                if ($error_line =~ /invalid version.*expected.*/ && is_sle('=15-SP5')) {
+                    $openQA_result = $self->record_testresult('softfail');
+                    $softfail_result = 1203060;
+                }
+                else {
+                    my $openQA_result = $self->record_testresult('fail');
+                    #$softfail_result = 0;
+                    #}
+                    $softfail_result = 0;
+                }
                 my $openQA_filename = $self->next_resultname('txt');
                 $openQA_result->{title} = $testunit;
                 $openQA_result->{text} = $openQA_filename;
                 #($softfail_result) ? $self->write_resultfile($openQA_filename, "# Softfail bsc#$softfail_result:\n$error_line\n") :
-                $self->write_resultfile($openQA_filename, "# Failure:\n$error_line\n");
+                ($softfail_result)
+                  ? $self->write_resultfile($openQA_filename, "# Softfail bsc#$softfail_result:\n$error_line\n")
+                  : $self->write_resultfile($openQA_filename, "# Failure:\n$error_line\n");
                 $self->{dents}++;
             }
 


### PR DESCRIPTION
poo#116311 & bsc#1203060

- Related ticket: https://progress.opensuse.org/issues/116311
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/9475034