### PR TITLE
hpc: Add missing user_settings_root for 15-SP3 installation scenarios

### DIFF
--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -22,6 +22,8 @@ conditional_schedule:
         - installation/user_settings_root
       15-SP4:
         - installation/user_settings_root
+      15-SP3:
+        - installation/user_settings_root
       15-SP2:
         - installation/user_settings_root
   systemrole_dev:

--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -28,6 +28,8 @@ conditional_schedule:
     VERSION:
       15-SP2:
         - installation/user_settings_root
+      15-SP3:
+        - installation/user_settings_root
       15-SP4:
         - installation/user_settings_root
       15-SP5:


### PR DESCRIPTION
Fix poo#121636: Installation scenarios for 15-SP3 failed, there was missing user_settings_root in YAML schedule.

- Related ticket: https://progress.opensuse.org/issues/121636
- Needles: none
- Verification run: 
15-SP3 jobgroup: https://openqa.suse.de/tests/overview?version=15-SP3&build=czerw%2Fos-autoinst-distri-opensuse%2316060&distri=sle  (shutdown failure is other issue).