### PR TITLE
Move PAM testing after registration

### DIFF
--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -46,9 +46,9 @@ schedule:
     - jeos/build_key
     - console/prjconf_excluded_rpms
     - console/journal_check
-    - console/pam
     - microos/libzypp_config
     - console/suseconnect_scc
+    - console/pam
     - '{{maintenance}}'
     - '{{efi}}'
     - jeos/glibc_locale


### PR DESCRIPTION
PAM test requires several packages to be installed, therefore we need refreshed repos to be available.

- VR: http://kepler.suse.cz/tests/20356#step/pam/17
