### PR TITLE
firstrun: Check 'jeos-please-configure-wifi' only on aarch64

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -124,7 +124,7 @@ sub run {
         send_key 'ret';
     }
 
-    if (is_generalhw && !is_leap("<15.5")) {
+    if (is_generalhw && is_aarch64 && !is_leap("<15.5")) {
         assert_screen 'jeos-please-configure-wifi';
         send_key 'n';
     }


### PR DESCRIPTION
since RPi2 is armv7 and without WiFi.

- Verification run: https://openqa.opensuse.org/t2751271
