### PR TITLE
Implement mr_test on EC2

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -1,0 +1,33 @@
+provider: "ec2"
+apiver: 2
+
+terraform:
+  variables:
+    # GENERAL VARIABLES #
+    aws_region: "%PUBLIC_CLOUD_REGION%"
+    admin_user: "cloudadmin"
+    public_key : "~/.ssh/id_rsa.pub"
+    private_key: "~/.ssh/id_rsa"
+    aws_credentials: "/root/amazon_credentials"
+    os_image: "%QESAP_CLUSTER_OS_VER%"
+    os_owner: "amazon"
+
+    hana_os_major_version: "%VERSION%"
+    iscsi_os_major_version: "%VERSION%"
+    monitoring_os_major_version: "%VERSION%"
+    drdb_os_major_version: "%VERSION%"
+    netweaver_os_major_version: "%VERSION%"
+    bastion_os_major_version: "%VERSION%"
+
+    # HANA
+    hana_cluster_fencing_mechanism: "%FENCING_MECHANISM%"
+    hana_count: "%NODE_COUNT%"
+    hana_ha_enabled: "%HA_CLUSTER%"
+    hana_instancetype: "%PUBLIC_CLOUD_INSTANCE_TYPE%"
+
+ansible:
+  hana_urls:
+    - "%HANA_SAR%"
+    - "%HANA_CLIENT_SAR%"
+    - "%HANA_SAPCAR%"
+    

--- a/schedule/sles4sap/sles4sap_gnome_saptune.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune.yaml
@@ -8,7 +8,6 @@ vars:
   BOOT_HDD_IMAGE: '1'
   TEST_CONTEXT: 'OpenQA::Test::RunArgs'
   NODE_COUNT: '1'
-  QESAP_CONFIG_FILE: 'sles4sap_azure_generic.yaml'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
   # START_AFTER_TEST: create_hdd_sles4sap_gnome

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -59,14 +59,10 @@ sub create_playbook_section {
     # Cluster related setup
     my @playbook_list;
     my @hana_playbook_list = (
-        "pre-cluster.yaml",
-        "sap-hana-preconfigure.yaml -e use_sapconf=" . set_var_output("USE_SAPCONF", "true"),
-        "cluster_sbd_prep.yaml",
-        "sap-hana-storage.yaml",
-        "sap-hana-download-media.yaml",
-        "sap-hana-install.yaml",
-        "sap-hana-system-replication.yaml",
-        "sap-hana-system-replication-hooks.yaml",
+        "pre-cluster.yaml", "sap-hana-preconfigure.yaml -e use_sapconf=" . set_var_output("USE_SAPCONF", "true"),
+        "cluster_sbd_prep.yaml", "sap-hana-storage.yaml",
+        "sap-hana-download-media.yaml", "sap-hana-install.yaml",
+        "sap-hana-system-replication.yaml", "sap-hana-system-replication-hooks.yaml",
         "sap-hana-cluster.yaml"
     );
 
@@ -141,7 +137,9 @@ sub run {
         $instance->wait_for_ssh();
         # Does not fail for some reason.
         my $real_hostname = $instance->run_ssh_command(cmd => "hostname", username => "cloudadmin");
-        die if ($expected_hostname ne $real_hostname);
+        # We expect hostnames reported by terraform to match the actual hostnames in Azure and GCE
+        die "Expected hostname $expected_hostname is different than actual hostname [$real_hostname]"
+          if ((is_azure || is_gce) && ($expected_hostname ne $real_hostname));
     }
 
     $self->{instances} = $run_args->{instances} = \@instances_export;


### PR DESCRIPTION
Implement mr test on EC2 for BYOS and PAYG Public Cloud images
Fix $expected_hostname not equal $real_hostname error in  
"tests/sles4sap/publiccloud/qesap_terraform.pm" on EC2

TEAM-6927 - "terraform apply" should supports Azure/AWS/GCE public images

- Related ticket: https://jira.suse.com/browse/TEAM-6709 
- Needles: NA
- Verification run: (Maintenance: Single Incidents)
  Flavor: EC2-SAP-BYOS-Incidents-saptune & EC2-SAP-PAYG-Incidents-saptune

  15sp4 (All cases are passed):
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP4&build=%3A26445%3Arelease-notes-sles-for-sap&groupid=21
        
  15sp3 (All cases are failed on dependency issues, see https://bugzilla.suse.com/show_bug.cgi?id=1205869):
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP3&build=%3A24847%3Ashim&groupid=22
        
  15sp2 (All cases are passed):
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP2&build=%3A26976%3Avim&groupid=23
        
  15sp1 (All cases are passed):
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP1&build=%3A26976%3Avim&groupid=24

  15GA (All cases are passed): 
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15&build=%3A26976%3Avim&groupid=25
        
  12sp5 (2 cases are passed. other failed cases are introduced by know issues):
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=12-SP5&build=26961%3Asupportutils&groupid=28
        
  12sp4 (All cases are failed on dependency issues, see https://bugzilla.suse.com/show_bug.cgi?id=1205872): 
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=12-SP4&build=%3A26961%3Asupportutils&groupid=29
        
