### PR TITLE
Try to make HPC module work again

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -432,10 +432,14 @@ run the MPI binaries
 sub mount_nfs_exports {
     my ($self, $exports) = @_;
     zypper_call 'in nfs-client';
+    systemctl "enable --now nfs-client.target";
+    record_info 'nfs-client status', script_output "systemctl status nfs-client.target";
+
     foreach my $dir (values %$exports) {
         assert_script_run "mkdir -p $dir" unless script_run("test -f $dir", quiet => 1) == 0;
         assert_script_run "mount master-node00:$dir $dir", timeout => 120;
     }
+    script_run "test -e /usr/lib/hpc";
 }
 
 1;

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -10,6 +10,8 @@ use Mojo::Base qw(hpcbase hpc::utils), -signatures;
 use lockapi;
 use utils;
 use serial_terminal 'select_serial_terminal';
+use testapi qw(record_info);
+use POSIX 'strftime';
 
 sub run ($self) {
     select_serial_terminal();
@@ -22,11 +24,15 @@ sub run ($self) {
     my @hpc_deps = $self->get_compute_nodes_deps($mpi);
     zypper_call("in @hpc_deps");
     barrier_wait('CLUSTER_PROVISIONED');
+    record_info 'CLUSTER_PROVISIONED', strftime("\%H:\%M:\%S", localtime);
     barrier_wait('MPI_SETUP_READY');
+    record_info 'MPI_SETUP_READY', strftime("\%H:\%M:\%S", localtime);
     $self->mount_nfs_exports(\%exports_path);
 
     barrier_wait('MPI_BINARIES_READY');
+    record_info 'MPI_BINARIES_READY', strftime("\%H:\%M:\%S", localtime);
     barrier_wait('MPI_RUN_TEST');
+    record_info 'MPI_RUN_TEST', strftime("\%H:\%M:\%S", localtime);
 }
 
 sub test_flags ($self) {


### PR DESCRIPTION
Most of the HPC test suites are failing to finish the tests successfully. Seems like a NFS issue and a problem while test login to the user.
- make sure nfs is enabled
- remove line feed from type_string
- add ui info among barriers

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: http://aquarius.suse.cz/tests/13719 http://aquarius.suse.cz/tests/13713
