### PR TITLE
WIP: Fix capitalization issue in addon check

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -44,6 +44,7 @@ our @EXPORT = qw(
   %ADDONS_REGCODE
   @SLE15_ADDONS_WITHOUT_LICENSE
   @SLE12_MODULES
+  @SOFTFAIL_ADDONS
 );
 
 # We already have needles with names which are different we would use here
@@ -95,6 +96,12 @@ our @SLE12_MODULES = qw(
   sle-module-toolchain
   sle-module-web-scripting
   sle-module-public-cloud
+);
+
+our @SOFTFAIL_ADDONS = qw(
+    IBM-POWER-Advance-toolchain
+    IBM-POWER-Adv-Toolchain
+    IBM-Power-tools
 );
 
 # Method to determine if a short name references a module based on what's defined
@@ -810,8 +817,7 @@ sub get_addon_fullname {
         tsm => 'sle-module-transactional-server',
         espos => 'ESPOS',
         nvidia => 'sle-module-NVIDIA-compute',
-        idu => is_sle('15+') ? 'IBM-POWER-Tools' : 'IBM-DLPAR-utils',
-        ids => is_sle('15+') ? 'IBM-POWER-Adv-Toolchain' : 'IBM-DLPAR-SDK',
+        idu => is_sle('15+') ? 'ibm-power-tools' : 'IBM-DLPAR-utils',
     );
     return $product_list{"$addon"};
 }

--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -14,7 +14,7 @@ use utils;
 use strict;
 use warnings;
 use version_utils 'is_sle';
-use registration 'get_addon_fullname';
+use registration 'get_addon_fullname', '@SOFTFAIL_ADDONS';
 use Mojo::JSON;
 use List::MoreUtils 'uniq';
 


### PR DESCRIPTION
While validating registered addons after migration, the test fails on `IBM-Power-Tools` and `IBM-Power-Advance-Toolchain`.

`IBM-Power-Tools` was failing due to capitalization, and passes when performing a case-insensitive string-matching. But `IBM-Power-Advance-Toolchain` is actually not registered, due to https://bugzilla.suse.com/show_bug.cgi?id=1202419. The proposed action is to softfail in case of IBM modules, since there are problems with the `-release` packages for them.

- Related ticket: https://progress.opensuse.org/issues/115697
- Verification run: https://openqa.suse.de/tests/9511344
