### PR TITLE
Remove terraform vars not used in qe-sap-deployment

### DIFF
--- a/data/sles4sap/qe_sap_deployment/hanasr_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/hanasr_azure.yaml
@@ -9,8 +9,6 @@ terraform:
     public_key: "~/.ssh/id_rsa.pub"
     private_key: "~/.ssh/id_rsa"
     sles4sap_uri: "https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%"
-    storage_account_name: "%STORAGE_ACCOUNT_NAME%"
-    storage_account_key: "%STORAGE_ACCOUNT_KEY%"
 
     # BASTION
     bastion_enabled: "false"

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -20,8 +20,6 @@ terraform:
     sles4sap_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
     os_image: "%PUBLIC_CLOUD_OS_IMAGE%"
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
-    storage_account_name: '%STORAGE_ACCOUNT_NAME%'
-    storage_account_key: '%STORAGE_ACCOUNT_KEY%'
 
     # HANA
     hana_count: '%NODE_COUNT%'


### PR DESCRIPTION
Remove storage_account_name/key that are no more used by qe-sap-deployment


- Verification run: http://openqaworker15.qa.suse.cz/tests/129440 for the sles4sap_azure_generic.yaml
