### PR TITLE
Public Cloud: Refactor the check_registercloudguest test module

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -39,80 +39,79 @@ sub run {
         # all BYOS related checks. So we just regestering system and going further
         registercloudguest($instance);
     } elsif (is_byos()) {
-        if ($instance->run_ssh_command(cmd => 'sudo zypper lr', proceed_on_failure => 1) !~ /No repositories defined/gm) {
+        if ($instance->ssh_script_output(cmd => 'sudo zypper lr', proceed_on_failure => 1) !~ /No repositories defined/gm) {
             die 'The BYOS instance should be unregistered and report "Warning: No repositories defined.".';
         }
 
-        if ($instance->run_ssh_command(cmd => 'sudo systemctl is-enabled guestregister.service', proceed_on_failure => 1) !~ /disabled/) {
+        if ($instance->ssh_script_output(cmd => 'sudo systemctl is-enabled guestregister.service', proceed_on_failure => 1) !~ /disabled/) {
             die('guestregister.service is not disabled');
         }
 
-        if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l', proceed_on_failure => 1) != 0) {
-            $instance->run_ssh_command(cmd => 'sudo ls -la /etc/zypp/credentials.d/', proceed_on_failure => 1);
-            die('/etc/zypp/credentials.d/ is not empty');
+        if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') != 0) {
+            $instance->ssh_script_run(cmd => 'sudo ls -la /etc/zypp/credentials.d/');
+            die("/etc/zypp/credentials.d/ is not empty:\n" . $instance->ssh_script_output(cmd => 'sudo ls -la /etc/zypp/credentials.d/'));
         }
 
-        if (is_azure() && $instance->run_ssh_command(cmd => 'sudo systemctl is-enabled regionsrv-enabler-azure.timer', proceed_on_failure => 1) !~ /enabled/) {
+        if (is_azure() && $instance->ssh_assert_script_run(cmd => 'sudo systemctl is-enabled regionsrv-enabler-azure.timer')) {
             die('regionsrv-enabler-azure.timer is not enabled');
         }
 
-        if ($instance->run_ssh_command(cmd => 'sudo stat --printf="%s" /var/log/cloudregister', proceed_on_failure => 1) != 0) {
+        if ($instance->ssh_script_output(cmd => 'sudo stat --printf="%s" /var/log/cloudregister') != 0) {
             die('/var/log/cloudregister is not empty');
         }
-        # The `sudo SUSEConnect -d` is not supported on BYOS and should fail.
-        $instance->run_ssh_command(cmd => '! sudo SUSEConnect -d');
+        $instance->ssh_assert_script_run(cmd => '! sudo SUSEConnect -d', fail_message => 'SUSEConnect succeeds but it is not supported should fail on BYOS');
     } else {
-        if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', proceed_on_failure => 1, timeout => 360) < 5) {
-            record_info('zypper lr', $instance->run_ssh_command(cmd => 'sudo zypper lr', proceed_on_failure => 1));
+        if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 360) < 5) {
+            record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
             die 'The list of zypper repositories is too short.';
         }
 
-        if ($instance->run_ssh_command(cmd => 'sudo systemctl is-enabled guestregister.service', proceed_on_failure => 1) !~ /enabled/) {
+        if ($instance->ssh_script_output(cmd => 'sudo systemctl is-enabled guestregister.service', proceed_on_failure => 1) !~ /enabled/) {
             die('guestregister.service is not enabled');
         }
 
-        if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l', proceed_on_failure => 1) == 0) {
+        if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') == 0) {
             die('/etc/zypp/credentials.d/ is empty');
         }
 
-        if ($instance->run_ssh_command(cmd => 'sudo stat --printf="%s" /var/log/cloudregister', proceed_on_failure => 1) == 0) {
+        if ($instance->ssh_script_output(cmd => 'sudo stat --printf="%s" /var/log/cloudregister') == 0) {
             die('/var/log/cloudregister is empty');
         }
     }
 
     my $path = is_sle('>15') && is_sle('<15-SP3') ? '/usr/sbin/' : '';
-    $instance->run_ssh_command(cmd => "sudo ${path}registercloudguest --clean");
-    if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600, proceed_on_failure => 1) > 2) {
+    $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
+    if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) > 2) {
         die('The list of zypper repositories is not empty.');
     }
-    if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l', proceed_on_failure => 1) != 0) {
+    if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l') != 0) {
         die('Directory /etc/zypp/credentials.d/ is not empty.');
     }
 
     # The SUSEConnect registration should still work on BYOS
     if (is_byos()) {
-        $instance->run_ssh_command(cmd => 'sudo SUSEConnect --version');
-        $instance->run_ssh_command(cmd => "sudo SUSEConnect $regcode_param");
+        $instance->ssh_assert_script_run(cmd => 'sudo SUSEConnect --version');
+        $instance->ssh_assert_script_run(cmd => "sudo SUSEConnect $regcode_param");
         # The registercloudguest tool is not yet part of 15-SP5 as the infrastructure is not yet ready for it.
-        $instance->run_ssh_command(cmd => "sudo ${path}registercloudguest --clean") if (get_var('PUBLIC_CLOUD_QAM'));
+        $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean") if (get_var('PUBLIC_CLOUD_QAM'));
     }
 
     # The registercloudguest tool is not yet part of 15-SP5 as the infrastructure is not yet ready for it.
-    $instance->run_ssh_command(cmd => "sudo ${path}registercloudguest $regcode_param") if (get_var('PUBLIC_CLOUD_QAM'));
-    if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
+    $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest $regcode_param") if (get_var('PUBLIC_CLOUD_QAM'));
+    if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
         die('The list of zypper repositories is empty.');
     }
-    if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l') == 0) {
+    if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l') == 0) {
         die('Directory /etc/zypp/credentials.d/ is empty.');
     }
 
     # The registercloudguest tool is not yet part of 15-SP5 as the infrastructure is not yet ready for it.
     if (get_var('PUBLIC_CLOUD_QAM')) {
-        $instance->run_ssh_command(cmd => "sudo ${path}registercloudguest $regcode_param --force-new");
-        if ($instance->run_ssh_command(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
+        $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest $regcode_param --force-new");
+        if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
             die('The list of zypper repositories is empty.');
         }
-        if ($instance->run_ssh_command(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l') == 0) {
+        if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/* | wc -l') == 0) {
             die('Directory /etc/zypp/credentials.d/ is empty.');
         }
     }


### PR DESCRIPTION
Instead of `run_ssh_command` switch to `ssh_script_run`, `ssh_assert_script_run` and `ssh_script_output`

- Related ticket: [poo#121630](https://progress.opensuse.org/issues/121630)
- Verification run: [sle-15-SP4-AZURE-BYOS-Updates@publiccloud_consoletests@aarch64](https://pdostal-server.suse.cz/tests/3453), [sle-15-SP4-EC2-Updates@publiccloud_consoletests@aarch64](https://pdostal-server.suse.cz/tests/3452), [sle-15-SP4-EC2-BYOS-Updates@publiccloud_consoletests@aarch64](https://pdostal-server.suse.cz/tests/3451)