### PR TITLE
chrome/chromium: i586 is no longer an applicable arch

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -665,7 +665,7 @@ sub snapper_is_applicable {
 }
 
 sub chromestep_is_applicable {
-    return is_opensuse && (is_i586 || is_x86_64);
+    return is_opensuse && is_x86_64;
 }
 
 sub chromiumstep_is_applicable {


### PR DESCRIPTION

- Related ticket: No ticket / identified while setting up LegacyX86 port
- Needles: N/A
- Verification run: N/A (no longer testing the module)
