### PR TITLE
Adjust bootloader_start on s390x to new YaST start message

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -194,7 +194,7 @@ EO_frickin_boot_parms
 
     my $output_delim
       = $display_type eq "SSH" || $display_type eq "SSH-X" ? qr/\Q***  run 'yast.ssh' to start the installation  ***\E/
-      : $display_type eq "VNC" ? qr/\Q*** Starting YaST2 ***\E/
+      : $display_type eq "VNC" ? qr/\*\*\* Starting YaST(2|) \*\*\*/
       : die "unknown vars.json:DISPLAY->TYPE <$display_type>";
 
     $r = $s3270->expect_3270(

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -85,7 +85,7 @@ sub run {
         }
         else {
             # On s390x zKVM we have to process startshell in bootloader
-            wait_serial(' Starting YaST2 ', 300) || die "yast didn't start";
+            wait_serial(' Starting YaST(2|) ', 300) || die "yast didn't start";
             select_console('installation');
         }
     }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/117100
- Needles: -
- Verification run: 
https://openqa.nue.suse.com/tests/9725227 sle-15-sp5 s390x kvm
https://openqa.nue.suse.com/tests/9725229 sle-15-sp5 s390x zvm
https://openqa.suse.de/tests/9725711 sle-15-sp4 s390x kvm
