### PR TITLE
Remove swap from disk layout for container host

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -163,6 +163,7 @@
           <format config:type="boolean">true</format>
           <fstopt>umask=0002,utf8=true</fstopt>
           <mount>/boot/efi</mount>
+          <size>512M</size>
         </partition>
         % }
         <partition>
@@ -181,6 +182,7 @@
           <format config:type="boolean">true</format>
           <fstopt>defaults</fstopt>
           <mount>/</mount>
+          <size>max</size>
         </partition>
       </partitions>
       <use>all</use>


### PR DESCRIPTION
The container host uses a swap partition that consumes half of the available disk space (30GB). This commit removes the swap partition, which is anyways not needed for the container tests.

- Related ticket: https://progress.opensuse.org/issues/117373
- Verification run: https://duck-norris.qam.suse.de/t10878
