### PR TITLE
Pass timeout/interval when using regex to find UI element

### DIFF
--- a/lib/Installation/ProductSelection/ProductSelectionPage.pm
+++ b/lib/Installation/ProductSelection/ProductSelectionPage.pm
@@ -34,7 +34,7 @@ sub init {
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rdb_SLES}->exist();
+    return $self->{rdb_SLES}->exist({timeout => 300, interval => 10});
 }
 
 sub install_product {

--- a/lib/YuiRestClient/Filter.pm
+++ b/lib/YuiRestClient/Filter.pm
@@ -39,15 +39,20 @@ sub is_resolved {
 }
 
 sub resolve {
-    my ($self, $json) = @_;
+    my ($self, $json, $args) = @_;
     my ($k, $v) = ($self->{regex}->{k}, $self->{regex}->{v});
-    my @widgets = grep {
-        defined $_->{$k} && YuiRestClient::Sanitizer::sanitize($_->{$k}) =~ $v
-    } @{$json};
-    if (scalar @widgets == 1) {
-        $self->{filter}->{$k} = YuiRestClient::Sanitizer::sanitize($widgets[0]->{$k});
-        $self->{resolved} = 1;
-    }
+    YuiRestClient::Wait::wait_until(object => sub {
+            my @widgets = grep {
+                defined $_->{$k} && YuiRestClient::Sanitizer::sanitize($_->{$k}) =~ $v
+            } @{$json};
+            if (scalar @widgets == 1) {
+                $self->{filter}->{$k} = YuiRestClient::Sanitizer::sanitize($widgets[0]->{$k});
+                $self->{resolved} = 1;
+            }
+        },
+        timeout => $args->{timeout},
+        interval => $args->{interval}
+    );
 }
 
 1;

--- a/lib/YuiRestClient/Widget/Base.pm
+++ b/lib/YuiRestClient/Widget/Base.pm
@@ -48,7 +48,7 @@ sub property {
 sub find_widgets {
     my ($self, $args) = @_;
 
-    $self->resolve_filter() unless $self->{filter}->is_resolved();
+    $self->resolve_filter($args) unless $self->{filter}->is_resolved();
     return $self->{widget_controller}->find({
             filter => $self->{filter}->get_filter(),
             timeout => $args->{timeout},
@@ -58,11 +58,17 @@ sub find_widgets {
 
 sub resolve_filter {
     my ($self, $args) = @_;
+    my $timeout = $args->{timeout} // $self->{timeout};
+    my $interval = $args->{interval} // $self->{interval};
 
     # get json with widgets according to current filter (which does not include regex)
-    my $json = $self->{widget_controller}->find({filter => $self->{filter}->get_filter()});
+    my $json = $self->{widget_controller}->find({
+            filter => $self->{filter}->get_filter(),
+            timeout => $timeout,
+            interval => $interval
+    });
     # replace regex by found value in the filter
-    $self->{filter}->resolve($json);
+    $self->{filter}->resolve($json, {timeout => $timeout, interval => $interval});
 }
 
 1;


### PR DESCRIPTION
When using regex to find UI element with libyui-rest-api, we need to pass timeout/interval as a parameter to the find function.

- Related ticket: https://progress.opensuse.org/issues/121807
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/10514451
  https://openqa.suse.de/tests/10514452
  https://openqa.suse.de/tests/10515226
  https://openqa.suse.de/tests/10521766
  https://openqa.suse.de/tests/10521869
  https://openqa.suse.de/tests/10521870
regression:
  https://openqa.suse.de/tests/10522710
