### PR TITLE
Whitelist bsc 1196335 on SLE Micro 5.3

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -382,7 +382,8 @@
         "description": "Failed to start Load kdump kernel and initrd",
         "products": {
             "opensuse": ["Tumbleweed"],
-            "microos":  ["Tumbleweed"]
+            "microos":  ["Tumbleweed"],
+            "sle-micro": ["5.3"]
         },
         "type": "ignore"
     },


### PR DESCRIPTION
Needed after kernel update, same behavior as in MicroOS.