### PR TITLE
WIP Add wait_still_screen before checking tomcat status

### DIFF
--- a/lib/Tomcat/JspTest.pm
+++ b/lib/Tomcat/JspTest.pm
@@ -256,7 +256,7 @@ sub form() {
     assert_screen('tomcat-form-example', TIMEOUT);
     send_key('tab');
     send_key('down');
-    for (1 .. 2) { send_key('ret'); }
+    for (1 .. 5) { send_key('ret'); }
 
     if (check_screen('tomcat-click-save-login', 60)) {
         assert_and_click('tomcat-click-save-login', timeout => TIMEOUT);

--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -55,6 +55,9 @@ EOF
 
     # start the tomcat daemon and check that it is running
     systemctl('start tomcat');
+    # sometimes it takes much longer to complete the start, so give a chance to
+    # finish start progress of tomcat before check status
+    wait_still_screen 120;
     systemctl('status tomcat');
 
     # check that tomcat is listening on port 8080


### PR DESCRIPTION
sometimes it takes much longer to complete start progress. 
see poo#120834

