### PR TITLE
Change expected default kernel package for SLE-11SP4

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -404,6 +404,7 @@ sub run {
     }
 
     $kernel_package = 'kernel-rt' if check_var('SLE_PRODUCT', 'slert');
+    $kernel_package = 'kernel-default-base' if is_sle('=11-SP4');
 
     if (get_var('KGRAFT')) {
         my $incident_klp_pkg = prepare_kgraft($repo, $incident_id);


### PR DESCRIPTION
SLE-11SP4 kernel files seem to be provided by kernel-default-base instead of the usual kernel-default.

- Related ticket: https://progress.opensuse.org/issues/122671
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/10516726