### PR TITLE
Fix missing is_sle in yast2_bootloader

### DIFF
--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -17,6 +17,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'type_string_slow_extended';
+use version_utils 'is_sle';
 
 sub run {
     select_console 'x11';


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15585#issuecomment-1264323002