### PR TITLE
Fix xterm case in LEAP 15.4

### DIFF
--- a/tests/x11/xterm.pm
+++ b/tests/x11/xterm.pm
@@ -14,9 +14,17 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use power_action_utils qw(power_action);
+use version_utils qw(is_leap);
 
 sub run {
     my ($self) = @_;
+    # workaround for bsc#1205518
+    if (is_leap) {
+        record_info 'workaround', 'bsc#1205518 - Rebooting the VM to avoid the gnome issue';
+        power_action('reboot', textmode => 1);
+        $self->wait_boot(bootloader_time => 300);
+    }
     select_console 'x11';
     $self->test_terminal('xterm');
 }


### PR DESCRIPTION
Due to the issue [bsc#1205518](https://bugzilla.opensuse.org/show_bug.cgi?id=1205518) in LEAP,  the 'xterm' test is failing. As suggested called VM reboot before the 'xterm' test.

- Related ticket: https://progress.opensuse.org/issues/122992
- Needles: NO
- Verification run:  [Leap_15.4](http://deepthi-openqa.qe.suse.de/tests/4142#step/xterm/1)