### PR TITLE
Prevent install_SLES from being called

### DIFF
--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x.yaml
@@ -15,6 +15,7 @@ vars:
   ADDONS: all-packages
   YUI_REST_API: 1
 schedule:
+  product_selection: []
   registration:
     - installation/registration/skip_registration
   extension_module_selection:

--- a/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base_s390x.yaml
@@ -7,7 +7,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration
   - installation/module_selection/select_extension_ha

--- a/schedule/yast/textmode/ha_textmode_skip_registration_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_s390x.yaml
@@ -7,7 +7,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration
   - installation/module_selection/select_extension_ha

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role@s390x.yaml
@@ -1,6 +1,6 @@
 ---
-name:           textmode_installation_minimal_role
-description:    >
+name: textmode_installation_minimal_role
+description: >
   Full Medium installation that covers the following cases:
     1. Installation in textmode;
     2. "Minimal" role is selected;
@@ -12,6 +12,7 @@ vars:
   DESKTOP: textmode
   YUI_REST_API: 1
 schedule:
+  product_selection: []
   system_role:
     - installation/system_role/select_role_minimal
   stop_timeout_system_reboot: []


### PR DESCRIPTION
- See https://jira.suse.com/browse/PED-2973 for details
- If there is no SUSE Manager the install_SLES dialog will not show up, so the test module is not needed.

- Related ticket: - 
- Needles: -
- [Verification runs](https://openqa.suse.de/tests/overview?version=15-SP5&build=rakoenig%2Fos-autoinst-distri-opensuse%23fix_ha_s390&distri=sle)
