### PR TITLE
Apply serial terminal to hpc modules explicitly

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -17,6 +17,7 @@ use version_utils 'is_sle';
 use hpc::formatter;
 
 sub run ($self) {
+    $self->select_serial_terminal();
     my $mpi = $self->get_mpi();
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
     my $mpi_bin = 'mpi_bin';

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -11,6 +11,7 @@ use lockapi;
 use utils;
 
 sub run ($self) {
+    $self->select_serial_terminal();
     my $mpi = $self->get_mpi();
     my %exports_path = (
         bin => '/home/bernhard/bin',

--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -16,6 +16,7 @@ use utils;
 
 sub run {
     my $self = shift;
+    $self->select_serial_terminal();
     # Get number of nodes
     my $nodes = get_required_var("CLUSTER_NODES");
 

--- a/tests/hpc/mrsh_slave.pm
+++ b/tests/hpc/mrsh_slave.pm
@@ -15,6 +15,7 @@ use lockapi;
 use utils;
 
 sub run ($self) {
+    $self->select_serial_terminal();
     # make sure that nobody has permissions for $serialdev to get openQA work properly
     assert_script_run("chmod 666 /dev/$serialdev");
 

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -15,6 +15,7 @@ use utils;
 use version_utils 'is_sle';
 
 sub run ($self) {
+    $self->select_serial_terminal();
     my $hostname = get_required_var("HOSTNAME");
 
     barrier_wait('CLUSTER_PROVISIONED');

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -452,6 +452,7 @@ sub extended_hpc_tests ($master_ip, $slave_ip) {
 }
 
 sub run ($self) {
+    $self->select_serial_terminal();
     my $nodes = get_required_var('CLUSTER_NODES');
     my $slurm_conf = get_required_var('SLURM_CONF');
     my $version = get_required_var('VERSION');

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -12,6 +12,7 @@ use lockapi;
 use utils;
 
 sub run ($self) {
+    $self->select_serial_terminal();
     my $nodes = get_required_var("CLUSTER_NODES");
 
     barrier_wait('CLUSTER_PROVISIONED');

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -14,6 +14,7 @@ use lockapi;
 use utils;
 
 sub run ($self) {
+    $self->select_serial_terminal();
     my $nodes = get_required_var("CLUSTER_NODES");
 
     barrier_wait('CLUSTER_PROVISIONED');

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -15,6 +15,7 @@ use utils;
 use version_utils 'is_sle';
 
 sub run ($self) {
+    $self->select_serial_terminal();
     $self->prepare_user_and_group();
 
     # Install slurm


### PR DESCRIPTION
Use `select_serial_terminal` explicitly on hpc modules. This required as the `post_run_hook` is called to all prior modules and change the flow, so there are tests which fail.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP5&build=b10n1k%2Fos-autoinst-distri-opensuse%2315544&distri=sle