### PR TITLE
Make sure httpd2-prefork pid is shown up in apache test

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -135,7 +135,7 @@ sub run {
 
             # Run and test this new environment
             assert_script_run 'httpd2-prefork -f /tmp/prefork/httpd.conf';
-            assert_script_run 'until ps aux|grep wwwrun; do echo waiting for httpd2-prefork pid; done';
+            assert_script_run 'until ps aux|grep wwwrun|grep -E httpd\(2\)?-prefork; do echo waiting for httpd2-prefork pid; done';
             assert_script_run 'ps aux | grep "\-f /tmp/prefork/httpd.conf" | grep httpd2-prefork';
 
             # Run and test the old environment too


### PR DESCRIPTION
https://progress.opensuse.org/issues/123334

Current logic only 'grep' wwwrun daemon, it will return 0 even the pid does not show up, so use more strict cmd line to make sure the pid is there before moving on the later tests.

- Verification run: 
[Leap](https://openqa.opensuse.org/tests/3052206) | [SLE](https://openqa.suse.de/tests/10344793) | [TW](https://openqa.opensuse.org/tests/3052205)