### PR TITLE
main_ltp: Fix kernel-live-patching on s390x z/VM on o3

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -87,8 +87,10 @@ sub log_versions {
     script_run("rpm -qi $kernel_pkg > $kernel_pkg_log 2>&1");
     upload_logs($kernel_pkg_log, failok => 1);
 
-    script_run(get_ltproot . "/ver_linux > $ver_linux_log 2>&1");
-    upload_logs($ver_linux_log, failok => 1);
+    if (get_var('LTP_COMMAND_FILE')) {
+        script_run(get_ltproot . "/ver_linux > $ver_linux_log 2>&1");
+        upload_logs($ver_linux_log, failok => 1);
+    }
 
     if ($kernel_config) {
         my $cmd = "echo '# $kernel_config'; echo; ";
@@ -113,7 +115,10 @@ sub log_versions {
     record_info('KERNEL VERSION', script_output('uname -a'));
     record_info('KERNEL DEFAULT PKG', script_output("cat $kernel_pkg_log", proceed_on_failure => 1));
     record_info('KERNEL EXTRA PKG', script_output('rpm -qi kernel-default-extra', proceed_on_failure => 1));
-    record_info('ver_linux', script_output("cat $ver_linux_log", proceed_on_failure => 1));
+
+    if (get_var('LTP_COMMAND_FILE')) {
+        record_info('ver_linux', script_output("cat $ver_linux_log", proceed_on_failure => 1));
+    }
 
     script_run('env');
     script_run('aa-enabled; aa-status');

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -22,7 +22,8 @@ our @EXPORT_OK = qw(
 );
 
 sub load_kernel_tests {
-    if (get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) {
+    if ((get_var('LTP_BAREMETAL') && get_var('INSTALL_LTP')) ||
+        is_backend_s390x) {
         load_kernel_baremetal_tests();
     } else {
         load_bootloader_s390x();

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -31,6 +31,9 @@ sub run {
     elsif (is_jeos) {
         record_info('Loaded JeOS image', 'nothing to do...');
     }
+    elsif (is_backend_s390x) {
+        record_info('s390x backend', 'nothing to do...');
+    }
     else {
         record_info('INFO', 'normal boot or boot with params');
         # during install_ltp, the second boot may take longer than usual

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -56,6 +56,9 @@ sub run {
         assert_script_run("uname -v | grep -E '(/kGraft-|/${lp_tag})'");
     }
 
+    # module is used by non-LTP tests, i.e. kernel-live-patching
+    return unless (get_var('LTP_COMMAND_FILE'));
+
     prepare_ltp_env;
     init_ltp_tests($cmd_file);
 


### PR DESCRIPTION
This is needed for kernel-live-patching tests on z/VM (BACKEND=s390x => use bootloader_s390 instead of bootloader_zkvm), which unlike LTP tests on z/VM does not use install_ltp.pm, but only boot_ltp.pm.

NOTE: with this fix z/VM tests (both LTP and kernel-live-patching) do *not* need to use LTP_BAREMETAL=1.

Verification run:
- https://openqa.opensuse.org/tests/2971882 (Tumbleweed kernel-live-patching@s390x-zVM-vswitch-l2)
- https://openqa.suse.de/tests/overview?build=kernel-live-patching-s390x (check for a regression)
- https://openqa.opensuse.org/tests/overview?build=kernel-live-patching-s390x