### PR TITLE
wget return code got lost due to pipe 

### DIFF
--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -33,9 +33,9 @@ sub run {
     }
 
     # Download the given image via wget. Note that by default wget retries 20 times before giving up
-    my $cmd = "wget -q --no-check-certificate --retry-connrefused --retry-on-host-error $img_url -O $img_name";
+    my $cmd = "wget -q --server-response --no-check-certificate --retry-connrefused --retry-on-host-error $img_url -O $img_name";
     # A generious timeout is required because downloading up to 30 GB (Azure images) can take more than an hour.
-    my $rc = script_run("$cmd 2>&1 | tee download.txt", timeout => 120 * 60);
+    my $rc = script_run("(set -o pipefail && $cmd 2>&1 | tee download.txt)", timeout => 120 * 60);
     if ($rc != 0) {
         # Check for 404 errors and make them better visible
         upload_logs("download.txt");


### PR DESCRIPTION
Current image download does not warn the use that [image has not been found](http://kepler.suse.cz/tests/20005#step/upload_image/63). Reading the HTTP header we can examine whether `wget` was successful or not. For testing purposes I have tried to download `I_do_Not_Exist.qcow2` image from OSD hdd store.

- ticket: https://progress.opensuse.org/issues/121258
- VR: http://kepler.suse.cz/tests/20004#step/upload_image/65


