### PR TITLE
Do not add SBD playbook for native fencing

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -18,6 +18,7 @@ terraform:
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     sles4sap_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
+    os_image: "%PUBLIC_CLOUD_OS_IMAGE%"
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
     storage_account_name: '%STORAGE_ACCOUNT_NAME%'
     storage_account_key: '%STORAGE_ACCOUNT_KEY%'

--- a/schedule/sles4sap/publiccloud_hanasr.yml
+++ b/schedule/sles4sap/publiccloud_hanasr.yml
@@ -6,7 +6,7 @@ description: |
     - test
     - destroy
 vars:
-  PUBLIC_CLOUD_RESOURCE_GROUP: 'HanaSR'
+  PUBLIC_CLOUD_RESOURCE_GROUP: 'hanasr'
   TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
   - boot/boot_to_desktop


### PR DESCRIPTION
This PR removes SBD playbook from default HANA setup list and adds it only in 
case of HA scenario with "FENCING_MECHANISM" set to "sbd".

- Related ticket: https://jira.suse.com/browse/TEAM-7174
- Needles: NA
- Verification run: 
Native fencing: https://openqaworker15.qa.suse.cz/tests/124284/#
SBD fencing: http://openqaworker15.qa.suse.cz/tests/124037#

VR test does not need to pass here, important is correct ansible playbook list being compiled. Check yaml files in logs.