### PR TITLE
Create default yaml files for svirt-xen-hvm

### DIFF
--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -4,36 +4,13 @@ description:    >
   Validation of partitioning for raid1 on lvm
   Installation of RAID1 using expert partitioner.
 vars:
-  RAIDLEVEL: 1
-  LVM: 1
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/setup_raid1_lvm
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/update_virsh_config_to_boot_from_hd
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/validate_lvm_raid1
+  suggested_partitioning:
+    - installation/partitioning/setup_raid1_lvm
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_lvm_raid1
 test_data:
   <<: !include test_data/yast/lvm_raid1/lvm+raid1_svirt-xen.yaml

--- a/schedule/yast/minimal+base/minimal+base@svirt-xen-hvm.yaml
+++ b/schedule/yast/minimal+base/minimal+base@svirt-xen-hvm.yaml
@@ -1,6 +1,6 @@
 ---
-name:           minimal+base@yast
-description:    >
+name: minimal+base@yast
+description: >
   Select a minimal textmode installation by starting with the default and unselecting all patterns
   except for "base" and "minimal". Not to be confused with the new system role "minimal" introduced with SLE15.
 vars:
@@ -9,43 +9,22 @@ vars:
   PATTERNS: base,enhanced_base
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/select_patterns
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/security/select_security_module_none
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/update_virsh_config_to_boot_from_hd
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/installation_snapshots
-  - console/zypper_lr
-  - console/zypper_ref
-  - console/ncurses
-  - update/zypper_up
-  - console/zypper_lifecycle
-  - console/orphaned_packages_check
-  - console/validate_installed_patterns
-  - console/consoletest_finish
+  software:
+    - installation/select_patterns
+  security:
+    - installation/security/select_security_module_none
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - update/zypper_up
+    - console/zypper_lifecycle
+    - console/orphaned_packages_check
+    - console/validate_installed_patterns
+    - console/consoletest_finish
 test_data:
   software:
     patterns:

--- a/schedule/yast/msdos/msdos@svirt-xen-hvm.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-hvm.yaml
@@ -1,36 +1,16 @@
 ---
-name:           msdos
-description:    >
+name: msdos
+description: >
   Test for installation on msdos partition table.
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/msdos_partition_table
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/update_virsh_config_to_boot_from_hd
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/validate_partition_table_via_parted
-  - console/validate_blockdevices
-  - console/validate_free_space
-  - console/validate_read_write
+  suggested_partitioning:
+    - installation/partitioning/msdos_partition_table
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_partition_table_via_parted
+    - console/validate_blockdevices
+    - console/validate_free_space
+    - console/validate_read_write

--- a/schedule/yast/sle/flows/default_svirt-xen-hvm.yaml
+++ b/schedule/yast/sle/flows/default_svirt-xen-hvm.yaml
@@ -1,0 +1,56 @@
+---
+# Default ordered sequence of steps to be optionally overwritten for this product
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+access_beta:
+  - installation/access_beta_distribution
+product_selection:
+  - installation/product_selection/install_SLES
+license_agreement:
+  - installation/licensing/accept_license
+registration:
+  - installation/registration/register_via_scc
+extension_module_selection:
+  - installation/module_registration/skip_module_registration
+add_on_product:
+  - installation/add_on_product/skip_install_addons
+add_on_product_installation: []
+system_role:
+  - installation/system_role/accept_selected_role_text_mode
+guided_partitioning: []
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+default_systemd_target: []
+security: []
+installation_settings:
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+  - installation/launch_installation
+installation:
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+stop_timeout_system_reboot: []
+installation_logs:
+  - installation/logs_from_installation_system
+virsh_boot_hdd:
+  - installation/performing_installation/update_virsh_config_to_boot_from_hd
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+reconnect_svirt:
+  - installation/performing_installation/reconnect_after_reboot
+grub:
+  - installation/grub_test
+first_login:
+  - installation/first_boot
+system_preparation: []
+system_validation: []

--- a/schedule/yast/sle/guided_xfs/guided_xfs_svirt_xen_hvm.yaml
+++ b/schedule/yast/sle/guided_xfs/guided_xfs_svirt_xen_hvm.yaml
@@ -1,7 +1,7 @@
 ---
-name:           guided_ext4
-description:    >
-  Guided Partitioning installation with ext4 filesystem.
+name: guided_xfs_svirt_xen_hvm
+description: >
+  Guided Partitioning installation with xfs filesystem.
 vars:
   YUI_REST_API: 1
 schedule:
@@ -12,17 +12,13 @@ schedule:
   guided_partitioning:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
-    - installation/partitioning/guided_setup/select_filesystem_option_ext4
+    - installation/partitioning/guided_setup/select_filesystem_option_xfs
+  booting:
+    - installation/bootloader_settings/disable_boot_menu_timeout
   default_systemd_target:
     - installation/installation_settings/validate_default_target
-  stop_timeout_system_reboot: []
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices
     - console/validate_free_space
     - console/validate_read_write
-test_data:
-  guided_partitioning:
-    filesystem_options:
-      root_filesystem_type: ext4
-  <<: !include test_data/yast/ext4/ext4_xen.yaml

--- a/schedule/yast/textmode/textmode@svirt-xen.yaml
+++ b/schedule/yast/textmode/textmode@svirt-xen.yaml
@@ -5,47 +5,21 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - '{{stop_reboot_timeout}}'
-  - installation/logs_from_installation_system
-  - installation/performing_installation/update_virsh_config_to_boot_from_hd
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - console/validate_product_installed_SLES
-  - console/verify_network
-  - locale/keymap_or_locale
-  - console/validate_installed_patterns
-  - console/force_scheduled_tasks
-  - console/textinfo
-  - console/orphaned_packages_check
-  - console/consoletest_finish
-conditional_schedule:
-  stop_reboot_timeout:
-    VIRSH_VMM_TYPE:
-      linux:
-        - installation/performing_installation/stop_timeout_system_reboot_now
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/prepare_test_data
+    - console/consoletest_setup
+  system_validation:
+    - console/validate_product_installed_SLES
+    - console/verify_network
+    - locale/keymap_or_locale
+    - console/validate_installed_patterns
+    - console/force_scheduled_tasks
+    - console/textinfo
+    - console/orphaned_packages_check
+    - console/consoletest_finish
 test_data:
   software:
     patterns:


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/119890
- Related MR on GitLab: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/459
- This PR only focuses on the svirt-xen-hvm backend
- [Verification runs](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=rakoenig%2Fos-autoinst-distri-opensuse%23default_x86_64_svirt_xen_hvm&groupid=96) (note that the failed test is due to a typo which referred to a test with 64bit backend) 