### PR TITLE
Test packagehub repo for sle micro

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -252,7 +252,11 @@ sub load_tests {
         # in 10G-disk tests, we don't run more tests
         return if check_var('HDDSIZEGB', '10');
         # Stop here if we are testing only scc extensions (live, phub, ...) activation
-        return if get_var('SCC_ADDONS');
+        if (get_var('SCC_ADDONS') =~ /phub/) {
+            loadtest 'transactional/check_phub';
+            return;
+        }
+
     }
 
     load_config_tests;

--- a/tests/transactional/check_phub.pm
+++ b/tests/transactional/check_phub.pm
@@ -1,0 +1,36 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Test packagehub repo on sle micro
+#
+# 1. Check if PackageHub extention is availble in sle micro
+# 2. Activate PackageHub extention
+# 3. Install a package from PackageHub repo
+#
+# Maintainer: qac <qa-c@suse.de>
+
+package check_phub;
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use transactional qw(trup_call check_reboot_changes);
+
+sub run {
+    select_console 'root-console';
+    my $out = script_output("transactional-update --quiet register --list-extensions|grep PackageHub", proceed_on_failure => 1);
+    if ($out ne "") {    #check if PackageHub extension is available
+        if ($out =~ /Activate with: transactional-update /p) {    #Check if it is activated
+            trup_call("${^POSTMATCH}");
+            check_reboot_changes;
+        }
+        trup_call("pkg install sshpass");
+        check_reboot_changes;
+        assert_script_run("rpm -q sshpass");
+    }
+    else {
+        record_info('INFO', "PackageHub Unavaible");
+    }
+}
+
+1;


### PR DESCRIPTION
Check availability of packagehub repo for sle micro

- Related ticket: https://progress.opensuse.org/issues/117418
- Needles: no
- Verification run: 
- x86_64, aarch, s390:  https://openqa.suse.de/tests/overview?build=tony.21.2_5.1_test&version=5.4&distri=sle-micro
