### PR TITLE
Unschedule regression test modules unrelated with migration

### DIFF
--- a/schedule/migration/aarch64_regression_test_offline.yaml
+++ b/schedule/migration/aarch64_regression_test_offline.yaml
@@ -3,9 +3,7 @@ description:    |
   This is for aarch64 offline regression test.
   #REGRESSION_SERVICE: '1' means support service check test. '0' means doesn't
   #support service check test, normally set '0' for package media test.
-  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
-  #means regression test part2 include x11 test.
-  #REGRESSION_389DS: '1' means load 389ds test.
+  #REGRESSION_TEST: '1' means load regression test modules after migration.
   #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
@@ -46,20 +44,21 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
-        - console/check_migration_features
+        - '{{check_migration_features}}'
         - console/check_network
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
         - '{{check_upgraded_service}}'
-        - '{{openldap_to_389ds}}'
         - '{{regression_tests}}'
-        - boot/grub_test_snapshot
-        - migration/version_switch_origin_system
-        - boot/snapper_rollback
+        - '{{rollback_after_migration}}'
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
+  check_migration_features:
+    MIGRATION_FEATURES:
+      1:
+        - console/check_migration_features
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:
@@ -72,57 +71,26 @@ conditional_schedule:
     REGRESSION_SERVICE:
       1:
         - installation/install_service
-  openldap_to_389ds:
-    REGRESSION_389DS:
-      1:
-        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/supportutils
         - console/force_scheduled_tasks
-        - console/textinfo
         - console/hostname
         - console/upgrade_snapshots
-        - console/x_vt
         - console/zypper_lr
-        - console/pam
-        - console/btrfsmaintenance
-        - console/cpio
-        - console/java
         - console/zypper_ref
-        - console/ncurses
-        - console/yast2_lan
-        - console/curl_https
-        - console/salt
-        - console/glibc_tunables
-        - console/zypper_in
-        - console/zypper_log
-        - console/yast2_i
-        - console/yast2_bootloader
+        - console/check_system_info
         - console/firewall_enabled
-        - console/krb5
-        - console/sshd
-        - console/ssh_cleanup
-        - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
-        - console/kdump_and_crash
-        - console/consoletest_finish
-      2:
         - console/consoletest_finish
         - x11/desktop_runner
         - x11/setup
         - x11/xterm
-        - locale/keymap_or_locale_x11
-        - x11/sshxterm
-        - x11/gnome_control_center
-        - x11/gnome_terminal
-        - x11/gedit
-        - x11/firefox
-        - x11/yast2_snapper
-        - x11/glxgears
-        - x11/nautilus
-        - x11/desktop_mainmenu
-        - x11/reboot_gnome
+  rollback_after_migration:
+    ROLLBACK_AFTER_MIGRATION:
+      1:
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback

--- a/schedule/migration/aarch64_regression_test_online.yaml
+++ b/schedule/migration/aarch64_regression_test_online.yaml
@@ -1,10 +1,7 @@
 name:           aarch64_regression_test_online.yaml
 description:    |
   This is for aarch64 online regression test.
-  #REGRESSION_LTSS: '1' means base system supports ltss test.
-  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
-  # means regression test part2 include x11 test.
-  #REGRESSION_389DS: '1' means load 389ds test.
+  #REGRESSION_TEST: '1' means load regression test modules after migration.
   #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
@@ -14,7 +11,6 @@ vars:
 schedule:
   - migration/version_switch_origin_system
   - '{{online_migration_test}}'
-  - '{{remove_ltss}}'
   - migration/version_switch_upgrade_target
   - migration/online_migration/pre_migration
   - '{{migration_method}}'
@@ -27,24 +23,21 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
-        - console/check_migration_features
+        - '{{check_migration_features}}'
         - console/check_network
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
         - console/check_upgraded_service
-        - '{{openldap_to_389ds}}'
         - '{{regression_tests}}'
