### PR TITLE
Use 'run_args' in Public Cloud instead of custom provider

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -120,8 +120,8 @@ sub _cleanup {
     return if ($flags->{publiccloud_multi_module} && !($self->{result} eq 'fail' && $flags->{fatal}));
     # 2. Job should have PUBLIC_CLOUD_NO_CLEANUP defined and job should have result = 'fail'
     return if ($self->{result} eq 'fail' && get_var('PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE'));
-    if ($self->{provider}) {
-        eval { $self->{provider}->cleanup(); } or bmwqemu::fctwarn("provider::cleanup() failed -- $@");
+    if ($self->{run_args} && $self->{run_args}->{my_provider}) {
+        eval { $self->{run_args}->{my_provider}->cleanup(); } or bmwqemu::fctwarn("provider::cleanup() failed -- $@");
     }
 }
 

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -302,7 +302,6 @@ sub measure_timings {
     if (get_var('PUBLIC_CLOUD_QAM')) {
         $instance = $args->{my_instance};
         $provider = $args->{my_provider};
-        $self->{provider} = $args->{my_provider};    # required for cleanup
     } else {
         $provider = $self->provider_factory();
         $instance = $self->{my_instance} = $provider->create_instance(check_connectivity => 0);

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -28,7 +28,6 @@ sub run {
     if (get_var('PUBLIC_CLOUD_QAM')) {
         $instance = $args->{my_instance};
         $provider = $args->{my_provider};
-        $self->{provider} = $args->{my_provider};    # required for cleanup
     } else {
         $provider = $self->provider_factory();
         $instance = $provider->create_instance();

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -20,8 +20,6 @@ use publiccloud::utils;
 
 sub run {
     my ($self, $args) = @_;
-    # Preserve args for post_fail_hook
-    $self->{provider} = $args->{my_provider};
 
     script_run("hostname -f");
     assert_script_run("uname -a");

--- a/tests/publiccloud/nvidia.pm
+++ b/tests/publiccloud/nvidia.pm
@@ -16,8 +16,6 @@ use publiccloud::utils;
 
 sub run {
     my ($self, $args) = @_;
-    $self->{provider} = $args->{my_provider};
-
     script_run("cat /etc/os-release");
     zypper_call('--gpg-auto-import-keys addrepo -p 90 ' . get_required_var('NVIDIA_REPO') . ' nvidia_repo');
     zypper_call '--gpg-auto-import-keys ref';

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -20,7 +20,6 @@ sub run {
     my ($self, $args) = @_;
     select_host_console();    # select console on the host, not the PC instance
 
-    $self->{provider} = $args->{my_provider};    # required for cleanup
     my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
 
     my $cmd_time = time();

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -22,8 +22,6 @@ use publiccloud::ssh_interactive "select_host_console";
 sub run {
     my ($self, $args) = @_;
 
-    # Preserve args for post_fail_hook
-    $self->{provider} = $args->{my_provider};    # required for cleanup
     $self->{instance} = $args->{my_instance};
 
     select_host_console();    # select console on the host, not the PC instance
@@ -32,13 +30,12 @@ sub run {
     register_addons_in_pc($args->{my_instance});
 }
 
-sub post_fail_hook {
+sub cleanup {
     my ($self) = @_;
     $self->{instance}->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
     if (is_azure()) {
         record_info('azuremetadata', $self->{instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
     }
-    $self->SUPER::post_fail_hook;
 }
 
 sub test_flags {

--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -15,7 +15,6 @@ use utils;
 
 sub run {
     my ($self, $args) = @_;
-    $self->{provider} = $args->{my_provider};    # required for cleanup
     select_host_console(force => 1);
     $args->{my_provider}->cleanup();
 }

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -19,8 +19,6 @@ sub run {
     my ($self, $args) = @_;
     die "tunnel-console requires the TUNELLED=1 setting" unless (is_tunneled());
 
-    $self->{provider} = $args->{my_provider};    # required for cleanup
-
     # Initialize ssh tunnel for the serial device, if not yet happened
     ssh_interactive_tunnel($args->{my_instance}) if (get_var('_SSH_TUNNELS_INITIALIZED', 0) == 0);
     die("expect ssh serial") unless (get_var('SERIALDEV') =~ /ssh/);

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -20,7 +20,6 @@ sub run {
     my ($self, $args) = @_;
     select_host_console();    # select console on the host, not the PC instance
 
-    $self->{provider} = $args->{my_provider};    # required for cleanup
     my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
     my @addons = split(/,/, get_var('SCC_ADDONS', ''));
     my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);


### PR DESCRIPTION
This removes need to define in PC tests:
`$self->{provider} = $args->{my_provider};    # required for cleanup`

VR GCE:
- http://quasar.suse.cz/tests/1214
- http://quasar.suse.cz/tests/1213
- registration -> http://quasar.suse.cz/tests/1215

VR Azure:
- registration -> http://quasar.suse.cz/tests/1220
- http://quasar.suse.cz/tests/1238
- http://quasar.suse.cz/tests/1239

VR EC2:
- registration -> http://quasar.suse.cz/tests/1221
- http://quasar.suse.cz/tests/1223
- http://quasar.suse.cz/tests/1240

