### PR TITLE
Revert "Fix xterm case in LEAP 15.4"

### DIFF
--- a/tests/x11/xterm.pm
+++ b/tests/x11/xterm.pm
@@ -14,17 +14,9 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
-use power_action_utils qw(power_action);
-use version_utils qw(is_leap);
 
 sub run {
     my ($self) = @_;
-    # workaround for bsc#1205518
-    if (is_leap) {
-        record_info 'workaround', 'bsc#1205518 - Rebooting the VM to avoid the gnome issue';
-        power_action('reboot', textmode => 1);
-        $self->wait_boot(bootloader_time => 300);
-    }
     select_console 'x11';
     $self->test_terminal('xterm');
 }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16219

This breaks most Leap 15.4 tests: https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.4&build=31.94&groupid=89

Is this actually Leap specific? IMO this should at least do `if (is_leap("=15.4") && is_gnome)`, ideally also check for this specific error condition.

Why is this workaround in the `xterm` module?

@DeepthiYV