### PR TITLE
Fix Unschedule health_check for spvm

### DIFF
--- a/schedule/yast/transactional_server/transactional_server_helper_apps.yaml
+++ b/schedule/yast/transactional_server/transactional_server_helper_apps.yaml
@@ -15,11 +15,4 @@ schedule:
   - transactional/filesystem_ro
   - transactional/transactional_update
   - transactional/rebootmgr
-  - '{{health_check}}'
-conditional_schedule:
-  health_check:
-    BACKEND:
-      qemu:
-        - transactional/health_check
-      svirt:
-        - transactional/health_check
+  - transactional/health_check

--- a/schedule/yast/transactional_server/transactional_server_helper_apps_exclude_rebootmgr.yaml
+++ b/schedule/yast/transactional_server/transactional_server_helper_apps_exclude_rebootmgr.yaml
@@ -14,4 +14,3 @@ schedule:
   - console/hostname
   - transactional/filesystem_ro
   - transactional/transactional_update
-  - transactional/health_check


### PR DESCRIPTION
Unschedule health_check for spvm, the previous one[16409](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16409), didn't 
get that we use a **different**  yaml file transactional_server_helper_apps_exclude_rebootmgr.yaml for spvm.
- Related ticket: https://progress.opensuse.org/issues/124589
- Needles: N/A
- Verification run: 
   https://openqa.suse.de/tests/10539002
   https://openqa.suse.de/tests/10539007
   https://openqa.suse.de/tests/10539008
   https://openqa.suse.de/tests/10539005