### PR TITLE
Prevent duplicate NTP SLP anouncements

### DIFF
--- a/tests/console/slp.pm
+++ b/tests/console/slp.pm
@@ -64,7 +64,7 @@ sub run {
     # Deregister one NTP service and find the other one
     assert_script_run 'slptool deregister ntp://tik.cesnet.cz:123,en,65535';
     assert_script_run 'slptool findsrvs ntp';
-    assert_script_run 'if [[ $(slptool findsrvs ntp | grep -c "tik\|tak") = "1" ]]; then echo "One remaining NTP announcement was found"; else false; fi';
+    assert_script_run 'if [[ $(slptool findsrvs ntp | grep -c "tik\|tak" | cut -d, -f1 | sort | uniq ) = "1" ]]; then echo "One remaining NTP announcement was found"; else false; fi';
 
     # Turn off slpd
     systemctl 'stop slpd';


### PR DESCRIPTION
The there are multiple sources announcing the same NTP servers in our network.
This pull request deduplicates the SLP announcements which makes the test more stable.

- Related ticket: [poo#116395](https://progress.opensuse.org/issues/116395)
- Verification run: [pdostal-server.suse.cz](https://pdostal-server.suse.cz/tests/539#)
