### PR TITLE
Add a timeout for the 15-sp4 failure ipsec_client

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -191,7 +191,6 @@ sub run {
 
     # Firefox Preferences
     firefox_preferences;
-
     # Search "Certificates" section
     search_certificates;
 

--- a/tests/security/cc/ipsec/ipsec_client.pm
+++ b/tests/security/cc/ipsec/ipsec_client.pm
@@ -42,6 +42,8 @@ sub run {
     # Test the IPSec connection
     assert_script_run('ipsec start');
     assert_script_run('stime=$(date +\'%H:%M:%S\')');
+    record_soft_failure("poo#117208 - The addition of the sleep command is a temporary workaround");
+    sleep 60;
     assert_script_run('ipsec up ikev2suse');
 
     # Test the IPSec connection


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/117208
- Needles: N/A 
- Verification run: [ipsec_server](https://openqa.suse.de/tests/9602089) | [ipsec_client](https://openqa.suse.de/tests/9602088)

