### PR TITLE
Add log and pip management in qesapdeploy lib

### DIFF
--- a/tests/sles4sap/trento/cluster_configure.pm
+++ b/tests/sles4sap/trento/cluster_configure.pm
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Summary: Configuration steps for qe-sap-deployment
+# Summary: Setup and install more tools in the running jumphost image for qe-sap-deployment
 # Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
 
 use strict;
@@ -15,13 +15,15 @@ sub run {
     $self->select_serial_terminal;
 
     # Get the code for the qe-sap-deployment
-    $self->qesap_create_folder_tree();
-    $self->qesap_get_deployment_code();
+    qesap_create_folder_tree();
+    qesap_get_deployment_code();
+    qesap_pip_install();
 }
 
 sub post_fail_hook {
     my ($self) = shift;
     $self->select_serial_terminal;
+    qesap_upload_logs('', 1);
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Add some constants about cloud resource group name and pip log location. 
Add a method to upload all logs from a list
Add method to pip install all the qe-sap-deployment dependency, it is mind to be used in a pctools qcow2 image

- Verification run: https://openqaworker15.qa.suse.cz/tests/24133
