### PR TITLE
Add debug info and improve dowload_script and save/restore_guests

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -21,14 +21,15 @@ use DateTime;
 use NetAddr::IP;
 use Net::IP qw(:PROC);
 use File::Basename;
+use LWP::Simple 'head';
 use Utils::Architectures;
 use IO::Socket::INET;
 use Carp;
 
 our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest guest_is_sle is_guest_ballooned is_xen_host is_kvm_host check_host check_guest
   print_cmd_output_to_file ssh_setup ssh_copy_id create_guest import_guest install_default_packages upload_y2logs ensure_default_net_is_active ensure_guest_started
-  ensure_online add_guest_to_hosts restart_libvirtd remove_additional_disks remove_additional_nic collect_virt_system_logs shutdown_guests wait_guest_online start_guests
-  is_guest_online wait_guests_shutdown setup_common_ssh_config add_alias_in_ssh_config parse_subnet_address_ipv4 backup_file manage_system_service setup_rsyslog_host
+  ensure_online add_guest_to_hosts restart_libvirtd remove_additional_disks remove_additional_nic collect_virt_system_logs shutdown_guests wait_guest_online start_guests restore_downloaded_guests save_original_guest_xmls restore_original_guests
+  is_guest_online wait_guests_shutdown remove_vm setup_common_ssh_config add_alias_in_ssh_config parse_subnet_address_ipv4 backup_file manage_system_service setup_rsyslog_host
   check_port_state subscribe_extensions_and_modules download_script download_script_and_execute is_sev_es_guest);
 
 # helper function: Trim string
