### PR TITLE
Wait longer to install cockpit and dependencies

### DIFF
--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -49,7 +49,7 @@ sub run {
 
     if (@pkgs) {
         record_info('TEST', 'Installing Cockpit\'s Modules...');
-        trup_call("pkg install @pkgs", timeout => 360);
+        trup_call("pkg install @pkgs", timeout => 480);
         check_reboot_changes;
     }
 


### PR DESCRIPTION
`cockpit cockpit-machines cockpit-tukit` pulls additional 290+ packages. This process currently times out on aarch64 or ALP test suites.

- Verification run: [alp-0.1-kvm-x86_64-Build21.12-alp_default@64bit](https://openqa.opensuse.org/t2917331)
