### PR TITLE
Adopt the new open-vm-tools test in MU incident testing

### DIFF
--- a/lib/virt_autotest/esxi_utils.pm
+++ b/lib/virt_autotest/esxi_utils.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends qw(is_qemu is_svirt);
 
 our @EXPORT = qw(
   esxi_vm_get_vmid
@@ -25,61 +26,128 @@ our @EXPORT = qw(
   esxi_vm_public_ip
   get_host_timestamp
   disable_vm_time_synchronization
+  revert_vm_timesync_setting
 );
+
+my $hypervisor = get_var('HYPERVISOR') // 'esxi7.qa.suse.cz';
 
 sub esxi_vm_get_vmid {
     my $vm_name = shift;
-    my $vim_cmd = "vim-cmd vmsvc/getallvms | grep -i $vm_name | awk -F' ' '{print \$1}'";
-    my (undef, $vmid) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
-    chomp($vmid);
+    my $vim_cmd = "vim-cmd vmsvc/getallvms | grep -i $vm_name | cut -d' ' -f1";
+    my $vmid;
+    if (is_svirt) {
+        (undef, $vmid) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
+    }
+    elsif (is_qemu) {
+        $vmid = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd"));
+        chomp($vmid);
+    }
     return $vmid;
 }
 
 sub esxi_vm_power_getstate {
     my $vmid = shift;
     my $vim_cmd = "vim-cmd vmsvc/power.getstate";
-    my (undef, $power_state) = console('svirt')->run_cmd("$vim_cmd $vmid", domain => 'sshVMwareServer', wantarray => 1);
+    my $power_state;
+    if (is_svirt) {
+        (undef, $power_state) = console('svirt')->run_cmd("$vim_cmd $vmid", domain => 'sshVMwareServer', wantarray => 1);
+    }
+    elsif (is_qemu) {
+        $power_state = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd $vmid"));
+    }
     return $power_state;
 }
 
 sub esxi_vm_power_ops {
     my ($vmid, $powerops) = @_;
     my $vim_cmd = "vim-cmd vmsvc/$powerops";
-    return console('svirt')->run_cmd("$vim_cmd $vmid", domain => 'sshVMwareServer', wantarray => 1);
+    if (is_svirt) {
+        return console('svirt')->run_cmd("$vim_cmd $vmid", domain => 'sshVMwareServer', wantarray => 1);
+    }
+    elsif (is_qemu) {
+        return script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd $vmid"));
+    }
 }
 
 sub esxi_vm_network_binding {
     my $vmid = shift;
-    my $vim_cmd = "vim-cmd vmsvc/get.environment $vmid | grep vswitch | sed -n 1p | cut -d'\"' -f2";
-    my (undef, $vswitch) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
+    my $vim_cmd = qq(vim-cmd vmsvc/get.environment $vmid | grep vswitch | sed -n 1p | cut -d'\\"' -f2);
+    my $vswitch;
+    if (is_svirt) {
+        (undef, $vswitch) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
+    }
+    elsif (is_qemu) {
+        $vswitch = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd"));
+    }
     return $vswitch;
 }
 
 sub esxi_vm_public_ip {
     my $vmid = shift;
-    my $vim_cmd = "vim-cmd vmsvc/get.guest $vmid | grep ipAddress | sed -n 1p | cut -d'\"' -f2";
-    my (undef, $vm_ip) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
+    my $vim_cmd = qq(vim-cmd vmsvc/get.guest $vmid | grep ipAddress | sed -n 1p | cut -d'\\"' -f2);
+    my $vm_ip;
+    if (is_svirt) {
+        (undef, $vm_ip) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
+    }
+    elsif (is_qemu) {
+        $vm_ip = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd"));
+    }
     return $vm_ip;
 }
 
 sub get_host_timestamp {
     my $date_cmd = shift // "date -u +'\%F \%T'";    # Default to get UTC time
-    my (undef, $host_time) = console('svirt')->run_cmd($date_cmd, domain => 'sshVMwareServer', wantarray => 1);
+    my $host_time;
+    if (is_svirt) {
+        (undef, $host_time) = console('svirt')->run_cmd($date_cmd, domain => 'sshVMwareServer', wantarray => 1);
+    }
+    elsif (is_qemu) {
+        $host_time = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$date_cmd"));
+    }
     return $host_time;
 }
 
 sub disable_vm_time_synchronization {
     my $vm_name = shift;
-    my $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/openQA/$vm_name.vmx";
+    my $vmx_file;
 
     # Set all time synchronization properties to FALSE
-    console('svirt')->run_cmd("sed -ie 's/tools.syncTime.*/tools.syncTime=\"FALSE\"/' $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-    console('svirt')->run_cmd("echo time.synchronize.continue=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-    console('svirt')->run_cmd("echo time.synchronize.restore=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-    console('svirt')->run_cmd("echo time.synchronize.resume.disk=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-    console('svirt')->run_cmd("echo time.synchronize.shrink=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-    console('svirt')->run_cmd("echo time.synchronize.tools.startup=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-    console('svirt')->run_cmd("echo time.synchronize.resume.host=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+    if (is_svirt) {
+        $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/openQA/$vm_name.vmx";
+        console('svirt')->run_cmd("sed -ie 's/tools.syncTime.*/tools.syncTime=\"FALSE\"/' $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+        console('svirt')->run_cmd("echo time.synchronize.continue=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+        console('svirt')->run_cmd("echo time.synchronize.restore=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+        console('svirt')->run_cmd("echo time.synchronize.resume.disk=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+        console('svirt')->run_cmd("echo time.synchronize.shrink=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+        console('svirt')->run_cmd("echo time.synchronize.tools.startup=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+        console('svirt')->run_cmd("echo time.synchronize.resume.host=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+    }
+    elsif (is_qemu) {
+        $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/$vm_name/$vm_name.vmx";
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "sed -ie 's/tools.syncTime.*/tools.syncTime=\"FALSE\"/' $vmx_file"));
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.continue=\"FALSE\" >> $vmx_file"));
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.restore=\"FALSE\" >> $vmx_file"));
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.resume.disk=\"FALSE\" >> $vmx_file"));
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.shrink=\"FALSE\" >> $vmx_file"));
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.tools.startup=\"FALSE\" >> $vmx_file"));
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.resume.host=\"FALSE\" >> $vmx_file"));
+    }
+}
+
+sub revert_vm_timesync_setting {
+    my $vm_name = shift;
+    my $vmx_file;
+
+    # Remove time synchronization properties
+    if (is_svirt) {
+        $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/openQA/$vm_name.vmx";
+        console('svirt')->run_cmd("sed -i '/time.synchronize/d' $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
+    }
+    elsif (is_qemu) {
+        $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/$vm_name/$vm_name.vmx";
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "sed -i 's/tools.syncTime.*/tools.syncTime=\"FALSE\"/' $vmx_file"));
+        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "sed -i '/time.synchronize/d' $vmx_file"));
+    }
 }
 
 1;