-        - boot/grub_test_snapshot
-        - migration/version_switch_origin_system
-        - boot/snapper_rollback
+        - '{{rollback_after_migration}}'
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
-  remove_ltss:
-    REGRESSION_LTSS:
+  check_migration_features:
+    MIGRATION_FEATURES:
       1:
-        - migration/online_migration/register_without_ltss
+        - console/check_migration_features
   migration_method:
     MIGRATION_METHOD:
       yast:
@@ -60,57 +53,26 @@ conditional_schedule:
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
         - installation/install_service
-  openldap_to_389ds:
-    REGRESSION_389DS:
-      1:
-        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/supportutils
         - console/force_scheduled_tasks
-        - console/textinfo
         - console/hostname
         - console/upgrade_snapshots
-        - console/x_vt
         - console/zypper_lr
-        - console/pam
-        - console/btrfsmaintenance
-        - console/cpio
-        - console/java
         - console/zypper_ref
-        - console/ncurses
-        - console/yast2_lan
-        - console/curl_https
-        - console/salt
-        - console/glibc_tunables
-        - console/zypper_in
-        - console/zypper_log
-        - console/yast2_i
-        - console/yast2_bootloader
+        - console/check_system_info
         - console/firewall_enabled
-        - console/krb5
-        - console/sshd
-        - console/ssh_cleanup
-        - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
-        - console/kdump_and_crash
-        - console/consoletest_finish
-      2:
         - console/consoletest_finish
         - x11/desktop_runner
         - x11/setup
         - x11/xterm
-        - locale/keymap_or_locale_x11
-        - x11/sshxterm
-        - x11/gnome_control_center
-        - x11/gnome_terminal
-        - x11/gedit
-        - x11/firefox
-        - x11/yast2_snapper
-        - x11/glxgears
-        - x11/nautilus
-        - x11/desktop_mainmenu
-        - x11/reboot_gnome
+  rollback_after_migration:
+    ROLLBACK_AFTER_MIGRATION:
+      1:
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback

--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -3,9 +3,7 @@ description:    |
   This is for ppc64le offline regression test.
   #REGRESSION_SERVICE: '1' means support service check test. '0' means doesn't
   #support service check test, normally set '0' for package media test.
-  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
-  #means regression test part2 include x11 test.
-  #REGRESSION_389DS: '1' means load 389ds test.
+  #REGRESSION_TEST: '1' means load regression test modules after migration.
   #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
@@ -45,20 +43,21 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
-        - console/check_migration_features
+        - '{{check_migration_features}}'
         - console/check_network
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
         - '{{check_upgraded_service}}'
-        - '{{openldap_to_389ds}}'
         - '{{regression_tests}}'
-        - boot/grub_test_snapshot
-        - migration/version_switch_origin_system
-        - boot/snapper_rollback
+        - '{{rollback_after_migration}}'
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
+  check_migration_features:
+    MIGRATION_FEATURES:
+      1:
+        - console/check_migration_features
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:
@@ -71,57 +70,26 @@ conditional_schedule:
     REGRESSION_SERVICE:
       1:
         - installation/install_service
-  openldap_to_389ds:
-    REGRESSION_389DS:
-      1:
-        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/supportutils
         - console/force_scheduled_tasks
-        - console/textinfo
         - console/hostname
         - console/upgrade_snapshots
-        - console/x_vt
         - console/zypper_lr
-        - console/pam
-        - console/btrfsmaintenance
-        - console/cpio
-        - console/java
         - console/zypper_ref
-        - console/ncurses
-        - console/yast2_lan
-        - console/curl_https
-        - console/salt
-        - console/glibc_tunables
-        - console/zypper_in
-        - console/zypper_log
-        - console/yast2_i
-        - console/yast2_bootloader
+        - console/check_system_info
         - console/firewall_enabled
-        - console/krb5
-        - console/sshd
-        - console/ssh_cleanup
-        - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
-        - console/kdump_and_crash
-        - console/consoletest_finish
-      2:
         - console/consoletest_finish
         - x11/desktop_runner
         - x11/setup
         - x11/xterm
