### PR TITLE
Install yast2-migration package when creating hdd for HA on ppc64le

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_ha_ppc64le.xml.ep
+++ b/data/autoyast_sle15/create_hdd/create_hdd_ha_ppc64le.xml.ep
@@ -85,6 +85,7 @@
   </services-manager>
   <software>
     <packages config:type="list">
+        <package>yast2-migration</package>
     % foreach (values %$addons) {
         <package><%= lc($_->{name}) %>-release</package>
     % }


### PR DESCRIPTION
yast2-migration package is needed to do HA online migration testing.

- Related ticket: https://progress.opensuse.org/issues/117238
- Verification run: https://openqa.suse.de/tests/9822941, https://openqa.suse.de/tests/9822942