### PR TITLE
Extend timeout for validate_script_output on aarch64

### DIFF
--- a/tests/console/rust.pm
+++ b/tests/console/rust.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(zypper_call);
+use Utils::Architectures 'is_aarch64';
 
 sub run {
     select_console('root-console');
@@ -21,8 +22,10 @@ sub run {
     select_console('user-console');
     assert_script_run('cargo new testproject');
     assert_script_run(qq(echo 'uuid = "0.8"' >> testproject/Cargo.toml));
+    # it takes longer on aarch64, so extend timeout value for aarch64
+    my $timeout = (is_aarch64) ? 600 : 300;
     validate_script_output("cargo run --manifest-path testproject/Cargo.toml",
-        sub { m/Hello, world!/ }, timeout => 300);
+        sub { m/Hello, world!/ }, timeout => $timeout);
 }
 
 1;


### PR DESCRIPTION
we have issue with timeout for validate_script_output 
see https://progress.opensuse.org/issues/120871
VR: https://openqa.suse.de/tests/10049875#step/rust/9