### PR TITLE
openssl3: Accept "Engine" and "engine" output from openssl

### DIFF
--- a/tests/security/tpm2/tpm2_engine/tpm2_engine_random_data.pm
+++ b/tests/security/tpm2/tpm2_engine/tpm2_engine_random_data.pm
@@ -18,7 +18,7 @@ sub run {
     select_serial_terminal;
 
     # Random data
-    validate_script_output "openssl rand -engine tpm2tss -hex 10  2>&1", sub { m/engine\s\"tpm2tss\"\sset/ };
+    validate_script_output "openssl rand -engine tpm2tss -hex 10  2>&1", sub { m/[Ee]ngine\s\"tpm2tss\"\sset/ };
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/123918
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3100967
