### PR TITLE
Remove workaround for 'start_systemd_testkit_offline'

### DIFF
--- a/tests/console/start_systemd_testkit_offline.pm
+++ b/tests/console/start_systemd_testkit_offline.pm
@@ -92,24 +92,14 @@ sub parse_results_from_output {
                 #   $openQA_result = $self->record_testresult('softfail');
                 #   $softfail_result = 119565;
                 #} else {
-                my ($openQA_result, $softfail_result);
-                if ($error_line =~ /invalid version.*expected.*/ && is_sle('=15-SP5')) {
-                    $openQA_result = $self->record_testresult('softfail');
-                    $softfail_result = 1203060;
-                }
-                else {
-                    my $openQA_result = $self->record_testresult('fail');
-                    #$softfail_result = 0;
-                    #}
-                    $softfail_result = 0;
-                }
+                my $openQA_result = $self->record_testresult('fail');
+                #$softfail_result = 0;
+                #}
                 my $openQA_filename = $self->next_resultname('txt');
                 $openQA_result->{title} = $testunit;
                 $openQA_result->{text} = $openQA_filename;
                 #($softfail_result) ? $self->write_resultfile($openQA_filename, "# Softfail bsc#$softfail_result:\n$error_line\n") :
-                ($softfail_result)
-                  ? $self->write_resultfile($openQA_filename, "# Softfail bsc#$softfail_result:\n$error_line\n")
-                  : $self->write_resultfile($openQA_filename, "# Failure:\n$error_line\n");
+                $self->write_resultfile($openQA_filename, "# Failure:\n$error_line\n");
                 $self->{dents}++;
             }
 


### PR DESCRIPTION
The fix for bsc#1203060 is implemented, remove the workaround.

https://progress.opensuse.org/issues/123049
https://bugzilla.suse.com/show_bug.cgi?id=1203060

The workaround is pushed via PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15492

- Related ticket: https://progress.opensuse.org/issues/123049
- Verification run: 
[15-SP3](http://openqa.suse.de/tests/10312326) | [15-SP4](http://openqa.suse.de/tests/10312327) | [15-SP5](http://openqa.suse.de/tests/10312312)
