### PR TITLE
Increase timeout to enable mandatory features 

### DIFF
--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -92,12 +92,12 @@ sub run {
     # reboot the SUT
     $self->run_in_powershell(
         cmd => $powershell_cmds->{enable_wsl_feature}->{wsl},
-        timeout => 120
+        timeout => 240
     );
     if (get_var('WSL2')) {
         $self->run_in_powershell(
             cmd => $powershell_cmds->{enable_wsl_feature}->{vm_platform},
-            timeout => 120
+            timeout => 240
         );
     }
 


### PR DESCRIPTION
MS features require more time to process in Windows 11.

- failures: https://openqa.suse.de/tests/10363492#step/prepare_wsl_feature/20
- Verification run: http://kepler.suse.cz/tests/20317#step/prepare_wsl_feature/39
