### PR TITLE
sles4sap: Fix download of sapconf tests from gitlab.suse.de

### DIFF
--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -12,26 +12,29 @@ use testapi;
 use version_utils qw(is_staging is_sle is_upgrade);
 use Utils::Architectures;
 use Utils::Systemd 'systemctl';
+use utils qw(zypper_call);
 use strict;
 use warnings;
 
 sub run_developers_tests {
-    my $devel_repo = 'https://gitlab.suse.de/AngelaBriel/sapconf-test/repository/sapconf_v5/archive.tar.gz';
+    my $devel_repo = 'https://gitlab.suse.de/AngelaBriel/sapconf-test';
+    my $branch = 'sapconf_v5';
     my $log = '/tmp/sapconf_test.log';
 
     # Download and unpack the test scripts supplied by the developers
     # Continue if it can not be downloaded
     enter_cmd "cd /tmp";
-    my $ret = script_run "curl -k $devel_repo | tar -zxvf -";
+    zypper_call 'in git-core';
+    my $ret = script_run "git clone -q  -c http.sslVerify=false --branch $branch $devel_repo";
     unless (defined $ret and $ret == 0) {
         record_info 'Download problem', 'Could not download developer test script';
         return;
     }
 
     # Run script as is and upload results
-    $ret = script_run 'cd sapconf-test-*';
+    $ret = script_run 'cd sapconf-test';
     unless (defined $ret and $ret == 0) {
-        record_info 'Script not found', 'sapconf-test-master-* directory not found in the developer test package';
+        record_info 'Script not found', 'sapconf-test directory not found in the developer test package';
         return;
     }
     my $output = script_output 'ls';


### PR DESCRIPTION
Getting the sapconf tests from gitlab.suse.de using `curl` fails.  Use `git clone` instead.

- Failing test: https://openqa.suse.de/tests/9564320/logfile?filename=serial_terminal.txt
- Verification run: https://openqa.suse.de/tests/9612236