### PR TITLE
Force chrony timesync to be immediate

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -160,7 +160,7 @@ sub run {
         }
     } else {
         assert_script_run("systemctl start chronyd");
-        script_retry("chronyc waitsync 60 1 0 5", timeout => 300, retry => 3, die => 1);
+        assert_script_run("chronyc makestep", timeout => 30, fail_message => "chrony time synchronization failed");
         systemctl('enable chrony-wait.service');
     }
 


### PR DESCRIPTION
To fix some rare test failures where the system time is off too much, we make chrony fix the time without slewing it.

- Verification run: [Tumbleweed](https://duck-norris.qe.suse.de/tests/12063#step/journalctl/5) | [TW JeOS aarch64](https://openqa.opensuse.org/tests/3140333)| [15-SP4](https://duck-norris.qe.suse.de/tests/12051#step/journalctl/5) | [15-SP4 aarch64](https://openqa.suse.de/tests/10565204) | [15-SP3](https://duck-norris.qe.suse.de/tests/12052#step/journalctl/5) | [15-SP2](https://duck-norris.qe.suse.de/tests/12053#step/journalctl/5) | [12-SP5](https://duck-norris.qe.suse.de/tests/12054#) | [12-SP4](https://duck-norris.qe.suse.de/tests/12050) | [12-SP3](https://duck-norris.qe.suse.de/tests/12055)

Please note, that SLES12 won't be affected by this change.
