### PR TITLE
Update fix mode regex

### DIFF
--- a/tests/fips/gnutls/gnutls_base_check.pm
+++ b/tests/fips/gnutls/gnutls_base_check.pm
@@ -37,7 +37,7 @@ sub run {
     if (!get_var("FIPS_ENV_MODE")) {
         validate_script_output 'gnutls-cli --fips140-mode 2>&1', sub {
             m/
-                library\sis\sin\sFIPS140-2\smode.*/sx
+                library\sis\sin\sFIPS140-[2-3]\smode.*/sx
         };
     }
 


### PR DESCRIPTION
`gnutls` has received a new mode `FIPS140-3`, therefore the validation
regex needs to be updated.

- failure: https://openqa.suse.de/tests/10371775#step/gnutls_base_check/16
- VRs:
  * [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-x86_64-Build20230124-1-jeos-fips@uefi-virtio-vga](https://openqa.suse.de/t10374522)
  * [sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20230124-1-jeos-fips@uefi-virtio-vga](https://openqa.suse.de/t10374523)