### PR TITLE
Install open-iscsi before running yast2-iscsi-client

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -105,7 +105,7 @@ sub initiator_connected_targets_tab {
 
 sub run {
     prepare_xterm_and_setup_static_network(ip => $test_data->{initiator_conf}->{ip}, message => 'Configure MM network - client');
-    zypper_call("in yast2-iscsi-client");
+    zypper_call("in open-iscsi");
     mutex_wait('iscsi_target_ready', undef, 'Target configuration in progress!');
     record_info 'Target Ready!', 'iSCSI target is configured, start initiator configuration';
     my $module_name = y2_module_guitest::launch_yast2_module_x11('iscsi-client', target_match => 'iscsi-client');


### PR DESCRIPTION
Tackle this failure https://openqa.suse.de/tests/10341568#step/iscsi_client/46
VR: https://openqa.suse.de/tests/10352875#step/iscsi_client/47
