### PR TITLE
Disable "Short Survey" Notification

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -534,6 +534,7 @@ EOF
         q{cat <<EOF > $(rpm --eval %_libdir)/firefox/firefox.cfg
 // Mandatory comment
 // https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/first-run.html
+pref("app.normandy.enabled", false);
 pref("browser.aboutwelcome.enabled", false);
 pref("browser.startup.upgradeDialog.enabled", false);
 pref("privacy.restrict3rdpartystorage.rollout.enabledByDefault", false);


### PR DESCRIPTION
Similar to https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/105

- Related ticket: https://progress.opensuse.org/issues/122830
- Verification run: https://openqa.opensuse.org/tests/3037712
