### PR TITLE
General Improvements to HanaSR Test

### DIFF
--- a/data/sles4sap/hana_cluster.conf
+++ b/data/sles4sap/hana_cluster.conf
@@ -15,16 +15,20 @@ primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% IPaddr2 \
         op start timeout=20 interval=0 \
         op stop timeout=20 interval=0 \
         op monitor interval=10 timeout=20
-primitive rsc_stonith_sbd stonith:external/sbd \
+primitive stonith-sbd stonith:external/sbd \
         params pcmk_delay_max=15
 ms msl_SAPHana_%SID%_HDB%HDB_INSTANCE% rsc_SAPHana_%SID%_HDB%HDB_INSTANCE% \
-        meta clone-max=2 clone-node-max=1 interleave=true
+        meta clone-max=2 clone-node-max=1 interleave=true maintenance=true
 clone cln_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% \
         meta clone-node-max=1 interleave=true
 colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started msl_SAPHana_%SID%_HDB%HDB_INSTANCE%:Master
 order ord_SAPHana_%SID%_HDB%HDB_INSTANCE% Optional: cln_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% msl_SAPHana_%SID%_HDB%HDB_INSTANCE%
 property SAPHanaSR: \
         hana_prd_site_srHook_SECONDARY_SITE_NAME=SOK
