### PR TITLE
Add fatal flag to proper Trento test modules

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -242,7 +242,7 @@ sub get_qesap_resource_group {
 =head3 config_cluster
 
 Create a variable map and prepare the qe-sap-deployment using it
-=over 2
+=over 3
 
 =item B<PROVIDER> - CloudProvider name
 

--- a/tests/sles4sap/trento/cluster_configure.pm
+++ b/tests/sles4sap/trento/cluster_configure.pm
@@ -24,6 +24,10 @@ sub run {
 
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 sub post_fail_hook {
     my ($self) = shift;
     select_serial_terminal;

--- a/tests/sles4sap/trento/cluster_deploy.pm
+++ b/tests/sles4sap/trento/cluster_deploy.pm
@@ -32,7 +32,11 @@ sub run {
     my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
     my $inventory = qesap_get_inventory($prov);
 
-    qesap_ansible_cmd(cmd => 'crm status', provider => $prov, filter => $_) for ('vmhana01', 'vmhana02');
+    qesap_ansible_cmd(cmd => 'crm status', provider => $prov, filter => 'vmhana01');
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 sub post_fail_hook {

--- a/tests/sles4sap/trento/deploy_trento.pm
+++ b/tests/sles4sap/trento/deploy_trento.pm
@@ -30,6 +30,10 @@ sub run {
     trento_support('deploy_trento');
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 sub post_fail_hook {
     my ($self) = @_;
 

--- a/tests/sles4sap/trento/init_jumphost.pm
+++ b/tests/sles4sap/trento/init_jumphost.pm
@@ -23,4 +23,8 @@ sub run {
     my $provider = $self->provider_factory();
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;

--- a/tests/sles4sap/trento/install_agents.pm
+++ b/tests/sles4sap/trento/install_agents.pm
@@ -10,7 +10,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use qesapdeployment 'qesap_upload_logs';
-use trento qw(destroy_qesap get_trento_ip get_trento_password az_delete_group install_agent k8s_logs trento_support);
+use trento;
 
 sub run {
     my ($self) = @_;
@@ -32,6 +32,10 @@ sub run {
     }
 
     $cmd = install_agent($wd, '/root/test', $agent_api_key);
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
- Verification run: 
   https://openqaworker15.qa.suse.cz/tests/68512#step/init_jumphost/25 init_jumphost ERROR: FATAL and no more steps are executed
   https://openqaworker15.qa.suse.cz/tests/68182  error during the deployment: FATAL and no more steps are executed
   https://openqaworker15.qa.suse.cz/tests/68471,    https://openqaworker15.qa.suse.cz/tests/68511 fatal later at agent installation
   https://openqaworker15.qa.suse.cz/tests/68514 PASS
