### PR TITLE
Modify selinux tests to run on ALP

### DIFF
--- a/lib/selinuxtest.pm
+++ b/lib/selinuxtest.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils qw(is_alp);
 use Utils::Backends 'is_pvm';
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
 use power_action_utils 'power_action';
@@ -26,7 +27,13 @@ our @EXPORT = qw(
   download_policy_pkgs
 );
 
-our $file_contexts_local = '/etc/selinux/minimum/contexts/files/file_contexts.local';
+our $file_contexts_local;
+# On ALP we want to use the default selinux targeted policy and do not have minimum installed which this checks
+if (is_alp) {
+    $file_contexts_local = '/etc/selinux/targeted/contexts/files/file_contexts.local';
+} else {
+    $file_contexts_local = '/etc/selinux/minimum/contexts/files/file_contexts.local';
+}
 our $file_output = '/tmp/cmd_output';
 our $policypkg_repo = get_var('SELINUX_POLICY_PKGS');
 our $policyfile_tar = 'testing-master';

--- a/schedule/security/selinux.yaml
+++ b/schedule/security/selinux.yaml
@@ -6,8 +6,7 @@ schedule:
     - boot/boot_to_desktop
     - security/selinux/selinux_setup
     - security/selinux/sestatus
-    - security/selinux/selinux_smoke
-    - security/selinux/enforcing_mode_setup
+    - '{{selinux_enforcing}}'
     - security/selinux/semanage_fcontext
     - security/selinux/semanage_boolean
     - security/selinux/fixfiles
@@ -27,3 +26,11 @@ conditional_schedule:
                 - installation/bootloader_zkvm
             ppc64le:
                 - installation/bootloader
+    selinux_enforcing:
+        DISTRI:
+            opensuse:
+                - security/selinux/selinux_smoke
+                - security/selinux/enforcing_mode_setup
+            sle:
+                - security/selinux/selinux_smoke
+                - security/selinux/enforcing_mode_setup

