### PR TITLE
Add new yaml schedules for security maintenance

### DIFF
--- a/schedule/security/fips_strongswan_maint.yaml
+++ b/schedule/security/fips_strongswan_maint.yaml
@@ -1,0 +1,27 @@
+name: fips_strongswan
+description:    >
+    This is for testing strongswan in fips mode
+schedule:
+    - '{{bootloader_zkvm}}'
+    - boot/boot_to_desktop
+    - '{{setup_multimachine}}'
+    - console/consoletest_setup
+    - fips/fips_setup
+    - '{{strongswan}}'
+conditional_schedule:
+    bootloader_zkvm:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    setup_multimachine:
+        ARCH:
+            aarch64:
+                - network/setup_multimachine
+            x86_64:
+                - network/setup_multimachine
+    strongswan:
+        HOSTNAME:
+            server:
+                - fips/strongswan/strongswan_server
+            client:
+                - fips/strongswan/strongswan_client

--- a/schedule/security/stunnel_fips_maint.yaml
+++ b/schedule/security/stunnel_fips_maint.yaml
@@ -1,0 +1,9 @@
+name: stunntl fips test
+description: >
+    Update stunnel to 5.59
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - network/setup_multimachine
+    - fips/fips_setup
+    - fips/stunnel

--- a/schedule/security/xca_fips_maint.yaml
+++ b/schedule/security/xca_fips_maint.yaml
@@ -1,0 +1,8 @@
+name: xca fips test
+description: >
+    xca basic function tests in FIPS mode
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - fips/fips_setup
+    - fips/xca


### PR DESCRIPTION
`test_repo_setup.pm` to be removed from maintenance tests, as it is only related to product testing

- Related ticket: https://progress.opensuse.org/issues/116956
- Needles: N/A
- Verification run: N/A
