### PR TITLE
[virt_autotest] Enhancement for SLE Virtual Network Test

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -1,10 +1,10 @@
 # SUSE's openQA tests
 #
-# Copyright 2020 SUSE LLC
+# Copyright 2020-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: virtualization test utilities.
-# Maintainer: Julie CAO <jcao@suse.com>
+# Maintainer: Julie CAO <jcao@suse.com>, qe-virt@suse.de
 
 package virt_autotest::utils;
 
@@ -355,7 +355,7 @@ sub install_default_packages {
 sub ensure_online {
     my ($guest, %args) = @_;
 
-    my $hypervisor = $args{HYPERVISOR} // "192.168.122.1";
+    my $hypervisor = $args{HYPERVISOR} // " ";
     my $dns_host = $args{DNS_TEST_HOST} // "www.suse.com";
     my $skip_ssh = $args{skip_ssh} // 0;
     my $skip_network = $args{skip_network} // 0;
@@ -363,6 +363,8 @@ sub ensure_online {
     my $ping_delay = $args{ping_delay} // 15;
     my $ping_retry = $args{ping_retry} // 60;
     my $use_virsh = $args{use_virsh} // 1;
+
+    $hypervisor = get_var('VIRT_AUTOTEST') ? "192.168.123.1" : "192.168.122.1";
 
     # Ensure guest is running
     # Only xen/kvm support to reboot guest at the moment
@@ -379,7 +381,7 @@ sub ensure_online {
         }
         unless ($skip_ssh == 1) {
             # Wait for ssh to come up
-            die "$guest does not start ssh" if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12) != 0);
+            die "$guest does not start ssh" if (script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 12, timeout => 360) != 0);
             die "$guest not ssh-reachable" if (script_run("ssh $guest uname") != 0);
             # Ensure default route is set
             if (script_run("ssh $guest ip r s | grep default") != 0) {

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: HOST bridge virtual network test:
 #    - Create HOST bridge virtual network
 #    - Confirm HOST bridge virtual network
 #    - Destroy HOST bridge virtual network
-# Maintainer: Leon Guo <xguo@suse.com>
+# Maintainer: Leon Guo <xguo@suse.com>, qe-virt@suse.de
 
 use base "virt_feature_test_base";
 use virt_utils;
@@ -41,11 +41,15 @@ sub run_test {
     upload_logs "$vnet_host_bridge_cfg_name";
     assert_script_run("rm -rf $vnet_host_bridge_cfg_name");
 
-    my ($mac, $model, $affecter, $exclusive);
+    my ($mac, $model, $affecter, $exclusive, $skip_type);
     my $gate = script_output "ip r s | grep 'default via ' | cut -d' ' -f3";
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "HOST BRIDGE NETWORK for $guest";
-        ensure_online $guest, skip_network => 1;
+        #Just only 15-SP5 PV guest system have a rebooting problem due to bsc#1206250
+        $skip_type = ($guest =~ m/sles-15-sp5-64-pv-def-net/i) ? 'skip_ping' : 'skip_network';
+        #Ensures the given guests is started and fixes some common network issues
+        ensure_online $guest, $skip_type => 1;
+        save_screenshot;
 
         if (is_sle('=11-sp4') && is_xen_host) {
             $affecter = "--persistent";

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Isolated virtual network test:
 #    - Create Isolated virtual network
 #    - Confirm Isolated virtual network
 #    - Destroy Isolated virtual network
-# Maintainer: Leon Guo <xguo@suse.com>
+# Maintainer: Leon Guo <xguo@suse.com>, qe-virt@suse.de
 
 use base "virt_feature_test_base";
 use virt_utils;
@@ -33,11 +33,15 @@ sub run_test {
     upload_logs "vnet_isolated.xml";
     assert_script_run("rm -rf vnet_isolated.xml");
 
-    my ($mac, $model, $affecter, $exclusive);
+    my ($mac, $model, $affecter, $exclusive, $skip_type);
     my $gate = '192.168.127.1';    # This host exists but should not work as a gate in the ISOLATED NETWORK
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "ISOLATED NETWORK for $guest";
-        ensure_online $_, skip_network => 1;
+        #Just only 15-SP5 PV guest system have a rebooting problem due to bsc#1206250
+        $skip_type = ($guest =~ m/sles-15-sp5-64-pv-def-net/i) ? 'skip_ping' : 'skip_network';
+        #Ensures the given guests is started and fixes some common network issues
+        ensure_online($guest, $skip_type => 1);
+        save_screenshot;
 
         if (is_sle('=11-sp4') && is_xen_host) {
             $affecter = "--persistent";

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: NAT based virtual network test:
 #    - Define NAT based virtual network
 #    - Confirm NAT based virtual network
 #    - Destroy NAT based virtual network
-# Maintainer: Leon Guo <xguo@suse.com>
+# Maintainer: Leon Guo <xguo@suse.com>, qe-virt@suse.de
 
 use base "virt_feature_test_base";
 use virt_utils;
@@ -35,11 +35,15 @@ sub run_test {
     upload_logs "vnet_nated.xml";
     assert_script_run("rm -rf vnet_nated.xml");
 
-    my ($mac, $model, $affecter, $exclusive);
+    my ($mac, $model, $affecter, $exclusive, $skip_type);
     my $gate = '192.168.128.1';
     foreach my $guest (keys %virt_autotest::common::guests) {
         record_info "$guest", "NAT BASED NETWORK for $guest";
-        ensure_online $guest, skip_network => 1;
+        #Just only 15-SP5 PV guest system have a rebooting problem due to bsc#1206250
+        $skip_type = ($guest =~ m/sles-15-sp5-64-pv-def-net/i) ? 'skip_ping' : 'skip_network';
+        #Ensures the given guests is started and fixes some common network issues
+        ensure_online $guest, $skip_type => 1;
+        save_screenshot;
 
         if (is_sle('=11-sp4') && is_xen_host) {
             $affecter = "--persistent";

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Routed virtual network test:
 #    - Create Routed virtual network
 #    - Confirm Routed virtual network
 #    - Destroy Routed virtual network
-# Maintainer: Leon Guo <xguo@suse.com>
+# Maintainer: Leon Guo <xguo@suse.com>, qe-virt@suse.de
 
 use base "virt_feature_test_base";
 use virt_utils;


### PR DESCRIPTION
- Refer to [poo#121351](https://progress.opensuse.org/issues/121351) and [poo#121348](https://progress.opensuse.org/issues/121348) , confirm that there is a new product bug about the 15-SP5 PV guest reboot problem, filed as [bsc#1206250](https://bugzilla.suse.com/show_bug.cgi?id=1206250) - [ENHANCEMENT][15-SP5][XEN][PV] 15SP5 guest system take long time to finish reboot operation. 
- Current each 15-SP5 PV guest system will take almost 5mins to finish reboot, depend on this situation, try to use the function `ensure_online()` to ensures given guest system is ready to prepare to attach the new network interface to given guest system as the enhancement for SLE Virtual Network Test.  

- Related ticket: 
https://progress.opensuse.org/issues/121351
https://progress.opensuse.org/issues/121348
- Verification run:
[gi-guest_developing-on-host_developing-kvm](http://10.67.129.218/tests/254#)
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/10231004)
[gi-guest_developing-on-host_sles12sp5-xen](https://openqa.suse.de/tests/10157422#)
[gi-guest_developing-on-host_sles15sp4-xen](https://openqa.suse.de/tests/10158754#)