### PR TITLE
Exclude rebootmgr in transactional_server_helper_apps

### DIFF
--- a/schedule/yast/transactional_server/transactional_server_helper_apps_exclude_rebootmgr.yaml
+++ b/schedule/yast/transactional_server/transactional_server_helper_apps_exclude_rebootmgr.yaml
@@ -1,0 +1,17 @@
+---
+name:           transactional_server_helper_apps_exclude_rebootmgr
+description:    >
+   Test transactional updates with Btrfs and helper applications
+   in a transactional update server.
+vars:
+  BOOT_HDD_IMAGE: 1
+  HDDSIZEGB: 40
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/hostname
+  - transactional/filesystem_ro
+  - transactional/transactional_update
+  - transactional/health_check


### PR DESCRIPTION
We need exclude rebootmgr in transactional_server_helper_apps in yast group.

- Related ticket: https://progress.opensuse.org/issues/117127
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/9798317#details
