### PR TITLE
Enable libyui-rest-api in test suites for SLE-15-SP4

### DIFF
--- a/schedule/yast/maintenance/create_hdd_transactional_server_dev.yaml
+++ b/schedule/yast/maintenance/create_hdd_transactional_server_dev.yaml
@@ -1,0 +1,40 @@
+---
+name: create_hdd_transactional_server
+description: >
+    Installation of a Transactional Server which uses a read-only
+    root filesystem to provide atomic, automatic updates of a
+    system without interfering with the running system.
+vars:
+    DESKTOP: textmode
+    HDDSIZEGB: 20
+    DUD_ADDONS: sdk
+    YUI_REST_API: 1
+schedule:
+    - installation/bootloader_start
+    - installation/setup_libyui
+    - installation/product_selection/install_SLES
+    - installation/licensing/accept_license
+    - installation/registration/register_via_scc
+    - installation/module_registration/register_module_transactional
+    - installation/add_on_product_installation/add_additional_products
+    - installation/add_on_product/skip_install_addons
+    - installation/system_role/accept_selected_role_transactional_server
+    - installation/partitioning/accept_proposed_layout
+    - installation/clock_and_timezone/accept_timezone_configuration
+    - installation/authentication/use_same_password_for_root
+    - installation/authentication/default_user_simple_pwd
+    - installation/bootloader_settings/disable_boot_menu_timeout
+    - installation/security/select_security_module_none
+    - installation/launch_installation
+    - installation/confirm_installation
+    - installation/performing_installation/perform_installation
+    - installation/logs_from_installation_system
+    - installation/performing_installation/confirm_reboot
+    - installation/grub_test
+    - installation/first_boot
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/yast/maintenance/lvm_thin_provisioning_dev.yaml
+++ b/schedule/yast/maintenance/lvm_thin_provisioning_dev.yaml
@@ -1,0 +1,34 @@
+---
+name: lvm_thin_provisioning_dev
+vars:
+  DUD_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_extensions_and_modules
+  - installation/add_on_product_installation/add_additional_products
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/partitioning/new_partitioning_gpt
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/handle_reboot
+  - installation/first_boot
+  - console/system_prepare
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/lvm_thin_check
+...

--- a/schedule/yast/maintenance/ncurses_interactive_installation_dev.yaml
+++ b/schedule/yast/maintenance/ncurses_interactive_installation_dev.yaml
@@ -1,0 +1,39 @@
+---
+name: ncurses_interactive_installation
+description: >
+  Interactive installation with ncurses (textmode).
+vars:
+  DUD_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_extensions_and_modules
+  - installation/add_on_product_installation/add_additional_products
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/select_role_text_mode
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/installation_snapshots
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - update/zypper_up
+  - console/zypper_lifecycle
+  - console/orphaned_packages_check
+  - console/consoletest_finish

--- a/schedule/yast/maintenance/qam-yast_self_update_dev.yaml
+++ b/schedule/yast/maintenance/qam-yast_self_update_dev.yaml
@@ -1,0 +1,35 @@
+---
+name: qam-yast_self_update
+description: installation using self_update as boot parameter
+vars:
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/validate_self_update
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_extensions_and_modules
+  - installation/add_on_product/add_maintenance_repos
+  - installation/addon_products_sle
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - '{{efi}}'
+conditional_schedule:
+  efi:
+    MACHINE:
+      uefi:
+        - console/consoletest_setup
+        - console/verify_efi_mok

--- a/schedule/yast/maintenance/yast-mru-install-minimal-with-addons.yaml
+++ b/schedule/yast/maintenance/yast-mru-install-minimal-with-addons.yaml
@@ -1,0 +1,49 @@
+---
+name: yast-mru-install-minimal-with-addons
+vars:
+  PATTERNS: base,minimal
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - '{{installsles}}'
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_extensions_and_modules
+  - installation/add_on_product/add_maintenance_repos
+  - installation/addon_products_sle
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/select_patterns
+  - '{{validate}}'
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - '{{stoptimeout}}'
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/grub_test
+  - installation/first_boot
+conditional_schedule:
+  installsles:
+    ARCH:
+      x86_64:
+        - installation/product_selection/install_SLES
+      aarch64:
+        - installation/product_selection/install_SLES
+  validate:
+    ARCH:
+      x86_64:
+        - installation/installation_settings/validate_default_target
+  stoptimeout:
+    ARCH:
+      aarch64:
+        - installation/performing_installation/stop_timeout_system_reboot_now
+      s390x:
+        - installation/performing_installation/stop_timeout_system_reboot_now
+...

--- a/schedule/yast/maintenance/yast-mru-install_dev.yaml
+++ b/schedule/yast/maintenance/yast-mru-install_dev.yaml
@@ -1,0 +1,29 @@
+---
+name: yast-mru-install_dev
+vars:
+  DUD_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_extensions_and_modules
+  - installation/add_on_product_installation/add_additional_products
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/grub_test
+  - installation/first_boot
+...


### PR DESCRIPTION
Enable libyui-rest-api in test suites for SLE-15-SP4

- Related ticket: https://progress.opensuse.org/issues/116284
- Verification run:https://openqa.suse.de/tests/9715936
   https://openqa.suse.de/tests/9715845
   https://openqa.suse.de/tests/9715846
   https://openqa.suse.de/tests/9715585
   https://openqa.suse.de/tests/9715587
   https://openqa.suse.de/tests/9715586
   https://openqa.suse.de/tests/9715588
x86_64: https://openqa.nue.suse.com/tests/9749598
s390x: https://openqa.nue.suse.com/tests/9749599#
aarch64: https://openqa.nue.suse.com/tests/9749601#
Related MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/404
