### PR TITLE
PC LTP runtime python version default

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -24,9 +24,6 @@ use version_utils;
 
 our $root_dir = '/root';
 
-# LTP runtime can be 1 for 'python' (new runner) or 0 for the default old 'perl' runner
-my $ltp_runtime = get_var('LTP_RUNTIME_SWITCH', 0);
-
 sub get_ltp_rpm
 {
     my ($url) = @_;
@@ -133,7 +130,7 @@ sub run {
     }
 
     my $runltp_ng_repo = get_var("LTP_RUN_NG_REPO", "https://github.com/acerv/runltp-ng.git");
-    my $runltp_ng_branch = get_var("LTP_RUN_NG_BRANCH", "ssh");
+    my $runltp_ng_branch = get_var("LTP_RUN_NG_BRANCH", "master");
     record_info('LTP CLONE REPO', "Repo: " . $runltp_ng_repo . "\nBranch: " . $runltp_ng_branch);
 
     assert_script_run("git clone -q --single-branch -b $runltp_ng_branch --depth 1 $runltp_ng_repo");

--- a/variables.md
+++ b/variables.md
@@ -110,7 +110,6 @@ LTP_KNOWN_ISSUES | string | | Used to specify a url for a json file with well kn
 LTP_REPO | string | | The repo which will be added and is used to install LTP package.
 LTP_RUN_NG_BRANCH | string | master | Define the branch of the LTP_RUN_NG_REPO.
 LTP_RUN_NG_REPO | string | https://github.com/metan-ucw/runltp-ng.git | Define the runltp-ng repo to be used. Default in publiccloud/run_ltp.pm is the upstream master branch from https://github.com/metan-ucw/runltp-ng.git.
-LTP_RUNTIME_SWITCH | boolean | false | Values: true for `python`, false for `perl`. This parameter is temporary and used to run proof and consolidation tests on the new python version of the LTP runltp-ng repository, allowing to switch between the original Perl and the new Python repo versions. **NOTE**: when `python` value set(true), also needed to set: `LTP_RUN_NG_REPO=`*https://github.com/acerv/runltp-ng.git* and `LTP_RUN_NG_BRANCH=`*ssh*.
 LVM | boolean | false | Use lvm for partitioning.
 LVM_THIN_LV | boolean | false | Use thin provisioning logical volumes for partitioning,
 MACHINE | string | | Define machine name which defines worker specific configuration, including WORKER_CLASS.


### PR DESCRIPTION
New _python_ runner for public cloud LTP tests set as default _runltp-ng_ and removed the existing _perl_  version

- Related ticket: https://progress.opensuse.org/issues/116668
- Needles: none
- Verification run: TBD

