### PR TITLE
Implement automation test for nvidia in pubcloud

### DIFF
--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -78,6 +78,12 @@ variable "enable_confidential_vm" {
 	default=false
 }
 
+variable "gpu" {
+  description = "Enable and configure node GPUs"
+
+  default = false
+}
+
 resource "random_id" "service" {
     count = var.instance_count
     keepers = {
@@ -91,7 +97,12 @@ resource "google_compute_instance" "openqa" {
     name                         = "${var.name}-${element(random_id.service.*.hex, count.index)}"
     machine_type                 = var.type
     zone                         = var.region
-    
+
+    guest_accelerator {
+      type = "nvidia-tesla-t4"
+      count = var.gpu ? 1 : 0
+    }
+
     confidential_instance_config {
     	enable_confidential_compute = var.enable_confidential_vm ? true : false
     }

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -14,6 +14,7 @@ use main_common qw(loadtest);
 use testapi qw(check_var get_var);
 use Utils::Architectures qw(is_aarch64);
 use main_containers qw(load_container_tests);
+require bmwqemu;
 
 our @EXPORT = qw(
   load_publiccloud_tests
@@ -58,7 +59,11 @@ sub load_maintenance_publiccloud_tests {
             loadtest "publiccloud/az_l8s_nvme" if (get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'Standard_L(8|16|32|64)s_v2');
         } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
             loadtest("publiccloud/azure_nfs", run_args => $args);
+        } elsif (check_var('PUBLIC_CLOUD_NVIDIA', 1)) {
+            die "ConfigError: Either the provider is not supported or SLE version is old!\n" unless (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE') && is_sle('15-SP4+'));
+            loadtest "publiccloud/nvidia", run_args => $args;
         }
+
         loadtest("publiccloud/ssh_interactive_end", run_args => $args);
     }
 }
@@ -82,6 +87,16 @@ sub load_publiccloud_consoletests {
     loadtest 'console/libgcrypt' unless is_sle '=12-SP4';
 }
 
+my $should_use_runargs = sub {
+    my @public_cloud_variables = qw(
+      PUBLIC_CLOUD_CONSOLE_TESTS
+      PUBLIC_CLOUD_CONTAINERS
+      PUBLIC_CLOUD_SMOKETEST
+      PUBLIC_CLOUD_AZURE_NFS_TEST
+      PUBLIC_CLOUD_NVIDIA);
+    return grep { exists $bmwqemu::vars{$_} } @public_cloud_variables;
+};
+
 sub load_latest_publiccloud_tests {
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
         loadtest "publiccloud/img_proof";
@@ -101,7 +116,7 @@ sub load_latest_publiccloud_tests {
     elsif (get_var('PUBLIC_CLOUD_FIO')) {
         loadtest 'publiccloud/storage_perf';
     }
-    elsif (get_var('PUBLIC_CLOUD_CONSOLE_TESTS') || get_var('PUBLIC_CLOUD_CONTAINERS') || get_var('PUBLIC_CLOUD_SMOKETEST') || get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
+    elsif (&$should_use_runargs()) {
         my $args = OpenQA::Test::RunArgs->new();
         loadtest "publiccloud/prepare_instance", run_args => $args;
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
@@ -113,6 +128,10 @@ sub load_latest_publiccloud_tests {
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
             load_publiccloud_consoletests($args);
+        }
+        elsif (check_var('PUBLIC_CLOUD_NVIDIA', 1)) {
+            die "ConfigError: The provider is not supported\n" unless (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE') && is_sle('15-SP4+'));
+            loadtest "publiccloud/nvidia", run_args => $args;
         }
         elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
             load_container_tests();

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -433,7 +433,9 @@ sub terraform_apply {
     if (get_var('FLAVOR') =~ 'UEFI') {
         $cmd .= "-var 'uefi=true' ";
     }
-
+    if (get_var('PUBLIC_CLOUD_NVIDIA')) {
+        $cmd .= "-var gpu=true ";
+    }
     $cmd .= "-out myplan";
     record_info('TFM cmd', $cmd);
 

--- a/tests/publiccloud/nvidia.pm
+++ b/tests/publiccloud/nvidia.pm
@@ -1,0 +1,76 @@
+# SUSE's openQA tests
+#
+# Copyright @ SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Opensource Nvidia test
+#          Test the opensourced nvidia drivers (SLE15-SP4+)
+# Maintainer: ybonatakis <ybonatakis@suse.com>
+
+#use Mojo::Base 'consoletest';
+use Mojo::Base 'publiccloud::basetest';
+use registration;
+use testapi;
+use utils;
+use publiccloud::utils;
+
+sub run {
+    my ($self, $args) = @_;
+    $self->{provider} = $args->{my_provider};
+
+    script_run("cat /etc/os-release");
+    zypper_call('--gpg-auto-import-keys addrepo -p 90 ' . get_required_var('NVIDIA_REPO') . ' nvidia_repo');
+    zypper_call '--gpg-auto-import-keys ref';
+    zypper_call("in nvidia-open-gfxG06-kmp-default ", quiet => 1);
+    $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
+
+    validate_script_output("hwinfo --gfxcard", sub { /nVidia.*Tesla T4/mg });    # depends on terraform setup
+    assert_script_run("LD_LIBRARY_PATH=/usr/lib/kernel-firmware-nvidia-gsp /usr/lib/kernel-firmware-nvidia-gsp/nvidia-smi --query");
+    assert_script_run("SUSEConnect --status-text", 300);
+}
+
+1;
+
+=head1 Discussion
+
+Test module to run Opensource Nvidia test on publiccloud with Turing or Ampere architecture GPUs.
+To do so, Public Cloud instance is provisioned by terraform. Setting instance with required hardware
+apply on F<publiccloud/terraform/gce.tf> using the C<guest_accelerator>. If you want to provide a
+custom terraform, C<PUBLIC_CLOUD_TERRAFORM_FILE> job variable can be used to define an alternative
+file.
+
+At the moment, the test uses https://download.opensuse.org/repositories/X11:/Drivers:/Video/SLE_15_SP4/ repo
+
+=head1 Configuration
+
+=head2 Hardware requirement and GCE instance configuration
+
+Most of the supported GPU are listed on https://sndirsch.github.io/nvidia/2022/06/07/nvidia-opengpu.html.
+One of them which GCE provides is B<Tesla T4>. GPU is provided via the B<europe-west1-*> regions, series C<N1>
+and machine type C<n1-standard-1>.
+
+Terraform can request which GPU to use, through C<guest_accelerator> inside the C<google_compute_instance> resource.
+
+=begin txt
+
+accelerator_config {
+    type         = "NVIDIA_TESLA_T4"
+    core_count   = 1
+  }
+
+=end txt
+
+The terraform configuration creates the required block with a dynamic block which reads the variable inputs
+assigned to the C<gnu> variable. If the job variable C<PUBLIC_CLOUD_NVIDIA> is true, then the following
+parameter will be passed in the terraform plan
+
+=begin bash
+  -var 'gpu={"count":1,"type":"nvidia-tesla-t4"}'
+=end bash
+
+This gives us agility to pass any I<type> or I<count> as value.
+
+If the C<PUBLIC_CLOUD_NVIDIA> is false, the object will be null and it will return an empty list. That disables
+the C<guest_accelerator>.
+
+=cut

--- a/variables.md
+++ b/variables.md
@@ -132,6 +132,7 @@ NO_ADD_MAINT_TEST_REPOS | boolean | true |  Do not add again (and duplicate) rep
 NOAUTOLOGIN | boolean | false | Indicates disabled auto login.
 NOIMAGES |||
 NOLOGS | boolean | false | Do not collect logs if set to true. Handy during development.
+NVIDIA_REPO | string | '' | Define the external repo for nvidia driver. Used by `nvidia.pm` module.
 OPT_KERNEL_PARAMS | string | Specify optional kernel command line parameters on bootloader settings page of the installer.
 PERF_KERNEL | boolean | false | Enables kernel performance testing.
 PERF_INSTALL | boolean | false | Enables kernel performance testing installation part.
@@ -296,6 +297,7 @@ PUBLIC_CLOUD_K8S_CLUSTER | string | "" | Name for the kubernetes cluster.
 PUBLIC_CLOUD_AZURE_K8S_RESOURCE_GROUP | string | "" | Name for the resource group which is subscribed the kubernetes cluster.
 PUBLIC_CLOUD_CREDENTIALS_URL | string | "" | Base URL where to get the credentials from. This will be used to compose the full URL together with `PUBLIC_CLOUD_NAMESPACE`.
 PUBLIC_CLOUD_NAMESPACE | string | "" | The Public Cloud Namespace name that will be used to compose the full credentials URL together with `PUBLIC_CLOUD_CREDENTIALS_URL`.
+PUBLIC_CLOUD_NVIDIA | boolean | 0 | If enabled, nvidia module would be scheduled. This variable should be enabled only sle15SP4 and above.
 PUBLIC_CLOUD_USER | string | "" | The public cloud instance system user.
 PUBLIC_CLOUD_XEN | boolean | false | Indicates if this is a Xen test run.
 PUBLIC_CLOUD_STORAGE_ACCOUNT | string | "" | Storage account used e.g. for custom disk and container images


### PR DESCRIPTION
Test open source nvidia drivers on GCE. Test jobs require
`PUBLIC_CLOUD_TERRAFORM_FILE=publiccloud/terraform/nvidia_gce.tf` and
`PUBLIC_CLOUD_NVIDIA=1`. With the given terraform the provider enables an
instance with *Nvidia Tesla T4 GPU*. Maybe i should name the tf accordantly as
other GPU can be used according the provider's GPU support

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/117316
- Verification run: http://aquarius.suse.cz/tests/13450