### PR TITLE
Don't install cockpit-wicked in ALP

### DIFF
--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -13,7 +13,7 @@ use testapi;
 use transactional;
 use utils qw(systemctl);
 use mm_network qw(is_networkmanager);
-use version_utils qw(is_microos is_sle_micro is_leap_micro);
+use version_utils qw(is_microos is_sle_micro is_leap_micro is_alp);
 
 sub run {
     my ($self) = @_;
@@ -33,7 +33,7 @@ sub run {
         push @pkgs, 'cockpit-networkmanager';
     }
 
-    if (!is_microos && (script_run('rpm -q cockpit-wicked') != 0)) {
+    if (!is_microos && !is_alp && (script_run('rpm -q cockpit-wicked') != 0)) {
         push @pkgs, 'cockpit-wicked';
     }
 


### PR DESCRIPTION
Do not attempt to install `cockpit-wicked` in ALP runs as the `wicked` is not used in this product. `NetworkManager` is the preferred package.

https://build.opensuse.org/package/view_file/SUSE:ALP/ALP/ALP.kiwi?expand=1

- Verification run: https://openqa.opensuse.org/tests/2764342#step/cockpit_service/14
