### PR TITLE
Remove workaround of bsc#1191112 on sles15sp5

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
@@ -35,8 +35,6 @@ sub select_tab {
 
 sub select_bond_slave_in_list {
     assert_screen(BOND_SLAVES_TAB);
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED, 'alt-f10', 10, 2);
     assert_and_click(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
@@ -36,8 +36,6 @@ sub select_tab {
 
 sub select_bridged_device_in_list {
     assert_screen(BRIDGED_DEVICES_TAB);
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(BRIDGED_DEVICE_CHECKBOX_UNCHECKED, 'alt-f10', 10, 2);
     assert_and_click(BRIDGED_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
@@ -26,8 +26,7 @@ sub select_device_type {
         bond => 'alt-o',
         vlan => 'alt-v'
     };
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(DEVICE_TYPE_DIALOG, 'alt-f10', 10, 2);
+    assert_screen(DEVICE_TYPE_DIALOG);
     send_key $shortcut->{$device};
 }
 

--- a/lib/YaST/NetworkSettings/OverviewTab.pm
+++ b/lib/YaST/NetworkSettings/OverviewTab.pm
@@ -27,20 +27,17 @@ sub new {
 }
 
 sub press_add {
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 10, 2);
+    assert_screen(OVERVIEW_TAB);
     send_key('alt-a');
 }
 
 sub press_edit {
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 10, 2);
+    assert_screen(OVERVIEW_TAB);
     send_key('alt-i');
 }
 
 sub press_delete {
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 10, 2);
+    assert_screen(OVERVIEW_TAB);
     send_key('alt-t');
 }
 
@@ -68,8 +65,7 @@ sub select_device {
 }
 
 sub press_ok {
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch(OVERVIEW_TAB, 'alt-f10', 10, 2);
+    assert_screen(OVERVIEW_TAB);
     send_key('alt-o');
 }
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -616,7 +616,7 @@ sub handle_scc_popups {
         push @tags, 'expired-gpg-key' if is_sle('=15');
         while ($counter--) {
             die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
-            if (is_sle('15-SP4+')
+            if (is_sle('=15-SP4')
                 && (get_var('VIDEOMODE', '') !~ /text|ssh-x/)
                 && (get_var("DESKTOP") !~ /textmode/)
                 && (get_var('REMOTE_CONTROLLER') !~ /vnc/)

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -266,11 +266,6 @@ sub rmt_wizard {
     zypper_call 'in mariadb';
 
     enter_cmd "yast2 rmt;echo yast2-rmt-wizard-\$? > /dev/$serialdev";
-    # On x11, workaround bsc#1191112 by mouse click or drag the dialog.
-    if (($setup_console =~ /x11/) && (check_var('RMT_TEST', 'rmt_chinese'))) {
-        record_soft_failure('bsc#1191112 - When navigating through YaST module screens the next screen appears, but its content is not loaded');
-        mouse_set(100, 100);
-    }
     assert_screen 'yast2_rmt_registration';
     send_key 'alt-u';
     wait_still_screen(2, 5);
@@ -295,12 +290,6 @@ sub rmt_wizard {
     send_key 'alt-n';
     assert_screen 'yast2_rmt_ssl_CA_password';
     type_password_twice;
-    # On x11, workaround bsc#1191112 by mouse click or drag the dialog.
-    if (($setup_console =~ /x11/) && (check_var('RMT_TEST', 'rmt_chinese'))) {
-        record_soft_failure('bsc#1191112 - When navigating through YaST module screens the next screen appears, but its content is not loaded');
-        wait_still_screen(10, 15);
-        mouse_drag(startx => 480, starty => 50, endx => 485, endy => 50, button => 'left');
-    }
     assert_screen [qw(yast2_rmt_firewall yast2_rmt_firewall_disable)], 50;
     if (match_has_tag('yast2_rmt_firewall')) {
         if (check_var('RMT_TEST', 'rmt_chinese')) {

--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -120,10 +120,6 @@ sub y2snapper_new_snapshot {
     # Have to focus to Snapshots list manually in ncurses
     if ($ncurses) {
         send_key_until_needlematch 'yast2_snapper-focus-in-snapshots', 'tab';
-    } else {
-        # Workaround for bsc#1191112
-        record_soft_failure('bsc#1191112 - When navigating through YaST module screens the next screen appears, but its content is not loaded');
-        send_key 'tab' for (1 .. 10);
     }
 
     # Make sure the snapshot is listed in the main window

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -62,8 +62,13 @@ sub initiator_discovered_targets_tab {
     send_key "alt-i";
     my $target_ip_only = (split('/', $test_data->{target_conf}->{ip}))[0];
     type_string_slow_extended $target_ip_only;
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('iscsi-initiator-discovered-IP-adress', 'alt-f10', 10, 2);
+    if (is_sle('=15-SP4')) {
+        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        send_key_until_needlematch('iscsi-initiator-discovered-IP-adress', 'alt-f10', 10, 2);
+    }
+    else {
+        assert_screen 'iscsi-initiator-discovered-IP-adress';
+    }
     # next and press connect button
     send_key "alt-n";
     assert_and_click 'iscsi-initiator-connect-button';
@@ -87,8 +92,13 @@ sub initiator_discovered_targets_tab {
 sub initiator_connected_targets_tab {
     # go to discovered targets tab
     send_key "alt-d";
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('iscsi-initiator-discovered-targets', 'alt-f10', 10, 2);
+    if (is_sle('=15-SP4')) {
+        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        send_key_until_needlematch('iscsi-initiator-discovered-targets', 'alt-f10', 10, 2);
+    }
+    else {
+        assert_screen 'iscsi-initiator-discovered-targets';
+    }
     # go to connected targets tab
     send_key "alt-n";
     assert_screen 'iscsi-initiator-connected-targets';

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -92,8 +92,13 @@ sub target_service_tab {
 }
 
 sub config_2way_authentication {
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('iscsi-target-modify-acls', 'alt-f10', 10, 2);
+    if (is_sle('=15-SP4')) {
+        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        send_key_until_needlematch('iscsi-target-modify-acls', 'alt-f10', 10, 2);
+    }
+    else {
+        assert_screen 'iscsi-target-modify-acls';
+    }
     send_key 'alt-a';
     assert_screen 'iscsi-target-modify-acls-initiator-popup';
     if (is_sle('>=15')) {

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -65,8 +65,7 @@ sub nis_server_configuration {
     assert_screen 'nis-server-server-maps-setup-finished';
     send_key $cmd{next};
     # NIS Server Query Hosts
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('nis-server-query-hosts-setup', 'alt-f10', 10, 2);
+    assert_screen 'nis-server-query-hosts-setup';
     send_key 'alt-a';    # add
     assert_screen 'nis-server-network-conf-popup';
     type_string $setup_nis_nfs_x11{net_mask};

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -45,10 +45,17 @@ sub run {
     type_string '16';
 
     #	default boot section
-    for (1 .. 2) { send_key 'alt-f10' }
+    if (is_sle('=15-SP4')) {
+        for (1 .. 2) { send_key 'alt-f10' }
+    }
     assert_and_click 'yast2-bootloader_default-boot-section';
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2-bootloader_default-boot-section_tw', 'alt-f10', 9, 2);
+    if (is_sle('=15-SP4')) {
+        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        send_key_until_needlematch('yast2-bootloader_default-boot-section_tw', 'alt-f10', 9, 2);
+    }
+    else {
+        assert_screen 'yast2-bootloader_default-boot-section_tw';
+    }
     send_key 'esc';    # Close drop down
 
     #	proctect boot loader with password

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -204,8 +204,7 @@ sub start_partitioner {
 sub start_vpn_gateway {
     search('vpn');
     assert_and_click 'yast2_control-center_vpn-gateway-client';
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2-vpn-gateway-client', 'alt-f10', 20, 9);
+    assert_screen 'yast2-vpn-gateway-client', timeout => 180;
     send_key 'alt-c';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
@@ -245,8 +244,7 @@ sub start_hypervisor {
 sub start_add_system_extensions_or_modules {
     search 'system ext';
     assert_and_click 'yast2_control-center_add-system-extensions-or-modules';
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2_control-center_registration', 'alt-f10', 10, 2);
+    assert_screen 'yast2_control-center_registration', timeout => 180;
     send_key 'alt-r';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
@@ -281,8 +279,7 @@ sub start_wake_on_lan {
     assert_and_click 'yast2_control-center_wake-on-lan';
     assert_screen 'yast2_control-center_wake-on-lan_install_wol';
     send_key $cmd{install};    # wol needs to be installed
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2_control-center_wake-on-lan_overview', 'alt-f10', 10, 2);
+    assert_screen 'yast2_control-center_wake-on-lan_overview', timeout => 180;
     send_key 'alt-f';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -31,8 +31,7 @@ sub run {
     clear_console;
     select_console 'x11';
     y2_module_guitest::launch_yast2_module_x11($module, match_timeout => 90);
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2_hostnames_added', 'alt-f10', 10, 2);
+    assert_screen 'yast2_hostnames_added', timeout => 180;
     assert_and_click "yast2_hostnames_added";
     send_key 'alt-i';
     assert_screen 'yast2_hostnames_edit_popup';

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -110,8 +110,13 @@ sub test_http_instserver {
     wait_still_screen 2, 2;
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-a", 2);
-    record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
-    send_key_until_needlematch('yast2-instserver-repository-conf', 'alt-f10', 9, 2);
+    if (is_sle('=15-SP4')) {
+        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        send_key_until_needlematch('yast2-instserver-repository-conf', 'alt-f10', 9, 2);
+    }
+    else {
+        assert_screen('yast2-instserver-repository-conf');
+    }
     send_key_and_wait("alt-p", 2);
     type_string "instserver";
     wait_still_screen 2, 2;
@@ -122,7 +127,13 @@ sub test_http_instserver {
     send_key_until_needlematch("yast2-instserver_sr0dev", "down", 4);
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
-    send_key_until_needlematch([qw(yast2-instserver-ui yast2-instserver-change-media)], 'alt-f10', 21, 30);
+    if (is_sle('=15-SP4')) {
+        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        send_key_until_needlematch([qw(yast2-instserver-ui yast2-instserver-change-media)], 'alt-f10', 21, 30);
+    }
+    else {
+        assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 300);
+    }
     # skip "insert next cd" on SLE 12.x
     send_key_and_wait("alt-s", 2) if is_sle("<=12-SP5") && match_has_tag('yast2-instserver-change-media');
     assert_screen('yast2-instserver-ui');

--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -40,7 +40,7 @@ sub run {
     # Check previously set values + Login Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-pwd-settings";
-    if (is_sle('15-SP4+')) {
+    if (is_sle('=15-SP4')) {
         record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('yast2_security-check-min-pwd-len-and-exp-days', 'alt-f10', 10, 2);
     }
@@ -54,7 +54,7 @@ sub run {
 
     # Check previously set values + Miscellaneous Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
-    if (is_sle('15-SP4+')) {
+    if (is_sle('=15-SP4')) {
         record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('yast2_security-login-settings', 'alt-f10', 10, 2);
     }
@@ -69,7 +69,7 @@ sub run {
     # Check previously set values
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-misc-settings";
-    if (is_sle('15-SP4+')) {
+    if (is_sle('=15-SP4')) {
         record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('yast2_security-file-perms-secure', 'alt-f10', 10, 2);
     }


### PR DESCRIPTION
We should remove the workaround of bsc#1191112 and check that everything is ok now for SLE-15-SP5.

- Related ticket: https://progress.opensuse.org/issues/116917
- Needles: N/A
- Verification run: 
Run yast_gui on all arches to verify:

https://openqa.nue.suse.com/tests/9609448#
https://openqa.nue.suse.com/tests/9609449#details
https://openqa.nue.suse.com/tests/9609450#details
VR on s390x blocked the qcow creation failure.

VRs for maintenance group:
https://openqa.nue.suse.com/tests/9609452#details
https://openqa.nue.suse.com/tests/9609454#details
https://openqa.nue.suse.com/tests/9609453#details