### PR TITLE
Test SLED regcodes with or without wsl_gui

### DIFF
--- a/tests/wsl/wsl_cmd_check.pm
+++ b/tests/wsl/wsl_cmd_check.pm
@@ -7,7 +7,7 @@
 # Maintainer: qa-c <qa-c@suse.de>
 
 use Mojo::Base qw(windowsbasetest);
-use testapi qw(assert_and_click enter_cmd get_var);
+use testapi qw(assert_and_click enter_cmd get_var check_var);
 use version_utils qw(is_sle is_opensuse);
 use wsl qw(is_sut_reg);
 
@@ -34,6 +34,10 @@ sub run {
         $self->run_in_powershell(cmd => 'wsl -u root zypper -q -n in python3', timeout => 120);
         $self->run_in_powershell(cmd => q{wsl python3 -c "print('Hello from Python living in WSL')"});
     }
+    # Check if wsl_gui has been installed during the YaST2 firstboot
+    $self->run_in_powershell(cmd => 'wsl /bin/bash -c "zypper -q se -i -t pattern wsl"') if (get_var('WSL_GUI'));
+    # Check if SLED has been enabled during the YaST2 firstboot
+    $self->run_in_powershell(cmd => 'wsl /bin/bash -c "cat /etc/os-release | grep -i desktop"') if (check_var('SLE_PRODUCT', 'sled'));
     $self->run_in_powershell(cmd => 'wsl --shutdown', timeout => 60);
     $self->run_in_powershell(cmd => 'wsl --list --verbose', timeout => 60);
 }


### PR DESCRIPTION
Add the chance for registering SLE WSL with SLED codes. It will be possible to choose also to install or not the `wsl_gui` pattern.

- Related ticket: *pending*
- Needles:
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/firstrun-wsl-sled-license-20221103.png
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/wsl_sled_install-20221103.png
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/wsl_gui-pattern-install-20221103.png
- Verification runs:
  - [SLE15-SP3 register](https://openqa.suse.de/t9874539)
  - [SLE15-SP5 register](https://openqa.suse.de/t9874535)
  - [SLE15-SP4 skip register](https://openqa.suse.de/t9874534)
  - [SLE15-SP4 register](https://openqa.suse.de/t9874532)
  - [SLE15-SP4 register +wsl_gui](https://openqa.suse.de/t9874519)
  - [SLE15-SP4 register +SLED](https://openqa.suse.de/t9874523)
  - [SLE15-SP4 register +SLED +wsl_gui](https://openqa.suse.de/t9874526)
