### PR TITLE
Fix autoyast grub_test issue

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -61,10 +61,6 @@ sub handle_installer_medium_bootup {
     return unless (check_var("BOOTFROM", "d") || (get_var('UEFI') && get_var('USBBOOT')));
     assert_screen 'inst-bootmenu', 180;
 
-    if (check_var("BOOTFROM", "d") && get_var('AUTOUPGRADE') && get_var('PATCH')) {
-        assert_screen 'grub2';
-    }
-
     # Layout of live is different from installation media
     my $key = is_livecd() ? 'down' : 'up';
     send_key_until_needlematch 'inst-bootmenu-boot-harddisk', $key;


### PR DESCRIPTION
Assert 'grub2' here is not expected flow, it should be inst-bootmenu -> inst-bootmenu-boot-harddisk -> grub2, 

- Related ticket: https://progress.opensuse.org/issues/115466
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/9475375#step/grub_test/2