--- a/tests/security/selinux/audit2allow.pm
+++ b/tests/security/selinux/audit2allow.pm
@@ -12,7 +12,8 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_sle);
+use power_action_utils 'power_action';
+use version_utils qw(is_alp is_sle);
 use registration qw(add_suseconnect_product);
 
 sub run {
@@ -31,16 +32,22 @@ sub run {
 
     # read input from logs and translate to why
     assert_script_run("cp $original_audit $audit_log");
-    validate_script_output("audit2allow -a", sub { m/allow\ .*_t\ .*;.*/sx });
+    # audit2allow is empty (no denials) on ALP, so create a fake denial for testing purposes for the later commmands
+    if (is_alp) {
+        script_run("echo 'type=AVC msg=audit(1670248641.102:242): avc:  denied  { read } for  pid=2160 comm=\"useradd\" name=\"run\" dev=\"dm-0\" ino=19939 scontext=unconfined_u:unconfined_r:useradd_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:unlabeled_t:s0 tclass=lnk_file permissive=1' >> $audit_log");
+        validate_script_output("audit2allow -a", sub { m/^\s*$/sx });
+    } else {
+        validate_script_output("audit2allow -a", sub { m/allow\ .*_t\ .*;.*/sx });
+    }
     validate_script_output("audit2allow -i $audit_log", sub { m/allow\ .*_t\ .*;.*/sx });
     assert_script_run("tail -n 500 $audit_log > $audit_log_short");
     validate_script_output(
         "audit2allow -w -i $audit_log_test",
         sub {
             m/
-	    type=.*AVC.*denied.*
-	    Was\ caused\ by:.*
-	    You\ can\ use\ audit2allow\ to\ generate\ a\ loadable\ module\ to\ allow\ this\ access.*/sx
+        type=.*AVC.*denied.*
+        Was\ caused\ by:.*
+        You\ can\ use\ audit2allow\ to\ generate\ a\ loadable\ module\ to\ allow\ this\ access.*/sx
         }, 600);
 
     # upload aduit log for reference
@@ -73,6 +80,10 @@ sub run {
         zypper_call("in policycoreutils-devel");
     } elsif (is_sle('<15')) {
         zypper_call("in selinux-policy-devel");
+    } elsif (is_alp) {
+        # NOTE: ALP does not have policycoreutils-devel at the moment.
+        # If it would have, we could install it and reboot at this point.
+        return 0;
     } else {
         zypper_call("in policycoreutils-devel");
     }

--- a/tests/security/selinux/chcat.pm
+++ b/tests/security/selinux/chcat.pm
@@ -17,7 +17,7 @@ use utils;
 
 sub run {
     my ($self) = shift;
-    my $test_dir = "/testdir";
+    my $test_dir = "/tmp/testdir";
     my $test_file = "testfile";
     my $test_user = "root";
 

--- a/tests/security/selinux/chcon.pm
+++ b/tests/security/selinux/chcon.pm
@@ -15,7 +15,7 @@ use utils;
 
 sub run {
     my ($self) = shift;
-    my $test_dir = "/testdir";
+    my $test_dir = "/tmp/testdir";
     my $test_file = "testfile";
     my $fcontext_type1 = "etc_t";
     my $fcontext_type2 = "bin_t";

--- a/tests/security/selinux/fixfiles.pm
+++ b/tests/security/selinux/fixfiles.pm
@@ -12,6 +12,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils qw(is_alp);
 
 sub run {
     my ($self) = shift;
@@ -33,11 +34,18 @@ sub run {
 
     # test `fixfiles verify/check`: to double confirm, there should be nothing to do with $file_name
     my $script_output = script_output("fixfiles verify $file_name", proceed_on_failure => 1);
+    # On ALP, there is always a note about excluded fixfiles directory overlay
+    if (is_alp) {
+        $script_output =~ s/skipping the directory \/var\/lib\/overlay//;
+    }
     if ($script_output) {
         record_info("ERROR", "verify $file_name, it is not well restored: $script_output", result => "fail");
         $self->result("fail");
     }
     $script_output = script_output("fixfiles check $file_name", proceed_on_failure => 1);
+    if (is_alp) {
+        $script_output =~ s/skipping the directory \/var\/lib\/overlay//;
+    }
     if ($script_output) {
         record_info("ERROR", "check $file_name, it is not well restored: $script_output", result => "fail");
         $self->result("fail");

--- a/tests/security/selinux/restorecon.pm
+++ b/tests/security/selinux/restorecon.pm
@@ -15,7 +15,7 @@ use utils;
 
 sub run {
     my ($self) = shift;
-    my $test_dir = "/testdir";
+    my $test_dir = "/tmp/testdir";
     my $test_file = "testfile";
     my $fcontext_type1 = "etc_t";
     my $fcontext_type2 = "bin_t";

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -12,7 +12,8 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_sle is_leap is_tumbleweed);
+use power_action_utils 'power_action';
+use version_utils qw(is_sle is_leap is_tumbleweed is_alp);
 use Utils::Architectures;
 
 sub run {
@@ -27,18 +28,34 @@ sub run {
     my $policy_pkg_20200219 = 'selinux-20200219.tgz';
 
     # Program 'sestatus' can be found in policycoreutils
-    zypper_call("in policycoreutils");
+    if (is_alp) {
+        assert_script_run('transactional-update --non-interactive pkg install policycoreutils');
+    }
+    else {
+        zypper_call("in policycoreutils");
+    }
     # Program 'semanage' is found in:
-    #  - policycoreutils-python-utils pkgs on TW and SLES 15-SP4
+    #  - policycoreutils-python-utils pkgs on ALP, TW and SLES 15-SP4
     #  - policycoreutils for 15-SP{0,3}
     #  - policycoreutils-python for <= 12-SP5
-    if (is_tumbleweed || is_sle('>=15-SP4')) {
-        zypper_call("in policycoreutils-python-utils");
+    if (is_alp) {
+        assert_script_run('transactional-update --non-interactive pkg install policycoreutils-python-utils');
     }
-    if (!is_sle('>=15')) {
-        assert_script_run('zypper -n in policycoreutils-python');
+    else {
+        if (is_tumbleweed || is_sle('>=15-SP4')) {
+            zypper_call("in policycoreutils-python-utils");
+        }
+        if (!is_sle('>=15')) {
+            assert_script_run('zypper -n in policycoreutils-python');
+        }
     }
-
+    # Reboot ALP after transactional updates finished
+    if (is_alp) {
+        my $prev_console = current_console();
+        power_action('reboot', textmode => 1);
+        $self->wait_boot(bootloader_time => 300);
+        select_console($prev_console);
+    }
     # Install as many as SELinux related packages
     my @pkgs = (
         'selinux-tools', 'libselinux-devel', 'libselinux1', 'python3-selinux',
@@ -47,19 +64,20 @@ sub run {
         'setools-devel', 'setools-java', 'setools-libs', 'setools-tcl',
         'policycoreutils-python-utils'
     );
-    foreach my $pkg (@pkgs) {
-        my $results = script_run("zypper --non-interactive se $pkg");
-        if ($results) {
-            record_info('WARNING', "Package $pkg is missing, zypper search returns: $results");
+    if (!is_alp) {
+        foreach my $pkg (@pkgs) {
+            my $results = script_run("zypper --non-interactive se $pkg");
+            if ($results) {
+                record_info('WARNING', "Package $pkg is missing, zypper search returns: $results");
+            }
+            else {
+                zypper_call("in $pkg");
+            }
         }
-        else {
-            zypper_call("in $pkg");
+        if (is_x86_64) {
+            zypper_call('in libselinux1-32bit');
         }
     }
-    if (is_x86_64) {
-        zypper_call('in libselinux1-32bit');
-    }
-
     # For opensuse, e.g, Tumbleweed install selinux_policy pkgs as needed
     # For sle15 and sle15+ "selinux-policy-*" pkgs will not be released
     # NOTE: have to install "selinux-policy-minimum-*" pkg due to this bug: bsc#1108949
@@ -76,13 +94,13 @@ sub run {
         assert_script_run("tar -xzf $policy_pkg_20200219");
         assert_script_run("rpm -ivhU --nosignature --nodeps --noplugins ./selinux*20200219*.rpm", timeout => 120);
     }
-    elsif (!is_sle && !is_leap) {
+    elsif (!is_sle && !is_leap && !is_alp) {
         my @files = ('selinux-policy', 'selinux-policy-minimum', 'selinux-policy-devel');
         foreach my $file (@files) {
             zypper_call("in $file");
         }
     }
-    else {
+    elsif (!is_alp) {
         zypper_call('in selinux-policy-minimum');
     }
 
@@ -90,11 +108,14 @@ sub run {
     my $results = script_output('zypper se -s selinux policy');
     record_info('Pkg_ver', "SELinux packages' version is: $results");
 
-    # Check SELinux status by default, it should be disabled
+    # Check SELinux status by default, it should be disabled otherwise but enabled on ALP
+    # On ALP, it will be checked in the sestatus module
     # 'selinuxenabled' exits with status 0 if SELinux is enabled and 1 if it is not enabled
-    validate_script_output('sestatus', sub { m/SELinux status: .*disabled/ });
-    if (script_run('selinuxenabled') == 0) {
-        $self->result('fail');
+    if (!is_alp) {
+        validate_script_output('sestatus', sub { m/SELinux status: .*disabled/ });
+        if (script_run('selinuxenabled') == 0) {
+            $self->result('fail');
+        }
     }
 }
 

--- a/tests/security/selinux/semanage_boolean.pm
+++ b/tests/security/selinux/semanage_boolean.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils qw(is_alp);
 use Utils::Backends 'is_pvm';
 
 sub run {
@@ -28,8 +29,7 @@ sub run {
             m/
             authlogin_.*(off.*,.*off).*
             daemons_.*(off.*,.*off).*
-            domain_.*(off.*,.*off).*
-            selinuxuser_.*(on.*,.*on).*/sx
+            domain_.*(off.*,.*off).*/sx
         });
 
     # test option "-m": to set boolean value "off/on"
@@ -39,20 +39,28 @@ sub run {
     validate_script_output("semanage boolean -l | grep $test_boolean", sub { m/${test_boolean}.*(on.*,.*on).*Allow.*to.*/ });
 
     # reboot and check again
+    my $prev_console = current_console();
     power_action("reboot", textmode => 1);
     reconnect_mgmt_console if is_pvm;
     $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
-    select_serial_terminal;
+    select_console($prev_console);
 
     validate_script_output("semanage boolean -l | grep $test_boolean", sub { m/${test_boolean}.*(on.*,.*on).*Allow.*to.*/ });
 
     # test option "-C": to list boolean local customizations
-    validate_script_output(
-        "semanage boolean -l -C",
-        sub {
-            m/(?=.*SELinux\s+boolean\s+State\s+Default\s+Description)(?=.*${test_boolean}\s+\(on\s+,\s+on\))(?=.*selinuxuser_execmod\s+\(on\s+,\s+on\))/s;
-        });
-
+    if (is_alp) {
+        validate_script_output(
+            "semanage boolean -l -C",
+            sub {
+m/(?=.*SELinux\s+boolean\s+State\s+Default\s+Description)(?=.*${test_boolean}\s+\(on\s+,\s+on\))(?=.*virt_sandbox_use_all_caps\s+\(on\s+,\s+on\))(?=.*virt_use_nfs\s+\(on\s+,\s+on\))/s;
+            });
+    } else {
+        validate_script_output(
+            "semanage boolean -l -C",
+            sub {
+                m/(?=.*SELinux\s+boolean\s+State\s+Default\s+Description)(?=.*${test_boolean}\s+\(on\s+,\s+on\))(?=.*selinuxuser_execmod\s+\(on\s+,\s+on\))/s;
+            });
+    }
 
     # test option "-D": to delete boolean local customizations
     assert_script_run("semanage boolean -D");

--- a/tests/security/selinux/semanage_fcontext.pm
+++ b/tests/security/selinux/semanage_fcontext.pm
@@ -13,14 +13,16 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils qw(is_alp);
 
 sub run {
     my ($self) = shift;
     my $file_contexts_local = $selinuxtest::file_contexts_local;
     my $test_boolean = "fips_mode";
-    my $test_dir = "/testdir";
+    # /tmp is required for ALP since / is read-only
+    my $test_dir = "/tmp/testdir";
     my $test_file = "testfile";
-    my $fcontext_type_default = "default_t";    # or, "user_tmp_t";
+    my $fcontext_type_default = "user_tmp_t";    # or, "default_t" if the file would be in / instead of /tmp;
     my $fcontext_type1 = "etc_t";
     my $fcontext_type2 = "bin_t";
     my $fcontext_type3 = "var_t";

--- a/tests/security/selinux/semodule.pm
+++ b/tests/security/selinux/semodule.pm
@@ -11,6 +11,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils qw(is_alp);
 
 sub run {
     my $test_module = "openvpn";
@@ -46,15 +47,27 @@ sub run {
     assert_script_run("semodule -lfull | grep -w $test_module", sub { m/100\ $test_module\ .*pp.*/sx });
 
     # test option "-l": list all modules and verify some of them (disabled + enabled)
-    validate_script_output(
-        "semodule -lfull",
-        sub {
-            m/
-            100\ abrt.*pp\ disabled.*
-            100\ apache.*pp.*
-            100\ userdomain.*pp.*
-            100\ zosremote.*pp\ disabled.*/sx
-        });
+    if (is_alp) {
+        validate_script_output(
+            "semodule -lfull",
+            sub {
+                m/
+                100\ abrt.*pp.*
+                100\ apache.*pp.*
+                100\ userdomain.*pp.*
+                100\ zosremote.*pp.*/sx
+            });
+    } else {
+        validate_script_output(
+            "semodule -lfull",
+            sub {
+                m/
+                100\ abrt.*pp\ disabled.*
+                100\ apache.*pp.*
+                100\ userdomain.*pp.*
+                100\ zosremote.*pp\ disabled.*/sx
+            });
+    }
 }
 
 1;

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -14,11 +14,15 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils qw(is_alp);
 
 sub run {
     my ($self) = @_;
     select_serial_terminal;
-    $self->set_sestatus('permissive', 'minimum');
+    # ALP is already set to enforcing mode
+    if (!is_alp) {
+        $self->set_sestatus('permissive', 'minimum');
+    }
 
     # Check SELinux status: 'selinuxenabled' exits with status 0 if SELinux is enabled and 1 if it is not enabled
     assert_script_run('selinuxenabled');


### PR DESCRIPTION
This modifies selinux tests to run on ALP while preserving compatibility with others. ALP is quite different from others as it comes with selinux enabled by default and even in enforcing mode.

- Related ticket: https://progress.opensuse.org/issues/119824
- Verification runs:

ALP
x86_64 http://timo-openqa.qe.suse.de/tests/387
x86_64 uefi http://timo-openqa.qe.suse.de/tests/391

15-SP4
x86_64 https://openqa.suse.de/t10268860
s390x https://openqa.suse.de/t10268861

15-SP3
x86_64 https://openqa.suse.de/t10268862
s390x https://openqa.suse.de/t10268863

15-SP2
x86_64 https://openqa.suse.de/t10268864
s390x https://openqa.suse.de/t10268865

12-SP5
x86_64 https://openqa.suse.de/t10268866

Tumbleweed
x86_64 https://openqa.opensuse.org/t3011194

