### PR TITLE
lib/x11utils: Fix desktop_runner_hotkey for icewm

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -55,7 +55,7 @@ desktop
 
 =cut
 
-sub desktop_runner_hotkey { check_var('DESKTOP', 'minimalx') ? 'super-spc' : 'alt-f2' }
+sub desktop_runner_hotkey { check_var('DESKTOP', 'minimalx') ? 'ctrl-alt-spc' : 'alt-f2' }
 
 
 =head2


### PR DESCRIPTION
It's Ctrl-Alt-Space, not Super-Space. With this, `consoletest_finish` takes just ~46s instead of >6min!

- Verification run: https://openqa.opensuse.org/tests/2798170
