### PR TITLE
qesap regression on sapconf

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -2,19 +2,13 @@ provider: "%PROVIDER%"
 apiver: 3
 terraform:
   variables:
-    project: "ei-sle-qa-sap-8469"
-    region: "%REGION%"
+    aws_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    hana_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    iscsi_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    monitoring_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    drdb_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    netweaver_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    bastion_os_major_version: "%QESAP_CLUSTER_OS_VER%"
+    os_owner: "amazon"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
-    gcp_credentials_file: "/root/google_credentials.json"
+    aws_credentials: "/root/amazon_credentials"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"
@@ -35,7 +29,7 @@ ansible:
   create:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
+    - sap-hana-preconfigure.yaml-e use_sapconf=true
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml
     - sap-hana-install.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -2,19 +2,11 @@ provider: "%PROVIDER%"
 apiver: 3
 terraform:
   variables:
-    project: "ei-sle-qa-sap-8469"
-    region: "%REGION%"
+    az_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    hana_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    iscsi_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    monitoring_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    drdb_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    netweaver_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    bastion_os_major_version: "%QESAP_CLUSTER_OS_VER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
-    gcp_credentials_file: "/root/google_credentials.json"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"
@@ -35,13 +27,14 @@ ansible:
   create:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
+    - sap-hana-preconfigure.yaml -e use_sapconf=true
+    - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml
     - sap-hana-install.yaml
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml -e use_sbd=false
+    - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml
   variables:

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -3,7 +3,6 @@ apiver: 3
 terraform:
   variables:
     project: "ei-sle-qa-sap-8469"
-    bastion_enabled: "false"
     region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -468,7 +468,7 @@ sub qesap_ansible_script_output {
     my $local_file = 'testout.txt';
     my $local_tmp = $local_path . $local_file;
 
-    if (script_run 'test -e script_output.yaml') {
+    if (script_run "test -e $pb") {
         my $cmd = join(' ',
             'curl', '-v', '-fL',
             data_url("sles4sap/$pb"),

--- a/tests/sles4sap/trento/test_hana_restore_stopped.pm
+++ b/tests/sles4sap/trento/test_hana_restore_stopped.pm
@@ -38,7 +38,7 @@ sub run {
     cluster_wait_status($primary_host, sub { ((shift =~ m/.+DEMOTED.+SOK/) && (shift =~ m/.+PROMOTED.+PRIM/)); });
 
     my $cypress_test_dir = "/root/test/test";
-    enter_cmd "cd " . $cypress_test_dir;
+    enter_cmd "cd $cypress_test_dir";
     cypress_test_exec($cypress_test_dir, 'restore_cluster', bmwqemu::scale_timeout(900));
     trento_support('test_hana_restore_stopped');
 }

--- a/tests/sles4sap/trento/test_hana_stop.pm
+++ b/tests/sles4sap/trento/test_hana_stop.pm
@@ -27,7 +27,7 @@ sub run {
     cluster_wait_status($primary_host, sub { ((shift =~ m/.+UNDEFINED.+SFAIL/) && (shift =~ m/.+PROMOTED.+PRIM/)); });
 
     my $cypress_test_dir = "/root/test/test";
-    enter_cmd "cd " . $cypress_test_dir;
+    enter_cmd "cd $cypress_test_dir";
     cypress_test_exec($cypress_test_dir, 'stop_primary', bmwqemu::scale_timeout(900));
     trento_support('test_hana_stop');
 }

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -19,7 +19,7 @@ sub run {
     select_serial_terminal;
 
     my $cypress_test_dir = "/root/test/test";
-    enter_cmd "cd " . $cypress_test_dir;
+    enter_cmd "cd $cypress_test_dir";
 
     cypress_configs($cypress_test_dir);
     assert_script_run "mkdir " . CYPRESS_LOG_DIR;


### PR DESCRIPTION
Add conf.yaml for sapconf test variant of qesap regression and remove what match to qe-sap-deployment internal default.

Improve CY folder composition in Trento

Verification run: 
- qesap regression AWS saptune: http://openqaworker15.qa.suse.cz/tests/108377 failure in terraform due to lack of resources (not related to code change). http://openqaworker15.qa.suse.cz/tests/108382 
- qesap regression AWS sapconf: http://openqaworker15.qa.suse.cz/tests/108376 failure in terraform due to lack of resources (not related to code change). http://openqaworker15.qa.suse.cz/tests/108383
- qesap regression Azure saptune: http://openqaworker15.qa.suse.cz/tests/108378 PASS
- qesap regression Azure sapconf: http://openqaworker15.qa.suse.cz/tests/108380 PASS
- qesap regression CGP saptune: http://openqaworker15.qa.suse.cz/tests/108379 it is failing in saptune (new one)
- qesap regression GCP sapconf: http://openqaworker15.qa.suse.cz/tests/108381 Known hana disk name failure
