### PR TITLE
Use solver_focus for new binaries too

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -239,7 +239,7 @@ sub run {
         # Install binaries newly added by the incident.
         if (scalar @new_binaries) {
             record_info 'Install new packages', "New packages: @new_binaries";
-            zypper_call("in -l @new_binaries", exitcode => [0, 102, 103], log => "new_$patch.log", timeout => 1500);
+            zypper_call("in -l $solver_focus @new_binaries", exitcode => [0, 102, 103], log => "new_$patch.log", timeout => 1500);
         }
 
         # After the patches have been applied and the new binaries have been


### PR DESCRIPTION
required for packages like postgresql-devel, where different package versions can't be installed in parallel
solver will auto choose to uninstall conflicting postgresql packages

https://suse.slack.com/archives/C02D16TCP99/p1670576343184949

- Fail:
https://openqa.suse.de/tests/overview?build=%3A26875%3Apostgresql&distri=sle&groupid=367 qam-insidentinstall
https://openqa.suse.de/tests/overview?build=%3A26875%3Apostgresql&distri=sle&groupid=439 qam-insidentinstall
- Verification run:
15-SP3
https://openqa.suse.de/tests/10169943
https://openqa.suse.de/tests/10169944
https://openqa.suse.de/tests/10169945
https://openqa.suse.de/tests/10169946
15-SP4
https://openqa.suse.de/tests/10169947
https://openqa.suse.de/tests/10169948
https://openqa.suse.de/tests/10169949
https://openqa.suse.de/tests/10169950