### PR TITLE
Installer secure storage for qesap regression

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -1,5 +1,5 @@
 provider: "%PROVIDER%"
-apiver: 2
+apiver: 3
 terraform:
   variables:
     az_region: "%REGION%"
@@ -9,7 +9,10 @@ terraform:
     public_key: "%SSH_KEY_PUB%"
 
 ansible:
-  hana_urls:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
     - "%HANA_SAR%"
     - "%HANA_CLIENT_SAR%"
     - "%HANA_SAPCAR%"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -1,5 +1,5 @@
 provider: "%PROVIDER%"
-apiver: 2
+apiver: 3
 terraform:
   variables:
     project: "ei-sle-qa-sap-8469"
@@ -18,7 +18,10 @@ terraform:
     gcp_credentials_file: "/root/google_credentials.json"
 
 ansible:
-  hana_urls:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
     - "%HANA_SAR%"
     - "%HANA_CLIENT_SAR%"
     - "%HANA_SAPCAR%"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -2,15 +2,20 @@ provider: "%PROVIDER%"
 apiver: 3
 terraform:
   variables:
-    aws_region: "%REGION%"
+    project: "ei-sle-qa-sap-8469"
+    bastion_enabled: "false"
+    region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    os_owner: "amazon"
+    hana_os_major_version: "%QESAP_CLUSTER_OS_VER%"
+    iscsi_os_major_version: "%QESAP_CLUSTER_OS_VER%"
+    monitoring_os_major_version: "%QESAP_CLUSTER_OS_VER%"
+    drdb_os_major_version: "%QESAP_CLUSTER_OS_VER%"
+    netweaver_os_major_version: "%QESAP_CLUSTER_OS_VER%"
+    bastion_os_major_version: "%QESAP_CLUSTER_OS_VER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
-    aws_credentials: "/root/amazon_credentials"
-    hana_cluster_fencing_mechanism: "sbd"
-    hana_ha_enabled: "true"
+    gcp_credentials_file: "/root/google_credentials.json"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"
@@ -31,7 +36,7 @@ ansible:
   create:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
+    - sap-hana-preconfigure.yaml -e "use_sapconf=true"
     - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -30,9 +30,19 @@ sub run {
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';
     $variables{SCC_REGCODE_SLES4SAP} = get_required_var('SCC_REGCODE_SLES4SAP');
+
+
+    $variables{HANA_ACCOUNT} = get_required_var("QESAPDEPLOY_HANA_ACCOUNT");
+    $variables{HANA_CONTAINER} = get_required_var("QESAPDEPLOY_HANA_CONTAINER");
+    if (get_var("QESAPDEPLOY_HANA_TOKEN")) {
+        $variables{HANA_TOKEN} = get_required_var("QESAPDEPLOY_HANA_TOKEN");
+        # escape needed by 'sed'
+        # but not implemented in file_content_replace() yet poo#120690
+        $variables{HANA_TOKEN} =~ s/\&/\\\&/g;
+    }
     $variables{HANA_SAR} = get_required_var("QESAPDEPLOY_SAPCAR");
-    $variables{HANA_CLIENT_SAR} = get_required_var("QESAPDEPLOY_IMDB_SERVER");
-    $variables{HANA_SAPCAR} = get_required_var("QESAPDEPLOY_IMDB_CLIENT");
+    $variables{HANA_CLIENT_SAR} = get_required_var("QESAPDEPLOY_IMDB_CLIENT");
+    $variables{HANA_SAPCAR} = get_required_var("QESAPDEPLOY_IMDB_SERVER");
     qesap_prepare_env(openqa_variables => \%variables, provider => $qesap_provider);
 }
 


### PR DESCRIPTION
Move SAP installer source to secured blob server
Add sapconf variant of the GCP test

Verification run:
- Azure https://openqaworker15.qa.suse.cz/tests/100224


- GCP saptune https://openqaworker15.qa.suse.cz/tests/100230
- GCP sapconf https://openqaworker15.qa.suse.cz/tests/100229
GCP is broken for other reasons but  conf.yaml ( https://openqaworker15.qa.suse.cz/tests/100230/file/configure-qesap_gcp.yaml ) and Ansible Media file ( https://openqaworker15.qa.suse.cz/tests/100229/file/configure-hana_media.yaml ) are properly generated