### PR TITLE
Revert "Switch possible parts of post_fail_hooks to serial terminal"

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -16,7 +16,6 @@ use warnings;
 use testapi;
 use utils qw(clear_console show_oom_info remount_tmp_if_ro detect_bsc_1063638);
 use Utils::Systemd 'get_started_systemd_services';
-use serial_terminal 'select_serial_terminal';
 use Mojo::File 'path';
 
 our @EXPORT = qw(
@@ -184,7 +183,8 @@ This method will call several other log gathering methods from this class.
 =cut
 
 sub export_logs {
-    select_serial_terminal();
+    select_log_console();
+    save_screenshot();
     show_oom_info();
     remount_tmp_if_ro();
     export_logs_basic();
@@ -193,6 +193,8 @@ sub export_logs {
     # Just after the setup: let's see the network configuration
     save_and_upload_log("ip addr show", "/tmp/ip-addr-show.log");
     save_and_upload_log("cat /etc/resolv.conf", "/tmp/resolv-conf.log");
+
+    save_screenshot();
 
     export_logs_desktop();
 
@@ -334,7 +336,8 @@ Upload several KDE, GNOME, X11, GDM and SDDM related logs and configs.
 =cut
 
 sub export_logs_desktop {
-    select_serial_terminal();
+    select_log_console;
+    save_screenshot;
 
     if (check_var("DESKTOP", "kde")) {
         if (get_var('PLASMA5')) {

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -9,6 +9,7 @@ use warnings;
 use testapi;
 use known_bugs;
 use version_utils qw(is_public_cloud is_openstack);
+use Utils::Logging qw(export_logs_basic export_logs_desktop);
 use utils;
 
 my %avc_record = (
@@ -52,6 +53,11 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
     # at this point the instance is shutdown
     return if (is_public_cloud() || is_openstack());
+    select_console('log-console');
+    remount_tmp_if_ro;
+    export_logs_basic;
+    # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
+    export_logs_desktop;
 }
 
 =head2 record_avc_selinux_alerts


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16083

There are structural issues: whenever a test triggers the new fail hook, triggering a restore of LASTGOOD, subsequent tests are not clear on the console state

