### PR TITLE
Adapt default+schedule for YaST cases for x86_64 online part1

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings_x86_64.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_x86_64.yaml
@@ -1,0 +1,24 @@
+---
+name: btrfs+warnings
+description: >
+  Test suite verifies variety of warning which are expected to be shown when
+  something is missing during manual partitioning using Expert Partitioner.
+  Following warning are verified:
+    - Missing root partition;
+    - Minimal size for the root with btrfs and snapshots
+    - Missing boot partition (bios boot,/boot/zipl/,EFI, prep-boot).
+vars:
+  FILESYSTEM: btrfs
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/warning/no_root
+    - installation/partitioning/warning/snapshots_small_root
+    - installation/partitioning/warning/no_boot
+    - installation/partitioning/warning/boot_small_for_kernel
+    - installation/partitioning/warning/bios_boot_small_for_bootloader
+    - installation/partitioning/warning/prep_small
+    - installation/partitioning/warning/zipl_small
+    - installation/partitioning/warning/rootfs_small
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -12,34 +12,21 @@ vars:
   SCC_ADDONS: base,serverapp,desktop
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product_installation/add_additional_products
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - console/validate_dud_addon_repos
-  - console/orphaned_packages_check
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  add_on_product:
+    - installation/add_on_product_installation/add_additional_products
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - console/validate_dud_addon_repos
+    - console/orphaned_packages_check
 test_data:
   dud_repos:
     # repos here should correspond with repos in 'data/add_on_products.xml'

--- a/schedule/yast/encryption/crypt_no_lvm_x86_64.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_x86_64.yaml
@@ -1,26 +1,24 @@
 ---
-name: cryptlvm_iscsi
+name: crypt_no_lvm
 description: >
-  Conducts installation on iSCSI device relying on iBFT with encrypted LVM.
+  Test installation with encrypted partitions but without lvm enabled.
+  This is supported only by storage-ng, hence, do NOT enable test suite on
+  distris without storage-ng.
+  Encrypted installations can take longer, especially on non-x86_64
+  architectures.
 vars:
-  DESKTOP: gnome
   ENCRYPT: 1
-  IBFT: 1
-  LVM: 1
-  NBF: iqn.2016-02.openqa.de:for.openqa
-  NICTYPE: user
+  LVM: 0
+  MAX_JOB_TIME: 14400
   YUI_REST_API: 1
 schedule:
-  disk_activation:
-    - installation/iscsi_configuration
   extension_module_selection:
     - installation/module_registration/register_module_desktop
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   guided_partitioning:
     - installation/partitioning/select_guided_setup
-    - installation/partitioning/guided_setup/select_disks
-    - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
+    - installation/partitioning/guided_setup/encrypt_simple_pwd
     - installation/partitioning/guided_setup/accept_default_fs_options
   default_systemd_target:
     - installation/installation_settings/validate_default_target
@@ -29,16 +27,7 @@ schedule:
     - installation/first_boot
   system_preparation:
     - console/system_prepare
-    - console/hostname
-    - console/force_scheduled_tasks
   system_validation:
-    - installation/validation/ibft
-    - console/validate_lvm
     - console/validate_encrypt
 test_data:
-  guided_partitioning:
-    disks:
-      - sda
-  crypttab:
-    num_devices_encrypted: 1
-  <<: !include test_data/yast/encryption/default_enc.yaml
+  <<: !include test_data/yast/encryption/encrypt_no_lvm.yaml

--- a/schedule/yast/encryption/cryptlvm_sle_15_x86_64.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_x86_64.yaml
@@ -1,25 +1,18 @@
 ---
-name: cryptlvm_iscsi
 description: >
-  Conducts installation on iSCSI device relying on iBFT with encrypted LVM.
+  Conduct installation with encrypted LVM selected during installation.
+  Generated disk image used in downstream jobs. (crypt-)LVM installations can
+  take longer, especially on non-x86_64 architectures.
+name: cryptlvm
 vars:
