### PR TITLE
Revert "Add grub timeout"

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -60,7 +60,7 @@
       % } else {
       <append>splash=verbose</append>
       % }
-      <timeout config:type="integer">10</timeout>
+      <timeout config:type="integer">-1</timeout>
     </global>
     % if ($check_var->('ARCH', 'ppc64le') or $check_var->('ARCH', 's390x')) {
     <loader_type>grub2</loader_type>


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#15649

The disabled timeout is apperently expected by `boot_to_desktop`, see e.g. https://openqa.suse.de/tests/9670114