### PR TITLE
Fix mpi failure on permission issues with ping

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -272,7 +272,7 @@ sub check_nodes_availability {
     my ($self) = @_;
     my @cluster_nodes = cluster_names();
     foreach (@cluster_nodes) {
-        assert_script_run("ping -c 3 $_");
+        script_sudo("ping -i 5 -c 3 $_");
     }
 }
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -31,7 +31,7 @@ Base class implementation of distribution class necessary for testapi
 
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
 use testapi qw(send_key %cmd assert_screen check_screen check_var click_lastmatch get_var save_screenshot
-  match_has_tag set_var type_password type_string enter_cmd wait_serial $serialdev
+  match_has_tag set_var type_password type_string enter_cmd wait_serial $serialdev is_serial_terminal
   mouse_hide send_key_until_needlematch record_info record_soft_failure
   wait_still_screen wait_screen_change get_required_var diag);
 
@@ -59,7 +59,11 @@ sub handle_password_prompt {
     $console //= '';
 
     return if get_var("LIVETEST") || get_var('LIVECD');
-    assert_screen("password-prompt", 60);
+    if (is_serial_terminal()) {
+        wait_serial(qr/Password:\s*$/i, timeout => 30);
+    } else {
+        assert_screen("password-prompt", 60);
+    }
     if ($console eq 'hyperv-intermediary') {
         type_string get_required_var('VIRSH_GUEST_PASSWORD');
     }
@@ -347,7 +351,8 @@ sub script_sudo {
 
     my $str = time;
     if ($wait > 0) {
-        $prog = "$prog; echo $str-\$?- > /dev/$testapi::serialdev" unless $prog eq 'bash';
+        $prog = "$prog; echo $str-\$?-" unless $prog eq 'bash';
+        $prog = "$prog > /dev/$testapi::serialdev" unless is_serial_terminal();
     }
     enter_cmd "clear";    # poo#13710
     enter_cmd "su -c \'$prog\'", max_interval => 125;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -54,7 +54,7 @@ sub run ($self) {
     select_console('root-console');
     systemctl 'restart nfs-server';
     # And login as normal user to run the tests
-    type_string('pkill -u root');
+    type_string('pkill -u root', lf => 1);
     $self->select_serial_terminal(0);
     # load mpi after all the relogins
     assert_script_run "module load gnu $mpi";


### PR DESCRIPTION
Two commits:
* Make handle_password_prompt to consider serial_terminal
* Remove assertion on check_nodes_availability of HPC library

Verification run: http://aquarius.suse.cz/tests/13115
