### PR TITLE
Bci xfail soft 1

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -29,7 +29,7 @@ sub run_tox_cmd {
     my $bci_timeout = get_var('BCI_TIMEOUT', 1200);
     my $bci_reruns = get_var('BCI_RERUNS', 3);
     my $bci_reruns_delay = get_var('BCI_RERUNS_DELAY', 10);
-    my $cmd = "tox -e $env -- -n auto";
+    my $cmd = "tox -e $env -- -rx -n auto";
     $cmd .= " -k \"$bci_marker\"" if $bci_marker;
     $cmd .= " --reruns $bci_reruns --reruns-delay $bci_reruns_delay";
     record_info("tox", "Running command: $cmd");


### PR DESCRIPTION
PR to set in opeqa as soft-failures the XFAIL tests resulting from pytest of containers BCI-tests in python

- Related ticket: https://progress.opensuse.org/issues/113510
- Verification run: https://openqa.suse.de/tests/9520968