### PR TITLE
Install old kiwi templates in leap15.5

### DIFF
--- a/tests/jeos/kiwi_templates.pm
+++ b/tests/jeos/kiwi_templates.pm
@@ -18,7 +18,7 @@ sub run {
     my $rpm;
     if (is_sle('<15-SP2')) {
         $rpm = 'kiwi-templates-SLES15-JeOS';
-    } elsif (is_leap('<=15.4') || is_sle('<15-SP4') || is_tumbleweed) {
+    } elsif (is_leap('<=15.5') || is_sle('<15-SP4') || is_tumbleweed) {
         $rpm = 'kiwi-templates-JeOS';
     } else {
         $rpm = 'kiwi-templates-Minimal';


### PR DESCRIPTION
JeOS rename has not proceeded in Leap15.5 yet.
Install kiwi templates for JeOS.

- http://kepler.suse.cz/tests/19474#step/kiwi_templates/17
