### PR TITLE
Revert the previous, the revert was intentional and not due to rebase!

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,7 +69,7 @@ sub get_product_shortcuts {
             sles => (is_sle '15-SP5+') ? 's'    # for now treat 15-SP5+ as if they would have new shortcuts
             : (is_ppc64le() || is_s390x()) ? 'u'    # s390 doesn't have a product selection screen for now
             : is_aarch64() ? 's'
-            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 'i'
+            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'
             : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
In fact the previous revert (https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16411) was not due to the erronous rebasing in the previous PR, but an intentional as the change affected 15-SP4 Maintenance.

Flavor should be checked instead.