### PR TITLE
Adjustments for testing Minimal-VM and MicroOS Images in TW Stagings

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -327,10 +327,10 @@ sub is_updates_test_repo {
 }
 
 sub is_repo_replacement_required {
-    return is_opensuse()    # Is valid scenario onlu for openSUSE
-      && !is_staging()    # Do not have mirrored repos on staging
+    return is_opensuse()    # Is valid scenario only for openSUSE
       && !get_var('KEEP_ONLINE_REPOS')    # Set variable no to replace variables
-      && get_var('SUSEMIRROR')    # Skip if required variable is not set (leap live tests)
+                                          # Skip if there isn't a repo to use (e.g. Leap live tests)
+      && (get_var('SUSEMIRROR') || (is_staging && get_var('ISO_1')))
       && !get_var('ZYPPER_ADD_REPOS')    # Skip if manual repos are specified
       && !get_var('OFFLINE_SUT')    # Do not run if SUT is offine
       && !get_var('ZDUP');    # Do not run on ZDUP as these tests handle repos on their own
@@ -2936,8 +2936,6 @@ sub load_installation_validation_tests {
 
 sub load_transactional_role_tests {
     replace_opensuse_repos_tests if is_repo_replacement_required;
-    # ^ runs only outside of stagings, clear repos otherwise
-    loadtest "update/zypper_clear_repos" if is_staging;
     loadtest 'transactional/filesystem_ro';
     loadtest 'transactional/transactional_update';
     loadtest 'transactional/rebootmgr';

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1230,7 +1230,7 @@ sub load_consoletests {
     }
     if (is_jeos) {
         loadtest "jeos/glibc_locale";
-        loadtest "jeos/kiwi_templates" unless (is_leap('<15.2'));
+        loadtest "jeos/kiwi_templates" unless (is_leap('<15.2') || is_staging);
     }
     loadtest 'console/systemd_wo_udev' if (is_sle('15-sp4+') || is_leap('15.4+') || is_tumbleweed);
     loadtest "console/ncurses" if is_leap;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1302,7 +1302,10 @@ sub load_consoletests {
         loadtest "feature/feature_console/deregister";
     }
     loadtest "console/nginx" if ((is_opensuse && !is_staging) || (is_sle('15+') && !is_desktop));
-    loadtest 'console/orphaned_packages_check' if is_jeos || get_var('UPGRADE') || get_var('ZDUP') || !is_sle('<12-SP4');
+    # Checking for orphaned packages only really makes sense with the full FTP tree
+    unless (is_staging) {
+        loadtest 'console/orphaned_packages_check' if is_jeos || get_var('UPGRADE') || get_var('ZDUP') || !is_sle('<12-SP4');
+    }
     loadtest "console/zypper_log_packages" unless x11tests_is_applicable();
     loadtest "console/consoletest_finish";
 }

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -75,7 +75,7 @@ sub load_image_tests_docker {
     load_image_test($run_args);
     # container_diff package is not avaiable for <=15 in aarch64
     # Also, we don't want to run it on 3rd party hosts
-    unless ((is_sle("<=15") and is_aarch64) || get_var('CONTAINERS_NO_SUSE_OS')) {
+    unless ((is_sle("<=15") and is_aarch64) || get_var('CONTAINERS_NO_SUSE_OS') || is_staging) {
         loadtest 'containers/container_diff';
     }
 }
@@ -91,8 +91,8 @@ sub load_host_tests_podman {
         loadtest 'containers/podman_pods';
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
         loadtest 'containers/podman_firewall' unless (is_public_cloud || is_openstack || is_microos || is_alp);
-        # Buildah is not available in SLE Micro and MicroOS
-        loadtest 'containers/buildah' unless (is_sle_micro || is_microos || is_leap_micro || is_alp);
+        # Buildah is not available in SLE Micro, MicroOS and staging projects
+        loadtest 'containers/buildah' unless (is_sle_micro || is_microos || is_leap_micro || is_alp || is_staging);
         # https://github.com/containers/podman/issues/5732#issuecomment-610222293
         # exclude rootless poman on public cloud because of cgroups2 special settings
         loadtest 'containers/rootless_podman' unless (is_sle('=15-sp1') || is_openstack || is_public_cloud);
@@ -113,7 +113,7 @@ sub load_host_tests_docker {
         loadtest 'containers/zypper_docker' unless (is_tumbleweed || is_sle_micro || is_microos || is_leap_micro);
         loadtest 'containers/docker_runc';
     }
-    unless (check_var('BETA', 1) || is_sle_micro || is_microos || is_leap_micro) {
+    unless (check_var('BETA', 1) || is_sle_micro || is_microos || is_leap_micro || is_staging) {
         # These tests use packages from Package Hub, so they are applicable
         # to maintenance jobs or new products after Beta release
         # PackageHub is not available in SLE Micro | MicroOS

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -103,7 +103,7 @@ Returns true if called on jeos
 =cut
 
 sub is_jeos {
-    return get_var('FLAVOR', '') =~ /^JeOS/;
+    return get_var('FLAVOR', '') =~ /JeOS/;
 }
 
 =head2 is_vmware

--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -43,8 +43,6 @@ sub load_boot_from_disk_tests {
     }
     loadtest 'installation/system_workarounds' if is_aarch64;
     replace_opensuse_repos_tests if is_repo_replacement_required;
-    # ^ runs only outside of stagings, clear repos otherwise
-    loadtest 'update/zypper_clear_repos' if is_staging;
     loadtest 'transactional/enable_selinux' if (get_var("ENABLE_SELINUX"));
     loadtest 'microos/networking';
 }

--- a/tests/console/zypper_ar.pm
+++ b/tests/console/zypper_ar.pm
@@ -12,6 +12,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use version_utils 'is_staging';
 use utils 'zypper_call';
 
 sub run {
@@ -29,6 +30,12 @@ sub run {
             if ($rc) {
                 ($_ =~ m/^OSS$/) ? die 'Adding OSS repo failed!' : record_info("$_ repo failure", "zypper exited with code $rc");
             }
+        }
+    }
+    elsif (is_staging && get_var('ISO_1')) {
+        # Use the product DVD as repository if not already there
+        if (script_run('grep -qR "baseurl=cd:" /etc/zypp/repos.d/') != 0) {
+            zypper_call 'ar -G cd:/ dvd';
         }
     }
     else {

--- a/tests/update/zypper_clear_repos.pm
+++ b/tests/update/zypper_clear_repos.pm
@@ -23,7 +23,7 @@ sub run {
     my $repos_folder = '/etc/zypp/repos.d';
     zypper_call 'lr -d', exitcode => [0, 6];
     assert_script_run(
-"find $repos_folder/*.repo -type f -exec grep -Eq 'baseurl=(http|https)://download.opensuse.org/' {} \\; -delete && echo 'unneed_repos_removed' > /dev/$serialdev",
+"find $repos_folder/ -name \\*.repo -type f -exec grep -Eq 'baseurl=(http|https)://download.opensuse.org/' {} \\; -delete && echo 'unneed_repos_removed' > /dev/$serialdev",
         15
     );
     zypper_call 'lr -d', exitcode => [0, 6];


### PR DESCRIPTION
This PR contains various changes to allow testing the new `Staging-MicroOS-Image-ContainerHost` and `Staging-JeOS-for-kvm-and-xen` flavors.

Currently there are several failures, which will be fixed in the product soon:
- [X] `docker` is available in stagings but missing in the MicroOS DVD, so `image_docker` and `container_diff` fail
- [X] The JeOS container_* tests need `docker`, `podman` and `podman-cni-config` on the staging DVD
- [X] `prjconf_excluded_rpms` fails because `NetworkManager-branding` was missing in staging projects
- [X] `snapper_jeos_cli` needs `zsh` on the staging DVD
- [X] `glibc_locale` fails because `live-langset-data` thinks that `Tumbleweed 1` is < 15.x: https://build.opensuse.org/request/show/1035815
- [X] `kiwi_templates` needs `kiwi-templates-Minimal` on the staging DVD
- [X] `cifs` needs `nmap`, but for weird reasons. I changed the code to avoid that.

Verification runs:
- MicroOS: https://openqa.opensuse.org/tests/overview?distri=microos&version=Staging%3AH&build=H.57.2&groupid=38
- JeOS: https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Staging%3AH&build=H.5.1&groupid=38