-  DESKTOP: gnome
-  ENCRYPT: 1
-  IBFT: 1
-  LVM: 1
-  NBF: iqn.2016-02.openqa.de:for.openqa
-  NICTYPE: user
   YUI_REST_API: 1
 schedule:
-  disk_activation:
-    - installation/iscsi_configuration
   extension_module_selection:
     - installation/module_registration/register_module_desktop
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   guided_partitioning:
     - installation/partitioning/select_guided_setup
-    - installation/partitioning/guided_setup/select_disks
     - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
     - installation/partitioning/guided_setup/accept_default_fs_options
   default_systemd_target:
@@ -27,18 +20,10 @@ schedule:
   first_login:
     - installation/boot_encrypt
     - installation/first_boot
-  system_preparation:
-    - console/system_prepare
-    - console/hostname
-    - console/force_scheduled_tasks
   system_validation:
-    - installation/validation/ibft
     - console/validate_lvm
     - console/validate_encrypt
-test_data:
-  guided_partitioning:
-    disks:
-      - sda
-  crypttab:
-    num_devices_encrypted: 1
-  <<: !include test_data/yast/encryption/default_enc.yaml
+    - console/zypper_lr
+    - console/yast2_i
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -5,32 +5,18 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/edit_proposal_encrypt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/boot_encrypt
-  - installation/first_boot
-  - console/system_prepare
-  - console/verify_separate_home
-  - console/validate_encrypt
+  suggested_partitioning:
+    - installation/partitioning/edit_proposal_encrypt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/verify_separate_home
+    - console/validate_encrypt
 test_data:
   crypttab:
     num_devices_encrypted: 1

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_x86_64.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_x86_64.yaml
@@ -1,0 +1,30 @@
+---
+name: lvm-encrypt-separate-boot
+description: >
+  Same as lvm-full-encrypt, but with separate boot not encrypted partition, only
+  installation to not repeat everything again with small risk.
+vars:
+  UNENCRYPTED_BOOT: 1
+  ENCRYPT: 1
+  FULL_LVM_ENCRYPT: 1
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/encryption/lvm_full_encrypt_x86_64.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_x86_64.yaml
@@ -1,0 +1,28 @@
+---
+name: lvm-full-encrypt
+description: >
+  Installation with encrypted root and swap logical volumes and encrypted
+  boot partition outside of volume group as plain partition.
+  Partitioning is validated in the booted system after the installation,
+  including check for separate boot partition.
+vars:
+  ENCRYPT: 1
+  FULL_LVM_ENCRYPT: 1
+  MAX_JOB_TIME: '14400'
+  YUI_REST_API: 1
+schedule:
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -8,29 +8,12 @@ vars:
   YUI_REST_API: 1
   DESKTOP: textmode
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/select_role_text_mode
-  - installation/partitioning/new_partitioning_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/validate_fstab
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_fstab
 test_data:
   disks:
     - name: vda

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -5,32 +5,18 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/change_desktop
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/hostname
-  - console/validate_partition_table_via_blkid
-  - console/validate_blockdevices
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  software:
+    - installation/change_desktop
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/hostname
+    - console/validate_partition_table_via_blkid
+    - console/validate_blockdevices
 test_data:
   disks:
   - name: vda

