### PR TITLE
Trento adopts secured storage for qe-sap-deployment

### DIFF
--- a/data/sles4sap/qe_sap_deployment/trento_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/trento_azure.yaml
@@ -1,5 +1,5 @@
 provider: "%PROVIDER%"
-apiver: 2
+apiver: 3
 terraform:
   variables:
     az_region: "%REGION%"
@@ -10,7 +10,10 @@ terraform:
     admin_user: "%CLUSTER_USER%"
 
 ansible:
-  hana_urls:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
     - "%HANA_SAR%"
     - "%HANA_CLIENT_SAR%"
     - "%HANA_SAPCAR%"

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -271,6 +271,15 @@ sub config_cluster {
     $variables{SSH_KEY_PRIV} = SSH_KEY;
     $variables{SSH_KEY_PUB} = $ssh_key_pub;
     $variables{SCC_REGCODE_SLES4SAP} = $scc;
+
+    $variables{HANA_ACCOUNT} = get_required_var("TRENTO_QESAPDEPLOY_HANA_ACCOUNT");
+    $variables{HANA_CONTAINER} = get_required_var("TRENTO_QESAPDEPLOY_HANA_CONTAINER");
+    if (get_var("TRENTO_QESAPDEPLOY_HANA_TOKEN")) {
+        $variables{HANA_TOKEN} = get_required_var("TRENTO_QESAPDEPLOY_HANA_TOKEN");
+        # escape needed by 'sed'
+        # but not implemented in file_content_replace() yet poo#120690
+        $variables{HANA_TOKEN} =~ s/\&/\\\&/g;
+    }
     $variables{HANA_SAR} = get_required_var("TRENTO_QESAPDEPLOY_SAPCAR");
     $variables{HANA_CLIENT_SAR} = get_required_var("TRENTO_QESAPDEPLOY_IMDB_CLIENT");
     $variables{HANA_SAPCAR} = get_required_var("TRENTO_QESAPDEPLOY_IMDB_SERVER");
@@ -405,7 +414,12 @@ sub install_trento {
         '-k', SSH_KEY,
         '-u', VM_USER);
 
-    push @cmd_list, ('-c', get_var('TRENTO_REGISTRY_CHART_VERSION')) if (get_var('TRENTO_REGISTRY_CHART_VERSION'));
+    if (get_var('TRENTO_REGISTRY_CHART_VERSION')) {
+        push @cmd_list, ('-c', get_var('TRENTO_REGISTRY_CHART_VERSION'));
+    }
+    elsif (get_var('TRENTO_VERSION')) {
+        push @cmd_list, ('-c', get_var('TRENTO_VERSION'));
+    }
     if (get_var("TRENTO_REGISTRY_IMAGE_$imgs[0]") || get_var("TRENTO_REGISTRY_IMAGE_$imgs[1]")) {
         push @cmd_list, ('-x', $acr->{'trento_cluster_install'});
     }

--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -46,6 +46,7 @@ subtest '[k8s_logs] Get logs from running pods as it is also required' => sub {
     $trento->redefine(trento_support => sub { return; });
 
     k8s_logs(qw(panino));
+
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  L-->  " . join("\n  L-->  ", @logs));
     ok scalar @calls == 3, sprintf '3 in place of %d remote commands expected: 1 to get the list of the pods, 2 to get from the required one all the logs', scalar @calls;
@@ -61,11 +62,13 @@ subtest '[trento_support]' => sub {
     $trento->redefine(get_trento_ip => sub { return '42.42.42.42' });
     $trento->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $trento->redefine(upload_logs => sub { push @logs, $_[0]; });
+
     trento_support();
+
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  L-->  " . join("\n  L-->  ", @logs));
-    like $calls[0], qr/mkdir.*remote_logs/, 'Create remote_logs local folder';
 
+    like $calls[0], qr/mkdir.*remote_logs/, 'Create remote_logs local folder';
     ok((any { /ssh.*trento-support\.sh/ } @calls), 'Run trento-support.sh remotely');
     ok((any { /scp.*\.tar\.gz.*remote_logs/ } @calls), 'scp trento-support.sh output locally');
     ok((any { /ssh.*dump_scenario_from_k8\.sh/ } @calls), 'Run dump_scenario_from_k8.sh remotely');

--- a/tests/sles4sap/trento/cluster_deploy.pm
+++ b/tests/sles4sap/trento/cluster_deploy.pm
@@ -32,6 +32,7 @@ sub run {
     my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
     my $inventory = qesap_get_inventory($prov);
 
+    qesap_ansible_cmd(cmd => 'crm cluster wait_for_startup', provider => $prov, filter => 'vmhana01');
     qesap_ansible_cmd(cmd => 'crm status', provider => $prov, filter => 'vmhana01');
 }
 

--- a/tests/sles4sap/trento/test_hana_stop.pm
+++ b/tests/sles4sap/trento/test_hana_stop.pm
@@ -25,7 +25,8 @@ sub run {
 
     qesap_ansible_cmd(cmd => "su - hdbadm -c 'HDB stop'", provider => $prov, filter => 'vmhana02');
 
-    qesap_ansible_cmd(cmd => 'crm status', provider => $prov, filter => 'vmhana01');
+    my $cmr_status = qesap_ansible_script_output(cmd => 'crm status', provider => $prov, host => 'vmhana01', root => 1);
+    record_info("crm status", $cmr_status);
     qesap_ansible_cmd(cmd => 'SAPHanaSR-showAttr', provider => $prov, filter => 'vmhana01');
 
     my $cypress_test_dir = "/root/test/test";

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -33,6 +33,8 @@ sub run {
 
     # all other cypress tests
     cypress_test_exec($cypress_test_dir, 'all', 900);
+
+    trento_support('test_trento_web');
 }
 
 sub post_fail_hook {

--- a/variables.md
+++ b/variables.md
@@ -233,14 +233,17 @@ TRENTO_AGENT_RPM | string | | Trento-agent rpm file name
 TRENTO_EXT_DEPLOY_IP | string | | Public IP of a Trento web instance not deployed by openQA
 TRENTO_WEB_PASSWORD | string | | Trento web password for the admin user. If not provided, random generated one.
 TRENTO_QESAPDEPLOY_CLUSTER_OS_VER | string | | OS for nodes in SAP cluster.
-TRENTO_QESAPDEPLOY_SAPCAR | string | | SAPCAR url for the qe-sap-deployment hana_media.yaml.
-TRENTO_QESAPDEPLOY_IMDB_SERVER | string | | IMDB_SERVER url for the qe-sap-deployment hana_media.yaml.
-TRENTO_QESAPDEPLOY_IMDB_CLIENT | string | | IMDB_CLIENT url for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_HANA_ACCOUNT | string | | Azure blob server account for the SAP installers for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_HANA_CONTAINER | string | | Azure blob server container for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_HANA_TOKEN | string | | Azure blob server token for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_SAPCAR | string | | SAPCAR file name for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_IMDB_SERVER | string | | IMDB_SERVER file name for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_IMDB_CLIENT | string | | IMDB_CLIENT file name for the qe-sap-deployment hana_media.yaml.
 QESAP_CONFIG_FILE | string | | filename (of relative path) of the config YAML file for the qesap.py script, within `sles4sap/qe_sap_deployment/` subfolder in `data`.
 QESAP_DEPLOYMENT_DIR | string | /root/qe-sap-deployment | JumpHost folder where to install the qe-sap-deployment code
-QESAP_INSTALL_VERSION | string | | If configured, test will run with a specific release of qe-sap-deployment code from https://github.com/SUSE/qe-sap-deployment/releases.
-QESAP_INSTALL_GITHUB_REPO | string | github.com/SUSE/qe-sap-deployment | Git repository where to clone from. Ignored if QESAP_VER is configured.
-QESAP_INSTALL_GITHUB_BRANCH | string | | Git branch. Ignored if QESAP_VER is configured.
+QESAP_INSTALL_VERSION | string | | If configured, test will run with a specific release of qe-sap-deployment code from https://github.com/SUSE/qe-sap-deployment/releases. Otherwise the code is used from a latest version controlled by QESAP_INSTALL_GITHUB_REPO and QESAP_INSTALL_GITHUB_BRANCH
+QESAP_INSTALL_GITHUB_REPO | string | github.com/SUSE/qe-sap-deployment | Git repository where to clone from. Ignored if QESAP_INSTALL_VERSION is configured.
+QESAP_INSTALL_GITHUB_BRANCH | string | | Git branch. Ignored if QESAP_INSTALL_VERSION is configured.
 QESAP_INSTALL_GITHUB_NO_VERIFY | string | | Configure http.sslVerify false. Ignored if QESAP_VER is configured.
 
 


### PR DESCRIPTION
Move qe-sap-deployment conf.yaml for Trento to apiver:3 Add new Trento settings for the MEDIA
Fix for the testing of the official Trento releases Collect more photofinish scenarios
Add crm wait_for_startup before to start testing the Trento web interface
Adopt the new Ansible api for 'crm status' reading Improve variables documentation

- Related ticket: CFSA-1577
- Verification run: 
-  WITH WRONG TOKEN https://openqaworker15.qa.suse.cz/tests/69380
- https://openqaworker15.qa.suse.cz/tests/69978  the installer download is ok https://openqaworker15.qa.suse.cz/tests/69978/logfile?filename=cluster_deploy-qesap_exec_ansible.log.txt
- https://openqaworker15.qa.suse.cz/tests/69987 https://openqaworker15.qa.suse.cz/tests/70534 https://openqaworker15.qa.suse.cz/tests/70535 https://openqaworker15.qa.suse.cz/tests/70536
