### PR TITLE
License agreement only showed once for migrations SLE 15 SP5 for s390x

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -616,9 +616,12 @@ sub handle_scc_popups {
         if (get_var('SCC_URL') || get_var('SMT_URL')) {
             push @tags, 'untrusted-ca-cert';
         }
+        # For s390 there is only one product therefore license is confirmed in the initial welcome dialog.
+        my $only_one_license = !(is_sle('=15-SP5') && (is_s390x));
         # The SLE15-SP2 license page moved after registration.
-        push @tags, 'license-agreement' if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
-        push @tags, 'license-agreement-accepted' if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
+        push @tags, 'license-agreement' if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+') && $only_one_license);
+        push @tags, 'license-agreement-accepted' if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+') && $only_one_license);
+        push @tags, 'remove-repository' if (!get_var('MEDIA_UPGRADE') && is_sle('15-SP2+'));
         push @tags, 'leap-to-sle-registrition-finished' if (is_leap_migration);
         # The "Extension and Module Selection" won't be shown during upgrade to sle15, refer to:
         # https://bugzilla.suse.com/show_bug.cgi?id=1070031#c11
@@ -691,8 +694,11 @@ sub handle_scc_popups {
                 send_key 'alt-a';
                 assert_screen('license-agreement-accepted');
                 send_key $cmd{next};
-                assert_screen "remove-repository";
+                next;
+            }
+            elsif (match_has_tag("remove-repository")) {
                 send_key $cmd{next};
+                next;
             }
             elsif (match_has_tag('leap-to-sle-registrition-finished')) {
                 # leap to sle do not need to add any addons


### PR DESCRIPTION
For s390 there is only one product therefore license is confirmed in the initial welcome dialog, so no license agreement needed in scc-registration on s390x any more.

- Related ticket: https://progress.opensuse.org/issues/124511
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/10516480#step/scc_registration/12  no license agreement on s390x
                                http://openqa.suse.de/tests/10516656#step/scc_registration/10    have license agreement on x86_64
