### PR TITLE
run_ltp: Redirect stderr to serialdev

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -314,7 +314,7 @@ sub run {
         send_key 'ret';
     }
     else {
-        enter_cmd("($cmd_text) | tee /dev/$serialdev");
+        enter_cmd("($cmd_text) 2>\&1 | tee /dev/$serialdev");
     }
     my $test_log = wait_serial(qr/$fin_msg\d+\./, $timeout, 0, record_output => 1);
     my ($timed_out, $result_export) = $self->record_ltp_result($runfile, $test, $test_log, $fin_msg, thetime() - $start_time, $is_posix);


### PR DESCRIPTION
LTP new API tests write to stderr instead of stdout, which was not caught on non-serial terminal (e.g. s390x using bootloader_s390.pm on o3).

Verification run:
- https://openqa.opensuse.org/tests/2957583#step/af_alg01/4 
https://openqa.opensuse.org/tests/2957172/file/serial0.txt
https://openqa.opensuse.org/tests/2957583#step/af_alg01/1
`(af_alf01; echo "### TEST af_alg01 COMPLETE >>> $?.") 2>&1 | tee /dev/hvc0`

compare with original:
- https://openqa.opensuse.org/tests/2957172#step/af_alg01/4
https://openqa.opensuse.org/tests/2957172/file/serial0.txt
https://openqa.opensuse.org/tests/2957172#step/af_alg01/1
`(af_alf01; echo "### TEST af_alg01 COMPLETE >>> $?.") | tee /dev/hvc0`

Just in case run QEMU tests:
- sle-15-SP5-Online-aarch64-Build58.1-ltp_crypto@aarch64-virtio -> https://openqa.suse.de/t10182777
- sle-15-SP5-Online-ppc64le-Build58.1-ltp_crypto@ppc64le-virtio -> https://openqa.suse.de/t10182778
- sle-15-SP5-Online-s390x-Build58.1-ltp_cve@s390x-kvm-sle15 -> https://openqa.suse.de/t10182779

