### PR TITLE
Update textmode key for HA/SLES on Full 15-SP5

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -75,8 +75,8 @@ sub get_product_shortcuts {
         return (
             sles => (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'
-            : ((is_sle '15-SP4+') && (get_var('ISO') =~ /Full/)) ? 's'
-            : 'i',
+            : ((is_sle '15-SP4+') && (get_var('ISO') =~ /Full/)) ? 'i'
+            : 's',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',
             rt => is_x86_64() ? 't' : undef


### PR DESCRIPTION
Related to 77be306
This keyboard shortcuts are changing/switching in developed product constantly

- Related ticket: http://progress.opensuse.org/issues/115352
- Verification run:
https://openqa.suse.de/tests/9540691
https://openqa.suse.de/tests/9540692