### PR TITLE
Improve HA check logs

### DIFF
--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -29,13 +29,15 @@ sub run {
     ha_export_logs;
 
     # Looking for segfault during the test
-    if (script_run '(( $(grep -sR segfault /var/log | wc -l) == 0 ))') {
-        if (script_run '(( $(grep -E -sR iscsiadm.+segfault /var/log | wc -l) == 0 ))') {
-            record_soft_failure "bsc#1181052 - segfault on iscsiadm";
-        }
-        else {
-            die "segfault detected in the system! Aborting";
-        }
+    if (script_run '(( $(grep -E -sR iscsiadm.+segfault /var/log | wc -l) == 0 ))') {
+        record_soft_failure "bsc#1181052 - segfault on iscsiadm";
+    } else {
+        validate_script_output(
+            'grep -sR --before-context=5 --after-context=15 segfault /var/log || echo "There is no SEGFAULT in the logs."',
+            # there must be _no_ segfault
+            sub { /segfault/ ? 0 : 1 },
+            title => 'segfault?'
+        );
     }
 }
 


### PR DESCRIPTION
The check logs module is looks for segfault in the logs.
This change implements that some lines of the log around the failure are shown on the card of the failure.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1206661
- Verification run: 
   - failing (with segfault in log): https://openqa.suse.de/tests/10336202#step/check_logs/51
   - successful (no segfault): https://openqa.suse.de/tests/10337188#step/check_logs/47