### PR TITLE
Extend the timeout for add on product page to appear

### DIFF
--- a/lib/Installation/AddOnProduct/AddOnProductPage.pm
+++ b/lib/Installation/AddOnProduct/AddOnProductPage.pm
@@ -24,7 +24,7 @@ sub is_shown {
     my ($self) = @_;
     # on slower archs like aarch64 the system probing might take longer, so
     # we extend the timeout for this page to appear
-    return $self->{rdb_specify_url}->exist({timeout => 240});
+    return $self->{rdb_specify_url}->exist({timeout => 600});
 }
 
 sub confirm_like_additional_add_on {


### PR DESCRIPTION
Extend the timeout for add on product page to appear

- Related ticket: https://progress.opensuse.org/issues/119038
- Verification run: https://openqa.suse.de/tests/9766606#
