### PR TITLE
Update yamllint to produce github annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        apt-get -y install yamllint libdbus-1-dev libssh2-1-dev parallel python3-dev python3-yaml python3-jsonschema
+        apt-get -y install libdbus-1-dev libssh2-1-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip
+        pip3 install yamllint
     - name: Setup perl
       env:
         INLINE_PYTHON_EXECUTABLE: /usr/bin/python3


### PR DESCRIPTION
The current stable version of yamllint supports Github annotations
to make the warnings and errors more visible and easier to locate.

- Related ticket: [poo#118588](https://progress.opensuse.org/issues/118588)
