### PR TITLE
Fix chrony default config path

### DIFF
--- a/schedule/yast/autoyast/autoyast_tftp.yaml
+++ b/schedule/yast/autoyast/autoyast_tftp.yaml
@@ -30,7 +30,7 @@ test_data:
     - path: /etc/hosts
       entries:
         - '10.226.154.19\tnew.entry.de h999uz'
-    - path: /etc/chrony.conf
+    - path: /etc/chrony.d/pool.conf
       entries:
         - pool ntp.suse.de iburst
         - driftfile /var/lib/chrony/drift

--- a/tests/console/verify_config_files.pm
+++ b/tests/console/verify_config_files.pm
@@ -9,7 +9,7 @@
 #    - path: /etc/hosts
 #      entries:
 #        - 'new.entry.de\t10.226.154.19 h999uz'
-#    - path: /etc/chrony.conf
+#    - path: /etc/chrony.d/pool.conf
 #      entries:
 #        - pool ntp.suse.de iburst
 # See lib/cfg_files_utils.pm

--- a/tests/console/verify_systemd_timesync.pm
+++ b/tests/console/verify_systemd_timesync.pm
@@ -29,7 +29,7 @@ sub run {
 
     record_info("Check server", "Check if the configured time synchronization server is the expected one.");
     my $expected_server = $test_data->{profile}->{'ntp-client'}->{ntp_servers}->{ntp_server}->{address};
-    my $chrony_conf = script_output("cat /etc/chrony.conf");
+    my $chrony_conf = script_output("cat /etc/chrony.d/pool.conf");
     $chrony_conf =~ /(\R|^)pool\s(?<server>\S+)/;
     assert_equals($expected_server, $+{server});
 

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -165,7 +165,7 @@ sub run {
     script_run('sed -i \'s/^\\(NTPD_FORCE_SYNC_ON_STARTUP=\\).*$/\\1yes/\' /etc/sysconfig/ntp') if (!$is_chronyd);
 
     # Verify that ntp server is added to the config file
-    assert_script_run("grep 'pool $ntp_server' /etc/chrony.conf") if $is_chronyd;
+    assert_script_run("grep 'pool $ntp_server' /etc/chrony.d/pool.conf") if $is_chronyd;
 
     # restart ntp daemon
     systemctl "restart $ntp_service.service";


### PR DESCRIPTION
Fix chrony default config path

**Ticket:**

- https://progress.opensuse.org/issues/123739

**Verification run:**

- https://openqa.suse.de/tests/10514459
- https://openqa.suse.de/tests/10514460
- https://openqa.suse.de/tests/10539520
- https://openqa.opensuse.org/tests/3122224