### PR TITLE
Add 5.4 slem to know bug list

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -57,7 +57,7 @@
     "bsc#1126272": {
         "description": "Failed unmounting \/\\S+\\.|-- Reboot --|pam_systemd.*Failed to release session",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" , "5.4"],
             "leap-micro": [ "5.2", "5.3" ],
             "microos":  ["Tumbleweed"],
             "alp":  ["0.1", "0.1:S:A", "0.1:S:B"]
@@ -67,7 +67,7 @@
     "bsc#1022525|bsc#1177461": {
         "description": ".*rpcbind.*cannot(.*open file.*rpcbind.xdr.*|.*open file.*portmap.xdr.*|.*save any registration.*)",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" ],
             "leap-micro": ["5.2", "5.3"],
             "microos":  ["Tumbleweed"]
         },
@@ -319,7 +319,7 @@
     "health-check-typo": {
         "description": "health-checker/fail.sh check\" failed|Machine didn't come up correct, do a rollback",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" ],
             "leap-micro": ["5.2", "5.3"],
             "microos":  ["Tumbleweed"],
             "alp":  ["0.1", "0.1:S:A", "0.1:S:B"]
@@ -410,7 +410,7 @@
     "bsc#1200490": {
         "description": "Unable to open /dev/kvm: No such file or directory",
         "products": {
-            "sle-micro": ["5.2", "5.3"],
+            "sle-micro": ["5.2", "5.3", "5.4"],
             "leap-micro": ["5.3"]
         },
         "type": "ignore"


### PR DESCRIPTION
In the process of enabling slem 5.4 testing we need to add slem 5.4 in order to ignore expected issues

- ticket: [Setup IBS sync for slem5.4](https://progress.opensuse.org/issues/120600)
- Verification runs:
  * [sle-micro-5.4-Default-A-Staging-x86_64-Build4.3_1.3-sle-micro_update@64bit](http://kepler.suse.cz/tests/19635#)
  * [sle-micro-5.4-Default-B-Staging-x86_64-Build8.2_1.1-sle-micro_update@64bit](http://kepler.suse.cz/tests/19634#)
