### PR TITLE
Schedule only container related test modules

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -241,5 +241,5 @@ sub load_container_tests {
         }
     }
     loadtest 'containers/bci_logs' if (get_var('BCI_TESTS'));
-    loadtest 'console/coredump_collect' unless (is_public_cloud || is_jeos || is_sle_micro || is_microos || is_leap_micro || get_var('BCI_TESTS') || is_ubuntu_host || is_expanded_support_host);
+    loadtest 'console/coredump_collect' unless (is_public_cloud || is_jeos || is_sle_micro || is_microos || is_leap_micro || is_alp || get_var('BCI_TESTS') || is_ubuntu_host || is_expanded_support_host);
 }

--- a/products/alp/main.pm
+++ b/products/alp/main.pm
@@ -35,7 +35,6 @@ sub load_selfinstall_boot_tests {
 }
 
 sub load_common_tests {
-    loadtest 'transactional/host_config';
     loadtest 'transactional/enable_selinux';
     loadtest 'microos/networking';
     loadtest 'microos/libzypp_config';
@@ -67,10 +66,17 @@ if (get_var('BOOT_HDD_IMAGE')) {
     load_selfinstall_boot_tests;
 }
 
-load_common_tests;
-load_transactional_tests;
-load_container_tests() if (is_container_test());
+loadtest 'transactional/host_config';
 
+# Unless specified otherwise load standard tests only
+if (is_container_test()) {
+    load_container_tests();
+} else {
+    load_common_tests;
+    load_transactional_tests;
+}
+
+# Enclosing test cases
 loadtest 'console/journal_check';
 loadtest 'shutdown/shutdown';
 


### PR DESCRIPTION
[alp-0.1-kvm-x86_64-Build14.5-containers@64bit](https://openqa.opensuse.org/tests/2753195) schedules complete set of tests with container tests at the end. This PR should restrict basic tests that should be executed in `alp_default` test suite only.

- VRs:
  * [alp_default](http://kepler.suse.cz/tests/19243#)
  * [alp_containers](http://kepler.suse.cz/tests/19244#step/journal_check/1)
