### PR TITLE
Drop fatal flag from decision if we want to skip cleanup or not

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -116,8 +116,8 @@ sub _cleanup {
     my $flags = $self->test_flags();
     # currently we have two cases when cleanup of image will be skipped:
     # 1. Calling module needs to have publiccloud_multi_module => 1 test flag
-    # and not have fatal => 1. Job should not have result = 'fail'
-    return if ($flags->{publiccloud_multi_module} && !($self->{result} eq 'fail' && $flags->{fatal}));
+    # and should not have result = 'fail'
+    return if ($flags->{publiccloud_multi_module} && !($self->{result} eq 'fail'));
     # 2. Job should have PUBLIC_CLOUD_NO_CLEANUP defined and job should have result = 'fail'
     return if ($self->{result} eq 'fail' && get_var('PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE'));
     if ($self->{run_args} && $self->{run_args}->{my_provider}) {


### PR DESCRIPTION
Here is table of all possible combinations of flags and expected answers to
question if we want to skip or not:

|publiccloud_multi_module |result |fatal |CHECK?|
|--- | --- | --- | ---| 
|1| failed|1|YES|
|1|passed|1|NO|
|1|passed|0|NO|
|0|passed|1|YES|
|0|passed|0|YES|
|0|failed|0|YES|

this table clear showing that we do not want to do cleanup for
both states of fatal flag which means that we can drop it from formula