### PR TITLE
Increase timeout for dolly operation

### DIFF
--- a/tests/hpc/dolly_master.pm
+++ b/tests/hpc/dolly_master.pm
@@ -31,7 +31,7 @@ sub run ($self) {
     my $server_hostname = get_required_var("HOSTNAME");
     my @slave_nodes = $self->slave_node_names();
     my $client_hostnames = join(',', @slave_nodes);
-    assert_script_run("dolly -v -S $server_hostname -H $client_hostnames -I $test_dev -O $test_dev");
+    assert_script_run("dolly -v -S $server_hostname -H $client_hostnames -I $test_dev -O $test_dev", timeout => 2400);
     barrier_wait("DOLLY_DONE");
 }
 


### PR DESCRIPTION
Fix for timeout issues for the new module which in OSD seems to encounter slow performance when it executes dolly

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Related ticket: https://progress.opensuse.org/issues/113605
- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP5&build=b10n1k%2Fos-autoinst-distri-opensuse%2315549&distri=sle