### PR TITLE
Disable Plasma tooltips on login

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -26,6 +26,7 @@ our @EXPORT = qw(
   select_user_gnome
   turn_off_screensaver
   turn_off_kde_screensaver
+  turn_off_plasma_tooltips
   turn_off_plasma_screen_energysaver
   turn_off_plasma_screenlocker
   turn_off_gnome_screensaver
@@ -390,7 +391,7 @@ sub turn_off_plasma_screen_energysaver {
 
 =head2 turn_off_plasma_screenlocker
 
- turnoff_plasma_screenlocker()
+ turn_off_plasma_screenlocker()
 
 Turns off the Plasma desktop screenlocker.
 
@@ -403,6 +404,20 @@ sub turn_off_plasma_screenlocker {
     # Was 'alt-o' before, but does not work in Plasma 5.17 due to kde#411758
     send_key 'ctrl-ret';
     assert_screen 'generic-desktop';
+}
+
+=head2 turn_off_plasma_tooltips
+
+  turn_off_plasma_tooltips()
+
+Disable Plasma tooltips, especially the one triggered by the "Peek Desktop" below the default
+mouse_hide location can break needles and break or slow down matches.
+
+=cut
+
+sub turn_off_plasma_tooltips {
+    x11_start_program('kwriteconfig5 --file plasmarc --group PlasmaToolTips --key Delay -- -1',
+        target_match => 'generic-desktop', no_wait => 1) if check_var('DESKTOP', 'kde');
 }
 
 =head2 turn_off_kde_screensaver

--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -4,7 +4,7 @@
 # Copyright 2012-2018 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: move all inst/$DESKTOP.pm into one global 999_finish_desktop and runthe tests from start.pl
+# Summary: move all inst/$DESKTOP.pm into one global 999_finish_desktop and run the tests from start.pl
 # Maintainer: Stephan Kulow <coolo@suse.de>
 
 use base "installbasetest";
@@ -12,6 +12,7 @@ use testapi;
 use strict;
 use warnings;
 use main_common 'opensuse_welcome_applicable';
+use x11utils 'turn_off_plasma_tooltips';
 
 # using this as base class means only run when an install is needed
 sub run {
@@ -33,6 +34,8 @@ sub run {
         @tags = grep { !/gnome-activities/ } @tags;
         assert_screen \@tags, $timeout;
     }
+
+    turn_off_plasma_tooltips();
 }
 
 sub post_fail_hook {

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -16,9 +16,11 @@
 use strict;
 use warnings;
 use base 'bootbasetest';
+use x11utils 'turn_off_plasma_tooltips';
 
 sub run {
     shift->wait_boot_past_bootloader;
+    turn_off_plasma_tooltips;
 }
 
 sub test_flags {


### PR DESCRIPTION
With Plasma Framework 5.100, tooltips don't expire anymore. Unfortunately mouse_hide places the cursor on top of the "Peek desktop" button in the bottom right corner, which triggers a tooltip covering some relevant UI elements. The best option (for now) is to disable tooltips as soon as possible.

Verification run: https://openqa.opensuse.org/t2864295
