### PR TITLE
Fix bug with tomcat-succesfully-installed needle

### DIFF
--- a/tests/x11/tomcat.pm
+++ b/tests/x11/tomcat.pm
@@ -40,7 +40,7 @@ sub run() {
 
     # check that the tomcat web service works
     $self->firefox_open_url('localhost:8080');
-    send_key_until_needlematch('tomcat-succesfully-installed', 'ret');
+    assert_screen('tomcat-succesfully-installed');
 
     # verify that the tomcat manager page works
     Tomcat::Utils->tomcat_manager_test($self);


### PR DESCRIPTION
- Related fix: #15563
- Failing test: [openqa.suse.de/t9695750](https://openqa.suse.de/tests/9695750#step/tomcat/332)
- Related ticket: [poo#117793](https://progress.opensuse.org/issues/117793)
- Verification run: [pdostal-server.suse.cz/t1973](https://pdostal-server.suse.cz/tests/1973), [SLE12-SP5](https://pdostal-server.suse.cz/tests/2012), [SLE15-SP4](https://pdostal-server.suse.cz/tests/2011)
