### PR TITLE
Enable gnome-music for SLE15+

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2041,6 +2041,7 @@ sub load_x11_other {
             loadtest "x11/gnome_control_center";
             loadtest "x11/gnome_tweak_tool";
             loadtest "x11/seahorse";
+            loadtest "x11/gnome_music";
         }
         loadtest 'x11/flatpak' if (is_opensuse);
     }


### PR DESCRIPTION
Current now, gnome-music is only enabled for Leap and TW. Enable gnome-music for SLE to avoid omission.

- Related ticket: https://progress.opensuse.org/issues/122767
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/10296574#step/gnome_music/20