### PR TITLE
Fix failing HPC tests in Incidents

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -27,7 +27,7 @@ sub run ($self) {
         bin => '/home/bernhard/bin',
         hpc_lib => '/usr/lib/hpc',
     );
-
+    script_run("sudo -u $testapi::username mkdir $exports_path{bin}");
     zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel python3-devel");
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;


### PR DESCRIPTION
The user directory which needs to mounted and where hosts MPI source code and binaries is missing when `exportfs` is running. This directory needs to created with right privileges as a user.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

http://aquarius.suse.cz/tests/12649
http://aquarius.suse.cz/tests/12644