### PR TITLE
Increase installation timeout for containers

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -19,7 +19,7 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
     my $interface;
-    my $update_timeout = 1200;
+    my $update_timeout = 2400;    # aarch64 takes sometimes 20-30 minutes for completion
     my ($version, $sp, $host_distri) = get_os_release;
     my $engine = get_required_var('CONTAINER_RUNTIME');
 


### PR DESCRIPTION
Updating a system runs sometimes into timeouts on aarch64. This commit increases the timeout for the installation to avoid those issues.

- Related failure: https://openqa.suse.de/tests/9647221#step/host_configuration/24
- Verification run: https://duck-norris.qam.suse.de/tests/10886#step/host_configuration/1
