### PR TITLE
Improve results parsing in ha/pacemaker_cts_cluster_exerciser

### DIFF
--- a/tests/ha/pacemaker_cts_cluster_exerciser.pm
+++ b/tests/ha/pacemaker_cts_cluster_exerciser.pm
@@ -49,12 +49,17 @@ sub run {
 
         # Start pacemaker cts cluster exerciser
         my $cts_start_time = time;
-        my $retval = script_run "$cts_bin --nodes '$node_01 $node_02' --stonith-type $stonith_type --stonith-args $stonith_args --test-ip-base $test_ip --no-loop-tests --no-unsafe-tests --at-boot 1 --outputfile $log --once", $timeout;
+        my $cmd = join(' ', $cts_bin, '--nodes', "'$node_01 $node_02'",
+            '--stonith-type', $stonith_type, '--stonith-args', $stonith_args,
+            '--test-ip-base', $test_ip, '--no-loop-tests', '--no-unsafe-tests',
+            '--at-boot 1', '--outputfile', $log, '--once');
+        my $retval = script_run $cmd, $timeout;
         record_info 'CTS failed', "$cts_bin exited with retval=[$retval]" if ($retval);
         my $cts_end_time = time;
 
         # Parse the logs to get a better overview in openQA
-        my $output = script_output "awk '(\$5 == \"Test\" && \$6 != \"Summary\") {print}' $log";
+        $cmd = q|awk '($5 == "Test" && $6 != "Summary" && substr($6, length($6), 1) == ":") {print}' | . $log;
+        my $output = script_output $cmd;
 
         my %results;
 


### PR DESCRIPTION
Current version of the parser can wrongfully pick results like `test name\t failed` (see [this](https://openqa.suse.de/tests/10517143) example) which are processed later in the output due to a small issue in the `awk` command getting results from the log. This commit fixes the `awk` command while also re-writing some of the commands so the fit in under 100 characters per line.

- Related ticket: N/A
- Failing Test: https://openqa.suse.de/tests/10517143
- Needles: N/A
- Verification run: http://mango.qa.suse.de/tests/5513 (Test failure is expected, as in order to test the parser we need failures in the log)
