### PR TITLE
Containers: force install systemd from SLE_BCI repo

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -260,7 +260,8 @@ sub test_systemd_install {
     if ($image_id eq 'opensuse-tumbleweed' ||
         ($image_id eq 'opensuse-leap' && check_version('>=15.4', "$image_version.$image_sp", qr/\d{2}\.\d/)) ||
         ($image_id eq 'sles' && check_version('>=15-SP4', "$image_version-SP$image_sp", qr/\d{2}-sp\d/))) {
-        assert_script_run("$runtime run $image /bin/bash -c 'zypper al udev && zypper -n in systemd'", timeout => 300);
+        my $repo = $image_id eq 'sles' ? '-r SLE_BCI' : '';
+        assert_script_run("$runtime run $image /bin/bash -c 'zypper al udev && zypper -n in $repo systemd'", timeout => 300);
     }
 }
 


### PR DESCRIPTION
There is an issue in in jobs where we use the proxy scc, where suseconnect plugin will try to reach an unexisting asset from OSD. To workaround this, we can simply specify to install it from BCI repository.

