### PR TITLE
Expect correct cockpit module

### DIFF
--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -29,13 +29,19 @@ sub run {
         push @pkgs, 'cockpit';
     }
 
-    if (is_networkmanager && (script_run('rpm -q cockpit-networkmanager') != 0)) {
-        push @pkgs, 'cockpit-networkmanager';
+    if (is_networkmanager) {
+        if (script_run('rpm -q cockpit-networkmanager') != 0) {
+            push @pkgs, 'cockpit-networkmanager';
+        }
+    } else {
+        if (is_microos || is_alp || is_leap_micro('5.3+') || is_sle_micro('5.3+')) {
+            die sprintf('NetworkManager should be used by %s %s', get_var('DISTRI'), get_var('VERSION'));
+        }
+        if (script_run('rpm -q cockpit-wicked') != 0) {
+            push @pkgs, 'cockpit-wicked';
+        }
     }
 
-    if (!is_microos && !is_alp && (script_run('rpm -q cockpit-wicked') != 0)) {
-        push @pkgs, 'cockpit-wicked';
-    }
 
     unless (is_sle_micro('<5.2') || is_leap_micro('<5.2')) {
         push @pkgs, qw(cockpit-machines cockpit-tukit);


### PR DESCRIPTION
Starting with `{leap/sle}-micro 5.3` wicked is being dropped and replaced by `NetworkManager`. MicroOS and ALP will have no support for wicked at all.

##### Verification runs: 

* [leap-micro-5.3-MicroOS-Image-x86_64-Build5.1](http://kepler.suse.cz/tests/19275#step/cockpit_service/12)
* [sle-micro-5.3-Default-x86_64-Build44.1_20.9](http://kepler.suse.cz/tests/19269#step/cockpit_service/12)
* [sle-micro-5.1-MicroOS-Image-Updates-x86_64-Build20221003-1](http://kepler.suse.cz/tests/19270#step/cockpit_service/9)
* [sle-micro-5.2-MicroOS-Image-Updates-x86_64-Build20221003-1](http://kepler.suse.cz/tests/19271#step/cockpit_service/12)
* [TW-MicroOS](http://kepler.suse.cz/tests/19267#step/cockpit_service/13)
* [ALP](http://kepler.suse.cz/tests/19273#step/cockpit_service/11)