### PR TITLE
Reduce execution of compile tests by checking changed files only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
             perl-version: 5.32
           - test: unit
             perl-version: 5.32
+          - test: compile-changed
+            perl-version: 5.26
           - test: compile
             perl-version: 5.26
     container:

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge
 .PHONY: test
 ifeq ($(TESTS),compile)
 test: test-compile
+else ifeq ($(TESTS),compile-changed)
+test: test-compile-changed
 else ifeq ($(TESTS),static)
 test: test-static
 else ifeq ($(TESTS),unit)


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/124688

- Verification run: n/a
Now only changed files are checked
`export PERL5LIB=../..:os-autoinst:lib:tests/installation:tests/x11:tests/qa_automation:tests/virt_autotest:tests/cpu_bugs:tests/sles4sap/saptune:$PERL5LIB: ; for f in `git diff --name-only | grep '.pm'` ; do perl -c $f 2>&1 | grep -v " OK$" && exit 2; done ; true`