### PR TITLE
Add 'valgrind' test for sles12sp5 and all sle15 releases

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -47,54 +47,55 @@ conditional_schedule:
         - console/nginx
         - '{{arch_specific}}'
         - '{{arch_specific15_sp4}}'
+        - console/valgrind
       15-SP3:
         - console/osinfo_db
         - console/ovn
         - console/firewalld
         - console/libgcrypt
-        - console/valgrind
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
         - console/nginx
         - console/ansible
         - '{{arch_specific}}'
+        - console/valgrind
       15-SP2:
         - console/osinfo_db
         - console/ovn
         - console/firewalld
         - console/libgcrypt
-        - console/valgrind
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
         - console/nginx
         - '{{arch_specific}}'
+        - console/valgrind
       15-SP1:
         - console/osinfo_db
         - console/libgcrypt
-        - console/valgrind
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
         - console/nginx
+        - console/valgrind
         - '{{arch_specific}}'
       15:
         - console/osinfo_db
         - console/libgcrypt
-        - console/valgrind
         - console/zziplib
         - console/journald_fss
         - console/openvswitch_ssl
         - console/nginx
+        - console/valgrind
         - '{{arch_specific}}'
       12-SP5:
         - console/osinfo_db
         - console/libgcrypt
-        - console/valgrind
         - console/zziplib
         - console/openvswitch_ssl
         - '{{arch_specific}}'
+        - console/valgrind
         - '{{arch_12sp5}}'
       12-SP4:
         - console/osinfo_db
@@ -121,6 +122,5 @@ conditional_schedule:
   arch_specific15_sp4:
     ARCH:
       x86_64:
-        - console/valgrind
         - console/ansible
 ...


### PR DESCRIPTION
https://progress.opensuse.org/issues/119278

- Related ticket: https://progress.opensuse.org/issues/119278
- Verification run: [VRs](https://openqa.suse.de/tests/overview?result=passed&result=softfailed&arch=&flavor=&machine=&test=&modules=&module_re=&distri=sle&build=rfan20221206#)
