### PR TITLE
ansible: hostnamectl cut only the first part of domain

### DIFF
--- a/tests/console/ansible.pm
+++ b/tests/console/ansible.pm
@@ -94,7 +94,7 @@ sub run {
     # Check Ansible version
     record_info('ansible --version', script_output('ansible --version'));
 
-    my $hostname = script_output(is_sle('=15-sp3') ? 'hostname -s' : 'hostnamectl hostname');
+    my $hostname = script_output(is_sle('=15-sp3') ? 'hostname -s' : 'hostnamectl hostname | cut -d. -f1');
     validate_script_output 'ansible -m setup localhost | grep ansible_hostname', sub { m/$hostname/ };
 
     my $arch = get_var 'ARCH';


### PR DESCRIPTION
- Related ticket: [poo#120031](https://progress.opensuse.org/issues/120031)
- Failure example: [openqa.opensuse.org/t2858934](https://openqa.opensuse.org/tests/2858934#step/ansible/101)
- Verification run: [openqa.opensuse.org/t2861108](https://openqa.opensuse.org/tests/2861108)
