### PR TITLE
Remove non-stable test modules in test suite yast2_cmd

### DIFF
--- a/schedule/yast/yast2_cmd_dev.yaml
+++ b/schedule/yast/yast2_cmd_dev.yaml
@@ -6,10 +6,14 @@ schedule:
   - boot/boot_to_desktop
   - yast2_cmd/yast_rdp
   - yast2_cmd/yast_timezone
+  - '{{yast_keyboard}}'
   - yast2_cmd/yast_ftp_server
   - yast2_cmd/yast_nfs_server
   - yast2_cmd/yast_nfs_client
   - yast2_cmd/yast_tftp_server
+  - '{{yast_dns_server}}'
+  - '{{yast_lan}}'
+  - yast2_cmd/yast_users
   - yast2_cmd/yast_sysconfig
   - '{{yast_lang}}'
 conditional_schedule:


### PR DESCRIPTION
Remove non-stable test modules in test suite yast2_cmd

- Related ticket: https://progress.opensuse.org/issues/116299
- Verification run: https://openqa.suse.de/tests/9507822
MR: https://gitlab.suse.de/coolgw/wegao-test/-/merge_requests/137