@@ -137,31 +138,34 @@ sub print_cmd_output_to_file {
 }
 
 sub download_script_and_execute {
-    my (%args) = @_;
+    my ($script_name, %args) = @_;
     $args{output_file} //= "$args{script_name}.log";
     $args{machine} //= 'localhost';
 
-    download_script(script_name => $args{script_name}, script_url => $args{script_url}, machine => $args{machine});
-    my $cmd = "~/$args{script_name}";
+    download_script($script_name, script_url => $args{script_url}, machine => $args{machine});
+    my $cmd = "~/$script_name";
     $cmd = "ssh root\@$args{machine} " . "\"$cmd\"" if ($args{machine} ne 'localhost');
     script_run("$cmd >> $args{output_file} 2>&1");
 }
 
 sub download_script {
-    my (%args) = @_;
-    $args{script_name} //= '';
-    $args{script_url} //= data_url("virt_autotest/$args{script_name}");
-    $args{machine} //= 'localhost';
+    my ($script_name, %args) = @_;
+    my $script_url = $args{script_url} // data_url("virt_autotest/$script_name");
+    my $machine = $args{machine} // 'localhost';
 
-    my $cmd = "curl -s -o ~/$args{script_name} $args{script_url}";
-    $cmd = "ssh root\@$args{machine} " . "\"$cmd\"" if ($args{machine} ne 'localhost');
-    my $ret = script_run($cmd);
-    unless ($ret == 0) {
-        record_info('Softfail', "Failed to download $args{script_name} from $args{script_url}!", result => 'softfail');
-        return $ret;
+    my $cmd = "curl -s -o ~/$script_name $script_url";
+    $cmd = "ssh root\@$machine " . "\"$cmd\"" if ($machine ne 'localhost');
+    unless (script_retry($cmd, retry => 2, die => 0) eq 0) {
+        # Add debug codes as the url only exists in a dynamic openqa URL
+        record_info("URL is not accessible", "$script_url", result => 'fail') unless head($script_url);
+        unless ($machine eq 'localhost') {
+            record_info("machine is not ssh accessible", "$machine", result => 'fail') unless script_run("ssh root\@$machine 'hostname'") == 0;
+            record_info("OSD is unaccessible from $machine", "that means the machine is having problem to access SUSE network", result => 'fail') unless script_run("ssh root\@$machine 'ping openqa.suse.de'") == 0;
+        }
+        die "Failed to download $script_url!";
     }
-    $cmd = "chmod +x ~/$args{script_name}";
-    $cmd = "ssh root\@$args{machine} " . "\"$cmd\"" if ($args{machine} ne 'localhost');
+    $cmd = "chmod +x ~/$script_name";
+    $cmd = "ssh root\@$machine " . "\"$cmd\"" if ($machine ne 'localhost');
     script_run($cmd);
 }
 
@@ -716,6 +720,55 @@ sub is_sev_es_guest {
     else {
         record_info("$guest_name is not sev(es) guest", "Guest $guest_name is not a sev or sev-es enabled guest judging by its name.");
         return 'notsev';
+    }
+}
+
+# remove a vm listed via 'virsh list'
+sub remove_vm {
+    my $vm = shift;
+    my $is_persistent_vm = script_output "virsh dominfo $vm | sed -n '/Persistent:/p' | awk '{print \$2}'";
+    my $vm_state = script_output "virsh domstate $vm";
+    if ($vm_state ne "shut off") {
+        assert_script_run("virsh destroy $vm", 30);
+    }
+    if ($is_persistent_vm eq "yes") {
+        assert_script_run("virsh undefine $vm || virsh undefine $vm --keep-nvram", 30);
+    }
+}
+
+#Start the guest from the downloaded vm xml and vm disk file
+sub restore_downloaded_guests {
+    my ($guest, $vm_xml_dir) = @_;
+    record_info("Guest restored", "$guest");
+    my $vm_xml = "$vm_xml_dir/$guest.xml";
+    assert_script_run("virsh define $vm_xml", 30);
+}
+
+sub save_original_guest_xmls {
+    my ($save_dir, @guests) = @_;
+    $save_dir //= "/tmp/download_vm_xml";
+    @guests = keys %virt_autotest::common::guests if @guests == 0;
+    assert_script_run "mkdir -p $save_dir" unless script_run("ls $save_dir") == 0;
+    foreach my $guest (@guests) {
+        unless (script_run("ls $save_dir/$guest.xml") == 0) {
+            assert_script_run "virsh dumpxml --inactive $guest > $save_dir/$guest.xml";
+        }
+    }
+}
+
+sub restore_original_guests {
+    my ($save_dir, @guests) = @_;
+    $save_dir //= "/tmp/download_vm_xml";
+    @guests = keys %virt_autotest::common::guests if @guests == 0;
+    foreach my $guest (@guests) {
+        remove_vm($guest);
+        if (script_run("ls $save_dir/$guest.xml") == 0) {
+            restore_downloaded_guests($guest, $save_dir);
+            record_info "Guest $guest is restored.";
+        }
+        else {
+            record_info("Fail to restore guest!", "$guest", result => 'softfail');
+        }
     }
 }
 

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -131,6 +131,10 @@ sub test_network_interface {
     # Show the IP address of secondary (tested) interface
     assert_script_run("ssh root\@$guest ip -o -4 addr list $nic | awk \"{print \\\$4}\" | cut -d/ -f1 | head -n1");
     my $addr = script_output "ssh root\@$guest ip -o -4 addr list $nic | awk \"{print \\\$4}\" | cut -d/ -f1 | head -n1";
+    if ($addr eq "") {
+        assert_script_run "ssh root\@$guest 'ip a'";
+        die "No IP found for $nic in $guest";
+    }
 
     # Route our test via the tested interface
     script_run "ssh root\@$addr '[ `ip r | grep $target | wc -l` -gt 0 ] && ip r del $target'";

--- a/tests/virt_autotest/cleanup_service.pm
+++ b/tests/virt_autotest/cleanup_service.pm
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 use base "virt_autotest_base";
 use testapi;
-use virt_utils qw(remove_vm);
+use virt_autotest::utils qw(remove_vm);
 
 sub run {
     #revert dns setting

--- a/tests/virt_autotest/restore_guests.pm
+++ b/tests/virt_autotest/restore_guests.pm
@@ -11,7 +11,8 @@ use strict;
 use warnings;
 use testapi;
 use base "virt_autotest_base";
-use virt_utils qw(get_guest_list remove_vm restore_downloaded_guests);
+use virt_autotest::utils qw(remove_vm restore_downloaded_guests);
+use virt_utils qw(get_guest_list);
 
 sub run {
     my $guest_list = get_guest_list();

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -27,7 +27,7 @@ use virt_autotest::utils;
 use version_utils qw(is_sle get_os_release);
 
 our @EXPORT
-  = qw(enable_debug_logging update_guest_configurations_with_daily_build locate_sourcefile get_repo_0_prefix repl_repo_in_sourcefile repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk get_guest_list remove_vm download_guest_assets restore_downloaded_guests is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles is_registered_sles);
+  = qw(enable_debug_logging update_guest_configurations_with_daily_build locate_sourcefile get_repo_0_prefix repl_repo_in_sourcefile repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk get_guest_list download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles is_registered_sles);
 
 sub enable_debug_logging {
 
@@ -398,19 +398,6 @@ sub get_guest_list {
     return $guest_list;
 }
 
-# remove a vm listed via 'virsh list'
-sub remove_vm {
-    my $vm = shift;
-    my $is_persistent_vm = script_output "virsh dominfo $vm | sed -n '/Persistent:/p' | awk '{print \$2}'";
-    my $vm_state = script_output "virsh domstate $vm";
-    if ($vm_state ne "shut off") {
-        assert_script_run("virsh destroy $vm", 30);
-    }
-    if ($is_persistent_vm eq "yes") {
-        assert_script_run("virsh undefine $vm || virsh undefine $vm --keep-nvram", 30);
-    }
-}
-
 # Download guest image and xml from a NFS location to local
 # the image and xml is coming from a guest installation testsuite
 # need set SKIP_GUEST_INSTALL=1 in the test suite settings
@@ -501,15 +488,6 @@ sub download_guest_assets {
 
     return $guest_count;
 }
-
-#Start the guest from the downloaded vm xml and vm disk file
-sub restore_downloaded_guests {
-    my ($guest, $vm_xml_dir) = @_;
-    record_info("Guest restored", "$guest");
-    my $vm_xml = "$vm_xml_dir/$guest.xml";
-    assert_script_run("virsh define $vm_xml", 30);
-}
-
 
 sub is_installed_equal_upgrade_major_release {
     #get the version that the host is installed to

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -14,8 +14,8 @@ use utils 'script_retry';
 use version_utils qw(is_sle);
 use set_config_as_glue;
 use virt_autotest::common;
-use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute);
-use virt_utils qw(upload_virt_logs remove_vm restore_downloaded_guests);
+use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute remove_vm save_original_guest_xmls restore_downloaded_guests restore_original_guests);
+use virt_utils qw(upload_virt_logs);
 
 our $vm_xml_save_dir = "/tmp/download_vm_xml";
 
@@ -102,28 +102,11 @@ sub run_test {
 
 #save the guest configuration files into a folder
 sub save_original_guests {
-    assert_script_run "mkdir -p $vm_xml_save_dir" unless script_run("ls $vm_xml_save_dir") == 0;
+    my $vm_xml_save_dir = "/tmp/download_vm_xml";
+    save_original_guest_xmls($vm_xml_save_dir);
     my $changed_xml_dir = "$vm_xml_save_dir/changed_xml";
     script_run("[ -d $changed_xml_dir ] && rm -rf $changed_xml_dir/*");
     script_run("mkdir -p $changed_xml_dir");
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        unless (script_run("ls $vm_xml_save_dir/$guest.xml") == 0) {
-            assert_script_run "virsh dumpxml --inactive $guest > $vm_xml_save_dir/$guest.xml";
-        }
-    }
-}
-
-#restore guest from the configuration files in a folder
-sub restore_original_guests {
-    foreach my $guest (keys %virt_autotest::common::guests) {
-        remove_vm($guest);
-        if (script_run("ls $vm_xml_save_dir/$guest.xml") == 0) {
-            restore_downloaded_guests($guest, $vm_xml_save_dir);
-        }
-        else {
-            record_info('Softfail', "Fail to restore $guest!", result => 'softfail');
-        }
-    }
 }
 
 #restore guest which xml configuration files were changed in prepare_guest_for_irqbalance()
@@ -214,7 +197,7 @@ sub post_fail_hook {
     foreach my $guest (keys %virt_autotest::common::guests) {
         my $log_file = $log_dir . "/$guest" . "_irqbalance_debug";
         my $debug_script = "xen_irqbalance_guest_logging.sh";
-        download_script_and_execute(machine => $guest, script_name => $debug_script, output_file => $log_file);
+        download_script_and_execute($debug_script, machine => $guest, output_file => $log_file);
     }
     upload_virt_logs($log_dir, "irqbalance_debug");
     $self->SUPER::post_fail_hook;


### PR DESCRIPTION
- Improve download_script by adding debug info and optimize arguments. 
- Make failure of test guest network more accurate, fg. [No IP found acturally](https://openqa.suse.de/tests/9756873#step/sriov_network_card_pci_passthrough/402)
- Move a few save/restore_guests functions to lib/ as it is needed by multiple tests
- Move remove_vm() from tests/virt_autotest/virt_utils.pm to lib/virt_autotest/utils.pm as it is needed by utils.pm.
- Don't use `ifup` because it turns off the forwarding map, which made guest unable to access some external IPs.


- Related ticket: https://progress.opensuse.org/issues/118345

Verification run: 
[gi-guest_developing-on-host_sles15sp4-xen](https://openqa.suse.de/tests/9731592)   //for xen_irq + sriov test. fail on purpose to check if debug info is printed as expected
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/9742583)  //xen_irq_balance test passed.
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/9756564)  //for both xen_irqp + sriov test on machine with multiple SR-IOV network cards. succeeded.
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/9756873)    //an entire test chain on kvm. Fail due to a likely product bug. looking into... It is a different issue and does't block the PR to be merged.
[gi-guest_developing-on-host_sles15sp4-xen](https://openqa.suse.de/tests/9775375)   //sriove & irqbalance test on zen3.  but zen3 is having login problem.

