### PR TITLE
Unschedule image_info for now

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -596,7 +596,7 @@ sub load_jeos_openstack_tests {
     } else {
         loadtest 'publiccloud/ssh_interactive_start', run_args => $args;
     }
-    loadtest "jeos/image_info";
+    #    loadtest "jeos/image_info";
     loadtest "jeos/record_machine_id";
     loadtest "console/system_prepare" if is_sle;
     loadtest "console/force_scheduled_tasks";
@@ -623,7 +623,7 @@ sub load_jeos_tests {
     }
     load_boot_tests();
     loadtest "jeos/firstrun";
-    loadtest "jeos/image_info";
+    #    loadtest "jeos/image_info";
     loadtest "jeos/record_machine_id";
     loadtest "console/force_scheduled_tasks";
     unless (get_var('INSTALL_LTP') || get_var('SYSTEMD_TESTSUITE')) {

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -38,7 +38,7 @@ conditional_schedule:
 schedule:
     - '{{bootloader}}'
     - '{{wizard}}'
-    - jeos/image_info
+      #    - jeos/image_info
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks

--- a/schedule/sle-micro/virt.yaml
+++ b/schedule/sle-micro/virt.yaml
@@ -33,7 +33,7 @@ conditional_schedule:
         - microos/rebuild_initrd
 schedule:
   - '{{boot}}'
-  - jeos/image_info
+    #  - jeos/image_info
   - transactional/host_config
   - '{{rebuild_initrd}}'
   - '{{registration}}'


### PR DESCRIPTION
The VM with size monitoring DB is currently down and it will take some time while it will be fully restored. For now we do not need to schedule this test.

