### PR TITLE
ltp: Create own installation job for ALP

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -11,8 +11,9 @@ use utils;
 use main_common qw(boot_hdd_image load_bootloader_s390x load_kernel_baremetal_tests);
 use 5.018;
 use Utils::Backends;
-use version_utils 'is_opensuse';
+use version_utils qw(is_opensuse is_alp);
 use LTP::utils qw(loadtest_kernel shutdown_ltp);
+use main_common 'loadtest';
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
 # use warnings;
 
@@ -30,6 +31,11 @@ sub load_kernel_tests {
     loadtest_kernel "../installation/bootloader" if is_pvm;
 
     if (get_var('INSTALL_LTP')) {
+        if (is_alp) {
+            loadtest('microos/disk_boot');
+            loadtest('transactional/host_config');
+        }
+
         if (get_var('INSTALL_KOTD')) {
             loadtest_kernel 'install_kotd';
         }

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -364,7 +364,7 @@ sub run {
         die 'INSTALL_LTP must contain "git" or "repo"';
     }
 
-    if (!get_var('KGRAFT') && !get_var('LTP_BAREMETAL') && !is_jeos) {
+    if (!get_var('KGRAFT') && !get_var('LTP_BAREMETAL') && !is_jeos && !is_alp) {
         $self->wait_boot;
     }
 


### PR DESCRIPTION
LTP installation was depending on default installation scenario, but was not stable enough and blocked kernel testing. LTP installation job will now boot from official ALP image and prepares system for further testing. Installation job needs additional variables NUMDISKS=2 and HDD_2=ignition.qcow2 to boot original image defined in HDD_1. ALP qemu image has kernel-default-base as default kernel. It is recommended to set KERNEL_BASE=1 to correctly show information during installation.

- Related ticket: none
- Needles: none
- Verification run: 
installation: http://10.100.12.105/tests/2013
test: http://10.100.12.105/tests/2014

Related jobgroup reconfiguration: https://github.com/os-autoinst/opensuse-jobgroups/pull/245