### PR TITLE
Increase timeout for booting to local disk

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -276,7 +276,7 @@ sub boot_local_disk {
             push @tags, 'displaymanager' if check_var('DESKTOP', 'gnome');
         }
 
-        assert_screen(\@tags);
+        assert_screen(\@tags, 60);
         if (match_has_tag 'grub2') {
             diag 'already in grub2, returning from boot_local_disk';
             stop_grub_timeout;


### PR DESCRIPTION
The default timeout occasionaly causes a stall on test runs, because the display manager screen takes longer to appear. Increasing the timeout mitigates this.

- Related ticket: https://progress.opensuse.org/issues/118336, related to [this failure](https://openqa.suse.de/tests/9889455#step/snapper_rollback/22)
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/9907879#step/snapper_rollback/24 (passed 3 consecutive times)
