### PR TITLE
Add a method to record SAP workloads startup type

### DIFF
--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -103,6 +103,8 @@ sub run {
 
     # Disconnect SAP account
     $self->reset_user_change;
+    # Record whether HANA was started with sapinit or systemd
+    $self->startup_type;
 }
 
 1;

--- a/tests/sles4sap/netweaver_test_systemd.pm
+++ b/tests/sles4sap/netweaver_test_systemd.pm
@@ -16,6 +16,7 @@ use warnings;
 use utils;
 
 sub run {
+    my ($self) = @_;
     my $instance_type = get_required_var('INSTANCE_TYPE');
     my $instance_id = get_required_var('INSTANCE_ID');
     my $sid = get_required_var('INSTANCE_SID');
@@ -24,12 +25,13 @@ sub run {
     my $sap_dir = "/usr/sap/$sid";
 
     select_serial_terminal;
+    $self->set_sap_info($sid, $instance_id);    # Set SID, Instance ID, product for regexps
 
-    validate_script_output('cat /usr/sap/sapservices', qr/sapstartsrv/, title => 'sapstartsrv');
+    validate_script_output('cat /usr/sap/sapservices', $self->SAPINIT_RE, title => 'sapstartsrv');
     validate_script_output('systemctl list-unit-files | grep -i sap', sub { /^(?!SAP..._\d\d.service)/ }, title => 'NO systemd'); # there must be _no_ SAP*.service
     assert_script_run "LD_LIBRARY_PATH=$sap_dir/${instance_type}${instance_id}/exe:\$LD_LIBRARY_PATH;export LD_LIBRARY_PATH;$sap_dir/${instance_type}${instance_id}/exe/sapstartsrv pf=$sap_dir/SYS/profile/${sid}_${instance_type}${instance_id}_${hostname} -reg";
-    validate_script_output('cat /usr/sap/sapservices', qr/systemctl/, title => 'systemctl');
-    validate_script_output('systemctl list-unit-files | grep -i sap', sub { /SAP..._\d\d.service/ }, title => 'USE systemd'); # SAP*.service _must_ be there now
+    validate_script_output('cat /usr/sap/sapservices', $self->SYSTEMD_RE, title => 'systemctl');
+    validate_script_output('systemctl list-unit-files | grep -i sap', $self->SYSTEMCTL_UNITS_RE, title => 'USE systemd');    # SAP*.service _must_ be there now
 }
 
 1;


### PR DESCRIPTION
This commits adds 3 things:

1. A method to record whether HANA was started using sapinit or systemd units.
2. Improves the regexp used to determine when an SAP workload is started via sapinit. Existing regexp checks for `sapstart` which is present in `/usr/sap/sapservices` when started via sapinit or systemd.
3. Since the check can now be done on multiple modules (`sles4sap/netweaver_test_systemd` and `sles4sap/hana_test`), the regular expressions were refactored into the `lib/sles4sap` library as accessors.

Additionally, since the regexps are defined as accessors in `lib/sles4sap`, it was necessary to change the way the sles4sap package inherits from its parent class. Now it is using `Mojo::Base`.

- Related ticket: https://jira.suse.com/browse/TEAM-6854
- Needles: N/A
- Verification run (netweaver_test_systemd): http://mango.qa.suse.de/tests/5094#step/netweaver_test_systemd/1, http://mango.qa.suse.de/tests/5094#step/netweaver_test_systemd/6, http://mango.qa.suse.de/tests/5094#step/netweaver_test_systemd/7
- Verification run (hana_test): http://mango.qa.suse.de/tests/5093#step/hana_test/337
- Verification runs (regression tests): [HanaSR node1](http://mango.qa.suse.de/tests/5089), [HanaSR node2](http://mango.qa.suse.de/tests/5090), [HANA Wizard](http://mango.qa.suse.de/tests/5043), [saptune notes](http://mango.qa.suse.de/tests/5044)