### PR TITLE
Add grub timeout

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -60,7 +60,7 @@
       % } else {
       <append>splash=verbose</append>
       % }
-      <timeout config:type="integer">-1</timeout>
+      <timeout config:type="integer">10</timeout>
     </global>
     % if ($check_var->('ARCH', 'ppc64le') or $check_var->('ARCH', 's390x')) {
     <loader_type>grub2</loader_type>


### PR DESCRIPTION
Add a grub timeout value so that the created image will boot automatically.

- Related failures: https://openqa.suse.de/tests/9654971#step/disk_boot/6
- Verification run: [15-SP4 aarch64](https://openqa.suse.de/t9662341) | [15-SP4 s390x](https://openqa.suse.de/t9662346) | [15-SP4 ppc64le](https://openqa.suse.de/t9662347) | [15-SP4 x86_64](https://openqa.suse.de/t9662348)
