### PR TITLE
x11/network/NM_wpa2_enterprise: Do not click "Connect" in the second time

### DIFF
--- a/tests/x11/network/NM_wpa2_enterprise.pm
+++ b/tests/x11/network/NM_wpa2_enterprise.pm
@@ -28,8 +28,8 @@ sub run {
     enter_cmd "exit";
     enter_cmd "exit";
 
-    # connect again to see if NM has a "connection" after we disabled v4 and v6
-    $self->connect_to_network;
+    # wait for auto reconnect to see if NM has a "connection" after we disabled v4 and v6
+    wait_still_screen;
     assert_screen [qw(network_manager-network_connected network_manager-wrong_card_selected)];
     if (match_has_tag 'network_manager-wrong_card_selected') {
         record_soft_failure 'boo#1079320';


### PR DESCRIPTION
In the second time we connect to the wifi, there is no need to click "Connect" again -- we already typed password, so the system will auto-connect in the background.

- Related ticket: https://progress.opensuse.org/issues/117031
- Needles: None
- Verification run:
Leap15.4: https://openqa.opensuse.org/tests/2861035#step/NM_wpa2_enterprise/34
TW: https://openqa.opensuse.org/tests/2861036