### PR TITLE
Add an autoyast installation schedule file

### DIFF
--- a/schedule/migration/autoyast_offline_pre@pvm.yaml
+++ b/schedule/migration/autoyast_offline_pre@pvm.yaml
@@ -1,0 +1,20 @@
+---
+name: autoyast_offline_pre@pvm
+description: >
+  autoYaST installation and prepare base system for offline migration cases
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - console/system_prepare
+  - console/hostname
+  - console/force_scheduled_tasks
+  - update/patch_sle
+  - shutdown/grub_set_bootargs
+  - shutdown/shutdown


### PR DESCRIPTION
Add an autoyast installation schedule file for power offline migration cases.

- Related ticket: https://progress.opensuse.org/issues/120546#note-12
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/10441920#
- Related mr: https://gitlab.suse.de/coolgw/wegao-test/-/merge_requests/215
