### PR TITLE
Container runtime test registration

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -611,6 +611,9 @@ sub load_jeos_openstack_tests {
     loadtest "jeos/grub2_gfxmode";
     loadtest "jeos/build_key";
     loadtest "console/prjconf_excluded_rpms";
+    unless (get_var('CI_VERIFICATION')) {
+        loadtest "console/suseconnect_scc";
+    }
     unless (get_var('CONTAINER_RUNTIME')) {
         loadtest "console/journal_check";
         loadtest "microos/libzypp_config";


### PR DESCRIPTION
Registration is required for container runtime test in openstack.
As these testsuites are using simple cloud init configuration that lack
SCC registration

- Verification run: http://kepler.suse.cz/tests/20370#step/suseconnect_scc/1
