### PR TITLE
ping: Add check for capability with ICMP socket

### DIFF
--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -21,12 +21,16 @@ use version_utils qw(is_jeos is_sle);
 
 sub run {
     my ($self) = @_;
+    my $ping_group_range = script_output('sysctl net.ipv4.ping_group_range');
+    my $capability;
 
     select_serial_terminal;
+
     zypper_call('in iputils libcap-progs sudo');
+    $capability = script_output('getcap $(which ping)', proceed_on_failure => 1);
 
     record_info('KERNEL VERSION', script_output('uname -a'));
-    record_info('net.ipv4.ping_group_range', script_output('sysctl net.ipv4.ping_group_range'));
+    record_info('net.ipv4.ping_group_range', $ping_group_range);
     record_info('ping', script_output('ping -V'));
 
     my $kernel_pkg = is_jeos ? 'kernel-default-base' : 'kernel-default';
@@ -34,7 +38,7 @@ sub run {
         record_info($pkg, script_output("rpm -qi $pkg", proceed_on_failure => 1));
     }
 
-    record_info('getcap', script_output('getcap $(which ping)', proceed_on_failure => 1));
+    record_info('getcap', $capability);
 
     my $ifname = script_output('ip -6 link |grep "^[0-9]:" |grep -v lo: | head -1 | awk "{print \$2}" | sed s/://');
     my $addr = script_output("ip -6 addr show $ifname | grep 'scope link' | head -1 | awk '{ print \$2 }' | cut -d/ -f1");
@@ -63,6 +67,16 @@ sub run {
         } else {
             record_info("Unknown failure on $cmd, maybe related to: bsc#1200617, bsc#1195826, bsc#1196840, bsc#1199918, bsc#1199926, bsc#1199927",
                 result => 'fail');
+            $self->result("fail");
+        }
+    }
+
+    if ($capability && $ping_group_range !~ m/^net.ipv4.ping_group_range\s*=\s*1\s*0/) {
+        my $msg = "capability '$capability' is not needed when ICMP socket allowed for non-root user: '$ping_group_range'";
+        if (is_sle('=15-SP3')) {
+            record_info('unneeded capability', "bsc#1196840#c29: $msg", result => 'softfail');
+        } else {
+            record_info('unneeded capability', $msg, result => 'fail');
             $self->result("fail");
         }
     }

--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -61,8 +61,9 @@ sub run {
         if (defined($bug)) {
             record_info('Softfail', $bug, result => 'softfail');
         } else {
+            record_info("Unknown failure on $cmd, maybe related to: bsc#1200617, bsc#1195826, bsc#1196840, bsc#1199918, bsc#1199926, bsc#1199927",
+                result => 'fail');
             $self->result("fail");
-            record_info("Unknown failure on $cmd, maybe related to: bsc#1200617, bsc#1195826, bsc#1196840, bsc#1199918, bsc#1199926, bsc#1199927");
         }
     }
 }

--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -65,7 +65,7 @@ sub run {
         if (defined($bug)) {
             record_info('Softfail', $bug, result => 'softfail');
         } else {
-            record_info("Unknown failure on $cmd, maybe related to: bsc#1200617, bsc#1195826, bsc#1196840, bsc#1199918, bsc#1199926, bsc#1199927",
+            record_info("Fail", "Unknown failure on $cmd, maybe related to: bsc#1200617, bsc#1195826, bsc#1196840, bsc#1199918, bsc#1199926, bsc#1199927",
                 result => 'fail');
             $self->result("fail");
         }


### PR DESCRIPTION
To detect bsc#1196840#c29 (https://openqa.suse.de/tests/10223015#step/ping/134) on other versions.

Verification run:
- https://openqa.suse.de/tests/overview?build=ping%2Fcheck-capability-vs-ping_group_range
- https://openqa.opensuse.org/tests/overview?build=ping%2Fcheck-capability-vs-ping_group_range