### PR TITLE
Fix broken mpi execution with wrong parameter

### DIFF
--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -20,7 +20,7 @@ has mpirun => sub {
     push @mpirun_args, '--allow-run-as-root ' if $mpi =~ m/openmpi/;
     # avoid openmpi3 warnings since 3.1.6-150500.11.3
     # TODO: map versions with mpi
-    push @mpirun_args, '--mca btl_base_warn_component_unused 0 ' if ($mpi == 'openmpi3' && $self->compare_mpi_versions("$mpi-gnu-hpc", undef, '3.1.6-150500.11.3'));
+    push @mpirun_args, '--mca btl_base_warn_component_unused 0 ' if ($mpi eq 'openmpi3' && $self->compare_mpi_versions("$mpi-gnu-hpc", undef, '3.1.6-150500.11.3'));
     (@mpirun_args == 0) ? $self->mpirun :
       sprintf "%s %s", $self->mpirun, join(' ', @mpirun_args);
 };


### PR DESCRIPTION
`--mca` applies only for openmpi3. This patch fixes condition which makes the parameter passes on other implementations.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>


- Verification run: http://aquarius.suse.cz/tests/14335#details
