### PR TITLE
Pass provider via args instead of re-creating

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -201,8 +201,9 @@ sub load_publiccloud_tests {
     else {
         loadtest 'boot/boot_to_desktop';
         if (get_var('PUBLIC_CLOUD_MIGRATION')) {
-            loadtest('publiccloud/upload_image');
-            loadtest('publiccloud/migration');
+            my $args = OpenQA::Test::RunArgs->new();
+            loadtest('publiccloud/upload_image', run_args => $args);
+            loadtest('publiccloud/migration', run_args => $args);
         } elsif (check_var('PUBLIC_CLOUD_DOWNLOAD_TESTREPO', 1)) {
             load_publiccloud_download_repos();
         } elsif (get_var('PUBLIC_CLOUD_QAM')) {

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -26,7 +26,7 @@ our $not_clean_vm = get_var('PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE');
 sub run {
     my ($self, $args) = @_;
     select_serial_terminal();
-    my $provider = $self->provider_factory();
+    my $provider = $args->{my_provider};
     my $instance = $provider->create_instance();
     $instance->wait_for_guestregister();
     registercloudguest($instance) if is_byos();

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -19,11 +19,12 @@ use publiccloud::openstack;
 use serial_terminal 'select_serial_terminal';
 
 sub run {
-    my ($self) = @_;
+    my ($self, $args) = @_;
     # Better use the root-console here so that the download progress can be monitored in openQA
     select_serial_terminal();
 
     my $provider = $self->provider_factory();
+    $args->{my_provider} = $provider;
 
     my $img_url = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
     my ($img_name) = $img_url =~ /([^\/]+)$/;


### PR DESCRIPTION
VR: http://autobot.qa.suse.de/tests/3660 ( test failure unrelated to this PR and happens far away from changed code ) 
VR : http://autobot.qa.suse.de/tests/3661 ( checking that I haven't broke other upload_image tests which not passing args ) 