### PR TITLE
Wait before send next key for remove-repository

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -697,7 +697,9 @@ sub handle_scc_popups {
                 next;
             }
             elsif (match_has_tag("remove-repository")) {
+                wait_still_screen 10;
                 send_key $cmd{next};
+                wait_still_screen 10;
                 next;
             }
             elsif (match_has_tag('leap-to-sle-registrition-finished')) {


### PR DESCRIPTION
We need wait before and after send next key after assert remove-repository.

- Related ticket: https://progress.opensuse.org/issues/124511
- Needles: N/A
- Verification run: 
  http://openqa.nue.suse.com/tests/10538983#             on s390x  sles12sp5
  http://openqa.nue.suse.com/tests/10538985#             on s390x  sles15sp2
  http://openqa.nue.suse.com/tests/10538987#details  on ppc64le with license on scc_registration
