### PR TITLE
multi_users_dm: Fix delete_users script

### DIFF
--- a/data/delete_users
+++ b/data/delete_users
@@ -3,8 +3,10 @@ set -eu
 
 n_users="$1"
 
+killall -u user1
+sleep 1
+ps auxf|grep user1
+
 for i in `seq 1 $n_users` ; do
-	num=`printf "%02d" $i`
-	killall -9 -u "user${i}" || true
 	userdel -r "user${i}"
 done


### PR DESCRIPTION
-kill only logged in user1 processes
-wait 1 sec and print user1 processes
-remove num it's not used

- Related ticket: https://progress.opensuse.org/issues/120832
- Verification run: https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=multi_user_120832