### PR TITLE
Adapt test suites for power VM

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -11,6 +11,7 @@ use Utils::Architectures;
 use utils;
 use version_utils qw(is_sle is_livecd);
 use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
+use Utils::Backends;
 
 our @EXPORT = qw(
   grub_test
@@ -31,6 +32,7 @@ Handle grub menu after reboot
 sub grub_test {
     my $timeout = get_var('GRUB_TIMEOUT', 200);
 
+    reconnect_mgmt_console if is_pvm;
     handle_installer_medium_bootup();
     workaround_type_encrypted_passphrase;
     # 60 due to rare slowness e.g. multipath poo#11908

--- a/schedule/yast/releasenotes_origin+unregistered@pvm.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered@pvm.yaml
@@ -1,0 +1,26 @@
+---
+name: releasenotes_origin+unregistered@pvm
+description: >
+  Test fate#323273 - Check the origin (rpm or url) of the showed release notes.
+vars:
+  SCC_REGISTER: 'none'
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/skip_registration
+  - installation/module_selection/skip_module_selection
+  - installation/add_on_product_installation/accept_add_on_installation
+  - installation/release_notes_from_url
+  - installation/system_role/accept_selected_role_text_mode
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation

--- a/tests/installation/release_notes_from_url.pm
+++ b/tests/installation/release_notes_from_url.pm
@@ -10,17 +10,19 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     assert_screen('release-notes-button');
-    send_key('ctrl-shift-alt-x');
-    assert_screen('yast-xterm');
+    select_console 'install-shell';
     enter_cmd "zgrep -oh \"Got release notes.*\" /var/log/YaST2/y2log*";
     assert_screen [qw(got-releasenotes-RPM got-releasenotes-URL)];
     unless (match_has_tag 'got-releasenotes-URL') {
         record_soft_failure('bsc#1190711 - Release notes source does NOT match expectations or not found in YaST logs, expected source: URL');
     }
-    enter_cmd "exit";
+    reset_consoles;
+    select_console 'installation';
 }
 
 1;


### PR DESCRIPTION
We need adapt test suites for power VM.

- Related ticket: https://progress.opensuse.org/issues/117532
- Needles: got-releasenotes-RPM, merged in OSD.
- Related MR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/434
- Verification run: 
   http://openqa.nue.suse.com/tests/9812368#    textmode_installation_minimal_role:
   http://openqa.nue.suse.com/tests/9869911#    releasenotes_origin+unregistered
   
