### PR TITLE
Fix to include winget's new parameter

### DIFF
--- a/tests/wsl/install_from_MSStore.pm
+++ b/tests/wsl/install_from_MSStore.pm
@@ -77,7 +77,7 @@ sub run {
 
     # Install required SUSE distro from the MS Store
     $self->run_in_powershell(
-        cmd => 'winget install --accept-package-agreements --accept-source-agreements "' . $WSL_version . '"',
+        cmd => 'winget install --source msstore --accept-package-agreements --accept-source-agreements "' . $WSL_version . '"',
         code => sub {
             assert_screen 'install-SUSE-WSL-finish', timeout => 720;
         }


### PR DESCRIPTION
Fix to include winget's new parameter. Update to use latest version of winget

- Related ticket: https://progress.opensuse.org/issues/120001
- Needles: *none*
- Verification run:
  - https://openqa.suse.de/t9891031
