### PR TITLE
dbus_services_exposure.pm: add missing dbus names

### DIFF
--- a/lib/atsec_test.pm
+++ b/lib/atsec_test.pm
@@ -38,8 +38,11 @@ our @white_list_for_dbus = (
     'org.opensuse.Network.AUTO4',
     'org.opensuse.Network.Nanny',
     'org.opensuse.Snapper',
-    '1.13',
-    '1.22'
+    ':1.13',
+    ':1.19',
+    ':1.22',
+    ':1.36',
+    ':1.37'
 );
 
 our $server_ip = get_var('SERVER_IP', '10.0.2.101');

--- a/tests/security/atsec/dbus_services_exposure.pm
+++ b/tests/security/atsec/dbus_services_exposure.pm
@@ -25,7 +25,10 @@ my %white_list_for_busctl = (
     'wickedd-nanny' => 1,
     'systemd-machine' => 1,
     libvirtd => 1,
-    busctl => 1
+    busctl => 1,
+    snapperd => 1,
+    'session-1' => 1,
+    'session-3' => 1
 );
 
 sub parse_results {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/120970
- Verification runs:
  - aarch64: https://openqa.suse.de/tests/10048843#step/dbus_services_exposure/1
  - s390x: https://openqa.suse.de/tests/10048842#step/dbus_services_exposure/1
