### PR TITLE
Expect display manager to appear earlier on boot 

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -269,6 +269,13 @@ sub boot_local_disk {
         }
         my @tags = qw(inst-slof grub2);
         push @tags, 'encrypted-disk-password-prompt' if (get_var('ENCRYPT'));
+
+        # Workaround for poo#118336
+        if (is_ppc64le && is_qemu) {
+            push @tags, 'linux-login' if check_var('DESKTOP', 'textmode');
+            push @tags, 'displaymanager' if check_var('DESKTOP', 'gnome');
+        }
+
         assert_screen(\@tags);
         if (match_has_tag 'grub2') {
             diag 'already in grub2, returning from boot_local_disk';
@@ -285,6 +292,9 @@ sub boot_local_disk {
         if (match_has_tag 'encrypted-disk-password-prompt') {
             # It is possible to show encrypted prompt directly by pressing 'local' boot-menu
             # Simply return and do enter passphrase operation in checking block of sub wait_boot
+            return;
+        }
+        if (match_has_tag('linux-login') or match_has_tag('displaymanager')) {
             return;
         }
     }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -793,6 +793,12 @@ sub wait_grub_to_boot_on_local_disk {
     my @tags = qw(grub2 tianocore-mainmenu);
     push @tags, 'encrypted-disk-password-prompt' if (get_var('ENCRYPT'));
 
+    # Workaround for poo#118336
+    if (is_ppc64le && is_qemu) {
+        push @tags, 'linux-login' if check_var('DESKTOP', 'textmode');
+        push @tags, 'displaymanager' if check_var('DESKTOP', 'gnome');
+    }
+
     # Enable boot menu for x86_64 uefi workaround, see bsc#1180080 for details
     if (is_sle && get_required_var('FLAVOR') =~ /Migration/ && is_x86_64 && get_var('UEFI')) {
         if (!check_screen(\@tags, 15)) {
@@ -937,6 +943,19 @@ sub grub_select {
         } else {
             bmwqemu::fctinfo("Boot $first_menu");
             boot_grub_item($first_menu);
+        }
+    }
+    elsif (is_ppc64le && is_qemu) {
+        my @tags = qw(grub2);
+
+        # Workaround for poo#118336
+        push @tags, 'linux-login' if check_var('DESKTOP', 'textmode');
+        push @tags, 'displaymanager' if check_var('DESKTOP', 'gnome');
+
+        assert_screen(\@tags);
+
+        if (match_has_tag 'grub2') {
+            send_key 'ret';
         }
     }
     elsif (!get_var('S390_ZKVM')) {


### PR DESCRIPTION
Sometimes, on ppc64le architecture with qemu backend, the grub entries will not bounce back and we can land directly to the dispay manager. In order to avoid the occasional failure we must anticipate display manager to appear earlier when running `boot_to_desktop` on ppc64le.

- Related ticket: https://progress.opensuse.org/issues/118336
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=ge0r%2Fos-autoinst-distri-opensuse%23fix-boot-to-desktop-ppc64le-verification 
Verification run link contains testsuites with both textmode and gnome. 
Success rate is 100% for a run of 50 jobs for each testsuite (see Next & Previous results).
Without this fix the success rate is around 54%.
