### PR TITLE
Collect AVC generated by each test module

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -11,6 +11,11 @@ use known_bugs;
 use version_utils qw(is_public_cloud is_openstack);
 use utils;
 
+my %avc_record = (
+    start => 0,
+    end => undef
+);
+
 =head1 consoletest
 
 C<consoletest> - Base class for all console tests
@@ -29,6 +34,7 @@ sub post_run_hook {
     # start next test in home directory
     enter_cmd "cd";
 
+    record_avc_selinux_alerts();
     # clear screen to make screen content ready for next test
     $self->clear_and_verify_console;
 }
@@ -41,6 +47,7 @@ Method executed when run() finishes and the module has result => 'fail'
 
 sub post_fail_hook {
     my ($self) = @_;
+    record_avc_selinux_alerts();
     $self->SUPER::post_fail_hook;
     # at this point the instance is shutdown
     return if (is_public_cloud() || is_openstack());
@@ -49,6 +56,31 @@ sub post_fail_hook {
     $self->export_logs_basic;
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
     $self->export_logs_desktop;
+}
+
+=head2 record_avc_selinux_alerts
+
+List AVCs that have been recorded during a runtime of a test module that executes this function
+
+=cut
+
+sub record_avc_selinux_alerts {
+    if ((current_console() !~ /root|log/) || (script_run('test -f /var/log/audit/audit.log') != 0)) {
+        return;
+    }
+
+    my @logged = split(/\n/, script_output('ausearch -m avc -r', proceed_on_failure => 1));
+
+    # no new messages are registered
+    if ($avc_record{end} <= $avc_record{start}) {
+        return;
+    }
+
+    $avc_record{end} = scalar @logged - 1;
+    my @avc = @logged[$avc_record{start} .. $avc_record{end}];
+    $avc_record{start} = $avc_record{end} + 1;
+
+    record_info('AVC', join("\n", @avc));
 }
 
 =head2 use_wicked_network_manager

--- a/tests/console/journal_check.pm
+++ b/tests/console/journal_check.pm
@@ -107,6 +107,13 @@ sub run {
             $failed = 1;
         }
     }
+
+    # upload all content of audit directory
+    if (script_run('test -d /var/log/audit/') == 0) {
+        assert_script_run('tar cvf /tmp/audit.tar  /var/log/audit/*');
+        upload_logs('/tmp/audit.tar');
+    }
+
     $self->result('fail') if $failed;
 }
 

--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -6,7 +6,7 @@
 # Summary: Basic check for cockpit service
 # Maintainer: qa-c team <qa-c@suse.de>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -6,7 +6,7 @@
 # Summary: Boot from disk and login into MicroOS
 # Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/enable_lp_module.pm
+++ b/tests/microos/enable_lp_module.pm
@@ -6,7 +6,7 @@
 # Summary: Enable Live Patching module in SLE Micro
 # Maintainer: qa-c@suse.de
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -6,7 +6,7 @@
 # Summary: Run simple image specific checks
 # Maintainer: Fabian Vogt <fvogt@suse.de>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/libzypp_config.pm
+++ b/tests/microos/libzypp_config.pm
@@ -7,7 +7,7 @@
 # fate#321764
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/networking.pm
+++ b/tests/microos/networking.pm
@@ -6,7 +6,7 @@
 # Summary: Test network connectivity
 # Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/one_line_checks.pm
+++ b/tests/microos/one_line_checks.pm
@@ -6,7 +6,7 @@
 # Summary: Run simple checks after installation
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/rcshell_start.pm
+++ b/tests/microos/rcshell_start.pm
@@ -6,7 +6,7 @@
 # Summary: Start feature tests before installation
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/rebuild_initrd.pm
+++ b/tests/microos/rebuild_initrd.pm
@@ -9,7 +9,7 @@
 #          e.g. qemu/qemu.pm (s390x)
 # Maintainer: qa-c team <qa-c@suse.de>
 
-use Mojo::Base "opensusebasetest";
+use Mojo::Base "consoletest";
 use testapi;
 use transactional;
 

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -6,7 +6,7 @@
 # Summary: Boot SelfInstallation image for SLEM
 # Maintainer: QA-C team <qa-c@suse.de>
 
-use Mojo::Base qw(opensusebasetest);
+use Mojo::Base qw(consoletest);
 use testapi;
 use microos "microos_login";
 use Utils::Architectures qw(is_aarch64);

