### PR TITLE
installation/boot_encrypt: Skip second passphrase entry in Staging:M

### DIFF
--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -12,9 +12,14 @@ use strict;
 use warnings;
 use base "installbasetest";
 use utils;
-use testapi qw(get_var record_info);
+use testapi qw(check_var get_var record_info);
 
 sub run {
+    # In TW (Staging:M only for now), entering the passphrase in GRUB2
+    # is enough. The key is passed on during boot, so it's not asked for
+    # a second time.
+    return if is_boot_encrypted && check_var('VERSION', 'Staging:M');
+
     unlock_if_encrypted(check_typed_password => 1);
 }
 


### PR DESCRIPTION
The conditions for this are too complex to put it into all relevant YAML files, so I had to put it into the test module itself.
Autodetection is not a viable option either because then `unlock_if_encrypted` would need most of `wait_boot_past_bootloader` inside it. It would also miss if the second PW entry unexpectedly came back.

- Related ticket: https://progress.opensuse.org/issues/117811
- Verification run: https://openqa.opensuse.org/tests/2861684
