### PR TITLE
SLERT: Install kernel-devel-rt instead of kernel-devel

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -25,7 +25,12 @@ sub run {
     }
 
     if (script_run('[ -d /lib/modules/$(uname -r)/build ]') != 0) {
-        zypper_call('in -l kernel-devel');
+        if (check_var('SLE_PRODUCT', 'slert')) {
+            zypper_call('in -l kernel-devel-rt');
+        }
+        else {
+            zypper_call('in -l kernel-devel');
+        }
     }
 
     my $git_repo = get_required_var('QA_TEST_KLP_REPO');

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -82,7 +82,13 @@ sub update_kernel {
     my ($repo, $incident_id) = @_;
 
     fully_patch_system;
-    zypper_call('in kernel-devel') if is_sle('12+');
+
+    if (check_var('SLE_PRODUCT', 'slert')) {
+        zypper_call('in kernel-devel-rt');
+    }
+    elsif (is_sle('12+')) {
+        zypper_call('in kernel-devel');
+    }
 
     my @repos = split(",", $repo);
     while (my ($i, $val) = each(@repos)) {


### PR DESCRIPTION
`kernel-rt` has its own devel package which is required for livepatching tests. Install the correct devel package according to `SLE_PRODUCT`.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - SLERT install_ltp: https://openqa.suse.de/tests/10215257
  - SLERT kernel-live-patching: https://openqa.suse.de/tests/10215260
  - SLE install_ltp: https://openqa.suse.de/tests/10215258
  - SLE kernel-live-patching: https://openqa.suse.de/tests/10215328