### PR TITLE
Fix the test gnuhealth_client_preconfigure

### DIFF
--- a/tests/gnuhealth/gnuhealth_client_preconfigure.pm
+++ b/tests/gnuhealth/gnuhealth_client_preconfigure.pm
@@ -17,10 +17,12 @@ sub run {
     x11_start_program($gnuhealth);
     assert_and_click "$gnuhealth-manage_profiles";
     # wait for indexing to be done
-    wait_still_screen(3);
+    wait_still_screen(5);
     assert_and_click "$gnuhealth-manage_profiles-add";
+    wait_still_screen(3);
     type_string 'localhost';
     send_key_until_needlematch "$gnuhealth-manage_profiles-host_textfield_selected", 'tab';
+    wait_still_screen(3);
     type_string 'localhost';
     send_key 'tab';
     assert_screen "$gnuhealth-manage_profiles-database_selected";


### PR DESCRIPTION
For more reliability called funcation  _wait_still_screen_  before typing the localhost in the test.

- Related ticket: https://progress.opensuse.org/issues/118354
- Needles: No
- Verification run:  https://openqa.opensuse.org/tests/2803442
