### PR TITLE
Update the Trento tool image generator

### DIFF
--- a/schedule/sles4sap/trento/trento_jumphost.yml
+++ b/schedule/sles4sap/trento/trento_jumphost.yml
@@ -6,12 +6,12 @@ description: |
     - Install all tools like az cli, helm
     - Pull all needed conteiners like Cypress/include
 vars:
-    TRENTO_DEPLOY_SCRIPTS_REPO: 'gitlab.suse.de/qa-css/trento'
-    TRENTO_HELM_VERSION: '3.8.2'
-    TRENTO_CYPRESS_VERSION: '4.4.0'
     TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
-    - boot/boot_to_desktop
+    - autoyast/prepare_profile
+    - installation/bootloader
+    - autoyast/installation
+    - publiccloud/prepare_tools
     - sles4sap/trento/setup_jumphost
     - shutdown/cleanup_before_shutdown
     - shutdown/shutdown

--- a/tests/sles4sap/trento/setup_jumphost.pm
+++ b/tests/sles4sap/trento/setup_jumphost.pm
@@ -41,7 +41,7 @@ sub run {
     clone_trento_deployment($work_dir);
 
     # Cypress.io installation
-    cypress_install_container(cypress_version());
+    cypress_install_container();
 }
 
 sub post_fail_hook {

--- a/variables.md
+++ b/variables.md
@@ -219,7 +219,7 @@ PUBLIC_CLOUD_CONTAINER_IMAGES_REPO | string | | The Container images repository 
 PREPARE_TEST_DATA_TIMEOUT | integer | 300 | Download assets in the prepare_test_data module timeout
 ZFS_REPOSITORY | string | | Optional repository used to test zfs from
 TRENTO_HELM_VERSION | string | 3.8.2 | Helm version of the JumpHost
-TRENTO_CYPRESS_VERSION | string | 4.4.0 | used as tag for the docker.io/cypress/included registry
+TRENTO_CYPRESS_VERSION | string | 9.6.1 | used as tag for the docker.io/cypress/included registry.
 TRENTO_VM_IMAGE | string | SUSE:sles-sap-15-sp3-byos:gen2:latest | used as --image parameter during the Azure VM creation
 TRENTO_VERSION | string | (implicit 1.0.0) | Optional. Used as reference version string for the installed Trento
 TRENTO_REGISTRY_CHART | string | registry.suse.com/trento/trento-server | Helm chart registry


### PR DESCRIPTION
Update the schedule to generate the Trento tool qcow2 image. The new sequence is now the same of the PC tool image, with just the Trento specific step to install some tools  on top of it. Add multiple tag support: TRENTO_CYPRESS_VERSION is now an array var Code for the test and lib simplified

- Related ticket: [CFSA-1732](https://jira.suse.com/browse/CFSA-1732)
- Verification run:
    New qcow2 generated http://openqaworker15.qa.suse.cz/tests/130742 and http://openqaworker15.qa.suse.cz/tests/130743. It has two CY: 9.6.1 and 12.1.0
    Trento test using this new qcow2: http://openqaworker15.qa.suse.cz/tests/130745 and **TRENTO_CYPRESS_VERSION=9.6.1**
    Trento test using this new http://openqaworker15.qa.suse.cz/tests/130746 and **TRENTO_CYPRESS_VERSION=12.1.0** As expected actual tests code does not run with cy 12.x.x and needs to be adapted http://openqaworker15.qa.suse.cz/tests/130746#step/test_hana_restore_stopped/76 > Here one more verification http://openqaworker15.qa.suse.cz/tests/130753# with a preview of the CY test code adapted to the newer CY framework version
