### PR TITLE
x11/multi_users_dm: Wait for gdm before switching console

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -89,6 +89,8 @@ sub run {
     assert_script_run "~$username/data/delete_users $users_to_create";
     script_run "clear";
     assert_script_run "rcxdm restart";
+    # Wait for gdm to be started before selecting x11-console
+    wait_still_screen 10;
     select_console 'x11';
     # after restart of X11 give the desktop a bit more time to show up to
     # prevent the post_run_hook to fail being too impatient


### PR DESCRIPTION
This test failures always happens on arm64, after analyzing gdm logs, I confirmed the root cause is that we switch to tty2 too quickly, before gdm restart is ready.  So the solution is to add wait_still_screen here.

- Related ticket: https://progress.opensuse.org/issues/120103
- Needles: None
- Verification run: https://openqa.opensuse.org/tests/2882399#step/multi_users_dm/43
