### PR TITLE
btrfs_autocompletion: Type sufficiently to also work with btrfsprogs 6.1

### DIFF
--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -45,7 +45,7 @@ sub run {
     compare_commands("btrfs device stats ", "btrfs d\tst\t");
     compare_commands("btrfs subvolume get-default ", "btrfs su\tg\t");
     compare_commands("btrfs filesystem usage ", "btrfs fi\tu\t");
-    compare_commands("btrfs inspect-internal min-dev-size ", "btrfs i\tm\t");
+    compare_commands("btrfs inspect-internal min-dev-size ", "btrfs i\tmi\t");
 
     # Check loading of complete function
     assert_script_run "complete | grep '_btrfs btrfs'";


### PR DESCRIPTION
btrfs inspect-internal now has two sub-commands starting with m:
map-swapfile  min-dev-size

- Related ticket: https://progress.opensuse.org/issues/122809
- Needles: N/A
- Verification run: [JeOS for KVM](https://openqa.opensuse.org/tests/3029740) | [extra_test_filesystem](https://openqa.opensuse.org/t3029741)
