### PR TITLE
bootloader: Only execute the SVGA firmware setting when necessary

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -996,7 +996,7 @@ sub tianocore_ensure_svga_resolution {
 
 sub tianocore_select_bootloader {
     tianocore_enter_menu;
-    tianocore_ensure_svga_resolution if check_var('QEMUVGA', 'qxl');
+    tianocore_ensure_svga_resolution if check_var('QEMUVGA', 'qxl') && get_var('UEFI_PFLASH_VARS', '') !~ /800x600/;
     tianocore_enter_menu;
     send_key_until_needlematch('tianocore-bootmanager', 'down', 6, 5);
     send_key 'ret';


### PR DESCRIPTION
We created a patched OVMF pflash variables file and have it stored as an
asset on openqa.opensuse.org. So we only need to set the resolution if
we are not already using the patched image with "800x600" in the name.

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15537 https://openqa.opensuse.org/tests/2664073 UEFI_PFLASH_VARS=ovmf-x86_64-ms-vars-800x600.qcow2
```

Created job #2670542: opensuse-Tumbleweed-DVD-x86_64-Build20220914-gnome_dual_windows10@uefi_win -> https://openqa.opensuse.org/t2670542

Related progress issue: https://progress.opensuse.org/issues/113794