### PR TITLE
New steps to avoid Microsoft account in install

### DIFF
--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -26,21 +26,29 @@ sub run {
 
     # Network setup takes ages
     assert_screen 'windows-account-setup', 360;
-    assert_and_click 'windows-select-personal-use', dclick => 1;
-    wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
-    assert_and_click 'windows-next';
 
-    # To select an offline account in Win11 requires an intermediate step
+    # From 22H2 build, the offline account selection process has diverted a lot
     if (check_var "WIN_VERSION", "11") {
-        assert_and_click('windows-signin-options', timeout => 300);
+        # There's need to select a work or school account and then choose a
+        # domain join in order to skip the MS account
+        assert_and_click 'windows-work-school-account', dclick => 1;
+        wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
+        assert_and_click 'windows-next';
+        assert_and_click 'windows-signin-options', timeout => 300;
+        assert_and_click 'windows-domain-join';
+        wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
+
     }
     else {
+        assert_and_click 'windows-select-personal-use', dclick => 1;
+        wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
+        assert_and_click 'windows-next';
         assert_screen 'windows-signin-with-ms', timeout => 60;
+        assert_and_click 'windows-offline';
+        wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
+        assert_and_click 'windows-limited-exp', timeout => 60;
+        wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
     }
-    assert_and_click 'windows-offline';
-    wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
-    assert_and_click 'windows-limited-exp', timeout => 60;
-    wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
     assert_and_click 'windows-create-account';
     wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
     type_string $realname;
@@ -94,7 +102,7 @@ sub run {
         assert_screen 'windows-desktop';
     }
 
-    # setup stable lock screen background
+    # setup stable lock screen background only in Win10
     $self->use_search_feature('lock screen settings');
     assert_screen 'windows-lock-screen-in-search';
     wait_still_screen stilltime => 2, timeout => 10, similarity_level => 43;
@@ -149,7 +157,7 @@ sub run {
     );
 
     # poweroff
-    $self->reboot_or_shutdown();
+    $self->reboot_or_shutdown;
 }
 
 1;


### PR DESCRIPTION
From 22H2 build, the offline account selection process has diverted a lot. Now, there's need to select a work or school account and then choose "domain join" in order to skip the MS account creation.

- Related ticket: https://progress.opensuse.org/issues/120537
- Needles:
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/win10_desktop-20221115.png
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/SUSE-wsl-search-20220803.png
  - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/win10_desktop-20221111.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-install-cmd-20221114.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-device-name-20221114.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/win10_firstboot-windows-signin-with-ms-20221114.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-start-with-region-20220623.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-lock-screen-in-search-20220714.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-device-name-20221114.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-account-setup-20220624.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-select-personal-use-20220624.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-work-school-account-20221115.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-signin-options-20221115.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-domain-join-20221115.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-create-account-20220624.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-desktop-20221115.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-search-bar-20221115.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-lock-screen-in-search-20221115.png
- Verification runs:
  - https://openqa.suse.de/tests/9974391
  - https://openqa.suse.de/tests/9974534
  - https://openqa.suse.de/tests/9974397
