### PR TITLE
[VIRT for SLEM 5.4] Change package name back because autotest can not load it

### DIFF
--- a/schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml
+++ b/schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml
@@ -19,7 +19,7 @@ vars:
 schedule:
   - "{{bootup_and_install}}"
   - virt_autotest/login_console
-  - virt_autotest/transactional/prepare_transactional_server
+  - virt_autotest/prepare_transactional_server
   - "{{install_guest}}"
 conditional_schedule:
   bootup_and_install:

--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -8,7 +8,7 @@
 # Maintainer: Nan Zhang <nan.zhang@suse.com> qe-virt@suse.de
 
 use base multi_machine_job_base;
-use base transactional::prepare_transactional_server;
+use base prepare_transactional_server;
 use strict;
 use warnings;
 use testapi;

--- a/tests/virt_autotest/prepare_transactional_server.pm
+++ b/tests/virt_autotest/prepare_transactional_server.pm
@@ -9,7 +9,7 @@
 # only or which need to to performed by leveraging transactional-update command.
 #
 # Maintainer: Wayne Chen <wchen@suse.com> qe-virt@suse.de
-package transactional::prepare_transactional_server;
+package prepare_transactional_server;
 
 use base "opensusebasetest";
 use strict;


### PR DESCRIPTION
* **Package** prepare_transactional_server.pm had been renamed to transactional::prepare_transactional_server.pm in [pr#15878](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15878), which leads to test run failure, because autotest can not load it, for example, [this failure](https://openqa.suse.de/tests/10097711). So need to change the package name back to the original one prepare_transactional_server.

* **Move** prepare_transactional_server one level up, so it can still be used in kubevirt test as the base module.

* **Verification runs:**
  * [install guest on sle-micro test can load](https://openqa.nue.suse.com/tests/10097764)
  * [kubevirt test can still use it](http://10.67.129.66/tests/1785)
