### PR TITLE
[HA/SLES4SAP] Deployment tests for qesapdeployment project

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#   Settings are meant to be controlled via OpenQA variables and managed by test:
+#   tests/sles4sap/publiccloud/qesap_ansible.pm
+
+provider: 'azure'
+apiver: 2
+terraform:
+  provider: 'azure'
+  variables:
+    # GENERAL VARIABLES #
+    az_region: '%PUBLIC_CLOUD_REGION%'
+    admin_user: 'cloudadmin'
+    public_key : '~/.ssh/id_rsa.pub'
+    private_key: '~/.ssh/id_rsa'
+    sles4sap_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
+    hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
+    storage_account_name: '%STORAGE_ACCOUNT_NAME%'
+    storage_account_key: '%STORAGE_ACCOUNT_KEY%'
+
+    # HANA
+    hana_count: '%NODE_COUNT%'
+    hana_ha_enabled: '%HA_CLUSTER%'
+    vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+
+ansible:
+  hana_urls:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  destroy:
+    - deregister.yaml
+

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -1,0 +1,146 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Library used for SLES4SAP publicccloud deployment and tests
+
+use base 'publiccloud::basetest';
+package sles4sap_publiccloud;
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+use List::MoreUtils qw(uniq);
+use Exporter 'import';
+use Carp qw(croak);
+use hacluster '$crm_mon_cmd';
+
+our @EXPORT = qw(
+  run_cmd
+  get_promoted_hostname
+  get_hana_topology
+  wait_for_sync
+);
+
+=head2 run_cmd
+    run_cmd(cmd => 'command', [runas => 'user', timeout => 60]);
+
+Runs a command C<cmd> via ssh in the given VM and log the output.
+All commands are executed through C<sudo>.
+If 'runas' defined, command will be executed as specified user,
+otherwise it will be executed as root.
+
+=cut
+
+sub run_cmd {
+    my ($self, %args) = @_;
+    croak('Argument <cmd> missing') unless ($args{cmd});
+    my $timeout = bmwqemu::scale_timeout($args{timeout} // 60);
+    my $title = $args{title} // $args{cmd};
+    $title =~ s/[[:blank:]].+// unless defined $args{title};
+    my $cmd = defined($args{runas}) ? "su - $args{runas} -c '$args{cmd}'" : "$args{cmd}";
+
+    # Without cleaning up variables SSH commands get executed under wrong user
+    delete($args{cmd});
+    delete($args{title});
+    delete($args{timeout});
+    delete($args{runas});
+
+    my $out = $self->{my_instance}->run_ssh_command(cmd => "sudo $cmd", timeout => $timeout, %args);
+    record_info("$title output - $self->{my_instance}->{instance_id}", $out) unless ($timeout == 0 or $args{quiet} or $args{rc_only});
+    return $out;
+}
+
+=head2 get_promoted_hostname()
+    get_promoted_hostname();
+
+Checks and returns hostname of HANA promoted node.
+=cut
+
+sub get_promoted_hostname {
+    my ($self) = @_;
+    my $hana_resource = join("_",
+        "msl",
+        "SAPHana",
+        "HDB",
+        get_required_var("INSTANCE_SID") . get_required_var("INSTANCE_ID"));
+
+    my $resource_output = $self->run_cmd(cmd => "crm resource status " . $hana_resource, quiet => 1);
+    record_info("crm out", $resource_output);
+    my @master = $resource_output =~ /:\s(\S+)\sMaster/g;
+    if (scalar @master != 1) {
+        diag("Master database not found or command returned abnormal output.\n
+        Check 'crm resource status' command output below:\n");
+        diag($resource_output);
+        die("Master database was not found, check autoinst.log");
+    }
+
+    return join("", @master);
+}
+
+
+=head2 wait_for_sync
+    wait_for_sync();
+    Wait for replica site to sync data with primary.
+    Checks "SAPHanaSR-showAttr" output and ensures replica site has "sync_state" "SOK".
+=cut
+
+sub wait_for_sync {
+    my ($self, %args) = @_;
+    my $timeout = bmwqemu::scale_timeout($args{timeout} // 900);
+    my $sok = 0;
+    record_info("Sync wait", "Waiting for data sync between nodes");
+
+    # Check sync status periodically until ok or timeout
+    my $start_time = time;
+
+    while ($sok == 0) {
+        my $topology = $self->get_hana_topology();
+        for my $entry (@$topology) {
+            my %entry = %$entry;
+            next if !exists($entry{sync_state});
+            $sok = 1 if $entry{sync_state} eq "SOK";
+            last if $sok == 1;
+        }
+
+        if (time - $start_time > $timeout) {
+            record_info("Cluster status", $self->run_cmd(cmd => $crm_mon_cmd));
+            record_info("Sync FAIL", "Host replication status: " . $self->run_cmd(cmd => 'SAPHanaSR-showAttr'));
+            die("Replication SYNC did not finish within defined timeout. ($timeout sec).");
+        }
+        sleep 30;
+    }
+    record_info("Sync OK", $self->run_cmd(cmd => "SAPHanaSR-showAttr"));
+    return 1;
+}
+
+
+=head2 get_hana_topology
+    get_hana_topology([hostname => $hostname]);
+    Parses  command output, returns list of hashes containing values for each host.
+    If hostname defined, returns hash with values only for host specified.
+=cut
+
+sub get_hana_topology {
+    my ($self, %args) = @_;
+    my @topology;
+    my $hostname = $args{hostname};
+    my $cmd_out = $self->run_cmd(cmd => "SAPHanaSR-showAttr --format=script", quiet => 1);
+    record_info("cmd_out", $cmd_out);
+    my @all_parameters = map { if (/^Hosts/) { s,Hosts/,,; s,",,g; $_ } else { () } } split("\n", $cmd_out);
+    my @all_hosts = uniq map { (split("/", $_))[0] } @all_parameters;
+
+    for my $host (@all_hosts) {
+        my %host_parameters = map { my ($node, $parameter, $value) = split(/[\/=]/, $_);
+            if ($host eq $node) { ($parameter, $value) } else { () } } @all_parameters;
+        push(@topology, \%host_parameters);
+
+        if (defined($hostname) && $hostname eq $host) {
+            return \%host_parameters;
+        }
+    }
+
+    return \@topology;
+}
+
+1;

--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Base test providing cleanup, post fail and post run hooks for tests using qe-sap-deployment project.
+# https://github.com/SUSE/qe-sap-deployment
+
+package sles4sap_publiccloud_basetest;
+
+use Mojo::Base 'publiccloud::basetest';
+use strict;
+use warnings FATAL => 'all';
+use Exporter 'import';
+use testapi;
+use qesapdeployment;
+
+our @EXPORT = qw(cleanup);
+
+
+sub cleanup {
+    my ($self) = @_;
+    # Do not run destroy if already executed
+    return if ($self->{cleanup_called});
+    $self->{cleanup_called} = 1;
+
+    for my $command ("ansible", "terraform") {
+
+        # Skip cleanup if ansible inventory is not present (deployment could not have been done without it)
+        my $inventory_check_cmd = join(" ", ("test", "-f", qesap_get_inventory()));
+        next if script_run($inventory_check_cmd) == 0;
+
+        record_info("Cleanup", "Executing $command cleanup");
+        # 3 attempts for both terraform and ansible cleanup
+        for (1 .. 3) {
+            my $cleanup_cmd_rc = qesap_execute(verbose => "--verbose", cmd => $command, cmd_options => "-d", timeout => 1200);
+            if ($cleanup_cmd_rc == 0) {
+                diag(ucfirst($command) . " cleanup attempt # $_ PASSED.");
+                record_info("Clean $command", ucfirst($command) . " cleanup PASSED.");
+                last;
+            }
+            else {
+                diag(ucfirst($command) . " cleanup attempt # $_ FAILED.");
+                sleep 10;
+            }
+            record_info("Cleanup FAILED", "Cleanup $command FAILED", result => "fail") if $_ == 3 && $cleanup_cmd_rc;
+            $self->{result} = "fail" if $_ == 3 && $cleanup_cmd_rc;
+        }
+    }
+    record_info("Cleanup finished");
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    if (get_var("PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE")) {
+        diag("Skip post fail", "Variable 'PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE' defined.");
+        return;
+    }
+    $self->cleanup();
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    if ($self->test_flags()->{publiccloud_multi_module} or get_var("PUBLIC_CLOUD_NO_CLEANUP")) {
+        diag("Skip post run", "Skipping post run hook. \n Variable 'PUBLIC_CLOUD_NO_CLEANUP' defined or test_flag 'publiccloud_multi_module' active");
+        return;
+    }
+    $self->cleanup();
+}
+
+1;

--- a/schedule/sles4sap/publiccloud_hanasr.yml
+++ b/schedule/sles4sap/publiccloud_hanasr.yml
@@ -1,0 +1,15 @@
+---
+name: publiccloud_hanasr
+description: |
+  Run HANASR tests on public cloud instances using qe-sap-deployment project:
+    - deploy
+    - test
+    - destroy
+vars:
+  PUBLIC_CLOUD_RESOURCE_GROUP: 'HanaSR'
+  TEST_CONTEXT: 'OpenQA::Test::RunArgs'
+schedule:
+  - boot/boot_to_desktop
+  - sles4sap/publiccloud/qesap_terraform
+  - sles4sap/publiccloud/qesap_ansible
+  - sles4sap/publiccloud/qesap_cleanup

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -8,6 +8,10 @@ use List::Util qw(any);
 use testapi 'set_var';
 use qesapdeployment;
 set_var('QESAP_CONFIG_FILE', 'MARLIN');
+set_var('BACKEND', 'qemu');
+set_var('AUTOINST_URL_HOSTNAME', 'praisethesun');
+set_var('QEMUPORT', 9000);
+set_var('JOBTOKEN', "solaire");
 
 subtest '[qesap_get_inventory] upper case' => sub {
     my $inventory_path = qesap_get_inventory('NEMO');

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Execute ansible deployment using qe-sap-deployment project.
+# https://github.com/SUSE/qe-sap-deployment
+
+use base 'sles4sap_publiccloud_basetest';
+use strict;
+use warnings;
+use testapi;
+use Mojo::File 'path';
+use publiccloud::utils;
+use sles4sap_publiccloud;
+use qesapdeployment;
+use serial_terminal 'select_serial_terminal';
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    select_serial_terminal;
+    my $ha_enabled = get_required_var("HA_CLUSTER") =~ /false|0/i ? 0 : 1;
+    my $instances = $run_args->{instances};
+
+    die("Ansible deploymend FAILED. Check 'qesap*' logs for details.") if qesap_execute(cmd => 'ansible', timeout => 3600, verbose => 1) > 0;
+    record_info("FINISHED", "Ansible deployment process finished successfully.");
+    return unless $ha_enabled;
+
+    # In canse of Hana/HA deployment, detect initial primary and secondary site location
+    record_info("HANA chk", "Ansible deployment process finished successfully.");
+    foreach my $instance (@$instances) {
+        $self->{my_instance} = $instance;
+        my $instance_id = $instance->{'instance_id'};
+        # Skip instances without HANA db
+        next if ($instance_id !~ m/vmhana/);
+        $self->wait_for_sync();
+
+        # Define initial state for both sites
+        # Site A is always PROMOTED (Master node) after deployment
+        my $resource_output = $self->run_cmd(cmd => "crm status full", quiet => 1); record_info("crm out", $resource_output);
+        my $master_node = $self->get_promoted_hostname();
+        $run_args->{site_a} = $instance if ($instance_id eq $master_node);
+        $run_args->{site_b} = $instance if ($instance_id ne $master_node);
+        record_info("Instances:", "Detected HANA instances:
+        Site A: $run_args->{site_a}{instance_id}
+        Site B: $run_args->{site_b}{instance_id}") if ($instance_id eq $master_node);
+    }
+
+    return 1;
+}
+
+1;

--- a/tests/sles4sap/publiccloud/qesap_cleanup.pm
+++ b/tests/sles4sap/publiccloud/qesap_cleanup.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Cleanup test meant to be used with multimodule setup with qe-sap-deployment project.
+# https://github.com/SUSE/qe-sap-deployment
+
+use base 'sles4sap_publiccloud_basetest';
+use sles4sap_publiccloud_basetest;
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+
+
+sub run {
+    my ($self) = @_;
+    return if get_var("PUBLIC_CLOUD_NO_CLEANUP");
+    $self->cleanup();
+}
+
+1;

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -1,0 +1,152 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Deploy public cloud infrastructure using terraform using qe-sap-deployment project.
+# https://github.com/SUSE/qe-sap-deployment
+
+# Available OpenQA parameters:
+# HA_CLUSTER - Enables HA/Hana cluser scenario
+# NODE_COUNT - number of nodes to deploy. Needs to be >1 for cluster usage.
+# PUBLIC_CLOUD_INSTANCE_TYPE - VM size, sets terraform 'vm_size' parameter
+# USE_SAPCONF - (true/false) set 'false' to use saptune
+# HANA_OS_MAJOR_VERSION - sets 'hana_os_major_version' terraform parameter - default is taken from 'VERSION'
+# FENCING_MECHANISM - (sbd/native) choose fencing mechanism
+# QESAP_SCC_NO_REGISTER - define variable in openqa to skip SCC registration via ANSIBLE
+# HANA_MEDIA - Hana install media directory
+# _HANA_MASTER_PW (mandatory) - Hana master PW (secret)
+# INSTANCE_SID - SAP Sid
+# INSTANCE_ID - SAP instance id
+
+
+use base 'sles4sap_publiccloud_basetest';
+use strict;
+use warnings;
+use testapi;
+use Mojo::File 'path';
+use publiccloud::utils;
+use qesapdeployment;
+use sles4sap_publiccloud;
+use serial_terminal 'select_serial_terminal';
+
+our $ha_enabled = set_var_output("HA_CLUSTER", "0") =~ /false|0/i ? 0 : 1;
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+=head2 set_var_output
+    Check if requested openQA variable is defined and returns it's current value.
+    If the variable is not defined, it will set up the default value provided and returns it.
+    $variable - variable to check against OpenQA settings
+    $default - default value to set in case the variable is missing.
+=cut
+
+sub set_var_output {
+    my ($variable, $default) = @_;
+    set_var($variable, get_var($variable, $default));
+    return (get_var($variable));
+}
+
+=head2 create_ansible_playbook_list
+
+    Detects HANA/HA scenario from openQA variables and creates "ansible: create:" section in config.yaml file.
+
+=cut
+
+sub create_playbook_section {
+    # Cluster related setup
+    my @playbook_list;
+    my @hana_playbook_list = (
+        "pre-cluster.yaml",
+        "sap-hana-preconfigure.yaml -e use_sapconf=" . set_var_output("USE_SAPCONF", "true"),
+        "cluster_sbd_prep.yaml",
+        "sap-hana-storage.yaml",
+        "sap-hana-download-media.yaml",
+        "sap-hana-install.yaml",
+        "sap-hana-system-replication.yaml",
+        "sap-hana-system-replication-hooks.yaml",
+        "sap-hana-cluster.yaml"
+    );
+
+    # Add registration module - "QESAP_SCC_NO_REGISTER" skips scc registration via ansible
+    unless (get_var("QESAP_SCC_NO_REGISTER")) {
+        my $reg_playbook = "registration.yaml -e reg_code=" . get_required_var("SCC_REGCODE_SLES4SAP") . " -e email_address=''";
+        push(@playbook_list, $reg_playbook);
+    }
+
+    if ($ha_enabled == 1) {
+        push(@playbook_list, @hana_playbook_list);
+    }
+    return (\@playbook_list);
+}
+
+=head2 create_ansible_playbook_list
+
+    Detects HANA/HA scenario from openQA variables and creates "ansible: create:" section in config.yaml file.
+
+=cut
+
+sub create_hana_vars_section {
+    # Cluster related setup
+    my %hana_vars;
+    if ($ha_enabled == 1) {
+        $hana_vars{sap_hana_install_software_directory} = get_required_var("HANA_MEDIA");
+        $hana_vars{sap_hana_install_master_password} = get_required_var("_HANA_MASTER_PW");
+        $hana_vars{sap_hana_install_sid} = get_required_var("INSTANCE_SID");
+        $hana_vars{sap_hana_install_instance_number} = get_required_var("INSTANCE_ID");
+        $hana_vars{sap_domain} = get_var("SAP_DOMAIN", "qesap.example.com");
+        $hana_vars{primary_site} = get_var("HANA_PRIMARY_SITE", "site_a");
+        $hana_vars{secondary_site} = get_var("HANA_SECONDARY_SITE", "site_b");
+        set_var("SAP_SIDADM", lc(get_var("INSTANCE_SID") . "adm"));
+    }
+    return (\%hana_vars);
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    select_serial_terminal();
+
+    # Collect OpenQA variables and default values
+    set_var_output("NODE_COUNT", 1) if $ha_enabled == 0;
+    set_var_output("HANA_OS_MAJOR_VERSION", (split("-", get_var("VERSION")))[0]);
+    # Cluster needs at least 2 nodes
+    die("HA cluster needs at least 2 nodes. Check 'NODE_COUNT' parameter.") if $ha_enabled && get_var("NODE_COUNT") <= 1;
+
+    get_required_var("PUBLIC_CLOUD_INSTANCE_TYPE");
+    set_var("FENCING_MECHANISM", "native") if $ha_enabled == 0;
+
+    my $provider = $self->provider_factory();
+    set_var("SLE_IMAGE", $provider->get_image_id());
+    my $ansible_playbooks = create_playbook_section();
+    my $ansible_hana_vars = create_hana_vars_section();
+
+    # Prepare QESAP deplyoment
+    qesap_prepare_env(provider => lc(get_required_var('PUBLIC_CLOUD_PROVIDER')));
+    qesap_create_ansible_section(ansible_section => 'create', section_content => $ansible_playbooks) if @$ansible_playbooks;
+    qesap_create_ansible_section(ansible_section => 'hana_vars', section_content => $ansible_hana_vars) if %$ansible_hana_vars;
+
+    # Regenerate config files (This workaround will be replaced with full yaml generator)
+    qesap_prepare_env(provider => lc(get_required_var('PUBLIC_CLOUD_PROVIDER')), only_configure => 1);
+    # This tells "create_instances" to skip the deployment setup related to old ha-sap-terraform-deployment project
+    $provider->{terraform_env_prepared} = 1;
+    my @instances = $provider->create_instances(check_connectivity => 0);
+    my @instances_export;
+
+    foreach my $instance (@instances) {
+        $self->{my_instance} = $instance;
+        my $expected_hostname = $instance->{instance_id};
+        push(@instances_export, $instance);
+        $instance->wait_for_ssh();
+        # Does not fail for some reason.
+        my $real_hostname = $instance->run_ssh_command(cmd => "hostname", username => "cloudadmin");
+        die if ($expected_hostname ne $real_hostname);
+    }
+
+    $self->{instances} = $run_args->{instances} = \@instances_export;
+    record_info("Deployment OK",);
+    return 1;
+}
+
+1;


### PR DESCRIPTION
Introduces HA/SLES4SAP tests and library for PC infra deployment and 
cleanup using qe-sap-deployment project. Has ability to execute 
ansible and terraform deployment in separate steps with behavior 
controlled via OpenQA variables. Cleanup is done with separate test 
module and included in post run/fail hooks.

- Related ticket: https://jira.suse.com/browse/TEAM-6852
- Needles: none
- Verification run: 
Single VM, no cluster: https://mordor.suse.cz/tests/5506
HANA Cluster:  https://mordor.suse.cz/tests/5505
With HANASR test: https://mordor.suse.cz/tests/5512#
  - HanaSR test fails due to unrelated test code issue. However test is able to interact and execute commands on SUT.