### PR TITLE
Fix select_serial_terminal for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15496

### DIFF
--- a/tests/yast2_gui/yast2_firewall_set_default_zone.pm
+++ b/tests/yast2_gui/yast2_firewall_set_default_zone.pm
@@ -14,12 +14,13 @@ use testapi;
 use utils;
 use network_utils 'iface';
 use YaST::Module;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my $self = shift;
     my $iface = iface();
 
-    $self->select_serial_terminal();
+    select_serial_terminal();
     validate_script_output("firewall-cmd --get-default-zone", sub { m/public/ }, proceed_on_failure => 1);
     select_console 'x11', await_console => 0;
     YaST::Module::open(module => 'firewall', ui => 'qt');
@@ -31,7 +32,7 @@ sub run {
     save_screenshot;
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
-    $self->select_serial_terminal();
+    select_serial_terminal();
     validate_script_output("firewall-cmd --list-interfaces --zone=trusted", sub { m/$iface/ }, proceed_on_failure => 1);
     validate_script_output("firewall-cmd --get-default-zone", sub { m/trusted/ }, proceed_on_failure => 1);
 

--- a/tests/yast2_gui/yast2_firewall_set_interface.pm
+++ b/tests/yast2_gui/yast2_firewall_set_interface.pm
@@ -14,6 +14,7 @@ use testapi;
 use utils;
 use network_utils 'iface';
 use YaST::Module;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my $self = shift;
@@ -28,7 +29,7 @@ sub run {
     save_screenshot;
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
-    $self->select_serial_terminal();
+    select_serial_terminal();
     validate_script_output("firewall-cmd --list-interfaces --zone=$setting{zone}", sub { m/$setting{device}/ }, proceed_on_failure => 1);
 }
 

--- a/tests/yast2_gui/yast2_firewall_set_service_port.pm
+++ b/tests/yast2_gui/yast2_firewall_set_service_port.pm
@@ -14,6 +14,7 @@ use testapi;
 use utils;
 use network_utils 'iface';
 use YaST::Module;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my $self = shift;
@@ -30,7 +31,7 @@ sub run {
     save_screenshot;
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
-    $self->select_serial_terminal();
+    select_serial_terminal();
     validate_script_output("firewall-cmd --list-all --zone=trusted", sub { m/services: bitcoin/ }, proceed_on_failure => 1);
     validate_script_output("firewall-cmd --list-all --zone=trusted", sub { m/ports: 7777\/tcp/ }, proceed_on_failure => 1);
 }

--- a/tests/yast2_gui/yast2_firewall_start_service.pm
+++ b/tests/yast2_gui/yast2_firewall_start_service.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use utils;
 use YaST::Module;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my $self = shift;
@@ -24,7 +25,7 @@ sub run {
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
 
-    $self->select_serial_terminal();
+    select_serial_terminal();
     validate_script_output("firewall-cmd --state", sub { m/^running/ }, proceed_on_failure => 1);
 }
 

--- a/tests/yast2_gui/yast2_firewall_stop_service.pm
+++ b/tests/yast2_gui/yast2_firewall_stop_service.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use utils;
 use YaST::Module;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my $self = shift;
@@ -25,7 +26,7 @@ sub run {
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
 
-    $self->select_serial_terminal();
+    select_serial_terminal();
     validate_script_output("firewall-cmd --state", sub { m/91mnot running/ }, proceed_on_failure => 1);
 }
 


### PR DESCRIPTION
Fix select_serial_terminal for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15496

- Related ticket: https://progress.opensuse.org/issues/113492
- Needles: na
- Verification run: https://openqa.opensuse.org/tests/2851957#step/setup_libyui_running_system/2
