### PR TITLE
Remove PUBLIC_CLOUD=1 from saptune schedule

### DIFF
--- a/schedule/sles4sap/sles4sap_gnome_saptune.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune.yaml
@@ -7,7 +7,6 @@ vars:
   BOOTFROM: c
   BOOT_HDD_IMAGE: '1'
   NODE_COUNT: '1'
-  PUBLIC_CLOUD: '1'
   TEST_CONTEXT: 'OpenQA::Test::RunArgs'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2


### PR DESCRIPTION
The sles4sap/sles4sap_gnome_saptune.yaml schedule is used both on public cloud tests and on premises tests, so it should not have a PUBLIC_CLOUD=1 setting in it. Setting will be defined in the job group only on public cloud scenarios.

This is a fix for an issue introduced in #16424 

- Related ticket: https://progress.opensuse.org/issues/124982
- Needles: N/A
- Verification run: N/A
