### PR TITLE
lib/services/sshd: Work around busybox-psmisc being there (boo#1198137)

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -45,6 +45,11 @@ sub prepare_test_data {
     # Allow password authentication for $ssh_testman
     assert_script_run(qq(echo -e "Match User $ssh_testman\\n\\tPasswordAuthentication yes" >> /etc/ssh/sshd_config)) if (get_var('PUBLIC_CLOUD'));
 
+    if (script_run('rpm -q busybox-psmisc') == 0) {
+        record_soft_failure("boo#1198137 - busybox-psmisc preferred by zypper");
+        zypper_call("in psmisc -busybox-psmisc");
+    }
+
     # Install software needed for this test module
     zypper_call("in netcat-openbsd expect psmisc");
 }


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/2957633#step/sshd/27

Needs a workaround because it's a fatal module.

- Verification run: https://openqa.opensuse.org/tests/2959197
