### PR TITLE
Public Cloud: azure_nfstest.tf: Change data.http .body to .response_body

### DIFF
--- a/data/publiccloud/terraform/azure_nfstest.tf
+++ b/data/publiccloud/terraform/azure_nfstest.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     azurerm = {
-      version = ">= 3.2.0"
+      version = "= 3.5.0"
       source = "hashicorp/azurerm"
     }
     random = {


### PR DESCRIPTION
The data source data.http attribute .body is now deprecated in favor of .response_body
See: https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http#read-only

- Related ticket: 
- Verification run: 