### PR TITLE
Drop system_prepare from sle12sp5

### DIFF
--- a/schedule/jeos/sle/jeos12sp5-main.yaml
+++ b/schedule/jeos/sle/jeos12sp5-main.yaml
@@ -25,7 +25,6 @@ schedule:
     - '{{bootloader}}'
     - jeos/firstrun
     - jeos/record_machine_id
-    - console/system_prepare
     - console/force_scheduled_tasks
     - jeos/grub2_gfxmode
     - jeos/diskusage


### PR DESCRIPTION
- ticket: https://progress.opensuse.org/issues/123694
- VR:
  * [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20230125-1-jeos-main@svirt-xen-hvm](http://kepler.suse.cz/tests/20321#)
  * [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20230125-1-jeos-main@64bit-virtio-vga](http://kepler.suse.cz/tests/20320#)

