### PR TITLE
wicked-sysctl: Fix dummy creation

### DIFF
--- a/tests/wicked/sysctl/sut/t02_sysctl_check_defaults.pm
+++ b/tests/wicked/sysctl/sut/t02_sysctl_check_defaults.pm
@@ -77,7 +77,8 @@ EOT
     script_run('systemctl disable --now wickedd', die_on_timeout => 1);
     $self->reboot();
 
-    assert_script_run('ip link add type dummy');
+    assert_script_run('modprobe dummy numdummies=0');
+    assert_script_run('ip link add dummy0 type dummy');
     my $out_native = script_output($cmd);
 
     $self->record_console_test_result("Sysctl Native", $out_native, result => 'ok');


### PR DESCRIPTION
If there is no modprobe rule to load dummy module with
```
options dummy numdummies=0
```
then a default dummy will be created. Some older SUSE versions doesn't have such rule e.g. in /lib/modprobe.d/systemd.conf, so we need to take care of it manually.

- Verification run: http://openqa.wicked.suse.de/tests/79523 
