### PR TITLE
Add python3 new version check on QEM tests

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -43,6 +43,7 @@ conditional_schedule:
       15-SP4:
         - console/golang
         - console/redis
+        - console/python3_new_version_check
         - '{{arch_specific}}'
       15-SP3:
         - console/openssl_nodejs

--- a/tests/console/python3_new_version_check.pm
+++ b/tests/console/python3_new_version_check.pm
@@ -33,7 +33,7 @@ sub run {
     }
 
     # Test new python3 versions if any
-    my @python_versions = split(/,/, get_var('PYTHON_VERSIONS'), '3.10');
+    my @python_versions = split(/,/, get_var('PYTHON_VERSIONS', '3.10'));
     my $sub_version;
     foreach my $python_version (@python_versions) {
         record_info("python$python_version is tested now");


### PR DESCRIPTION
https://progress.opensuse.org/issues/124535
At the same time, fix an issue for default
value of "PYTHON_VERIONS"

- Verification run: 
[15SP4](https://openqa.suse.de/tests/10555022)
[TW](https://openqa.opensuse.org/tests/3136454)
