### PR TITLE
Extend time to wait  yast2-keyboard-ui screen

### DIFF
--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -77,7 +77,7 @@ sub run {
     # 5. Reproduce bug 1142559
     x11_start_program("xterm");
     enter_cmd "/sbin/yast2 keyboard";
-    if (check_screen("yast2-keyboard-ui", 5)) {
+    if (check_screen("yast2-keyboard-ui", 10)) {
         record_soft_failure "bsc#1142559, yast2 keyboard should not start as non root user";
         send_key "alt-c";
         wait_still_screen 2;


### PR DESCRIPTION
Extend time to wait  yast2-keyboard-ui screen

- Related ticket: https://progress.opensuse.org/issues/121648
- Verification run: 
   https://openqa.suse.de/tests/10252781/logfile?filename=autoinst-log.txt (Use 8s)
   https://openqa.suse.de/tests/10252784/logfile?filename=autoinst-log.txt (Use 6s)
