### PR TITLE
Fix timeout issue with yast clone-system

### DIFF
--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -23,7 +23,9 @@ sub run {
     if (check_screen 'autoyast2-install-accept', 10) {
         send_key 'alt-i';    # confirm package installation
     }
-    wait_serial("$module_name-0", 700) || die "'yast2 clone_system' exited with non-zero code";
+    # performance issue on aarch64-virtio, need to extend timeout value, see poo#119134
+    my $timeout = (get_var('MACHINE', 'aarch64-virtio')) ? 1400 : 700;
+    wait_serial("$module_name-0", $timeout) || die "'yast2 clone_system' exited with non-zero code";
     upload_logs '/root/autoinst.xml';
 
     # original autoyast on kernel cmdline


### PR DESCRIPTION
extend timeout value for yast clone-system on aarch64-virtio
see https://progress.opensuse.org/issues/119134

VRs:
https://openqa.suse.de/tests/9798914
https://openqa.suse.de/tests/9799793
https://openqa.suse.de/tests/9800185
https://openqa.opensuse.org/tests/2831200
https://openqa.opensuse.org/tests/2831402