### PR TITLE
Run qe-sap-deployment with Python 3.9

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -34,6 +34,7 @@ use YAML::PP;
 use utils 'file_content_replace';
 use testapi;
 use Exporter 'import';
+use utils 'zypper_call';
 
 
 my @log_files = ();
@@ -148,16 +149,16 @@ sub qesap_create_ansible_section {
 =cut
 
 sub qesap_pip_install {
-    enter_cmd 'pip config --site set global.progress_bar off';
-    my $pip_ints_cmd = 'pip install --no-color --no-cache-dir ';
+    zypper_call('in python39');
+    enter_cmd 'pip3.9 config --site set global.progress_bar off';
+    my $pip_ints_cmd = 'pip3.9 install --no-color --no-cache-dir ';
     my $pip_install_log = '/tmp/pip_install.txt';
     my %paths = qesap_get_file_paths();
 
-    # Hack to fix an installation conflict. Someone install PyYAML 6.0 and awscli needs an older one
+
     push(@log_files, $pip_install_log);
     record_info("QESAP repo", "Installing pip requirements");
-    assert_script_run(join(" ", $pip_ints_cmd, 'awscli==1.19.48 | tee', $pip_install_log), 240);
-    assert_script_run(join(" ", $pip_ints_cmd, '-r', $paths{deployment_dir} . '/requirements.txt | tee -a', $pip_install_log), 240);
+    assert_script_run(join(" ", $pip_ints_cmd, '-r', $paths{deployment_dir} . '/requirements.txt | tee -a', $pip_install_log), 360);
 }
 
 =head3 qesap_upload_logs
@@ -272,7 +273,7 @@ sub qesap_execute {
     $exec_log .= '.log.txt';
     $exec_log =~ s/[-\s]+/_/g;
 
-    my $qesap_cmd = join(" ", $paths{deployment_dir} . "/scripts/qesap/qesap.py",
+    my $qesap_cmd = join(" ", "python3.9", $paths{deployment_dir} . "/scripts/qesap/qesap.py",
         $verbose,
         "-c", $paths{qesap_conf_trgt},
         "-b", $paths{deployment_dir},

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -36,6 +36,10 @@ sub run {
     qesap_prepare_env(openqa_variables => \%variables, provider => $qesap_provider);
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 sub post_fail_hook {
     my ($self) = shift;
     qesap_upload_logs();

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -19,6 +19,10 @@ sub run {
     upload_logs($inventory);
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 sub post_fail_hook {
     my ($self) = shift;
     qesap_upload_logs();


### PR DESCRIPTION
Install python 3.9 side by side with existing python 3.65 in the PublicCloud tools qcow2 ver37
Install latest new Ansible from updated qe-sap-deployment requirements Explicitly run the glue script with python 3.9

https://jira.suse.com/browse/TEAM-6939 and https://github.com/SUSE/qe-sap-deployment/pull/101

Verification run: 
 - Trento with qe-sap-deployment cersion 0.4.0 (old Ansible) https://openqaworker15.qa.suse.cz/tests/66458  --> PIP step https://openqaworker15.qa.suse.cz/tests/66458#step/cluster_configure/61
 - Trento with new Ansible from PR#101 https://openqaworker15.qa.suse.cz/tests/66487  --> PIP step https://openqaworker15.qa.suse.cz/tests/66487#step/cluster_configure/58
 - qesap regression on GCP  with qe-sap-deployment version 0.4.0 (old Ansible) https://openqaworker15.qa.suse.cz/tests/66488 --> endup like https://openqaworker15.qa.suse.cz/tests/66488#step/deploy/12
  - qesap regression on GCP  with new Ansible https://openqaworker15.qa.suse.cz/tests/66489 https://openqaworker15.qa.suse.cz/tests/66490
