### PR TITLE
Add serial console also on ZVM_HOST

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -339,7 +339,7 @@ sub select_serial_terminal {
         } else {
             $console = $root ? 'root-virtio-terminal' : 'user-virtio-terminal';
         }
-    } elsif (get_var('SUT_IP')) {
+    } elsif (get_var('SUT_IP') || is_backend_s390x) {
         $console = $root ? 'root-serial-ssh' : 'user-serial-ssh';
     } elsif ($backend eq 'svirt') {
         if (check_var('SERIAL_CONSOLE', 0)) {

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -569,6 +569,21 @@ sub init_consoles {
             set_var("S390_NETWORK_PARAMS", $s390_params);
 
             ($hostname) = $s390_params =~ /Hostname=(\S+)/;
+
+            # adds serial console for S390_ZKVM
+            # NOTE: adding consoles just at the top of init_consoles() is not enough, otherwise
+            # using just them would fail with:
+            # ::: basetest::runtest: # Test died: Error connecting to <root@192.168.112.9>: Connection refused at /usr/lib/os-autoinst/testapi.pm line 1700.
+            unless (get_var('SUT_IP')) {
+                $self->add_console(
+                    'root-serial-ssh',
+                    'ssh-serial',
+                    {
+                        hostname => $hostname,
+                        password => $testapi::password,
+                        username => 'root'
+                    });
+            }
         }
 
         if (check_var("VIDEOMODE", "text")) {    # adds console for text-based installation on s390x


### PR DESCRIPTION
Needed for LTP tests on o3, where it can save 2 hours testing on ltp_syscalls testsuite.

Suggested-by: Martin Doucha <mdoucha@suse.cz>
Signed-off-by: Petr Vorel <pvorel@suse.cz>

Verification run:

- ltp_syscalls https://openqa.opensuse.org/tests/2968986 (01:19, without serial console even 2 hours was not enough https://openqa.opensuse.org/tests/2968462)
- https://openqa.suse.de/tests/10218749
- https://openqa.suse.de/tests/overview?build=s390-add-serial-console (verification of various osd tests)
- https://openqa.opensuse.org/tests/overview?build=s390-add-serial-console (verification of various osd tests)

@os-autoinst/tests-maintainer Could you please have look and possibly suggest what else I should test?
