### PR TITLE
Add workaround for bsc#1184679 on wizard_hana_install

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -78,12 +78,16 @@ sub run {
     type_password $sles4sap::instance_password;
     wait_screen_change { send_key 'tab' };
     type_password $sles4sap::instance_password;
-    if (is_sle('<15-SP4')) {
-        wait_screen_change { send_key $cmd{ok} };
-    } else {
-        wait_screen_change { send_key $cmd{next} };
+    wait_screen_change { send_key is_sle('<15-SP4') ? $cmd{ok} : $cmd{next} };
+    while (1) {
+        assert_screen ['sap-wizard-profile-ready', 'displaymanager', 'dm-nousers'], 300;
+        if (match_has_tag 'sap-wizard-profile-ready') { last; }
+        else {
+            record_soft_failure 'bsc#1184679 - Crash of Gnome session during wizard_hana_install';
+            # Gnome session crashed. Need to log in again
+            $self->handle_displaymanager_login(ready_time => 60);
+        }
     }
-    assert_screen 'sap-wizard-profile-ready', 300;
     send_key $cmd{next};
 
     while (1) {

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -80,8 +80,9 @@ sub run {
     type_password $sles4sap::instance_password;
     wait_screen_change { send_key is_sle('<15-SP4') ? $cmd{ok} : $cmd{next} };
     while (1) {
-        assert_screen ['sap-wizard-profile-ready', 'displaymanager', 'dm-nousers'], 300;
+        assert_screen ['sap-wizard-profile-ready', 'displaymanager', 'dm-nousers', 'oh-no-something-has-gone-wrong'], 300;
         if (match_has_tag 'sap-wizard-profile-ready') { last; }
+        elsif (match_has_tag 'oh-no-something-has-gone-wrong') { send_key 'ret'; }
         else {
             record_soft_failure 'bsc#1184679 - Crash of Gnome session during wizard_hana_install';
             # Gnome session crashed. Need to log in again


### PR DESCRIPTION
Module `sles4sap/wizard_hand_install` is currently failing on some specific bare metal Dell servers on `BACKEND=ipmi` with a crash on the Gnome session that takes the SUT back to the displaymanager login screen. Since the related bug hasn't been active in a while, this adds a workaround and a softfail.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1184679
- Needles: N/A
- Verification run: [ipmi](https://openqa.suse.de/t9485609), [x86_64 gnome](http://mango.qa.suse.de/tests/4963), [x86_64 textmode](http://mango.qa.suse.de/tests/4966), [ppc64le gnome](https://openqa.suse.de/t9485611), [ppc64le textmode](https://openqa.suse.de/t9485614)
