### PR TITLE
Increase zypper timeout

### DIFF
--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -36,7 +36,7 @@ sub run {
 
     record_info('installs SLE15-Migration and suse-migration-sle15-activation');
 
-    $instance->run_ssh_command(cmd => "sudo zypper -n in SLES15-Migration suse-migration-sle15-activation");
+    $instance->run_ssh_command(cmd => "sudo zypper -n in SLES15-Migration suse-migration-sle15-activation", timeout => 300);
     record_info('system reboots');
     my ($shutdown_time, $startup_time) = $instance->softreboot(
         timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 400)


### PR DESCRIPTION
Increase the timeout for installation of the migration packages.

- Related ticket: https://progress.opensuse.org/issues/119602
- Verification run: https://duck-norris.qam.suse.de/tests/11071