### PR TITLE
Install *-hpc-gnu packages on HPC compute nodes

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -383,11 +383,21 @@ sub uninstall_spack_module {
 This function is used to select dependencies packages which are required to be installed
 on HPC compute nodes in order to run code against particular C<mpi> implementation.
 C<get_compute_nodes_deps> returns an array of packages
+
+=head2 CAVEATS
+
+Obsolete function. Not in use since sle15sp5
+Used to install dependencies of the HPC modules when the binaries were shared
+through NFS. Changes in openmpi breaks this on SLE15SP5. Need to get updated to
+be functional again. As for now can be used to find those dependencies prior to
+that version.
+
 =cut
 
 sub get_compute_nodes_deps {
     my ($self, $mpi) = @_;
     die "missing C<mpi> parameter" unless $mpi;
+    die "This function is deprecated. Rather install *hpc-gnu package";
     my @deps = ('libucp0');
     if (is_sle('>=15-SP3')) {
         push @deps, 'libhwloc15' if $mpi =~ m/mpich/;

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -17,12 +17,9 @@ sub run ($self) {
     select_serial_terminal();
     my $mpi = $self->get_mpi();
     my %exports_path = (
-        bin => '/home/bernhard/bin',
-        hpc_lib => '/usr/lib/hpc',
+        bin => '/home/bernhard/bin'
     );
-    # Install required HPC dependencies on the nodes act as compute nodes
-    my @hpc_deps = $self->get_compute_nodes_deps($mpi);
-    zypper_call("in @hpc_deps");
+    zypper_call("in $mpi-gnu-hpc");
     barrier_wait('CLUSTER_PROVISIONED');
     record_info 'CLUSTER_PROVISIONED', strftime("\%H:\%M:\%S", localtime);
     barrier_wait('MPI_SETUP_READY');


### PR DESCRIPTION
Some time ago I implemented a NFS sharing between management and compute
nodes. This had the advantage that we had to install the binaries just once
and make them available immediately to the other nodes. Only requirement was
that the compute nodes were needed to install some dependencies. It turned out
that this might not an optimal solution for those binaries as the dependencies
are likely to cause a hell among the various products. As it happens with the
latest builds on sle15sp5 after some changes on openmpi.


- Verification run: http://aquarius.suse.cz/tests/13747
