### PR TITLE
Rename sap-b1 pattern to sap-bone in 15-SP5

### DIFF
--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -19,6 +19,7 @@ use warnings;
 
 sub run {
     my @sappatterns = qw(sap-nw sap-b1 sap-hana);
+    $sappatterns[1] =~ s/b1/bone/ if (is_sle('15-SP5+'));
     my $output = '';
 
     select_serial_terminal;


### PR DESCRIPTION
`sap-b1` pattern will be renamed to `sap-bone` per https://build.suse.de/request/show/290491.

- Related ticket: https://build.suse.de/request/show/290491
- Needles: N/A
- Verification run: https://openqa.suse.de/t10581807
