### PR TITLE
Fix bugged `check_version` function

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -12,6 +12,7 @@ use version 'is_lax';
 use Carp 'croak';
 use Utils::Backends;
 use Utils::Architectures;
+use SemVer;
 
 use constant {
     VERSION => [
@@ -190,6 +191,12 @@ sub check_version {
         if (is_lax($pv) && is_lax($qv)) {
             $pv = version->declare($pv);
             $qv = version->declare($qv);
+        }
+        elsif (index($pv, "sp") == -1 && index($qv, "sp") == -1) {
+            eval {
+                $pv = SemVer->declare($pv);
+                $qv = SemVer->declare($qv);
+            }
         }
         return $pv ge $qv if $+{plus} || $+{op} eq '>=';
         return $pv le $qv if $+{op} eq '<=';

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -26,6 +26,8 @@ subtest 'check_version' => sub {
 
     ok version_utils::check_version($_, '10.5.0-Maria'), "check $_, 15.5" for qw(>10.4.4 10.4+ >=10.4-Maria >10.3.0-MySQL);
     ok !version_utils::check_version($_, '10.5.1'), "check $_, 10.5.1" for qw(=10.4.9 <10.5.0);
+    ok version_utils::check_version('>=10.4', '10.10'), "check that poo#120918 doesn't happen";
+    ok version_utils::check_version('>=10.4', '10.10-mariadb'), "check that poo#120918 doesn't happen";
 };
 
 subtest 'is_microos' => sub {


### PR DESCRIPTION
In it's current form, `check_version` tries to check if versions can be parsed by the `Version` module. The problem is, if they can't, the function still goes ahead and compares them, using string comparison. While this would yield the same (correct)results if all version numbers are under 10, it yields wrong results in cases such as `10.10.2 >= 10.4` due to alphabetic precedence.

I added code to instead use the `SemVer` module if the initial parsing by the Version module is not successful. I keep on relying on string comparison if that fails (or if any version string contains `sp`), since comparing OS versions actually relies on string comparisson.

- Related ticket: https://progress.opensuse.org/issues/120918