### PR TITLE
ansible: do not test on MicroOS in staging projects

### DIFF
--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -65,7 +65,8 @@ sub load_feature_tests {
     # MicroOS -old images use wicked, but cockpit-wicked is no longer supported in TW
     loadtest 'microos/cockpit_service' unless is_staging || (is_microos('Tumbleweed') && get_var('HDD_1') =~ /-old/);
     loadtest 'console/journal_check';
-    loadtest 'console/ansible';
+    # Staging has no access to repos and the MicroOS-DVD does not contain ansible
+    loadtest 'console/ansible' unless is_staging;
     if (check_var 'SYSTEM_ROLE', 'kubeadm') {
         loadtest 'console/kubeadm';
     }


### PR DESCRIPTION
Staging projects only have access to the DVD, which in turn does not
include ansible. The repository is only available on full product tests.

- Related ticket: https://openqa.opensuse.org/tests/2836358#step/ansible/14
- Needles: N/A
- Verification run: N/A
