### PR TITLE
Fix check for network restart in yast2_lan

### DIFF
--- a/lib/YaST/NetworkSettings/ActionButtons.pm
+++ b/lib/YaST/NetworkSettings/ActionButtons.pm
@@ -23,12 +23,24 @@ sub new {
 sub init {
     my $self = shift;
     $self->{btn_ok} = $self->{app}->button({id => 'next'});
+    $self->{btn_cancel} = $self->{app}->button({id => 'abort'});
+    $self->{btn_yes} = $self->{app}->button({id => 'yes'});
     return $self;
 }
 
 sub press_ok {
     my ($self) = @_;
     $self->{btn_ok}->click();
+}
+
+sub press_cancel {
+    my ($self) = @_;
+    $self->{btn_cancel}->click();
+}
+
+sub press_yes {
+    my ($self) = @_;
+    $self->{btn_yes}->click();
 }
 
 1;

--- a/lib/YaST/NetworkSettings/v4_3/NetworkSettingsController.pm
+++ b/lib/YaST/NetworkSettings/v4_3/NetworkSettingsController.pm
@@ -85,6 +85,16 @@ sub save_changes {
     $self->get_action_buttons()->press_ok();
 }
 
+sub cancel_changes {
+    my ($self) = @_;
+    $self->get_action_buttons()->press_cancel();
+}
+
+sub accept_all_changes_will_be_lost {
+    my ($self) = @_;
+    $self->get_action_buttons()->press_yes();
+}
+
 sub proceed_with_current_configuration {
     my ($self) = @_;
     $self->get_overview_tab()->is_shown();

--- a/tests/yast2_gui/yast2_lan_restart_bond.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bond.pm
@@ -51,7 +51,8 @@ sub run {
     record_info('bond', 'Verify network is not restarted after saving bond device settings without changes.');
     open_network_settings;
     $network_settings->view_bond_slave_without_editing();
-    $network_settings->save_changes();
+    $network_settings->cancel_changes();
+    $network_settings->accept_all_changes_will_be_lost();
     wait_for_xterm_to_be_visible();
     check_network_status('no_restart_or_reload', 'bond');
 }

--- a/tests/yast2_gui/yast2_lan_restart_bridge.pm
+++ b/tests/yast2_gui/yast2_lan_restart_bridge.pm
@@ -51,7 +51,8 @@ sub run {
     record_info('bridge', 'Verify network is not restarted after saving bridged device settings without changes.');
     open_network_settings;
     $network_settings->view_bridged_device_without_editing();
-    $network_settings->save_changes();
+    $network_settings->cancel_changes();
+    $network_settings->accept_all_changes_will_be_lost();
     wait_for_xterm_to_be_visible();
     check_network_status('no_restart_or_reload', 'bridge');
 }

--- a/tests/yast2_gui/yast2_lan_restart_vlan.pm
+++ b/tests/yast2_gui/yast2_lan_restart_vlan.pm
@@ -51,7 +51,8 @@ sub run {
     record_info('VLAN', 'Verify network is not restarted after saving VLAN device settings without changes.');
     open_network_settings;
     $network_settings->view_vlan_device_without_editing();
-    $network_settings->save_changes();
+    $network_settings->cancel_changes();
+    $network_settings->accept_all_changes_will_be_lost();
     wait_for_xterm_to_be_visible();
     check_network_status('no_restart_or_reload', 'vlan');
 }


### PR DESCRIPTION
Add code to handle the cancel button for network testing. And modify the yast2_lan_restart* test modules by using the cancel button instead of next button.

- Related ticket: https://progress.opensuse.org/issues/120639
- Needles: n/a
- Verification run: 
https://openqa.suse.de/tests/10149238#
