### PR TITLE
textinfo: do not fail if /etc/sysconfig/network does not exist

### DIFF
--- a/data/textinfo
+++ b/data/textinfo
@@ -11,7 +11,7 @@ ip -o a s
 ip r s
 ip -6 r s
 cat /etc/resolv.conf
-ls -al /etc/sysconfig/network
+ls -al /etc/sysconfig/network || true
 rpm -qa 'kernel-*'
 grep DISPLAYMANAGER /etc/sysconfig/displaymanager || true
 grep DEFAULT /etc/sysconfig/windowmanager || true


### PR DESCRIPTION
The /etc/sysconfig/network directory structure is only used by wicked; it used to be created on all systems, irrespective of the network managing daemon in use. The latest filesystem change eliminated.

- Related ticket: https://build.opensuse.org/request/show/1064299
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3117428
