### PR TITLE
Move logging subroutines from opensusebasetest

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -1,4 +1,4 @@
-# Copyright 2022 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 =head1 Utils::Logging
@@ -13,9 +13,68 @@ use base 'Exporter';
 use Exporter;
 use strict;
 use warnings;
-use Mojo::File qw(path);
+use testapi;
+use utils qw(clear_console show_oom_info remount_tmp_if_ro detect_bsc_1063638);
+use Utils::Systemd 'get_started_systemd_services';
+use Mojo::File 'path';
 
-our @EXPORT = qw(save_ulog);
+our @EXPORT = qw(
+  save_and_upload_log
+  tar_and_upload_log
+  save_and_upload_systemd_unit_log
+  save_ulog
+  export_healthcheck_basic
+  select_log_console
+  upload_coredumps
+  export_logs
+  problem_detection
+  upload_solvertestcase_logs
+  export_logs_basic
+  export_logs_desktop
+);
+
+=head2 save_and_upload_log
+
+ save_and_upload_log($cmd, $file [, timeout => $timeout] [, screenshot => $screenshot] [, noupload => $noupload]);
+
+Will run C<$cmd> on the SUT (without caring for the return code) and tee the standard output to a file called C<$file>.
+The C<$timeout> parameter specifies how long C<$cmd> may run.
+When C<$cmd> returns, the output file will be uploaded to openQA unless C<$noupload> is set.
+Afterwards a screenshot will be created if C<$screenshot> is set.
+=cut
+
+sub save_and_upload_log {
+    my ($cmd, $file, $args) = @_;
+    script_run("$cmd | tee $file", $args->{timeout});
+    my $lname = $args->{logname} ? $args->{logname} : '';
+    upload_logs($file, failok => 1, log_name => $lname) unless $args->{noupload};
+    save_screenshot if $args->{screenshot};
+}
+
+=head2 tar_and_upload_log
+
+ tar_and_upload_log($sources, $dest, [, timeout => $timeout] [, screenshot => $screenshot] [, noupload => $noupload]);
+
+Will create an xz compressed tar archive with filename C<$dest> from the folder(s) listed in C<$sources>.
+The return code of C<tar> will be ignored.
+The C<$timeout> parameter specifies how long C<tar> may run.
+When C<tar> returns, the output file will be uploaded to openQA unless C<$noupload> is set.
+Afterwards a screenshot will be created if C<$screenshot> is set.
+
+=cut
+
+sub tar_and_upload_log {
+    my ($sources, $dest, $args) = @_;
+    script_run("tar -jcv -f $dest $sources", $args->{timeout});
+    upload_logs($dest, failok => 1) unless $args->{noupload};
+    save_screenshot() if $args->{screenshot};
+}
+
+=head2 save_and_upload_systemd_unit_log
+
+ save_and_upload_systemd_unit_log($unit);
+
+Saves the journal of the systemd unit C<$unit> to C<journal_$unit.log> and uploads it to openQA.
 
 =head2
 
