### PR TITLE
Fix tomcat-succesfully-installed needle matching

### DIFF
--- a/tests/x11/tomcat.pm
+++ b/tests/x11/tomcat.pm
@@ -89,10 +89,10 @@ sub run() {
     $self->switch_to_desktop();
 
     $self->firefox_open_url('http://localhost');
-    send_key_until_needlematch('tomcat-succesfully-installed', 'ret');
+    assert_screen('tomcat-succesfully-installed');
 
     $self->firefox_open_url('http://localhost:8080');
-    send_key_until_needlematch('tomcat-succesfully-installed', 'ret');
+    assert_screen('tomcat-succesfully-installed');
 
     $self->close_firefox();
     assert_screen('generic-desktop');


### PR DESCRIPTION
- Follows: #15672
- Failure: [openqa.suse.de/t9806761](https://openqa.suse.de/tests/9806761#step/tomcat/329)
- Verification run: [openqa.suse.de/t9806813](https://openqa.suse.de/tests/9806813)
