### PR TITLE
Add Distribution provider for ALP

### DIFF
--- a/lib/Distribution/Alp.pm
+++ b/lib/Distribution/Alp.pm
@@ -1,0 +1,16 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class represents ALP distribution and provides access to
+# its features.
+
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Distribution::Alp;
+use strict;
+use warnings FATAL => 'all';
+use parent 'susedistribution';
+
+1;

--- a/lib/DistributionProvider.pm
+++ b/lib/DistributionProvider.pm
@@ -20,6 +20,7 @@ use Distribution::Sle::12;
 use Distribution::Opensuse::Leap::42;
 use Distribution::Opensuse::Leap::15;
 use Distribution::Opensuse::Tumbleweed;
+use Distribution::Alp;
 
 =head2 provide
 
@@ -38,6 +39,7 @@ sub provide {
     return Distribution::Sle::12->new() if is_sle('12+');
     return Distribution::Opensuse::Leap::15->new() if is_leap('15.0+');
     return Distribution::Opensuse::Leap::42->new() if is_leap('42.0+');
+    return Distribution::Alp->new() if is_alp;
     return Distribution::Opensuse::Tumbleweed->new();
 }
 

--- a/products/alp/main.pm
+++ b/products/alp/main.pm
@@ -3,6 +3,7 @@ use warnings;
 use needle;
 use File::Basename;
 use scheduler 'load_yaml_schedule';
+use DistributionProvider;
 BEGIN {
     unshift @INC, dirname(__FILE__) . '/../../lib';
 }
@@ -15,7 +16,7 @@ init_main();
 
 my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
-testapi::set_distribution(susedistribution->new());
+testapi::set_distribution(DistributionProvider->provide());
 
 return 1 if load_yaml_schedule;
 main_micro_alp::load_tests();


### PR DESCRIPTION
We need add Distribution provider for ALP.

- Related ticket:  https://progress.opensuse.org/issues/123277
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3109492#step/podman_yast_firewall/22
