### PR TITLE
Enhance sol stable

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -120,6 +120,12 @@ sub login_to_console {
             #send key 'up' to stop grub timer counting down, to be more robust to select xen
             send_key 'up';
             save_screenshot;
+            #If sol console is stuck, reconnect it and resend key up
+            if (check_screen 'virttest-bootmenu-xen-kernel-count-down', 1) {
+                reset_consoles;
+                select_console 'sol', await_console => 0;
+                send_key 'up';
+            }
 
             for (1 .. 20) {
                 if ($_ == 10) {


### PR DESCRIPTION
poo#[118381](https://progress.opensuse.org/issues/118381)
Sometimes ipmi sol does not work, reset it and re-send key 'up' again.

- Related ticket: [poo#118381](https://progress.opensuse.org/issues/118381)
- Needles:  
         - Needle name: login_console-virttest-bootmenu-xen-kernel-count-down-20221207
         - Tag name: virttest-bootmenu-xen-kernel-count-down
- Verification run: 
         - [sle15sp4](http://openqa.qam.suse.cz/tests/48690)
         - [sle15sp4 Check_screen_count_down](http://openqa.qam.suse.cz/tests/48657#step/login_console/4) (just for test module)
