### PR TITLE
Fix MPI used on formatter

### DIFF
--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -13,7 +13,7 @@ use version_utils qw(is_sle);
 
 has mpirun => sub {
     my ($self) = shift;
-    my $mpi = get_required_var('MPI');
+    my $mpi = $self->get_mpi();
     $self->mpirun("mpirun");
     my @mpirun_args;
     ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'


### PR DESCRIPTION
Because of a weird logic the code uses different version from the one defined on 15sp1. Fix breaking tests from later commit which introduced the problem and breaks specific MPI test which use openmpi3

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: http://aquarius.suse.cz/tests/14322
