### PR TITLE
usr_sbin_smbd: Adjust interaction with Nautilus to be compatible with v43

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -126,7 +126,7 @@ sub samba_client_access {
     assert_screen("nautilus-sharedir-opened");
 
     # Do some operations, e.g., create a test folder then delete it
-    assert_and_click("nautilus-open-menu");
+    assert_and_click('nautilus-sharedir-opened', button => 'right');
     assert_and_click("nautilus-new-folder");
     assert_screen("nautilus-folder-name-input-box");
     type_string("sub-testdir", wait_screen_change => 10);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/117034
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2912936
