### PR TITLE
Ensure crypto checks are done on first boot

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2655,6 +2655,7 @@ sub load_system_prepare_tests {
     loadtest 'console/install_rt_kernel' if check_var('SLE_PRODUCT', 'SLERT');
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
     loadtest 'console/check_selinux_fails' if get_var('SELINUX');
+    loadtest 'security/cc/ensure_crypto_checks_enabled' if check_var('SYSTEM_ROLE', 'Common_Criteria');
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');

--- a/tests/security/cc/ensure_crypto_checks_enabled.pm
+++ b/tests/security/cc/ensure_crypto_checks_enabled.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: ensure crypto checks are done on boot for common criteria installations
+#
+# Maintainer: QE Security <none@suse.de>
+# Tags: poo#120894
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self, $run_args) = @_;
+    select_console 'root-console';
+    my $output = script_output "journalctl -u dracut-pre-pivot";
+    record_info $output;
+    die unless $output =~ /Checking integrity of kernel/m;
+    die unless $output =~ /All initrd crypto checks done/m;
+}
+
+1;


### PR DESCRIPTION
Check that common criteria installation has crypto checks done upon reboot

- Related ticket: https://progress.opensuse.org/issues/120894
- Verification runs: 
  - aarch64     https://openqa.suse.de/tests/10275694    
  - s390x       https://openqa.suse.de/tests/10275695  
  - x86_64      https://openqa.suse.de/tests/10275689 
  - x86_64@uefi https://openqa.suse.de/tests/10275696    
