### PR TITLE
Set ncurses option for spvm yast tests

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -7,8 +7,7 @@ use utils qw(systemctl file_content_replace clear_console zypper_call clear_cons
 use Utils::Systemd 'disable_and_stop_service';
 use mm_network;
 use version_utils;
-use Utils::Backends 'is_pvm_hmc';
-
+use Utils::Backends qw(is_pvm_hmc is_spvm);
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(server_configure_network try_nfsv2 prepare_exports yast_handle_firewall add_shares
@@ -215,7 +214,8 @@ sub config_service {
     try_nfsv2();
 
     prepare_exports($rw, $ro);
-    my $y2_opts = is_pvm_hmc() ? "--ncurses" : "";
+    my $y2_opts = "";
+    $y2_opts = "--ncurses" if (is_pvm_hmc() || is_spvm());
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nfs-server', yast2_opts => $y2_opts);
 
     yast2_server_initial();

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -20,7 +20,7 @@ use Exporter 'import';
 use testapi;
 use utils 'systemctl';
 use version_utils qw(is_sle is_leap);
-use Utils::Backends 'is_pvm_hmc';
+use Utils::Backends qw(is_pvm_hmc is_spvm);
 use y2_module_basetest qw(accept_warning_network_manager_default is_network_manager_default);
 use y2_module_consoletest;
 use Test::Assert ':all';
@@ -417,7 +417,7 @@ sub open_yast2_lan {
       = ($options{ui} =~ /ncurses/)
       ? "--" . $options{ui}
       : "";
-    $y2_opts = "--ncurses" if is_pvm_hmc();
+    $y2_opts = "--ncurses" if (is_pvm_hmc() || is_spvm());
 
     $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'lan', yast2_opts => $y2_opts);
 

--- a/schedule/yast/yast2_ncurses/yast2_ncurses_textmode_pvm.yaml
+++ b/schedule/yast/yast2_ncurses/yast2_ncurses_textmode_pvm.yaml
@@ -12,6 +12,4 @@ schedule:
   - console/yast2_lan
   - console/yast2_i
   - console/yast2_bootloader
-  - console/yast2_lan_device_settings
-  - console/yast2_nfs_server
   - console/yast2_kdump

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -18,7 +18,7 @@ use warnings;
 use testapi;
 use Utils::Architectures;
 use utils;
-use Utils::Backends qw(is_hyperv is_pvm_hmc);
+use Utils::Backends qw(is_hyperv is_pvm_hmc is_spvm);
 
 sub run {
     my $self = shift;
@@ -26,7 +26,8 @@ sub run {
 
     # make sure yast2 bootloader module is installed
     zypper_call 'in yast2-bootloader';
-    my $y2_opts = is_pvm_hmc() ? "--ncurses" : "";
+    my $y2_opts = "";
+    $y2_opts = "--ncurses" if (is_pvm_hmc() || is_spvm());
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'bootloader', yast2_opts => $y2_opts);
 
     # YaST2 prompts user to install missing packages found during storage probing.


### PR DESCRIPTION

Ppc test fails due to neglecting spvm machines to be specifies to use ncurses.
https://openqa.suse.de/tests/10197089
https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/21ec86201becbcbe92c1d3bf44c2242b1f8e9255 
