### PR TITLE
Increase timeout in upload logs check

### DIFF
--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -14,6 +14,7 @@ package network_utils;
 
 use base Exporter;
 use Exporter;
+use Socket;
 
 use strict;
 use warnings;
@@ -72,7 +73,8 @@ Returns if can ping worker host gateway
 sub can_upload_logs {
     my ($gw) = @_;
     $gw ||= testapi::host_ip();
-    return (script_run('ping -c 1 ' . $gw) == 0);
+    my $gw_ip = inet_ntoa(inet_aton($gw));
+    return (script_run('ping -c 1 -W 120 ' . $gw_ip, timeout => 120) == 0);
 }
 
 


### PR DESCRIPTION
Occasionally the default time out is not enough when checking if we can upload logs, and, while the ping command returns successfully, the script_run command times out. We increase the timeout to 60 seconds to mitigate this sporadic issue.

- Related ticket: https://progress.opensuse.org/issues/120429
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/10064769#step/logs_from_installation_system/4
