### PR TITLE
pc: Add support for TERRAFORM_LOG variable

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -479,7 +479,12 @@ sub terraform_apply {
     record_info('TFM cmd', $cmd);
 
     script_retry($cmd, timeout => $terraform_timeout, delay => 3, retry => 6);
-    my $ret = script_run('terraform apply -no-color -input=false myplan', $terraform_timeout);
+
+    # Valid values according to documentation: TRACE, DEBUG, INFO, WARN, ERROR & OFF
+    # https://developer.hashicorp.com/terraform/internals/debugging
+    my $tf_log = get_var("TERRAFORM_LOG", "");
+
+    my $ret = script_run("TF_LOG=$tf_log terraform apply -no-color -input=false myplan", $terraform_timeout);
     $self->terraform_applied(1);    # Must happen here to prevent resource leakage
     unless (defined $ret) {
         if (is_serial_terminal()) {


### PR DESCRIPTION
Add support for TERRAFORM_LOG variable.

Valid values according to [documentation](https://developer.hashicorp.com/terraform/internals/debugging): TRACE, DEBUG, INFO, WARN, ERROR & OFF.

If a wrong value is entered, terraform defaults to TRACE:
```
TF_LOG=aja terraform apply
[WARN] Invalid log level: "AJA". Defaulting to level: TRACE. Valid levels are: [TRACE DEBUG INFO WARN ERROR OFF]2023-02-23T18:03:18.108+0100 [INFO]  Terraform version: 1.3.9
```

Verification runs (failing because of another bug):
- http://1b124.qa.suse.de/tests/331 (`TERRAFORM_LOG=DEBUG`)
- http://1b124.qa.suse.de/tests/332 (`TERRAFORM_LOG` unset)