### PR TITLE
New wsl_gui pattern added to the repos

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -108,6 +108,11 @@ sub run {
         assert_screen 'local-user-credentials';
         enter_user_details([$realname, undef, $password, $password]);
         send_key 'alt-n';
+        # wsl-gui pattern installation
+        if (is_sle('>15-SP3')) {
+            assert_screen 'wsl-gui-pattern';
+            send_key 'alt-n';
+        }
         # Registration
         is_sle && register_via_scc();
         # And done!


### PR DESCRIPTION
By adding the new `wsl_gui` pattern to the repos, also a new screen has been added to the YaST2 installation, causing all the tests to fail. This fix will take that screen into account and also, mark the option to install that package only in tests that will register into SCC.

- Related ticket: https://progress.opensuse.org/issues/110140
- Needles:
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/wsl-gui-pattern-20221028.png
- Verification runs: :heavy_check_mark: 
  - [Win11 SLE15-SP3 register](https://openqa.suse.de/tests/9855037)
  - [Win11 SLE15-SP3 skip register](https://openqa.suse.de/tests/9855038)
  - [Win10-BIOS SLE15-SP4 register](https://openqa.suse.de/tests/9855034)
  - [Win10-BIOS SLE15-SP4 skip register](https://openqa.suse.de/tests/9855036)
  - [Win10-UEFI Tumbleweed](https://openqa.opensuse.org/tests/2849191)