### PR TITLE
Install libvirt package

### DIFF
--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -91,6 +91,11 @@ sub run {
 
     # Ensure additional package is installed
     zypper_call '-t in libvirt-client iputils nmap supportutils';
+
+    # If testing libvirt package specificly
+    if ('libvirt' eq get_var("UPDATE_PACKAGE")) {
+        zypper_call '-t in libvirt';
+    }
     if (script_run("virsh net-list --all | grep default") != 0) {
         assert_script_run "curl " . data_url("virt_autotest/default_network.xml") . " -o ~/default_network.xml";
         assert_script_run "virsh net-define --file ~/default_network.xml";


### PR DESCRIPTION
Install libvirt package when testing libvirt.

- Related ticket: https://progress.opensuse.org/issues/116407
- Needles: N/A
- Verification run: [KVM](http://openqa.qam.suse.cz/tests/47083#) and [XEN](http://openqa.qam.suse.cz/tests/47089#)
