### PR TITLE
Fix mr_test registration + curl failures on EC2

### DIFF
--- a/data/sles4sap/qe_sap_deployment/hanasr_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/hanasr_azure.yaml
@@ -6,7 +6,7 @@ terraform:
     # GENERAL VARIABLES #
     az_region: "%REGION%"
     admin_user: "cloudadmin"
-    public_key : "~/.ssh/id_rsa.pub"
+    public_key: "~/.ssh/id_rsa.pub"
     private_key: "~/.ssh/id_rsa"
     sles4sap_uri: "https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%"
     storage_account_name: "%STORAGE_ACCOUNT_NAME%"

--- a/data/sles4sap/qe_sap_deployment/hanasr_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/hanasr_ec2.yaml
@@ -5,7 +5,7 @@ terraform:
     # GENERAL VARIABLES #
     aws_region: "%REGION%"
     admin_user: "cloudadmin"
-    public_key : "~/.ssh/id_rsa.pub"
+    public_key: "~/.ssh/id_rsa.pub"
     private_key: "~/.ssh/id_rsa"
     aws_credentials: "/root/amazon_credentials"
     os_image: "%SLE_IMAGE%"

--- a/data/sles4sap/qe_sap_deployment/hanasr_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/hanasr_gcp.yaml
@@ -11,7 +11,7 @@ terraform:
     admin_user: "cloudadmin"
     reg_code: "%SCC_REGCODE_SLES4SAP%"
     os_image: "%SLE_IMAGE%"
-    public_key : "~/.ssh/id_rsa.pub"
+    public_key: "~/.ssh/id_rsa.pub"
     private_key: "~/.ssh/id_rsa"
 
     # BASTION

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -15,7 +15,7 @@ terraform:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
     admin_user: 'cloudadmin'
-    public_key : '~/.ssh/id_rsa.pub'
+    public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     os_image: "%QESAP_CLUSTER_OS_VER%"
 

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -6,7 +6,7 @@ terraform:
     # GENERAL VARIABLES #
     aws_region: "%PUBLIC_CLOUD_REGION%"
     admin_user: "cloudadmin"
-    public_key : "~/.ssh/id_rsa.pub"
+    public_key: "~/.ssh/id_rsa.pub"
     private_key: "~/.ssh/id_rsa"
     aws_credentials: "/root/amazon_credentials"
     os_image: "%QESAP_CLUSTER_OS_VER%"

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -15,7 +15,7 @@ terraform:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
     admin_user: 'cloudadmin'
-    public_key : '~/.ssh/id_rsa.pub'
+    public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     sles4sap_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -499,7 +499,7 @@ sub qesap_ansible_script_output {
 sub qesap_create_aws_credentials {
     my ($key, $secret) = @_;
     my %paths = qesap_get_file_paths();
-    my $credfile = script_output q|awk -F\" '/aws_credentials/ {print $2}' | . $paths{qesap_conf_trgt};
+    my $credfile = script_output q|awk -F ' ' '/aws_credentials/ {print $2}' | . $paths{qesap_conf_trgt};
     save_tmp_file('credentials', "[default]\naws_access_key_id = $key\naws_secret_access_key = $secret\n");
     assert_script_run 'mkdir -p ~/.aws';
     assert_script_run 'curl ' . autoinst_url . "/files/credentials -o $credfile";
@@ -513,7 +513,7 @@ sub qesap_create_aws_credentials {
 
 sub qesap_create_aws_config {
     my %paths = qesap_get_file_paths();
-    my $region = script_output q|awk -F\" '/aws_region/ {print $2}' | . $paths{qesap_conf_trgt};
+    my $region = script_output q|awk -F ' ' '/aws_region/ {print $2}' | . $paths{qesap_conf_trgt};
     $region = get_required_var('PUBLIC_CLOUD_REGION') if ($region =~ /^%.+%$/);
     save_tmp_file('config', "[default]\nregion = $region\n");
     assert_script_run 'mkdir -p ~/.aws';

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -26,7 +26,7 @@ sub run {
 
     select_host_console();    # select console on the host, not the PC instance
 
-    registercloudguest($args->{my_instance}) if (is_byos());
+    registercloudguest($args->{my_instance}) if (is_byos() || get_var('PUBLIC_CLOUD_FORCE_REGISTRATION'));
     register_addons_in_pc($args->{my_instance});
 }
 

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -39,7 +39,7 @@ sub run {
     my @remote_ips = qesap_remote_hana_public_ips;
     record_info 'Remote IPs', join(' - ', @remote_ips);
     foreach my $host (@remote_ips) { wait_for_ssh $host; }
-    $ret = qesap_execute(cmd => 'ansible', verbose => 1, timeout => 1800);
+    $ret = qesap_execute(cmd => 'ansible', verbose => 1, timeout => 3600);
     die "'qesap.py ansible' return: $ret" if ($ret);
 }
 

--- a/variables.md
+++ b/variables.md
@@ -282,6 +282,7 @@ PUBLIC_CLOUD_EC2_UPLOAD_VPCSUBNET | string | "" | Allow to instruct ec2uploadimg
 PUBLIC_CLOUD_FIO | boolean | false | If set, storage_perf test module is added to the job.
 PUBLIC_CLOUD_FIO_RUNTIME | integer | 300 | Set the execution time for each FIO tests.
 PUBLIC_CLOUD_FIO_SSD_SIZE | string | "100G" | Set the additional disk size for the FIO tests.
+PUBLIC_CLOUD_FORCE_REGISTRATION | boolean | false | If set, tests/publiccloud/registration.pm will register cloud guest
 PUBLIC_CLOUD_IGNORE_EMPTY_REPO | boolean | false | Ignore empty maintenance update repos
 PUBLIC_CLOUD_IMAGE_ID | string | "" | The image ID we start the instance from
 PUBLIC_CLOUD_IMAGE_LOCATION | string | "" | The URL where the image gets downloaded from. The name of the image gets extracted from this URL.


### PR DESCRIPTION
Fix mr_test registration + curl failures on EC2

Fix mr_test registration failed on 'zypper lr' reports 'Warning: No repositories defined'
Fix mr_test qesap_terraform failed on 'curl: option -o: requires parameter'
Also increased the timeout value as https://openqaworker15.qa.suse.cz/tests/114030 (failed on timed out, it is not related to my changes)
Also remove the `space` after `public_key` for all files under `data/sles4sap/qe_sap_deployment`

TEAM-7137 - Fix all "FLAVOR=EC2-SAP-PAYG-Incidents-saptune" test cases failed on 'registration'

Related ticket: https://jira.suse.com/browse/TEAM-7137
Needles: NA
Verification runs:
https://openqaworker15.qa.suse.cz/tests/114028 (passed)
https://openqaworker15.qa.suse.cz/tests/114040 (failed on "Test died: 'qesap.py ansible' return: 2" it seems not related to my changes)