-        - locale/keymap_or_locale_x11
-        - x11/sshxterm
-        - x11/gnome_control_center
-        - x11/gnome_terminal
-        - x11/gedit
-        - x11/firefox
-        - x11/yast2_snapper
-        - x11/glxgears
-        - x11/nautilus
-        - x11/desktop_mainmenu
-        - x11/reboot_gnome
+  rollback_after_migration:
+    ROLLBACK_AFTER_MIGRATION:
+      1:
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback

--- a/schedule/migration/ppc64le_regression_test_online.yaml
+++ b/schedule/migration/ppc64le_regression_test_online.yaml
@@ -1,10 +1,7 @@
 name:           ppc64le_regression_test_online.yaml
 description:    |
   This is for ppc64le online regression test.
-  #REGRESSION_LTSS: '1' means base system supports ltss test.
-  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
-  # means regression test part2 include x11 test.
-  #REGRESSION_389DS: '1' means load 389ds test.
+  #REGRESSION_TEST: '1' means load regression test modules after migration.
   #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
@@ -14,7 +11,6 @@ vars:
 schedule:
   - migration/version_switch_origin_system
   - '{{online_migration_test}}'
-  - '{{remove_ltss}}'
   - '{{install_service}}'
   - migration/version_switch_upgrade_target
   - migration/online_migration/pre_migration
@@ -28,28 +24,25 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
-        - console/check_migration_features
+        - '{{check_migration_features}}'
         - console/check_network
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
         - console/check_upgraded_service
-        - '{{openldap_to_389ds}}'
         - '{{regression_tests}}'
-        - boot/grub_test_snapshot
-        - migration/version_switch_origin_system
-        - boot/snapper_rollback
+        - '{{rollback_after_migration}}'
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
+  check_migration_features:
+    MIGRATION_FEATURES:
+      1:
+        - console/check_migration_features
   install_service:
     REGRESSION_SERVICE:
       1:
         - installation/install_service
-  remove_ltss:
-    REGRESSION_LTSS:
-      1:
-        - migration/online_migration/register_without_ltss
   migration_method:
     MIGRATION_METHOD:
       yast:
@@ -64,57 +57,26 @@ conditional_schedule:
         - migration/online_migration/online_migration_setup
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
-  openldap_to_389ds:
-    REGRESSION_389DS:
-      1:
-        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/supportutils
         - console/force_scheduled_tasks
-        - console/textinfo
         - console/hostname
         - console/upgrade_snapshots
-        - console/x_vt
         - console/zypper_lr
-        - console/pam
-        - console/btrfsmaintenance
-        - console/cpio
-        - console/java
+        - console/check_system_info
         - console/zypper_ref
-        - console/ncurses
-        - console/yast2_lan
-        - console/curl_https
-        - console/salt
-        - console/glibc_tunables
-        - console/zypper_in
-        - console/zypper_log
-        - console/yast2_i
-        - console/yast2_bootloader
         - console/firewall_enabled
-        - console/krb5
-        - console/sshd
-        - console/ssh_cleanup
-        - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
-        - console/kdump_and_crash
-        - console/consoletest_finish
-      2:
         - console/consoletest_finish
         - x11/desktop_runner
         - x11/setup
         - x11/xterm
-        - locale/keymap_or_locale_x11
-        - x11/sshxterm
-        - x11/gnome_control_center
-        - x11/gnome_terminal
-        - x11/gedit
-        - x11/firefox
-        - x11/yast2_snapper
-        - x11/glxgears
-        - x11/nautilus
-        - x11/desktop_mainmenu
-        - x11/reboot_gnome
+  rollback_after_migration:
+    ROLLBACK_AFTER_MIGRATION:
+      1:
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback

--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -3,9 +3,7 @@ description:    |
   This is for s390x zkvm upgrade regression test.
   #REGRESSION_SERVICE: '1' means support service check test. '0' means doesn't
   #support service check test, normally set '0' for package media test.
