### PR TITLE
openvswitch_ssl: add back SLES 12 support

### DIFF
--- a/tests/console/openvswitch_ssl.pm
+++ b/tests/console/openvswitch_ssl.pm
@@ -14,12 +14,16 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
 
-    # Install python3 here since pox scripts need python3
-    zypper_call('in python3 python3-base openvswitch');
+    if (is_sle("<=12-SP5")) {
+        zypper_call('in python python-base openvswitch');
+    } else {
+        zypper_call('in python3 python3-base openvswitch');
+    }
 
     # Start openvswitch service
     systemctl('start openvswitch');
@@ -39,8 +43,9 @@ sub run {
     }
 
     # Get pox for openflow test
-    assert_script_run 'wget --quiet ' . data_url('pox-py3.tar.bz2');
-    assert_script_run 'tar jvfx pox-py3.tar.bz2';
+    my $fname = is_sle("<=12-SP5") ? "pox.tar.bz2" : "pox-py3.tar.bz2";
+    assert_script_run 'wget --quiet ' . data_url("$fname");
+    assert_script_run "tar jvfx $fname";
 
     # Setup a simulated open-flow controller with POX
     type_string


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/118630
- Verification runs:
  - 15-SP4: https://openqa.suse.de/tests/9721612
  - 15-SP3: https://openqa.suse.de/tests/9721644
  - 15-SP2: https://openqa.suse.de/tests/9721645
  - 15-SP1: https://openqa.suse.de/tests/9721669
  - 12-SP5: https://openqa.suse.de/tests/9721613
  - 12-SP4: https://openqa.suse.de/tests/9721668
  - 12-SP3: https://openqa.suse.de/tests/9721667
  - Tumbleweed: https://openqa.opensuse.org/tests/2798668
  - Leap: https://openqa.opensuse.org/tests/2798708