### PR TITLE
Skip prepare_serial_console() for non-qemu backends

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -77,6 +77,11 @@ sub prepare_serial_console {
         return;
     }
 
+    unless (is_qemu) {
+        record_info('skip virtio', 'Skipped adding consoles due unsupported backend (only BACKEND=qemu supported)');
+        return;
+    }
+
     record_info('getty before', script_output('systemctl | grep serial-getty'));
 
     my $console = 'hvc1';

--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -69,25 +69,31 @@ for ppc64le).
 =cut
 
 sub prepare_serial_console {
+    # Virtio console is disabled only with VIRTIO_CONSOLE=0 (by default
+    # VIRTIO_CONSOLE is not set which also means that virtio console is
+    # *enabled*).
+    unless (!check_var('VIRTIO_CONSOLE', 0)) {
+        record_info('skip virtio', 'Skipped due to disabled virtio console');
+        return;
+    }
+
     record_info('getty before', script_output('systemctl | grep serial-getty'));
 
-    if (!check_var('VIRTIO_CONSOLE', 0)) {
-        my $console = 'hvc1';
+    my $console = 'hvc1';
 
-        # poo#18860 Enable console on hvc0 on SLES < 12-SP2 (root-virtio-terminal)
-        if (is_sle('<12-SP2') && !is_s390x) {
-            add_serial_console('hvc0');
-        }
-        # poo#44699 Enable console on hvc1 to fix login issues on ppc64le
-        # (root-virtio-terminal)
-        elsif (get_var('OFW')) {
-            add_serial_console('hvc1');
-            $console = 'hvc2';
-        }
-
-        # user-virtio-terminal
-        add_serial_console($console);
+    # poo#18860 Enable console on hvc0 on SLES < 12-SP2 (root-virtio-terminal)
+    if (is_sle('<12-SP2') && !is_s390x) {
+        add_serial_console('hvc0');
     }
+    # poo#44699 Enable console on hvc1 to fix login issues on ppc64le
+    # (root-virtio-terminal)
+    elsif (get_var('OFW')) {
+        add_serial_console('hvc1');
+        $console = 'hvc2';
+    }
+
+    # user-virtio-terminal
+    add_serial_console($console);
 
     record_info('getty after', script_output('systemctl | grep serial-getty'));
 }


### PR DESCRIPTION
This should fix RPI and jeos-main@svirt-xen-hvm failures reported in https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/4a89bfb0f44e961b9c5a9b9f5d152391c0bb40d3#r98153902

More notes in: https://progress.opensuse.org/issues/122935#note-13

Verification run:
- https://openqa.suse.de/tests/overview?build=fix/prepare_serial_console
- https://openqa.opensuse.org/tests/overview?build=fix/prepare_serial_console
Tests which were broken:
- RPi3 https://openqa.opensuse.org/tests/3074834#step/system_prepare/3
- RPi4: https://openqa.opensuse.org/tests/3074835#step/system_prepare/3

@ggardet @mloviska FYI
@os-autoinst/tests-maintainer Could you please review this? I suppose I'm correct that starting getty is needed really only on virtio, but maybe I'm wrong.