### PR TITLE
Add known slem5.2 and ALP bugs

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -385,10 +385,17 @@
         },
         "type": "bug"
     },
+    "boo#1203899": {
+        "description": "NetworkManager.*kill child process 'helper'.* failed due to unexpected return value -1 by waitpid",
+        "products": {
+            "alp": ["0.1"]
+        },
+        "type": "bug"
+    },
     "bsc#1200490": {
         "description": "Unable to open /dev/kvm: No such file or directory",
         "products": {
-            "sle-micro": [ "5.3" ],
+            "sle-micro": ["5.2", "5.3"],
             "leap-micro": ["5.3"]
         },
         "type": "ignore"


### PR DESCRIPTION
softfail know bug that appear in migration scenario from slem5.2 to 5.3 and ALP NetworkManager issue that appears in all runs.

- Verification run: http://kepler.suse.cz/tests/19284#live
