### PR TITLE
Use python virtual environment in qesapdeployment

### DIFF
--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -224,6 +224,8 @@ subtest '[qesap_execute] simple call' => sub {
     my $res = qesap_execute(cmd => $cmd);
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /.*qesap.py.*-c.*-b.*$cmd\s+.*tee.*$expected_log_name/ } @calls), 'qesap.py and log redirection are fine');
+    ok((any { /.*activate/ } @calls), 'virtual environment activated');
+    ok((any { /.*deactivate/ } @calls), 'virtual environment deactivated');
     ok $res == $expected_res;
 };
 


### PR DESCRIPTION
In order to avoid possible problems and clashes with packages present in the image we are using, this pr creates and activates a python3.9 virtual environment to use for pip installations and the execution of the gluescript.

- Related ticket: https://jira.suse.com/browse/TEAM-6758
- Verification run: http://openqaworker15.qa.suse.cz/tests/124527
