### PR TITLE
Use serial terminal in transactional tests

### DIFF
--- a/tests/console/ansible.pm
+++ b/tests/console/ansible.pm
@@ -48,7 +48,7 @@ sub run {
     ensure_serialdev_permissions;
 
     if (is_transactional) {
-        trup_call("-n pkg install $pkgs sudo");
+        trup_call("pkg install $pkgs sudo");
         check_reboot_changes;
     } else {
         zypper_call "in $pkgs sudo";
@@ -201,7 +201,7 @@ sub cleanup {
     # Remove ansible, yamllint and git
     $pkgs .= ' ed' unless (is_alp);
     if (is_transactional) {
-        trup_call("-n pkg remove $pkgs");
+        trup_call("pkg remove $pkgs");
         check_reboot_changes;
     } else {
         # ed has been installed in ansible-playbook

--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -14,11 +14,12 @@ use transactional;
 use utils qw(systemctl);
 use mm_network qw(is_networkmanager);
 use version_utils qw(is_microos is_sle_micro is_leap_micro is_alp);
+use serial_terminal;
 
 sub run {
     my ($self) = @_;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     # Install cockpit if needed, this is needed for DVD flavor where
     # Cockpit pattern is not selected during install

--- a/tests/transactional/filesystem_ro.pm
+++ b/tests/transactional/filesystem_ro.pm
@@ -12,9 +12,10 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use serial_terminal;
 
 sub run {
-    select_console 'root-console';
+    select_serial_terminal;
 
     die 'Should have failed' unless script_run('touch /should_fail');
     assert_script_run "touch /etc/should_succeed";

--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -13,10 +13,13 @@ use testapi;
 use qam;
 use transactional;
 use version_utils 'is_sle_micro';
+use serial_terminal;
 
 sub run {
     my ($self) = @_;
-    select_console 'root-console';
+
+    select_serial_terminal;
+
     if (is_sle_micro) {
         assert_script_run 'curl -k https://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt';
         assert_script_run 'update-ca-certificates -v';

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -79,6 +79,8 @@ sub check_strategy_maint_window {
 }
 
 sub run {
+    select_console 'root-console';
+
     get_utt_packages;
 
     record_info 'Instantly', 'Test instant reboot';

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -18,6 +18,7 @@ use testapi;
 use version_utils qw(is_staging is_opensuse is_leap is_sle is_sle_micro is_leap_micro is_alp);
 use transactional;
 use utils;
+use serial_terminal;
 
 
 =head2 check_package
@@ -59,7 +60,7 @@ sub check_package {
 }
 
 sub run {
-    select_console 'root-console';
+    select_serial_terminal;
 
     script_run "rebootmgrctl set-strategy off";
 
@@ -90,7 +91,7 @@ sub run {
 
         # Check that zypper does not return 0 if update was aborted
         record_info 'Broken pkg', 'Install broken package poo#18644 - snapshot #3';
-        trup_call "pkg install" . rpmver('broken');
+        trup_call "pkg install" . rpmver('broken'), interactive => 1;
         check_reboot_changes;
         # Systems with repositories would downgrade on DUP
         if (is_leap) {

--- a/tests/transactional/trup_smoke.pm
+++ b/tests/transactional/trup_smoke.pm
@@ -14,6 +14,7 @@ use testapi;
 use transactional;
 use Utils::Architectures qw(is_s390x);
 use version_utils qw(is_sle_micro);
+use serial_terminal;
 
 sub action {
     my ($target, $text, $reboot) = @_;
@@ -26,7 +27,7 @@ sub action {
 sub run {
     my ($self) = @_;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     if (is_sle_micro && is_s390x) {
         record_soft_failure "bsc#1191863 -  [s390x] Can't reboot after transactional-update bootloader";


### PR DESCRIPTION
Allow running `trup_call()` on serial terminals and make the commands non-interactive by default. Tests which validate interactive commands must call the function with `interactive => 1`.

This PR fixes a testing issue on s390x where bogus Btrfs messages triggered by `snapper` pollute test command output and confuse the test.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - x86_64: https://openqa.suse.de/tests/10272686
  - s390x: https://openqa.suse.de/tests/10269051
  - aarch64: https://openqa.suse.de/tests/10269050
