### PR TITLE
Apply bsc#1189550 workaround to cryptlvm_minimal_x

### DIFF
--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -69,6 +69,7 @@ sub change_desktop {
     }
     else {
         if (!check_var('DESKTOP', 'gnome')) {
+            $self->workaround_bsc1189550();
             send_key_until_needlematch 'gnome-selected', 'down';
             send_key ' ';
         }


### PR DESCRIPTION
Related to poo#119119.
Scrolling for pattern selection can encounter bsc#1189550. A workaround is to scroll to the end and back via "End" and "Home" keys. This workaround now needs to be applied to the change_desktop module of cryptlvm_minimal_x testsuite.


- Related ticket: https://progress.opensuse.org/issues/119119
- Needles: No needles
- Verification run: Pending
