### PR TITLE
Enable sqlite3 and postgresql_server tests on ALP

### DIFF
--- a/tests/console/sqlite3.pm
+++ b/tests/console/sqlite3.pm
@@ -19,13 +19,19 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
-
+use version_utils qw(is_transactional);
+use transactional qw(trup_call check_reboot_changes);
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
-
-    zypper_call('install sqlite3 expect perl');
+    if (is_transactional) {
+        select_console 'root-console';
+        trup_call("pkg install sqlite3 expect perl");
+        check_reboot_changes;
+    } else {
+        $self->select_serial_terminal;
+        zypper_call('install sqlite3 expect perl');
+    }
 
     my $archive = "sqlite3-tests.data";
     assert_script_run(


### PR DESCRIPTION
- Related ticket:https://progress.opensuse.org/issues/116057
- Needles: No
- Verification run: 
   [alp-0.1-kvm-x86_64](http://deepthi-openqa.qam.suse.de/tests/4014#step/sqlite3/1)