### PR TITLE
LTP: Filter openposix tests by test name

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -308,9 +308,9 @@ sub parse_openposix_runfile {
 
     for my $line (@$cmds) {
         chomp($line);
-        if ($line =~ m/$cmd_pattern/ && !($line =~ m/$cmd_exclude/)) {
-            my $testname = basename($line, '.run-test') . $suffix;
+        my $testname = basename($line, '.run-test') . $suffix;
 
+        if ($testname =~ m/$cmd_pattern/ && !($testname =~ m/$cmd_exclude/)) {
             # For ULP tests, start all processes in the background immediately
             # and change the test command to unpause the existing process
             if ($ulp_test) {


### PR DESCRIPTION
`LTP_COMMAND_PATTERN` and `LTP_COMMAND_EXCLUDE` currently filter by absolute path to openposix executables, which means that line start and line end characters don't match where people expect. Apply the regexes to scheduled test name instead of executable path to unify filter behavior with other LTP tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/10292429