+property cib-bootstrap-options: \
+    stonith-action="reboot" \
+    stonith-timeout="120" \
+    priority-fencing-delay="60"
 rsc_defaults rsc-options: \
         resource-stickiness=1000 \
         migration-threshold=5000

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -101,6 +101,7 @@ sub run {
     # We need to set it for reproducing the same behaviour we had with no-quorum-policy=ignore
     if (!check_var('TWO_NODES', 'no')) {
         record_info("Cluster info", "Two nodes cluster detected");
+        wait_for_idle_cluster;
         assert_script_run "crm corosync set quorum.wait_for_all 0";
         assert_script_run "grep -q 'wait_for_all: 0' $corosync_conf";
         assert_script_run "crm cluster stop";

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -61,9 +61,13 @@ sub run {
         barrier_wait "HANA_CREATED_CONF_$cluster_name";
 
         # Upload the configuration into the cluster
-        assert_script_run 'crm configure property maintenance-mode=true';
-        assert_script_run "crm configure load update $cluster_conf";
-        assert_script_run 'crm configure property maintenance-mode=false';
+        my @crm_cmds = ("crm configure load update $cluster_conf",
+            "crm resource refresh msl_SAPHana_${sid}_HDB${instance_id}",
+            "crm resource maintenance msl_SAPHana_${sid}_HDB${instance_id} off");
+        foreach my $cmd (@crm_cmds) {
+            wait_for_idle_cluster;
+            assert_script_run $cmd;
+        }
     }
     else {
         # Synchronize the nodes
@@ -94,12 +98,17 @@ sub run {
 
     # Synchronize the nodes
     barrier_wait "HANA_LOADED_CONF_$cluster_name";
+    save_state;
 
     # Wait for resources to be started
     wait_until_resources_started(timeout => 300);
 
     # And check for the state of the whole cluster
     check_cluster_state;
+    $self->check_replication_state;
+    $self->check_hanasr_attr;
+    $self->check_landscape;
+    assert_script_run 'cs_clusterstate';
 }
 
 1;

--- a/tests/sles4sap/netweaver_cluster.pm
+++ b/tests/sles4sap/netweaver_cluster.pm
@@ -85,6 +85,7 @@ sub run {
         barrier_wait "NW_CREATED_CONF_$cluster_name";
 
         # Upload the configuration into the cluster
+        wait_for_idle_cluster;
         assert_script_run 'crm configure property maintenance-mode=true';
         assert_script_run "crm configure load update $nw_cluster_conf";
         assert_script_run 'crm configure property maintenance-mode=false';

--- a/tests/sles4sap/sap_suse_cluster_connector.pm
+++ b/tests/sles4sap/sap_suse_cluster_connector.pm
@@ -26,6 +26,7 @@ sub exec_conn_cmd {
     my $cmd = $args{cmd};
     $cmd .= " --out $args{log_file}" if ($args{log_file});
 
+    wait_for_idle_cluster;
     assert_script_run("$args{binary} $cmd", timeout => $timeout);
     if ($args{log_file}) {
         my $output = script_output("cat $args{log_file}", proceed_on_failure => 1);
@@ -80,6 +81,8 @@ sub run {
 
     # Wait for the resources to be restarted
     wait_until_resources_started(timeout => 1200);
+    save_state;    # do a check of the cluster with a screenshot
+    assert_script_run 'crm_resource --cleanup';
 
     # Check for the state of the whole cluster
     check_cluster_state;


### PR DESCRIPTION
This PR introduces general improvements to the HanaSR test with the goal of making it follow more strictly the best practices published on https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/ and to provide more information regarding the cluster status and the host environment to help in the debugging of issues.

4 commits are included in the PR. Please read each of them for more details on the changes introduced.

- Related ticket: N/A
- Needles: N/A
- Verification runs:

HanaSR on 15-SP5: [node 1](http://mango.qa.suse.de/tests/5357#step/hana_cluster/73) & [node 2](http://mango.qa.suse.de/tests/5358#step/fencing#1/72) (fencing with `pkill -9 corosync`)
HanaSR on 15-SP4: [node 1](http://mango.qa.suse.de/tests/5329#step/hana_cluster/63) & [node 2](http://mango.qa.suse.de/tests/5330#step/fencing/21) (fencing with `crm -F node fence`)
HanaSR on 15-SP3: [node 1](http://mango.qa.suse.de/tests/5325#step/hana_cluster/63) & [node 2](http://mango.qa.suse.de/tests/5326#step/fencing/21) (fencing with `crm -F node fence`)
HanaSR on 15-SP2: [node 1](http://mango.qa.suse.de/tests/5321#step/hana_cluster/63) & [node 2](http://mango.qa.suse.de/tests/5322#step/fencing/21) (fencing with `crm -F node fence`)
HanaSR on 15-SP1: [node 1](http://mango.qa.suse.de/tests/5317#step/hana_cluster/65) & [node 2](http://mango.qa.suse.de/tests/5318#step/fencing/21) (fencing with `crm -F node fence`)
HanaSR on 12-SP5: [node 1](http://mango.qa.suse.de/tests/5313#step/hana_cluster/63) & [node 2](http://mango.qa.suse.de/tests/5314#step/fencing/21) (fencing with `crm -F node fence`)
HanaSR on 12-SP4: [node 1](http://mango.qa.suse.de/tests/5370#step/hana_cluster/69) & [node 2](http://mango.qa.suse.de/tests/5371#step/fencing#1/30) (fencing with `pkill -9 corosync`)
2 Node Cluster without SAP workload: [node 1](http://mango.qa.suse.de/tests/5344#step/fencing/14) & [node 2](http://mango.qa.suse.de/tests/5345) (fencing with `echo b > /proc/sysrq-trigger`)
2 Node Cluster without SAP workload: [node 1](http://mango.qa.suse.de/tests/5347) & [node 2](http://mango.qa.suse.de/tests/5348#step/fencing/14) (fencing with `crm -F node fence`)
3 Node Cluster without SAP workload: [node 1](http://mango.qa.suse.de/tests/5377), [node 2](http://mango.qa.suse.de/tests/5378#step/fencing/14), [node 3](http://mango.qa.suse.de/tests/5379) (fencing with `crm -F node fence`)
NetWeaver Cluster (ASCS/ERS): [node 1](http://mango.qa.suse.de/tests/5374#step/netweaver_cluster/59) & [node 2](http://mango.qa.suse.de/tests/5375#step/fencing/14) (fencing with `crm -F node fence`)