### PR TITLE
ulp_openposix: Add support for testing arbitrary incidents

### DIFF
--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -13,13 +13,16 @@ use testapi;
 use utils;
 use serial_terminal;
 use klp;
+use qam;
 use LTP::utils;
 use OpenQA::Test::RunArgs;
 
 sub prepare_repo {
-    my ($packname) = @_;
-    my @repos = split(",", get_required_var('INCIDENT_REPO'));
+    my $incident_id = get_required_var('INCIDENT_ID');
+    my $repo = get_required_var('INCIDENT_REPO');
+    my @repos = split(",", $repo);
     my @repo_names;
+    my $packname;
 
     install_klp_product;
     zypper_call('in libpulp0 libpulp-tools');
@@ -30,44 +33,70 @@ sub prepare_repo {
     }
 
     my $repo_args = join(' ', map({ "-r $_" } @repo_names));
+    my $patches = get_patches($incident_id, $repo);
+
+    die "Patch isn't needed" unless $patches;
+
+    my $packlist = zypper_search("-st package $repo_args");
+
+    if (grep { $$_{name} eq 'glibc-livepatches' } @$packlist) {
+        record_info('Livepatch tests', "Incident $incident_id contains userspace livepatches.");
+        $packname = 'glibc-livepatches';
+    }
+    elsif (grep { $$_{name} eq 'libpulp0' || $$_{name} eq 'libpulp-tools' } @$packlist) {
+        record_info('Tools tests', "Incident $incident_id contains livepatching tools.");
+        $packname = 'openposix-livepatches';
+        $repo_args = '';
+
+        # Install the libpulp/tools update before running tests
+        zypper_call("in -l -t patch $patches", exitcode => [0, 102, 103],
+            log => 'zypper.log', timeout => 1400);
+    }
+    else {
+        # Incident has no userspace livepatch related packages, nothing to do
+        record_info('Exit', "Incident $incident_id contains no userspace livepatching related packages. Nothing to test.");
+        return undef;
+    }
+
     my $provides = script_output("zypper -n info --provides $repo_args $packname");
     my @versions = $provides =~ m/^\s*libc_([^_]+)_livepatch\d+\.so\(\)\([^)]+\)\s*$/gm;
 
-    die "Package $packname contains no libc livepatches" unless scalar @versions;
+    die "Package $packname contains no libc livepatches"
+      unless scalar @versions;
 
     prepare_ltp_env;
-    return \@versions;
+    return OpenQA::Test::RunArgs->new(run_id => 0,
+        glibc_versions => \@versions, packname => $packname);
 }
 
 sub run {
     my ($self, $tinfo) = @_;
-    my ($glibc_versions, $run_id);
-    my $packname = "glibc-livepatches";
 
     select_serial_terminal;
 
     if (!defined($tinfo)) {
         # First test round in the job, prepare environment
-        $glibc_versions = prepare_repo($packname);
-        $run_id = 0;
+        $tinfo = prepare_repo();
+
+        # Incident has no userspace livepatch related packages, nothing to do
+        return if not $tinfo;
     } else {
-        $glibc_versions = $tinfo->{glibc_versions};
-        $run_id = $tinfo->{run_id};
-        zypper_call("rm $packname");
+        zypper_call("rm " . $tinfo->{packname});
     }
 
     # Schedule openposix tests and install the livepatch
-    my $libver = $$glibc_versions[$run_id];
+    my $libver = $tinfo->{glibc_versions}[$tinfo->{run_id}];
     record_info('glibc version', $libver);
     zypper_call("in --oldpackage glibc-$libver");
     schedule_tests('openposix', "_glibc-$libver");
     loadtest_kernel('ulp_threads', name => "ulp_threads_glibc-$libver");
-    zypper_call("in $packname");
+    zypper_call("in " . $tinfo->{packname});
 
     # Run tests again with the next untested glibc version
-    if ($run_id < $#$glibc_versions) {
-        my $runargs = OpenQA::Test::RunArgs->new(run_id => $run_id + 1,
-            glibc_versions => $glibc_versions);
+    if ($tinfo->{run_id} < $#{$tinfo->{glibc_versions}}) {
+        my $runargs = OpenQA::Test::RunArgs->new(run_id => $tinfo->{run_id} + 1,
+            glibc_versions => $tinfo->{glibc_versions},
+            packname => $tinfo->{packname});
 
         loadtest_kernel('ulp_openposix', run_args => $runargs);
     }


### PR DESCRIPTION
Add support for running `ulp_openposix` on any maintenance incident. The test will first read package list from incident repos and decide how to proceed:
1) Repo contains `glibc-livepatches`: Continue as in the previous version.
2) Repo contains `libpulp0` or `libpulp-tools`: Install update, then run openposix tests livepatched by openposix-livepatches from `QA:Head` repo.
3) Repo contains none of the above: Nothing to do, exit.

- Related ticket: https://progress.opensuse.org/issues/112004
- Needles: N/A
- Verification runs:
  - Normal LTP job: https://openqa.suse.de/tests/10152547
  - ULP job, case 1 (glibc-livepatches): https://openqa.suse.de/tests/10157485 (Expected to fail, the `glibc-livepatches` package intentionally breaks `calloc()`. The job uses a [workaround](https://github.com/mdoucha/os-autoinst-distri-opensuse/commit/6827d1787ad2e89c6f07344d50b49b3ccfb33763) to even allow the package to install, otherwise `zypper` would fail)
  - ULP job, case 3 (no livepatching packages): https://openqa.suse.de/tests/10157502
