### PR TITLE
Drop sound for all but SLE

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -342,7 +342,7 @@ sub run {
     start_online_update;
     start_software_repositories;
     start_printer;
-    start_sound;
+    start_sound if is_sle('<=15-sp5') or is_leap('<=15.5');
     start_sysconfig_editor;
     start_partitioner;
     start_vpn_gateway;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/123924
- Needles: -
- [Verification run](https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=rakoenig%2Fos-autoinst-distri-opensuse%23drop_yast2_sound)
