### PR TITLE
lib/x11utils: Add a new function 'x11_start_program_xterm'

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -16,7 +16,7 @@ use utils qw(
   zypper_call
 );
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_opensuse);
-use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop);
+use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop x11_start_program_xterm);
 use Utils::Backends;
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
 use Cwd;
@@ -332,7 +332,7 @@ sub ensure_installed {
     my $pkglist = ref $pkgs eq 'ARRAY' ? join ' ', @$pkgs : $pkgs;
     $args{timeout} //= 90;
 
-    testapi::x11_start_program('xterm');
+    x11_start_program_xterm;
     $self->become_root;
     ensure_serialdev_permissions;
     quit_packagekit;

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   turn_off_gnome_show_banner
   untick_welcome_on_next_startup
   start_root_shell_in_xterm
+  x11_start_program_xterm
   handle_gnome_activities
 );
 
@@ -563,6 +564,23 @@ sub start_root_shell_in_xterm {
     mouse_set(400, 400);
     mouse_click(['left']);
     become_root;
+}
+
+=head2 x11_start_program_xterm
+
+    x11_start_program_xterm()
+
+Start xterm, if it is not focused, record a soft-failure and focus the xterm window.
+
+=cut
+
+sub x11_start_program_xterm {
+    x11_start_program('xterm', target_match => [qw(xterm xterm-without-focus)]);
+    if (match_has_tag 'xterm-without-focus') {
+        record_soft_failure('poo#111752: xterm is not focused');
+        click_lastmatch;
+        assert_screen 'xterm';
+    }
 }
 
 =head2 handle_gnome_activities


### PR DESCRIPTION
Fixes the problem that sometimes 'xterm' is launched without focus.

Also see ticket https://progress.opensuse.org/issues/107386

@mloviska , you tried on this issue before, can you give a review here?

- Related ticket: https://progress.opensuse.org/issues/111752
- Needles: None
- Verification run: https://openqa.opensuse.org/tests/3106496#step/gnucash/6
