### PR TITLE
tuned: Update error handling for SLE <15-SP1

### DIFF
--- a/tests/kernel/tuned.pm
+++ b/tests/kernel/tuned.pm
@@ -28,8 +28,8 @@ sub run {
     my $tuned_log = '/var/log/tuned/tuned.log';
     # Already known errors with bug reference
     my %known_errors;
-    $known_errors{bsc_1148789} = 'Executing cpupower error: Error setting perf-bias value on CPU' if is_sle '<15';
-    $known_errors{bsc_1148789} = 'Failed to set energy_perf_bias on cpu' if (is_sle('>=15') || is_tumbleweed);
+    $known_errors{bsc_1148789} = 'Executing cpupower error: Error setting perf-bias value on CPU' if is_sle '<15-sp1';
+    $known_errors{bsc_1148789} = 'Failed to set energy_perf_bias on cpu' if (is_sle('>=15-sp1') || is_tumbleweed);
 
     select_serial_terminal;
     # Install tuned package


### PR DESCRIPTION
Fix poo#121558: SLE older than 15-SP1 has same error output like SLE 12.

- Related ticket: none
- Needles: none
- Verification run: 
12-SP5: https://openqa.suse.de/t10092167
15: https://openqa.suse.de/tests/10092199
15-SP1: https://openqa.suse.de/t10092168
15-SP5: https://openqa.suse.de/t10092163
TW: https://openqa.opensuse.org/t2931813
