### PR TITLE
 wicked-wlan: Run dnsmasq with --dhcp-authoritative 

### DIFF
--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -153,7 +153,7 @@ sub restart_dhcp_server {
     $args{sut_ip} //= $self->sut_ip(bss => $args{bss});
 
     $self->stop_dhcp_server(%args);
-    $self->netns_exec(sprintf('dnsmasq --no-resolv --pid-file=%s --log-facility=%s --log-dhcp --interface=%s --except-interface=lo --bind-interfaces --dhcp-range=%s,static --dhcp-host=%s,%s',
+    $self->netns_exec(sprintf('dnsmasq --no-resolv --pid-file=%s --log-facility=%s --log-dhcp --interface=%s --except-interface=lo --bind-interfaces --dhcp-authoritative --dhcp-range=%s,static --dhcp-host=%s,%s',
             $self->dhcp_pidfile(%args), $self->dhcp_logfile(%args), $args{ref_ifc}, $args{sut_ip}, $self->sut_hw_addr, $args{sut_ip}));
     $self->add_post_log_file($self->dhcp_logfile(%args));
 }

--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -140,6 +140,12 @@ sub dhcp_pidfile {
     return "/var/run/dnsmasq_$args{ref_ifc}.pid";
 }
 
+sub dhcp_logfile {
+    my ($self, %args) = @_;
+    $args{ref_ifc} //= $self->ref_bss(bss => $args{bss});
+    return "/var/log/dnsmasq_$args{ref_ifc}.log";
+}
+
 sub restart_dhcp_server {
     my ($self, %args) = @_;
 
@@ -147,8 +153,9 @@ sub restart_dhcp_server {
     $args{sut_ip} //= $self->sut_ip(bss => $args{bss});
 
     $self->stop_dhcp_server(%args);
-    $self->netns_exec(sprintf('dnsmasq --no-resolv --pid-file=%s --interface=%s --except-interface=lo --bind-interfaces --dhcp-range=%s,static --dhcp-host=%s,%s',
-            $self->dhcp_pidfile(%args), $args{ref_ifc}, $args{sut_ip}, $self->sut_hw_addr, $args{sut_ip}));
+    $self->netns_exec(sprintf('dnsmasq --no-resolv --pid-file=%s --log-facility=%s --log-dhcp --interface=%s --except-interface=lo --bind-interfaces --dhcp-range=%s,static --dhcp-host=%s,%s',
+            $self->dhcp_pidfile(%args), $self->dhcp_logfile(%args), $args{ref_ifc}, $args{sut_ip}, $self->sut_hw_addr, $args{sut_ip}));
+    $self->add_post_log_file($self->dhcp_logfile(%args));
 }
 
 sub stop_dhcp_server {


### PR DESCRIPTION
Wicked 0.6.70  does implement RFC#2131 more correctly (https://github.com/openSUSE/wicked/pull/934). Thus if wicked
had a lease on an interface it send out a REQUEST including
the old IP Address and wait for a NAK from DHCP server if this IP
isn't managed by the DHCP server, otherwise wicked would use the old one.

Also we store the log file of dnsmasq and push it to openqa.

- Verification run:  http://openqa.wicked.suse.de/tests/84110