### PR TITLE
Update mpirun parameters to prevent warnings when in Ethernet

### DIFF
--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -10,6 +10,7 @@ package hpc::formatter;
 use Mojo::Base 'hpcbase', -signatures;
 use hpc::utils;
 use testapi qw(get_var get_required_var);
+use version_utils qw(is_sle);
 
 has mpirun => sub {
     my ($self) = shift;
@@ -18,6 +19,8 @@ has mpirun => sub {
     my @mpirun_args;
     ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
     push @mpirun_args, '--allow-run-as-root ' if $mpi =~ m/openmpi/;
+    # avoid openmpi warnings since 3.1.6-150500
+    push @mpirun_args, '--mca btl_base_warn_component_unused 0 ' if is_sle('>=15-SP5');
     (@mpirun_args == 0) ? $self->mpirun :
       sprintf "%s %s", $self->mpirun, join(' ', @mpirun_args);
 };

--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -7,8 +7,7 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 package hpc::formatter;
-use Mojo::Base 'hpcbase', -signatures;
-use hpc::utils;
+use Mojo::Base qw(hpcbase hpc::utils), -signatures;
 use testapi qw(get_var get_required_var);
 use version_utils qw(is_sle);
 
@@ -19,8 +18,9 @@ has mpirun => sub {
     my @mpirun_args;
     ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
     push @mpirun_args, '--allow-run-as-root ' if $mpi =~ m/openmpi/;
-    # avoid openmpi warnings since 3.1.6-150500
-    push @mpirun_args, '--mca btl_base_warn_component_unused 0 ' if is_sle('>=15-SP5');
+    # avoid openmpi3 warnings since 3.1.6-150500.11.3
+    # TODO: map versions with mpi
+    push @mpirun_args, '--mca btl_base_warn_component_unused 0 ' if ($mpi == 'openmpi3' && $self->compare_mpi_versions("$mpi-gnu-hpc", undef, '3.1.6-150500.11.3'));
     (@mpirun_args == 0) ? $self->mpirun :
       sprintf "%s %s", $self->mpirun, join(' ', @mpirun_args);
 };


### PR DESCRIPTION
With recent updates the `openmpi` throws warnings when mpirun runs. That should occur when the Ethernet is used instead of the Infiniband. AFAIK the detection of one or the other is not easy task and even enabling a whole bunch of log it's not easy to be sure what is really being used

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/119758
- Verification run: http://aquarius.suse.cz/tests/14047#step/mpi_master/120 vs https://openqa.suse.de/tests/9916014#step/mpi_master/120

VR with second commit:
- http://aquarius.suse.cz/tests/14280#step/mpi_master/134
- http://aquarius.suse.cz/tests/14271#step/mpi_master/3
- http://aquarius.suse.cz/tests/14284