### PR TITLE
Update new shortcut key for SLES 15SP5

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -80,6 +80,7 @@ sub get_product_shortcuts {
             sles => (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'
             : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'
+            : ((is_sle '=15-SP5') && (get_var('ISO') =~ /Online/)) ? 's'
             : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
Poo:https://progress.opensuse.org/issues/124346
That's a feature about shortcut conflict resolver. So just update code to fix it.

- Related ticket: https://progress.opensuse.org/issues/124346
- Needles: None
- Verification run: N/A
