### PR TITLE
gpo enforcement

### DIFF
--- a/data/supportserver/samba/sssd/conf.d/suse.conf
+++ b/data/supportserver/samba/sssd/conf.d/suse.conf
@@ -9,6 +9,8 @@ filter_groups = root
 [domain/GEEKO.COM]
 id_provider = ad
 auth_provider = ad
+access_provider = ad
+ad_gpo_access_control = enforcing
 ad_domain = geeko.com
 cache_credentials = true
 enumerate = false

--- a/lib/Utils/Systemd.pm
+++ b/lib/Utils/Systemd.pm
@@ -69,7 +69,7 @@ sub systemctl {
     croak "systemctl(): no command specified" if ($command =~ /^ *$/);
     my $expect_false  = $args{expect_false} ? '! ' : '';
     my @script_params = ("${expect_false}systemctl --no-pager $command", timeout => $args{timeout}, fail_message => $args{fail_message});
-    if ($command =~ /^(re)?start ([^ ]+)/) {
+    if ($command =~ /^(start|restart|enable) ([^ ]+)/) {
         my $unit_name = $2;
         $started_systemd_services{$unit_name} = 1;
     }

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -51,7 +51,7 @@ Method executed when run() finishes and the module has result => 'fail'
 sub post_fail_hook {
     my ($self) = @_;
     $self->SUPER::post_fail_hook;
-    select_console('log-console');
+    $self->select_serial_terminal;
     $self->remount_tmp_if_ro;
     $self->export_logs_basic;
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -466,14 +466,12 @@ sub export_logs {
     $self->problem_detection;
 
     $self->export_logs_basic;
+    $self->export_logs_desktop;
 
     # Just after the setup: let's see the network configuration
     $self->save_and_upload_log("ip addr show",         "/tmp/ip-addr-show.log");
     $self->save_and_upload_log("cat /etc/resolv.conf", "/tmp/resolv-conf.log");
 
-    save_screenshot;
-
-    $self->export_logs_desktop;
 
     $self->save_and_upload_log('systemctl list-unit-files', '/tmp/systemctl_unit-files.log');
     $self->save_and_upload_log('systemctl status',          '/tmp/systemctl_status.log');
@@ -545,9 +543,6 @@ Upload several KDE, GNOME, X11, GDM and SDDM related logs and configs.
 =cut
 sub export_logs_desktop {
     my ($self) = @_;
-    select_log_console;
-    save_screenshot;
-
     if (check_var("DESKTOP", "kde")) {
         if (get_var('PLASMA5')) {
             $self->tar_and_upload_log("/home/$username/.config/*rc", '/tmp/plasma5_configs.tar.bz2');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -461,6 +461,7 @@ sub export_logs {
     select_log_console;
     save_screenshot;
     show_oom_info;
+    $self->select_serial_terminal;
     $self->remount_tmp_if_ro;
     $self->problem_detection;
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1546,8 +1546,8 @@ sub script_retry {
         $ret = script_run($exec, ($timeout + 3));
         last if defined($ret) && $ret == $ecode;
 
-        die("Waiting for Godot: $cmd") if $retry == $_ && $die == 1;
-        sleep $delay                   if ($delay > 0);
+        die("Max retries reached ($retry): $cmd") if $retry == $_ && $die == 1;
+        sleep $delay                              if ($delay > 0);
     }
 
     return $ret;


### PR DESCRIPTION
GPO stands for Global Policy Objects which is a fancy acronym for an
ACL, in general we want to ensure that users that are explicitly denied
access to services (or have other kind of permissions on their profile)
can't login, and that sssd honors such options.

Prior to enabling the following settings, user bernhard (from geeko.com
domain) would be able to login via ssh to the SUT.

+access_provider = ad
+ad_gpo_access_control = enforcing


VR: 

* samba_adcli: Export relevant logs on failure
* Support getting journal files for enabled services
* opensusebasetest: Update the flow of error detection mechanism
* consoletest: Use serial terminal after parent's post_fail_hook
* Run parent post_fail_hooks to get better logging

At the moment, if the SUT is using a serial terminal, we simply return,
and let the rest of the post-fail-hook to do the work, so if the child
(e.g consoletest) doesn't call export_logs() or doesn't do any specific
actions, export_logs_basic will be called, and these logs aren't really
providing much.

VR:
* [sle-15-SP1-Server-DVD-Updates-aarch64-Build20210729-1-mau-extratests2@aarch64-virtio](https://openqa.suse.de/tests/6607376)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20210729-1-mau-extratests2@64bit](https://openqa.suse.de/tests/6607377)
* [sle-15-SP2-Server-DVD-Updates-x86_64-Build20210729-1-mau-extratests2@64bit](https://openqa.suse.de/tests/6607375)
* [sle-15-SP3-Server-DVD-Updates-aarch64-Build20210729-1-mau-extratests2@aarch64-virtio](https://openqa.suse.de/tests/6607373)
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20210729-1-mau-extratests2@64bit](https://openqa.suse.de/tests/6607381)

See: #12517