### PR TITLE
Update SLES product textmode keyboard shortcut

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -75,7 +75,6 @@ sub get_product_shortcuts {
         return (
             sles => (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'
-            : ((is_sle '15-SP4+') && (get_var('ISO') =~ /Full/)) ? 's'
             : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
77be306 1ba3be7244e04f356d357f0f62abbba9aea51526

I think the confusion happened because of old needle with keyboard shortcut 's' for SLES e.g. https://dzedro.suse.cz/tests/883#step/welcome/4
On left side is reference needle with old key 's', but right now the key is 'i'

- Related ticket: http://progress.opensuse.org/issues/115352
- Verification run:

https://dzedro.suse.cz/tests/883 15-SP5
https://dzedro.suse.cz/tests/885 15-SP4
https://dzedro.suse.cz/tests/884 15-SP3
https://dzedro.suse.cz/tests/886 15-SP2
https://dzedro.suse.cz/tests/887 15-SP1
