### PR TITLE
Revert "Fix product shortcuts for 15-SP4 QU Full image as well"

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -81,7 +81,7 @@ sub get_product_shortcuts {
             sles => (is_sle '15-SP5+') ? 's'    # for now treat 15-SP5+ as if they would have new shortcuts
             : (is_ppc64le() || is_s390x()) ? 'u'    # s390 doesn't have a product selection screen for now
             : is_aarch64() ? 's'
-            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 'i'
+            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'
             : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16370

#16370  introduced the wrong product selection in the Maintenance run of 15-SP4 https://openqa.suse.de/tests/10522945#step/welcome/4. 

Progress Ticket: https://progress.opensuse.org/issues/124718
VR: https://openqa.suse.de/tests/10526110#