### PR TITLE
multi_users_dm: Add || true back to killall #16372

### DIFF
--- a/data/delete_users
+++ b/data/delete_users
@@ -3,7 +3,7 @@ set -eu
 
 n_users="$1"
 
-killall -u user1
+killall -u user1 || true
 sleep 1
 ps auxf|grep user1
 


### PR DESCRIPTION
user1 process must not block userdel

- Related ticket: https://progress.opensuse.org/issues/120832
- Verification run: https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=muti_user
