### PR TITLE
Schedule kdump_and_crash in isolated test

### DIFF
--- a/schedule/jeos/sle/jeos-extratest.yaml
+++ b/schedule/jeos/sle/jeos-extratest.yaml
@@ -60,4 +60,3 @@ schedule:
     - console/dstat
     - console/journalctl
     - console/procps
-    - console/kdump_and_crash


### PR DESCRIPTION
In favor of https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/965 schedule `kdump_and_test` in stand-alone test suite.
