### PR TITLE
Add softfail for 'gnome_music' test due to known issue

### DIFF
--- a/tests/x11/gnome_music.pm
+++ b/tests/x11/gnome_music.pm
@@ -10,13 +10,28 @@
 # - Close gnome-music
 # Maintainer: Max Lin <mlin@suse.com>
 
-use base "x11test";
+use base "opensusebasetest";
+use version_utils qw(is_sle is_leap);
 use strict;
 use warnings;
 use testapi;
 use utils;
 
+sub check_bsc1206793 {
+    # Due to bsc#1206793, the test may fail with package version at '41.1-150400.3.3.1'
+    if (is_sle || is_leap) {
+        select_console 'root-console';
+        if (script_output('rpm -q gnome-music') =~ '41.1-150400.3.3.1') {
+            record_soft_failure 'bsc#1206793, Update breaks gnome-music';
+            return 1;
+        }
+    }
+    return 0;
+}
+
 sub run {
+    return if check_bsc1206793;
+    select_console 'x11';
     assert_gui_app('gnome-music', install => 1);
     send_key_until_needlematch("generic-desktop", 'alt-f4', 6, 5);
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/122725
https://bugzilla.suse.com/show_bug.cgi?id=1206793

Related ticket: https://progress.opensuse.org/issues/122725
Verification:
https://openqa.opensuse.org/tests/3028197 -Leap
https://openqa.opensuse.org/tests/3026390 -TW