### PR TITLE
Unschedule logs_from_installation_system

### DIFF
--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -29,7 +29,7 @@ schedule:
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
-  - installation/logs_from_installation_system
+  - '{{logs_from_installation_system}}'
   - installation/reboot_after_installation
   - installation/handle_reboot
   - installation/first_boot
@@ -64,6 +64,10 @@ conditional_schedule:
     REGRESSION_SERVICE:
       1:
         - installation/install_service
+  logs_from_installation_system:
+    FLAVOR:
+      Regression-on-Migration-from-SLE15-SPx:
+        - installation/logs_from_installation_system
   regression_tests:
     REGRESSION_TEST:
       1:


### PR DESCRIPTION
Due to poo#122608, test module logs_from_installation_system occasionaly fails. This is because the exit code of the first command we run in the serial console is sometimes not captured and the command times out. 
To avoid this we unschedule logs_from_installation_system where this issue occurs.

- Related ticket: https://progress.opensuse.org/issues/125078
- Needles: No needles
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=ge0r%2Fos-autoinst-distri-opensuse%23unschedule-logs