@@ -35,6 +94,276 @@ sub save_ulog {
     my ($out, $filename) = @_;
     mkdir('ulogs') if (!-d 'ulogs');
     path("ulogs/$filename")->spurt($out);    # save the logs to the ulogs directory on the worker directly
+}
+
+=head2 export_healthcheck_basic
+
+ export_healthcheck_basic();
+
+Upload healthcheck logs that make sense for any failure.
+This includes C<cpu>, C<memory> and C<fdisk>.
+
+=cut
+
+sub export_healthcheck_basic {
+
+    my $cmd = <<'EOF';
+health_log_file="/tmp/basic_health_check.txt"
+echo -e "free -h" > $health_log_file
+free -h >> $health_log_file
+echo -e "\nvmstat" >> $health_log_file
+vmstat >> $health_log_file
+echo -e "\nfdisk -l" >> $health_log_file
+fdisk -l >> $health_log_file
+echo -e "\ndh -h" >> $health_log_file
+df -h >> $health_log_file
+echo -e "\ndh -i" >> $health_log_file
+df -i >> $health_log_file
+echo -e "\nTop 10 CPU Processes" >> $health_log_file
+ps axwwo %cpu,pid,user,cmd | sort -k 1 -r -n | head -11 | sed -e '/^%/d' >> $health_log_file
+echo -e "\nTop 10 Memory Processes" >> $health_log_file
+ps axwwo %mem,pid,user,cmd | sort -k 1 -r -n | head -11 | sed -e '/^%/d' >> $health_log_file
+echo -e "\nALL Processes" >> $health_log_file
+ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd >> $health_log_file
+EOF
+    script_run($_) foreach (split /\n/, $cmd);
+    upload_logs "/tmp/basic_health_check.txt";
+
+}
+
+=head2 select_log_console
+
+ select_log_console();
+
+Select 'log-console' with higher timeout on screen check to even cover systems
+that react very slow due to high background load or high memory consumption.
+This should be especially useful in C<post_fail_hook> implementations.
+
+=cut
+
+sub select_log_console { select_console('log-console', timeout => 180, @_) }
+
+=head2 upload_coredumps
+
+ upload_coredumps(%args);
+
+Upload all coredumps to logs. In case `proceed_on_failure` key is set to true,
+errors during logs collection will be ignored, which is usefull for the
+post_fail_hook calls.
+=cut
+
+sub upload_coredumps {
+    my (%args) = @_;
+    my $res = script_run('coredumpctl --no-pager');
+    if (!$res) {
+        record_info("COREDUMPS found", "we found coredumps on SUT, attemp to upload");
+        script_run("coredumpctl info --no-pager | tee coredump-info.log");
+        upload_logs("coredump-info.log", failok => $args{proceed_on_failure});
+        my $basedir = '/var/lib/systemd/coredump/';
+        my @files = split("\n", script_output("\\ls -1 $basedir | cat", proceed_on_failure => $args{proceed_on_failure}));
+        foreach my $file (@files) {
+            upload_logs($basedir . $file, failok => $args{proceed_on_failure});
+        }
+    }
+}
+
+=head2 export_logs
+
+ export_logs();
+
+This method will call several other log gathering methods from this class.
+
+=cut
+
+sub export_logs {
+    select_log_console();
+    save_screenshot();
+    show_oom_info();
+    remount_tmp_if_ro();
+    export_logs_basic();
+    problem_detection();
+
+    # Just after the setup: let's see the network configuration
+    save_and_upload_log("ip addr show", "/tmp/ip-addr-show.log");
+    save_and_upload_log("cat /etc/resolv.conf", "/tmp/resolv-conf.log");
+
+    save_screenshot();
+
+    export_logs_desktop();
+
+    save_and_upload_log('systemctl list-unit-files', '/tmp/systemctl_unit-files.log');
+    save_and_upload_log('systemctl status', '/tmp/systemctl_status.log');
+    save_and_upload_log('systemctl', '/tmp/systemctl.log', {screenshot => 1});
+
+    if ($utils::IN_ZYPPER_CALL) {
+        upload_solvertestcase_logs();
+    }
+}
+
+=head2 problem_detection
+
+ problem_detection();
+
+This method will upload a number of logs and debugging information.
+This includes a log with all journal errors, a systemd unit plot and the
+output of rpmverify.
+The files will be uploaded as a single tarball called C<problem_detection_logs.tar.xz>.
+
+=cut
+
+sub problem_detection {
+    enter_cmd "pushd \$(mktemp -d)";
+    detect_bsc_1063638;
+    # Slowest services
+    save_and_upload_log("systemd-analyze blame", "systemd-analyze-blame.txt", {noupload => 1});
+    clear_console;
+
+    # Generate and upload SVG out of `systemd-analyze plot'
+    save_and_upload_log('systemd-analyze plot', "systemd-analyze-plot.svg", {noupload => 1});
+    clear_console;
+
+    # Failed system services
+    save_and_upload_log('systemctl --all --state=failed', "failed-system-services.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Unapplied configuration files
+    save_and_upload_log("find /* -name '*.rpmnew'", "unapplied-configuration-files.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Errors, warnings, exceptions, and crashes mentioned in dmesg
+    save_and_upload_log("dmesg | grep -i 'error\\|warn\\|exception\\|crash'", "dmesg-errors.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Errors in journal
+    save_and_upload_log("journalctl --no-pager -p 'err' -o short-precise", "journalctl-errors.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Tracebacks in journal
+    save_and_upload_log('journalctl -o short-precise | grep -i traceback', "journalctl-tracebacks.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Segmentation faults
+    save_and_upload_log("coredumpctl list", "segmentation-faults-list.txt", {screenshot => 1, noupload => 1});
+    save_and_upload_log("coredumpctl info", "segmentation-faults-info.txt", {screenshot => 1, noupload => 1});
+    # Save core dumps
+    enter_cmd "mkdir -p coredumps";
+    enter_cmd 'awk \'/Storage|Coredump/{printf("cp %s ./coredumps/\n",$2)}\' segmentation-faults-info.txt | sh';
+    clear_console;
+
+    # Broken links
+    save_and_upload_log(
+"find / -type d \\( -path /proc -o -path /run -o -path /.snapshots -o -path /var \\) -prune -o -xtype l -exec ls -l --color=always {} \\; -exec rpmquery -f {} \\;",
+        "broken-symlinks.txt",
+        {screenshot => 1, noupload => 1, timeout => 60});
+    clear_console;
+
+    # Binaries with missing libraries
+    save_and_upload_log("
+IFS=:
+for path in \$PATH; do
+    for bin in \$path/*; do
+        ldd \$bin 2> /dev/null | grep 'not found' && echo -n Affected binary: \$bin 'from ' && rpmquery -f \$bin
+    done
+done", "binaries-with-missing-libraries.txt", {timeout => 60, noupload => 1});
+    clear_console;
+
+    # rpmverify problems
+    save_and_upload_log("rpmverify -a | grep -v \"[S5T].* c \"", "rpmverify-problems.txt", {timeout => 1200, screenshot => 1, noupload => 1});
+    clear_console;
+
+    # VMware specific
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+        script_run('vm-support');
+        upload_logs('vm-*.*.tar.gz', failok => 1);
+        clear_console;
+    }
+
+    script_run 'tar cvvJf problem_detection_logs.tar.xz *';
+    upload_logs('problem_detection_logs.tar.xz', failok => 1);
+    enter_cmd "popd";
+}
+
+=head2 upload_solvertestcase_logs
+
+ upload_solvertestcase_logs();
+
+Upload C</tmp/solverTestCase.tar.bz2>.
+
+=cut
+
+sub upload_solvertestcase_logs {
+    my $ret = script_run("zypper -n patch --debug-solver --with-interactive -l");
+    # if zypper was not found, we just skip upload solverTestCase.tar.bz2
+    return if $ret != 0;
+    script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");
+    upload_logs "/tmp/solverTestCase.tar.bz2 ";
+}
+
+=head2 export_logs_basic
+
+ export_logs_basic();
+
+Upload logs that make sense for any failure.
+This includes C</proc/loadavg>, C<ps axf>, complete journal since last boot, C<dmesg> and C</etc/sysconfig>.
+
+=cut
+
+sub export_logs_basic {
+    save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg.txt', {screenshot => 1});
+    save_and_upload_log('ps axf', '/tmp/psaxf.log', {screenshot => 1});
+    save_and_upload_log('journalctl -b -o short-precise', '/tmp/journal.log', {screenshot => 1});
+    save_and_upload_log('dmesg', '/tmp/dmesg.log', {screenshot => 1});
+    tar_and_upload_log('/etc/sysconfig', '/tmp/sysconfig.tar.bz2');
+
+    for my $service (get_started_systemd_services()) {
+        save_and_upload_log("journalctl -b -u $service", "/tmp/journal_$service.log", {screenshot => 1});
+    }
+}
+
+=head2 export_logs_desktop
+
+ export_logs_desktop();
+
+Upload several KDE, GNOME, X11, GDM and SDDM related logs and configs.
+
+=cut
+
+sub export_logs_desktop {
+    select_log_console;
+    save_screenshot;
+
+    if (check_var("DESKTOP", "kde")) {
+        if (get_var('PLASMA5')) {
+            tar_and_upload_log("/home/$username/.config/*rc", '/tmp/plasma5_configs.tar.bz2');
+        }
+        else {
+            tar_and_upload_log("/home/$username/.kde4/share/config/*rc", '/tmp/kde4_configs.tar.bz2');
+        }
+        save_screenshot;
+    } elsif (check_var("DESKTOP", "gnome")) {
+        tar_and_upload_log("/home/$username/.cache/gdm", '/tmp/gdm.tar.bz2');
+    }
+
+    # check whether xorg logs exist in user's home, if yes, upload xorg logs
+    # from user's home instead of /var/log
+    my $log_path = '/home/*/.local/share/xorg/';
+    if (!script_run("test -d $log_path")) {
+        tar_and_upload_log("$log_path", '/tmp/Xlogs.users.tar.bz2', {screenshot => 1});
+    }
+    $log_path = '/var/log/X*';
+    if (!script_run("ls -l $log_path")) {
+        save_and_upload_log("cat $log_path", '/tmp/Xlogs.system.log', {screenshot => 1});
+    }
+
+    # do not upload empty .xsession-errors
+    $log_path = '/home/*/.xsession-errors*';
+    if (!script_run("ls -l $log_path")) {
+        save_and_upload_log("cat $log_path", '/tmp/xsession-errors.log', {screenshot => 1});
+    }
+    $log_path = '/home/*/.local/share/sddm/*session.log';
+    if (!script_run("ls -l $log_path")) {
+        save_and_upload_log("cat $log_path", '/tmp/sddm_session.log', {screenshot => 1});
+    }
 }
 
 1;

--- a/lib/bootbasetest.pm
+++ b/lib/bootbasetest.pm
@@ -27,8 +27,6 @@ sub post_fail_hook {
 
     # crosscheck for text login on tty1
     select_console 'root-console';
-    # collect and upload some stuff
-    $self->export_logs();
     # call parent's post fail hook
     $self->SUPER::post_fail_hook;
 

--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -120,7 +120,6 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 
     upload_logs('/var/log/snapper.log');
-    $self->export_logs;
 }
 
 1;

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -9,6 +9,7 @@ use warnings;
 use testapi;
 use known_bugs;
 use version_utils qw(is_public_cloud is_openstack);
+use Utils::Logging qw(export_logs_basic export_logs_desktop);
 use utils;
 
 my %avc_record = (
@@ -52,10 +53,10 @@ sub post_fail_hook {
     # at this point the instance is shutdown
     return if (is_public_cloud() || is_openstack());
     select_console('log-console');
-    $self->remount_tmp_if_ro;
-    $self->export_logs_basic;
+    remount_tmp_if_ro;
+    export_logs_basic;
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
-    $self->export_logs_desktop;
+    export_logs_desktop;
 }
 
 =head2 record_avc_selinux_alerts

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -18,6 +18,7 @@ use testapi;
 use lockapi;
 use isotovideo;
 use x11utils 'ensure_unlocked_desktop';
+use Utils::Logging 'export_logs';
 
 our @EXPORT = qw(
   $crm_mon_cmd
@@ -898,7 +899,7 @@ sub post_fail_hook {
 
     # Try to save logs as a last resort
     ha_export_logs;
-    $self->export_logs;
+    export_logs;
 }
 
 sub test_flags {

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -14,6 +14,7 @@ use utils;
 use Utils::Architectures;
 use version_utils 'is_sle';
 use lockapi;
+use Utils::Logging 'save_and_upload_log';
 
 =head2 enable_and_start
 
@@ -96,7 +97,7 @@ sub post_run_hook {
     select_console('log-console');
     my $hname = get_var('HOSTNAME', 'susetest');
     foreach (keys %log_files) {
-        $self->save_and_upload_log($log_files{$_}{cmd}, "/tmp/$hname-" . $log_files{$_}{logfile}, {screenshot => 1});
+        save_and_upload_log($log_files{$_}{cmd}, "/tmp/$hname-" . $log_files{$_}{logfile}, {screenshot => 1});
     }
     $self->upload_service_log("wicked");
     if ($hname =~ /master/) {

--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -89,7 +89,6 @@ sub post_fail_hook {
     my ($self) = shift;
     select_console('log-console');
     $self->SUPER::post_fail_hook;
-    $self->export_logs_basic;
 }
 
 1;

--- a/lib/rear.pm
+++ b/lib/rear.pm
@@ -11,6 +11,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Logging 'save_and_upload_log';
 
 our @EXPORT = qw(
   upload_rear_logs
@@ -40,7 +41,7 @@ sub upload_rear_logs {
     upload_logs('/etc/rear/local.conf', failok => 1);
 
     # List of block devices
-    $self->save_and_upload_log('lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,SIZE,MOUNTPOINT', '/tmp/lsblk.log');
+    save_and_upload_log('lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,SIZE,MOUNTPOINT', '/tmp/lsblk.log');
 
     # Create tarball with logfiles and upload it
     my $logfile = '/tmp/rear-recover-logs.tar.bz2';

--- a/lib/s390base.pm
+++ b/lib/s390base.pm
@@ -17,6 +17,7 @@ use testapi;
 use utils;
 use strict;
 use warnings;
+use Utils::Logging qw(tar_and_upload_log export_logs);
 
 =head2 execute_script
 
@@ -42,10 +43,10 @@ Collect and upload logs for investigation. cleanup test suite files.
 
 sub upload_logs_and_cleanup {
     my ($self) = @_;
-    $self->export_logs();
+    export_logs();
 
     my $test_name = get_var('IBM_TESTSET') . get_var('IBM_TESTS');
-    $self->tar_and_upload_log("/root/$test_name/logs/", "/tmp/$test_name.tar.bz2");
+    tar_and_upload_log("/root/$test_name/logs/", "/tmp/$test_name.tar.bz2");
 }
 
 =head2 post_fail_hook

--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -10,7 +10,7 @@ use warnings;
 use testapi;
 use known_bugs;
 
-use utils qw(zypper_call systemctl);
+use utils qw(zypper_call systemctl remount_tmp_if_ro);
 
 sub master_prepare {
     # Install the salt master
@@ -135,8 +135,7 @@ sub post_fail_hook {
     stop();
 
     $self->SUPER::post_fail_hook;
-    $self->remount_tmp_if_ro;
-    $self->export_logs_basic;
+    remount_tmp_if_ro;
 }
 
 1;

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -25,6 +25,7 @@ use registration qw(add_suseconnect_product);
 use version_utils qw(is_sle);
 use utils qw(zypper_call);
 use Utils::Systemd qw(systemctl);
+use Utils::Logging 'save_and_upload_log';
 
 our @EXPORT = qw(
   $instance_password
@@ -839,8 +840,8 @@ Upload NetWeaver installation logs from SUT.
 sub upload_nw_install_log {
     my ($self) = @_;
 
-    $self->save_and_upload_log('ls -alF /sapinst/unattended', '/tmp/nw_unattended_ls.log');
-    $self->save_and_upload_log('ls -alF /sbin/mount*', '/tmp/sbin_mount_ls.log');
+    save_and_upload_log('ls -alF /sapinst/unattended', '/tmp/nw_unattended_ls.log');
+    save_and_upload_log('ls -alF /sbin/mount*', '/tmp/sbin_mount_ls.log');
     upload_logs('/tmp/check-nw-media', failok => 1);
     upload_logs '/sapinst/unattended/sapinst.log';
     upload_logs('/sapinst/unattended/sapinst_ASCS.log', failok => 1);

--- a/lib/systemd_testsuite_test.pm
+++ b/lib/systemd_testsuite_test.pm
@@ -20,6 +20,7 @@ use power_action_utils 'power_action';
 use utils 'zypper_call';
 use version_utils qw(is_opensuse is_sle is_tumbleweed);
 use bootloader_setup qw(change_grub_config grub_mkconfig);
+use Utils::Logging qw(save_and_upload_log tar_and_upload_log);
 
 sub testsuiteinstall {
     my ($self) = @_;
@@ -123,9 +124,9 @@ sub testsuiteprepare {
 sub post_fail_hook {
     my ($self) = @_;
     #upload logs from given testname
-    $self->tar_and_upload_log('/usr/lib/systemd/tests/logs', '/tmp/systemd_testsuite-logs.tar.bz2');
-    $self->tar_and_upload_log('/var/log/journal /run/log/journal', 'binary-journal-log.tar.bz2');
-    $self->save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.txt');
+    tar_and_upload_log('/usr/lib/systemd/tests/logs', '/tmp/systemd_testsuite-logs.tar.bz2');
+    tar_and_upload_log('/var/log/journal /run/log/journal', 'binary-journal-log.tar.bz2');
+    save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.txt');
     upload_logs('/shutdown-log.txt', failok => 1);
 }
 

--- a/lib/y2_base.pm
+++ b/lib/y2_base.pm
@@ -24,6 +24,7 @@ use Mojo::JSON 'to_json';
 
 use YuiRestClient;
 use YuiRestClient::Logger;
+use Utils::Logging 'save_and_upload_log';
 
 =head1 y2_base
 
@@ -60,7 +61,7 @@ sub save_strace_gdb_output {
 
         my $opt = defined($is_yast_module) ? 'module' : 'installer';
         foreach (@procfs_files) {
-            $self->save_and_upload_log("cat /proc/$yast_pid/$_", "/tmp/yast2-$opt.$_");
+            save_and_upload_log("cat /proc/$yast_pid/$_", "/tmp/yast2-$opt.$_");
         }
         # We enable gdb differently in the installer and in the installed SUT
         my $system_management_locked;
@@ -103,8 +104,8 @@ sub save_system_logs {
     script_run('for run in {1..3}; do echo "RUN: $run"; vmstat; sleep 5; done | tee /tmp/cpu_mem_usage.log');
     upload_logs('/tmp/cpu_mem_usage.log', failok => 1);
 
-    $self->save_and_upload_log('pstree', '/tmp/pstree');
-    $self->save_and_upload_log('ps auxf', '/tmp/ps_auxf');
+    save_and_upload_log('pstree', '/tmp/pstree');
+    save_and_upload_log('ps auxf', '/tmp/ps_auxf');
 }
 
 sub save_upload_y2logs {

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -12,7 +12,7 @@ use Utils::Architectures;
 
 use version_utils qw(is_microos is_sle);
 use y2_logs_helper 'get_available_compression';
-use utils qw(type_string_slow zypper_call);
+use utils qw(type_string_slow zypper_call remount_tmp_if_ro detect_bsc_1063638);
 use lockapi;
 use mmapi;
 use Test::Assert 'assert_equals';
@@ -616,9 +616,9 @@ sub post_fail_hook {
         # error pop-up and system will reboot, so log collection will fail (see poo#61052)
         $self->SUPER::post_fail_hook unless get_var('AUTOYAST');
         get_to_console;
-        $self->detect_bsc_1063638;
+        detect_bsc_1063638;
         $self->get_ip_address;
-        $self->remount_tmp_if_ro;
+        remount_tmp_if_ro;
         # Avoid collectin logs twice when investigate_yast2_failure() is inteded to hard-fail
         $self->save_upload_y2logs unless get_var('ASSERT_Y2LOGS');
         return if is_microos;

--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -8,6 +8,7 @@ use network_utils;
 use utils 'zypper_call';
 use Exporter 'import';
 use Utils::Architectures;
+use Utils::Logging 'tar_and_upload_log';
 
 
 our @EXPORT_OK = qw(
@@ -184,7 +185,7 @@ sub upload_autoyast_schema {
     my $xml_schema_path = "/usr/share/YaST2/schema/autoyast/rng";
     # Upload schema files if directory exists
     if (script_run("test -e $xml_schema_path") == 0) {
-        $self->tar_and_upload_log("$xml_schema_path/*.rng", '/tmp/autoyast_schema.tar.bz2');
+        tar_and_upload_log("$xml_schema_path/*.rng", '/tmp/autoyast_schema.tar.bz2');
     }
 }
 

--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -19,7 +19,7 @@ use Exporter 'import';
 use strict;
 use warnings;
 use testapi;
-use utils 'show_tasks_in_blocked_state';
+use utils qw(show_tasks_in_blocked_state remount_tmp_if_ro);
 use version_utils qw(is_opensuse is_leap is_tumbleweed);
 
 our @EXPORT = qw(is_network_manager_default
@@ -119,7 +119,7 @@ sub post_fail_hook {
 
     show_tasks_in_blocked_state if ($defer_blocked_task_info);
 
-    $self->remount_tmp_if_ro;
+    remount_tmp_if_ro;
     $self->save_upload_y2logs();
     upload_logs('/var/log/zypper.log', failok => 1);
     $self->save_system_logs();

--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -11,6 +11,7 @@ use testapi;
 use utils;
 use version_utils;
 use YaST::workarounds;
+use Utils::Logging 'export_logs';
 
 =head2 y2snapper_select_current_conf
 
@@ -248,7 +249,7 @@ sub y2snapper_failure_analysis {
     my $additional_sleep_time = 10;
     sleep $additional_sleep_time;
 
-    $self->export_logs;
+    export_logs;
 
     # Upload y2log for analysis if yast2 snapper fails
     assert_script_run "save_y2logs /tmp/y2logs.tar.bz2";

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -22,6 +22,7 @@ use utils;
 use strict;
 use warnings;
 use x11utils 'ensure_unlocked_desktop';
+use Utils::Logging 'export_logs';
 
 sub run {
     my $self = shift;
@@ -64,7 +65,7 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
 
-    $self->export_logs();
+    export_logs();
 }
 
 sub test_flags {

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -23,6 +23,7 @@ use serial_terminal 'select_serial_terminal';
 use utils qw(check_console_font disable_serial_getty);
 use Utils::Backends qw(has_ttys);
 use Utils::Systemd qw(disable_and_stop_service systemctl);
+use Utils::Logging 'export_logs';
 use strict;
 use warnings;
 
@@ -78,7 +79,7 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
     select_console 'log-console', timeout => 180;
-    $self->export_logs();
+    export_logs();
     $self->export_logs_locale();
 }
 

--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -16,6 +16,7 @@ use base "consoletest";
 use testapi;
 use Utils::Architectures;
 use utils qw(is_bridged_networking systemctl zypper_call);
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     select_console 'root-console';
@@ -47,7 +48,7 @@ sub post_fail_hook {
     select_console 'log-console';
     upload_logs '/etc/named.conf';
     # to see if zone file is present
-    $self->save_and_upload_log('ls /var/lib/named', 'named_files.log');
+    save_and_upload_log('ls /var/lib/named', 'named_files.log');
     upload_logs '/var/lib/named/localhost.zone';
     script_run '/usr/sbin/named-checkzone localhost /var/lib/named/localhost.zone';
     $self->SUPER::post_fail_hook;

--- a/tests/console/fs_stress.pm
+++ b/tests/console/fs_stress.pm
@@ -12,6 +12,7 @@ use serial_terminal 'select_serial_terminal';
 use strict;
 use warnings;
 use utils;
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     select_serial_terminal;
@@ -35,7 +36,7 @@ sub post_fail_hook {
     assert_script_run("lsblk -f");
     assert_script_run("df -h");
     assert_script_run("free -h");
-    $self->save_and_upload_log('cat /tmp/file_copy_*.log', 'file_copy_all.log');
+    save_and_upload_log('cat /tmp/file_copy_*.log', 'file_copy_all.log');
 }
 
 1;

--- a/tests/console/ntp.pm
+++ b/tests/console/ntp.pm
@@ -14,6 +14,7 @@ use testapi;
 use utils;
 use services::ntpd;
 use serial_terminal qw(select_serial_terminal);
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     select_serial_terminal;
@@ -29,7 +30,7 @@ sub run {
 sub post_fail_hook {
     assert_script_run 'cp /etc/ntp.conf.bkp /etc/ntp.conf' if (script_run('test -f /etc/ntp.conf.bkp') == 0);
     upload_logs '/var/log/ntp';
-    shift->save_and_upload_log('journalctl --no-pager -o short-precise', 'journalctl.txt');
+    save_and_upload_log('journalctl --no-pager -o short-precise', 'journalctl.txt');
 }
 
 sub post_run_hook {

--- a/tests/console/orphaned_packages_check.pm
+++ b/tests/console/orphaned_packages_check.pm
@@ -12,6 +12,7 @@ use Mojo::Base qw(consoletest);
 use testapi;
 use utils 'zypper_call';
 use version_utils 'is_upgrade';
+use Utils::Logging 'export_logs';
 
 # Performing a DVD/Offline system upgrade cannot update
 # all potential packages already present on the SUT
@@ -81,7 +82,7 @@ sub post_fail_hook {
     my $self = shift;
 
     select_console 'log-console';
-    (script_run q{test -s /tmp/orphaned.log}) ? $self->export_logs() : upload_logs '/tmp/orphaned.log';
+    (script_run q{test -s /tmp/orphaned.log}) ? export_logs() : upload_logs '/tmp/orphaned.log';
     upload_logs '/var/log/zypper.log';
 }
 

--- a/tests/console/prjconf_excluded_rpms.pm
+++ b/tests/console/prjconf_excluded_rpms.pm
@@ -13,6 +13,7 @@
 use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal qw(select_serial_terminal);
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     select_serial_terminal;
@@ -26,7 +27,7 @@ sub post_fail_hook {
     my $self = shift;
     select_console 'log-console';
     upload_logs './excluded_rpms';
-    $self->save_and_upload_log('rpm -qa', '/tmp/rpmquery_all', {screenshot => 1});
+    save_and_upload_log('rpm -qa', '/tmp/rpmquery_all', {screenshot => 1});
 }
 
 1;

--- a/tests/console/slp.pm
+++ b/tests/console/slp.pm
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 use utils qw(zypper_call systemctl script_retry);
 use Utils::Systemd 'disable_and_stop_service';
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     my ($self) = @_;
@@ -78,10 +79,10 @@ sub post_fail_hook {
     assert_script_run 'slptool findsrvs ntp';
     upload_logs '/var/log/slpd.log';
     upload_logs '/var/log/zypper.log';
-    $self->save_and_upload_log('journalctl --no-pager -o short-precise', '/tmp/journal.log', {screenshot => 1});
-    $self->save_and_upload_log('rpm -ql openslp-server', '/tmp/openslp-server.content', {screenshot => 1});
-    $self->save_and_upload_log('rpm -ql openslp', '/tmp/openslp.content', {screenshot => 1});
-    $self->save_and_upload_log('lsmod', '/tmp/loaded_modules.txt', {screenshot => 1});
+    save_and_upload_log('journalctl --no-pager -o short-precise', '/tmp/journal.log', {screenshot => 1});
+    save_and_upload_log('rpm -ql openslp-server', '/tmp/openslp-server.content', {screenshot => 1});
+    save_and_upload_log('rpm -ql openslp', '/tmp/openslp.content', {screenshot => 1});
+    save_and_upload_log('lsmod', '/tmp/loaded_modules.txt', {screenshot => 1});
 }
 
 1;

--- a/tests/console/system_state.pm
+++ b/tests/console/system_state.pm
@@ -17,6 +17,7 @@ use Utils::Backends;
 use Utils::Architectures;
 use strict;
 use warnings;
+use Utils::Logging 'tar_and_upload_log';
 
 sub run {
     my ($self) = shift;
@@ -25,7 +26,7 @@ sub run {
     script_run("mkdir /tmp/system_state", timeout => $timeout);
     script_run "ps axf > /tmp/system_state/psaxf.log";
     script_run "cat /proc/loadavg > /tmp/system_state/loadavg_consoletest_setup.txt";
-    $self->tar_and_upload_log('/tmp/system_state', '/tmp/stats_during_installation.tar.bz2');
+    tar_and_upload_log('/tmp/system_state', '/tmp/stats_during_installation.tar.bz2');
 }
 
 1;

--- a/tests/console/systemd_sapstart_check.pm
+++ b/tests/console/systemd_sapstart_check.pm
@@ -28,6 +28,7 @@ use version_utils qw(is_sle is_opensuse is_tumbleweed);
 use Mojo::JSON qw(encode_json);
 use strict;
 use warnings;
+use Utils::Logging qw(save_and_upload_log tar_and_upload_log);
 
 my $log = '/tmp/systemd_run.log';
 my $testdir = '/usr/lib/systemd/test/SAP';
@@ -111,8 +112,8 @@ sub parse_results_from_output {
 
 sub upload_systemdlib_tests_logs {
     my ($self) = @_;
-    $self->tar_and_upload_log($log, "$log.tar.bz2");
-    $self->save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.txt');
+    tar_and_upload_log($log, "$log.tar.bz2");
+    save_and_upload_log('journalctl --no-pager -axb -o short-precise', 'journal.txt');
 }
 
 sub run {
@@ -137,7 +138,7 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
     #upload logs from given testname
-    $self->tar_and_upload_log('/var/log/journal /run/log/journal', 'binary-journal-log.tar.bz2');
+    tar_and_upload_log('/var/log/journal /run/log/journal', 'binary-journal-log.tar.bz2');
     $self->upload_systemdlib_tests_logs;
 }
 

--- a/tests/console/validate_md_raid.pm
+++ b/tests/console/validate_md_raid.pm
@@ -32,7 +32,7 @@ use scheduler 'get_test_suite_data';
 
 use Config::Tiny;
 use Test::Assert ':all';
-
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     select_console 'root-console';
@@ -57,7 +57,7 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
     $self->SUPER::post_fail_hook;
-    $self->save_and_upload_log('mdadm --detail', 'mdadm_output.txt');
+    save_and_upload_log('mdadm --detail', 'mdadm_output.txt');
     upload_logs('/proc/mdstat', failok => 1);
 }
 

--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -19,6 +19,7 @@ use base "y2_module_consoletest";
 use testapi;
 use utils qw(zypper_call systemctl);
 use version_utils qw(is_pre_15 is_sle is_opensuse is_leap);
+use Utils::Logging 'save_and_upload_systemd_unit_log';
 
 sub install_extra_packages_requested {
     if (check_screen 'yast2_apparmor_extra_packages_requested', 15) {
@@ -236,7 +237,7 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
-    $self->save_and_upload_systemd_unit_log('apparmor');
+    save_and_upload_systemd_unit_log('apparmor');
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -20,6 +20,7 @@ use testapi;
 use utils 'zypper_call';
 use version_utils qw(is_sle is_leap);
 use yast2_widget_utils 'change_service_configuration';
+use Utils::Logging 'save_and_upload_systemd_unit_log';
 
 sub run {
     select_console 'root-console';
@@ -134,7 +135,7 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
-    $self->save_and_upload_systemd_unit_log('apache2');
+    save_and_upload_systemd_unit_log('apache2');
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/console/yast2_nfs_server.pm
+++ b/tests/console/yast2_nfs_server.pm
@@ -29,6 +29,7 @@ use mmapi;
 use mm_network;
 use nfs_common;
 use version_utils 'is_sle';
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     my ($self) = @_;
@@ -76,7 +77,7 @@ sub run {
 
     wait_for_children;
 
-    $self->save_and_upload_log("journalctl --no-pager -u nfs-server -o short-precise", "journal_nfs_server.log");
+    save_and_upload_log("journalctl --no-pager -u nfs-server -o short-precise", "journal_nfs_server.log");
 }
 
 1;

--- a/tests/console/yast2_xinetd.pm
+++ b/tests/console/yast2_xinetd.pm
@@ -13,6 +13,7 @@ use base "y2_module_consoletest";
 
 use testapi;
 use utils;
+use Utils::Logging 'problem_detection';
 
 sub run {
     my ($self) = @_;
@@ -31,7 +32,7 @@ sub run {
         # softfail when yast2 crashed and throws core dumped message
         # we need logs even after yast2 got crashed
         record_soft_failure "bsc#1049433";
-        $self->problem_detection();
+        problem_detection();
         return;
 
     }

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -27,6 +27,7 @@ use power_action_utils 'power_action';
 use bootloader_setup 'add_grub_cmdline_settings';
 use Utils::Architectures;
 use transactional 'process_reboot';
+use Utils::Logging 'save_and_upload_log';
 
 my $bsc1200623 = 0;    # to prevent printing the soft-failure more than once
 
@@ -201,11 +202,11 @@ sub post_run_hook {
 
 sub post_fail_hook {
     my $self = shift;
-    $self->save_and_upload_log('cat /etc/{subuid,subgid}', "/tmp/permissions.txt");
+    save_and_upload_log('cat /etc/{subuid,subgid}', "/tmp/permissions.txt");
     assert_script_run("tar -capf /tmp/proc_files.tar.xz /proc/self");
     upload_logs("/tmp/proc_files.tar.xz");
     if (is_sle) {
-        $self->save_and_upload_log('ls -la /etc/zypp/credentials.d', "/tmp/credentials.d.perm.txt");
+        save_and_upload_log('ls -la /etc/zypp/credentials.d', "/tmp/credentials.d.perm.txt");
         assert_script_run "setfacl -x u:$testapi::username /etc/zypp/credentials.d/*";
     }
     $self->SUPER::post_fail_hook;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -15,6 +15,7 @@ use lockapi;
 use utils;
 use registration;
 use version_utils 'is_sle';
+use Utils::Logging 'export_logs';
 use hpc::formatter;
 use POSIX 'strftime';
 
@@ -120,7 +121,7 @@ sub test_flags ($self) {
 
 sub post_fail_hook ($self) {
     $self->destroy_test_barriers();
-    $self->export_logs();
+    export_logs();
 }
 
 1;

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -10,6 +10,7 @@ use Mojo::Base qw(hpcbase hpc::utils), -signatures;
 use lockapi;
 use utils;
 use serial_terminal 'select_serial_terminal';
+use Utils::Logging 'export_logs';
 use testapi qw(record_info);
 use POSIX 'strftime';
 
@@ -38,7 +39,7 @@ sub test_flags ($self) {
 
 sub post_fail_hook ($self) {
     $self->destroy_test_barriers();
-    $self->export_logs();
+    export_logs();
 }
 
 1;

--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -23,6 +23,7 @@ use Mojo::Base 'hpcbase', -signatures;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Architectures;
+use Utils::Logging 'export_logs_basic';
 use utils;
 
 our $file = 'tmpresults.xml';
@@ -121,7 +122,7 @@ sub post_run_hook ($self) {
 
 sub post_fail_hook ($self) {
     select_serial_terminal;
-    $self->export_logs_basic;
+    export_logs_basic;
 }
 
 1;

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -14,6 +14,7 @@ use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
 use version_utils 'is_sle';
+use Utils::Logging 'export_logs_basic';
 
 our @all_tests_results;
 
@@ -477,7 +478,7 @@ sub post_fail_hook ($self) {
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');
     $self->upload_service_log('slurmctld');
-    $self->export_logs_basic;
+    export_logs_basic;
     $self->get_remote_logs('slave-node02', 'slurmdbd.log');
     upload_logs('/var/log/slurmctld.log');
 }

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -13,6 +13,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use lockapi;
+use Utils::Logging qw(tar_and_upload_log export_logs);
 
 sub run ($self) {
     my $mpi = $self->get_mpi();
@@ -73,9 +74,9 @@ sub post_fail_hook ($self) {
     my $compiler_ver = script_output("gcc --version | grep -E '\\b[0-9]+\.[0-9]+\.[0-9]+\$' | awk '{print \$4}'");
     my $arch = get_var('ARCH');
     my $node = script_output('hostname');
-    $self->tar_and_upload_log("/opt/spack/linux-sle_hpc15-$arch/gcc-$compiler_ver", "/tmp/spack_$node.tar.bz2", timeout => 360);
+    tar_and_upload_log("/opt/spack/linux-sle_hpc15-$arch/gcc-$compiler_ver", "/tmp/spack_$node.tar.bz2", timeout => 360);
     upload_logs('/tmp/make.out');
-    $self->export_logs();
+    export_logs();
 }
 
 1;

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -10,6 +10,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
+use Utils::Logging 'tar_and_upload_log';
 
 sub run ($self) {
     my $mpi = $self->get_mpi();
@@ -45,7 +46,7 @@ sub post_fail_hook ($self) {
     my $compiler_ver = script_output("gcc --version | grep -E '\\b[0-9]+\.[0-9]+\.[0-9]+\$' | awk '{print \$4}'");
     my $arch = get_var('ARCH');
     my $node = script_output('hostname');
-    $self->tar_and_upload_log("/opt/spack/linux-sle_hpc15-$arch/gcc-$compiler_ver", "/tmp/spack_$node.tar.bz2");
+    tar_and_upload_log("/opt/spack/linux-sle_hpc15-$arch/gcc-$compiler_ver", "/tmp/spack_$node.tar.bz2");
 }
 
 1;

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -55,7 +55,6 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
     $self->SUPER::post_fail_hook;
-    $self->export_logs;
 }
 
 1;

--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 use main_common 'opensuse_welcome_applicable';
 use x11utils 'turn_off_plasma_tooltips';
+use Utils::Logging qw(save_and_upload_log export_logs);
 
 # using this as base class means only run when an install is needed
 sub run {
@@ -43,10 +44,10 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
 
-    $self->export_logs();
+    export_logs();
 
     # Also list branding packages (help to debug desktop branding issues)
-    $self->save_and_upload_log('zypper --no-refresh se *branding*', '/tmp/list_branding_packages.txt', {screenshot => 1});
+    save_and_upload_log('zypper --no-refresh se *branding*', '/tmp/list_branding_packages.txt', {screenshot => 1});
 }
 
 1;

--- a/tests/installation/resolve_dependency_issues.pm
+++ b/tests/installation/resolve_dependency_issues.pm
@@ -15,6 +15,7 @@ use base "y2_installbase";
 use strict;
 use warnings;
 use testapi;
+use Utils::Logging 'upload_solvertestcase_logs';
 
 sub run {
     my ($self) = @_;
@@ -34,7 +35,7 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
     select_console 'root-console';
-    $self->upload_solvertestcase_logs();
+    upload_solvertestcase_logs();
     # workaround to get the y2logs.tar.bz2 at early stage
     script_run "save_y2logs /tmp/y2logs.tar.bz2";
     upload_logs "/tmp/y2logs.tar.bz2";

--- a/tests/installation/rollback_from_ro_snapshot.pm
+++ b/tests/installation/rollback_from_ro_snapshot.pm
@@ -59,7 +59,6 @@ sub test_flags {
 sub post_fail_hook {
     my $self = shift;
     $self->SUPER::post_fail_hook;
-    $self->export_logs;
 }
 
 1;

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -14,6 +14,7 @@ use warnings;
 use testapi;
 use utils qw(OPENQA_FTP_URL zypper_call);
 use Utils::Backends 'is_pvm';
+use Utils::Logging 'export_logs';
 
 sub run {
     my $self = shift;
@@ -180,7 +181,7 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
     $utils::IN_ZYPPER_CALL = 1;
-    $self->export_logs();
+    export_logs();
 }
 
 1;

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -27,6 +27,7 @@ use yast2_widget_utils 'change_service_configuration';
 use utils qw(systemctl type_string_slow_extended zypper_call);
 use scheduler 'get_test_suite_data';
 use y2_mm_common 'prepare_xterm_and_setup_static_network';
+use Utils::Logging 'save_and_upload_log';
 
 # load expected test data from yaml
 # common for both iscsi MM modules
@@ -155,8 +156,8 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
     $self->SUPER::post_fail_hook;
-    $self->save_and_upload_log("iscsiadm --mode session -P 3", "/tmp/iscsi_init_session_data.log");
-    $self->save_and_upload_log("tar czvf /tmp/iscsi_initconf.tar.gz /etc/iscsi/*", "/tmp/iscsi_initconf.tar.gz");
+    save_and_upload_log("iscsiadm --mode session -P 3", "/tmp/iscsi_init_session_data.log");
+    save_and_upload_log("tar czvf /tmp/iscsi_initconf.tar.gz /etc/iscsi/*", "/tmp/iscsi_initconf.tar.gz");
 }
 
 1;

--- a/tests/jeos/rpi_bluetooth.pm
+++ b/tests/jeos/rpi_bluetooth.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Logging 'save_and_upload_log';
 
 # This requires a discoverable bluetooth device in range:
 #===========================
@@ -46,8 +47,8 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->save_and_upload_log('dmesg', 'dmesg.log');
-    $self->save_and_upload_log('journalctl -b', 'journal.log');
+    save_and_upload_log('dmesg', 'dmesg.log');
+    save_and_upload_log('journalctl -b', 'journal.log');
 }
 
 1;

--- a/tests/jeos/rpi_wifi.pm
+++ b/tests/jeos/rpi_wifi.pm
@@ -11,6 +11,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     my ($self) = @_;
@@ -48,7 +49,7 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->save_and_upload_log('cat /etc/sysconfig/network/ifcfg-wlan0', 'ifcfg-wlan0.txt');
+    save_and_upload_log('cat /etc/sysconfig/network/ifcfg-wlan0', 'ifcfg-wlan0.txt');
 }
 
 1;

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -14,6 +14,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use repo_tools 'add_qa_head_repo';
+use Utils::Logging 'export_logs_basic';
 
 sub prepare_blktests_config {
     my ($devices) = @_;
@@ -81,7 +82,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = @_;
     select_serial_terminal;
-    $self->export_logs_basic;
+    export_logs_basic;
     script_run('rpm -qi kernel-default > /tmp/kernel_info');
     upload_logs('/tmp/kernel_info');
 }

--- a/tests/kernel/ibtests.pm
+++ b/tests/kernel/ibtests.pm
@@ -16,6 +16,7 @@ use utils;
 use power_action_utils 'power_action';
 use lockapi;
 use mmapi;
+use Utils::Logging qw(save_and_upload_log save_and_upload_systemd_unit_log);
 
 our $master;
 our $slave;
@@ -23,19 +24,19 @@ our $slave;
 sub upload_ibtest_logs {
     my $self = shift;
 
-    $self->save_and_upload_log('dmesg', '/tmp/dmesg.log', {screenshot => 0});
-    $self->save_and_upload_log('systemctl list-units -l', '/tmp/systemd_units.log', {screenshot => 0});
+    save_and_upload_log('dmesg', '/tmp/dmesg.log', {screenshot => 0});
+    save_and_upload_log('systemctl list-units -l', '/tmp/systemd_units.log', {screenshot => 0});
 
-    $self->save_and_upload_systemd_unit_log('opensm.service');
-    $self->save_and_upload_systemd_unit_log('srp_daemon.service');
-    $self->save_and_upload_systemd_unit_log('nvmet.service');
-    $self->save_and_upload_systemd_unit_log('nvmf-autoconnect.service');
-    $self->save_and_upload_systemd_unit_log('rdma-hw.service');
-    $self->save_and_upload_systemd_unit_log('rdma-load-modules@infiniband.service');
-    $self->save_and_upload_systemd_unit_log('rdma-load-modules@rdma.service');
-    $self->save_and_upload_systemd_unit_log('rdma-load-modules@roce.service');
-    $self->save_and_upload_systemd_unit_log('rdma-ndd.service');
-    $self->save_and_upload_systemd_unit_log('rdma-sriov.service');
+    save_and_upload_systemd_unit_log('opensm.service');
+    save_and_upload_systemd_unit_log('srp_daemon.service');
+    save_and_upload_systemd_unit_log('nvmet.service');
+    save_and_upload_systemd_unit_log('nvmf-autoconnect.service');
+    save_and_upload_systemd_unit_log('rdma-hw.service');
+    save_and_upload_systemd_unit_log('rdma-load-modules@infiniband.service');
+    save_and_upload_systemd_unit_log('rdma-load-modules@rdma.service');
+    save_and_upload_systemd_unit_log('rdma-load-modules@roce.service');
+    save_and_upload_systemd_unit_log('rdma-ndd.service');
+    save_and_upload_systemd_unit_log('rdma-sriov.service');
 }
 
 sub ibtest_slave {

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -18,6 +18,7 @@ use power_action_utils 'power_action';
 use version_utils qw(is_desktop_installed is_sle);
 use x11utils qw(ensure_unlocked_desktop turn_off_screensaver);
 use Utils::Backends 'is_pvm';
+use Utils::Logging qw(save_and_upload_log export_logs_desktop);
 
 sub yast2_migration_gnome_remote {
     return check_var('MIGRATION_METHOD', 'yast') && check_var('DESKTOP', 'gnome') && get_var('REMOTE_CONNECTION');
@@ -291,8 +292,8 @@ sub post_fail_hook {
     select_console 'log-console';
     $self->save_upload_y2logs;
     set_var('Y2LOGS_UPLOADED', 1);
-    $self->save_and_upload_log('journalctl -b -o short-precise', '/tmp/journal.log', {screenshot => 1});
-    $self->export_logs_desktop;
+    save_and_upload_log('journalctl -b -o short-precise', '/tmp/journal.log', {screenshot => 1});
+    export_logs_desktop;
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -16,6 +16,7 @@ use utils;
 use power_action_utils 'power_action';
 use version_utils qw(is_desktop_installed is_sles4sap is_leap_migration is_sle_micro);
 use Utils::Backends 'is_pvm';
+use Utils::Logging 'upload_solvertestcase_logs';
 use transactional;
 
 sub check_migrated_version {
@@ -179,7 +180,7 @@ sub post_fail_hook {
     select_serial_terminal;
     script_run("pkill zypper");
     upload_logs '/var/log/zypper.log';
-    $self->upload_solvertestcase_logs();
+    upload_solvertestcase_logs();
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/migration/openldap_to_389ds.pm
+++ b/tests/migration/openldap_to_389ds.pm
@@ -16,6 +16,7 @@ use lockapi;
 use Utils::Systemd qw(systemctl disable_and_stop_service);
 use registration qw(add_suseconnect_product);
 use version_utils;
+use Utils::Logging 'tar_and_upload_log';
 
 sub run {
     my ($self) = @_;
@@ -82,7 +83,7 @@ sub run {
     assert_script_run "slaptest -f slapd.conf -F ./slapd.d";
 
     # Check migration tools
-    $self->tar_and_upload_log('./slapd.d', 'slapd.d.tar.bz2');
+    tar_and_upload_log('./slapd.d', 'slapd.d.tar.bz2');
     upload_logs("./db.ldif", timeout => 100);
     upload_logs("./slapd.conf", timeout => 100);
     assert_script_run "openldap_to_ds -v --confirm localhost ./slapd.d ./db.ldif > ldap2dslog";
@@ -114,8 +115,8 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
-    $self->tar_and_upload_log('/var/log/dirsrv', '/tmp/ds389.tar.bz2');
-    $self->tar_and_upload_log('/var/log/sssd', '/tmp/sssd.tar.bz2');
+    tar_and_upload_log('/var/log/dirsrv', '/tmp/ds389.tar.bz2');
+    tar_and_upload_log('/var/log/sssd', '/tmp/sssd.tar.bz2');
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/openqa/install/openqa_bootstrap_container.pm
+++ b/tests/openqa/install/openqa_bootstrap_container.pm
@@ -11,7 +11,7 @@ use warnings;
 use base "consoletest";
 use testapi;
 use utils;
-
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     select_console 'root-console';
@@ -34,7 +34,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     $self->SUPER::post_fail_hook;
-    $self->save_and_upload_log("journalctl -M openqa1 -b -o short-precise --no-pager", "journal_container.log", {screenshot => 1});
+    save_and_upload_log("journalctl -M openqa1 -b -o short-precise --no-pager", "journal_container.log", {screenshot => 1});
 }
 
 1;

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -17,6 +17,7 @@ use testapi;
 use strict;
 use utils;
 use publiccloud::utils;
+use Utils::Logging 'tar_and_upload_log';
 
 sub run {
     my ($self, $args) = @_;
@@ -61,7 +62,7 @@ sub collect_system_information {
     assert_script_run("cat /proc/cpuinfo | tee instance_overview/cpuinfo.txt");
     assert_script_run("cat /proc/meminfo | tee instance_overview/meminfo.txt");
     assert_script_run("uname -a | tee instance_overview/uname.txt");
-    $self->tar_and_upload_log("instance_overview/", "instance_overview.tar.gz");
+    tar_and_upload_log("instance_overview/", "instance_overview.tar.gz");
     script_run("cd");
 }
 

--- a/tests/rt/cpuset_shield.pm
+++ b/tests/rt/cpuset_shield.pm
@@ -19,6 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use Utils::Logging qw(export_logs_basic upload_coredumps);
 
 # Used in post_fail_hook as well
 my $cpuset_log = '/var/log/cpuset';
@@ -71,8 +72,8 @@ sub post_fail_hook {
     my $self = shift;
 
     select_console 'log-console';
-    $self->export_logs_basic;
-    $self->upload_coredumps;
+    export_logs_basic;
+    upload_coredumps;
     upload_logs($cpuset_log) unless (script_run("test -f $cpuset_log"));
 }
 

--- a/tests/rt/kmp_modules.pm
+++ b/tests/rt/kmp_modules.pm
@@ -21,6 +21,7 @@ use rt_utils qw(select_kernel);
 use File::Basename qw(fileparse);
 use power_action_utils qw(power_action);
 use Utils::Systemd qw(systemctl);
+use Utils::Logging 'save_and_upload_log';
 
 sub run_lttng_demo_trace {
     my $trace = {
@@ -100,9 +101,9 @@ sub post_fail_hook {
 
     select_console 'log-console';
 
-    $self->save_and_upload_log("dmesg", "dmesg.log", {screenshot => 1});
-    $self->save_and_upload_log("journalctl --no-pager -o short-precise", "journalctl.log", {screenshot => 1});
-    $self->save_and_upload_log('rpm -qa *-kmp-rt', "list_of_kmp_rpms", {screenshot => 1});
+    save_and_upload_log("dmesg", "dmesg.log", {screenshot => 1});
+    save_and_upload_log("journalctl --no-pager -o short-precise", "journalctl.log", {screenshot => 1});
+    save_and_upload_log('rpm -qa *-kmp-rt', "list_of_kmp_rpms", {screenshot => 1});
     if ((script_run 'test -e /var/log/modprobe.out') == 0) {
         upload_logs '/var/log/modprobe.out';
     }

--- a/tests/rt/rt_chrt.pm
+++ b/tests/rt/rt_chrt.pm
@@ -21,6 +21,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Systemd 'systemctl';
 use version_utils qw(is_sle);
+use Utils::Logging qw(export_logs_basic upload_coredumps);
 
 #****************************** SLERT default setup ******************************#
 # The default values for sched_rt_period_us (1000000 or 1s) and
@@ -120,8 +121,8 @@ sub post_fail_hook {
     my $self = shift;
 
     select_console 'log-console';
-    $self->export_logs_basic;
-    $self->upload_coredumps;
+    export_logs_basic;
+    upload_coredumps;
 }
 
 1;

--- a/tests/rt/rt_is_realtime.pm
+++ b/tests/rt/rt_is_realtime.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use Utils::Logging qw(export_logs_basic upload_coredumps);
 
 sub run {
     select_serial_terminal;
@@ -40,7 +41,7 @@ sub post_fail_hook {
 
     select_console 'log-console';
 
-    $self->export_logs_basic;
+    export_logs_basic;
     $self->upload_coredumps;
 }
 

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -23,6 +23,7 @@ use serial_terminal 'prepare_serial_console';
 use utils;
 use version_utils;
 use Utils::Backends;
+use Utils::Logging 'save_and_upload_systemd_unit_log';
 
 sub run {
     select_console('root-console');
@@ -77,7 +78,7 @@ END_SCRIPT
 sub post_fail_hook {
     my ($self) = @_;
     $self->SUPER::post_fail_hook;
-    $self->save_and_upload_systemd_unit_log('systemd-journald');
+    save_and_upload_systemd_unit_log('systemd-journald');
 }
 
 1;

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -18,6 +18,7 @@ use utils qw(file_content_replace zypper_call);
 use Utils::Systemd 'systemctl';
 use version_utils 'is_sle';
 use POSIX 'ceil';
+use Utils::Logging 'save_and_upload_log';
 
 sub is_multipath {
     return (get_var('MULTIPATH') and (get_var('MULTIPATH_CONFIRM') !~ /\bNO\b/i));
@@ -64,7 +65,7 @@ sub debug_locked_device {
     for ('dmsetup info', 'dmsetup ls', 'mount', 'df -h', 'pvscan', 'vgscan', 'lvscan', 'pvdisplay', 'vgdisplay', 'lvdisplay') {
         my $filename = $_;
         $filename =~ s/[^\w]/_/g;
-        $self->save_and_upload_log($_, "$filename.txt");
+        save_and_upload_log($_, "$filename.txt");
     }
 }
 
@@ -253,8 +254,8 @@ sub run {
 
     # Upload installations logs
     $self->upload_hana_install_log;
-    $self->save_and_upload_log('rpm -qa', 'packages.list');
-    $self->save_and_upload_log('systemctl list-units --all', 'systemd-units.list');
+    save_and_upload_log('rpm -qa', 'packages.list');
+    save_and_upload_log('systemctl list-units --all', 'systemd-units.list');
 
     # Quick check of block/filesystem devices after installation
     assert_script_run 'mount';

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -29,6 +29,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'zypper_call';
 use version_utils qw(is_sle is_opensuse);
+use Utils::Logging 'export_logs_basic';
 
 sub run {
     select_serial_terminal;
@@ -90,7 +91,7 @@ sub run {
 
 sub post_fail_hook {
     select_console 'log-console';
-    shift->export_logs_basic;
+    export_logs_basic;
 }
 
 1;

--- a/tests/systemd_testsuite/runner.pm
+++ b/tests/systemd_testsuite/runner.pm
@@ -9,6 +9,7 @@
 use Mojo::Base qw(systemd_testsuite_test);
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use Utils::Logging 'save_and_upload_log';
 
 my $test_hash;
 
@@ -65,7 +66,7 @@ sub post_fail_hook {
     select_console('log-console');
     script_run("xz -9 $lpath");
     upload_logs("$lpath" . '.xz', failok => 1);
-    shift->save_and_upload_log('journalctl -o short-precise --no-pager', "journalctl-host.txt");
+    save_and_upload_log('journalctl -o short-precise --no-pager', "journalctl-host.txt");
 }
 
 1;

--- a/tests/toolchain/gcc_compilation.pm
+++ b/tests/toolchain/gcc_compilation.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use testapi;
 use utils 'clear_console';
+use Utils::Logging 'export_logs';
 
 sub run {
     assert_script_run('curl --output ./gawk-src.tar.gz ' . data_url('toolchain/gawk-src.tar.gz'));
@@ -27,7 +28,7 @@ sub post_fail_hook {
     my $self = shift;
     upload_logs '/tmp/make.log';
     upload_logs '/tmp/configure.log';
-    $self->export_logs();
+    export_logs();
 }
 
 1;

--- a/tests/toolchain/gcc_fortran_compilation.pm
+++ b/tests/toolchain/gcc_fortran_compilation.pm
@@ -54,7 +54,6 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
 
-    $self->export_logs();
     upload_logs '/tmp/build.log';
     upload_logs '/tmp/test.log';
     script_run 'tar cfJ fcvs21_f95_results.tar.xz *.res';

--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -15,6 +15,7 @@ use testapi;
 use transactional qw(process_reboot);
 use version_utils qw(is_sle_micro);
 use Utils::Systemd qw(systemctl);
+use Utils::Logging 'save_and_upload_log';
 
 sub run {
     select_console 'root-console';
@@ -27,7 +28,7 @@ sub run {
     if (script_run('test -d /sys/fs/selinux && test -e /etc/selinux/config') != 0) {
         assert_script_run('transactional-update setup-selinux');
         upload_logs('/var/log/transactional-update.log');
-        shift->save_and_upload_log('rpm -qa', 'installed_pkgs.txt');
+        save_and_upload_log('rpm -qa', 'installed_pkgs.txt');
         process_reboot(trigger => 1);
     }
 

--- a/tests/virt_autotest/kubevirt_tests_agent.pm
+++ b/tests/virt_autotest/kubevirt_tests_agent.pm
@@ -17,6 +17,7 @@ use utils;
 use version_utils qw(is_transactional);
 use Utils::Systemd;
 use Utils::Backends 'use_ssh_serial_console';
+use Utils::Logging qw(save_and_upload_log save_and_upload_systemd_unit_log);
 
 sub run {
     my ($self) = shift;
@@ -130,9 +131,9 @@ sub post_fail_hook {
     my $self = shift;
 
     select_console 'log-console';
-    $self->save_and_upload_log('dmesg', '/tmp/dmesg.log', {screenshot => 0});
-    $self->save_and_upload_log('systemctl list-units -l', '/tmp/systemd_units.log', {screenshot => 0});
-    $self->save_and_upload_systemd_unit_log('rke2-agent.service');
+    save_and_upload_log('dmesg', '/tmp/dmesg.log', {screenshot => 0});
+    save_and_upload_log('systemctl list-units -l', '/tmp/systemd_units.log', {screenshot => 0});
+    save_and_upload_systemd_unit_log('rke2-agent.service');
 }
 
 1;

--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -20,6 +20,7 @@ use version_utils qw(is_transactional);
 use File::Basename;
 use Utils::Systemd;
 use Utils::Backends 'use_ssh_serial_console';
+use Utils::Logging qw(save_and_upload_log save_and_upload_systemd_unit_log);
 
 our $if_case_fail;
 my @full_tests = (
@@ -476,9 +477,9 @@ sub post_fail_hook {
     my $self = shift;
 
     select_console 'log-console';
-    $self->save_and_upload_log('dmesg', '/tmp/dmesg.log', {screenshot => 0});
-    $self->save_and_upload_log('systemctl list-units -l', '/tmp/systemd_units.log', {screenshot => 0});
-    $self->save_and_upload_systemd_unit_log('rke2-server.service');
+    save_and_upload_log('dmesg', '/tmp/dmesg.log', {screenshot => 0});
+    save_and_upload_log('systemctl list-units -l', '/tmp/systemd_units.log', {screenshot => 0});
+    save_and_upload_systemd_unit_log('rke2-server.service');
 }
 
 1;

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -109,7 +109,6 @@ sub post_fail_hook {
     my ($self) = shift;
     select_console('log-console');
     $self->SUPER::post_fail_hook;
-    $self->export_logs_basic;
 }
 
 1;

--- a/tests/x11/network/NM_wpa2_enterprise.pm
+++ b/tests/x11/network/NM_wpa2_enterprise.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Logging 'save_and_upload_systemd_unit_log';
 
 sub run {
     my $self = shift;
@@ -108,7 +109,7 @@ sub NM_disable_ip {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
-    $self->save_and_upload_systemd_unit_log($_) foreach qw(NetworkManager hostapd);
+    save_and_upload_systemd_unit_log($_) foreach qw(NetworkManager hostapd);
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/x11/network/hwsim_wpa2_enterprise_setup.pm
+++ b/tests/x11/network/hwsim_wpa2_enterprise_setup.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Logging 'save_and_upload_systemd_unit_log';
 
 sub run {
     my $self = shift;
@@ -88,7 +89,7 @@ sub reload_services {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
-    $self->save_and_upload_systemd_unit_log('hostapd');
+    save_and_upload_systemd_unit_log('hostapd');
     systemctl 'status hostapd';
     $self->SUPER::post_fail_hook;
 }

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -68,7 +68,6 @@ sub run {
 
 sub post_fail_hook {
     my $self = shift;
-    $self->export_logs;
 }
 
 sub test_flags {

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -35,7 +35,6 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
     $self->SUPER::post_fail_hook;
-    $self->export_logs;
 }
 
 sub test_flags {


### PR DESCRIPTION
Move logs related subroutines which do not make sense in `opensusebasetest` to `Utils::Loging` and some not related subroutines to `utils`. Some subroutines removed because of the `post_fail_hook` inheritance.

That is required for deduplication of the code in order to log exporting speedup in upcoming commits.

- Related ticket: [poo#120735](https://progress.opensuse.org/issues/120735)
- Verification run: [extra_tests_gnome@64bit](https://pdostal-server.suse.cz/tests/3357), [extra_tests_textmode@64bit](https://pdostal-server.suse.cz/tests/3358), [ha_qdevice_node1@64bit](https://pdostal-server.suse.cz/tests/3382), [qam-wicked_basic_sut@64bit](https://pdostal-server.suse.cz/tests/3366), [publiccloud_containers@64bit](https://pdostal-server.suse.cz/tests/3370), [kubectl_tests@64bit](https://pdostal-server.suse.cz/tests/3408)