### PR TITLE
disable GRUB_TIMEOUT in grub_test_snapshot.pm

### DIFF
--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -13,13 +13,16 @@ use base 'opensusebasetest';
 use testapi;
 use power_action_utils 'power_action';
 use utils qw(workaround_type_encrypted_passphrase reconnect_mgmt_console);
-use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
+use bootloader_setup qw(stop_grub_timeout boot_into_snapshot change_grub_config);
 use Utils::Backends 'is_pvm';
+use Utils::Architectures qw(is_aarch64);
 
 sub run {
     my $self = shift;
 
     select_console 'root-console';
+    # disable GRUB_TIMEOUT to avoid this module failed since grub menu timeout
+    change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT', '', 1) if (is_aarch64);
     power_action('reboot', keepconsole => 1, textmode => 1);
     reset_consoles;
     reconnect_mgmt_console if is_pvm;


### PR DESCRIPTION
**Desciption**:
grub_test_snapshot.pm failed in grub boot menu because of timeout like this https://openqa.suse.de/tests/9759181#step/grub_test_snapshot/82, so I disable GRUB_TIMEOUT in the module to fix the issue.

- Related ticket:
> https://progress.opensuse.org/issues/119329

- Verification run:
> https://openqa.suse.de/tests/9863029
> https://openqa.suse.de/tests/9865632
> https://openqa.suse.de/tests/9869445
> https://openqa.suse.de/tests/9869566
