### PR TITLE
[vagrant] install system-group-wheel for vagrant-sshfs tests

### DIFF
--- a/tests/virtualization/vagrant/sshfs.pm
+++ b/tests/virtualization/vagrant/sshfs.pm
@@ -16,7 +16,9 @@ sub run() {
     setup_vagrant_libvirt();
 
     select_console('root-console');
-    zypper_call("in vagrant-sshfs vagrant-sshfs-testsuite");
+    # vagrant-sshfs' testsuite wants to mount certain folders as the wheel group
+    # => must be present on the system
+    zypper_call("in vagrant-sshfs vagrant-sshfs-testsuite system-group-wheel");
 
     select_console('user-console');
 


### PR DESCRIPTION
vagrant-sshfs requires the `wheel` group to exist on the SUT since version 1.3.7: https://github.com/dustymabe/vagrant-sshfs/blob/f60ff0e28401a6fcd119c6b4959e8a44245a90a3/test/misc/Vagrantfile This made the testsuite fail and is remedied by creating the group first via the `system-group-wheel` package.


- Related ticket: [boo#1200894](https://bugzilla.opensuse.org/show_bug.cgi?id=1200894)
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2851604
