### PR TITLE
Fix product shortcuts for 15-SP4 QU Full image as well

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,7 +69,7 @@ sub get_product_shortcuts {
             sles => (is_sle '15-SP5+') ? 's'    # for now treat 15-SP5+ as if they would have new shortcuts
             : (is_ppc64le() || is_s390x()) ? 'u'    # s390 doesn't have a product selection screen for now
             : is_aarch64() ? 's'
-            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'
+            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 'i'
             : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
The 15-SP4 QU2 candidate images have added SUSE Manager products to the Full images, resulting in shortcut changes. Earlier QUs will not be further tested.

(this is basically re-try of merging https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16370 ...)

Related ticket: https://progress.opensuse.org/issues/124206
Verification run: https://openqa.suse.de/t10555611
