### PR TITLE
Stroll down install overview window to discover ssh port entry

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -16,7 +16,7 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_microos is_sle_micro is_upgrade is_sle);
+use version_utils qw(is_microos is_sle_micro is_upgrade is_sle is_tumbleweed);
 use Utils::Backends qw(is_remote_backend is_hyperv);
 use Test::Assert ':all';
 
@@ -25,8 +25,14 @@ sub ensure_ssh_unblocked {
 
         # ssh section is not shown up directly in text mode. Navigate into
         # installation overview frame and hitting down button to get there.
-        if (check_var('VIDEOMODE', 'text') and is_sle_micro()) {
-            send_key_until_needlematch 'installation-settings-overview-selected', 'tab', 25;
+        if (check_var('VIDEOMODE', 'text') and (is_sle_micro() or is_tumbleweed)) {
+            if (is_sle_micro) {
+                send_key_until_needlematch 'installation-settings-overview-selected', 'tab', 25;
+            }
+            else {
+                send_key_until_needlematch 'installation-settings-release-notes-selected', 'tab', 25;
+                send_key 'tab';
+            }
             send_key_until_needlematch [qw(ssh-blocked ssh-open)], 'down', 60;
         }
         else {


### PR DESCRIPTION
Host installation failed on new ZEN2 SUT at https://openqa.opensuse.org/tests/3026620#step/installation_overview/63 because the ssh port entry does not show up in the screenshot. This PR is to move the focus on the correct window and move down to make it appeared.

- Related ticket: https://progress.opensuse.org/issues/103742
- a new needle added: https://openqa.opensuse.org/tests/3029555#step/installation_overview/2
- Verification run: https://openqa.opensuse.org/tests/3029555
