### PR TITLE
Use base 'consoletest' for transactional_update test

### DIFF
--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -13,7 +13,7 @@
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "consoletest";
 use testapi;
 use version_utils qw(is_staging is_opensuse is_leap is_sle is_sle_micro is_leap_micro is_alp);
 use transactional;


### PR DESCRIPTION
https://progress.opensuse.org/issues/117472
Use consoletest as parent/base so that the post_fail_hooks can be called

- Related ticket: https://progress.opensuse.org/issues/117472
- Verification run: 
 https://openqa.opensuse.org/t2860324
[BTW, QEMU=2048 is set in test suite]
