### PR TITLE
Adapt test suite configuration with YAML feature default+flows for non-product selection in s390x

### DIFF
--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -15,38 +15,20 @@ vars:
   ADDONS: all-packages
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/licensing/accept_license
-  - installation/registration/skip_registration
-  - installation/module_selection/select_nonconflicting_modules
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/select_patterns
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_installed_packages
-  - console/validate_installed_patterns
-  - console/suseconnect_scc
-  - shutdown/cleanup_before_shutdown
-  - shutdown/shutdown
-  - shutdown/svirt_upload_assets
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_nonconflicting_modules
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  software:
+    - installation/select_patterns
+  system_validation:
+    - console/validate_installed_packages
+    - console/validate_installed_patterns
+    - console/suseconnect_scc
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown
+    - shutdown/svirt_upload_assets

--- a/schedule/yast/sle/flows/default_s390x_kvm.yaml
+++ b/schedule/yast/sle/flows/default_s390x_kvm.yaml
@@ -1,0 +1,60 @@
+---
+# Default ordered sequence of steps to be optionally overwritten for s390x kvm
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+access_beta:
+  - installation/access_beta_distribution
+product_selection:
+  - installation/product_selection/install_SLES
+license_agreement:
+  - installation/licensing/accept_license
+registration:
+  - installation/registration/register_via_scc
+extension_module_selection:
+  - installation/module_registration/skip_module_registration
+add_on_product:
+  - installation/add_on_product/skip_install_addons
+system_role:
+  - installation/system_role/accept_selected_role_text_mode
+guided_open: []
+guided_hard_disks: []
+guided_scheme: []
+guided_filesystem: []
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+security: []
+default_systemd_target: []
+installation_settings:
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+installation:
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+stop_timeout_system_reboot:
+  - installation/performing_installation/stop_timeout_system_reboot_now
+installation_logs:
+  - installation/logs_from_installation_system
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+reconnect_svirt:
+  - installation/performing_installation/reconnect_after_reboot
+grub:
+  - installation/handle_reboot
+first_login:
+  - installation/first_boot
+system_preparation:
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+system_validation: []

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -12,36 +12,17 @@ vars:
   DESKTOP: textmode
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/select_role_minimal
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/installation_snapshots
-  - console/zypper_lr
-  - console/zypper_ref
-  - console/ncurses
-  - update/zypper_up
-  - console/zypper_lifecycle
-  - console/orphaned_packages_check
-  - console/consoletest_finish
+  system_role:
+    - installation/system_role/select_role_minimal
+  stop_timeout_system_reboot: []
+  system_preparation:
+    - console/system_prepare
+    - console/installation_snapshots
+  system_validation:
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - update/zypper_up
+    - console/zypper_lifecycle
+    - console/orphaned_packages_check
+    - console/consoletest_finish


### PR DESCRIPTION
For s390x, we need to design a single default YAML to handle its specific workflow. we use the default+flow feature to have one place to update it for s390x's strange variation.

- Related ticket:
   * https://progress.opensuse.org/issues/115319
- Needles:
  * N/A
- Verification run:
  * https://openqa.nue.suse.com/tests/9716056
  * https://openqa.nue.suse.com/tests/9716140
  * https://openqa.nue.suse.com/tests/9716138

  
- Related MR:
   https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/419