### PR TITLE
Move conditions for the 2nd passphrase workaround to the correct place

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -11,7 +11,7 @@ use warnings;
 use testapi qw(is_serial_terminal :DEFAULT);
 use lockapi 'mutex_wait';
 use mm_network;
-use version_utils qw(is_sle_micro is_microos is_leap is_public_cloud is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos package_version_cmp);
+use version_utils qw(is_sle_micro is_microos is_leap is_leap_micro is_public_cloud is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos package_version_cmp);
 use Utils::Architectures;
 use Utils::Systemd qw(systemctl disable_and_stop_service);
 use Utils::Backends;
@@ -891,6 +891,12 @@ anymore for storage-ng.
 sub workaround_type_encrypted_passphrase {
     # nothing to do if the boot partition is not encrypted in FULL_LVM_ENCRYPT
     return unless is_boot_encrypted();
+
+    # With newer grub2 (in TW only currently), entering the passphrase in GRUB2
+    # is enough. The key is passed on during boot, so it's not asked for
+    # a second time.
+    return if !is_leap && !is_sle && !is_leap_micro && !is_sle_micro;
+
     record_info(
         "LUKS pass", "Workaround for 'Provide kernel interface to pass LUKS password from bootloader'.\n" .
           'For further info, please, see https://fate.suse.com/320901, https://jira.suse.com/browse/SLE-2941, ' .

--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -13,14 +13,8 @@ use warnings;
 use base "installbasetest";
 use utils;
 use testapi qw(check_var get_var record_info);
-use version_utils qw(is_leap is_sle is_leap_micro is_sle_micro);
 
 sub run {
-    # With newer grub2 (in TW only currently), entering the passphrase in GRUB2
-    # is enough. The key is passed on during boot, so it's not asked for
-    # a second time.
-    return if is_boot_encrypted && !is_leap && !is_sle && !is_leap_micro && !is_sle_micro;
-
     unlock_if_encrypted(check_typed_password => 1);
 }
 


### PR DESCRIPTION
There's already a function specificially for the second passphrase, add the conditions for the workaround there instead of handling it in boot_encrypt only.

- Related ticket: https://progress.opensuse.org/issues/117811#change-575406
- Verification runs: https://openqa.opensuse.org/tests/2881690#live https://openqa.opensuse.org/tests/2881691#live
