### PR TITLE
Fix incompability of AY on 15sp3 on aarch64

### DIFF
--- a/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
@@ -340,7 +340,9 @@
     <gid_min>1000</gid_min>
     <hibernate_system>active_console</hibernate_system>
     <kernel.sysrq>184</kernel.sysrq>
+    % unless ($check_var->('VERSION', '15-SP3')) {
     <lsm_select>apparmor</lsm_select>
+    % }
     <mandatory_services>secure</mandatory_services>
     <net.ipv4.ip_forward>0</net.ipv4.ip_forward>
     <net.ipv4.tcp_syncookies>0</net.ipv4.tcp_syncookies>
@@ -354,6 +356,9 @@
     <passwd_use_cracklib>yes</passwd_use_cracklib>
     <permission_security>easy</permission_security>
     <run_updatedb_as/>
+    % if ($check_var->('VERSION', '15-SP3')) {
+    <selinux_mode>disabled</selinux_mode>
+    % }
     <smtpd_listen_remote>no</smtpd_listen_remote>
     <sys_gid_max>499</sys_gid_max>
     <sys_gid_min>100</sys_gid_min>


### PR DESCRIPTION
No idea why but those conditions makes the autoyast valid and the installation continues. As a quick fix for incidents, i havent test the profile against other versions. i just kept it untouched for anything else. Same as c0939e6d5ea8d61728a4b02132515668f75df3c9

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Related ticket: no ticket
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
