### PR TITLE
Schedule firewalld test module only on SLES15+

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -4,7 +4,6 @@ description: First set of CLI extratests
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - console/firewalld
   - console/prepare_test_data
   - console/consoletest_setup
   - console/check_os_release
@@ -73,10 +72,19 @@ conditional_schedule:
         - '{{sle15}}'
   sle15:
     VERSION:
+      15-SP4:
+        - console/firewalld
+        - console/lshw
+      15-SP3:
+        - console/firewalld
+        - console/lshw
       15-SP2:
+        - console/firewalld
         - console/lshw
       15-SP1:
+        - console/firewalld
         - console/lshw
       15:
         - console/lshw
+        - console/firewalld
 ...


### PR DESCRIPTION
- Related ticket: [poo#116785](https://progress.opensuse.org/issues/116785)
- Verification run: [15](https://pdostal-server.suse.cz/tests/626), [15-SP1](https://pdostal-server.suse.cz/tests/627), [15-SP2](https://pdostal-server.suse.cz/tests/628), [15-SP3](https://pdostal-server.suse.cz/tests/625), [15-SP4](https://pdostal-server.suse.cz/tests/624)