### PR TITLE
Always do a rollback after zfs tests

### DIFF
--- a/tests/console/zfs.pm
+++ b/tests/console/zfs.pm
@@ -294,4 +294,9 @@ sub post_run_hook {
     cleanup();
 }
 
+sub test_flags {
+    # Test is rather intrusive, so to be sure to not disturb the rest of the test run, do a rollback
+    return {always_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
The zfs test is rather intrusive on the system. To prevent disturbances with other test runs, always do a rollback after the test run.

- Related ticket: https://progress.opensuse.org/issues/122773
- Verification run: https://duck-norris.qe.suse.de/tests/11696
