### PR TITLE
Reduce serial log output

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -756,8 +756,12 @@ sub fully_patch_system {
 
     # Repeatedly call zypper patch until it returns something other than 103 (package manager updates)
     my $ret = 1;
+    # Add -q to reduce the unnecessary log output.
+    # Reduce the pressure of serial port when running hyperv test with sle15.
+    # poo#115454
+    my $zypp_opt = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? '-q' : '';
     for (1 .. 3) {
-        $ret = zypper_call('patch --with-interactive -l', exitcode => [0, 4, 102, 103], timeout => 6000);
+        $ret = zypper_call("$zypp_opt patch --with-interactive -l", exitcode => [0, 4, 102, 103], timeout => 6000);
         last if $ret != 103;
     }
 


### PR DESCRIPTION
poo:https://progress.opensuse.org/issues/115454

When executing command: zypper -n patch --with-interactive -l on hyperv BareMetal with sle15
The serial console will print a lot of logs for about 6 minutes
It will install 600+ packages to upgrade
But so many massive log will effect serial because of the poor speed 115200
It may let serial port down expecially parallel operation
The parameter -q can reduce the log output
zypper -n -q patch --with-interactive -l

- Related ticket: https://progress.opensuse.org/issues/115454
- Needles: N/A
- Verification run: 
   -SLE15sp4 parallel test:
                          -- http://openqa.suse.de/tests/9509375#step/zypper_patch/9
                          -- http://openqa.suse.de/tests/9509374#step/zypper_patch/9
   -SLE15sp5 parallel test:
                          -- http://openqa.suse.de/tests/9536619#step/zypper_patch/9
                          -- http://openqa.suse.de/tests/9536439#step/zypper_patch/9
   -SLE15SP4 without hyperv test:
                          -- https://openqa.suse.de/tests/9546279#step/zypper_patch/6 (zypper_patch module)

