### PR TITLE
Export define_secret_variable

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -103,6 +103,7 @@ our @EXPORT = qw(
   script_start_io
   script_finish_io
   handle_screen
+  define_secret_variable
   @all_tests_results
 );
 


### PR DESCRIPTION
Export the newly defined define_secret_variable function.

Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16482

- Verification run: [https://duck-norris.qe.suse.de/tests/12140](https://duck-norris.qe.suse.de/tests/12140#step/prepare_instance/29) and [https://duck-norris.qe.suse.de/tests/12141](https://duck-norris.qe.suse.de/tests/12141#step/push_container_image_to_EC2/28)
