### PR TITLE
Move Trento test to qesap.py

### DIFF
--- a/data/sles4sap/qe_sap_deployment/trento_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/trento_azure.yaml
@@ -1,0 +1,32 @@
+provider: "%PROVIDER%"
+apiver: 1
+terraform:
+  variables:
+    az_region: "%REGION%"
+    deployment_name: "%DEPLOYMENTNAME%"
+    os_image: "%TRENTO_CLUSTER_OS_VER%"
+    private_key: "%SSH_KEY_PRIV%"
+    public_key: "%SSH_KEY_PUB%"
+
+ansible:
+  hana_urls:
+    - "%HANA_SAR%"
+    - "%HANA_CLIENT_SAR%"
+    - "%HANA_SAPCAR%"
+  create:
+    - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml -e use_sapconf=${SAPCONF}
+    - cluster_sbd_prep.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml
+  destroy:
+    - deregister.yaml
+  variables:
+    REG_CODE: "%SCC_REGCODE_SLES4SAP%"
+    EMAIL: testing@suse.com
+    SAPCONF: true

--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -2,13 +2,11 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Warnings;
+use Test::MockModule;
 use List::Util qw(any);
-
 use testapi qw(set_var);
-
 use trento;
 
-use Test::MockModule;
 my $trento = Test::MockModule->new('trento', no_auto => 1);
 my @calls;
 my @logs;
@@ -53,7 +51,7 @@ subtest '[get_vnet] get_vnet has to call az and return a vnet' => sub {
 
     note(join("\n  1C-->  ", @calls));
     like $calls[0], qr/az network vnet list -g GELATOGROUP --query "\[0\]\.name" -o tsv/, 'AZ command';
-    ok $net_name eq $expected_net_name, 'expected_net_name:' . $expected_net_name . ' but get net_name:' . $net_name;
+    is $net_name, $expected_net_name, "expected_net_name:$expected_net_name get net_name:$net_name";
 };
 
 subtest '[get_trento_deployment] with TRENTO_DEPLOY_VER' => sub {
@@ -83,7 +81,7 @@ subtest '[get_trento_deployment] with TRENTO_DEPLOY_VER' => sub {
     set_var('TRENTO_DEPLOY_VER', $gitlab_ver);
     set_var('_SECRET_TRENTO_GITLAB_TOKEN', $password);
     get_trento_deployment('self', '/tmp');
-    note(join("\n  1C-->  ", @calls));
+    note(join("\n  -->  ", @calls));
     like $recorded_passwords[0], qr/$password/;
     ok any { /curl.*api\/v4\/projects\/$gitlab_prj_id\/repository\/.*sha=$gitlab_sha.*--output $gitlag_tar/ } @calls;
     ok any { /tar.*$gitlag_tar/ } @calls;

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -2,23 +2,71 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Warnings;
-
+use Test::MockModule;
+use List::Util qw(any);
+use testapi 'set_var';
 use qesapdeployment;
+set_var('QESAP_CONFIG_FILE', 'MARLIN');
 
 subtest '[qesap_get_inventory] upper case' => sub {
-    use testapi 'set_var';
-    set_var('QESAP_CONFIG_FILE', 'MARLIN');
     my $inventory_path = qesap_get_inventory('NEMO');
     note('inventory_path --> ' . $inventory_path);
-    ok $inventory_path eq '/root/qe-sap-deployment/terraform/nemo/inventory.yaml';
+    is $inventory_path, '/root/qe-sap-deployment/terraform/nemo/inventory.yaml', "inventory_path:$inventory_path is the expected one";
 };
 
 subtest '[qesap_get_inventory] lower case' => sub {
-    use testapi 'set_var';
-    set_var('QESAP_CONFIG_FILE', 'MARLIN');
     my $inventory_path = qesap_get_inventory('nemo');
     note('inventory_path --> ' . $inventory_path);
-    ok $inventory_path eq '/root/qe-sap-deployment/terraform/nemo/inventory.yaml';
+    is $inventory_path, '/root/qe-sap-deployment/terraform/nemo/inventory.yaml', "inventory_path:$inventory_path is the expected one";
 };
+
+subtest '[qesap_create_folder_tree] default' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my @calls;
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    qesap_create_folder_tree();
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    is $calls[0], 'mkdir -p /root/qe-sap-deployment';
+};
+
+subtest '[qesap_create_folder_tree] user specified deployment_dir' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my @calls;
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    set_var('QESAP_DEPLOYMENT_DIR', '/DORY');
+    qesap_create_folder_tree();
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    set_var('QESAP_DEPLOYMENT_DIR', undef);
+    is $calls[0], 'mkdir -p /DORY';
+};
+
+subtest '[qesap_get_deployment_code] from default github' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my @calls;
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    set_var('QESAP_DEPLOYMENT_DIR', '/DORY');
+    qesap_get_deployment_code();
+    set_var('QESAP_DEPLOYMENT_DIR', undef);
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok any { /git.*clone.*github.*com\/SUSE\/qe-sap-deployment.*DORY/ } @calls;
+    ok 1;
+};
+
+subtest '[qesap_get_deployment_code] from a release' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my @calls;
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    set_var('QESAPDEPLOY_VER', 'CORAL');
+    qesap_get_deployment_code();
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    set_var('QESAPDEPLOY_VER', undef);
+    ok any { /curl.*github.com\/SUSE\/qe-sap-deployment\/archive\/refs\/tags\/vCORAL\.tar\.gz.*-ovCORAL\.tar\.gz/ } @calls;
+    ok any { /tar.*[xvf]+.*vCORAL\.tar\.gz/ } @calls;
+};
+
 
 done_testing;


### PR DESCRIPTION
Move Trento test SAP deployment from build.sh to qesap.py. Minor qesapdeploy lib API change to not directly use PUBLICCLOUD settings.

- Verification run: http://openqaworker15.qa.suse.cz/tests/49008 http://openqaworker15.qa.suse.cz/tests/49518 http://openqaworker15.qa.suse.cz/tests/49519