### PR TITLE
Revert "Pass timeout/interval when using regex to find UI element"

### DIFF
--- a/lib/Installation/ProductSelection/ProductSelectionPage.pm
+++ b/lib/Installation/ProductSelection/ProductSelectionPage.pm
@@ -34,7 +34,7 @@ sub init {
 
 sub is_shown {
     my ($self) = @_;
-    return $self->{rdb_SLES}->exist({timeout => 300, interval => 10});
+    return $self->{rdb_SLES}->exist();
 }
 
 sub install_product {

--- a/lib/YuiRestClient/Filter.pm
+++ b/lib/YuiRestClient/Filter.pm
@@ -39,20 +39,15 @@ sub is_resolved {
 }
 
 sub resolve {
-    my ($self, $json, $args) = @_;
+    my ($self, $json) = @_;
     my ($k, $v) = ($self->{regex}->{k}, $self->{regex}->{v});
-    YuiRestClient::Wait::wait_until(object => sub {
-            my @widgets = grep {
-                defined $_->{$k} && YuiRestClient::Sanitizer::sanitize($_->{$k}) =~ $v
-            } @{$json};
-            if (scalar @widgets == 1) {
-                $self->{filter}->{$k} = YuiRestClient::Sanitizer::sanitize($widgets[0]->{$k});
-                $self->{resolved} = 1;
-            }
-        },
-        timeout => $args->{timeout},
-        interval => $args->{interval}
-    );
+    my @widgets = grep {
+        defined $_->{$k} && YuiRestClient::Sanitizer::sanitize($_->{$k}) =~ $v
+    } @{$json};
+    if (scalar @widgets == 1) {
+        $self->{filter}->{$k} = YuiRestClient::Sanitizer::sanitize($widgets[0]->{$k});
+        $self->{resolved} = 1;
+    }
 }
 
 1;

--- a/lib/YuiRestClient/Widget/Base.pm
+++ b/lib/YuiRestClient/Widget/Base.pm
@@ -48,7 +48,7 @@ sub property {
 sub find_widgets {
     my ($self, $args) = @_;
 
-    $self->resolve_filter($args) unless $self->{filter}->is_resolved();
+    $self->resolve_filter() unless $self->{filter}->is_resolved();
     return $self->{widget_controller}->find({
             filter => $self->{filter}->get_filter(),
             timeout => $args->{timeout},
@@ -58,17 +58,11 @@ sub find_widgets {
 
 sub resolve_filter {
     my ($self, $args) = @_;
-    my $timeout = $args->{timeout} // $self->{timeout};
-    my $interval = $args->{interval} // $self->{interval};
 
     # get json with widgets according to current filter (which does not include regex)
-    my $json = $self->{widget_controller}->find({
-            filter => $self->{filter}->get_filter(),
-            timeout => $timeout,
-            interval => $interval
-    });
+    my $json = $self->{widget_controller}->find({filter => $self->{filter}->get_filter()});
     # replace regex by found value in the filter
-    $self->{filter}->resolve($json, {timeout => $timeout, interval => $interval});
+    $self->{filter}->resolve($json);
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16225. 
This PR fogot to take care of the lib/Installation/ModuleRegistration/SeparateRegCodesController.pm

- Now we hit register_extensions_and_modules fails 
  https://openqa.suse.de/tests/10562270
  https://openqa.suse.de/tests/10562273
  https://openqa.suse.de/tests/10575645
  https://openqa.suse.de/tests/10575638
  and MU
  https://openqa.suse.de/tests/10575518#step/add_ltss_regcode/2