### PR TITLE
Change bug id for YaST content not refreshing

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -621,7 +621,7 @@ sub handle_scc_popups {
                 && (get_var("DESKTOP") !~ /textmode/)
                 && (get_var('REMOTE_CONTROLLER') !~ /vnc/)
                 && !(get_var('PUBLISH_HDD_1') || check_var('SLE_PRODUCT', 'hpc'))) {
-                record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+                record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
                 for (1 .. 2) { send_key 'alt-f10' }
             }
             assert_screen(\@tags, timeout => 360);

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -63,7 +63,7 @@ sub initiator_discovered_targets_tab {
     my $target_ip_only = (split('/', $test_data->{target_conf}->{ip}))[0];
     type_string_slow_extended $target_ip_only;
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('iscsi-initiator-discovered-IP-adress', 'alt-f10', 10, 2);
     }
     else {
@@ -93,7 +93,7 @@ sub initiator_connected_targets_tab {
     # go to discovered targets tab
     send_key "alt-d";
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('iscsi-initiator-discovered-targets', 'alt-f10', 10, 2);
     }
     else {

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -93,7 +93,7 @@ sub target_service_tab {
 
 sub config_2way_authentication {
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('iscsi-target-modify-acls', 'alt-f10', 10, 2);
     }
     else {

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -51,7 +51,7 @@ sub run {
     }
     assert_and_click 'yast2-bootloader_default-boot-section';
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('yast2-bootloader_default-boot-section_tw', 'alt-f10', 9, 2);
     }
     else {

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -111,7 +111,7 @@ sub test_http_instserver {
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-a", 2);
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('yast2-instserver-repository-conf', 'alt-f10', 9, 2);
     }
     else {
@@ -128,7 +128,7 @@ sub test_http_instserver {
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch([qw(yast2-instserver-ui yast2-instserver-change-media)], 'alt-f10', 21, 30);
     }
     else {

--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -41,7 +41,7 @@ sub run {
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-pwd-settings";
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('yast2_security-check-min-pwd-len-and-exp-days', 'alt-f10', 10, 2);
     }
     assert_screen "yast2_security-check-min-pwd-len-and-exp-days";
@@ -55,7 +55,7 @@ sub run {
     # Check previously set values + Miscellaneous Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('yast2_security-login-settings', 'alt-f10', 10, 2);
     }
     assert_and_click "yast2_security-login-settings";
@@ -70,7 +70,7 @@ sub run {
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-misc-settings";
     if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1191112 - Resizing window as workaround for YaST content not loading');
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
         send_key_until_needlematch('yast2_security-file-perms-secure', 'alt-f10', 10, 2);
     }
     assert_screen "yast2_security-file-perms-secure";


### PR DESCRIPTION
Bug bsc#1191112 still appears in our new product build, despite the fix.
We have create a follow-up bug, bsc#1204176, as requested by the developers in the comments.
In order to indicate this, the bug id mentioned in our workarounds for 15-SP4 have been modified.
