### PR TITLE
WIP: Call systemd-vconsole-setup before accessing virtual consoles to avoid wrong visualization with ncurses

### DIFF
--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -60,6 +60,9 @@ sub run {
     # From now we need needles
     select_console 'root-console';
 
+    # Call systemd-vconsole-setup before accessing virtual consoles to avoid wrong visualization with ncurses
+    assert_script_run '/usr/lib/systemd/systemd-vconsole-setup';
+
     #
     # YaST nfs-client execution
     #


### PR DESCRIPTION
Call systemd-vconsole-setup before accessing virtual consoles to avoid wrong visualization with ncurses

- Related ticket: https://progress.opensuse.org/issues/120450
- Needles: na
- Verification run: https://openqa.suse.de/tests/10156593#

- Verification 50 runs: https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=wegao_investigation_120450
