### PR TITLE
Take screenshot from failed guests

### DIFF
--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -16,6 +16,18 @@ use testapi;
 use utils;
 use version_utils 'is_sle';
 
+# Open vnc and take screenshot of guests
+sub screenshot_vnc_guests {
+    foreach my $guest (keys %virt_autotest::common::guests) {
+        # Wait for virt-viewer to fully connect and display VNC stream
+        enter_cmd "virt-viewer -f $guest & sleep 21 && killall virt-viewer";
+        sleep 19;
+        record_info "$guest", "$guest screenshot";
+        save_screenshot();
+        sleep 6;
+    }
+}
+
 sub run {
     my $self = shift;
     select_console('root-console');
@@ -53,6 +65,7 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
+    screenshot_vnc_guests();
     collect_virt_system_logs();
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/109328
- Needles: N/A
- Verification run: [KVM](http://openqa.qam.suse.cz/tests/48580#dependencies) 
simulating failure :
[KVM-12-SP3](http://openqa.qam.suse.cz/tests/48542#dependencies)
[KVM-12-SP4](http://openqa.qam.suse.cz/tests/48544#dependencies)
[KVM-12-SP5](http://openqa.qam.suse.cz/tests/48546#dependencies)
[KVM-15-SP1](http://openqa.qam.suse.cz/tests/48548#dependencies)
[KVM-15-SP3](http://openqa.qam.suse.cz/tests/48550#dependencies)
[KVM-15-SP4](http://openqa.qam.suse.cz/tests/48552#dependencies)
[XEN-12-SP4](http://openqa.qam.suse.cz/tests/48554#dependencies)
[XEN-12-SP5](http://openqa.qam.suse.cz/tests/48556#dependencies)
[XEN-15-SP2](http://openqa.qam.suse.cz/tests/48558#dependencies)