### PR TITLE
Fix select_serial_terminal for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15496

### DIFF
--- a/tests/yast2_gui/yast2_firewall_set_default_zone_prepare.pm
+++ b/tests/yast2_gui/yast2_firewall_set_default_zone_prepare.pm
@@ -14,6 +14,7 @@ use testapi;
 use utils;
 use network_utils 'iface';
 use YaST::Module;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my $self = shift;
@@ -28,7 +29,7 @@ sub run {
     save_screenshot;
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
-    $self->select_serial_terminal();
+    select_serial_terminal();
     validate_script_output("firewall-cmd --list-interfaces --zone=$settings{zone}", sub { m/$settings{device}/ }, proceed_on_failure => 0);
 }
 


### PR DESCRIPTION
Fix select_serial_terminal for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15496

    Related ticket: https://progress.opensuse.org/issues/113492
    Needles: na
    Verification run: 