### PR TITLE
Create equivalent yast2_firewall test module based on libyui-rest-api

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -49,6 +49,7 @@ use YaST::Firstboot::NTPConfigurationController;
 use YaST::Firstboot::WelcomeController;
 use YaST::NetworkSettings::v4_3::NetworkSettingsController;
 use YaST::SystemSettings::SystemSettingsController;
+use YaST::Firewall::FirewallController;
 
 sub get_language_keyboard {
     return Installation::LanguageKeyboard::LanguageKeyboardController->new();
@@ -108,6 +109,10 @@ sub get_firstboot_ntp_configuration {
 
 sub get_firstboot_welcome {
     return YaST::Firstboot::WelcomeController->new();
+}
+
+sub get_firewall {
+    return YaST::Firewall::FirewallController->new();
 }
 
 sub get_navigation {

--- a/lib/YaST/Firewall/ChangeZonePage.pm
+++ b/lib/YaST/Firewall/ChangeZonePage.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Change Zone Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::ChangeZonePage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{cmb_zone_options} = $self->{app}->combobox({id => "\"Y2Firewall::Widgets::ZoneOptions\""});
+    $self->{btn_ok} = $self->{app}->button({id => "ok"});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{cmb_zone_options}->exist();
+}
+
+sub set_interface_zone {
+    my ($self, $zone) = @_;
+    $self->{cmb_zone_options}->select($zone);
+    $self->{btn_ok}->click();
+}
+1;

--- a/lib/YaST/Firewall/FirewallController.pm
+++ b/lib/YaST/Firewall/FirewallController.pm
@@ -1,0 +1,156 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces actions Firewall Settings Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::FirewallController;
+use strict;
+use warnings;
+use testapi;
+use YaST::Firewall::MainPage;
+use YaST::Firewall::StartUpPage;
+use YaST::Firewall::InterfacesPage;
+use YaST::Firewall::ZonesPage;
+use YaST::Firewall::ZonePage;
+use YaST::Firewall::ServicesPage;
+use YaST::Firewall::PortsPage;
+
+use YuiRestClient;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{MainPage} = YaST::Firewall::MainPage->new({app => YuiRestClient::get_app()});
+    $self->{StartUpPage} = YaST::Firewall::StartUpPage->new({app => YuiRestClient::get_app()});
+    $self->{InterfacesPage} = YaST::Firewall::InterfacesPage->new({app => YuiRestClient::get_app()});
+    $self->{ZonesPage} = YaST::Firewall::ZonesPage->new({app => YuiRestClient::get_app()});
+    $self->{ZonePage} = YaST::Firewall::ZonePage->new({app => YuiRestClient::get_app()});
+    $self->{ServicesPage} = YaST::Firewall::ServicesPage->new({app => YuiRestClient::get_app()});
+    $self->{PortsPage} = YaST::Firewall::PortsPage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_main_page {
+    my ($self) = @_;
+    die 'Main Firewall Page is not displayed' unless $self->{MainPage}->is_shown();
+    return $self->{MainPage};
+}
+
+sub get_start_up_page {
+    my ($self) = @_;
+    die 'StartUp Pane is not displayed' unless $self->{StartUpPage}->is_shown();
+    return $self->{StartUpPage};
+}
+
+sub get_interfaces_page {
+    my ($self) = @_;
+    die 'Interfaces Pane is not displayed' unless $self->{InterfacesPage}->is_shown();
+    return $self->{InterfacesPage};
+}
+
+sub get_zones_page {
+    my ($self) = @_;
+    die 'Zones Pane is not displayed' unless $self->{ZonesPage}->is_shown();
+    return $self->{ZonesPage};
+}
+
+sub get_zone_page {
+    my ($self) = @_;
+    die 'Zone Pane is not displayed' unless $self->{ZonePage}->is_shown();
+    return $self->{ZonePage};
+}
+
+sub get_services_page {
+    my ($self) = @_;
+    die 'Services Pane is not displayed' unless $self->{ServicesPage}->is_shown();
+    return $self->{ServicesPage};
+}
+
+sub get_ports_page {
+    my ($self) = @_;
+    die 'Ports Pane is not displayed' unless $self->{PortsPage}->is_shown();
+    return $self->{PortsPage};
+}
+
+sub select_start_up_page {
+    my ($self, $zone) = @_;
+    $self->get_main_page()->select_start_up_page();
+}
+
+sub select_interfaces_page {
+    my ($self, $zone) = @_;
+    $self->get_main_page()->select_interfaces_page();
+}
+
+sub select_zones_page {
+    my ($self, $zone) = @_;
+    $self->get_main_page()->select_zones_page();
+}
+
+sub select_zone_page {
+    my ($self, $zone) = @_;
+    $self->get_main_page()->select_zone_page($zone);
+}
+
+sub start_firewall {
+    my ($self) = @_;
+    $self->get_start_up_page()->start_firewall();
+}
+
+sub stop_firewall {
+    my ($self) = @_;
+    $self->get_start_up_page()->stop_firewall();
+}
+
+sub accept_change {
+    my ($self) = @_;
+    $self->get_main_page()->press_accept();
+}
+
+sub set_default_zone {
+    my ($self, $zone) = @_;
+    $self->get_zones_page()->select_zone($zone);
+    save_screenshot;
+    $self->get_zones_page()->set_default_zone();
+}
+
+sub set_interface_zone {
+    my ($self, $device, $zone) = @_;
+    $self->get_interfaces_page()->set_interface_zone($device, $zone);
+}
+
+sub switch_ports_tab {
+    my ($self) = @_;
+    $self->get_zone_page()->switch_ports_tab();
+}
+
+sub switch_services_tab {
+    my ($self) = @_;
+    $self->get_zone_page()->switch_services_tab();
+}
+
+sub add_service {
+    my ($self, $zone, $service) = @_;
+    $self->switch_services_tab();
+    save_screenshot;
+    $self->get_services_page()->select_service($zone, $service);
+    save_screenshot;
+    $self->get_services_page()->add_service();
+}
+
+sub add_tcp_port {
+    my ($self, $port) = @_;
+    $self->switch_ports_tab();
+    save_screenshot;
+    $self->get_ports_page()->set_tcp_port($port);
+}
+
+1;

--- a/lib/YaST/Firewall/InterfacesPage.pm
+++ b/lib/YaST/Firewall/InterfacesPage.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Firewall Interfaces Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::InterfacesPage;
+use strict;
+use warnings;
+use YaST::Firewall::ChangeZonePage;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{tbl_interfaces} = $self->{app}->table({id => "\"interfaces_table\""});
+    $self->{btn_change_zone} = $self->{app}->button({id => "\"Y2Firewall::Widgets::ChangeZoneButton\""});
+    $self->{cmb_zone_options} = $self->{app}->combobox({id => "\"Y2Firewall::Widgets::ZoneOptions\""});
+    $self->{ChangeZonePage} = YaST::Firewall::ChangeZonePage->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{tbl_interfaces}->exist();
+}
+
+sub get_items {
+    my ($self) = @_;
+    return $self->{tbl_interfaces}->items();
+}
+
+sub set_interface_zone {
+    my ($self, $device, $zone) = @_;
+    $self->{tbl_interfaces}->select(value => $device);
+    $self->{btn_change_zone}->click();
+    $self->{ChangeZonePage}->is_shown();
+    $self->{ChangeZonePage}->set_interface_zone($zone);
+}
+
+1;

--- a/lib/YaST/Firewall/MainPage.pm
+++ b/lib/YaST/Firewall/MainPage.pm
@@ -1,0 +1,58 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Firewall Main Page(Include left view tree menu and bottom button).
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::MainPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{tre_overview} = $self->{app}->tree({id => "\"Y2Firewall::Widgets::OverviewTree\""});
+    $self->{btn_accept} = $self->{app}->button({id => 'next'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{tre_overview}->exist();
+}
+
+sub select_start_up_page {
+    my ($self) = @_;
+    $self->{tre_overview}->select("Start-Up");
+}
+
+sub select_interfaces_page {
+    my ($self) = @_;
+    $self->{tre_overview}->select("Interfaces");
+}
+
+sub select_zones_page {
+    my ($self) = @_;
+    $self->{tre_overview}->select("Zones");
+}
+
+sub press_accept {
+    my ($self) = @_;
+    $self->{btn_accept}->click();
+}
+
+sub select_zone_page {
+    my ($self, $zone) = @_;
+    $self->{tre_overview}->select("Zones|$zone");
+}
+
+1;

--- a/lib/YaST/Firewall/PortsPage.pm
+++ b/lib/YaST/Firewall/PortsPage.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Firewall Ports Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::PortsPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{txb_tcp} = $self->{app}->textbox({id => "tcp"});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{txb_tcp}->exist();
+}
+
+sub set_tcp_port {
+    my ($self, $tcp_port) = @_;
+    $self->{txb_tcp}->set($tcp_port);
+}
+
+1;

--- a/lib/YaST/Firewall/ServicesPage.pm
+++ b/lib/YaST/Firewall/ServicesPage.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Firewall Service Settings Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::ServicesPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{tbl_known_trusted} = $self->{app}->table({id => "\"known:trusted\""});
+    $self->{btn_add} = $self->{app}->button({id => "add"});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{tbl_known_trusted}->exist();
+}
+
+sub select_service {
+    my ($self, $zone, $service) = @_;
+    $self->{"tbl_known_$zone"}->select(value => $service);
+}
+
+sub add_service {
+    my ($self) = @_;
+    $self->{btn_add}->click();
+}
+
+1;

