### PR TITLE
ulp_openposix: Read patchlist only for libpulp update

### DIFF
--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -33,10 +33,6 @@ sub prepare_repo {
     }
 
     my $repo_args = join(' ', map({ "-r $_" } @repo_names));
-    my $patches = get_patches($incident_id, $repo);
-
-    die "Patch isn't needed" unless $patches;
-
     my $packlist = zypper_search("-st package $repo_args");
 
     if (grep { $$_{name} eq 'glibc-livepatches' } @$packlist) {
@@ -45,6 +41,10 @@ sub prepare_repo {
     }
     elsif (grep { $$_{name} eq 'libpulp0' || $$_{name} eq 'libpulp-tools' } @$packlist) {
         record_info('Tools tests', "Incident $incident_id contains livepatching tools.");
+
+        my $patches = get_patches($incident_id, $repo);
+
+        die "Patch isn't needed" unless $patches;
         $packname = 'openposix-livepatches';
         $repo_args = '';
 


### PR DESCRIPTION
Calling `get_patches()` in `ulp_openposix` test module and validating that patches are needed makes sense only for incidents with `libpulp` updates. In other cases, the packages to be updated may not be preinstalled and the test will always fail because the patch is not needed.

- Related ticket: https://progress.opensuse.org/issues/112004
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/10297726
