### PR TITLE
Fix Public Cloud AMD-SEV test for SLE15-SP5

### DIFF
--- a/tests/publiccloud/sev.pm
+++ b/tests/publiccloud/sev.pm
@@ -18,7 +18,7 @@ use version_utils qw(is_sle);
 sub get_sev_message {
     return "AMD Secure Encrypted Virtualization (SEV) active" if is_sle('=15-SP2');
     # More messages will be added pas a pas, as more versions run this test.
-    return "AMD Memory Encryption Features active";    # Default message
+    return "Memory Encryption Features active";    # Default message
 }
 
 sub run {


### PR DESCRIPTION
```
# dmesg | grep SEV | head; echo AJfEB-$?-
[    0.253078] Memory Encryption Features active: AMD SEV
# dmesg | grep SEV | grep 'AMD Memory Encryption Features active'; echo vIRoJ-$?-
vIRoJ-1-
```

- Related failure: [openqa.suse.de/t10088947](https://openqa.suse.de/tests/10088947)
- Verification run: [pdostal-server.suse.cz/t3427](https://pdostal-server.suse.cz/tests/3427#step/sev/17)
