### PR TITLE
Fix ssh_key in run_ltp test

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -150,7 +150,7 @@ sub run {
     zypper_call("in -y python3-paramiko python3-scp");
     my $sut = ':user=' . $instance->username;
     $sut .= ':sudo=1';
-    $sut .= ':key_file=' . $instance->ssh_key;
+    $sut .= ':key_file=' . $instance->provider->ssh_key;
     $sut .= ':host=' . $instance->public_ip;
     $sut .= ':reset_command=\'' . $reset_cmd . '\'';
     $sut .= ':hostkey_policy=missing';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/123010
- Verification run: http://openqa.suse.de/tests/10308301 (in progress)
http://openqa.suse.de/tests/10308294 (In progress)