### PR TITLE
openscap: multiple fixes

### DIFF
--- a/data/openscap/xccdf.xml
+++ b/data/openscap/xccdf.xml
@@ -3,6 +3,7 @@
   <status date="2017-10-09">draft</status>
   <title>Hardening SUSE Linux Enterprise</title>
   <platform idref="cpe:/o:suse"/>
+  <platform idref="cpe:/o:opensuse"/>
   <version>1</version>
 
   <Profile id="standard">

--- a/tests/security/openscap/oscap_remediating_offline.pm
+++ b/tests/security/openscap/oscap_remediating_offline.pm
@@ -38,7 +38,7 @@ sub run {
     ensure_generated_file($xccdf_result);
     prepare_remediate_validation;
 
-    validate_script_output "oscap xccdf remediate --results $remediate_result $xccdf_result", sub { $remediate_match };
+    validate_script_output_retry("oscap xccdf remediate --results $remediate_result $xccdf_result", sub { $remediate_match }, retry => 5, delay => 10);
     validate_result($remediate_result, $remediate_result_match);
 
     # Verify the remediate action result

--- a/tests/security/openscap/oscap_setup.pm
+++ b/tests/security/openscap/oscap_setup.pm
@@ -19,11 +19,6 @@ sub run {
 
     oscap_get_test_file("oval.xml");
     oscap_get_test_file("xccdf.xml");
-
-    # xccdf.xml is for SLE, the CPE is different on openSUSE
-    if (is_opensuse) {
-        assert_script_run "sed -i 's#cpe:/o:suse#cpe:/o:opensuse#g' xccdf.xml";
-    }
 }
 
 sub test_flags {


### PR DESCRIPTION
poo: https://progress.opensuse.org/issues/116368

* as suggested on https://bugzilla.suse.com/show_bug.cgi?id=1203408#c8 , use two tags instead of a sed expression
* on opensuse, manually add the 15.5 data while we wait for an update

Verification runs:
- x86_64: https://openqa.suse.de/tests/9523918
- aarch64: https://openqa.suse.de/tests/9524048
- leap aarch64: https://openqa.opensuse.org/tests/2675105
- leap x86_64: https://openqa.opensuse.org/tests/2675220
