### PR TITLE
SElinux select box handling

### DIFF
--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -36,6 +36,9 @@ sub run {
         send_key 'ret' if $textmode;
     } else {
         # Select SELinux first
+        # sle-micro 5.3+ selects SELinux by default
+        # let's wait for YaST2 to load the settings
+        wait_still_screen stilltime => 9, timeout => 45;
         send_key 'alt-s';
         send_key_until_needlematch 'security-module-selinux', 'up';
         send_key 'ret' if $textmode;


### PR DESCRIPTION
According to video, SElinux seems to be unselected by default. YaST2 logs are claiming it should have been. Maybe the default settings are being loaded slowly than the test expects.

```
2023-01-21 20:35:32 <1> install(3767) [Ruby]
lsm/config.rb(propose_default):56 The settings are {:select=>"selinux",
:configurable=>true, :apparmor=>{"patterns"=>"apparmor",
"selectable"=>false}, :selinux=>{"mode"=>"permissive",
"configurable"=>true, "selectable"=>true,
"patterns"=>"microos-selinux"}}
```

- Related ticket: [test fails in enable_selinux on SLEM 5.3](https://progress.opensuse.org/issues/122581)
- Verification runs: 

Created job #10380753: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380753
Created job #10380754: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380754
Created job #10380755: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380755
Created job #10380756: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380756
Created job #10380757: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380757
Created job #10380758: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380758
Created job #10380759: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380759
Created job #10380760: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380760
Created job #10380761: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380761
Created job #10380762: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380762
Created job #10380763: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380763
Created job #10380764: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380764
Created job #10380765: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380765
Created job #10380766: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380766
Created job #10380767: sle-micro-5.3-DVD-Updates-aarch64-Build20230125-1-slem_installation_selinux@aarch64 -> https://openqa.suse.de/t10380767

