### PR TITLE
Disable grub timeout for LTP testing

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -626,8 +626,9 @@ sub load_jeos_tests {
     #    loadtest "jeos/image_info";
     loadtest "jeos/record_machine_id";
     loadtest "console/force_scheduled_tasks";
+    # this test case also disables grub timeout
+    loadtest "jeos/grub2_gfxmode";
     unless (get_var('INSTALL_LTP') || get_var('SYSTEMD_TESTSUITE')) {
-        loadtest "jeos/grub2_gfxmode";
         loadtest "jeos/diskusage" unless is_openstack;
         loadtest "jeos/build_key";
         loadtest "console/prjconf_excluded_rpms";


### PR DESCRIPTION
[patch_and_reboot](https://openqa.suse.de/tests/10021250#step/patch_and_reboot/269) often fails to match grub screen after applying updates. In general, test suites are configured to disable grub's timeout in most of the scenarios. LTP test suites were missing this module that modifies grub in JeOS testing.

- ticket: [[qac][jeos][sporadic] test fails in patch_and_reboot as the system correctly boots but the test expects the grub screen auto_review:"(?s)jeos.*patch_and_reboot.*Stall detected.*no candidate needle with tag.*grub2.*matched":retry""](https://progress.opensuse.org/issues/113429)

- Verification run: [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20221122-1-jeos-ltp-cve@64bit-virtio-vga](http://kepler.suse.cz/tests/19636#step/patch_and_reboot/265)
