### PR TITLE
sqlite3: adhere to the SQL standard when it comes to string literals

### DIFF
--- a/data/sqlite3/alter-tables.sql
+++ b/data/sqlite3/alter-tables.sql
@@ -5,7 +5,7 @@ BEGIN
 UPDATE movie SET mtime = datetime('NOW') WHERE rowid = new.rowid;
 END;
 
-CREATE VIEW cinema AS SELECT m.name, m.year, GROUP_CONCAT(d.name, "+")
+CREATE VIEW cinema AS SELECT m.name, m.year, GROUP_CONCAT(d.name, '+')
 AS directors
 FROM movie m JOIN director_movie dm
 ON m.mid=dm.mid JOIN director d ON dm.did=d.did GROUP by m.mid;

--- a/data/sqlite3/init-tables.sql
+++ b/data/sqlite3/init-tables.sql
@@ -14,19 +14,19 @@ CREATE TABLE director_movie (
 
 CREATE UNIQUE INDEX movie_dirx on director_movie(did,mid);
 
-INSERT INTO director (name) VALUES ("Jim Jarmusch"), ( "Tim Burton");
+INSERT INTO director (name) VALUES ('Jim Jarmusch'), ( 'Tim Burton');
 INSERT INTO director VALUES(3,'Lana Wachowski');
 INSERT INTO director VALUES(4,'Lilly Wachowski');
 INSERT INTO director VALUES(5,'Alejandro González Iñárritu');
 
 INSERT INTO movie (name, year) VALUES
-    ("The Dead Dont Die", 2019),
-    ("Night on Earth", 1991),
-    ("Only Lovers Left Alive", 2013);
+    ('The Dead Dont Die', 2019),
+    ('Night on Earth', 1991),
+    ('Only Lovers Left Alive', 2013);
 INSERT INTO movie (name, year) VALUES
-    ("Ed Wood", 1994),
-    ("Sleepy Hollow", 1999),
-    ("Edward Scissorhands", 1990);
+    ('Ed Wood', 1994),
+    ('Sleepy Hollow', 1999),
+    ('Edward Scissorhands', 1990);
 INSERT INTO movie (name, year)
     VALUES('The Matrix', 1999),
     ('Amores Perros', 2000);

--- a/data/sqlite3/rollback.sql
+++ b/data/sqlite3/rollback.sql
@@ -1,6 +1,6 @@
 SAVEPOINT major;
 
-INSERT INTO movie (name,year) VALUES("The Matrix Reloaded", 2003);
+INSERT INTO movie (name,year) VALUES('The Matrix Reloaded', 2003);
 SELECT * FROM movie WHERE year=2003 ORDER BY mid;
 
 ROLLBACK TO SAVEPOINT major;

--- a/data/sqlite3/run-tests.t
+++ b/data/sqlite3/run-tests.t
@@ -66,8 +66,8 @@ subtest test_view => sub {
 };
 
 subtest test_trigger => sub {
-    my $cmd = sprintf q{echo '%s;' | sqlite3 %s},
-      q{UPDATE movie SET name="The Dead Don'"'"'t Die" WHERE mid=1},
+    my $cmd = sprintf q{echo "%s;" | sqlite3 %s},
+      q{UPDATE movie SET name='The Dead Don''t Die' WHERE mid=1},
       $dbfile;
     note "Command: '$cmd'";
     my @output = qx{$cmd};


### PR DESCRIPTION
 The SQL standard requires double-quotes around identifiers and single-quotes around string literals. For example:

    "this is a legal SQL column name"
    'this is an SQL string literal'


- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1208636 (was thought to be a prod bug first)
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3141813
