### PR TITLE
check_failures_in_journal(): Upload system logs when needed

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -164,6 +164,12 @@ sub check_failures_in_journal {
         else {
             record_soft_failure("Found new failures: Fake bsc#5555(by PR rule)\n" . $failures . "This is an unknown failure which need to be investigated!");
         }
+
+        my $logfile = "/tmp/journalctl-$machine.log";
+
+        script_run("rm -f $logfile");
+        print_cmd_output_to_file('journalctl -b', $logfile, $machine);
+        upload_logs($logfile);
     }
     return $failures;
 }


### PR DESCRIPTION
Reporting detected errors is nice, but it's really hard to debug them when there's no info about **what error** it actually was.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/10526689
