### PR TITLE
Revert ansible and valgrind from 15-sp4

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -47,6 +47,7 @@ conditional_schedule:
         - network/samba/samba_adcli
         - console/nginx
         - '{{arch_specific}}'
+        - '{{arch_specific15_sp4}}'
       15-SP3:
         - console/osinfo_db
         - console/ovn
@@ -125,4 +126,9 @@ conditional_schedule:
         - console/journald_fss
       aarch64:
         - console/journald_fss
+  arch_specific15_sp4:
+    ARCH:
+      x86_64:
+        - console/valgrind
+        - console/ansible
 ...

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -41,13 +41,11 @@ conditional_schedule:
         - console/ovn
         - console/firewalld
         - console/libgcrypt
-        - console/valgrind
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
         - network/samba/samba_adcli
         - console/nginx
-        - console/ansible
         - '{{arch_specific}}'
       15-SP3:
         - console/osinfo_db


### PR DESCRIPTION
Revert part of #15720 since these tests do not work on 15-sp4 and are blocking update approval.



- Related ticket: https://progress.opensuse.org/issues/119278 and https://progress.opensuse.org/issues/119377
- Needles: none
- Verification run: none
