### PR TITLE
Add autoyast_create_hdd_gnome test case  modify_existing_partition on PowerVM

### DIFF
--- a/data/autoyast_sle15/autoyast_create_hdd_gnome.xml
+++ b/data/autoyast_sle15/autoyast_create_hdd_gnome.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- minimal autoyast profile with sshd service explicitly enabled for the remote installation -->
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons config:type="list">
+            <addon>
+                <name>sle-module-basesystem</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <partitioning config:type="list">
+        <drive>
+            <device>/dev/sda</device>
+            <initialize config:type="boolean">true</initialize> 
+        </drive>
+    </partitioning>
+    <services-manager>
+        <default_target>multi-user</default_target>
+        <services>
+            <enable config:type="list">
+                <service>sshd</service>
+            </enable>
+            <on_demand config:type="list"/>
+        </services>
+    </services-manager>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+</profile>


### PR DESCRIPTION
We need to add autoyast_create_hdd_gnome for modify_existing_partition
in PowerVM.

- Related ticket: https://progress.opensuse.org/issues/110773#note-14
- Related MR:  https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/443/
- Needles: N/A
- Verification run: 
   https://openqa.suse.de/tests/10048974
   https://openqa.suse.de/tests/10048975
