### PR TITLE
JeOS: Handle WiFi interface in JeOS firstboot, if shown

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -122,11 +122,11 @@ sub run {
     if (is_sle || is_sle_micro) {
         assert_screen 'jeos-please-register';
         send_key 'ret';
+    }
 
-        if (is_generalhw) {
-            assert_screen 'jeos-please-configure-wifi';
-            send_key 'n';
-        }
+    if (is_generalhw && (is_tumbleweed || is_sle || is_sle_micro)) {
+        assert_screen 'jeos-please-configure-wifi';
+        send_key 'n';
     }
 
     # Our current Hyper-V host and it's spindles are quite slow. Especially


### PR DESCRIPTION
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/95f12905385467ec9883b95482443339e421ae69
- Verification run: https://openqa.opensuse.org/tests/2703648#step/firstrun/12