### PR TITLE
Select gnome role for validate_default_target

### DIFF
--- a/schedule/yast/sle/guided_btrfs/guided_btrfs.yaml
+++ b/schedule/yast/sle/guided_btrfs/guided_btrfs.yaml
@@ -9,6 +9,10 @@ vars:
 schedule:
   default_systemd_target:
     - installation/installation_settings/validate_default_target
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
   system_preparation:
     - console/system_prepare
     - console/force_scheduled_tasks

--- a/schedule/yast/sle/guided_ext4/guided_ext4_s390x_kvm.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4_s390x_kvm.yaml
@@ -10,6 +10,10 @@ schedule:
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
   default_systemd_target:
     - installation/installation_settings/validate_default_target
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices


### PR DESCRIPTION
We need select gnome role to fix the mismatch issue for validate_default_target.

Failed jobs: https://openqa.nue.suse.com/tests/10435004#
                     https://openqa.nue.suse.com/tests/10435536#step/validate_default_target/8
- Related ticket: https://progress.opensuse.org/issues/123391
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/10442011#
                                https://openqa.suse.de/tests/10442043#details
