### PR TITLE
ha: Rebase hawk_test Docker image on Leap 15.4

### DIFF
--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -52,7 +52,7 @@ sub run {
     # TODO: Use another namespace using team group name
     # Docker image source in https://github.com/ricardobranco777/hawk_test
     # It will be eventually moved to https://github.com/ClusterLabs/hawk/e2e_test
-    my $docker_image = "registry.opensuse.org/home/rbranco/branches/opensuse/templates/images/15.3/containers/hawk_test:latest";
+    my $docker_image = "registry.opensuse.org/home/rbranco/branches/opensuse/templates/images/15.4/containers/hawk_test:latest";
 
     assert_script_run("docker pull $docker_image", 240);
 


### PR DESCRIPTION
Rebase hawk_test Docker image on Leap 15.4

openSUSE Leap 15.3 - is expected to be maintained until end of November 2022 according to [official documentation](https://en.opensuse.org/Lifetime)

- Verification run: https://openqa.suse.de/tests/9492411