### PR TITLE
Add SLE 15-SP5 SEV-ES guest profile

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_kvm_hvm_sev_es_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_kvm_hvm_sev_es_x86_64.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>sles</guest_os_name>
-    <guest_version>15-sp3</guest_version>
+    <guest_version>15-sp5</guest_version>
     <guest_version_major>15</guest_version_major>
-    <guest_version_minor>3</guest_version_minor>
+    <guest_version_minor>5</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build>gm</guest_build>
+    <guest_build></guest_build>
     <host_hypervisor_uri></host_hypervisor_uri>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
@@ -24,7 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP3-Full-x86_64-GM-Media1/</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP5-Full-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/ovmf-x86_64-vars.bin</guest_boot_settings>
     <guest_secure_boot>false</guest_secure_boot>
@@ -84,7 +84,7 @@
     <guest_autoconsole>text</guest_autoconsole>
     <guest_noreboot></guest_noreboot>
     <guest_default_target>graphical</guest_default_target>
-    <guest_do_registration>true</guest_do_registration>
+    <guest_do_registration>false</guest_do_registration>
     <guest_registration_server></guest_registration_server>
     <guest_registration_username>www@suse.com</guest_registration_username>
     <guest_registration_password></guest_registration_password>

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -1444,7 +1444,7 @@ sub config_guest_installation_extra_args {
 
     if (is_transactional and $self->{guest_os_name} eq 'slem') {
         record_soft_failure("bsc#1202405 - SLE Micro 5.3 media can not be successfully loaded automatically for virtual machine installation");
-        $self->{guest_installation_extra_args_options} = $self->{guest_installation_extra_args_options} . "--extra-args \"install=$self->{guest_installation_media}\"";
+        $self->{guest_installation_extra_args_options} = $self->{guest_installation_extra_args_options} . " --extra-args \"install=$self->{guest_installation_media}\"";
     }
 
     if (($self->{guest_installation_automation} ne '') and ($self->{guest_installation_automation_file} ne '')) {


### PR DESCRIPTION
* **Add** SLE 15-SP5 SEV-ES guest profile sles_15_sp5_64_kvm_hvm_sev_es_x86_64.xml for openQA test suites sev-es-gi-guest_developing-on-host_developing-kvm and sev-es-gi-guest_developing-on-host_sles15sp4-kvm. 

* **At** the same time, remove outdated SLE 15-SP3 guest profile sles_15_sp3_64_kvm_hvm_sev_es_x86_64.xml.

* **Insert** a space into --extra-args workaround to make sure virt-install command concatenation works under any circumstances.

* **Verification runs:**
  * [sles15sp5 on sles15sp4](https://openqa.suse.de/tests/9634003)
  * [slem test](https://openqa.suse.de/tests/9634205)
  * sev/sev-es guest installation fails on sles15sp5 due to bsc#1203923
