### PR TITLE
Verify secure boot successfully in kernel v6.0

### DIFF
--- a/tests/console/verify_secure_boot.pm
+++ b/tests/console/verify_secure_boot.pm
@@ -14,16 +14,24 @@ use testapi;
 use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
 
+# The minimum number of octal digits in the efivars file should be 5,
+# because the fifth octal digit shows whether Secure Boot is enabled (1) or disabled (0)
+use constant MIN_OCTALS => 5;
+
 sub run {
     my $test_data = get_test_suite_data();
+
     select_console 'root-console';
-    record_info("Check file", "Check if file /sys/firmware/efi/vars/SecureBoot-*/data exists");
-    assert_script_run("ls /sys/firmware/efi/vars/SecureBoot-*/data");
+    record_info("Check file", "Check if file /sys/firmware/efi/efivars/SecureBoot-* exists");
+    # From v6.0 kernel and onwards, the SecureBoot file resides in /sys/firmware/efi/efivars/
+    assert_script_run("ls /sys/firmware/efi/efivars/SecureBoot-*");
     record_info("Check secure boot", "Check if secure boot option is set as expected");
-    my $secure_boot = script_output("od -An -t u1 /sys/firmware/efi/vars/SecureBoot-*/data") ? 'enabled' : 'disabled';
+    my $octal_str = script_output("od -An -t u1 /sys/firmware/efi/efivars/SecureBoot-*");
+    my @octal_array = split(/\s+/, $octal_str);
+
+    die 'Unexpected values in Secure Boot file' unless 0 + @octal_array >= MIN_OCTALS && $octal_array[MIN_OCTALS - 1] =~ /0|1/;
+    my $secure_boot = $octal_array[MIN_OCTALS - 1] ? 'enabled' : 'disabled';
     assert_equals($test_data->{secure_boot}, $secure_boot, "The secure boot option is not $test_data->{secure_boot}");
 }
 
 1;
-
-


### PR DESCRIPTION
In kernel v6.0, the /sys/firmware/efi/vars interface has been removed.
Instead we are to use the contents of /sys/firmware/efi/efivars to verify whether secure boot has been enabled or not.

- Related ticket: https://progress.opensuse.org/issues/120100
- Needles: No needles
- Verification run: https://openqa.suse.de/tests/10171482#details