### PR TITLE
publiccloud : Optimize registercloud log upload

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -127,7 +127,16 @@ sub _cleanup {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->_cleanup() unless $self->{cleanup_called};
+    unless ($self->{cleanup_called}) {
+        my $instance = $self->{run_args}->{my_instance};
+        if ($instance->ssh_script_run(cmd => 'sudo stat --printf="%s" /var/log/cloudregister', proceed_on_failure => 1) != 0) {
+            $instance->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log', failok => 1);
+        }
+        else {
+            bmwqemu::fctwarn("Test failed but cloudregister log is empty so skipping upload");
+        }
+        $self->_cleanup();
+    }
 }
 
 sub post_run_hook {

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -281,16 +281,13 @@ sub wait_for_guestregister
         my $out = $self->run_ssh_command(cmd => 'sudo systemctl is-active guestregister', proceed_on_failure => 1, quiet => 1);
         # guestregister is expected to be inactive because it runs only once
         if ($out eq 'inactive') {
-            $self->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
             return time() - $start_time;
         } elsif ($out eq 'failed') {
-            $self->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
             $out = $self->run_ssh_command(cmd => 'sudo systemctl status guestregister', proceed_on_failure => 1, quiet => 1);
             record_info("guestregister failed", $out, result => 'fail');
             record_soft_failure("bsc#1195414");
             return time() - $start_time;
         } elsif ($out eq 'active') {
-            $self->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
             die "guestregister should not be active on BYOS" if (is_byos);
         }
 
@@ -301,7 +298,6 @@ sub wait_for_guestregister
         sleep 1;
     }
 
-    $self->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
     die('guestregister didn\'t end in expected timeout=' . $args{timeout});
 }
 

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -122,7 +122,6 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->{instance}->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
     if (is_azure()) {
         record_info('azuremetadata', $self->{instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
     }

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -64,9 +64,7 @@ sub run {
             my $filename = 'result-' . $t->{name} . '.json';
             my $file = path(bmwqemu::result_dir(), $filename);
             my $json = Mojo::JSON::decode_json($file->slurp);
-            next if ($json->{result} ne 'fail');
-            $instance->upload_log('/var/log/cloudregister', log_name => 'cloudregister.log');
-            last;
+            last if ($json->{result} eq 'fail');
         }
         $instance->run_ssh_command(cmd => 'rpm -qa > /tmp/rpm_qa.txt', no_quote => 1);
         upload_logs('/tmp/rpm_qa.txt');

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -32,7 +32,6 @@ sub run {
 
 sub cleanup {
     my ($self) = @_;
-    $self->{instance}->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
     if (is_azure()) {
         record_info('azuremetadata', $self->{instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
     }


### PR DESCRIPTION
Before this patch upload of registercloud log was
spreaded in several places. Which makes us uploading
file with same content several times. In some cases we
even uploading empty files.
This patch brings order into this process. From now on
we will upload regsitercloud only when there is test
failure AND file is not empty.