### PR TITLE
Add SLES4SAP Netweaver test using systemd

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -802,6 +802,8 @@ sub upload_nw_install_log {
     $self->save_and_upload_log('ls -alF /sbin/mount*', '/tmp/sbin_mount_ls.log');
     upload_logs('/tmp/check-nw-media', failok => 1);
     upload_logs '/sapinst/unattended/sapinst.log';
+    upload_logs('/sapinst/unattended/sapinst_ASCS.log', failok => 1);
+    upload_logs('/sapinst/unattended/sapinst_ERS.log', failok => 1);
     upload_logs '/sapinst/unattended/sapinst_dev.log';
     upload_logs '/sapinst/unattended/start_dir.cd';
 }

--- a/schedule/sles4sap/netweaver/netweaver_cluster_systemd.yaml
+++ b/schedule/sles4sap/netweaver/netweaver_cluster_systemd.yaml
@@ -1,0 +1,76 @@
+---
+name: netweaver_cluster_systemd
+description: >
+  NetWeaver Cluster Test (with switch to systemd). Schedule for all nodes.
+
+  This test just adds the patching (needed as long as NW does not come with systemd
+  support without patching) and the systemd registration before doing the cluster test.
+
+  Some settings are required in the job group or test suite for this schedule to work.
+
+  The other settings required in the job group are.
+
+  CLUSTER_INFOS must be defined in the parent job to the name of the cluster, number
+  of nodes and number of LUNs. Example 'nw:2:3'
+  CLUSTER_NAME must be defined for all jobs as a string.
+  INSTANCE_ID, INSTANCE_IP_CIDR, INSTANCE_SID and INSTANCE_TYPE must be defined and set
+  according to NE needs.
+  HA_CLUSTER_INIT must be defined to yes on the job that initializes the cluster, and to
+  no in the rest of the cluster node jobs
+  HA_CLUSTER_JOIN must be defined for the rest of the jobs, and it must contain the
+  hostname of the job where HA_CLUSTER_INIT is defined to yes
+  NW must be defined pointing to the location of the NW installation masters
+  HOSTNAME must be defined to different hostnames for each node.
+  MAX_JOB_TIME is recommended to be defined as well to a high value (ex. 20000)
+  All jobs with the exception of the parent job must include a PARALLEL_WITH setting
+  referencing the parent job.
+  SLE_PRODUCT must be defined and set to sles4sap.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  BOOT_HDD_IMAGE: '1'
+  USE_SUPPORT_SERVER: '1'
+  HDD_SCC_REGISTERED: '1'
+  VIRTIO_CONSOLE: '0'
+  HA_CLUSTER: '1'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - sles4sap/patterns
+  - '{{cluster_setup}}'
+  - sles4sap/netweaver_network
+  - sles4sap/netweaver_filesystems
+  - sles4sap/netweaver_install
+  - sles4sap/netweaver_patch
+  - sles4sap/netweaver_test_systemd
+  - sles4sap/netweaver_cluster
+  - sles4sap/monitoring_services
+  - '{{sap_suse_cluster_connector}}'
+  - ha/fencing
+  - '{{boot_to_desktop}}'
+  - ha/check_after_reboot
+  - ha/check_logs
+conditional_schedule:
+  cluster_setup:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/ha_cluster_init
+      no:
+        - ha/ha_cluster_join
+  sap_suse_cluster_connector:
+    HA_CLUSTER_INIT:
+      yes:
+        - sles4sap/sap_suse_cluster_connector
+  boot_to_desktop:
+    HA_CLUSTER_INIT:
+      yes:
+        - boot/boot_to_desktop

