### PR TITLE
Update migration test case for SLEM5.3

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -47,7 +47,9 @@ sub run {
     # start migration
     if (is_sle_micro) {
         # We need to stop and disable apparmor service before migration due to bsc#1197368
-        systemctl('disable --now apparmor.service');
+        if (script_run('systemctl is-active apparmor.service') == 0) {
+            systemctl('disable --now apparmor.service');
+        }
         script_run("(transactional-update migration; echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
     } else {
         my $option = (is_leap_migration) || (get_var("SCC_ADDONS") =~ /phub/) || (get_var("SMT_URL") =~ /smt/) ? " --allow-vendor-change " : " ";


### PR DESCRIPTION
`apparmor.service` does not run for slem 5.3.
Related job group MR: [Enable migration testing from 5.2 to 5.3](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/958)

#### Verification runs

* [sle-micro-5.1-MicroOS-Image-Updates-x86_64](http://kepler.suse.cz/tests/19283)
* [sle-micro-5.2-MicroOS-Image-Updates-x86_64](http://kepler.suse.cz/tests/19282#step/zypper_migration/29)