### PR TITLE
Remove variable GA_REPO from schedules

### DIFF
--- a/schedule/kernel/ibtest-master-autoyast.yaml
+++ b/schedule/kernel/ibtest-master-autoyast.yaml
@@ -5,7 +5,6 @@ vars:
     AUTOYAST: autoyast_mlx_con5.xml
     AUTOYAST_PREPARE_PROFILE: 1
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
-    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -4,7 +4,6 @@ description:    >
 vars:
     DESKTOP: textmode
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
-    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -4,7 +4,6 @@ description:    >
 vars:
     DESKTOP: textmode
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/15.4/devel:tools.repo
-    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-slave-autoyast.yaml
+++ b/schedule/kernel/ibtest-slave-autoyast.yaml
@@ -5,7 +5,6 @@ vars:
     AUTOYAST: autoyast_mlx_con5.xml
     AUTOYAST_PREPARE_PROFILE: 1
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/home:/MMoese:/branches:/devel:/tools/SLE_12_SP4/home:MMoese:branches:devel:tools.repo
-    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -4,7 +4,6 @@ description:    >
 vars:
     DESKTOP: textmode
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
-    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -4,7 +4,6 @@ description:    >
 vars:
     DESKTOP: textmode
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
-    GA_REPO: http://dist.suse.de/ibs/SUSE:/SLE-%VERSION%:/GA/standard/SUSE:SLE-%VERSION%:GA.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master


### PR DESCRIPTION
This variable isn't used in the tests for quite some time now, so we should remove it from the schedules.
