### PR TITLE
filesystem: Add a debug para for pynfs and cthon04

### DIFF
--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -45,7 +45,8 @@ sub install_dependencies_cthon04 {
 
 sub install_testsuite {
     my $testsuite = shift;
-    if (get_var("PYNFS")) {
+    my $debug_with_commit = get_var('DEBUG_WITH_COMMIT');
+    if (get_var('PYNFS')) {
         my $url = get_var('PYNFS_GIT_URL', 'git://git.linux-nfs.org/projects/bfields/pynfs.git');
         my $rel = get_var('PYNFS_RELEASE');
 
@@ -53,12 +54,20 @@ sub install_testsuite {
 
         install_dependencies_pynfs;
         assert_script_run("git clone -q --depth 1 $url $rel && cd ./pynfs");
+        if ($debug_with_commit) {
+            script_run('git fetch --unshallow');
+            script_run("git checkout $debug_with_commit");
+        }
         assert_script_run('./setup.py build && ./setup.py build_ext --inplace');
     }
-    elsif (get_var("CTHON04")) {
+    elsif (get_var('CTHON04')) {
         my $url = get_var('CTHON04_GIT_URL', 'git://git.linux-nfs.org/projects/steved/cthon04.git');
         install_dependencies_cthon04;
         assert_script_run("git clone -q --depth 1 $url && cd ./cthon04");
+        if ($debug_with_commit) {
+            script_run('git fetch --unshallow');
+            script_run("git checkout $debug_with_commit");
+        }
         assert_script_run('make');
     }
     record_info('git version', script_output('git log -1 --pretty=format:"git-%h" | tee'));


### PR DESCRIPTION
Add a debug parameter(DEBUG_WITH_COMMIT) for pynfs and cthon04 to debug script issue.

- Related ticket: https://progress.opensuse.org/issues/121480
- Verification run: https://openqa.opensuse.org/t2929948
- git checkout OK with given commit set in DEBUG_WITH_COMMIT https://openqa.opensuse.org/tests/2929948#step/install/27