### PR TITLE
Add zypper lr to output on error case

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -63,6 +63,7 @@ sub run {
         $instance->run_ssh_command(cmd => '! sudo SUSEConnect -d');
     } else {
         if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', proceed_on_failure => 1, timeout => 360) < 5) {
+            record_info('zypper lr', $instance->run_ssh_command(cmd => 'sudo zypper lr', proceed_on_failure => 1));
             die 'The list of zypper repositories is too short.';
         }
 


### PR DESCRIPTION
Print the output of 'zypper lr' in case the test detects missing repositories.

- Related failure: https://openqa.suse.de/tests/9703449
- Verification run: https://duck-norris.qam.suse.de/tests/11010#step/check_registercloudguest/86
