### PR TITLE
Add Win11 case to Windows Update

### DIFF
--- a/schedule/wsl/install/create_windows_image.yaml
+++ b/schedule/wsl/install/create_windows_image.yaml
@@ -7,3 +7,4 @@ description:  >
 schedule:
   - wsl/install/ms_win_installation
   - wsl/install/ms_win_firstboot
+  - wsl/update_windows

--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -157,7 +157,8 @@ sub run {
     );
 
     # poweroff
-    $self->reboot_or_shutdown;
+    $self->reboot_or_shutdown(1);
+    $self->wait_boot_windows;
 }
 
 1;

--- a/tests/wsl/update_windows.pm
+++ b/tests/wsl/update_windows.pm
@@ -7,24 +7,34 @@
 # Maintainer: qa-c <qa-c@suse.de>
 
 use Mojo::Base qw(windowsbasetest);
-use testapi qw(assert_and_click assert_screen check_screen match_has_tag);
+use testapi qw(assert_and_click assert_screen check_screen match_has_tag click_lastmatch);
 
 sub run {
     my $self = shift;
     $self->windows_run('control update');
 
-    assert_screen 'windows-update';
-    while (defined(check_screen('windows-updates-available', 60))) {
+    assert_screen 'windows-update', timeout => 30;
+    # Sometimes there's need to press the "Check for updates" button manually
+    click_lastmatch if (check_screen 'windows-no-updates-available');
+    while (defined(check_screen(['windows-updates-available', 'windows-checking-updates'], 60))) {
+        # Windows 11 sometimes fails some update and there's need to push a
+        # button to install the rest
+        click_lastmatch if (check_screen 'windows11-updates-available-to-install');
         bmwqemu::diag("Updating windows base image file...");
-        sleep 30;
+        sleep 60;
     }
 
     assert_screen([qw(windows-updates-required-restart windows-up-to-date)]);
 
-    $self->windows_run('shutdown -s -t 0');
+    # A reboot for finishing updating...
+    $self->reboot_or_shutdown(1);
     while (defined(check_screen('windows-updating', 60))) {
         bmwqemu::diag("Applying updates while shutting down the machine...");
     }
+    $self->wait_boot_windows;
+
+    # Shutdown
+    $self->reboot_or_shutdown;
 }
 
 1;


### PR DESCRIPTION
The idea here is to update Windows right after the installation, and then run the update process in a separate job who will be pre-requisite to all WSL ones.

- Related ticket: https://progress.opensuse.org/issues/117577
- Needles: *so many...*
- Verification runs:
#### Install and update
  - https://openqa.suse.de/tests/9987150
  - https://openqa.suse.de/tests/9987246
  - https://openqa.suse.de/tests/10004268
#### Just update
  - https://openqa.suse.de/tests/9987552
  - https://openqa.suse.de/tests/9987603
  - https://openqa.suse.de/tests/10013051