### PR TITLE
Add AWS configuration when running on EC2 and wait for ssh

### DIFF
--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -10,11 +10,35 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use qesapdeployment;
 
+sub wait_for_ssh {
+    my ($host) = @_;
+    my $timeout //= bmwqemu::scale_timeout(600);
+    my $start_time = time();
+    my $check_port = 1;
+
+    # Looping until reaching timeout or passing two conditions :
+    # - SSH port 22 is reachable
+    # - journalctl got message about reaching one of certain targets
+    while ((my $duration = time() - $start_time) < $timeout) {
+        if ($check_port) {
+            $check_port = 0 if (script_run('nc -vz -w 1 ' . $host . ' 22', quiet => 1) == 0);
+        }
+        else {
+            return $duration;
+        }
+        sleep 5;
+    }
+    die 'Timed out while waiting for ssh to be available in the CSP instances';
+}
+
 sub run {
     my $ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => 1800);
     die "'qesap.py terraform' return: $ret" if ($ret);
     my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
     upload_logs($inventory, failok => 1);
+    my @remote_ips = qesap_remote_hana_public_ips;
+    record_info 'Remote IPs', join(' - ', @remote_ips);
+    foreach my $host (@remote_ips) { wait_for_ssh $host; }
     $ret = qesap_execute(cmd => 'ansible', verbose => 1, timeout => 1800);
     die "'qesap.py ansible' return: $ret" if ($ret);
 }


### PR DESCRIPTION
Regression tests of [qe-sap-deployments](https://github.com/SUSE/qe-sap-deployment) in openQA are failing on [EC2](http://openqaworker15.qa.suse.cz/tests/104272#) because the ansible commands over SSH are called before the cloud infrastructure is ready for SSH connections and because of a missing `~/.aws/config` file referenced by the ansible playbooks.

This PR fixes both issues by adding new methods into `lib/qesapdeployment.pm` to create the configuration files required by AWS/EC2 and to get the public IP addresses from the terraform deployment so the module can wait until SSH is ready.

- Related ticket: N/A
- Needles: N/A
- Verification run: [Azure SLES for SAP 15-SP3](http://openqaworker15.qa.suse.cz/t104320), [AWS/EC2 SLES for SAP 15-SP3](http://openqaworker15.qa.suse.cz/t104328), [Azure SLES for SAP 12-SP5](http://openqaworker15.qa.suse.cz/t104322)
