### PR TITLE
Add a WMP test for Netweaver on baremetal

### DIFF
--- a/schedule/kernel/sles4sap/setup_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/setup_hana_baremetal.yaml
@@ -12,6 +12,7 @@ vars:
   INSTANCE_ID: '00'
   INSTANCE_TYPE: HBD
   RECLAIM_ROOT: '1'
+  ROOTONLY: '1'
   START_AFTER_TEST: install_sles4sap_baremetal
 schedule:
   - boot/boot_to_desktop

--- a/schedule/kernel/sles4sap/setup_netweaver_baremetal.yaml
+++ b/schedule/kernel/sles4sap/setup_netweaver_baremetal.yaml
@@ -1,0 +1,18 @@
+---
+name: setup_netweaver_baremetal
+description: >
+  Install Netweaver on a baremetal machine
+vars:
+  GRUB_TIMEOUT: 300
+  INSTANCE_ID: '00'
+  INSTANCE_SID: QAD
+  INSTANCE_TYPE: ASCS
+  NW: nfs://1c119.qa.suse.de/srv/nfs/sap/NW75_CLUSTER
+  ROOTONLY: '1'
+  START_AFTER_TEST: install_sles4sap_baremetal
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/netweaver_install
+  - sles4sap/netweaver_test_instance

--- a/schedule/kernel/sles4sap/wmp_simple_netweaver_baremetal.yaml
+++ b/schedule/kernel/sles4sap/wmp_simple_netweaver_baremetal.yaml
@@ -1,0 +1,46 @@
+---
+name: install_sles4sap_dvd
+description: >
+  Installation tests for SLES4SAP, use the DVD to boot the installer.
+  Can be used to install sles4sap on baremetal machines using ipxe_install
+vars:
+  DESKTOP: textmode
+  GRUB_TIMEOUT: 300
+  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
+  INSTANCE_SID: QAD
+  INSTANCE_ID: '00'
+  INSTANCE_TYPE: ASCS
+  NOLOGIN: '1'
+  RECLAIM_ROOT: '1'
+  ROOTONLY: '1'
+  START_AFTER_TEST: setup_netweaver_baremetal
+  WMP_TEST_REPO: https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz
+schedule:
+  - boot/boot_to_desktop
+  - '{{test_sles4sap}}'
+  - '{{scc_deregister}}'
+  - '{{generate_image}}'
+conditional_schedule:
+  sles4sap_product_installation_mode:
+    SYSTEM_ROLE:
+      default:
+        - installation/sles4sap_product_installation_mode
+  test_sles4sap:
+    TEST_SLES4SAP:
+      1:
+        - console/system_prepare
+        - sles4sap/wmp_setup
+        - sles4sap/wmp_check_process
+        - kernel/wmp_simple
+  scc_deregister:
+    SCC_DEREGISTER:
+      1:
+        - console/scc_deregistration
+  generate_image:
+    GENERATE_IMAGE:
+      1:
+        - console/hostname
+        - console/force_scheduled_tasks
+        - shutdown/grub_set_bootargs
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown

--- a/tests/sles4sap/wmp_setup.pm
+++ b/tests/sles4sap/wmp_setup.pm
@@ -38,8 +38,9 @@ sub run {
     # Add cgroup capture program to startup profile
     my $sid = get_required_var('INSTANCE_SID');
     my $instance_id = get_required_var('INSTANCE_ID');
+    my $instance_type = get_var('INSTANCE_TYPE', 'HDB');
     my $hostname = get_hostname;
-    my $profile = "/usr/sap/${sid}/SYS/profile/${sid}_HDB${instance_id}_${hostname}";
+    my $profile = "/usr/sap/${sid}/SYS/profile/${sid}_${instance_type}${instance_id}_${hostname}";
     assert_script_run 'echo "# all programs spawned below will be put in dedicated cgroup" >> ' . $profile;
     assert_script_run 'echo "Execute_20 = local /usr/lib/sapwmp/sapwmp-capture -a" >> ' . $profile;
     assert_script_run "tail $profile";


### PR DESCRIPTION
Make the WMP tests also runnable with netweaver on baremetal. Included a verification run to show it does not break the HANA test. Also note: a single case fails for netweaver, as we don't have a database connection in this scenario.

- Related ticket: https://progress.opensuse.org/issues/105226
- Needles: - 
- Verification run: http://baremetal-support.qa.suse.de/tests/2406 and http://baremetal-support.qa.suse.de/tests/2409 
