### PR TITLE
Bring back install_SLES on aarch64

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -14,7 +14,7 @@ schedule:
   - installation/bootloader_start
   - installation/setup_libyui
   - installation/access_beta_distribution
-  - '{{install_sles}}'
+  - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration
@@ -41,8 +41,3 @@ schedule:
   - installation/performing_installation/confirm_reboot
   - installation/handle_reboot
   - installation/first_boot
-conditional_schedule:
-  install_sles:
-    ARCH:
-      aarch64:
-        - installation/product_selection/install_SLES

--- a/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server.yaml
@@ -12,7 +12,7 @@ schedule:
     - installation/bootloader_start
     - installation/setup_libyui
     - installation/access_beta_distribution
-    - '{{install_sles}}'
+    - installation/product_selection/install_SLES
     - installation/licensing/accept_license
     - installation/registration/register_via_scc
     - installation/module_registration/register_module_transactional
@@ -37,8 +37,3 @@ schedule:
     - shutdown/grub_set_bootargs
     - shutdown/cleanup_before_shutdown
     - shutdown/shutdown
-conditional_schedule:
-    install_sles:
-        ARCH:
-            aarch64:
-                - installation/product_selection/install_SLES


### PR DESCRIPTION
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16357 removed a bit too much, on aarch64 some test suites now fail because hpc product is also avialable.

- Related ticket: 
- Needles: 
- [Verification runs](https://openqa.suse.de/tests/overview?version=15-SP5&build=rakoenig%2Fos-autoinst-distri-opensuse%23fix_aarch64_problems&distri=sle) 