### PR TITLE
Fix Firefox headers and Tomcat tests

### DIFF
--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -73,7 +73,7 @@ sub tomcat_manager_test() {
     my ($self) = shift;
 
     $self->firefox_open_url('localhost:8080/manager');
-    send_key_until_needlematch('tomcat-manager-authentication', 'ret');
+    assert_screen('tomcat-manager-authentication', 180);
     type_string('admin');
     send_key('tab');
     type_string('admin');

--- a/tests/x11/firefox/firefox_extcontent.pm
+++ b/tests/x11/firefox/firefox_extcontent.pm
@@ -35,11 +35,15 @@ sub run {
     sleep 1;
     enter_cmd "license.tar.gz";
 
-    assert_screen('firefox-extcontent-opening', 60);
-
-    send_key "alt-o";
-    sleep 1;
-    send_key "ret";
+    assert_screen ['firefox-extcontent-opening', 'firefox-extcontent-downloaded'], 30;
+    # If firefox does not prompt us with the opening window we need to double click the downloaded file
+    if (match_has_tag 'firefox-extcontent-downloaded') {
+        assert_and_dclick('firefox-extcontent-downloaded');
+    } else {
+        send_key "alt-o";
+        sleep 1;
+        send_key "ret";
+    }
 
     assert_screen(is_sle('15+') ? 'firefox-extcontent-nautils' : 'firefox-extcontent-archive_manager');
 

--- a/tests/x11/firefox/firefox_headers.pm
+++ b/tests/x11/firefox/firefox_headers.pm
@@ -41,13 +41,9 @@ sub run {
     wait_still_screen 3;
     assert_screen 'firefox-url-loaded';
     assert_and_click('firefox-headers-select-gnu.org');
-    assert_screen('firefox-headers-first_item');
-
-    send_key "shift-f10";
-    #"Edit and Resend"
-    send_key "e";
-
-    assert_screen('firefox-headers-user_agent', 50);
+    # click into the area so we can scrool down
+    assert_and_click('firefox-headers-first_item');
+    send_key_until_needlematch('firefox-headers-user_agent', 'down', 30);
 
     # Exit
     $self->exit_firefox;


### PR DESCRIPTION
Two fixes:
 1) Tomcat test was hitting `ret` and closed the authentication dialog too soon.
 2) The Firefox headers test didn't detected the user agent as the UI changed.

- Related ticket: [poo#116518](https://progress.opensuse.org/issues/116518)
- Needles: [gitlab.suse.de/openqa/os-autoinst-needles-sles!1624](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1624)
- Failures: [firefox_headers](https://openqa.suse.de/tests/9545621#step/firefox_headers/21), [tomcat](https://openqa.suse.de/tests/9545606#step/tomcat/43)
- Verification run: [Tomcat](https://pdostal-server.suse.cz/tests/641), [Firefox_headers](https://pdostal-server.suse.cz/tests/642) (See the instance for runs on other SLE versions)
