### PR TITLE
Ensure proper timing on xca key generation

### DIFF
--- a/tests/fips/xca.pm
+++ b/tests/fips/xca.pm
@@ -62,10 +62,12 @@ sub run {
     send_key 'alt-g';
     wait_still_screen 2;
     save_screenshot;
-    send_key 'ret';
-    wait_still_screen 2;
+    # press enter to generate key.
+    # Key generation can take some time on a busy system
+    send_key 'ret', wait_screen_change => 1;
+    wait_still_screen 10;
     save_screenshot;
-    send_key 'alt-o';
+    send_key 'alt-o', wait_screen_change => 1;
     assert_and_click('ok_to_create_certificate');
 
     # The certificate contains no extensions, you may apply the


### PR DESCRIPTION
key generation can be computationally intensive. Wait for screen change between steps

- Related ticket: https://progress.opensuse.org/issues/121081
- Verification runs (20 jobs in parallel):
  - https://openqa.suse.de/tests/10049763  passed
  - https://openqa.suse.de/tests/10049764  passed
  - https://openqa.suse.de/tests/10049765  passed
  - https://openqa.suse.de/tests/10049766  passed
  - https://openqa.suse.de/tests/10049767  passed
  - https://openqa.suse.de/tests/10049768  passed
  - https://openqa.suse.de/tests/10049769  passed
  - https://openqa.suse.de/tests/10049747  passed
  - https://openqa.suse.de/tests/10049748  passed
  - https://openqa.suse.de/tests/10049749  passed
  - https://openqa.suse.de/tests/10049751  passed
  - https://openqa.suse.de/tests/10049752  passed
  - https://openqa.suse.de/tests/10049753  passed
  - https://openqa.suse.de/tests/10049754  passed
  - https://openqa.suse.de/tests/10049755  passed
  - https://openqa.suse.de/tests/10049756  passed
  - https://openqa.suse.de/tests/10049757  passed
  - https://openqa.suse.de/tests/10049758  passed
  - https://openqa.suse.de/tests/10049759  passed
  - https://openqa.suse.de/tests/10049419  passed
  - https://openqa.suse.de/tests/10049560  passed
  - https://openqa.suse.de/tests/10049561  passed
  - https://openqa.suse.de/tests/10049422  passed
  - https://openqa.suse.de/tests/10049423  passed
  - https://openqa.suse.de/tests/10049424  passed
  - https://openqa.suse.de/tests/10049425  passed
  - https://openqa.suse.de/tests/10049558  passed
  - https://openqa.suse.de/tests/10049571  passed
  - https://openqa.suse.de/tests/10049428  passed
  - https://openqa.suse.de/tests/10049429  passed
  - https://openqa.suse.de/tests/10049431  passed
  - https://openqa.suse.de/tests/10049559  passed
  - https://openqa.suse.de/tests/10049433  passed
  - https://openqa.suse.de/tests/10049434  passed
  - https://openqa.suse.de/tests/10049435  passed
  - https://openqa.suse.de/tests/10049436  passed
  - https://openqa.suse.de/tests/10049437  passed
  - https://openqa.suse.de/tests/10049438  passed
  
