### PR TITLE
mm_network: Attempt to fix issues when we sporadically get no nameservers

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -31,11 +31,17 @@ sub get_host_resolv_conf {
     while (my $line = <$fh>) {
         if ($line =~ /^nameserver\s+([0-9.]+)\s*$/) {
             $conf{nameserver} //= [];
+            diag('mm_network::get_host_resolv_conf nameserver ' . $1);
             push @{$conf{nameserver}}, $1;
         }
         if ($line =~ /search\s+(.+)\s*$/) {
+            diag('mm_network::get_host_resolv_conf search ' . $1);
             $conf{search} = $1;
         }
+    }
+    if (scalar @{$conf{nameserver}} == 0) {
+        # If we don't get the name server from openQA worker we try to use the worker IP address
+        push(@{$conf{nameserver}}, script_output("ip route show | awk '/default/ { print \$3 }'"));
     }
     close($fh);
     return \%conf;


### PR DESCRIPTION
mm_network: Attempt to fix issues when we sporadically get no nameservers

As this issue is sporadic there is no easy way of debugging so I added some debug output and in case of no name server from the system we return the SUT's default gateway.

 - Related ticket: [poo#121555](https://progress.opensuse.org/issues/121555)
 - Verification run: [yast2_nfs_v3_client@64bit](https://pdostal-server.suse.cz/tests/3489)