### PR TITLE
Test trento-agent installation on cluster nodes

### DIFF
--- a/schedule/sles4sap/trento/trento.yml
+++ b/schedule/sles4sap/trento/trento.yml
@@ -15,5 +15,6 @@ schedule:
     - sles4sap/trento/deploy_trento
     - sles4sap/trento/test_trento_deploy
     - sles4sap/trento/cluster_deploy
+    - sles4sap/trento/install_agents
     - sles4sap/trento/test_trento_web
     - sles4sap/trento/cluster_destroy

--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Warnings;
+
+use trento;
+
+use Test::MockModule;
+my $trento = Test::MockModule->new('trento', no_auto => 1);
+my @calls;
+my @logs;
+$trento->redefine(script_run => sub { push @calls, $_[0]; return 'PATATINE'; });
+#$trento->redefine(get_current_job_id => sub { return 'canetto'} );
+$trento->redefine(get_trento_ip => sub { return '42.42.42.42' });
+$trento->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+$trento->redefine(upload_logs => sub { push @logs, @_; });
+
+subtest '[k8s_logs] None of the pods are for any of the required trento-server' => sub {
+    # Only one PANINO pod is running in the cluster
+    $trento->redefine(script_output => sub { push @calls, $_[0]; return 'PANINO'; });
+
+    # Ask for the log of trento-server-web and trento-server-runner (none of them in the list of running pods)
+    k8s_logs(qw(web runner));
+
+    note(join("\n  1C-->  ", @calls));
+    note(join("\n  1L-->  ", @logs));
+    like $calls[0], qr/.*kubectl get pods/, 'Start by getting the list of pods';
+    ok scalar @calls == 1, 'Only one remote commands expected as none of the running pods match with any of the requested pods';
+};
+
+subtest '[k8s_logs] Get logs from running pods as it is also required' => sub {
+    @calls = ();
+    @logs = ();
+    $trento->redefine(script_output => sub { push @calls, $_[0]; return 'trento-server-panino'; });
+    k8s_logs(qw(panino));
+    note(join("\n  2C-->  ", @calls));
+    note(join("\n  2L-->  ", @logs));
+    ok scalar @calls == 3, '3 remote commands expected: one to get the list of the pods, two to get from the required one all the logs';
+    ok scalar @logs == 2, '2 logs uploaded for each pod';
+};
+
+subtest '[get_vnet] get_vnet has to call az and return a vnet' => sub {
+    @calls = ();
+    $trento->redefine(script_output => sub { push @calls, $_[0]; return 'PIZZANET'; });
+
+    my $net_name = get_vnet(qw(GELATOGROUP));
+
+    note(join("\n  1C-->  ", @calls));
+    like $calls[0], qr/az network vnet list -g GELATOGROUP --query "\[0\]\.name" -o tsv/, 'AZ command';
+    ok $net_name eq 'PIZZANET', 'Directly return the script_output return string';
+};
+
+
+done_testing;

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Warnings;
+
+use qesapdeployment;
+
+subtest '[qesap_get_inventory] upper case' => sub {
+    use testapi 'set_var';
+    set_var('QESAP_CONFIG_FILE', 'MARLIN');
+    my $inventory_path = qesap_get_inventory('NEMO');
+    note('inventory_path --> ' . $inventory_path);
+    ok $inventory_path eq '/root/qe-sap-deployment/terraform/nemo/inventory.yaml';
+};
+
+subtest '[qesap_get_inventory] lower case' => sub {
+    use testapi 'set_var';
+    set_var('QESAP_CONFIG_FILE', 'MARLIN');
+    my $inventory_path = qesap_get_inventory('nemo');
+    note('inventory_path --> ' . $inventory_path);
+    ok $inventory_path eq '/root/qe-sap-deployment/terraform/nemo/inventory.yaml';
+};
+
+done_testing;

--- a/tests/sles4sap/trento/install_agents.pm
+++ b/tests/sles4sap/trento/install_agents.pm
@@ -15,18 +15,16 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    $self->deploy_qesap();
+    my $wd = '/root/work_dir';
+    enter_cmd "mkdir $wd";
+    my $cmd = '/root/test/trento-server-api-key.sh' .
+      ' -u admin' .
+      ' -p ' . $self->get_trento_password() .
+      ' -i ' . $self->get_trento_ip() .
+      " -d $wd";
+    my $agent_api_key = script_output($cmd);
 
