### PR TITLE
Work around network issue and 'authenticate the localhost' on svirt backend

### DIFF
--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -19,6 +19,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_opensuse is_sle is_jeos);
+use Utils::Backends qw(is_svirt_except_s390x);
 
 sub run {
     my $self = shift;
@@ -39,7 +40,15 @@ sub run {
     my $md5_initial_sh = script_output('md5sum /tmp/rsync_test_folder_a/rsync_test_sh.sh');
     my $md5_initial_tar = script_output('md5sum /tmp/rsync_test_folder_a/rsync_test_tar.tar');
 
-    enter_cmd("rsync -avzr /tmp/rsync_test_folder_a/ root\@localhost:/tmp/rsync_test_folder_b; echo \$\? > /tmp/rsync_return_code.txt");
+    # we have an issue with 'authenticate the localhost' on svirt backend
+    if (is_svirt_except_s390x) {
+        my $filename = "/root/.ssh/known_hosts";
+        # assert_script_run("touch $filename") unless (-f $filename);
+        assert_script_run("ssh-keyscan localhost 127.0.0.1 ::1 | tee -a $filename");
+        assert_script_run 'cp ~/.ssh/{id_rsa.pub,authorized_keys}';
+    }
+
+    assert_script_run("rsync -avzr /tmp/rsync_test_folder_a/ root\@localhost:/tmp/rsync_test_folder_b");
     assert_script_run('time sync');
 
     # keep the md5 hash value of the synced file and folder
@@ -56,7 +65,6 @@ sub run {
 sub post_run_hook {
     assert_script_run('rm -rf /tmp/rsync_test_folder_a');
     assert_script_run('rm -rf /tmp/rsync_test_folder_b');
-    assert_script_run('rm /tmp/rsync_return_code.txt');
 
     if (is_opensuse) {
         systemctl 'restart sshd';


### PR DESCRIPTION
provide a workaround to fix the issue with authenticate on localhost

see https://progress.opensuse.org/issues/108728
verified test runs:
VRs:
https://openqa.suse.de/tests/9746602
https://openqa.suse.de/tests/9751207
https://openqa.suse.de/tests/9751302
https://openqa.suse.de/tests/9751303
https://openqa.opensuse.org/tests/2812720
https://openqa.suse.de/tests/9751300
https://openqa.opensuse.org/tests/2812726

