### PR TITLE
Fix the image creation of SAP image for migration

### DIFF
--- a/data/autoyast_sle12/create_hdd/create_hdd_sap_sles.xml.ep
+++ b/data/autoyast_sle12/create_hdd/create_hdd_sap_sles.xml.ep
@@ -3,7 +3,7 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
   <do_registration config:type="boolean">true</do_registration>
-  <reg_code>{{SCC_REGCODE}}</reg_code>
+  <reg_code><%= $get_var->('SCC_REGCODE_SLES4SAP') %></reg_code>
     <install_updates config:type="boolean">true</install_updates>
   </suse_register>
   <bootloader>
@@ -209,6 +209,8 @@
         <service>YaST2-Firstboot</service>
         <service>YaST2-Second-Stage</service>
         <service>getty@tty1</service>
+        <service>sapconf</service>
+        <service>sapinit</service>
       </enable>
     </services>
   </services-manager>
@@ -265,7 +267,6 @@
   <user_defaults>
     <expire/>
     <group>100</group>
-    <groups/>
     <home>/home</home>
     <inactive>-1</inactive>
     <no_groups config:type="boolean">true</no_groups>
@@ -273,6 +274,29 @@
     <skel>/etc/skel</skel>
     <umask>022</umask>
   </user_defaults>
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1002</gid>
+      <group_password>x</group_password>
+      <groupname>sapsys</groupname>
+      <userlist>qadadm</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>saprouter</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist>qadadm</userlist>
+    </group>
+  </groups>
   <users config:type="list">
     <user>
       <encrypted config:type="boolean">true</encrypted>
@@ -291,6 +315,60 @@
       <uid>0</uid>
       <user_password>$6$FPZli6dRHjYZ$3bxzkOeXFG1BDzcZFVCAQyqPrErPgFIY2XCMT.sGMZ6Ld1nNUrw2cr0Mxj6V9Hj5G9Mcus/6w5Sd/ZNwwmlV./</user_password>
       <username>root</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SAP System Administrator</fullname>
+      <gid>1002</gid>
+      <home>/home/qadadm</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/csh</shell>
+      <uid>1001</uid>
+      <user_password>$6$FPZli6dRHjYZ$3bxzkOeXFG1BDzcZFVCAQyqPrErPgFIY2XCMT.sGMZ6Ld1nNUrw2cr0Mxj6V9Hj5G9Mcus/6w5Sd/ZNwwmlV./</user_password>
+      <username>qadadm</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname/>
+      <gid>100</gid>
+      <home>/var/lib/saprouter</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>1000</uid>
+      <user_password>!</user_password>
+      <username>saprouter</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SAP System Administrator</fullname>
+      <gid>1002</gid>
+      <home>/home/sapadm</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>1002</uid>
+      <user_password>$6$emPnZkjg$.YdCvmDjOXNKXpxzUTeUg41QJoRZnJNd3RkbDPtlMUdcDSnkSKJw3LE70chae5mX4mKuJ5Y.JJ3kjM2KDq8tJ0</user_password>
+      <username>sapadm</username>
     </user>
   </users>
 </profile>

--- a/schedule/yast/maintenance/sap_autoyast_create_hdd_gnome_netweaver_sle12.yaml
+++ b/schedule/yast/maintenance/sap_autoyast_create_hdd_gnome_netweaver_sle12.yaml
@@ -1,0 +1,48 @@
+---
+name: sap_autoyast_create_hdd_gnome_netweaver_sle12
+description: '|
+
+  NetWeaver tests for SLES for SAP Applications on a registered
+  system.** VERSION FOR SLE12 - NEEDED FOR UPGRADE TO SLE15+ **PUBLISH_HDD_1 is here
+  to be able to do upgrade tests from a SLE-N version to SLE-N+1 (in case of SLE-12
+  to SLE-15 for example) The image has to be de-registered before the upgrade process.'
+vars:
+  APPTESTS: console/system_prepare,sles4sap/patterns,sles4sap/netweaver_install,sles4sap/netweaver_test_instance
+  AUTOYAST: autoyast_sle12/create_hdd/create_hdd_sap_sles.xml.ep
+  DESKTOP: gnome
+  DM_NEEDS_USERNAME: '1'
+  HDDSIZEGB: '60'
+  INSTALLONLY: '1'
+  INSTANCE_ID: '00'
+  INSTANCE_SID: QAD
+  INSTANCE_TYPE: ASCS
+  PUBLISH_HDD_1: autoyast_SLES-%VERSION%-%ARCH%-SAP-updated.qcow2
+  ROOTONLY: '1'
+  SCC_DEREGISTER: '1'
+  SCC_REGISTER: installation
+  SHUTDOWN_NEEDS_AUTH: '1'
+  SLES4SAP_MODE: sles4sap
+  SLE_PRODUCT: sles4sap
+  _OLD_TIMEOUT_SCALE: '2'
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - sles4sap/netweaver_install
+  - sles4sap/netweaver_test_instance
+  - console/scc_deregistration
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
eab10590931f0d07f8b03797df40667cdc4df7dc:
Fix small problems in create_hdd_sap_sles.xml.ep

- Adds some users groups and services necessary for the children jobs.
- use the scripted way instead of markup to feed scc_regcode, for some
  reason soemtimes the markup is not processed.

Follows https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15840#discussion_r1033563162
related ticket https://progress.opensuse.org/issues/119683

95bea144658da86d23bfaffce84d991c8941ab89:
 Add a schedule file for sap_autoyast_create_hdd_gnome_12

Until now we used the same Yaml as for create_hdd_maintenance, but we
were missing the installation of netweaver, needed by children jobs.
Also we don't need path_and_reboot here. This schedule is based on the
original parent test suite, create_hdd_sles4sap_gnome_sle12*.

VRs: https://openqa.suse.de/tests/overview?distri=sle&build=JRivrain%2Fos-autoinst-distri-opensuse%2316013
There are some failures on few jobs on ppc, but maybe it's the scope of the child task https://progress.opensuse.org/issues/120076 to solve this.

MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/436