### PR TITLE
Update shortcuts for SLES 15-SP5

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -53,7 +53,7 @@ sub run {
     # Depending on an optional button "release notes" we need to press "tab"
     # to go to the first tab
     send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
-    send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right';
+    send_key_until_needlematch 'inst-bootloader-options-highlighted', is_sle('15-SP5+') ? 'alt-t' : 'right';
     assert_screen 'installation-bootloader-options';
     # Select Timeout dropdown box and disable
     send_key 'alt-t';

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -16,6 +16,7 @@ use base 'y2_installbase';
 use testapi;
 use utils;
 use version_utils qw(is_sle is_leap is_upgrade);
+use Utils::Architectures;
 
 sub run {
     my ($self) = shift;
@@ -53,7 +54,9 @@ sub run {
     # Depending on an optional button "release notes" we need to press "tab"
     # to go to the first tab
     send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
-    send_key_until_needlematch 'inst-bootloader-options-highlighted', is_sle('15-SP5+') ? 'alt-t' : 'right';
+
+    my $bootloader_shortcut = (is_x86_64) ? 'alt-r' : 'alt-t';    # Seems now the bootloader shortcut is a different one
+    send_key_until_needlematch 'inst-bootloader-options-highlighted', is_sle('15-SP5+') ? $bootloader_shortcut : 'right';
     assert_screen 'installation-bootloader-options';
     # Select Timeout dropdown box and disable
     send_key 'alt-t';

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -77,7 +77,8 @@ sub get_product_shortcuts {
         # Full (15-SP4)     s
         return (sles => 's') if (get_var('ISO') =~ /Full/ && is_ppc64le() && get_var('NTLM_AUTH_INSTALL'));
         return (
-            sles => (is_ppc64le() || is_s390x()) ? 'u'
+            sles => (is_sle '15-SP5+') ? 's'
+            : (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'
             : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'
             : (is_sle '=15-SP5') ? 's' : 'i',

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -77,11 +77,11 @@ sub get_product_shortcuts {
         # Full (15-SP4)     s
         return (sles => 's') if (get_var('ISO') =~ /Full/ && is_ppc64le() && get_var('NTLM_AUTH_INSTALL'));
         return (
-            sles => (is_sle '15-SP5+') ? 's'
-            : (is_ppc64le() || is_s390x()) ? 'u'
+            sles => (is_sle '15-SP5+') ? 's'    # for now treat 15-SP5+ as if they would have new shortcuts
+            : (is_ppc64le() || is_s390x()) ? 'u'    # s390 doesn't have a product selection screen for now
             : is_aarch64() ? 's'
             : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'
-            : (is_sle '=15-SP5') ? 's' : 'i',
+            : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',
             rt => is_x86_64() ? 't' : undef


### PR DESCRIPTION
Quck and dirty hack to try to get: https://progress.opensuse.org/issues/124347#note-3


Trying out:
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16366 https://openqa.suse.de/tests/10478712

Created job #10483482: sle-15-SP5-Online-x86_64-Build70.1-gi-guest_developing-on-host_developing-xen@64bit-ipmi-large-mem-intel -> https://openqa.suse.de/t10483482
Created job #10483534: sle-15-SP5-Online-ppc64le-Build70.1-create_hdd_textmode@ppc64le-spvm -> https://openqa.suse.de/t10483534