### PR TITLE
Do not run yast2_rmt on i586

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1479,7 +1479,7 @@ sub load_extra_tests_y2uitest_ncurses {
         return;
     }
     # start extra yast console tests (self-contained only) from here
-    loadtest "console/yast2_rmt" unless (is_sle('<15-sp1') || is_leap('<15.0'));
+    loadtest "console/yast2_rmt" unless (is_sle('<15-sp1') || is_leap('<15.0') || is_i586);
     loadtest "console/yast2_ntpclient";
     loadtest "console/yast2_tftp";
     # We don't schedule some tests on s390x as they are unstable, see poo#42692


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/121948
- Needles: N/A
- Verification run: Non-testing is hard to test :)
