### PR TITLE
console/snapper_used_space: Use "none" disable btrfs compression

### DIFF
--- a/tests/console/snapper_used_space.pm
+++ b/tests/console/snapper_used_space.pm
@@ -19,7 +19,7 @@ use testapi;
 
 use constant COLUMN_FILTER => "awk -F '|' '{print \$1  \$6}'";    # Filter by columns: # and Used Space
 use constant SUBVOLUME_FILTER => "tail -n4 | sed -n 2,3p | cut -d ' ' -f2";    # Subvolume IDs
-use constant CREATE_BIG_FILE => "touch /big-data && btrfs prop set /big-data compression '' && dd if=/dev/zero of=/big-data bs=1M count=1024";
+use constant CREATE_BIG_FILE => "touch /big-data && btrfs prop set /big-data compression 'none' && dd if=/dev/zero of=/big-data bs=1M count=1024";
 use constant REMOVE_BIG_FILE => "rm /big-data";
 
 =head2 ensure_size_displayed


### PR DESCRIPTION
In newer kernel versions, the meaning of "" changed in a backwards-incompatible way. To disable compression, "none" has to be used instead. This also works with older versions of the kernel and btrfsprogs.

- Related tickets: https://bugzilla.opensuse.org/show_bug.cgi?id=1195224, https://jira.suse.com/browse/PED-63
- Verification run: https://openqa.opensuse.org/tests/2813217
