### PR TITLE
Split register_extensions_and_modules to handle separately additional registration

### DIFF
--- a/schedule/yast/maintenance/lvm_thin_provisioning_dev.yaml
+++ b/schedule/yast/maintenance/lvm_thin_provisioning_dev.yaml
@@ -10,6 +10,8 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_extensions_and_modules
+  - installation/module_registration/add_additional_regcodes
+  - installation/module_registration/import_untrusted_gnpupg_key
   - installation/add_on_product_installation/add_additional_products
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_SLES_with_GNOME

--- a/schedule/yast/maintenance/ncurses_interactive_installation_dev.yaml
+++ b/schedule/yast/maintenance/ncurses_interactive_installation_dev.yaml
@@ -12,6 +12,8 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_extensions_and_modules
+  - installation/module_registration/add_additional_regcodes
+  - installation/module_registration/import_untrusted_gnpupg_key
   - installation/add_on_product_installation/add_additional_products
   - installation/add_on_product/skip_install_addons
   - installation/system_role/select_role_text_mode

--- a/schedule/yast/maintenance/qam-yast_self_update_dev.yaml
+++ b/schedule/yast/maintenance/qam-yast_self_update_dev.yaml
@@ -11,6 +11,8 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_extensions_and_modules
+  - installation/module_registration/add_additional_regcodes
+  - installation/module_registration/import_untrusted_gnpupg_key
   - installation/add_on_product/add_maintenance_repos
   - installation/addon_products_sle
   - installation/partitioning/accept_proposed_layout

--- a/schedule/yast/maintenance/yast-mru-install_dev.yaml
+++ b/schedule/yast/maintenance/yast-mru-install_dev.yaml
@@ -10,6 +10,8 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_extensions_and_modules
+  - installation/module_registration/add_additional_regcodes
+  - installation/module_registration/import_untrusted_gnpupg_key
   - installation/add_on_product_installation/add_additional_products
   - installation/add_on_product/skip_install_addons
   - installation/system_role/accept_selected_role_SLES_with_GNOME

--- a/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_aarch64_dev.yaml
+++ b/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_aarch64_dev.yaml
@@ -1,0 +1,9 @@
+---
+name: yast_mru_install_minimal_with_addons_aarch64
+vars:
+  PATTERNS: base,enhanced_base
+  YUI_REST_API: 1
+schedule:
+  stop_timeout_system_reboot:
+    - installation/performing_installation/stop_timeout_system_reboot_now
+...

--- a/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_s390x_dev.yaml
+++ b/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_s390x_dev.yaml
@@ -1,0 +1,10 @@
+---
+name: yast_mru_install_minimal_with_addons_s390x
+vars:
+  PATTERNS: base,enhanced_base
+  YUI_REST_API: 1
+schedule:
+  product_selection: []
+  stop_timeout_system_reboot:
+    - installation/performing_installation/stop_timeout_system_reboot_now
+...

--- a/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_x86_dev.yaml
+++ b/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_x86_dev.yaml
@@ -1,0 +1,13 @@
+---
+name: yast_mru_install_minimal_with_addons_x86
+vars:
+  PATTERNS: base,enhanced_base
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_extensions_and_modules
+    - installation/module_registration/add_additional_regcodes
+    - installation/module_registration/import_untrusted_gnpupg_key
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+...

--- a/schedule/yast/qam-yast_self_update.yaml
+++ b/schedule/yast/qam-yast_self_update.yaml
@@ -11,6 +11,8 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_extensions_and_modules
+  - installation/module_registration/add_additional_regcodes
+  - installation/module_registration/import_untrusted_gnpupg_key
   - installation/add_update_test_repo
   - installation/addon_products_sle
   - installation/system_role

--- a/schedule/yast/qam-yast_self_update_libyui.yaml
+++ b/schedule/yast/qam-yast_self_update_libyui.yaml
@@ -11,6 +11,8 @@ schedule:
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_extensions_and_modules
+  - installation/module_registration/add_additional_regcodes
+  - installation/module_registration/import_untrusted_gnpupg_key
   - installation/add_on_product/add_maintenance_repos
   - installation/addon_products_sle
   - installation/partitioning

--- a/schedule/yast/sle/flows/default_sle15sp4.yaml
+++ b/schedule/yast/sle/flows/default_sle15sp4.yaml
@@ -1,49 +1,45 @@
 ---
-name: yast-mru-install-minimal-with-addons
-vars:
-  PATTERNS: base,minimal
-  YUI_REST_API: 1
-schedule:
+# Default ordered sequence of steps for sle15sp4 with maintenance updates
+bootloader:
   - installation/bootloader_start