-  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
-  #means regression test part2 include x11 test.
-  #REGRESSION_389DS: '1' means load 389ds test.
+  #REGRESSION_TEST: '1' means load regression test modules after migration.
   #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
@@ -44,17 +42,20 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
-        - console/check_migration_features
+        - '{{check_migration_features}}'
         - console/check_network
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
         - '{{check_upgraded_service}}'
-        - '{{openldap_to_389ds}}'
         - '{{regression_tests}}'
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
+  check_migration_features:
+    MIGRATION_FEATURES:
+      1:
+        - console/check_migration_features
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:
@@ -63,57 +64,20 @@ conditional_schedule:
     REGRESSION_SERVICE:
       1:
         - installation/install_service
-  openldap_to_389ds:
-    REGRESSION_389DS:
-      1:
-        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/supportutils
         - console/force_scheduled_tasks
-        - console/textinfo
         - console/hostname
         - console/upgrade_snapshots
         - console/zypper_lr
-        - console/pam
-        - console/btrfsmaintenance
-        - console/cpio
-        - console/java
         - console/check_system_info
         - console/zypper_ref
-        - console/ncurses
-        - console/yast2_lan
-        - console/curl_https
-        - console/salt
-        - console/glibc_tunables
-        - console/zypper_in
-        - console/zypper_log
-        - console/yast2_i
-        - console/yast2_bootloader
         - console/firewall_enabled
-        - console/krb5
-        - console/sshd
-        - console/ssh_cleanup
-        - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
-        - console/kdump_and_crash
-        - console/consoletest_finish
-      2:
         - console/consoletest_finish
         - x11/desktop_runner
         - x11/setup
         - x11/xterm
-        - locale/keymap_or_locale_x11
-        - x11/sshxterm
-        - x11/gnome_control_center
-        - x11/gnome_terminal
-        - x11/gedit
-        - x11/firefox
-        - x11/yast2_snapper
-        - x11/glxgears
-        - x11/nautilus
-        - x11/desktop_mainmenu
-        - x11/reboot_gnome

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -1,10 +1,7 @@
 name:           s390x_regression_test_online.yaml
 description:    |
   This is for s390x online regression test.
-  #REGRESSION_LTSS: '1' means base system supports ltss test.
-  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
-  # means regression test part2 include x11 test.
-  #REGRESSION_389DS: '1' means load 389ds test.
+  #REGRESSION_TEST: '1' means load regression test modules after migration.
   #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
@@ -14,7 +11,6 @@ vars:
 schedule:
   - migration/version_switch_origin_system
   - '{{online_migration_test}}'
-  - '{{remove_ltss}}'
   - installation/install_service
   - migration/version_switch_upgrade_target
   - migration/online_migration/pre_migration
@@ -29,20 +25,19 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
-        - console/check_migration_features
+        - '{{check_migration_features}}'
         - console/check_network
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
-        - '{{openldap_to_389ds}}'
         - '{{regression_tests}}'
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
-  remove_ltss:
-    REGRESSION_LTSS:
+  check_migration_features:
+    MIGRATION_FEATURES:
       1:
-        - migration/online_migration/register_without_ltss
+        - console/check_migration_features
   migration_method:
     MIGRATION_METHOD:
       yast:
@@ -56,58 +51,20 @@ conditional_schedule:
         - migration/online_migration/online_migration_setup
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
-  openldap_to_389ds:
-    REGRESSION_389DS:
-      1:
-        - migration/openldap_to_389ds
   regression_tests:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/supportutils
         - console/force_scheduled_tasks
-        - console/textinfo
         - console/hostname
         - console/upgrade_snapshots
         - console/zypper_lr
-        - console/pam
-        - console/btrfsmaintenance
-        - console/cpio
-        - console/java
         - console/check_system_info
         - console/zypper_ref
-        - console/ncurses
-        - console/yast2_lan
-        - console/curl_https
-        - console/salt
-        - console/glibc_tunables
-        - console/zypper_in
-        - console/zypper_log
-        - console/yast2_i
-        - console/yast2_bootloader
         - console/firewall_enabled
