### PR TITLE
[virtualization] ALP host preparations for VT test

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/alp_kvm_hvm_x86_64_imported_disk_vnet.xml
+++ b/data/virt_autotest/guest_params_xml_files/alp_kvm_hvm_x86_64_imported_disk_vnet.xml
@@ -32,7 +32,7 @@
     <guest_storage_format>qcow2</guest_storage_format>
     <guest_storage_label>gpt</guest_storage_label>
     <guest_storage_size>40</guest_storage_size>
-    <guest_storage_others>backing_store=/var/lib/libvirt/images/ALP-VM.x86_64-0.0.1-kvm-back.qcow2,backing_format=qcow2,bus=virtio,cache=none</guest_storage_others>
+    <guest_storage_others>backing_store=/var/lib/libvirt/images/ALP-VM.x86_64-0.0.1-kvm-Snapshot##guest_build##-back.qcow2,backing_format=qcow2,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>virtual_network</guest_network_type>
     <guest_network_device>br123</guest_network_device>
     <guest_network_others></guest_network_others>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64_imported_disk_vnet.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64_imported_disk_vnet.xml
@@ -1,24 +1,26 @@
 <?xml version="1.0"?>
 <guest>
-    <guest_os_name>alp</guest_os_name>
-    <guest_version>0.1</guest_version>
-    <guest_version_major>0</guest_version_major>
-    <guest_version_minor>1</guest_version_minor>
+    <guest_os_name>sles</guest_os_name>
+    <guest_version>15-sp4</guest_version>
+    <guest_version_major>15</guest_version_major>
+    <guest_version_minor>4</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build></guest_build>
+    <guest_build>gm</guest_build>
     <host_hypervisor_uri></host_hypervisor_uri>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
-    <guest_machine_type>q35</guest_machine_type>
+    <guest_machine_type></guest_machine_type>
     <guest_arch>x86_64</guest_arch>
     <guest_name></guest_name>
     <guest_domain_name></guest_domain_name>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>host-model</guest_cpumodel>
+    <guest_cpumodel></guest_cpumodel>
     <guest_metadata></guest_metadata>
     <guest_boot_settings>uefi</guest_boot_settings>
-    <guest_xpath></guest_xpath>
+    <guest_secure_boot>true</guest_secure_boot>
+    <guest_power_management>suspend_to_mem.enabled=yes,suspend_to_disk.enabled=yes</guest_power_management>
+    <guest_xpath>./os/boot[@dev='hd']/@order=1#./os/boot[@dev='network']/@order=2</guest_xpath>
     <guest_installation_automation></guest_installation_automation>
     <guest_installation_automation_file></guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
@@ -27,21 +29,21 @@
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media></guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
-    <guest_os_variant>opensusetumbleweed</guest_os_variant>
+    <guest_os_variant>sle15sp4</guest_os_variant>
     <guest_storage_path></guest_storage_path>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>
     <guest_storage_label>gpt</guest_storage_label>
-    <guest_storage_size>40</guest_storage_size>
-    <guest_storage_others>backing_store=/var/lib/libvirt/images/ALP-VM.x86_64-0.0.1-kvm-Snapshot##guest_build##-back.qcow2,backing_format=qcow2,bus=virtio,cache=none</guest_storage_others>
+    <guest_storage_size>20</guest_storage_size>
+    <guest_storage_others>backing_store=/var/lib/libvirt/images/sles_15_sp4_64_kvm_hvm_uefi_x86_64-back.qcow2,backing_format=qcow2,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>virtual_network</guest_network_type>
     <guest_network_device>br123</guest_network_device>
     <guest_network_others></guest_network_others>
     <guest_netaddr>192.168.123.0/24</guest_netaddr>
     <guest_ipaddr></guest_ipaddr>
     <guest_ipaddr_static>false</guest_ipaddr_static>
-    <guest_macaddr></guest_macaddr>
     <guest_virtual_network>test-virt-net</guest_virtual_network>
+    <guest_macaddr></guest_macaddr> 
     <guest_graphics>vnc</guest_graphics>
     <guest_controller></guest_controller>
     <guest_input></guest_input>
@@ -53,7 +55,7 @@
     <guest_filesystem></guest_filesystem>
     <guest_sound></guest_sound>
     <guest_watchdog></guest_watchdog>
