### PR TITLE
Enforce naming convention for qe-sap-deployment settings

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -3,6 +3,7 @@ apiver: 2
 terraform:
   variables:
     project: "ei-sle-qa-sap-8469"
+    bastion_enabled: "false"
     region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"

--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -147,7 +147,7 @@ subtest '[cypress_configs]' => sub {
     $trento->redefine(get_trento_ip => sub { return '43.43.43.43' });
     $trento->redefine(get_trento_password => sub { return 'SPUMA_DI_TONNO'; });
     my $nodes = 42;
-    $trento->redefine(get_agents_number => sub { return $nodes; });
+    $trento->redefine(qesap_get_nodes_number => sub { return $nodes; });
     $trento->redefine(upload_logs => sub { push @logs, @_; });
     # calls to ignore
     $trento->redefine(enter_cmd => sub { return; });
@@ -160,57 +160,6 @@ subtest '[cypress_configs]' => sub {
     note("\n  L-->  " . join("\n  L-->  ", @logs));
     ok any { /cypress\.env\.py -u .*43\.43\.43\.43 -p SPUMA_DI_TONNO -f Premium -n $nodes --trento-version $ver/ } @calls;
     ok any { /cypress\.env\.json/ } @logs;
-};
-
-subtest '[get_agents_number]' => sub {
-    my $trento = Test::MockModule->new('trento', no_auto => 1);
-    @calls = ();
-
-    my $cloud_provider = 'POLPETTE';
-    set_var('PUBLIC_CLOUD_PROVIDER', $cloud_provider);
-    set_var('QESAP_CONFIG_FILE', 'MELANZANE_FRITTE');
-
-    my $tmp_folder = '/FESTA';
-    note("-->tmp_folder=$tmp_folder");
-    set_var('QESAP_DEPLOYMENT_DIR', $tmp_folder);
-
-    my $inv_path = "$tmp_folder/terraform/" . lc $cloud_provider . '/inventory.yaml';
-    note("-->inv_path=$inv_path");
-
-    my $str = <<END;
-all:
-  children:
-    hana:
-      hosts:
-        vmhana01:
-          ansible_host: 1.2.3.4
-          ansible_python_interpreter: /usr/bin/python3
-        vmhana02:
-          ansible_host: 1.2.3.5
-          ansible_python_interpreter: /usr/bin/python3
-
-    iscsi:
-      hosts:
-        vmiscsi01:
-          ansible_host: 1.2.3.6
-          ansible_python_interpreter: /usr/bin/python3
-
-  hosts: null
-END
-
-    $trento->redefine(script_output => sub { push @calls, $_[0]; return $str; });
-
-    my $res = get_agents_number();
-
-    set_var('PUBLIC_CLOUD_PROVIDER', undef);
-    set_var('QESAP_CONFIG_FILE', undef);
-    set_var('QESAP_DEPLOYMENT_DIR', undef);
-
-    note("\n  C-->  " . join("\n  C-->  ", @calls));
-
-    is $res, 3, 'Number of agents like expected';
-    like $calls[0], qr/cat $inv_path/;
-
 };
 
 subtest '[deploy_qesap] ok' => sub {

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -16,6 +16,8 @@ sub run {
     my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
     my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
 
+    my $chdir = qesap_get_terraform_dir();
+    assert_script_run("terraform -chdir=$chdir output");
     qesap_ansible_cmd(cmd => $_, provider => $prov, $_) for ('pwd', 'uname -a', 'cat /etc/os-release');
     qesap_ansible_cmd(cmd => 'ls -lai /hana/', provider => $prov, filter => 'hana');
     qesap_ansible_cmd(cmd => $_, provider => $prov, filter => 'vmhana01'), for ('crm status', $crm_mon_cmd);

--- a/variables.md
+++ b/variables.md
@@ -226,13 +226,22 @@ TRENTO_REGISTRY_IMAGE_WEB | string |  | Optional. Overwrite the trento-web image
 TRENTO_REGISTRY_IMAGE_WEB_VERSION | string |  | Optional. Version tag for the trento-web image
 TRENTO_GITLAB_REPO | string | gitlab.suse.de/qa-css/trento | Repository for the deployment scripts
 TRENTO_GITLAB_BRANCH | string | master | Branch to use in the deployment script repository
-TRENTO_GITLAB_TOKEN | string | | Force te use of a custom token
+TRENTO_GITLAB_TOKEN | string | from SECRET_TRENTO_GITLAB_TOKEN | Force the use of a custom token
 TRENTO_DEPLOY_VER | string | | Force the Trento deployment script to be used from a release
 TRENTO_AGENT_REPO | string | https://dist.suse.de/ibs/Devel:/SAP:/trento:/factory/SLE_15_SP3/x86_64 | Repository where to get the trento-agent installer
 TRENTO_AGENT_RPM | string | | Trento-agent rpm file name
 TRENTO_EXT_DEPLOY_IP | string | | Public IP of a Trento web instance not deployed by openQA
 TRENTO_WEB_PASSWORD | string | | Trento web password for the admin user. If not provided, random generated one.
-TRENTO_CLUSTER_OS_VER | string | | OS for nodes in SAP cluster.
+TRENTO_QESAPDEPLOY_CLUSTER_OS_VER | string | | OS for nodes in SAP cluster.
+TRENTO_QESAPDEPLOY_SAPCAR | string | | SAPCAR url for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_IMDB_SERVER | string | | IMDB_SERVER url for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_IMDB_CLIENT | string | | IMDB_CLIENT url for the qe-sap-deployment hana_media.yaml.
+QESAP_CONFIG_FILE | string | | filename (of relative path) of the config YAML file for the qesap.py script, within `sles4sap/qe_sap_deployment/` subfolder in `data`.
+QESAP_DEPLOYMENT_DIR | string | /root/qe-sap-deployment | JumpHost folder where to install the qe-sap-deployment code
+QESAP_INSTALL_VERSION | string | | If configured, test will run with a specific release of qe-sap-deployment code from https://github.com/SUSE/qe-sap-deployment/releases.
+QESAP_INSTALL_GITHUB_REPO | string | github.com/SUSE/qe-sap-deployment | Git repository where to clone from. Ignored if QESAP_VER is configured.
+QESAP_INSTALL_GITHUB_BRANCH | string | | Git branch. Ignored if QESAP_VER is configured.
+QESAP_INSTALL_GITHUB_NO_VERIFY | string | | Configure http.sslVerify false. Ignored if QESAP_VER is configured.
 
 
 ### Publiccloud specific variables


### PR DESCRIPTION
Rename variables in qesap and Trento. List of renamed settings:

QESAPDEPLOY_VER --> QESAP_INSTALL_VERSION
QESAPDEPLOY_GIT_NO_VERIFY --> QESAP_INSTALL_GITHUB_NO_VERIFY
QESAPDEPLOY_GITHUB_BRANCH --> QESAP_INSTALL_GITHUB_BRANCH
QESAPDEPLOY_GITHUB_REPO --> QESAP_INSTALL_GITHUB_REPO
TRENTO_CLUSTER_OS_VER --> TRENTO_QESAPDEPLOY_CLUSTER_OS_VER
QESAPDEPLOY_SAPCAR --> TRENTO_QESAPDEPLOY_SAPCAR
QESAPDEPLOY_IMDB_SERVER --> TRENTO_QESAPDEPLOY_IMDB_SERVER
QESAPDEPLOY_IMDB_CLIENT --> TRENTO_QESAPDEPLOY_IMDB_CLIENT


Add QESAP variables documentation.
Add qesapdeploy API to get agents number and terraform dir.
Use -f for curl of config and releases
Disable bastion in GCP regression test.

- Verification run:
  -- Tested in Trento http://openqaworker15.qa.suse.cz/tests/59796#
  -- Tested with qesap regression:  AZURE:https://openqaworker15.qa.suse.cz/tests/59811#  https://openqaworker15.qa.suse.cz/tests/59812#    GCP (fails): https://openqaworker15.qa.suse.cz/tests/59810 and https://openqaworker15.qa.suse.cz/tests/59711
