### PR TITLE
Correct variable name for openqa url

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -467,7 +467,7 @@ sub upload_test_results {
             upload_logs("$html_dir/$_", log_name => "$_");
         }
 
-        my $openqa_host = get_var('OPENQA_SERVER');
+        my $openqa_host = get_var('OPENQA_URL');
         my $job_id = get_current_job_id();
         record_info('HTML report URL', "http://$openqa_host/tests/$job_id/file/index.html");
     }


### PR DESCRIPTION
Using default variable 'OPENQA_URL' instead of creating a new 'OPENQA_SERVER'.

- Related ticket: https://progress.opensuse.org/issues/121063
- Verification run: http://10.67.129.96/tests/1832
