### PR TITLE
Replace softfail of bsc1204176 with poo reference

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
@@ -37,7 +37,7 @@ sub select_tab {
 
 sub select_bond_slave_in_list {
     assert_screen(BOND_SLAVES_TAB);
-    apply_workaround_bsc1204176(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED) if (is_sle('>=15-SP4'));
     assert_and_click(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BridgedDevicesTab.pm
@@ -38,7 +38,7 @@ sub select_tab {
 
 sub select_bridged_device_in_list {
     assert_screen(BRIDGED_DEVICES_TAB);
-    apply_workaround_bsc1204176(BRIDGED_DEVICE_CHECKBOX_UNCHECKED) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652(BRIDGED_DEVICE_CHECKBOX_UNCHECKED) if (is_sle('>=15-SP4'));
     assert_and_click(BRIDGED_DEVICE_CHECKBOX_UNCHECKED);
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/DeviceTypeDialog.pm
@@ -28,7 +28,7 @@ sub select_device_type {
         bond => 'alt-o',
         vlan => 'alt-v'
     };
-    apply_workaround_bsc1204176(DEVICE_TYPE_DIALOG) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652(DEVICE_TYPE_DIALOG) if (is_sle('>=15-SP4'));
     assert_screen(DEVICE_TYPE_DIALOG);
     send_key $shortcut->{$device};
 }

--- a/lib/YaST/NetworkSettings/OverviewTab.pm
+++ b/lib/YaST/NetworkSettings/OverviewTab.pm
@@ -29,19 +29,19 @@ sub new {
 }
 
 sub press_add {
-    apply_workaround_bsc1204176(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
     assert_screen(OVERVIEW_TAB);
     send_key('alt-a');
 }
 
 sub press_edit {
-    apply_workaround_bsc1204176(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
     assert_screen(OVERVIEW_TAB);
     send_key('alt-i');
 }
 
 sub press_delete {
-    apply_workaround_bsc1204176(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
     assert_screen(OVERVIEW_TAB);
     send_key('alt-t');
 }
@@ -72,7 +72,7 @@ sub select_device {
 }
 
 sub press_ok {
-    apply_workaround_bsc1204176(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652(OVERVIEW_TAB) if (is_sle('>=15-SP4'));
     send_key('alt-o');
 }
 

--- a/lib/YaST/workarounds.pm
+++ b/lib/YaST/workarounds.pm
@@ -12,11 +12,11 @@ use utils;
 use version_utils;
 
 
-our @EXPORT = qw(apply_workaround_bsc1204176 apply_workaround_bsc1207157);
+our @EXPORT = qw(apply_workaround_poo124652 apply_workaround_bsc1207157);
 
 =head1 Workarounds for known issues
 
-=head2 apply_workaround_bsc1204176 ($mustmatch, [,[$timeout] | timeout => $timeout] ):
+=head2 apply_workaround_poo124652 ($mustmatch, [,[$timeout] | timeout => $timeout] ):
 
 Workaround for the screen refresh issue.
 
@@ -31,13 +31,13 @@ with maximazing and shrinking the screen twice by sending 'alt-f10' two times.
 
 =cut
 
-sub apply_workaround_bsc1204176 {
+sub apply_workaround_poo124652 {
     my ($mustmatch) = shift;
     my $timeout;
     $timeout = shift if (@_ % 2);
     my %args = (timeout => $timeout // 0, @_);
     if (!check_screen($mustmatch, %args)) {
-        record_soft_failure('bsc#1204176 - Resizing window as workaround for YaST content not loading');
+        record_info('poo#124652', 'poo#124652 - gtk glitch not showing dialog window decoration on openQA');
         send_key('shift-f3', wait_screen_change => 1);
         send_key('esc', wait_screen_change => 1);
         # in some verification tests this didn't work, so let's check

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -635,7 +635,7 @@ sub handle_scc_popups {
                 && (get_var("DESKTOP") !~ /textmode/)
                 && (get_var('REMOTE_CONTROLLER') !~ /vnc/)
                 && !(get_var('PUBLISH_HDD_1') || check_var('SLE_PRODUCT', 'hpc'))) {
-                apply_workaround_bsc1204176(\@tags, timeout => 360);
+                apply_workaround_poo124652(\@tags, timeout => 360);
             }
             assert_screen(\@tags, timeout => 360);
             if (match_has_tag('import-untrusted-gpg-key')) {

--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -124,7 +124,7 @@ sub y2snapper_new_snapshot {
         send_key_until_needlematch 'yast2_snapper-focus-in-snapshots', 'tab';
     }
     else {
-        apply_workaround_bsc1204176([qw(yast2_snapper-new_snapshot yast2_snapper-new_snapshot_selected)]) if (is_sle('>=15-SP4'));
+        apply_workaround_poo124652([qw(yast2_snapper-new_snapshot yast2_snapper-new_snapshot_selected)]) if (is_sle('>=15-SP4'));
     }
 
     # Make sure the snapshot is listed in the main window

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -65,7 +65,7 @@ sub initiator_discovered_targets_tab {
     send_key "alt-i";
     my $target_ip_only = (split('/', $test_data->{target_conf}->{ip}))[0];
     type_string_slow_extended $target_ip_only;
-    apply_workaround_bsc1204176('iscsi-initiator-discovered-IP-adress') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('iscsi-initiator-discovered-IP-adress') if (is_sle('>=15-SP4'));
     assert_screen 'iscsi-initiator-discovered-IP-adress';
     # next and press connect button
     send_key "alt-n";
@@ -91,7 +91,7 @@ sub initiator_connected_targets_tab {
     # go to discovered targets tab
     send_key "alt-d";
     wait_still_screen(2);
-    apply_workaround_bsc1204176('iscsi-initiator-discovered-targets') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('iscsi-initiator-discovered-targets') if (is_sle('>=15-SP4'));
     assert_screen 'iscsi-initiator-discovered-targets';
     # go to connected targets tab
     send_key "alt-n";

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -94,7 +94,7 @@ sub target_service_tab {
 
 sub config_2way_authentication {
     if (is_sle('>=15-SP4')) {
-        apply_workaround_bsc1204176('iscsi-target-modify-acls') if (is_sle('>=15-SP4'));
+        apply_workaround_poo124652('iscsi-target-modify-acls') if (is_sle('>=15-SP4'));
     }
     else {
         assert_screen 'iscsi-target-modify-acls';

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -56,7 +56,7 @@ sub nis_server_configuration {
     send_key 'alt-o';    # OK
     send_key $cmd{next};
     # NIS Server Maps Setup
-    apply_workaround_bsc1204176('nis-server-server-maps-setup') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('nis-server-server-maps-setup') if (is_sle('>=15-SP4'));
     assert_screen 'nis-server-server-maps-setup';
     send_key 'tab';    # jump to map list
     my $c = 1;    # select all maps
@@ -68,7 +68,7 @@ sub nis_server_configuration {
     assert_screen 'nis-server-server-maps-setup-finished';
     send_key $cmd{next};
     # NIS Server Query Hosts
-    apply_workaround_bsc1204176('nis-server-query-hosts-setup') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('nis-server-query-hosts-setup') if (is_sle('>=15-SP4'));
     send_key 'alt-a';    # add
     assert_screen 'nis-server-network-conf-popup';
     type_string $setup_nis_nfs_x11{net_mask};

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -48,7 +48,7 @@ sub run {
 
     #	default boot section
     if (is_sle('>=15-SP4')) {
-        apply_workaround_bsc1204176('yast2-bootloader_default-boot-section') if (is_sle('>=15-SP4'));
+        apply_workaround_poo124652('yast2-bootloader_default-boot-section') if (is_sle('>=15-SP4'));
         assert_and_click 'yast2-bootloader_default-boot-section';
     }
     else {

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -57,7 +57,7 @@ sub start_media_check {
     search 'check';
     assert_and_click 'yast2_control-center_media-check';
     wait_still_screen;
-    apply_workaround_bsc1204176('yast2_control-center_media-check_close') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2_control-center_media-check_close') if (is_sle('>=15-SP4'));
     assert_screen 'yast2_control-center_media-check_close';
     send_key 'alt-l';
     assert_screen 'yast2-control-center-ui';
@@ -206,7 +206,7 @@ sub start_partitioner {
 sub start_vpn_gateway {
     search('vpn');
     assert_and_click 'yast2_control-center_vpn-gateway-client';
-    apply_workaround_bsc1204176('yast2-vpn-gateway-client', 180) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2-vpn-gateway-client', 180) if (is_sle('>=15-SP4'));
     assert_screen 'yast2-vpn-gateway-client', timeout => 180;
     send_key 'alt-c';
     assert_screen 'yast2-control-center-ui', timeout => 60;
@@ -248,7 +248,7 @@ sub start_add_system_extensions_or_modules {
     search 'system ext';
     assert_and_click 'yast2_control-center_add-system-extensions-or-modules';
     wait_still_screen(5, 10);
-    apply_workaround_bsc1204176('yast2_control-center_registration', 180) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2_control-center_registration', 180) if (is_sle('>=15-SP4'));
     assert_screen 'yast2_control-center_registration', timeout => 180;
     send_key 'alt-r';
     assert_screen 'yast2-control-center-ui', timeout => 60;
@@ -284,7 +284,7 @@ sub start_wake_on_lan {
     assert_and_click 'yast2_control-center_wake-on-lan';
     assert_screen 'yast2_control-center_wake-on-lan_install_wol';
     send_key $cmd{install};    # wol needs to be installed
-    apply_workaround_bsc1204176('yast2_control-center_wake-on-lan_overview', 180) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2_control-center_wake-on-lan_overview', 180) if (is_sle('>=15-SP4'));
     assert_screen 'yast2_control-center_wake-on-lan_overview', timeout => 180;
     send_key 'alt-f';
     assert_screen 'yast2-control-center-ui', timeout => 60;

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -33,7 +33,7 @@ sub run {
     clear_console;
     select_console 'x11';
     y2_module_guitest::launch_yast2_module_x11($module, match_timeout => 90);
-    apply_workaround_bsc1204176('yast2_hostnames_added', 180) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2_hostnames_added', 180) if (is_sle('>=15-SP4'));
     assert_screen 'yast2_hostnames_added', timeout => 180;
     assert_and_click "yast2_hostnames_added";
     send_key 'alt-i';

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -111,7 +111,7 @@ sub test_http_instserver {
     wait_still_screen 2, 2;
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-a", 2);
-    apply_workaround_bsc1204176('yast2-instserver-repository-conf') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2-instserver-repository-conf') if (is_sle('>=15-SP4'));
     assert_screen('yast2-instserver-repository-conf');
     send_key_and_wait("alt-p", 2);
     type_string "instserver";
@@ -123,7 +123,7 @@ sub test_http_instserver {
     send_key_until_needlematch("yast2-instserver_sr0dev", "down", 4);
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
-    apply_workaround_bsc1204176([qw(yast2-instserver-ui yast2-instserver-change-media)], 300) if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652([qw(yast2-instserver-ui yast2-instserver-change-media)], 300) if (is_sle('>=15-SP4'));
     assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 300);
     # skip "insert next cd" on SLE 12.x
     send_key_and_wait("alt-s", 2) if is_sle("<=12-SP5") && match_has_tag('yast2-instserver-change-media');

--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -41,7 +41,7 @@ sub run {
     # Check previously set values + Login Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-pwd-settings";
-    apply_workaround_bsc1204176('yast2_security-check-min-pwd-len-and-exp-days') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2_security-check-min-pwd-len-and-exp-days') if (is_sle('>=15-SP4'));
     assert_screen "yast2_security-check-min-pwd-len-and-exp-days";
     assert_and_click "yast2_security-login-settings";
     send_key "alt-d";
@@ -52,7 +52,7 @@ sub run {
 
     # Check previously set values + Miscellaneous Settings
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
-    apply_workaround_bsc1204176('yast2_security-login-settings') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2_security-login-settings') if (is_sle('>=15-SP4'));
     assert_and_click "yast2_security-login-settings";
     assert_screen "yast2_security-login-attempts";
     # set file permissions to 'secure'
@@ -64,7 +64,7 @@ sub run {
     # Check previously set values
     y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
     assert_and_click "yast2_security-misc-settings";
-    apply_workaround_bsc1204176('yast2_security-file-perms-secure') if (is_sle('>=15-SP4'));
+    apply_workaround_poo124652('yast2_security-file-perms-secure') if (is_sle('>=15-SP4'));
     assert_screen "yast2_security-file-perms-secure";
     wait_screen_change { send_key "alt-o" };
 }


### PR DESCRIPTION
Bug bsc#1204176 has been marked as WONTFIX by the yast developers. The bug can be only reproduced in the openQA environment and, as such, it is now considered an openQA framework issue.
The resulting progress issue ticke is poo#124652 and it will be the new reference point for the gtk refresh issue workaround.

- Related ticket: No ticket
- Needles: No needles
- Verification runs: https://openqa.suse.de/tests/overview?build=ge0r%2Fos-autoinst-distri-opensuse%23replace-softfailure-bsc1204176&version=15-SP5&distri=sle
