### PR TITLE
Detect usage of egrep and fgrep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,8 @@ and additionally the following rules:
   with non-zero timeout to prevent introducing any timing dependant behaviour,
   to save test execution time as well as state more explicitly from the testers
   point of view what are the expected alternatives. For example:
+* Avoid use of egrep and fgrep. The two commands are deprecated, so please use 
+  `grep -E` and `grep -F` respectively.
 
 ```perl
 assert_screen([qw(yast2_console-finished yast2_missing_package)]);

--- a/t/01_style.t
+++ b/t/01_style.t
@@ -11,4 +11,5 @@ ok system(qq{git grep -I -l 'This program is free software.*if not, see <http://
 ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!t/01_style.t'}) != 0, 'SPDX-License-Identifier correctly terminated';
 $out = qx{git grep -ne "check_var('ARCH',.*)" -e "check_var('BACKEND',.*)" ':!lib/Utils/Architectures.pm' ':!lib/Utils/Backends.pm' 'lib' 'tests'};
 ok $? != 0 && $out eq '', 'No check_var function to verify ARCH/BACKEND types' or diag $out;
+ok system(qq{git grep -I -l \\( -e "egrep" -e "fgrep" \\) ':!t/01_style.t' ':!CONTRIBUTING.md'}) != 0, 'No usage of the deprecated egrep and fgrep commands';
 done_testing;


### PR DESCRIPTION
The usage of `egrep` and `fgrep` is deprecated - starting with GNU Grep 3.8, there will be a warning issued prompting users to use grep -E and grep -F respectively. This mr adds checks for repo files that contain those commands.

- Related ticket: https://progress.opensuse.org/issues/117118

~~**DO NOT MERGE until https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15547 is merged**, as it will lead to all prs failing.~~ Merged.