--- a/schedule/yast/installer_extended/installer_extended_x86_64.yaml
+++ b/schedule/yast/installer_extended/installer_extended_x86_64.yaml
@@ -1,0 +1,91 @@
+---
+name: installer_extended
+description: >
+  Test suite performs additional UI checks. As of now following is tested:
+     - Switch keyboard layout and test it (only when is not VNC installation)
+     - License has to be accepted and there is pop-up with a hint.
+     - License translations (except SLE 15 due to missing translations in the
+       beta phase).
+     - Check available and selected by default modules for installation.
+vars:
+  CHECK_PRESELECTED_MODULES: '1'
+  CHECK_RELEASENOTES: '1'
+  EXIT_AFTER_START_INSTALL: '1'
+  EXTRABOOTPARAMS: Y2STRICTTEXTDOMAIN=1
+  YUI_REST_API: 1
+schedule:
+  bootloader:
+    - installation/isosize
+    - installation/data_integrity
+    - installation/bootloader_start
+  product_selection:
+    - installation/language_keyboard/switch_keyboard_layout
+    - installation/product_selection/install_SLES
+  license_agreement:
+    - installation/licensing/verify_license_translations
+    - installation/licensing/verify_license_has_to_be_accepted
+    - installation/licensing/accept_license
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/verify_module_registration
+    - installation/module_registration/skip_module_registration
+  clock_and_timezone:
+    - installation/releasenotes
+    - installation/clock_and_timezone/accept_timezone_configuration
+  local_user:
+  - installation/authentication/default_user_simple_pwd
+  - installation/authentication/root_simple_pwd
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  installation_logs: []
+  grub: []
+  first_login: []
+test_data:
+  license:
+    language: English (US)
+    translations:
+      - language: Czech
+        text: Licenční smlouva s koncovým uživatelem
+      - language: English (US)
+        text: End User License Agreement for SUSE Products
+      - language: French
+        text: Contrat de licence utilisateur final
+      - language: German
+        text: Endbenutzer-Lizenzvereinbarung
+      - language: Italian
+        text: Contratto di licenza
+      - language: Japanese
+        text: エンドユーザ使用許諾契約
+      - language: Korean
+        text: SUSE 제품에 관한
+      - language: Portuguese (Brazilian)
+        text: Contrato de Licença para Usuário Final
+      - language: Russian
+        text: Лицензионное соглашение
+      - language: Simplified Chinese
+        text: SUSE 产品
+      - language: Spanish
+        text: Acuerdo de licencia de usuario final
+      - language: Traditional Chinese
+        text: 最終使用者授權合約
+  beta_text: 'You are accessing our Beta Distribution'
+  modules:
+    - sle-ha
+    - sle-module-live-patching
+    - sle-we
+    - sle-module-basesystem
+    - sle-module-certifications
+    - sle-module-containers
+    - sle-module-desktop-applications
+    - sle-module-development-tools
+    - sle-module-legacy
+    - sle-module-public-cloud
+    - sle-module-NVIDIA-compute
+    - sle-module-python3
+    - PackageHub
+    - sle-module-server-applications
+    - sle-module-transactional-server
+    - sle-module-web-scripting
+  registered_modules:
+    - sle-module-basesystem
+    - sle-module-server-applications

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -9,33 +9,21 @@ vars:
   NICTYPE: user
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/iscsi_configuration
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning
-  - installation/partitioning_iscsi
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/system_prepare
-  - console/hostname
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - installation/validation/ibft
+  disk_activation:
+    - installation/iscsi_configuration
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning_iscsi
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/hostname
+    - console/force_scheduled_tasks
+  system_validation:
+    - shutdown/grub_set_bootargs
+    - installation/validation/ibft

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_x86_64.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_x86_64.yaml
@@ -1,0 +1,30 @@
+---
+description: >
+  Test suite cancels encrypted partitions activation and performs installation
+  with unencrypted lvm.
+name: lvm+cancel_existing_cryptlvm
+vars:
+  LVM: 1
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+    - installation/system_probing/cancel_encrypted_volume
+    - console/validate_encrypted_partition_not_activated
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/lvm_ignore_existing
+    - installation/partitioning/accept_proposed_layout
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/system_prepare
+    - console/force_scheduled_tasks
+  system_validation:
+    - console/validate_lvm
+test_data:
+  enc_disk_part: vda2

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -9,38 +9,23 @@ vars:
   HDDSIZEGB: 50
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup/enable_lvm
-  - installation/partitioning/guided_setup/do_not_propose_separate_home
-  - installation/partitioning/resize_existing_lv
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/system_prepare
-  - console/check_network
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - locale/keymap_or_locale
-  - console/consoletest_finish
-  - console/validate_modify_existing_partition
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/enable_lvm
+    - installation/partitioning/guided_setup/do_not_propose_separate_home
+    - installation/partitioning/resize_existing_lv
+  suggested_partitioning: []
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/check_network
+    - console/prepare_test_data
+    - console/consoletest_setup
+  system_validation:
+    - locale/keymap_or_locale
+    - console/consoletest_finish
+    - console/validate_modify_existing_partition
 test_data:
   volume_groups:
     - name: system

