### PR TITLE
[VIRT for SLEM 5.4] Run guest installation tests on SLE Micro 5.4

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/slem_5_4_64_kvm_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/slem_5_4_64_kvm_hvm_x86_64.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>slem</guest_os_name>
-    <guest_version>5.3</guest_version>
+    <guest_version>5.4</guest_version>
     <guest_version_major>5</guest_version_major>
-    <guest_version_minor>3</guest_version_minor>
+    <guest_version_minor>4</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
     <guest_build></guest_build>
     <host_hypervisor_uri></host_hypervisor_uri>
@@ -24,7 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-5.3-Micro-POOL-x86_64-Build12345-Media1/</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-5.4-Micro-POOL-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings></guest_boot_settings>
     <guest_secure_boot></guest_secure_boot>

--- a/tests/installation/ntp_config_settings.pm
+++ b/tests/installation/ntp_config_settings.pm
@@ -16,7 +16,8 @@ sub run {
     assert_screen('ntp_config_settings');
 
     my $ntp_pool = (is_microos || is_tumbleweed) ? 'opensuse-pool' : 'suse-pool';
-    assert_screen($ntp_pool);
+    # ipmi backend is linked to physical machine which can have ntp ip address offered by dhcp
+    assert_screen($ntp_pool) unless (get_var('BACKEND', '') eq 'ipmi' and check_var('VIDEOMODE', 'text'));
 
     send_key 'alt-n';
 }

--- a/tests/virt_autotest/prepare_transactional_server.pm
+++ b/tests/virt_autotest/prepare_transactional_server.pm
@@ -57,7 +57,7 @@ sub prepare_packages {
     my $self = shift;
 
     # Install necessary virtualization client packages
-    zypper_call("--non-interactive install --no-allow-downgrade --no-allow-name-change --no-allow-vendor-change virt-install libvirt-client libguestfs0 guestfs-tools yast2-schema-micro sshpass");
+    zypper_call("--non-interactive install --no-allow-downgrade --no-allow-name-change --no-allow-vendor-change virt-install libvirt-client libguestfs0 guestfs-tools yast2-schema-micro");
     $self->install_additional_pkgs;
 }
 


### PR DESCRIPTION
* **The** two test suites to be added are: SLE Micro 5.4 on SLE Micro 5.4 and SLE 15-SP4 on SLE Micro 5.4. Yaml configuration will be updated later.

* **For** SLE Micro host installation using ipmi backend and text mode , internal ntp server ip addresses, for example, [this one](https://openqa.nue.suse.com/tests/10112615#step/ntp_config_settings/2), are used instead of suse pools, for example, [this one](https://openqa.suse.de/tests/10113550#step/ntp_config_settings/3). So do not do assert_screen for text mode installation on ipmi backend, because ipmi backend is linked to physical machine which can get NTP server from DHCP. By the contrast, qemu backend may can only use the default "x.suse.pool.ntp.org". Actually previous SLE Micro 5.3 testing does not assert ip address of ntp server either.

* **CI** does not allow check_var('BACKEND', 'xxx') anymore. Use get_var('BACKEND', '') eq 'xxx' instead.

* **Update** guest profile to support SLE Micro 5.4.

* **Do** not install sshpass directly because PackageHub might not be available for SLE Micro 5.4. The package can be obtained from [SLE-15 network repo](https://download.opensuse.org/repositories/network/SLE_15/).


* **Verification runs:**
  * [slem5.4 on slem5.4](https://openqa.nue.suse.com/tests/10156380)
  * [sles15sp4 on slem5.4](https://openqa.nue.suse.com/tests/10207933)
  * [sles15sp5 on slem5.4](https://openqa.nue.suse.com/tests/10164674)
  * [qemu backend](https://openqa.nue.suse.com/tests/10164671)