### PR TITLE
publiccloud : change image registration flow

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -275,7 +275,7 @@ sub wait_for_guestregister
     my $last_info = 0;
 
     # Check what version of registercloudguest binary we use
-    $self->run_ssh_command(cmd => "sudo rpm -qa cloud-regionsrv-client", proceed_on_failure => 1);
+    $self->run_ssh_command(cmd => "rpm -qa cloud-regionsrv-client", proceed_on_failure => 1);
 
     while (time() - $start_time < $args{timeout}) {
         my $out = $self->run_ssh_command(cmd => 'sudo systemctl is-active guestregister', proceed_on_failure => 1, quiet => 1);

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -26,7 +26,7 @@ sub run {
 
     select_host_console();    # select console on the host, not the PC instance
 
-    registercloudguest($args->{my_instance});
+    registercloudguest($args->{my_instance}) if (is_byos());
     register_addons_in_pc($args->{my_instance});
 }
 

--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -10,7 +10,7 @@
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use publiccloud::utils 'is_byos';
+use publiccloud::utils qw(is_byos registercloudguest);
 use publiccloud::ssh_interactive 'select_host_console';
 use utils qw(zypper_call systemctl);
 use version_utils 'is_sle';
@@ -23,8 +23,7 @@ sub run {
     $provider->{username} = 'suse';
     my $instance = $self->{my_instance} = $provider->create_instance();
     my $test_package = 'strace';
-    my $reg_bin = is_sle('>15-sp3') ? 'registercloudguest' : 'SUSEConnect';
-    $instance->run_ssh_command(cmd => sprintf("sudo %s -r %s", $reg_bin, get_required_var('SCC_REGCODE')), timeout => 600);
+    registercloudguest($instance);
     $instance->run_ssh_command(cmd => 'zypper lr -d', timeout => 600);
     $instance->run_ssh_command(cmd => 'systemctl is-enabled issue-generator');
     $instance->run_ssh_command(cmd => 'systemctl is-enabled transactional-update.timer');

--- a/variables.md
+++ b/variables.md
@@ -315,3 +315,4 @@ TERRAFORM_TIMEOUT | integer | 1800 | Set timeout for terraform actions
 PUBLIC_CLOUD_INSTANCE_IP | string | "" | If defined, no instance will be created and this IP will be used to connect to
 _SECRET_PUBLIC_CLOUD_INSTANCE_SSH_KEY | string | "" | The `~/.ssh/id_rsa` existing key allowed by `PUBLIC_CLOUD_INSTANCE_IP` instance
 PUBLIC_CLOUD_TERRAFORM_DIR | string | "/root/terraform" | Override default root path to terraform directory
+PUBLIC_CLOUD_SCC_ENDPOINT | string | "registercloudguest" | Name of binary which will be used to register image . Except default value only possible value is "SUSEConnect" anything else will lead to test failure!


### PR DESCRIPTION
With this PR which regirstration binary is used controled by special variable
PUBLIC_CLOUD_SCC_ENDPOINT. Also flexibility around registercloudguest
not being pre-installed is dropped.