### PR TITLE
Revisit wrong settings for HA migrations

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_ha_aarch64.xml.ep
+++ b/data/autoyast_sle15/create_hdd/create_hdd_ha_aarch64.xml.ep
@@ -215,7 +215,7 @@
     <enabled config:type="boolean">false</enabled>
   </proxy>
   <services-manager config:type="map">
-    <default_target>graphical</default_target>
+    <default_target>multi-user</default_target>
     <services config:type="map">
       <enable config:type="list">
         <service>firewalld</service>

--- a/data/autoyast_sle15/create_hdd/create_hdd_ha_ppc64le.xml.ep
+++ b/data/autoyast_sle15/create_hdd/create_hdd_ha_ppc64le.xml.ep
@@ -74,7 +74,7 @@
     <ntp_policy>auto</ntp_policy>
   </ntp-client>
   <services-manager config:type="map">
-    <default_target>graphical</default_target>
+    <default_target>multi-user</default_target>
     <services config:type="map">
       <enable config:type="list">
         <service>firewalld</service>

--- a/data/autoyast_sle15/create_hdd/create_hdd_ha_s390x.xml.ep
+++ b/data/autoyast_sle15/create_hdd/create_hdd_ha_s390x.xml.ep
@@ -223,7 +223,7 @@
     <enabled config:type="boolean">false</enabled>
   </proxy>
   <services-manager config:type="map">
-    <default_target>graphical</default_target>
+    <default_target>multi-user</default_target>
     <services config:type="map">
       <enable config:type="list">
         <service>firewalld</service>

--- a/data/autoyast_sle15/create_hdd/create_hdd_ha_x86_64.xml.ep
+++ b/data/autoyast_sle15/create_hdd/create_hdd_ha_x86_64.xml.ep
@@ -216,7 +216,7 @@
     <enabled config:type="boolean">false</enabled>
   </proxy>
   <services-manager config:type="map">
-    <default_target>graphical</default_target>
+    <default_target>multi-user</default_target>
     <services config:type="map">
       <enable config:type="list">
         <service>firewalld</service>


### PR DESCRIPTION
Revisit wrong settings for HA migrations

- Related ticket: https://progress.opensuse.org/issues/120444
- Verification run: https://openqa.suse.de/tests/10291139
  http://openqa.suse.de/t10307585
https://openqa.suse.de/tests/10307721
aarch 15sp3
 http://openqa.suse.de/t10307586
 https://openqa.suse.de/tests/10307632
s390x 15sp2
