### PR TITLE
Enable Azure gen2 image uploading

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -151,6 +151,7 @@ resource "azurerm_image" "image" {
     name                      = "${azurerm_resource_group.openqa-group.name}-disk1"
     location                  = var.region
     resource_group_name       = azurerm_resource_group.openqa-group.name
+    hyper_v_generation        = var.sku == "gen1" ? "V1" : "V2"
     count = var.image_id != "" ? 1 : 0
 
     os_disk {


### PR DESCRIPTION
### Current Status
 * Works fine with `x64` images `gen2`.
 * Doesn't work with `Arm64` images:

      `{ "error": { "code": "OperationNotAllowed", "message": "Creating an image with snapshot source that has CPU Architecture 'Arm64' is not supported. Please select a source resource with a supported CPU Architecture: 'x64'."
  } }`

### Metadata
- Related issue: Azure/azure-sdk-for-go#19665
- Related ticket: [poo#122083](https://progress.opensuse.org/issues/122083)
- Verification run: [upload_img@SLE-15-SP5-Azure-BYOS-gen2](https://pdostal-server.suse.cz/tests/3855), [consoletests@SLE-15-SP5-Azure-BYOS-gen2](https://pdostal-server.suse.cz/tests/3856), [upload_img@SLE-15-SP5-Azure-BYOS-ARM](https://pdostal-server.suse.cz/tests/3854), [publiccloud_smoketests_gen1@az_Standard_A2_v2](https://pdostal-server.suse.cz/tests/3857), [publiccloud_smoketests_gen2@az_Standard_L8s_v2](https://pdostal-server.suse.cz/tests/3859), [publiccloud_img_proof@64bit](https://pdostal-server.suse.cz/tests/3860)