### PR TITLE
wicked: Add authoritative to dhcp-server config

### DIFF
--- a/data/wicked/dhcp/dhcpd.conf
+++ b/data/wicked/dhcp/dhcpd.conf
@@ -1,6 +1,7 @@
 default-lease-time 14400;
 ddns-update-style standard;
 ddns-updates on;
+authoritative;
 update-conflict-detection false;
 
         zone openqa.test. {

--- a/data/wicked/dhcp/dhcpd_2nics.conf
+++ b/data/wicked/dhcp/dhcpd_2nics.conf
@@ -1,5 +1,6 @@
 # Reference DHCP server
 # Default configuration
+authoritative; 
 subnet 10.20.30.0 netmask 255.255.255.0
 {
   range 10.20.30.2 10.20.30.254;


### PR DESCRIPTION
This is the second approach for bsc#1204604 the first https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15868 didn't fixed it.

Adding `authoritative;` let the DHCP server also answer on REQUEST, if the request has a IP which doesn't belong to the own pool. This is a common configuration, if you have only one DHCP-Server in a broadcast domain.

- Verification run: 
  - https://openqa.opensuse.org/t2866369
  - https://openqa.opensuse.org/t2866255
