### PR TITLE
Enable lf on type_string and switch to root-console before reboot

### DIFF
--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -57,8 +57,8 @@ Useful to rerun configuration scripts after some changes
 
 sub relogin_root {
     my $self = shift;
-    record_info 'relogin', 'user needs to logout and login back to trigger scripts which set env variales and others';
-
+    record_info 'relogin', 'user needs to logout and login back to trigger scripts which set env variales and others. Switch to root-console';
+    select_console "root-console";
     type_string('pkill -u root', lf => 1);
     record_info "pkill done";
     $self->wait_boot_textmode(ready_time => 180);

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -54,7 +54,7 @@ sub run ($self) {
     select_console('root-console');
     systemctl 'restart nfs-server';
     # And login as normal user to run the tests
-    type_string('pkill -u root');
+    type_string('pkill -u root', lf => 1);
     $self->select_serial_terminal(0);
     # load mpi after all the relogins
     assert_script_run "module load gnu $mpi";


### PR DESCRIPTION
Make sure that the lf is passed to the type_string because it fails sometimes and test jumps to the next instruction. Also switch to the root-console instead the serial terminal before reboot. That seems to work better with that particular scenario for some reason

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


