### PR TITLE
Don't install packages during system installation

### DIFF
--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -17,7 +17,6 @@ vars:
     IPXE_CONSOLE: ttyS1,115200
     KERNEL_GIT_TREE: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
     KERNEL_GIT_BRANCH: for-next
-    PACKAGES: rdma-core,rdma-ndd
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
 schedule:
@@ -33,7 +32,6 @@ schedule:
     - installation/user_settings
     - installation/user_settings_root
     - installation/resolve_dependency_issues
-    - installation/select_packages
     - installation/installation_overview
     - installation/disable_grub_graphics
     - installation/disable_grub_timeout

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -15,7 +15,6 @@ vars:
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_CONSOLE: ttyS1,115200
-    PACKAGES: rdma-core,rdma-ndd
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
 schedule:
@@ -31,7 +30,6 @@ schedule:
     - installation/user_settings
     - installation/user_settings_root
     - installation/resolve_dependency_issues
-    - installation/select_packages
     - installation/installation_overview
     - installation/disable_grub_graphics
     - installation/disable_grub_timeout

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -17,7 +17,6 @@ vars:
     IPXE_CONSOLE: ttyS1,115200
     KERNEL_GIT_TREE: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
     KERNEL_GIT_BRANCH: for-next
-    PACKAGES: rdma-core,rdma-ndd
     PARALLEL_WITH: ibtest-master
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
@@ -33,7 +32,6 @@ schedule:
     - installation/user_settings
     - installation/user_settings_root
     - installation/resolve_dependency_issues
-    - installation/select_packages
     - installation/installation_overview
     - installation/disable_grub_graphics
     - installation/disable_grub_timeout

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -15,7 +15,6 @@ vars:
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
     IPXE_CONSOLE: ttyS1,115200
-    PACKAGES: rdma-core,rdma-ndd
     PARALLEL_WITH: ibtest-master
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
@@ -31,7 +30,6 @@ schedule:
     - installation/user_settings
     - installation/user_settings_root
     - installation/resolve_dependency_issues
-    - installation/select_packages
     - installation/installation_overview
     - installation/disable_grub_graphics
     - installation/disable_grub_timeout


### PR DESCRIPTION
Currently, we install rdma-core and rdma-ndd during system installation. Initially the idea was to save a reboot after installation, but in the meantime, we both install these packages and do an unconditional reboot in ibtests_prepare.pm. So it is perfectly fine to remove this from our schedules, and thus avoid failing needle checks during installation.
