### PR TITLE
Revert "security/yast2_users/add_users.pm: improve test reliability"

### DIFF
--- a/tests/security/yast2_users/add_users.pm
+++ b/tests/security/yast2_users/add_users.pm
@@ -74,10 +74,17 @@ sub run {
     # If no, check the user was created successfully
     assert_screen("Yast2-Users-Add-User-Created");
     wait_screen_change { send_key "alt-o" };
-    assert_screen("yast2-user-add_xterm_nokogiri");
+    # Until bsc#1202053 is fixed, we need to send "enter" a couple of times before we can clear the console
+    send_key "ret";
+    send_key "ret";
+
+    # Enhence code for stability: avoid time racing
+    clear_console;
+    assert_screen("root-console-x11");
 
     # Exit x11 and turn to console
-    wait_screen_change { send_key "alt-f4" };
+    send_key "alt-f4";
+    assert_screen("generic-desktop");
     select_console("root-console");
     send_key "ctrl-c";
     clear_console;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16059

Expecting nokogiri to print out a warning to be compiled about different components (mostly libxml in my experience) is wrong. nokogiri needs to be properly rebuild.

