### PR TITLE
Solve the installation failue on disable_grub_graphics stage when SUT installation

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -119,6 +119,9 @@ sub run {
         # select None for Major Linux Security Module.
         set_linux_security_to_none if (is_sle('>=15-SP4') && check_screen("apparmor-not-selected") && !(get_var('PATTERNS') =~ 'default|all|apparmor'));
         ensure_ssh_unblocked;
+        until (!check_screen("install-overview-options-evaluating-pkg-selection")) {
+            save_screenshot;
+        }
         $self->check_default_target();
     }
 }


### PR DESCRIPTION
To solve the installation failue  on disable_grub_graphics stage when SUT installtion.It needs to check whether have the cover.
http://10.67.129.4/tests/56463
![image](https://user-images.githubusercontent.com/59908740/227414263-55735aec-879a-4bab-bc80-571c80f048bd.png)

Verification run: [](http://10.67.129.4/tests/56464#[](url))