### PR TITLE
Stabilize clock and for journalctl check

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -160,8 +160,8 @@ sub run {
         }
     } else {
         assert_script_run("systemctl start chronyd");
-        assert_script_run("chronyc waitsync", fail_message => "time synchronization failed");
-        assert_script_run("systemctl enable --now chrony-wait.service", fail_message => "error enabling chrony-wait");
+        script_retry("chronyc waitsync 60 1 0 5", timeout => 300, retry => 3, die => 1);
+        systemctl('enable chrony-wait.service');
     }
 
 


### PR DESCRIPTION
`chrony-wait.service` is failing often in journalctl. The service needs to run in each boot so the SUT won't start with drifted time. In order to ensure minimal time drift, we need to make sure that `waitsync` call syncs the time properly.

- ticket: [15-SP5 Beta 4 Minimal-VM times out in enabling chrony](https://progress.opensuse.org/issues/123385)
- VR: [sle-15-SP4-JeOS-for-kvm-and-xen-Updates](http://kepler.suse.cz/tests/20312)
