### PR TITLE
Workaround SelfInstall kexec issue on UEFI runs

### DIFF
--- a/schedule/sle-micro/selfinstall.yaml
+++ b/schedule/sle-micro/selfinstall.yaml
@@ -19,10 +19,15 @@ conditional_schedule:
     FLAVOR:
       'Default-RT-SelfInstall':
         - rt/rt_is_realtime
+  efi:
+    UEFI:
+      '1':
+        - microos/efiboot_check
 schedule:
   - installation/bootloader_uefi
   - microos/selfinstall
   - transactional/host_config
+  - '{{efi}}'
   - '{{rt}}'
   - '{{registration}}'
   - '{{maintenance}}'

--- a/tests/microos/efiboot_check.pm
+++ b/tests/microos/efiboot_check.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Basic smoke test to verify SUSE/openSUSE efiboot
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base qw(opensusebasetest);
+use testapi;
+use transactional qw(trup_call check_reboot_changes);
+use version_utils qw(is_sle_micro);
+use utils qw(assert_secureboot_status);
+
+sub run {
+    select_console('root-console');
+
+    trup_call('bootloader');
+    check_reboot_changes;
+
+    my $efiboot = script_output('efibootmgr -v', proceed_on_failure => 1);
+
+    unless ($efiboot == /^Boot\w{4}\*\s(opensuse|sle)-secureboot/) {
+        die 'System has booted from unexpected efi boot record!';
+    }
+
+    validate_script_output('mokutil --sb-state', sub { m/secureboot enabled/i });
+}
+
+1;

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -21,6 +21,15 @@ sub run {
     send_key 'ret';
     # Use firmware boot manager of aarch64 to boot HDD
     $self->handle_uefi_boot_disk_workaround if is_aarch64;
+
+    # workaround failed *kexec* execution on UEFI with SecureBoot
+    assert_screen(['failed-to-kexec', 'linux-login-microos'], 150);
+    if (get_var('UEFI') && match_has_tag('failed-to-kexec')) {
+        eject_cd();
+        record_soft_failure('bsc#1203896 - kexec fail in selfinstall with secureboot');
+        send_key 'ret';
+    }
+
     microos_login;
 }
 


### PR DESCRIPTION
As currently used dracut module (`kiwi-dump-reboot-system.sh`) attempts to `kexec` signed kernel with KEXEC_LOAD` syscall, we need to add workaround for [bsc#1203896](https://bugzilla.suse.com/show_bug.cgi?id=1203896).

The image was successfully copied on the drive, but as the first boot options stays set to CD, before rebooting after failed `kexec` tests need to eject the CD so the SUT boots from HDD.

This PR also adds a verification module that after re-installing the bootloader, `sle|opensuse` efi boot record used instead of generic boot option.

- ticket: [Add new job for Self-Install images with UEFI machine](https://progress.opensuse.org/issues/117130)

#### Verification runs

* [slem5.2](http://kepler.suse.cz/tests/19349#step/host_config/1)
* [slem5.3](http://kepler.suse.cz/tests/19348#step/host_config/1)
