### PR TITLE
[WIP] Windows search feature fails to find WSL sometimes :construction:

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -170,4 +170,30 @@ sub install_wsl2_kernel {
     );
 }
 
+sub reset_search_bar {
+    my $self = shift;
+
+    # Plan B: download the MS provided script
+    # "https://www.microsoft.com/en-us/download/confirmation.aspx?id=100295"
+
+    # Open the help dialog
+    $self->open_powershell_as_admin;
+    $self->run_in_powershell(
+        cmd => 'msdt.exe -ep WindowsHelp id SearchDiagnostic'
+    );
+    assert_and_click('search-bar-restart-next');
+    assert_and_click('search-bar-restart-choose');
+    assert_and_click('search-bar-restart-next');
+    assert_and_click('search-bar-restart-finish', timeout => 120);
+
+    $self->run_in_powershell(
+        cmd => q{$port.close()},
+        code => sub { }
+    );
+    $self->run_in_powershell(
+        cmd => 'exit',
+        code => sub { }
+    );
+}
+
 1;

--- a/tests/wsl/install_from_MSStore.pm
+++ b/tests/wsl/install_from_MSStore.pm
@@ -93,9 +93,25 @@ sub run {
         cmd => q{$port.close()},
         code => sub { }
     );
+    $self->run_in_powershell(
+        cmd => 'exit',
+        code => sub { }
+    );
 
+    $self->reset_search_bar;
     $self->use_search_feature(get_var('WSL_VERSION'));
     assert_and_click 'SUSE-wsl-search';
+    # $self->use_search_feature(get_var('WSL_VERSION'));
+    # assert_screen [('SUSE-wsl-search', 'SUSE-wsl-search-failed')];
+    # if (match_has_tag('SUSE-wsl-search')) {
+    #     assert_and_click 'SUSE-wsl-search';
+    # } else {
+    #     # If SUSE WSL does not appear in the search, the best solution seems to
+    #     # be a reboot...
+    #     $self->reset_search_bar;
+    #     $self->use_search_feature(get_var('WSL_VERSION'));
+    #     assert_and_click 'SUSE-wsl-search';
+    # }
 }
 
 1;


### PR DESCRIPTION
If SUSE WSL does not appear in the search, the best solution seems to be restarting the search bar

- Related ticket: https://progress.opensuse.org/issues/116470
- Needles:
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/SUSE-wsl-search-failed-20221003.png
- Verification run: [*in progress*](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=vr_116470)
