### PR TITLE
Use correct REGcode for sles4sap migration

### DIFF
--- a/tests/sles4sap/migrate_sles_to_sles4sap.pm
+++ b/tests/sles4sap/migrate_sles_to_sles4sap.pm
@@ -28,7 +28,7 @@ sub run {
     # Clean up and re-register not to affect other job which are sharing same qcow2
     if (is_sle('15+')) {
         cleanup_registration();
-        register_product();
+        assert_script_run('SUSEConnect -r ' . get_required_var('SCC_REGCODE'), 200);
     }
 
     # Check the build number, can useful for debugging!


### PR DESCRIPTION
With recent change in lib/registration, function "register_product" uses 
incorrect reg code in SLES to SLES4SAP migration scenarios. This PR replaces 
function with simple registration via command for failed test. 

- Related ticket: N/A
- Needles: N/A
- Failed run: https://openqa.suse.de/tests/10471116#step/migrate_sles_to_sles4sap/20
- Verification runs:
 
https://openqa.suse.de/tests/10504561#
https://openqa.suse.de/tests/10504563
https://openqa.suse.de/tests/10504559
https://openqa.suse.de/tests/10504560