### PR TITLE
Add --profile to Ansible in qesap deployment

### DIFF
--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -39,7 +39,7 @@ sub run {
     my @remote_ips = qesap_remote_hana_public_ips;
     record_info 'Remote IPs', join(' - ', @remote_ips);
     foreach my $host (@remote_ips) { wait_for_ssh $host; }
-    $ret = qesap_execute(cmd => 'ansible', verbose => 1, timeout => 3600);
+    $ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
     die "'qesap.py ansible' return: $ret" if ($ret);
 }
 


### PR DESCRIPTION
Force `qesap.py ansible` to be executed with `--profile`. The command output of Ansible will report some more timing logs

- Related ticket: [TEAM-6829](https://jira.suse.com/browse/TEAM-6829) and PR https://github.com/SUSE/qe-sap-deployment/pull/113

- Verification run:  http://openqaworker15.qa.suse.cz/tests/118210

profile info are in http://openqaworker15.qa.suse.cz/tests/118210/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt

```
DEBUG    OUTPUT: PLAY RECAP *********************************************************************
DEBUG    OUTPUT: vmhana01                   : ok=6    changed=3    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   
DEBUG    OUTPUT: vmhana02                   : ok=6    changed=3    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   
DEBUG    OUTPUT: vmiscsi01                  : ok=6    changed=3    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   
DEBUG    OUTPUT: 
DEBUG    OUTPUT: Friday 30 December 2022  05:49:54 -0500 (0:00:00.530)       0:01:05.502 ******* 
DEBUG    OUTPUT: =============================================================================== 
DEBUG    OUTPUT: registercloudguest registration ---------------------------------------- 55.56s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:34 ----------------
DEBUG    OUTPUT: Gathering Facts --------------------------------------------------------- 4.97s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:2 -----------------
DEBUG    OUTPUT: Check for registration -------------------------------------------------- 2.14s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:12 ----------------
DEBUG    OUTPUT: registercloudguest pre-run cleaning ------------------------------------- 1.43s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:28 ----------------
DEBUG    OUTPUT: Check if repos are added after registration ----------------------------- 0.53s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:89 ----------------
DEBUG    OUTPUT: Check for registercloudguest -------------------------------------------- 0.51s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:19 ----------------
DEBUG    OUTPUT: Add SLES 15 public cloud module ----------------------------------------- 0.09s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:78 ----------------
DEBUG    OUTPUT: SUSEConnect registration ------------------------------------------------ 0.08s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:45 ----------------
DEBUG    OUTPUT: Add SLES 12 Advanced Systems Modules ------------------------------------ 0.08s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:56 ----------------
DEBUG    OUTPUT: Add SLES 12 public cloud module ----------------------------------------- 0.08s
DEBUG    OUTPUT: /root/qe-sap-deployment/ansible/playbooks/registration.yaml:67 ----------------
```