--- a/lib/YaST/Firewall/StartUpPage.pm
+++ b/lib/YaST/Firewall/StartUpPage.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Firewall Startup Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::StartUpPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{lbl_status} = $self->{app}->label({id => 'service_widget_status'});
+    $self->{cmb_set_firewall_state} = $self->{app}->combobox({id => 'service_widget_action'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{lbl_status}->exist();
+}
+
+sub start_firewall {
+    my ($self) = @_;
+    $self->{cmb_set_firewall_state}->select("Start");
+}
+
+sub stop_firewall {
+    my ($self) = @_;
+    $self->{cmb_set_firewall_state}->select("Stop");
+}
+
+1;

--- a/lib/YaST/Firewall/ZonePage.pm
+++ b/lib/YaST/Firewall/ZonePage.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Firewall Zone Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::ZonePage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{tab_services_ports} = $self->{app}->tab({id => "\"CWM::DumbTabPager\""});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{tab_services_ports}->exist();
+}
+
+# Using "Ports" instead of "&Ports" as tab select function parameter since YuiRestClient::Widget::Base will
+# using sanitize function remove "&" before compare the string
+sub switch_ports_tab {
+    my ($self) = @_;
+    $self->{tab_services_ports}->select("Ports");
+}
+
+sub switch_services_tab {
+    my ($self) = @_;
+    $self->{tab_services_ports}->select("Services");
+}
+
+1;

