### PR TITLE
Install curl if not present when running script_output 

### DIFF
--- a/tests/console/orphaned_packages_check.pm
+++ b/tests/console/orphaned_packages_check.pm
@@ -62,6 +62,7 @@ sub run {
 
     record_info((is_offline_upgrade_or_livecd) ? 'Upgrade/LiveCD' : 'No upgrade/LiveCD', 'Upgraded or installed from LIVECD can possibly cause orphans');
 
+    zypper_call('in curl') if (script_run('rpm -qi curl') == 1);
     # Orphans are also expected in JeOS without SDK module (jeos-firstboot, jeos-license and live-langset-data)
     # Save the orphaned packages list to one log file and upload the log, so QA can use this log to report bug
     # Filter out zypper warning messages and release or skelcd packages

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -64,6 +64,7 @@ sub run {
     # For some reason the system will change the permission on /var/cache/zypp/{solv,raw}
     # files. this cause the zypper lifecycle failed when building cache for non-root user.
     assert_script_run('chmod -R u+rwX,og+rX /var/cache/zypp');
+    zypper_call('in curl') if (script_run('rpm -qi curl') == 1);
 
     select_console 'user-console';
     my $overview = script_output('zypper lifecycle', 600);


### PR DESCRIPTION
Install curl if not present when running script_output with content fetched through HTTP

- Related ticket: https://progress.opensuse.org/issues/116854
- Verification run: http://openqa.suse.de/t9725451
http://openqa.suse.de/tests/9750431#