### PR TITLE
Remove install_SLES as SUSE Manager is not part of installer in SLE15SP5

### DIFF
--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
@@ -8,7 +8,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -14,7 +14,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
@@ -14,7 +14,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
@@ -11,7 +11,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_module_desktop

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -13,7 +13,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
@@ -12,7 +12,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
@@ -9,7 +9,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/msdos/msdos@s390x.yaml
+++ b/schedule/yast/msdos/msdos@s390x.yaml
@@ -8,7 +8,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
@@ -9,7 +9,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_nonconflicting_modules

--- a/schedule/yast/sle/flows/default_s390x_kvm.yaml
+++ b/schedule/yast/sle/flows/default_s390x_kvm.yaml
@@ -6,8 +6,6 @@ setup_libyui:
   - installation/setup_libyui
 access_beta:
   - installation/access_beta_distribution
-product_selection:
-  - installation/product_selection/install_SLES
 license_agreement:
   - installation/licensing/accept_license
 registration:

--- a/schedule/yast/sle/flows/default_s390x_zvm.yaml
+++ b/schedule/yast/sle/flows/default_s390x_zvm.yaml
@@ -6,8 +6,6 @@ setup_libyui:
   - installation/setup_libyui
 access_beta:
   - installation/access_beta_distribution
-product_selection:
-  - installation/product_selection/install_SLES
 license_agreement:
   - installation/licensing/accept_license
 configure_dasd_disks:

--- a/schedule/yast/textmode/ha_textmode_minimal_base_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_minimal_base_s390x.yaml
@@ -7,7 +7,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/view_development_versions

--- a/schedule/yast/textmode/ha_textmode_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_s390x.yaml
@@ -7,7 +7,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/view_development_versions

--- a/schedule/yast/textmode/textmode@s390x_svirt.yaml
+++ b/schedule/yast/textmode/textmode@s390x_svirt.yaml
@@ -8,7 +8,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -12,7 +12,6 @@ schedule:
     - installation/bootloader_start
     - installation/setup_libyui
     - installation/access_beta_distribution
-    - installation/product_selection/install_SLES
     - installation/licensing/accept_license
     - installation/registration/register_via_scc
     - installation/module_registration/register_module_transactional

--- a/schedule/yast/yast_no_self_update/yast_no_self_update@s390x_kvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update@s390x_kvm.yaml
@@ -10,7 +10,6 @@ vars:
   YUI_REST_API: 1
 schedule:
   product_selection:
-    - installation/product_selection/install_SLES
     - installation/validate_no_self_update
   default_systemd_target:
     - installation/installation_settings/validate_default_target

--- a/schedule/yast/yast_self_update/yast_self_update@s390x_kvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update@s390x_kvm.yaml
@@ -10,7 +10,6 @@ vars:
   YUI_REST_API: 1
 schedule:
   product_selection:
-    - installation/product_selection/install_SLES
     - installation/validate_self_update
   default_systemd_target:
     - installation/installation_settings/validate_default_target

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -10,7 +10,6 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/disk_activation/select_configure_zfcp_disks
   - installation/disk_activation/select_add_zfcp_device


### PR DESCRIPTION
Remove install_SLES as SUSE Manager is not part of installer in SLE15SP5
Refer bsc#1207283

- Verification run: http://openqa.suse.de/t10481204
http://openqa.suse.de/t10481216
http://openqa.suse.de/t10481244
http://openqa.suse.de/t10481212
