### PR TITLE
HANA installer secure storage adoption

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -1,5 +1,5 @@
 provider: "%PROVIDER%"
-apiver: 2
+apiver: 3
 terraform:
   variables:
     az_region: "%REGION%"
@@ -9,7 +9,10 @@ terraform:
     public_key: "%SSH_KEY_PUB%"
 
 ansible:
-  hana_urls:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
     - "%HANA_SAR%"
     - "%HANA_CLIENT_SAR%"
     - "%HANA_SAPCAR%"

--- a/data/sles4sap/qe_sap_deployment/trento_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/trento_azure.yaml
@@ -1,5 +1,5 @@
 provider: "%PROVIDER%"
-apiver: 2
+apiver: 3
 terraform:
   variables:
     az_region: "%REGION%"
@@ -10,7 +10,9 @@ terraform:
     admin_user: "%CLUSTER_USER%"
 
 ansible:
-  hana_urls:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  hana_media:
     - "%HANA_SAR%"
     - "%HANA_CLIENT_SAR%"
     - "%HANA_SAPCAR%"

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -242,7 +242,7 @@ sub get_qesap_resource_group {
 =head3 config_cluster
 
 Create a variable map and prepare the qe-sap-deployment using it
-=over 2
+=over 3
 
 =item B<PROVIDER> - CloudProvider name
 
@@ -271,6 +271,12 @@ sub config_cluster {
     $variables{SSH_KEY_PRIV} = SSH_KEY;
     $variables{SSH_KEY_PUB} = $ssh_key_pub;
     $variables{SCC_REGCODE_SLES4SAP} = $scc;
+
+    $variables{HANA_ACCOUNT} = get_required_var("TRENTO_QESAPDEPLOY_HANA_ACCOUNT");
+    $variables{HANA_CONTAINER} = get_required_var("TRENTO_QESAPDEPLOY_HANA_CONTAINER");
+    if (get_var("TRENTO_QESAPDEPLOY_HANA_TOKEN")) {
+        $variables{HANA_TOKEN} = get_required_var("TRENTO_QESAPDEPLOY_HANA_TOKEN");
+    }
     $variables{HANA_SAR} = get_required_var("TRENTO_QESAPDEPLOY_SAPCAR");
     $variables{HANA_CLIENT_SAR} = get_required_var("TRENTO_QESAPDEPLOY_IMDB_CLIENT");
     $variables{HANA_SAPCAR} = get_required_var("TRENTO_QESAPDEPLOY_IMDB_SERVER");

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -30,6 +30,13 @@ sub run {
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';
     $variables{SCC_REGCODE_SLES4SAP} = get_required_var('SCC_REGCODE_SLES4SAP');
+    $variables{HANA_ACCOUNT} = get_required_var("QESAPDEPLOY_HANA_ACCOUNT");
+    $variables{HANA_CONTAINER} = get_required_var("QESAPDEPLOY_HANA_CONTAINER");
+    if(get_var("QESAPDEPLOY_HANA_TOKEN")) {
+        $variables{HANA_TOKEN} = get_var("QESAPDEPLOY_HANA_TOKEN");
+        # something not escaped in file_content_replace()
+        $variables{HANA_TOKEN} =~ s/\&/\\\&/g;
+    }
     $variables{HANA_SAR} = get_required_var("QESAPDEPLOY_SAPCAR");
     $variables{HANA_CLIENT_SAR} = get_required_var("QESAPDEPLOY_IMDB_SERVER");
     $variables{HANA_SAPCAR} = get_required_var("QESAPDEPLOY_IMDB_CLIENT");

--- a/tests/sles4sap/trento/cluster_configure.pm
+++ b/tests/sles4sap/trento/cluster_configure.pm
@@ -24,6 +24,10 @@ sub run {
 
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 sub post_fail_hook {
     my ($self) = shift;
     select_serial_terminal;

--- a/tests/sles4sap/trento/cluster_deploy.pm
+++ b/tests/sles4sap/trento/cluster_deploy.pm
@@ -35,6 +35,10 @@ sub run {
     qesap_ansible_cmd(cmd => 'crm status', provider => $prov, filter => $_) for ('vmhana01', 'vmhana02');
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 sub post_fail_hook {
     my ($self) = shift;
     select_serial_terminal;

--- a/tests/sles4sap/trento/deploy_trento.pm
+++ b/tests/sles4sap/trento/deploy_trento.pm
@@ -30,6 +30,10 @@ sub run {
     trento_support('deploy_trento');
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 sub post_fail_hook {
     my ($self) = @_;
 

--- a/tests/sles4sap/trento/init_jumphost.pm
+++ b/tests/sles4sap/trento/init_jumphost.pm
@@ -23,4 +23,8 @@ sub run {
     my $provider = $self->provider_factory();
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;

--- a/tests/sles4sap/trento/install_agents.pm
+++ b/tests/sles4sap/trento/install_agents.pm
@@ -10,7 +10,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use qesapdeployment 'qesap_upload_logs';
-use trento qw(destroy_qesap get_trento_ip get_trento_password az_delete_group install_agent k8s_logs trento_support);
+use trento;
 
 sub run {
     my ($self) = @_;
@@ -32,6 +32,10 @@ sub run {
     }
 
     $cmd = install_agent($wd, '/root/test', $agent_api_key);
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 sub post_fail_hook {

--- a/variables.md
+++ b/variables.md
@@ -233,9 +233,11 @@ TRENTO_AGENT_RPM | string | | Trento-agent rpm file name
 TRENTO_EXT_DEPLOY_IP | string | | Public IP of a Trento web instance not deployed by openQA
 TRENTO_WEB_PASSWORD | string | | Trento web password for the admin user. If not provided, random generated one.
 TRENTO_QESAPDEPLOY_CLUSTER_OS_VER | string | | OS for nodes in SAP cluster.
-TRENTO_QESAPDEPLOY_SAPCAR | string | | SAPCAR url for the qe-sap-deployment hana_media.yaml.
-TRENTO_QESAPDEPLOY_IMDB_SERVER | string | | IMDB_SERVER url for the qe-sap-deployment hana_media.yaml.
-TRENTO_QESAPDEPLOY_IMDB_CLIENT | string | | IMDB_CLIENT url for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_HANA_ACCOUNT | string | | Account name for the blob server for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_HANA_CONTAINER | string | | Container name for the blob server for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_SAPCAR | string | | SAPCAR executable name for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_IMDB_SERVER | string | | IMDB_SERVER executable name for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_IMDB_CLIENT | string | | IMDB_CLIENT executable name for the qe-sap-deployment hana_media.yaml.
 QESAP_CONFIG_FILE | string | | filename (of relative path) of the config YAML file for the qesap.py script, within `sles4sap/qe_sap_deployment/` subfolder in `data`.
 QESAP_DEPLOYMENT_DIR | string | /root/qe-sap-deployment | JumpHost folder where to install the qe-sap-deployment code
 QESAP_INSTALL_VERSION | string | | If configured, test will run with a specific release of qe-sap-deployment code from https://github.com/SUSE/qe-sap-deployment/releases.


### PR DESCRIPTION
qesap regression, adopt apiver:3 and secured storage for test on Azure. Trento adopt apiver:3 but not secured storage
Fatal flag in more Trento tests

- VR with secure mode https://openqaworker15.qa.suse.cz/tests/67259

 https://openqaworker15.qa.suse.cz/tests/67259/logfile?filename=deploy-qesap_exec_ansible.log.txt

```
DEBUG    OUTPUT: TASK [Download HANA media with SAS token] **************************************
```