### PR TITLE
Restore  sort order in select_device

### DIFF
--- a/lib/YaST/NetworkSettings/OverviewTab.pm
+++ b/lib/YaST/NetworkSettings/OverviewTab.pm
@@ -49,7 +49,9 @@ sub press_delete {
 sub select_device {
     my ($self, $device) = @_;
     assert_and_click(NAME_COLUMN);
-    send_key 'home';
+    for my $shot (1 .. 3) {
+        send_key 'home';
+    }
     my $device_needle;
     if ($device eq 'bridge') {
         $device_needle = BRIDGE_DEVICE_IN_LIST;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/122224
- Problem solution is to fire the pressure of "home" 3 times, so that it might be recognized by the SUT and then the topmost item in the list is selected
- Needles: - no change in needles
- Verification run: https://openqa.suse.de/tests/10368383#