### PR TITLE
Remove test_repo_setup from maintenance runs

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2214,7 +2214,8 @@ sub load_applicationstests {
 
 sub load_security_console_prepare {
     loadtest "console/consoletest_setup";
-    loadtest "security/test_repo_setup" if (get_var("SECURITY_TEST") =~ /^crypt_/ && !is_opensuse);
+    # Add this setup only in product testing
+    loadtest "security/test_repo_setup" if (get_var("SECURITY_TEST") =~ /^crypt_/ && !is_opensuse && get_var("BETA"));
     loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
     loadtest "console/openssl_alpn" if (get_var("FIPS_ENABLED") && get_var("JEOS"));
     loadtest "console/yast2_vnc" if (get_var("FIPS_ENABLED") && is_pvm);


### PR DESCRIPTION
The `test_repo_setup` module is not needed in maintenance runs. For enabling fips tests in 15-SP4, this module has to be excluded.

- Related ticket: https://progress.opensuse.org/issues/116956
- Needles: N/A
- Verification run: [15-SP4](https://openqa.suse.de/tests/9602455#step/fips_setup/91) | [15-sp5](https://openqa.suse.de/tests/9602613#step/fips_setup/91)
