### PR TITLE
Expect ip instead of FQDN in ibft validation

### DIFF
--- a/tests/installation/validation/ibft.pm
+++ b/tests/installation/validation/ibft.pm
@@ -14,6 +14,7 @@
 use base "opensusebasetest";
 use strict;
 use warnings;
+use Socket;
 use testapi;
 use Test::Assert 'assert_equals';
 use version_utils qw(is_sle);
@@ -35,7 +36,6 @@ my $ibft_expected = {
         target_name => get_required_var('NBF'),
         flags => 3,
         port => 3260,
-        ip_addr => get_required_var('WORKER_HOSTNAME'),
         chap_type => 0
     },
     acpi_header => {
@@ -112,6 +112,9 @@ sub run {
     my $reg_rx = qr/rxdata_octets:\s+\d+/;
     # Requires NICTYPE=user and backend/qemu.pm code to run
     $ibft_expected->{ethernet}->{mac} = get_required_var('NICMAC');
+
+    my $fqdn = testapi::get_required_var('WORKER_HOSTNAME');
+    $ibft_expected->{target}->{ip_addr} = inet_ntoa(inet_aton($fqdn));
 
     select_console 'root-console';
     # find iscsi drive


### PR DESCRIPTION
After a recent change in the worker salt states, the variable `WORKER_HOSTNAME` will always return the FQDN.
Since in ibft test the expected ip address was initialized using the `WORKER_HOSTNAME` variable, this means that currently there is a difference between the expected ip value and the actual ip value. We mitigate this by acquiring the expected ip based on the FQDN.

- Related ticket: https://progress.opensuse.org/issues/120079
- Needles: No needles
- Verification run:  https://openqa.suse.de/tests/9987191#step/ibft/57

