### PR TITLE
Fix product shortcuts for 15-SP4 QU Full image as well

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -79,7 +79,7 @@ sub get_product_shortcuts {
         return (
             sles => (is_ppc64le() || is_s390x()) ? 'u'
             : is_aarch64() ? 's'
-            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'
+            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 'i'
             : (is_sle '=15-SP5') ? 's' : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
The 15-SP4 QU2 candidate images have added SUSE Manager products to the Full images, resulting in shortcut changes. Earlier QUs will not be further tested.

- Related ticket: https://progress.opensuse.org/issues/124206
- Verification run: https://openqa.suse.de/tests/10494658
