### PR TITLE
Add post fail hook to qesap_terraform

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -206,4 +206,8 @@ sub run {
     return 1;
 }
 
+sub post_fail_hook {
+    qesap_upload_logs();
+}
+
 1;


### PR DESCRIPTION
In certain situations, `qesap_execute` may fail without uploading all the relevant logs. This happens because uploading of the logs takes place internally in the `qesapdeployment.pm` functions like this:

- `qesap_execute` calls `qesapdeployment.pm` functions
- those functions create files and push their paths into a global variable called `log_files`
- before returning, `qesapdeployment.pm` functions call the `upload_logs` function which uploads all files in `log_files`

However, if some `qesapdeployment.pm` function fails after the files have been generated and their paths have been pushed in the `log_files` variable, but before the end of the function where `upload_files` is called, the files won't be uploaded.

This pr calls a `post_fail_hook` in `qesap_execute`, so `qesap_upload_logs` is called every time on failure and all logs (that have been created so far) are uploaded.

- Related ticket: https://jira.suse.com/browse/TEAM-7146
- Verification runs (look at uploaded files - all failing runs are force failed in the same place):
-- Run without post_fail_hook: http://openqaworker15.qa.suse.cz/tests/129953#downloads
-- Run with post_fail_hook: http://openqaworker15.qa.suse.cz/tests/129952#downloads
-- Normal run: http://openqaworker15.qa.suse.cz/tests/129954
