### PR TITLE
Add x11_yast pattern on expected patterns

### DIFF
--- a/schedule/qam/QR/15-SP4/textmode/textmode.yaml
+++ b/schedule/qam/QR/15-SP4/textmode/textmode.yaml
@@ -48,4 +48,5 @@ test_data:
       - base
       - enhanced_base
       - x11
+      - x11_yast
       - yast2_basis


### PR DESCRIPTION
On the 15-SP4 QR build, `x11_yast` pattern is installed, among other patterns. This is not among the expected ones in the 15-SP4 QR schedule for textmode. This PR adds the `x11_yast` to the expected patterns, as we have done for the non QR textmode schedules.

- Related ticket: https://progress.opensuse.org/issues/120420
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/10003541
