### PR TITLE
Remove deprecated probing in iscsi_client.

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -114,7 +114,6 @@ sub run {
     record_info 'Systemd', 'Verify status of iscsi services and sockets';
     systemctl("is-active iscsid.service");
     systemctl("is-active iscsid.socket");
-    systemctl("is-active iscsiuio.socket");
     if (!is_sle('=12-SP4') && !is_sle('=12-SP5')) {
         systemctl("is-active iscsi.service");
     }


### PR DESCRIPTION
In iscsi_client.pm we are testing if iscsiuio.socket is activated. It used to be activated by default, but that was un actual bug: this socket is only useful if a Qlogic HBA is connected to the system but if it isn't,
the activation of the socket delays the system startup for no reason. So it was decided to no longer activate that socket unless such hardware is detected.
See details here https://bugzilla.suse.com/show_bug.cgi?id=1203062 and here https://github.com/yast/yast-iscsi-client/pull/116. It does not look like we can easily emulate such hardware in Qemu. In older products, the socket will likely still be activated but not in 15.5 and later, so it looks like a reasonable option to just stop probing that socket.

VR https://openqa.suse.de/tests/9519817