### PR TITLE
runltp debug.log download

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -50,7 +50,11 @@ sub upload_ltp_logs
     my ($self) = @_;
     my $ltp_testsuite = get_required_var('LTP_COMMAND_FILE');
     my $log_file = Mojo::File::path('ulogs/result.json');
+    record_info('LTP Logs', 'upload');
     upload_logs("$root_dir/result.json", log_name => $log_file->basename, failok => 1);
+    # debug file in the standart LTP log-dir. structure:
+    assert_script_run("test -f /tmp/runltp.\$USER/latest/debug.log || echo No debug log");
+    upload_logs("/tmp/runltp.\$USER/latest/debug.log", failok => 1);
 
     return unless -e $log_file->to_string;
 
@@ -171,7 +175,6 @@ sub cleanup {
     # Ensure that the ltp script gets killed
     type_string('', terminate_with => 'ETX');
     $self->upload_ltp_logs();
-
     if ($self->{my_instance} && script_run("test -f $root_dir/log_instance.sh") == 0) {
         assert_script_run($root_dir . '/log_instance.sh stop ' . $self->instance_log_args());
         assert_script_run("(cd /tmp/log_instance && tar -zcf $root_dir/instance_log.tar.gz *)");


### PR DESCRIPTION
To improve the Public cloud LTP TEST debugging, the full directory `/tmp/runltp.root`, containing also the 
 `debug.log` file, has been compressed and the archive named **run_ltp-runltproot.tar.gz** uploaded with the other logs of the test.

- Related ticket: https://progress.opensuse.org/issues/121624
    - ticket Title: LTP tests needs to upload debug log to get more info about run
- Needles: N/A
- Verification run:TBD

Here are the logs of a test run passed ok on a local machine, with the only ltp test `faccessat01` executed, to quick check the logs:
[serial_terminal.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/10190541/serial_terminal.txt)
[run_ltp-runltproot.tar.gz](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/10190542/run_ltp-runltproot.tar.gz)

