### PR TITLE
Containers: SLE15-SP5: Use client 1.23 instead of 1.18

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -84,7 +84,9 @@ sub install_kubectl {
             # kubectl is in the container module
             add_suseconnect_product(get_addon_fullname('contm'));
             # SLES-15SP2+ ships a specific kubernetes client version. Older versions hold a version-independent kubernetes-client package.
-            if (is_sle(">15-SP1")) {
+            if (is_sle(">=15-SP3")) {
+                zypper_call("in kubernetes1.23-client");
+            } elsif (is_sle("=15-SP2")) {
                 zypper_call("in kubernetes1.18-client");
             } else {
                 zypper_call("in kubernetes-client");


### PR DESCRIPTION
This is because SLE15-SP5 comes with the new version.

- Verification run: [Tumbleweed](https://pdostal-server.suse.cz/tests/3509), [15-SP5](https://pdostal-server.suse.cz/tests/3510), [15-SP4](https://pdostal-server.suse.cz/tests/3507), [15-SP3](https://pdostal-server.suse.cz/tests/3511), [15-SP2](https://pdostal-server.suse.cz/tests/3512), [15-SP1](https://pdostal-server.suse.cz/tests/3508)