### PR TITLE
Switch to use timer() to control monitoring loop

### DIFF
--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -122,10 +122,10 @@ sub monitor_concurrent_guest_installations {
     my $self = shift;
 
     $self->reveal_myself;
-    my $_installation_timeout = 0;
     my $_guest_installations_left = scalar(keys %guest_instances) - scalar(@guest_installations_done);
     my $_guest_installations_not_the_last = 1;
-    while ($_installation_timeout < 3600) {
+    my $_monitor_start_time = time();
+    while (time() - $_monitor_start_time <= 7200) {
         foreach (keys %guest_instances) {
             if ($guest_instances{$_}->{guest_installation_result} eq '') {
                 $guest_instances{$_}->attach_guest_installation_screen if (($_guest_installations_not_the_last ne 0) or ($guest_instances{$_}->{guest_installation_attached} ne 'true'));
@@ -145,7 +145,6 @@ sub monitor_concurrent_guest_installations {
         }
         last if ($_guest_installations_left eq 0);
         sleep 60;
-        $_installation_timeout += 60;
     }
     return $self;
 }


### PR DESCRIPTION
* **Use** Perl built-in timer() function, which is more accurate, to control monitoring loop.

* **The** time out value is 7200 seconds which provides enough buffer for extremely sluggish network and huge number of packages to be installed. Any smaller value may cause unexpected early failure issue because installation is still in progress. So better time efficiency and stay stable and reliable.

* **I** have a real and precise slow installation case, installing 15sp5 guest manually on 12sp5 xen local machine using openQA media recently, which costs more than 1.5 hours, so 7200 seconds is really a reasonable value to cover nearly all use cases.

* **Verification runs:**
  * [oraclelinux on sles15sp5 kvm](https://openqa.suse.de/tests/10048955)
  * [sles15sp5 on sles12sp5 xen failed kernel panic](https://openqa.suse.de/tests/10050255#step/unified_guest_installation/1177)
  * [3 guests in total, 1 guest failed, non-sles guests](https://openqa.suse.de/tests/10049725)
  * [3 guests in total, 2 guests failed, sles guests](https://openqa.suse.de/tests/10049777)