### PR TITLE
Fix "terraform destroy" issues

### DIFF
--- a/data/publiccloud/terraform/azure_nfstest.tf
+++ b/data/publiccloud/terraform/azure_nfstest.tf
@@ -163,7 +163,7 @@ resource "azurerm_storage_account_network_rules" "openqa-group" {
   default_action             = "Deny"
   virtual_network_subnet_ids = [azurerm_subnet.openqa-subnet.id]
   // AZURE LIMITATION: After setting Deny, we need to allow this host otherwise we cannot do changes or delete the resources
-  ip_rules = [chomp(data.http.myip.body)]
+  ip_rules = [chomp(data.http.myip.response_body)]
   
   private_link_access {
     endpoint_resource_id     = azurerm_subnet.openqa-subnet.id

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -573,6 +573,8 @@ sub terraform_destroy {
             $cmd .= " -var 'storage-account=$storage_account'" if ($storage_account);
         }
     }
+    # Ignore lock to avoid "Error acquiring the state lock"
+    $cmd .= " -lock=false";
     # Retry 3 times with considerable delay. This has been introduced due to poo#95932 (RetryableError)
     # terraform keeps track of the allocated and destroyed resources, so its safe to run this multiple times.
     my $ret = script_retry($cmd, retry => 3, delay => 60, timeout => get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT), die => 0);

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -38,9 +38,9 @@ sub run {
     my %instance_args;
     $instance_args{check_connectivity} = 1;
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
+    $args->{my_provider} = $provider;
     my $instance = $provider->create_instance(%instance_args);
     $instance->wait_for_guestregister();
-    $args->{my_provider} = $provider;
     $args->{my_instance} = $instance;
     $instance->ssh_opts("");    # Clear $instance->ssh_opts which ombit the known hosts file and strict host checking by default
 


### PR DESCRIPTION
This PR:
- Fixes `terraform destroy` not running on failed `terraform apply` in the `prepare_instance` module. Found by @alvarocarvajald. 
- Adds `-lock=false` to avoid the `Error acquiring the state lock` shown [here](https://openqa.suse.de/tests/10573585#step/ssh_interactive_end/59)
- Fixes issue with deprecated `body` parameter.

---

- Related ticket: https://progress.opensuse.org/issues/125027
- Verification run: http://1b124.qa.suse.de/tests/349 (failing due to [poo#124259](https://progress.opensuse.org/issues/124259))
- Failing test: https://openqa.suse.de/tests/10457970