### PR TITLE
Fix ssh key creation in JeOS Openstack provider

### DIFF
--- a/lib/publiccloud/openstack.pm
+++ b/lib/publiccloud/openstack.pm
@@ -13,6 +13,7 @@ use Mojo::JSON 'decode_json';
 use testapi;
 use publiccloud::openstack_client;
 
+has ssh_key => undef;
 has ssh_key_name => undef;
 has public_ip => undef;
 has instance_id => undef;
@@ -38,7 +39,6 @@ sub find_img {
 
 sub create_keypair {
     my ($self, $prefix) = @_;
-
     return $self->ssh_key if ($self->ssh_key);
 
     for my $i (0 .. 9) {


### PR DESCRIPTION
Openstack provider needs a different key name, not the one that comes by default in provider.pm
/root/.ssh/id_rsa

Fixes regression caused by
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16010

VR: https://openqa.suse.de/tests/10345796