### PR TITLE
Enable trufflehog (again)

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,7 +1,8 @@
-name: WIP. Please Ignore this failure. Leaked Secrets Scan Test
+name: Leaked Secrets Scan Test
 on:
+  pull_request:
   push:
-    branches: [ "trufflehog" ]
+    branches: [ "master" ]
 jobs:
   TruffleHog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/trufflesecurity/trufflehog/issues/666 has been resolved, so we can enable TruffleHog again
