### PR TITLE
Fix libjpeg conflict on updinstall

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -64,6 +64,7 @@ sub has_conflict {
         'SAPHanaSR-ScaleOut-doc' => 'SAPHanaSR-doc',
         'dapl-devel' => 'dapl-debug-devel',
         'libdat2-2' => 'dapl-debug-libs',
+        'libjpeg8-devel' => 'libjpeg62-devel',
         dapl => 'dapl-debug'
     );
     return $conflict{$binary};


### PR DESCRIPTION
Fix libjpeg conflict on updinstall

- Related ticket: https://progress.opensuse.org/issues/117361
- Needles: none 
- Verification run: https://openqa.suse.de/tests/9628498#details
