### PR TITLE
Apply firewall restart after each command that change configuration only in SLE

### DIFF
--- a/tests/yast2_gui/yast2_firewall_set_default_zone_prepare.pm
+++ b/tests/yast2_gui/yast2_firewall_set_default_zone_prepare.pm
@@ -29,8 +29,10 @@ sub run {
     save_screenshot;
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
-    select_serial_terminal();
+    select_console 'root-console';
+    systemctl 'restart firewalld', timeout => 200 if (script_run(("grep 'FlushAllOnReload.*no' /etc/firewalld/firewalld.conf") == 0));
     validate_script_output("firewall-cmd --list-interfaces --zone=$settings{zone}", sub { m/$settings{device}/ }, proceed_on_failure => 0);
+    select_console 'x11', await_console => 0;
 }
 
 sub post_fail_hook {

--- a/tests/yast2_gui/yast2_firewall_set_interface.pm
+++ b/tests/yast2_gui/yast2_firewall_set_interface.pm
@@ -18,6 +18,7 @@ use serial_terminal 'select_serial_terminal';
 
 sub run {
     my $self = shift;
+    select_console 'root-console';
     my $iface = iface();
     my %setting = (device => $iface, zone => 'public');
 
@@ -29,8 +30,10 @@ sub run {
     save_screenshot;
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
-    select_serial_terminal();
+    select_console 'root-console';
+    systemctl 'restart firewalld', timeout => 200 if (script_run(("grep 'FlushAllOnReload.*no' /etc/firewalld/firewalld.conf") == 0));
     validate_script_output("firewall-cmd --list-interfaces --zone=$setting{zone}", sub { m/$setting{device}/ }, proceed_on_failure => 1);
+    select_console 'x11', await_console => 0;
 }
 
 1;

--- a/tests/yast2_gui/yast2_firewall_set_service_port.pm
+++ b/tests/yast2_gui/yast2_firewall_set_service_port.pm
@@ -18,6 +18,7 @@ use serial_terminal 'select_serial_terminal';
 
 sub run {
     my $self = shift;
+    select_console 'root-console';
     my $iface = iface();
     my %setting = (zone => 'trusted', service => 'bitcoin', port => '7777');
 
@@ -31,9 +32,11 @@ sub run {
     save_screenshot;
     $testapi::distri->get_firewall()->accept_change();
     assert_screen 'generic-desktop';
-    select_serial_terminal();
+    select_console 'root-console';
+    systemctl 'restart firewalld', timeout => 200 if (script_run(("grep 'FlushAllOnReload.*no' /etc/firewalld/firewalld.conf") == 0));
     validate_script_output("firewall-cmd --list-all --zone=trusted", sub { m/services: bitcoin/ }, proceed_on_failure => 1);
     validate_script_output("firewall-cmd --list-all --zone=trusted", sub { m/ports: 7777\/tcp/ }, proceed_on_failure => 1);
+    select_console 'x11', await_console => 0;
 }
 
 1;


### PR DESCRIPTION
Apply firewall restart after each command that change configuration only in SLE

- Related ticket: https://progress.opensuse.org/issues/120411
- Verification run: https://openqa.suse.de/tests/10281302
  TW: https://openqa.opensuse.org/tests/3017210#
