### PR TITLE
Increase timeout for k8s job

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -141,7 +141,7 @@ Find pods using kubectl queries
 
 sub wait_for_k8s_job_complete {
     my ($job) = @_;
-    assert_script_run("kubectl wait --for=condition=complete --timeout=300s job/$job");
+    assert_script_run("kubectl wait --for=condition=complete --timeout=300s job/$job", timeout => 360);
 }
 
 =head2 wait_for_k8s_job_complete


### PR DESCRIPTION
Set the timeout for the assert_script_run of the k8s job to match the timeout for the kubectl command.

- Related ticket: https://progress.opensuse.org/issues/120624
- Verification run: https://duck-norris.qam.suse.de/tests/11114#step/run_container_in_k8s_GCE/53

While it doesn't resolve the issue, it is still a needed change to match the actual timeout.