### PR TITLE
Catch regression when sending right key when switching to tab Bootloader Options in ncurses

### DIFF
--- a/lib/YaST/Bootloader/BootloaderOptionsTab.pm
+++ b/lib/YaST/Bootloader/BootloaderOptionsTab.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces all accessing methods for Bootloader Options tab
+# in Boot Loader Settings.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package YaST::Bootloader::BootloaderOptionsTab;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my $self = shift;
+    return $self;
+}
+
+sub navigate {
+    my ($self) = @_;
+    send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
+    send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right';
+}
+
+1;

--- a/lib/YaST/Bootloader/BootloaderSettingsController.pm
+++ b/lib/YaST/Bootloader/BootloaderSettingsController.pm
@@ -13,6 +13,7 @@ use YuiRestClient;
 use YaST::Bootloader::BootCodeOptionsPage;
 use YaST::Bootloader::KernelParametersPage;
 use YaST::Bootloader::BootloaderOptionsPage;
+use YaST::Bootloader::BootloaderOptionsTab;
 
 sub new {
     my ($class, $args) = @_;
@@ -25,6 +26,7 @@ sub init {
     $self->{BootCodeOptionsPage} = YaST::Bootloader::BootCodeOptionsPage->new({app => YuiRestClient::get_app()});
     $self->{KernelParametersPage} = YaST::Bootloader::KernelParametersPage->new({app => YuiRestClient::get_app()});
     $self->{BootloaderOptionsPage} = YaST::Bootloader::BootloaderOptionsPage->new({app => YuiRestClient::get_app()});
+    $self->{BootloaderOptionsTab} = YaST::Bootloader::BootloaderOptionsTab->new({});
     return $self;
 }
 
@@ -44,6 +46,11 @@ sub get_bootloader_options_page {
     my ($self) = @_;
     die 'Bootloader Options tab is not shown' unless $self->{BootloaderOptionsPage}->is_shown();
     return $self->{BootloaderOptionsPage};
+}
+
+sub get_bootloader_options_tab {
+    my ($self) = @_;
+    return $self->{BootloaderOptionsTab};
 }
 
 sub get_current_settings {
@@ -77,6 +84,14 @@ sub write_to_partition {
     my ($self) = @_;
     $self->get_boot_code_options_page->check_write_to_partition();
     $self->get_boot_code_options_page->press_next();
+}
+
+sub disable_grub_timeout_navigating_tabs {
+    my ($self) = @_;
+    $self->get_boot_code_options_page;
+    $self->get_bootloader_options_tab->navigate();
+    $self->get_bootloader_options_page->set_grub_timeout('-1');
+    $self->get_bootloader_options_page->press_next();
 }
 
 sub disable_grub_timeout {

--- a/schedule/staging/textmode_install@64bit-staging.yaml
+++ b/schedule/staging/textmode_install@64bit-staging.yaml
@@ -19,7 +19,7 @@ schedule:
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/bootloader_settings/disable_boot_menu_timeout_navigating_tabs
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role_x86_64.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role_x86_64.yaml
@@ -15,6 +15,8 @@ schedule:
     - installation/add_on_product/skip_install_addons
   system_role:
     - installation/system_role/select_role_minimal
+  booting:
+    - installation/bootloader_settings/disable_boot_menu_timeout_navigating_tabs
   default_systemd_target:
     - installation/installation_settings/validate_default_target
   system_preparation:

--- a/tests/installation/bootloader_settings/disable_boot_menu_timeout_navigating_tabs.pm
+++ b/tests/installation/bootloader_settings/disable_boot_menu_timeout_navigating_tabs.pm
@@ -1,0 +1,18 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Disable grub timeout from the Installer to catch regression of bsc#1208266
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    $testapi::distri->get_installation_settings()->access_booting_options();
+    $testapi::distri->get_bootloader_settings()->disable_grub_timeout_navigating_tabs();
+}
+
+1;


### PR DESCRIPTION
Catch regression when sending right key when switching to tab Bootloader Options in ncurses

- Related ticket: https://progress.opensuse.org/issues/124610
- Verification run: https://openqa.suse.de/tests/11038962#step/disable_boot_menu_timeout_navigating_tabs/3
https://openqa.suse.de/tests/11041255#step/disable_boot_menu_timeout_navigating_tabs/3