### PR TITLE
Reorder cs_wait_for_cluster calls in sles4sap/sap_suse_cluster_connector

### DIFF
--- a/tests/sles4sap/sap_suse_cluster_connector.pm
+++ b/tests/sles4sap/sap_suse_cluster_connector.pm
@@ -26,7 +26,6 @@ sub exec_conn_cmd {
     my $cmd = $args{cmd};
     $cmd .= " --out $args{log_file}" if ($args{log_file});
 
-    wait_for_idle_cluster(timeout => 300);
     assert_script_run("$args{binary} $cmd", timeout => $timeout);
     if ($args{log_file}) {
         my $output = script_output("cat $args{log_file}", proceed_on_failure => 1);
@@ -69,14 +68,17 @@ sub run {
     my @resources = get_var('NW') ? ('ip', 'fs', 'sap') : ('ip', 'SAPHanaTopology', 'SAPHana');
     foreach my $rsc_type (@resources) {
         my $rsc = "rsc_${rsc_type}_${instance_sid}_${instance_type}${instance_id}";
+        wait_for_idle_cluster;
         exec_conn_cmd(binary => $binary, cmd => "lsn --res $rsc", log_file => $log_file);
     }
 
     # Test Stop/Start of SAP resource
     my $rsc = get_var('NW') ? "rsc_sap_${instance_sid}_${instance_type}${instance_id}" : "rsc_SAPHana_${instance_sid}_${instance_type}${instance_id}";
+    wait_for_idle_cluster;
     exec_conn_cmd(binary => $binary, cmd => "$_ --res $rsc --act stop", timeout => 120) foreach qw(fra cpa);
     wait_until_resources_stopped(timeout => 1200);
     save_state;    # do a check of the cluster with a screenshot
+    wait_for_idle_cluster;
     exec_conn_cmd(binary => $binary, cmd => "$_ --res $rsc --act start", timeout => 120) foreach qw(fra cpa);
 
     # Wait for the resources to be restarted


### PR DESCRIPTION
In the `sles4sap/sap_suse_cluster_connector` test module, not all calls to the `sap_suse_cluster_connector` binary results in changes in the cluster, so calls to `wait_for_idle_cluster` are not always needed. Moreover, the big two calls (stop & start) already had calls to `wait_until_resources_started` and to `wait_until_resources_stopped` with a wait time of 1200 seconds, which should also cover the wait for idle cluster function. This commit drop calls to `wait_for_idle_cluster` introduced to `sles4sap/sap_suse_cluster_connector` in commit 7b07cb6, and adds them only before the calls to `exec_conn_cmd` which would impact the cluster itself.