--- a/lib/YaST/Firewall/ZonesPage.pm
+++ b/lib/YaST/Firewall/ZonesPage.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles Firewall Zones Settings Page.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+package YaST::Firewall::ZonesPage;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{tbl_zones} = $self->{app}->table({id => "\"zones_table\""});
+    $self->{btn_set_as_default} = $self->{app}->button({id => "\"Y2Firewall::Widgets::DefaultZoneButton\""});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{tbl_zones}->exist();
+}
+
+sub get_items {
+    my ($self) = @_;
+    return $self->{tbl_zones}->items();
+}
+
+sub select_zone {
+    my ($self, $zone) = @_;
+    $self->{tbl_zones}->select(value => $zone);
+}
+
+sub set_default_zone {
+    my ($self) = @_;
+    $self->{btn_set_as_default}->click();
+}
+1;

--- a/schedule/yast/opensuse/yast2_gui/yast2_gui.yaml
+++ b/schedule/yast/opensuse/yast2_gui/yast2_gui.yaml
@@ -22,13 +22,18 @@ schedule:
   - yast2_gui/yast2_bootloader
   - "{{bootcode_options}}"
   - yast2_gui/yast2_datetime
-  - yast2_gui/yast2_firewall
+  - yast2_gui/yast2_firewall_stop_service
+  - yast2_gui/yast2_firewall_start_service
+  - yast2_gui/yast2_firewall_set_default_zone
+  - yast2_gui/yast2_firewall_set_interface
+  - yast2_gui/yast2_firewall_set_service_port
   - yast2_gui/yast2_hostnames
   - yast2_gui/yast2_lang
   - yast2_gui/yast2_network_settings
   - yast2_gui/yast2_software_management
   - yast2_gui/yast2_users
   - yast2_gui/yast2_security
+
 conditional_schedule:
   bootcode_options:
     ARCH:

