### PR TITLE
Reset the VMs in textmode for xen VMs for test 'user_defined_snapshot'

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -64,7 +64,13 @@ sub run {
     wait_serial("$module_name-0", 200) || die "'yast2 $module_name' didn't finish";
     $self->{in_wait_boot} = 1;
     record_info 'Snapshot created', 'booting the system into created snapshot';
-    power_action('reboot', keepconsole => 1);
+    if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
+        record_info('workaround for poo#123999');
+        power_action('reboot', textmode => 1, keepconsole => 1);
+    }
+    else {
+        power_action('reboot', keepconsole => 1);
+    }
     $self->wait_grub(bootloader_time => 350);
     send_key_until_needlematch("boot-menu-snapshot", 'down', 11, 5);
     send_key 'ret';


### PR DESCRIPTION
https://progress.opensuse.org/issues/123999

On xen setups, reset the VMs in x11 mode fails sometimes. however it can't be reproduced stably.
Swith the reboot operation in textmode will get better performance.

- Verification run: [VRs](http://openqa.suse.de/tests/overview?build=rfan_xen&version=15-SP5&distri=sle)