### PR TITLE
Remove any previous java installed before installing jdk11

### DIFF
--- a/tests/fips/openjdk/openjdk_fips.pm
+++ b/tests/fips/openjdk/openjdk_fips.pm
@@ -18,6 +18,14 @@ use warnings;
 use testapi;
 use utils;
 
+sub remove_any_installed_java {
+    my @output = grep /java-\d+-openjdk/, split(/\n/, script_output "rpm -qa 'java-*'");
+    return unless scalar @output;    # nothing to remove
+    my $pkgs = join ' ', @output;
+    zypper_call "rm ${pkgs}";
+}
+
+
 sub run {
     my $self = @_;
 
@@ -40,7 +48,10 @@ sub run {
     script_run_interactive("certutil -d /etc/pki/nssdb -N", $interactive_str, 30);
     assert_script_run("chmod og+r /etc/pki/nssdb/*");
 
-    # Install openJDK
+    # ensure there ain't newer JDK before installing jdk11
+    remove_any_installed_java();
+
+    # Install openJDK 11
     zypper_call("in java-11-openjdk java-11-openjdk-devel");
 
     # Simple java crypto test


### PR DESCRIPTION
Test installs and check crypto features on jdk11, but there can be some newer JDK on the image; so we uninstall them before testing. 

- Related ticket: https://progress.opensuse.org/issues/116263
- Verification run: https://openqa.suse.de/t10322798
