### PR TITLE
usr_sbin_smbd.pm: add retry on s390x

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -35,6 +35,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_sle);
+use Utils::Architectures;
 
 # Setup samba server
 sub samba_server_setup {
@@ -126,7 +127,13 @@ sub samba_client_access {
     assert_screen("nautilus-sharedir-opened");
 
     # Create new folder
-    send_key "shift-ctrl-n";
+    if (is_s390x()) {
+        # on s390x the keyboard shortcut doesn't always work, that's why we use needles instead.
+        assert_and_click("nautilus-empty-view-dclick", button => "right");
+        assert_and_click("nautilus-create-folder");
+    } else {
+        send_key "shift-ctrl-n";
+    }
     assert_screen("nautilus-folder-name-input-box");
     type_string("sub-testdir", wait_screen_change => 10);
     send_key "ret";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/122245
- Verification run: https://openqa.suse.de/tests/10456434#step/usr_sbin_smbd/1
