### PR TITLE
Add kernel audit messages

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -13,6 +13,7 @@ use testapi;
 use version_utils qw(is_sle_micro is_leap_micro);
 use Utils::Architectures qw(is_aarch64);
 use microos "microos_login";
+use transactional "record_kernel_audit_messages";
 
 sub run {
 
@@ -28,6 +29,7 @@ sub run {
         shift->wait_boot(bootloader_time => 300);
     }
     microos_login;
+    record_kernel_audit_messages(log_upload => 1);
 }
 
 sub test_flags {


### PR DESCRIPTION
Record the kernel audit messages before the auditd daemon was started.

- Related ticket: https://progress.opensuse.org/issues/121450
- Verification runs: [SLEM 5.4](https://duck-norris.qe.suse.de/tests/11381#step/disk_boot/15) | [MicroOS](https://duck-norris.qe.suse.de/tests/11382#step/disk_boot/17)
