### PR TITLE
Move journalctl after ntp_client

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -151,7 +151,6 @@ schedule:
     - console/mutt
     - '{{sle_tests}}'
     - console/mdadm
-    - console/journalctl
     - console/systemd_nspawn
     - console/quota
     - console/vhostmd
@@ -167,6 +166,7 @@ schedule:
     - console/osinfo_db
     - '{{opensuse_tests}}'
     - '{{tumbleweed_tests}}'
+    - console/journalctl
     - console/tar
     - console/coredump_collect
     - console/valgrind


### PR DESCRIPTION
Move the journalctl tests after ntp_client test to ensure that the system time is synchronized.

- Related ticket: https://progress.opensuse.org/issues/122683
- Verification run: https://duck-norris.qe.suse.de/t11741
