### PR TITLE
Change InfluxDB to v2

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -291,7 +291,11 @@ PUBLIC_CLOUD_IMG_PROOF_EXCLUDE | string | "" | Tests to be excluded by img-proof
 PUBLIC_CLOUD_INSTANCE_TYPE | string | "" | Specify the instance type. Which instance types exists depends on the CSP. (default-azure: Standard_A2, default-ec2: t2.large )
 PUBLIC_CLOUD_LTP | boolean | false | If set, the run_ltp test module is added to the job.
 PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE | boolean | false | Do not remove the instance when the test fails.
-PUBLIC_CLOUD_PERF_DB_URI | string | "" | Optional variable. If set, the bootup times get stored in the influx database. The database name is 'publiccloud'. (e.g. PUBLIC_CLOUD_PERF_DB_URI=http://openqa-perf.qa.suse.de:8086)
+PUBLIC_CLOUD_PERF_DB_URI | string | "" | If set, the bootup times get stored in the influx database. (e.g. PUBLIC_CLOUD_PERF_DB_URI=http://publiccloud-ng.qe.suse.de:8086)
+PUBLIC_CLOUD_PERF_DB | string | "perf" | If `PUBLIC_CLOUD_PERF_DB_URI` is defined, this variable defines the bucket in which the performance metrics are stored
+PUBLIC_CLOUD_PERF_DB_ORG | string | "qec" | If `PUBLIC_CLOUD_PERF_DB_URI` is defined, this variable defines the organization in which the performance metrics are stored
+_PUBLIC_CLOUD_PERF_DB_TOKEN | string | "" | | If `PUBLIC_CLOUD_PERF_DB_URI` is defined, this required variable is the access token
+_PUBLIC_CLOUD_PERF_PUSH_DATA | boolean | "" | If set to `1`, then the test run will push it's metrics to the InfluxDB. This variable is used as secret variable, so that cloned jobs by default do not push metrics to avoid accidental database contamination.
 PUBLIC_CLOUD_PREPARE_TOOLS | boolean | false | Activate prepare_tools test module by setting this variable.
 PUBLIC_CLOUD_GOOGLE_PROJECT_ID | string | "" | GCP only, used to specify the project id.
 PUBLIC_CLOUD_PROVIDER | string | "" | The type of the CSP (e.g. AZURE, EC2, GCE).


### PR DESCRIPTION
Change the handling of InfluxDB requests to use version 2 for the publiccloud metric database.

- Related ticket: https://progress.opensuse.org/issues/118936
- Verification runs: [Azure boottime](https://duck-norris.qe.suse.de/tests/11479) | [EC2 Boottime](https://duck-norris.qe.suse.de/tests/11465) | [GCE Boottime](https://duck-norris.qe.suse.de/tests/11453) | [Azure fio](https://duck-norris.qe.suse.de/tests/11470) | [EC2 fio](https://duck-norris.qe.suse.de/tests/11473) | [GCE fio](https://duck-norris.qe.suse.de/tests/11474)

Failures are due to performance deviations outside of the scope of this PR. Only the [GCE fio](https://duck-norris.qe.suse.de/tests/11474) test run compares old values.