### PR TITLE
Unschedule test modules after sapconf in SAP migration

### DIFF
--- a/schedule/migration/migration_offline_sap.yaml
+++ b/schedule/migration/migration_offline_sap.yaml
@@ -31,8 +31,6 @@ schedule:
   - console/consoletest_setup
   - console/zypper_lr
   - '{{test_sles4sap}}'
-  - boot/grub_test_snapshot
-  - boot/snapper_rollback
 
 conditional_schedule:
   handle_bootimg:

--- a/schedule/migration/migration_online_sap.yaml
+++ b/schedule/migration/migration_online_sap.yaml
@@ -23,8 +23,6 @@ schedule:
   - migration/online_migration/post_migration
   - console/system_prepare
   - '{{test_sles4sap}}'
-  - boot/grub_test_snapshot
-  - boot/snapper_rollback
 
 conditional_schedule:
   test_sles4sap:


### PR DESCRIPTION
See https://progress.opensuse.org/issues/124421
After SAP domain specific modules in original job that we move to Yam squad, we didn't have any other check afterward, some un-necessary tests were added that we don't really need to cover. This change removes the extra tests.

VR https://openqa.suse.de/tests/10582065
