### PR TITLE
Call the new trento authentication script

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -768,11 +768,12 @@ Get the api-key from the Trento installation
 
 sub trento_api_key {
     my ($wd, $basedir) = @_;
-    my $cmd = join(' ', $basedir . '/trento-server-api-key.sh',
+    my $cmd = join(' ', $basedir . 'trento_deploy/trento_deploy.py',
+        '--verbose', 'api_key',
         '-u', 'admin',
         '-p', get_trento_password(),
         '-i', get_trento_ip(),
-        '-d', $wd, '-v');
+        '-v');
     my $agent_api_key = '';
     my @lines = split(/\n/, script_output($cmd));
     foreach my $line (@lines) {

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -768,7 +768,7 @@ Get the api-key from the Trento installation
 
 sub trento_api_key {
     my ($wd, $basedir) = @_;
-    my $cmd = join(' ', $basedir . 'trento_deploy/trento_deploy.py',
+    my $cmd = join(' ', $basedir . '/trento_deploy/trento_deploy.py',
         '--verbose', 'api_key',
         '-u', 'admin',
         '-p', get_trento_password(),

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -767,7 +767,7 @@ Get the api-key from the Trento installation
 =cut
 
 sub trento_api_key {
-    my ($wd, $basedir) = @_;
+    my ($basedir) = @_;
     my $cmd = join(' ', $basedir . '/trento_deploy/trento_deploy.py',
         '--verbose', 'api_key',
         '-u', 'admin',

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -772,8 +772,7 @@ sub trento_api_key {
         '--verbose', 'api_key',
         '-u', 'admin',
         '-p', get_trento_password(),
-        '-i', get_trento_ip(),
-        '-v');
+        '-i', get_trento_ip());
     my $agent_api_key = '';
     my @lines = split(/\n/, script_output($cmd));
     foreach my $line (@lines) {

--- a/tests/sles4sap/trento/install_agents.pm
+++ b/tests/sles4sap/trento/install_agents.pm
@@ -20,7 +20,7 @@ sub run {
     my $wd = '/root/work_dir';
     enter_cmd "mkdir $wd";
 
-    my $agent_api_key = trento_api_key($wd, $basedir);
+    my $agent_api_key = trento_api_key($basedir);
 
     cluster_install_agent($wd, $basedir, $agent_api_key);
 }


### PR DESCRIPTION
Starting using the new authentication script on trento.pm file, change the name of the script and some arguments.

- Related ticket: CFSA-1726
- Verification run: here the script called https://openqaworker15.qa.suse.cz/tests/131816#step/install_agents/30 and here the output https://openqaworker15.qa.suse.cz/tests/131816#step/install_agents/34 and here the key used from the output in the next command https://openqaworker15.qa.suse.cz/tests/131816#step/install_agents/55