--- a/schedule/virtualization/vmware_hyperv.yaml
+++ b/schedule/virtualization/vmware_hyperv.yaml
@@ -1,6 +1,6 @@
 name:           vmware_hyperv
 description:    >
-    Maintainer: pdostal@suse.cz
+    Maintainer: pdostal@suse.cz, nan.zhang@suse.com
     Testing Kernel on VMware / Hyper-V SLE hosts
 schedule:
     - support_server/login
@@ -10,9 +10,28 @@ schedule:
     - virtualization/universal/upgrade_guests
     - virtualization/universal/patch_guests
     - '{{open_vm_tools}}'
-
 conditional_schedule:
     open_vm_tools:
         REGRESSION:
             vmware:
+                - '{{product_version}}'
+    product_version:
+        VERSION:
+            12-SP2:
                 - virtualization/universal/open_vm_tools
+            12-SP3:
+                - virtualization/universal/open_vm_tools
+            12-SP4:
+                - virtualization/universal/open_vm_tools
+            12-SP5:
+                - virt_autotest/esxi_open_vm_tools
+            15-SP1:
+                - virtualization/universal/open_vm_tools
+            15-SP2:
+                - virtualization/universal/open_vm_tools
+            15-SP3:
+                - virtualization/universal/open_vm_tools
+            15-SP4:
+                - virt_autotest/esxi_open_vm_tools
+            15-SP5:
+                - virt_autotest/esxi_open_vm_tools

--- a/tests/virtualization/universal/ssh_hypervisor_init.pm
+++ b/tests/virtualization/universal/ssh_hypervisor_init.pm
@@ -20,6 +20,9 @@ sub run {
     select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
     my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
+    # Backup ssh key pairs
+    assert_script_run 'mkdir ~/backup && cp ~/.ssh/* ~/backup';
+
     # Remove old files
     assert_script_run 'rm ~/.ssh/* || true';
 
@@ -45,6 +48,9 @@ sub run {
     my ($sles_running_version, $sles_running_sp) = get_os_release();
     zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/SLE_" . $sles_running_version . "/SUSE:CA.repo", exitcode => [0, 4, 102, 103, 106]);
     zypper_call("in ca-certificates-suse", exitcode => [0, 102, 103, 106]);
+
+    # Revert ssh key pairs
+    assert_script_run 'rm -rf ~/.ssh/* && cp -f ~/backup/* ~/.ssh/';
 }
 
 sub test_flags {


### PR DESCRIPTION
1. Support qemu backend for MU incident tests.
2. Update ssh_hypervisor_init.pm to backup ssh keys for connecting vmware server.

- Related ticket: https://progress.opensuse.org/issues/103266
- Verification run: 
   sle12sp3 - https://openqa.suse.de/tests/10698228
   sle12sp4 - https://openqa.suse.de/tests/10698232
   sle12sp5 - https://openqa.suse.de/tests/10701678
   sle15sp1 - https://openqa.suse.de/tests/10698229
   sle15sp2 - https://openqa.suse.de/tests/10698219
   sle15sp3 - https://openqa.suse.de/tests/10698218
   sle15sp4 - https://openqa.suse.de/tests/10702262
   post_fail_hook - https://openqa.suse.de/tests/10715902#step/esxi_open_vm_tools/71