### PR TITLE
Install gnu-hpc packages on HPC compute nodes

### DIFF
--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -20,23 +20,12 @@ sub run ($self) {
     my $mpi_bin = 'mpi_bin';
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);
+    my %exports_path = (bin => '/home/bernhard/bin');
+    $self->setup_nfs_server(\%exports_path);
     $self->prepare_spack_env($mpi);
-    my %exports_path = (
-        bin => '/home/bernhard/bin',
-        spack => '/home/bernhard/spack',
-        hpc_lib => '/usr/lib/hpc',
-        spack_lib => '/opt/spack'
-    );
 
     record_info 'boost info', script_output 'spack info boost';
     barrier_wait('CLUSTER_PROVISIONED');
-    script_run "pkill -u $testapi::username";
-    select_console('root-console');
-    $self->setup_nfs_server(\%exports_path);
-
-    # And login as normal user to run the tests
-    type_string('pkill -u root');
-    select_serial_terminal(0);
 
     ## all nodes should be able to ssh to each other, as MPIs requires so
     $self->generate_and_distribute_ssh($testapi::username);


### PR DESCRIPTION
Due to the `openmpi` changes I refactored the spack test to use the gnu-hpc packages. As for now the spack test suite uses *mpich* so the test suite is not affected directly. However, with this refactoring, we remove the use of `get_compute_nodes_deps` which is now deprecated.
The only binaries shared with NFS is the directory with the code to run and `prepare_spack_env` takes care of the installation of the required libraries

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/119983
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2315860
