### PR TITLE
Restart systemd-journald before checking it's status

### DIFF
--- a/tests/console/systemd_nspawn.pm
+++ b/tests/console/systemd_nspawn.pm
@@ -69,6 +69,8 @@ sub run {
     validate_script_output "machinectl list", qr/$machine/;
     assert_script_run "machinectl shell $machine /bin/echo foobar | grep foobar";
     assert_script_run 'machinectl shell messagebus@' . $machine . ' /usr/bin/whoami | grep messagebus';
+    # on backend svirt-xen-hvm we have problem with systemd-journald and it requires a restart before checking status
+    assert_script_run "machinectl shell $machine /usr/bin/systemctl restart systemd-journald";
     assert_script_run "machinectl shell $machine /usr/bin/systemctl status systemd-journald | grep -B100 -A100 'active (running)'";
     assert_script_run "machinectl stop test1";
     script_retry 'systemctl status systemd-nspawn@' . $machine, retry => 30, delay => 5, expect => 3;


### PR DESCRIPTION
on svirt-xen-hvm we have issue for checking status of systemd-journald.
add restart command before checking it's status.
see https://progress.opensuse.org/issues/118198

VR: https://openqa.suse.de/tests/9725275