+setup_libyui:
   - installation/setup_libyui
-  - '{{installsles}}'
+product_selection:
+  - installation/product_selection/install_SLES
+license_agreement:
   - installation/licensing/accept_license
+registration:
   - installation/registration/register_via_scc
+extension_module_selection:
   - installation/module_registration/register_extensions_and_modules
+add_on_product:
   - installation/add_on_product/add_maintenance_repos
   - installation/addon_products_sle
+suggested_partitioning:
   - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
   - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/select_patterns
-  - '{{validate}}'
+software:
+  - installation/select_only_visible_patterns_from_top
+default_systemd_target: []
+booting:
   - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/installation_overview
-  - installation/disable_grub_timeout
+none_security:
+  - installation/security/select_security_module_none
+installation_settings:
   - installation/launch_installation
+installation:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
-  - '{{stoptimeout}}'
+stop_timeout_system_reboot: []
+installation_logs:
   - installation/logs_from_installation_system
+confirm_reboot:
   - installation/performing_installation/confirm_reboot
+grub:
   - installation/grub_test
+first_login:
   - installation/first_boot
-conditional_schedule:
-  installsles:
-    ARCH:
-      x86_64:
-        - installation/product_selection/install_SLES
-      aarch64:
-        - installation/product_selection/install_SLES
-  validate:
-    ARCH:
-      x86_64:
-        - installation/installation_settings/validate_default_target
-  stoptimeout:
-    ARCH:
-      aarch64:
-        - installation/performing_installation/stop_timeout_system_reboot_now
-      s390x:
-        - installation/performing_installation/stop_timeout_system_reboot_now
-...

--- a/tests/installation/module_registration/add_additional_regcodes.pm
+++ b/tests/installation/module_registration/add_additional_regcodes.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: After register Application module
+#          in "Extension and Module Selection" dialog
+#          input register code at register page
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi qw(save_screenshot get_var);
+
+sub run {
+    my $timeout = 60 * get_var('TIMEOUT_SCALE', 1);
+    my $regcode = get_var('SCC_REGCODE_WE');
+    $testapi::distri->get_module_regcode()->add_separate_registration_code($regcode, $timeout);
+    save_screenshot;
+}
+
+1;

--- a/tests/installation/module_registration/import_untrusted_gnpupg_key.pm
+++ b/tests/installation/module_registration/import_untrusted_gnpupg_key.pm
@@ -1,0 +1,18 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: import GPG key
+#
+# Maintainer: QA SLE YaST team <qa-sle-yast@suse.de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    $testapi::distri->get_module_regcode()->trust_gnupg_key();
+}
+
+1;

--- a/tests/installation/module_registration/register_extensions_and_modules.pm
+++ b/tests/installation/module_registration/register_extensions_and_modules.pm
@@ -11,21 +11,12 @@
 use base 'y2_installbase';
 use strict;
 use warnings;
-use testapi qw(save_screenshot get_var get_required_var);
+use testapi qw(save_screenshot get_required_var);
 
 sub run {
     my @scc_addons = grep($_, split(/,/, get_required_var('SCC_ADDONS')));
     $testapi::distri->get_module_registration()->register_extension_and_modules([@scc_addons]);
     save_screenshot;
-
-    # when some module (e.g. workstation extension) requires registration, provide separate code
-    my $timeout = 60 * get_var('TIMEOUT_SCALE', 1);
-    my $regcode = get_var('SCC_REGCODE_WE');
-    $testapi::distri->get_module_regcode()->add_separate_registration_code($regcode, $timeout);
-    save_screenshot;
-
-    # confirm to trust the untrusted GPG key
-    $testapi::distri->get_module_regcode()->trust_gnupg_key();
 }
 
 1;

--- a/tests/installation/select_only_visible_patterns_from_top.pm
+++ b/tests/installation/select_only_visible_patterns_from_top.pm
@@ -15,7 +15,6 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
-use utils 'type_string_slow';
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
* Split register_extensions_and_modules to handle separately additional registration
* Replaced '- installation/installation_overview' and '- installation/disable_grub_timeout' to '- installation/security/select_security_module_none'. In order to use libyui test module.
* Remove useless code at 'tests/installation/select_only_visible_patterns_from_top.pm'. As I added this test module in my last PR.

- Related ticket: https://progress.opensuse.org/issues/118993
- Verification run: https://openqa.nue.suse.com/tests/9869593
  https://openqa.nue.suse.com/tests/9869587
  https://openqa.nue.suse.com/tests/9869588#