### PR TITLE
Move generic k8s tools to k8s library from k8sbasetest

### DIFF
--- a/lib/publiccloud/k8sbasetest.pm
+++ b/lib/publiccloud/k8sbasetest.pm
@@ -14,7 +14,7 @@ use testapi;
 use warnings;
 use strict;
 use utils qw(random_string);
-use containers::k8s qw(install_kubectl);
+use containers::k8s qw(install_kubectl apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log);
 
 =head2 init
 
@@ -32,53 +32,6 @@ sub init {
 
     $self->provider_factory(provider => $args{provider}, service => $args{service});
 }
-
-=head2 apply_manifest
-
-Apply a kubernetes manifest
-=cut
-
-sub apply_manifest {
-    my ($self, $manifest) = @_;
-
-    my $path = sprintf('/tmp/%s.yml', random_string(32));
-
-    script_output("echo -e '$manifest' > $path");
-    upload_logs($path, failok => 1);
-
-    assert_script_run("kubectl apply -f $path");
-}
-
-=head2 find_pods
-
-Find pods using kubectl queries
-=cut
-
-sub find_pods {
-    my ($self, $query) = @_;
-    return script_output("kubectl get pods --no-headers -l $query -o custom-columns=':metadata.name'");
-}
-
-=head2 wait_for_job_complete
-
-Wait until the job is complete
-=cut
-
-sub wait_for_job_complete {
-    my ($self, $job) = @_;
-    assert_script_run("kubectl wait --for=condition=complete --timeout=300s job/$job");
-}
-
-=head2 validate_log
-
-Validates that the logs contains a text
-=cut
-
-sub validate_log {
-    my ($self, $pod, $text) = @_;
-    validate_script_output("kubectl logs $pod 2>&1", qr/$text/);
-}
-
 
 =head2 get_k8s_service_name
 

--- a/tests/containers/run_container_in_k8s.pm
+++ b/tests/containers/run_container_in_k8s.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'publiccloud::k8sbasetest';
 use testapi;
+use containers::k8s qw(apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log);
 
 sub run {
     my ($self, $run_args) = @_;
@@ -47,18 +48,18 @@ spec:
             cpu: "0.5"
             memory: 256Mi
           requests:
-            cpu: "0.1"
+            cpu: "0.1"  
             memory: 128Mi
       restartPolicy: Never
   backoffLimit: 4
 EOT
 
     record_info('Manifest', "Applying manifest:\n$manifest");
-    $self->apply_manifest($manifest);
-    $self->wait_for_job_complete($job_name);
-    my $pod = $self->find_pods("job-name=$job_name");
+    apply_manifest($manifest);
+    wait_for_k8s_job_complete($job_name);
+    my $pod = find_pods("job-name=$job_name");
     record_info('Pod', "Container (POD) successfully created.\n$pod");
-    $self->validate_log($pod, "SUSE Linux Enterprise Server");
+    validate_pod_log($pod, "SUSE Linux Enterprise Server");
     record_info('cmd', "Command `$cmd` successfully executed in the image.");
 }
 


### PR DESCRIPTION
In order to use these tools without having a test with k8sbasetest as base. The best option is to move these tools to k8s library

- Related ticket: https://progress.opensuse.org/issues/117004
- Verification run: https://openqa.suse.de/tests/9646619
