### PR TITLE
Catch retval of CTS and report when it fails

### DIFF
--- a/tests/ha/pacemaker_cts_cluster_exerciser.pm
+++ b/tests/ha/pacemaker_cts_cluster_exerciser.pm
@@ -49,7 +49,8 @@ sub run {
 
         # Start pacemaker cts cluster exerciser
         my $cts_start_time = time;
-        assert_script_run "$cts_bin --nodes '$node_01 $node_02' --stonith-type $stonith_type --stonith-args $stonith_args --test-ip-base $test_ip --no-loop-tests --no-unsafe-tests --at-boot 1 --outputfile $log --once", $timeout;
+        my $retval = script_run "$cts_bin --nodes '$node_01 $node_02' --stonith-type $stonith_type --stonith-args $stonith_args --test-ip-base $test_ip --no-loop-tests --no-unsafe-tests --at-boot 1 --outputfile $log --once", $timeout;
+        record_info 'CTS failed', "$cts_bin exited with retval=[$retval]" if ($retval);
         my $cts_end_time = time;
 
         # Parse the logs to get a better overview in openQA


### PR DESCRIPTION
Cluster Test Script (`/usr/share/pacemaker/tests/cts/CTSlab.py`) was executed in SUT using `assert_script_run`. Apparently this script always returned 0 even when it detected failures, and test module would parse results from the log to report those failures. Now, `CTSlab.py` returns non-zero values when detecting errors, so whole module dies when called with `assert_script_run`, preventing the parsing and reporting of the actual issues detected by `CTSlab.py`. This PR changes the `assert_script_run` call for `script_run` and also record the return value when `CTSlab.py` returns something other than 0.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/5497 (failure is expected as it shows how module behaves when it detects failures)
