### PR TITLE
Replace WORKER_HOSTNAME with IP for ay iscsi test

### DIFF
--- a/data/autoyast_sle15/autoyast_iscsi_ibft.xml
+++ b/data/autoyast_sle15/autoyast_iscsi_ibft.xml
@@ -20,7 +20,7 @@
             <listentry t="map">
                 <authmethod>None</authmethod>
                 <iface>default</iface>
-                <portal>{{WORKER_HOSTNAME}}:3260</portal>
+                <portal>{{WORKER_IP}}:3260</portal>
                 <startup>onboot</startup>
                 <target>{{NBF}}</target>
             </listentry>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -27,6 +27,7 @@ use File::Copy 'copy';
 use File::Find qw(finddepth);
 use File::Path 'make_path';
 use LWP::Simple 'head';
+use Socket;
 
 use xml_utils;
 
@@ -678,6 +679,9 @@ sub expand_variables {
         $profile =~ s/\{\{SALT_FORMULAS_PATH\}\}/$tarfile/g;
     }
     for my $var (@vars) {
+        if ($var eq 'WORKER_IP') {
+            set_var('WORKER_IP', inet_ntoa(inet_aton(get_var 'WORKER_HOSTNAME')));
+        }
         # Skip if value is not defined
         next unless my ($value) = get_var($var);
         $profile =~ s/\{\{$var\}\}/$value/g;

--- a/schedule/yast/autoyast/autoyast_iscsi_ibft.yaml
+++ b/schedule/yast/autoyast/autoyast_iscsi_ibft.yaml
@@ -7,7 +7,7 @@ description: >
 vars:
   AUTOYAST: autoyast_sle15/autoyast_iscsi_ibft.xml
   # Using it for specifying iscsi portal
-  AY_EXPAND_VARS: WORKER_HOSTNAME,NBF
+  AY_EXPAND_VARS: WORKER_IP,NBF
   DESKTOP: textmode
   IBFT: '1'
   NBF: iqn.2016-02.openqa.de:for.openqa


### PR DESCRIPTION
Fixes sporadic failure for autoyast_iscsi_ibft test by replacing the worker hostname with worker ip.
https://openqa.suse.de/tests/10525306#step/installation/45

Progress ticket: https://progress.opensuse.org/issues/123418
VRs: https://openqa.suse.de/tests/10555533#next_previous