### PR TITLE
Prevent install_SLES from being called part 2

### DIFF
--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x_zvm.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration@s390x_zvm.yaml
@@ -15,6 +15,7 @@ vars:
   ADDONS: all-packages
   YUI_REST_API: 1
 schedule:
+  product_selection: []
   registration:
     - installation/registration/skip_registration
   extension_module_selection:


### PR DESCRIPTION
- See https://jira.suse.com/browse/PED-2973 for details

- If there is no SUSE Manager the install_SLES dialog will not show up, so the test module is not needed. -

- Next patch for S390x-zVM

[
