### PR TITLE
Adjust default yaml file for SLE 15 SP5

### DIFF
--- a/schedule/yast/detect_yast2_failures_full.yaml
+++ b/schedule/yast/detect_yast2_failures_full.yaml
@@ -10,6 +10,10 @@ vars:
 schedule:
   registration:
     - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/skip_module_selection
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/select_role_text_mode
   suggested_partitioning:

--- a/schedule/yast/gnome_install_from_source.yaml
+++ b/schedule/yast/gnome_install_from_source.yaml
@@ -18,6 +18,8 @@ schedule:
     - installation/registration/skip_registration
   extension_module_selection:
     - installation/module_selection/select_module_desktop
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   default_systemd_target:

--- a/schedule/yast/releasenotes_origin+unregistered_x86_64.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered_x86_64.yaml
@@ -9,6 +9,8 @@ schedule:
     - installation/registration/skip_registration
   extension_module_selection:
     - installation/module_selection/select_module_desktop
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/release_notes_from_url
     - installation/system_role/accept_selected_role_SLES_with_GNOME

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration_x86_64.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration_x86_64.yaml
@@ -16,6 +16,8 @@ schedule:
     - installation/registration/skip_registration
   extension_module_selection:
     - installation/module_selection/select_nonconflicting_modules
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   software:

--- a/schedule/yast/skip_registration/skip_registration_x86_64.yaml
+++ b/schedule/yast/skip_registration/skip_registration_x86_64.yaml
@@ -1,6 +1,6 @@
 ---
-name:           skip_registration
-description:    >
+name: skip_registration
+description: >
   Skipping registration for SLE 15, as requires network connection.
   This is default behavior for SLE 12.
 vars:
@@ -10,6 +10,8 @@ schedule:
     - installation/registration/skip_registration
   extension_module_selection:
     - installation/module_selection/select_module_desktop
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   default_systemd_target:

--- a/schedule/yast/sle/flows/default_x86_64.yaml
+++ b/schedule/yast/sle/flows/default_x86_64.yaml
@@ -13,12 +13,14 @@ license_agreement:
 registration:
   - installation/registration/register_via_scc
 extension_module_selection:
-  - installation/module_selection/skip_module_selection
+  - installation/module_registration/skip_module_registration
+additional_products: []
 add_on_product:
-  - installation/add_on_product_installation/accept_add_on_installation
+  - installation/add_on_product/skip_install_addons
 add_on_product_installation: []
 system_role:
   - installation/system_role/accept_selected_role_text_mode
+guided_partitioning: []
 suggested_partitioning:
   - installation/partitioning/accept_proposed_layout
 clock_and_timezone:

--- a/schedule/yast/sle/usb_install_x86_64.yaml
+++ b/schedule/yast/sle/usb_install_x86_64.yaml
@@ -2,11 +2,17 @@
 name: USBinstall
 description: >
   Basic installation test with USB boot. Verification that usb repo is enabled
-  after first boot. Test covers both Online and Full medium installations.
+  after first boot. Test covers only Full medium installations.
 vars:
   USBBOOT: 1
   YUI_REST_API: 1
 schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/skip_module_selection
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
   default_systemd_target:
     - installation/installation_settings/validate_default_target
   system_preparation:


### PR DESCRIPTION
- default_x86_64.yaml should be the default for Online Medium.
- Therefore slight modifications in the default file were made.
- Adjustment to all testsuites that got merged with PR15959

- Related ticket: https://progress.opensuse.org/issues/119887
- Needles: - 
- Verification run: [VRs in test group](https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&groupid=96&build=rakoenig%2Fos-autoinst-distri-opensuse%23fix_default-x86_64)