### PR TITLE
  Enable btrfs validation for aarch64

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -124,7 +124,7 @@ sub load_host_tests_docker {
     # Expected to work for all but JeOS on 15sp4 after
     # https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13860
     # Disabled on svirt backends (VMWare, Hyper-V and XEN) as the device name might be different than vdX
-    if ((is_x86_64 && is_qemu) && !(is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro)) {
+    if (!(is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro)) {
         loadtest 'containers/validate_btrfs';
     }
 }


### PR DESCRIPTION
Since aarch64 can swap disk label, test module cannot expect that `b`
drives are guaranteed as second.
This PR add a generic detection of the used devices allowing to execute
the test in SUTs run by other hypervisors than QEMU.

- ticket: [Enable validate_btrfs module for
  aarch64](https://progress.opensuse.org/issues/103977)
  
#### Verification runs: 
 * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-aarch64-Build20221106-1-jeos-containers-docker@aarch64](https://openqa.suse.de/t9891609)
 * [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-aarch64-jeos-containers-docker](https://openqa.suse.de/tests/9891306#step/validate_btrfs/1)
 * [sle-15-SP4-JeOS-for-MS-HyperV-QR](https://openqa.suse.de/tests/9891307)