### PR TITLE
Quick fix for yast default+schedule

### DIFF
--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_x86_64.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_x86_64.yaml
@@ -15,7 +15,6 @@ schedule:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   guided_partitioning:
     - installation/partitioning/lvm_ignore_existing
-    - installation/partitioning/accept_proposed_layout
   default_systemd_target:
     - installation/installation_settings/validate_default_target
   first_login:

--- a/schedule/yast/lvm/lvm_thin_provisioning_x86_64.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning_x86_64.yaml
@@ -14,6 +14,7 @@ schedule:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   expert_partitioning:
     - installation/partitioning/new_partitioning_gpt
+  suggested_partitioning: []
   default_systemd_target:
     - installation/installation_settings/validate_default_target
   system_preparation:

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_x86_64.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_x86_64.yaml
@@ -10,6 +10,7 @@ vars:
 schedule:
   expert_partitioning:
     - installation/partitioning/setup_raid1_lvm
+  suggested_partitioning: []
   default_systemd_target:
     - installation/installation_settings/validate_default_target
   system_validation:


### PR DESCRIPTION
Quick fix for yast default+schedule for build 70.1

- Related ticket:  https://progress.opensuse.org/issues/119887
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/10480950
  https://openqa.suse.de/tests/10480951
  https://openqa.suse.de/tests/10480980
