### PR TITLE
Cleanup gpg-agent.conf when it was created on gpg_ver >= 2.1

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -150,7 +150,7 @@ EOF
     assert_script_run("gpg2 -u $email --verify --verbose $tfile_asc");
 
     # cleanup
-    assert_script_run("rm -f ~/.gnupg/gpg-agent.conf ; gpg-connect-agent reloadagent /bye");
+    assert_script_run("rm -f ~/.gnupg/gpg-agent.conf ; gpg-connect-agent reloadagent /bye") if $gpg_ver ge 2.1;
     # Restore
     assert_script_run("rm -rf $tfile.* $egg_file");
     assert_script_run("rm -rf .gnupg && gpg -K");    # Regenerate default ~/.gnupg


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/123679 #16297
- Verification run:
https://openqa.suse.de/tests/10400094
https://openqa.suse.de/tests/10400095
https://openqa.suse.de/tests/10400096
https://openqa.suse.de/tests/10400137
https://openqa.suse.de/tests/10400138