-    my $trento_rg = $self->get_resource_group;
-    my $cluster_rg = $self->get_qesap_resource_group();
-    my $cmd = join(' ',
-        '/root/test/00.050-trento_net_peering_tserver-sap_group.sh',
-        '-s', $trento_rg,
-        '-n', trento::get_vnet($trento_rg),
-        '-t', $cluster_rg,
-        '-a', trento::get_vnet($cluster_rg));
-    record_info('NET PEERING');
-    assert_script_run($cmd, 360);
+    $cmd = $self->install_agent($wd, '/root/test', $agent_api_key, '10.0.0.4');
 }
 
 sub post_fail_hook {

--- a/tests/sles4sap/trento/test_trento_deploy.pm
+++ b/tests/sles4sap/trento/test_trento_deploy.pm
@@ -26,11 +26,11 @@ sub run {
         assert_script_run("az vm list -g $resource_group --query \"[].name\"  -o tsv", 180);
 
         # get deployed version from the cluster
-        my $kubectl_pods = script_output($self->az_vm_ssh_cmd('kubectl get pods', $machine_ip), 180);
+        my $kubectl_pods = script_output(trento::az_vm_ssh_cmd('kubectl get pods', $machine_ip), 180);
         foreach my $row (split(/\n/, $kubectl_pods)) {
             if ($row =~ m/trento-server-web/) {
                 my $pod_name = (split /\s/, $row)[0];
-                my $trento_ver_cmd = $self->az_vm_ssh_cmd("kubectl exec --stdin $pod_name -- /app/bin/trento version", $machine_ip);
+                my $trento_ver_cmd = trento::az_vm_ssh_cmd("kubectl exec --stdin $pod_name -- /app/bin/trento version", $machine_ip);
                 script_run($trento_ver_cmd, 180);
             }
         }
@@ -52,7 +52,7 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
     if (!get_var('TRENTO_EXT_DEPLOY_IP')) {
-        $self->k8s_logs(qw(web runner));
+        trento::k8s_logs(qw(web runner));
         $self->az_delete_group;
     }
     $self->SUPER::post_fail_hook;

--- a/variables.md
+++ b/variables.md
@@ -224,7 +224,12 @@ TRENTO_REGISTRY_IMAGE_WEB | string |  | Optional. Overwrite the trento-web image
 TRENTO_REGISTRY_IMAGE_WEB_VERSION | string |  | Optional. Version tag for the trento-web image
 TRENTO_GITLAB_REPO | string | gitlab.suse.de/qa-css/trento | Repository for the deployment scripts
 TRENTO_GITLAB_BRANCH | string | master | Branch to use in the deployment script repository
-
+TRENTO_GITLAB_TOKEN | string | | Force te use of a custom token
+TRENTO_DEPLOY_VER | string | | Force the Trento deployment script to be used from a release
+TRENTO_AGENT_REPO | string | https://dist.suse.de/ibs/Devel:/SAP:/trento:/factory/SLE_15_SP3/x86_64 | Repository where to get the trento-agent installer
+TRENTO_AGENT_RPM | string | | Trento-agent rpm file name
+TRENTO_EXT_DEPLOY_IP | string | | Public IP of a Trento web instance not deployed by openQA
+TRENTO_WEB_PASSWORD | string | | Trento web password for the admin user
 
 ### Publiccloud specific variables
 


### PR DESCRIPTION
Create a test to install the agents on all the nodes of the SAP Landscape cluster.
Add proper trento and qesap destroy in more post fail hooks.

qesapdeploy lib:
 - new api to get the location of the generated Ansible inventory
 - longer timeout for the python requirements installation
 - setting rename DEPLOYMENT_DIR --> QESAP_DEPLOYMENT_DIR
 - git clone log fix
 - api change in qesap_prepare_env
  
 trento lib:
 - new deploy_vm function for 00.040
 - new install_agent function
 - expose k8s_logs
 - deploy_qesap to save the inventory Unit test for qesapdeploy and trento lib
Improve documentation for the TRENTO settings


- Verification run: http://openqaworker15.qa.suse.cz/tests/35612 http://openqaworker15.qa.suse.cz/tests/38602
