### PR TITLE
Add Trento test for number of connected nodes

### DIFF
--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -2,6 +2,9 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Warnings;
+use List::Util qw(any);
+
+use testapi qw(set_var);
 
 use trento;
 
@@ -10,14 +13,16 @@ my $trento = Test::MockModule->new('trento', no_auto => 1);
 my @calls;
 my @logs;
 $trento->redefine(script_run => sub { push @calls, $_[0]; return 'PATATINE'; });
-#$trento->redefine(get_current_job_id => sub { return 'canetto'} );
-$trento->redefine(get_trento_ip => sub { return '42.42.42.42' });
+$trento->redefine(enter_cmd => sub { push @calls, $_[0]; return 'PATATINE'; });
+$trento->redefine(type_password => sub { push @calls, $_[0]; return 'PATATINE'; });
+
 $trento->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 $trento->redefine(upload_logs => sub { push @logs, @_; });
 
 subtest '[k8s_logs] None of the pods are for any of the required trento-server' => sub {
     # Only one PANINO pod is running in the cluster
     $trento->redefine(script_output => sub { push @calls, $_[0]; return 'PANINO'; });
+    $trento->redefine(get_trento_ip => sub { return '42.42.42.42' });
 
     # Ask for the log of trento-server-web and trento-server-runner (none of them in the list of running pods)
     k8s_logs(qw(web runner));
@@ -41,14 +46,117 @@ subtest '[k8s_logs] Get logs from running pods as it is also required' => sub {
 
 subtest '[get_vnet] get_vnet has to call az and return a vnet' => sub {
     @calls = ();
-    $trento->redefine(script_output => sub { push @calls, $_[0]; return 'PIZZANET'; });
+    my $expected_net_name = 'PIZZANET';
+    $trento->redefine(script_output => sub { push @calls, $_[0]; return $expected_net_name; });
 
     my $net_name = get_vnet(qw(GELATOGROUP));
 
     note(join("\n  1C-->  ", @calls));
     like $calls[0], qr/az network vnet list -g GELATOGROUP --query "\[0\]\.name" -o tsv/, 'AZ command';
-    ok $net_name eq 'PIZZANET', 'Directly return the script_output return string';
+    ok $net_name eq $expected_net_name, 'expected_net_name:' . $expected_net_name . ' but get net_name:' . $net_name;
 };
 
+subtest '[get_trento_deployment] with TRENTO_DEPLOY_VER' => sub {
+    @calls = ();
+
+    my $password = 'MAIONESE';
+    my @recorded_passwords;
+    $trento->redefine(type_password => sub { push @recorded_passwords, $_[0]; });
+    $trento->redefine(assert_script_run => sub { push @calls, $_[0]; return 'PATATINE'; });
+
+    my $gitlab_prj_id = 'MORTADELLA';
+    my $gitlab_ver = 'TARTINE1.2.3';
+    my $gitlab_sha = 'OLIVE';
+    my $gitlag_tar = 'ARANCINO.tar.gz';
+
+    $trento->redefine(script_output => sub {
+            push @calls, $_[0];
+            # curl -s -H @gitlab_conf "https://gitlab.suse.de/api/v4/projects/qa-css%2Ftrento"
+            if ($_[0] =~ /curl.*api\/v4\/projects\/qa-css.*/) { return "{\"id\":\"$gitlab_prj_id\"}"; }
+
+            # curl -s -H @gitlab_conf https://gitlab.suse.de/api/v4/projects/7183/releases/v0.2.0
+            # {"assets": {"sources": [{"format": "tar.gz", "url": "https://gitlab.suse.de/qa-css/trento/-/archive/v0.2.0/trento-v0.2.0.tar.gz"}]}}
+            if ($_[0] =~ /curl.*api\/v4\/projects\/$gitlab_prj_id\/releases\/v$gitlab_ver.*jq.*assets/) { return $gitlag_tar; }
+            if ($_[0] =~ /curl.*api\/v4\/projects\/$gitlab_prj_id\/releases\/v$gitlab_ver.*jq.*commit/) { return $gitlab_sha; }
+            return '';
+    });
+    set_var('TRENTO_DEPLOY_VER', $gitlab_ver);
+    set_var('_SECRET_TRENTO_GITLAB_TOKEN', $password);
+    get_trento_deployment('self', '/tmp');
+    note(join("\n  1C-->  ", @calls));
+    like $recorded_passwords[0], qr/$password/;
+    ok any { /curl.*api\/v4\/projects\/$gitlab_prj_id\/repository\/.*sha=$gitlab_sha.*--output $gitlag_tar/ } @calls;
+    ok any { /tar.*$gitlag_tar/ } @calls;
+};
+
+subtest '[get_trento_ip] check the az command' => sub {
+    @calls = ();
+    $trento->redefine(get_current_job_id => sub { return 'PASTICCINO'; });
+    $trento->redefine(script_output => sub { push @calls, $_[0]; return 'GINGERINO'; });
+
+    my $out = get_trento_ip();
+    note(join("\n  1C-->  ", @calls));
+    is $out, 'GINGERINO', 'get_trento_ip output as expected';
+    like $calls[0], qr/az vm show -d -g .*PASTICCINO -n .*PASTICCINO --query "publicIps" -o tsv/;
+};
+
+subtest '[cypress_configs]' => sub {
+    @calls = ();
+    $trento->redefine(assert_script_run => sub { push @calls, $_[0]; return 'PATATINE'; });
+    $trento->redefine(get_trento_ip => sub { return '43.43.43.43' });
+    $trento->redefine(get_trento_password => sub { return 'SPUMA_DI_TONNO'; });
+    my $nodes = 42;
+    $trento->redefine(get_agents_number => sub { return $nodes; });
+
+    my $ver = '9.8.7';
+    set_var('TRENTO_VERSION' => $ver);
+    cypress_configs('/FESTA/BANCONE/SPREMUTA');
+    note(join("\n -->  ", @calls));
+    ok any { /cypress\.env\.py -u .*43\.43\.43\.43 -p SPUMA_DI_TONNO -f Premium -n $nodes --trento-version $ver/ } @calls;
+};
+
+subtest '[get_agents_number]' => sub {
+    @calls = ();
+    my $cloud_provider = 'POLPETTE';
+    set_var('PUBLIC_CLOUD_PROVIDER' => $cloud_provider);
+    set_var('QESAP_CONFIG_FILE' => 'MELANZANE_FRITTE');
+
+
+    my $tmp_folder = '/FESTA';
+    note("-->tmp_folder=$tmp_folder");
+    set_var('QESAP_DEPLOYMENT_DIR' => $tmp_folder);
+
+
+    my $inv_path = "$tmp_folder/terraform/" . lc $cloud_provider . '/inventory.yaml';
+    note("-->inv_path=$inv_path");
+
+    my $str = <<END;
+all:
+  children:
+    hana:
+      hosts:
+        vmhana01:
+          ansible_host: 1.2.3.4
+          ansible_python_interpreter: /usr/bin/python3
+        vmhana02:
+          ansible_host: 1.2.3.5
+          ansible_python_interpreter: /usr/bin/python3
+
+    iscsi:
+      hosts:
+        vmiscsi01:
+          ansible_host: 1.2.3.6
+          ansible_python_interpreter: /usr/bin/python3
+
+  hosts: null
+END
+
+    $trento->redefine(script_output => sub { push @calls, $_[0]; return $str; });
+    my $res = get_agents_number();
+
+    note(join("\n -->  ", @calls));
+    is $res, 3, 'Number of agents like expected';
+    like $calls[0], qr/cat $inv_path/;
+};
 
 done_testing;

--- a/tests/sles4sap/trento/install_agents.pm
+++ b/tests/sles4sap/trento/install_agents.pm
@@ -21,8 +21,14 @@ sub run {
       ' -u admin' .
       ' -p ' . $self->get_trento_password() .
       ' -i ' . $self->get_trento_ip() .
-      " -d $wd";
-    my $agent_api_key = script_output($cmd);
+      " -d $wd -v";
+    my $agent_api_key;
+    my @lines = split(/\n/, script_output($cmd));
+    foreach my $line (@lines) {
+        if ($line =~ /api_key:(.*)/) {
+            $agent_api_key = $1;
+        }
+    }
 
     $cmd = $self->install_agent($wd, '/root/test', $agent_api_key, '10.0.0.4');
 }

--- a/tests/sles4sap/trento/setup_jumphost.pm
+++ b/tests/sles4sap/trento/setup_jumphost.pm
@@ -12,7 +12,6 @@ use testapi;
 use utils 'zypper_call';
 use base 'trento';
 
-use constant GITLAB_CLONE_LOG => '/tmp/gitlab_clone.log';
 
 sub run {
     my ($self) = @_;
@@ -31,22 +30,14 @@ sub run {
     # If 'az' is pre installed, we test that version
     assert_script_run('az --version');
 
-    # Get the code for the Trento deployment
-    my $gitlab_repo = get_var(TRENTO_GITLAB_REPO => 'gitlab.suse.de/qa-css/trento');
+    my $work_dir = '/root/test';
+    enter_cmd "mkdir $work_dir";
 
-    # The usage of a variable with a different name is to
-    # be able to overwrite the token when manually triggering
-    # the setup_jumphost test.
-    #
-    # Note: this test is mostly only used to create
+    # Note about TRENTO_GITLAB_TOKEN: this test is mostly only used to create
     # a HDD image; part of this test and the qcow2 image is this cloned repo.
     # The key is part of the cloned repo itself so TRENTO_GITLAB_TOKEN (for the moment)
     # cannot be changed as running init_jumphost
-    my $gitlab_token = get_var(TRENTO_GITLAB_TOKEN => get_required_var('_SECRET_TRENTO_GITLAB_TOKEN'));
-
-    my $gitlab_clone_cmd = 'https://git:' . $gitlab_token . '@' . $gitlab_repo;
-    enter_cmd 'mkdir ${HOME}/test && cd ${HOME}/test';
-    assert_script_run("git clone $gitlab_clone_cmd . | tee " . GITLAB_CLONE_LOG);
+    $self->clone_trento_deployment($work_dir);
 
     # Cypress.io installation
     $self->cypress_install_container($self->cypress_version);
@@ -54,8 +45,6 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    # $self->select_serial_terminal;
-    upload_logs(GITLAB_CLONE_LOG);
     upload_logs($self->PODMAN_PULL_LOG);
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -17,21 +17,10 @@ sub run {
     die "Only AZURE deployment supported for the moment" unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
     $self->select_serial_terminal;
 
-    my $machine_ip = $self->get_trento_ip;
-    my $trento_web_password = $self->get_trento_password;
-
     my $cypress_test_dir = "/root/test/test";
     enter_cmd "cd " . $cypress_test_dir;
-    my $cypress_env_cmd = './cypress.env.py' .
-      " -u http://$machine_ip" .
-      " -p $trento_web_password" .
-      ' -f Premium';
-    if (get_var('TRENTO_VERSION')) {
-        $cypress_env_cmd .= ' --trento-version ' . get_var('TRENTO_VERSION');
-    }
-    assert_script_run($cypress_env_cmd);
-    assert_script_run('cat cypress.env.json');
-    upload_logs('cypress.env.json');
+
+    trento::cypress_configs($cypress_test_dir);
     assert_script_run "mkdir " . $self->CYPRESS_LOG_DIR;
 
     #  Cypress verify: cypress.io self check about the framework installation

--- a/variables.md
+++ b/variables.md
@@ -229,7 +229,9 @@ TRENTO_DEPLOY_VER | string | | Force the Trento deployment script to be used fro
 TRENTO_AGENT_REPO | string | https://dist.suse.de/ibs/Devel:/SAP:/trento:/factory/SLE_15_SP3/x86_64 | Repository where to get the trento-agent installer
 TRENTO_AGENT_RPM | string | | Trento-agent rpm file name
 TRENTO_EXT_DEPLOY_IP | string | | Public IP of a Trento web instance not deployed by openQA
-TRENTO_WEB_PASSWORD | string | | Trento web password for the admin user
+TRENTO_WEB_PASSWORD | string | | Trento web password for the admin user. If not provided, random generated one.
+TRENTO_CLUSTER_OS_VER | string | | OS for nodes in SAP cluster.
+
 
 ### Publiccloud specific variables
 


### PR DESCRIPTION
Change test code to handle cypress.env.py to also accept expected number of connected nodes.
Add more unit testing for trento lib.
Rename setting QESAPDEPLOY_OS_VER to TRENTO_CLUSTER_OS_VER. Get_api_key script in verbose mode.

- Verification run: http://openqaworker15.qa.suse.cz/tests/48372   http://1c242.qa.suse.de/tests/1170 http://1c242.qa.suse.de/tests/1179
