### PR TITLE
jeos/firstrun: Skip WiFi configuration on Leap 15.4

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -129,7 +129,7 @@ sub run {
         send_key 'ret';
     }
 
-    if (is_generalhw && is_aarch64 && !is_leap("<15.5")) {
+    if (is_generalhw && is_aarch64 && !is_leap("<15.4")) {
         assert_screen 'jeos-please-configure-wifi';
         send_key 'n';
     }


### PR DESCRIPTION
15.4 JeOS images got jeos-firstboot-rpiwifi as well now, deal with it.

- Verification run: https://openqa.opensuse.org/tests/2932104
