### PR TITLE
ping: Move script_output after select_serial_terminal

### DIFF
--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -21,10 +21,11 @@ use version_utils qw(is_jeos is_sle);
 
 sub run {
     my ($self) = @_;
-    my $ping_group_range = script_output('sysctl net.ipv4.ping_group_range');
+    my $ping_group_range;
     my $capability;
 
     select_serial_terminal;
+    $ping_group_range = script_output('sysctl net.ipv4.ping_group_range');
 
     zypper_call('in iputils libcap-progs sudo');
     $capability = script_output('getcap $(which ping)', proceed_on_failure => 1);


### PR DESCRIPTION
To make sure user is logged. The module is not the first one, thus there will be already logged user, but it's a bad practise to depend on it.

Fixes: b98825f75 ("ping: Add check for capability with ICMP socket")
Link: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16138#discussion_r1060352520

Reported-by: Martin Loviska <mloviska@suse.com>

Verification run:
- http://quasar.suse.cz/tests/1611#step/ping/29 (the broken test)
- http://quasar.suse.cz/tests/1609#step/ping/29
- http://quasar.suse.cz/tests/1610#step/ping/29

@mloviska FYI
