### PR TITLE
Unschedule health_check for spvm

### DIFF
--- a/schedule/yast/transactional_server/transactional_server_helper_apps.yaml
+++ b/schedule/yast/transactional_server/transactional_server_helper_apps.yaml
@@ -15,4 +15,11 @@ schedule:
   - transactional/filesystem_ro
   - transactional/transactional_update
   - transactional/rebootmgr
-  - transactional/health_check
+  - '{{health_check}}'
+conditional_schedule:
+  health_check:
+    BACKEND:
+      qemu:
+        - transactional/health_check
+      svirt:
+        - transactional/health_check


### PR DESCRIPTION
We'd unschedule health_check from spvm and in the future perhaps take a look.

- Related ticket: https://progress.opensuse.org/issues/124589
- Needles: N/A
- Verification run: 
