### PR TITLE
Get guests from local array instead of common.pm

### DIFF
--- a/lib/virt_autotest/virtual_storage_utils.pm
+++ b/lib/virt_autotest/virtual_storage_utils.pm
@@ -32,7 +32,8 @@ our @EXPORT
 
 # Basic Virtualization Storage Management
 sub virt_storage_management {
-    my ($vstorage_pool_name, %args) = @_;
+    my ($vstorage_pool_name, $vms, %args) = @_;
+    my @guests = @{$vms};
     my $vol_size = $args{size};
     my $timeout = $args{timeout} // 120;
     my $dir = $args{dir} // 0;
@@ -50,29 +51,29 @@ sub virt_storage_management {
     ## Basic Virtualization Storage Volume Management
     # Create a Storage Volume
     record_info "Create a Storage Volume";
-    assert_script_run("virsh vol-create-as $vstorage_pool_name $_-storage $vol_size", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh vol-create-as $vstorage_pool_name $_-storage $vol_size", $timeout) foreach (@guests);
     record_info "List Storage Volumes";
-    assert_script_run("virsh vol-list $vstorage_pool_name | grep $_-storage", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh vol-list $vstorage_pool_name | grep $_-storage", $timeout) foreach (@guests);
     record_info "Dump Storage Volumes in XML";
-    assert_script_run("virsh vol-dumpxml --pool $vstorage_pool_name $_-storage", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh vol-dumpxml --pool $vstorage_pool_name $_-storage", $timeout) foreach (@guests);
     if ($dir == 1) {
         record_info "Resize";
-        assert_script_run("virsh vol-resize --pool testing $_-storage $vol_resize", $timeout) foreach (keys %virt_autotest::common::guests);
+        assert_script_run("virsh vol-resize --pool testing $_-storage $vol_resize", $timeout) foreach (@guests);
     }
     # Attach a Storage Volume to guest system
     record_info "Attached";
     my $target = (is_xen_host) ? "xvdx" : "vdx";
-    assert_script_run("virsh attach-disk --domain $_ --source `virsh vol-path --pool $vstorage_pool_name $_-storage` --target $target", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh attach-disk --domain $_ --source `virsh vol-path --pool $vstorage_pool_name $_-storage` --target $target", $timeout) foreach (@guests);
     # Detach a Storage Volume from guest system
     record_info "Detached";
-    assert_script_run("virsh detach-disk $_ $target", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh detach-disk $_ $target", $timeout) foreach (@guests);
     record_info "Clone";
-    assert_script_run("virsh vol-clone --pool $vstorage_pool_name $_-storage $_-clone", $timeout) foreach (keys %virt_autotest::common::guests);
-    assert_script_run("virsh vol-info --pool $vstorage_pool_name $_-clone", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh vol-clone --pool $vstorage_pool_name $_-storage $_-clone", $timeout) foreach (@guests);
+    assert_script_run("virsh vol-info --pool $vstorage_pool_name $_-clone", $timeout) foreach (@guests);
     # Delete and Remove a Storage Volume from storage pool
     record_info "Remove";
-    assert_script_run("virsh vol-delete --pool $vstorage_pool_name $_-clone", $timeout) foreach (keys %virt_autotest::common::guests);
-    assert_script_run("virsh vol-delete --pool $vstorage_pool_name $_-storage", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh vol-delete --pool $vstorage_pool_name $_-clone", $timeout) foreach (@guests);
+    assert_script_run("virsh vol-delete --pool $vstorage_pool_name $_-storage", $timeout) foreach (@guests);
 }
 
 # Destroy Virtualization Storage Pool

--- a/tests/virt_autotest/hotplugging_utils.pm
+++ b/tests/virt_autotest/hotplugging_utils.pm
@@ -71,7 +71,6 @@ sub get_disk_image_name {
 sub reset_guest {
     my $guest = shift;
     return if $guest == "";
-    my $guest_instance = $virt_autotest::common::guests{$guest};
     my $MAC_PREFIX = $_[1];
 
     ## Network
@@ -83,11 +82,9 @@ sub reset_guest {
     script_run("rm -f $disk_image");
     ## CPU and memory
     set_vcpus($guest, 2);
-    my $memory = $guest_instance->{memory} // "2048";
-    set_guest_memory($guest, $memory);
+    set_guest_memory($guest, 2048);
     # max memory
-    my $maxmemory = $guest_instance->{maxmemory} // "4096";
-    script_run("virsh setmaxmem $_ $maxmemory" . "M --config") foreach (keys %virt_autotest::common::guests);
+    script_run("virsh setmaxmem $guest 4096" . "M --config");
 }
 
 # Try to attach a NIC or disk device and check for bsc1175218

--- a/tests/virt_autotest/libvirt_extend_storage_lvm.pm
+++ b/tests/virt_autotest/libvirt_extend_storage_lvm.pm
@@ -33,10 +33,10 @@ our $lvm_vg_name = 'lvm_vg';
 our $lvm_pool_name = 'guest_image_lvm';
 sub run_test {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     record_info "Prepare Guest Systems";
-    foreach (keys %virt_autotest::common::guests) {
-        start_guests() unless is_guest_online($_);
+    foreach (@guests) {
+        assert_script_run("virsh start $_") unless is_guest_online($_);
     }
     ## Prepare Virtualization LVM Storage Pool Source
     my $lvm_disk = $self->prepare_lvm_storage_pool_source();

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -27,6 +27,7 @@ sub run_test {
 
     #Prepare VM HOST SERVER Network Interface Configuration
     #for libvirt virtual network testing
+    my @guests = keys %virt_autotest::common::guests;
     virt_autotest::virtual_network_utils::prepare_network($virt_host_bridge, $based_guest_dir);
 
     #Download libvirt host bridge virtual network configuration file
@@ -43,7 +44,7 @@ sub run_test {
 
     my ($mac, $model, $affecter, $exclusive);
     my $gate = script_output "ip r s | grep 'default via ' | cut -d' ' -f3";
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         record_info "$guest", "HOST BRIDGE NETWORK for $guest";
         ensure_online $guest, skip_network => 1;
 

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -22,7 +22,7 @@ use version_utils 'is_sle';
 
 sub run_test {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     #Download libvirt isolated virtual network configuration file
     my $vnet_isolated_cfg_name = "vnet_isolated.xml";
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_isolated_cfg_name);
@@ -35,7 +35,7 @@ sub run_test {
 
     my ($mac, $model, $affecter, $exclusive);
     my $gate = '192.168.127.1';    # This host exists but should not work as a gate in the ISOLATED NETWORK
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         record_info "$guest", "ISOLATED NETWORK for $guest";
         ensure_online $_, skip_network => 1;
 

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -22,12 +22,11 @@ use version_utils 'is_sle';
 
 sub run_test {
     my ($self) = @_;
+    my @guests = keys %virt_autotest::common::guests;
 
     #Download libvirt host bridge virtual network configuration file
     my $vnet_nated_cfg_name = "vnet_nated.xml";
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_nated_cfg_name);
-
-    die "The default(NAT BASED NETWORK) virtual network does not exist" if (script_run('virsh net-list --all | grep default') != 0);
 
     #Create NAT BASED NETWORK
     assert_script_run("virsh net-create vnet_nated.xml");
@@ -37,7 +36,7 @@ sub run_test {
 
     my ($mac, $model, $affecter, $exclusive);
     my $gate = '192.168.128.1';
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         record_info "$guest", "NAT BASED NETWORK for $guest";
         ensure_online $guest, skip_network => 1;
 

--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -21,7 +21,7 @@ sub run_test {
     my ($self) = @_;
     #Snapshots are supported on KVM VM Host Servers only
     return unless is_kvm_host;
-
+    my @guests = keys %virt_autotest::common::guests;
     my $vm_types = "sles|win";
     my $wait_script = "30";
     my $vm_hostnames = script_output("virsh list --all --name", $wait_script, type_command => 0, proceed_on_failure => 0);
@@ -37,7 +37,7 @@ sub run_test {
     my $vm_hostnames_inactive = script_output("virsh list --inactive --name", $wait_script, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_inactive_array = split(/\n+/, $vm_hostnames_inactive);
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         if (virt_autotest::utils::is_sev_es_guest($guest) ne 'notsev') {
             record_info "Skip external snapshot on $guest", "SEV/SEV-ES guest $guest does not support external snapshot";
             next;

--- a/tests/virt_autotest/virsh_internal_snapshot.pm
+++ b/tests/virt_autotest/virsh_internal_snapshot.pm
@@ -21,7 +21,8 @@ sub run_test {
     #Snapshots are supported on KVM VM Host Servers only
     return unless is_kvm_host;
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    my @guests = keys %virt_autotest::common::guests;
+    foreach my $guest (@guests) {
         if (virt_autotest::utils::is_sev_es_guest($guest) ne 'notsev') {
             record_info "Skip internal snapshot on $guest", "SEV/SEV-ES guest $guest does not support internal snapshot";
             next;

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -18,7 +18,7 @@ use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_
 use virt_utils qw(upload_virt_logs remove_vm restore_downloaded_guests);
 
 our $vm_xml_save_dir = "/tmp/download_vm_xml";
-
+my @guests = keys %virt_autotest::common::guests;
 sub run_test {
     my $self = shift;
 
@@ -26,7 +26,7 @@ sub run_test {
 
     save_original_guests();
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
 
         if (guest_is_sle($guest, '=15-sp0')) {
             record_soft_failure("Skip the test as fix for SLE15 was not requested by customer in bsc#1178477.");
@@ -106,7 +106,7 @@ sub save_original_guests {
     my $changed_xml_dir = "$vm_xml_save_dir/changed_xml";
     script_run("[ -d $changed_xml_dir ] && rm -rf $changed_xml_dir/*");
     script_run("mkdir -p $changed_xml_dir");
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         unless (script_run("ls $vm_xml_save_dir/$guest.xml") == 0) {
             assert_script_run "virsh dumpxml --inactive $guest > $vm_xml_save_dir/$guest.xml";
         }
@@ -115,7 +115,7 @@ sub save_original_guests {
 
 #restore guest from the configuration files in a folder
 sub restore_original_guests {
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         remove_vm($guest);
         if (script_run("ls $vm_xml_save_dir/$guest.xml") == 0) {
             restore_downloaded_guests($guest, $vm_xml_save_dir);
@@ -211,7 +211,7 @@ sub post_fail_hook {
     diag("Module xen_guest_irqbalance post fail hook starts.");
     my $log_dir = "/tmp/irqbalance";
     script_run("[ -d $log_dir ] && rm -rf $log_dir/*; mkdir -p $log_dir");
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         my $log_file = $log_dir . "/$guest" . "_irqbalance_debug";
         my $debug_script = "xen_irqbalance_guest_logging.sh";
         download_script_and_execute(machine => $guest, script_name => $debug_script, output_file => $log_file);

--- a/tests/virtualization/universal/dom_install.pm
+++ b/tests/virtualization/universal/dom_install.pm
@@ -15,11 +15,11 @@ use utils;
 
 sub run {
     select_console 'root-console';
-    opensusebasetest::select_serial_terminal();
+    my @guests = keys %virt_autotest::common::guests;
 
     zypper_call '-t in vhostmd', exitcode => [0, 4, 102, 103, 106];
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         ensure_online($guest, use_virsh => 0);
         record_info "$guest", "Install vm-dump-metrics on xl-$guest";
         script_retry("ssh root\@$guest 'zypper -n in vm-dump-metrics'", delay => 120, retry => 3);

--- a/tests/virtualization/universal/dom_metrics.pm
+++ b/tests/virtualization/universal/dom_metrics.pm
@@ -13,9 +13,10 @@ use testapi;
 use utils;
 
 sub run {
+    my @guests = keys %virt_autotest::common::guests;
     assert_script_run 'vhostmd';
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         record_info "$guest", "Obtaining dom0 metrics on xl-$guest";
         assert_script_run "xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro", 180;
         assert_script_run "ssh root\@$guest 'vm-dump-metrics' | grep 'SUSE LLC'";

--- a/tests/virtualization/universal/guest_management.pm
+++ b/tests/virtualization/universal/guest_management.pm
@@ -16,6 +16,7 @@ use testapi;
 use utils;
 
 sub run {
+    my @guests = keys %virt_autotest::common::guests;
     record_info '<on_reboot>', 'Check that every no guest has <on_reboot>destroy</on_reboot> but <on_reboot>restart</on_reboot>';
     if (script_run("find /etc/libvirt/ -name *.xml -exec grep on_reboot '{}' \\; | grep destroy") == 0) {
         record_soft_failure "bsc#1153028 - The on_reboot parameter is not set correctly";
@@ -24,7 +25,7 @@ sub run {
     }
 
     record_info "REBOOT", "Reboot all guests";
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         assert_script_run "virsh reboot $guest";
         if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, die => 0)) {
             record_info('Softfail', "Reboot on $guest failed", result => 'softfail');
@@ -34,7 +35,7 @@ sub run {
     }
 
     record_info "SHUTDOWN", "Shut all guests down";
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, die => 0)) {
             record_info('Softfail', "Guest $guest is not running after the reboot", result => 'softfail');
             assert_script_run "virsh start $guest", 60;
@@ -49,7 +50,7 @@ sub run {
     }
 
     record_info "START", "Start all guests";
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         if (script_retry("virsh start $guest", delay => 120, retry => 3, die => 0) != 0) {
             restart_libvirtd;
             script_retry("virsh start $guest", delay => 120, retry => 3);
@@ -58,13 +59,13 @@ sub run {
     }
 
     record_info "SUSPEND", "Suspend all guests";
-    assert_script_run "virsh suspend $_" foreach (keys %virt_autotest::common::guests);
-    script_retry "virsh list --all | grep $_ | grep paused", delay => 15, retry => 12 foreach (keys %virt_autotest::common::guests);
+    assert_script_run "virsh suspend $_" foreach (@guests);
+    script_retry "virsh list --all | grep $_ | grep paused", delay => 15, retry => 12 foreach (@guests);
 
     record_info "RESUME", "Resume all guests";
-    assert_script_run "virsh resume $_" foreach (keys %virt_autotest::common::guests);
+    assert_script_run "virsh resume $_" foreach (@guests);
     assert_script_run "virsh list --all";
-    script_retry "nmap $_ -PN -p ssh | grep open", delay => 3, retry => 60 foreach (keys %virt_autotest::common::guests);
+    script_retry "nmap $_ -PN -p ssh | grep open", delay => 3, retry => 60 foreach (@guests);
 }
 
 1;

--- a/tests/virtualization/universal/hotplugging_HDD.pm
+++ b/tests/virtualization/universal/hotplugging_HDD.pm
@@ -55,26 +55,28 @@ sub test_add_virtual_disk {
 
 sub run_test {
     my ($self) = @_;
+    my @guests = keys %virt_autotest::common::guests;
     my ($sles_running_version, $sles_running_sp) = get_os_release;
 
     record_info "SSH", "Check guests are online with SSH";
-    wait_guest_online($_) foreach (keys %virt_autotest::common::guests);
+    wait_guest_online($_) foreach (@guests);
 
     # Hotplug HDD
     my $lsblk = 0;
     my $disk_format = get_var("QEMU_DISK_FORMAT") // "raw";
     record_info "Disk", "Adding another raw disk";
     assert_script_run "mkdir -p /var/lib/libvirt/images/add/";
-    test_add_virtual_disk($_) foreach (keys %virt_autotest::common::guests);
+    test_add_virtual_disk($_) foreach (@guests);
 }
 
 sub post_fail_hook {
     my ($self) = @_;
+    my @guests = keys %virt_autotest::common::guests;
 
     # Call parent post_fail_hook to collect logs on failure
     $self->SUPER::post_fail_hook;
     # Ensure guests remain in a consistent state also on failure
-    reset_guest($_, $MAC_PREFIX) foreach (keys %virt_autotest::common::guests);
+    reset_guest($_, $MAC_PREFIX) foreach (@guests);
 }
 
 1;

--- a/tests/virtualization/universal/hotplugging_cleanup.pm
+++ b/tests/virtualization/universal/hotplugging_cleanup.pm
@@ -22,11 +22,11 @@ my $MAC_PREFIX = '00:16:3f:32';
 
 sub run_test {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     # Ensure guests remain in a consistent state also
-    shutdown_guests();
-    reset_guest($_, $MAC_PREFIX) foreach (keys %virt_autotest::common::guests);
-    start_guests();
+    shutdown_guests(@guests);
+    reset_guest($_, $MAC_PREFIX) foreach (@guests);
+    start_guests(@guests);
 }
 
 sub post_fail_hook {

--- a/tests/virtualization/universal/hotplugging_guest_preparation.pm
+++ b/tests/virtualization/universal/hotplugging_guest_preparation.pm
@@ -23,6 +23,7 @@ my $MAC_PREFIX = '00:16:3f:32';
 
 sub run_test {
     my ($self) = @_;
+    my @guests = keys %virt_autotest::common::guests;
     my ($sles_running_version, $sles_running_sp) = get_os_release;
 
     if ($sles_running_version eq '15' && get_var("VIRT_AUTOTEST") && !get_var("VIRT_UNIFIED_GUEST_INSTALL")) {
@@ -35,18 +36,19 @@ sub run_test {
     }
 
     # Guest preparation
-    shutdown_guests();
-    reset_guest($_, $MAC_PREFIX) foreach (keys %virt_autotest::common::guests);
-    start_guests();
+    shutdown_guests(@guests);
+    reset_guest($_, $MAC_PREFIX) foreach (@guests);
+    start_guests(@guests);
 }
 
 sub post_fail_hook {
     my ($self) = @_;
+    my @guests = keys %virt_autotest::common::guests;
 
     # Call parent post_fail_hook to collect logs on failure
     $self->SUPER::post_fail_hook;
     # Ensure guests remain in a consistent state also on failure
-    reset_guest($_, $MAC_PREFIX) foreach (keys %virt_autotest::common::guests);
+    reset_guest($_, $MAC_PREFIX) foreach (@guests);
 }
 
 1;

--- a/tests/virtualization/universal/hotplugging_memory.pm
+++ b/tests/virtualization/universal/hotplugging_memory.pm
@@ -38,14 +38,15 @@ sub test_vmem_change {
 
 sub run_test {
     my ($self) = @_;
+    my @guests = keys %virt_autotest::common::guests;
     my ($sles_running_version, $sles_running_sp) = get_os_release;
 
     record_info "SSH", "Check if guests are online with SSH";
-    wait_guest_online($_, 300, 1) foreach (keys %virt_autotest::common::guests);
+    wait_guest_online($_, 300, 1) foreach (@guests);
 
     # Live memory change of guests
     record_info "Memory", "Changing the amount of memory available";
-    test_vmem_change($_) foreach (keys %virt_autotest::common::guests);
+    test_vmem_change($_) foreach (@guests);
 
     # Workaround to drop all live provisions of all vm guests
     if (get_var('VIRT_AUTOTEST') && is_kvm_host && (($sles_running_version eq '12' and $sles_running_sp eq '5') || ($sles_running_version eq '15' and $sles_running_sp eq '1'))) {
@@ -56,11 +57,11 @@ sub run_test {
 
 sub post_fail_hook {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     # Call parent post_fail_hook to collect logs on failure
     $self->SUPER::post_fail_hook;
     # Ensure guests remain in a consistent state also on failure
-    reset_guest($_, $MAC_PREFIX) foreach (keys %virt_autotest::common::guests);
+    reset_guest($_, $MAC_PREFIX) foreach (@guests);
 }
 
 1;

--- a/tests/virtualization/universal/hotplugging_vCPUs.pm
+++ b/tests/virtualization/universal/hotplugging_vCPUs.pm
@@ -68,14 +68,14 @@ sub test_add_vcpu {
 
 sub run_test {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     record_info "SSH", "Check if guests are online with SSH";
-    wait_guest_online($_) foreach (keys %virt_autotest::common::guests);
+    wait_guest_online($_) foreach (@guests);
 
     # Hotplugging of vCPUs
     record_info("CPU", "Changing the number of CPUs available");
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         if (virt_autotest::utils::is_sev_es_guest($guest) ne 'notsev') {
             record_info "Skip hotplugging vCPU on $guest", "SEV/SEV-ES guest $guest does not support hotplugging vCPU";
             next;
@@ -94,7 +94,8 @@ sub post_fail_hook {
     # Call parent post_fail_hook to collect logs on failure
     $self->SUPER::post_fail_hook;
     # Ensure guests remain in a consistent state also on failure
-    reset_guest($_, $MAC_PREFIX) foreach (keys %virt_autotest::common::guests);
+    my @guests = keys %virt_autotest::common::guests;
+    reset_guest($_, $MAC_PREFIX) foreach (@guests);
 }
 
 1;

--- a/tests/virtualization/universal/save_and_restore.pm
+++ b/tests/virtualization/universal/save_and_restore.pm
@@ -20,16 +20,17 @@ use testapi;
 use utils;
 
 sub run_test {
+    my @guests = keys %virt_autotest::common::guests;
     assert_script_run "mkdir -p /var/lib/libvirt/images/saves/";
 
     record_info "Remove", "Remove previous saves (if there were any)";
-    script_run "rm /var/lib/libvirt/images/saves/$_.vmsave || true" foreach (keys %virt_autotest::common::guests);
+    script_run "rm /var/lib/libvirt/images/saves/$_.vmsave || true" foreach (@guests);
 
     record_info "Save", "Save the machine states";
-    assert_script_run("virsh save $_ /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh save $_ /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (@guests);
 
     record_info "Check", "Check saved states";
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         if (script_run("virsh list --all | grep $guest | grep shut") != 0) {
             record_info 'Softfail', "Guest $guest should be shut down now", result => 'softfail';
             script_run "virsh destroy $guest", 90;
@@ -37,13 +38,13 @@ sub run_test {
     }
 
     record_info "Restore", "Restore guests";
-    assert_script_run("virsh restore /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh restore /var/lib/libvirt/images/saves/$_.vmsave", 300) foreach (@guests);
 
     record_info "Check", "Check restored states";
-    assert_script_run "virsh list --all | grep $_ | grep running" foreach (keys %virt_autotest::common::guests);
+    assert_script_run "virsh list --all | grep $_ | grep running" foreach (@guests);
 
     record_info "SSH", "Check hosts are listening on SSH";
-    script_retry "nmap $_ -PN -p ssh | grep open", delay => 3, retry => 60 foreach (keys %virt_autotest::common::guests);
+    script_retry "nmap $_ -PN -p ssh | grep open", delay => 3, retry => 60 foreach (@guests);
 }
 
 1;

--- a/tests/virtualization/universal/smoketest.pm
+++ b/tests/virtualization/universal/smoketest.pm
@@ -36,6 +36,7 @@ my %cves = (
 sub run_test {
     my $self = shift;
     $self->select_serial_terminal;
+    my @guests = keys %virt_autotest::common::guests;
 
     # Print latest Kernel version
     script_run('uname -a');
@@ -51,7 +52,7 @@ sub run_test {
     script_run('chmod 0755 /var/tmp/spectre-meltdown-checker.sh');
     # Run smoketests on guests
     smoketest('localhost');
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         # This should fix some common issues on the guests. If the procedure fails we still want to go on
         eval {
             ensure_online($guest);

--- a/tests/virtualization/universal/ssh_final.pm
+++ b/tests/virtualization/universal/ssh_final.pm
@@ -14,7 +14,8 @@ use testapi;
 use utils;
 
 sub run_test {
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    my @guests = keys %virt_autotest::common::guests;
+    foreach my $guest (@guests) {
         record_info "$guest", "Establishing SSH connection to $guest";
         assert_script_run "ping -c3 -W1 $guest";
         assert_script_run "ssh root\@$guest 'hostname -f; uptime'";

--- a/tests/virtualization/universal/storage.pm
+++ b/tests/virtualization/universal/storage.pm
@@ -21,10 +21,10 @@ use version_utils;
 our $dir_pool_name = 'testing';
 sub run_test {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     record_info "Prepare";
-    foreach (keys %virt_autotest::common::guests) {
-        script_run("virsh start '$_'") unless is_guest_online($_);
+    foreach (@guests) {
+        script_run("virsh start $_") unless is_guest_online($_);
     }
     ## Prepare Virtualization Dir Storage Pool source
     prepare_dir_storage_pool_source($dir_pool_name);
@@ -35,7 +35,7 @@ sub run_test {
     ## Basic Dir Storage Management
     my $dir_vol_size = '100M';
     my $dir_vol_resize = '200M';
-    virt_storage_management($dir_pool_name, size => $dir_vol_size, dir => 1, resize => $dir_vol_resize);
+    virt_storage_management($dir_pool_name, \@guests, size => $dir_vol_size, dir => 1, resize => $dir_vol_resize);
 
     ## Cleanup
     # Destroy the Dir storage pool
@@ -45,10 +45,11 @@ sub run_test {
 # Prepare Virtualization Dir Storage Pool source
 sub prepare_dir_storage_pool_source {
     my $dir_pool_name = shift;
+    my @guests = keys %virt_autotest::common::guests;
     assert_script_run "mkdir -p /pool_testing";
     script_run "virsh pool-destroy $dir_pool_name";
-    script_run "virsh vol-delete --pool $dir_pool_name $_-storage" foreach (keys %virt_autotest::common::guests);
-    script_run "virsh vol-delete --pool $dir_pool_name $_-clone" foreach (keys %virt_autotest::common::guests);
+    script_run "virsh vol-delete --pool $dir_pool_name $_-storage" foreach (@guests);
+    script_run "virsh vol-delete --pool $dir_pool_name $_-clone" foreach (@guests);
     script_run "virsh pool-undefine $dir_pool_name";
     # Ensure the new pool directory is empty
     script_run('rm -f /pool_testing/*');

--- a/tests/virtualization/universal/stresstest.pm
+++ b/tests/virtualization/universal/stresstest.pm
@@ -19,11 +19,12 @@ sub run_test {
     my $self = shift;
     # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
     $self->select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
+    my @guests = keys %virt_autotest::common::guests;
     # Fetch the test script to local host, before distributing it to the guests
     script_run('curl -v -o /var/tmp/stresstest.sh ' . data_url('virtualization/stresstest.sh'));
     script_run('chmod 0755 /var/tmp/stresstest.sh');
     my ($sles_running_version, $sles_running_sp);
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         # sysbench only available on SLE15+
         ($sles_running_version, $sles_running_sp) = get_os_release("ssh root\@$guest");
         if ($sles_running_version >= 15) {

--- a/tests/virtualization/universal/virsh_start.pm
+++ b/tests/virtualization/universal/virsh_start.pm
@@ -14,8 +14,9 @@ use testapi;
 use utils;
 
 sub run {
+    my @guests = keys %virt_autotest::common::guests;
     record_info "AUTOSTART ENABLE", "Enable autostart for all guests";
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         if (script_run("virsh autostart $guest", 30) != 0) {
             record_info('Softfail', "Cannot enable autostart on $guest guest", result => 'softfail');
         }
@@ -26,7 +27,7 @@ sub run {
 
 
     # Ensure all guests have network connectivity
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         eval {
             ensure_online($guest);
         } or do {

--- a/tests/virtualization/universal/virsh_stop.pm
+++ b/tests/virtualization/universal/virsh_stop.pm
@@ -14,12 +14,13 @@ use testapi;
 use utils;
 
 sub run {
+    my @guests = keys %virt_autotest::common::guests;
     record_info "POWEROFF", "Shut every guest down";
-    script_run "ssh root\@$_ poweroff" foreach (keys %virt_autotest::common::guests);
+    script_run "ssh root\@$_ poweroff" foreach (@guests);
     script_retry "virsh list --all | grep -v Domain-0 | grep running", delay => 3, retry => 60, expect => 1;
 
     record_info "AUTOSTART DISABLE", "Disable autostart for all guests";
-    assert_script_run "virsh autostart --disable $_" foreach (keys %virt_autotest::common::guests);
+    assert_script_run "virsh autostart --disable $_" foreach (@guests);
 
     record_info "LIBVIRTD", "Restart libvirtd and expect all guests to stay down";
     restart_libvirtd;

--- a/tests/virtualization/universal/virtmanager_add_devices.pm
+++ b/tests/virtualization/universal/virtmanager_add_devices.pm
@@ -16,13 +16,13 @@ use virtmanager;
 
 sub run_test {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     #x11_start_program 'virt-manager';
     enter_cmd "virt-manager";
 
     establish_connection();
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         unless ($guest =~ m/hvm/i) {
             record_info "$guest", "VM $guest will get some new devices";
             my $attachFail = 0;    # Indicating if we are having problems attaching devices

--- a/tests/virtualization/universal/virtmanager_final.pm
+++ b/tests/virtualization/universal/virtmanager_final.pm
@@ -15,6 +15,7 @@ use virtmanager;
 
 sub run_test {
     select_console 'root-console';
+    my @guests = keys %virt_autotest::common::guests;
     zypper_call '-t in virt-manager', exitcode => [0, 4, 102, 103, 106];
 
     #x11_start_program 'virt-manager';
@@ -22,7 +23,7 @@ sub run_test {
 
     establish_connection();
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         record_info "$guest", "VM $guest will be turned off and then on again";
 
         select_guest($guest);

--- a/tests/virtualization/universal/virtmanager_init.pm
+++ b/tests/virtualization/universal/virtmanager_init.pm
@@ -17,12 +17,12 @@ use virtmanager;
 sub run_test {
     my ($self) = @_;
     select_console 'root-console';
-
+    my @guests = keys %virt_autotest::common::guests;
     zypper_call '-t in virt-manager', exitcode => [0, 4, 102, 103, 106];
 
     # Ensure additional devices are removed (if present).
     # This is necessary for restarting the virtmanager tests, as we assume the state is clear.
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         remove_additional_nic($guest, "00:16:3e:32");
         remove_additional_disks($guest);
     }

--- a/tests/virtualization/universal/virtmanager_offon.pm
+++ b/tests/virtualization/universal/virtmanager_offon.pm
@@ -15,13 +15,13 @@ use virtmanager;
 
 sub run_test {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     #x11_start_program 'virt-manager';
     enter_cmd "virt-manager";
 
     establish_connection();
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         record_info "$guest", "VM $guest will be turned off and then on again";
 
         select_guest($guest);

--- a/tests/virtualization/universal/virtmanager_rm_devices.pm
+++ b/tests/virtualization/universal/virtmanager_rm_devices.pm
@@ -15,13 +15,13 @@ use virtmanager;
 
 sub run_test {
     my ($self) = @_;
-
+    my @guests = keys %virt_autotest::common::guests;
     #x11_start_program 'virt-manager';
     enter_cmd "virt-manager";
 
     establish_connection();
 
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    foreach my $guest (@guests) {
         unless ($guest =~ m/hvm/i) {
             record_info "$guest", "VM $guest will loose it's aditional HV";
 

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -35,7 +35,7 @@ sub run {
     if (is_sle('>15') && get_var("KVM")) {
         # Adding the PCI bridges requires the guests to be shutdown
         record_info("shutdown guests", "Shutting down all guests");
-        shutdown_guests();
+        shutdown_guests(@guests);
 
         # Add a PCIe root port and a PCIe to PCI bridge for Q35 machine
         if (is_sle('<15-SP4')) {
@@ -44,7 +44,7 @@ sub run {
             assert_script_run("virt-xml $_ --add-device --controller type=pci,model=pcie-to-pci-bridge") foreach (@guests);
         }
         record_info("Starting guests", "Starting all guests");
-        start_guests();
+        start_guests(@guests);
         ensure_online $_, skip_ssh => 1, ping_delay => 45 foreach (@guests);
     }
     assert_script_run('virsh list --all');

--- a/tests/virtualization/universal/windows.pm
+++ b/tests/virtualization/universal/windows.pm
@@ -30,8 +30,6 @@ sub run {
 
     # Remove already existing guests to ensure a fresh start (needed for restarting jobs)
     remove_guest $_ foreach (keys %virt_autotest::common::imports);
-    #    shutdown_guests();    # Shutdown SLES guests as they are not needed here
-
     import_guest $_, 'virt-install' foreach (values %virt_autotest::common::imports);
     add_guest_to_hosts $_, $virt_autotest::common::imports{$_}->{ip} foreach (keys %virt_autotest::common::imports);
 

--- a/tests/virtualization/universal/xl_create.pm
+++ b/tests/virtualization/universal/xl_create.pm
@@ -13,24 +13,25 @@ use testapi;
 use utils;
 
 sub run {
+    my @guests = keys %virt_autotest::common::guests;
     record_info "XML", "Export the XML from virsh and convert it into Xen config file";
-    assert_script_run "virsh dumpxml $_ > $_.xml" foreach (keys %virt_autotest::common::guests);
-    assert_script_run "virsh domxml-to-native xen-xl $_.xml > $_.xml.cfg" foreach (keys %virt_autotest::common::guests);
+    assert_script_run "virsh dumpxml $_ > $_.xml" foreach (@guests);
+    assert_script_run "virsh domxml-to-native xen-xl $_.xml > $_.xml.cfg" foreach (@guests);
 
     record_info "Name", "Change the name by adding suffix _xl";
-    assert_script_run "sed -rie 's/(name = \\W)/\\1xl-/gi' $_.xml.cfg" foreach (keys %virt_autotest::common::guests);
-    assert_script_run "cat $_.xml.cfg | grep name" foreach (keys %virt_autotest::common::guests);
+    assert_script_run "sed -rie 's/(name = \\W)/\\1xl-/gi' $_.xml.cfg" foreach (@guests);
+    assert_script_run "cat $_.xml.cfg | grep name" foreach (@guests);
 
     record_info "UUID", "Change the UUID by using f00 as three first characters";
-    assert_script_run "sed -rie 's/(uuid = \\W)(...)/\\1f00/gi' $_.xml.cfg" foreach (keys %virt_autotest::common::guests);
-    assert_script_run "cat $_.xml.cfg | grep uuid" foreach (keys %virt_autotest::common::guests);
+    assert_script_run "sed -rie 's/(uuid = \\W)(...)/\\1f00/gi' $_.xml.cfg" foreach (@guests);
+    assert_script_run "cat $_.xml.cfg | grep uuid" foreach (@guests);
 
     record_info "Start", "Start the new VM";
-    assert_script_run "xl create $_.xml.cfg" foreach (keys %virt_autotest::common::guests);
-    assert_script_run "xl list xl-$_" foreach (keys %virt_autotest::common::guests);
+    assert_script_run "xl create $_.xml.cfg" foreach (@guests);
+    assert_script_run "xl list xl-$_" foreach (@guests);
 
     record_info "SSH", "Test that the new VM listens on SSH";
-    script_retry "nmap $_ -PN -p ssh | grep open", delay => 30, retry => 12 foreach (keys %virt_autotest::common::guests);
+    script_retry "nmap $_ -PN -p ssh | grep open", delay => 30, retry => 12 foreach (@guests);
 
 }
 

--- a/tests/virtualization/universal/xl_stop.pm
+++ b/tests/virtualization/universal/xl_stop.pm
@@ -13,7 +13,8 @@ use testapi;
 use utils;
 
 sub run {
-    foreach my $guest (keys %virt_autotest::common::guests) {
+    my @guests = keys %virt_autotest::common::guests;
+    foreach my $guest (@guests) {
         record_info "$guest", "Stopping xl-$guest guests";
         assert_script_run "xl shutdown -w xl-$guest", 180;
     }


### PR DESCRIPTION
Get guest list through local array instead of directly accessing "virt_autotest::common::guests" defined in lib/virt_autotest/common.pm.

https://progress.opensuse.org/issues/116797

- Related ticket: https://progress.opensuse.org/issues/116797
- Needles: no
- Verification run: 
- sle12sp5: http://10.67.183.130/tests/overview?distri=sle&groupid=2&build=%3AS%3AM%3A25280%3A277208%3Acm&version=12-SP5
- sle15sp3 kvm: http://openqa.qam.suse.cz/tests/overview?version=15-SP3&distri=sle&build=zoe%3A30201&groupid=154
- sle15sp4 xen: http://openqa.qam.suse.cz/tests/overview?version=15-SP4&distri=sle&groupid=163&build=%3Atest%3Aboot%3Aamidala
