### PR TITLE
jeos/firstrun: Handle WiFi on Leap 15.5 as well

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -124,7 +124,7 @@ sub run {
         send_key 'ret';
     }
 
-    if (is_generalhw && (is_tumbleweed || is_sle || is_sle_micro)) {
+    if (is_generalhw && !is_leap("<15.5")) {
         assert_screen 'jeos-please-configure-wifi';
         send_key 'n';
     }


### PR DESCRIPTION
15.5 also includes jeos-firstboot-rpiwifi now.

Failure: https://openqa.opensuse.org/tests/2741790#step/firstrun/12

- Verification run: https://openqa.opensuse.org/tests/2749361