### PR TITLE
 Fix record_info calls 

### DIFF
--- a/tests/console/journal_check.pm
+++ b/tests/console/journal_check.pm
@@ -70,7 +70,7 @@ sub run {
             } elsif ($bug_pattern->{$bug}->{type} eq 'ignore') {
                 bmwqemu::diag("Ignoring log message:\n$buffer\n");
             } else {
-                record_info("$bug:\n$buffer", result => 'softfail');
+                record_info($bug, $buffer, result => 'softfail');
             }
         }
     }
@@ -98,11 +98,11 @@ sub run {
             my $failed_service_output = script_output("systemctl status $service -l || true");
             foreach my $bsc (@matched_bugs) {
                 if ($failed_service_output =~ /$bug_pattern->{$bsc}->{description}/) {
-                    record_info("Service: $service failed due to $bsc\n$failed_service_output", result => 'softfail');
+                    record_info('Service:', "$service failed due to $bsc\n$failed_service_output", result => 'softfail');
                     next SRV;
                 }
             }
-            record_info "$service failed", $failed_service_output, result => 'fail';
+            record_info("$service failed", $failed_service_output, result => 'fail');
             $failed = 1;
         }
     }


### PR DESCRIPTION
Error:
```
[2022-09-28T16:13:47.911404+02:00] [info] ::: basetest::runtest: # Test
died: Odd name/value argument for subroutine 'testapi::record_info' at
opensuse/tests/console/journal_check.pm line 73.
    testapi::record_info("boo#1193426:\x{a}Aug 18 12:00:51.237727
localhost libapparmor[999"..., "result", "softfail") called at
opensuse/tests/console/journal_check.pm line 73"]")
```

- Verification runs: 
  * [opensuse-15.4-JeOS-for-RPi-aarch64](https://openqa.opensuse.org/tests/2758666)
  * [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-aarch64](https://openqa.suse.de/tests/9623418#step/journal_check/8)
