### PR TITLE
New module to enable FIPS on transactional servers

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -209,6 +209,10 @@ sub load_qemu_tests {
     loadtest 'qemu/user' unless (is_sle_micro || is_leap_micro);
 }
 
+sub load_fips_tests {
+    loadtest 'transactional/enable_fips';
+}
+
 sub load_rcshell_tests {
     # Tests before the YaST installation
     loadtest 'microos/rcshell_start';
@@ -274,6 +278,8 @@ sub load_tests {
         loadtest 'microos/verify_setup' unless is_microos;
     } elsif (check_var('EXTRA', 'virtualization')) {
         load_qemu_tests;
+    } elsif (check_var('EXTRA', 'fips')) {
+        load_fips_tests;
     } else {
         load_common_tests;
         load_transactional_tests unless is_zvm;

--- a/tests/transactional/enable_fips.pm
+++ b/tests/transactional/enable_fips.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: FIPS
+# Summary: Enable FIPS on transactional server
+#
+# Maintainer: QA-C team <qa-c@suse.de>
+
+use Mojo::Base "consoletest";
+use testapi;
+use transactional;
+use bootloader_setup qw(change_grub_config);
+use version_utils qw(is_sle_micro);
+
+sub run {
+    select_console 'root-console';
+
+    # make sure fips is not enabled
+    assert_script_run("grep '^0\$' /proc/sys/crypto/fips_enabled");
+
+    # install fips pattern
+    my $pkg = is_sle_micro ? 'microos-fips' : 'fips';
+    record_info('INFO', "Installing pattern: $pkg");
+    trup_call("pkg install -t pattern $pkg");
+    change_grub_config('=\"[^\"]*', '& fips=1 ', 'GRUB_CMDLINE_LINUX_DEFAULT');
+    trup_call('--continue grub.cfg');
+    check_reboot_changes;
+
+    record_info('kernel cmdline', script_output('cat /proc/cmdline'));
+    assert_script_run("grep '^1\$' /proc/sys/crypto/fips_enabled");
+    record_info('INFO', 'FIPS enabled');
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/125081

VRs:
[SLE Micro 5.3](https://openqa.suse.de/tests/10599918)
[SLE Micro 5.4](https://openqa.suse.de/tests/10599917)
[MicroOS](https://openqa.opensuse.org/tests/3149462) [bsc#1198065](https://bugzilla.suse.com/show_bug.cgi?id=1198065)