### PR TITLE
Run YaST with ncurses in yast2_migration module in PowerVM

### DIFF
--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -152,7 +152,8 @@ sub run {
     }
 
     my $migration_cmd = get_var('LEAP_TECH_PREVIEW_REPO') ? 'migration_sle' : 'migration';
-    script_run("yast2 $migration_cmd; echo yast2-migration-done-\$? > /dev/$serialdev", 0);
+    my $yast_cmd = is_pvm ? 'yast' : 'yast2';
+    script_run("$yast_cmd $migration_cmd; echo yast2-migration-done-\$? > /dev/$serialdev", 0);
 
     # yast2 migration would check and install minimal update before migration
     # if the system doesn't perform full update or minimal update


### PR DESCRIPTION
make sure run yast2_migration with ncurses in PowerVM

- Related ticket: https://progress.opensuse.org/issues/119950
- Verification run: https://openqa.suse.de/tests/10070229#step/yast2_migration/2, https://openqa.suse.de/tests/10070231#step/yast2_migration/1