### PR TITLE
kdump: Skip cli configuration if is kdump already enabled

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -213,6 +213,10 @@ sub activate_kdump {
 
 # Activate kdump using yast command line interface
 sub activate_kdump_cli {
+    # Skip configuration, if is kdump already enabled and no special memory settings is required
+    my $status = script_run('yast kdump show 2>&1 | grep "Kdump is disabled"', 180);
+    return if ($status and !get_var('CRASH_MEMORY'));
+
     # Make sure fadump is disabled on PowerVM
     assert_script_run('yast2 kdump fadump disable', 180) if is_pvm;
 

--- a/schedule/kernel/kdump.yaml
+++ b/schedule/kernel/kdump.yaml
@@ -3,7 +3,6 @@ description:    >
     Kdump kernel testing for various architectures with possibility to change crash
     memory using CRASH_MEMORY variable.
 schedule:
-    - installation/bootloader_start
     - boot/boot_to_desktop
     - kernel/kdump
     - shutdown/shutdown


### PR DESCRIPTION
We don't need to configure kdump if is already enabled and there is no need for special crash memory settings. Removed unnecessary bootloader_start from YAML schedule.

- Related ticket: none
- Needles: 
- Verification run: 
qemu TW: https://openqa.opensuse.org/tests/2922155 (fail is related to other bug)
qemu SLES: https://openqa.suse.de/tests/10071523
baremetal SLES: https://openqa.suse.de/tests/10071536
baremetal XEN SLES: http://openqa.qam.suse.cz/tests/48572