### PR TITLE
Expand kernel mismatch message

### DIFF
--- a/tests/console/systemtap.pm
+++ b/tests/console/systemtap.pm
@@ -28,7 +28,7 @@ sub run {
         my $kernel_d = script_output('uname -r | grep -oP ".*(?=-default)"');
         my $dev = zypper_call("se -i -s kernel-default-devel", exitcode => [0, 104]);
         if ($dev ne '104') {
-            die "Installed kernel-devel does not match kernel version.\nExpected: $kernel_d, Found: Other kernel-default-devel versions";
+            die "Installed kernel-devel does not match kernel version. This usually happens when there's a new kernel, wait a day to see if the image is updated \nExpected: $kernel_d, Found: Other kernel-default-devel versions";
         } else {
             die "kernel-devel package is required but not installed\nExpected: $kernel_d, Found: No kernel-default-devel package installed";
         }


### PR DESCRIPTION
Expands the error message when the kernel doesn't match the kernel-default-devel version, which usually happens briefly when there's a new kernel, to better inform testers.

- Related ticket: https://progress.opensuse.org/issues/116860
- Verification run: (tbd - but it's just a string expansion, so everything is expected to be ok)
