### PR TITLE
Move ansible on sle from extra_tests_textmode to extra_tests_phub

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -76,6 +76,7 @@ conditional_schedule:
                 - console/python_scientific
                 - console/vmstat
                 - console/kdump_and_crash
+                - console/ansible
     validate_packages_and_patterns:
         DISTRI:
             sle:
@@ -168,6 +169,5 @@ schedule:
     - '{{opensuse_tests}}'
     - '{{tumbleweed_tests}}'
     - console/tar
-    - console/ansible
     - console/coredump_collect
     - console/zypper_log_packages

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -1,6 +1,6 @@
 name:           extra_tests_in_textmode_phub
 description:    >
-    Maintainer: slindomansilla.
+    Maintainer: qe-core
     Extra tests about software in package hub
 schedule:
     - installation/bootloader_start
@@ -11,8 +11,9 @@ schedule:
     - '{{wpa_supplicant}}'
     - console/vmstat
     - console/sssd_389ds_functional
-    - console/coredump_collect
-    - console/zypper_log_packages
+    - console/ansible
+    - console/coredump_collect  # For coredumps during the suite. Please put near end.
+    - console/zypper_log_packages  # Records packages installed in the suite. Please put at end.
 conditional_schedule:
     wpa_supplicant:
         ARCH:


### PR DESCRIPTION
Ansible is only available in PackageHub for SLES. As a result the test needs to be moved to extra_tests_textmode_phub for SLES and the opensuse_tests conditional schedule.

- Related Ticket: https://progress.opensuse.org/issues/119518
* Verification runs:
1. Runs where ansible should be scheduled:
- [TW](https://openqa.opensuse.org/tests/2866747)
- [Leap](https://openqa.opensuse.org/tests/2866748)
- extra_tests_textmode_phub:
[aarch64](https://openqa.suse.de/tests/9921380) [ppc64le](https://openqa.suse.de/tests/9921381) [s390x](https://openqa.suse.de/tests/9921382) [x86_64](https://openqa.suse.de/tests/9921383)

2. Runs where ansible should NOT be scheduled:
- extra_tests_textmode on SLE
[aarch64](https://openqa.suse.de/tests/9921376) [ppc64le](https://openqa.suse.de/tests/9921377) [s390x](https://openqa.suse.de/tests/9921378) [x86_64](https://openqa.suse.de/tests/9921379)