### PR TITLE
Fix argument passed to assert_script_sudo

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -33,7 +33,7 @@ Base class implementation of distribution class necessary for testapi
 use testapi qw(send_key %cmd assert_screen check_screen check_var click_lastmatch get_var save_screenshot
   match_has_tag set_var type_password type_string enter_cmd wait_serial $serialdev is_serial_terminal
   mouse_hide send_key_until_needlematch record_info record_soft_failure
-  wait_still_screen wait_screen_change get_required_var diag);
+  wait_still_screen wait_screen_change get_required_var diag hashed_string);
 
 
 =head2 new
@@ -349,7 +349,7 @@ Execute the given command as sudo
 sub script_sudo {
     my ($self, $prog, $wait) = @_;
 
-    my $str = time;
+    my $str = hashed_string("ASS$prog");
     if ($wait > 0) {
         unless ($prog =~ /^bash/) {
             $prog .= "; echo $str-\$?-";

--- a/tests/x11/pidgin/clean_pidgin.pm
+++ b/tests/x11/pidgin/clean_pidgin.pm
@@ -20,7 +20,7 @@ sub remove_pkg {
     x11_start_program('xterm');
 
     # Remove packages
-    assert_script_sudo "zypper -n rm @packages", timeout => 180;
+    assert_script_sudo "zypper -n rm @packages", 180;
     assert_script_run "zypper --no-refresh if @packages|grep 'not installed'";
     enter_cmd "exit";
 }


### PR DESCRIPTION
assert_script_sudo` doesnt make use of timeout. There is a positional argument in place.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Related ticket: https://progress.opensuse.org/issues/120984
- Verification run: http://aquarius.suse.cz/tests/14356

Depends on changes on testapi.pm as well. PR: https://github.com/os-autoinst/os-autoinst/pull/2223
