### PR TITLE
Turn off plasma tooltips after handling opensuse_welcome

### DIFF
--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -35,7 +35,9 @@ sub run {
         assert_screen \@tags, $timeout;
     }
 
-    turn_off_plasma_tooltips();
+    # This only works with generic-desktop. In the opensuse-welcome case,
+    # the opensuse-welcome module will handle it instead.
+    turn_off_plasma_tooltips if match_has_tag('generic-desktop');
 }
 
 sub post_fail_hook {

--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -12,7 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use x11utils 'handle_welcome_screen';
+use x11utils qw(handle_welcome_screen turn_off_plasma_tooltips);
 use version_utils 'is_upgrade';
 
 sub run {
@@ -27,6 +27,8 @@ sub run {
     } else {
         handle_welcome_screen;
     }
+
+    turn_off_plasma_tooltips;
 }
 
 sub test_flags {


### PR DESCRIPTION
There are two issues with disabling plasma tooltips while the welcome screen
is open. opensuse-welcome can match before the desktop (and krunner) are
ready, which breaks x11_run_program. Even in the case that it worked,
x11_run_program then only expects generic-desktop and not opensuse-welcome.

Avoid those issues by disabling tooltips after reaching generic-desktop.

- Verification run: https://openqa.opensuse.org/tests/2880821
