### PR TITLE
wicked: Fix usage of time in startandstop/[15|16]

### DIFF
--- a/tests/wicked/startandstop/sut/t15_bridge_ifreload_all_bond.pm
+++ b/tests/wicked/startandstop/sut/t15_bridge_ifreload_all_bond.pm
@@ -14,7 +14,7 @@ use Mojo::Base 'wickedbase';
 sub run {
     my ($self, $ctx) = @_;
     $self->get_from_data('wicked/ifreload-3.sh', '/tmp/ifreload-3.sh');
-    my $script_cmd = sprintf(q(bond_slaves='%s' time sh /tmp/ifreload-3.sh), join(" ", $ctx->iface, $ctx->iface2));
+    my $script_cmd = sprintf(q(time bond_slaves='%s' sh /tmp/ifreload-3.sh), join(" ", $ctx->iface, $ctx->iface2));
     $self->run_test_shell_script('ifreload-3', $script_cmd);
 }
 

--- a/tests/wicked/startandstop/sut/t16_bridge_ifreload_physical.pm
+++ b/tests/wicked/startandstop/sut/t16_bridge_ifreload_physical.pm
@@ -14,7 +14,7 @@ use Mojo::Base 'wickedbase';
 sub run {
     my ($self, $ctx) = @_;
     $self->get_from_data('wicked/ifreload-4.sh', '/tmp/ifreload-4.sh');
-    my $script_cmd = sprintf(q(bridge_port='%s' time sh /tmp/ifreload-4.sh), $ctx->iface2);
+    my $script_cmd = sprintf(q(time bridge_port='%s' sh /tmp/ifreload-4.sh), $ctx->iface2);
     $self->run_test_shell_script('ifreload-4', $script_cmd);
 }
 


### PR DESCRIPTION
The buildin command `time` should be the first token of the command.

- Failed run: http://openqa.wicked.suse.de/tests/108322#step/t15_bridge_ifreload_all_bond/7

