### PR TITLE
Pass the ARCH variable to the BCI test environment

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -86,6 +86,7 @@ sub run {
     my $bci_devel_repo = get_var('BCI_DEVEL_REPO');
     my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
     my $version = get_required_var('VERSION');
+    my $arch = get_required_var('ARCH');
     my $test_envs = get_required_var('BCI_TEST_ENVS');
 
     $self->reset_engines($engine);
@@ -96,6 +97,7 @@ sub run {
     assert_script_run("export CONTAINER_RUNTIME=$engine");
     $version =~ s/-SP/./g;
     assert_script_run("export OS_VERSION=$version");
+    assert_script_run("export ARCH=$arch");
     assert_script_run("export TARGET=ibs-cr");
     assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;
 


### PR DESCRIPTION
We need to pass the ARCH to avoid the execution of the BCI test of cassandra in case of ppc

- Related ticket: https://progress.opensuse.org/issues/119344
- Verification run: http://openqa.suse.de/tests/9921160
