### PR TITLE
publiccloud : drop flags which does not make sense

### DIFF
--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -19,8 +19,4 @@ sub run {
     $args->{my_provider}->cleanup($args);
 }
 
-sub test_flags {
-    return {fatal => 1, publiccloud_multi_module => 1};
-}
-
 1;


### PR DESCRIPTION
ssh_interactive_end is designed to run at the end of test suite
currently only thing which module is doing is cleanup which makes
use of fatal flag unappropriate, publiccloud_multi_module is designed
to allow other modules to run AFTER this one, but as was stated above
it is not the case for ssh_interactive_end