### PR TITLE
Increase timeout for SCC commands

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -30,6 +30,8 @@ use testapi;
 sub packages_to_install {
     my ($version, $sp, $host_distri) = @_;
     my $arch = get_required_var('ARCH');
+    my $scc_timeout = 1200;    # SCC can take really long timetimes
+
     # common packages
     my @packages = ('git-core', 'python3', 'gcc', 'jq');
     if ($host_distri eq 'ubuntu') {
@@ -43,16 +45,16 @@ sub packages_to_install {
         push @packages, 'python3-devel';
         if ($version eq "12.5") {
             # PackageHub is needed for jq
-            script_retry("SUSEConnect -p PackageHub/12.5/$arch", delay => 60, retry => 3, timeout => 300);
+            script_retry("SUSEConnect -p PackageHub/12.5/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             push @packages, 'python36-pip';
         } elsif ($version eq '15.0') {
             # On SLES15 go needs to be installed from packagehub. On later SLES it comes from the SDK module
-            script_retry("SUSEConnect -p PackageHub/15/$arch", delay => 60, retry => 3, timeout => 300);
+            script_retry("SUSEConnect -p PackageHub/15/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             push @packages, ('go1.10', 'skopeo');
         } else {
             # Desktop module is needed for SDK module, which is required for installing go
-            script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3, timeout => 300);
-            script_retry("SUSEConnect -p sle-module-development-tools/$version/$arch", delay => 60, retry => 3, timeout => 300);
+            script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
+            script_retry("SUSEConnect -p sle-module-development-tools/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             push @packages, ('go', 'skopeo');
         }
     } elsif ($host_distri =~ /opensuse/) {


### PR DESCRIPTION
Due to occasional timeout issues we increase the timeout delay for SCC related operations.

- Related ticket: https://progress.opensuse.org/issues/117787
- Verification run: https://duck-norris.qam.suse.de/tests/11002#step/bci_prepare/14 (unrelated failure)
