### PR TITLE
Apply workaround to force screen refresh on YaST QT window

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
@@ -12,6 +12,8 @@ use strict;
 use warnings;
 use testapi;
 use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+use YaST::workarounds;
+use version_utils qw(is_sle);
 
 use constant {
     NETWORK_CARD_SETUP => 'yast2_lan_network_card_setup',
@@ -35,6 +37,7 @@ sub select_tab {
 
 sub select_bond_slave_in_list {
     assert_screen(BOND_SLAVES_TAB);
+    apply_workaround_bsc1204176(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED) if (is_sle('>=15-SP4'));
     assert_and_click(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
@@ -12,6 +12,8 @@ use strict;
 use warnings;
 use testapi;
 use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+use YaST::workarounds;
+use version_utils qw(is_sle);
 
 use constant {
     NETWORK_CARD_SETUP => 'yast2_lan_network_card_setup',
@@ -36,6 +38,7 @@ sub select_tab {
 
 sub select_bridged_device_in_list {
     assert_screen(BRIDGED_DEVICES_TAB);
+    apply_workaround_bsc1204176(BRIDGED_DEVICE_CHECKBOX_UNCHECKED) if (is_sle('>=15-SP4'));
     assert_and_click(BRIDGED_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
@@ -12,6 +12,8 @@ use strict;
 use warnings;
 use testapi;
 use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
+use YaST::workarounds;
+use version_utils qw(is_sle);
 
 use constant {
     DEVICE_TYPE_DIALOG => 'yast2_lan_device_type_dialog'
@@ -26,6 +28,7 @@ sub select_device_type {
         bond => 'alt-o',
         vlan => 'alt-v'
     };
+    apply_workaround_bsc1204176(DEVICE_TYPE_DIALOG) if (is_sle('>=15-SP4'));
     assert_screen(DEVICE_TYPE_DIALOG);
     send_key $shortcut->{$device};
 }

--- a/lib/YaST/NetworkSettings/OverviewTab.pm
+++ b/lib/YaST/NetworkSettings/OverviewTab.pm
@@ -11,6 +11,8 @@ package YaST::NetworkSettings::OverviewTab;
 use strict;
 use warnings;
 use testapi;
+use YaST::workarounds;
+use version_utils qw(is_sle);
 
 use constant {
     OVERVIEW_TAB => 'yast2_lan_overview_tab_selected',
@@ -27,16 +29,19 @@ sub new {
 }
 
 sub press_add {
+    apply_workaround_bsc1204176(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
     assert_screen(OVERVIEW_TAB);
     send_key('alt-a');
 }
 
 sub press_edit {
+    apply_workaround_bsc1204176(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
     assert_screen(OVERVIEW_TAB);
     send_key('alt-i');
 }
 
 sub press_delete {
+    apply_workaround_bsc1204176(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
     assert_screen(OVERVIEW_TAB);
     send_key('alt-t');
 }
@@ -65,9 +70,8 @@ sub select_device {
 }
 
 sub press_ok {
-    assert_screen(OVERVIEW_TAB);
+    apply_workaround_bsc1204176(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
     send_key('alt-o');
 }
-
 
 1;

--- a/lib/YaST/workarounds.pm
+++ b/lib/YaST/workarounds.pm
@@ -1,0 +1,51 @@
+# Copyright 2015-2022 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package YaST::workarounds;
+
+
+use strict;
+use warnings;
+use Exporter 'import';
+use testapi;
+use version_utils;
+
+
+our @EXPORT = qw(apply_workaround_bsc1204176);
+
+=head1 Workarounds for known issues
+
+=head2 apply_workaround_bsc1204176 ($mustmatch, [,[$timeout] | timeout => $timeout] ):
+
+Workaround for the screen refresh issue.
+
+First checks if we need to apply the workaround, if the needle matches 
+already no workaround is required.
+
+If the workaround is needed we record a soft failure and apply a 'shift-f3' 
+and 'esc' sequence that should fix the problem
+
+If the problem still persists (we saw one occasion in the VRs) then we retry
+with maximazing and shrinking the screen twice by sending 'alt-f10' two times. 
+
+=cut
+
+sub apply_workaround_bsc1204176 {
+    my ($mustmatch) = shift;
+    my $timeout;
+    $timeout = shift if (@_ % 2);
+    my %args = (timeout => $timeout // 0, @_);
+    if (!check_screen($mustmatch, %args)) {
+        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
+        send_key('shift-f3', wait_screen_change => 1);
+        send_key('esc', wait_screen_change => 1);
+        # in some verification tests this didn't work, so let's check
+        if (!check_screen($mustmatch)) {
+            record_info('Retry', "shift-f3 workaround did not solve the problem");
+            send_key('alt-f10', wait_screen_change => 1);
+            send_key('alt-f10', wait_screen_change => 1);
+        }
+    }
+}
+
+1;

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -616,13 +616,12 @@ sub handle_scc_popups {
         push @tags, 'expired-gpg-key' if is_sle('=15');
         while ($counter--) {
             die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
-            if (is_sle('=15-SP4')
+            if (is_sle('>=15-SP4')
                 && (get_var('VIDEOMODE', '') !~ /text|ssh-x/)
                 && (get_var("DESKTOP") !~ /textmode/)
                 && (get_var('REMOTE_CONTROLLER') !~ /vnc/)
                 && !(get_var('PUBLISH_HDD_1') || check_var('SLE_PRODUCT', 'hpc'))) {
-                record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-                for (1 .. 2) { send_key 'alt-f10' }
+                apply_workaround_bsc1204176(\@tags, timeout => 360);
             }
             assert_screen(\@tags, timeout => 360);
             if (match_has_tag('import-untrusted-gpg-key')) {

--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -10,6 +10,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils;
+use YaST::workarounds;
 
 =head2 y2snapper_select_current_conf
 
@@ -120,6 +121,9 @@ sub y2snapper_new_snapshot {
     # Have to focus to Snapshots list manually in ncurses
     if ($ncurses) {
         send_key_until_needlematch 'yast2_snapper-focus-in-snapshots', 'tab';
+    }
+    else {
+        apply_workaround_bsc1204176([qw(yast2_snapper-new_snapshot yast2_snapper-new_snapshot_selected)]) if (is_sle('>=15-SP4'));
     }
 
     # Make sure the snapshot is listed in the main window

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -62,13 +62,8 @@ sub initiator_discovered_targets_tab {
     send_key "alt-i";
     my $target_ip_only = (split('/', $test_data->{target_conf}->{ip}))[0];
     type_string_slow_extended $target_ip_only;
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('iscsi-initiator-discovered-IP-adress', 'alt-f10', 10, 2);
-    }
-    else {
-        assert_screen 'iscsi-initiator-discovered-IP-adress';
-    }
+    apply_workaround_bsc1204176('iscsi-initiator-discovered-IP-adress') if (is_sle('>=15-SP4'));
+    assert_screen 'iscsi-initiator-discovered-IP-adress';
     # next and press connect button
     send_key "alt-n";
     assert_and_click 'iscsi-initiator-connect-button';
@@ -92,13 +87,8 @@ sub initiator_discovered_targets_tab {
 sub initiator_connected_targets_tab {
     # go to discovered targets tab
     send_key "alt-d";
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('iscsi-initiator-discovered-targets', 'alt-f10', 10, 2);
-    }
-    else {
-        assert_screen 'iscsi-initiator-discovered-targets';
-    }
+    apply_workaround_bsc1204176('iscsi-initiator-discovered-targets') if (is_sle('>=15-SP4'));
+    assert_screen 'iscsi-initiator-discovered-targets';
     # go to connected targets tab
     send_key "alt-n";
     assert_screen 'iscsi-initiator-connected-targets';

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -29,6 +29,7 @@ use utils qw(zypper_call systemctl type_string_slow_extended);
 use yast2_widget_utils 'change_service_configuration';
 use scheduler 'get_test_suite_data';
 use y2_mm_common 'prepare_xterm_and_setup_static_network';
+use YaST::workarounds;
 
 # load expected test data from yaml
 # common for both iscsi MM modules
@@ -92,9 +93,8 @@ sub target_service_tab {
 }
 
 sub config_2way_authentication {
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('iscsi-target-modify-acls', 'alt-f10', 10, 2);
+    if (is_sle('>=15-SP4')) {
+        apply_workaround_bsc1204176('iscsi-target-modify-acls') if (is_sle('>=15-SP4'));
     }
     else {
         assert_screen 'iscsi-target-modify-acls';

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -20,6 +20,8 @@ use y2_module_guitest '%setup_nis_nfs_x11';
 use x11utils 'turn_off_gnome_screensaver';
 use y2_module_consoletest;
 use scheduler 'get_test_suite_data';
+use YaST::workarounds;
+use version_utils qw(is_sle);
 
 sub setup_verification {
     script_run 'rpcinfo -u localhost ypserv';    # ypserv is running
@@ -54,6 +56,7 @@ sub nis_server_configuration {
     send_key 'alt-o';    # OK
     send_key $cmd{next};
     # NIS Server Maps Setup
+    apply_workaround_bsc1204176('nis-server-server-maps-setup') if (is_sle('>=15-SP4'));
     assert_screen 'nis-server-server-maps-setup';
     send_key 'tab';    # jump to map list
     my $c = 1;    # select all maps

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -18,6 +18,7 @@ use warnings;
 use testapi;
 use utils 'type_string_slow_extended';
 use version_utils 'is_sle';
+use YaST::workarounds;
 
 sub run {
     select_console 'x11';
@@ -46,18 +47,13 @@ sub run {
     type_string '16';
 
     #	default boot section
-    if (is_sle('=15-SP4')) {
-        for (1 .. 2) { send_key 'alt-f10' }
-    }
-    assert_and_click 'yast2-bootloader_default-boot-section';
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('yast2-bootloader_default-boot-section_tw', 'alt-f10', 9, 2);
+    if (is_sle('>=15-SP4')) {
+        apply_workaround_bsc1204176('yast2-bootloader_default-boot-section') if (is_sle('>=15-SP4'));
+        assert_and_click 'yast2-bootloader_default-boot-section';
     }
     else {
         assert_screen 'yast2-bootloader_default-boot-section_tw';
     }
-    send_key 'esc';    # Close drop down
 
     #	proctect boot loader with password
     assert_and_click 'yast2-bootloader_protect-bootloader-with-password';

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -17,6 +17,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_opensuse is_sle is_leap is_tumbleweed is_storage_ng);
+use YaST::workarounds;
 
 sub search {
     my ($name) = @_;
@@ -56,6 +57,7 @@ sub start_media_check {
     search 'check';
     assert_and_click 'yast2_control-center_media-check';
     wait_still_screen;
+    apply_workaround_bsc1204176('yast2_control-center_media-check_close') if (is_sle('>=15-SP4'));
     assert_screen 'yast2_control-center_media-check_close';
     send_key 'alt-l';
     assert_screen 'yast2-control-center-ui';
@@ -204,6 +206,7 @@ sub start_partitioner {
 sub start_vpn_gateway {
     search('vpn');
     assert_and_click 'yast2_control-center_vpn-gateway-client';
+    apply_workaround_bsc1204176('yast2-vpn-gateway-client', 180) if (is_sle('>=15-SP4'));
     assert_screen 'yast2-vpn-gateway-client', timeout => 180;
     send_key 'alt-c';
     assert_screen 'yast2-control-center-ui', timeout => 60;
@@ -244,6 +247,8 @@ sub start_hypervisor {
 sub start_add_system_extensions_or_modules {
     search 'system ext';
     assert_and_click 'yast2_control-center_add-system-extensions-or-modules';
+    wait_still_screen(5, 10);
+    apply_workaround_bsc1204176('yast2_control-center_registration', 180) if (is_sle('>=15-SP4'));
     assert_screen 'yast2_control-center_registration', timeout => 180;
     send_key 'alt-r';
     assert_screen 'yast2-control-center-ui', timeout => 60;
@@ -279,6 +284,7 @@ sub start_wake_on_lan {
     assert_and_click 'yast2_control-center_wake-on-lan';
     assert_screen 'yast2_control-center_wake-on-lan_install_wol';
     send_key $cmd{install};    # wol needs to be installed
+    apply_workaround_bsc1204176('yast2_control-center_wake-on-lan_overview', 180) if (is_sle('>=15-SP4'));
     assert_screen 'yast2_control-center_wake-on-lan_overview', timeout => 180;
     send_key 'alt-f';
     assert_screen 'yast2-control-center-ui', timeout => 60;

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -16,6 +16,8 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(type_string_slow_extended clear_console);
+use version_utils qw(is_sle);
+use YaST::workarounds;
 
 sub run {
     my $module = "host";
@@ -31,6 +33,7 @@ sub run {
     clear_console;
     select_console 'x11';
     y2_module_guitest::launch_yast2_module_x11($module, match_timeout => 90);
+    apply_workaround_bsc1204176('yast2_hostnames_added', 180) if (is_sle('>=15-SP4'));
     assert_screen 'yast2_hostnames_added', timeout => 180;
     assert_and_click "yast2_hostnames_added";
     send_key 'alt-i';

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -20,6 +20,7 @@ use warnings;
 use testapi;
 use utils "zypper_call";
 use version_utils "is_sle";
+use YaST::workarounds;
 
 sub send_key_and_wait {
     my $key = shift;
@@ -110,13 +111,8 @@ sub test_http_instserver {
     wait_still_screen 2, 2;
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-a", 2);
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('yast2-instserver-repository-conf', 'alt-f10', 9, 2);
-    }
-    else {
-        assert_screen('yast2-instserver-repository-conf');
-    }
+    apply_workaround_bsc1204176('yast2-instserver-repository-conf') if (is_sle('>=15-SP4'));
+    assert_screen('yast2-instserver-repository-conf');
     send_key_and_wait("alt-p", 2);
     type_string "instserver";
     wait_still_screen 2, 2;
@@ -127,13 +123,8 @@ sub test_http_instserver {
     send_key_until_needlematch("yast2-instserver_sr0dev", "down", 4);
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch([qw(yast2-instserver-ui yast2-instserver-change-media)], 'alt-f10', 21, 30);
-    }
-    else {
-        assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 300);
-    }
+    apply_workaround_bsc1204176([qw(yast2-instserver-ui yast2-instserver-change-media)], 300) if (is_sle('>=15-SP4'));
+    assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 300);
     # skip "insert next cd" on SLE 12.x
     send_key_and_wait("alt-s", 2) if is_sle("<=12-SP5") && match_has_tag('yast2-instserver-change-media');
     assert_screen('yast2-instserver-ui');

--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -22,6 +22,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils qw(is_sle);
+use YaST::workarounds;
 
 sub run {
     select_console "x11";
@@ -40,10 +41,7 @@ sub run {
     # Check previously set values + Login Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-pwd-settings";
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('yast2_security-check-min-pwd-len-and-exp-days', 'alt-f10', 10, 2);
-    }
+    apply_workaround_bsc1204176('yast2_security-check-min-pwd-len-and-exp-days') if (is_sle('>=15-SP4'));
     assert_screen "yast2_security-check-min-pwd-len-and-exp-days";
     assert_and_click "yast2_security-login-settings";
     send_key "alt-d";
@@ -53,11 +51,8 @@ sub run {
     wait_still_screen 3;
 
     # Check previously set values + Miscellaneous Settings
-    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('yast2_security-login-settings', 'alt-f10', 10, 2);
-    }
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120) if (is_sle('>=15-SP4'));
+    apply_workaround_bsc1204176('yast2_security-login-settings');
     assert_and_click "yast2_security-login-settings";
     assert_screen "yast2_security-login-attempts";
     # set file permissions to 'secure'
@@ -69,10 +64,7 @@ sub run {
     # Check previously set values
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-misc-settings";
-    if (is_sle('=15-SP4')) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
-        send_key_until_needlematch('yast2_security-file-perms-secure', 'alt-f10', 10, 2);
-    }
+    apply_workaround_bsc1204176('yast2_security-file-perms-secure') if (is_sle('>=15-SP4'));
     assert_screen "yast2_security-file-perms-secure";
     wait_screen_change { send_key "alt-o" };
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/117949
- All workarounds for screen refresh problems that used alt-f10 are now replaced with the shift-f3 workaround.
- The workaround code is outsourced into a library module and called with the needle(s) that we are looking for. The workaround is only applied when necessary (needle would not match) and then accompanied by a soft failure. So soft failures are only recorded when the screen refresh problem occurs.
- Version matiching is now is_sle(''>=15-SP4') because problem seems to occur on SLE 15-SP5 too.

- Verification run: https://openqa.suse.de/tests/10032585 (remaining errors are related to firewall problems)