### PR TITLE
Workaround for disable_grub_timeout

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -53,7 +53,7 @@ sub run {
     # Depending on an optional button "release notes" we need to press "tab"
     # to go to the first tab
     send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
-    send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right';
+    send_key 'alt-r';
     assert_screen 'installation-bootloader-options';
     # Select Timeout dropdown box and disable
     send_key 'alt-t';


### PR DESCRIPTION
The disable_grub_timeout module fails and blocks multiple test down the line.

Use alr-r instead of multiple right key presses.

This is a fix for an issue that should not be there. 
The multiple 'right' key presses used to work and still should, but don't.
As this issue is not reproducible manually and hard to pinpoint, I introduce this workaround fix to get the tests done that come after this module.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1208266 https://progress.opensuse.org/issues/124430
- Verification run: https://openqa.suse.de/tests/10504562#
