### PR TITLE
Remove validation from svirt-hyperv failing jobs

### DIFF
--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -8,28 +8,11 @@ vars:
   LVM: 1
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/setup_raid1_lvm
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
+  suggested_partitioning:
+    - installation/partitioning/setup_raid1_lvm
+  security:
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/validate_lvm_raid1
+  installation_logs: []
 test_data:
   <<: !include test_data/yast/lvm_raid1/lvm+raid1_hyperv.yaml

--- a/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-svirt-hyperv.yaml
@@ -10,41 +10,13 @@ vars:
   PATTERNS: base,enhanced_base
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
+  software:
   - installation/select_patterns
+  security:
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/security/select_security_module_none
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/confirm_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/installation_snapshots
-  - console/zypper_lr
-  - console/zypper_ref
-  - console/ncurses
-  - console/glibc_sanity
-  - update/zypper_up
-  - console/zypper_lifecycle
-  - console/orphaned_packages_check
-  - console/validate_installed_patterns
-  - console/consoletest_finish
+  installation_logs: []
 test_data:
   software:
     patterns:

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@svirt-hyperv.yaml
@@ -15,35 +15,17 @@ vars:
   ADDONS: all-packages
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/skip_registration
-  - installation/module_selection/select_nonconflicting_modules
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/select_patterns
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/integration_services
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_installed_packages
-  - console/validate_installed_patterns
-  - shutdown/cleanup_before_shutdown
-  - console/suseconnect_scc
-  - shutdown/shutdown
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_nonconflicting_modules
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  software:
+    - installation/select_patterns
+  security:
+    - installation/installation_settings/validate_ssh_service_enabled
+    - installation/installation_settings/open_ssh_port
+  installation_logs: []


### PR DESCRIPTION
We need to remove the validations from jobs like svirt-hyperv in yast dev, cause this kind
of virtualization is pretty slow and the problem is not going to be fixed any time soon.

- Related ticket: https://progress.opensuse.org/issues/111231
- Needles: N/A
- Verification run: 
   https://openqa.suse.de/tests/9750427
   https://openqa.suse.de/tests/9750428
   https://openqa.suse.de/tests/9750568
   https://openqa.suse.de/tests/9750569
   https://openqa.suse.de/tests/9751314
   https://openqa.suse.de/tests/9751315
- Related MR:
  https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/431