### PR TITLE
Introduce cleanup logic in helm test

### DIFF
--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -102,7 +102,7 @@ sub run {
     assert_script_run("helm uninstall helm-test-$job_id");
 
     assert_script_run("kubectl config set-context --current --namespace=default");
-    script_run("kubectl delete namespace helm-ns-$job_id");
+    assert_script_run("kubectl delete namespace helm-ns-$job_id");
 
     # Add repo, search and show values
     assert_script_run(


### PR DESCRIPTION
1) Implement k8s old namespace cleanup
2) Assert classic namespace deletion

- Related ticket: [poo#123511](https://progress.opensuse.org/issues/123511)
- Verification run: [pdostal-server.suse.cz/t4000](https://pdostal-server.suse.cz/t4000)
