### PR TITLE
return value for qesap_execute

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -346,6 +346,7 @@ sub qesap_sh_destroy {
 
     Execute qesap glue script commands. Check project documentation for available options:
     https://github.com/SUSE/qe-sap-deployment
+    Test only returns execution result, failure has to be handled by calling method.
 =cut
 
 sub qesap_execute {
@@ -368,8 +369,9 @@ sub qesap_execute {
 
     push(@log_files, $exec_log);
     record_info('QESAP exec', "Executing: \n$qesap_cmd");
-    assert_script_run($qesap_cmd, timeout => $args{timeout});
+    my $exec_rc = script_run($qesap_cmd, timeout => $args{timeout});
     qesap_upload_logs();
+    return $exec_rc;
 }
 
 =head3 qesap_get_inventory
@@ -395,6 +397,7 @@ sub qesap_get_inventory {
     - generates config files with qesap script
 
     For variables example see 'qesap_yaml_replace'
+    Returns only result, failure handling has to be done by calling method.
 =cut
 
 sub qesap_prepare_env {
@@ -423,8 +426,9 @@ sub qesap_prepare_env {
 
     record_info("QESAP conf", "Generating tfvars file");
     push(@log_files, $paths{terraform_dir} . '/' . $provider . "/terraform.tfvars");
-    qesap_execute(cmd => 'configure', verbose => 1);
+    my $exec_rc = qesap_execute(cmd => 'configure', verbose => 1);
     qesap_upload_logs();
+    return $exec_rc;
 }
 
 1;

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -428,7 +428,8 @@ sub qesap_prepare_env {
     push(@log_files, $paths{terraform_dir} . '/' . $provider . "/terraform.tfvars");
     my $exec_rc = qesap_execute(cmd => 'configure', verbose => 1);
     qesap_upload_logs();
-    return $exec_rc;
+    die if $exec_rc != 0;
+    return;
 }
 
 1;


### PR DESCRIPTION
Currently, qesap_exec (lib/qesapdeployment) function handles command 
execution failures which does not allow calling function to make the 
decision. This PR makes execution done via script_run with returning 
RC only.

- Related ticket: https://jira.suse.com/browse/TEAM-6822
- Needles: N/A
- Verification run: https://mordor.suse.cz/tests/5059
