### PR TITLE
More generic pattern to match SEV/SEV-ES signatures on both new and old operating systems

### DIFF
--- a/tests/virt_autotest/sev_es_guest_verification.pm
+++ b/tests/virt_autotest/sev_es_guest_verification.pm
@@ -160,7 +160,7 @@ sub check_sev_es_dmesg {
     foreach (@flags) {
         $cmd1 = ($args{dst_machine} eq 'localhost' ? "\"$_( |\$)\"" : "\\\"$_( |\$)\\\"");
         $cmd1 = "grep -i -E -o " . $cmd1;
-        $cmd2 = ($args{dst_machine} eq 'localhost' ? "\"AMD Memory Encryption Features active\"" : "\\\"AMD Memory Encryption Features active\\\"");
+        $cmd2 = ($args{dst_machine} eq 'localhost' ? "\"Memory Encryption Features active\"" : "\\\"Memory Encryption Features active\\\"");
         $cmd2 = "grep -i " . $cmd2;
         $cmd1 = "dmesg | $cmd2 | $cmd1";
         $cmd1 = "ssh root\@$args{dst_machine} " . "\"$cmd1\"" if ($args{dst_machine} ne 'localhost');


### PR DESCRIPTION
* **AMD** SEV/SEV-ES feature changes its signature from previous "AMD Memory Encryption Features active: SEV SEV-ES" to new "Memory Encryption Features active: AMD SEV SEV-ES" in dmesg on the new 15-SP5 virtual machine. 

* **In** order to make the pattern compatible with both new and old operating systems, it will take the form of: grep "Memory Encryption Features active" | grep ("SEV" or "SEV-ES").

* **Verification runs:**
  * [15sp5 on 15sp5](https://openqa.nue.suse.com/tests/10100489)
  * [15sp5 on 15sp4](https://openqa.nue.suse.com/tests/10100488)
  * [15sp4 on 15sp5](https://openqa.nue.suse.com/tests/10104496)