### PR TITLE
SELinux Mode has different key short cut for leap-micro 5.3 

### DIFF
--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -40,7 +40,7 @@ sub run {
         send_key_until_needlematch 'security-module-selinux', 'up';
         send_key 'ret' if $textmode;
         # Switch it into enforcing mode
-        send_key 'alt-u';
+        send_key is_leap_micro ? 'alt-i' : 'alt-u';
         send_key_until_needlematch 'security-selinux-enforcing', 'down';
         send_key 'ret' if $textmode;
     }


### PR DESCRIPTION
press `alt-i` in order to choose SELinux Mode for leap-micro 5.3

#### Verification runs:

* [opensuse-Tumbleweed-NET-x86_64-Build20221107-textmode+selinux@uefi](http://kepler.suse.cz/tests/19500#step/enable_selinux/6)
* [sle-micro-5.1-DVD-Updates-x86_64-Build20221107-1-slem_installation_selinux@64bit](http://kepler.suse.cz/tests/19501#step/enable_selinux/26)
* [sle-micro-5.2-DVD-Updates-x86_64-Build20221107-1-slem_installation_selinux@64bit](http://kepler.suse.cz/tests/19504#step/enable_selinux/26)
* [sle-micro-5.3-DVD-Updates-x86_64-Build20221107-1-slem_installation_selinux@64bit](http://kepler.suse.cz/tests/19505#live)
* [leap-micro-5.3-DVD-aarch64](https://openqa.opensuse.org/tests/2861876#step/enable_selinux/28)