### PR TITLE
wicked: Delay ifup of t08_setup_second_card

### DIFF
--- a/tests/wicked/basic/sut/t08_setup_second_card.pm
+++ b/tests/wicked/basic/sut/t08_setup_second_card.pm
@@ -17,6 +17,9 @@ use lockapi;
 
 sub run {
     my ($self, $ctx) = @_;
+
+    sleep(30);    # OVS on a worker is slow sometimes to change and we haven't found better way how to handle it
+
     my $cfg_ifc1 = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
     my $cfg_ifc2 = '/etc/sysconfig/network/ifcfg-' . $ctx->iface2();
     my $dhcp_ip_sut = $self->get_ip(type => 'dhcp_2nic');


### PR DESCRIPTION
OVS is blocking the port in the beginning sometimes. This cause trouble in this test, as the first DHCP-Request times out and wicked is using the last lease (which is something from the installation).

Now we simply wait 30s to give OVS some time. Most properly this is something related to RSTP configured on the OVS bridge.

Reference: [bsc#1204604](https://bugzilla.suse.com/show_bug.cgi?id=1204604)

- Verification run: https://openqa.opensuse.org/tests/2863400
