### PR TITLE
Increase tianocore-secureboot timeout on aarch64

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -958,6 +958,7 @@ sub tianocore_disable_secureboot {
     my $neelle_sb_conf_attempt = $revert ? 'tianocore-devicemanager-sb-conf-disabled' : 'tianocore-devicemanager-sb-conf-attempt-sb';
     my $neelle_sb_change_state = $revert ? 'tianocore-devicemanager-sb-conf-enabled' : 'tianocore-devicemanager-sb-conf-attempt-sb';
     my $neelle_sb_config_state = $revert ? 'tianocore-secureboot-enabled' : 'tianocore-secureboot-not-enabled';
+    my $timeout = is_aarch64 ? '30' : '20';
 
     assert_screen 'grub2';
     send_key 'c';
@@ -980,7 +981,7 @@ sub tianocore_disable_secureboot {
     send_key_until_needlematch 'tianocore-devicemanager', 'esc';
     send_key_until_needlematch 'tianocore-mainmenu-reset', 'down';
     send_key 'ret';
-    send_key 'ret' if check_screen($neelle_sb_config_state, 20);
+    send_key 'ret' if check_screen($neelle_sb_config_state, $timeout);
     $basetest->wait_grub;
 }
 


### PR DESCRIPTION
- Fail:
https://openqa.suse.de/tests/10538723#step/boot_without_secureboot/29
https://openqa.suse.de/tests/10538738#step/boot_without_secureboot/29
- Verification run:
https://openqa.suse.de/tests/10543216#step/boot_without_secureboot/29
https://openqa.suse.de/tests/10543217#step/boot_without_secureboot/29
https://openqa.suse.de/tests/10547615#step/boot_without_secureboot/29