### PR TITLE
Restore serial console on hpsbase post_run

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -105,6 +105,8 @@ sub post_run_hook {
         upload_logs('/tmp/mpi_bin.log')
           if (check_var('HPC', 'mpi_master') && script_run(qq{test -e /tmp/mpi_bin.log}) == 0);
     }
+    # Restore serial_console
+    select_serial_terminal if check_var('VIRTIO_CONSOLE', '1');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Whenever a module finishes and runs the post_run_hook we miss the correct serial console from the next module in order. That causes to miss logs in the serial_terminal.txt

- Verification run: 
https://aquarius.suse.cz/tests/14701/logfile?filename=serial_terminal.txt