### PR TITLE
Enhance result check after virsh command

### DIFF
--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -66,6 +66,8 @@ sub run_test {
         test_network_interface($guest, mac => $mac, gate => $gate, net => $net);
 
         assert_script_run("virsh detach-interface $guest bridge --mac $mac $exclusive");
+        my $check = script_run("ssh root\@$guest ip l | grep " . $mac, 60);
+        die "Failed to detach bridge interface for guest $guest." if ($check eq 0);
     }
 
     #Destroy HOST BRIDGE NETWORK


### PR DESCRIPTION
poo#https://progress.opensuse.org/issues/122620
Need double check device status in the system, even though virsh command succeed.


- Related ticket: https://progress.opensuse.org/issues/122620
- Needles: N/A
- Verification run: 
    - [Success](http://openqa.qam.suse.cz/tests/50056#step/libvirt_host_bridge_virtual_network/452)
    - [Failure](http://openqa.qam.suse.cz/tests/50056#step/libvirt_host_bridge_virtual_network/520)
