### PR TITLE
Create new slem5.3 AY profile

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro53_updates.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro53_updates.xml.ep
@@ -9,9 +9,9 @@
   <add-on>
     <add_on_products config:type="list">
       <listentry>
-        <name>SUSE-MicroOS-<%= $get_var->('VERSION') %>-Updates</name>
-        <alias>SUSE-MicroOS-<%= $get_var->('VERSION') %>-Updates</alias>
-        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Updates/SUSE-MicroOS/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
+        <name>SLE-Micro-<%= $get_var->('VERSION') %>-Updates</name>
+        <alias>SLE-Micro-<%= $get_var->('VERSION') %>-Updates</alias>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Updates/SLE-Micro/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
       </listentry>
     </add_on_products>
   </add-on>
@@ -26,9 +26,12 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <networking>
+    <managed config:type="boolean">true</managed>
+  </networking>
   <software>
     <products config:type="list">
-      <product>SUSE-MicroOS</product>
+      <product>SLE-Micro</product>
     </products>
     <install_recommended config:type="boolean">true</install_recommended>
     <packages config:type="list">


### PR DESCRIPTION
Due to changes in the assets names and product name, and also because of
NM replacing `wicked`, we have to introduce a new profile.
The `<networking>` section is a workaround for
https://bugzilla.suse.com/show_bug.cgi?id=1203934

- Verification run: [sle-micro-5.3-DVD-Updates-x86_64-Build20221018-1-slem_installation_autoyast@64bit](http://kepler.suse.cz/tests/19436#)
