### PR TITLE
Add milestone for 'add_phub_extension'

### DIFF
--- a/tests/console/add_phub_extension.pm
+++ b/tests/console/add_phub_extension.pm
@@ -19,4 +19,10 @@ sub run {
     add_suseconnect_product(get_addon_fullname('phub'));
 }
 
+# Add milestone flag to save setup into the snapshot which
+# packagehub is activated
+sub test_flags {
+    return {milestone => 1};
+}
+
 1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/120393

Add milestone flag to save setup into the snapshot which 'packagehub' is activated, then all dependent jobs can re-use it

- Related ticket: https://progress.opensuse.org/issues/120393
- Verification run: https://openqa.suse.de/tests/10027279 [we can see even test `python_flake8` failed, the test `vmstat` can   roll back to new snapshot and pass]