### PR TITLE
Avoid repository key update prompts

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -159,7 +159,7 @@ sub ssh_add_test_repositories {
     }
     # refresh repositories, inf 106 is accepted because repositories with test
     # can be removed before test start
-    my $ret = script_run("ssh root\@$host 'zypper -n ref'", 240);
+    my $ret = script_run("ssh root\@$host 'zypper -n --gpg-auto-import-keys ref'", 240);
     die "Zypper failed with $ret" if ($ret != 0 && $ret != 106);
 }
 


### PR DESCRIPTION
poo#https://progress.opensuse.org/issues/121735
Add new parameter --gpg-auto-import-keys when executing zypper

- Related ticket: [poo:121735](https://progress.opensuse.org/issues/121735)
- Needles: None
- Verification run: 
     - [sle15-sp2](http://openqa.suse.de/tests/10112457#step/patch_guests/9) 
     - [sle12-sp5](http://openqa.suse.de/tests/10112462#step/patch_guests/9)