-        - console/krb5
-        - console/sshd
-        - console/ssh_cleanup
-        - console/mtab
         - console/zypper_lifecycle
         - console/orphaned_packages_check
-        - console/upgrade_snapshots
-        - console/kdump_and_crash
-        - console/consoletest_finish
-      2:
         - console/consoletest_finish
         - x11/desktop_runner
         - x11/setup
         - x11/xterm
-        - locale/keymap_or_locale_x11
-        - x11/sshxterm
-        - x11/gnome_control_center
-        - x11/gnome_terminal
-        - x11/gedit
-        - x11/firefox
-        - x11/yast2_snapper
-        - x11/glxgears
-        - x11/nautilus
-        - x11/desktop_mainmenu
-        - x11/reboot_gnome

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -3,8 +3,7 @@ description:    |
   This is for x86 offline regression test.
   #REGRESSION_SERVICE: '1' means support service check test. '0' means doesn't
   #support service check test, normally set '0' for package media test.
-  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
-  #means regression test part2 include x11 test.
+  #REGRESSION_TEST: '1' means load regression test modules after migration.
   #QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: 'gnome'
@@ -44,7 +43,7 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
-        - console/check_migration_features
+        - '{{check_migration_features}}'
         - console/check_network
         - console/system_state
         - console/prepare_test_data
@@ -52,12 +51,14 @@ conditional_schedule:
         - '{{check_upgraded_service}}'
         - migration/openldap_to_389ds
         - '{{regression_tests}}'
-        - boot/grub_test_snapshot
-        - migration/version_switch_origin_system
-        - boot/snapper_rollback
+        - '{{rollback_after_migration}}'
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
+  check_migration_features:
+    MIGRATION_FEATURES:
+      1:
+        - console/check_migration_features
   check_upgraded_service:
     REGRESSION_SERVICE:
       1:
@@ -74,63 +75,22 @@ conditional_schedule:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/supportutils
         - console/force_scheduled_tasks
-        - console/textinfo
         - console/hostname
         - console/upgrade_snapshots
-        - console/x_vt
         - console/zypper_lr
-        - console/pam
-        - console/btrfsmaintenance
-        - console/java
-        - console/cpio
         - console/check_system_info
         - console/zypper_ref
-        - console/ncurses
-        - console/yast2_lan
-        - console/curl_https
-        - console/salt
-        - console/glibc_sanity
-        - console/glibc_tunables
-        - console/zypper_in
-        - console/zypper_log
-        - console/yast2_i
-        - console/yast2_bootloader
-        - console/vim
         - console/firewall_enabled
-        - console/krb5
-        - console/sshd
-        - console/ssh_cleanup
-        - console/mtab
-        - console/upgrade_snapshots
         - console/zypper_lifecycle
         - console/orphaned_packages_check
-        - console/consoletest_finish
-
-      2:
         - console/consoletest_finish
         - x11/desktop_runner
         - x11/setup
         - x11/xterm
-        - locale/keymap_or_locale_x11
-        - x11/sshxterm
-        - x11/gnome_control_center
-        - x11/gnome_terminal
-        - x11/gedit
-        - x11/firefox
-        - x11/tomcat
-        - x11/eog
-        - x11/gnome_music
-        - x11/wireshark
-        - x11/ImageMagick
-        - x11/ghostscript
-        - x11/ooffice
-        - x11/oomath
-        - x11/oocalc
-        - x11/yast2_snapper
-        - x11/glxgears
-        - x11/nautilus
-        - x11/evolution
-        - x11/desktop_mainmenu
-        - x11/reboot_gnome
+  rollback_after_migration:
+    ROLLBACK_AFTER_MIGRATION:
+      1:
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -1,9 +1,7 @@
 name:           x86_regression_test_online.yaml
 description:    |
   This is for x86_64 online regression test.
-  #REGRESSION_LTSS: '1' means base system supports ltss test.
-  #REGRESSION_TEST: '1' means regression test part1 include console test. '2'
-  # means regression test part2 include x11 test.
+  #REGRESSION_TEST: '1' means load regression test modules after migration.
   # QCOW_GENERATION: '1' means publish qcow after migration; '0' means no need.
 vars:
   DESKTOP: gnome
