### PR TITLE
Introduce cloud-init verification test

### DIFF
--- a/data/jeos/g_cloudinit.cfg
+++ b/data/jeos/g_cloudinit.cfg
@@ -1,0 +1,49 @@
+#cloud-config
+# vim: syntax=yaml
+# examples are documented here https://documentation.suse.com/sles/15-SP4/html/SLES-all/article-minimal-vm.html#sec-cloud-init-config-examples
+hostname: cucaracha
+timezone: Europe/Prague
+users:
+  - default
+# New user with password and sudo
+  - name: bernhard
+    shell: /bin/bash
+    groups: users
+    # lock_passwd: Disable password login. Defaults to true
+    lock_passwd: false
+    passwd: $6$SalTsaLt$QZZq7a5g5.CHg2zW6VGhKV2NZ6WnYDmrX1P8aVvE5YZtVBk9I4UhWkmT9yegT35QYXjOWCxGWAKnFcuC84w46/
+    sudo: ALL=(ALL) NOPASSWD:ALL
+# New user with SSH keys and sudo #
+  - name: tester_ssh
+    shell: /bin/bash
+    groups: users
+    ssh_import_id: None
+    lock_passwd: true
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - %SSH_PUBK_RSA%
+      - %SSH_PUBK_ECDSA%
+
+# Register system
+bootcmd:
+  - SUSEConnect -r %SCC_REGCODE% %SCC_URL%
+# Register with RMT
+# runcmd:
+#   - curl http://RMT_SERVER/tools/rmt-client-setup \ --output rmt-client-setup
+#   - sh rmt-client-setup https://RMT_SERVER/
+
+# set root password
+chpasswd:
+  list: |
+    root:%PASSWORD%
+  expire: False
+
+# installs a package and starts a service during the first boot.
+packages:
+  - iotop
+
+# start services
+runcmd:
+  - systemctl enable qemu-guest-agent.service
+  - systemctl start --no-block qemu-guest-agent.service
+

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -597,7 +597,14 @@ sub load_jeos_openstack_tests {
     } else {
         loadtest 'publiccloud/ssh_interactive_start', run_args => $args;
     }
-    #    loadtest "jeos/image_info";
+
+    if (get_var('CLOUD_INIT_VERIFICATION')) {
+        loadtest 'jeos/verify_cloudinit', run_args => $args;
+        loadtest("publiccloud/ssh_interactive_end", run_args => $args);
+        return;
+    }
+
+    loadtest "jeos/image_info";
     loadtest "jeos/record_machine_id";
     loadtest "console/system_prepare" if is_sle;
     loadtest "console/force_scheduled_tasks";
@@ -608,7 +615,6 @@ sub load_jeos_openstack_tests {
         loadtest "console/journal_check";
         loadtest "microos/libzypp_config";
     }
-    loadtest "console/suseconnect_scc" if is_sle;
 
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
     replace_opensuse_repos_tests if is_repo_replacement_required;

--- a/tests/jeos/verify_cloudinit.pm
+++ b/tests/jeos/verify_cloudinit.pm
@@ -1,0 +1,102 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check cloud-init configuration of the image
+# Maintainer: QA-c <qa-c@suse.com>
+
+use Mojo::Base qw(publiccloud::basetest);
+use testapi;
+use Utils::Systemd qw(systemctl);
+use Utils::Logging qw(save_and_upload_log);
+use publiccloud::ssh_interactive qw(select_host_console);
+use utils qw(ensure_serialdev_permissions);
+
+sub run {
+    my ($self, $args) = @_;
+    my @errors = ();
+    my $users = {
+        tester_ssh => {
+            passwd => 'L',
+            keyid => '~/.ssh/test_ci_ecdsa'
+        },
+        $testapi::username => {
+            passwd => 'P',
+            keyid => '~/.ssh/id_rsa'
+        }
+    };
+
+    select_console('root-console');
+    assert_script_run('cloud-init status --wait --long');
+
+    # Registration
+    if (script_run('test -f /etc/zypp/credentials.d/SCCcredentials')) {
+        push @errors, 'System was not registered';
+    }
+    assert_script_run('SUSEConnect --status-text | grep -i active', timeout => 120);
+
+    # qemu-guest-agent service should be enabled and started
+    assert_script_run('rpm -q qemu-guest-agent');
+    systemctl('is-enabled qemu-guest-agent');
+    if (script_run('systemctl --no-pager is-active qemu-guest-agent')) {
+        record_soft_failure("bsc#1207135 - [Build 2.56] qemu-guest-agent.service: Job qemu-guest-agent.service/start failed with result 'dependency'");
+    }
+
+    # Package installation
+    assert_script_run('rpm -q iotop');
+    assert_script_run('iotop -b -n 1');
+
+    # Hostname and timezone
+    assert_script_run('hostnamectl hostname | grep cucaracha');
+    assert_script_run('timedatectl status | grep Europe/Prague');
+
+    # User checks
+    assert_script_run('ls -la ~/.ssh/');
+    assert_script_run('test -s ~/.ssh/authorized_keys');
+    foreach my $u (keys %{$users}) {
+        my $policy = (split(' ', script_output("passwd --status $u")))[1];
+        if ($policy !~ /\b$users->{$u}->{passwd}\b/) {
+            push @errors, "$u has wrong password policy, detected $policy and expected $users->{$u}";
+        }
+    }
+
+    select_console('user-console');
+    assert_script_run('sudo sysctl -a');
+    enter_cmd('sudo -u tester_ssh -i');
+    assert_script_run('cat ~/.ssh/authorized_keys | grep rsa');
+    assert_script_run('cat ~/.ssh/authorized_keys | grep ecdsa');
+    assert_script_run('sudo sysctl -a');
+    enter_cmd('exit');
+
+    select_host_console(force => 1);
+    foreach my $u (keys %{$users}) {
+        $args->{my_instance}->ssh_assert_script_run(cmd => "who -u | grep $u",
+            username => $u,
+            ssh_opts => "-i $users->{$u}->{keyid}"
+        );
+    }
+
+    if (@errors) {
+        die join('\n', @errors);
+    }
+}
+
+sub test_flags {
+    return {
+        fatal => 0,
+        milestone => 0,
+        publiccloud_multi_module => 1
+    };
+}
+
+sub post_fail_hook {
+    select_console('log-console');
+
+    upload_logs("/var/log/cloud-init.log");
+    upload_logs("/var/log/cloud-init-output.log");
+    save_and_upload_log('journalctl --no-pager', 'journal.txt');
+    save_and_upload_log('dmesg -x', 'dmesg.txt');
+}
+
+1;


### PR DESCRIPTION
Using `CI_DATA_FILE` the custom Cloud config data file to configure the SUT. Boolean variable `CI_VERIFICATION` loads the test verification module.
I have extended and also a bit modified the provided Cloud config file form the Jira ticket.

- ticket: [[JeOS OpenStack] Cloud-init specific test](https://progress.opensuse.org/issues/107458)
- motivation: https://jira.suse.com/browse/TEAM-6907
- Verification run: http://kepler.suse.cz/tests/19925#step/verify_cloudinit/1
