### PR TITLE
Add valgrind test on sle15sp5

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -169,4 +169,5 @@ schedule:
     - '{{tumbleweed_tests}}'
     - console/tar
     - console/coredump_collect
+    - console/valgrind
     - console/zypper_log_packages


### PR DESCRIPTION
https://progress.opensuse.org/issues/121534

The valgrind test is running at QEM but missing at sle15sp5 which is in development, adding it then.


- Related ticket: https://progress.opensuse.org/issues/121534
- Verification run: [VRs for all platforms](https://openqa.suse.de/tests/overview?build=rfanvalgrind&distri=sle&version=15-SP5)