### PR TITLE
Replace get_var with is_ltss variable on HPC create_hdd_textmode

### DIFF
--- a/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
@@ -74,7 +74,7 @@
         <version>15</version>
       </addon>
       % }
-      % if ($get_var->('SCC_ADDONS') =~ m/ltss/) {
+      % if ($is_ltss) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
         <name>SLE_HPC-LTSS</name>

--- a/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
@@ -74,7 +74,7 @@
         <version>15</version>
       </addon>
       % }
-      % if ($get_var->('SCC_ADDONS') =~ m/ltss/) {
+      % if ($is_ltss) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
         <name>SLE_HPC-LTSS</name>


### PR DESCRIPTION
`$get_var->('SCC_ADDONS') =~ m/ltss/` breaks `autoyast/prepare_profile` on non ltss product for some reason. Fortunately `lib/autoyast.pm` provides `is_ltss` variable. This variable checks whether `SCC_REGCODE_LTSS` job variable is defined.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: http://aquarius.suse.cz/tests/13944
