### PR TITLE
Fix Nvidia GPG trust keys screen not showing in 15-SP5

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -111,11 +111,6 @@ sub wsl_gui_pattern {
     send_key 'alt-n';
 }
 
-sub trust_nvidia_gpg_keys {
-    assert_screen 'trust_nvidia_gpg_keys', timeout => 300;
-    send_key 'alt-t';
-}
-
 sub run {
     # WSL installation is in progress
     assert_screen [qw(yast2-wsl-firstboot-welcome wsl-installing-prompt)], 480;
@@ -138,7 +133,9 @@ sub run {
         # SLED Workstation license agreement and trust nVidia GPG keys
         if (check_var('SLE_PRODUCT', 'sled')) {
             license;
-            trust_nvidia_gpg_keys;
+            # Nvidia GPG keys screen does not always shows up
+            assert_screen ['wsl-installation-completed', 'trust_nvidia_gpg_keys'], timeout => 240;
+            send_key 'alt-t' if (match_has_tag 'trust_nvidia_gpg_keys');
         }
         # And done!
         assert_screen 'wsl-installation-completed', 240;


### PR DESCRIPTION
The screen for accepting Nvidia GPG keys does not always show up.

- Related ticket: https://progress.opensuse.org/issues/120330
- Needles: *none*
- Verification runs:
  - [15-SP4](https://openqa.suse.de/tests/10004240)
  - [15-SP5](https://openqa.suse.de/tests/10004241)
