### PR TITLE
Set patterns to default for HPC installations of system role

### DIFF
--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -2,11 +2,11 @@
 name: hpc_installation_node_dev
 description:    >
      Maintainer: qe-kernel
-     Installation scenario with HPC system role hpc-node and hpc-dev
+     Installation scenario with HPC system role hpc-dev
 vars:
-  DESKTOP: textmode
+  DESKTOP: gnome
   INSTALLONLY: 1
-  PATTERNS: base,minimal,apparmor
+  PATTERNS: default
   SLE_PRODUCT: hpc
   HDDSIZEGB: 30
 conditional_schedule:

--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -2,11 +2,11 @@
 name: hpc_installation_server
 description:    >
      Maintainer: qe-kernel
-     Installation scenario with HPC system role hpc-server.
+     Installation scenario with HPC system role hpc-server and hpc-node.
 vars:
   DESKTOP: textmode
   INSTALLONLY: 1
-  PATTERNS: base,minimal,apparmor
+  PATTERNS: default
   SLE_PRODUCT: hpc
   HDDSIZEGB: 30
 conditional_schedule:
@@ -16,6 +16,14 @@ conditional_schedule:
         - installation/bootloader_uefi
       x86_64:
         - installation/bootloader
+  hostname_inst:
+    HPC:
+      server:
+        - installation/hostname_inst
+  user_settings:
+    HPC:
+      server:
+        - installation/user_settings
   user_settings_root:
     VERSION:
       15-SP2:
@@ -43,8 +51,8 @@ schedule:
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
-  - installation/user_settings
+  - '{{hostname_inst}}'
+  - '{{user_settings}}'
   - '{{user_settings_root}}'
   - installation/resolve_dependency_issues
   - installation/select_patterns


### PR DESCRIPTION
HPC test suites which do a regular installation do not need to use selective patterns as the purpose is to verify a happy path with the recommended configuration.
This change is solving also another problem on the way the Openqa operation works to select patterns in loop. The result is that the test does not install the given patterns because the later deselection removes required pattern as a dependency and causes unexpected fails (missing curl, in particular case).

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/120303
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2315944&version=15-SP4
