### PR TITLE
Fix xterm case in LEAP 15.4

### DIFF
--- a/tests/x11/xterm.pm
+++ b/tests/x11/xterm.pm
@@ -14,10 +14,16 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use version_utils qw(is_leap);
 
 sub run {
     my ($self) = @_;
-    select_console 'x11';
+    # workaround for boo#1205518
+    if (is_leap("=15.4") && check_var('DESKTOP', 'gnome')) {
+        select_console "root-console";
+        assert_script_run('systemctl mask getty@tty2', timeout => 300);
+    }
+    select_console('x11', await_console => 0);
     $self->test_terminal('xterm');
 }
 


### PR DESCRIPTION
workaround for https://bugzilla.opensuse.org/show_bug.cgi?id=1205518 as suggested.

- Related ticket: https://progress.opensuse.org/issues/122992
- Needles: NO
- Verification run: 
[15.4-GNOME-Live-aarch64](https://openqa.opensuse.org/tests/3059831#step/xterm/16)
[ opensuse-15.4-GNOME](https://openqa.opensuse.org/tests/3059857#step/xterm/16)
[opensuse-15.4-KDE-Live](https://openqa.opensuse.org/tests/3060316#step/xterm/8)