### PR TITLE
Skip ntp sync on SLES12 publiccloud

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -147,13 +147,17 @@ sub run {
 
     # Ensure the time is correct, otherwise we might run into issues with the persistent journal
     # See e.g. https://bugzilla.suse.com/show_bug.cgi?id=1182802
+
     if (is_sle("<15")) {
-        # SLE 12 has no chrony by default but uses ntp
-        assert_script_run("ntpdate -b 0.suse.pool.ntp.org", fail_message => "forced time sync failed");
-        assert_script_run("systemctl enable --now ntpd");
-        # We're not enabling ntp-wait until bsc#1207042 is resolved
-        record_soft_failure("bsc#1207042 - Won't enable ntp-wait due to cron issues");
-        #assert_script_run("systemctl enable ntp-wait.service");
+        # SLES12 on Publiccloud has ntp enabled by default.
+        if (!is_public_cloud) {
+            # SLE 12 has no chrony by default but uses ntp
+            assert_script_run("ntpdate -b 0.suse.pool.ntp.org", fail_message => "forced time sync failed");
+            assert_script_run("systemctl enable --now ntpd");
+            # We're not enabling ntp-wait until bsc#1207042 is resolved
+            record_soft_failure("bsc#1207042 - Won't enable ntp-wait due to cron issues");
+            #assert_script_run("systemctl enable ntp-wait.service");
+        }
     } else {
         assert_script_run("systemctl start chronyd");
         assert_script_run("chronyc waitsync", fail_message => "time synchronization failed");


### PR DESCRIPTION
Skip the manual time synchronization on publiccloud instances, since this is enabled there by default.

- Related ticket: https://progress.opensuse.org/issues/123073
- Verification run: [12-SP5 GCE](https://duck-norris.qe.suse.de/tests/11882) | [12-SP5](https://duck-norris.qe.suse.de/tests/11883)
