### PR TITLE
Fix desktopapps-gnome failures on GNOME43

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -30,7 +30,7 @@
 # - Close xterm
 # - Call dconf and rollback changes for save session
 
-# Maintainer: xiaojun <xjin@suse.com>
+# Maintainer: Grace Wang <grace.wang@suse.com>
 
 use base "x11test";
 use strict;
@@ -45,8 +45,7 @@ sub tweak_startupapp_menu {
     my ($self) = shift;
 
     $self->start_gnome_tweak_tool;
-    # increase the default timeout - the switching can be slow
-    send_key_until_needlematch "tweak-startapp", "down", 11, 2;
+    assert_and_click "tweak-startapp-menu";
 }
 
 sub start_dconf {

--- a/tests/x11/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11/gnomecase/nautilus_open_ftp.pm
@@ -21,6 +21,10 @@ sub run {
     wait_screen_change { send_key 'ctrl-l' };
     enter_cmd "ftp://ftp.suse.com";
     assert_screen 'nautilus-ftp-login';
+    if (is_tumbleweed) {
+        record_soft_failure("bsc#1205589 Enter key doesn't work on nautilus-ftp-login screen");
+        assert_and_click "nautilus-ftp-connect";
+    }
     send_key 'ret';
     assert_screen 'nautilus-ftp-suse-com';
     assert_and_click('ftp-path-selected', button => 'right');

--- a/tests/x11/gnomecase/nautilus_permission.pm
+++ b/tests/x11/gnomecase/nautilus_permission.pm
@@ -14,7 +14,7 @@
 # - Close nautilus dialog
 # - Right click, open permissions again, check if permittions were changed
 # - Close nautilus
-# Maintainer: Xudong Zhang <xdzhang@suse.com>
+# Maintainer: Grace Wang <grace.wang@suse.com>
 
 use base "x11test";
 use strict;
@@ -37,21 +37,11 @@ sub run {
     assert_screen 'nautilus-rightkey-menu';
     send_key "r";    #choose properties
     assert_screen 'nautilus-properties';
-    send_key "up";    #move focus onto tab
-                      # For Tumbleweed it is needed one more hit to reach the tab
-                      # In case that the problem appears again, switch to an assert and click strategy for reaching the tab
-    send_key "up";
-    send_key "right";    #move to tab Permissions
-    for (1 .. 4) { send_key "tab" }
-    send_key "ret";
-    assert_screen 'nautilus-access-permission';
-    send_key "down";
-    send_key "ret";
-    send_key "tab";
-    send_key "ret";
-    assert_screen 'nautilus-access-permission';
-    send_key "down";
-    send_key "ret";
+    assert_and_click 'nautilus-access-permission';
+    assert_and_click 'nautilus-default-group-access-permission';
+    assert_and_click 'nautilus-read-write-permission';
+    assert_and_click 'nautilus-default-other-access-permission';
+    assert_and_click 'nautilus-read-write-permission';
     send_key "esc";    #close the dialog
                        #reopen the properties menu to check if the changes kept
     if (is_sle('15+') || is_leap('15.0+') || is_tumbleweed) {
@@ -63,18 +53,13 @@ sub run {
     assert_screen 'nautilus-rightkey-menu';
     send_key "r";    #choose properties
     assert_screen 'nautilus-properties';
-    send_key "up";    #move focus onto tab
-                      # For Tumbleweed it is needed one more hit to reach the tab
-                      # In case that the problem appears again, switch to an assert and click strategy for reaching the tab
-    send_key "up";
-    send_key "right";    #move to tab Permissions
+    assert_and_click 'nautilus-access-permission';
     assert_screen 'nautilus-permissions-changed';
     send_key "esc";    #close the dialog
 
-
     #clean: remove the created new note
     x11_start_program('rm newfile', valid => 0);
-    send_key "ctrl-w";
+    assert_and_click 'nautilus-close-window';
 }
 
 1;


### PR DESCRIPTION
Use `assert_and_click` instead of `send_key_until_needlematch` to make application_starts_on_login more robust.
Add record_soft_failure and workaround for bsc#1205589 
Update code to adapt to new nautilus UI for file permissions

- Related ticket: https://progress.opensuse.org/issues/117154
- Needles: already added when debugging on o3 and osd
- Verification run: 

>TW:
> desktopapps-gnome  https://openqa.opensuse.org/tests/2904284
> desktopapps-gnome-x11 https://openqa.opensuse.org/tests/2904285# (The failure of application_starts_on_login is caused by the product bug https://bugzilla.opensuse.org/show_bug.cgi?id=1205699)
SLE:
> x11-desktopapps-gnome https://openqa.suse.de/tests/10037572#
> wayland-desktopapps-gnome https://openqa.suse.de/tests/10037573#