### PR TITLE
kiwi_templates: on Tumbleweed we also have kiwi-templates-Minimal

### DIFF
--- a/tests/jeos/kiwi_templates.pm
+++ b/tests/jeos/kiwi_templates.pm
@@ -8,7 +8,7 @@
 
 use Mojo::Base qw(opensusebasetest);
 use testapi;
-use version_utils qw(is_sle is_leap is_tumbleweed);
+use version_utils qw(is_sle is_leap);
 use utils qw(zypper_call);
 use serial_terminal qw(select_serial_terminal);
 
@@ -18,7 +18,7 @@ sub run {
     my $rpm;
     if (is_sle('<15-SP2')) {
         $rpm = 'kiwi-templates-SLES15-JeOS';
-    } elsif (is_leap('<=15.5') || is_sle('<15-SP4') || is_tumbleweed) {
+    } elsif (is_leap('<=15.5') || is_sle('<15-SP4')) {
         $rpm = 'kiwi-templates-JeOS';
     } else {
         $rpm = 'kiwi-templates-Minimal';


### PR DESCRIPTION
kiwi-templates-Minimal was introduced in Tumbleweed in April 2022, but
only now the legacy kiwi-templates-JeOS was finally dropped.

- Related ticket: https://progress.opensuse.org/issues/120214
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2866161
