### PR TITLE
Fix pycairo module in tumbleweed

### DIFF
--- a/data/python/pycairo_sample_tumbleweed.svg
+++ b/data/python/pycairo_sample_tumbleweed.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="200" height="200" viewBox="0 0 200 200">
+<path fill="none" stroke-width="0.04" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 0%)" stroke-opacity="1" stroke-miterlimit="10" d="M 0.1 0.5 C 0.4 0.9 0.6 0.1 0.9 0.5 " transform="matrix(200, 0, 0, 200, 0, 0)"/>
+<path fill="none" stroke-width="0.02" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(100%, 20%, 20%)" stroke-opacity="0.6" stroke-miterlimit="10" d="M 0.1 0.5 L 0.4 0.9 M 0.6 0.1 L 0.9 0.5 " transform="matrix(200, 0, 0, 200, 0, 0)"/>
+</svg>

--- a/tests/console/python_pycairo.pm
+++ b/tests/console/python_pycairo.pm
@@ -17,6 +17,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'zypper_call';
+use version_utils 'is_tumbleweed';
 
 sub run {
     my $self = shift;
@@ -27,13 +28,15 @@ sub run {
 
     # Import pycairo script and sample svg file
     assert_script_run("curl -O " . data_url("python/pycairo_sample.py"));
-    assert_script_run("curl -O " . data_url("python/pycairo_sample.svg"));
+
+    my $sample_svg = is_tumbleweed ? "pycairo_sample_tumbleweed.svg" : "pycairo_sample.svg";
+    assert_script_run("curl -O " . data_url("python/$sample_svg"));
 
     # Execute pycairo script and generate the svg file
     assert_script_run("python3 pycairo_sample.py");
 
     # Compare generated svg file with the expected one
-    assert_script_run("diff pycairo_sample.svg pycairo_generated.svg");
+    assert_script_run("diff $sample_svg  pycairo_generated.svg");
 
     $self->cleanup();
 }
@@ -46,7 +49,7 @@ sub post_fail_hook {
 }
 
 sub cleanup {
-    script_run("rm -f pycairo_sample.py pycairo_sample.svg pycairo_generated.svg");
+    script_run("rm -f pycairo_sample.py pycairo_sample.svg pycairo_sample_tumbleweed.svg pycairo_generated.svg");
 }
 
 1;


### PR DESCRIPTION
Created a new SVG sample file for tumbleweed.  


- Related ticket: https://progress.opensuse.org/issues/117331
- Needles: No
- Verification run: 
 Tumbleweed : [x86_64](https://openqa.opensuse.org/tests/3069746#step/python_pycairo/14) | [aarch64](https://openqa.opensuse.org/tests/3069664#step/python_pycairo/14)
SLE15-SP5 :  [aarch64](https://openqa.suse.de/tests/10379156#step/python_pycairo/14) |  [x86_64](https://openqa.suse.de/tests/10379173#step/python_pycairo/14) | [ppc64le](https://openqa.suse.de/tests/10379172#step/python_pycairo/14)| [s390](https://openqa.suse.de/tests/10379174#step/python_pycairo/14)
