### PR TITLE
Add settings for the trento-wanda image

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -339,7 +339,7 @@ sub trento_acr_azure {
     record_info($script_id);
     my $trento_registry_chart = get_var('TRENTO_REGISTRY_CHART', 'registry.suse.com/trento/trento-server');
     my $cfg_json = 'config_images_gen.json';
-    my @imgs = qw(WEB RUNNER);
+    my @imgs = qw(WEB RUNNER WANDA);
 
     # this setting combination require config_helper.py and trento_cluster_install.sh
     my $rolling_mode = (get_var("TRENTO_REGISTRY_IMAGE_$imgs[0]") || get_var("TRENTO_REGISTRY_IMAGE_$imgs[1]") || get_var('TRENTO_REGISTRY_CHART_VERSION'));

--- a/variables.md
+++ b/variables.md
@@ -225,6 +225,8 @@ TRENTO_REGISTRY_CHART | string | registry.suse.com/trento/trento-server | Helm c
 TRENTO_REGISTRY_CHART_VERSION | string |  | Optional. Tag for the chart image
 TRENTO_REGISTRY_IMAGE_RUNNER | string |  | Optional. Overwrite the trento-runner image in the helm chart
 TRENTO_REGISTRY_IMAGE_RUNNER_VERSION | string |  | Optional. Version tag for the trento-runner image
+TRENTO_REGISTRY_IMAGE_WANDA | string |  | Optional. Overwrite the trento-wanda image in the helm chart
+TRENTO_REGISTRY_IMAGE_WANDA_VERSION | string |  | Optional. Version tag for the trento-wand image
 TRENTO_REGISTRY_IMAGE_WEB | string |  | Optional. Overwrite the trento-web image in the helm chart
 TRENTO_REGISTRY_IMAGE_WEB_VERSION | string |  | Optional. Version tag for the trento-web image
 TRENTO_GITLAB_REPO | string | gitlab.suse.de/qa-css/trento | Repository for the deployment scripts


### PR DESCRIPTION
Setting support are only for the images push/pull and the 'helm update' command composition. 
More adaptation are needed to have Wanda enabled at runtime

- Related ticket: CFSA-1743
- Verification run: http://openqaworker15.qa.suse.cz/tests/124742#step/deploy_trento/10
