### PR TITLE
Exclude test 'rails' from opensuse extra_test

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -65,7 +65,6 @@ conditional_schedule:
                 - console/wpa_supplicant
                 - appgeo/gdal
                 - console/rabbitmq
-                - console/rails
                 - console/openqa_review
                 - console/zbar
                 - console/a2ps


### PR DESCRIPTION
rails is broken, see https://bugzilla.opensuse.org/show_bug.cgi?id=1204481 and https://progress.opensuse.org/issues/119044

