### PR TITLE
[virt_autotest] Enhancement for libvirt_virtual_network_init

### DIFF
--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright 2019-2022 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Initialize testing environment for Libvirt Virtual Networks
@@ -69,8 +69,8 @@ sub run_test {
         upload_logs "/tmp/$guest.xml";
         #Used with attach-detach(hotplugging) interface to confirm all virtual network mode
         #NOTE: Required all guests keep running status
-        #Check that all guests are still running before virtual network tests
-        script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 180);
+        #Ensures the SSH connection and ICMP PING responses is workable for given guest system
+        validate_guest_status($guest);
         save_guest_ip($guest, name => "br123");
         virt_autotest::utils::ssh_copy_id($guest);
         check_guest_health($guest);


### PR DESCRIPTION
- Enhancement for libvirt_virtual_network_init
We need to ensure the given guest system is keeping running status, the SSH connection and the ICMP PING responses is workable together at the libvirt_virtual_network_init test module as our expected. So, add the new `function validate_guest_status() `to ensure each check point as our expected for given guest system at the libvirt_virtual_network_init test module here, instead of current `script_retry()` this easy check way. 
- Related ticket: 
https://progress.opensuse.org/issues/122080
- Verification run: 
[gi-guest_developing-on-host_developing-kvm](http://10.67.129.218/tests/289)
[gi-guest_developing-on-host_developing-xen](http://10.67.129.218/tests/284)