### PR TITLE
wicked: Increase timeout for test-ext-firwall.sh on aarch64

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -835,9 +835,11 @@ END_OF_CONTENT_$rand
 
 sub run_test_shell_script
 {
-    my ($self, $title, $script_cmd) = @_;
+    my ($self, $title, $script_cmd, %args) = @_;
+    $args{timeout} //= 300;
+
     $self->check_logs(sub {
-            my $output = script_output($script_cmd . '; echo "==COLLECT_EXIT_CODE==$?=="', proceed_on_failure => 1, timeout => 300);
+            my $output = script_output($script_cmd . '; echo "==COLLECT_EXIT_CODE==$?=="', proceed_on_failure => 1, timeout => $args{timeout});
             my $result = $output =~ m/==COLLECT_EXIT_CODE==0==/ ? 'ok' : 'fail';
             $self->record_console_test_result($title, $output, result => $result);
     });

--- a/tests/wicked/startandstop/sut/t18_firewall_extension.pm
+++ b/tests/wicked/startandstop/sut/t18_firewall_extension.pm
@@ -10,6 +10,7 @@
 use Mojo::Base 'wickedbase';
 use testapi;
 use Utils::Systemd;
+use Utils::Architectures;
 use version_utils 'is_sle';
 
 has wicked_version => '>=0.6.70';
@@ -17,6 +18,7 @@ has wicked_version => '>=0.6.70';
 sub run {
     my ($self, $ctx) = @_;
     my $ifc = $ctx->iface();
+    my %args;
 
     return if ($self->skip_by_wicked_version());
 
@@ -29,7 +31,9 @@ sub run {
     systemctl('enable --now firewalld');
 
     $self->get_from_data('wicked/test-ext-firewall.sh', '/tmp/test-ext-firewall.sh', executable => 1);
-    $self->run_test_shell_script("ext-firewall $ifc", "time /tmp/test-ext-firewall.sh '$ifc'");
+
+    $args{timeout} = 600 if is_aarch64;
+    $self->run_test_shell_script("ext-firewall $ifc", "time /tmp/test-ext-firewall.sh '$ifc'", %args);
 
     $self->skip_check_logs_on_post_run();
 }


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1207293
- Verification run: https://openqa.suse.de/tests/10352904


```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16267 https://openqa.suse.de/tests/10345487 WICKED_EXCLUDE='^(?!t18_).*$' | openqa-wait-job
```
