### PR TITLE
Use correct base in PubCloud tests for post_fail_hook

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -43,7 +43,7 @@ sub load_maintenance_publiccloud_tests {
         loadtest('publiccloud/ahb');
     } else {
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
-        loadtest "publiccloud/instance_overview" unless get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
+        loadtest("publiccloud/instance_overview", run_args => $args) unless get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
             load_publiccloud_consoletests($args);
         } elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -10,7 +10,7 @@
 #
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
-use base 'consoletest';
+use base 'publiccloud::basetest';
 use registration;
 use warnings;
 use testapi;
@@ -69,13 +69,6 @@ sub collect_system_information {
 
 sub test_flags {
     return {fatal => 1};
-}
-
-sub post_fail_hook {
-    my ($self) = @_;
-    select_host_console(force => 1);
-    # Destroy the public cloud instance
-    $self->{provider}->cleanup();
 }
 
 1;

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -8,7 +8,7 @@
 #
 # Maintainer: qa-c@suse.de
 
-use Mojo::Base 'consoletest';
+use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;


### PR DESCRIPTION
VR - ( worker without preparation for terraform and extended diag in post_fail_hooks) -> http://quasar.suse.cz/tests/1199/logfile?filename=autoinst-log.txt

VR - instance_overview.pm -> http://quasar.suse.cz/tests/1200/logfile?filename=autoinst-log.txt
VR - instance_overview.pm with run_args -> http://quasar.suse.cz/tests/1205/logfile?filename=autoinst-log.txt