### PR TITLE
Fix dbus_services_exposure

### DIFF
--- a/lib/atsec_test.pm
+++ b/lib/atsec_test.pm
@@ -37,7 +37,9 @@ our @white_list_for_dbus = (
     'org.opensuse.Network.DHCP6',
     'org.opensuse.Network.AUTO4',
     'org.opensuse.Network.Nanny',
-    'org.opensuse.Snapper'
+    'org.opensuse.Snapper',
+    '1.13',
+    '1.22'
 );
 
 our $server_ip = get_var('SERVER_IP', '10.0.2.101');

--- a/tests/security/atsec/dbus_services_exposure.pm
+++ b/tests/security/atsec/dbus_services_exposure.pm
@@ -24,7 +24,8 @@ my %white_list_for_busctl = (
     'systemd-logind' => 1,
     'wickedd-nanny' => 1,
     'systemd-machine' => 1,
-    libvirtd => 1
+    libvirtd => 1,
+    busctl => 1
 );
 
 sub parse_results {


### PR DESCRIPTION
* whitelist 1.13 (libvirtd) and 1.22 (busctl) in lib/atsec_test.pm
* whitelist busctl in tests/security/atsec/dbus_services_exposure.pm

poo: https://progress.opensuse.org/issues/116869
VRs:
* https://openqa.suse.de/tests/9602108
