### PR TITLE
Add hana_vars and proper sshkey sharing in Trento

### DIFF
--- a/data/sles4sap/qe_sap_deployment/trento_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/trento_azure.yaml
@@ -13,6 +13,14 @@ ansible:
     - "%HANA_SAR%"
     - "%HANA_CLIENT_SAR%"
     - "%HANA_SAPCAR%"
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HDB'
+    sap_hana_install_instance_number: '00'
+    sap_domain: "qe-test.example.com"
+    primary_site: 'goofy'
+    secondary_site: 'miky'
   create:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -283,11 +283,12 @@ sub qesap_prepare_env {
     qesap_yaml_replace(openqa_variables => $variables);
     push(@log_files, $paths{qesap_conf_trgt});
 
-    record_info("QESAP conf", "Generating tfvars file");
+    record_info("QESAP conf", "Generating all terraform and Ansible configuration files");
     push(@log_files, "$paths{terraform_dir}/$provider/terraform.tfvars");
     push(@log_files, "$paths{deployment_dir}/ansible/playbooks/vars/hana_media.yaml");
-    push(@log_files, "$paths{deployment_dir}/ansible/playbooks/vars/hana_vars.yaml");
+    my $hana_vars = "$paths{deployment_dir}/ansible/playbooks/vars/hana_vars.yaml";
     my $exec_rc = qesap_execute(cmd => 'configure', verbose => 1);
+    push(@log_files, $hana_vars) if (script_run("test -e $hana_vars") == 0);
     qesap_upload_logs();
     die if $exec_rc != 0;
     return;

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -235,11 +235,6 @@ sub config_cluster {
     my $ssh_key_pub = SSH_KEY . '.pub';
     my $qesap_provider = lc get_required_var('PUBLIC_CLOUD_PROVIDER');
 
-    # Get the code for the qe-sap-deployment
-    qesap_create_folder_tree();
-    qesap_get_deployment_code();
-    qesap_pip_install();
-
     my %variables;
     $variables{PROVIDER} = $qesap_provider;
     $variables{REGION} = $region;
@@ -445,7 +440,7 @@ sub install_agent {
     if (get_var('TRENTO_AGENT_RPM')) {
         my $package = get_var('TRENTO_AGENT_RPM');
         my $ibs_location = get_var(TRENTO_AGENT_REPO => 'https://dist.suse.de/ibs/Devel:/SAP:/trento:/factory/SLE_15_SP3/x86_64');
-        $cmd = "curl \"$ibs_location/$package\" --output $wd/$package";
+        $cmd = "curl --verbose \"$ibs_location/$package\" --output $wd/$package";
         assert_script_run($cmd);
         $local_rpm_arg = " -e agent_rpm=$wd/$package";
     }
@@ -455,7 +450,8 @@ sub install_agent {
         "$playbook_location/trento-agent.yaml",
         $local_rpm_arg,
         '-e', "api_key=$agent_api_key",
-        '-e', "trento_private_addr=$priv_ip");
+        '-e', "trento_private_addr=$priv_ip",
+        '-e', 'trento_server_pub_key=' . SSH_KEY . '.pub');
     assert_script_run($cmd);
 }
 

--- a/tests/sles4sap/trento/deploy_trento.pm
+++ b/tests/sles4sap/trento/deploy_trento.pm
@@ -63,6 +63,7 @@ sub run {
     my $cmd = $script_run . $script_id . '.sh' .
       " -g $resource_group" .
       " -n $acr_name" .
+      " -u " . $self->VM_USER .
       " -r $trento_registry_chart";
     if (get_var("TRENTO_REGISTRY_IMAGE_$imgs[0]") || get_var("TRENTO_REGISTRY_IMAGE_$imgs[1]")) {
         $trento_acr_azure_timeout += 240;


### PR DESCRIPTION
Add mandatory hana_vars variables to the Trento config.yaml Add new argument about ssh key to use when calling trento-agent.yaml Ansible playbook



- Verification run: https://openqaworker15.qa.suse.cz/tests/56198