### PR TITLE
Re-add btrfsmaintenance for SLES15-SP2-4

### DIFF
--- a/schedule/qam/15-SP2/mau-filesystem.yaml
+++ b/schedule/qam/15-SP2/mau-filesystem.yaml
@@ -16,6 +16,7 @@ schedule:
 - console/btrfs_qgroups
 - console/snapper_cleanup
 - console/btrfs_send_receive
+- console/btrfsmaintenance
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm

--- a/schedule/qam/15-SP3/mau-filesystem.yaml
+++ b/schedule/qam/15-SP3/mau-filesystem.yaml
@@ -16,6 +16,7 @@ schedule:
 - console/btrfs_qgroups
 - console/snapper_cleanup
 - console/btrfs_send_receive
+- console/btrfsmaintenance
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm

--- a/schedule/qam/15-SP4/mau-filesystem.yaml
+++ b/schedule/qam/15-SP4/mau-filesystem.yaml
@@ -16,6 +16,7 @@ schedule:
 - console/btrfs_qgroups
 - console/snapper_cleanup
 - console/btrfs_send_receive
+- console/btrfsmaintenance
 - console/snapper_undochange
 - console/snapper_create
 - console/snapper_thin_lvm


### PR DESCRIPTION
Add the missing btrfsmaintenance test run to SLES15-SP2, SP3 and SP4 where this was missing.

- Related ticket: https://progress.opensuse.org/issues/124898
- Verification run: [15-SP4](https://duck-norris.qe.suse.de/tests/12101#step/btrfsmaintenance/58) | [15-SP3](https://duck-norris.qe.suse.de/tests/12102#step/btrfsmaintenance/58) | [15-SP2](https://duck-norris.qe.suse.de/tests/12106#step/btrfsmaintenance/58) | [15-SP4 aarch64](https://openqa.suse.de/t10580217) | [15-SP3 aarch64](https://openqa.suse.de/t10580218) | [15-SP2 aarch64](https://openqa.suse.de/t10580219)
