### PR TITLE
Uncomment targetpw for azure based on sle12 

### DIFF
--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -14,6 +14,7 @@ use publiccloud::ssh_interactive "select_host_console";
 use testapi;
 use version_utils;
 use utils;
+use publiccloud::utils;
 
 sub prepare_ssh_tunnel {
     my $instance = shift;
@@ -86,6 +87,13 @@ sub run {
 
     # ssh-tunnel settings
     prepare_ssh_tunnel($instance) if (is_tunneled());
+
+    # azure images based on sle12-sp{4,5} code streams come with commented entries 'Defaults targetpw' in /etc/sudoers
+    # because the Azure Linux agent creates an entry in /etc/sudoers.d for users without the NOPASSWD flag
+    # this is an exception in comparision with other images
+    if (is_sle('<15') && is_azure) {
+        $instance->ssh_assert_script_run(q(sudo sed -i "/Defaults targetpw/s/^#//" /etc/sudoers));
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Commented 'Defaults targetpw' out in SLE 12 for Azure because the Azure
Linux agent creates an entry in /etc/sudoers.d for users without the
NOPASSWD flag in case they have a password associated, not just an ssh
key.
More in: https://bugzilla.suse.com/show_bug.cgi?id=1205325#c4

- ticket: [test fails in sudo](https://progress.opensuse.org/issues/119860)
- Verification runs: 
  * [sle-12-SP4-AZURE-BYOS-Updates-x86_64-Build20221110-1-publiccloud_consoletests@64bit](http://kepler.suse.cz/tests/19550#step/sudo/5)
  * [sle-12-SP5-AZURE-BYOS-Updates-x86_64-Build20221110-1-publiccloud_consoletests@64bit](http://kepler.suse.cz/tests/19551#step/sudo/5)
  * [sle-15-SP1-AZURE-BYOS-Updates-x86_64-Build20221110-1-publiccloud_consoletests@64bit](http://kepler.suse.cz/tests/19541#step/sudo/5)
  * [sle-12-SP4-EC2-BYOS-Updates-x86_64-Build20221110-1-publiccloud_consoletests@64bit](http://kepler.suse.cz/tests/19542#step/sudo/5)
