### PR TITLE
Remove mariadb_srv from schedule

### DIFF
--- a/schedule/alp/alp_databases.yaml
+++ b/schedule/alp/alp_databases.yaml
@@ -13,7 +13,6 @@ schedule:
     - microos/one_line_checks
     - microos/services_enabled
     - microos/cockpit_service
-    - console/mariadb_srv
     - console/sqlite3
     - console/postgresql_server
     - transactional/trup_smoke


### PR DESCRIPTION
since mariadb is not available in container repo, so we cannot schedue it on ALP for now.
