### PR TITLE
Enhance log collections

### DIFF
--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -310,7 +310,7 @@
         <source><![CDATA[
 cat >> /etc/libvirt/libvirtd.conf<< EOF
 log_level = 1
-log_filters="1:qemu 3:remote 4:event 3:util.json 3:rpc"
+log_filters="1:qemu 1:libxl 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci"
 log_outputs="1:file:/var/log/libvirt/libvirtd.log"
 EOF
 if [ -e /etc/xen/xl.conf ]; then sed -i '/autoballoon=/ s/.*/autoballoon="off"/' /etc/xen/xl.conf; fi

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -274,7 +274,7 @@
         <source><![CDATA[
 cat >> /etc/libvirt/libvirtd.conf<< EOF
 log_level = 1
-log_filters="1:qemu 3:remote 4:event 3:util.json 3:rpc"
+log_filters="1:qemu 1:libxl 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci"
 log_outputs="1:file:/var/log/libvirt/libvirtd.log"
 EOF
 cp /usr/lib/systemd/network/99-default.link  /etc/systemd/network/99-default.link

--- a/schedule/qam/common/virt/qam_virt_tests.yaml
+++ b/schedule/qam/common/virt/qam_virt_tests.yaml
@@ -4,6 +4,7 @@ description:    >
     Tests for virtualization tests
 schedule:
   - console/login
+  - virt_autotest/cleanup_libvirtd_log
   - '{{qam_tests}}'
   - virtualization/universal/finish
 conditional_schedule:

--- a/tests/virt_autotest/cleanup_libvirtd_log.pm
+++ b/tests/virt_autotest/cleanup_libvirtd_log.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Cleanup libvirtd log before test.
+# Maintainer: qe-virt@suse.de
+package cleanup_libvirtd_log;
+
+use strict;
+use warnings;
+use base "virt_autotest_base";
+use testapi;
+
+sub run {
+    # Cleanup libvirtd.log
+    my $libvirtd_log_file = "/var/log/libvirt/libvirtd.log";
+    if (script_run("test -f $libvirtd_log_file") == 0) {
+        script_run("echo '' > $libvirtd_log_file");
+        record_info "Set file $libvirtd_log_file empty before every test.";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/virtualization/universal/finish.pm
+++ b/tests/virtualization/universal/finish.pm
@@ -26,8 +26,6 @@ sub run {
     # Show all guests
     assert_script_run 'virsh list --all';
     script_run 'history -a';
-
-    collect_virt_system_logs();
 }
 
 1;


### PR DESCRIPTION
poo#https://progress.opensuse.org/issues/118816
Enhance log collections

1. Keep libvirt log level = 1
2. Add a new module to clear libvirtd.log before every test.
3. If job doesn't fail, don't collect virt system logs in module finish.
4. Next step, if need, will add virt system logs function in some modules. In order to collect virt logs when jobs failed on the module. 


- Related ticket: [poo#118816](https://progress.opensuse.org/issues/118816)
- Needles: n/a
- Verification run: [12sp4](http://openqa.qam.suse.cz/tests/overview?distri=sle&version=12-SP4&build=:S:M:27236:286760:cailf_test:horror) [15sp4](http://openqa.qam.suse.cz/tests/overview?distri=sle&version=15-SP4&build=:S:M:27142:286552:cailftest:zoe:kvm)
