### PR TITLE
Adjust ansible test module for ALP and SLEM and get rid of user serial terminal

### DIFF
--- a/data/console/ansible/hosts
+++ b/data/console/ansible/hosts
@@ -1,3 +1,3 @@
 [all]
-localhost  ansible_connection=ssh ansible_user=ANSIBLEUSER
+localhost  ansible_connection=ssh ansible_user=ANSIBLEUSER ansible_ssh_private_key_file=~/.ssh/ansible_rsa
 

--- a/data/console/ansible/hosts
+++ b/data/console/ansible/hosts
@@ -1,3 +1,3 @@
 [all]
-localhost  ansible_connection=ssh
+localhost  ansible_connection=ssh ansible_user=ANSIBLEUSER
 

--- a/data/console/ansible/roles/test/tasks/main.yaml
+++ b/data/console/ansible/roles/test/tasks/main.yaml
@@ -29,7 +29,6 @@
     src: /etc/os-release
     dest: /tmp/ansible/os-release
     state: link
-    owner: johnd
 
 - name: Copy static file to /tmp/ansible/static.txt
   ansible.builtin.copy:
@@ -41,6 +40,7 @@
 # In later we should use community.general.zypper
 - name: Install ed
   become: true
+  tags: zypper
   COMMUNITYGENERALzypper:
     name: ed
     state: present 

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -65,6 +65,7 @@ sub load_feature_tests {
     # MicroOS -old images use wicked, but cockpit-wicked is no longer supported in TW
     loadtest 'microos/cockpit_service' unless is_staging || (is_microos('Tumbleweed') && get_var('HDD_1') =~ /-old/);
     loadtest 'console/journal_check';
+    loadtest 'console/ansible';
     if (check_var 'SYSTEM_ROLE', 'kubeadm') {
         loadtest 'console/kubeadm';
     }

--- a/schedule/jeos/sle/jeos-extratest.yaml
+++ b/schedule/jeos/sle/jeos-extratest.yaml
@@ -60,3 +60,4 @@ schedule:
     - console/dstat
     - console/journalctl
     - console/procps
+    - console/ansible


### PR DESCRIPTION
 * Enable the Ansible test module for ALP, MicroOS and JeOS.
 * Get rid of user serial terminal as it's hacky and unstable on s390x.

- Follows after: #15684
- Related ticket: [poo#116935](https://progress.opensuse.org/issues/116935)
- Discovered bug: [bsc#1204544](https://bugzilla.suse.com/show_bug.cgi?id=1204544)
- Verification run:
  - opensuse-Tumbleweed-DVD.x86_64 [extra_tests_textmode@64bit](https://pdostal-server.suse.cz/tests/2864)
  - jeos-extratest@uefi-virtio-vga [jeos-extratest@uefi-virtio-vga](https://pdostal-server.suse.cz/tests/2866)
  - microos@64bit [microos@64bit](https://pdostal-server.suse.cz/tests/2867)
  - mau-extratests2@64bit [mau-extratests2@64bit](https://pdostal-server.suse.cz/tests/2870)
  - alp_default@64bit [alp_default@64bit](https://pdostal-server.suse.cz/tests/2871)

This currently does not test the `zypper` module on transactional systems - that will be added later.