### PR TITLE
Add run for installing updates on container host

### DIFF
--- a/schedule/containers/create_hdd_autoyast.yaml
+++ b/schedule/containers/create_hdd_autoyast.yaml
@@ -21,6 +21,7 @@ schedule:
     - autoyast/logs
     - autoyast/save_y2logs
     - '{{grub_set_bootargs}}'
+    - containers/install_updates
     - shutdown/cleanup_before_shutdown
     - shutdown/shutdown
     - '{{svirt_upload_assets}}'

--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Install available updates on the host image
+# Maintainer: qac team <qa-c@suse.de>
+
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use utils;
+use power_action_utils;
+use version_utils qw(check_os_release get_os_release is_sle);
+
+sub run {
+    my ($self) = @_;
+    my $update_timeout = 2400;
+    my ($version, $sp, $host_distri) = get_os_release;
+
+    # Update the system to get the latest released state of the hosts.
+    # Check routing table is well configured
+    if ($host_distri =~ /sles|opensuse/) {
+        zypper_call("--quiet up", timeout => $update_timeout);
+        ensure_ca_certificates_suse_installed() if is_sle();
+    } elsif ($host_distri eq 'ubuntu') {
+        # Sometimes, the host doesn't get an IP automatically via dhcp, we need force it just in case
+        assert_script_run("dhclient -v");
+        script_retry("apt-get update -qq -y", timeout => $update_timeout);
+    } elsif ($host_distri eq 'centos') {
+        assert_script_run("dhclient -v");
+        script_retry("yum update -q -y --nobest", timeout => $update_timeout);
+    } elsif ($host_distri eq 'rhel') {
+        script_retry("yum update -q -y", timeout => $update_timeout);
+    } else {
+        die "Unsupported OS version";
+    }
+
+    # Perform system reboot to ensure the system is still ok
+    my $prev_console = current_console();
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(bootloader_time => 300);
+    select_console($prev_console);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Adds a module for installing current system updates when creating the container test system images.

- Related ticket: https://progress.opensuse.org/issues/117517
- Verification run: [ sle-15-SP4-Container-Host-x86_64](https://duck-norris.qam.suse.de/tests/10899) | [sle-15-SP4-Container-Host-aarch64](https://openqa.suse.de/tests/9651514) | [sle-15-SP4-Container-Host-ppc64le](https://openqa.suse.de/t9651348) | [sle-15-SP4-Container-Host-s390x](https://openqa.suse.de/t9651349)
