### PR TITLE
SLEM: Updated GM images have no GRUB timeout

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -19,7 +19,10 @@ sub run {
     # default timeout in grub2 is set to 10s
     # osd's arm machines tend to stall when trying to match grub2
     # this leads to test failures because openQA does not assert grub2 properly
-    if (is_sle_micro && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
+    # SLEM updated GM images from https://openqa.suse.de/group_overview/377
+    # already have disabled grub timeout in order to install updates and reboot
+    # therefore *aarch64* images would hang in GRUB2
+    if ((is_sle_micro && get_var('HDD_1') !~ /GM-Updated/) && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
         shift->wait_boot_past_bootloader(textmode => 1, ready_time => 300);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
GRUB2 timeout is set to `-1` before updating GM images, regardless of architecture.

- Related ticket: [SLEM fails to boot on aarch64](https://progress.opensuse.org/issues/117781)

##### Verification runs: 

* [sle-micro-5.3-Container-Image-Updates-aarch64](https://openqa.suse.de/tests/9696225#step/disk_boot/10)
* [sle-micro-5.2-Container-Image-Updates-aarch64](https://openqa.suse.de/tests/9696226#step/disk_boot/10)
* [sle-micro-5.1-Container-Image-Updates-aarch64](https://openqa.suse.de/tests/9696227#step/disk_boot/10)
