### PR TITLE
Switch source of SUSE CA to http

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -18,7 +18,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
     if (is_sle_micro) {
-        assert_script_run 'curl -k https://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt';
+        assert_script_run 'curl -kL http://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt';
         assert_script_run 'update-ca-certificates -v';
 
         # Clean the journal to avoid capturing bugs that are fixed after installing updates


### PR DESCRIPTION
https requests on ca.suse.de redirect now to the confluence page, so that we need to use http for the SUSE CA certificate.

- Verification run: https://duck-norris.qe.suse.de/t11582
