### PR TITLE
Fix regexp to detect key issue in wait_for_ssh

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -340,7 +340,7 @@ sub wait_for_ssh {
             if ($output =~ m/Reached target.*/) {
                 return $duration;
             }
-            elsif ($output =~ m/Permission denied (publickey).*/) {
+            elsif ($output =~ m/Permission denied \(publickey\).*/) {
                 die "ssh permission denied (pubkey)";
             }
         }


### PR DESCRIPTION
The API need to detect messages like

```
someuser@1.2.3.4: Permission denied (publickey).
```

Add a parenthesis escape in the regexp about it.

- Verification run:  https://openqa.suse.de/tests/10312736
