### PR TITLE
Ensure that users have access to serial console

### DIFF
--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -35,6 +35,7 @@ conditional_schedule:
                 - jeos/firstrun
             'cloud-init':
                 - installation/first_boot
+                - console/system_prepare
 schedule:
     - '{{bootloader}}'
     - '{{wizard}}'


### PR DESCRIPTION
`jeos-firstboot` takes care of granting permissions for other users to use serial console.
In the CI testsuites we need to add other modules to do the job.

- failure: https://openqa.suse.de/tests/10504544#step/glibc_locale/8
- Verification run: http://kepler.suse.cz/tests/20364#
