### PR TITLE
Add path to utilities located in /usr/sbin

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -92,6 +92,7 @@ sub registercloudguest {
     my ($instance) = @_;
     my $regcode = get_required_var('SCC_REGCODE');
     my $remote = $instance->username . '@' . $instance->public_ip;
+    my $path = is_sle('>15') && is_sle('<15-SP3') ? '/usr/sbin/' : '';
     # not all images currently have registercloudguest pre-installed .
     # in such a case,we need to regsiter against SCC and install registercloudguest with all needed dependencies and then
     # unregister and re-register with registercloudguest
@@ -112,13 +113,13 @@ sub registercloudguest {
             die 'Unexpected provider ' . get_var('PUBLIC_CLOUD_PROVIDER');
         }
         $instance->ssh_assert_script_run(cmd => "sudo zypper -q -n in $install_packages", timeout => 420);
-        $instance->ssh_assert_script_run(cmd => "sudo registercloudguest --clean");
+        $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
     }
     # Check what version of registercloudguest binary we use
     $instance->ssh_script_run(cmd => "sudo rpm -qa cloud-regionsrv-client");
     # Register the system
     my $cmd_time = time();
-    $instance->ssh_script_retry(cmd => "sudo registercloudguest -r $regcode", timeout => 420, retry => 3, delay => 120);
+    $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest -r $regcode", timeout => 420, retry => 3, delay => 120);
     record_info('registercloudguest time', 'The command registercloudguest took ' . (time() - $cmd_time) . ' seconds.');
 }
 

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -85,7 +85,8 @@ sub run {
         record_soft_failure('bsc#1198815 - Package cloud-regionsrv-client is not installed');
         registercloudguest($instance);
     } else {
-        $instance->run_ssh_command(cmd => 'sudo registercloudguest --clean');
+        my $path = is_sle('>15') && is_sle('<15-SP3') ? '/usr/sbin/' : '';
+        $instance->run_ssh_command(cmd => "sudo ${path}registercloudguest --clean");
         if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600, proceed_on_failure => 1) > 2) {
             die('The list of zypper repositories is not empty.');
         }
@@ -97,10 +98,10 @@ sub run {
         if (is_byos()) {
             $instance->run_ssh_command(cmd => 'sudo SUSEConnect --version');
             $instance->run_ssh_command(cmd => "sudo SUSEConnect $regcode_param");
-            $instance->run_ssh_command(cmd => 'sudo registercloudguest --clean');
+            $instance->run_ssh_command(cmd => "sudo ${path}registercloudguest --clean");
         }
 
-        $instance->run_ssh_command(cmd => "sudo registercloudguest $regcode_param");
+        $instance->run_ssh_command(cmd => "sudo ${path}registercloudguest $regcode_param");
         if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
             die('The list of zypper repositories is empty.');
         }
@@ -108,7 +109,7 @@ sub run {
             die('Directory /etc/zypp/credentials.d/ is empty.');
         }
 
-        $instance->run_ssh_command(cmd => "sudo registercloudguest $regcode_param --force-new");
+        $instance->run_ssh_command(cmd => "sudo ${path}registercloudguest $regcode_param --force-new");
         if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
             die('The list of zypper repositories is empty.');
         }

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -41,7 +41,8 @@ sub prepare_ssh_tunnel {
     $instance->ssh_assert_script_run(sprintf("sudo install -o root -g root -m 0644 /home/%s/.ssh/authorized_keys /root/.ssh/", $instance->{username}));
 
     # Create remote user and set him a password
-    $instance->ssh_assert_script_run("test -d /home/$testapi::username || sudo useradd -m $testapi::username");
+    my $path = (is_sle('>15') && is_sle('<15-SP3')) ? '/usr/sbin/' : '';
+    $instance->ssh_assert_script_run("test -d /home/$testapi::username || sudo ${path}useradd -m $testapi::username");
     $instance->ssh_assert_script_run(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd $testapi::username));
 
     # Copy SSH settings for remote user


### PR DESCRIPTION
As [ [Build 20221110-1] Defaults secure_path is commented in /etc/sudoers for images v20221108 and newer ](https://bugzilla.suse.com/show_bug.cgi?id=1205325) has hit all new PC images and we cannot block the updates, I would propose to call some of our utils with absolute path.

VRs:

* [sle-15-SP1-EC2-BYOS-Updates-x86_64-Build20221110-1-publiccloud_consoletests@64bit ](http://kepler.suse.cz/tests/19529#)
* [sle-15-SP4-GCE-BYOS-Updates](http://kepler.suse.cz/tests/19531#)
* [sle-15-SP2-EC2-BYOS-Updates-x86_64](http://kepler.suse.cz/tests/19533)