--- a/schedule/yast/lvm/lvm_sle_x86_64.yaml
+++ b/schedule/yast/lvm/lvm_sle_x86_64.yaml
@@ -1,0 +1,27 @@
+---
+description: >
+  Conduct installation with LVM selected during installation using guided setup.
+  In comparison to SLE 12 we register the installation and have system roles
+  wizard screen.
+name: cryptlvm
+vars:
+  DESKTOP: textmode
+  LVM: '1'
+  MAX_JOB_TIME: '14400'
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  YUI_REST_API: 1
+schedule:
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/enable_lvm
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/validate_lvm
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/zypper_in
+    - console/firewall_enabled

--- a/schedule/yast/lvm/lvm_thin_provisioning_x86_64.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning_x86_64.yaml
@@ -1,0 +1,25 @@
+---
+name: lvm_thin_provisioning
+description: >
+  Complete OS deployment with unencrypted LVM drive management. Test creates
+  2 LVM and BIOS boot partitions. Thin pool and thin lv reside on the second
+  LVM partition, where /home (XFS) is being mounted. Partitioning is validated
+  in the booted system after the installation.
+vars:
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  expert_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/hostname
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/lvm_thin_check

--- a/schedule/yast/lvm_multipath_encrypted_x86_64.yaml
+++ b/schedule/yast/lvm_multipath_encrypted_x86_64.yaml
@@ -1,0 +1,51 @@
+---
+name:           lvm_multipath_encrypted
+description:    >
+  Textmode installation test for encrypted lvm partitioning on multipath with lvm and encryption validation.
+vars:
+  DESKTOP: textmode
+  MULTIPATH: 1
+  LVM: 1
+  ENCRYPT: 1
+  SEPARATE_HOME: 0
+  HDDMODEL: scsi-hd
+  YUI_REST_API: 1
+schedule:
+  multipath:
+    - installation/multipath
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+  system_validation:
+    - console/validate_multipath
+    - console/validate_lvm
+    - console/validate_encrypt
+    - console/consoletest_finish
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  cryptsetup:
+    device_status:
+      message: is active and is in use.
+      properties:
+        type: LUKS1
+        cipher: aes-xts-plain64
+        device: /dev/mapper/0QEMU_QEMU_HARDDISK_hd0-part2
+        key_location: dm-crypt
+        mode: read/write
+  backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
+  backup_path: '/root/bkp_luks_header_cr_home'
+  <<: !include test_data/yast/multipath.yaml

--- a/schedule/yast/lvm_multipath_x86_64.yaml
+++ b/schedule/yast/lvm_multipath_x86_64.yaml
@@ -1,0 +1,32 @@
+---
+name:           lvm_multipath
+description:    >
+  Textmode installation test for lvm partitioning with no spearate home, on multipath with lvm validation.
+vars:
+  DESKTOP: textmode
+  MULTIPATH: 1
+  LVM: 1
+  SEPARATE_HOME: 0
+  HDDMODEL: scsi-hd
+  YUI_REST_API: 1
+schedule:
+  multipath:
+    - installation/multipath
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/enable_lvm
+    - installation/partitioning/guided_setup/do_not_propose_separate_home
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+  system_validation:
+    - console/validate_multipath
+    - console/validate_lvm
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown
+test_data:
+  <<: !include test_data/yast/multipath.yaml

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_x86_64.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_x86_64.yaml
@@ -1,0 +1,18 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/setup_raid1_lvm
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_lvm_raid1
+test_data:
+  <<: !include test_data/yast/lvm_raid1/lvm+raid1.yaml

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -10,28 +10,15 @@ vars:
   VALIDATE_INST_SRC: '1'
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/validation/repo_inst
-  - installation/validation/validate_install_repo
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/validate_mirror_repos
+  product_selection:
+    - installation/validation/repo_inst
+    - installation/validation/validate_install_repo
+    - installation/product_selection/install_SLES
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_mirror_repos

