### PR TITLE
Fix script_sudo condition from 739deb2a4b

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -31,7 +31,7 @@ Base class implementation of distribution class necessary for testapi
 
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
 use testapi qw(send_key %cmd assert_screen check_screen check_var click_lastmatch get_var save_screenshot
-  match_has_tag set_var type_password type_string enter_cmd wait_serial $serialdev
+  match_has_tag set_var type_password type_string enter_cmd wait_serial $serialdev is_serial_terminal
   mouse_hide send_key_until_needlematch record_info record_soft_failure
   wait_still_screen wait_screen_change get_required_var diag);
 
@@ -59,7 +59,11 @@ sub handle_password_prompt {
     $console //= '';
 
     return if get_var("LIVETEST") || get_var('LIVECD');
-    assert_screen("password-prompt", 60);
+    if (is_serial_terminal()) {
+        wait_serial(qr/Password:\s*$/i, timeout => 30);
+    } else {
+        assert_screen("password-prompt", 60);
+    }
     if ($console eq 'hyperv-intermediary') {
         type_string get_required_var('VIRSH_GUEST_PASSWORD');
     }
@@ -347,13 +351,14 @@ sub script_sudo {
 
     my $str = time;
     if ($wait > 0) {
-        $prog = "$prog; echo $str-\$?- > /dev/$testapi::serialdev" unless $prog eq 'bash';
+        $prog .= "; echo $str-\$?-" unless $prog eq 'bash';
+        $prog .= " > /dev/$testapi::serialdev" unless is_serial_terminal();
     }
     enter_cmd "clear";    # poo#13710
     enter_cmd "su -c \'$prog\'", max_interval => 125;
     handle_password_prompt unless ($testapi::username eq 'root');
     if ($wait > 0) {
-        if ($prog eq 'bash') {
+        if ($prog =~ /^bash/) {
             return wait_still_screen(4, 8);
         }
         else {

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -351,8 +351,10 @@ sub script_sudo {
 
     my $str = time;
     if ($wait > 0) {
-        $prog .= "; echo $str-\$?-" unless $prog eq 'bash';
-        $prog .= " > /dev/$testapi::serialdev" unless is_serial_terminal();
+        unless ($prog =~ /^bash/) {
+            $prog .= "; echo $str-\$?-";
+            $prog .= " > /dev/$testapi::serialdev" unless is_serial_terminal();
+        }
     }
     enter_cmd "clear";    # poo#13710
     enter_cmd "su -c \'$prog\'", max_interval => 125;

--- a/t/10_susedistribution.t
+++ b/t/10_susedistribution.t
@@ -1,0 +1,75 @@
+#!/usr/bin/perl
+# Copyright @ SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use testapi;
+use Test::MockModule;
+use susedistribution;
+
+my $testapi_mocked = Test::MockModule->new('testapi');
+$testapi_mocked->mock(type_string => sub { 'randompass' });
+my $susedistri = susedistribution->new();
+
+my $suse_mocked = Test::MockModule->new('susedistribution');
+$suse_mocked->noop(qw(send_key enter_cmd));
+# Increase counter for each wait_serial invocation
+my $wait_serial_hit = 0;
+$suse_mocked->mock(wait_serial => sub { $wait_serial_hit++; return 'Password:' });
+# Increase counter for each assert_screen invocation
+my $assert_screen_called = 0;
+$suse_mocked->mock(assert_screen => sub { $assert_screen_called++; return 1 });
+# Increase counter for each wait_still_screen invocation
+my $wait_still_screen_called = 0;
+$suse_mocked->mock(wait_still_screen => sub { $wait_still_screen_called++; return 1 });
+
+subtest 'handle_password_prompt on serial terminal checks wait_serial' => sub {
+    set_var('VIRTIO_CONSOLE', '1');
+    set_var('BACKEND', 'qemu');
+    $suse_mocked->mock('is_serial_terminal' => 1);
+    ok susedistribution::handle_password_prompt(), 'password prompt is handled';
+    is $wait_serial_hit, 1, 'wait_serial is called';
+    is $assert_screen_called, 0, 'assert screen is not called';
+};
+
+subtest 'handle_password_prompt assert screen on when not serial_terminal' => sub {
+    set_var('BACKEND', 'qemu');
+    $suse_mocked->mock('is_serial_terminal' => 0);
+    ok susedistribution::handle_password_prompt(), 'password prompt handled';
+    is $wait_serial_hit, 1, 'wait_serial is not called';
+    is $assert_screen_called, 1, 'assert screen is called';
+};
+
+subtest 'script_sudo works when is not serial_terminal and wait>0' => sub {
+    set_var('BACKEND', 'qemu');
+    $suse_mocked->mock('is_serial_terminal' => 0);
+    local $testapi::serialdev = 23;
+    local $testapi::username = 'me';
+    ok $susedistri->script_sudo('echo foo', 10);
+    is $wait_serial_hit, 2, 'wait_serial is called';
+    is $assert_screen_called, 2, 'assert screen is called';
+    is $wait_still_screen_called, 0, 'wait still screen is not called';
+};
+
+subtest 'script_sudo works when is cmd is bash and is not serial_terminal and wait>0' => sub {
+    set_var('BACKEND', 'qemu');
+    $suse_mocked->mock('is_serial_terminal' => 0);
+    local $testapi::serialdev = 23;
+    local $testapi::username = 'me';
+    ok $susedistri->script_sudo('bash', 10);
+    is $wait_serial_hit, 2, 'wait_serial called';
+    is $assert_screen_called, 3, 'assert screen called';
+    is $wait_still_screen_called, 1, 'wait still screen is called';
+};
+
+subtest 'script_sudo works when is serial_terminal and wait>0' => sub {
+    set_var('BACKEND', 'qemu');
+    $suse_mocked->mock('is_serial_terminal' => 1);
+    local $testapi::username = 'me';
+    ok $susedistri->script_sudo('echo foo', 10);
+    is $wait_serial_hit, 4, 'wait_serial is called twice';
+    is $assert_screen_called, 3, 'assert screen is not called';
+    is $wait_still_screen_called, 1, 'wait still screen is not called';
+};
+
+done_testing;


### PR DESCRIPTION
The refactoring of the condition which took place in 739deb2a4b should have
include both statements as it was stated in first place, and not pass
redirection to serial device.

- Verification run: http://aquarius.suse.cz/tests/13762 
http://aquarius.suse.cz/tests/13761