### PR TITLE
Increase wait_boot time for failing cases from mpi modules

### DIFF
--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -61,7 +61,7 @@ sub relogin_root {
 
     type_string('pkill -u root', lf => 1);
     record_info "pkill done";
-    $self->wait_boot_textmode(ready_time => 120);
+    $self->wait_boot_textmode(ready_time => 180);
     select_console('root-virtio-terminal');
     # Make sure that sshd is up. (TODO: investigate)
     systemctl('restart sshd');


### PR DESCRIPTION
Some jobs still failing after the increasing of that timeout, so it needs another addition which seems that stabilize and works for other ones too.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/117541
- Verification run: http://aquarius.suse.cz/tests/13028#details
