### PR TITLE
wicked/wlan: Skip auto keymgmt with SAE on wpa_supplicant <2.10

### DIFF
--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -14,8 +14,10 @@ use version_utils qw(is_sle);
 use repo_tools qw(add_qa_head_repo generate_version);
 use utils qw(zypper_call);
 use testapi;
+use version_utils 'check_version';
 
 has wicked_version => undef;
+has wpa_supplicant_version => undef;
 has need_key_mgmt => undef;
 has eap_user => 'tester';
 has eap_password => 'test1234';
@@ -311,6 +313,32 @@ sub skip_by_supported_key_mgmt {
     return 0;
 }
 
+sub get_wpa_supplicant_version {
+    my $v = script_output(q(rpm -qa 'wpa_supplicant' --qf '%{VERSION}\n'));
+    die("Unable to get wpa_suplicant version '$v'") unless $v =~ /^\d+\.\d+$/;
+    return $v;
+}
+
+sub check_wpa_supplicant_version {
+    my ($self, $query) = @_;
+    return check_version($query, $self->get_wpa_supplicant_version());
+}
+
+sub skip_by_wpa_supplicant_version {
+    my ($self) = @_;
+    return 0 unless $self->wpa_supplicant_version;
+
+    if (!$self->check_wpa_supplicant_version($self->wpa_supplicant_version)) {
+        record_info('SKIP', 'Skip test - wpa_supplicant version does not match ' .
+              $self->wpa_supplicant_version,
+            result => 'softfail');
+        $self->result('skip');
+        return 1;
+    }
+
+    return 0;
+}
+
 sub hostapd_start {
     my ($self, $config, %args) = @_;
     $args{name} //= 'hostapd';
@@ -384,7 +412,7 @@ sub __as_config_array {
     my $param = shift;
     my @ret;
     foreach my $in (__as_array($param)) {
-        my $cfg = {config => '', wicked_version => '>=0.0.0'};
+        my $cfg = {config => '', wicked_version => '>=0.0.0', wpa_supplicant_version => '>=0.0.0'};
         if (ref($in) eq 'HASH') {
             $cfg = {%{$cfg}, %{$in}};
         } else {
@@ -400,6 +428,7 @@ sub run {
     $self->select_serial_terminal;
     return if ($self->skip_by_wicked_version());
     return if ($self->skip_by_supported_key_mgmt());
+    return if ($self->skip_by_wpa_supplicant_version());
 
     $self->setup_ref();
 
@@ -413,7 +442,8 @@ sub run {
         for my $ifcfg_wlan (__as_config_array($self->ifcfg_wlan())) {
             $self->hostapd_start($hostapd_conf->{config});
 
-            if ($self->check_wicked_version($ifcfg_wlan->{wicked_version})) {
+            if ($self->check_wicked_version($ifcfg_wlan->{wicked_version}) &&
+                $self->check_wpa_supplicant_version($ifcfg_wlan->{wpa_supplicant_version})) {
                 # Setup sut
                 $self->write_cfg('/etc/sysconfig/network/ifcfg-' . $self->sut_ifc, $ifcfg_wlan->{config});
                 $self->wicked_command('ifup', $self->sut_ifc);

--- a/tests/wicked/wlan/sut/t15_wpa3_personal.pm
+++ b/tests/wicked/wlan/sut/t15_wpa3_personal.pm
@@ -3,13 +3,11 @@
 # Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Test WiFi setup with wicked for wpa3 transition
+# Summary: Test WiFi setup with wicked for wpa3-personal only
 #          (WPA-PSK or SAE with DHCP)
-#   - The AP is connfiguered to allow WPA-PSK and SAE connections
-#   - Connect to AP with WPA-PSK
-#   - Connect to AP with WPA-PSK + PMF
+#   - The AP is connfiguered to allow SAE connections with PMF
+#   - Connect to AP with only SSID and PSK set (autosection)
 #   - Connect to AP with SAE
-#   - Connect to AP with SAE + PMF
 #   - Each connection is checked with data bi-directional traffic
 #
 # Maintainer: cfamullaconrad@suse.com
@@ -41,14 +39,18 @@ has hostapd_conf => q(
 );
 
 has ifcfg_wlan => sub { [
-        q(
-        # By default, 80211mac_hwsim has SAE capabilities, so autoselection should work
-        BOOTPROTO='dhcp'
-        STARTMODE='auto'
+        {
+            config => q(
+            # By default, 80211mac_hwsim has SAE capabilities, so autoselection should work
+            # Do not run with wpa_supplicant <2.10, as SAE isn't propagated via DBus capabilities
+            BOOTPROTO='dhcp'
+            STARTMODE='auto'
 
-        WIRELESS_ESSID='{{ssid}}'
-        WIRELESS_WPA_PSK='{{psk}}'
-    ),
+            WIRELESS_ESSID='{{ssid}}'
+            WIRELESS_WPA_PSK='{{psk}}'
+        ),
+            wpa_supplicant_version => '>=2.10'
+        },
         q(
         BOOTPROTO='dhcp'
         STARTMODE='auto'


### PR DESCRIPTION
wpa_supplicant <2.10 does not send SAE in DBus capabilites. Thus wicked will not auto select SAE, which is in my point of view correct.

- Verification run: http://openqa.wicked.suse.de/tests/84944#step/t15_wpa3_personal/10
