### PR TITLE
yast2_users: send enter before clearing console

### DIFF
--- a/tests/security/yast2_users/add_users.pm
+++ b/tests/security/yast2_users/add_users.pm
@@ -74,6 +74,9 @@ sub run {
     # If no, check the user was created successfully
     assert_screen("Yast2-Users-Add-User-Created");
     wait_screen_change { send_key "alt-o" };
+    # Until bsc#1202053 is fixed, we need to send "enter" a couple of times before we can clear the console
+    send_key "ret";
+    send_key "ret";
 
     # Enhence code for stability: avoid time racing
     clear_console;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/117163
- Verification run: https://openqa.suse.de/tests/9646051