### PR TITLE
Fix relogin issue caused by missing LF

### DIFF
--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -59,7 +59,7 @@ sub relogin_root {
     my $self = shift;
     record_info 'relogin', 'user needs to logout and login back to trigger scripts which set env variales and others';
 
-    type_string('pkill -u root');
+    type_string("pkill -u root\n");
     record_info "pkill done";
     $self->wait_boot_textmode(ready_time => 30);
     select_console('root-virtio-terminal');


### PR DESCRIPTION
`type_string` doesnt send LF and the text is hanging in the terminal. This seems to solve the problem even if i dont have no idea why it worked on verification runs at the first place.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

