### PR TITLE
Fix redis-cli get foo nil output

### DIFF
--- a/tests/console/redis.pm
+++ b/tests/console/redis.pm
@@ -37,7 +37,7 @@ sub run {
     validate_script_output('redis-cli get foo', sub { m/bar/ });
     validate_script_output('redis-cli pfselftest', sub { m/OK/ });
     validate_script_output('redis-cli flushdb', sub { m/OK/ });
-    validate_script_output('redis-cli get foo', sub { m/(nil)/ });
+    validate_script_output('redis-cli get foo', sub { !m/bar/ });
 
     assert_script_run 'curl -O ' . data_url('console/movies.redis');
     assert_script_run('redis-cli -h localhost -p 6379 < ./movies.redis');


### PR DESCRIPTION
As the serial console is handled differently on svirt backends it is not possible to check for `nil`.

- Related ticket: [poo#116773](https://progress.opensuse.org/issues/116773)
- Previous attempt: #15592
- Verification run: [svirt](https://openqa.suse.de/tests/9645893#step/redis/15), [qemu](https://openqa.suse.de/tests/9645894#step/redis/18)
