### PR TITLE
Not run smartctl commands on YaST verification

### DIFF
--- a/tests/installation/validation/ibft.pm
+++ b/tests/installation/validation/ibft.pm
@@ -153,7 +153,6 @@ sub run {
     for (1 .. 3) {
         assert_script_run 'hdparm -tT /dev/' . $iscsi_drive;
     }
-    assert_script_run 'smartctl -i /dev/' . $iscsi_drive;
     assert_script_run 'sg_turs /dev/' . $iscsi_drive . ' -vt -n 10';
     $self->ibft_validation;
 }


### PR DESCRIPTION
As result of discussion in bsc#1203566 this command seems not realiable after installation with iscsi ibft failing sporadically. In the server (worker) the command works perfectly and shows correct information, active and enable smart commands, so we can drop the use of this command from the VM to validate this YaST installation.

- Related ticket: https://progress.opensuse.org/issues/122554
