### PR TITLE
usr_sbin_smbd.pm: use keyboard shortcut instead of needles

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -125,9 +125,8 @@ sub samba_client_access {
     send_key "ret";
     assert_screen("nautilus-sharedir-opened");
 
-    # Do some operations, e.g., create a test folder then delete it
-    assert_and_click('nautilus-sharedir-opened', button => 'right');
-    assert_and_click("nautilus-new-folder");
+    # Create new folder
+    send_key "shift-ctrl-n";
     assert_screen("nautilus-folder-name-input-box");
     type_string("sub-testdir", wait_screen_change => 10);
     send_key "ret";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/121426
- Verification runs:
  - 15-SP4: https://openqa.suse.de/tests/10092287
  - 15-SP3: https://openqa.suse.de/tests/10092309
  - 15-SP2: https://openqa.suse.de/tests/10092267
  - 15-SP1: https://openqa.suse.de/tests/10092278
  - 15: https://openqa.suse.de/tests/10092308
  - 12-SP5: https://openqa.suse.de/tests/10092265
  - 12-SP4: https://openqa.suse.de/tests/10092307
  - 12-SP3: https://openqa.suse.de/tests/10092306