### PR TITLE
Move django to phub tests

### DIFF
--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -8,6 +8,7 @@ schedule:
     - console/add_phub_extension
     - console/python_scientific
     - console/python_flake8
+    - console/django
     - '{{wpa_supplicant}}'
     - console/vmstat
     - console/sssd_389ds_functional

--- a/schedule/qam/common/mau-webserver.yaml
+++ b/schedule/qam/common/mau-webserver.yaml
@@ -53,7 +53,6 @@ conditional_schedule:
         - console/django
         - console/nginx
       15-SP5:
-        - console/django
         - console/nginx
       tumbleweed:
         - console/django

--- a/tests/console/django.pm
+++ b/tests/console/django.pm
@@ -14,10 +14,13 @@ use strict;
 use warnings;
 use utils 'zypper_call';
 use version_utils 'is_sle';
-use registration qw(add_suseconnect_product get_addon_fullname);
+use registration qw(add_suseconnect_product get_addon_fullname is_phub_ready);
 
 sub run {
     select_serial_terminal;
+
+    # python3-Django and various dependencies require PackageHub available
+    return unless is_phub_ready();
 
     add_suseconnect_product("PackageHub", undef, undef, undef, 300, 1) if is_sle;
     add_suseconnect_product(get_addon_fullname('desktop'), undef, undef, undef, 300, 1) if is_sle('<=15');


### PR DESCRIPTION
python3-django and various dependencies are under packagehub, so this pr moves the django test to packagehub and removes it from 15sp5 webserver tests. It also adds the `is_phub_ready` check to  the django test, which is introduced [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15978).

- Related ticket: https://progress.opensuse.org/issues/120369
- Verification run: -