### PR TITLE
security/cc/filter.pm: disable failing tests on 15-SP3

### DIFF
--- a/tests/security/cc/filter.pm
+++ b/tests/security/cc/filter.pm
@@ -12,12 +12,21 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Architectures;
+use version_utils;
 use audit_test qw(run_testcase compare_run_log rerun_fail_cases);
 
 sub run {
     my ($self) = shift;
 
     select_console 'root-console';
+
+    if (is_sle('=15-sp3')) {
+        my $test_dir = $audit_test::test_dir;
+        assert_script_run("sed -i 's/+ class_exec//' $test_dir/audit-test/filter/run.conf") if !is_aarch64;
+        assert_script_run("sed -i 's/+ class_attr//' $test_dir/audit-test/filter/run.conf");
+        record_soft_failure("poo#116683 - class_exec and class_attr fail on 15-SP3");
+    }
 
     run_testcase('filter', (make => 1, timeout => 180));
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/116683
- Verification runs:
  - x86_64: https://openqa.suse.de/tests/9659625
  - s390x: https://openqa.suse.de/tests/9659626
  - aarch64: https://openqa.suse.de/tests/9659627