### PR TITLE
Provide a correct schedule for guided_ext4

### DIFF
--- a/schedule/yast/sle/guided_ext4/guided_ext4_s390x_kvm.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4_s390x_kvm.yaml
@@ -6,7 +6,9 @@ vars:
   FILESYSTEM: ext4
   YUI_REST_API: 1
 schedule:
-  guided_filesystem:
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
   default_systemd_target:
     - installation/installation_settings/validate_default_target

--- a/schedule/yast/sle/guided_ext4/guided_ext4_svirt_xen.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4_svirt_xen.yaml
@@ -16,6 +16,7 @@ schedule:
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
   default_systemd_target:
     - installation/installation_settings/validate_default_target
+  stop_timeout_system_reboot: []
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices


### PR DESCRIPTION
Provide a correct schedule for test suite guided_ext4 on s390x and Xen.
We also fixed that on Xen it can't work with [stop_timeout_system_reboot_now](https://openqa.suse.de/tests/10547289#step/stop_timeout_system_reboot_now/2).

- Related ticket: [124038](https://progress.opensuse.org/issues/124038)
- Related MR: [476](https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/476)
- Needles: N/A
- Verification run: 
   Xen
   https://openqa.suse.de/tests/10547335
   https://openqa.suse.de/tests/10547343
   https://openqa.suse.de/tests/10547380
   s390x
   https://openqa.suse.de/tests/10539596