### PR TITLE
Schedule test for Mutt TLS in security

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2307,6 +2307,8 @@ sub load_security_tests_crypt_tool {
     loadtest "console/yast2_ntpclient";
     loadtest "console/cups";
     loadtest "console/syslog";
+    loadtest "x11/evolution/evolution_prepare_servers";
+    loadtest "console/mutt";
 }
 
 sub load_security_tests_crypt_libtool {


### PR DESCRIPTION
Scheduling tests for Mutt email client to check if it works with TLS. Originally old broken tests were rewritten, but as it turns out, the existing test `console/mutt` does the same and more. `x11/evolution/evolution_prepare_servers` is needed for preparing dovecot and postfix with TLS support.

- Related ticket: https://progress.opensuse.org/issues/123403
- Verification runs:
    - https://openqa.suse.de/tests/10452502
    - https://openqa.suse.de/tests/10452501
