### PR TITLE
Assert correct NTP pool in installer

### DIFF
--- a/tests/installation/ntp_config_settings.pm
+++ b/tests/installation/ntp_config_settings.pm
@@ -10,18 +10,14 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use version_utils qw(is_tumbleweed is_microos);
 
 sub run {
-    assert_screen ['ntp_config_settings', 'kubeadm-settings'];
-    if (check_screen 'kubeadm-ntp-empty') {
-        record_soft_failure 'bsc#1114818';
-    }
+    assert_screen('ntp_config_settings');
 
-    send_key 'alt-t';
-    type_string '0.opensuse.pool.ntp.org';
+    my $ntp_pool = (is_microos || is_tumbleweed) ? 'opensuse-pool' : 'suse-pool';
+    assert_screen($ntp_pool);
 
-    sleep 1;
-    save_screenshot;
     send_key 'alt-n';
 }
 


### PR DESCRIPTION
Check whether the installer picked correct and if any NTP server rather than setting by the test code.

- ticket: [[microos] ntp_config_settings types in opensuse pool](https://progress.opensuse.org/issues/66421)
- Needles: [o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/791), [osd](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1632)

#### Verification runs
* [microos-Tumbleweed-DVD-x86_64-Build20221117-microos@64bit](http://kepler.suse.cz/tests/19600#step/ntp_config_settings/2)
* [sle-micro-5.3-DVD-Updates-x86_64-Build20221117-1-slem_installation_default@64bit](http://kepler.suse.cz/tests/19603#step/ntp_config_settings/2)
