### PR TITLE
Add a test suite to create install image for HA

### DIFF
--- a/data/autoyast_sle12/create_hdd/create_hdd_ha.xml
+++ b/data/autoyast_sle12/create_hdd/create_hdd_ha.xml
@@ -1,0 +1,167 @@
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- Simple install wit HA addon -->
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email>e</email>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <addons config:type="list">
+            <addon>
+                <name>sle-ha</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+                <reg_code>{{SCC_REGCODE_HA}}</reg_code>
+            </addon>
+        </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">45</timeout>
+        </global>
+    </bootloader>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+        <signature-handling>
+            <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+            <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+            <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+            <import_gpg_key config:type="boolean">true</import_gpg_key>
+        </signature-handling>
+    </general>
+    <partitioning config:type="list">
+        <drive>
+            <initialize config:type="boolean">true</initialize>
+            <use>all</use>
+        </drive>
+    </partitioning>
+    <networking>
+        <interfaces config:type="list">
+            <interface>
+                <bootproto>dhcp</bootproto>
+                <device>eth0</device>
+                <dhclient_set_default_route>yes</dhclient_set_default_route>
+                <startmode>auto</startmode>
+            </interface>
+        </interfaces>
+    </networking>
+    <firewall>
+        <enable_firewall config:type="boolean">true</enable_firewall>
+        <start_firewall config:type="boolean">true</start_firewall>
+        <zones config:type="list">
+            <zone>
+                <name>public</name>
+                <interfaces config:type="list">
+                    <interface>eth0</interface>
+                </interfaces>
+                <services config:type="list">
+                    <service>ssh</service>
+                </services>
+                <ports config:type="list">
+                    <port>22/tcp</port>
+                    <port>30000-50000/tcp</port>
+                </ports>
+            </zone>
+        </zones>
+    </firewall>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+    <keyboard>
+        <keyboard_values>
+            <delay/>
+            <discaps config:type="boolean">false</discaps>
+            <numlock>bios</numlock>
+            <rate/>
+        </keyboard_values>
+        <keymap>english-us</keymap>
+    </keyboard>
+    <language>
+        <language>en_US</language>
+        <languages/>
+    </language>
+    <ntp-client>
+        <ntp_policy>auto</ntp_policy>
+    </ntp-client>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+        <!-- Workaround for bsc#1202234: [addon]-release packages are missing after autoyast installation. -->
+        <packages config:type="list">
+            <package>sle-ha-release</package>
+        </packages>
+        <!-- end of workaround -->
+    </software>
+    <services-manager>
+        <default_target>multi-user</default_target>
+        <services>
+            <disable config:type="list"/>
+            <enable config:type="list">
+                <service>sshd</service>
+            </enable>
+        </services>
+    </services-manager>
+    <timezone>
+        <hwclock>UTC</hwclock>
+        <timezone>Europe/Berlin</timezone>
+    </timezone>
+    <users config:type="list">
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <gid>100</gid>
+            <home>/home/bernhard</home>
+            <password_settings>
+                <expire/>
+                <flag/>
+                <inact>-1</inact>
+                <max>99999</max>
+                <min>0</min>
+                <warn>7</warn>
+            </password_settings>
+            <shell>/bin/bash</shell>
+            <uid>1000</uid>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <fullname>root</fullname>
+            <gid>0</gid>
+            <home>/root</home>
+            <password_settings>
+                <expire/>
+                <flag/>
+                <inact/>
+                <max/>
+                <min/>
+                <warn/>
+            </password_settings>
+            <shell>/bin/bash</shell>
+            <uid>0</uid>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+</profile>


### PR DESCRIPTION
See https://progress.opensuse.org/issues/116536

gitlab MR https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/400

The new profile is based on https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/data/autoyast_sle15/create_hdd/create_hdd_maintenance.xml.ep, but simplified, as the cloned profile triggered a bug.

VR https://openqa.suse.de/tests/9693308#