### PR TITLE
Find dynamically the second disk for dolly module

### DIFF
--- a/tests/hpc/dolly_master.pm
+++ b/tests/hpc/dolly_master.pm
@@ -34,7 +34,8 @@ sub run ($self) {
     my $server_hostname = get_required_var("HOSTNAME");
     my @slave_nodes = $self->slave_node_names();
     my $client_hostnames = join(',', @slave_nodes);
-    assert_script_run("dolly -v -S $server_hostname -H $client_hostnames -I $test_dev -O $test_dev");
+    # timeout should be in sync with slave_node
+    assert_script_run("dolly -v -S $server_hostname -H $client_hostnames -I $test_dev -O $test_dev", timeout => 1600);
     barrier_wait("DOLLY_DONE");
 }
 

--- a/tests/hpc/dolly_master.pm
+++ b/tests/hpc/dolly_master.pm
@@ -6,15 +6,18 @@
 # Summary: Test Dolly package duplication block on all nodes, create sha256 for validation
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase', -signatures;
+use Mojo::Base qw(hpcbase btrfs_test), -signatures;
 use testapi;
 use lockapi;
 use utils;
 
 our $test_dir = "/mnt/test";
-our $test_dev = "/dev/vdb";
+our $test_dev;
 
 sub run ($self) {
+    $self->set_playground_disk();    # sets PLAYGROUNDDISK variable
+    $test_dev = get_required_var('PLAYGROUNDDISK');
+    record_info 'test_dev', "$test_dev";
     my $nodes = get_required_var("CLUSTER_NODES");
     $self->select_serial_terminal();
     zypper_call('in dolly');

--- a/tests/hpc/dolly_slave.pm
+++ b/tests/hpc/dolly_slave.pm
@@ -6,16 +6,20 @@
 # Summary: Operates as the client of the dolly server and checks final results
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
-use Mojo::Base 'hpcbase', -signatures;
+use Mojo::Base qw(hpcbase btrfs_test), -signatures;
 use testapi;
 use lockapi;
 use utils;
 
 our $test_dir = "/mnt/test";
-our $test_dev = "/dev/vdb";
+our $test_dev;
 
 sub run ($self) {
     $self->select_serial_terminal();
+    $self->set_playground_disk();    # sets PLAYGROUNDDISK variable
+    $test_dev = get_required_var('PLAYGROUNDDISK');
+    record_info 'test_dev', "$test_dev";
+
     zypper_call("in dolly");
     barrier_wait("DOLLY_INSTALLATION_FINISHED");
     assert_script_run("mkfs.ext4 -v $test_dev");

--- a/tests/hpc/dolly_slave.pm
+++ b/tests/hpc/dolly_slave.pm
@@ -24,7 +24,7 @@ sub run ($self) {
     barrier_wait("DOLLY_INSTALLATION_FINISHED");
     assert_script_run("mkfs.ext4 -v $test_dev");
     barrier_wait("DOLLY_SERVER_READY");
-    assert_script_run("dolly -v");
+    assert_script_run("dolly -v", timeout => 1600);    # timeout should be in sync with master_node
     barrier_wait("DOLLY_DONE");
     assert_script_run("mkdir -p $test_dir");
     assert_script_run("mount $test_dev $test_dir");


### PR DESCRIPTION
This solves the problem with the pre-installed qcow image which boots the system from wherever it finds the root btrfs filesystem. Relying in hardcoded device is not safe in this case. Use `btrfs_test` library to solve the problem with a subroutine which returns the correct second disk device.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/113605
- Verification run: 
https://openqa.suse.de/tests/9612408
https://openqa.suse.de/tests/9612405