### PR TITLE
Be agnostic about the order of GREEN instances on NetWeaver install

### DIFF
--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -90,8 +90,13 @@ sub run {
              # Therefore we accept a failing return code and check the output instead.
              (
                  # This is the success pattern for newer versions (which succeed on install).
-                 msg_server,.MessageServer,.GREEN,.Running.*[\r\n]+
-                 enserver,.EnqueueServer,.GREEN,.Running.*[\r\n]+
+                 (
+                     enserver,.EnqueueServer,.GREEN,.Running.*[\r\n]+
+                     msg_server,.MessageServer,.GREEN,.Running.*[\r\n]+
+                 ) | (
+                     msg_server,.MessageServer,.GREEN,.Running.*[\r\n]+
+                     enserver,.EnqueueServer,.GREEN,.Running.*[\r\n]+
+                 )
                  .*[\r\n]+
                  .*[\r\n]+
                  Startup.of.instance.${sid}/.*.finished:.\[ACTIVE\]


### PR DESCRIPTION
The SAP NetWeaver install tests for running instances.
It must not matter which of the instances is listed first or second.

So, either 
```GetProcessList
OK
name, description, dispstatus, textstatus, starttime, elapsedtime, pid
msg_server, MessageServer, GREEN, Running, 2022 09 26 12:47:56, 0:00:08, 13686
enserver, EnqueueServer, GREEN, Running, 2022 09 26 12:47:56, 0:00:08, 13687

INFO       2022-09-26 12:48:04.685 (root/sapinst) (startInstallation) [iaxxbjsmod.cpp:83] id=nw.progress.instanceRunning
Startup of instance QAD/ASCS00 finished: [ACTIVE]. Elapsed time: 0:10 minutes.
```
or 
```
GetProcessList
OK
name, description, dispstatus, textstatus, starttime, elapsedtime, pid
enserver, EnqueueServer, GREEN, Running, 2022 09 28 00:18:40, 0:00:10, 14091
msg_server, MessageServer, GREEN, Running, 2022 09 28 00:18:40, 0:00:10, 14090

INFO       2022-09-28 00:18:50.552 (root/sapinst) (startInstallation) [iaxxbjsmod.cpp:83] id=nw.progress.instanceRunning
Startup of instance QAD/ASCS00 finished: [ACTIVE]. Elapsed time: 0:10 minutes.
```
shall be OK.

