### PR TITLE
Use correct base in publiccloud modules

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -43,7 +43,7 @@ sub load_maintenance_publiccloud_tests {
         loadtest('publiccloud/ahb');
     } else {
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
-        loadtest "publiccloud/instance_overview" unless get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
+        loadtest("publiccloud/instance_overview", run_args => $args) unless get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS');
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
             load_publiccloud_consoletests($args);
         } elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -10,7 +10,7 @@
 #
 # Maintainer: Pavel Dostal <pdostal@suse.cz>
 
-use base 'consoletest';
+use base 'publiccloud::basetest';
 use registration;
 use warnings;
 use testapi;
@@ -68,14 +68,7 @@ sub collect_system_information {
 }
 
 sub test_flags {
-    return {fatal => 1};
-}
-
-sub post_fail_hook {
-    my ($self) = @_;
-    select_host_console(force => 1);
-    # Destroy the public cloud instance
-    $self->{provider}->cleanup();
+    return {fatal => 1, publiccloud_multi_module => 1};
 }
 
 1;

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -8,7 +8,7 @@
 #
 # Maintainer: qa-c@suse.de
 
-use Mojo::Base 'consoletest';
+use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;


### PR DESCRIPTION
Also adds `publiccloud_multi_module` flag to instance_overview

This reverts commit 6115440fa23d2dbb4db1969684ae8d2221838c2b.

VR for instance_overview passed: http://quasar.suse.cz/tests/1237
