### PR TITLE
Move zypper lr after setting staging repos

### DIFF
--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -25,13 +25,14 @@ sub run {
     change_grub_config('=\"[^\"]*', "& $extrabootparams", 'GRUB_CMDLINE_LINUX_DEFAULT') if $extrabootparams;
     $keep_grub_timeout or change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT');
 
-    record_info('REPOS', script_output('zypper lr --url', proceed_on_failure => 1));
+    record_info('REPOS (Default)', script_output('zypper lr --url', proceed_on_failure => 1));
 
     if (is_alp) {
         change_grub_config('=.*', '=1024x768', 'GRUB_GFXMODE=');
         zypper_call('mr -e ALP-Build');
 
         add_staging_repos() if (get_var("STAGING"));
+        record_info('REPOS (all)', script_output('zypper lr --url', proceed_on_failure => 1));
     }
 
     if (!$keep_grub_timeout or $extrabootparams) {


### PR DESCRIPTION
Add the listing of the repositories after setting of the staging repositories.

- Related ticket: https://progress.opensuse.org/issues/119086
- Verification run: [after](https://duck-norris.qam.suse.de/tests/11115#step/host_config/17)| [before](https://duck-norris.qam.suse.de/tests/11111#step/host_config/6)

Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15915