### PR TITLE
Ensure s390x kvm instance is accessible via ssh

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -80,7 +80,7 @@
     <keep_install_network config:type="boolean">true</keep_install_network>
     % }
   </networking>
-  % if ($check_var->('VERSION', '15-SP4')) {
+  % if ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
   <firewall>
     <enable_firewall config:type="boolean">true</enable_firewall>
     <start_firewall config:type="boolean">true</start_firewall>


### PR DESCRIPTION
Port 22 is not open on the s390x KVM system that is installed with the containers autoyast for SLE 15-SP5. This PR ensures that the ssh service is not blocked by the SUT's firewall.

- Related ticket: https://progress.opensuse.org/issues/120142
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/10042759#step/console/1
