### PR TITLE
Refactor the post_fail_hook functionality

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -17,6 +17,7 @@ use testapi;
 use utils qw(clear_console show_oom_info remount_tmp_if_ro detect_bsc_1063638);
 use Utils::Systemd 'get_started_systemd_services';
 use Mojo::File 'path';
+use serial_terminal 'select_serial_terminal';
 
 our @EXPORT = qw(
   save_and_upload_log
@@ -183,9 +184,7 @@ This method will call several other log gathering methods from this class.
 =cut
 
 sub export_logs {
-    select_log_console();
-    save_screenshot();
-    show_oom_info();
+    select_serial_terminal();
     remount_tmp_if_ro();
     export_logs_basic();
     problem_detection();
@@ -193,8 +192,6 @@ sub export_logs {
     # Just after the setup: let's see the network configuration
     save_and_upload_log("ip addr show", "/tmp/ip-addr-show.log");
     save_and_upload_log("cat /etc/resolv.conf", "/tmp/resolv-conf.log");
-
-    save_screenshot();
 
     export_logs_desktop();
 
@@ -336,8 +333,7 @@ Upload several KDE, GNOME, X11, GDM and SDDM related logs and configs.
 =cut
 
 sub export_logs_desktop {
-    select_log_console;
-    save_screenshot;
+    select_serial_terminal();
 
     if (check_var("DESKTOP", "kde")) {
         if (get_var('PLASMA5')) {
@@ -346,7 +342,7 @@ sub export_logs_desktop {
         else {
             tar_and_upload_log("/home/$username/.kde4/share/config/*rc", '/tmp/kde4_configs.tar.bz2');
         }
-        save_screenshot;
+        #save_screenshot;
     } elsif (check_var("DESKTOP", "gnome")) {
         tar_and_upload_log("/home/$username/.cache/gdm", '/tmp/gdm.tar.bz2');
     }

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -53,12 +53,11 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
     # at this point the instance is shutdown
     return if (is_public_cloud() || is_openstack());
+    # Remaining log functions are executed in Utils::Logging::export_logs()
+    # called in opensusebasetest::post_fail_hook()
     select_console('log-console');
-    remount_tmp_if_ro;
+    show_oom_info;
     show_tasks_in_blocked_state;
-    export_logs_basic;
-    # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
-    export_logs_desktop;
 }
 
 =head2 record_avc_selinux_alerts

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -24,6 +24,7 @@ use IO::Socket::INET;
 use x11utils qw(handle_login ensure_unlocked_desktop handle_additional_polkit_windows);
 use publiccloud::ssh_interactive 'select_host_console';
 use Utils::Logging qw(save_and_upload_log tar_and_upload_log export_healthcheck_basic select_log_console upload_coredumps export_logs);
+use serial_terminal 'select_serial_terminal';
 
 # Base class for all openSUSE tests
 
@@ -981,21 +982,18 @@ base method using C<$self-E<gt>SUPER::post_fail_hook;> at the end.
 
 sub post_fail_hook {
     my ($self) = @_;
-    return if is_serial_terminal();    # unless VIRTIO_CONSOLE=0 nothing below make sense
-
-    show_tasks_in_blocked_state;
 
     return if (get_var('NOLOGS'));
 
     # Upload basic health check log
-    select_log_console;
+    select_serial_terminal();
     export_healthcheck_basic;
 
     # set by x11_start_program
     if (get_var('IN_X11_START_PROGRAM')) {
         my ($program) = get_var('IN_X11_START_PROGRAM') =~ m/(\S+)/;
         set_var('IN_X11_START_PROGRAM', undef);
-        select_log_console;
+
         my $r = script_run "which $program";
         if ($r != 0) {
             record_info("no $program", "Could not find '$program' on the system", result => 'fail');
@@ -1003,7 +1001,6 @@ sub post_fail_hook {
     }
 
     if (get_var('FULL_LVM_ENCRYPT') && get_var('LVM_THIN_LV')) {
-        select_console 'root-console';
         my $lvmdump_regex = qr{/root/lvmdump-.*?-\d+\.tgz};
         my $out = script_output('lvmdump', proceed_on_failure => 1);
         if ($out =~ /(?<lvmdump_gzip>$lvmdump_regex)/) {
@@ -1013,7 +1010,6 @@ sub post_fail_hook {
     }
 
     if (get_var('COLLECT_COREDUMPS')) {
-        select_console 'root-console';
         upload_coredumps(proceed_on_failure => 1);
     }
 
@@ -1025,19 +1021,9 @@ sub post_fail_hook {
     }
     # Find out in post-fail-hook if system is I/O-busy, poo#35877
     else {
-        select_log_console;
         my $io_status = script_output("sed -n 's/^.*da / /p' /proc/diskstats | cut -d' ' -f10");
         record_info('System I/O status:', ($io_status =~ /^0$/) ? 'idle' : 'busy');
     }
-
-    # In case the system is stuck in shutting down or during boot up, press
-    # 'esc' just in case the plymouth splash screen is shown and we can not
-    # see any interesting console logs.
-    send_key 'esc';
-    save_screenshot;
-    # the space prevents the esc from eating up the next alphanumerical
-    # character typed into the console
-    send_key 'spc';
 
     export_logs;
 

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -20,6 +20,7 @@ use x11utils qw(select_user_gnome start_root_shell_in_xterm handle_gnome_activit
 use POSIX 'strftime';
 use mm_network;
 use Utils::Logging qw(export_healthcheck_basic select_log_console export_logs_basic export_logs_desktop);
+use serial_terminal 'select_serial_terminal';
 
 sub post_run_hook {
     my ($self) = @_;
@@ -29,12 +30,13 @@ sub post_run_hook {
 
 sub post_fail_hook {
     return if (get_var('NOLOGS'));
-    select_log_console;
+    select_serial_terminal();
     export_healthcheck_basic;
-    show_tasks_in_blocked_state;
     export_logs_basic;
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
     export_logs_desktop;
+    select_log_console;
+    show_tasks_in_blocked_state;
 }
 
 sub dm_login {


### PR DESCRIPTION
- Related ticket:  https://progress.opensuse.org/issues/120735
- Needles: No
- Verification run: 
 I forcefully made the firefox test fail and results looks fine : https://openqa.opensuse.org/tests/3161410#
  Other VRs:

https://openqa.suse.de/tests/10635862
https://openqa.opensuse.org/tests/3161407
https://openqa.opensuse.org/tests/3161403
https://openqa.opensuse.org/tests/3161402#
https://openqa.opensuse.org/tests/3161404#

