### PR TITLE
Implement userspace livepatching tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -254,7 +254,8 @@ sub packagekit_available {
 
 sub is_ltp_test {
     return (get_var('INSTALL_LTP')
-          || get_var('LTP_COMMAND_FILE'));
+          || get_var('LTP_COMMAND_FILE')
+          || get_var('LIBC_LIVEPATCH'));
 }
 
 sub is_publiccloud_ltp_test {

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -42,9 +42,18 @@ sub load_kernel_tests {
             loadtest_kernel 'update_kernel';
         }
         loadtest_kernel 'install_ltp';
+
+        if (get_var('LIBC_LIVEPATCH')) {
+            die 'LTP_COMMAND_FILE and LIBC_LIVEPATCH are mutually exclusive'
+              if get_var('LTP_COMMAND_FILE');
+            loadtest_kernel 'ulp_openposix';
+        }
+
         # If there is a command file then install_ltp schedules boot_ltp which
-        # will schedule shutdown
-        shutdown_ltp() unless get_var('LTP_COMMAND_FILE');
+        # will schedule shutdown. If there is LIBC_LIVEPATCH, shutdown will be
+        # scheduled by ulp_openposix.
+        shutdown_ltp()
+          unless get_var('LTP_COMMAND_FILE') || get_var('LIBC_LIVEPATCH');
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
         if (get_var('INSTALL_KOTD')) {
@@ -99,6 +108,10 @@ sub load_kernel_tests {
     } elsif (get_var('NUMA_IRQBALANCE')) {
         boot_hdd_image();
         loadtest_kernel 'numa_irqbalance';
+    }
+    elsif (get_var('LIBC_LIVEPATCH')) {
+        loadtest_kernel 'boot_ltp';
+        loadtest_kernel 'ulp_openposix';
     }
 
     if (is_svirt && get_var('PUBLISH_HDD_1')) {

--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -1,0 +1,92 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Install glibc livepatch and run openposix testsuite
+# Maintainer: Martin Doucha <mdoucha@suse.cz>
+
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use serial_terminal;
+use klp;
+use LTP::utils;
+use OpenQA::Test::RunArgs;
+
+sub prepare_repo {
+    my ($packname) = @_;
+    my @repos = split(",", get_required_var('INCIDENT_REPO'));
+    my @repo_names;
+
+    install_klp_product;
+    zypper_call('in libpulp0 libpulp-tools');
+
+    while ((my ($i, $url)) = (each(@repos))) {
+        push @repo_names, "ULP_$i";
+        zypper_ar($url, name => $repo_names[$i]);
+    }
+
+    my $repo_args = join(' ', map({ "-r $_" } @repo_names));
+    my $provides = script_output("zypper -n info --provides $repo_args $packname");
+    my @versions = $provides =~ m/^\s*libc_([^_]+)_livepatch\d+\.so\(\)\([^)]+\)\s*$/gm;
+
+    die "Package $packname contains no libc livepatches" unless scalar @versions;
+
+    prepare_ltp_env;
+    return \@versions;
+}
+
+sub run {
+    my ($self, $tinfo) = @_;
+    my ($glibc_versions, $run_id);
+    my $packname = "glibc-livepatches";
+
+    select_serial_terminal;
+
+    if (!defined($tinfo)) {
+        # First test round in the job, prepare environment
+        $glibc_versions = prepare_repo($packname);
+        $run_id = 0;
+    } else {
+        $glibc_versions = $tinfo->{glibc_versions};
+        $run_id = $tinfo->{run_id};
+        zypper_call("rm $packname");
+    }
+
+    # Schedule openposix tests and install the livepatch
+    my $libver = $$glibc_versions[$run_id];
+    record_info('glibc version', $libver);
+    zypper_call("in --oldpackage glibc-$libver");
+    schedule_tests('openposix', "_glibc-$libver");
+    loadtest_kernel('ulp_threads', name => "ulp_threads_glibc-$libver");
+    zypper_call("in $packname");
+
+    # Run tests again with the next untested glibc version
+    if ($run_id < $#$glibc_versions) {
+        my $runargs = OpenQA::Test::RunArgs->new(run_id => $run_id + 1,
+            glibc_versions => $glibc_versions);
+
+        loadtest_kernel('ulp_openposix', run_args => $runargs);
+    }
+    else {
+        shutdown_ltp;
+    }
+}
+
+sub test_flags {
+    return {
+        fatal => 1,
+        milestone => 1,
+    };
+}
+
+=head1 Configuration
+
+This test module is activated by LIBC_LIVEPATCH=1
+
+=cut
+
+1;

--- a/tests/kernel/ulp_threads.pm
+++ b/tests/kernel/ulp_threads.pm
@@ -1,0 +1,65 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Apply livepatch to a process with multiple (thousand) threads
+# Maintainer: Martin Doucha <mdoucha@suse.cz>
+
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+
+sub run {
+    my ($self) = @_;
+
+    my $threadcount = get_var('ULP_THREAD_COUNT', 1000);
+    my $threadsleep = get_var('ULP_THREAD_SLEEP', 100);
+    my $livepatch_list = script_output('rpm -ql glibc-livepatches');
+    assert_script_run('export LD_PRELOAD=/usr/lib64/libpulp.so.0');
+
+    # Do not use background_script_run() here. The actual test runs inside
+    # a subprocess and we need to read the target PID from test output.
+    # Using background_script_run() would create a race condition and cause
+    # random failures.
+    enter_cmd("ulp_threads01 -t $threadcount -s $threadsleep &");
+
+    # Read test PID for sending SIGUSR1
+    my $status = wait_serial(qr/PID \d+ ready/);
+    die 'Failed to parse test PID' unless $status =~ m/PID (\d+) ready/;
+    my $pid = $1;
+
+    # Read test PID for `wait`
+    enter_cmd('echo PID:$!.');
+    my $parent = wait_serial(qr/PID:\d+\./);
+    die 'Failed to parse test PID' unless $parent =~ m/PID:(\d+)\./;
+    $parent = $1;
+
+    for my $patch (split /\n/, $livepatch_list) {
+        assert_script_run("time ulp trigger -r 100 --timeout 200 '$patch'",
+            timeout => 600) if $patch =~ m/\.so$/;
+    }
+
+    assert_script_run("kill -s USR1 $pid; wait $parent");
+}
+
+1;
+
+=head1 Configuration
+
+This test module is activated by LIBC_LIVEPATCH=1
+
+=head2 ULP_THREAD_COUNT
+
+The number of threads that will run during process livepatching. The test
+program can adjust system thread count limits if necessary. Default: 1000
+
+=head2 ULP_THREAD_SLEEP
+
+Sleep length after each thread loop iteration (in milliseconds). High
+thread-to-CPU ratio requires longer sleep length, otherwise the test process
+may time out during clean up after receiving signal to terminate.
+Default: 100ms
+
+=cut

--- a/variables.md
+++ b/variables.md
@@ -98,6 +98,7 @@ KEEP_DISKS | boolean | false | Prevents disks wiping for remote backends without
 KEEP_ONLINE_REPOS | boolean | false | openSUSE specific variable, not to replace original repos in the installed system with snapshot mirrors which are not yet published.
 KEEP_PERSISTENT_NET_RULES | boolean | false | Keep udev rules 70-persistent-net.rules, which are deleted on backends with image support (qemu, svirt) by default.
 LAPTOP |||
+LIBC_LIVEPATCH | boolean | false | If set, run userspace livepatching tests
 LINUX_BOOT_IPV6_DISABLE | boolean | false | If set, boots linux kernel with option named "ipv6.disable=1" which disables IPv6 from startup.
 LINUXRC_KEXEC | integer | | linuxrc has the capability to download and run a new kernel and initrd pair from the repository.<br> There are four settings for the kexec option:<br> 0: feature disabled;<br> 1: always restart with kernel/initrd from repository (without bothering to check if it's necessary);<br>2: restart only if needed - that is, if linuxrc detects that the booted initrd is outdated (this is the default);<br>3: like kexec=2 but without user interaction.<br> *More details [here](https://en.opensuse.org/SDB:Linuxrc)*.
 LIVECD | boolean | false | Indicates live image being used.
@@ -180,6 +181,8 @@ TOGGLEHOME | boolean | false | Changes the state of partitioning to have or not 
 TUNNELED | boolean | false | Enables the use of normal consoles like "root-consoles" on a remote SUT while configuring the tunnel in a local "tunnel-console"
 TYPE_BOOT_PARAMS_FAST | boolean | false | When set, forces `bootloader_setup::type_boot_parameters` to use the default typing interval.
 UEFI | boolean | false | Indicates UEFI in the testing environment.
+ULP_THREAD_COUNT | integer | 1000 | Number of threads to create in `ulp_threads` test module.
+ULP_THREAD_SLEEP | integer | 100 | Sleep length after each thread loop iteration in `ulp_threads` module. High thread-to-CPU ratio needs longer sleep length.
 UPGRADE | boolean | false | Indicates upgrade scenario.
 USBBOOT | boolean | false | Indicates booting to the usb device.
 USEIMAGES |||


### PR DESCRIPTION
New test based on ltp_openposix (ulp_openposix):
1. Install `libpulp` and `libpulp-tools`
2. Start all openposix tests in background (paused)
3. Livepatch all openposix test processes
4. Unpause all openposix test processes and check results as usual

New multithread livepatching test (ulp_threads):
1. Start test process with given number of threads
2. Apply livepatches
3. Send exit signal to test process
4. Check result

When the livepatch package applies to multiple glibc target versions, the above tests will be scheduled multiple times in the job, once for each target version.

New job settings:
- `LIBC_LIVEPATCH` - Enables the above test scenario if set to 1
- `ULP_THREAD_COUNT` - Number of threads to create in ulp_threads
- `ULP_THREAD_SLEEP` - Sleep length after each thread loop iteration in ulp_threads

----

- Related ticket: https://progress.opensuse.org/issues/112004
- Needles: N/A
- Verification run: Pending (waiting for related LTP changes)
