### PR TITLE
ping:Select console at the start of test

### DIFF
--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -21,10 +21,10 @@ use version_utils qw(is_jeos is_sle);
 
 sub run {
     my ($self) = @_;
-    my $ping_group_range = script_output('sysctl net.ipv4.ping_group_range');
     my $capability;
 
     select_serial_terminal;
+    my $ping_group_range = script_output('sysctl net.ipv4.ping_group_range');
 
     zypper_call('in iputils libcap-progs sudo');
     $capability = script_output('getcap $(which ping)', proceed_on_failure => 1);


### PR DESCRIPTION
User `bernhard` does not have rights to execute `sysctl`.

Failure: https://openqa.suse.de/tests/10266147#step/ping/4
VR: http://kepler.suse.cz/tests/19781#step/ping/4