--- a/schedule/yast/yast2_gui/yast2_gui_sle.yaml
+++ b/schedule/yast/yast2_gui/yast2_gui_sle.yaml
@@ -29,7 +29,12 @@ conditional_schedule:
         - yast2_gui/yast2_expert_partitioner
         - yast2_gui/yast2_software_management
         - yast2_gui/yast2_security
-        - yast2_gui/yast2_firewall
+        - yast2_gui/yast2_firewall_stop_service
+        - yast2_gui/yast2_firewall_start_service
+        - yast2_gui/yast2_firewall_set_default_zone_prepare
+        - yast2_gui/yast2_firewall_set_default_zone
+        - yast2_gui/yast2_firewall_set_interface
+        - yast2_gui/yast2_firewall_set_service_port
         - yast2_gui/yast2_bootloader
         - yast2_gui/bootloader/bootcode_options
         - x11/yast2_snapper

--- a/test_data/yast/yast2_gui.yaml
+++ b/test_data/yast/yast2_gui.yaml
@@ -28,3 +28,5 @@ bootcode_applied_params:
 bootcode_device:
   default: /dev/vda
   write_to_partition: /dev/vda2
+port: 30000-50000
+zone: public

--- a/tests/yast2_gui/yast2_firewall_set_default_zone.pm
+++ b/tests/yast2_gui/yast2_firewall_set_default_zone.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: YaST2 Firewall UI test checks verious configurations and settings of firewall
+# Make sure yast2 firewall can opened properly. Configurations can be changed and written correctly.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use network_utils 'iface';
+use YaST::Module;
+
+sub run {
+    my $self = shift;
+    my $iface = iface();
+
+    $self->select_serial_terminal();
+    validate_script_output("firewall-cmd --get-default-zone", sub { m/public/ }, proceed_on_failure => 1);
+    select_console 'x11', await_console => 0;
+    YaST::Module::open(module => 'firewall', ui => 'qt');
+    $testapi::distri->get_firewall()->select_interfaces_page();
+    save_screenshot;
+    $testapi::distri->get_firewall()->select_zones_page();
+    save_screenshot;
+    $testapi::distri->get_firewall()->set_default_zone("trusted");
+    save_screenshot;
+    $testapi::distri->get_firewall()->accept_change();
+    assert_screen 'generic-desktop';
+    $self->select_serial_terminal();
+    validate_script_output("firewall-cmd --list-interfaces --zone=trusted", sub { m/$iface/ }, proceed_on_failure => 1);
+    validate_script_output("firewall-cmd --get-default-zone", sub { m/trusted/ }, proceed_on_failure => 1);
+
+}
+
+1;

--- a/tests/yast2_gui/yast2_firewall_set_default_zone_prepare.pm
+++ b/tests/yast2_gui/yast2_firewall_set_default_zone_prepare.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This module should schedule before yast2_firewall_set_default_zone.pm on SLES productor since
+# TW set default zone with iface together but sle not, so we need update iface's zone to trusted zone firstly
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use network_utils 'iface';
+use YaST::Module;
+
+sub run {
+    my $self = shift;
+    my $iface = iface();
+    my %settings = (device => $iface, zone => 'trusted');
+
+    select_console 'x11', await_console => 0;
+    YaST::Module::open(module => 'firewall', ui => 'qt');
+    $testapi::distri->get_firewall()->select_interfaces_page();
+    save_screenshot;
+    $testapi::distri->get_firewall()->set_interface_zone($settings{device}, $settings{zone});
+    save_screenshot;
+    $testapi::distri->get_firewall()->accept_change();
+    assert_screen 'generic-desktop';
+    $self->select_serial_terminal();
+    validate_script_output("firewall-cmd --list-interfaces --zone=$settings{zone}", sub { m/$settings{device}/ }, proceed_on_failure => 0);
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    select_console 'root-console';
+    $self->save_upload_y2logs;
+}
+
+1;

