### PR TITLE
tsm should be used short for transactional

### DIFF
--- a/lib/Installation/ModuleRegistration/ModuleRegistrationPage.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegistrationPage.pm
@@ -31,7 +31,7 @@ sub init {
     $self->{rct_item_desktop} = 'sle-module-desktop-applications';
     $self->{rct_item_sdk} = 'sle-module-development-tools';
     $self->{rct_item_legacy} = 'sle-module-legacy';
-    $self->{rct_item_transactional} = 'sle-module-transactional-server';
+    $self->{rct_item_tsm} = 'sle-module-transactional-server';
     $self->{rct_item_script} = 'sle-module-web-scripting';
     $self->{rct_item_python2} = 'sle-module-python2';
     $self->{rct_item_python3} = 'sle-module-python3';

--- a/tests/installation/module_registration/register_extensions_and_modules.pm
+++ b/tests/installation/module_registration/register_extensions_and_modules.pm
@@ -11,10 +11,10 @@
 use base 'y2_installbase';
 use strict;
 use warnings;
-use testapi qw(save_screenshot get_var);
+use testapi qw(save_screenshot get_var get_required_var);
 
 sub run {
-    my @scc_addons = split ',', get_var('SCC_ADDONS');
+    my @scc_addons = grep($_, split(/,/, get_required_var('SCC_ADDONS')));
     $testapi::distri->get_module_registration()->register_extension_and_modules([@scc_addons]);
     save_screenshot;
 

--- a/tests/installation/module_registration/register_module_transactional.pm
+++ b/tests/installation/module_registration/register_module_transactional.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 
 sub run {
-    $testapi::distri->get_module_registration()->register_module('transactional');
+    $testapi::distri->get_module_registration()->register_module('tsm');
 }
 
 1;


### PR DESCRIPTION
tsm should be used short for transactional

- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15539
- VR: http://openqa.suse.de/tests/9750635#
https://openqa.suse.de/tests/9750699#