### PR TITLE
Ignore QESAPDEPLOY_GITHUB_REPO when using QESAPDEPLOY_VER

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -131,7 +131,7 @@ sub qesap_upload_logs {
 =cut
 
 sub qesap_get_deployment_code {
-    my $git_repo = get_var(QESAPDEPLOY_GITHUB_REPO => 'github.com/SUSE/qe-sap-deployment');
+    my $official_repo = 'github.com/SUSE/qe-sap-deployment';
     my $qesap_git_clone_log = '/tmp/git_clone.txt';
     my %paths = qesap_get_file_paths();
 
@@ -144,7 +144,7 @@ sub qesap_get_deployment_code {
     if (get_var('QESAPDEPLOY_VER')) {
         my $ver_artifact = 'v' . get_var('QESAPDEPLOY_VER') . '.tar.gz';
 
-        my $curl_cmd = "curl -v -L https://$git_repo/archive/refs/tags/$ver_artifact -o$ver_artifact";
+        my $curl_cmd = "curl -v -L https://$official_repo/archive/refs/tags/$ver_artifact -o$ver_artifact";
         assert_script_run("set -o pipefail ; $curl_cmd | tee " . $qesap_git_clone_log, quiet => 1);
 
         my $tar_cmd = "tar xvf $ver_artifact --strip-components=1";
@@ -156,6 +156,7 @@ sub qesap_get_deployment_code {
         assert_script_run('git config --global http.sslVerify false', quiet => 1) if get_var('QESAPDEPLOY_GIT_NO_VERIFY');
         my $git_branch = get_var('QESAPDEPLOY_GITHUB_BRANCH', 'main');
 
+        my $git_repo = get_var('QESAPDEPLOY_GITHUB_REPO', $official_repo);
         my $git_clone_cmd = 'git clone --depth 1 --branch ' . $git_branch . ' https://' . $git_repo . ' ' . $paths{deployment_dir};
         assert_script_run("set -o pipefail ; $git_clone_cmd  2>&1 | tee $qesap_git_clone_log", quiet => 1);
     }

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -54,6 +54,36 @@ subtest '[qesap_get_deployment_code] from default github' => sub {
     ok any { /git.*clone.*github.*com\/SUSE\/qe-sap-deployment.*DORY/ } @calls;
 };
 
+subtest '[qesap_get_deployment_code] from fork' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my @calls;
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    set_var('QESAP_DEPLOYMENT_DIR', '/DORY');
+    set_var('QESAPDEPLOY_GITHUB_REPO', 'WHALE');
+    qesap_get_deployment_code();
+    set_var('QESAP_DEPLOYMENT_DIR', undef);
+    set_var('QESAPDEPLOY_GITHUB_REPO', undef);
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok any { /git.*clone.*https:\/\/WHALE.*DORY/ } @calls;
+};
+
+subtest '[qesap_get_deployment_code] from branch' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my @calls;
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    set_var('QESAP_DEPLOYMENT_DIR', '/DORY');
+    set_var('QESAPDEPLOY_GITHUB_BRANCH', 'TED');
+    qesap_get_deployment_code();
+    set_var('QESAP_DEPLOYMENT_DIR', undef);
+    set_var('QESAPDEPLOY_GITHUB_BRANCH', undef);
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok any { /git.*clone.*--branch.*TED/ } @calls;
+};
+
 subtest '[qesap_get_deployment_code] from a release' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     my @calls;
@@ -61,9 +91,12 @@ subtest '[qesap_get_deployment_code] from a release' => sub {
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
     set_var('QESAPDEPLOY_VER', 'CORAL');
+    # set to test that it is ignored
+    set_var('QESAPDEPLOY_GITHUB_REPO', 'WHALE');
     qesap_get_deployment_code();
     note("\n  -->  " . join("\n  -->  ", @calls));
     set_var('QESAPDEPLOY_VER', undef);
+    set_var('QESAPDEPLOY_GITHUB_REPO', undef);
     ok any { /curl.*github.com\/SUSE\/qe-sap-deployment\/archive\/refs\/tags\/vCORAL\.tar\.gz.*-ovCORAL\.tar\.gz/ } @calls;
     ok any { /tar.*[xvf]+.*vCORAL\.tar\.gz/ } @calls;
 };


### PR DESCRIPTION
Ignore QESAPDEPLOY_GITHUB_REPO when using QESAPDEPLOY_VER and only get the release from the official repo

- Verification run: https://openqaworker15.qa.suse.cz/tests/52583
 It is a qesapdeploy minimal test, it has been intentionally triggered with a not existing repo
  'QESAPDEPLOY_VER=0.3.0' 'QESAPDEPLOY_GITHUB_REPO=mozzarella.com'
Now th etest code properly ignore it when requesting a specific QESAPDEPLOY_VER https://openqaworker15.qa.suse.cz/tests/52583/logfile?filename=serial_terminal.txt
```
# set -o pipefail ; curl -v -L https://github.com/SUSE/qe-sap-deployment/archive/refs/tags/v0.3.0.tar.gz -ov0.3.0.tar.gz | tee /tmp/git_clone.txt; echo h8msD-$?-
```