### PR TITLE
Change shortcut to alt-u on ppc64le NTLM

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2020 SUSE LLC
+# Copyright 2012-2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Wait for installer welcome screen. Covers loading linuxrc
@@ -71,7 +71,7 @@ sub get_product_shortcuts {
     }
     # We got new products in SLE 15 SP1
     elsif (is_sle '15-SP1+') {
-        return (sles => 's') if (get_var('ISO') =~ /Full/ && is_ppc64le() && get_var('NTLM_AUTH_INSTALL'));
+        return (sles => 'u') if (get_var('ISO') =~ /Full/ && is_ppc64le() && get_var('NTLM_AUTH_INSTALL'));
         return (
             sles => (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'


### PR DESCRIPTION
In 15-SP5 the shortcut has changed from `alt-s` to `alt-u`. Since we don't execute this test in maintenance, there's no point to add a case for `<=15-SP4`.

- Related ticket: https://progress.opensuse.org/issues/117514
- Verification run: https://openqa.suse.de/tests/9696210
