### PR TITLE
Add install_SLES to fix no license shown on s390x

### DIFF
--- a/schedule/yast/textmode/ha_textmode_skip_registration_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_s390x.yaml
@@ -7,6 +7,7 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
+  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/skip_registration
   - installation/module_selection/select_extension_ha


### PR DESCRIPTION
We need add install_SLES to fix no license shown on s390x. 
failed job: https://openqa.nue.suse.com/tests/10434468#step/accept_license/1

- Related ticket: N/A
- Needles: N/A
- Verification run:  https://openqa.suse.de/tests/10441730#details
