### PR TITLE
PublicCloud - split post_fail_hook and post_run_hook logic

### DIFF
--- a/lib/publiccloud/acr.pm
+++ b/lib/publiccloud/acr.pm
@@ -40,7 +40,11 @@ sub delete_image {
 
 sub cleanup() {
     my ($self) = @_;
-    $self->provider_client->cleanup();
+}
+
+sub destroy() {
+    my ($self) = @_;
+    $self->provider_client->destroy();
 }
 
 1;

--- a/lib/publiccloud/aks.pm
+++ b/lib/publiccloud/aks.pm
@@ -38,6 +38,12 @@ sub delete_container_image {
         "az acr repository delete --yes --name " . $self->provider_client->container_registry . " --image " . $tag);
 }
 
+sub destroy() {
+    my ($self) = @_;
+
+    $self->provider_client->destroy();
+}
+
 sub cleanup() {
     my ($self) = @_;
 

--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -74,6 +74,10 @@ sub configure_podman {
           . " | podman login --username AWS --password-stdin $full_name_prefix");
 }
 
+sub destroy {
+    my ($self) = @_;
+}
+
 sub cleanup {
     my ($self) = @_;
 }

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -283,10 +283,21 @@ sub parse_instance_id
 }
 
 =head2 cleanup
-This method is called called after each test on failure or success to revoke the credentials
+This method is called after each test module to cleanup
 =cut
 
 sub cleanup {
+    my ($self) = @_;
+    $self->SUPER::cleanup();
+    $self->provider_client->cleanup();
+}
+
+
+=head2 destroy
+This method is called called after each test on failure or success to revoke the credentials
+=cut
+
+sub destroy {
     my ($self, $args) = @_;
     select_host_console(force => 1);
 
@@ -295,8 +306,8 @@ sub cleanup {
     script_run("az vm boot-diagnostics get-boot-log --ids $id | jq -r '.' > bootlog.txt");
     upload_logs("bootlog.txt", failok => 1);
 
-    $self->SUPER::cleanup();
-    $self->provider_client->cleanup();
+    $self->SUPER::destroy();
+    $self->provider_client->destroy();
 }
 
 1;

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -77,6 +77,10 @@ sub get_container_image_full_name {
 }
 
 
+sub destroy {
+    my ($self) = @_;
+}
+
 sub cleanup {
     my ($self) = @_;
 }

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -177,6 +177,10 @@ sub img_proof {
 }
 
 sub cleanup {
+    my ($self) = @_;
+}
+
+sub destroy {
     my ($self, $args) = @_;
     my $instance_id = $args->{my_instance}->{instance_id};
 
@@ -190,7 +194,7 @@ sub cleanup {
 
     $self->terraform_destroy() if ($self->terraform_applied);
     $self->delete_keypair();
-    $self->provider_client->cleanup();
+    $self->provider_client->destroy();
 }
 
 sub describe_instance

--- a/lib/publiccloud/ecr.pm
+++ b/lib/publiccloud/ecr.pm
@@ -35,6 +35,11 @@ sub delete_image {
     return;
 }
 
+sub destroy() {
+    my ($self) = @_;
+    $self->provider_client->destroy();
+}
+
 sub cleanup() {
     my ($self) = @_;
     $self->provider_client->cleanup();

--- a/lib/publiccloud/eks.pm
+++ b/lib/publiccloud/eks.pm
@@ -40,6 +40,12 @@ sub delete_container_image {
           . $tag);
 }
 
+sub destroy() {
+    my ($self) = @_;
+
+    $self->provider_client->destroy();
+}
+
 sub cleanup() {
     my ($self) = @_;
 

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -159,6 +159,13 @@ sub start_instance
 }
 
 sub cleanup {
+    my ($self) = @_;
+
+    $self->SUPER::cleanup();
+    $self->provider_client->cleanup();
+}
+
+sub destroy {
     my ($self, $args) = @_;
 
     select_host_console(force => 1);
@@ -170,8 +177,8 @@ sub cleanup {
     script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region --port=1 > instance_serial.txt", timeout => 180);
     upload_logs("instance_serial.txt", failok => 1);
 
-    $self->SUPER::cleanup();
-    $self->provider_client->cleanup();
+    $self->SUPER::destroy();
+    $self->provider_client->destroy();
 }
 
 1;

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -78,4 +78,8 @@ sub cleanup {
     my ($self) = @_;
 }
 
+sub destroy {
+    my ($self) = @_;
+}
+
 1;

--- a/lib/publiccloud/gke.pm
+++ b/lib/publiccloud/gke.pm
@@ -46,4 +46,10 @@ sub cleanup() {
     $self->provider_client->cleanup();
 }
 
+sub destroy() {
+    my ($self) = @_;
+
+    $self->provider_client->destroy();
+}
+
 1;

--- a/lib/publiccloud/noprovider.pm
+++ b/lib/publiccloud/noprovider.pm
@@ -62,4 +62,9 @@ sub cleanup {
     # Do nothing with existing instance.
 }
 
+sub destroy {
+    my ($self) = @_;
+    # Do nothing with existing instance.
+}
+
 1;

--- a/lib/publiccloud/openstack.pm
+++ b/lib/publiccloud/openstack.pm
@@ -98,11 +98,17 @@ sub terraform_apply {
     return @instances;
 }
 
+
 sub cleanup {
+    my ($self) = @_;
+    $self->provider_client->cleanup();
+}
+
+sub destroy {
     my ($self) = @_;
     $self->terraform_destroy() if ($self->terraform_applied);
     $self->delete_keypair();
-    $self->provider_client->cleanup();
+    $self->provider_client->destroy();
     $self->delete_floating_ip();
 }
 

--- a/lib/publiccloud/openstack_client.pm
+++ b/lib/publiccloud/openstack_client.pm
@@ -77,4 +77,8 @@ sub cleanup {
     my ($self) = @_;
 }
 
+sub destroy {
+    my ($self) = @_;
+}
+
 1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -575,16 +575,28 @@ sub escape_single_quote {
     return $s;
 }
 
+=head2 destroy
+
+This method is called called after each test on failure or complete testsuite run.
+
+=cut
+
+sub destroy {
+    my ($self) = @_;
+    $self->terraform_destroy();
+    assert_script_run "cd";
+}
+
 =head2 cleanup
 
-This method is called called after each test on failure or success.
+This method is called called after each test module.
 
 =cut
 
 sub cleanup {
     my ($self) = @_;
-    $self->terraform_destroy();
-    assert_script_run "cd";
+    # return true value -> disables warning
+    return 1;
 }
 
 =head2 stop_instance

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -196,6 +196,11 @@ sub gen_ltp_env {
     return $environment;
 }
 
+sub test_flags {
+    return {last => 1};
+}
+
+
 1;
 
 =head1 Discussion

--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -16,7 +16,8 @@ use utils;
 sub run {
     my ($self, $args) = @_;
     select_host_console(force => 1);
-    $args->{my_provider}->cleanup($args);
 }
+
+sub test_flags { return {last => 1}; }
 
 1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/119761

This change adds new method destroy to basetest and to overrrides

Now `cleanup` - code which clean up after test module , used by post_run_hook -> for upload extra logs or change state of SUT after test module run

`destroy` starts after fatal fail or on test with `last` flag destroys public cloud instace, it can be overrided (added code) in testmodule itself

New test_flag `last` used by last module in testsuite, now `run_ltp.pm` and `ssh_interactive_end` for start destroy in post_run_hook

- VR's:
  - http://quasar.suse.cz/tests/1348
  - http://quasar.suse.cz/tests/1349
  - http://quasar.suse.cz/tests/1353
