### PR TITLE
Slow down typing while search for primary password setting

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -48,15 +48,15 @@ sub firefox_crashreporter {
 
 sub firefox_preferences {
     send_key "alt-e";
-    wait_still_screen 2;
+    wait_still_screen 10;
     send_key "n";
     assert_screen("firefox-preferences");
 }
 
 sub search_certificates {
-    type_string "certificates";
+    type_string "certificates", timeout => 20, max_interval => 40;
     send_key "tab";
-    wait_still_screen 2;
+    wait_still_screen 10;
 }
 
 sub run {
@@ -92,13 +92,13 @@ sub run {
 
     # Firefox Preferences
     firefox_preferences;
-
+    wait_still_screen 20;
     # Search "Passwords" section
     if ($firefox_version >= 91) {
-        type_string "Use a primary", timeout => 2;
+        type_string "Use a primary", timeout => 15, max_interval => 40;
     }
     else {
-        type_string "Use a master", timeout => 2;
+        type_string "Use a master", timeout => 15, max_interval => 40;
     }
     assert_and_click("firefox-master-password-checkbox");
     assert_screen("firefox-passwd-master_setting");
@@ -166,20 +166,20 @@ sub run {
     x11_start_program('xterm');
     mouse_hide(1);
     enter_cmd("firefox --setDefaultBrowser https://html5test.opensuse.org");
-
+    wait_still_screen 30;
     if (check_screen("firefox-passowrd-typefield", 120)) {
 
         # Add max_interval while type password and extend time of click needle match
-        type_string($fips_password, max_interval => 2);
+        type_string($fips_password, timeout => 10, max_interval => 30);
         assert_and_click('firefox-enter-password-OK', timeout => 120);
-        wait_still_screen 10;
+        wait_still_screen 30;
 
         # Add a condition to avoid the password missed input
         # Retype password again once the password missed input
         # The problem frequently happened in aarch64
         if (check_screen("firefox-password-typefield-miss")) {
             record_info("aarch64 type_missing", "Firefox password is missing to input, please refer to bsc#1179749 & poo#105343");
-            type_string($fips_password, max_interval => 2);
+            type_string($fips_password, timeout => 10, max_interval => 30);
             send_key "ret";
         }
     }


### PR DESCRIPTION
Need to adjust timeouts and typing speed to better suit aarch64 worker infrastructure

- Related ticket: https://progress.opensuse.org/issues/115769
- Verification runs: 
  - https://openqa.suse.de/tests/9980919 passed
  - https://openqa.suse.de/tests/9980920 passed
  - https://openqa.suse.de/tests/9980921 passed
  - https://openqa.suse.de/tests/9980922 passed
  - https://openqa.suse.de/tests/9980923 passed
  - https://openqa.suse.de/tests/9980924 passed
  - https://openqa.suse.de/tests/9980925 passed
  - https://openqa.suse.de/tests/9980926 passed
  - https://openqa.suse.de/tests/9980927 passed
  - https://openqa.suse.de/tests/9980928 passed
  - https://openqa.suse.de/tests/9980929 passed
  - https://openqa.suse.de/tests/9980930 passed
  - https://openqa.suse.de/tests/9980931 passed
  - https://openqa.suse.de/tests/9980932 passed
  - https://openqa.suse.de/tests/9980933 passed
  - https://openqa.suse.de/tests/9980934 passed
  - https://openqa.suse.de/tests/9980935 passed
  - https://openqa.suse.de/tests/9980936 passed
  - https://openqa.suse.de/tests/9980937 passed
  - https://openqa.suse.de/tests/9980938 passed
   
