### PR TITLE
Move define_secret_variable to utils

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -10,6 +10,7 @@
 package publiccloud::aws_client;
 use Mojo::Base -base;
 use testapi;
+use utils;
 use publiccloud::utils;
 
 has region => sub { get_var('PUBLIC_CLOUD_REGION', 'eu-central-1') };

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -174,14 +174,6 @@ sub is_embargo_update {
     return 0;
 }
 
-sub define_secret_variable {
-    my ($var_name, $var_value) = @_;
-    script_run("set -a");
-    script_run("read -sp \"enter value: \" $var_name", 0);
-    type_password($var_value . "\n");
-    script_run("set +a");
-}
-
 # Get credentials from the Public Cloud micro service, which requires user
 # and password. The resulting json will be stored in a file.
 sub get_credentials {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -103,6 +103,7 @@ our @EXPORT = qw(
   script_start_io
   script_finish_io
   handle_screen
+  define_secret_variable
   @all_tests_results
 );
 
@@ -2634,6 +2635,24 @@ sub handle_screen {
     }
 
     return $exit;
+}
+
+=head2 define_secret_variable
+    define_secret_variable($var_name, $var_value);
+define_secret_variable sets a hidden environment variable without exposing it to openQA.
+This function is useful to hide secrets from openQA by setting them as an accessible
+environment variable, but without any traces in the output terminals.
+e.g. define_secret_variable('SECRET', get_var('_SECRET_VARIABLE')) would store the
+openQA variable '_SECRET_VARIABLE' into the '$SECRET' environment variable, which can be
+used afterwards by using $SECRET.
+=cut
+
+sub define_secret_variable {
+    my ($var_name, $var_value) = @_;
+    script_run("set -a");
+    script_run("read -sp '$var_name: ' $var_name", 0);
+    type_password($var_value . "\n");
+    script_run("set +a");
 }
 
 1;


### PR DESCRIPTION
Moves the `define_secret_variable` function from `publicclout/utils.pm` to `lib/utils.pm`. The function defines a secret variable, which is not directly accessible or visible to openQA.

- Related ticket: https://progress.opensuse.org/issues/96512
- Verification runs: [AKS](https://duck-norris.qe.suse.de/tests/12150#step/push_container_image_to_EC2/28) | [Azure consoletest](https://duck-norris.qe.suse.de/tests/12154#step/prepare_instance/29) | [EC2](https://duck-norris.qe.suse.de/tests/12170) | [samba-ad](https://duck-norris.qe.suse.de/tests/12164#step/samba_adcli/5)

Reintroduced https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16482
