### PR TITLE
[WIP] Windows search feature fails to find WSL sometimes :construction:

### DIFF
--- a/tests/wsl/install_from_MSStore.pm
+++ b/tests/wsl/install_from_MSStore.pm
@@ -95,7 +95,17 @@ sub run {
     );
 
     $self->use_search_feature(get_var('WSL_VERSION'));
-    assert_and_click 'SUSE-wsl-search';
+    assert_screen [('SUSE-wsl-search', 'SUSE-wsl-search-failed')];
+    if (match_has_tag('SUSE-wsl-search')) {
+        assert_and_click 'SUSE-wsl-search';
+    } else {
+        # If SUSE WSL does not appear in the search, the best solution seems to
+        # be a reboot...
+        $self->reboot_or_shutdown(1);
+        $self->wait_boot_windows;
+        $self->use_search_feature(get_var('WSL_VERSION'));
+        assert_and_click 'SUSE-wsl-search';
+    }
 }
 
 1;


### PR DESCRIPTION
If SUSE WSL does not appear in the search, the best solution seems to be a reboot...

- Related ticket: https://progress.opensuse.org/issues/116470
- Needles:
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/SUSE-wsl-search-failed-20221003.png
- Verification run: [*in progress*](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=vr_116470)
