### PR TITLE
Add gnutls related tests under fips

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2299,6 +2299,10 @@ sub load_security_tests_crypt_tool {
     loadtest "console/git";
     loadtest "console/clamav";
     loadtest "console/openvswitch_ssl";
+    loadtest "console/ntp_client";
+    loadtest "console/yast2_ntpclient";
+    loadtest "console/cups";
+    loadtest "console/syslog";
 }
 
 sub load_security_tests_crypt_libtool {


### PR DESCRIPTION
Add ntp_client.pm, yast2_ntpclient.pm, cups.pm, syslog.pm under fips testing

- Related ticket: https://progress.opensuse.org/issues/119764
- Needles: N/A
- Verification runs:
fips_env_mode_tests_crypt_tool:
https://openqa.suse.de/tests/10171078
https://openqa.suse.de/tests/10171137
https://openqa.suse.de/tests/10171138
https://openqa.suse.de/tests/10171139
fips_ker_mode_tests_crypt_tool:
https://openqa.suse.de/tests/10171079
https://openqa.suse.de/tests/10171140
https://openqa.suse.de/tests/10171141
https://openqa.suse.de/tests/10171142

The failure happening to -fips_ker_mode_tests_crypt_tool, 15-SP5-aarch64 to be checked during the openQA review.
