### PR TITLE
Fix typo json->join

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -935,7 +935,7 @@ sub cypress_install_container {
     assert_script_run('podman search --list-tags ' . CYPRESS_IMAGE);
 
     # Pull in advance the cypress container
-    my $podman_pull_cmd = json(' ', 'time', 'podman',
+    my $podman_pull_cmd = join(' ', 'time', 'podman',
         '--log-level', 'trace',
         'pull',
         '--quiet',


### PR DESCRIPTION
Method in trento lib is composing a string to run a command. all the part are joined using method `join`


- Related ticket: CFSA-1759
- Verification run: https://openqaworker15.qa.suse.cz/tests/127511#