@@ -13,7 +11,6 @@ vars:
 schedule:
   - migration/version_switch_origin_system
   - '{{online_migration_test}}'
-  - '{{remove_ltss}}'
   - installation/install_service
   - migration/version_switch_upgrade_target
   - migration/online_migration/pre_migration
@@ -28,23 +25,17 @@ conditional_schedule:
         - console/system_prepare
         - console/check_os_release
         - console/check_system_info
-        - console/check_migration_features
+        - '{{check_migration_features}}'
         - console/check_network
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
         - migration/openldap_to_389ds
         - '{{regression_tests}}'
-        - boot/grub_test_snapshot
-        - migration/version_switch_origin_system
-        - boot/snapper_rollback
+        - '{{rollback_after_migration}}'
       1:
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
-  remove_ltss:
-    REGRESSION_LTSS:
-      1:
-        - migration/online_migration/register_without_ltss
   migration_method:
     MIGRATION_METHOD:
       yast:
@@ -59,68 +50,30 @@ conditional_schedule:
         - migration/online_migration/online_migration_setup
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
+  check_migration_features:
+    MIGRATION_FEATURES:
+      1:
+        - console/check_migration_features
   regression_tests:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/supportutils
         - console/force_scheduled_tasks
-        - console/textinfo
         - console/hostname
         - console/upgrade_snapshots
-        - console/x_vt
         - console/zypper_lr
-        - console/pam
-        - console/btrfsmaintenance
-        - console/java
-        - console/cpio
         - console/check_system_info
         - console/zypper_ref
-        - console/ncurses
-        - console/yast2_lan
-        - console/curl_https
-        - console/salt
-        - console/glibc_sanity
-        - console/glibc_tunables
-        - console/zypper_in
-        - console/zypper_log
-        - console/yast2_i
-        - console/yast2_bootloader
-        - console/vim
         - console/firewall_enabled
-        - console/krb5
-        - console/sshd
-        - console/ssh_cleanup
-        - console/mtab
-        - console/upgrade_snapshots
         - console/zypper_lifecycle
         - console/orphaned_packages_check
-        - console/kdump_and_crash
-        - console/consoletest_finish
-
-      2:
         - console/consoletest_finish
         - x11/desktop_runner
         - x11/setup
         - x11/xterm
-        - locale/keymap_or_locale_x11
-        - x11/sshxterm
-        - x11/gnome_control_center
-        - x11/gnome_terminal
-        - x11/gedit
-        - x11/firefox
-        - x11/tomcat
-        - x11/eog
-        - x11/gnome_music
-        - x11/wireshark
-        - x11/ImageMagick
-        - x11/ghostscript
-        - x11/ooffice
-        - x11/oomath
-        - x11/oocalc
-        - x11/yast2_snapper
-        - x11/glxgears
-        - x11/nautilus
-        - x11/evolution
-        - x11/desktop_mainmenu
-        - x11/reboot_gnome
+  rollback_after_migration:
+    ROLLBACK_AFTER_MIGRATION:
+      1:
+        - boot/grub_test_snapshot
+        - migration/version_switch_origin_system
+        - boot/snapper_rollback


### PR DESCRIPTION
This pr is to unschedule the test modules unrelated with migration in regression job group. So I update the schedule yaml files of migration regression jobs.

- Related ticket: https://progress.opensuse.org/issues/115487
- Related mr: https://gitlab.suse.de/coolgw/wegao-test/-/merge_requests/139
- Needles: N/A
- Verification run: 
offline:
x86_64: https://openqa.suse.de/tests/9554935#
s390x: https://openqa.suse.de/tests/9555425#
ppc64le: https://openqa.suse.de/tests/9548988#
online:
aarch64: https://openqa.suse.de/tests/9548989#
x86_64: https://openqa.suse.de/tests/9548990#

