### PR TITLE
Use yast workarounds header in registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -13,6 +13,7 @@ use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call s
 use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
+use YaST::workarounds;
 
 our @EXPORT = qw(
   add_suseconnect_product


### PR DESCRIPTION
- Related ticket: No ticket, related to [this](https://openqa.suse.de/tests/10062298#step/scc_registration/3) recent failure
- Needles: No needles
- Verification run: Pending
