### PR TITLE
Fix disabled timeout issue

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -64,6 +64,7 @@ sub run {
     $timeout = "90" if (get_var("REGRESSION", '') =~ /xen|kvm|qemu/);
     type_string $timeout;
 
+    wait_still_screen(1);
     # ncurses uses blocking modal dialog, so press return is needed
     send_key 'ret' if check_var('VIDEOMODE', 'text');
 


### PR DESCRIPTION
poo#[119953](https://progress.opensuse.org/issues/119953)
Fix module: disable_grub_timeout, wait one second before the next operation.
Prevent matching failure of needle.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: [119953](https://progress.opensuse.org/issues/119953)
- Needles: None
- Verification run: 
      - [Build58.1-textmode_svirt@svirt-hyperv2012r2](http://10.67.129.83/tests/500)
      - [Build58.1-textmode_svirt@svirt-hyperv2022](http://10.67.129.83/tests/504)
