### PR TITLE
Detect coredump and host reboot during test

### DIFF
--- a/data/virt_autotest/sriov_network_guest_logging.sh
+++ b/data/virt_autotest/sriov_network_guest_logging.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/bin/bash -x
 #xen irqbalance guest debugging
 date
-set -x
 #save udev rules
 ls -l /etc/udev/rules.d/70-persistent-net.rules
 cat /etc/udev/rules.d/70-persistent-net.rules
@@ -10,4 +9,7 @@ echo ""
 lspci
 echo ""
 ip a
-lsmod
+echo ""
+lsmod | grep -e vf -e virt -e kvm -e xen -e pci
+echo ""
+journalctl -n 3000 | grep -e 'kernel:' -e wickedd-dhcp4 -e systemd-udevd

--- a/data/virt_autotest/virt_logs_collector.sh
+++ b/data/virt_autotest/virt_logs_collector.sh
@@ -93,7 +93,7 @@ while { \${retry_times} > 0 } {
          expect -re "~( |\\\])#"
          if { \${extra_logs} == {support_config} } {
             send "rm -f -r \${logs_folder}/*supportconfig*\r"
-            send "supportconfig -y -A -t \${logs_folder} -B guest_\${guest_transformed}_supportconfig_\\\${time_stamp}\r"
+            send "supportconfig -y -A -o AUDIT -t \${logs_folder} -B guest_\${guest_transformed}_supportconfig_\\\${time_stamp}\r"
          }
          if { \${extra_logs} == {sos_report} } {
             send "rm -f -r \${logs_folder}/*sosreport*\r"
@@ -187,8 +187,8 @@ function collect_system_log_and_diagnosis() {
 	   else	   
     	      local time_stamp=`date '+%Y%m%d%H%M%S'`
 	      ${sshpass_ssh_cmd} rm -f -r ${logs_folder}/*supportconfig*
-	      echo -e "${sshpass_ssh_cmd} supportconfig -y -A -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}"
-	      ${sshpass_ssh_cmd} supportconfig -y -A -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}
+	      echo -e "${sshpass_ssh_cmd} supportconfig -y -A -o AUDIT -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}"
+	      ${sshpass_ssh_cmd} supportconfig -y -A -o AUDIT -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}
 	   fi
 	   ret_result=$?
 	   if [[ ${ret_result} -eq 0 ]];then

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -925,6 +925,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
     elsif (get_var("VIRT_NEW_GUEST_MIGRATION_DESTINATION")) {
         loadtest "virt_autotest/guest_migration_dst";
     }
+    loadtest "virt_autotest/validate_system_health" unless get_var('DIRECT_CHAINED_VIRT_FEATURE_TEST') || !is_x86_64;
 }
 elsif (get_var("PERF_KERNEL")) {
     if (get_var("PERF_INSTALL")) {

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -15,7 +15,7 @@ use testapi;
 use Utils::Architectures;
 use Utils::Backends qw(use_ssh_serial_console is_remote_backend set_ssh_console_timeout);
 use ipmi_backend_utils;
-use virt_autotest::utils qw(is_xen_host check_port_state);
+use virt_autotest::utils qw(is_xen_host check_port_state check_host_health);
 use IPC::Run;
 
 sub set_ssh_console_timeout_before_use {
@@ -202,6 +202,7 @@ sub login_to_console {
 sub run {
     my $self = shift;
     $self->login_to_console;
+    check_host_health();
 }
 
 sub post_fail_hook {

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -16,7 +16,7 @@
 #    - reboot the domain.
 #    - unplug these VFs from domain.
 #    - for each of the plugging/unplugging step above, check domain network status and host&guest status.
-# Maintainer: Julie CAO <JCao@suse.com>
+# Maintainer: Julie CAO <JCao@suse.com>, qe-virt@suse.de
 
 use base "virt_feature_test_base";
 use strict;
@@ -25,7 +25,6 @@ use utils;
 use testapi;
 use virt_autotest::common;
 use version_utils qw(is_sle);
-use set_config_as_glue;
 use virt_autotest::utils;
 use virt_autotest::virtual_network_utils qw(save_guest_ip test_network_interface);
 use virt_utils qw(upload_virt_logs);
@@ -93,10 +92,12 @@ sub run_test {
         #hotplug the first vf to vm
         plugin_vf_device($guest, $vfs[0]);
         #upload test specific logs
+        script_run("cp $vfs[0]->{host_id}.xml $log_dir");
         save_network_device_status_logs($log_dir, $guest, "2-after_hotplug_$vfs[0]->{host_id}");
         #check the networking of the plugged interface
         #use br123 as ssh connection
         test_network_interface($guest, gate => $gateway, mac => $vfs[0]->{vm_mac}, net => 'br123');
+        check_guest_health($guest);
 
         #unplug the first vf from vm
         unplug_vf_from_vm($guest, $vfs[0]);
@@ -108,8 +109,11 @@ sub run_test {
         #test network after reboot as dhcp lease spends time
         for (my $i = 1; $i < $passthru_vf_count; $i++) {
             plugin_vf_device($guest, $vfs[$i]);
+            script_run("cp $vfs[$i]->{host_id}.xml $log_dir");
+            test_network_interface($guest, gate => $gateway, mac => $vfs[$i]->{vm_mac}, net => 'br123') if $i == 1;
             save_network_device_status_logs($log_dir, $guest, $i + 3 . "-after_hotplug_$vfs[$i]->{host_id}");
         }
+        check_guest_health($guest);
 
         #reboot the guest
         record_info("VM reboot", "$guest");
@@ -118,11 +122,10 @@ sub run_test {
         save_network_device_status_logs($log_dir, $guest, $passthru_vf_count + 3 . '-after_guest_reboot');
 
         #check host and guest to make sure they work well
-        check_host();
-        check_guest($guest);
+        check_guest_health($guest);
 
         #check the remaining vf(s) inside vm
-        for (my $i = 1; $i < $passthru_vf_count; $i++) {
+        for (my $i = 2; $i < $passthru_vf_count; $i++) {
             test_network_interface($guest, gate => $gateway, mac => $vfs[$i]->{vm_mac}, net => 'br123');
         }
 
@@ -132,13 +135,13 @@ sub run_test {
             assert_script_run("virsh nodedev-reattach $vfs[$i]->{host_id}", 60);
             record_info("Reattach VF to host", "vm=$guest \nvf=$vfs[$i]->{host_id}");
             save_network_device_status_logs($log_dir, $guest, $passthru_vf_count + 4 + $i . "-after_hot_unplug_$vfs[$i]->{host_id}");
+            script_run("ssh root\@$guest 'dmesg' >> $log_dir/dmesg_$guest 2>&1", die_on_timeout => 0) if $i == $passthru_vf_count - 1;
         }
         script_run "lspci | grep Ethernet";
         save_screenshot;
 
         #check host and guest to make sure they work well
-        check_host();
-        check_guest($guest);
+        check_guest_health($guest);
 
     }
 
@@ -163,6 +166,7 @@ sub prepare_host {
 
     #enable pciback debug logs
     script_run "echo \"module xen_pciback +p\" > /sys/kernel/debug/dynamic_debug/control" if is_xen_host;
+
 }
 
 
@@ -191,7 +195,7 @@ sub find_sriov_ethernet_devices {
             }
         }
     }
-    die "Error: No SR-IOV ethernet card on host!" if @sriov_devices == 0;
+    die "Error: No SR-IOV ethernet card on host!" unless @sriov_devices;
 
     return @sriov_devices;
 }
@@ -219,50 +223,35 @@ sub enable_vf {
 sub prepare_guest_for_sriov_passthrough {
     my $vm = shift;
 
-    unless (is_sle('=12-SP5') && (is_kvm_host || (is_fv_guest($vm) && !is_guest_ballooned($vm)))) {
+    unless (is_kvm_host || is_sle('=12-SP5') && is_fv_guest($vm) && !is_guest_ballooned($vm)) {
 
         #don't not use 'virsh edit' to change domain.xml because 'virsh define' does some error checking
         assert_script_run "virsh dumpxml --inactive $vm > $vm.xml";
         script_run "virsh destroy $vm";
 
-        if (is_kvm_host) {
-            unless (is_sle('<15-SP2')) {
-                #for sles15sp2+, PCIe replaces PCI. We need add pcie controllers to allow hotplug more SR-IOV Ethernet vf devices
-                my $cmd = "xmlstarlet edit -L \\
-                           -s //devices -t elem -n pcicontroller -v '' \\
-                           -i //devices/pcicontroller -t attr -n type -v pci \\
-                           -i //devices/pcicontroller -t attr -n model -v pcie-root-port \\
-                           -r //devices/pcicontroller -v controller \\
-                           $vm.xml";
-                assert_script_run "$cmd; $cmd; $cmd";
-            }
+        #disable memory ballooning for fv guest as it is not supported
+        if (is_fv_guest($vm) && is_guest_ballooned($vm)) {
+            assert_script_run "sed -i '/<currentMemory/d' $vm.xml";
+            record_info "Disable guest ballooning", "$vm";
         }
-        elsif (is_xen_host) {
-
-            #disable memory ballooning for fv guest as it is not supported
-            if (is_fv_guest($vm) && is_guest_ballooned($vm)) {
-                assert_script_run "sed -i '/<currentMemory/d' $vm.xml";
-                record_info "Disable guest ballooning", "$vm";
+        #enable pci-passthrough on sles15sp2+
+        #set e820_host for pv guest
+        #refer to bug #1167217 and but #1185081 for the reason
+        unless (is_fv_guest($vm) && is_sle('<15-SP2')) {
+            unless (script_run("xmlstarlet sel -t -c /domain/features $vm.xml") == 0) {
+                assert_script_run "xmlstarlet edit -L -s /domain -t elem -n features -v '' $vm.xml";
             }
-            #enable pci-passthrough on sles15sp2+
-            #set e820_host for pv guest
-            #refer to bug #1167217 and but #1185081 for the reason
-            unless (is_fv_guest($vm) && is_sle('<15-SP2')) {
-                unless (script_run("xmlstarlet sel -t -c /domain/features $vm.xml") == 0) {
-                    assert_script_run "xmlstarlet edit -L -s /domain -t elem -n features -v '' $vm.xml";
-                }
-                unless (script_run("xmlstarlet sel -t -c /domain/features/xen $vm.xml") == 0) {
-                    assert_script_run "xmlstarlet edit -L -s /domain/features -t elem -n xen -v '' $vm.xml";
-                }
-                assert_script_run "xmlstarlet edit -L \\
-                                       -s /domain/features/xen -t elem -n passthrough -v '' \\
-                                       -s ////passthrough -t attr -n state -v on \\
-                                       $vm.xml" unless is_sle('<15-SP2');
-                assert_script_run "xmlstarlet edit -L \\
-                                           -s /domain/features/xen -t elem -n e820_host -v '' \\
-                                           -s ////e820_host -t attr -n state -v on \\
-                                           $vm.xml" if is_pv_guest($vm);
+            unless (script_run("xmlstarlet sel -t -c /domain/features/xen $vm.xml") == 0) {
+                assert_script_run "xmlstarlet edit -L -s /domain/features -t elem -n xen -v '' $vm.xml";
             }
+            assert_script_run "xmlstarlet edit -L \\
+                                   -s /domain/features/xen -t elem -n passthrough -v '' \\
+                                   -s ////passthrough -t attr -n state -v on \\
+                                   $vm.xml" unless is_sle('<15-SP2');
+            assert_script_run "xmlstarlet edit -L \\
+                                   -s /domain/features/xen -t elem -n e820_host -v '' \\
+                                   -s ////e820_host -t attr -n state -v on \\
+                                   $vm.xml" if is_pv_guest($vm);
         }
 
         #try undefine with --keep-nvram if undefine fails on uefi guest
@@ -281,6 +270,16 @@ sub prepare_guest_for_sriov_passthrough {
     if (script_run("ssh root\@$vm \"ls $udev_conf_file\"") == 0) {
         script_run "ssh root\@$vm \"sed -i '/udev_log *=/{h;s/^[# ]*udev_log *=.*\\\$/udev_log=debug/};\\\${x;/^\\\$/{s//udev_log=debug/;H};x}' $udev_conf_file\"";
     }
+
+    # Journals with previous reboot
+    my $journald_conf_file = "/etc/systemd/journald.conf";
+    if (!script_run "ssh root\@$vm \"ls $journald_conf_file\"") {
+        script_run "ssh root\@$vm \"sed -i '/^[# ]*Storage *=/{h;s/^[# ]*Storage *=.*\\\$/Storage=persistent/};\\\${x;/^\\\$/{s//Storage=persistent/;H};x}' $journald_conf_file\"";
+        script_run "ssh root\@$vm \"grep Storage $journald_conf_file\"";
+        script_run "ssh root\@$vm 'systemctl restart systemd-journald'";
+    }
+
+    check_guest_health($vm);
 
 }
 
@@ -315,7 +314,6 @@ sub plugin_vf_device {
     #create the device xml to passthrough to vm
     my $vf_host_addr_xml = "<address type='pci' domain='$dev_domain' bus='$dev_bus' slot='$dev_slot' function='$dev_func'/>";
     assert_script_run("echo \"<interface type='hostdev'>\n  <source>\n    $vf_host_addr_xml\n  </source>\n</interface>\" > $vf->{host_id}.xml", 60);
-    upload_logs("$vf->{host_id}.xml");
 
     #attach device to vm
     assert_script_run "virsh -d 1 attach-device $vm $vf->{host_id}.xml --persistent";
@@ -393,7 +391,7 @@ sub save_network_device_status_logs {
     my ($log_dir, $vm, $test_step) = @_;
 
     #vm configuration file
-    script_run "virsh dumpxml $vm > $log_dir/${vm}_${test_step}.xml";
+    script_run("virsh dumpxml $vm > $log_dir/${vm}_${test_step}.xml", die_on_timeout => 0);
 
     my $log_file = "log.txt";
     script_run "echo `date` > $log_file";
@@ -404,7 +402,7 @@ sub save_network_device_status_logs {
     #logging device information in guest
     my $debug_script = "sriov_network_guest_logging.sh";
     download_script($debug_script, machine => $vm) if (${test_step} eq "1-initial");
-    script_run("ssh root\@$vm \"~/$debug_script\" >> $log_file 2>&1");
+    script_run("ssh root\@$vm \"~/$debug_script\" >> $log_file 2>&1", die_on_timeout => 0);
 
     script_run "mv $log_file $log_dir/${vm}_${test_step}_network_device_status.txt";
 
@@ -415,7 +413,10 @@ sub post_fail_hook {
 
     diag("Module sriov_network_card_pci_passthrough post fail hook starts.");
     my $log_dir = "/tmp/sriov_pcipassthru";
-    save_network_device_status_logs($log_dir, $_, "post_fail_hook") foreach (keys %virt_autotest::common::guests);
+    foreach (keys %virt_autotest::common::guests) {
+        save_network_device_status_logs($log_dir, $_, "post_fail_hook");
+        script_run("ssh root\@$_ 'dmesg' >> $log_dir/dmesg_$_ 2>&1", die_on_timeout => 0);
+    }
     upload_virt_logs($log_dir, "network_device_status");
     $self->SUPER::post_fail_hook;
     restore_original_guests();

--- a/tests/virt_autotest/validate_system_health.pm
+++ b/tests/virt_autotest/validate_system_health.pm
@@ -1,0 +1,74 @@
+# SUSE's openQA tests
+#
+# Copyright 2012-2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Do a basic examination to the host and guests after tests run
+# Maintainer: Julie CAO <JCao@suse.com>, qe-virt@suse.de
+
+use base "virt_feature_test_base";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use ipmi_backend_utils qw(reconnect_when_ssh_console_broken);
+use Utils::Architectures;
+use virt_autotest::common;
+use virt_autotest::utils qw(start_guests check_host_health check_guest_health);
+use virt_utils qw(collect_host_and_guest_logs);
+
+sub prepare_run_test {
+    reconnect_when_ssh_console_broken unless defined(script_run("rm -f /root/{commands_history,commands_failure}", die_on_timeout => 0));
+    script_run("history -c");
+}
+
+sub run_test {
+    return unless is_x86_64;
+
+    my $self = shift;
+    my %health_status = ();
+    @health_status{(keys %virt_autotest::common::guests)} = ();
+    $health_status{host} = check_host_health;
+    foreach my $guest (grep { $_ ne 'host' } keys %health_status) {
+        script_run("virsh start $guest", die_on_timeout => 0);
+        if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 2, retry => 60, die => 0) == 0) {
+            $health_status{$guest} = check_guest_health($guest);
+        }
+        else {
+            $health_status{$guest} = "Unreachable";
+        }
+        record_info("Failed guest", "$guest: $health_status{$guest}", result => 'fail') unless $health_status{$guest} eq 'pass';
+    }
+    my @unhealthy_list = grep { $health_status{$_} ne 'pass' } keys %health_status;
+
+    # Upload logs on x86_64
+    if (get_var('FORCE_UPLOAD_LOGS') || @unhealthy_list != 0) {
+        if (get_var('FORCE_UPLOAD_LOGS')) {
+            collect_host_and_guest_logs(join(' ', grep { $_ ne 'host' } keys %health_status));
+        }
+        else {
+            collect_host_and_guest_logs(join(' ', grep { $_ ne 'host' } @unhealthy_list));
+        }
+        $self->upload_coredumps;
+        save_screenshot;
+    }
+    die "Host or guests are not healthy!" unless @unhealthy_list == 0;
+}
+
+sub post_fail_hook {
+    my $self = shift;
+    diag("Module validate_system_health post fail hook starts.");
+    $self->junit_log_provision((caller(0))[3]);
+    reconnect_when_ssh_console_broken unless defined(script_run("history -w /root/commands_history", die_on_timeout => 0));
+    $self->upload_coredumps;
+    upload_logs("/var/log/clean_up_virt_logs.log");
+    upload_logs("/var/log/guest_console_monitor.log");
+    script_run("rm -f -r /var/log/clean_up_virt_logs.log /var/log/guest_console_monitor.log");
+    save_screenshot;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -17,6 +17,7 @@ use XML::Writer;
 use IO::File;
 use virt_utils;
 use Utils::Architectures;
+use virt_autotest::utils;
 use upload_system_log;
 
 sub analyzeResult {
@@ -188,6 +189,8 @@ sub run_test {
         $timeout = 300;
     }
 
+    check_host_health;
+
     my $test_cmd = $self->get_script_run();
     #FOR S390X LPAR
     if (is_s390x) {
@@ -262,6 +265,8 @@ sub post_fail_hook {
 
     $self->post_run_test;
     save_screenshot;
+
+    check_host_health;
 
     if (get_var('VIRT_PRJ1_GUEST_INSTALL')) {
         #collect and upload guest autoyast control files


### PR DESCRIPTION
related ticket: https://progress.opensuse.org/issues/119752

The PR is to:
- detect coredump, call trace on host & guest. after install host and before each test run because of bsc#1204727
- add an extra test module to check health of host and guests.
- add FORCE_UPLOAD_LOGS to allow upload logs when test passes because of bsc#1204882 comment 4 and 8
- provide sol console screenshot to help to find host crash if it happens and collect logs because of bsc#1204197.
- adjust the step of sriov test a little to ease reproducing bugs and upload more logs
- add KNOWN_KERNEL_BUGS to pass known bugs which leads to coredump/calltrace
- allow to connitue to log guest after reboot and print more info

New verification runs on x86_64 with an extra validate_system_health test module:

Tests with calltrace:
[passed uefi-xen test](https://openqa.suse.de/tests/9948735)
[failed prj1 xen test ](https://openqa.suse.de/tests/9980016#)
[failed prj1 xen test with KNOWN_KERNEL_BUGS](https://openqa.suse.de/tests/9980015)
[failed prj4 xen](https://openqa.suse.de/tests/9948630)


Tests without calltrace:
[passed prj1 kvm with FORCE_UPLOAD_LOGS](https://openqa.suse.de/tests/9944805)
[failed prj1 kvm](https://openqa.suse.de/tests/9936226)
[passed prj2](https://openqa.suse.de/tests/9948617)
[passed oracle test](https://openqa.suse.de/tests/9948626)
[passed sev-es test](https://openqa.suse.de/tests/9948627)
[chained sriov tests without validate_system_health](https://openqa.suse.de/tests/9948908#dependencies)
