### PR TITLE
Fix check_system_info related issues

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -32,6 +32,7 @@ sub check_addons {
     foreach my $addon (@unique_addons) {
         my $name = get_addon_fullname($addon);
         record_info("$addon module fullname: ", $name);
+        $name = "sle-product-ha" if (($name =~ /sle-ha/) && is_sle('15+'));
         $name = "sle-product-we" if (($name =~ /sle-we/) && !get_var("MEDIA_UPGRADE") && is_sle('15+'));
         $name = "SLE-Module-DevTools" if (($name =~ /development/) && !get_var("MEDIA_UPGRADE"));
         $name =~ s/sle-module-//g if (is_sle('=15-sp3') && ($name =~ /sle-module-/));


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/124862
- Needles: 
- [Verification run for the ha naming issue](https://openqa.suse.de/tests/10598525#)
- [Verification run for thezdup problem](https://openqa.suse.de/tests/10604472)

Starting with fixing the mapping from "ha" to a product match string.
For the other part (zdup) problem it was enough to set `ONLINE_MIGRATON=0` on testsuite level (nothing included in this PR).