### PR TITLE
Revert "Start sshd service for test 'sshterm'"

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -23,11 +23,6 @@ sub run {
     my ($self) = @_;
     mouse_hide(1);
     x11_start_program('xterm');
-    # Restart sshd service in case it is not started
-    enter_cmd("sudo systemctl restart sshd");
-    wait_still_screen(2, 2);
-    type_password;
-    send_key "ret";
     enter_cmd("ssh -o StrictHostKeyChecking=no -XC root\@localhost xterm");
     assert_screen "ssh-second-xterm";
     $self->set_standard_prompt();


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16240

I have enabled the sshd service for the disk images, then don't need this workaround anymore.
at the same time, this workaround may cause new failures due to some timing issues.