### PR TITLE
[virtualization] Fix feature test warnings and enable core feature tests in ALP

### DIFF
--- a/data/virt_autotest/clean_up_virt_logs.sh
+++ b/data/virt_autotest/clean_up_virt_logs.sh
@@ -108,9 +108,9 @@ function do_cleanup_on_host() {
 
 #Just power on or reboot active guests to give them a clear start
 function do_cleanup_on_guests() {
-	local guest_domain_types="sles"
-	local guests_inactive_array=`virsh list --inactive | grep -E "${guest_domain_types}" | awk '{print $2}'`
-	local guest_domains_array=`virsh list  --all | grep -E "${guest_domain_types}" | awk '{print $2}'`
+	local guest_domain_types="sles|alp"
+	local guests_inactive_array=`virsh list --inactive | grep -Ei "${guest_domain_types}" | awk '{print $2}'`
+	local guest_domains_array=`virsh list  --all | grep -Ei "${guest_domain_types}" | awk '{print $2}'`
 	local guest_current=""
 	local ret_result=0
 

--- a/data/virt_autotest/guest_params_xml_files/alp_kvm_hvm_x86_64_uefi_imported_disk_vnet.xml
+++ b/data/virt_autotest/guest_params_xml_files/alp_kvm_hvm_x86_64_uefi_imported_disk_vnet.xml
@@ -17,6 +17,7 @@
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
     <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata></guest_metadata>
+    <guest_boot_settings>uefi</guest_boot_settings>
     <guest_xpath></guest_xpath>
     <guest_installation_automation></guest_installation_automation>
     <guest_installation_automation_file></guest_installation_automation_file>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64_vnet.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64_vnet.xml
@@ -1,46 +1,49 @@
 <?xml version="1.0"?>
 <guest>
-    <guest_os_name>alp</guest_os_name>
-    <guest_version>0.1</guest_version>
-    <guest_version_major>0</guest_version_major>
-    <guest_version_minor>1</guest_version_minor>
+    <guest_os_name>sles</guest_os_name>
+    <guest_version>15-sp4</guest_version>
+    <guest_version_major>15</guest_version_major>
+    <guest_version_minor>4</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build></guest_build>
+    <guest_build>gm</guest_build>
     <host_hypervisor_uri></host_hypervisor_uri>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
-    <guest_machine_type>q35</guest_machine_type>
+    <guest_machine_type></guest_machine_type>
     <guest_arch>x86_64</guest_arch>
     <guest_name></guest_name>
     <guest_domain_name></guest_domain_name>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>host-model</guest_cpumodel>
+    <guest_cpumodel></guest_cpumodel>
     <guest_metadata></guest_metadata>
-    <guest_xpath></guest_xpath>
-    <guest_installation_automation></guest_installation_automation>
-    <guest_installation_automation_file></guest_installation_automation_file>
-    <guest_installation_method>import</guest_installation_method>
-    <guest_installation_extra_args></guest_installation_extra_args>
+    <guest_boot_settings>uefi</guest_boot_settings>
+    <guest_secure_boot>true</guest_secure_boot>
+    <guest_power_management>suspend_to_mem.enabled=yes,suspend_to_disk.enabled=yes</guest_power_management>
+    <guest_xpath>./os/boot[@dev='hd']/@order=1#./os/boot[@dev='network']/@order=2</guest_xpath>
+    <guest_installation_automation>autoyast</guest_installation_automation>
+    <guest_installation_automation_file>sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml</guest_installation_automation_file>
+    <guest_installation_method>location</guest_installation_method>
+    <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media></guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1/</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
-    <guest_os_variant>opensusetumbleweed</guest_os_variant>
+    <guest_os_variant></guest_os_variant>
     <guest_storage_path></guest_storage_path>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>
     <guest_storage_label>gpt</guest_storage_label>
-    <guest_storage_size>40</guest_storage_size>
-    <guest_storage_others>backing_store=/var/lib/libvirt/images/ALP-VM.x86_64-0.0.1-kvm-back.qcow2,backing_format=qcow2,bus=virtio,cache=none</guest_storage_others>
+    <guest_storage_size></guest_storage_size>
+    <guest_storage_others></guest_storage_others>
     <guest_network_type>virtual_network</guest_network_type>
     <guest_network_device>br123</guest_network_device>
     <guest_network_others></guest_network_others>
     <guest_netaddr>192.168.123.0/24</guest_netaddr>
     <guest_ipaddr></guest_ipaddr>
     <guest_ipaddr_static>false</guest_ipaddr_static>
-    <guest_macaddr></guest_macaddr>
     <guest_virtual_network>test-virt-net</guest_virtual_network>
+    <guest_macaddr></guest_macaddr> 
     <guest_graphics>vnc</guest_graphics>
     <guest_controller></guest_controller>
     <guest_input></guest_input>
@@ -71,22 +74,21 @@
     <guest_memorybacking></guest_memorybacking>
     <guest_features></guest_features>
     <guest_clock></guest_clock>
-    <guest_power_management></guest_power_management>
     <guest_events></guest_events>
     <guest_resource></guest_resource>
-    <guest_sysinfo>type=fwcfg,entry0.name="opt/com.coreos/config",entry0.file="/var/lib/libvirt/images/VIRT_TEST_VM_config.ign"</guest_sysinfo>
+    <guest_sysinfo></guest_sysinfo>
     <guest_qemu_command></guest_qemu_command>
     <guest_launchSecurity></guest_launchSecurity>
     <guest_autostart></guest_autostart>
     <guest_transient></guest_transient>
     <guest_destroy_on_exit></guest_destroy_on_exit>
-    <guest_autoconsole></guest_autoconsole>
-    <guest_noautoconsole>false</guest_noautoconsole>
+    <guest_autoconsole>text</guest_autoconsole>
     <guest_noreboot></guest_noreboot>
     <guest_default_target>graphical</guest_default_target>
-    <guest_do_registration>false</guest_do_registration>
+    <guest_do_registration>true</guest_do_registration>
     <guest_registration_server></guest_registration_server>
-    <guest_registration_username></guest_registration_username>
+    <guest_registration_username>www@suse.com</guest_registration_username>
     <guest_registration_password></guest_registration_password>
-    <guest_registration_extensions></guest_registration_extensions>
+    <guest_registration_extensions>sle-module-legacy#sle-module-basesystem#sle-module-server-applications#sle-module-desktop-applications#sle-module-web-scripting</guest_registration_extensions>
 </guest>
+

--- a/data/virt_autotest/guest_unattended_installation_files/VIRT_TEST_VM_config.ign
+++ b/data/virt_autotest/guest_unattended_installation_files/VIRT_TEST_VM_config.ign
@@ -19,7 +19,16 @@
         "contents": {
           "source": "data:text/plain;charset=utf-8;base64,UGVybWl0Um9vdExvZ2luIHllcwpQdWJrZXlBdXRoZW50aWNhdGlvbiB5ZXMKUGFzc3dvcmRBdXRoZW50aWNhdGlvbiB5ZXM="
         }
+      },
+      {
+        "path": "/etc/selinux/config",
+        "mode": 420,
+        "overwrite": true,
+        "contents": {
+          "source": "data:text/plain;charset=utf-8;base64,"
+        }
       }
     ]
   }
 }
