### PR TITLE
Fix License screen in s390x, which is now using different UI controls

### DIFF
--- a/lib/Installation/License/Sle/LicenseAgreementController.pm
+++ b/lib/Installation/License/Sle/LicenseAgreementController.pm
@@ -20,11 +20,11 @@ sub init {
     my ($self, $args) = @_;
     $self->{AcceptLicensePopup} = Installation::License::AcceptLicensePopup->new({
             app => YuiRestClient::get_app(),
-            btn_ok_filter => {id => 'ok'}});
+            btn_ok_filter => {id => qr/ok_msg|ok/}});
     $self->{LicenseAgreementPage} = Installation::License::LicenseAgreementExplicitPage->new({
             app => YuiRestClient::get_app(),
             chb_accept_license_filter => {id => '"Y2Packager::Widgets::ProductLicenseConfirmation"'},
-            cmb_language_filter => {id => '"simple_language_selection"'},
+            cmb_language_filter => {id => qr/Y2Country::Widgets::LanguageSelection|simple_language_selection/},
             rct_eula_filter => {id => '"CWM::RichText"'}});
     return $self;
 }

--- a/tests/installation/licensing/verify_license_translations.pm
+++ b/tests/installation/licensing/verify_license_translations.pm
@@ -45,14 +45,13 @@ sub run {
 
     my @available_translations = @{$license_agreement_info->{available_languages}};
     foreach my $translation (@{$test_data->{license}->{translations}}) {
-        unless (first { $_ eq $translation->{language} } @available_translations)
-        {
+        my $found_lang = first { /^\Q$translation->{language}\E/ } @available_translations;
+        if (!defined($found_lang)) {
             $errors .= "Language: '$translation->{language}' cannot be found in the list of available EULA translations.\n";
             next;
         }
-
         # Select language and validate translation
-        $license_agreement->select_language($translation->{language});
+        $license_agreement->select_language($found_lang);
         $license_agreement_info = $license_agreement->collect_current_license_agreement_info();
         if ($license_agreement_info->{text} !~ /$translation->{text}/) {
             record_soft_failure("EULA content for the language: '$translation->{language}' didn't validate. See bsc#1203004 for details.\n");


### PR DESCRIPTION
The license screen for s390x is using different UI controls because now SUMA is not there.

- Related ticket: https://progress.opensuse.org/issues/124418
- Needles: N/A
- Verification run: 
  * s390x:
  https://openqa.suse.de/tests/10603872
  https://openqa.suse.de/tests/10603874
  * regression:
  https://openqa.suse.de/tests/10603875
  https://openqa.suse.de/tests/10603876
  https://openqa.suse.de/tests/10603877
  
  
  
  
  