### PR TITLE
Fix mau-extratests2 yaml schedule for SLE 15-SP4

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -37,7 +37,18 @@ conditional_schedule:
   version_specific:
     VERSION:
       15-SP4:
+        - console/osinfo_db
+        - console/ovn
+        - console/firewalld
+        - console/libgcrypt
+        - console/valgrind
+        - console/zziplib
+        - console/journald_fss
+        - console/openvswitch_ssl
+        - network/samba/samba_adcli
+        - console/nginx
         - console/ansible
+        - '{{arch_specific}}'
       15-SP3:
         - console/osinfo_db
         - console/ovn


### PR DESCRIPTION
Schedule **15-SP4** -specific tests from **15-SP3** in `mau-extratests2.yaml`

- Verification run: [pdostal-server.suse.cz/t2746](https://pdostal-server.suse.cz/tests/2746)
