### PR TITLE
WIP fix redis cli for validate_script_output('redis-cli get foo', sub { m/(nil)/ })

### DIFF
--- a/tests/console/redis.pm
+++ b/tests/console/redis.pm
@@ -37,7 +37,7 @@ sub run {
     validate_script_output('redis-cli get foo', sub { m/bar/ });
     validate_script_output('redis-cli pfselftest', sub { m/OK/ });
     validate_script_output('redis-cli flushdb', sub { m/OK/ });
-    validate_script_output('redis-cli get foo', sub { m/(nil)/ });
+    validate_script_output('redis-cli get foo', sub { chomp; m/(nil)/ });
 
     assert_script_run 'curl -O ' . data_url('console/movies.redis');
     assert_script_run('redis-cli -h localhost -p 6379 < ./movies.redis');


### PR DESCRIPTION
need to use svirt remote worker on OSD

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
