### PR TITLE
ping: Add -v to ping6 command

### DIFF
--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -48,7 +48,7 @@ sub run {
         assert_script_run("$sudo $cmd -c2");
     }
 
-    my $cmd = "ping6 -c2 $addr -I$ifname";
+    my $cmd = "ping6 -c2 $addr -I$ifname -v";
     my $rc = script_run("$sudo $cmd -c2");
     if ($rc) {
         my $bug;


### PR DESCRIPTION
Add `-v` to ping6 command which verifies problematic bug.

Keep previous ping calls without `-v`, so that we keep testing both code paths (verbose and non-verbose).

Verification run:
* http://quasar.suse.cz/tests/1307#step/ping/133 (15-SP4)
* http://quasar.suse.cz/tests/1308#step/ping/133 (15-SP3)
* http://quasar.suse.cz/tests/1306#step/ping/133 (15-SP1)
* http://quasar.suse.cz/tests/1309#step/ping/133 (15-GA)