### PR TITLE
Disable openldap_to_389ds temporarily

### DIFF
--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -49,7 +49,6 @@ conditional_schedule:
         - console/prepare_test_data
         - console/consoletest_setup
         - '{{check_upgraded_service}}'
-        - migration/openldap_to_389ds
         - '{{regression_tests}}'
         - '{{rollback_after_migration}}'
       1:

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -30,7 +30,6 @@ conditional_schedule:
         - console/system_state
         - console/prepare_test_data
         - console/consoletest_setup
-        - migration/openldap_to_389ds
         - '{{regression_tests}}'
         - '{{rollback_after_migration}}'
       1:


### PR DESCRIPTION
Disabling openldap_to_389ds module until it is fixed.

- Related ticket: https://progress.opensuse.org/issues/119662

