### PR TITLE
Unschedule cpuid from aarch64 as package is not provided

### DIFF
--- a/schedule/hpc/multi_machine_test.yaml
+++ b/schedule/hpc/multi_machine_test.yaml
@@ -11,6 +11,10 @@ conditional_schedule:
   bootmenu:
     ARCH:
       aarch64:
+  cpuid:
+    ARCH:
+      x86_64:
+        - hpc/cpuid
   hpctest:
     HPC:
       slurm_master:
@@ -60,5 +64,5 @@ schedule:
   - '{{bootmenu}}'
   - boot/boot_to_desktop
   - hpc/before_test
-  - hpc/cpuid
+  - '{{cpuid}}'
   - '{{hpctest}}'


### PR DESCRIPTION
cpuid is not found in aarch64 and need to be excluded at the moment from the scheduling.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/116170
