### PR TITLE
Remove DESKTOP from vars of the hpc_installation_dev yaml

### DIFF
--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -4,7 +4,6 @@ description:    >
      Maintainer: qe-kernel
      Installation scenario with HPC system role hpc-dev
 vars:
-  DESKTOP: gnome
   INSTALLONLY: 1
   PATTERNS: default
   SLE_PRODUCT: hpc


### PR DESCRIPTION
The variable is moved from the yaml to the test suite.

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>



- Related ticket: https://progress.opensuse.org/issues/121657
