### PR TITLE
Add php8 tests for sles15sp5

### DIFF
--- a/schedule/qam/common/mau-webserver.yaml
+++ b/schedule/qam/common/mau-webserver.yaml
@@ -20,7 +20,7 @@ schedule:
   - console/php_postgresql
   - console/php_timezone
   - console/flask
-  - '{{ version_specific }}'
+  - '{{version_specific}}'
 conditional_schedule:
   version_specific:
     VERSION:
@@ -45,6 +45,8 @@ conditional_schedule:
         - console/shibboleth
         - console/django
       15-SP4:
+        - console/django
+      15-SP5:
         - console/django
       tumbleweed:
         - console/django

--- a/tests/console/curl_https.pm
+++ b/tests/console/curl_https.pm
@@ -20,6 +20,7 @@ use warnings;
 use utils qw(clear_console ensure_serialdev_permissions);
 use Utils::Architectures;
 use Utils::Backends;
+use serial_terminal 'select_serial_terminal';
 
 # test for bug https://bugzilla.novell.com/show_bug.cgi?id=598574
 sub run {
@@ -27,6 +28,7 @@ sub run {
     # On s390x platform, make sure that non-root user has
     # permissions for $serialdev to get openQA work properly.
     # Please refer to bsc#1195620
+    select_serial_terminal;    # Switch to root user at first if not
     ensure_serialdev_permissions if (is_s390x);
 
     # Switch to user console: exclude ipmi backends as under non-root user session the $serialdev can not be found


### PR DESCRIPTION
https://progress.opensuse.org/issues/119530
Ues yaml schedule to load the tests

- Related ticket: 119530
- Verification run:[VRs for all archs]( https://openqa.suse.de/tests/overview?version=15-SP5&build=rfan&test=rfan_php8&distri=sle)

Please omit the failed case, it is already tracked via another ticket