### PR TITLE
Remove obsolete RHOST workaround for LTP network tests

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -305,12 +305,6 @@ sub run {
     my $cmd_text = qq($test->{command}; echo "$fin_msg\$?");
     my $klog_stamp = "echo 'OpenQA::run_ltp.pm: Starting $test->{name}' > /dev/$serialdev";
     my $start_time = thetime();
-    # See poo#16648 for disabled LTP networking related tests.
-    my $set_rhost = $test->{command} =~ m/^finger01|ftp01|rcp01|rdist01|rlogin01|rpc01|rpcinfo01|rsh01|telnet01/;
-
-    if ($set_rhost) {
-        assert_script_run(q(export RHOST='127.0.0.1'));
-    }
 
     if (is_serial_terminal) {
         script_run($klog_stamp);
@@ -335,10 +329,6 @@ sub run {
             save_memory_dump(filename => $test->{name});
         }
         die "Timed out waiting for LTP test case which may still be running or the OS may have crashed!";
-    }
-
-    if ($set_rhost) {
-        assert_script_run('unset RHOST');
     }
 
     script_run('vmstat -w');


### PR DESCRIPTION
Two of the tests affected by this workaround got enabled in the upcoming LTP release and they're broken by this workaround. Remove it to fix the tests.

- Related ticket: https://progress.opensuse.org/issues/16648
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/9582368
