### PR TITLE
runner env option added and new LTP repo default in PC runltp

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -133,16 +133,19 @@ sub run {
         }
     }
 
-    my $runltp_ng_repo = get_var("LTP_RUN_NG_REPO", "https://github.com/acerv/runltp-ng.git");
+    my $runltp_ng_repo = get_var("LTP_RUN_NG_REPO", "https://github.com/linux-test-project/runltp-ng.git");
     my $runltp_ng_branch = get_var("LTP_RUN_NG_BRANCH", "master");
     record_info('LTP CLONE REPO', "Repo: " . $runltp_ng_repo . "\nBranch: " . $runltp_ng_branch);
 
     assert_script_run("git clone -q --single-branch -b $runltp_ng_branch --depth 1 $runltp_ng_repo");
     $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 ' . get_ltproot() . '/IDcheck.sh', timeout => 300);
     record_info('Kernel info', $instance->run_ssh_command(cmd => q(rpm -qa 'kernel*' --qf '%{NAME}\n' | sort | uniq | xargs rpm -qi)));
+    record_info('VM Detect', $instance->run_ssh_command(cmd => 'systemd-detect-virt'));
 
     my $reset_cmd = $root_dir . '/restart_instance.sh ' . $self->instance_log_args();
     my $log_start_cmd = $root_dir . '/log_instance.sh start ' . $self->instance_log_args();
+
+    my $env = get_var('LTP_PC_RUNLTP_ENV');
 
     assert_script_run($log_start_cmd);
 
@@ -164,6 +167,7 @@ sub run {
     $cmd .= '--run-suite ' . get_required_var('LTP_COMMAND_FILE') . ' ';
     $cmd .= '--skip-tests \'' . get_var('LTP_COMMAND_EXCLUDE') . '\' ' if get_var('LTP_COMMAND_EXCLUDE');
     $cmd .= '--sut=ssh' . $sut . ' ';
+    $cmd .= '--env ' . $env . ' ' if ($env);
     record_info('LTP START', 'Command launch');
     assert_script_run($cmd, timeout => get_var('LTP_TIMEOUT', 30 * 60));
     record_info('LTP END', 'tests done');
@@ -225,6 +229,12 @@ The repo which will be added and is used to install LTP package.
 
 Used to specify a url for a json file with well known LTP issues. If an error occur
 which is listed, then the result is overwritten with softfailure.
+
+=head2 LTP_PC_RUNLTP_ENV
+
+Contains eventual internal environment new parameters for `runltp-ng` , 
+defined with the `--env` option, initialized in a column-separated string format: 
+"PAR1=xxx:PAR2=yyy:...". By default it is empty, not defined.
 
 =head2 PUBLIC_CLOUD_LTP
 

--- a/variables.md
+++ b/variables.md
@@ -111,6 +111,7 @@ LTP_KNOWN_ISSUES | string | | Used to specify a url for a json file with well kn
 LTP_REPO | string | | The repo which will be added and is used to install LTP package.
 LTP_RUN_NG_BRANCH | string | master | Define the branch of the LTP_RUN_NG_REPO.
 LTP_RUN_NG_REPO | string | https://github.com/metan-ucw/runltp-ng.git | Define the runltp-ng repo to be used. Default in publiccloud/run_ltp.pm is the upstream master branch from https://github.com/metan-ucw/runltp-ng.git.
+LTP_PC_RUNLTP_ENV | string | empty | Contains eventual internal environment new parameters for `runltp-ng`, defined with the `--env` option, initialized in a column-separated string format: "PAR1=xxx:PAR2=yyy:...". By default it is empty, undefined.
 LVM | boolean | false | Use lvm for partitioning.
 LVM_THIN_LV | boolean | false | Use thin provisioning logical volumes for partitioning,
 MACHINE | string | | Define machine name which defines worker specific configuration, including WORKER_CLASS.


### PR DESCRIPTION
A new `--env ` option addedt to runltp-ng runner, to inject env parameters in ltp sessions using `LTP_PC_RUNLTP_ENV` new param.
Also `LTP_RUN_NG_REPO` default changed to official ltp repo, after agreement with #team-lsg-qe-kernel team

- Related ticket: : 
    - https://progress.opensuse.org/issues/104478
    - https://github.com/linux-test-project/runltp-ng/issues/11
    - https://github.com/linux-test-project/runltp-ng/pull/13
- Needles: none
- Verification run: _TBD soon_