--- a/schedule/sles4sap/netweaver/netweaver_single_systemd.yaml
+++ b/schedule/sles4sap/netweaver/netweaver_single_systemd.yaml
@@ -1,0 +1,21 @@
+---
+name: test_netweaver_systemd
+description: >
+  NetWeaver single node tests for SLES4SAP (including patching and use of systemd).
+vars:
+  BOOTFROM: c
+  BOOT_HDD_IMAGE: '1'
+  INSTANCE_ID: '00'
+  INSTANCE_SID: QAD
+  INSTANCE_TYPE: ASCS
+  NW: nfs://1c119.qa.suse.de/srv/nfs/sap/NW753
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-%DESKTOP%.qcow2
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/netweaver_install
+  - sles4sap/netweaver_patch
+  - sles4sap/netweaver_test_systemd
+  - sles4sap/netweaver_test_instance

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -164,6 +164,9 @@ sub run {
         barrier_create("ERS_INSTALLED_$cluster_name", $num_nodes);
         barrier_create("NW_CLUSTER_HOSTS_$cluster_name", $num_nodes);
         barrier_create("NW_CLUSTER_INSTALL_$cluster_name", $num_nodes);
+        barrier_create("NW_CLUSTER_PATCH_$cluster_name", $num_nodes);
+        barrier_create("NW_CLUSTER_PATCH_${cluster_name}_before", $num_nodes);
+        barrier_create("NW_CLUSTER_PATCH_${cluster_name}_after", $num_nodes);
         barrier_create("NW_INIT_CONF_$cluster_name", $num_nodes);
         barrier_create("NW_CREATED_CONF_$cluster_name", $num_nodes);
         barrier_create("NW_LOADED_CONF_$cluster_name", $num_nodes);

--- a/tests/sles4sap/netweaver_filesystems.pm
+++ b/tests/sles4sap/netweaver_filesystems.pm
@@ -32,6 +32,7 @@ sub run {
     assert_script_run "mkfs -t xfs -f \"$lun\"";
     assert_script_run "mkdir -p $sap_dir/${type}${instance_id}";
     assert_script_run "mount \"$lun\" $sap_dir/${type}${instance_id}";
+    assert_script_run "chmod 0777 \"$lun\" $sap_dir/${type}${instance_id}";
 
     # Mount NFS filesystem
     assert_script_run "echo '$path/$arch/nfs_share/sapmnt /sapmnt $proto defaults,bg 0 0' >> /etc/fstab";

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -22,7 +22,7 @@ sub run {
     my $sid = get_required_var('INSTANCE_SID');
     my $hostname = get_var('INSTANCE_ALIAS', '$(hostname)');
     my $params_file = "/sapinst/$instance_type.params";
-    my $timeout = 900 * get_var('TIMEOUT_SCALE', 1);    # Time out for NetWeaver's sources related commands
+    my $timeout = bmwqemu::scale_timeout(900);    # Time out for NetWeaver's sources related commands
     my $product_id = undef;
 
     # Set Product ID depending on the type of Instance
@@ -31,6 +31,9 @@ sub run {
     }
     elsif ($instance_type eq 'ERS') {
         $product_id = 'NW_ERS';
+    }
+    else {
+        die "Unknown SAP NetWeaver instance type $instance_type";
     }
 
     my @sapoptions = qw(SAPINST_START_GUISERVER=false SAPINST_SKIP_DIALOGS=true SAPINST_SLP_MODE=false IS_HOST_LOCAL_USING_STRING_COMPARE=true);
@@ -55,7 +58,7 @@ sub run {
     assert_script_run "sed -i -e \"s/%HOSTNAME%/$hostname/g\" -e 's/%INSTANCE_ID%/$instance_id/g' -e 's/%INSTANCE_SID%/$sid/g' $params_file";
 
     # Create an appropiate start_dir.cd file and an unattended installation directory
-    my $cmd = 'cd /sapinst ; ls | while read d; do if [ -d "$d" -a ! -h "$d" ]; then echo $d; fi ; done | sed -e "s@^@/sapinst/@" ; cd -';
+    my $cmd = 'cd /sapinst ; ls -1 | grep -xv patch | while read d; do if [ -d "$d" -a ! -h "$d" ]; then echo $d; fi ; done | sed -e "s@^@/sapinst/@" ; cd -';
     assert_script_run 'mkdir -p /sapinst/unattended';
     assert_script_run "($cmd) > /sapinst/unattended/start_dir.cd";
     script_run 'cd -';
@@ -67,7 +70,7 @@ sub run {
 
     # Start the installation
     enter_cmd "cd /sapinst/unattended";
-    $cmd = '../SWPM/sapinst ' . join(' ', @sapoptions);
+    $cmd = '../SWPM/sapinst ' . join(' ', @sapoptions) . " | tee sapinst_$instance_type.log";
 
     # Synchronize with other nodes
     if (get_var('HA_CLUSTER') && !is_node(1)) {
@@ -75,22 +78,35 @@ sub run {
         barrier_wait("ASCS_INSTALLED_$cluster_name");
     }
 
-    if ($instance_type eq 'ASCS') {
-        assert_script_run $cmd, $timeout;
-    }
-    elsif ($instance_type eq 'ERS') {
-        # We have to workaround an installation issue:
-        # ERS installation try to stop the ASCS server but that doesn't work
-        #  because ASCS is running on the first node!
-        # It's "normal" and documentation says that we have to install ERS on the 2nd node
-        #  in order to have the SAP environment correctly set-up.
-        script_run $cmd, $timeout;
-
-        # So we have to check in the log file that's the installation goes well
-        # We simply checking for the ASCS stop error message!
-        # TODO: maybe change this to something more robust!
-        assert_script_run "grep -q 'Cannot stop instance.*ASCS' /sapinst/unattended/sapinst.log";
-    }
+    validate_script_output(
+        $cmd,
+        qr{
+             # On older SAP versions (known bad: NW75, known good: NW753) we have to
+             # workaround an installation issue:
+             # ERS installation on the second node tries to stop the ASCS server
+             # but that doesn't work because ASCS is running on the first node.
+             # It's "normal" and documentation says that we have to install ERS on
+             # the 2nd node in order to have the SAP environment correctly set up.
+             # Therefore we accept a failing return code and check the output instead.
+             (
+                 # This is the success pattern for newer versions (which succeed on install).
+                 msg_server,.MessageServer,.GREEN,.Running.*[\r\n]+
+                 enserver,.EnqueueServer,.GREEN,.Running.*[\r\n]+
+                 .*[\r\n]+
+                 .*[\r\n]+
+                 Startup.of.instance.${sid}/.*.finished:.\[ACTIVE\]
+             ) | (
+                 # And for older versions we also allow the ASCS stop error message.
+                 # ASCS00 is intentionally not a var, because this error occours on the other node.
+                 stopInstanceRemote.errno=CJS-20081.*[\r\n]+
+                 .*Error.when.stopping.instance.*Cannot.stop.instance.*ASCS00
+             )
+         }x,
+        proceed_on_failure => 1,    # this is needed to succeed on faulty SAP NW versions
+        timeout => $timeout,
+        title => "start ${sid}",
+        fail_message => "Instance ${sid}/* (${instance_type}${instance_id}) start did not succeed."
+    );
 
     $self->upload_nw_install_log;
 

--- a/tests/sles4sap/netweaver_patch.pm
+++ b/tests/sles4sap/netweaver_patch.pm
@@ -1,0 +1,93 @@
+# SUSE's openQA tests
+#
+# Copyright 2017-2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Patch SAP NetWeaver with the patches from the ./patch subdirectory
+# Requires: ENV variable NW pointing to installation media
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base "sles4sap";
+use testapi;
+use lockapi;
+use hacluster;
+use strict;
+use warnings;
+
+sub run {
+    my ($self) = @_;
+    my ($proto, $path) = $self->fix_path(get_required_var('NW'));
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my $instance_id = get_required_var('INSTANCE_ID');
+    my $sid = get_required_var('INSTANCE_SID');
+    my $arch = get_required_var('ARCH');
+    my $hostname = get_var('INSTANCE_ALIAS', '$(hostname)');
+    my $params_file = "/sapinst/$instance_type.params";
+    my $timeout = bmwqemu::scale_timeout(900);    # Time out for NetWeaver's sources related commands
+    my $product_id = undef;
+    my $pscmd = $self->set_ps_cmd(get_required_var('INSTANCE_TYPE'));
+    my $sap_dir = "/usr/sap/$sid";
+    my $cluster_name = undef;
+    $cluster_name = get_cluster_name if get_var('HA_CLUSTER');
+
+    # Set Product ID depending on the type of Instance
+    if ($instance_type eq 'ASCS') {
+        $product_id = 'NW_ABAP_ASCS';
+    }
+    elsif ($instance_type eq 'ERS') {
+        $product_id = 'NW_ERS';
+    }
+
+    $self->select_serial_terminal;
+
+    # The SAP Admin was set in sles4sap/netweaver_install
+    $self->set_sap_info(get_required_var('INSTANCE_SID'), get_required_var('INSTANCE_ID'));
+
+    $self->user_change;
+
+    # start with patching only if both nodes are ready
+    barrier_wait("NW_CLUSTER_PATCH_${cluster_name}_before") if ${cluster_name};
+
+    validate_script_output("sapcontrol -nr ${instance_id} -function GetVersionInfo | tee GetVersionInfo_${instance_id}.before_patching", sub { /GetVersionInfo[\r\n]+OK/ }, title => "Versions before");
+
+    # Patch ALL nodes from node 1
+    if (!get_var('HA_CLUSTER') || get_var('HA_CLUSTER') && is_node(1)) {
+
+        # The media mount with the patches was already done in sles4sap/netweaver_install (the patches are just in a subdir of the install media)
+
+        # put the patches in place to get applied on SAP restart (only on one node, because it's on a shared filesystem)
+        validate_script_output("/mnt/SAPCAR -gvxf '/sapinst/patches/*.sar' -R /sapmnt/${sid}/exe/uc/linux${arch}/", sub { /SAPCAR: .* extracted/ }, timeout => $timeout, title => "SAP extract");
+
+        # stop/start to get the patches applied
+        validate_script_output("sapcontrol -nr ${instance_id} -function StopSystem ALL", sub { /StopSystem[\r\n]+OK/ }, title => "StopSystem");
+        $self->test_stop;
+
+        $self->test_start;
+        validate_script_output("sapcontrol -nr ${instance_id} -function StartSystem ALL", sub { /StartSystem[\r\n]+OK/ }, title => "StartSystem");
+        $self->check_instance_state('green');
+
+        # Patching ALL nodes is done now
+        barrier_wait("NW_CLUSTER_PATCH_${cluster_name}") if ${cluster_name} && is_node(1);
+    }
+
+    # Node 1 does the patching, the others have to wait for that to be finished
+    barrier_wait("NW_CLUSTER_PATCH_${cluster_name}") if ${cluster_name} && !is_node(1);
+
+    validate_script_output("sapcontrol -nr ${instance_id} -function GetVersionInfo | tee GetVersionInfo_${instance_id}.after_patching", sub { /GetVersionInfo[\r\n]+OK/ }, timeout => 300, title => "Versions after");
+
+    # compare running versions (patch levels), they should differ
+    validate_script_output(
+        "diff --side-by-side --width=160 --suppress-common-lines GetVersionInfo_${instance_id}.before_patching GetVersionInfo_${instance_id}.after_patching",
+        sub { /patch/ },    # succeeds if at least one patch level is different after patching
+        fail_message => 'Patching FAILED. The versions are the same before and after patching :-(',
+        proceed_on_failure => 1,    # this needs to be here because the diff command will always find at least the difference in the timestamp
+        title => "Version compare",
+    );
+
+    $self->reset_user_change;
+
+    # go on to the next module only if patching is done on both nodes
+    barrier_wait("NW_CLUSTER_PATCH_${cluster_name}_after") if ${cluster_name};
+}
+
+1;

--- a/tests/sles4sap/netweaver_test_systemd.pm
+++ b/tests/sles4sap/netweaver_test_systemd.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright 2017-2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Register systemd services for SAP NetWeaver and check for success
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base "sles4sap";
+use testapi;
+use lockapi;
+use hacluster;
+use strict;
+use warnings;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my $instance_id = get_required_var('INSTANCE_ID');
+    my $sid = get_required_var('INSTANCE_SID');
+    my $hostname = get_var('INSTANCE_ALIAS', '$(hostname)');
+    my $timeout = bmwqemu::scale_timeout(900);    # Time out for NetWeaver's sources related commands
+    my $sap_dir = "/usr/sap/$sid";
+
+    $self->select_serial_terminal;
+
+    validate_script_output('cat /usr/sap/sapservices', qr/sapstartsrv/, title => 'sapstartsrv');
+    validate_script_output('systemctl list-unit-files | grep -i sap', sub { /^(?!SAP..._\d\d.service)/ }, title => 'NO systemd'); # there must be _no_ SAP*.service
+    assert_script_run "LD_LIBRARY_PATH=$sap_dir/${instance_type}${instance_id}/exe:\$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;$sap_dir/${instance_type}${instance_id}/exe/sapstartsrv pf=$sap_dir/SYS/profile/${sid}_${instance_type}${instance_id}_${hostname} -reg";
+    validate_script_output('cat /usr/sap/sapservices', qr/systemctl/, title => 'systemctl');
+    validate_script_output('systemctl list-unit-files | grep -i sap', sub { /SAP..._\d\d.service/ }, title => 'USE systemd'); # SAP*.service _must_ be there now
+}
+
+1;


### PR DESCRIPTION
SAP NetWeaver still does not include systemd support without patching. This PR will
- add `tests/sles4sap/netweaver_patch.pm` to patch a NW install with the patches from the ./patch install subdirectory
- add `tests/sles4sap/netweaver_test_systemd.pm` to activate systemd usage
- add `schedule/sles4sap/netweaver/netweaver_single_systemd.yaml` for a single host systemd test
- add `schedule/sles4sap/netweaver/netweaver_cluster_systemd.yaml` for a cluster systemd test
- add more logfile uploads in `lib/sles4sap.pm`
- change `tests/sles4sap/netweaver_install.pm` to allow install of faulty NW versions as well as fixed ones

- Related ticket: https://jira.suse.com/browse/TEAM-5960
- Needles: N/A
- Verification runs:
   - http://keks.qa.suse.de/tests/1061 (cluster test)
   - http://keks.qa.suse.de/tests/1062 (single node test)
