### PR TITLE
Fix regex for health-checker

### DIFF
--- a/tests/console/journal_check.pm
+++ b/tests/console/journal_check.pm
@@ -98,7 +98,7 @@ sub run {
             my $service = $1;
             my $failed_service_output = script_output("systemctl status $service -l || true");
             foreach my $bsc (@matched_bugs) {
-                if ($failed_service_output =~ /$bug_pattern->{$bsc}->{description}/) {
+                if ($failed_service_output =~ $bug_pattern->{$bsc}->{description}) {
                     record_info('Softfail', "Service: $service failed due to $bsc\n$failed_service_output", result => 'softfail');
                     next SRV;
                 }


### PR DESCRIPTION
- failure: [ALP](https://openqa.opensuse.org/tests/2842805#step/journal_check/20)
- Verification run: [alp-0.1-kvm-x86_64](https://openqa.opensuse.org/t2868588)
