### PR TITLE
Adapt modify_existing_partition for PowerVM

### DIFF
--- a/schedule/yast/modify_existing_partition/modify_existing_partition@spvm.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition@spvm.yaml
@@ -1,0 +1,22 @@
+---
+name: modify_existing_partition
+description: >
+  Installation where we modify some pre-existing partitions. Must depend on some
+  create_hdd test suite.
+vars:
+  YUI_REST_API: 1
+schedule:
+  suggested_partitioning:
+    - installation/partitioning/modify_existing_partition
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  installation_settings:
+    - installation/installation_settings/validate_ssh_service_enabled
+    - installation/installation_settings/open_ssh_port
+    - installation/launch_installation
+  grub:
+    - installation/handle_reboot
+  system_validation:
+    - console/validate_modify_existing_partition
+test_data:
+  <<: !include test_data/yast/modify_existing_partition/modify_existing_partition.yaml

--- a/test_data/yast/modify_existing_partition/modify_existing_partition@spvm.yaml
+++ b/test_data/yast/modify_existing_partition/modify_existing_partition@spvm.yaml
@@ -1,0 +1,27 @@
+---
+disks:
+- name: sda
+  table_type: gpt
+  partitions:
+  - name: sda2
+    # Sizes should be preferably expressed in human readable binary units (eg GiB)
+    # for this test suite: we use lsblk in validation modules, which uses human
+    # readable binary unit (*ibits).
+    # part_size is the size we input in partitioner, as we use lsbls output for validation.
+    size: 11G
+    role: raw-volume
+    formatting_options:
+      should_format: 1
+      filesystem: btrfs
+    mounting_options:
+      should_mount: 1
+      mount_point: /
+  - name: sda4
+    size: 2G
+    role: raw-volume
+    formatting_options:
+      should_format: 1
+      filesystem: swap
+    mounting_options:
+      should_mount: 1
+      mount_point: '[SWAP]'


### PR DESCRIPTION
We need to adapt modify_existing_partition case to make it run on PowerWM.

- Related ticket: https://progress.opensuse.org/issues/110773 
- Needles: 
   N/A
- Verification run: 
   https://openqa.suse.de/tests/9898910
   https://openqa.suse.de/tests/9898911

  https://openqa.suse.de/tests/9915878
  https://openqa.suse.de/tests/9915879
- Related MR:
  https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/435