### PR TITLE
PubCloud: root password set by tests

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
-use version_utils qw(is_sle is_public_cloud);
+use version_utils qw(is_sle);
 
 sub sudo_with_pw {
     my ($command, %args) = @_;
@@ -48,14 +48,8 @@ sub run {
     select_console 'root-console';
     zypper_call 'in sudo expect';
     select_console 'user-console';
-    # Verify that sudo works with the default configuration.
-    if (is_public_cloud) {
-        # No defaults targetpw (public cloud) -> asks for user PW
-        assert_script_run("expect -c 'spawn sudo id -un;expect \"password for $testapi::username\" {send \"$testapi::password\\r\";interact} default {exit 1}' | grep ^root");
-    } else {
-        # Defaults targetpw -> asks for root PW
-        assert_script_run("expect -c 'spawn sudo id -un;expect \"password for root\" {send \"$testapi::password\\r\";interact} default {exit 1}' | grep ^root");
-    }
+    # Defaults targetpw -> asks for root PW
+    assert_script_run("expect -c 'spawn sudo id -un;expect \"password for root\" {send \"$testapi::password\\r\";interact} default {exit 1}' | grep ^root");
     select_console 'root-console';
     # Prepare a file with content '1' for later IO redirection test
     assert_script_run 'echo 1 >/run/openqa_sudo_test';
@@ -64,10 +58,6 @@ sub run {
     # use script_run because yes is still writing to the pipe and then command is exiting with 141
     script_run "groupadd sudo_group && useradd -m -d /home/sudo_test -G sudo_group,\$(stat -c %G /dev/$serialdev) sudo_test && yes $test_password|passwd -q sudo_test";
     assert_script_run 'echo "%sudo_group ALL = (root) NOPASSWD: /usr/bin/journalctl, PASSWD: /usr/bin/zypper" >/etc/sudoers.d/sudo_group';
-    # on publiccloud the root password is not yet set
-    # note: due to security reasons, the root password must be reset afterwards
-    my $password = $testapi::password;
-    assert_script_run("echo -e '$password\n$password' | passwd root") if is_public_cloud;
     select_console 'user-console';
     # check if password is required
     assert_script_run 'sudo -K && ! timeout 5 sudo id -un';
@@ -116,8 +106,6 @@ sub post_run_hook {
     assert_script_run 'rm -f /etc/sudoers.d/test /etc/sudoers.d/sudo_group';
     # remove test user
     assert_script_run 'userdel -r sudo_test && groupdel sudo_group';
-    # remove root password on publiccloud again
-    assert_script_run("passwd root --lock") if is_public_cloud;
 }
 
 1;


### PR DESCRIPTION
Follow up for PR#15849
Password for root is configured in `publiccloud/prepare_instance.pm` in order to run console tests.

- ticket: [test fails in sudo](https://progress.opensuse.org/issues/119860)
- Verification run: 
  * [sle-15-SP1-AZURE-BYOS-Updates-x86_64-Build20221108-1-publiccloud_consoletests@64bit](http://kepler.suse.cz/tests/19507#step/sudo/5)
  * [sle-15-SP4-AZURE-BYOS-Updates-x86_64-Build20221108-1-publiccloud_consoletests@64bit](http://kepler.suse.cz/tests/19508#live)