### PR TITLE
Enable libyui-rest-api in test suites for SLE15SP3 MU dev group

### DIFF
--- a/schedule/yast/maintenance/create_hdd_transactional_server_sle15sp3_dev.yaml
+++ b/schedule/yast/maintenance/create_hdd_transactional_server_sle15sp3_dev.yaml
@@ -1,0 +1,24 @@
+---
+name: create_hdd_transactional_server
+description: >
+  Installation of a Transactional Server which uses a read-only
+  root filesystem to provide atomic, automatic updates of a
+  system without interfering with the running system.
+vars:
+  DESKTOP: textmode
+  HDDSIZEGB: 20
+  DUD_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_transactional
+  system_role:
+    - installation/system_role/accept_selected_role_transactional_server
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+  system_validation:
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/yast/maintenance/lvm_thin_provisioning_sle15sp3_dev.yaml
+++ b/schedule/yast/maintenance/lvm_thin_provisioning_sle15sp3_dev.yaml
@@ -1,0 +1,17 @@
+---
+name: lvm_thin_provisioning_dev
+vars:
+  DUD_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/hostname
+    - console/force_scheduled_tasks
+  system_validation:
+    - shutdown/grub_set_bootargs
+    - console/lvm_thin_check

--- a/schedule/yast/maintenance/ncurses_interactive_installation_sle15sp3_dev.yaml
+++ b/schedule/yast/maintenance/ncurses_interactive_installation_sle15sp3_dev.yaml
@@ -1,0 +1,23 @@
+---
+name: ncurses_interactive_installation
+description: >
+  Interactive installation with ncurses (textmode).
+vars:
+  DUD_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  system_role:
+    - installation/system_role/select_role_text_mode
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - update/zypper_up
+    - console/zypper_lifecycle
+    - console/orphaned_packages_check
+    - console/consoletest_finish

--- a/schedule/yast/maintenance/qam-yast_self_update_sle15sp3_dev.yaml
+++ b/schedule/yast/maintenance/qam-yast_self_update_sle15sp3_dev.yaml
@@ -1,0 +1,10 @@
+---
+name: qam-yast_self_update
+description: installation using self_update as boot parameter
+vars:
+  YUI_REST_API: 1
+schedule:
+  self_update:
+    - installation/validate_self_update
+  add_on_product:
+    - installation/add_on_product/add_maintenance_repos

--- a/schedule/yast/maintenance/yast-mru-install-minimal-with-addons_sle15sp3_aarch64_dev.yaml
+++ b/schedule/yast/maintenance/yast-mru-install-minimal-with-addons_sle15sp3_aarch64_dev.yaml
@@ -1,0 +1,15 @@
+---
+name: yast-mru-install-minimal-with-addons
+vars:
+  PATTERNS: base,minimal
+  YUI_REST_API: 1
+schedule:
+  additional_products: []
+  add_on_product:
+    - installation/add_on_product/add_maintenance_repos
+    - installation/addon_products_sle
+  system_role: []
+  software:
+    - installation/select_patterns
+  stop_timeout_system_reboot:
+    - installation/performing_installation/stop_timeout_system_reboot_now

--- a/schedule/yast/maintenance/yast-mru-install-minimal-with-addons_sle15sp3_s390x_dev.yaml
+++ b/schedule/yast/maintenance/yast-mru-install-minimal-with-addons_sle15sp3_s390x_dev.yaml
@@ -1,0 +1,15 @@
+---
+name: yast-mru-install-minimal-with-addons
+vars:
+  PATTERNS: base,minimal
+  YUI_REST_API: 1
+schedule:
+  additional_products: []
+  add_on_product:
+    - installation/add_on_product/add_maintenance_repos
+    - installation/addon_products_sle
+  system_role: []
+  software:
+    - installation/select_patterns
+  stop_timeout_system_reboot:
+    - installation/performing_installation/stop_timeout_system_reboot_now

--- a/schedule/yast/maintenance/yast-mru-install-minimal-with-addons_sle15sp3_x86_dev.yaml
+++ b/schedule/yast/maintenance/yast-mru-install-minimal-with-addons_sle15sp3_x86_dev.yaml
@@ -1,0 +1,15 @@
+---
+name: yast-mru-install-minimal-with-addons
+vars:
+  PATTERNS: base,minimal
+  YUI_REST_API: 1
+schedule:
+  additional_products: []
+  add_on_product:
+    - installation/add_on_product/add_maintenance_repos
+    - installation/addon_products_sle
+  system_role: []
+  software:
+    - installation/select_patterns
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/maintenance/yast-mru-install_sle15sp3_dev.yaml
+++ b/schedule/yast/maintenance/yast-mru-install_sle15sp3_dev.yaml
@@ -1,0 +1,8 @@
+---
+name: yast-mru-install_dev
+vars:
+  DUD_ADDONS: sdk
+  YUI_REST_API: 1
+schedule:
+  {}
+...

--- a/schedule/yast/sle/flows/default_sle15sp3.yaml
+++ b/schedule/yast/sle/flows/default_sle15sp3.yaml
@@ -1,0 +1,48 @@
+---
+# Default ordered sequence of steps for sle15sp3 with maintenance updates
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+product_selection:
+  - installation/product_selection/install_SLES
+self_update: []
+license_agreement:
+  - installation/licensing/accept_license
+additional_products:
+  - installation/add_on_product_installation/add_additional_products
+registration:
+  - installation/registration/register_via_scc
+extension_module_selection:
+  - installation/module_registration/register_extensions_and_modules
+add_on_product:
+  - installation/add_on_product/skip_install_addons
+system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+default_systemd_target: []
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+installation_settings:
+  - installation/launch_installation
+installation:
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+stop_timeout_system_reboot: []
+installation_logs:
+  - installation/logs_from_installation_system
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+grub:
+  - installation/grub_test
+first_login:
+  - installation/first_boot
+system_preparation: []
+system_validation: []


### PR DESCRIPTION
We need to enable libyui-rest-api for all SLE15SP3 MU dev cases.

- Related ticket: https://progress.opensuse.org/issues/116482

- Needles: N/A

- MR
  https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/387

- Verification run: 
  https://openqa.suse.de/tests/9861283
  https://openqa.suse.de/tests/9861289
  https://openqa.suse.de/tests/9861284
  https://openqa.suse.de/tests/9861369
  https://openqa.suse.de/tests/9861286
  https://openqa.suse.de/tests/9861287
  https://openqa.suse.de/tests/9861421
s390x:
  https://openqa.suse.de/tests/9861466
aarch64:
  https://openqa.suse.de/tests/9861467