### PR TITLE
public cloud: google clients use chrony in all SLE15

### DIFF
--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -32,7 +32,7 @@ sub init {
     $self->project_id($data->{project_id});
     $self->account($data->{client_id});
     assert_script_run('source ~/.bashrc');
-    (is_sle('>15-SP4')) ? assert_script_run("chronyd -q 'pool time.google.com iburst'") : assert_script_run('ntpdate -s time.google.com');
+    (is_sle('>=15')) ? assert_script_run("chronyd -q 'pool time.google.com iburst'") : assert_script_run('ntpdate -s time.google.com');
     assert_script_run('gcloud config set account ' . $self->account);
     assert_script_run(
         'gcloud auth activate-service-account --key-file=' . CREDENTIALS_FILE . ' --project=' . $self->project_id);

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -70,7 +70,7 @@ sub run {
             gcloud_install();
 
             # package needed by init():
-            my $pkg = is_sle('>15-SP4') ? "in chrony" : "in ntp";
+            my $pkg = is_sle('>=15') ? "in chrony" : "in ntp";
             zypper_call($pkg, timeout => 300);
 
             $provider = publiccloud::gke->new();


### PR DESCRIPTION
Use chrony instead of ntp for all SLE15 in google clients

- Related ticket: https://progress.opensuse.org/issues/120498
- Verification run:
-- 15SP5 http://openqa.suse.de/tests/9962081
-- 15SP4 http://openqa.suse.de/tests/9962075
-- 15SP3 http://openqa.suse.de/tests/9962050
-- 15SP4 (alt) http://openqa.suse.de/tests/9962166