### PR TITLE
pynfs: Modify grace time and add client info

### DIFF
--- a/tests/nfs/run.pm
+++ b/tests/nfs/run.pm
@@ -16,20 +16,27 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use power_action_utils 'power_action';
+use version_utils 'is_sle';
 
 sub pynfs_server_test_all {
     my $folder = get_required_var('PYNFS');
-
     assert_script_run("cd ./$folder");
     script_run('./testserver.py -v --rundeps --hidepass --json results.json --maketree localhost:/exportdir all', 3600);
 }
 
+sub collect_client_info {
+    if (!is_sle) {
+        record_info('client status', script_output('nfsdclnts'));
+    }
+    record_info('client number', script_output('ls /proc/fs/nfsd/clients/ | wc -w'));
+}
+
 sub run {
     select_serial_terminal;
-
     if (get_var("PYNFS")) {
         script_run('cd ~/pynfs');
         pynfs_server_test_all;
+        collect_client_info;
     }
     elsif (get_var("CTHON04")) {
         script_run('cd ~/cthon04');


### PR DESCRIPTION
- The default grace time in openSUSE is 90, so sync it to 90.
- Add client info collection at the end of the test in pynfs.

- Verification run: 
- pynfs: 
4.0 https://openqa.opensuse.org/t2990026
4.1 https://openqa.opensuse.org/t2990027
15SP3: https://openqa.suse.de/t10275660
15SP4: https://openqa.suse.de/t10275661
15SP5: https://openqa.suse.de/t10275663

