### PR TITLE
Drop system_prepare in JeOS main testsuite

### DIFF
--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -40,7 +40,6 @@ schedule:
     - '{{wizard}}'
     # - jeos/image_info
     - jeos/record_machine_id
-    - console/system_prepare
     - console/force_scheduled_tasks
     - jeos/grub2_gfxmode
     - jeos/diskusage


### PR DESCRIPTION
There is only one xen console defined in the xml file for xen domains. As we do not have any serial console support for xens at the moment, we can drop this module until the support is added.

Culprit: https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/4a89bfb0f44e961b9c5a9b9f5d152391c0bb40d3

- ticket: [[Investigate] agetty[2476]: /dev/hvc1: cannot open as standard input: No such device](https://progress.opensuse.org/issues/123694)
- VR: https://openqa.suse.de/tests/10379171#step/journal_check/2
