### PR TITLE
LTP: Fix installation on 32 bit archs

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -16,6 +16,7 @@ use LTP::WhiteList;
 use LTP::TestInfo 'testinfo';
 use version_utils qw(is_openstack is_jeos);
 use File::Basename 'basename';
+use Utils::Architectures;
 
 our @EXPORT = qw(
   get_ltproot
@@ -27,6 +28,7 @@ our @EXPORT = qw(
   prepare_ltp_env
   schedule_tests
   shutdown_ltp
+  want_ltp_32bit
 );
 
 sub loadtest_kernel {
@@ -53,10 +55,13 @@ sub shutdown_ltp {
 }
 
 sub want_ltp_32bit {
+    my $pkg = shift // get_var('LTP_PKG');
+
     # TEST_SUITE_NAME is for running 32bit tests (e.g. ltp_syscalls_m32),
     # checking LTP_PKG is for install_ltp.pm which also uses prepare_ltp_env()
     return (get_required_var('TEST_SUITE_NAME') =~ m/[-_]m32$/
-          || get_var('LTP_PKG', '') =~ m/^(ltp|qa_test_ltp)-32bit$/);
+          || $pkg =~ m/-32bit$/
+          || is_32bit);
 }
 
 sub get_ltproot {
@@ -72,7 +77,7 @@ sub get_ltp_openposix_test_list_file {
 }
 
 sub get_ltp_version_file {
-    my $want_32bit = shift // get_required_var('TEST_SUITE_NAME') =~ m/[-_]m32$/;
+    my $want_32bit = shift // want_ltp_32bit;
 
     return get_ltproot($want_32bit) . '/version';
 }

--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -30,6 +30,7 @@ use constant {
           is_orthos_machine
           is_supported_suse_domain
           is_zvm
+          is_32bit
         )
     ]
 };
@@ -193,6 +194,18 @@ Returns C<true if machine is s390x zVM>.
 
 sub is_zvm {
     return (get_var('MACHINE') =~ /zvm/i);
+}
+
+=head2 is_32bit
+
+ is_32bit();
+
+Returns C<true if machine is 32 bit architecture>.
+
+=cut
+
+sub is_32bit {
+    return is_i586 || is_i686 || is_arm;
 }
 
 1;

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -298,7 +298,8 @@ sub install_from_repo {
 
     my $run_cmd = is_transactional ? 'transactional-update -c -d --quiet run' : '';
     for my $pkg (@pkgs) {
-        my $want_32bit = $pkg =~ m/32bit/;
+        my $want_32bit = want_ltp_32bit($pkg);
+
         record_info("LTP pkg: $pkg", script_output("$run_cmd rpm -qi $pkg | tee "
                   . get_ltp_version_file($want_32bit)));
         assert_script_run "find " . get_ltproot($want_32bit) .


### PR DESCRIPTION
LTP package compiled for i586 does not have `/opt/ltp/Version`, it has only `/opt/ltp-32/Version`. Trying to cat nonexisting file fails the installation.

Also, the condition should be only in `want_ltp_32bit()` (be on single place), other functions should reuse it.

Verification run:
https://openqa.opensuse.org/tests/overview?build=pevik%2Fos-autoinst-distri-opensuse%23ltp%2F32bit
https://openqa.suse.de/tests/overview?build=pevik%2Fos-autoinst-distri-opensuse%23ltp%2F32bit

## install_ltp
* opensuse-Tumbleweed-LegacyX86-DVD-i586 -> https://openqa.opensuse.org/tests/2965727#step/install_ltp/54
* sle-15-SP5-Online-x86_64-Build61.1-install_ltp+sle+Online@64bit -> https://openqa.suse.de/tests/10215457#step/install_ltp/68 https://openqa.suse.de/tests/10215457#step/install_ltp/80
* opensuse-Tumbleweed-DVD-ppc64le-Build20221218-install_ltp+opensuse+DVD@ppc64le -> https://openqa.opensuse.org/tests/2965728#step/install_ltp/55
* opensuse-Tumbleweed-DVD-x86_64-Build20221218-install_ltp+opensuse+DVD@64bit -> https://openqa.opensuse.org/tests/2965729#step/install_ltp/54 https://openqa.opensuse.org/tests/2965729#step/install_ltp/66
* alp-0.1-kvm-aarch64-Build20221216-install_ltp@aarch64 -> https://openqa.opensuse.org/tests/2965730#step/install_ltp/52
* alp-0.1-kvm-x86_64-Build20221216-install_ltp@64bit -> https://openqa.opensuse.org/tests/2965731#step/install_ltp/52
* sle-15-SP4-Server-DVD-Incidents-Kernel-KOTD-x86_64 https://openqa.suse.de/tests/10215465#step/install_ltp/54 https://openqa.suse.de/tests/10215465#step/install_ltp/66
* sle-15-SP4-Server-DVD-Incidents-Kernel-KOTD-ppc64le https://openqa.suse.de/tests/10215466#step/install_ltp/55
* openposix http://quasar.suse.cz/tests/1503#step/boot_ltp/15

# run_ltp
* 64 bit: http://quasar.suse.cz/tests/1499#step/boot_ltp/144 http://quasar.suse.cz/tests/1498#step/boot_ltp/144
* 32 bit: http://quasar.suse.cz/tests/1501#step/boot_ltp/138 http://quasar.suse.cz/tests/1500#step/boot_ltp/138