### PR TITLE
Use serial terminal for dolly module

### DIFF
--- a/tests/hpc/dolly_master.pm
+++ b/tests/hpc/dolly_master.pm
@@ -16,7 +16,7 @@ our $test_dev = "/dev/vdb";
 
 sub run ($self) {
     my $nodes = get_required_var("CLUSTER_NODES");
-
+    $self->select_serial_terminal();
     zypper_call('in dolly');
     barrier_wait("DOLLY_INSTALLATION_FINISHED");
 

--- a/tests/hpc/dolly_slave.pm
+++ b/tests/hpc/dolly_slave.pm
@@ -15,6 +15,7 @@ our $test_dir = "/mnt/test";
 our $test_dev = "/dev/vdb";
 
 sub run ($self) {
+    $self->select_serial_terminal();
     zypper_call("in dolly");
     barrier_wait("DOLLY_INSTALLATION_FINISHED");
     assert_script_run("mkfs.ext4 -v $test_dev");


### PR DESCRIPTION
Because of recent addition in the scheduling, previous module change the terminal and output is not directed to serial terminal. This is happenning due to the post_run_hook, so each module needs to restore the expected behavior using `select_serial_terminal`.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/113605
- Verification run: http://aquarius.suse.cz/tests/12530