### PR TITLE
Fix for Maintenance Update problem in yast2_http

### DIFF
--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -70,7 +70,8 @@ sub run {
                                           # Sometimes we don't get to the next page after first key press
                                           # As part of poo#20668 we introduce this workaround to have reliable tests
                                           # Go to http server wizard (4/5)--virtual hosts and check page (4/5 )is open
-    send_key_until_needlematch 'http_add_host', $cmd{next}, 3, 3;
+    send_key $cmd{next};
+    assert_screen 'http_add_host';
     wait_still_screen 1;
     send_key 'alt-a';
     assert_screen 'http_new_host_info';    # check new host information page got open to edit


### PR DESCRIPTION
Fixes this problem: https://openqa.suse.de/tests/9659018#step/yast2_http/21
by just sending one "next" key and then asserting that we're on the right screen. 

- Verification run: https://openqa.suse.de/tests/9659748
