### PR TITLE
x11/remote_desktop: use assert_and_click to close vncviewer

### DIFF
--- a/tests/x11/remote_desktop/onetime_vncsession_multilogin_failed.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_multilogin_failed.pm
@@ -52,7 +52,7 @@ sub run {
     assert_screen 'xvnc-multilogin-refused';
     send_key 'f8';
     assert_screen 'vncviewer-menu';
-    send_key 'x';
+    assert_and_click 'vncviewer-menu-exit';
 
     # Exit the minimized session
     hold_key 'alt';
@@ -61,7 +61,7 @@ sub run {
     assert_screen 'generic-desktop';
     send_key 'f8';
     assert_screen 'vncviewer-menu';
-    send_key 'x';
+    assert_and_click 'vncviewer-menu-exit';
 
     mutex_unlock 'xvnc';
 }

--- a/tests/x11/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
@@ -51,7 +51,7 @@ sub run {
     # Exit vncviewer
     send_key 'f8';
     assert_screen 'vncviewer-menu';
-    send_key 'x';
+    assert_and_click 'vncviewer-menu-exit';
 
     mutex_unlock 'xvnc';
 }

--- a/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
@@ -81,7 +81,7 @@ sub run {
     # Exit the vncviewer
     send_key 'f8';
     assert_screen 'vncviewer-menu';
-    send_key 'x';
+    assert_and_click 'vncviewer-menu-exit';
     assert_screen 'generic-desktop';
 
     # Re-login to the previous session
@@ -99,7 +99,7 @@ sub run {
     # Exit the sharing session
     send_key 'f8';
     assert_screen 'vncviewer-menu';
-    send_key 'x';
+    assert_and_click 'vncviewer-menu-exit';
 
     # Terminate the minimized session
     hold_key 'alt';


### PR DESCRIPTION
In recent build, vncviewer is updated to version 1.12.0, some key shortcuts are changed.  So to make the test more robust and compatible with both old and new version, it is better to use "assert_and_click" instead of "send_key" to close the vncviewer.

- Related ticket: https://progress.opensuse.org/issues/121297
- Needles: already added
- Verification run: 
https://openqa.suse.de/tests/10070042#step/onetime_vncsession_xvnc_tigervnc/30
https://openqa.suse.de/tests/10070045#step/persistent_vncsession_xvnc/24
opensuse does not contain such tests.
