### PR TITLE
Add ping to extra_tests_in_textmode@aarch32

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1685,6 +1685,7 @@ sub load_extra_tests_geo_desktop {
 }
 
 sub load_extra_tests_console {
+    loadtest "console/ping";
     loadtest "console/check_os_release";
     loadtest "console/orphaned_packages_check";
     loadtest "console/cleanup_qam_testrepos" if has_test_issues;


### PR DESCRIPTION
extra_tests_in_textmode is missing ping test, which is already added in extra_tests_textmode, jeos-main (openSUSE) and mau-extratests1 (SLE).

Verification run:
- https://openqa.suse.de/tests/overview?build=add-ping-to-extra_tests_in_textmode
- https://openqa.opensuse.org/tests/overview?build=add-ping-to-extra_tests_in_textmode