### PR TITLE
Modify existing default yaml file for x86_64 64bit offline in YaST group

### DIFF
--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -8,27 +8,11 @@ vars:
   RAIDLEVEL:  '0'
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/skip_registration
-  - installation/module_selection/skip_module_selection
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/select_role_text_mode
-  - installation/partitioning/raid_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
+  registration:
+    - installation/registration/skip_registration
+  system_role:
+    - installation/system_role/select_role_text_mode
+  suggested_partitioning:
+    - installation/partitioning/raid_gpt
 test_data:
   <<: !include test_data/yast/raid/raid0_gpt_bios_boot.yaml

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -6,31 +6,21 @@ description: >
   Scenario is thought to use Online medium to boot
   and Full medium for remote repositories.
 vars:
-  DESKTOP: gnome
   NETBOOT: 1
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/validation/validate_install_repo
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/skip_registration
-  - installation/module_selection/select_module_desktop
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/validate_mirror_repos
+  access_beta:
+    - installation/access_beta_distribution
+  product_selection:
+    - installation/validation/validate_install_repo
+    - installation/product_selection/install_SLES
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_mirror_repos

--- a/schedule/yast/releasenotes_origin+unregistered_x86_64.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered_x86_64.yaml
@@ -1,0 +1,20 @@
+---
+name: releasenotes_origin+unregistered
+description: >
+  Test fate#323273 - Check the origin (rpm or url) of the showed release notes.
+vars:
+  YUI_REST_API: 1
+schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_module_desktop
+  system_role:
+    - installation/release_notes_from_url
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  installation:
+    - installation/confirm_installation
+  installation_logs: []
+  confirm_reboot: []
+  grub: []
+  first_login: []

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration_x86_64.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration_x86_64.yaml
@@ -1,0 +1,38 @@
+---
+name: select_modules_and_patterns+registration
+description: >
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
+     2. Yast patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  YUI_REST_API: 1
+schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_nonconflicting_modules
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  software:
+    - installation/select_visible_patterns_from_bottom
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_installed_packages
+    - console/validate_installed_patterns
+    - console/scc_cleanup_reregister
+    - console/install_packages_simple
+    - console/scc_deregistration
+    - console/firewalld_add_port
+    - console/setup_libyui_running_system
+    - x11/addon_products_via_SCC_yast2
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/yast/skip_registration/skip_registration_x86_64.yaml
+++ b/schedule/yast/skip_registration/skip_registration_x86_64.yaml
@@ -1,0 +1,24 @@
+---
+name:           skip_registration
+description:    >
+  Skipping registration for SLE 15, as requires network connection.
+  This is default behavior for SLE 12.
+vars:
+  YUI_REST_API: 1
+schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/yast/sle/flows/default_x86_64.yaml
+++ b/schedule/yast/sle/flows/default_x86_64.yaml
@@ -1,0 +1,48 @@
+---
+# Default ordered sequence of steps to be optionally overwritten for this product
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+access_beta:
+  - installation/access_beta_distribution
+product_selection:
+  - installation/product_selection/install_SLES
+license_agreement:
+  - installation/licensing/accept_license
+registration:
+  - installation/registration/register_via_scc
+extension_module_selection:
+  - installation/module_selection/skip_module_selection
+add_on_product:
+  - installation/add_on_product_installation/accept_add_on_installation
+add_on_product_installation: []
+system_role:
+  - installation/system_role/accept_selected_role_text_mode
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+security: []
+default_systemd_target: []
+installation_settings:
+  - installation/launch_installation
+installation:
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+installation_logs:
+  - installation/logs_from_installation_system
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+grub:
+  - installation/grub_test
+first_login:
+  - installation/first_boot
+system_preparation: []
+system_validation: []

--- a/schedule/yast/sle/usb_install_x86_64.yaml
+++ b/schedule/yast/sle/usb_install_x86_64.yaml
@@ -1,0 +1,18 @@
+---
+name: USBinstall
+description: >
+  Basic installation test with USB boot. Verification that usb repo is enabled
+  after first boot. Test covers both Online and Full medium installations.
+vars:
+  USBBOOT: 1
+  YUI_REST_API: 1
+schedule:
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/hostname
+    - console/force_scheduled_tasks
+  system_validation:
+    - console/enable_usb_repo
+    - console/zypper_lr

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role_x86_64.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role_x86_64.yaml
@@ -1,0 +1,30 @@
+---
+name:           textmode_installation_minimal_role
+description:    >
+  Full Medium installation that covers the following cases:
+    1. Installation in textmode;
+    2. "Minimal" role is selected;
+    3. Boot to command-line mode;
+    4. Installation is validated by default set of smoke tests.
+vars:
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/skip_module_registration
+  add_on_product:
+    - installation/add_on_product/skip_install_addons
+  system_role:
+    - installation/system_role/select_role_minimal
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - update/zypper_up
+    - console/zypper_lifecycle
+    - console/orphaned_packages_check
+    - console/consoletest_finish


### PR DESCRIPTION
We need to modify existing default yaml file for x86_64 64bit and adapt test suites to use it in YaST group.

This is the PR for the 'Flavor: Full' to make the review easier.

- Related ticket:  https://progress.opensuse.org/issues/119887
- Related MR:      https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/438/
- Needles: N/A
- Verification run:  [YaST_X86_64_Offline]( https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=hjluo%2Fos-autoinst-distri-opensuse%23x86_defaut)