-    <guest_video>cirrus</guest_video>
+    <guest_video></guest_video>
     <guest_smartcard></guest_smartcard>
     <guest_redirdev></guest_redirdev>
     <guest_memballoon></guest_memballoon>
@@ -72,22 +74,16 @@
     <guest_memorybacking></guest_memorybacking>
     <guest_features></guest_features>
     <guest_clock></guest_clock>
-    <guest_power_management></guest_power_management>
     <guest_events></guest_events>
     <guest_resource></guest_resource>
-    <guest_sysinfo>type=fwcfg,entry0.name="opt/com.coreos/config",entry0.file="/var/lib/libvirt/images/VIRT_TEST_VM_config.ign"</guest_sysinfo>
+    <guest_sysinfo></guest_sysinfo>
     <guest_qemu_command></guest_qemu_command>
     <guest_launchSecurity></guest_launchSecurity>
     <guest_autostart></guest_autostart>
     <guest_transient></guest_transient>
     <guest_destroy_on_exit></guest_destroy_on_exit>
-    <guest_autoconsole></guest_autoconsole>
-    <guest_noautoconsole>false</guest_noautoconsole>
+    <guest_autoconsole>text</guest_autoconsole>
     <guest_noreboot></guest_noreboot>
     <guest_default_target>graphical</guest_default_target>
-    <guest_do_registration>false</guest_do_registration>
-    <guest_registration_server></guest_registration_server>
-    <guest_registration_username></guest_registration_username>
-    <guest_registration_password></guest_registration_password>
-    <guest_registration_extensions></guest_registration_extensions>
 </guest>
