### PR TITLE
Replace serial_terminal on apptainer module with select_console

### DIFF
--- a/tests/containers/apptainer.pm
+++ b/tests/containers/apptainer.pm
@@ -14,7 +14,9 @@ use containers::utils qw(registry_url);
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
+    # Not used of serial_terminal because causes some delays due to wait_serial
+    # failing match on `serial_term_prompt`
+    select_console 'root-console';
     my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
     my $registry = registry_url() . "/library";
     record_info('reg', "$registry");


### PR DESCRIPTION
This is a workaround to speed up the test as the serial terminal causes some delays due to failing wait_serial check. The `serial_term_prompt` doesnt match with the apptainer interactive terminal.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: http://aquarius.suse.cz/tests/13387
