### PR TITLE
Run yast ui test with ncurse for pvm backend

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -7,6 +7,7 @@ use utils qw(systemctl file_content_replace clear_console zypper_call clear_cons
 use Utils::Systemd 'disable_and_stop_service';
 use mm_network;
 use version_utils;
+use Utils::Backends 'is_pvm_hmc';
 
 
 our @ISA = qw(Exporter);
@@ -214,8 +215,8 @@ sub config_service {
     try_nfsv2();
 
     prepare_exports($rw, $ro);
-
-    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nfs-server');
+    my $y2_opts = is_pvm_hmc() ? "--ncurses" : "";
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nfs-server', yast2_opts => $y2_opts);
 
     yast2_server_initial();
 

--- a/schedule/yast/yast2_ncurses/yast2_ncurses_textmode_pvm.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_textmode_pvm.yaml
@@ -9,4 +9,9 @@ schedule:
   - boot/boot_to_desktop
   - console/prepare_test_data
   - console/consoletest_setup
+  - console/yast2_lan
+  - console/yast2_i
+  - console/yast2_bootloader
+  - console/yast2_lan_device_settings
+  - console/yast2_nfs_server
   - console/yast2_kdump

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -18,7 +18,7 @@ use warnings;
 use testapi;
 use Utils::Architectures;
 use utils;
-use Utils::Backends 'is_hyperv';
+use Utils::Backends qw(is_hyperv is_pvm_hmc);
 
 sub run {
     my $self = shift;
@@ -26,8 +26,8 @@ sub run {
 
     # make sure yast2 bootloader module is installed
     zypper_call 'in yast2-bootloader';
-
-    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'bootloader');
+    my $y2_opts = is_pvm_hmc() ? "--ncurses" : "";
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'bootloader', yast2_opts => $y2_opts);
 
     # YaST2 prompts user to install missing packages found during storage probing.
     # Otherwise YaST2 shows bootloader settings options

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -24,6 +24,7 @@ use testapi;
 use utils;
 use y2lan_restart_common;
 use version_utils ':VERSION';
+use Utils::Backends 'is_pvm_hmc';
 
 my $module_name;
 
@@ -38,7 +39,8 @@ sub run {
     script_run('ls -alF /etc/sysconfig/network/');
     save_screenshot;
 
-    my $opened = open_yast2_lan();
+    my $y2_opts = is_pvm_hmc() ? "ncurses" : "";
+    my $opened = open_yast2_lan(ui => $y2_opts);
     wait_still_screen(14);
     if ($opened eq "Controlled by network manager") {
         return;


### PR DESCRIPTION
Run yast ui test with ncurse for pvm backend

- Related ticket: https://progress.opensuse.org/issues/110779
- Needles: na
- Verification run: https://openqa.suse.de/tests/10081723
