### PR TITLE
RPi image comes with enlarged offset of the first partition

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils qw(is_microos is_sle_micro);
+use Utils::Architectures qw(is_aarch64);
 
 sub run {
     select_console 'root-console';
@@ -23,7 +24,8 @@ sub run {
     die "Disk not bigger than the default size, got $disksize KiB" unless $disksize > (20 * 1024 * 1024);
 
     # Verify that there is no unpartitioned space left
-    validate_script_output("sfdisk --list-free /dev/$disk", qr/Unpartitioned space .* 0 sectors/);
+    my $left_sectors = (is_sle_micro("5.4+") && is_aarch64) ? 2048 : 0;
+    validate_script_output("sfdisk --list-free /dev/$disk", qr/Unpartitioned space .* $left_sectors sectors/);
 
     # Verify that the filesystem mounted at /var grew beyond the default 5GiB
     my $varsize = script_output "findmnt -rnboSIZE -T/var";


### PR DESCRIPTION
This issue leads to failing test that expects 0 sectors left unpartitioned.

- motivation: https://jira.suse.com/browse/PED-3457
- failure: https://openqa.suse.de/tests/10504718#step/image_checks/6
- Verification runs: 
  * [sle-micro-5.4-Default-aarch64-Build21.2_5.1-slem_image_default@aarch64](https://openqa.suse.de/tests/10506705#step/image_checks/6)
  * [sle-micro-5.3-MicroOS-Image-Updates-aarch64-Build20230214-1-slem_image_default@aarch64](https://openqa.suse.de/t10507142)
