### PR TITLE
Set defaut grub when system_role is xen

### DIFF
--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -386,6 +386,17 @@ chmod 600 /root/.ssh/id_rsa /root/.ssh/authorized_keys /root/.ssh/config
 ]]>
         </source>
       </script>
+   % if ($check_var->('XEN_DEFAULT_BOOT_IS_SET', '1')) {
+      <script>
+        <filename>workround_default_grub_xen.sh</filename>
+        <source><![CDATA[
+    defautl_grub_name=`/usr/bin/grep ^menuentry /boot/grub2/grub.cfg | /usr/bin/cut -d "'" -f2 | /usr/bin/grep "Xen hypervisor"`
+    /usr/sbin/grub2-set-default "$defautl_grub_name"
+    /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+]]>
+        </source>
+      </script>
+   % }
     </post-scripts>
   </scripts>
 </profile>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -367,6 +367,17 @@ if [ -e /etc/xen/xl.conf ]; then sed -i '/autoballoon=/ s/.*/autoballoon="off"/'
 ]]>
         </source>
       </script>
+   % }
+    % if ($check_var->('XEN_DEFAULT_BOOT_IS_SET', '1')) {
+      <script>
+        <filename>workround_default_grub_xen.sh</filename>
+        <source><![CDATA[
+    defautl_grub_name=`/usr/bin/grep ^menuentry /boot/grub2/grub.cfg | /usr/bin/cut -d "'" -f2 | /usr/bin/grep "Xen hypervisor"`
+    /usr/sbin/grub2-set-default "$defautl_grub_name"
+    /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+]]>
+        </source>
+      </script>
    % } 
     </post-scripts>
   </scripts>

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -116,7 +116,7 @@ sub login_to_console {
 
     if (!get_var('UPGRADE_AFTER_REBOOT')) {
         set_var('REBOOT_AFTER_UPGRADE', '') if (get_var('REBOOT_AFTER_UPGRADE'));
-        if (is_xen_host) {
+        if (is_xen_host && !check_var('XEN_DEFAULT_BOOT_IS_SET', 1)) {
             #send key 'up' to stop grub timer counting down, to be more robust to select xen
             send_key 'up';
             save_screenshot;


### PR DESCRIPTION
Poo#https://progress.opensuse.org/issues/118381
Sometimes IPMI cannot work, failed to select grub. Set default grub in autoyast installation.



- Related ticket: https://progress.opensuse.org/issues/118381
- Needles: N/A
- Verification run: 
    - [sle15sp3 xen test](http://openqa.qam.suse.cz/tests/50074#step/login_console/3)
    - [sle15sp3 kvm test](http://openqa.qam.suse.cz/tests/50075#step/login_console/3)
    - [sle12sp5 xen test(old logic)](http://openqa.qam.suse.cz/tests/50077#step/login_console/5)   
    - [sle12sp5 xen test](http://openqa.qam.suse.cz/tests/50087#step/login_console/3) 