--- a/schedule/yast/sle/flows/default_x86_64.yaml
+++ b/schedule/yast/sle/flows/default_x86_64.yaml
@@ -10,17 +10,20 @@ product_selection:
   - installation/product_selection/install_SLES
 license_agreement:
   - installation/licensing/accept_license
+disk_activation: []
 registration:
   - installation/registration/register_via_scc
 extension_module_selection:
   - installation/module_registration/skip_module_registration
 additional_products: []
+multipath: []
 add_on_product:
   - installation/add_on_product/skip_install_addons
 add_on_product_installation: []
 system_role:
   - installation/system_role/accept_selected_role_text_mode
 guided_partitioning: []
+expert_partitioning: []
 suggested_partitioning:
   - installation/partitioning/accept_proposed_layout
 clock_and_timezone:

--- a/schedule/yast/ssh_keys/do_not_import_ssh_keys.yaml
+++ b/schedule/yast/ssh_keys/do_not_import_ssh_keys.yaml
@@ -7,30 +7,18 @@ vars:
   ADDONS: all-packages
   YUI_REST_API: 1
 schedule:
-  - boot/boot_to_desktop
-  - x11/ssh_key_check
-  - x11/reboot_and_install
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/ssh_host_key_settings/do_not_import_ssh_host_keys
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/reboot_after_installation
-  - installation/grub_test
-  - installation/first_boot
-  - installation/ssh_host_key_settings/verify_ssh_key_not_imported
-  - shutdown/shutdown
+  bootloader:
+    - boot/boot_to_desktop
+    - x11/ssh_key_check
+    - x11/reboot_and_install
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  security:
+    - installation/ssh_host_key_settings/do_not_import_ssh_host_keys
+  system_validation:
+    - installation/ssh_host_key_settings/verify_ssh_key_not_imported
+    - shutdown/shutdown

--- a/schedule/yast/ssh_keys/import_ssh_keys.yaml
+++ b/schedule/yast/ssh_keys/import_ssh_keys.yaml
@@ -7,30 +7,19 @@ vars:
   ADDONS: all-packages
   YUI_REST_API: 1
 schedule:
-  - boot/boot_to_desktop
-  - x11/ssh_key_check
-  - x11/reboot_and_install
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/ssh_host_key_settings/import_ssh_host_keys
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/reboot_after_installation
-  - installation/grub_test
-  - installation/first_boot
-  - installation/ssh_host_key_settings/verify_ssh_key_imported
-  - shutdown/shutdown
+  bootloader:
+    - boot/boot_to_desktop
+    - x11/ssh_key_check
+    - x11/reboot_and_install
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  installation_settings:
+    - installation/ssh_host_key_settings/import_ssh_host_keys
+    - installation/launch_installation
+  system_validation:
+    - installation/ssh_host_key_settings/verify_ssh_key_imported
+    - shutdown/shutdown


### PR DESCRIPTION
Adapt default+schedule for YaST online cases for x86_64 part 1.

- Related ticket:  https://progress.opensuse.org/issues/119887
- Related MR:  https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/450
- Needles: N/A
- Verification run:  [YaST_Online_Part1](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=hjluo%2Fos-autoinst-distri-opensuse%23x86_def_online_p1)
