### PR TITLE
tests/locale/keymap_or_locale_x11: Remove broken clear_console

### DIFF
--- a/tests/locale/keymap_or_locale_x11.pm
+++ b/tests/locale/keymap_or_locale_x11.pm
@@ -12,12 +12,10 @@ use base "locale";
 use strict;
 use warnings;
 use testapi;
-use utils 'clear_console';
 
 
 sub run {
     my ($self) = @_;
-    clear_console;
     select_console('x11');
     # uncomment in case of different keyboard than us is used during installation ( feature not ready yet )
     # my $expected   = get_var('INSTALL_KEYBOARD_LAYOUT','us');


### PR DESCRIPTION
Calling it at this point is simply broken, it types "clear\n" into the desktop. There is no reason to clear a console that is being switched away.

This was added by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15717/files without explanation and it causes failures like https://openqa.opensuse.org/tests/2849685 everywhere.

Verification run: https://openqa.opensuse.org/tests/2851441

