### PR TITLE
Move prepare_ssh_tunnel from publiccloud::ssh_interactive to publiccloud::utils

### DIFF
--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -8,16 +8,15 @@
 # Maintainer: qa-c@suse.de
 
 package publiccloud::ssh_interactive;
-use testapi qw(is_serial_terminal);
 use base Exporter;
+use strict;
+use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Backends qw(set_sshserial_dev unset_sshserial_dev);
-use version_utils qw(is_tunneled is_sle);
-use strict;
-use warnings;
+use version_utils qw(is_tunneled);
 
-our @EXPORT = qw(ssh_interactive_tunnel ssh_interactive_leave select_host_console prepare_ssh_tunnel);
+our @EXPORT = qw(ssh_interactive_tunnel ssh_interactive_leave select_host_console);
 
 # Helper call to activate a console and establish the ssh connection therein
 sub establish_tunnel_console {
@@ -123,45 +122,6 @@ sub select_host_console {
     set_var('TUNNELED', $tunneled);
     record_info("hostname", script_output("hostname"));
     assert_script_run("true", fail_message => "host console is broken");    # basic health check
-}
-
-sub prepare_ssh_tunnel {
-    my $instance = shift;
-
-    # configure ssh client
-    my $ssh_config_url = data_url('publiccloud/ssh_config');
-    assert_script_run("curl $ssh_config_url -o ~/.ssh/config");
-
-    # Create the ssh alias
-    assert_script_run(sprintf(q(echo -e 'Host sut\n  Hostname %s' >> ~/.ssh/config), $instance->public_ip));
-
-    # Copy SSH settings also for normal user
-    assert_script_run("install -o $testapi::username -g users -m 0700 -dD /home/$testapi::username/.ssh");
-    assert_script_run("install -o $testapi::username -g users -m 0600 ~/.ssh/* /home/$testapi::username/.ssh/");
-
-    # Skip setting root password for img_proof, because it expects the root password to NOT be set
-    $instance->ssh_assert_script_run(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd root));
-
-    # Permit root passwordless login over SSH
-    $instance->ssh_assert_script_run('sudo sed -i "s/PermitRootLogin no/PermitRootLogin prohibit-password/g" /etc/ssh/sshd_config');
-    $instance->ssh_assert_script_run('sudo systemctl reload sshd');
-
-    # Copy SSH settings for remote root
-    $instance->ssh_assert_script_run('sudo install -o root -g root -m 0700 -dD /root/.ssh');
-    $instance->ssh_assert_script_run(sprintf("sudo install -o root -g root -m 0644 /home/%s/.ssh/authorized_keys /root/.ssh/", $instance->{username}));
-
-    # Create remote user and set him a password
-    my $path = (is_sle('>15') && is_sle('<15-SP3')) ? '/usr/sbin/' : '';
-    $instance->ssh_assert_script_run("test -d /home/$testapi::username || sudo ${path}useradd -m $testapi::username");
-    $instance->ssh_assert_script_run(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd $testapi::username));
-
-    # Copy SSH settings for remote user
-    $instance->ssh_assert_script_run("sudo install -o $testapi::username -g users -m 0700 -dD /home/$testapi::username/.ssh");
-    $instance->ssh_assert_script_run("sudo install -o $testapi::username -g users -m 0644 ~/.ssh/authorized_keys /home/$testapi::username/.ssh/");
-
-    # Create log file for ssh tunnel
-    my $ssh_sut = '/var/tmp/ssh_sut.log';
-    assert_script_run "touch $ssh_sut; chmod 777 $ssh_sut";
 }
 
 1;

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   register_openstack
   register_addons_in_pc
   gcloud_install
+  prepare_ssh_tunnel
 );
 
 # Get the current UTC timestamp as YYYY/mm/dd HH:MM:SS
