### PR TITLE
Exclude validate_btrfs test on real hw

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -120,11 +120,8 @@ sub load_host_tests_docker {
         loadtest 'containers/registry' if (is_x86_64 || is_sle('>=15-sp4'));
         loadtest 'containers/docker_compose' unless is_public_cloud;
     }
-    # works currently only for x86_64, more are coming (poo#103977)
-    # Expected to work for all but JeOS on 15sp4 after
-    # https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/13860
-    # Disabled on svirt backends (VMWare, Hyper-V and XEN) as the device name might be different than vdX
-    if (!(is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro)) {
+    # Expected to work anywhere except of real HW backends, PC and Micro
+    unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro) {
         loadtest 'containers/validate_btrfs';
     }
 }


### PR DESCRIPTION
Follow up for PR #15837, exclude backends or archs that either do not run btrfs or cannot make an use of `NUMDISKS` variable.

- failure: [opensuse-Tumbleweed-JeOS-for-RPi-aarch64-Build20221107-jeos-containers@RPi3](https://openqa.opensuse.org/tests/2860891#step/validate_btrfs/2)
