### PR TITLE
Apply keyboard based workaround for bsc1189550

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -17,8 +17,6 @@ use lockapi;
 use mmapi;
 use Test::Assert 'assert_equals';
 
-my $workaround_bsc1189550_done;
-
 =head1 y2_installbase
 
 C<y2_installbase> - Base class for Yast installer related functionality
@@ -183,9 +181,11 @@ highlight cursor one item down.
 =cut
 
 sub move_down {
+    # Sending 'down' twice, followed by 'up', scrolls to the intended item.
+    wait_screen_change { send_key 'down' } if is_sle('>=15-sp3');
     my $ret = wait_screen_change { send_key 'down' };
-    workaround_bsc1189550() if (!$workaround_bsc1189550_done && is_sle('>=15-sp3'));
     last if (!$ret);    # down didn't change the screen, so exit here
+    wait_screen_change { send_key 'up' } if is_sle('>=15-sp3');
     check12qtbug if check_var('VERSION', '12');
 }
 
@@ -623,12 +623,6 @@ sub post_fail_hook {
         # Collect yast2 installer  strace and gbd debug output if is still running
         $self->save_strace_gdb_output;
     }
-}
-
-sub workaround_bsc1189550 {
-    wait_screen_change { send_key 'end' };
-    wait_screen_change { send_key 'home' };
-    $workaround_bsc1189550_done = 1;
 }
 
 # All steps in the installation are 'fatal'.


### PR DESCRIPTION
Sending "End" and "Home" no longer works for mitigating the scrolling bar issue described in [bsc#1189550](https://bugzilla.suse.com/show_bug.cgi?id=1189550).
A new workaround is to press down twice and the press up, forcing the scroll bar to adjust on the proper item.
The issue can be seen [here](https://openqa.suse.de/tests/9807690#step/select_patterns/53) where the Gnome Desktop Environment pattern is not unselected, because the bar has not scrolled down to make it visible, causing the test to fail at the final module. This was mitigated by an old workaround that no longer works.

- Related ticket: No
- Needles: No needles
- Verification run:  [with workaround](https://openqa.suse.de/tests/9808175#) | [without workaround](https://openqa.suse.de/tests/9808170#)