+

--- a/lib/alp_workloads/kvm_workload_utils.pm
+++ b/lib/alp_workloads/kvm_workload_utils.pm
@@ -91,7 +91,8 @@ sub config_host_and_kvm_container {
 }
 
 sub cleanup_host_and_kvm_container {
-    assert_script_run("if $ct_engine ps | grep libvirtd; then kvm-container-manage.sh stop;fi");
+    script_run("if $ct_engine ps | grep libvirtd; then kvm-container-manage.sh stop;fi");
+    validate_script_output("$ct_engine ps", sub { $_ !~ 'libvirtd' });
     assert_script_run("if $ct_engine ps --all | grep libvirtd; then kvm-container-manage.sh rm;fi");
     assert_script_run("if which kvm-container-manage.sh;then kvm-container-manage.sh uninstall;fi");
     validate_script_output("$ct_engine ps --all", sub { $_ !~ 'libvirtd' });
@@ -135,7 +136,7 @@ sub install_tools_within_kvm_container {
     my $_tools_to_install = shift;
 
     # The packages needed by guest installation and following tests`
-    $_tools_to_install //= "wget screen xmlstarlet yast2-schema python3 nmap openssh hostname gawk expect supportutils systemd-coredump";
+    $_tools_to_install //= "wget screen xmlstarlet yast2-schema python3 nmap openssh hostname gawk expect supportutils systemd-coredump util-linux-systemd file iputils";
 
     assert_script_run("clear");
     assert_screen('in-libvirtd-container-bash');

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -530,7 +530,6 @@ sub set_grub_terminal_and_timeout {
 }
 
 sub reconnect_when_ssh_console_broken {
-
     # Switch to sol console to check serial console output
     # It is useful in the case of host crash and reboot
     record_info("WARN", "ssh connection is broken and switch to SOL console", result => 'fail');

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -165,7 +165,7 @@ sub check_host_health {
 # Welcome everybody to extend this function
 sub check_guest_health {
     my $vm = shift;
-    return unless is_x86_64 and guest_is_sle($vm);
+    return unless is_x86_64 and ($vm =~ /sle|alp/i);
 
     #check if guest is still alive
     validate_script_output "virsh domstate $vm", sub { /running/ };

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -24,9 +24,7 @@ use utils 'script_retry';
 use upload_system_log 'upload_supportconfig_log';
 use proxymode;
 use version_utils qw(is_sle is_alp);
-use virt_autotest_base;
 use virt_autotest::utils;
-use virt_utils;
 
 our @EXPORT
   = qw(download_network_cfg prepare_network restore_standalone destroy_standalone restart_network
@@ -299,10 +297,10 @@ sub enable_libvirt_log {
 
 sub upload_debug_log {
     script_run("dmesg > /tmp/dmesg.log");
-    virt_autotest_base::upload_virt_logs("/tmp/dmesg.log /var/log/libvirt /var/log/messages", "libvirt-virtual-network-debug-logs");
+    upload_virt_logs("/tmp/dmesg.log /var/log/libvirt /var/log/messages", "libvirt-virtual-network-debug-logs");
     if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
         script_run("xl dmesg > /tmp/xl-dmesg.log");
-        virt_autotest_base::upload_virt_logs("/tmp/dmesg.log /var/log/libvirt /var/log/messages /var/log/xen /var/lib/xen/dump /tmp/xl-dmesg.log", "libvirt-virtual-network-debug-logs");
+        upload_virt_logs("/tmp/dmesg.log /var/log/libvirt /var/log/messages /var/log/xen /var/lib/xen/dump /tmp/xl-dmesg.log", "libvirt-virtual-network-debug-logs");
     }
     upload_system_log::upload_supportconfig_log();
     script_run("rm -rf scc_* nts_*");

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -5,7 +5,7 @@
 
 # Summary: virtual_network_utils:
 #          This file provides fundamental utilities for virtual network.
-# Maintainer: Leon Guo <xguo@suse.com>
+# Maintainer: Leon Guo <xguo@suse.com>, qe-virt@suse.de
 
 package virt_autotest::virtual_network_utils;
 
@@ -32,7 +32,7 @@ our @EXPORT
   = qw(download_network_cfg prepare_network restore_standalone destroy_standalone restart_network
   restore_guests restore_network destroy_vir_network restore_libvirt_default enable_libvirt_log pload_debug_log
   check_guest_status check_guest_module check_guest_ip save_guest_ip test_network_interface hosts_backup
-  hosts_restore get_free_mem get_active_pool_and_available_space clean_all_virt_networks setup_vm_simple_dns_with_ip);
+  hosts_restore get_free_mem get_active_pool_and_available_space clean_all_virt_networks setup_vm_simple_dns_with_ip get_guest_ip_from_vnet_with_mac update_simple_dns_for_all_vm);
 
 sub check_guest_ip {
     my ($guest, %args) = @_;
@@ -44,15 +44,28 @@ sub check_guest_ip {
 
     # ensure guest is still alive
     if (script_output("virsh domstate $guest") eq "running") {
-        script_run "sed -i '/ $guest /d' /etc/hosts";
         my $mac_guest = script_output("virsh domiflist $guest | grep $net | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"");
-        my $syslog_cmd = "journalctl --no-pager | grep DHCPACK";
-        script_retry "$syslog_cmd | grep $mac_guest | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", delay => 90, retry => 9, timeout => 90;
-        my $gi_guest = script_output("$syslog_cmd | grep $mac_guest | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"");
-        assert_script_run "echo '$gi_guest $guest # virtualization' >> /etc/hosts";
+        my $gi_guest = '';
+        if (is_alp) {
+            $gi_guest = get_guest_ip_from_vnet_with_mac($mac_guest, $net);
+        } else {
+            my $syslog_cmd = "journalctl --no-pager | grep DHCPACK";
+            script_retry "$syslog_cmd | grep $mac_guest | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", delay => 90, retry => 9, timeout => 90;
+            $gi_guest = script_output("$syslog_cmd | grep $mac_guest | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"");
+        }
+        setup_vm_simple_dns_with_ip($guest, $gi_guest);
         script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 60) if ($guest =~ m/sles-11/i);
         die "Ping $guest failed !" if (script_retry("ping -c5 $guest", delay => 30, retry => 6, timeout => 60) ne 0);
     }
+}
+
+sub get_guest_ip_from_vnet_with_mac {
+    my ($mac, $net) = @_;
+
+    my $cmd = "virsh net-dhcp-leases $net | sed  '1,2d' | grep '$mac'";
+    script_retry($cmd, delay => 3, retry => 20);
+    $cmd .= " | gawk '{print \$5 }' | sed -r 's/\\\/[0-9]+//'";
+    return script_output($cmd);
 }
 
 sub check_guest_module {
@@ -75,13 +88,17 @@ sub save_guest_ip {
 
     # If we don't know guest's address or the address is wrong so the guest is not responding to ICMP
     if (script_run("grep $guest /etc/hosts") != 0 || script_retry("ping -c3 $guest", delay => 6, retry => 30, die => 0) != 0) {
-        script_run "sed -i '/ $guest /d' /etc/hosts";
         assert_script_run "virsh domiflist $guest";
         my $mac_guest = script_output("virsh domiflist $guest | grep $name | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"");
-        my $syslog_cmd = is_sle('=11-sp4') ? 'grep DHCPACK /var/log/messages' : 'journalctl --no-pager | grep DHCPACK';
-        script_retry "$syslog_cmd | grep $mac_guest | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", delay => 90, retry => 9, timeout => 90;
-        my $gi_guest = script_output("$syslog_cmd | grep $mac_guest | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"");
-        assert_script_run "echo '$gi_guest $guest # virtualization' >> /etc/hosts";
+        my $gi_guest = '';
+        if (is_alp) {
+            $gi_guest = get_guest_ip_from_vnet_with_mac($mac_guest, $name);
+        } else {
+            my $syslog_cmd = is_sle('=11-sp4') ? 'grep DHCPACK /var/log/messages' : 'journalctl --no-pager | grep DHCPACK';
+            script_retry "$syslog_cmd | grep $mac_guest | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", delay => 90, retry => 9, timeout => 90;
+            $gi_guest = script_output("$syslog_cmd | grep $mac_guest | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"");
+        }
+        setup_vm_simple_dns_with_ip($guest, $gi_guest);
         script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 60) if ($guest =~ m/sles-11/i);
         die "Ping $guest failed !" if (script_retry("ping -c5 $guest", delay => 30, retry => 6, timeout => 60) ne 0);
     }
@@ -96,7 +113,7 @@ sub test_network_interface {
     my $routed = $args{routed} // 0;
     my $target = $args{target} // script_output("dig +short openqa.suse.de");
 
-    check_guest_ip("$guest") if (is_sle('>15') && ($isolated == 1) && get_var('VIRT_AUTOTEST'));
+    check_guest_ip("$guest", net => $net) if ((is_sle('>15') || is_alp) && ($isolated == 1) && get_var('VIRT_AUTOTEST'));
 
     save_guest_ip("$guest", name => $net);
 
@@ -246,7 +263,7 @@ sub restart_network {
 
 sub restore_guests {
     return if get_var('INCIDENT_ID');    # QAM does not recreate guests every time
-    my $get_vm_hostnames = "virsh list --all | grep -e sles -e opensuse | awk \'{print \$2}\'";
+    my $get_vm_hostnames = "virsh list --all | grep -e sles -e opensuse -e alp -i | awk \'{print \$2}\'";
     my $vm_hostnames = script_output($get_vm_hostnames, 30, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
     foreach (@vm_hostnames_array)
@@ -293,8 +310,8 @@ sub upload_debug_log {
 
 sub check_guest_status {
     my $wait_script = "30";
-    my $vm_types = "sles";
-    my $get_vm_hostnames = "virsh list  --all | grep $vm_types | awk \'{print \$2}\'";
+    my $vm_types = "sles|alp";
+    my $get_vm_hostnames = "virsh list  --all | grep -E \"$vm_types\" -i | awk \'{print \$2}\'";
     my $vm_hostnames = script_output($get_vm_hostnames, $wait_script, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
     foreach (@vm_hostnames_array) {
@@ -323,7 +340,12 @@ sub get_active_pool_and_available_space {
     # get some debug info about storage pool
     script_run 'virsh pool-list --details';
     # ensure the available disk space size for active pool
-    my $active_pool = script_output("virsh pool-list --persistent | grep -iv nvram | grep active | awk '{print \$1}'");
+    my $active_pool = '';
+    if (is_alp) {
+        $active_pool = script_output("virsh pool-list | grep -ivE \"nvram|boot\" | grep active | awk '{print \$1}'");
+    } else {
+        $active_pool = script_output("virsh pool-list --persistent | grep -iv nvram | grep active | awk '{print \$1}'");
+    }
     my $available_size = script_output("virsh pool-info $active_pool | grep ^Available | awk '{print \$2}'");
     my $pool_unit = script_output("virsh pool-info $active_pool | grep ^Available | awk '{print \$3}'");
     # default available pool unit as GiB
@@ -360,6 +382,14 @@ sub setup_vm_simple_dns_with_ip {
     assert_script_run "cp $_dns_file /etc/hosts" if (is_alp);
     save_screenshot;
     record_info("Simple DNS setup in /etc/hosts for $_ip $_vm is successful!", script_output("cat /etc/hosts"));
+}
+
+sub update_simple_dns_for_all_vm {
+    my $_vnet = shift;
+
+    my $_cmd = "virsh list --all | grep -e sles -e opensuse -e alp -i | awk \'{print \$2}\'";
+    my $_vms = script_output($_cmd, 30, type_command => 0, proceed_on_failure => 0);
+    check_guest_ip("$_", net => $_vnet) foreach (split(/\n+/, $_vms));
 }
 
 1;

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -22,7 +22,6 @@ use XML::Writer;
 use IO::File;
 use utils 'script_retry';
 use upload_system_log 'upload_supportconfig_log';
-use proxymode;
 use version_utils qw(is_sle is_alp);
 use virt_autotest::utils;
 

--- a/lib/virt_autotest/virtual_storage_utils.pm
+++ b/lib/virt_autotest/virtual_storage_utils.pm
@@ -20,7 +20,6 @@ use testapi;
 use Data::Dumper;
 use XML::Writer;
 use IO::File;
-use proxymode;
 use version_utils 'is_sle';
 use virt_autotest::utils;
 use virt_utils;

--- a/lib/virt_autotest/virtual_storage_utils.pm
+++ b/lib/virt_autotest/virtual_storage_utils.pm
@@ -22,7 +22,6 @@ use XML::Writer;
 use IO::File;
 use proxymode;
 use version_utils 'is_sle';
-use virt_autotest_base;
 use virt_autotest::utils;
 use virt_utils;
 

--- a/schedule/virt_autotest/alp-virt-core-tests.yaml
+++ b/schedule/virt_autotest/alp-virt-core-tests.yaml
@@ -6,10 +6,51 @@ schedule:
     - virt_autotest/login_console
     - virt_autotest/setup_kvm_container
     - "{{install_guest}}"
+    - virt_autotest/set_config_as_glue
+    - '{{uefi_guest_verification}}'
+    - '{{virtual_network_test}}'
+    - '{{hotplugging_test}}'
+    - '{{storage_test}}'
+    - '{{snapshot_test}}'
+    - '{{validate_system_health}}'
 conditional_schedule:
     install_guest:
         SKIP_GUEST_INSTALL:
             0:
                 - virt_autotest/unified_guest_installation
+    uefi_guest_verification:
+        VIRT_UEFI_GUEST_INSTALL:
+            1:
+                - virt_autotest/uefi_guest_verification
+    virtual_network_test:
+        ENABLE_VIR_NET:
+            1:
+                - virt_autotest/libvirt_virtual_network_init
+                - virt_autotest/libvirt_nated_virtual_network
+                - virt_autotest/libvirt_routed_virtual_network
+                - virt_autotest/libvirt_isolated_virtual_network
+    hotplugging_test:
+        ENABLE_HOTPLUGGING:
+            1:
+                - virtualization/universal/hotplugging_guest_preparation
+                - virtualization/universal/hotplugging_network_interfaces
+                - virtualization/universal/hotplugging_HDD
+                - virtualization/universal/hotplugging_vCPUs
+                - virtualization/universal/hotplugging_memory
+                - virtualization/universal/hotplugging_cleanup
+    storage_test:
+        ENABLE_STORAGE:
+            1:
+                - virtualization/universal/storage
+    snapshot_test:
+        ENABLE_SNAPSHOT:
+            1:
+                - virt_autotest/virsh_internal_snapshot
+                - virt_autotest/virsh_external_snapshot
+    validate_system_health:
+        VALIDATE_SYSTEM_HEALTH:
+            1:
+                - virt_autotest/validate_system_health
+
 
 # To be extended

--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -14,7 +14,7 @@ use testapi;
 use lockapi;
 use mmapi;
 use upload_system_log 'upload_supportconfig_log';
-use virt_autotest::utils qw(is_xen_host is_kvm_host);
+use virt_autotest::utils qw(is_xen_host is_kvm_host upload_virt_logs);
 use version_utils 'is_sle';
 
 sub run {
@@ -48,7 +48,7 @@ sub run {
         upload_logs "var_log_xen.tar.gz";
     }
     my $logs = "/var/log/libvirt /var/log/messages $xen_logs";
-    virt_autotest_base::upload_virt_logs($logs, "guest-migration-dst-logs");
+    upload_virt_logs($logs, "guest-migration-dst-logs");
     upload_system_log::upload_supportconfig_log();
     script_run("rm -rf scc_* nts_*");
     save_screenshot;

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -11,7 +11,6 @@
 
 use base "virt_feature_test_base";
 use virt_utils;
-use set_config_as_glue;
 use virt_autotest::virtual_network_utils;
 use virt_autotest::utils;
 use strict;

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -11,7 +11,6 @@
 
 use base "virt_feature_test_base";
 use virt_utils;
-use set_config_as_glue;
 use virt_autotest::virtual_network_utils;
 use virt_autotest::utils;
 use strict;

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_alp);
 
 sub run_test {
     my ($self) = @_;
@@ -26,7 +26,7 @@ sub run_test {
     my $vnet_nated_cfg_name = "vnet_nated.xml";
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_nated_cfg_name);
 
-    die "The default(NAT BASED NETWORK) virtual network does not exist" if (script_run('virsh net-list --all | grep default') != 0);
+    die "The default(NAT BASED NETWORK) virtual network does not exist" if (script_run('virsh net-list --all | grep default') != 0 && !is_alp);
 
     #Create NAT BASED NETWORK
     assert_script_run("virsh net-create vnet_nated.xml");

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -11,7 +11,6 @@
 
 use base "virt_feature_test_base";
 use virt_utils;
-use set_config_as_glue;
 use virt_autotest::virtual_network_utils;
 use virt_autotest::utils;
 use strict;

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -16,7 +16,6 @@ use virt_autotest::virtual_network_utils;
 use virt_autotest::utils;
 use base "virt_feature_test_base";
 use virt_utils;
-use set_config_as_glue;
 use strict;
 use warnings;
 use testapi;

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_alp);
 use virt_autotest::utils qw(is_xen_host);
 
 sub run_test {
@@ -42,15 +42,18 @@ sub run_test {
     assert_script_run("test $AVAILABLE_POOL_SIZE -ge $expected_pool_size",
         fail_message => "The SUT needs at least " . $expected_pool_size . "GiB available space of active pool for virtual network test");
 
-    #Need to reset up environemt - br123 for virt_atuo test due to after
-    #finished guest installation to trigger cleanup step on sles11sp4 vm hosts
-    virt_autotest::virtual_network_utils::restore_standalone() if (is_sle('=11-sp4'));
+    # ALP has done this in earlier setup
+    unless (is_alp) {
+        #Need to reset up environemt - br123 for virt_atuo test due to after
+        #finished guest installation to trigger cleanup step on sles11sp4 vm hosts
+        virt_autotest::virtual_network_utils::restore_standalone() if (is_sle('=11-sp4'));
 
-    #Enable libvirt debug log
-    virt_autotest::virtual_network_utils::enable_libvirt_log();
+        #Enable libvirt debug log
+        virt_autotest::virtual_network_utils::enable_libvirt_log();
 
-    #VM HOST SSH SETUP
-    virt_autotest::utils::ssh_setup();
+        #VM HOST SSH SETUP
+        virt_autotest::utils::ssh_setup();
+    }
 
     #Backup file /etc/hosts before virtual network testing
     virt_autotest::virtual_network_utils::hosts_backup();
@@ -71,6 +74,9 @@ sub run_test {
         save_guest_ip($guest, name => "br123");
         virt_autotest::utils::ssh_copy_id($guest);
         check_guest_health($guest);
+
+        # ALP guest uses networkmanager to control network, no /etc/sysconfig/network/ifcfg*
+        next if ($guest =~ /alp/i);
         #Prepare the new guest network interface files for libvirt virtual network
         #for some guests, interfaces are named eth0, eth1, eth2, ...
         #for TW kvm guest, they are enp1s0, enp2s0, enp3s0, ...

--- a/tests/virt_autotest/set_config_as_glue.pm
+++ b/tests/virt_autotest/set_config_as_glue.pm
@@ -16,8 +16,8 @@ use testapi;
 
 sub fufill_guests_in_setting {
     my $wait_script = "30";
-    my $vm_types = "sles|win|opensuse|oracle";
-    my $get_vm_hostnames = "virsh list --all | grep -E \"${vm_types}\" | awk \'{print \$2}\'";
+    my $vm_types = "sles|win|opensuse|alp|oracle";
+    my $get_vm_hostnames = "virsh list --all | grep -Ei \"${vm_types}\" | awk \'{print \$2}\'";
     my $vm_hostnames = script_output($get_vm_hostnames, $wait_script, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
     foreach (@vm_hostnames_array) {

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -27,7 +27,6 @@ use virt_autotest::common;
 use version_utils qw(is_sle);
 use virt_autotest::utils;
 use virt_autotest::virtual_network_utils qw(save_guest_ip test_network_interface);
-use virt_utils qw(upload_virt_logs);
 
 sub run_test {
     my $self = shift;
@@ -146,7 +145,7 @@ sub run_test {
     }
 
     #upload network device related logs
-    upload_virt_logs($log_dir, "logs");
+    virt_autotest::utils::upload_virt_logs($log_dir, "logs");
 
     #redefine guest from their original configuration files
     restore_original_guests();
@@ -417,7 +416,7 @@ sub post_fail_hook {
         save_network_device_status_logs($log_dir, $_, "post_fail_hook");
         script_run("ssh root\@$_ 'dmesg' >> $log_dir/dmesg_$_ 2>&1", die_on_timeout => 0);
     }
-    upload_virt_logs($log_dir, "network_device_status");
+    virt_autotest::utils::upload_virt_logs($log_dir, "network_device_status");
     $self->SUPER::post_fail_hook;
     restore_original_guests();
 

--- a/tests/virt_autotest/uefi_guest_verification.pm
+++ b/tests/virt_autotest/uefi_guest_verification.pm
@@ -22,7 +22,7 @@ use utils;
 use virt_utils;
 use virt_autotest::common;
 use virt_autotest::utils;
-use version_utils "is_sle";
+use version_utils qw(is_sle is_alp);
 
 sub run_test {
     my $self = shift;
@@ -30,13 +30,22 @@ sub run_test {
     $self->check_guest_bootloader($_) foreach (keys %virt_autotest::common::guests);
     $self->check_guest_bootcurrent($_) foreach (keys %virt_autotest::common::guests);
     if (is_kvm_host) {
-        record_soft_failure("In order to implement pm features, current kvm virtual machine uses uefi firmware that does not support PXE/HTTP boot and secureboot. bsc#1182886 UEFI virtual machine boots with trouble");
+        if (is_sle) {
+            record_soft_failure("In order to implement pm features, current kvm virtual machine uses uefi firmware that does not support PXE/HTTP boot and secureboot. bsc#1182886 UEFI virtual machine boots with trouble");
+        }
+        elsif (is_alp) {
+            # The current default uefi firmware in alp kvm container supports secure boot,
+            # but does not support PXE/HTTP boot, and pm is not well supported either.
+            $self->check_guest_secure_boot($_) foreach (keys %virt_autotest::common::guests);
+        }
         #$self->check_guest_uefi_boot($_) foreach (keys %virt_autotest::common::guests);
-        #$self->check_guest_secure_boot($_) foreach (keys %virt_autotest::common::guests);
+
     }
     else {
         record_soft_failure("UEFI implementation for xen fullvirt uefi virtual machine is incomplete. bsc#1184936 Xen fullvirt lacks of complete support for UEFI");
     }
+
+    # TODO: enable pm check for alp once default uefi firmware supports it well
     if (is_sle('>=15')) {
         $self->check_guest_pmsuspend_enabled;
     }

--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -21,7 +21,6 @@ sub run_test {
     #Snapshots are supported on KVM VM Host Servers only
     return unless is_kvm_host;
 
-    my $vm_types = "sles|win";
     my $wait_script = "30";
     my $vm_hostnames = script_output("virsh list --all --name", $wait_script, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);

--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -11,7 +11,6 @@ use base "virt_feature_test_base";
 use strict;
 use warnings;
 use testapi;
-use set_config_as_glue;
 use utils;
 use virt_utils;
 use virt_autotest::common;

--- a/tests/virt_autotest/virsh_internal_snapshot.pm
+++ b/tests/virt_autotest/virsh_internal_snapshot.pm
@@ -25,6 +25,11 @@ sub run_test {
             record_info "Skip internal snapshot on $guest", "SEV/SEV-ES guest $guest does not support internal snapshot";
             next;
         }
+        if (script_output("virsh dumpxml $guest | xmlstarlet sel -t -v ///loader/\@type", proceed_on_failure => 1) eq 'pflash') {
+            record_info("Skip internal snapshot on $guest", "VM with pflash based firmware are not supported to make internal snapshots.");
+            next;
+        }
+
         my $type = check_guest_disk_type($guest);
         next if ($type == 1);
         record_info "virsh-snapshot", "Cleaning in case of rerun";

--- a/tests/virt_autotest/virsh_internal_snapshot.pm
+++ b/tests/virt_autotest/virsh_internal_snapshot.pm
@@ -10,7 +10,6 @@ use base "virt_feature_test_base";
 use strict;
 use warnings;
 use testapi;
-use set_config_as_glue;
 use utils;
 use virt_utils;
 use virt_autotest::common;

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -19,6 +19,7 @@ use virt_utils;
 use Utils::Architectures;
 use virt_autotest::utils;
 use upload_system_log;
+use virt_autotest::utils qw(upload_virt_logs);
 
 sub analyzeResult {
     die "You need to overload analyzeResult in your class";

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -21,7 +21,6 @@ use XML::Writer;
 use IO::File;
 use List::Util 'first';
 use LWP::Simple 'head';
-use proxymode;
 use version_utils 'is_sle';
 use virt_autotest::utils;
 use version_utils qw(is_sle is_alp get_os_release);

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -27,7 +27,7 @@ use virt_autotest::utils;
 use version_utils qw(is_sle is_alp get_os_release);
 
 our @EXPORT
-  = qw(enable_debug_logging update_guest_configurations_with_daily_build locate_sourcefile get_repo_0_prefix repl_repo_in_sourcefile repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk get_guest_list download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type recreate_guests perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles is_registered_sles);
+  = qw(enable_debug_logging update_guest_configurations_with_daily_build locate_sourcefile get_repo_0_prefix repl_repo_in_sourcefile repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk get_guest_list download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles is_registered_sles);
 
 sub enable_debug_logging {
 
@@ -294,16 +294,6 @@ sub lpar_cmd {
         record_info('INFO', "Command $cmd run on S390X LPAR: FAIL");
         die 'Find new failure, please check manually';
     }
-}
-
-sub upload_virt_logs {
-    my ($log_dir, $compressed_log_name) = @_;
-
-    my $full_compressed_log_name = "/tmp/$compressed_log_name.tar.gz";
-    script_run("tar -czf $full_compressed_log_name $log_dir; rm $log_dir -r", 60);
-    save_screenshot;
-    upload_logs "$full_compressed_log_name";
-    save_screenshot;
 }
 
 # Guest xml will be uploaded with name format [generated_name_by_this_func].xml
@@ -612,22 +602,6 @@ sub check_guest_disk_type {
             record_info "INFO", "Start Snapshot test with the guest disk type as $guest_disk_type";
             return 0;
         }
-    }
-}
-
-#recreate all defined guests
-sub recreate_guests {
-    my $based_guest_dir = shift;
-    return if get_var('INCIDENT_ID');    # QAM does not recreate guests every time
-    my $get_vm_hostnames = "virsh list  --all | grep -e sles -e opensuse | awk \'{print \$2}\'";
-    my $vm_hostnames = script_output($get_vm_hostnames, 30, type_command => 0, proceed_on_failure => 0);
-    my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
-    foreach (@vm_hostnames_array)
-    {
-        script_run("virsh destroy $_");
-        script_run("virsh undefine $_ || virsh undefine $_ --keep-nvram");
-        script_run("virsh define /$based_guest_dir/$_.xml");
-        script_run("virsh start $_");
     }
 }
 

--- a/tests/virt_autotest/virt_v2v_src.pm
+++ b/tests/virt_autotest/virt_v2v_src.pm
@@ -14,6 +14,7 @@ use testapi;
 use lockapi;
 use mmapi;
 use virt_utils;
+use virt_autotest::utils qw(upload_virt_logs);
 
 sub run {
     my ($self) = @_;
@@ -31,7 +32,7 @@ sub run {
     wait_for_children;
 
     script_run("xl dmesg > /tmp/xl-dmesg.log");
-    virt_utils::upload_virt_logs("/var/log/libvirt /var/log/messages /var/log/xen /var/lib/xen/dump /tmp/xl-dmesg.log", "virt-v2v-xen-src-logs");
+    upload_virt_logs("/var/log/libvirt /var/log/messages /var/log/xen /var/lib/xen/dump /tmp/xl-dmesg.log", "virt-v2v-xen-src-logs");
 }
 
 1;

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -14,8 +14,7 @@ use utils 'script_retry';
 use version_utils qw(is_sle);
 use set_config_as_glue;
 use virt_autotest::common;
-use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute remove_vm save_original_guest_xmls restore_downloaded_guests restore_original_guests);
-use virt_utils qw(upload_virt_logs);
+use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute remove_vm save_original_guest_xmls restore_downloaded_guests restore_original_guests upload_virt_logs);
 
 our $vm_xml_save_dir = "/tmp/download_vm_xml";
 

--- a/tests/virtualization/universal/hotplugging_guest_preparation.pm
+++ b/tests/virtualization/universal/hotplugging_guest_preparation.pm
@@ -15,8 +15,9 @@ use warnings;
 use testapi;
 use utils;
 use virt_utils;
-use version_utils;
+use version_utils qw(is_alp get_os_release);
 use hotplugging_utils;
+use virt_autotest::virtual_network_utils qw(update_simple_dns_for_all_vm);
 
 # Magic MAC prefix for temporary devices. Must be of the format 'XX:XX:XX:XX'
 my $MAC_PREFIX = '00:16:3f:32';
@@ -25,6 +26,7 @@ sub run_test {
     my ($self) = @_;
     my ($sles_running_version, $sles_running_sp) = get_os_release;
 
+    # Update dns records if needed
     if ($sles_running_version eq '15' && get_var("VIRT_AUTOTEST") && !get_var("VIRT_UNIFIED_GUEST_INSTALL")) {
         record_info("DNS Setup", "SLE 15+ host may have more strict rules on dhcp assigned ip conflict prevention, so guest ip may change");
         my $dns_bash_script_url = data_url("virt_autotest/setup_dns_service.sh");
@@ -32,6 +34,8 @@ sub run_test {
         script_output("chmod +x ~/setup_dns_service.sh && ~/setup_dns_service.sh -f testvirt.net -r 123.168.192 -s 192.168.123.1", 180, type_command => 0, proceed_on_failure => 0);
         upload_logs("/var/log/virt_dns_setup.log");
         save_screenshot;
+    } elsif (is_alp) {
+        update_simple_dns_for_all_vm('test-virt-net');
     }
 
     # Guest preparation


### PR DESCRIPTION
This PR mainly does:
- fix feature test warnings in https://progress.opensuse.org/issues/120750#note-24
- move 2 functions recreate_guests and upload_virt_logs from tests/virt_autotest/ to lib/virt_autotest, so that library files under lib can call the functions freely
- reconnect for ALP when ssh connection is broken
- add selinux config to ignition config file for alp guest (new feature in December prototype)
- all needed code adaptions to enable the core feature tests on alp, which include
    - Hotplugging(vcpu, mem, disk)
    - Snapshot (internal, external)
    - Virtual network management(nat, routed, isolated)
    - Storage management
    - UEFI and secure boot

- Related ticket: 
    - https://progress.opensuse.org/issues/118942 
    - https://progress.opensuse.org/issues/120750#note-24
- Needles: no


- Verification run: 

```
- alp-uefi-virt-core-tests:
PASS: http://10.67.129.185/tests/496#
FAIL(post_fail_hook check only, works well): http://10.67.129.185/tests/478#downloads

- alp-virt-core-tests:
PASS: http://10.67.129.185/tests/489
OK: reconnect when ssh console is broken: http://10.67.129.185/tests/495#step/libvirt_virtual_network_init/12

- uefi-gi-guest_developing-on-host_developing-kvm
OK: https://openqa.suse.de/t10303006 (fail at the last module validate_system_health, same as OSD official job https://openqa.suse.de/tests/10227142, and post_fail_hook is verified)

- uefi-gi-guest_developing-on-host_developing-xen
OK: https://openqa.suse.de/tests/10304339# (same fail with cloned job at last module https://openqa.suse.de/tests/10055942, post_fail_hook works well)

- virt-guest-migration-developing-from-developing-to-developing-kvm-src
PASSED
Created job #10302790: sle-15-SP5-Online-x86_64-Build64.1-virt-guest-migration-developing-from-developing-to-developing-kvm-src@virt-mm-64bit-ipmi -> https://openqa.suse.de/t10302790
Created job #10302791: sle-15-SP5-Online-x86_64-Build64.1-virt-guest-migration-developing-from-developing-to-developing-kvm-dst@virt-mm-64bit-ipmi -> https://openqa.suse.de/t10302791

- gi-guest_developing-on-host_sles15sp4-kvm
OK:  https://openqa.suse.de/t10304534 (same fail with cloned job https://openqa.suse.de/tests/10232868, logs uploaded in post_fail_hook )

- uefi-gi-guest_developing-on-host_sles12sp5-kvm
OK: https://openqa.suse.de/t10302796(same fail at the last module  with cloned job https://openqa.suse.de/tests/10227144, logs uploaded in post_fail_hook )
```
