### PR TITLE
Fix typo on django test check_version

### DIFF
--- a/tests/console/django.pm
+++ b/tests/console/django.pm
@@ -20,7 +20,7 @@ sub run {
     $self->select_serial_terminal;
 
     add_suseconnect_product("PackageHub", undef, undef, undef, 300, 1) if is_sle;
-    add_suseconnect_product(get_addon_fullname('desktop'), undef, undef, undef, 300, 1) if is_sle('=<15');
+    add_suseconnect_product(get_addon_fullname('desktop'), undef, undef, undef, 300, 1) if is_sle('<=15');
 
     zypper_call "in python3-Django";
 


### PR DESCRIPTION
Fix check_version syntax

- Related ticket: https://progress.opensuse.org/issues/117319
- Needles: none
- Verification run: https://openqa.suse.de/tests/9621431#details
- 
Fixes #15536 
