### PR TITLE
Trento call new CY tests after cluster restore

### DIFF
--- a/tests/sles4sap/trento/test_hana_restore_stopped.pm
+++ b/tests/sles4sap/trento/test_hana_restore_stopped.pm
@@ -37,6 +37,9 @@ sub run {
         filter => $primary_host);
     cluster_wait_status($primary_host, sub { ((shift =~ m/.+DEMOTED.+SOK/) && (shift =~ m/.+PROMOTED.+PRIM/)); });
 
+    my $cypress_test_dir = "/root/test/test";
+    enter_cmd "cd " . $cypress_test_dir;
+    cypress_test_exec($cypress_test_dir, 'restore_cluster', bmwqemu::scale_timeout(900));
     trento_support('test_hana_restore_stopped');
 }
 


### PR DESCRIPTION
Call the new set of Cypress tests after the rejoin and restart of the stopped HANA db

- Related ticket: [CFSA-917](https://jira.suse.com/browse/CFSA-917)

- Verification run: 
