### PR TITLE
WIP: Ensure deregistered and clean MUs before migration

### DIFF
--- a/schedule/yast/maintenance/autoupgrade_sle15sp4-1_scc_we_sdk_basesys_wsm_srv_desk_lgm_contm_pcm_def_full.yaml
+++ b/schedule/yast/maintenance/autoupgrade_sle15sp4-1_scc_we_sdk_basesys_wsm_srv_desk_lgm_contm_pcm_def_full.yaml
@@ -1,0 +1,33 @@
+---
+name: autoupgrade_sle15sp4-1_scc_we_sdk_basesys_wsm_srv_desk_lgm_contm_pcm_def_full
+description: >
+  Performs a migration between installed system with unreleased maintenance updates installed, and next release, eg sle15 sp3>sp4
+schedule:
+  - autoyast/prepare_profile
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - console/setup_libyui_running_system
+  - update/patch_sle
+  - migration/record_disk_info
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - installation/isosize
+  - installation/bootloader
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - boot/grub_test_snapshot
+  - migration/version_switch_origin_system
+  - boot/snapper_rollback
+test_data:
+  install_packages:
+    - libyui-rest-api
+  port: 30000-50000
+  zone: public

--- a/schedule/yast/sle_15_sp3/autoyast_create_hdd_maintenance_deregister.yaml
+++ b/schedule/yast/sle_15_sp3/autoyast_create_hdd_maintenance_deregister.yaml
@@ -1,0 +1,23 @@
+---
+name: autoyast_create_hdd_maintenance
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - qa_automation/patch_and_reboot
+  - console/scc_deregistration
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
We need ensure system de-registered and MUs repo cleaned before migration, add libyui to make the test more faster and avoid the disturb of needle.

- Related ticket: https://progress.opensuse.org/issues/116578
- MR :  https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/384
- Needles:  N/A
- Verification run:    
  https://openqa.nue.suse.com/tests/9600119# 15sp3 installation
  https://openqa.nue.suse.com/tests/9600120#  migration with MUs
