### PR TITLE
Removed packages in AutoYaST profile

### DIFF
--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -672,7 +672,6 @@
       <package>libbtrfs0</package>
       <package>libdconf1</package>
       <package>libgirepository-1_0-1</package>
-      <package>plymouth-dracut</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-intel</package>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -705,7 +705,6 @@
       <package>libgirepository-1_0-1</package>
       <package>libvmtools0</package>
       <package>open-vm-tools</package>
-      <package>plymouth-dracut</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-amd</package>


### PR DESCRIPTION
Removed packages in AutoYaST profile to fix the dependency problem

**Ticket:**

- https://progress.opensuse.org/issues/124427

**Verification run:**

- https://openqa.suse.de/tests/10547786
- https://openqa.suse.de/tests/10547787


