### PR TITLE
[virt_autotest] Fix up Perl warnings with stack traces in jobs

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -772,12 +772,10 @@ sub is_sev_es_guest {
     $guest_name //= '';
     croak('Arugment guest_name should not be empty') if ($guest_name eq '');
 
-    $guest_name =~ /(sev-es|sev)/img;
-    if ($1 ne '') {
+    if ($guest_name =~ /(sev-es|sev)/img) {
         record_info("$guest_name is $1 guest", "Guest $guest_name is a $1 enabled guest judging by its name.");
         return $1;
-    }
-    else {
+    } else {
         record_info("$guest_name is not sev(es) guest", "Guest $guest_name is not a sev or sev-es enabled guest judging by its name.");
         return 'notsev';
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -870,7 +870,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {
         load_virt_guest_install_tests;
-        if (is_x86_64 && !(get_var("GUEST_PATTERN") =~ /win/img) && !get_var("LTSS")) {
+        if (!(get_var('GUEST_PATTERN', '') =~ /win/img) && is_x86_64 && !get_var("LTSS")) {
             load_virt_feature_tests;
             loadtest "virt_autotest/validate_system_health" if get_var("VALIDATE_SYSTEM_HEALTH");
         }

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -100,7 +100,7 @@ sub install_package {
     virt_autotest::utils::install_default_packages();
 
     ###Install required package for window guest installation on xen host
-    if (get_var('GUEST_LIST') =~ /^win-.*/ && (is_xen_host)) { zypper_call '--no-refresh --no-gpg-checks in mkisofs' }
+    if (get_var('GUEST_LIST', '') =~ /^win-.*/ && (is_xen_host)) { zypper_call '--no-refresh --no-gpg-checks in mkisofs' }
 
     #Subscribing packagehub from SLE 15-SP4 onwards that enables access to many useful software tools
     virt_autotest::utils::subscribe_extensions_and_modules(reg_exts => 'PackageHub') if (is_sle('>=15-sp4') and !is_s390x);

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -37,6 +37,8 @@ sub generateXML {
     my $skip_nums = 0;
     my $test_time_hours = 0;
     my $test_time_mins = 0;
+    my $time_hours = 0;
+    my $time_mins = 0;
     foreach my $item (keys(%my_hash)) {
         if ($my_hash{$item}->{status} =~ m/PASSED/) {
             $pass_nums += 1;
@@ -50,8 +52,8 @@ sub generateXML {
         }
         my $test_time = eval { $my_hash{$item}->{test_time} ? $my_hash{$item}->{test_time} : '' };
         if ($test_time ne '') {
-            my ($time_hours) = $test_time =~ /^(\d+)m.*s$/i;
-            my ($time_mins) = $test_time =~ /^.*m(\d+)s$/i;
+            $time_hours = $test_time =~ /^(\d+)m.*s$/i;
+            $time_mins = $test_time =~ /^.*m(\d+)s$/i;
             $test_time_hours += $time_hours;
             $test_time_mins += $time_mins;
         }
@@ -188,6 +190,9 @@ sub run_test {
     if (!$timeout) {
         $timeout = 300;
     }
+    $add_junit_log_flag //= 'no';
+    $upload_virt_log_flag //= 'no';
+    $upload_guest_assets_flag //= 'no';
 
     check_host_health;
 


### PR DESCRIPTION
Refer to poo#120750, try to fix up the Perl warnings with stack traces in jobs. 
Such as:
```
Use of uninitialized value in string eq at sle/tests/virt_autotest/virt_autotest_base.pm line 122.
	virt_autotest_base::post_execute_script_run(host_upgrade_generate_run_file=HASH(0x55ba82a94238)) called at sle/tests/virt_autotest/virt_autotest_base.pm line 200
	virt_autotest_base::run_test(host_upgrade_generate_run_file=HASH(0x55ba82a94238), 180, "Generated test run file") called at sle/tests/virt_autotest/host_upgrade_generate_run_file.pm line 45
	host_upgrade_generate_run_file::run(host_upgrade_generate_run_file=HASH(0x55ba82a94238)) called at /usr/lib/os-autoinst/basetest.pm line 337
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 331
	basetest::runtest(host_upgrade_generate_run_file=HASH(0x55ba82a94238)) called at /usr/lib/os-autoinst/autotest.pm line 360
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 360
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 243
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 243
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 294
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x55ba833fb5b0)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x55ba833fb5b0), CODE(0x55ba832d0350)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 488
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x55ba833fb5b0)) called at /usr/lib/os-autoinst/autotest.pm line 296
	autotest::start_process() called at /usr/bin/isotovideo line 258
```
Solution: 
Before using, declare and assign variables - `$add_junit_log_flag, $upload_virt_log_flag and $upload_guest_assets_flag` in advance

```
Use of uninitialized value in pattern match (m//) at sle/products/sle/main.pm line 873.
	require sle/products/sle/main.pm called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 245
	OpenQA::Isotovideo::Utils::try {...} () called at /usr/lib/perl5/vendor_perl/5.26.1/Try/Tiny.pm line 102
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Try/Tiny.pm line 93
	Try::Tiny::try(CODE(0x1002379a5b8), Try::Tiny::Catch=REF(0x1002128c070)) called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 262
	OpenQA::Isotovideo::Utils::load_test_schedule() called at /usr/bin/isotovideo line 232
Subroutine fufill_guests_in_setting redefined at sle/tests/virt_autotest/set_config_as_glue.pm line 17.
	require set_config_as_glue.pm called at sle/tests/virt_autotest/libvirt_virtual_network_init.pm line 19
	libvirt_virtual_network_init::BEGIN() called at sle/tests/virt_autotest/set_config_as_glue.pm line 17
	eval {...} called at sle/tests/virt_autotest/set_config_as_glue.pm line 17
	require sle/tests/virt_autotest/libvirt_virtual_network_init.pm called at (eval 378) line 1
	eval 'package libvirt_virtual_network_init;use lib \'.\';use lib \'sle/lib\';use lib \'sle/tests/virt_autotest\';require \'sle/tests/virt_autotest/libvirt_virtual_network_init.pm\';' called at /usr/lib/os-autoinst/autotest.pm line 125
	autotest::loadtest("tests/virt_autotest/libvirt_virtual_network_init.pm") called at sle/lib/main_common.pm line 142
	main_common::loadtest("virt_autotest/libvirt_virtual_network_init") called at sle/products/sle/main.pm line 613
	OpenQA::Isotovideo::Utils::load_virt_feature_tests() called at sle/products/sle/main.pm line 874
	require sle/products/sle/main.pm called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 245
	OpenQA::Isotovideo::Utils::try {...} () called at /usr/lib/perl5/vendor_perl/5.26.1/Try/Tiny.pm line 102
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Try/Tiny.pm line 93
	Try::Tiny::try(CODE(0x1002379a5b8), Try::Tiny::Catch=REF(0x1002128c070)) called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 262
	OpenQA::Isotovideo::Utils::load_test_schedule() called at /usr/bin/isotovideo line 232
Subroutine run redefined at sle/tests/virt_autotest/set_config_as_glue.pm line 30.
	require set_config_as_glue.pm called at sle/tests/virt_autotest/libvirt_virtual_network_init.pm line 19
	libvirt_virtual_network_init::BEGIN() called at sle/tests/virt_autotest/set_config_as_glue.pm line 30
	eval {...} called at sle/tests/virt_autotest/set_config_as_glue.pm line 30
	require sle/tests/virt_autotest/libvirt_virtual_network_init.pm called at (eval 378) line 1
	eval 'package libvirt_virtual_network_init;use lib \'.\';use lib \'sle/lib\';use lib \'sle/tests/virt_autotest\';require \'sle/tests/virt_autotest/libvirt_virtual_network_init.pm\';' called at /usr/lib/os-autoinst/autotest.pm line 125
	autotest::loadtest("tests/virt_autotest/libvirt_virtual_network_init.pm") called at sle/lib/main_common.pm line 142
	main_common::loadtest("virt_autotest/libvirt_virtual_network_init") called at sle/products/sle/main.pm line 613
	OpenQA::Isotovideo::Utils::load_virt_feature_tests() called at sle/products/sle/main.pm line 874
	require sle/products/sle/main.pm called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 245
	OpenQA::Isotovideo::Utils::try {...} () called at /usr/lib/perl5/vendor_perl/5.26.1/Try/Tiny.pm line 102
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Try/Tiny.pm line 93
	Try::Tiny::try(CODE(0x1002379a5b8), Try::Tiny::Catch=REF(0x1002128c070)) called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 262
	OpenQA::Isotovideo::Utils::load_test_schedule() called at /usr/bin/isotovideo line 232
```
Solution:
Try to use `!(get_var('GUEST_PATTERN', '') ` if `$GUEST_PATTERN` was not declared

```
Use of uninitialized value in pattern match (m//) at sle/tests/virt_autotest/install_package.pm line 103.
	install_package::install_package() called at sle/tests/virt_autotest/install_package.pm line 110
	install_package::run(install_package=HASH(0x10026bd2450)) called at /usr/lib/os-autoinst/basetest.pm line 339
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 333
	basetest::runtest(install_package=HASH(0x10026bd2450)) called at /usr/lib/os-autoinst/autotest.pm line 387
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 387
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 244
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 244
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 295
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98), CODE(0x1002931bf58)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 489
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98)) called at /usr/lib/os-autoinst/autotest.pm line 297
	autotest::start_process() called at /usr/bin/isotovideo line 243
```
Solution:
Try to use `(get_var('GUEST_LIST', '') ` if `$GUEST_LIST` was not declared  

```
Use of uninitialized value $time_hours in addition (+) at sle/tests/virt_autotest/virt_autotest_base.pm line 55.
	virt_autotest_base::generateXML(unified_guest_installation=HASH(0x10026cbe508), HASH(0x100294999e8)) called at sle/lib/concurrent_guest_installations.pm line 211
	concurrent_guest_installations::junit_log_provision(unified_guest_installation=HASH(0x10026cbe508), "concurrent_guest_installations::concurrent_guest_installation"...) called at sle/lib/concurrent_guest_installations.pm line 250
	concurrent_guest_installations::concurrent_guest_installations_run(unified_guest_installation=HASH(0x10026cbe508), HASH(0x100272ae278)) called at sle/tests/virt_autotest/unified_guest_installation.pm line 72
	unified_guest_installation::run(unified_guest_installation=HASH(0x10026cbe508)) called at /usr/lib/os-autoinst/basetest.pm line 339
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 333
	basetest::runtest(unified_guest_installation=HASH(0x10026cbe508)) called at /usr/lib/os-autoinst/autotest.pm line 387
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 387
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 244
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 244
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 295
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98), CODE(0x1002931bf58)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 489
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98)) called at /usr/lib/os-autoinst/autotest.pm line 297
	autotest::start_process() called at /usr/bin/isotovideo line 243
```
Solution:
Before using, declare and assign variables - `$time_hours` and `$time_mins`  in advance

```
Use of uninitialized value $1 in string ne at sle/lib/virt_autotest/utils.pm line 776.
	virt_autotest::utils::is_sev_es_guest("sles-15-sp5-64-fv-uefi-kvm") called at sle/tests/virt_autotest/sriov_network_card_pci_passthrough.pm line 57
	sriov_network_card_pci_passthrough::run_test(sriov_network_card_pci_passthrough=HASH(0x1002735fb88)) called at sle/lib/virt_feature_test_base.pm line 67
	virt_feature_test_base::run(sriov_network_card_pci_passthrough=HASH(0x1002735fb88)) called at /usr/lib/os-autoinst/basetest.pm line 339
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 333
	basetest::runtest(sriov_network_card_pci_passthrough=HASH(0x1002735fb88)) called at /usr/lib/os-autoinst/autotest.pm line 387
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 387
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 244
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 244
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 295
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98), CODE(0x1002931bf58)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 489
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x10027a70d98)) called at /usr/lib/os-autoinst/autotest.pm line 297
	autotest::start_process() called at /usr/bin/isotovideo line 243
```
Reason:
When ever the Regular Expression fails to match, $1 have no value.

Solution:
For this reason, it's considered best practice on ever to use $1, etc. inside a conditional which tests the success of the Regular Expression. 
Which is why in most cases one should use if(regex) { # use $1, etc.

- Related ticket: https://progress.opensuse.org/issues/120750
- Verification run: 
[prj2_host_upgrade_sles15sp4_to_developing_xen](https://openqa.suse.de/tests/10057377#)
[prj2_host_upgrade_sles12sp5_to_developing_xen](https://openqa.suse.de/tests/10057447#)
[prj2_host_upgrade_sles12sp5_to_developing_kvm](https://openqa.suse.de/tests/10057593#)
[prj2_host_upgrade_sles15sp4_to_developing_kvm](https://openqa.suse.de/tests/10057594#)
[uefi-gi-guest_sles15sp4-on-host_developing-kvm](https://openqa.suse.de/tests/10253285#)
[uefi-gi-guest_sles12sp5-on-host_developing-kvm](https://openqa.suse.de/tests/10253287#)
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/10253293#)