### PR TITLE
Add workaround for bug failed in first boot

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1049,6 +1049,15 @@ sub wait_boot_past_bootloader {
     my $nologin = $args{nologin};
     my $forcenologin = $args{forcenologin};
 
+    # Workaround for bsc#1204221 and bsc#1204230
+    if (is_sle('=15-SP5') && check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        # This should only happen on SLE15SP5 and on hyperv
+        record_soft_failure 'workaround bsc#1204221 - Failed to boot at SLES15SP5 with gnome in hyperv 2019' if check_var('DESKTOP', 'gnome');
+        record_soft_failure 'workaround bsc#1204230 - Failed to boot at SLES15SP5 with x server in hyperv 2019' if check_var('DESKTOP', 'textmode');
+        sleep 30;
+        send_key 'esc';
+    }
+
     # On IPMI, when selecting x11 console, we are connecting to the VNC server on the SUT.
     # select_console('x11'); also performs a login, so we should be at generic-desktop.
     my $gnome_ipmi = (is_ipmi && check_var('DESKTOP', 'gnome'));


### PR DESCRIPTION
Poo#https://progress.opensuse.org/issues/118975
Workaround for bsc#1204221 and bsc#1204230


- Related ticket: https://progress.opensuse.org/issues/118975
- Needles: N/A
- Verification run: [x server](http://openqa.suse.de/tests/9757145#step/first_boot/1) and [Gnome](https://openqa.suse.de/tests/9756649#step/first_boot/1)
