### PR TITLE
Add define_secret_variable to utils

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -174,12 +174,11 @@ sub is_embargo_update {
     return 0;
 }
 
+# Defines a secret environment variable, which is not directly visible to openQA
+# This call wraps around utils::define_secret_variable so that modules in this directory have access to it
 sub define_secret_variable {
     my ($var_name, $var_value) = @_;
-    script_run("set -a");
-    script_run("read -sp \"enter value: \" $var_name", 0);
-    type_password($var_value . "\n");
-    script_run("set +a");
+    utils::define_secret_variable($var_name, $var_value);
 }
 
 # Get credentials from the Public Cloud micro service, which requires user

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2636,4 +2636,25 @@ sub handle_screen {
     return $exit;
 }
 
+=head2 define_secret_variable
+    define_secret_variable($var_name, $var_value);
+
+define_secret_variable sets a hidden environment variable without exposing it to openQA.
+This function is useful to hide secrets from openQA by setting them as an accessible
+environment variable, but without any traces in the output terminals.
+
+e.g. define_secret_variable('SECRET', get_var('_SECRET_VARIABLE')) would store the
+openQA variable '_SECRET_VARIABLE' into the '$SECRET' environment variable, which can be
+used afterwards by using $SECRET.
+=cut
+
+sub define_secret_variable {
+    my ($var_name, $var_value) = @_;
+    script_run("set -a");
+    script_run("read -sp '$var_name: ' $var_name", 0);
+    type_password($var_value . "\n");
+    script_run("set +a");
+}
+
+
 1;


### PR DESCRIPTION
Moves the `define_secret_variable` function from publicclout/utils to utils/. The finction defines a secret variable, which is not directly accessible or visible to openQA.

- Related ticket: https://progress.opensuse.org/issues/96512
- Verification run: [sle-15-SP4-AZURE-BYOS-Updates-x86_64](https://duck-norris.qe.suse.de/tests/12137#step/prepare_instance/50) | [sle-15-SP5-BCI-Updates-x86_64-Buildgrisu48_os-autoinst-distri-opensuse_define_secret-15sp5_image_on_k8s](https://duck-norris.qe.suse.de/tests/12138#step/push_container_image_to_EC2/28)
