### PR TITLE
Retry zypper install as opensuse download is unstable laterly

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -1,6 +1,6 @@
 # VIRTUAL MACHINE INSTALLATION AND CONFIGURATION BASE MODULE
 #
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: This module provides framework and APIs to install virtual
@@ -253,7 +253,8 @@ sub initialize_guest_params {
     $self->{$_} //= '' foreach (keys %guest_params);
     $self->{host_ipaddr} = get_required_var('SUT_IP');
     $self->{host_name} = script_output("hostname");
-    $self->{host_domain_name} = script_output("dnsdomainname");
+    # For SUTs with multiple interfaces, `dnsdomainname` sometimes does not work
+    $self->{host_domain_name} = script_output("dnsdomainname", proceed_on_failure => 1);
     $self->{start_run} = time();
     return $self;
 }
@@ -401,9 +402,12 @@ sub prepare_non_transactional_environment {
         virt_autotest::utils::setup_rsyslog_host($common_log_folder);
         my $_packages_to_check = 'wget curl screen dnsmasq xmlstarlet yast2-schema python3 nmap';
         zypper_call("install -y $_packages_to_check");
-        my $_patterns_to_check = 'kvm_server kvm_tools';
-        $_patterns_to_check = 'xen_server xen_tools' if ($self->{host_virt_type} eq 'xen');
-        zypper_call("install -y -t pattern $_patterns_to_check");
+        # There is already the highest version for kvm/xen packages on TW
+        if (is_sle) {
+            my $_patterns_to_check = 'kvm_server kvm_tools';
+            $_patterns_to_check = 'xen_server xen_tools' if ($self->{host_virt_type} eq 'xen');
+            zypper_call("install -y -t pattern $_patterns_to_check");
+        }
     }
     return $self;
 }
@@ -1139,7 +1143,7 @@ sub config_guest_network_bridge_device {
     my $_bridge_network_in_route = shift;
     my $_bridge_device = shift;
     $_bridge_device //= $self->{guest_network_device};
-    if ((script_output("ip route show | grep -o $_bridge_device", proceed_on_failure => 1) eq '') and (script_output("ip route show | grep -o $_bridge_network_in_route", proceed_on_failure => 1) eq '')) {
+    unless ((script_run("ip route show | grep -o $_bridge_device") == 0) or (script_run("ip route show | grep -o $_bridge_network_in_route") == 0)) {
         my $_detect_active_route = '';
         my $_detect_inactive_route = '';
         if ($self->{guest_netaddr} ne 'host-default') {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2303,7 +2303,7 @@ sub permit_root_ssh_in_sol {
     my $sshd_config_file = shift;
 
     $sshd_config_file //= "/etc/ssh/sshd_config";
-    enter_cmd("[ `grep \"^PermitRootLogin *yes\" $sshd_config_file | wc -l` -gt 0 ] || (echo 'PermitRootLogin yes' >>$sshd_config_file; systemctl restart sshd)");
+    enter_cmd("[ `grep \"^PermitRootLogin *yes\" $sshd_config_file | wc -l` -gt 0 ] || (echo 'PermitRootLogin yes' >>$sshd_config_file; systemctl restart sshd)", wait_still_screen => 5);
 }
 
 =head2 cleanup_disk_space

--- a/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
+++ b/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
@@ -19,7 +19,7 @@ use base 'virt_autotest_base';
 use testapi;
 use ipmi_backend_utils;
 use Utils::Backends qw(use_ssh_serial_console is_remote_backend);
-use utils qw(zypper_call systemctl permit_root_ssh_in_sol);
+use utils qw(zypper_call systemctl permit_root_ssh_in_sol script_retry);
 use virt_autotest::utils qw(is_kvm_host is_xen_host);
 
 sub run {
@@ -49,7 +49,7 @@ sub run {
     die 'Need one of both to be true: is_kvm_host || is_xen_host' unless is_kvm_host || is_xen_host;
     my $hypervisor = is_kvm_host ? 'kvm' : 'xen';
     zypper_call('--gpg-auto-import-keys ref');
-    zypper_call("in -t pattern ${hypervisor}_server ${hypervisor}_tools", 1800);
+    script_retry("zypper -n in -t pattern ${hypervisor}_server ${hypervisor}_tools", timeout => 1800, retry => 5, delay => 10);
     set_grub_on_vh('', '', $hypervisor);
     systemctl 'enable libvirtd', ignore_failure => 1;
 


### PR DESCRIPTION
Improve test stability by following ways:

- try 5 times to zypper install kvm/xen patterns to fix this failing case: https://openqa.opensuse.org/tests/3049532#step/switch_to_ssh_and_install_hypervisor/18. 3 times tries still failed, fg. https://openqa.opensuse.org/tests/3077870.
- replace script_output() with script_run() as it always fails. fg. https://openqa.opensuse.org/tests/3069180#step/unified_guest_installation/38 & https://openqa.opensuse.org/tests/3076648#step/unified_guest_installation/100
- wait 5s after sshd restarted, because https://openqa.opensuse.org/tests/3073980
- Need not update kvm/xen packages as it is TumbleWeed.
- Make test continue with failing `dnsdomainname` command as it might
  not work on SUTs with multiple interfaces, fg. https://openqa.opensuse.org/tests/3082110#step/unified_guest_installation/336
- Try one more time login as TW fails with incorrect password sporatically in O3, fg. https://openqa.opensuse.org/tests/3089170#step/switch_to_ssh_and_install_hypervisor/5. have to verify this commit in O3 builds. Improve this change on need later.
- Mark dry run failed and continue tests as it always timeout in O3 when download kernel files from download.opensuse.org, fg. https://openqa.opensuse.org/tests/3102454#step/unified_guest_installation/296. In addition, reconnnect ssh console is added because https://openqa.opensuse.org/tests/3106501#step/unified_guest_installation/306.


Related ticket: https://progress.opensuse.org/issues/103742

Verification run: 
- TW kvm: https://openqa.opensuse.org/tests/3081080
- TW xen:  https://openqa.opensuse.org/tests/3078108
- SLE in my openqa: http://10.67.129.102/tests/473