@@ -214,6 +215,46 @@ sub gcloud_install {
     assert_script_run("source ~/.bashrc");
 
     record_info('GCE', script_output('gcloud version'));
+}
+
+sub prepare_ssh_tunnel {
+    my $instance = shift;
+
+    # configure ssh client
+    my $ssh_config_url = data_url('publiccloud/ssh_config');
+    assert_script_run("curl $ssh_config_url -o ~/.ssh/config");
+
+    # Create the ssh alias
+    assert_script_run(sprintf(q(echo -e 'Host sut\n  Hostname %s' >> ~/.ssh/config), $instance->public_ip));
+
+    # Copy SSH settings also for normal user
+    assert_script_run("install -o $testapi::username -g users -m 0700 -dD /home/$testapi::username/.ssh");
+    assert_script_run("install -o $testapi::username -g users -m 0600 ~/.ssh/* /home/$testapi::username/.ssh/");
+
+    # Skip setting root password for img_proof, because it expects the root password to NOT be set
+    $instance->ssh_assert_script_run(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd root));
+
+    # Permit root passwordless login over SSH
+    $instance->ssh_assert_script_run('sudo cat /etc/ssh/sshd_config');
+    $instance->ssh_assert_script_run('sudo sed -i "s/PermitRootLogin no/PermitRootLogin prohibit-password/g" /etc/ssh/sshd_config');
+    $instance->ssh_assert_script_run('sudo systemctl reload sshd');
+
+    # Copy SSH settings for remote root
+    $instance->ssh_assert_script_run('sudo install -o root -g root -m 0700 -dD /root/.ssh');
+    $instance->ssh_assert_script_run(sprintf("sudo install -o root -g root -m 0644 /home/%s/.ssh/authorized_keys /root/.ssh/", $instance->{username}));
+
+    # Create remote user and set him a password
+    my $path = (is_sle('>15') && is_sle('<15-SP3')) ? '/usr/sbin/' : '';
+    $instance->ssh_assert_script_run("test -d /home/$testapi::username || sudo ${path}useradd -m $testapi::username");
+    $instance->ssh_assert_script_run(qq(echo -e "$testapi::password\\n$testapi::password" | sudo passwd $testapi::username));
+
+    # Copy SSH settings for remote user
+    $instance->ssh_assert_script_run("sudo install -o $testapi::username -g users -m 0700 -dD /home/$testapi::username/.ssh");
+    $instance->ssh_assert_script_run("sudo install -o $testapi::username -g users -m 0644 ~/.ssh/authorized_keys /home/$testapi::username/.ssh/");
+
+    # Create log file for ssh tunnel
+    my $ssh_sut = '/var/tmp/ssh_sut.log';
+    assert_script_run "touch $ssh_sut; chmod 777 $ssh_sut";
 }
 
 1;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -10,7 +10,7 @@
 # Maintainer: <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
-use publiccloud::ssh_interactive qw(select_host_console prepare_ssh_tunnel);
+use publiccloud::ssh_interactive qw(select_host_console);
 use testapi;
 use version_utils;
 use utils;

--- a/tests/sles4sap/publiccloud/mr_test_setup_env.pm
+++ b/tests/sles4sap/publiccloud/mr_test_setup_env.pm
@@ -9,7 +9,7 @@
 
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
-use publiccloud::ssh_interactive qw(select_host_console prepare_ssh_tunnel);
+use publiccloud::ssh_interactive qw(select_host_console);
 use testapi;
 use Mojo::File 'path';
 use publiccloud::utils;


### PR DESCRIPTION
This is due to `publiccloud::ssh_interactive` package having very specific requirements so we don't want to use subroutines from other `publiccloud::` packages in it.

The `prepare_ssh_tunnel` subroutine used to be in prepare_instance test module and was recently moved because of it being now used also in SAP.

- Previous solution: #16133 (less preferred)
- Related merge requests: [qa-maintenance/metadata!750](https://gitlab.suse.de/qa-maintenance/metadata/-/merge_requests/750), [qac/qac-openqa-yaml!1049](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1049)
- Verification run: [pdostal-server.suse.cz](https://pdostal-server.suse.cz/tests/overview?build=&version=15-SP4&distri=sle&groupid=1) (The link contains also LTP, NFS and XFS tests but those will not be scheduled yet.)

Merge together with the other linked pull requests.