### PR TITLE
Wait longer for login prompt in selfinstall images

### DIFF
--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -23,7 +23,7 @@ sub run {
     $self->handle_uefi_boot_disk_workaround if is_aarch64;
 
     # workaround failed *kexec* execution on UEFI with SecureBoot
-    assert_screen(['failed-to-kexec', 'linux-login-microos'], 150);
+    assert_screen(['failed-to-kexec', 'linux-login-microos'], 240);
     if (get_var('UEFI') && match_has_tag('failed-to-kexec')) {
         eject_cd();
         record_soft_failure('bsc#1203896 - kexec fail in selfinstall with secureboot');


### PR DESCRIPTION
[Issue](https://openqa.suse.de/tests/10004258#step/selfinstall/19) happens while waiting for the first boot of a freshly copied image into drive.

- ticket: [Add new job for Self-Install images with UEFI machine](https://progress.opensuse.org/issues/117130)
- Verification run: [sle-micro-5.2-Default-SelfInstall-Updates-x86_64-Build20221120-1-slem_installation_default@64bit](https://openqa.suse.de/t10004917)
