### PR TITLE
keymap_or_locale_x11: remove stray clear_console

### DIFF
--- a/tests/locale/keymap_or_locale_x11.pm
+++ b/tests/locale/keymap_or_locale_x11.pm
@@ -12,12 +12,10 @@ use base "locale";
 use strict;
 use warnings;
 use testapi;
-use utils 'clear_console';
 
 
 sub run {
     my ($self) = @_;
-    clear_console;
     select_console('x11');
     # uncomment in case of different keyboard than us is used during installation ( feature not ready yet )
     # my $expected   = get_var('INSTALL_KEYBOARD_LAYOUT','us');


### PR DESCRIPTION
The test switches as first action to X1!. Additionally, we can't guarantee
to not already be on an X11 session, which means 'clear_screen' would not
do what it is expected to do here.

- Related ticket: https://openqa.opensuse.org/tests/2850897#step/keymap_or_locale_x11/1
- Needles: N/A
- Verification run: N/A

Fixes a regression that was introduced this morning and blocks stagings
