### PR TITLE
Make sure xterm test is run in x11 console

### DIFF
--- a/tests/x11/xterm.pm
+++ b/tests/x11/xterm.pm
@@ -17,6 +17,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
+    select_console 'x11';
     $self->test_terminal('xterm');
 }
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/121300
Switch to console x11 in case previous jobs
are run in serial terminal

- Related ticket: https://progress.opensuse.org/issues/121300
- Verification run: [VR](https://openqa.suse.de/tests/10070040#details)
