### PR TITLE
Add Azure Compute Galleries for Arm64 image upload

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -19,6 +19,7 @@ use publiccloud::ssh_interactive 'select_host_console';
 
 has resource_group => 'openqa-upload';
 has container => 'sle-images';
+has image_gallery => 'test_image_gallery';
 has lease_id => undef;
 
 sub init {
@@ -100,6 +101,21 @@ sub create_resources {
     record_info('INFO', 'Create storage container ' . $self->container);
     assert_script_run('az storage container create --account-name ' . $storage_account
           . ' --name ' . $self->container, $timeout);
+    # Image gallery for Arm64 images
+    assert_script_run('az sig create --resource-group ' . $self->resource_group . ' --gallery-name "' . $self->image_gallery . '" --description "openQA upload Gallery"', timeout => 300);
+}
+
+sub calc_img_version {
+    # Build the image Version for upload to the Compute Gallery.
+    # The expected format is 'X.Y.Z'.
+    # We assemble the img version by the PUBLIC_CLOUD_BUILD (Format: 'X.Y') and the digits of PUBLIC_CLOUD_KIWI_BUILD, formatted as integer
+
+    my $build = get_required_var('PUBLIC_CLOUD_BUILD');
+    # Take only the digits of PUBLIC_CLOUD_KIWI_BUILD and convert to an int, to remove leading zeros
+    my $kiwi = get_required_var('PUBLIC_CLOUD_BUILD_KIWI');
+    $kiwi =~ s/\.//g;
+    $kiwi = int($kiwi);
+    return "$build.$kiwi";
 }
 
 sub upload_img {
@@ -124,16 +140,70 @@ sub upload_img {
 
     my $key = $self->get_storage_account_keys($storage_account);
 
-    assert_script_run('az storage blob upload --max-connections 4 --account-name '
-          . $storage_account . ' --account-key ' . $key . ' --container-name ' . $self->container
-          . ' --type page --file ' . $file . ' --name ' . $img_name, timeout => 60 * 60 * 2);
-    assert_script_run('az disk create --resource-group ' . $self->resource_group . ' --name ' . $disk_name
-          . ' --source https://' . $storage_account . '.blob.core.windows.net/' . $self->container . '/' . $img_name
-          . ' --hyper-v-generation=' . $sku . ' --architecture=' . $arch);
 
-    assert_script_run('az image create --resource-group ' . $self->resource_group . ' --name ' . $img_name
-          . ' --os-type Linux --hyper-v-generation=' . $sku . ' --source=' . $disk_name);
 
+    # Check if blob already exists
+    my $container = $self->container;
+    my $blobs = script_output("az storage blob list --container-name '$container' --account-name '$storage_account' | jq '.[].name'");
+    $blobs =~ s/^\s+|\s+$//g;    # trim
+    my @blobs = split(/\n/, $blobs);
+    if (grep(/$img_name/, @blobs)) {
+        record_info('blob', "Blob already exists, omitting upload\nExisting blobs:\n$blobs");
+    } else {
+        record_info("blobs", $blobs);
+        # Note: VM images need to be a page blob type
+        assert_script_run('az storage blob upload --max-connections 4 --account-name '
+              . $storage_account . ' --account-key ' . $key . ' --container-name ' . $self->container
+              . ' --type page --file ' . $file . ' --name ' . $img_name, timeout => 60 * 60 * 2);
+    }
+
+    if ($arch eq 'Arm64') {
+        # For Arm64 images we need to use the image galleries
+        my $publisher = get_var("PUBLIC_CLOUD_AZURE_PUBLISHER", "qe-c");
+        my $offer = get_required_var("PUBLIC_CLOUD_AZURE_OFFER");
+        my $definition = get_required_var('DISTRI') . '-' . get_required_var('FLAVOR') . '-' . get_required_var('VERSION');
+        $definition = get_var("PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION", uc($definition));
+        $sku = get_required_var("PUBLIC_CLOUD_AZURE_SKU");
+        ## For the Azure Compute Gallery, multiple target regions are supported.
+        # This is necessary, because the image version upload needs to happen once for all regions, for which we want to
+        # execute test runs. For reasons of being concise we re-use the existing variable PUBLIC_CLOUD_REGION, but here
+        # it can contain a comma-separated list of all regions, in which the uploaded image should be available
+        my $target_regions = get_var("PUBLIC_CLOUD_REGION", "westeurope");
+        $target_regions =~ s/,/ /g;    # CLI expects spaces as separation, not commas
+        my $hyperv = $sku =~ 'gen1' ? 'V1' : 'V2';
+        my $subscription = $self->provider_client->subscription;
+        my $sa_url = "/subscriptions/$subscription/resourceGroups/imageGroups/providers/Microsoft.Storage/storageAccounts/$storage_account";
+        my $version = calc_img_version();
+
+        my $resource_group = $self->resource_group;
+        my $gallery = $self->image_gallery;
+
+        ## Create image definition. This image definition can then be used by addressing it with it's
+        ## /subscription/.../resourceGroups/openqa-upload/providers/Microsoft.Compute/galleries/...
+        ## link.
+        ## 1. Ensure the image definition in the Azure Compute Gallery exists
+        ## 2. Create a new image version for that definition. Use the link to the uploaded blob to create this version
+
+        # Print image definitions as a help to debug possible conflicting definitions
+        my $images = script_output("az sig image-definition list -g '$resource_group' -r '$gallery'");
+        record_info("img-def", "Existing image definitions:\n$images");
+
+        # Note: Repetitive calls are do not fail
+        assert_script_run("az sig image-definition create --resource-group '$resource_group' --gallery-name '$gallery' " .
+              "--gallery-image-definition '$definition' --os-type Linux --publisher '$publisher' --offer '$offer' --sku '$sku' " .
+              "--architecture '$arch' --hyper-v-generation '$hyperv' --os-state 'Generalized'", timeout => 300);
+        assert_script_run("az sig image-version create --resource-group '$resource_group' --gallery-name '$gallery' " .
+              "--gallery-image-definition '$definition' --gallery-image-version '$version' --os-vhd-storage-account '$sa_url' " .
+              "--os-vhd-uri https://$storage_account.blob.core.windows.net/$container/$img_name --target-regions $target_regions", timeout => 60 * 30);
+    } else {
+        # Create disk from blob
+        assert_script_run('az disk create --resource-group ' . $self->resource_group . ' --name ' . $disk_name
+              . ' --source https://' . $storage_account . '.blob.core.windows.net/' . $self->container . '/' . $img_name
+              . ' --hyper-v-generation=' . $sku . ' --architecture=' . $arch);
+        # Create image from disk
+        assert_script_run('az image create --resource-group ' . $self->resource_group . ' --name ' . $img_name
+              . ' --os-type Linux --hyper-v-generation=' . $sku . ' --source=' . $disk_name);
+    }
     return $img_name;
 }
 

--- a/variables.md
+++ b/variables.md
@@ -265,6 +265,7 @@ PUBLIC_CLOUD_AZ_API_VERSION | string | "2021-02-01" | For Azure, it is the API v
 PUBLIC_CLOUD_HDD2_SIZE | integer | "" | If set, the instance will have an additional disk with the given capacity in GB
 PUBLIC_CLOUD_HDD2_TYPE | string | "" | If PUBLIC_CLOUD_ADDITIONAL_DISK_SIZE is set, this defines the additional disk type (optional). The required value depends on the cloud service provider.
 PUBLIC_CLOUD_ARCH | string | "x86_64" | The architecture of created VM.
+PUBLIC_CLOUD_AZURE_PUBLISHER | string | "SUSE" | Specific to Azure. Allows to define the used publisher, if it should not be "SUSE"
 PUBLIC_CLOUD_AZURE_OFFER | string | "" | Specific to Azure. Allow to query for image based on offer and sku. Should be used together with PUBLIC_CLOUD_AZURE_SKU.
 PUBLIC_CLOUD_AZURE_SKU | string | "" | Specific to Azure.
 PUBLIC_CLOUD_BUILD | string | "" | The image build number. Used only when we use custom built image.
@@ -287,6 +288,7 @@ PUBLIC_CLOUD_IGNORE_EMPTY_REPO | boolean | false | Ignore empty maintenance upda
 PUBLIC_CLOUD_IMAGE_ID | string | "" | The image ID we start the instance from
 PUBLIC_CLOUD_IMAGE_LOCATION | string | "" | The URL where the image gets downloaded from. The name of the image gets extracted from this URL.
 PUBLIC_CLOUD_IMAGE_PROJECT | string | "" | Google Compute Engine image project
+PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION | string | "" | Defines the image definition for uploading Arm64 images to the image gallery.
 PUBLIC_CLOUD_IMG_PROOF_TESTS | string | "test-sles" | Tests run by img-proof.
 PUBLIC_CLOUD_IMG_PROOF_EXCLUDE | string | "" | Tests to be excluded by img-proof.
 PUBLIC_CLOUD_INSTANCE_TYPE | string | "" | Specify the instance type. Which instance types exists depends on the CSP. (default-azure: Standard_A2, default-ec2: t2.large )
@@ -302,7 +304,7 @@ PUBLIC_CLOUD_GOOGLE_PROJECT_ID | string | "" | GCP only, used to specify the pro
 PUBLIC_CLOUD_PROVIDER | string | "" | The type of the CSP (e.g. AZURE, EC2, GCE).
 PUBLIC_CLOUD_QAM | boolean | false | Previously used to recognize maintenance jobs - now deprecated - should be removed.
 PUBLIC_CLOUD_REBOOT_TIMEOUT | integer | 600 | Number of seconds we wait for instance to reboot.
-PUBLIC_CLOUD_REGION | string | "" | The region to use. (default-azure: westeurope, default-ec2: eu-central-1, default-gcp: europe-west1-b).
+PUBLIC_CLOUD_REGION | string | "" | The region to use. (default-azure: westeurope, default-ec2: eu-central-1, default-gcp: europe-west1-b). In `upload-img` for Azure Arm64 images, multiple comma-separated regions are supported (see `lib/publiccloud/azure.pm`)
 PUBLIC_CLOUD_RESOURCE_GROUP | string | "qashapopenqa" | Allows to specify resource group name on SLES4SAP PC tests.
 PUBLIC_CLOUD_RESOURCE_NAME | string | "openqa-vm" | The name we use when creating our VM.
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Debug variable used to run test without maintenance updates repository being applied.


### PR DESCRIPTION
For Arm64 image uploads, we need to use Azure Compute Galleries. This commit implements the handling for Arm64 image uploads, while preserves the workflow for all other ones.

- Related ticket: https://progress.opensuse.org/issues/119011
- Verification run: [Uploading Arm64 image](https://duck-norris.qe.suse.de/tests/11639) | [Upload x86_64 image](https://duck-norris.qe.suse.de/tests/11640)
