### PR TITLE
add 15.5 repo url to fix zfs test suite poo#116383

### DIFF
--- a/tests/console/zfs.pm
+++ b/tests/console/zfs.pm
@@ -28,6 +28,8 @@ my $disksize = "100M";    # Size of the test disks
 sub get_repository() {
     if (is_tumbleweed) {
         return 'https://download.opensuse.org/repositories/filesystems/openSUSE_Tumbleweed/filesystems.repo';
+    } elsif (is_leap("=15.5")) {
+        return 'https://download.opensuse.org/repositories/filesystems/15.5/filesystems.repo';
     } elsif (is_leap("=15.4")) {
         return 'https://download.opensuse.org/repositories/filesystems/15.4/filesystems.repo';
     } elsif (is_leap("=15.3")) {


### PR DESCRIPTION
add 15.5 repo url to zfs test suite

- I just enabled 15.5 in filesystem dev project to get it working
- tracker for the failing test on missing zfs test suite definitionpoo#116383
