### PR TITLE
Manage the new Terraform remote_python variable

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -7,6 +7,8 @@ terraform:
     os_image: "%QESAP_CLUSTER_OS_VER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
+    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -7,6 +7,8 @@ terraform:
     os_image: "%QESAP_CLUSTER_OS_VER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
+    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -42,6 +42,7 @@ sub run {
     $variables{HANA_SAR} = get_required_var("QESAPDEPLOY_SAPCAR");
     $variables{HANA_CLIENT_SAR} = get_required_var("QESAPDEPLOY_IMDB_CLIENT");
     $variables{HANA_SAPCAR} = get_required_var("QESAPDEPLOY_IMDB_SERVER");
+    $variables{ANSIBLE_REMOTE_PYTHON} = get_var("QESAPDEPLOY_ANSIBLE_REMOTE_PYTHON", "/usr/bin/python3");
     qesap_prepare_env(openqa_variables => \%variables, provider => $qesap_provider);
 }
 


### PR DESCRIPTION
Add the two new python_remote variables to the Terraform section of the Azure conf.yaml for the qesap regression. Add the test code to optionally read them. Default fallback is /usr/bin/python3


- Related ticket: TEAM-6956
- Verification run: 
  - SLES15 http://openqaworker15.qa.suse.cz/tests/128835#
  - SLES12 with custom python configured  http://openqaworker15.qa.suse.cz/tests/128833#