### PR TITLE
Pass timeout/interval when using regex to find UI element

### DIFF
--- a/lib/Installation/ProductSelection/ProductSelectionController.pm
+++ b/lib/Installation/ProductSelection/ProductSelectionController.pm
@@ -32,6 +32,14 @@ sub get_product_selection_page {
     return $self->{ProductSelectionPage};
 }
 
+sub wait_product_selection_page {
+    my ($self, $args) = @_;
+    $args->{timeout} = YuiRestClient::get_timeout() * $args->{timeout_scale};
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->{ProductSelectionPage}->is_shown({timeout => 0});
+    }, %$args);
+}
+
 sub get_access_beta_distribution_popup {
     my ($self) = @_;
     die "Popup for accessing Beta Distribution is not displayed" unless $self->{AccessBetaDistributionPopup}->is_shown();

--- a/lib/YuiRestClient.pm
+++ b/lib/YuiRestClient.pm
@@ -49,6 +49,10 @@ sub get_port {
     return $port;
 }
 
+sub get_timeout {
+    return $app->{timeout};
+}
+
 sub set_host {
     my ($yuihost) = @_;
     $host = $yuihost;
@@ -215,6 +219,8 @@ B<get_host(%args)> - returns name or IP of the REST server.
 The %args is a boolean $installation (see parameters of C<get_app()> above.)
 
 B<get_port()> - returns port number for the rest server.
+
+B<get_timeout()> - returns the current timeout.
 
 B<init_logger> - Initializes logger instance.
 

--- a/tests/installation/product_selection/install_SLES.pm
+++ b/tests/installation/product_selection/install_SLES.pm
@@ -5,11 +5,15 @@
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
 use base 'y2_installbase';
+use testapi 'get_var';
 use strict;
 use warnings;
 
 sub run {
-    $testapi::distri->get_product_selection()->install_product('SLES');
+    my $product_selection = $testapi::distri->get_product_selection();
+
+    $product_selection->wait_product_selection_page({timeout_scale => get_var('TIMEOUT_SCALE', 1), message => 'Product Selection page is not displayed'});
+    $product_selection->install_product('SLES');
 }
 
 1;


### PR DESCRIPTION
When using regex to find UI element with libyui-rest-api, we need to pass timeout/interval as a parameter to the find function while don't break anything.

- Related ticket: https://progress.opensuse.org/issues/121807
- Needles: N/A
- Verification run:
  * ARM MU [install_SLE](https://openqa.suse.de/tests/10596510#step/install_SLES/2)  with 
  TIMEoUT_SCALE=1
  https://openqa.suse.de/tests/10634836/ **FAILED**
  TIMEOUT_SCALE=3
  https://openqa.suse.de/tests/10640655
  https://openqa.suse.de/tests/10640646

  * regression with  add_ha_regcode in yast daily
   https://openqa.suse.de/tests/10640647
   https://openqa.suse.de/tests/10640648
   https://openqa.suse.de/tests/10640649
   https://openqa.suse.de/tests/10640650
   https://openqa.suse.de/tests/10640651
   https://openqa.suse.de/tests/10640652
   https://openqa.suse.de/tests/10640653
   https://openqa.suse.de/tests/10640654

   * MU [lvm_thin_provisioning](https://openqa.suse.de/tests/10583641 )
     https://openqa.suse.de/tests/10635628
     https://openqa.suse.de/tests/10640658
  * regression on yast daily
     https://openqa.suse.de/tests/10614955
     https://openqa.suse.de/tests/10614956
     https://openqa.suse.de/tests/10614957
     https://openqa.suse.de/tests/10614958
     https://openqa.suse.de/tests/10614959
     https://openqa.suse.de/tests/10614960
     https://openqa.suse.de/tests/10614955
      