### PR TITLE
Change SLE-11SP4 kernel-default before handling SLERT

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -403,8 +403,8 @@ sub run {
         $incident_id = get_required_var('INCIDENT_ID');
     }
 
-    $kernel_package = 'kernel-rt' if check_var('SLE_PRODUCT', 'slert');
     $kernel_package = 'kernel-default-base' if is_sle('=11-SP4');
+    $kernel_package = 'kernel-rt' if check_var('SLE_PRODUCT', 'slert');
 
     if (get_var('KGRAFT')) {
         my $incident_klp_pkg = prepare_kgraft($repo, $incident_id);


### PR DESCRIPTION
Even though SLERT-11SP4 is no longer supported and there is no risk of error, let's do things in the correct order. Fixes PR #16401.

- Related ticket: https://progress.opensuse.org/issues/122671
- Needles: N/A
- Verification run: N/A
