### PR TITLE
Provide workaround for iscsi failure bsc#1207157

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -105,9 +105,10 @@ sub initiator_connected_targets_tab {
 
 sub run {
     prepare_xterm_and_setup_static_network(ip => $test_data->{initiator_conf}->{ip}, message => 'Configure MM network - client');
-    zypper_call("in open-iscsi");
+    zypper_call("in open-iscsi yast2-iscsi-client");
     mutex_wait('iscsi_target_ready', undef, 'Target configuration in progress!');
     record_info 'Target Ready!', 'iSCSI target is configured, start initiator configuration';
+    apply_workaround_bsc1207157() if (is_sle('=15-SP3'));
     my $module_name = y2_module_guitest::launch_yast2_module_x11('iscsi-client', target_match => 'iscsi-client');
     initiator_service_tab;
     initiator_discovered_targets_tab;


### PR DESCRIPTION
Iscsi MU tests for 15 SP3 are failing due to yast2-iscsi-client return with an unexpected exit code. This is an issue that has already appeared on 15 SP5, was addressed with bsc#1206132 and subsequently fixed.
On 15 SP3, while waiting for the fix to land, in order to not block maintainance updates due to failure we apply the fix manually, as workaround, which is pretty straightforward requires some changes to iscsid service file.

- Related ticket: https://progress.opensuse.org/issues/123460
- Needles: No needles
- Verification run for 15 - SP3 : https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=ge0r%2Fos-autoinst-distri-opensuse%23iscsi-workaround
also VR for 15 - SP4 just to prove that it is not affected by the workaround and still works : https://openqa.suse.de/tests/10384717