### PR TITLE
Fix timeout issue of assert_script_run

### DIFF
--- a/tests/installation/add_serial_console.pm
+++ b/tests/installation/add_serial_console.pm
@@ -17,10 +17,10 @@ sub run {
     my $device = 'sda';
     # Find installed OS root device, mount it, and chroot into it
     assert_script_run("for part in /dev/${device}[1-4]; do
-            mount \$part /mnt &> /dev/null &&
+            mount \$part /mnt &&
             test -e /mnt/etc/default/grub &&
                 break ||
-                umount /mnt &> /dev/null
+                umount /mnt
         done");
     assert_script_run('mount -o bind /dev /mnt/dev');
     assert_script_run('mount -o bind /proc /mnt/proc');


### PR DESCRIPTION
POO:https://progress.opensuse.org/issues/115451
& symbol sometimes can effect return value of assert_script_run, expecially parallel jobs.
IMO: the best way to overcome it is to remove special character &.

- Related ticket: https://progress.opensuse.org/issues/115451
- Needles: None
- Parallel verification run with sle15sp5 on build 21.1:
      -- http://openqa.suse.de/tests/9562372#step/add_serial_console/9
      -- http://openqa.suse.de/tests/9562373#step/add_serial_console/9
