### PR TITLE
lib/qam: Don't add repo if already present

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -80,6 +80,7 @@ sub add_test_repositories {
     my $oldrepo = get_var('PATCH_TEST_REPO');
     my @repos = split(/,/, get_var('MAINT_TEST_REPO', ''));
     my $gpg = get_var('BUILD') =~ m/^MR:/ ? "-G" : "";
+    my $system_repos = script_output('zypper lr -u');
     # Be carefull. If you have defined both variables, the PATCH_TEST_REPO variable will always
     # have precedence over MAINT_TEST_REPO. So if MAINT_TEST_REPO is required to be installed
     # please be sure that the PATCH_TEST_REPO is empty.
@@ -91,6 +92,8 @@ sub add_test_repositories {
         zypper_call('--gpg-auto-import-keys ref', timeout => 1400, exitcode => [0, 106]);
     } else {
         for my $var (@repos) {
+            # don't add repo when it's already present
+            next if $system_repos =~ /$var/;
             zypper_call("--no-gpg-checks ar -f $gpg -n 'TEST_$counter' $var 'TEST_$counter'");
             $counter++;
         }


### PR DESCRIPTION
Update repos are added during installation, no need to waste time and add the repo again.

- Fail: https://openqa.suse.de/tests/9756589
- Verification run:

Before:
https://openqa.suse.de/tests/9756874 (02:00 hours)
https://openqa.suse.de/tests/9755387 (01:19 hours)
https://openqa.suse.de/tests/9755614 (01:23 hours)
https://openqa.suse.de/tests/9755661 (03:29 hours)
https://openqa.suse.de/tests/9755391 (02:50 hours)
https://openqa.suse.de/tests/9754154 (01:10 hours)

After:
https://openqa.suse.de/tests/9757130 (01:24 hours)
https://openqa.suse.de/tests/9757123 (01:15 hours)
https://openqa.suse.de/tests/9757124 (01:16 hours)
https://openqa.suse.de/tests/9757125 (02:44 hours)
https://openqa.suse.de/tests/9757126 (02:30 hours)
https://openqa.suse.de/tests/9757129 (53:26 minutes) not affected