### PR TITLE
Add switch to skip BCI test runs

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -87,6 +87,7 @@ sub run {
     my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
     my $version = get_required_var('VERSION');
     my $test_envs = get_required_var('BCI_TEST_ENVS');
+    return if ($test_envs eq '-');
 
     $self->reset_engines($engine);
 

--- a/variables.md
+++ b/variables.md
@@ -26,7 +26,7 @@ AY_EXPAND_VARS | string | | Commas separated list of variable names to be expand
 BASE_VERSION | string | | |
 BETA | boolean | false | Enables checks and processing of beta warnings. Defines current stage of the product under test.
 BCI_DEVEL_REPO | string | | This parameter is given to the bci-tests to inject a different SLE_BCI repository url to the container image instead of the default one. Used by `bci_test.pm`.
-BCI_TEST_ENVS | string | | The list of environments to be tested, e.g. `base,init,dotnet,python,node,go,multistage`. Used by `bci_test.pm`.
+BCI_TEST_ENVS | string | | The list of environments to be tested, e.g. `base,init,dotnet,python,node,go,multistage`. Used by `bci_test.pm`. Use `-` to not schedule any BCI test runs.
 BCI_TESTS_REPO | string | | Location of the bci-tests repository to be cloned. Used by `bci_prepare.pm`.
 BCI_TESTS_BRANCH | string | | Branch to be cloned from bci-tests. Used by `bci_prepare.pm`.
 BCI_TIMEOUT | string | | Timeout given to the command to test each environment. Used by `bci_test.pm`.


### PR DESCRIPTION
Adds the ability to not schedule any BCI test runs when BCI_TEST_ENVS is set to a minus sign (`-`). The minus sign marks a explicit signal to skip the test runs, as opposed to an empty string, which could also mean that the variable has been forgotten.


https://progress.opensuse.org/issues/120094
- Verification run: [With BCI test runs](https://duck-norris.qam.suse.de/tests/11150) | [With no BCI test runs](https://duck-norris.qam.suse.de/tests/11151)
