### PR TITLE
Start sshd service for test 'sshterm'

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -23,6 +23,11 @@ sub run {
     my ($self) = @_;
     mouse_hide(1);
     x11_start_program('xterm');
+    # Restart sshd service in case it is not started
+    enter_cmd("sudo systemctl restart sshd");
+    wait_still_screen(2, 2);
+    type_password;
+    send_key "ret";
     enter_cmd("ssh -o StrictHostKeyChecking=no -XC root\@localhost xterm");
     assert_screen "ssh-second-xterm";
     $self->set_standard_prompt();


### PR DESCRIPTION
https://progress.opensuse.org/issues/123205

We need to make sure sshd service is started
before carrying out the test 'sshxterm'.

- Related ticket: https://progress.opensuse.org/issues/123205
- Verification run: 
[Leap](https://openqa.opensuse.org/tests/3046276) | [TW](https://openqa.opensuse.org/tests/3046362) | [SLE](https://openqa.suse.de/tests/10329499)