### PR TITLE
InfiniBand: Add repositories to both machines and force update

### DIFF
--- a/tests/kernel/ibtests_prepare.pm
+++ b/tests/kernel/ibtests_prepare.pm
@@ -37,11 +37,11 @@ sub run {
     script_run('[ ! -f /root/.ssh/id_rsa ] && ssh-keygen -b 2048 -t rsa -q -N "" -f /root/.ssh/id_rsa');
 
 
-    if ($role eq 'IBTEST_MASTER') {
-        zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);
-        zypper_ar(get_required_var('SCIENCE_HPC_REPO'), no_gpg_check => 1, priority => 50) if get_var('SCIENCE_HPC_REPO', '');
-        $packages = $packages_master;
-    }
+    zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);
+    zypper_ar(get_var('SCIENCE_HPC_REPO'), no_gpg_check => 1, priority => 49) if get_var('SCIENCE_HPC_REPO', '');
+    zypper_call("ref");
+    zypper_call("dup --allow-vendor-change");
+    $packages = $packages_master if $role eq 'IBTEST_MASTER';
 
     zypper_call("in $packages", exitcode => [0, 65, 107]);
 


### PR DESCRIPTION
When we want to test against repositories like science:hpc we should a) enable this repository on both machines
and
b) make sure we switch packages over to the ones provided there.

Only this way we can be sure we are testing the complete stack provided from this repository. Plus, installation of packages fails with unresolved dependencies otherwise.

- Related ticket: https://progress.opensuse.org/issues/117334
- Needles: -
- Verification run: http://baremetal-support.qa.suse.de/tests/2416 and http://baremetal-support.qa.suse.de/tests/2417