### PR TITLE
Do SAP/LTSS module substitution on SLE 15+

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -120,7 +120,7 @@ sub run {
     my @modules = split(/,/, $repos);
     foreach (@modules) {
         # substitue SLES_SAP for LTSS repo at this point is SAP ESPOS
-        $_ =~ s/SAP_(\d+(-SP\d)?)/$1-LTSS/;
+        $_ =~ s/SAP_(\d+(-SP\d)?)/$1-LTSS/ if is_sle('15+');
         next if s{http.*SUSE_Updates_(.*)/?}{$1};
         die 'Modules regex failed. Modules could not be extracted from repos variable.';
     }


### PR DESCRIPTION
This is needed for non-SAP packages because test does check patchinfo of repo, then is looking for the channel from the repo in smelt, but there is no SAP channel for LTSS, SAP is ESPOS
e.g. pacakges tomcat and SAPHanaSR-ScaleOut on 15-SP1
tomcat                          Channel SLE-Product-SLES_15-SP1-LTSS
SAPHanaSR-ScaleOut Channel SLE-Module-SAP-Applications_15-SP1
see http://smelt.suse.de/maintained

- Related ticket: https://progress.opensuse.org/issues/115259
- Verification run:
non-SAP pacakge mozilla
https://dzedro.suse.cz/tests/52
https://dzedro.suse.cz/tests/53
https://dzedro.suse.cz/tests/54
SAPHanaSR-ScaleOut SLE 12 this will fail when substitution is done, fo SAP package there is SAP channel
https://dzedro.suse.cz/tests/55
https://dzedro.suse.cz/tests/56
SAPHanaSR-ScaleOut SLE 15
https://dzedro.suse.cz/tests/57
https://dzedro.suse.cz/tests/58
https://dzedro.suse.cz/tests/59
https://dzedro.suse.cz/tests/60