### PR TITLE
ltp: Add XEN host support

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -56,6 +56,7 @@ our @EXPORT = qw(
   GRUB_CFG_FILE
   GRUB_DEFAULT_FILE
   add_grub_cmdline_settings
+  add_grub_xen_replace_cmdline_settings
   change_grub_config
   get_cmdline_var
   grep_grub_cmdline_settings
@@ -1280,6 +1281,19 @@ C<$update_grub> if set, regenerate /boot/grub2/grub.cfg with grub2-mkconfig and 
 sub add_grub_xen_cmdline_settings {
     my ($add, $update_grub) = @_;
     add_grub_cmdline_settings($add, $update_grub, "GRUB_CMDLINE_XEN_DEFAULT");
+}
+
+=head2 add_grub_xen_replace_cmdline_settings
+
+    add_grub_xen_replace_cmdline_settings($add [, $update_grub ]);
+
+Add C<$add> into /etc/default/grub, using sed.
+C<$update_grub> if set, regenerate /boot/grub2/grub.cfg with grub2-mkconfig and upload configuration.
+=cut
+
+sub add_grub_xen_replace_cmdline_settings {
+    my ($add, $update_grub) = @_;
+    add_grub_cmdline_settings($add, update_grub => $update_grub, search => "GRUB_CMDLINE_LINUX_XEN_REPLACE_DEFAULT");
 }
 
 =head2 replace_grub_cmdline_settings

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -25,6 +25,8 @@ use Utils::Architectures;
 use Utils::Systemd qw(systemctl disable_and_stop_service);
 use LTP::utils;
 use rpi 'enable_tpm_slb9670';
+use bootloader_setup 'add_grub_xen_replace_cmdline_settings';
+use virt_autotest::utils 'is_xen_host';
 
 sub add_we_repo_if_available {
     # opensuse doesn't have extensions
@@ -419,6 +421,13 @@ sub run {
     }
 
     add_custom_grub_entries if (is_sle('12+') || is_opensuse || is_transactional) && !is_jeos;
+
+    if (is_xen_host) {
+        my $version = get_var('VERSION');
+        assert_script_run("grub2-set-default 'SLES ${version}, with Xen hypervisor'");
+        add_grub_xen_replace_cmdline_settings('console=ttyS1,115200n', update_grub => 1);
+    }
+
     setup_network unless is_transactional;
 
     # we don't run LVM tests in 32bit, thus not generating the runtest file


### PR DESCRIPTION
Default boot entry is set to XEN hypervisor. Serial console is enabled for XEN host.

- Related ticket:  https://progress.opensuse.org/issues/92602
- Needles: none
- Verification run:
install_ltp: http://openqa.qam.suse.cz/tests/48530
ltp_irq:  http://openqa.qam.suse.cz/tests/48526
