### PR TITLE
sssd: Switch to mdb openldap backend

### DIFF
--- a/data/sssd-tests/krb/slapd.conf
+++ b/data/sssd-tests/krb/slapd.conf
@@ -32,12 +32,11 @@ access to dn.subtree="ou=UnixUser,dc=ldapdom,dc=net"
 access to *
         by * read
 
-moduleload  back_hdb.la
+moduleload  back_mdb.la
 
-database	hdb
+database	mdb
 suffix		"dc=ldapdom,dc=net"
 checkpoint      1024    5
-cachesize       10000
 rootdn		"cn=root,dc=ldapdom,dc=net"
 rootpw		pass
 directory	/tmp/ldap-sssdtest

--- a/data/sssd-tests/krb/slapd_old.conf
+++ b/data/sssd-tests/krb/slapd_old.conf
@@ -32,12 +32,11 @@ access to dn.subtree="ou=UnixUser,dc=ldapdom,dc=net"
 access to *
         by * read
 
-moduleload  back_hdb.la
+moduleload  back_mdb.la
 
-database	hdb
+database	mdb
 suffix		"dc=ldapdom,dc=net"
 checkpoint      1024    5
-cachesize       10000
 rootdn		"cn=root,dc=ldapdom,dc=net"
 rootpw		pass
 directory	/tmp/ldap-sssdtest

--- a/data/sssd-tests/ldap-nested-groups/slapd.conf
+++ b/data/sssd-tests/ldap-nested-groups/slapd.conf
@@ -21,12 +21,11 @@ access to attrs=shadowLastChange
 access to *
         by * read
 
-moduleload  back_hdb.la
+moduleload  back_mdb.la
 
-database	hdb
+database	mdb
 suffix		"dc=ldapdom,dc=net"
 checkpoint      1024    5
-cachesize       10000
 rootdn		"cn=root,dc=ldapdom,dc=net"
 rootpw		pass
 directory	/tmp/ldap-sssdtest

--- a/data/sssd-tests/ldap-no-auth/slapd.conf
+++ b/data/sssd-tests/ldap-no-auth/slapd.conf
@@ -21,12 +21,11 @@ access to attrs=shadowLastChange
 access to *
         by * read
 
-moduleload  back_hdb.la
+moduleload  back_mdb.la
 
-database	hdb
+database	mdb
 suffix		"dc=ldapdom,dc=net"
 checkpoint      1024    5
-cachesize       10000
 rootdn		"cn=root,dc=ldapdom,dc=net"
 rootpw		pass
 directory	/tmp/ldap-sssdtest

--- a/data/sssd-tests/ldap/slapd.conf
+++ b/data/sssd-tests/ldap/slapd.conf
@@ -21,12 +21,11 @@ access to attrs=shadowLastChange
 access to *
         by * read
 
-moduleload  back_hdb.la
+moduleload  back_mdb.la
 
-database	hdb
+database	mdb
 suffix		"dc=ldapdom,dc=net"
 checkpoint      1024    5
-cachesize       10000
 rootdn		"cn=root,dc=ldapdom,dc=net"
 rootpw		pass
 directory	/tmp/ldap-sssdtest

--- a/data/sssd/openldap/slapd.conf
+++ b/data/sssd/openldap/slapd.conf
@@ -7,7 +7,7 @@ include /etc/openldap/schema/core.schema
 include /etc/openldap/schema/cosine.schema
 include /etc/openldap/schema/inetorgperson.schema
 include /etc/openldap/schema/rfc2307bis.schema
-include /etc/openldap/schema/ppolicy.schema
+include /etc/openldap/schema/policy.schema
 include /etc/openldap/schema/yast.schema
 include /etc/openldap/schema/sudo.schema
 TLSCACertificateFile /etc/ssl/ca-bundle.pem


### PR DESCRIPTION
The hdb backend was disabled when openldap was updated to 2.5.8 in Tumbleweed.

Signed-off-by: Samuel Cabrero <scabrero@suse.de>

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1205160