### PR TITLE
Hide passing check messages from the CI logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-links: tools/tidy tools/lib/ os-autoinst/
 
 .PHONY: check-links
 tidy-check: check-links
-	tools/tidy --check
+	tools/tidy --check --quiet
 
 .PHONY: tidy
 tidy: tools/tidy

--- a/tools/check_metadata
+++ b/tools/check_metadata
@@ -3,7 +3,7 @@ files="${@:?"Need files to check as argument"}"
 success=1
 for file in $files; do
     grep -q '# Summary: .\+' $file || (echo "Missing '# Summary: <multi line summary of test>'" in $file && exit 1) || success=0
-    grep -E '# Maintainer: .+(@| at ).+' $file || (echo "Missing '# Maintainer: <email address>'" in $file && exit 1) || success=0
+    grep -E -q '# Maintainer: .+(@| at ).+' $file || (echo "Missing '# Maintainer: <email address>'" in $file && exit 1) || success=0
     grep -q '# Copyright .\+' $file || (echo "Missing Copyright <year> SUSE LLC" in $file && exit 1) || success=0
 done
 [ $success = 1 ] && echo "SUCCESS" && exit 0


### PR DESCRIPTION
https://progress.opensuse.org/issues/122923
Enhance the tidy check and metadata check logic to hide passing messages,
then only failed messages are shown up.

- Related ticket: https://progress.opensuse.org/issues/122923
- Verification run: n/a

From the CI log: https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/3927393593/jobs/6713978350
The passed tidy check messages and metadata check messages are not shown up.