### PR TITLE
Ignore missing dmidecode in slem@aarch64

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -228,6 +228,13 @@
         },
         "type": "bug"
     },
+    "bsc#1202608": {
+        "description": "Cannot find 'dmidecode' in path: No such file or directory",
+        "products": {
+            "sle-micro": ["5.3"]
+        },
+        "type": "bug"
+    },
     "bsc#1186742": {
         "description": "Directory '.*.hdmi' with parent 'vc4-hdmi.*' already present",
         "products": {


### PR DESCRIPTION
Add https://bugzilla.suse.com/show_bug.cgi?id=1202608 to the list of known bugs as it is blocking slem5.3 updates testing

- Related ticket: https://progress.opensuse.org/issues/119158
- Verification run: https://openqa.suse.de/tests/9799801
