### PR TITLE
Partially revert PR#15897: remove absolute path to /usr/sbin for 15-SP2

### DIFF
--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -151,7 +151,8 @@ sub prepare_ssh_tunnel {
     $instance->ssh_assert_script_run(sprintf("sudo install -o root -g root -m 0644 /home/%s/.ssh/authorized_keys /root/.ssh/", $instance->{username}));
 
     # Create remote user and set him a password
-    my $path = (is_sle('>15') && is_sle('<15-SP3')) ? '/usr/sbin/' : '';
+    # Workaround to set absolute path for sudo commands due to bsc#1205325
+    my $path = is_sle('=15-SP1') ? '/usr/sbin/' : '';
     $instance->ssh_assert_script_run("test -d /home/$testapi::username || sudo ${path}useradd -m $testapi::username");
     $instance->ssh_assert_script_run(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd $testapi::username));
 

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -91,7 +91,8 @@ sub deregister_addon {
 sub registercloudguest {
     my ($instance) = @_;
     my $regcode = get_required_var('SCC_REGCODE');
-    my $path = is_sle('>15') && is_sle('<15-SP3') ? '/usr/sbin/' : '';
+    # Workaround to set absolute path for sudo commands due to bsc#1205325
+    my $path = is_sle('=15-SP1') ? '/usr/sbin/' : '';
     my $suseconnect = $path . get_var("PUBLIC_CLOUD_SCC_ENDPOINT", "registercloudguest");
     my $cmd_time = time();
     # Check what version of registercloudguest binary we use

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -79,7 +79,8 @@ sub run {
         }
     }
 
-    my $path = is_sle('>15') && is_sle('<15-SP3') ? '/usr/sbin/' : '';
+    # Workaround to set absolute path for sudo commands due to bsc#1205325
+    my $path = is_sle('=15-SP1') ? '/usr/sbin/' : '';
     $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
     if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) > 2) {
         die('The list of zypper repositories is not empty.');


### PR DESCRIPTION
Partially revert the temporary hotfix [PR#15897](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15897), where we added the absolute path to tools in `/usr/sbin` due to [bsc#1205325](https://bugzilla.suse.com/show_bug.cgi?id=1205325). This PR reverts the workaround for 15-SP2, but not for 15-SP1, where the issue is still present.

- Related ticket: https://progress.opensuse.org/issues/121675
- Verification runs: TBD
