### PR TITLE
Fix the ansible hostname check by using hostnamectl --static

### DIFF
--- a/tests/console/ansible.pm
+++ b/tests/console/ansible.pm
@@ -94,7 +94,7 @@ sub run {
     # Check Ansible version
     record_info('ansible --version', script_output('ansible --version'));
 
-    my $hostname = script_output(is_sle('=15-sp3') ? 'hostname -s' : 'hostnamectl hostname | cut -d. -f1');
+    my $hostname = script_output('hostnamectl --static');
     validate_script_output 'ansible -m setup localhost | grep ansible_hostname', sub { m/$hostname/ };
 
     my $arch = get_var 'ARCH';


### PR DESCRIPTION
Background: The `hostnamectl` command is inconsistent between versions. On some systems there is `hostnamectl get-hostname` on some systems `hostnamectl hostname` and on some there is only `hostnamectl status` but I currently have the impression that `hostnamectl --static` works on all our scenarios.

- Related ticket: [poo#120792](https://progress.opensuse.org/issues/120792)
- Failure: [JeOS Incidents](https://openqa.suse.de/tests/9988965/modules/ansible/steps/67)
- Verification run: [MicroOS](https://pdostal-server.suse.cz/tests/3129#step/ansible/1), [Tumbleweed](https://pdostal-server.suse.cz/tests/3130#step/ansible/1), [JeOS incident](https://pdostal-server.suse.cz/tests/3127#step/ansible/1), [JeOS update](https://pdostal-server.suse.cz/tests/3137#step/ansible/1), [SLE 15-SP3](https://pdostal-server.suse.cz/tests/3136#step/ansible/1), [ALP](https://pdostal-server.suse.cz/tests/3138#step/ansible/1)

Please suggest more verification runs. I finally want to fully solve this issue.