### PR TITLE
Ensure localhost entry in SUT /etc/hosts file before svn test

### DIFF
--- a/tests/security/libserf/libserf.pm
+++ b/tests/security/libserf/libserf.pm
@@ -23,7 +23,7 @@ sub run {
     zypper_call('in apache2 subversion-server openssl');
     # Activate the SSL Module
     assert_script_run('a2enmod ssl');
-    assert_script_run('echo "127.0.0.1 example-ssl.com" > /etc/hosts');
+    assert_script_run('echo "127.0.0.1 example-ssl.com localhost" > /etc/hosts');
     # Prepare certificates
     assert_script_run('gensslcert -n example-ssl.com -e webmaster@example.com');
     my $vhost_ssl_conf_path = '/etc/apache2/vhosts.d/vhost-ssl.conf';


### PR DESCRIPTION
libserf: fixes cobbler worker does not resolve 'localhost'  

Bug is reproducible before fix:
- [PASSED](https://openqa.opensuse.org/tests/2776638) on [openqa-aarch64:13](https://openqa.opensuse.org/admin/workers/160)  
- [FAILED](https://openqa.opensuse.org/tests/2776645) on [oss-cobbler-03:2](https://openqa.opensuse.org/admin/workers/419) 

- Related ticket: https://progress.opensuse.org/issues/115559
- Verification run:
    - aarch64 worker https://openqa.opensuse.org/t2777347
    - aarch64 worker https://openqa.opensuse.org/t2777580
    - cobbler worker https://openqa.opensuse.org/t2777398
    - cobbler worker https://openqa.opensuse.org/t2777579

