### PR TITLE
Configurable timeout for all Trento tests

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -9,8 +9,6 @@ terraform:
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     aws_credentials: "/root/amazon_credentials"
-    hana_cluster_fencing_mechanism: "sbd"
-    hana_ha_enabled: "true"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"
@@ -32,13 +30,12 @@ ansible:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml
-    - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml
     - sap-hana-install.yaml
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
+    - sap-hana-cluster.yaml -e use_sbd=false
   destroy:
     - deregister.yaml
   variables:

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -37,13 +37,12 @@ ansible:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml
-    - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml
     - sap-hana-install.yaml
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
+    - sap-hana-cluster.yaml -e use_sbd=false
   destroy:
     - deregister.yaml
   variables:

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -37,13 +37,12 @@ ansible:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=true
-    - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml
     - sap-hana-install.yaml
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
+    - sap-hana-cluster.yaml -e use_sbd=false
   destroy:
     - deregister.yaml
   variables:

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -156,7 +156,6 @@ sub qesap_pip_install {
     my $pip_install_log = '/tmp/pip_install.txt';
     my %paths = qesap_get_file_paths();
 
-
     push(@log_files, $pip_install_log);
     record_info("QESAP repo", "Installing pip requirements");
     assert_script_run(join(' ', $pip_ints_cmd, '-r', $paths{deployment_dir} . '/requirements.txt | tee -a', $pip_install_log), 360);

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -13,10 +13,10 @@ use qesapdeployment;
 sub run {
     my $ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => 1800);
     die "'qesap.py terraform' return: $ret" if ($ret);
+    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    upload_logs($inventory, failok => 1);
     $ret = qesap_execute(cmd => 'ansible', verbose => 1, timeout => 1800);
     die "'qesap.py ansible' return: $ret" if ($ret);
-    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
-    upload_logs($inventory);
 }
 
 sub test_flags {

--- a/tests/sles4sap/trento/cluster_deploy.pm
+++ b/tests/sles4sap/trento/cluster_deploy.pm
@@ -9,7 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use qesapdeployment qw(qesap_upload_logs qesap_get_inventory qesap_ansible_cmd);
+use qesapdeployment qw(qesap_upload_logs qesap_ansible_cmd);
 use trento;
 
 sub run {

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -25,14 +25,14 @@ sub run {
     assert_script_run "mkdir " . CYPRESS_LOG_DIR;
 
     #  Cypress verify: cypress.io self check about the framework installation
-    cypress_exec($cypress_test_dir, 'verify', 120, 'verify', 1);
+    cypress_exec($cypress_test_dir, 'verify', bmwqemu::scale_timeout(120), 'verify', 1);
     cypress_log_upload(('.txt'));
 
     # test about first visit: login and eula
-    cypress_test_exec($cypress_test_dir, 'first_visit', 900);
+    cypress_test_exec($cypress_test_dir, 'first_visit', bmwqemu::scale_timeout(900));
 
     # all other cypress tests
-    cypress_test_exec($cypress_test_dir, 'all', 900);
+    cypress_test_exec($cypress_test_dir, 'all', bmwqemu::scale_timeout(900));
 
     trento_support('test_trento_web');
 }


### PR DESCRIPTION
All the timeout values are managed with scale_timeout
qesap regression, proper native fencing config for AWS and GCP
lambda function for the cluster_wait_status in Trento

Verification run: 
- Trento http://openqaworker15.qa.suse.cz/tests/103222
- qesap Azure http://openqaworker15.qa.suse.cz/tests/103223
- qesap GCP saptune http://openqaworker15.qa.suse.cz/tests/103224
- qesap GCP sapconf http://openqaworker15.qa.suse.cz/tests/104276
- qesap AWS http://openqaworker15.qa.suse.cz/tests/104282