--- a/tests/microos/services_enabled.pm
+++ b/tests/microos/services_enabled.pm
@@ -9,7 +9,7 @@
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "consoletest";
 use utils;
 use testapi;
 

--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -6,7 +6,7 @@
 # Summary: Run simple toolbox tests
 # Maintainer: Jose Lausuch <jalausuch@suse.com>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/microos/verify_setup.pm
+++ b/tests/microos/verify_setup.pm
@@ -9,7 +9,7 @@
 # or ignition
 # Maintainer: qa-c team <qa-c@suse.de>
 
-use Mojo::Base qw(opensusebasetest);
+use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils qw(systemctl);

--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -8,7 +8,7 @@
 #
 # Maintainer: QA-C team <qa-c@suse.de>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/transactional/filesystem_ro.pm
+++ b/tests/transactional/filesystem_ro.pm
@@ -8,7 +8,7 @@
 # Maintainer: Martin Kravec <mkravec@suse.com>
 # Tags: https://fate.suse.com/321755
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/transactional/health_check.pm
+++ b/tests/transactional/health_check.pm
@@ -9,7 +9,7 @@
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "consoletest";
 use testapi;
 use utils;
 use transactional qw(process_reboot trup_install trup_shell);

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -9,7 +9,7 @@
 #
 # Maintainer: Jose Lausuch <jalausuch@suse.com>
 
-use Mojo::Base qw(opensusebasetest);
+use Mojo::Base qw(consoletest);
 use testapi;
 use transactional qw(process_reboot);
 use bootloader_setup qw(change_grub_config);

--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -6,7 +6,7 @@
 # Summary: Install Update repos in transactional server
 # Maintainer: qac team <qa-c@suse.de>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/transactional/tdup.pm
+++ b/tests/transactional/tdup.pm
@@ -7,7 +7,7 @@
 # Summary: To a transactional-update dup and reboot the node
 # Maintainer: Richard Brown <rbrown@suse.com>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/transactional/trup_install_tar.pm
+++ b/tests/transactional/trup_install_tar.pm
@@ -8,7 +8,7 @@
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "consoletest";
 use testapi;
 use transactional;
 

--- a/tests/transactional/trup_smoke.pm
+++ b/tests/transactional/trup_smoke.pm
@@ -7,7 +7,7 @@
 #           operations work and system can properly boot.
 # Maintainer: qa-c team <qa-c@suse.de>
 
-use base "opensusebasetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;

--- a/tests/transactional/verify_undelete_snapshots.pm
+++ b/tests/transactional/verify_undelete_snapshots.pm
@@ -9,7 +9,7 @@
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "consoletest";
 use testapi;
 use transactional qw(rpmver get_utt_packages trup_call);
 use Test::Assert 'assert_equals';


### PR DESCRIPTION
Search for AVC denials after execution of each test module that runs in
sle|leap-micro, MicroOS or ALP test suites.
Eventually as `journal_check` is scheduled at the end test suites,
upload content of `audit` log directory for further investigation if
required.

- ticket: [Upload and check the content of audit.log](https://progress.opensuse.org/issues/120070)

#### VRs:

* [Build20221121-1 of sle-micro-5.2-DVD-Updates.x86_64](http://kepler.suse.cz/tests/19633#live)
* [sle-micro-5.3-DVD-Updates-x86_64-Build20221121-1](http://kepler.suse.cz/tests/19632#)
* [sle-micro-5.1-DVD-Updates-x86_64-Build20221121-1](http://kepler.suse.cz/tests/19631#live)
* [microos-Tumbleweed-MicroOS-Image-x86_64-Build20221116-microos@64bit](http://kepler.suse.cz/tests/19630#)
* [sle-micro-5.3-MicroOS-Image-Updates-x86_64-Build20221117-1-slem_selinux@64bit](http://kepler.suse.cz/tests/19627#step/cockpit_service/81)
* [sle-micro-5.2-MicroOS-Image-Updates-x86_64-Build20221120-1-slem_selinux@64bit](http://kepler.suse.cz/tests/19629#step/disk_boot/19)
* [sle-micro-5.1-MicroOS-Image-Updates-x86_64-Build20221120-1-slem_selinux@64bit](http://kepler.suse.cz/tests/19628#step/install_updates/43)
* [alp-0.1-kvm-x86_64-Build21.3-alp_default@uefi](https://openqa.opensuse.org/tests/2886374#step/cockpit_service/84)