### PR TITLE
pam_basic_function: ask RPM for the correct libdir

### DIFF
--- a/tests/security/pam/pam_basic_function.pm
+++ b/tests/security/pam/pam_basic_function.pm
@@ -23,7 +23,7 @@ sub run {
 
     # Make sure all corresponding files are there
     assert_script_run 'ls /etc/pam.d';
-    assert_script_run 'ls /lib64/security';
+    assert_script_run 'ls /lib*/security';
     assert_script_run 'ls /etc/security';
 
     # Make sure the binaries are controlled by PAM


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/121888
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/2950725
