### PR TITLE
Support public cloud instance reboot for mr_test

### DIFF
--- a/tests/sles4sap/saptune/mr_test_run.pm
+++ b/tests/sles4sap/saptune/mr_test_run.pm
@@ -13,9 +13,10 @@ use base "sles4sap";
 use testapi;
 use Utils::Backends;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_public_cloud);
 use Utils::Architectures;
 use Mojo::JSON 'encode_json';
+use publiccloud::instances;
 use strict;
 use warnings;
 
@@ -36,9 +37,14 @@ our $result_module;
 sub reboot_wait {
     my ($self) = @_;
 
-    # Do not reboot if testing in public cloud instance,
-    # reboot will terminate the ssh tunnel
-    $self->reboot if (!get_var('PUBLIC_CLOUD_SLES4SAP'));
+    if (is_public_cloud) {
+        # Reboot on publiccloud needs to happen via their dedicated reboot routine
+        my $instance = publiccloud::instances::get_instance();
+        $instance->softreboot(timeout => 1200);
+    }
+    else {
+        $self->reboot;
+    }
 }
 
 sub get_notes {


### PR DESCRIPTION
Implement instance reboot on public cloud envs for mr_test after this commit was merged: https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/942e1d4a084de8bc8d4600e7399ef4a49c5a7802

NOTE for the code changes in `lib/publiccloud/instance.pm`:

1. I revised the execution condition of one debug line as it introduces random timed out failures on softreboot
(for example: https://openqaworker15.qa.suse.cz/tests/103196#step/1_saptune_overrides/39)
```
    # Exclude 'mr_test/saptune' test case as it will introduce random softreboot failures.
    if (!get_var('PUBLIC_CLOUD_SLES4SAP')) {
        $self->run_ssh_command(cmd => 'sudo journalctl -b', proceed_on_failure => 1, username => $args{username}, timeout => 360);
    }
```
2. Others changes are for fixing `CI check tidy errors`

- Related ticket: https://jira.suse.com/browse/TEAM-6980 (TEAM-6980 - Implement instance reboot on public cloud envs for mr_test)
- Needles: NA
- Verification run:
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP4&build=%3A27019%3Alibzypp&groupid=21 (15sp4: test results are as expected)
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=12-SP5&build=%3A27019%3Alibzypp&groupid=28 (12sp5: test results are as expected)
