### PR TITLE
Unschedule yast2_ntpclient test from security testsuite

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2304,7 +2304,6 @@ sub load_security_tests_crypt_tool {
     loadtest "console/clamav";
     loadtest "console/openvswitch_ssl";
     loadtest "console/ntp_client";
-    loadtest "console/yast2_ntpclient";
     loadtest "console/cups";
     loadtest "console/syslog";
 }


### PR DESCRIPTION
Rationale:
    - this test module only verifies the working of yast2 NTP, which has little to share with product security testing.
    - the actual time synchronization feature and communication protocol tests are already implemented and checked by module ntp_client
    - yast2_ntpclient module is properly tested in YaST testsuites, like [yast2_ncurses](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/schedule/yast/yast2_ncurses/yast2_ncurses_textmode.yaml) and [yast2_gnome](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/schedule/yast/yast2_ncurses/yast2_ncurses_gnome.yaml)
    - reduce complexity and resource usage


- Related ticket: https://progress.opensuse.org/issues/123442
- Verification runs: 
  - https://openqa.suse.de/tests/10458627
  - https://openqa.suse.de/tests/10458628
  - https://openqa.suse.de/tests/10462635
