### PR TITLE
Distinguish JeOS EULA vs BETA license

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -99,7 +99,12 @@ sub run {
     send_key 'ret';
 
     # Show license
-    assert_screen 'jeos-license';
+    # EULA license applies for sle products that are in GM(C) phase
+    my $license = 'jeos-license';
+    if ((is_sle || is_sle_micro) && !get_var('BETA')) {
+        $license = 'jeos-license-eula';
+    }
+    assert_screen $license;
     send_key 'ret';
 
     # Accept EULA if required


### PR DESCRIPTION
When a product becomes GM(C) the license change is required. As of now we had only a generic license needle, therefore the license had to be manually verified.

- ticket: [[JeOS][MicroOS/Micro] jeos-firstboot handler should check EULA/Beta licenses](https://progress.opensuse.org/issues/117415)
- needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1627

#### Verification runs:

* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221010-1-jeos-main@64bit-virtio-vga](http://kepler.suse.cz/tests/19394#step/firstrun/3)
* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221010-1-jeos-main@svirt-xen-pv](http://kepler.suse.cz/tests/19397#step/firstrun/3)
* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221010-1-jeos-main@svirt-xen-hvm](http://kepler.suse.cz/tests/19396#step/firstrun/3)
* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221010-1-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/19395#step/firstrun/3)
* [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221009-1-jeos-main@svirt-xen-pv](http://kepler.suse.cz/tests/19393#step/firstrun/4)
* [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221009-1-jeos-main@svirt-xen-hvm](http://kepler.suse.cz/tests/19392#step/firstrun/4)
* [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221009-1-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/19390#step/firstrun/4)
* [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221009-1-jeos-main@64bit-virtio-vga](http://kepler.suse.cz/tests/19391#step/firstrun/4)
* [sle-15-SP4-JeOS-for-MS-HyperV-QR-x86_64-Build3.6.1-jeos-main@svirt-hyperv-uefi](http://kepler.suse.cz/tests/19404#step/firstrun/4)
* [sle-15-SP4-JeOS-for-VMware-QR-x86_64-Build3.6.1-jeos-main@svirt-vmware65](http://kepler.suse.cz/tests/19400#step/firstrun/4)
* [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221010-1-jeos-main@svirt-xen-hvm](http://kepler.suse.cz/tests/19406#step/firstrun/5)
* [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221010-1-jeos-main@uefi-virtio-vga](http://kepler.suse.cz/tests/19405#step/firstrun/5)
* [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221010-1-jeos-main@64bit-virtio-vga](http://kepler.suse.cz/tests/19407#step/firstrun/5)
 