### PR TITLE
Add HanaSR master tests

### DIFF
--- a/schedule/sles4sap/publiccloud_hanasr.yml
+++ b/schedule/sles4sap/publiccloud_hanasr.yml
@@ -12,6 +12,6 @@ schedule:
   - boot/boot_to_desktop
   - sles4sap/publiccloud/qesap_terraform
   - sles4sap/publiccloud/qesap_ansible
-  # - sles4sap/publiccloud/hana_sr_schedule_primary_tests
+  - sles4sap/publiccloud/hana_sr_schedule_primary_tests
   - sles4sap/publiccloud/hana_sr_schedule_replica_tests
   - sles4sap/publiccloud/hana_sr_schedule_cleanup

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Test module for scheduling multiple instances of tests which target "Master" HANA database.
+#
+# Parameters:
+#  HANASR_PRIMARY_ACTIONS - optional, override list of fencing actions
+
+package hana_sr_schedule_primary_tests;
+
+use base 'sles4sap_publiccloud_basetest';
+use main_common 'loadtest';
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    record_info("Schedule", "Executing tests on master Hana DB");
+    # 'HANASR_PRIMARY_ACTIONS' - define to override test flow
+    my @database_actions = split(",", get_var("HANASR_PRIMARY_ACTIONS", 'stop,kill,crash'));
+    for my $action (@database_actions) {
+        for my $site ("site_a", "site_b") {
+            my $test_name = join(" ", ucfirst($action), $site, "-", "primary");
+            $run_args->{hana_test_definitions}{$test_name}{action} = $action;
+            $run_args->{hana_test_definitions}{$test_name}{site_name} = $site;
+            loadtest('sles4sap/publiccloud/hana_sr_takeover', name => $test_name, run_args => $run_args, @_);
+        }
+    }
+}
+
+1;

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -1,0 +1,65 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Test module for performing database takeover using various methods on "master" HANA database.
+
+use base 'sles4sap_publiccloud_basetest';
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+use publiccloud::utils;
+use sles4sap_publiccloud;
+use Data::Dumper;
+use serial_terminal 'select_serial_terminal';
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    select_serial_terminal;
+    $self->{instances} = $run_args->{instances};
+    my $test_name = $self->{name};
+    my $takeover_action = $run_args->{hana_test_definitions}{$test_name}{action};
+    my $site_name = $run_args->{hana_test_definitions}{$test_name}{site_name};
+    my $target_site = $run_args->{$site_name};
+    die("Target site '$site_name' data is missing. This might indicate deployment issue.")
+      unless $target_site;
+
+    # Switch to control to target site (currently PROMOTED)
+    $self->{my_instance} = $target_site;
+
+    # Check initial cluster status
+    my $cluster_status = $self->run_cmd(cmd => "crm status");
+    record_info("Cluster status", $cluster_status);
+    die(uc($site_name) . " '$target_site->{instance_id}' is NOT in MASTER mode.") if
+      $self->get_promoted_hostname() ne $target_site->{instance_id};
+    record_info(ucfirst($takeover_action) . " DB",
+        join(" ", ucfirst($takeover_action) . "DB on", ucfirst($site_name), "('", $target_site->{instance_id}, "')")
+    );
+
+    # Stop/kill/crash HANA DB and wait till SSH is again available with pacemaker running.
+    # Setup sbd delay in case of crash OS to prevent cluster starting too quickly after reboot
+    $self->setup_sbd_delay("30s") if $takeover_action eq "crash";
+    $self->stop_hana(method => $takeover_action);
+    $self->{my_instance}->wait_for_ssh(username => 'cloudadmin');
+    sleep 10;
+    $self->wait_for_pacemaker();
+
+
+    record_info("Takeover check");
+    $self->check_takeover;
+
+    record_info("Replication", join(" ", ("Enabling replication on", ucfirst($site_name), "(DEMOTED)")));
+    $self->enable_replication();
+
+    record_info(ucfirst($site_name) . " start");
+    $self->cleanup_resource();
+
+    record_info("Done", "Test finished");
+}
+
+1;


### PR DESCRIPTION
Extends HANA SR coverage with modues and libraries for testing primary 
database (stop, crash, kill).

- Related ticket: https://jira.suse.com/browse/TEAM-7079
- Needles: N/A
- Verification run: http://openqaworker15.qa.suse.cz/tests/107087
