### PR TITLE
Import map_incidents_to_repo from main_common

### DIFF
--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -8,7 +8,7 @@ BEGIN {
 }
 use utils;
 use testapi;
-use main_common qw(init_main is_updates_test_repo unregister_needle_tags);
+use main_common qw(init_main is_updates_test_repo unregister_needle_tags map_incidents_to_repo);
 use main_micro_alp;
 
 init_main();


### PR DESCRIPTION
Following issue affects all sle-micro updates jobs

```
Undefined subroutine &OpenQA::Isotovideo::Utils::map_incidents_to_repo
called at sle-micro/products/sle-micro/main.pm line 54.
Compilation failed in require at
/usr/lib/os-autoinst/OpenQA/Isotovideo/Utils.pm line 245.
```

- Issue: https://openqa.suse.de/tests/10153725
- Verification run: http://kepler.suse.cz/tests/19753#live
