### PR TITLE
Skip installation of sle-module-python in sle15GA

### DIFF
--- a/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
@@ -38,6 +38,7 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
+      % unless ($check_var->('VERSION', '15')) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
         % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
@@ -49,6 +50,7 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
+      % }
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-development-tools</name>
@@ -412,10 +414,12 @@
       <package>sle-module-development-tools-release</package>
       <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
+      % unless ($check_var->('VERSION', '15')) {
       % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
       % } else {
       <package>sle-module-python3-release</package>
+      % }
       % }
       % if ($check_var->('SCC_ADDONS', 'nvidia')) {
       <package>sle-module-NVIDIA-compute-release</package>

--- a/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
@@ -38,6 +38,7 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
+      % unless ($check_var->('VERSION', '15')) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
         % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
@@ -49,6 +50,7 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
+      % }
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-development-tools</name>
@@ -452,6 +454,7 @@
       <package>sle-module-development-tools-release</package>
       <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
+      % unless ($check_var->('VERSION', '15')) {
       % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
       % } else {
@@ -459,6 +462,7 @@
       % }
       % if ($check_var->('SCC_ADDONS', 'nvidia')) {
       <package>sle-module-NVIDIA-compute-release</package>
+      % }
       % }
       <package>openssh</package>
       <package>kexec-tools</package>


### PR DESCRIPTION
`sle-module-python` is not available on sle15GA and need to be excluded by autoyast installation.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Related ticket: https://progress.opensuse.org/issues/116866
- Verification run: https://openqa.suse.de/tests/9587173#
