### PR TITLE
Schedule trustedprograms only on SP4 and SP5

### DIFF
--- a/schedule/security/cc_audit_tests.yaml
+++ b/schedule/security/cc_audit_tests.yaml
@@ -5,7 +5,7 @@ schedule:
     - '{{bootloader_zkvm}}'
     - boot/boot_to_desktop
     - security/cc/cc_audit_test_setup
-    - security/cc/trustedprograms
+    - '{{trustedprograms}}'
     - '{{disable_root_ssh}}'
     - security/cc/filter
     - security/cc/syscalls
@@ -22,3 +22,9 @@ conditional_schedule:
         ARCH:
             s390x:
                 - security/cc/disable_root_ssh
+    trustedprograms:
+        VERSION:
+            15-SP5:
+                - security/cc/trustedprograms
+            15-SP4:
+                - security/cc/trustedprograms


### PR DESCRIPTION
The `trustedprograms` test should only be scheduled for SP4 and SP5.

- Related ticket: https://progress.opensuse.org/issues/125135