### PR TITLE
Increase timeout for vnc_two_passwords on aarch64 because of performance issue

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -28,7 +28,7 @@ use utils;
 use Utils::Architectures qw(is_aarch64);
 
 # set global timeout, increased for aarch64
-my $timeout = (is_aarch64 && is_sle) ? 90 : 30;
+my $timeout = (is_aarch64 && is_sle) ? 120 : 30;
 
 # Any free display
 my $display = ':37';


### PR DESCRIPTION
we still have sporadic timeout issue for closing xev or (xev not finished in time) 
see https://progress.opensuse.org/issues/119416
