### PR TITLE
Make test module to export results in xml

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -17,6 +17,7 @@ use Utils::Systemd qw(systemctl disable_and_stop_service);
 use Utils::Backends;
 use Mojo::UserAgent;
 use zypper qw(wait_quit_zypper);
+use Storable qw(dclone);
 
 our @EXPORT = qw(
   generate_results
@@ -96,6 +97,8 @@ our @EXPORT = qw(
   permit_root_ssh_in_sol
   cleanup_disk_space
   package_upgrade_check
+  test_case
+  @all_tests_results
 );
 
 =head1 SYNOPSIS
@@ -2413,7 +2416,6 @@ sub pars_results {
     # and if so, make sure the whole testsuite will fail
     my $fail_check = 0;
     for my $i (@test) {
-        record_info "i", $i;
         if ($i->{result} eq 'FAIL') {
             $fail_check++;
         }
@@ -2438,6 +2440,23 @@ sub pars_results {
         script_run("echo \"</testcase>\" >> $xmlfile");
     }
     script_run("echo \"</testsuite>\" >> $xmlfile");
+}
+
+our @all_tests_results;
+
+=head2 test_case
+    test_case($name, $description, $result);
+
+C<test_case> can produce a data_structure which C<pars_results> can utilize.
+Using C<test_case> in an OpenQA module you are able to /name/ and describe
+the whole test as subtasks, in a XUnit format.
+
+=cut
+
+sub test_case {
+    my ($name, $description, $result) = @_;
+    my %results = generate_results($name, $description, $result);
+    push(@all_tests_results, dclone(\%results));
 }
 
 1;

--- a/tests/hpc/powerman.pm
+++ b/tests/hpc/powerman.pm
@@ -16,8 +16,8 @@ use testapi;
 use utils;
 use susedistribution;
 
-
 our $cfg_file = "/etc/powerman/powerman.conf";
+our $file = 'tmpresults.xml';
 
 our $dev_caps = sub {
     my $dev = shift;
@@ -28,11 +28,13 @@ our $dev_caps = sub {
 };
 
 sub run ($self) {
-    # install powerman
     zypper_call('in powerman');
     my $powerman_dev = 'bashfun';
-    # Adapt config
+    assert_script_run("touch $file");
+    my $cfg_file = "/etc/powerman/powerman.conf";
     my $hostname = script_output('hostname');
+    test_case('hostname', 'Check hostname', $hostname);
+
     assert_script_run(
         "echo \"\$(cat >> $cfg_file <<EOF
 listen \"0.0.0.0:10101\"
@@ -51,25 +53,39 @@ EOF
     $self->enable_and_start('powerman');
 
     # list available targets
-    validate_script_output("powerman -l", sub { m/$hostname/ });
+    my $rt = validate_script_output("powerman -l", sub { m/$hostname/ });
+    test_case('Test powerman -l', 'powerman can find nodes', $rt);
 
     # check if target can be turned on
-    assert_script_run("powerman -1 \$(hostname)");
-    validate_script_output("powerman -Q \$(hostname)", sub { /on:\s+$hostname.*/ });
+    $rt = assert_script_run("powerman -1 \$(hostname)");
+    test_case('powerman on', 'powerman can turn on nodes', $rt);
+
+    $rt = validate_script_output("powerman -Q \$(hostname)", sub { /on:\s+$hostname.*/ });
+    test_case('powerman list online nodes', 'powerman can find nodes', $rt);
 
     # check if target can be turned off
-    assert_script_run("powerman -0 \$(hostname)");
-    validate_script_output("powerman -Q \$(hostname)", sub { /off:\s+$hostname.*/ });
+    $rt = assert_script_run("powerman -0 \$(hostname)");
+    test_case('powerman off', 'powerman can turn off nodes', $rt);
+    $rt = validate_script_output("powerman -Q \$(hostname)", sub { /off:\s+$hostname.*/ });
+    test_case('powerman list online nodes', 'powerman can turn off nodes', $rt);
 
     # check if command can be handled by power control device
     # This depends on the device/driver type.
     # Power cycle is not supported by *bashfun*.
     if (exists $$powerman_dev_caps{cycle}) {
         record_info('skip cycle', 'cycle is supported but check is not implemented');
-        assert_script_run("powerman -c \$(hostname)");
+        $rt = assert_script_run("powerman -c \$(hostname)");
+        test_case('powerman cycle', 'powerman can show node cycle', $rt);
     } else {
-        validate_script_output("powerman -c \$(hostname)", sub { /.*cannot be handled by power control device.*/ }, proceed_on_failure => 1);
+        $rt = validate_script_output("powerman -c \$(hostname)", sub { /.*cannot be handled by power control device.*/ }, proceed_on_failure => 1);
+        test_case('powerman cycle', 'powerman dev doesnt support cycle command', $rt);
     }
+}
+
+sub post_run_hook ($self) {
+    pars_results('HPC powerman tests', $file, @all_tests_results);
+    parse_extra_log('XUnit', $file);
+    $self->SUPER::post_run_hook();
 }
 
 sub post_fail_hook ($self) {


### PR DESCRIPTION
Refactor test module to export the results in xml and make use of the xml representation in OpenQA.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: http://aquarius.suse.cz/tests/12251
