### PR TITLE
Add new barrier for new test case of MPI

### DIFF
--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -61,6 +61,7 @@ sub run ($self) {
         barrier_create('MPI_SETUP_READY', $nodes);
         barrier_create('MPI_BINARIES_READY', $nodes);
         barrier_create('MPI_RUN_TEST', $nodes);
+        barrier_create('IBM_TEST_DONE', $nodes);
     }
     elsif (check_var('HPC', 'hpc_comprehensive')) {
         if (get_var('HPC_MIGRATION')) {

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -122,7 +122,9 @@ sub run ($self) {
 
     record_info 'testing IMB', 'Run all IMB-MPI1 components';
     my $imb_version = script_output("rpm -q --queryformat '%{VERSION}' imb-gnu-$mpi-hpc");
-    assert_script_run("mpirun -np 4 /usr/lib/hpc/gnu7/$mpi/imb/$imb_version/bin/IMB-MPI1", timeout => 320);
+    # Run IMB-MPI1 without args to run the whole set of testings. Mind the timeout if you do so
+    assert_script_run("mpirun -np 4 /usr/lib/hpc/gnu7/$mpi/imb/$imb_version/bin/IMB-MPI1 PingPong");
+    barrier_wait('IBM_TEST_DONE');
 }
 
 sub test_flags ($self) {

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -31,6 +31,8 @@ sub run ($self) {
     record_info 'MPI_BINARIES_READY', strftime("\%H:\%M:\%S", localtime);
     barrier_wait('MPI_RUN_TEST');
     record_info 'MPI_RUN_TEST', strftime("\%H:\%M:\%S", localtime);
+    barrier_wait('IBM_TEST_DONE');
+    record_info 'IBM_TEST_DONE', strftime("\%H:\%M:\%S", localtime);
 }
 
 sub test_flags ($self) {


### PR DESCRIPTION
I added a parameter to the IMB-MPI1 as the only purpose is to test if it works and not run performance tests. That reduces the runtime as well which on OSD seemed to not be enough. To sync the server-clients I added also a new barrier.


- Verification run: https://aquarius.suse.cz/tests/14549#details
