### PR TITLE
Disable kernel messages on console and wrap terraform container into bash -e

### DIFF
--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -61,6 +61,11 @@ sub run {
 
     select_host_console();    # select console on the host, not the PC instance
 
+    # Prevent kernel messages of the helper VM to contaminate the serial console
+    # this is needed on our ext4-based helper VM to avoid kernel messages from overlayfs
+    # to confuse openQA
+    assert_script_run("dmesg -n emerg");
+
     my $additional_disk_size = get_var('PUBLIC_CLOUD_HDD2_SIZE', 0);
     my $additional_disk_type = get_var('PUBLIC_CLOUD_HDD2_TYPE', '');    # Optional variable, also if PUBLIC_CLOUD_HDD2_SIZE is set
 

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -114,11 +114,12 @@ sub run {
     my $terraform_version = '1.1.7';
     # Terraform in a container
     my $terraform_wrapper = <<EOT;
-#!/bin/sh
-podman run -v /root/:/root/ --rm --env-host=true -w=\$PWD docker.io/hashicorp/terraform:$terraform_version \$@
+#!/bin/bash -e
+podman run --rm -w=\$PWD -v /root/:/root/ --env-host=true docker.io/hashicorp/terraform:$terraform_version \$@
 EOT
 
-    create_script_file('terraform', '/usr/bin/terraform', $terraform_wrapper);
+    create_script_file('terraform', '/usr/local/bin/terraform', $terraform_wrapper);
+    validate_script_output("terraform -version", qr/$terraform_version/);
     record_info('Terraform', script_output('terraform -version'));
 
     # Kubectl in a container


### PR DESCRIPTION
This PR contains two commits:

1. Disable kernel messages on the console for publiccloud test runs
2. Wrap terraform container into bash -e so that it terminates with non-success error code on errors.

- Related ticket: https://progress.opensuse.org/issues/116332
- Verification run: [image creation](https://duck-norris.qam.suse.de/tests/10707) | [img-proof](https://duck-norris.qam.suse.de/tests/10712) (using the new image) | [fixed console](https://duck-norris.qam.suse.de/tests/10713#step/prepare_instance/117) fails in unrelated later step
