### PR TITLE
Adjustments for KDE Applications 22.11

### DIFF
--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -67,8 +67,14 @@ sub run {
     # Remove the directory forcibly
     assert_screen 'dolphin_icon_stuff';
     send_key 'shift-delete';
-    assert_screen 'dolphin_force_remove';
-    send_key 'ret';
+    # Only before 22.11 the delete button was focused by default,
+    # click it directly on newer versions.
+    assert_screen([qw(dolphin_force_remove dolphin_force_remove_button)]);
+    if (match_has_tag('dolphin_force_remove_button')) {
+        click_lastmatch;
+    } else {
+        send_key 'ret';
+    }
 
     # Remove the places entry again
     assert_and_click('dolphin_places_stuff', button => 'right');

--- a/tests/x11/kate.pm
+++ b/tests/x11/kate.pm
@@ -17,7 +17,13 @@ use testapi;
 sub run {
     my ($self) = @_;
     ensure_installed("kate");
-    x11_start_program('kate');
+    x11_start_program('kate', target_match => [qw(kate kate-welcome)]);
+
+    # Handle the new (22.11) welcome screen
+    if (match_has_tag('kate-welcome')) {
+        send_key 'ctrl-n';
+        assert_screen 'kate';
+    }
 
     if (!get_var("PLASMA5")) {
         # close welcome screen


### PR DESCRIPTION
Slight behaviour changes in dolphin and kate.

- Verification run: https://openqa.opensuse.org/tests/2860423
- Needles: Created during the VR on o3.
