### PR TITLE
Unschedule validate_default_target from releasenote

### DIFF
--- a/schedule/yast/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered.yaml
@@ -21,7 +21,6 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation


### PR DESCRIPTION
Unschedule validate_default_target from releasenote, as there is not point to check that there, is not the goal of that test suite
Failed job : https://openqa.nue.suse.com/tests/10441838#step/validate_default_target/1

- Related ticket: N/A
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/10442073#
