### PR TITLE
Improve D-installer POC test suite.

### DIFF
--- a/schedule/yast/opensuse/d_installer.yaml
+++ b/schedule/yast/opensuse/d_installer.yaml
@@ -1,7 +1,11 @@
 ---
 name:           d-installer
 description:    >
-  First D-Installer test
+  First D-installer test
 schedule:
   - installation/bootloader_start
-  - installation/d_installer_test
+  - installation/d_installer/d_installer_start_cli
+  - installation/d_installer/d_installer_cli_setup
+  - installation/d_installer/d_installer_cli_installation
+  - installation/d_installer/d_installer_reboot
+  - installation/first_boot

--- a/tests/installation/d_installer/d_installer_cli_installation.pm
+++ b/tests/installation/d_installer/d_installer_cli_installation.pm
@@ -10,27 +10,14 @@ use warnings;
 
 use testapi;
 use utils;
-use power_action_utils qw(power_action);
 
 sub run {
-    $testapi::password = 'linux';
-
-    assert_screen('suse-alp-containerhost-os', 120);
-
-    select_console('root-console');
-
-    assert_script_run('dinstallerctl rootuser password nots3cr3t');
-
     script_start_io('dinstallerctl install');
     wait_serial('Do you want to start the installation?')
       or die 'Confirmation dialog not shown';
     type_string("y\n");
-    my $ret = script_finish_io(timeout => 60000);
+    my $ret = script_finish_io(timeout => 1200);
     die "dinstallerctl install didn't finish" unless defined($ret);
-
-    power_action('reboot', textmode => 1);
-
-    $testapi::password = 'nots3cr3t';
 }
 
 1;

--- a/tests/installation/d_installer/d_installer_cli_setup.pm
+++ b/tests/installation/d_installer/d_installer_cli_setup.pm
@@ -1,0 +1,22 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: First installation using D-Installer current CLI (only for development purpose)
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+use testapi;
+use utils;
+
+sub run {
+    # Set root password
+    assert_script_run('dinstallerctl rootuser password nots3cr3t');
+    # Select disk for installation
+    my @disks = script_output('dinstallerctl storage available_devices');
+    assert_script_run("dinstallerctl storage selected_devices $disks[0]");
+}
+
+1;

--- a/tests/installation/d_installer/d_installer_reboot.pm
+++ b/tests/installation/d_installer/d_installer_reboot.pm
@@ -1,0 +1,21 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: First installation using D-Installer current CLI (only for development purpose)
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+use testapi;
+use utils;
+use power_action_utils qw(power_action);
+
+
+sub run {
+    power_action('reboot', textmode => 1);
+    $testapi::password = 'nots3cr3t';
+}
+
+1;

--- a/tests/installation/d_installer/d_installer_start_cli.pm
+++ b/tests/installation/d_installer/d_installer_start_cli.pm
@@ -1,0 +1,20 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: First installation using D-Installer current CLI (only for development purpose)
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+use testapi;
+use utils;
+
+sub run {
+    $testapi::password = 'linux';
+    assert_screen('suse-alp-containerhost-os', 120);
+    select_console('root-console');
+}
+
+1;


### PR DESCRIPTION
See https://progress.opensuse.org/issues/123628

- Adds return in certain places, as code for previous live CDs does not apply here, to allow system to reboot after install otherwise.
- Splits the initial POC module in several modules
- Adds some cli experiments.

VRs https://openqa.opensuse.org/tests/overview?version=0.1&distri=alp&build=JRivrain%2Fos-autoinst-distri-opensuse%2316310
In aarch64, VRs fails sporadically, as qemu vnc display becomes available too late, after grub timeout. But it's rather out-of-scope, I did not find any workaround, I would suggest just RETRY until we find one.