### PR TITLE
update_kernel: Remove livepatch flavor restriction

### DIFF
--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -13,7 +13,14 @@ our @EXPORT_OK = qw(
 );
 
 sub remove_kernel_packages {
-    my @packages = qw(kernel-default kernel-default-devel kernel-macros kernel-source);
+    my @packages;
+
+    if (check_var('SLE_PRODUCT', 'slert')) {
+        @packages = qw(kernel-rt kernel-rt-devel kernel-source-rt);
+    }
+    else {
+        @packages = qw(kernel-default kernel-default-devel kernel-macros kernel-source);
+    }
 
     # SLE12 and SLE12SP1 has xen kernel
     if (is_sle('<=12-SP1')) {

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -124,19 +124,6 @@ sub kgraft_state {
     my $kver = $1;
     my $module;
 
-    # xen kernel exists only on SLE12 and SLE12SP1
-    if (is_sle('<=12-SP1')) {
-        script_run("lsinitrd /boot/initrd-$kver-xen | grep patch");
-        $module = script_output("lsinitrd /boot/initrd-$kver-xen | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}'");
-
-        if (check_var('REMOVE_KGRAFT', '1')) {
-            die 'Kgraft module exists when it should have been removed' if $module;
-        }
-        else {
-            mod_rpm_info($module);
-        }
-    }
-
     script_run("lsinitrd /boot/initrd-$kver-default | grep patch");
     $module = script_output("lsinitrd /boot/initrd-$kver-default | awk '/-patch-.*ko\$/ || /livepatch-.*ko\$/ {print \$NF}'");
 


### PR DESCRIPTION
SLERT-15SP4 supports livepatching, remove livepatch package restriction to kernel-default.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - kernel-rt: https://openqa.suse.de/tests/10438016
  - kernel-default: https://openqa.suse.de/tests/10438134