### PR TITLE
Remove code of removal default pattern

### DIFF
--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x-zVM.yaml
@@ -30,7 +30,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/select_patterns
+  - installation/select_visible_patterns_from_bottom
   - installation/installation_settings/validate_ssh_service_enabled
   - installation/installation_settings/open_ssh_port
   - installation/bootloader_settings/disable_boot_menu_timeout

--- a/tests/installation/select_visible_patterns_from_bottom.pm
+++ b/tests/installation/select_visible_patterns_from_bottom.pm
@@ -18,8 +18,6 @@ sub run {
     my ($self) = @_;
     $self->go_to_patterns();
     my @patterns = grep($_, split(/,/, get_required_var('PATTERNS')));
-    # delete special 'default' key from the check
-    @patterns = grep { $_ ne 'default' } @patterns;
     # specific for yast development at the end of list
     wait_screen_change { send_key 'alt-end'; }
     save_screenshot;


### PR DESCRIPTION
We remove the 'default' from PATTERNS in test suite, so do not need to remove it in code any more.

- Related ticket: https://progress.opensuse.org/issues/108380
- Needles: N/A
- Verification run: N/A
