### PR TITLE
Update openssl_fips_alglist.pm

### DIFF
--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 # openssl FIPS test
 #
-# Copyright 2016-2021 SUSE LLC
+# Copyright 2022 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Package: openssl
@@ -36,12 +36,6 @@ sub run {
 
     # Seperate the diffrent openssl command usage between SLE12 and SLE15
     if (is_sle('<15')) {
-        # List cipher algorithms in fips mode
-        # only AES and DES3 are approved in fips mode
-        validate_script_output
-          "echo -n 'Invalid Cipher: '; openssl list-cipher-algorithms | sed -e '/AES/d' -e '/aes/d' -e '/DES3/d' -e '/des3/d' -e '/DES-EDE/d' | wc -l",
-          sub { m/^Invalid Cipher: 0$/ };
-
         # List message digest algorithms in fips mode
         # only SHA1 and SHA2 (224, 256, 384, 512) are approved in fips mode
         # Note: DSA is short of DSA-SHA1, so it is also valid item
@@ -54,30 +48,17 @@ sub run {
         validate_script_output
 "echo -n 'Invalid Pubkey: '; openssl list-public-key-algorithms | grep '^Name' | sed -e '/RSA/d' -e '/rsa/d' -e '/DSA/d' -e '/dsa/d' -e '/EC/d' -e '/DH/d' -e '/HMAC/d' -e '/CMAC/d' | wc -l",
           sub { m/^Invalid Pubkey: 0$/ };
-    }
-
-    # openssl-1.1.0 is working in SLE15
-    # The openssl command is adjustment
-    else {
-        # Add 3DES and 3des support
+    } else {
         eval {
-            validate_script_output(
-"echo -n 'Invalid Cipher: '; openssl list -cipher-algorithms | sed -e '/AES/d' -e '/aes/d' -e '/DES3/d' -e '/des3/d' -e '/DES-EDE/d' -e '/3DES/d' -e '/3des/d' | wc -l",
-                sub { m/^Invalid Cipher: 0$/ }); };
-        if ($@) {
-            # It is not an important function, just record soft failure.
-            # POO#111818
-            record_soft_failure('bsc#1161276 - It is not important function about openssl list -cipher-algorithms, and marked this as WONTFIX'); }
+            validate_script_output
+"echo -n 'Invalid Hash: '; openssl list -digest-algorithms | sed -e '/SHA1/d' -e '/SHA224/d' -e '/SHA256/d' -e '/SHA384/d' -e '/SHA512/d' -e '/DSA/d' -e '/SHA3-224/d' -e '/SHA3-256/d' -e '/SHA3-384/d' -e '/SHA3-512/d' -e '/SHAKE128/d' -e '/SHAKE256/d' | wc -l",
+              sub { m/^Invalid Hash: 0$/ };
 
-        validate_script_output
-"echo -n 'Invalid Hash: '; openssl list -digest-algorithms | sed -e '/SHA1/d' -e '/SHA224/d' -e '/SHA256/d' -e '/SHA384/d' -e '/SHA512/d' -e '/DSA/d' | wc -l",
-          sub { m/^Invalid Hash: 0$/ };
-
-        validate_script_output
+            validate_script_output
 "echo -n 'Invalid Pubkey: '; openssl list -public-key-algorithms | grep '^Name' | sed -e '/RSA/d' -e '/rsa/d' -e '/DSA/d' -e '/dsa/d' -e '/EC/d' -e '/DH/d' -e '/HMAC/d' -e '/CMAC/d' | wc -l",
-          sub { m/^Invalid Pubkey: 0$/ };
+              sub { m/^Invalid Pubkey: 0$/ };
+        }
     }
-
 }
 
 sub test_flags {


### PR DESCRIPTION
- openssl list -cipher-algorithms: remove the related test, since it won't be fixed
- openssl list -digest-algorithms: add new algos

see https://progress.opensuse.org/issues/115775 for more info.

Verification runs:
- https://openqa.suse.de/tests/9831689#step/openssl_fips_alglist/1
- https://openqa.suse.de/tests/9831687#step/openssl_fips_alglist/1
- https://openqa.suse.de/tests/9831690#step/openssl_fips_alglist/1
- https://openqa.suse.de/tests/9831688#step/openssl_fips_alglist/1
- https://openqa.suse.de/tests/9831691#step/openssl_fips_alglist/1
- https://openqa.suse.de/tests/9831692#step/openssl_fips_alglist/1
