### PR TITLE
Workaround for text installer shortcut

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -66,6 +66,7 @@ sub get_product_shortcuts {
     # Online            i      t
     if (check_var('SLE_PRODUCT', 'sles4sap')) {
         return (sles4sap => is_ppc64le() ? 'i' : 't') if get_var('ISO') =~ /Full/ && is_sle('15-SP5+');
+        return (sles4sap => is_ppc64le() ? 'u' : 'i') if get_var('ISO') =~ /Online/ && is_sle('15-SP5+');
         return (sles4sap => is_ppc64le() ? 'u' : 'i') if get_var('ISO') =~ /Full/;
         return (sles4sap => is_ppc64le() ? 'i' : is_quarterly_iso() ? 'p' : 't') unless get_var('ISO') =~ /Full/;
     }


### PR DESCRIPTION
Changed text mode installer shortcuts again, better solution should be done in the future,
according to bsc#1208202 (closed by maintainer as invalid).

VR at:
https://openqa.suse.de/tests/10507113
https://openqa.suse.de/tests/10507115

Fixes 
poo#115376