### PR TITLE
Skip cleanup routine

### DIFF
--- a/tests/publiccloud/nvidia.pm
+++ b/tests/publiccloud/nvidia.pm
@@ -27,6 +27,10 @@ sub run {
     assert_script_run("SUSEConnect --status-text", 300);
 }
 
+sub test_flags {
+    return {publiccloud_multi_module => 1};
+}
+
 1;
 
 =head1 Discussion


### PR DESCRIPTION
`nvidia` test case executed cleanup even after successful runs. This breaks the subsequent tests.

https://openqa.suse.de/tests/9887516#step/nvidia/79

VR: http://kepler.suse.cz/tests/19492#step/nvidia/40
