### PR TITLE
Remove soft-failure

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -21,7 +21,7 @@ sub server_configure_network {
     setup_static_mm_network('10.0.2.101/24');
 
     if (is_sle('15+') || is_opensuse) {
-        record_soft_failure 'boo#1083486 No firewalld service for nfs-kernel-server';
+        record_info('bsc#1083486', 'No firewalld service for nfs-kernel-server');
         disable_and_stop_service('firewalld');
     }
 }


### PR DESCRIPTION
Remove soft-failure for bsc#1083486 in yast2_nfs_server

**Ticket:**

- https://progress.opensuse.org/issues/125036

**Verification run:**

- https://openqa.suse.de/t10604430
