### PR TITLE
Split openldap_to_389ds

### DIFF
--- a/schedule/migration/openldap_to_389ds.yaml
+++ b/schedule/migration/openldap_to_389ds.yaml
@@ -4,4 +4,5 @@ description:    >
 schedule:
   - boot/boot_to_desktop
   - console/consoletest_setup
+  - migration/openldap_configuration
   - migration/openldap_to_389ds

--- a/schedule/migration/x86_regression_test_offline.yaml
+++ b/schedule/migration/x86_regression_test_offline.yaml
@@ -16,6 +16,7 @@ schedule:
   - boot/boot_to_desktop
   - update/patch_sle
   - migration/record_disk_info
+  - '{{openldap_configuration}}'
   - '{{install_service}}'
   - migration/reboot_to_upgrade
   - migration/version_switch_upgrade_target
@@ -37,6 +38,10 @@ schedule:
   - migration/post_upgrade
   - '{{qcow_generation}}'
 conditional_schedule:
+  openldap_configuration:
+    MEDIA_UPGRADE:
+      0:
+        - migration/openldap_configuration
   qcow_generation:
     QCOW_GENERATION:
       0:
@@ -49,7 +54,7 @@ conditional_schedule:
         - console/prepare_test_data
         - console/consoletest_setup
         - '{{check_upgraded_service}}'
-        - migration/openldap_to_389ds
+        - '{{openldap_to_389ds}}'
         - '{{regression_tests}}'
         - '{{rollback_after_migration}}'
       1:
@@ -63,6 +68,10 @@ conditional_schedule:
     REGRESSION_SERVICE:
       1:
         - console/check_upgraded_service
+  openldap_to_389ds:
+    MEDIA_UPGRADE:
+      0:
+        - migration/openldap_to_389ds
   isosize_test:
     REGRESSION_SERVICE:
       1:
@@ -79,7 +88,6 @@ conditional_schedule:
         - console/hostname
         - console/upgrade_snapshots
         - console/zypper_lr
-        - console/check_system_info
         - console/zypper_ref
         - console/firewall_enabled
         - console/zypper_lifecycle

--- a/schedule/migration/x86_regression_test_online.yaml
+++ b/schedule/migration/x86_regression_test_online.yaml
@@ -50,6 +50,7 @@ conditional_schedule:
         - migration/online_migration/online_migration_setup
         - migration/online_migration/register_system
         - migration/online_migration/zypper_patch
+        - migration/openldap_configuration
   check_migration_features:
     MIGRATION_FEATURES:
       1:

--- a/tests/migration/openldap_configuration.pm
+++ b/tests/migration/openldap_configuration.pm
@@ -1,0 +1,77 @@
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: The module attempts to save openldap configuration files in
+#          the system.
+#
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'consoletest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use strict;
+use warnings;
+use utils;
+use Utils::Systemd qw(systemctl disable_and_stop_service);
+use version_utils qw(is_tumbleweed is_sle);
+use Utils::Logging 'tar_and_upload_log';
+
+sub run {
+    my ($self) = @_;
+    select_serial_terminal;
+
+    # Install openldap since we need use slaptest tools
+    zypper_call("in sssd sssd-tools sssd-ldap openldap2 openldap2-client");
+
+    # Disable and stop the nscd daemon because it conflicts with sssd
+    disable_and_stop_service("nscd");
+
+    # On newer environments, nsswitch.conf is located in /usr/etc
+    # Copy it to /etc directory
+    script_run 'f=/etc/nsswitch.conf; [ ! -f $f ] && cp /usr$f $f';
+    # Configure nsswitch with sssd
+    assert_script_run "sed -i 's/^passwd:.*/passwd: compat sss/' /etc/nsswitch.conf";
+    assert_script_run "sed -i 's/^group:.*/group: compat sss/' /etc/nsswitch.conf";
+    assert_script_run "cat /etc/nsswitch.conf";
+
+    # Prepare test env
+    assert_script_run "cd; curl -L -v " . autoinst_url . "/data/openldap_to_389ds > openldap_to_389ds.data && cpio -id < openldap_to_389ds.data && mv data test && ls test";
+    assert_script_run("cd test");
+
+    # We need start openldap to kick out date base file which stored in directory
+    assert_script_run "mkdir /tmp/ldap-sssdtest";
+    if (is_tumbleweed) {
+        assert_script_run "sed -i -e '/cachesize/d' ./slapd.conf";
+        assert_script_run "sed -i -e 's/hdb/mdb/g' ./slapd.conf";
+        # for openqa debug
+        permit_root_ssh;
+    }
+    assert_script_run "cat ./slapd.conf";
+    my $slapd_command = (is_sle('<=12-sp5')) ? "/usr/lib/openldap/slapd" : "slapd";
+    assert_script_run "$slapd_command -h 'ldap:///' -f slapd.conf";
+
+    assert_script_run "ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif";
+    assert_script_run "killall slapd";
+    assert_script_run "ps -aux | grep slapd";
+
+    # setup sssd
+    assert_script_run "cp ./sssd.conf /etc/sssd/sssd.conf";
+    systemctl("stop sssd");
+    assert_script_run "rm -rf /var/lib/sss/db/*";
+    systemctl("restart sssd");
+    systemctl("status sssd");
+
+    # Prepare data file for migration
+    assert_script_run "mkdir slapd.d";
+    assert_script_run "slaptest -f slapd.conf -F ./slapd.d";
+
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    select_console 'log-console';
+    tar_and_upload_log('/var/log/sssd', '/tmp/sssd.tar.bz2');
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/migration/openldap_to_389ds.pm
+++ b/tests/migration/openldap_to_389ds.pm
@@ -12,9 +12,7 @@ use serial_terminal 'select_serial_terminal';
 use strict;
 use warnings;
 use utils;
-use lockapi;
-use Utils::Systemd qw(systemctl disable_and_stop_service);
-use registration qw(add_suseconnect_product);
+use Utils::Systemd qw(systemctl);
 use version_utils;
 use Utils::Logging 'tar_and_upload_log';
 
@@ -23,64 +21,16 @@ sub run {
     my $password = $testapi::password;
     select_serial_terminal;
 
-    # Install 389-ds and sssd on client
-    zypper_call("in 389-ds sssd sssd-tools");
+    # Install 389-ds
+    zypper_call("in 389-ds");
     zypper_call('info 389-ds');
-    # Install openldap since we need use slaptest tools
-    if (is_sle) {
-        my $openldap = get_required_var("OPENLDAP_PKG");
-        assert_script_run('wget ' . $openldap, 200);
-        my @ldap = split('/', $openldap);
-        assert_script_run 'rpm -i ' . $ldap[-1];
-    } else {
-        zypper_call("in openldap2");
-    }
-    zypper_call("in sssd-ldap openldap2-client");
-
-    # Disable and stop the nscd daemon because it conflicts with sssd
-    disable_and_stop_service("nscd");
-
-    # On newer environments, nsswitch.conf is located in /usr/etc
-    # Copy it to /etc directory
-    script_run 'f=/etc/nsswitch.conf; [ ! -f $f ] && cp /usr$f $f';
-    # Configure nsswitch with sssd
-    assert_script_run "sed -i 's/^passwd:.*/passwd: compat sss/' /etc/nsswitch.conf";
-    assert_script_run "sed -i 's/^group:.*/group: compat sss/' /etc/nsswitch.conf";
-    assert_script_run "cat /etc/nsswitch.conf";
-
-    # Prepare test env
-    assert_script_run "cd; curl -L -v " . autoinst_url . "/data/openldap_to_389ds > openldap_to_389ds.data && cpio -id < openldap_to_389ds.data && mv data test && ls test";
-    assert_script_run("cd test");
-
-    # We need start openldap to kick out date base file which stored in directory
-    assert_script_run "mkdir /tmp/ldap-sssdtest";
-    if (is_tumbleweed) {
-        assert_script_run "sed -i -e '/cachesize/d' ./slapd.conf";
-        assert_script_run "sed -i -e 's/hdb/mdb/g' ./slapd.conf";
-        # for openqa debug
-        permit_root_ssh;
-    }
-    assert_script_run "cat ./slapd.conf";
-    assert_script_run "slapd -h 'ldap:///' -f slapd.conf";
-
-    assert_script_run "ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif";
-    assert_script_run "killall slapd";
-    assert_script_run "ps -aux | grep slapd";
-
-    # setup sssd
-    assert_script_run "cp ./sssd.conf /etc/sssd/sssd.conf";
-    systemctl("stop sssd");
-    assert_script_run "rm -rf /var/lib/sss/db/*";
-    systemctl("restart sssd");
-    systemctl("status sssd");
 
     # Prepare data file for migration
+    assert_script_run("cd test");
     assert_script_run "sed -i 's/^root_password.*/root_password = $password/' ./instance.inf";
-    assert_script_run "mkdir slapd.d";
     assert_script_run("dscreate from-file ./instance.inf", timeout => 180);
     assert_script_run("echo '127.0.0.1    susetest' >> /etc/hosts");
     assert_script_run "dsctl localhost status";
-    assert_script_run "slaptest -f slapd.conf -F ./slapd.d";
 
     # Check migration tools
     tar_and_upload_log('./slapd.d', 'slapd.d.tar.bz2');
@@ -116,7 +66,6 @@ sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
     tar_and_upload_log('/var/log/dirsrv', '/tmp/ds389.tar.bz2');
-    tar_and_upload_log('/var/log/sssd', '/tmp/sssd.tar.bz2');
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Since openldap2 is depricated after SLE 15SP3, we need to reform out mirgation test so that the openldap is configurated before migration.

- Needed gitlab PR: https://gitlab.suse.de/coolgw/wegao-test/-/merge_requests/250/diffs
- Related ticket: https://progress.opensuse.org/issues/119662
- VRs: 

Tumbleweed : http://falafel.suse.cz/tests/991

SLE: https://openqa.suse.de/tests/overview?version=15-SP5&build=sofiasyria%2Fos-autoinst-distri-opensuse%23ldap&distri=sle

