### PR TITLE
Select last item on select_patterns

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -181,11 +181,15 @@ highlight cursor one item down.
 =cut
 
 sub move_down {
-    # Sending 'down' twice, followed by 'up', scrolls to the intended item.
-    wait_screen_change { send_key 'down' } if is_sle('>=15-sp3');
     my $ret = wait_screen_change { send_key 'down' };
     last if (!$ret);    # down didn't change the screen, so exit here
-    wait_screen_change { send_key 'up' } if is_sle('>=15-sp3');
+    if (is_sle('>=15-sp3')) {
+        # Sending 'down' twice, followed by 'up', scrolls to the intended item.
+        $ret = wait_screen_change { send_key 'down' };
+        # If screen did not change with the second down we are on the last item.
+        # In that case do not press up so that it remains selected.
+        wait_screen_change { send_key 'up' } if $ret;
+    }
     check12qtbug if check_var('VERSION', '12');
 }
 


### PR DESCRIPTION
Until now the workaround did not select the last item because the up button was pressed last. With this new fix we will only send up when the screen did not change after we have typed the second down, which means that we are on the last item. This will result with the last item being selected.

- Related ticket: https://progress.opensuse.org/issues/119584, related to [this failure](https://openqa.suse.de/tests/9842779#step/select_patterns/125).
- Needles: No
- Verification run: https://openqa.suse.de/tests/9936092#step/select_patterns/127

related MR: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1630