--- a/tests/yast2_gui/yast2_firewall_set_interface.pm
+++ b/tests/yast2_gui/yast2_firewall_set_interface.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: YaST2 Firewall UI test checks verious configurations and settings of firewall
+# Make sure yast2 firewall can opened properly. Configurations can be changed and written correctly.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use network_utils 'iface';
+use YaST::Module;
+
+sub run {
+    my $self = shift;
+    my $iface = iface();
+    my %setting = (device => $iface, zone => 'public');
+
+    select_console 'x11', await_console => 0;
+    YaST::Module::open(module => 'firewall', ui => 'qt');
+    $testapi::distri->get_firewall()->select_interfaces_page();
+    save_screenshot;
+    $testapi::distri->get_firewall()->set_interface_zone($setting{device}, $setting{zone});
+    save_screenshot;
+    $testapi::distri->get_firewall()->accept_change();
+    assert_screen 'generic-desktop';
+    $self->select_serial_terminal();
+    validate_script_output("firewall-cmd --list-interfaces --zone=$setting{zone}", sub { m/$setting{device}/ }, proceed_on_failure => 1);
+}
+
+1;

--- a/tests/yast2_gui/yast2_firewall_set_service_port.pm
+++ b/tests/yast2_gui/yast2_firewall_set_service_port.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: YaST2 Firewall UI test checks verious configurations and settings of firewall
+# Make sure yast2 firewall can opened properly. Configurations can be changed and written correctly.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use network_utils 'iface';
+use YaST::Module;
+
+sub run {
+    my $self = shift;
+    my $iface = iface();
+    my %setting = (zone => 'trusted', service => 'bitcoin', port => '7777');
+
+    select_console 'x11', await_console => 0;
+    YaST::Module::open(module => 'firewall', ui => 'qt');
+    $testapi::distri->get_firewall()->select_zone_page($setting{zone});
+    save_screenshot;
+    $testapi::distri->get_firewall()->add_service($setting{zone}, $setting{service});
+    save_screenshot;
+    $testapi::distri->get_firewall()->add_tcp_port($setting{port});
+    save_screenshot;
+    $testapi::distri->get_firewall()->accept_change();
+    assert_screen 'generic-desktop';
+    $self->select_serial_terminal();
+    validate_script_output("firewall-cmd --list-all --zone=trusted", sub { m/services: bitcoin/ }, proceed_on_failure => 1);
+    validate_script_output("firewall-cmd --list-all --zone=trusted", sub { m/ports: 7777\/tcp/ }, proceed_on_failure => 1);
+}
+
+1;

--- a/tests/yast2_gui/yast2_firewall_start_service.pm
+++ b/tests/yast2_gui/yast2_firewall_start_service.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: YaST2 Firewall UI test checks verious configurations and settings of firewall
+# Make sure yast2 firewall can start properly. Configurations can be changed and written correctly.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use YaST::Module;
+
+sub run {
+    my $self = shift;
+
+    select_console 'x11', await_console => 0;
+    YaST::Module::open(module => 'firewall', ui => 'qt');
+    $testapi::distri->get_firewall()->start_firewall();
+    save_screenshot;
+    $testapi::distri->get_firewall()->accept_change();
+    assert_screen 'generic-desktop';
+
+    $self->select_serial_terminal();
+    validate_script_output("firewall-cmd --state", sub { m/^running/ }, proceed_on_failure => 1);
+}
+
+1;

--- a/tests/yast2_gui/yast2_firewall_stop_service.pm
+++ b/tests/yast2_gui/yast2_firewall_stop_service.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: YaST2 Firewall UI test checks verious configurations and settings of firewall
+# Make sure yast2 firewall can stop properly. Configurations can be changed and written correctly.
+# Maintainer: QE YaST <qa-sle-yast@suse.de>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use YaST::Module;
+
+sub run {
+    my $self = shift;
+
+    select_console 'x11', await_console => 0;
+    YaST::Module::open(module => 'firewall', ui => 'qt');
+
+    $testapi::distri->get_firewall()->stop_firewall();
+    save_screenshot;
+    $testapi::distri->get_firewall()->accept_change();
+    assert_screen 'generic-desktop';
+
+    $self->select_serial_terminal();
+    validate_script_output("firewall-cmd --state", sub { m/91mnot running/ }, proceed_on_failure => 1);
+}
+
+1;


### PR DESCRIPTION
Using libyui to check yast firewall module 

- Related ticket: https://progress.opensuse.org/issues/113492
- Needles: na
- Latest VR: 
https://openqa.opensuse.org/tests/2844742#details
https://openqa.opensuse.org/tests/2846745
https://openqa.suse.de/tests/9843828#details