### PR TITLE
Add support for transactional systems to LTP

### DIFF
--- a/products/alp/main.pm
+++ b/products/alp/main.pm
@@ -55,6 +55,11 @@ sub load_transactional_tests {
 
 return 1 if load_yaml_schedule;
 
+if (is_kernel_test()) {
+    load_kernel_tests();
+    return 1;
+}
+
 # Handle boot of images
 if (get_var('BOOT_HDD_IMAGE')) {
     load_boot_from_disk_tests;

--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -80,4 +80,9 @@ if (is_container_test) {
     load_container_tests();
 }
 
+if (is_kernel_test()) {
+    load_kernel_tests();
+    return 1;
+}
+
 1;


### PR DESCRIPTION
Adaptible Linux Platform and SLE Micro use transactional approach for
system management. LTP installation and configuration had to be adapted.

The goal is to cover installation, syscalls and cve for ALP September prototype. Network setup is disabled, as we don't need at the moment. It will be explored/covered for ALP December release. 

- Related ticket: none
- Needles: none
- Verification runs

#####  ALP
- install_ltp: http://10.100.12.105/tests/1822
- run_ltp: http://10.100.12.105/tests/1803
- install_ltp with command file : http://10.100.12.105/tests/1828#

##### SLE Micro
- install_ltp: http://10.100.12.105/tests/1819
- run_ltp http://10.100.12.105/tests/1818

##### SLES
- https://openqa.suse.de/tests/9556110

`PUBLISH_HDD_1` variable was added to experimental runs of `slem_installation_default` and `alp_default`. 
