### PR TITLE
Leave 'post_fail_hook' early if 'NOLOGS' is set

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -802,6 +802,7 @@ Run post_fail_hook and upload audit logs
 sub post_fail_hook {
     my ($self) = shift;
 
+    return if get_var('NOLOGS');
     # Exit x11 and turn to console in case
     send_key("alt-f4");
     select_console("root-console");

--- a/lib/bootbasetest.pm
+++ b/lib/bootbasetest.pm
@@ -27,6 +27,7 @@ sub post_fail_hook {
 
     # crosscheck for text login on tty1
     select_console 'root-console';
+    return if get_var('NOLOGS');
     # call parent's post fail hook
     $self->SUPER::post_fail_hook;
 

--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -116,6 +116,7 @@ sub cron_mock_lastrun {
 
 sub post_fail_hook {
     my ($self) = shift;
+    return if get_var('NOLOGS');
     select_console('log-console');
     $self->SUPER::post_fail_hook;
 

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -48,6 +48,7 @@ Method executed when run() finishes and the module has result => 'fail'
 
 sub post_fail_hook {
     my ($self) = @_;
+    return if get_var('NOLOGS');
     record_avc_selinux_alerts();
     $self->SUPER::post_fail_hook;
     # at this point the instance is shutdown

--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -87,6 +87,7 @@ sub get_keystroke_list {
 # see https://progress.opensuse.org/issues/56636
 sub post_fail_hook {
     my ($self) = shift;
+    return if get_var('NOLOGS');
     select_console('log-console');
     $self->SUPER::post_fail_hook;
 }

--- a/lib/networkdbase.pm
+++ b/lib/networkdbase.pm
@@ -177,6 +177,7 @@ Upload the logs of all known containers.
 
 sub post_fail_hook {
     my ($self) = shift;
+    return if get_var('NOLOGS');
     select_console('log-console');
 
     my $machines = script_output("machinectl --no-legend --no-pager | cut -d ' ' -f 1");

--- a/lib/rear.pm
+++ b/lib/rear.pm
@@ -52,6 +52,7 @@ sub upload_rear_logs {
 sub post_fail_hook {
     my ($self) = @_;
 
+    return if get_var('NOLOGS');
     # We need to be sure that *ALL* consoles are closed, are SUPER:post_fail_hook
     # does not support virtio/serial console yet
     reset_consoles;

--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -126,6 +126,7 @@ Method executed when run() finishes and the module has result => 'fail'
 
 sub post_fail_hook {
     my ($self) = shift;
+    return if get_var('NOLOGS');
     select_console('log-console');
 
     # fetch Salt specific logs

--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -161,6 +161,7 @@ sub upload_widgets_json {
 
 sub post_fail_hook {
     my $self = shift;
+    return if get_var('NOLOGS');
     upload_widgets_json();
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/120729

For some reason, somebody might not want to collect logs, but still run the post_fail_hooks, and we only have that for opensusebasetest but not for subclasses of it
This will help to run the post_fail_hooks of specific test modules that are also calling $self->SUPER::post_fail_hook where collecting those extra logs isn't really necessary


- Related ticket: https://progress.opensuse.org/issues/120729
- Verification run: n/a
