### PR TITLE
Rework tests with indirect dependencies on PackageHub

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -170,4 +170,5 @@ schedule:
     - console/tar
     - console/coredump_collect
     - console/valgrind
+    - console/sssd_389ds_functional
     - console/zypper_log_packages

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -11,7 +11,6 @@ schedule:
     - console/django
     - '{{wpa_supplicant}}'
     - console/vmstat
-    - console/sssd_389ds_functional
     - console/ansible
     - console/coredump_collect  # For coredumps during the suite. Please put near end.
     - console/zypper_log_packages  # Records packages installed in the suite. Please put at end.


### PR DESCRIPTION
https://progress.opensuse.org/issues/121252
For sssd_389ds_functional test,  we depend on `ssh-askpass`, which make s389-ds break when PackageHub is not available.  replace `sshpass` command with interactive `enter_cmd` function, and move the test out of PackageHub test suite

- Verification run: 
 [Functional](https://openqa.suse.de/tests/10165582)
[QEM](http://openqa.suse.de/tests/overview?&distri=sle&build=rfan_389&test=rfan389)