### PR TITLE
Deactivate PackageHub for SLE Mciro 5.4

### DIFF
--- a/tests/virt_autotest/prepare_transactional_server.pm
+++ b/tests/virt_autotest/prepare_transactional_server.pm
@@ -34,7 +34,7 @@ sub prepare_in_trup_shell {
     my $self = shift;
 
     transactional::enter_trup_shell(global_options => '--drop-if-no-change');
-    $self->prepare_extensions;
+    #$self->prepare_extensions;
     $self->prepare_packages;
     $self->prepare_bootloader;
     transactional::exit_trup_shell_and_reboot();


### PR DESCRIPTION
* **PackageHub** is not needed at the moment, so it would be better to deactivate it because associated PackageHub repository can not be refreshed successfully with local registration.

* **Verification runs**:
  * [slem on slem](https://openqa.suse.de/tests/10481794)
  * [sles on slem](https://openqa.suse.de/tests/10481200)