+

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -295,8 +295,10 @@ sub config_guest_params {
 
 #Correct [guest_version],[guest_version_major],[guest_version_minor] and [guest_build] if they are not set correctly or mismatch with each other.
 #Set [guest_version] to the developing SLES version if it is not given. Set [guest_version_major] and [guest_version_minor] from [guest_version]
-#it they do not match with [guest_version].Set [guest_build] to get_required_var('BUILD') if it is empty and developing [guest_version], or 'GM'
-#if non-developing [guest_version].This subroutine help make things better and life easier but the end user should always pay attention and use
+#it they do not match with [guest_version].
+#Set [guest_build] to get_required_var('BUILD') if it is empty and developing [guest_version], or 'GM' if non-developing [guest_version].
+#Replace all vm config values which refer to [guest_build] via "##guest_build##".
+#This subroutine help make things better and life easier but the end user should always pay attention and use
 #meaningful and correct guest parameter and profile.
 sub revise_guest_version_and_build {
     my $self = shift;
@@ -331,6 +333,10 @@ sub revise_guest_version_and_build {
         else {
             $self->{guest_build} = 'gm';
         }
+
+        # Replace all guest config values which refer to guest_build via ##guest_build##
+        map { $self->{$_} =~ s/##guest_build##/$self->{guest_build}/g } keys %guest_params;
+
         record_info("Guest $self->{guest_name} does not have guest_build set.Set it to test suite setting BUILD or GM according to guest_version", "Please pay attention ! It is now $self->{guest_build}");
     }
     return $self;

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -432,18 +432,21 @@ sub clean_up_all_guests {
             script_run("virsh undefine $_ --nvram") if (script_run("virsh undefine $_") ne 0);
         }
         save_screenshot;
-        # With `import` installation method supported,
-        # storage root path shoud not be cleaned, but to delete potential affecting storage files
-        foreach my $_vm (split(/,/, get_required_var('UNIFIED_GUEST_LIST'))) {
-            script_run("rm -f -r /var/lib/libvirt/images/${_vm}.*");
-            script_run("rm -f -r $self->{guest_storage_path}/${_vm}.*") if ($self->{guest_storage_path} ne '');
-        }
-        save_screenshot;
-        record_info("Cleaned all existing vms and affecting disk files.");
+        record_info("Cleaned all existing vms.");
     }
     else {
         diag("No guests reside on this host $self->{host_name}");
     }
+
+    # With `import` installation method supported,
+    # storage root path shoud not be cleaned, but to delete potential affecting storage files
+    foreach my $_vm (split(/,/, get_required_var('UNIFIED_GUEST_LIST'))) {
+        script_run("rm -f -r /var/lib/libvirt/images/${_vm}.*");
+        script_run("rm -f -r $self->{guest_storage_path}/${_vm}.*") if ($self->{guest_storage_path} ne '');
+    }
+    save_screenshot;
+    record_info("Cleaned all potential affecting disk files.");
+
     return $self;
 }
 

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -357,10 +357,12 @@ sub clean_all_virt_networks {
     foreach my $vnet (split(/\n+/, $_virt_networks)) {
         my $_br = script_output(q@virsh net-dumpxml @ . $vnet . q@|grep -o "bridge name=[^\s]*" | sed  's#bridge name=##'@, type_command => 0, proceed_on_failure => 0);
         script_run("virsh net-destroy $vnet");
-        assert_script_run("virsh net-undefine $vnet");
+        script_run("virsh net-undefine $vnet");
         assert_script_run("if ip a|grep $_br;then ip link del $_br;fi");
         save_screenshot;
     }
+
+    die "Virtual networks are not fully cleaned!" if (script_output("virsh net-list --name --all"));
     record_info("All existing virtual networks: \n$_virt_networks \nhave been destroy and undefined.", script_output("ip a; ip route show all"));
 }
 

--- a/schedule/virt_autotest/alp-virt-core-tests.yaml
+++ b/schedule/virt_autotest/alp-virt-core-tests.yaml
@@ -4,6 +4,7 @@ description:    >
     ALP virtualization guest installation and virt feature tests schedule
 schedule:
     - virt_autotest/login_console
+    - virt_autotest/prepare_alp_host
     - virt_autotest/setup_kvm_container
     - "{{install_guest}}"
     - virt_autotest/set_config_as_glue

--- a/tests/virt_autotest/prepare_alp_host.pm
+++ b/tests/virt_autotest/prepare_alp_host.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: This file does the necessary setup and checks for alp host to do virtualization test.
+# Maintainer: alice <xlai@suse.com>, qe-virt@suse.de
+
+package prepare_alp_host;
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    # Validate that kernel-default is installed and kvm module is loaded.
+    # Note: the alp host unattended installation will include kernel-default
+    #       package installation. See poo#118939 for more details.
+    assert_script_run(q@rpm -qa | grep kernel-default-[0-9]@);
+    assert_script_run(q@lsmod |grep kvm@);
+    record_info("KVM module is successfully loaded.");
+
+    # Download alp vm ignition config files
+    assert_script_run("mkdir -p /var/lib/libvirt/images");
+    my $cmd = "curl -L "
+      . data_url("virt_autotest/guest_unattended_installation_files/VIRT_TEST_VM_config.ign")
+      . " -o /var/lib/libvirt/images/VIRT_TEST_VM_config.ign";
+    script_retry($cmd, retry => 2, delay => 5, timeout => 60, die => 1);
+    save_screenshot;
+    assert_script_run("ls -latr /var/lib/libvirt/images/");
+    record_info("Ignition file is successfully downloaded.");
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+sub post_fail_hook {
+    # Let it empty now.
+    # Need to let parent one called after yast team modifies the parent class to fit alp.
+}
+
+1;
+

--- a/tests/virt_autotest/setup_kvm_container.pm
+++ b/tests/virt_autotest/setup_kvm_container.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use alp_workloads::kvm_workload_utils qw(set_kvm_container_image clean_and_resetup_kvm_container collect_kvm_container_setup_logs);
+use virt_autotest::utils qw(download_vm_import_disks);
 
 sub run {
     my $self = shift;
@@ -19,8 +20,8 @@ sub run {
     if (get_var('KVM_WORKLOAD_IMAGE', '')) {
         set_kvm_container_image(get_var('KVM_WORKLOAD_IMAGE'));
     }
-
     clean_and_resetup_kvm_container;
+    download_vm_import_disks;
 }
 
 sub test_flags {


### PR DESCRIPTION
This PR mainly does 4 things in 4 commits:
    a) download vm imported disks
    b) alp host other preparations and checks to let VT test continue
    c) enhance virtual network cleanup function to survive non-persistent networks cleaning
    d) enhance unified_guest_installation to cleanup potential affecting vm disks when no vm exists but vm disks exist

- Related ticket: https://progress.opensuse.org/issues/123154

- Verification run:

    Fail on purpose job with wrong vm disk location:
    http://10.67.129.185/tests/534#step/setup_kvm_container/138

    PASS:   
    alp: http://10.67.129.185/tests/537#
    osd regression test:   https://openqa.suse.de/t10614820 , and https://openqa.suse.de/t10614891 
