### PR TITLE
Make ssh_interactive_leave more resilient

### DIFF
--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -88,7 +88,7 @@ sub ssh_interactive_leave {
         send_key 'ctrl-c';
         send_key 'ctrl-c';
         send_key 'ret';
-        last if (script_run("true") == 0);
+        last if (script_run("true", timeout => 5, die_on_timeout => 0) == 0);
         sleep 5;    # some cool down after a failed attempt
     }
     die "tunnel-console is not functional" if ($retries <= 0);


### PR DESCRIPTION
Prevent a test failure in case the serial console swallows character while probing true. This is necessary because script_run would make the test fail on a timeout, instead of retrying.

- Related ticket: https://progress.opensuse.org/issues/116332
- Related failure: https://openqa.suse.de/tests/9796056#step/ssh_interactive_end/4
- Verification run: https://duck-norris.qam.suse.de/tests/11069
