### PR TITLE
Move /etc/security/limits.d under /usr on Tumbleweed

### DIFF
--- a/tests/security/nproc_limits.pm
+++ b/tests/security/nproc_limits.pm
@@ -1,9 +1,9 @@
-# Copyright 2019 SUSE LLC
+# Copyright 2023 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Make sure the nproc limits are not set in limits.conf
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#43724
+# Tags: poo#43724, poo#123763
 
 use base "opensusebasetest";
 use power_action_utils "power_action";
@@ -12,15 +12,25 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils 'check_version';
 
 sub run {
     my ($self) = @_;
     select_serial_terminal;
 
     # Check the limits.conf config file
-    script_run('test ! -f /etc/security/limits.conf && install /usr/etc/security/limits.conf -t /etc/security');
-    my $limits_d = script_output('find /etc/security/limits.d/ -name *.conf -exec echo -n "{} " \;');
-    my $out = script_output("awk '!/^\$/ && !/^\\s*#/ {print \$3}' /etc/security/limits.conf $limits_d");
+    my $current_pam_ver = script_output("rpm -q --qf '%{version}\n' pam");
+    record_info('pam version', "Version of Current pam package: $current_pam_ver");
+    my $pathprefix;
+    if (check_version('>=1.5.2', $current_pam_ver))
+    {
+        $pathprefix = "/usr";    # on Tumbleweed
+    } else {
+        script_run('test ! -f /etc/security/limits.conf && install /usr/etc/security/limits.conf -t /etc/security');
+        $pathprefix = "";
+    }
+    my $limits_d = script_output("find $pathprefix" . '/etc/security/limits.d/ -name *.conf -exec echo -n " {} " \;');
+    my $out = script_output(qq{awk '!/^\$/ && !/^\\s*#/ {print \$3}' $pathprefix/etc/security/limits.conf $limits_d});
     die("Failed: nproc limits have been set") if $out =~ m/nproc/;
 
     # Set systemd config file and check with ulimit command


### PR DESCRIPTION
Last [pam update](https://build.opensuse.org/request/show/1060842) moved the limits.d conf directory under /usr 

- Related ticket: https://progress.opensuse.org/issues/123763
- Verification runs: 
    - https://openqa.opensuse.org/tests/3102535          
    - https://openqa.opensuse.org/tests/3101331          
    - https://openqa.suse.de/tests/10438400              
    - https://openqa.suse.de/tests/10438401              
    - https://openqa.suse.de/tests/10438403              
