### PR TITLE
Introduce PUBLIC_CLOUD_IMAGE_URI for Azure Arm64 images

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -35,6 +35,14 @@ variable "image_id" {
     default = ""
 }
 
+variable "image_uri" {
+	default = ""
+}
+
+variable "publisher" {
+	default="SUSE"
+}
+
 variable "offer" {
     default=""
 }
@@ -195,11 +203,11 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
     # disk_size_gb         = 30
   }
 
-  source_image_id =  var.image_id != "" ? azurerm_image.image.0.id : null
+  source_image_id = var.image_uri != "" ? var.image_uri : (var.image_id != "" ? azurerm_image.image.0.id : null)
   dynamic "source_image_reference" {
-    for_each = range(var.image_id != "" ? 0 : 1)
+    for_each = range(var.image_id == "" && var.image_uri == "" ? 1 : 0)
     content {
-      publisher = var.image_id != "" ? "" : "SUSE"
+      publisher = var.image_id != "" ? "" : var.publisher
       offer     = var.image_id != "" ? "" : var.offer
       sku       = var.image_id != "" ? "" : var.sku
       version   = var.image_id != "" ? "" : "latest"

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -374,8 +374,8 @@ sub terraform_apply {
 
     $self->terraform_prepare_env();
 
-    record_info('INFO', "Creating instance $instance_type from $image ...");
     if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
+        record_info('INFO', "Creating instance $instance_type from $image ...");
         assert_script_run('cd ' . TERRAFORM_DIR . "/$cloud_name");
         my $sap_media = get_required_var('HANA');
         my $sap_regcode = get_required_var('SCC_REGCODE_SLES4SAP');
@@ -403,8 +403,7 @@ sub terraform_apply {
         upload_logs(TERRAFORM_DIR . "/$cloud_name/terraform.tfvars", failok => 1);
         script_retry('terraform init -no-color', timeout => $terraform_timeout, delay => 3, retry => 6);
         assert_script_run("terraform workspace new ${resource_group}${suffix} -no-color", $terraform_timeout);
-    }
-    else {
+    } else {
         assert_script_run('cd ' . TERRAFORM_DIR);
         script_retry('terraform init -no-color', timeout => $terraform_timeout, delay => 3, retry => 6);
     }
@@ -421,8 +420,10 @@ sub terraform_apply {
             die "PUBLIC_CLOUD_IMAGE_URI and PUBLIC_CLOUD_IMAGE_ID are mutually exclusive";
         } elsif ($image_uri) {
             $cmd .= "-var 'image_uri=" . $image_uri . "' ";
+            record_info('INFO', "Creating instance $instance_type from $image_uri ...");
         } elsif ($image) {
             $cmd .= "-var 'image_id=" . $image . "' ";
+            record_info('INFO', "Creating instance $instance_type from $image ...");
         }
         if (is_azure) {
             # Note: Only the default Azure terraform profiles contains the 'storage-account' variable
@@ -536,7 +537,7 @@ sub terraform_destroy {
             my $sku = get_var('PUBLIC_CLOUD_AZURE_SKU');
             my $storage_account = get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT');
             $cmd .= " -var 'image_id=$image'" if ($image);
-            $cmd .= " -var 'image_uri=$image'" if ($image_uri);
+            $cmd .= " -var 'image_uri=${image_uri}'" if ($image_uri);
             $cmd .= " -var 'offer=$offer'" if ($offer);
             $cmd .= " -var 'sku=$sku'" if ($sku);
             $cmd .= " -var 'storage-account=$storage_account'" if ($storage_account);

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -235,6 +235,9 @@ sub get_image_id {
     my ($self, $img_url) = @_;
     my $predefined_id = get_var('PUBLIC_CLOUD_IMAGE_ID');
     return $predefined_id if ($predefined_id);
+    # If a URI is given, then no image ID should be determined
+    return '' if (get_var('PUBLIC_CLOUD_IMAGE_URI'));
+    # Determine image ID from image filename
     $img_url //= get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
     my ($img_name) = $img_url =~ /([^\/]+)$/;
     $self->{image_cache} //= {};
@@ -363,6 +366,7 @@ sub terraform_apply {
     $args{count} //= '1';
     my $instance_type = get_var('PUBLIC_CLOUD_INSTANCE_TYPE');
     my $image = $self->get_image_id();
+    my $image_uri = get_var("PUBLIC_CLOUD_IMAGE_URI");
     my $ssh_private_key_file = '/root/.ssh/id_rsa';
     my $cloud_name = $self->conv_openqa_tf_name;
 
@@ -412,7 +416,14 @@ sub terraform_apply {
             my $value = $args{vars}->{$key};
             $cmd .= sprintf(q(-var '%s=%s' ), $key, escape_single_quote($value));
         }
-        $cmd .= "-var 'image_id=" . $image . "' " if ($image);
+        # image_uri and image_id are mutally exclusive
+        if ($image_uri && $image) {
+            die "PUBLIC_CLOUD_IMAGE_URI and PUBLIC_CLOUD_IMAGE_ID are mutually exclusive";
+        } elsif ($image_uri) {
+            $cmd .= "-var 'image_uri=" . $image_uri . "' ";
+        } elsif ($image) {
+            $cmd .= "-var 'image_id=" . $image . "' ";
+        }
         if (is_azure) {
             # Note: Only the default Azure terraform profiles contains the 'storage-account' variable
             my $storage_account = get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT');
@@ -520,10 +531,12 @@ sub terraform_destroy {
         # Add image_id, offer and sku on Azure runs, if defined.
         if (is_azure) {
             my $image = $self->get_image_id();
+            my $image_uri = get_var('PUBLIC_CLOUD_IMAGE_URI');
             my $offer = get_var('PUBLIC_CLOUD_AZURE_OFFER');
             my $sku = get_var('PUBLIC_CLOUD_AZURE_SKU');
             my $storage_account = get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT');
             $cmd .= " -var 'image_id=$image'" if ($image);
+            $cmd .= " -var 'image_uri=$image'" if ($image_uri);
             $cmd .= " -var 'offer=$offer'" if ($offer);
             $cmd .= " -var 'sku=$sku'" if ($sku);
             $cmd .= " -var 'storage-account=$storage_account'" if ($storage_account);

--- a/variables.md
+++ b/variables.md
@@ -286,6 +286,7 @@ PUBLIC_CLOUD_FIO_SSD_SIZE | string | "100G" | Set the additional disk size for t
 PUBLIC_CLOUD_FORCE_REGISTRATION | boolean | false | If set, tests/publiccloud/registration.pm will register cloud guest
 PUBLIC_CLOUD_IGNORE_EMPTY_REPO | boolean | false | Ignore empty maintenance update repos
 PUBLIC_CLOUD_IMAGE_ID | string | "" | The image ID we start the instance from
+PUBLIC_CLOUD_IMAGE_URI | string | "" | The URI of the image to be used.
 PUBLIC_CLOUD_IMAGE_LOCATION | string | "" | The URL where the image gets downloaded from. The name of the image gets extracted from this URL.
 PUBLIC_CLOUD_IMAGE_PROJECT | string | "" | Google Compute Engine image project
 PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION | string | "" | Defines the image definition for uploading Arm64 images to the image gallery.


### PR DESCRIPTION
Introduce the possibility to create an VM instance from a given image URI via the PUBLIC_CLOUD_IMAGE_URI parameter. This is necessary for creating Arm64 instances on Azure, where this is the currently the only way of accessing uploaded disk images.

- Related ticket: https://progress.opensuse.org/issues/119011
- Verification run: 
- * [x86_64 15-SP4 maintenance img-proof](https://duck-norris.qe.suse.de/tests/11645) | [x86_64 15-SP4 containers](https://duck-norris.qe.suse.de/tests/11652) | [Arm64 15-SP4 maintenance containers](https://duck-norris.qe.suse.de/tests/11651)
- * [arm64 15-SP5 img_proof](https://duck-norris.qe.suse.de/tests/11649) | [arm64 15-SP5 consoletests](https://duck-norris.qe.suse.de/tests/11653#step/prepare_instance/203) (failures due to registration issues, unrelated)
