### PR TITLE
Do not run update CA certificates in parallel

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -14,6 +14,7 @@ use qam;
 use transactional;
 use version_utils 'is_sle_micro';
 use serial_terminal;
+use utils qw(script_retry);
 
 sub run {
     my ($self) = @_;
@@ -22,6 +23,7 @@ sub run {
 
     if (is_sle_micro) {
         assert_script_run 'curl -k https://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt';
+        script_retry('pgrep update-ca-certificates', retry => 5, delay => 2, die => 0);
         assert_script_run 'update-ca-certificates -v';
 
         # Clean the journal to avoid capturing bugs that are fixed after installing updates


### PR DESCRIPTION
`p11-kit: couldn't complete writing of file:
/var/lib/ca-certificates/ca-bundle.pem.tmp: Unknown error 17` appears lately in `sle-micro` updates tests as `update-ca-certificates` might already run in the background

- ticket: https://progress.opensuse.org/issues/123148
- Verification run: https://openqa.suse.de/tests/10324322#step/install_updates/6
