### PR TITLE
installation/rollback_from_ro_snapshot: Use enter_cmd instead of script_run

### DIFF
--- a/tests/installation/rollback_from_ro_snapshot.pm
+++ b/tests/installation/rollback_from_ro_snapshot.pm
@@ -48,7 +48,7 @@ sub run {
     reset_consoles;
     $self->wait_boot;
     select_console 'root-console';
-    script_run("systemctl poweroff");
+    enter_cmd("systemctl poweroff");
     assert_shutdown;
 }
 


### PR DESCRIPTION
script_run fails if the exit code can't be read, but the poweroff might happen before the echo. Use enter_cmd to avoid waiting for the command to exit. assert_shutdown is strong enough.

- Verification run: https://openqa.opensuse.org/t2783592
