### PR TITLE
Update open source nvidia installation and registration

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -849,8 +849,11 @@ sub is_quarterly_iso {
 
 Get SLES version from VERSION_ID in /etc/os-release. This subroutine also supports
 performing query on remote machine if dst_machine is given specific ip address or
-fqdn text of the remote machine. The default location that contains VERSION_ID is
-file /etc/os-release if nothing else is passed in to argument verid_file.
+fqdn text of the remote machine. If C<dst_machine> is given it will run on the remote
+as B<root>. To run it as another user, C<dst_machine> can be also specified as [user@]hostname.
+
+The default location that contains VERSION_ID is file /etc/os-release if nothing else
+is passed in to argument verid_file.
 
 =cut
 
@@ -860,7 +863,13 @@ sub get_version_id {
     $args{verid_file} //= '/etc/os-release';
 
     my $cmd = "cat $args{verid_file} | grep VERSION_ID | grep -Eo \"[[:digit:]]{1,}\\.[[:digit:]]{1,}\"";
-    $cmd = "ssh root\@$args{dst_machine} " . "$cmd" if ($args{dst_machine} ne 'localhost');
+    if ($args{dst_machine} ne 'localhost') {
+        if ($args{dst_machine} =~ /^(\w+)@.+/) {
+            $cmd = "ssh $args{dst_machine} " . "$cmd";
+        } else {
+            $cmd = "ssh root\@$args{dst_machine} " . "$cmd";
+        }
+    }
     return script_output($cmd);
 }
 

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -24,7 +24,7 @@ sub run {
 
     my $cmd_time = time();
     my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;
-    $args->{my_instance}->ssh_script_retry("sudo zypper -n ref", timeout => $ref_timeout, retry => 6, delay => 60);
+    $args->{my_instance}->ssh_script_retry("sudo zypper -n --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
     record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');
     record_soft_failure('bsc#1195382 - Considerable decrease of zypper performance and increase of registration times') if ((time() - $cmd_time) > 240);
 


### PR DESCRIPTION
Fix the broken nvidia test installing the correct packages. Update also other test modules in order to allow nvidia addon registration.

- Related ticket: https://progress.opensuse.org/issues/124382
- Verification run: [with registration](https://openqa.suse.de/t10504609) [without registration](https://openqa.suse.de/t10504669)