### PR TITLE
Increase timeout for yast2_software_management

### DIFF
--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -19,7 +19,7 @@ sub run {
     # Accept => Exit, or get to the installation report
     send_key 'alt-a';
     # Installation may take some time
-    assert_screen [qw(sw_single_ui_installation_report generic-desktop)], timeout => 150;
+    assert_screen [qw(sw_single_ui_installation_report generic-desktop)], timeout => 300;
     if (match_has_tag('sw_single_ui_installation_report')) {
         # Press finish
         send_key 'alt-f';


### PR DESCRIPTION
We need to Increase timeout for yast2_software_management.

- Related ticket: https://progress.opensuse.org/issues/124592
- Needles: N/A
- Verification run: 
   https://openqa.suse.de/tests/10522919
   https://openqa.suse.de/tests/10538731
   https://openqa.suse.de/tests/10538739
   https://openqa.suse.de/tests/10539295