### PR TITLE
Remove os_owner and bastion_os_major_version usage

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -10,14 +10,12 @@ terraform:
     private_key: "~/.ssh/id_rsa"
     aws_credentials: "/root/amazon_credentials"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    os_owner: "amazon"
 
     hana_os_major_version: "%VERSION%"
     iscsi_os_major_version: "%VERSION%"
     monitoring_os_major_version: "%VERSION%"
     drdb_os_major_version: "%VERSION%"
     netweaver_os_major_version: "%VERSION%"
-    bastion_os_major_version: "%VERSION%"
 
     # HANA
     hana_cluster_fencing_mechanism: "%FENCING_MECHANISM%"

--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -11,7 +11,6 @@ terraform:
     monitoring_os_major_version: "%HANA_OS_MAJOR_VERSION%"
     drdb_os_major_version: "%HANA_OS_MAJOR_VERSION%"
     netweaver_os_major_version: "%HANA_OS_MAJOR_VERSION%"
-    bastion_os_major_version: "%HANA_OS_MAJOR_VERSION%"
     private_key: "~/.ssh/id_rsa"
     public_key: "~/.ssh/id_rsa.pub"
     gcp_credentials_file: "/root/google_credentials.json"


### PR DESCRIPTION
Remove os_owner and bastion_os_major_version usage in qe_sap_deployment yaml files.
- The parameter "os_owner" can be removed and if set to "amazon" test cases will be failed on "aws image query error" as lots of images were added/moved to "aws-marketplace" but not "amazon".
- The parameter "bastion_os_major_version" was abandoned so delete it.

FYI:
TEAM-7313 - For saptune (mr_test) test cases: adjust the value of terraform parameter "os_owner" from "amazon" to "aws-marketplace" for AWS public images

- Related ticket: https://jira.suse.com/browse/TEAM-7313
- Needles: NA
- Verification run: 
sles4sap15sp4 (byos+payg):
 https://openqaworker15.qa.suse.cz/tests/128562 (EC2) (passed) 
 https://openqaworker15.qa.suse.cz/tests/128568 (EC2) (passed)
sles4sap12sp5 (byos+payg):
  https://openqaworker15.qa.suse.cz/tests/128563 (EC2) (passed)
  https://openqaworker15.qa.suse.cz/tests/128564 (GCE) (passed)
