### PR TITLE
Correct name passed to pars_results

### DIFF
--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -64,7 +64,7 @@ sub run {
 }
 
 sub post_run_hook ($self) {
-    pars_results('HPC rasdaemon tests', $file, @all_tests_results);
+    pars_results('HPC mrsh tests', $file, @all_tests_results);
     parse_extra_log('XUnit', $file);
     $self->SUPER::post_run_hook();
 }


### PR DESCRIPTION
Small correction as a result of a copy-paste

Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

