### PR TITLE
Remove cockpit_service from schedule

### DIFF
--- a/schedule/alp/alp_databases.yaml
+++ b/schedule/alp/alp_databases.yaml
@@ -12,7 +12,6 @@ schedule:
     - microos/image_checks
     - microos/one_line_checks
     - microos/services_enabled
-    - microos/cockpit_service
     - console/sqlite3
     - console/postgresql_server
     - transactional/trup_smoke


### PR DESCRIPTION
because cockpit_service failed in new build:
http://10.162.30.85/tests/5020#step/cockpit_service/ For database testsuite better not to include failing tests
