### PR TITLE
Increase timeout in sles4sap/sap_suse_cluster_connector

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -679,7 +679,8 @@ returns a non-zero return value.
 
 sub check_hanasr_attr {
     my ($self, %args) = @_;
-    my $looptime = bmwqemu::scale_timeout($args{timeout} // 90);
+    $args{timeout} //= 90;
+    my $looptime = bmwqemu::scale_timeout($args{timeout});
     my $out;
 
     while ($out = script_output 'SAPHanaSR-showAttr') {

--- a/tests/sles4sap/sap_suse_cluster_connector.pm
+++ b/tests/sles4sap/sap_suse_cluster_connector.pm
@@ -26,7 +26,7 @@ sub exec_conn_cmd {
     my $cmd = $args{cmd};
     $cmd .= " --out $args{log_file}" if ($args{log_file});
 
-    wait_for_idle_cluster;
+    wait_for_idle_cluster(timeout => 300);
     assert_script_run("$args{binary} $cmd", timeout => $timeout);
     if ($args{log_file}) {
         my $output = script_output("cat $args{log_file}", proceed_on_failure => 1);


### PR DESCRIPTION
`wait_for_idle_cluster` call in `sles4sap/sap_suse_cluster_connector` test module was using the default 2 minutes timeout, but in some test scenarios this is not enough. This commit increases it to 5 minutes.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/5487 & http://mango.qa.suse.de/tests/5488
