### PR TITLE
Adapt s390x-zVM-vswitch-l2 cases with install_SLES

### DIFF
--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -18,6 +18,7 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/disk_activation/select_configure_dasd_disks
   - installation/disk_activation/configure_dasd


### PR DESCRIPTION
We need to add install_SLES to make the s390x-zVM test case to work.

- Related ticket: https://progress.opensuse.org/issues/119587
- Needles: N/A
- Verification run: 
  http://openqa.nue.suse.com/t9842445
  http://openqa.nue.suse.com/t9842446
