### PR TITLE
Automation Development for Guest Migration Test

### DIFF
--- a/lib/parallel_guest_migration_base.pm
+++ b/lib/parallel_guest_migration_base.pm
@@ -1,0 +1,1760 @@
+# PARALLEL GUEST MIGRATION BASE MODULE
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Base module for parallel guest migration test run.
+#
+# Global structures:
+# %guest_matrix to record information about guest under test.
+# %guest_network_matrix to specify guest network information.
+# %guest_migration_matrix to store all guest migration tests.
+# %test_result to record test reults for all guests and tests.
+#
+# Run-time settings:
+# LOCAL_IPADDR, LOCAL_FQDN, PEER_IPADDR and PEER_FQDN store
+# ip address and FQDN of source and destination hosts.
+# GUEST_UNDER_TEST stores guest to be tested.
+# GUEST_UNDER_TEST_MACADDR, GUEST_UNDER_TEST_IPADDR,
+# GUEST_UNDER_TEST_NETTYPE, GUEST_UNDER_TEST_NETNAME,
+# GUEST_UNDER_TEST_NETMODE and GUEST_UNDER_TEST_STATICIP are
+# derived from %guest_matrix for source and destination hosts
+# to be on the same picture about about during test runs.
+# TEST_RUN_PROGRESS stores running subroutine name as progress.
+# TEST_RUN_RESULT stores the final test run result.
+#
+# Member subroutines to support guest migraton test:
+# Check hosts health and do logs cleanup in the first place
+# Initialize above global structures to facilitate test run
+# Check hosts meet requirements for guest migration test
+# Check guets meet requirements for guest migration test
+# Restore and create environment for guest to start
+# Check and update information about guest during test run
+# Check final test results and create junit logs
+# Synchronization between peers in pass/fail situations
+#
+# Maintainer: Wayne Chen <wchen@suse.com>, qe-virt <qe-virt@suse.de>
+package parallel_guest_migration_base;
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use POSIX 'strftime';
+use DateTime;
+use testapi;
+use Data::Dumper;
+use upload_system_log;
+use XML::LibXML;
+use Tie::IxHash;
+use lockapi;
+use mmapi;
+use Carp;
+use Utils::Systemd;
+use List::MoreUtils qw(firstidx);
+use List::Util 'first';
+use version_utils qw(is_opensuse is_sle is_alp is_microos get_os_release);
+use virt_utils qw(collect_host_and_guest_logs cleanup_host_and_guest_logs enable_debug_logging);
+use virt_autotest::utils qw(is_kvm_host is_xen_host check_host_health check_guest_health is_fv_guest is_pv_guest add_guest_to_hosts parse_subnet_address_ipv4 check_port_state setup_common_ssh_config);
+use virt_autotest::domain_management_utils qw(construct_uri create_guest remove_guest shutdown_guest show_guest check_guest_state);
+use utils qw(zypper_call systemctl script_retry define_secret_variable);
+use virt_autotest::common;
+
+tie our %guest_matrix, 'Tie::IxHash', ();
+tie our %guest_network_matrix, 'Tie::IxHash', ();
+tie our %test_result, 'Tie::IxHash', ();
+%guest_network_matrix = (
+    nat => {
+        device => 'virbrX',
+        ipaddr => '192.168.X.1',
+        netmask => '255.255.255.0',
+        masklen => '24',
+        startaddr => '192.168.X.2',
+        endaddr => '192.168.X.254'
+    },
+    route => {
+        device => 'virbrX',
+        ipaddr => '192.168.X.1',
+        netmask => '255.255.255.0',
+        masklen => '24',
+        startaddr => '192.168.X.2',
+        endaddr => '192.168.X.254'
+    },
+    default => {
+        device => 'virbr0',
+        ipaddr => '',
+        netmask => '',
+        masklen => '',
+        startaddr => '',
+        endaddr => ''
+    },
+    host => {
+        device => 'br0',
+        ipaddr => '',
+        netmask => '',
+        masklen => '',
+        startaddr => '',
+        endaddr => ''
+    },
+    bridge => {
+        device => 'brX',
+        ipaddr => '192.168.X.1',
+        netmask => '255.255.255.0',
+        masklen => '24',
+        startaddr => '192.168.X.2',
+        endaddr => '192.168.X.254'
+    }
+);
+tie our %guest_migration_matrix_kvm, 'Tie::IxHash', (
+    virsh_live_native => 'virsh --connect=srcuri --debug=0 migrate --verbose --live --unsafe guest dsturi',
+    virsh_live_native_p2p => 'virsh --connect=srcuri --debug=0 migrate --verbose --live --p2p --persistent --change-protection --unsafe --compressed --abort-on-error --undefinesource guest dsturi',
+    virsh_live_tunnel_p2p => 'virsh --connect=srcuri --debug=0 migrate --verbose --live --p2p --tunnelled --persistent --change-protection --unsafe --compressed --abort-on-error --undefinesource guest dsturi',
+    virsh_live_native_p2p_auto_postcopy => 'virsh --connect=srcuri --debug=0 migrate --verbose --live --p2p --persistent --change-protection --unsafe --compressed --abort-on-error --postcopy --postcopy-after-precopy --undefinesource guest dsturi',
+    virsh_live_native_p2p_manual_postcopy => 'virsh --connect=srcuri --debug=0 migrate --verbose --live --p2p --persistent --change-protection --unsafe --compressed --abort-on-error --postcopy --undefinesource guest dsturi#virsh --connect=srcuri --debug=0 migrate-postcopy guest',
+    virsh_offline_native_p2p => 'virsh --connect=srcuri --debug=0 migrate --verbose --offline --p2p --persistent --unsafe --undefinesource guest dsturi');
+tie our %guest_migration_matrix_xen, 'Tie::IxHash', (
+    xl_online => 'xl -vvv migrate guest dstip',
+    virsh_online => 'virsh --connect=srcuri --debug=0 migrate --verbose --undefinesource guest dsturi',
+    virsh_live => 'virsh --connect=srcuri --debug=0 migrate --verbose --live --undefinesource guest dsturi');
+tie our %guest_migration_matrix, 'Tie::IxHash', (kvm => \%guest_migration_matrix_kvm, xen => \%guest_migration_matrix_xen);
+
+
+=head2 run
+
+Main subroutine to execute test.
+=cut
+
+sub run {
+    my ($self) = @_;
+
+    $self->set_test_run_progress;
+    $self->pre_run_test;
+    $self->{"start_run"} = time();
+    $self->run_test;
+    $self->{"stop_run"} = time();
+    $self->post_run_test;
+}
+
+=head2 pre_run_test
+
+Run before test run starts. Check host healthy state and do logs cleanup.
+=cut
+
+sub pre_run_test {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    check_host_health;
+    cleanup_host_and_guest_logs;
+}
+
+=head2 run_test
+
+Actual test is executed in this subroutine which needs to be overloaded in test
+module which uses this module as base.
+=cut
+
+sub run_test {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    croak("Please overload this subroutine in children modules to run desired tests");
+}
+
+=head2 post_run_test
+
+Run after test run finishes. Judge overall test run result and die if test fails. 
+=cut
+
+sub post_run_test {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    print "Final Test Results Are:\n", Dumper(\%test_result);
+    foreach my $_guest (keys %test_result) {
+        foreach my $_test (keys %{$test_result{$_guest}}) {
+            if ($test_result{$_guest}{$_test}{status} eq 'FAILED') {
+                set_var('TEST_RUN_RESULT', 'FAILED');
+                bmwqemu::save_vars();
+                bmwqemu::load_vars();
+                croak("Test run failed because certain test case did not pass");
+            }
+        }
+    }
+    $self->create_junit_log;
+    set_var('TEST_RUN_RESULT', 'PASSED');
+    bmwqemu::save_vars();
+    bmwqemu::load_vars();
+}
+
+=head2 get_parallel_role
+
+Get role (parent or children) of job based on whether PARALLEL_WITH is given.
+=cut
+
+sub get_parallel_role {
+    my $self = shift;
+
+    return get_var('PARALLEL_WITH', '') ? 'children' : 'parent';
+}
+
+=head2 create_barrier
+
+Create barriers to be used for synchronization between peers.
+=cut
+
+sub create_barrier {
+    my ($self, %args) = @_;
+    $args{signal} //= '';
+    croak("Signal to be created must be given") if (!$args{signal});
+
+    foreach my $_signal (split(/ /, $args{signal})) {
+        barrier_create($_signal, 2);
+        record_info("$_signal(x2) barrier created");
+    }
+}
+
+=head2 set_test_run_progress
+
+Any subroutine calls this set_test_run_progress will set TEST_RUN_PROGRESS to
+the name of FILE::SUBROUTINE. If argument token is not empty, it will be added
+to the end of the name of FILE::SUBROUTINE.
+=cut
+
+sub set_test_run_progress {
+    my ($self, %args) = @_;
+    $args{token} //= '';
+
+    my $_test_run_progress = (caller(1))[3];
+    $_test_run_progress .= "_$args{token}" if ($args{token});
+    set_var('TEST_RUN_PROGRESS', $_test_run_progress);
+    bmwqemu::save_vars();
+    bmwqemu::load_vars();
+}
+
+=head2 get_test_run_progress
+
+Return TEST_RUN_PROGRESS of peer or self job depends on whether argument peer is
+set (1) or not (0);
+=cut
+
+sub get_test_run_progress {
+    my ($self, %args) = @_;
+    $args{peer} //= 1;
+
+    return get_var('TEST_RUN_PROGRESS', '') if ($args{peer} == 0);
+    my $_role = $self->get_parallel_role;
+    my ($_peer_info, $_peer_vars) = $self->get_peer_info(role => $_role);
+    return $_peer_vars->{'TEST_RUN_PROGRESS'} if (defined $_peer_vars->{'TEST_RUN_PROGRESS'});
+    return '';
+}
+
+=head2 get_test_run_result
+
+Return TEST_RUN_RESULT of peer or self job depends on whether argument peer is
+set (1) or not (0);
+=cut
+
+sub get_test_run_result {
+    my ($self, %args) = @_;
+    $args{peer} //= 1;
+
+    return get_var('TEST_RUN_RESULT', '') if ($args{peer} == 0);
+    my $_role = $self->get_parallel_role;
+    my ($_peer_info, $_peer_vars) = $self->get_peer_info(role => $_role);
+    return $_peer_vars->{'TEST_RUN_RESULT'} if (defined $_peer_vars->{'TEST_RUN_RESULT'});
+    return '';
+}
+
+=head2 do_local_initialization
+
+Initialization information about local host and save it into variables.
+=cut
+
+sub do_local_initialization {
+    my $self = shift;
+    $self->set_test_run_progress;
+
+    record_info("Local initialization");
+    my $_localip = '';
+    my $_localfqdn = '';
+    set_var('LOCAL_IPADDR', $_localip);
+    set_var('LOCAL_FQDN', $_localfqdn);
+    $_localip = script_output("hostname -i", type_command => 1) if (script_retry("hostname -i", option => '--kill-after=1 --signal=9', delay => 1, retry => 60) == 0);
+    (($_localip eq '' or $_localip eq '127.0.0.1' or $_localip eq '::1 127.0.0.1') and (is_sle('15+') or !is_sle)) ? set_var('LOCAL_IPADDR', (split(/ /, script_output("hostname -I", type_command => 1)))[0]) : set_var('LOCAL_IPADDR', $_localip);
+    $_localfqdn = script_output("hostname -f", type_command => 1) if (script_retry("hostname -f", option => '--kill-after=1 --signal=9', delay => 1, retry => 60) == 0);
+    (($_localfqdn eq '' or $_localfqdn eq 'localhost') and (is_sle('15+') or !is_sle)) ? set_var('LOCAL_FQDN', (split(/ /, script_output("hostname -A", type_command => 1)))[0]) : set_var('LOCAL_FQDN', $_localfqdn);
+    save_screenshot;
+    set_var('TEST_RUN_RESULT', '');
+    bmwqemu::save_vars();
+    bmwqemu::load_vars();
+}
+
+=head2 do_peer_initialization
+
+Initialization information about peer, save it into variables and setup passwordless
+ssh connection to it.
+=cut
+
+sub do_peer_initialization {
+    my $self = shift;
+    $self->set_test_run_progress;
+
+    record_info("Peer initialization");
+    my $_role = $self->get_parallel_role;
+    my ($_peer_info, $_peer_vars) = $self->get_peer_info(role => $_role);
+    set_var('PEER_IPADDR', $_peer_vars->{'LOCAL_IPADDR'});
+    set_var('PEER_FQDN', $_peer_vars->{'LOCAL_IPADDR'});
+    bmwqemu::save_vars();
+    bmwqemu::load_vars();
+    assert_script_run("sed -i -r \'/^PreferredAuthentications.*\$/d\' /root/.ssh/config") if (script_run("ls /root/.ssh/config") == 0);
+    $self->config_ssh_pubkey_auth(addr => get_required_var('PEER_IPADDR'), overwrite => 0);
+}
+
+=head2 get_peer_info
+
+Get peer job info and variables.
+=cut
+
+sub get_peer_info {
+    my $self = shift;
+
+    my $_peer = '';
+    my $_peerid = '';
+    my $_role = $self->get_parallel_role;
+    if ($_role eq 'parent') {
+        $_peer = get_children();
+        $_peerid = (keys %$_peer)[0];
+    }
+    elsif ($_role eq 'children') {
+        $_peer = get_parents();
+        $_peerid = $_peer->[0];
+    }
+
+    my $_peerinfo = get_job_info($_peerid);
+    my $_peervars = get_job_autoinst_vars($_peerid);
+    print "Peer Job Info:", Dumper($_peerinfo);
+    print "Peer Job Vars:", Dumper($_peervars);
+    return ($_peerinfo, $_peervars);
+}
+
+=head2 config_ssh_pubkey_auth
+
+Configure SSH Public Key Authentication to host or guest. Main arguments are
+address to which ssh connects, whether overwrite (1) or not (0) existing keys,
+either host (1) or guest (0) on which operation will be done and whether die
+(1) or not (0) if any failures happen.
+=cut
+
+sub config_ssh_pubkey_auth {
+    my ($self, %args) = @_;
+    $args{addr} //= '';
+    $args{overwrite} //= 0;
+    $args{host} //= 1;
+    $args{die} //= 0;
+    croak("The address of ssh connnection must be given") if (!$args{addr});
+
+    assert_script_run("clear && ssh-keygen -b 2048 -t rsa -q -N \"\" -f ~/.ssh/id_rsa <<< y") if ($args{overwrite} == 1 or script_run("ls ~/.ssh/id_rsa") != 0);
+    my $_ret = 0;
+    foreach my $_addr (split(/ /, $args{addr})) {
+        record_info("Config $_addr SSH PubKey auth");
+        next if (script_run("timeout --kill-after=1 --signal=9 15 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_addr ls") == 0);
+        enter_cmd("clear", wait_still_screen => 3);
+        enter_cmd("timeout --kill-after=1 --signal=9 30 ssh-copy-id -f -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa.pub root\@$_addr", wait_still_screen => 3);
+        if ($args{host} == 1) {
+            susedistribution::handle_password_prompt();
+        }
+        else {
+            check_screen("password-prompt", 60);
+            enter_cmd(get_var('_SECRET_GUEST_PASSWORD', ''), wait_screen_change => 50, max_interval => 1);
+            wait_still_screen(35);
+        }
+        my $_temp = 1;
+        $_temp = script_run("timeout --kill-after=1 --signal=9 15 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_addr ls");
+        $_ret |= $_temp;
+        record_info("Machine $_addr SSH PubKeyAuth failed", "Can not establish ssh connection to machine $_addr using Public Key Authentication", result => 'fail') if ($_temp != 0);
+    }
+    croak("SSH public key authentication setup failed for certain system") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 check_host_architecture
+
+Check source and destination hosts have the same architecture, otherwise test run
+can not proceed.
+=cut
+
+sub check_host_architecture {
+    my ($self, %args) = @_;
+
+    record_info("Check host architecture");
+    my $_localip = get_var('LOCAL_IPADDR');
+    my $_localarch = script_output("uname -i", type_command => 1);
+    my $_peerip = get_var('PEER_IPADDR');
+    my $_peerarch = script_output("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_peerip uname -i", type_command => 1);
+    save_screenshot;
+    croak("Architecture $_localarch on $_localip does not match $_peerarch on $_peerip") if ($_localarch ne $_peerarch);
+}
+
+=head2 check_host_os
+
+Check source and destination hosts operating system version. Guest migration can
+not be done from the newer to the older. Main argument is host role (src or dst).
+=cut
+
+sub check_host_os {
+    my ($self, %args) = @_;
+    $args{role} //= 'src';
+
+    record_info("Check host os");
+    my $_ret = 0;
+    my $_localip = get_var('LOCAL_IPADDR');
+    my $_peerip = get_var('PEER_IPADDR');
+    if (is_sle) {
+        my ($_localosver, $_localossp,) = get_os_release;
+        my ($_peerosver, $_peerossp,) = get_os_release("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_peerip");
+        save_screenshot;
+        unless (($_peerosver > $_localosver) or ($_peerosver == $_localosver and $_peerossp >= $_localossp)) {
+            $_ret = 1;
+            if ($args{role} eq 'src') {
+                croak("Destination os $_peerosver-sp$_peerossp falls behind source os $_localosver-sp$_localossp");
+            }
+            elsif ($args{role} eq 'dst') {
+                record_info("Source os $_peerosver-sp$_peerossp  falls behind destination os $_localosver-sp$_localossp");
+            }
+        }
+    }
+    return $_ret;
+}
+
+=head2 check_host_virtualization
+
+Check virtualization modules and services are ready, otherwise test run can not
+proceed.
+=cut
+
+sub check_host_virtualization {
+    my $self = shift;
+
+    record_info("Check host virtualization");
+    if (is_kvm_host) {
+        assert_script_run("lsmod | grep kvm");
+    }
+    elsif (is_xen_host) {
+        assert_script_run("lsmod | grep xen");
+    }
+
+    if (!is_alp) {
+        if (script_run("systemctl is-active libvirtd") != 0) {
+            systemctl("stop libvirtd", ignore_failure => 1);
+            systemctl("start libvirtd");
+            systemctl("is-active libvirtd");
+        }
+        else {
+            systemctl("restart libvirtd");
+        }
+        systemctl("status libvirtd");
+    }
+    save_screenshot;
+}
+
+=head2 check_host_package
+
+Install necessary packages to facilitate test run down the road. Main argument
+is packages to be installed.
+=cut
+
+sub check_host_package {
+    my ($self, %args) = @_;
+    $args{package} //= '';
+
+    record_info("Check host package");
+    zypper_call("--gpg-auto-import-keys ref");
+    is_kvm_host ? zypper_call("in -t pattern kvm_tools") : zypper_call("in -t pattern xen_tools") if (!is_alp and !is_microos);
+    zypper_call("in iputils nmap libguestfs* libguestfs0 guestfs-tools virt-install libvirt-client");
+    zypper_call("in $args{package}") if ($args{package});
+}
+
+=head2 check_host_uid
+
+Check source and destination hosts have the same user id for user qemu. If any 
+discrepancy, set the same group id on both side by using the value provided in 
+_user.
+=cut
+
+sub check_host_uid {
+    my $self = shift;
+
+    my %_user = (qemu => 996);
+    my $_local = get_var('LOCAL_IPADDR');
+    my $_peer = get_var('PEER_IPADDR');
+    my $_localuid = '';
+    my $_peeruid = '';
+    foreach my $_single_user (keys %_user) {
+        record_info("Check $_single_user uid on host");
+        $_localuid = script_output("id -u $_single_user", type_command => 1);
+        $_peeruid = script_output("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_peer id -u $_single_user", type_command => 1);
+        if ($_localuid != $_peeruid) {
+            my $_ret = script_run("usermod -u $_user{$_single_user} $_single_user");
+            croak("$_single_user UID modification failed on $_local") if ($_ret != 0 and $_ret != 12);
+            $_ret = script_run("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_peer usermod -u $_user{$_single_user} $_single_user");
+            croak("$_single_user UID modification failed on $_peer") if ($_ret != 0 and $_ret != 12);
+        }
+        save_screenshot;
+    }
+}
+
+=head2 check_host_gid
+
+Check source and destination hosts have the same group id for groups qemu, kvm and
+libvirt. If any discrepancy, set the same group id on both side by using the value
+provided in _group.
+=cut
+
+sub check_host_gid {
+    my $self = shift;
+
+    my %_group = (qemu => 999,
+        kvm => 998,
+        libvirt => 997
+    );
+    my $_local = get_var('LOCAL_IPADDR');
+    my $_peer = get_var('PEER_IPADDR');
+    my $_localgid = '';
+    my $_peergid = '';
+    foreach my $_single_group (keys %_group) {
+        record_info("Check $_single_group gid on host");
+        $_localgid = script_output("grep ^$_single_group /etc/group|cut -d \":\" -f 3", type_command => 1);
+        $_peergid = script_output("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_peer grep ^$_single_group /etc/group|cut -d \":\" -f 3", type_command => 1);
+        save_screenshot;
+        if ($_localgid != $_peergid) {
+            my $_ret = script_run("groupmod -g $_group{$_single_group} $_single_group");
+            save_screenshot;
+            croak("$_single_group GID modification failed on $_local") if ($_ret != 0);
+            $_ret = script_run("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_peer groupmod -g $_group{$_single_group} $_single_group");
+            save_screenshot;
+            croak("$_single_group GID modification failed on $_peer") if ($_ret != 0);
+        }
+    }
+}
+
+=head2 config_host_shared_storage
+
+Configure shared nfs storage on server and mount it on client. Main arguments
+are type of shared storage, path of exported shared storage, server or client 
+and mount path on client. 
+=cut
+
+sub config_host_shared_storage {
+    my ($self, %args) = @_;
+    $args{type} //= 'nfs';
+    $args{exppath} //= '/var/lib/libvirt/images';
+    $args{role} //= 'server';
+    $args{mntpath} //= '/var/lib/libvirt/images';
+
+    record_info("Configure host shared storage");
+    if ($args{type} eq 'nfs') {
+        my $_temppath = get_var('EXTERNAL_NFS_SHARE', '');
+        if ($_temppath) {
+            script_run("umount $args{mntpath} || umount -f -l $args{mntpath}");
+            assert_script_run("mount -t nfs $_temppath $args{mntpath}");
+            $args{role} eq 'server' ? assert_script_run("rm -f -r $args{mntpath}/nfsok; touch $args{mntpath}/nfsok") : assert_script_run("cd ~ && ls -lah $args{mntpath}/nfsok");
+        }
+        elsif ($args{role} eq 'server') {
+            if (script_run("ls /etc/nfs.conf") == 0) {
+                my $_cpu_num = 0;
+                $_cpu_num = script_output("grep -c ^processor /proc/cpuinfo", type_command => 1, proceed_on_failure => 1);
+                $_cpu_num = 1 if ($_cpu_num == 0 or $_cpu_num eq '');
+                my $_nfs_threads = 32 * $_cpu_num;
+                assert_script_run("sed -i -r \'s/^.*threads=.*\$/ threads=$_nfs_threads/g\' /etc/nfs.conf");
+            }
+            $_temppath = $args{exppath};
+            $_temppath =~ s/\//\\\//g;
+            assert_script_run("sed -i \'/^.*$_temppath.*\$/d\' /etc/exports");
+            assert_script_run("echo \"$args{exppath} *(rw,sync,no_root_squash,no_subtree_check)\" >> /etc/exports");
+            assert_script_run("exportfs -a");
+            systemctl('restart nfs-server.service');
+            systemctl('status nfs-server.service');
+            assert_script_run("rm -f -r $args{exppath}/nfsok; touch $args{exppath}/nfsok");
+            save_screenshot;
+        }
+        elsif ($args{role} eq 'client') {
+            my $_nfsserver = get_var('PEER_IPADDR');
+            script_run("umount $args{mntpath} || umount -f -l $args{mntpath}");
+            assert_script_run("mount -t nfs $_nfsserver:$args{exppath} $args{mntpath}");
+            assert_script_run("cd ~ && ls -lah $args{mntpath}/nfsok");
+            save_screenshot;
+        }
+    }
+}
+
+=head2 config_host_security
+
+Get rid of limitations come from security services and rules which may have impact
+on connectivity between host and guest.
+=cut
+
+sub config_host_security {
+    my $self = shift;
+
+    record_info("Config host security");
+    my @_security_service = ('SuSEFirewall2', 'firewalld', 'apparmor');
+    foreach my $_ss (@_security_service) {
+        if (script_run("systemctl is-enabled $_ss") == 0) {
+            systemctl("stop $_ss");
+            systemctl("disable $_ss");
+            save_screenshot;
+        }
+    }
+
+    if (script_run("cat /etc/selinux/config | grep -i ^SELINUX=enforcing\$") == 0) {
+        assert_script_run("sed -i -r \'s/^SELINUX=enforcing\$/SELINUX=permissive/g\' /etc/selinux/config");
+    }
+
+    script_run("iptables -P INPUT ACCEPT;
+iptables -P FORWARD ACCEPT;
+iptables -P OUTPUT ACCEPT;
+iptables -t nat -F;
+iptables -F;
+sysctl -w net.ipv4.ip_forward=1;
+sysctl -w net.ipv4.conf.all.forwarding=1;
+sysctl -w net.ipv6.conf.all.forwarding=1"
+    );
+    save_screenshot;
+    setup_common_ssh_config;
+}
+
+=head2 guest_under_test
+
+Obtain all guests to be tested, either from test suite level setting GUEST_LIST
+or those already on host. Destination host retrieves such information from source.
+At last, initialize guest_matrix to empty.
+=cut
+
+sub guest_under_test {
+    my ($self, %args) = @_;
+    $args{role} //= '';
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    $self->set_test_run_progress;
+    croak("Role used to differentiate migration source from destination must be given") if (!$args{role});
+
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    if ($args{role} eq 'src') {
+        my $_guest_under_test = get_var('GUEST_LIST', '');
+        if (!$_guest_under_test) {
+            $_guest_under_test = join(" ", split(/\n/, script_output("virsh $_uri list --all --name | grep -v Domain-0", type_command => 1)));
+        }
+        else {
+            $_guest_under_test = join(" ", split(/,/, $_guest_under_test));
+        }
+        set_var('GUEST_UNDER_TEST', $_guest_under_test);
+        bmwqemu::save_vars();
+        bmwqemu::load_vars();
+    }
+    elsif ($args{role} eq 'dst') {
+        my ($_peer_info, $_peer_vars) = $self->get_peer_info(role => $self->get_parallel_role);
+        set_var('GUEST_UNDER_TEST', $_peer_vars->{'GUEST_UNDER_TEST'});
+        bmwqemu::save_vars();
+        bmwqemu::load_vars();
+    }
+
+    foreach my $_guest (split(/ /, get_required_var('GUEST_UNDER_TEST'))) {
+        tie my %_single_guest_matrix, 'Tie::IxHash', (macaddr => '', ipaddr => '', nettype => '', netname => '', netmode => '', staticip => 'no');
+        $guest_matrix{$_guest} = \%_single_guest_matrix;
+    }
+    print "Guest Matrix After Initialization:\n", Dumper(\%guest_matrix);
+    return get_required_var('GUEST_UNDER_TEST');
+}
+
+=head2 initialize_test_result
+
+Initialize hash structure test_result, which contains all tests specified by
+test suite level setting GUEST_MIGRATION_TEST, to 'FAILED' and TEST_RUN_RESULT
+to empty. The detailed test commands are stored in guest_migration_matrix.
+=cut
+
+sub initialize_test_result {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    my @_guest_migration_test = split(/,/, get_var('GUEST_MIGRATION_TEST', ''));
+    my $_full_test_matrix = is_kvm_host ? $parallel_guest_migration_base::guest_migration_matrix{kvm} : $parallel_guest_migration_base::guest_migration_matrix{xen};
+    @_guest_migration_test = keys(%$_full_test_matrix) if (scalar @_guest_migration_test == 0);
+    my $_localip = get_required_var('LOCAL_IPADDR');
+    my $_peerip = get_required_var('PEER_IPADDR');
+    my $_localuri = virt_autotest::domain_management_utils::construct_uri();
+    my $_peeruri = virt_autotest::domain_management_utils::construct_uri(host => $_peerip);
+
+    foreach my $_guest (keys %parallel_guest_migration_base::guest_matrix) {
+        tie my %_single_guest_matrix, 'Tie::IxHash', ();
+        while (my ($_testindex, $_test) = each(@_guest_migration_test)) {
+            my $_command = $_full_test_matrix->{$_test};
+            $_command =~ s/guest/$_guest/g;
+            $_command =~ s/srcuri/$_localuri/g;
+            $_command =~ s/dsturi/$_peeruri/g;
+            $_command =~ s/dstip/$_peerip/g;
+            tie my %_single_test_matrix, 'Tie::IxHash', (status => 'FAILED', test_time => strftime("\%H:\%M:\%S", gmtime(0)), shortname => $_test);
+            $_single_guest_matrix{$_command} = \%_single_test_matrix;
+        }
+        $test_result{$_guest} = \%_single_guest_matrix;
+    }
+    set_var('TEST_RUN_RESULT', '');
+    bmwqemu::save_vars();
+    bmwqemu::load_vars();
+    print "Test Results After Initialization:\n", Dumper(\%test_result);
+}
+
+=head2 save_guest_asset
+
+Save guest xml config for use down the road. Main arguments are guest to be manipulated
+, directory in which xml config is stored and whether die (1) or not (0) if any failures 
+happen. This subroutine also calls construct_uri to determine the desired URI to be used
+if the interested party is not localhost. Please refer to subroutine construct_uri for 
+the arguments related.
+=cut
+
+sub save_guest_asset {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be saved must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Save $_guest asset");
+        my $_temp = 1;
+        $_temp = script_run("virsh $_uri dumpxml $_guest > $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/target\" $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/alias\" $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/source/\@portid\" $args{confdir}/$_guest.xml");
+        if (script_output("xmlstarlet sel -T -t -v \"//devices/interface/\@type\" $args{confdir}/$_guest.xml", type_command => 1, proceed_on_failure => 1) eq 'network') {
+            $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/source/\@bridge\" $args{confdir}/$_guest.xml");
+        }
+        $_ret |= $_temp;
+        record_info("Guest $_guest asset saving failed", "Failed to save guest $_guest asset", result => 'fail') if ($_temp != 0);
+    }
+    save_screenshot;
+    croak("Guest asset saving for certain guest failed") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 restore_guest_asset
+
+Find guest disk and xml config with domain name, restore them to their original
+names and places. Main arguments are guest to be manipulated, whether die (1) 
+or not (0) if any failures happen, directories in which guest asset and config 
+are stored. This subroutine also calls construct_uri to determine the desired 
+URI to be connected if the interested party is not localhost. Please refer to 
+subroutine construct_uri for the arguments related.
+=cut
+
+sub restore_guest_asset {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{assetdir} //= '/var/lib/libvirt/images';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be restored must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Restore $_guest asset");
+        my $_temp = 1;
+        my $_guest_asset_name = $_guest . '_on-host_' . get_required_var('DISTRI') . '-' . get_required_var('VERSION') . '*' . get_required_var('SYSTEM_ROLE') . '_' . get_required_var('ARCH');
+        my $_guest_disk_downloaded = script_output("find $args{assetdir} -type f \\( -iname \"*$_guest_asset_name*disk\" -o -iname \"*$_guest_asset_name*raw\" -o -iname \"*$_guest_asset_name*qcow2\" \\) | head -1", type_command => 1, proceed_on_failure => 1);
+        my $_guest_config = script_output("find $args{assetdir} -type f -iname \"*$_guest_asset_name*xml\" | head -1", type_command => 1, proceed_on_failure => 1);
+        my $_guest_disk_original = script_output("xmlstarlet sel -T -t -v \"//devices/disk/source/\@file\" $_guest_config", type_command => 1, proceed_on_failure => 1);
+        $_temp = script_run("nice ionice qemu-img convert -p -f qcow2 $_guest_disk_downloaded -O qcow2 $_guest_disk_original && rm -f -r $_guest_disk_downloaded", timeout => 300);
+        $_temp |= script_run("mv $_guest_config $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/target\" $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/alias\" $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/source/\@portid\" $args{confdir}/$_guest.xml");
+        if (script_output("xmlstarlet sel -T -t -v \"//devices/interface/\@type\" $args{confdir}/$_guest.xml", type_command => 1, proceed_on_failure => 1) eq 'network') {
+            $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/source/\@bridge\" $args{confdir}/$_guest.xml");
+        }
+        $_ret |= $_temp;
+        save_screenshot;
+        record_info("Guest $_guest asset restoring failed", "Failed to restoring guest $_guest asset", result => 'fail') if ($_temp != 0);
+    }
+    croak("Guest asset restoring for certain guest failed") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 config_guest_clock
+
+Configure guest clock to kvm-clock or tsc. Please refer to guest migration requirements:
+https://susedoc.github.io/doc-sle/main/single-html/SLES-virtualization/#libvirt-admin-live-migration-requirements
+Main arguments are guest to be configured, directory in which guest xml config is
+stored and whether die (1) or not (0) if any failures happen.
+=cut
+
+sub config_guest_clock {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{die} //= 0;
+    croak("Guest to be configured must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Config $_guest clock");
+        my $_temp = 1;
+        script_run("cp $args{confdir}/$_guest.xml $args{confdir}/$_guest.xml.backup");
+        $_temp = script_run("xmlstarlet ed --inplace --delete \"/domain/clock\" $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --subnode \"/domain\" --type elem -n clock -v \"\" $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --insert \"/domain/clock\" --type attr -n offset -v utc $args{confdir}/$_guest.xml");
+        my $_clock = is_kvm_host ? "kvm-clock" : "tsc";
+        $_temp |= script_run("xmlstarlet ed --inplace --insert \"/domain/clock/timer\" --type attr -n name -v $_clock --insert \"/domain/clock/timer\" --type attr -n present -v yes $args{confdir}/$_guest.xml");
+        $_ret |= $_temp;
+        if ($_temp != 0) {
+            script_run("mv $args{confdir}/$_guest.xml.backup $args{confdir}/$_guest.xml");
+            record_info("Guest $_guest clock config failed", "Failed to configure guest $_guest clock settings", result => 'fail');
+        }
+        save_screenshot;
+    }
+    croak("Clock configuration failed for certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 config_guest_storage
+
+Configure guest storage cache mode to none. Please refer to guest migration requirements:
+https://susedoc.github.io/doc-sle/main/single-html/SLES-virtualization/#libvirt-admin-live-migration-requirements
+Main arguments are guest to be configured, directory in which guest xml config is
+stored and whether die (1) or not (0) if any failures happen.
+=cut
+
+sub config_guest_storage {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{die} //= 0;
+    croak("Guest to be configured must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Config $_guest storage");
+        my $_temp = 1;
+        $_temp = script_run("cp $args{confdir}/$_guest.xml $args{confdir}/$_guest.xml.backup");
+        $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/disk/driver/\@cache\" $args{confdir}/$_guest.xml");
+        $_temp |= script_run("xmlstarlet ed --inplace --insert \"/domain/devices/disk/driver[\@name=\'qemu\']\" --type attr -n cache -v none $args{confdir}/$_guest.xml");
+        $_ret |= $_temp;
+        if ($_temp != 0) {
+            script_run("mv $args{confdir}/$_guest.xml.backup $args{confdir}/$_guest.xml");
+            record_info("Guest $_guest storage config failed", "Failed to configure guest $_guest storage settings", result => 'fail');
+        }
+        save_screenshot;
+    }
+    croak("Storage configuration failed for certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 config_guest_console
+
+Configure serial console for guest by using libguestfs tools. Main arguments are
+guest to be configured, directory in which guest xml config is stored and whether
+die (1) or not (0) if any failures happen. This subroutine also calls construct_uri
+to determine the desired URI to be connected if the interested party is not localhost.
+Please refer to subroutine construct_uri for the arguments related.
+=cut
+
+sub config_guest_console {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be configured must be given") if (!$args{guest});
+
+    my $_host_console = '';
+    my $_guest_console = '';
+    if (is_kvm_host) {
+        $_host_console = script_output("dmesg | grep -i \"console.*enabled\" | grep -ioE \"tty[A-Z]{1,}\" | head -1", type_command => 1, proceed_on_failure => 1);
+        $_guest_console = $_host_console ? $_host_console . 0 : 'ttyS0';
+    }
+
+    my $_ret = 0;
+    my $_guest_device = '';
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Config $_guest console");
+        my $_temp = 1;
+        $_guest_console = (is_fv_guest($_guest) ? 'ttyS0' : 'hvc0') if (is_xen_host);
+        script_run("virsh $_uri destroy $_guest");
+        $_temp = script_retry("! virsh $_uri list --all | grep \"$_guest \" | grep running", delay => 1, retry => 5, die => 0);
+        foreach my $_dev (split(/\/n/, script_output("virt-filesystems $_uri -d $_guest | grep -ioE \"^/dev.*[^@].*\$\"", type_command => 1, proceed_on_failure => 1))) {
+            if (script_run("virt-ls $_uri -d $_guest -m $_dev / | grep -ioE \"^boot\$\"") == 0) {
+                $_guest_device = $_dev;
+                last;
+            }
+        }
+        $_temp |= script_run("virt-edit $_uri -d $_guest -m $_guest_device /boot/grub2/grub.cfg -e \"s/\$/ console=tty console=$_guest_console,115200/ if /.*(linux|kernel).*\\\/boot\\\/(vmlinuz|image).*\$/i\"");
+        $_ret |= $_temp;
+        save_screenshot;
+        record_info("Guest $_guest console config failed", "Failed to configure console $_guest_device for guest $_guest", result => 'fail') if ($_temp != 0);
+    }
+    croak("Console configuration failed for certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 start_guest
+
+Start guest by using virsh start and wait for it up and running if necessary. Main
+arguments are guest to start, virtualization management tool to be used, whether
+restart (1) or not (0), whether die (1) or not (0) if any failures happen and whether
+wait (1) or not (0) for guest up and running. This subroutine also calls construct_uri
+to determine the desired URI to be connected if the interested party is not localhost.
+Please refer to subroutine construct_uri for the arguments related.
+=cut
+
+sub start_guest {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{restart} //= 0;
+    $args{die} //= 0;
+    $args{wait} //= 1;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be started must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $_guest (split(/ /, $args{guest})) {
+        my $_temp = 1;
+        $_temp = $args{restart} == 0 ? script_run("virsh $_uri start $_guest") : script_run("virsh $_uri reboot $_guest") if ($args{virttool} eq 'virsh');
+        $_temp = $args{restart} == 0 ? 0 : script_run("xl reboot -F $_guest") if ($args{virttool} eq 'xl');
+        $_temp |= $self->wait_guest(guest => $_guest) if ($_temp == 0 and $args{wait} == 1);
+        $_ret |= $_temp;
+        save_screenshot;
+        record_info("Guest $_guest starting failed", "Failed to start guest $_guest by using $args{virttool} ($_uri) start/create $_guest", result => 'fail') if ($_temp != 0);
+    }
+    croak("Failed to start all guests") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 wait_guest
+
+Wait for guest up and running by obtaining ip address, adding mapping in /etc/hosts,
+and calling wait_guest_ssh. Main arguments are guest to wait, whether check ip 
+address (1) or not (0) and whether die (1) or not (0) if any failures happen.
+=cut
+
+sub wait_guest {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{checkip} //= 1;
+    $args{die} //= 0;
+    croak("Guest to wait for must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    foreach my $_guest (split(/ /, $args{guest})) {
+        my $_temp = 1;
+        $self->check_guest_network_address(guest => $_guest) if ($args{checkip} == 1);
+        add_guest_to_hosts($_guest, $guest_matrix{$_guest}{ipaddr});
+        save_screenshot;
+        $_temp = $guest_matrix{$_guest}{ipaddr} eq '' ? 1 : $self->wait_guest_ssh(guest => $_guest);
+        $_ret |= $_temp;
+        save_screenshot;
+        record_info("Guest $_guest waiting failed", "Failed to wait guest up and running", result => 'fail') if ($_temp != 0);
+    }
+    croak("Waiting for guest up and running failed for certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 wait_guest_ssh
+
+Detect whether guest ssh port is open by using nc. Main arguments are guest to
+be detected, times of retry and whether die (1) or not (0) if any failures happen.
+=cut
+
+sub wait_guest_ssh {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{retry} //= 60;
+    $args{die} //= 0;
+    croak("Guest to be waited for must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    foreach my $_guest (split(/ /, $args{guest})) {
+        my $_temp = 1;
+        $_temp = script_retry("nc -zvD $_guest 22", option => '--kill-after=1 --signal=9', delay => 1, retry => $args{retry}, die => 0);
+        save_screenshot;
+        $_ret |= $_temp;
+        record_info("Guest $_guest ssh failed", "Failed to detect open port 22 on guest $_guest", result => 'fail') if ($_temp != 0);
+    }
+    croak("ssh connection failed for certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 check_guest_network_config
+
+Check and obtain guest network configuration. Guest xml config contains enough
+information about network to which guest connects on boot, for example:
+<interface type="network">
+  <mac address="00:16:3e:4f:5a:35"/>
+  <source network="vnet_nat"/>
+</interface>
+or
+<interface type='bridge'>
+  <mac address='52:54:00:70:9d:b2'/>
+  <source bridge='br123'/>
+  <model type='virtio'/>
+  <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+</interface>
+Interface type, source network/bridge name and model type are those useful ones
+determine the network, they will be stored in guest_matrix{guest}{nettype}, 
+guest_matrix{guest}{netname} and guest_matrix{guest}{netmode}. In order to obtain
+netmode conveniently and consistently, netname should take the form of "vnet_" +
+"nat/route/host" + "_other_strings" if virtual network to be used. Addtionally,
+guest_matrix{guest}{macaddr} is also upated by querying domiflist and ip address
+guest_matrix{guest}{ipaddr} can also be obtained from lib/virt_autotest/common.pm
+if static ip address is being used. The main arguments are guest to be checked 
+and directory in which guest xml config is stored. This subroutine also calls 
+construct_uri to determine the desired URI to be connected if the interested party 
+is not localhost. Please refer to subroutine construct_uri for the arguments related.
+=cut
+
+sub check_guest_network_config {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be checked must be given") if (!$args{guest});
+
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Check $_guest network config", "Check and store $_guest network config from xml config, including ip address if static ip is assigned");
+        $guest_matrix{$_guest}{macaddr} = script_output("virsh $_uri domiflist $_guest | grep -oE \"[[:xdigit:]]{2}(:[[:xdigit:]]{2}){5}\"", type_command => 1, proceed_on_failure => 1);
+        $guest_matrix{$_guest}{nettype} = script_output("xmlstarlet sel -T -t -v \"//devices/interface/\@type\" $args{confdir}/$_guest.xml", type_command => 1, proceed_on_failure => 1);
+        if ($guest_matrix{$_guest}{nettype} eq 'network' or $guest_matrix{$_guest}{nettype} eq 'bridge') {
+            $guest_matrix{$_guest}{netname} = script_output("xmlstarlet sel -T -t -v \"//devices/interface/source/\@$guest_matrix{$_guest}{nettype}\" $args{confdir}/$_guest.xml", type_command => 1, proceed_on_failure => 1);
+            if ($guest_matrix{$_guest}{nettype} eq 'network') {
+                $guest_matrix{$_guest}{netmode} = $guest_matrix{$_guest}{netname} ne 'default' ? (split(/_/, $guest_matrix{$_guest}{netname}))[1] : 'default';
+            }
+            if ($guest_matrix{$_guest}{nettype} eq 'bridge') {
+                $guest_matrix{$_guest}{netmode} = $guest_matrix{$_guest}{netname} eq 'br0' ? 'host' : 'bridge';
+            }
+        }
+        if (get_var('REGRESSION', '') =~ /xen|kvm|qemu/i and defined $virt_autotest::common::guests{$_guest}->{ip} and $virt_autotest::common::guests{$_guest}->{ip} ne '') {
+            $guest_matrix{$_guest}{ipaddr} = $virt_autotest::common::guests{$_guest}->{ip};
+            $guest_matrix{$_guest}{staticip} = 'yes';
+        }
+        save_screenshot;
+    }
+}
+
+=head2 check_guest_network_address
+
+Check and obtain guest ip address. If static ip address is being used, there is
+no need to check it anymore. If guest uses bridge device directly, its ip address 
+can be obtained by querying journal log or scanning subnet by using nmap (if host 
+bridge device br0 is being used directly) with mac address. If guest uses virtual 
+network created by virsh, its ip address can be obtained by querying dhcp leases 
+of the virtual network or scanning subnet by using nmap (if host bridge device is 
+being used in the virtual network directly) with mac address. The main arguments 
+is guest to be checked. This subroutine also calls construct_uri to determine the 
+desired URI to be connected if the interested party is not localhost. Please refer 
+to subroutine construct_uri for the arguments related.
+=cut
+
+sub check_guest_network_address {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be checked must be given") if (!$args{guest});
+
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Check $_guest network address", "Check and store $_guest network address assigned by dhcp service. Skip if static ip is being used.");
+        return if ($guest_matrix{$_guest}{staticip} eq 'yes');
+        if ($guest_matrix{$_guest}{nettype} eq 'network') {
+            if ($guest_matrix{$_guest}{netmode} eq 'host') {
+                my $_br0_network = script_output("ip route show all | grep -v default | grep \".* br0\" | awk \'{print \$1}\'", type_command => 1, proceed_on_failure => 1);
+                script_retry("nmap -sP $_br0_network | grep -i $guest_matrix{$_guest}{macaddr}", option => '--kill-after=1 --signal=9', timeout => 180, retry => 30, delay => 10, die => 0);
+                $guest_matrix{$_guest}{ipaddr} = script_output("nmap -sP $_br0_network | grep -i $guest_matrix{$_guest}{macaddr} -B2 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", type_command => 1, timeout => 180, proceed_on_failure => 1);
+            }
+            else {
+                script_retry("virsh $_uri net-dhcp-leases --network $guest_matrix{$_guest}{netname} | grep -ioE \"$guest_matrix{$_guest}{macaddr}.*([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", retry => 30, delay => 10, die => 0);
+                $guest_matrix{$_guest}{ipaddr} = script_output("virsh $_uri net-dhcp-leases --network $guest_matrix{$_guest}{netname} | grep -i $guest_matrix{$_guest}{macaddr} | awk \'{print \$5}\'", type_command => 1, proceed_on_failure => 1);
+                $guest_matrix{$_guest}{ipaddr} = (split(/\//, $guest_matrix{$_guest}{ipaddr}))[0];
+                save_screenshot;
+            }
+        }
+        elsif ($guest_matrix{$_guest}{nettype} eq 'bridge') {
+            if ($guest_matrix{$_guest}{netname} eq 'br0') {
+                my $_br0_network = script_output("ip route show all | grep -v default | grep \".* br0\" | awk \'{print \$1}\'", type_command => 1, proceed_on_failure => 1);
+                script_retry("nmap -sP $_br0_network | grep -i $guest_matrix{$_guest}{macaddr}", option => '--kill-after=1 --signal=9', timeout => 180, retry => 30, delay => 10, die => 0);
+                $guest_matrix{$_guest}{ipaddr} = script_output("nmap -sP $_br0_network | grep -i $guest_matrix{$_guest}{macaddr} -B2 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", type_command => 1, timeout => 180, proceed_on_failure => 1);
+            }
+            else {
+                script_retry("journalctl --no-pager -n 100 | grep -i \"DHCPACK.*$guest_matrix{$_guest}{netname}.*$guest_matrix{$_guest}{macaddr}\" | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", option => '--kill-after=1 --signal=9', retry => 30, delay => 10, die => 0);
+                $guest_matrix{$_guest}{ipaddr} = script_output("journalctl --no-pager -n 100 | grep -i \"DHCPACK.*$guest_matrix{$_guest}{netname}.*$guest_matrix{$_guest}{macaddr}\" | tail -1 | grep -oE \"([0-9]{1,3}[\.]){3}[0-9]{1,3}\"", type_command => 1, proceed_on_failure => 1);
+            }
+        }
+        save_screenshot;
+    }
+}
+
+=head2 create_guest_network
+
+Create network, type of which is either network or bridge, to be used with guest.
+In order to make this work consistent, data in hash structure guest_network_matrix
+will be used for network creating, and the network name should begin with "vnet_"
+followed by "nat", "route" or "host" if network type is "network", or be "br0" or 
+"br123" if network type is "bridge". For guest using static ip address, network
+address info is derived from guest ip address. Main arguments are guest to be 
+served, the directory in which network xml config will be stored and whether die 
+(1) or not (0) if any error.This subroutine also calls construct_uri to determine 
+the desired URI to be connected if the interested party is not localhost. Please 
+refer to subroutine construct_uri for the arguments related.
+=cut
+
+sub create_guest_network {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    $args{guest} = get_required_var('GUEST_UNDER_TEST') if (!$args{guest});
+
+    my $_ret = 1;
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    my @_guest_network_configured = ();
+    my @_defintfs = split(/\n/, script_output("ip route show default | grep -i dhcp | awk \'{print \$5}\'", type_command => 1, proceed_on_failure => 1));
+    while (my ($_intfidx, $_defintf) = each(@_defintfs)) {
+        if ($_intfidx == 0) {
+            $_ret = script_run("iptables --table nat --append POSTROUTING --out-interface $_defintf -j MASQUERADE");
+        }
+        else {
+            $_ret |= script_run("iptables --table nat --append POSTROUTING --out-interface $_defintf -j MASQUERADE");
+        }
+    }
+    my %_netmode_counter = (nat => 114, route => 115, bridge => 113);
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Create $guest_matrix{$_guest}{netname} network for $_guest", "Skip if $_guest network $guest_matrix{$_guest}{netname} is already configured");
+        next if grep(/^$guest_matrix{$_guest}{netname}$/, @_guest_network_configured);
+        my $_temp = 1;
+        my $_device = $guest_network_matrix{$guest_matrix{$_guest}{netmode}}{device};
+        my $_ipaddr = $guest_network_matrix{$guest_matrix{$_guest}{netmode}}{ipaddr};
+        my $_netmask = $guest_network_matrix{$guest_matrix{$_guest}{netmode}}{netmask};
+        my $_masklen = $guest_network_matrix{$guest_matrix{$_guest}{netmode}}{masklen};
+        my $_startaddr = $guest_network_matrix{$guest_matrix{$_guest}{netmode}}{startaddr};
+        my $_endaddr = $guest_network_matrix{$guest_matrix{$_guest}{netmode}}{endaddr};
+        if ($guest_matrix{$_guest}{netmode} =~ /nat|route|bridge/i) {
+            $_netmode_counter{$guest_matrix{$_guest}{netmode}} += 10;
+            $_device =~ s/X/$_netmode_counter{$guest_matrix{$_guest}{netmode}}/g;
+            $_ipaddr =~ s/X/$_netmode_counter{$guest_matrix{$_guest}{netmode}}/g;
+            $_startaddr =~ s/X/$_netmode_counter{$guest_matrix{$_guest}{netmode}}/g;
+            $_endaddr =~ s/X/$_netmode_counter{$guest_matrix{$_guest}{netmode}}/g;
+        }
+        if ($guest_matrix{$_guest}{staticip} eq 'yes') {
+            $_ipaddr = (split(/\.([^\.]+)$/, $guest_matrix{$_guest}{ipaddr}))[0] . '.1';
+            $_startaddr = (split(/\.([^\.]+)$/, $guest_matrix{$_guest}{ipaddr}))[0] . '.2';
+            $_endaddr = (split(/\.([^\.]+)$/, $guest_matrix{$_guest}{ipaddr}))[0] . '.254';
+        }
+        if ($guest_matrix{$_guest}{nettype} eq 'network') {
+            script_run("virsh $_uri net-destroy $guest_matrix{$_guest}{netname}");
+            if ($guest_matrix{$_guest}{netname} ne 'default') {
+                script_run("virsh $_uri net-undefine $guest_matrix{$_guest}{netname}");
+                my $_forward_mode = $guest_matrix{$_guest}{netmode} eq 'host' ? 'bridge' : $guest_matrix{$_guest}{netmode};
+                type_string("cat > $args{confdir}/$guest_matrix{$_guest}{netname}.xml <<EOF
+<network>
+  <name>$guest_matrix{$_guest}{netname}</name>
+  <bridge name=\"$_device\"/>
+EOF
+");
+                if ($guest_matrix{$_guest}{netmode} eq 'nat') {
+                    type_string("cat >> $args{confdir}/$guest_matrix{$_guest}{netname}.xml <<EOF
+  <forward mode=\"$_forward_mode\">
+    <nat>
+      <port start=\"20232\" end=\"65535\"/>
+    </nat>
+  </forward>
+EOF
+");
+                }
+                else {
+                    type_string("cat >> $args{confdir}/$guest_matrix{$_guest}{netname}.xml <<EOF
+  <forward mode=\"$_forward_mode\"/>
+EOF
+");
+                }
+                type_string("cat >> $args{confdir}/$guest_matrix{$_guest}{netname}.xml <<EOF
+  <ip address=\"$_ipaddr\" netmask=\"$_netmask\">
+    <dhcp>
+      <range start=\"$_startaddr\" end=\"$_endaddr\">
+        <lease expiry=\"24\" unit=\"hours\"/>
+      </range>
+    </dhcp>
+  </ip>
+EOF
+") if ($guest_matrix{$_guest}{netmode} ne 'host');
+                type_string("cat >> $args{confdir}/$guest_matrix{$_guest}{netname}.xml <<EOF
+</network>
+EOF
+");
+                $_temp = script_run("virsh $_uri net-define $args{confdir}/$guest_matrix{$_guest}{netname}.xml");
+            }
+            else {
+                $_temp = 0;
+            }
+            if (script_run("virsh $_uri net-start $guest_matrix{$_guest}{netname}") != 0) {
+                systemctl("restart libvirtd");
+                systemctl("status libvirtd");
+                $_temp |= script_run("virsh $_uri net-start $guest_matrix{$_guest}{netname}");
+            }
+            else {
+                $_temp |= 0;
+            }
+            $_temp |= script_run("iptables --append FORWARD --in-interface $_device -j ACCEPT") if ($_device ne 'br0');
+            if (script_run("virsh $_uri net-list | grep \"$guest_matrix{$_guest}{netname} .*active\"") != 0) {
+                record_info("Network $guest_matrix{$_guest}{netname} creation failed", script_output("virsh $_uri list --all; virsh $_uri net-dumpxml $guest_matrix{$_guest}{netname};ip route show all", type_command => 1, proceed_on_failure => 1), result => 'fail');
+                $_temp |= 1;
+            }
+        }
+        elsif ($guest_matrix{$_guest}{nettype} eq 'bridge') {
+            if ($guest_matrix{$_guest}{netname} ne 'br0') {
+                if (script_run("ip route show all | grep \"$guest_matrix{$_guest}{netname} \"") != 0) {
+                    script_run("ip -d addr del $_ipaddr/$_masklen dev $guest_matrix{$_guest}{netname}; ip -d link set dev $guest_matrix{$_guest}{netname} down; ip -d link del dev $guest_matrix{$_guest}{netname}");
+                    $_temp = script_retry("ip -d link add $guest_matrix{$_guest}{netname} type $guest_matrix{$_guest}{nettype}; ip -d addr flush dev $guest_matrix{$_guest}{netname}", option => '--kill-after=1 --signal=9', retry => 3, die => 0);
+                    $_temp |= script_retry("ip -d addr add $_ipaddr/$_masklen dev $guest_matrix{$_guest}{netname} && ip -d link set $guest_matrix{$_guest}{netname} up", option => '--kill-after=1 --signal=9', retry => 3, die => 0);
+                    $_temp |= script_run("iptables --append FORWARD --in-interface $guest_matrix{$_guest}{netname} -j ACCEPT");
+                    my $_find_netdev = grep(/^$guest_matrix{$_guest}{netname}$/, split(/\n/, script_output("ip route show | grep -v default | awk \'{print \$3}\'", type_command => 1, proceed_on_failure => 1)));
+                    $_temp |= 1 && record_info("Network $guest_matrix{$_guest}{netname} creation failed", script_output("ip addr show all;ip route show all", type_command => 1, proceed_on_failure => 1), result => 'fail') if (!$_find_netdev);
+                }
+                else {
+                    $_temp = 0;
+                }
+                my $_dnsmasq_command = "/usr/sbin/dnsmasq --bind-dynamic --listen-address=$_ipaddr --dhcp-range=$_startaddr,$_endaddr,$_netmask,8h --interface=br123 --dhcp-authoritative --no-negcache --dhcp-option=option:router,$_ipaddr --log-queries --log-dhcp --dhcp-sequential-ip --dhcp-client-update --no-daemon";
+                if (!script_output("ps ax | grep -i \"$_dnsmasq_command\" | grep -v grep | awk \'{print \$1}\'", type_command => 1, proceed_on_failure => 1)) {
+                    $_temp |= script_run("((nohup $_dnsmasq_command) &)");
+                    my $_find_dnsmasq = script_output("ps ax | grep -i \"$_dnsmasq_command\" | grep -v grep | awk \'{print \$1}\'", type_command => 1, proceed_on_failure => 1);
+                    $_temp |= 1 && record_info("DHCP service failed on $guest_matrix{$_guest}{netname}", "Command to start DHCP service is $_dnsmasq_command", result => 'fail') if (!$_find_dnsmasq);
+                }
+            }
+        }
+        push(@_guest_network_configured, $guest_matrix{$_guest}{netname});
+        $_ret |= $_temp;
+        save_screenshot;
+    }
+    record_info("Guest network configuration done", script_output("ip addr show;ip route show all;virsh $_uri net-list --all;(for i in \`virsh $_uri net-list --all --name\`;do virsh $_uri net-dumpxml \$i;done);ps axu | grep dnsmasq", type_command => 1, proceed_on_failure => 1));
+    croak("Guest network creation failed for certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 initialize_guest_matrix
+
+Initialize guest matrix and associated variables. If variables are not empty, then
+update them. These variables will be shared between source and destination host to
+facilitate collaborative operations. On source host, putting values of variables
+into corresponding arrays which will be filled up or updated by calling fill_up_array.
+At last, storing updated values in arrays in variables. On destination host,
+initialize or update variables by retrieving corresponding information from source.
+=cut
+
+sub initialize_guest_matrix {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{role} //= '';
+    croak("Role used to differentiate migration source from destination must be given") if (!$args{role});
+    $args{guest} = get_required_var('GUEST_UNDER_TEST') if (!$args{guest});
+
+    if ($args{role} eq 'src') {
+        my @_guest_ipaddr = split(/ /, get_var('GUEST_UNDER_TEST_IPADDR', ''));
+        my @_guest_macaddr = split(/ /, get_var('GUEST_UNDER_TEST_MACADDR', ''));
+        my @_guest_nettype = split(/ /, get_var('GUEST_UNDER_TEST_NETTYPE', ''));
+        my @_guest_netname = split(/ /, get_var('GUEST_UNDER_TEST_NETNAME', ''));
+        my @_guest_netmode = split(/ /, get_var('GUEST_UNDER_TEST_NETMODE', ''));
+        my @_guest_staticip = split(/ /, get_var('GUEST_UNDER_TEST_STATICIP', ''));
+
+        $self->fill_up_array(ref => \@_guest_ipaddr, guest => $args{guest}, var => 'GUEST_UNDER_TEST_IPADDR');
+        $self->fill_up_array(ref => \@_guest_macaddr, guest => $args{guest}, var => 'GUEST_UNDER_TEST_MACADDR');
+        $self->fill_up_array(ref => \@_guest_nettype, guest => $args{guest}, var => 'GUEST_UNDER_TEST_NETTYPE');
+        $self->fill_up_array(ref => \@_guest_netname, guest => $args{guest}, var => 'GUEST_UNDER_TEST_NETNAME');
+        $self->fill_up_array(ref => \@_guest_netmode, guest => $args{guest}, var => 'GUEST_UNDER_TEST_NETMODE');
+        $self->fill_up_array(ref => \@_guest_staticip, guest => $args{guest}, var => 'GUEST_UNDER_TEST_STATICIP');
+
+        set_var('GUEST_UNDER_TEST_IPADDR', join(" ", @_guest_ipaddr));
+        set_var('GUEST_UNDER_TEST_MACADDR', join(" ", @_guest_macaddr));
+        set_var('GUEST_UNDER_TEST_NETTYPE', join(" ", @_guest_nettype));
+        set_var('GUEST_UNDER_TEST_NETNAME', join(" ", @_guest_netname));
+        set_var('GUEST_UNDER_TEST_NETMODE', join(" ", @_guest_netmode));
+        set_var('GUEST_UNDER_TEST_STATICIP', join(" ", @_guest_staticip));
+        bmwqemu::save_vars();
+        bmwqemu::load_vars();
+    }
+    elsif ($args{role} eq 'dst') {
+        my ($_peer_info, $_peer_vars) = $self->get_peer_info(role => $self->get_parallel_role);
+        set_var('GUEST_UNDER_TEST_MACADDR', $_peer_vars->{'GUEST_UNDER_TEST_MACADDR'});
+        set_var('GUEST_UNDER_TEST_IPADDR', $_peer_vars->{'GUEST_UNDER_TEST_IPADDR'});
+        set_var('GUEST_UNDER_TEST_NETTYPE', $_peer_vars->{'GUEST_UNDER_TEST_NETTYPE'});
+        set_var('GUEST_UNDER_TEST_NETNAME', $_peer_vars->{'GUEST_UNDER_TEST_NETNAME'});
+        set_var('GUEST_UNDER_TEST_NETMODE', $_peer_vars->{'GUEST_UNDER_TEST_NETMODE'});
+        set_var('GUEST_UNDER_TEST_STATICIP', $_peer_vars->{'GUEST_UNDER_TEST_STATICIP'});
+        bmwqemu::save_vars();
+        bmwqemu::load_vars();
+        $args{guest} = get_required_var('GUEST_UNDER_TEST');
+        my @_guest_under_test = split(/ /, $args{guest});
+        while (my ($_index, $_element) = each(@_guest_under_test)) {
+            %{$guest_matrix{$_element}} = ();
+            $guest_matrix{$_element}{macaddr} = (split(/ /, get_required_var('GUEST_UNDER_TEST_MACADDR')))[$_index];
+            $guest_matrix{$_element}{ipaddr} = (split(/ /, get_required_var('GUEST_UNDER_TEST_IPADDR')))[$_index];
+            $guest_matrix{$_element}{nettype} = (split(/ /, get_required_var('GUEST_UNDER_TEST_NETTYPE')))[$_index];
+            $guest_matrix{$_element}{netname} = (split(/ /, get_required_var('GUEST_UNDER_TEST_NETNAME')))[$_index];
+            $guest_matrix{$_element}{netmode} = (split(/ /, get_required_var('GUEST_UNDER_TEST_NETMODE')))[$_index];
+            $guest_matrix{$_element}{staticip} = (split(/ /, get_required_var('GUEST_UNDER_TEST_STATICIP')))[$_index];
+        }
+    }
+    print "Guest Matrix After Initialization:\n", Dumper(\%guest_matrix);
+}
+
+=head2 fill_up_array
+
+Fill up or update existing array which contains information about running guest,
+mac address, ip address, network type, network name, network mode and use static 
+ip (yes) or not (no). Updated array will be used to set corresponding variables, 
+for example, GUEST_UNDER_TEST_IPADDR. Main arguments are reference to the array, 
+guest to be involved and variable related. Guest attribute name is derived from 
+corresponding variable, for example, guest_matrix{guest}{netmode} is derived 
+from GUEST_UNDER_TEST_NETMODE. At last, array will be filled up or updated by 
+the latest guest_matrix{guest}{attribute}.
+=cut
+
+sub fill_up_array {
+    my ($self, %args) = @_;
+    $args{ref} //= '';
+    $args{guest} //= '';
+    $args{var} //= '';
+    croak("Array reference/guest/variable to be filled up must be given") if (!$args{ref} or !$args{guest} or !$args{var});
+
+    my @_guest_under_test = split(/ /, get_required_var('GUEST_UNDER_TEST'));
+    my $_guest_var = lc((split(/_/, $args{var}))[-1]);
+    foreach my $_guest (split(/ /, $args{guest})) {
+        if (get_var($args{var}, '')) {
+            my $_index = firstidx { $_ eq $_guest } (@_guest_under_test);
+            $args{ref}[$_index] = $guest_matrix{$_guest}{$_guest_var};
+        }
+        else {
+            push(@{$args{ref}}, $guest_matrix{$_guest}{$_guest_var});
+        }
+    }
+}
+
+=head2 test_guest_network
+
+Test networking accessibility of guest. All guests should can be reached on host
+and can reach outside from inside. The only guest that can be reached from outside
+host is the one uses host bridge network. Main arguments are guest to be tested and 
+whether die (1) or not (0) if any error.
+=cut
+
+sub test_guest_network {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{die} //= 0;
+    croak("Guest to be tested must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Test $_guest network");
+        my $_temp = 1;
+        my $_ping_target = is_opensuse ? 'openqa.opensuse.org' : 'openqa.suse.de';
+        $_temp = script_run("timeout --kill-after=1 --signal=9 20 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_guest ping -c5 $_ping_target");
+        $_temp |= script_run("timeout --kill-after=1 --signal=9 20 ping -c5 $guest_matrix{$_guest}{ipaddr}");
+        $_temp |= 1 if (($guest_matrix{$_guest}{netmode} eq 'host') and (check_port_state($guest_matrix{$_guest}{ipaddr}, 22, 3) == 0));
+        $_ret |= $_temp;
+        save_screenshot;
+        record_info("Guest $_guest network connectivity failed", "Network connectivity testing failed for guest $_guest", result => 'fail') if ($_temp != 0);
+    }
+    croak("Network connectivity testing failed for certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 test_guest_storage
+
+Test whether writing into guest disk is successful and return the result. Main 
+arguments are guest to be tested and whether die (1) or not (0) if any error.
+=cut
+
+sub test_guest_storage {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{die} //= 0;
+    croak("Guest to be tested must be given") if (!$args{guest});
+
+    my $_ret = 0;
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Test $_guest storage");
+        my $_temp = 1;
+        $_temp = script_run("timeout --kill-after=1 --signal=9 20 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$_guest echo MIGRATION > /tmp/test_guest_storage && rm -f -r /tmp/test_guest_storage");
+        $_ret |= $_temp;
+        save_screenshot;
+        record_info("Guest $_guest storage access failed", "Storage read/write testing failed for guest $_guest") if ($_temp != 0);
+    }
+    croak("Storage accessbility testing failed for certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 do_guest_administration
+
+Perform basic administration on guest and return overall result. Main arguments
+are guest to be manipulated, virttool (virsh or xl) to be used, directory in which 
+original guest config file resides and whether die (1) or not (0) if any error. 
+This subroutine also calls construct_uri to determine the desired URI to be connected 
+if the interested party is not localhost. Please refer to subroutine construct_uri 
+for the arguments related.
+=cut
+
+sub do_guest_administration {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be administered must be given") if (!$args{guest});
+
+    my $_uri = "--connect=" . virt_autotest::domain_management_utils::construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    my @_administration = $args{virttool} eq 'virsh' ?
+      ("virsh $_uri destroy guest",
+        "virsh $_uri start guest",
+        "wait guest ssh",
+        "virsh $_uri list | grep \"guest .*running\"",
+        "virsh $_uri save guest /tmp/guest_administration.chckpnt",
+        "virsh $_uri restore /tmp/guest_administration.chckpnt",
+        "virsh $_uri dumpxml guest > /tmp/guest_administration.xml",
+        "virsh $_uri domxml-to-native --format native-format /tmp/guest_administration.xml > /tmp/guest_administration.cfg",
+        "virsh $_uri shutdown guest",
+        "virsh $_uri undefine guest --managed-save || virsh $_uri undefine guest --keep-nvram --managed-save",
+        "wait guest gone",
+        "virsh $_uri define --validate --file /tmp/guest_administration.xml",
+        "virsh $_uri list --all",
+        "virsh $_uri start guest"
+      ) :
+      ("xl -vvv list | grep \"guest \"",
+        "xl -vvv save guest /tmp/guest_administration.chckpnt",
+        "xl -vvv restore /tmp/guest_administration.chckpnt",
+        "xl -vvv shutdown -F guest",
+        "wait guest gone",
+        "xl -vvv create /tmp/guest_administration.cfg || xl -vvv create $args{confdir}/guest.cfg"
+      );
+    my $_native_format = is_xen_host ? "xen-xl" : "qemu-argv";
+    my $_ret = 0;
+    foreach my $_guest (split(/ /, $args{guest})) {
+        record_info("Do $_guest administration");
+        my $_temp1 = 0;
+        my @_guest_administration = ();
+        foreach my $_operation (@_administration) {
+            my $_temp2 = 1;
+            $_operation =~ s/guest/$_guest/g;
+            $_operation =~ s/native-format/$_native_format/g if ($_operation =~ /domxml-to-native/i);
+            push(@_guest_administration, $_operation);
+            if ($_operation eq "wait $_guest ssh") {
+                $_temp2 = $self->wait_guest_ssh(guest => $_guest);
+            }
+            elsif ($_operation eq "wait $_guest gone") {
+                $_temp2 = $args{virttool} eq 'virsh' ? script_retry("! virsh $_uri list --all | grep \"$_guest \"", retry => 120, delay => 1, die => 0) : script_retry("! xl list | grep \"$_guest \"", retry => 60, delay => 1, die => 0);
+            }
+            else {
+                $_temp2 = script_run("$_operation");
+            }
+            $_temp1 |= $_temp2;
+            if ($_temp2 != 0) {
+                save_screenshot;
+                record_info("Guest $_guest administration failed", "Administraton operation is $_operation", result => 'fail');
+            }
+        }
+        record_info("Guest $_guest administration failed", "Administraton operation is:\n" . join("\n", @_guest_administration), result => 'fail') if ($_temp1 != 0);
+        $_ret |= $_temp1;
+    }
+    croak("Administration failed on certain guest") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 virsh_migrate_manual_postcopy
+
+Perform manual postcopy guest migration which needs an extra command to be executed
+alongside main migration command. The return value of this extra command indicates
+whether it is a successful manual postcopy guest migration. Main arguments are guest
+to be migrated, main migraiton command and whether die (1) or not (0) if any error.
+=cut
+
+sub virsh_migrate_manual_postcopy {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{command} //= '';
+    $args{die} //= 0;
+    croak("Guest and command to be executed must be given") if (!$args{guest} or !$args{command});
+
+    my $_ret = 1;
+    my @_command = split(/#/, $args{command});
+    enter_cmd("sleep 120 && $_command[0]");
+    save_screenshot;
+    select_console("root-ssh-virt");
+    $testapi::serialdev = "virtsshserial";
+    enter_cmd("clear");
+    $_ret = script_run("(set -x;unset migrate_postcopy;export migrate_postcopy=1; for i in `seq 87000`;do $_command[1];migrate_postcopy=\$?; if [ \$migrate_postcopy -eq 0 ];then set +x;break;fi; done; if [ \$migrate_postcopy -eq 0 ];then echo -e \"Migrate Postcopy Succeeded! \\n\";else command-not-found;fi)", timeout => 300);
+    wait_still_screen(30);
+    save_screenshot;
+    select_console("root-ssh");
+    $testapi::serialdev = "sshserial";
+    wait_still_screen(30);
+    save_screenshot;
+    reset_consoles;
+    select_console("root-ssh");
+    $_ret |= script_retry("! ps ax | grep migrate | grep -v grep", timeout => 180, retry => 30, delay => 0, die => 0);
+    save_screenshot;
+    croak("Guest $args{guest} manual postcopy migration failed") if ($_ret != 0 and $args{die} == 1);
+    return $_ret;
+}
+
+=head2 create_junit_log
+
+Create xml file to be parsed by parse_junit_log by using XML::LibXML. The data
+source is a hash structure like test_result which stores test results and some
+other side information like product and time. 
+=cut
+
+sub create_junit_log {
+    my $self = shift;
+
+    my $_start_time = $self->{start_run};
+    my $_stop_time = $self->{stop_run};
+    $self->{test_time} = strftime("\%H:\%M:\%S", gmtime($_stop_time - $_start_time));
+    $self->{product_tested_on} = script_output("cat /etc/issue | grep -io -e \"SUSE.*\$(arch))\" -e \"openSUSE.*[0-9]\"", type_command => 1, proceed_on_failure => 1);
+    $self->{product_name} = ref($self);
+    $self->{package_name} = ref($self);
+
+    tie my %_result, 'Tie::IxHash', %test_result;
+    my @_overall_status = ('pass', 'fail', 'skip', 'softfail', 'timeout', 'unknown');
+    foreach my $_guest (keys %_result) {
+        foreach my $_test (keys %{$_result{$_guest}}) {
+            my $_status = $_result{$_guest}{$_test}{status};
+            my $_statustag = first { $_status =~ /^$_/i } (@_overall_status);
+            $self->{$_statustag . "_num"} += 1;
+        }
+    }
+
+    my $_count = 0;
+    foreach my $_status (@_overall_status) {
+        $self->{$_status . "_num"} = 0 if (!defined $self->{$_status . "_num"});
+        $_count += $self->{$_status . "_num"};
+    }
+
+    my $_dom = XML::LibXML::Document->createDocument('1.0', 'UTF-8');
+    tie my %_attribute, 'Tie::IxHash', ();
+    %_attribute = (
+        id => "0",
+        error => "n/a",
+        failures => $self->{fail_num},
+        softfailures => $self->{softfail_num},
+        name => $self->{product_name},
+        skipped => $self->{skip_num},
+        tests => $_count,
+        time => $self->{test_time}
+    );
+    my @_attributes = (\%_attribute);
+    my @_eles = ('testsuites');
+    my ($_testsuites,) = $self->create_junit_element(xmldoc => \$_dom, eles => \@_eles, attrs => \@_attributes);
+
+    %_attribute = (
+        id => "0",
+        error => "n/a",
+        failures => $self->{fail_num},
+        softfailures => $self->{softfail_num},
+        hostname => get_required_var('LOCAL_FQDN'),
+        name => $self->{product_tested_on},
+        package => $self->{package_name},
+        skipped => $self->{skip_num},
+        tests => $_count,
+        time => $self->{test_time},
+        timestamp => DateTime->now
+    );
+    @_attributes = (\%_attribute);
+    @_eles = ('testsuite');
+    my ($_testsuite,) = $self->create_junit_element(xmldoc => \$_dom, parent => \$_testsuites, eles => \@_eles, attrs => \@_attributes);
+
+    foreach my $_guest (keys %_result) {
+        my %_test2junit_status = (passed => "success", failed => "failure", skipped => "skipped", softfailed => "softfail", timeout => "timeout_exceeded", unknown => "unknown");
+        foreach my $_test (keys %{$_result{$_guest}}) {
+            my $_test_status = $_result{$_guest}{$_test}{status};
+            $_result{$_guest}{$_test}{status} = $_test2junit_status{first { /^$_test_status/i } (keys(%_test2junit_status))};
+            $_result{$_guest}{$_test}{guest} = $_guest;
+            %_attribute = (
+                classname => $_result{$_guest}{$_test}{shortname},
+                name => $_test,
+                status => $_result{$_guest}{$_test}{status},
+                time => ($_result{$_guest}{$_test}{test_time} ? $_result{$_guest}{$_test}{test_time} : 'n/a')
+            );
+            @_attributes = (\%_attribute);
+            @_eles = ('testcase');
+            my ($_testcase,) = $self->create_junit_element(xmldoc => \$_dom, parent => \$_testsuite, eles => \@_eles, attrs => \@_attributes);
+            my @_eles = ('system-err', 'system-out', 'failure');
+            my @_texts = (
+                ($_result{$_guest}{$_test}{error} ? $_result{$_guest}{$_test}{error} : 'n/a'),
+                ($_result{$_guest}{$_test}{output} ? $_result{$_guest}{$_test}{output} : 'n/a') . " time cost: $_result{$_guest}{$_test}{test_time}",
+                ($_result{$_guest}{$_test}{status} eq 'success' ? '' : "affected subject: $_result{$_guest}{$_test}{guest}")
+            );
+            $self->create_junit_element(xmldoc => \$_dom, parent => \$_testcase, eles => \@_eles, texts => \@_texts);
+        }
+    }
+
+    $_dom->setDocumentElement($_testsuites);
+    type_string("cat > /tmp/output.xml <<EOF\n" .
+          $_dom->toString(1) . "\nEOF\n");
+    script_run("cat /tmp/output.xml && chmod 777 /tmp/output.xml");
+    save_screenshot;
+    parse_junit_log("/tmp/output.xml");
+
+}
+
+=head2 create_junit_element
+
+Create xml elements that may have attributes, text or child and return array 
+of created elements. Accepted arguments are references to xml doc object, parent 
+of element to be created, array of elements to be created, array of attributes of 
+elements and array of texts of elements. The order in which elements appear in 
+array of elements to be created should be the same as those respective attributes 
+and texts in their arrays.
+=cut
+
+sub create_junit_element {
+    my ($self, %args) = @_;
+    $args{xmldoc} //= "";
+    $args{parent} //= "";
+    $args{eles} //= ();
+    $args{attrs} //= ();
+    $args{texts} //= ();
+    croak("JUnit xml object must be given") if (!$args{xmldoc});
+
+    my $_index = 0;
+    my @_eles = ();
+    foreach my $_ele (@{$args{eles}}) {
+        my $_element = ${$args{xmldoc}}->createElement($_ele);
+        push(@_eles, $_element);
+        if ($args{attrs}) {
+            tie my %_attrs, 'Tie::IxHash', ();
+            %_attrs = %{$args{attrs}->[$_index]};
+            foreach my $_attr (keys %_attrs) {
+                $_element->setAttribute("$_attr" => "$_attrs{$_attr}");
+            }
+        }
+        $_element->appendText($args{texts}->[$_index]) if ($args{texts});
+        ${$args{parent}}->appendChild($_element) if ($args{parent});
+        $_index += 1;
+    }
+    return @_eles;
+}
+
+=head2 check_peer_test_run
+
+Check progress of test run of peer job. This subroutine is called to verify whether
+peer job is destined to fail or not and return its test run result. This is usually
+called by paired job that is already in post_fail_hook to wait for peer job if it 
+already failed or is about to fail, so the peer job can finish operations instead of
+being cancelled due to paired job fails and terminates. This can be achieved simply
+by barrier_wait on certain lock by both jobs if the peer fails as well. There are 
+situations in which peer job needs to move pass current running subroutines like,
+do_guest_migration or post_run_test, before entering into post_fail_hook, so it is
+necessary to wait a period before having the final resolution. But if peer job still
+remains any earlier steps, it is not meaningful to wait anymore because locks ahead.
+=cut
+
+sub check_peer_test_run {
+    my $self = shift;
+
+    my $_peer_test_run_progress = $self->get_test_run_progress;
+    my $_peer_test_run_result = $self->get_test_run_result;
+    diag("LATEST PEER TEST RUN PROGRESS: $_peer_test_run_progress LATEST PEER TEST RUN RESULT: $_peer_test_run_result");
+    my $_wait_start_time = time();
+    while ($_peer_test_run_progress =~ /do_guest_migration|post_run_test/i) {
+        last if (($_peer_test_run_progress =~ /do_guest_migration/i and time() - $_wait_start_time > 1800) or ($_peer_test_run_progress =~ /post_run_test/i));
+        $_peer_test_run_progress = $self->get_test_run_progress;
+        $_peer_test_run_result = $self->get_test_run_result;
+        diag("LATEST PEER TEST RUN PROGRESS: $_peer_test_run_progress LATEST PEER TEST RUN RESULT: $_peer_test_run_result");
+    }
+    $_peer_test_run_result = 'FAILED' if ($_peer_test_run_progress =~ /post_fail_hook/i);
+    return $_peer_test_run_result;
+}
+
+=head2 post_fail_hook
+
+Set TEST_RUN_RESULT to FAILED, create junit log and collect logs.
+=cut
+
+sub post_fail_hook {
+    my $self = shift;
+
+    save_screenshot;
+    reset_consoles;
+    select_console("root-ssh");
+    $testapi::serialdev = "sshserial";
+    $self->set_test_run_progress;
+    set_var('TEST_RUN_RESULT', 'FAILED');
+    bmwqemu::save_vars();
+    bmwqemu::load_vars();
+
+    $self->{"stop_run"} = time();
+    $self->create_junit_log;
+    collect_host_and_guest_logs('', '', '', "_post_fail_hook");
+}
+
+1;

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -518,6 +518,16 @@ sub init_consoles {
                 serial => 'rm -f /dev/sshserial; mkfifo /dev/sshserial; chmod 666 /dev/sshserial; while true; do cat /dev/sshserial; done',
                 gui => 1
             });
+        $self->add_console(
+            'root-ssh-virt',
+            'ssh-xterm',
+            {
+                hostname => get_required_var('SUT_IP'),
+                password => $testapi::password,
+                username => 'root',
+                serial => 'rm -f /dev/virtsshserial; mkfifo /dev/virtsshserial; chmod 666 /dev/virtsshserial; while true; do cat /dev/virtsshserial; done',
+                gui => 1
+            }) if (get_var('VIRT_AUTOTEST', '') or get_var('REGRESSION', ''));
     }
 
     # Use ssh consoles on generalhw, without VNC connection

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1815,17 +1815,18 @@ sub script_retry {
     my $retry = $args{retry} // 10;
     my $delay = $args{delay} // 30;
     my $timeout = $args{timeout} // 30;
+    my $option = $args{option} // '';
     my $die = $args{die} // 1;
     my $fail_msg = $args{fail_message} // "Waiting for Godot: $cmd";
 
     my $ret;
 
-    my $exec = "timeout $timeout $cmd";
+    my $exec = "timeout $option $timeout $cmd";
     # Exclamation mark needs to be moved before the timeout command, if present
     if (substr($cmd, 0, 1) eq "!") {
         $cmd = substr($cmd, 1);
         $cmd =~ s/^\s+//;    # left trim spaces after the exclamation mark
-        $exec = "! timeout $timeout $cmd";
+        $exec = "! timeout $option $timeout $cmd";
     }
     for (1 .. $retry) {
         # timeout for script_run must be larger than for the 'timeout ...' command

--- a/lib/virt_autotest/domain_management_utils.pm
+++ b/lib/virt_autotest/domain_management_utils.pm
@@ -1,0 +1,277 @@
+# VIRTUALIZAITON DOMAIN MANAGEMENT UTILITIES
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Domain management utilities providied by various tools,
+# for example, libvirt, xl and etc.
+#
+# Maintainer: Wayne Chen <wchen@suse.com>, qe-virt <qe-virt@suse.de>
+package virt_autotest::domain_management_utils;
+
+use strict;
+use warnings;
+use testapi;
+use virt_autotest::utils qw(is_kvm_host is_xen_host);
+use utils qw(script_retry);
+use Carp;
+
+our @EXPORT = qw(
+  construct_uri
+  create_guest
+  remove_guest
+  shutdown_guest
+  show_guest
+  check_guest_state
+);
+
+=head2 construct_uri
+
+Construct connection URI to be used with virsh command. URI is composed of many
+parts which are all supported here. Please refer to libvirt page for details:
+https://libvirt.org/uri.html#remote-uris.
+=cut
+
+sub construct_uri {
+    my (%args) = @_;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    $args{driver} = is_kvm_host ? "qemu" : "xen" if (!$args{driver});
+
+    my $uri = "";
+    if ($args{host} eq 'localhost') {
+        $uri = "$args{driver}:///$args{path}";
+    }
+    else {
+        $uri = $args{transport} ? "$args{driver}+$args{transport}://" : "$args{driver}://";
+        $uri .= "$args{user}@" if ($args{user});
+        $uri .= $args{host};
+        $uri .= ":$args{port}" if ($args{port});
+        $uri .= "/";
+        $uri .= $args{path} if ($args{path});
+        $uri .= "?$args{extra}" if ($args{extra});
+    }
+    return $uri;
+}
+
+=head2 create_guest
+
+Create guest by using virsh define or xl create. Main arguments are guest to be
+created, virtualization management tool to be used, whether die (1) or not (0)
+if any failures happen, directory in which guest xml and xl config are stored
+and whether start (1) or not (0) guest after defining it. This subroutine also 
+calls construct_uri to determine the desired URI to be connected if the interested 
+party is not localhost. Please refer to subroutine construct_uri for the arguments 
+related.
+=cut
+
+sub create_guest {
+    my (%args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{confdir} //= '/var/lib/libvirt/images';
+    $args{start} //= 1;
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be created must be given") if (!$args{guest});
+
+    my $ret = 0;
+    my $uri = "--connect=" . construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $guest (split(/ /, $args{guest})) {
+        my $temp = 1;
+        if ($args{virttool} eq 'virsh') {
+            $temp = script_run("virsh $uri define --file $args{confdir}/$guest.xml --validate");
+            $temp |= script_run("virsh $uri start $guest") if ($args{start} == 1);
+            record_info("Failed to create guest $guest from $args{confdir}/$guest.xml", "Failed to create guest $guest using virsh define/start --file $args{confdir}/$guest.xml --validate", result => 'fail') if ($temp != 0);
+        }
+        elsif ($args{virttool} eq 'xl') {
+            $temp = script_run("ls $args{confdir}/$guest.cfg") == 0 ? 0 : script_run("virsh $uri domxml-to-native --xml $args{confdir}/$guest.xml --format xen-xl > $args{confdir}/$guest.cfg");
+            $temp |= script_run("xl -vvv create $args{confdir}/$guest.cfg");
+            record_info("Guest $guest creating failed", "Failed to create guest $guest using xl -vvv create $args{confdir}/$guest.cfg", result => 'fail') if ($temp != 0);
+        }
+        $ret |= $temp;
+        save_screenshot;
+        record_info("Guest $guest config", script_output("cat $args{confdir}/$guest.xml;cat $args{confdir}/$guest.cfg", type_command => 1, proceed_on_failure => 1));
+    }
+    croak("Failed to define all guests") if ($ret != 0 and $args{die} == 1);
+    return $ret;
+}
+
+=head2 shutdown_guest
+
+Shutdown guest and verify result. Main arguments are guest to be powered off,
+virtualization management tool (virsh or xl) to be used and whether die (1) or
+not (0) if any failures happen. This subroutine also calls construct_uri to
+determine the desired URI to be connected if the interested party is not
+localhost. Please refer to subroutine construct_uri for the arguments related.
+=cut
+
+sub shutdown_guest {
+    my (%args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be shut down must be given") if (!$args{guest});
+
+    my $ret = 0;
+    my $uri = "--connect=" . construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $guest (split(/ /, $args{guest})) {
+        my $temp = 1;
+        if ($args{virttool} eq 'virsh') {
+            if (script_run("virsh $uri list --state-shutoff | grep \"$guest \"") != 0) {
+                script_retry("virsh $uri shutdown $guest", retry => 12, delay => 10, die => 0);
+                if (script_retry("virsh $uri list --state-shutoff | grep \"$guest \"", retry => 12, delay => 10, die => 0) != 0) {
+                    script_run("virsh $uri destroy $guest");
+                    $temp = script_retry("virsh $uri list --state-shutoff | grep \"$guest \"", retry => 12, delay => 10, die => 0);
+                }
+                else {
+                    $temp = 0;
+                }
+            }
+            else {
+                $temp = 0;
+            }
+        }
+        elsif ($args{virttool} eq 'xl') {
+            if (script_run("xl -vvv list | grep \"$guest .*---s-- \"") != 0) {
+                script_retry("xl -vvv shutdown $guest", retry => 12, delay => 10, die => 0);
+                $temp = script_retry("xl -vvv list | grep \"$guest .*---s-- \"", retry => 12, delay => 10, die => 0);
+            }
+            else {
+                $temp = 0;
+            }
+        }
+        $ret |= $temp;
+        save_screenshot;
+        record_info("Failed to stop guest $guest", "Guest $guest can not be stopped using $args{virttool} shutdown or destroy", result => 'fail') if ($temp != 0);
+    }
+    croak("Failed to stop all guests") if ($ret != 0 and $args{die} == 1);
+    return $ret;
+}
+
+=head2 remove_guest
+
+Remove guest forcibly. Main arguments are guest to be removed, and whether die
+(1) or not (0) if any failures happen. This subroutine also calls construct_uri
+to determine the desired URI to be connected if the interested party is not
+localhost. Please refer to subroutine construct_uri for the arguments related.
+=cut
+
+sub remove_guest {
+    my (%args) = @_;
+    $args{guest} //= '';
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be removed must be given") if (!$args{guest});
+
+    my $ret = 0;
+    my $uri = "--connect=" . construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    foreach my $guest (split(/ /, $args{guest})) {
+        my $temp = 1;
+        script_run("virsh $uri destroy $guest");
+        $temp = script_run("virsh $uri list --all | grep \"$guest \"") == 0 ? script_run("virsh $uri undefine $guest || virsh $uri undefine $guest --keep-nvram") : 0;
+        $temp |= script_run("xl -vvv destroy $guest") if (is_xen_host and script_run("xl list | grep \"$guest \"") == 0);
+        $ret |= $temp;
+        save_screenshot;
+        record_info("Guest $guest removing failed", "Failed to remove guest $guest", result => 'fail') if ($temp != 0);
+    }
+    croak("Failed to remove all guests") if ($ret != 0 and $args{die} == 1);
+    return $ret;
+}
+
+=head2 show_guest
+
+Show all guests available on host or specified ones. Main arguments are guest to
+be checked, virtualization management tool to be used (virsh or xl) and whether 
+die (1) or not (0) if any failures happen. This subroutine also calls construct_uri 
+to determine the desired URI to be connected if the interested party is not localhost. 
+Please refer to subroutine construct_uri for the arguments related.
+=cut
+
+sub show_guest {
+    my (%args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{die} //= 0;
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+
+    my $ret = 0;
+    my $uri = "--connect=" . construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    if (!$args{guest}) {
+        $ret = script_run("virsh $uri list --all");
+        $ret |= script_run("xl -vvv list") if (is_xen_host);
+        save_screenshot;
+        record_info("Listing guests failed", "Failed to list all guests available on host", result => 'fail') if ($ret != 0);
+    }
+    else {
+        foreach my $guest (split(/ /, $args{guest})) {
+            my $temp = 1;
+            $temp = $args{virttool} eq 'virsh' ? script_run("virsh $uri list --all | grep \"$guest \"") : script_run("xl -vvv list | grep \"$guest \"");
+            $ret |= $temp;
+            save_screenshot;
+            record_info("Guest $guest xml config", script_output("virsh $uri dumpxml $guest", proceed_on_failure => 1));
+            record_info("Guest $guest listing failed", "Failed to list guest $guest", result => 'fail') if ($temp != 0);
+        }
+    }
+    croak("Certain guest listing failed") if ($ret != 0 and $args{die} == 1);
+    return $ret;
+}
+
+=head2 check_guest_state
+
+Check and return guest state. Main argument are guest to be checked and virtualization
+management tool to be used (virsh or xl). This subroutine also calls construct_uri to
+determine the desired URI to be connected if the interested party is not localhost.
+Please refer to subroutine construct_uri for the arguments related.
+=cut
+
+sub check_guest_state {
+    my (%args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{driver} //= '';
+    $args{transport} //= 'ssh';
+    $args{user} //= '';
+    $args{host} //= 'localhost';
+    $args{port} //= '';
+    $args{path} //= 'system';
+    $args{extra} //= '';
+    croak("Guest to be checked must be given") if (!$args{guest});
+
+    my $uri = "--connect=" . construct_uri(driver => $args{driver}, transport => $args{transport}, user => $args{user}, host => $args{host}, port => $args{port}, path => $args{path}, extra => $args{extra});
+    my $state = "";
+    $state = $args{virttool} eq 'virsh' ? script_output("virsh $uri list --all | grep \"$args{guest} \" | awk \'{print \$3\$4}\'", proceed_on_failure => 1) : script_output("xl list | grep \"$args{guest} \" | awk \'{print \$5}\'", proceed_on_failure => 1);
+    return $state;
+}
+
+1;

--- a/schedule/qam/common/virt/virt_guest_migration.yaml
+++ b/schedule/qam/common/virt/virt_guest_migration.yaml
@@ -1,0 +1,20 @@
+---
+name: virt_guest_migration.yaml
+description: |
+  Maintainer: Wayne Chen (wchen@suse.com) qe-virt@suse.de
+  Yaml scheduling file for guest migration test
+schedule:
+  - "{{create_barriers}}"
+  - virt_autotest/login_console
+  - "{{guest_migration}}"
+conditional_schedule:
+  create_barriers:
+    VIRT_NEW_GUEST_MIGRATION_SOURCE:
+      0:
+        - virt_autotest/parallel_guest_migration_barrier
+  guest_migration:
+    VIRT_NEW_GUEST_MIGRATION_SOURCE:
+      1:
+        - virt_autotest/parallel_guest_migration_source
+      0:
+        - virt_autotest/parallel_guest_migration_destination

--- a/tests/virt_autotest/parallel_guest_migration_barrier.pm
+++ b/tests/virt_autotest/parallel_guest_migration_barrier.pm
@@ -1,0 +1,23 @@
+# GUEST MIGRATION TEST BARRIERS MODULE
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Create barriers to be used during test run.
+#
+# Maintainer: Wayne Chen <wchen@suse.com>, qe-virt <qe-virt@suse.de>
+package parallel_guest_migration_barrier;
+
+use base "parallel_guest_migration_base";
+use strict;
+use warnings;
+use lockapi;
+use mmapi;
+
+sub run {
+    my $self = shift;
+
+    $self->create_barrier(signal => 'READY_TO_GO LOCAL_INITIALIZATION_DONE PEER_INITIALIZATION_DONE HOST_PREPARATION_DONE GUEST_PREPARATION_SOURCE_DONE GUEST_PREPARATION_DESTINATION_DONE LOG_PREPARATION_DONE DO_GUEST_MIGRATION_DONE_0 DO_GUEST_MIGRATION_READY_0 POST_FAIL_HOOK_DONE');
+}
+
+1;

--- a/tests/virt_autotest/parallel_guest_migration_destination.pm
+++ b/tests/virt_autotest/parallel_guest_migration_destination.pm
@@ -1,0 +1,315 @@
+# GUEST MIGRATION TEST DESTINATION MODULE
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Guest migration test destination module.
+#
+# Main features:
+# Prepare host for guest migration test.
+# Prepare guest for migration test.
+# Prepare logs for test run.
+# Perform guest migration test together with destination host in
+# collaborative manner.
+# Perform basci administration on guest if necessary.
+# Do logs collecting and cleanup for each failure if necessary.
+#
+# Test suite level settings to control test behavior:
+# GUEST_LIST specifies guest to be tested or empty.
+# GUEST_MIGRATION_TEST specifies migration test to be executed or empty.
+# EXTERNAL_SHARED_STORAGE indicates a common nfs server is available
+# and its nfs share is ready mounted locally.
+# SKIP_GUEST_INSTALL indicates whether guest is installed directly
+# locally instead of transferred to the host.
+# GUEST_ADMINISTRATION indicates whether do basic administration on
+# guest before and after migration test.
+# INTERVAL_LOG indicates whether each failed test invokes immediate
+# logs collecting for the failure.
+# REGRESSION indicates MU incidents testing activity.
+#
+# Maintainer: Wayne Chen <wchen@suse.com>, qe-virt <qe-virt@suse.de>
+package parallel_guest_migration_destination;
+
+use base "parallel_guest_migration_base";
+use strict;
+use warnings;
+use POSIX 'strftime';
+use testapi;
+use upload_system_log;
+use lockapi;
+use mmapi;
+use virt_autotest::utils qw(is_kvm_host is_xen_host check_host_health check_guest_health is_fv_guest is_pv_guest add_guest_to_hosts);
+use virt_utils qw(collect_host_and_guest_logs cleanup_host_and_guest_logs enable_debug_logging);
+use virt_autotest::domain_management_utils qw(construct_uri create_guest remove_guest shutdown_guest show_guest check_guest_state);
+
+=head2 run_test
+
+Execute entire test flow from initialization, preparation, to guest migration.
+=cut
+
+sub run_test {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    barrier_wait('READY_TO_GO');
+
+    $self->do_local_initialization;
+    barrier_wait('LOCAL_INITIALIZATION_DONE');
+
+    $self->do_peer_initialization;
+    barrier_wait('PEER_INITIALIZATION_DONE');
+
+    $self->prepare_host;
+    barrier_wait('HOST_PREPARATION_DONE');
+
+    script_run("echo -e \"Wait source prepare_guest ends\\n\"") while ($self->get_test_run_progress !~ /prepare_guest_end/i);
+    barrier_wait('GUEST_PREPARATION_SOURCE_DONE');
+
+    $self->prepare_guest;
+    barrier_wait('GUEST_PREPARATION_DESTINATION_DONE');
+
+    $self->prepare_log;
+    barrier_wait('LOG_PREPARATION_DONE');
+
+    $self->guest_migration_test;
+}
+
+=head2 prepare_host
+
+Prepare host for guest migration test, including virtualization, package and security.
+=cut
+
+sub prepare_host {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    $self->check_host_virtualization;
+    $self->check_host_package;
+    $self->config_host_security;
+}
+
+=head2 prepare_guest
+
+Prepare host for migration test, including initialization, shared storage and network.
+=cut
+
+sub prepare_guest {
+    my $self = shift;
+
+    $self->set_test_run_progress(token => 'start');
+    $self->config_host_shared_storage(role => 'client');
+    $self->guest_under_test(role => 'dst');
+    $self->initialize_test_result;
+    $self->initialize_guest_matrix(role => 'dst');
+    $self->create_guest_network;
+    $self->set_test_run_progress(token => 'end');
+}
+
+=head2 prepare_log
+
+Enable virtualization debug logging and check host health.
+=cut
+
+sub prepare_log {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    enable_debug_logging();
+    check_host_health();
+}
+
+=head2 guest_migration_test
+
+Do guest migration test in loop for all guests and tests. Source and destination
+hosts collaborate with each other during test run by employing barriers, including
+DO_GUEST_MIGRATION_DONE_counter and DO_GUEST_MIGRATION_READY_counter. Subroutines
+check_migration_result, test_after_migration and do_guest_migration do main actual
+works. Collect log for failure immediately and do log cleanup after each test if
+INTERVAL_LOG is set (1).
+=cut
+
+sub guest_migration_test {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    my @guest_migration_test = split(/,/, get_var('GUEST_MIGRATION_TEST'));
+    my $full_test_matrix = is_kvm_host ? $parallel_guest_migration_base::guest_migration_matrix{kvm} : $parallel_guest_migration_base::guest_migration_matrix{xen};
+    @guest_migration_test = keys(%$full_test_matrix) if (scalar @guest_migration_test == 0);
+    my $localip = get_required_var('LOCAL_IPADDR');
+    my $peerip = get_required_var('PEER_IPADDR');
+    my $localuri = virt_autotest::domain_management_utils::construct_uri();
+    my $peeruri = virt_autotest::domain_management_utils::construct_uri(host => $peerip);
+    my $migration = $self->check_host_os(role => 'dst');
+    my $counter = 0;
+    my $nextcounter = $counter + 1;
+
+    foreach my $guest (keys %parallel_guest_migration_base::guest_matrix) {
+        foreach my $test (@guest_migration_test) {
+            my $ret = 0;
+            my $command = $full_test_matrix->{$test};
+            $command =~ s/guest/$guest/g;
+            $command =~ s/srcuri/$localuri/g;
+            $command =~ s/dsturi/$peeruri/g;
+            $command =~ s/dstip/$peerip/g;
+            $command =~ /(xl|virsh)/i;
+            my $virttool = $1;
+            my $offline = $test =~ /offline/i;
+            my $persistent = ($command =~ /persistent/i | $virttool eq 'xl');
+            my $test_start_time = time();
+            my $test_stop_time = $test_start_time;
+
+            record_info("Start $test on $guest", "Migration command is $command");
+
+            barrier_wait("DO_GUEST_MIGRATION_DONE_$counter");
+            $self->create_barrier(signal => "DO_GUEST_MIGRATION_DONE_$nextcounter");
+            $ret = $self->check_migration_result(guest => $guest, virttool => $virttool, peer => $peerip, offline => $offline);
+            if ($ret == 0) {
+                $ret = $self->test_after_migration(guest => $guest, virttool => $virttool, persistent => $persistent, offline => $offline);
+                $ret |= $self->do_guest_migration(guest => $guest, test => $test, command => $command, offline => $offline, cando => ($migration == 0 ? 1 : 0));
+                collect_host_and_guest_logs($guest, '', '', "_$guest" . "_$test") if ($ret != 0 and get_var('INTERVAL_LOG', ''));
+            }
+            $test_stop_time = time();
+            $parallel_guest_migration_base::test_result{$guest}{$command}{test_time} = strftime("\%H:\%M:\%S", gmtime($test_stop_time - $test_start_time));
+            record_info("End $test on $guest", "Total test time is $parallel_guest_migration_base::test_result{$guest}{$command}{test_time}");
+            virt_autotest::domain_management_utils::remove_guest(guest => $guest) if ($ret != 0 or !($command =~ /undefinesource/i) or $offline == 1 or ($ret == 0 and $migration != 0));
+
+            barrier_wait("DO_GUEST_MIGRATION_READY_$counter");
+            $self->create_barrier(signal => "DO_GUEST_MIGRATION_READY_$nextcounter");
+            $counter = $nextcounter;
+            $nextcounter += 1;
+            cleanup_host_and_guest_logs if (get_var('INTERVAL_LOG', ''));
+        }
+    }
+}
+
+=head2 check_migration_result
+
+Check migration result by obtaining guest state and wait for ssh connection.
+=cut
+
+sub check_migration_result {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{peer} //= '';
+    $args{offline} //= 0;
+    die("Guest to be checked must be given") if (!$args{guest});
+
+    my $ret1 = 1;
+    my $ret2 = 1;
+    $self->initialize_guest_matrix(role => 'dst', guest => $args{guest});
+    virt_autotest::domain_management_utils::show_guest(guest => $args{guest}, virttool => $args{virttool});
+    my $guest_state = virt_autotest::domain_management_utils::check_guest_state(guest => $args{guest}, virttool => $args{virttool});
+    if (!$guest_state) {
+        record_info("Guest $args{guest} migration failed", "Guest $args{guest} can not be migrated successfully from $args{peer}", result => 'fail');
+    }
+    else {
+        if ($args{offline} == 1) {
+            $ret1 = $args{virttool} eq 'virsh' ? $self->start_guest(guest => $args{guest}, wait => 0) : 1;
+            if ($args{virttool} eq 'xl') {
+                record_info("xl does not support offline migration", "Guest $args{guest} can not be migrated offline by using xl migrate", result => 'fail');
+            }
+            else {
+                $ret1 |= $self->wait_guest(guest => $args{guest}, checkip => 0);
+            }
+        }
+        else {
+            $ret1 = $self->wait_guest(guest => $args{guest}, checkip => 0);
+        }
+
+        $ret2 = $self->wait_guest(guest => $args{guest}) if ($ret1 != 0 and !($args{offline} == 1 and $args{virttool} eq 'xl') and ($parallel_guest_migration_base::guest_matrix{$args{guest}}{staticip} ne 'yes'));
+        if ($ret1 == 0) {
+            record_info("Guest $args{guest} migration succeeded", "Guest $args{guest} migration from $args{peer} succeeded");
+        }
+        elsif ($ret2 == 0) {
+            record_info("Guest $args{guest} migration succeeded with changed ip", "Guest $args{guest} migration from $args{peer} succeeded but with changed ip address", result => 'softfail');
+        }
+        elsif ($ret2 != 0) {
+            record_info("Guest $args{guest} migration failed", "Guest $args{guest} in wrong state after migration from $args{peer}", result => 'fail');
+        }
+    }
+    return $ret1 == 0 ? $ret1 : $ret2;
+}
+
+=head2 test_after_migration
+
+Config passwordless ssh connection to guest, test network accessibility and disk 
+read/write in guest, perform basic administration on guest if GUEST_ADMINISTRATION
+is set (1).
+=cut
+
+sub test_after_migration {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{persistent} //= 1;
+    $args{offline} //= 0;
+    die("Guest to be checked must be given") if (!$args{guest});
+
+    my $ret = 0;
+    $ret |= $self->config_ssh_pubkey_auth(addr => $args{guest}, overwrite => 0, host => 0);
+    if ($ret == 0) {
+        check_guest_health($args{guest});
+        $ret = $self->test_guest_network(guest => $args{guest});
+        $ret |= $self->test_guest_storage(guest => $args{guest});
+    }
+
+    if (get_var('GUEST_ADMINISTRATION', '') and $args{persistent} == 1) {
+        $ret |= $self->do_guest_administration(guest => $args{guest}, virttool => $args{virttool});
+        $ret |= $self->wait_guest_ssh(guest => $args{guest});
+    }
+    return $ret;
+}
+
+=head2 do_guest_migration
+
+Do the actual guest migration test. Call virsh_migrate_manual_postcopy if test is
+manual postcopy. Record test result accordingly.
+=cut
+
+sub do_guest_migration {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{test} //= '';
+    $args{command} //= '';
+    $args{offline} //= 0;
+    $args{cando} //= 1;
+    die("Guest and test/command to be executed must be given") if (!$args{guest} or !$args{test} or !$args{command});
+
+    my $ret = 1;
+    if ($args{cando} == 1) {
+        virt_autotest::domain_management_utils::shutdown_guest(guest => $args{guest}) if ($args{offline} == 1);
+        $ret = $args{test} =~ /manual_postcopy/i ? $self->virsh_migrate_manual_postcopy(guest => $args{guest}, command => $args{command}) : script_run($args{command}, timeout => 120);
+
+        if ($ret != 0) {
+            record_info("Failed $args{test} migration", "Failed to migration back with $args{command}", result => 'fail');
+            save_screenshot;
+        }
+        else {
+            $parallel_guest_migration_base::test_result{$args{guest}}{$args{command}}{status} = 'PASSED';
+            record_info("Passed $args{test} migration", "Guest migration back succeeded with $args{command}");
+        }
+    }
+    else {
+        $ret = 0;
+        $parallel_guest_migration_base::test_result{$args{guest}}{$args{command}}{status} = 'SKIPPED';
+        record_info("SKIPPED $args{test} migration", "Guest migration back with $args{command} skipped");
+    }
+    return $ret;
+}
+
+=head2 post_fail_hook
+
+Do post_fail_hook task and wait for peer test run to finish as normal if it also
+fails.
+=cut
+
+sub post_fail_hook {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    $self->SUPER::post_fail_hook;
+    barrier_wait('POST_FAIL_HOOK_DONE') if ($self->check_peer_test_run eq 'FAILED');
+}
+
+1;

--- a/tests/virt_autotest/parallel_guest_migration_source.pm
+++ b/tests/virt_autotest/parallel_guest_migration_source.pm
@@ -1,0 +1,298 @@
+# GUEST MIGRATION TEST SOURCE MODULE
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Guest migration test source module.
+#
+# Main features:
+# Prepare host for guest migration test.
+# Prepare guest for migration test.
+# Prepare logs for test run.
+# Perform guest migration test together with destination host in
+# collaborative manner.
+# Perform basci administration on guest if necessary.
+# Do logs collecting and cleanup for each failure if necessary.
+#
+# Test suite level settings to control test behavior:
+# GUEST_LIST specifies guest to be tested or empty.
+# GUEST_MIGRATION_TEST specifies migration test to be executed or empty.
+# EXTERNAL_SHARED_STORAGE indicates a common nfs server is available
+# and its nfs share is ready mounted locally.
+# SKIP_GUEST_INSTALL indicates whether guest is installed directly
+# locally instead of transferred to the host.
+# GUEST_ADMINISTRATION indicates whether do basic administration on
+# guest before and after migration test.
+# INTERVAL_LOG indicates whether each failed test invokes immediate
+# logs collecting for the failure.
+# REGRESSION indicates MU incidents testing activity.
+#
+# Maintainer: Wayne Chen <wchen@suse.com>, qe-virt <qe-virt@suse.de>
+package parallel_guest_migration_source;
+
+use base "parallel_guest_migration_base";
+use strict;
+use warnings;
+use POSIX 'strftime';
+use testapi;
+use upload_system_log;
+use lockapi;
+use mmapi;
+use virt_autotest::utils qw(is_kvm_host is_xen_host check_host_health check_guest_health is_fv_guest is_pv_guest);
+use virt_utils qw(collect_host_and_guest_logs cleanup_host_and_guest_logs enable_debug_logging);
+use utils qw(script_retry);
+use virt_autotest::domain_management_utils qw(construct_uri create_guest remove_guest shutdown_guest show_guest check_guest_state);
+
+=head2 run_test
+
+Execute entire test flow from initialization, preparation, to guest migration.
+=cut
+
+sub run_test {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    barrier_wait('READY_TO_GO');
+
+    $self->do_local_initialization;
+    barrier_wait('LOCAL_INITIALIZATION_DONE');
+
+    $self->do_peer_initialization;
+    barrier_wait('PEER_INITIALIZATION_DONE');
+
+    $self->prepare_host;
+    barrier_wait('HOST_PREPARATION_DONE');
+
+    $self->prepare_guest;
+    barrier_wait('GUEST_PREPARATION_SOURCE_DONE');
+
+    script_run("echo -e \"Wait destination prepare_guest ends\\n\"") while ($self->get_test_run_progress !~ /prepare_guest_end/i);
+    barrier_wait('GUEST_PREPARATION_DESTINATION_DONE');
+
+    $self->prepare_log;
+    barrier_wait('LOG_PREPARATION_DONE');
+
+    $self->guest_migration_test;
+}
+
+=head2 prepare_host
+
+Prepare host for guest migration test, including checking architecture, operating
+system, virtualization, network, pacakge, user/group id, shared storage and security.
+Please refer to the following documentation:
+https://susedoc.github.io/doc-sle/main/single-html/SLES-virtualization/#sec-libvirt-admin-migrate
+=cut
+
+sub prepare_host {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    $self->check_host_architecture;
+    $self->check_host_os;
+    $self->check_host_virtualization;
+    $self->check_host_package;
+    $self->check_host_uid;
+    $self->check_host_gid;
+    $self->config_host_shared_storage(role => 'server');
+    $self->config_host_security;
+}
+
+=head2 prepare_guest
+
+Prepare guest for migration test, including initialization, clock, storage, console, 
+network and passwordless ssh connection. Please refer to the following documentation: 
+https://susedoc.github.io/doc-sle/main/single-html/SLES-virtualization/#sec-libvirt-admin-migrate
+=cut
+
+sub prepare_guest {
+    my $self = shift;
+
+    $self->set_test_run_progress(token => 'start');
+    my $guest = $self->guest_under_test(role => 'src');
+    $self->initialize_test_result;
+    unless (get_var('SKIP_GUEST_INSTALL', '')) {
+        $self->save_guest_asset(guest => $guest);
+        virt_autotest::domain_management_utils::remove_guest(guest => $guest);
+    }
+    else {
+        $self->restore_guest_asset(guest => $guest);
+    }
+    $self->config_guest_clock(guest => $guest);
+    $self->config_guest_storage(guest => $guest);
+    virt_autotest::domain_management_utils::create_guest(guest => $guest, start => 0);
+    $self->config_guest_console(guest => $guest);
+    $self->check_guest_network_config(guest => $guest);
+    $self->create_guest_network;
+    $self->start_guest(guest => $guest);
+    virt_autotest::domain_management_utils::show_guest();
+    $self->initialize_guest_matrix(role => 'src');
+    $self->config_ssh_pubkey_auth(addr => $guest, overwrite => 0, host => 0);
+    $self->set_test_run_progress(token => 'end');
+}
+
+=head2 prepare_log
+
+Enable virtualization debug logging, check host and guest health.
+=cut
+
+sub prepare_log {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    enable_debug_logging();
+    check_host_health();
+    my @guest_under_test = split(/ /, get_required_var('GUEST_UNDER_TEST'));
+    foreach (@guest_under_test) {
+        check_guest_health($_);
+    }
+    virt_autotest::domain_management_utils::shutdown_guest(guest => get_required_var('GUEST_UNDER_TEST'));
+}
+
+=head2 guest_migration_test
+
+Do guest migration test in loop for all guests and tests. Source and destination
+hosts collaborate with each other during test run by employing barriers, including
+DO_GUEST_MIGRATION_DONE_counter and DO_GUEST_MIGRATION_READY_counter. Subroutines
+pre_guest_migration, do_guest_migration and post_guest_migration do main actual
+works. Collect log for failure immediately and do log cleanup after each test if 
+INTERVAL_LOG is set (1).
+=cut
+
+sub guest_migration_test {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    my @guest_migration_test = split(/,/, get_var('GUEST_MIGRATION_TEST', ''));
+    my $full_test_matrix = is_kvm_host ? $parallel_guest_migration_base::guest_migration_matrix{kvm} : $parallel_guest_migration_base::guest_migration_matrix{xen};
+    @guest_migration_test = keys(%$full_test_matrix) if (scalar @guest_migration_test == 0);
+    my $localip = get_required_var('LOCAL_IPADDR');
+    my $peerip = get_required_var('PEER_IPADDR');
+    my $localuri = virt_autotest::domain_management_utils::construct_uri();
+    my $peeruri = virt_autotest::domain_management_utils::construct_uri(host => $peerip);
+    my $counter = 0;
+
+    foreach my $guest (keys %parallel_guest_migration_base::guest_matrix) {
+        while (my ($testindex, $test) = each(@guest_migration_test)) {
+            my $ret = 0;
+            my $command = $full_test_matrix->{$test};
+            $command =~ s/guest/$guest/g;
+            $command =~ s/srcuri/$localuri/g;
+            $command =~ s/dsturi/$peeruri/g;
+            $command =~ s/dstip/$peerip/g;
+            $command =~ /(xl|virsh)/i;
+            my $virttool = $1;
+            my $offline = $test =~ /offline/i;
+
+            record_info("Start $test on $guest", "Migration command is $command");
+            my $test_start_time = time();
+            my $test_stop_time = $test_start_time;
+            $self->pre_guest_migration(guest => $guest, virttool => $virttool, first => ($testindex == 0 ? 1 : 0));
+            $ret = $self->do_guest_migration(guest => $guest, test => $test, command => $command, offline => $offline);
+            collect_host_and_guest_logs($guest, '', '', "_$guest" . "_$test") if ($ret != 0 and get_var('INTERVAL_LOG', ''));
+
+            barrier_wait("DO_GUEST_MIGRATION_DONE_$counter");
+
+            barrier_wait("DO_GUEST_MIGRATION_READY_$counter");
+            $counter += 1;
+            $test_stop_time = time();
+            $parallel_guest_migration_base::test_result{$guest}{$command}{test_time} = strftime("\%H:\%M:\%S", gmtime($test_stop_time - $test_start_time));
+            record_info("End $test on $guest", "Total test time is $parallel_guest_migration_base::test_result{$guest}{$command}{test_time}");
+            $virttool = $testindex < scalar @guest_migration_test - 1 ? $guest_migration_test[$testindex + 1] =~ /(xl|virsh)/i && $1 : 'virsh';
+            $self->post_guest_migration(guest => $guest, virttool => $virttool, last => ($testindex == scalar @guest_migration_test - 1 ? 1 : 0));
+            cleanup_host_and_guest_logs if (get_var('INTERVAL_LOG', ''));
+        }
+    }
+}
+
+=head2 pre_guest_migration
+
+Transform guest to xen-xl form at the first test run if it is xl migration test.
+Perform basic administration on guest if GUEST_ADMINISTRATION is set (1). Update
+guest information by calling initialize_guest_matrix. 
+=cut
+
+sub pre_guest_migration {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{first} //= 0;
+    die("Guest to be tested must be given") if (!$args{guest});
+
+    if ($args{first} == 1) {
+        if ($args{virttool} eq 'xl') {
+            virt_autotest::domain_management_utils::remove_guest(guest => $args{guest});
+            virt_autotest::domain_management_utils::create_guest(guest => $args{guest}, virttool => $args{virttool}, start => 0);
+        }
+        $self->start_guest(guest => $args{guest}, virttool => $args{virttool});
+    }
+    if (get_var('GUEST_ADMINISTRATION', '')) {
+        $self->do_guest_administration(guest => $args{guest}, virttool => $args{virttool});
+        virt_autotest::domain_management_utils::remove_guest(guest => $args{guest});
+        virt_autotest::domain_management_utils::create_guest(guest => $args{guest}, virttool => $args{virttool}, start => 0);
+        $self->start_guest(guest => $args{guest}, virttool => $args{virttool});
+    }
+    $self->initialize_guest_matrix(role => 'src', guest => $args{guest});
+}
+
+=head2 do_guest_migration
+
+Do the actual guest migration test. Call virsh_migrate_manual_postcopy if test is
+manual postcopy. Record test result accordingly.
+=cut
+
+sub do_guest_migration {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{test} //= '';
+    $args{command} //= '';
+    $args{offline} //= 0;
+    die("Guest and test/command to be executed must be given") if (!$args{guest} or !$args{test} or !$args{command});
+
+    virt_autotest::domain_management_utils::shutdown_guest(guest => $args{guest}) if ($args{offline} == 1);
+    my $ret = $args{test} =~ /manual_postcopy/i ? $self->virsh_migrate_manual_postcopy(guest => $args{guest}, command => $args{command}) : script_run($args{command}, timeout => 120);
+    if ($ret != 0) {
+        record_info("Failed $args{test} migration", "Guest migration failed with $args{command}", result => 'fail');
+        save_screenshot;
+    }
+    else {
+        $parallel_guest_migration_base::test_result{$args{guest}}{$args{command}}{status} = 'PASSED';
+        record_info("Passed $args{test} migration", "Guest migration succeeded with $args{command}");
+    }
+    return $ret;
+}
+
+=head2 post_guest_migration
+
+Restore guest after current migration test finishes and prepare for the next test.
+Only re-create guest if the current test is not the last one for the guest.
+=cut
+
+sub post_guest_migration {
+    my ($self, %args) = @_;
+    $args{guest} //= '';
+    $args{virttool} //= 'virsh';
+    $args{last} //= 0;
+    die("Guest to be tested must be given") if (!$args{guest});
+
+    virt_autotest::domain_management_utils::remove_guest(guest => $args{guest});
+    if ($args{last} == 0) {
+        virt_autotest::domain_management_utils::create_guest(guest => $args{guest}, virttool => $args{virttool}, start => 0);
+        $self->start_guest(guest => $args{guest}, virttool => $args{virttool});
+    }
+}
+
+=head2 post_fail_hook
+
+Do post_fail_hook task and wait for peer test run to finish as normal if it also
+fails.
+=cut
+
+sub post_fail_hook {
+    my $self = shift;
+
+    $self->set_test_run_progress;
+    $self->SUPER::post_fail_hook;
+    barrier_wait('POST_FAIL_HOOK_DONE') if ($self->check_peer_test_run eq 'FAILED');
+}
+
+1;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -645,10 +645,11 @@ sub perform_guest_restart {
 #This subroutine collects desired logs from host and guest, and place them into folder /tmp/virt_logs_residence on host then compress it to /tmp/virt_logs_all.tar.gz
 #Please refer to virt_logs_collector.sh and fetch_logs_from_guest.sh in data/virt_autotest for their detailed functionality, implementation and usage
 sub collect_host_and_guest_logs {
-    my ($guest_wanted, $host_extra_logs, $guest_extra_logs) = @_;
+    my ($guest_wanted, $host_extra_logs, $guest_extra_logs, $log_token) = @_;
     $guest_wanted //= '';
     $host_extra_logs //= '';
     $guest_extra_logs //= '';
+    $log_token //= '';
 
     my $logs_collector_script_url = data_url("virt_autotest/virt_logs_collector.sh");
     script_output("curl -s -o ~/virt_logs_collector.sh $logs_collector_script_url", 180, type_command => 0, proceed_on_failure => 0);
@@ -662,9 +663,9 @@ sub collect_host_and_guest_logs {
     script_output("chmod +x ~/fetch_logs_from_guest.sh && ~/fetch_logs_from_guest.sh -g \"$guest_wanted\" -e \"$guest_extra_logs\"", 1800, type_command => 1, proceed_on_failure => 1);
     save_screenshot;
 
-    upload_logs("/tmp/virt_logs_all.tar.gz");
-    upload_logs("/var/log/virt_logs_collector.log");
-    upload_logs("/var/log/fetch_logs_from_guest.log");
+    upload_logs("/tmp/virt_logs_all.tar.gz", log_name => "virt_logs_all$log_token.tar.gz", timeout => 600);
+    upload_logs("/var/log/virt_logs_collector.log", log_name => "virt_logs_collector$log_token.log");
+    upload_logs("/var/log/fetch_logs_from_guest.log", log_name => "fetch_logs_from_guest$log_token.log");
     save_screenshot;
     script_run("rm -f -r /tmp/virt_logs_all.tar.gz /var/log/virt_logs_collector.log /var/log/fetch_logs_from_guest.log");
     save_screenshot;


### PR DESCRIPTION
* **Add** one more console root-ssh-virt for virtualization testing using ipmi backend. Manual postcopy guest migration needs two commands consecutively, the latter one needs to run during execution of the former, but unfortunately the former does not return until it finishes, so the latter do not have chance to run in the same terminal on some SLES versions. A second console is needed.

* **Extend** script_retry to have $option which can be used for passing additional arguments for "timeout".

* **New** file ```lib/virt_autotest/domain_management_utils.pm``` to hold domain management subroutines, including ```construct_uri```, ```create_guest```, ```remove_guest```, ```shutdown_guest```, ```show_guest``` and ```check_guest_state```.

* **Add** ssh options ```-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no``` in ```check_failures_in_journal``` and ```check_guest_health```, get rid of "localhost" on ssh command if machine is "localhost" and ensure ```validate_script_output``` more resilient to avoid unnecessary failures.

* **YAML** file ```schedule/qam/common/virt/virt_guest_migration.yaml``` to run guest migration test suite. This can be changed later on demand.

* **Add** option ```log_token``` in ```collect_host_and_guest_logs```, so uploaded logs can use personalized names to avoid duplicates.

* **File** ```tests/virt_autotest/parallel_guest_migration_barrier.pm``` creates locks that are going to be used during test urn in advance. ```DO_GUEST_MIGRATION_DONE_[1...N]``` and ```DO_GUEST_MIGRATION_READY_[1...N]``` will created dynamically in ```guest_migration_test```.

* **The** entire test can be broken down into 4 parts, ```prepare_host```, ```prepare_guest```, ```prepare_log``` and ```guest_migration_test```:
  * **```prepare_host```** is responsible for checking architecture, operation system version, virtualization module/service, connected network segment, software packages need to be available, qemu user id, qemu/kvm/libvirt group id, setup nfs shared storage and turning off unnecessary security services on both source and destination hosts.
  * **```prepare_guest```** is responsible for getting info about guest to be tested, initializing test result at the beginning, saving/restoring guest assets, configuring guest clock/storage/serial console, gathering networking info about guest, creating network to be used by guest and populating %guest_matrix which stores info about guest mac address, ip address, type/name/mode of network to which guest connected.
  * **```prepare_host```** and **```prepare_guest```** are mainly based on [Migration Requirements](https://susedoc.github.io/doc-sle/main/single-html/SLES-virtualization/#libvirt-admin-live-migration-requirements).
  * **```prepare_log```** is responsible for enabling debugging log, checking host and guest health before test starts.
  * **```guest_migration_test```** is responsible for performing guest migration tests. Source and destination hosts execute tests in collaborative manner by employing locks ```DO_GUEST_MIGRATION_DONE_[0...N]``` and ```DO_GUEST_MIGRATION_READY_[0...N]```. 
    * **Source** does basic administration on guest before migration if ```GUSET_ADMINISTRATION``` is set followed by guest migration test with virsh or xl command. It restores and re-creates guest before next guest migration test starts by using virsh or xl command accordingly.
    * **Destination** checks migration result from source. If it is successful migration from source, setup passwordless ssh connection, testing networking accessibility and disk read/write, and basic administration after migration will be performed. At last, destination will migrate the guest back to source. Destination only needs remove guest under certain circumstances, for example, failed migration back, undefinesource is not given during migration back or etc.

* **Test** suite level settings:
  * **GUEST_LIST** specifies guest to be tested. If empty, all guests defined on host will be tested.
  * **GUEST_MIGRATION_TEST** specifies migration test to be executed. If empty, all tests in %guest_migration_matrix will be executed.
  * **SKIP_GUEST_INSTALL** indicates whether guest is already installed directly on host. 
  * **GUEST_ADMINISTRATION** indicates whether basic administration on guest is needed.
  * **INTERVAL_LOG** indicates whether collecting log for each failed migration test and cleanup log after each test.
  * **EXTERNAL_NFS_SHARE** indicates both source and destination needs to mount external standalone nfs share.
  * **REGRESSION** indicates MU incidents testing activity which may use static ip address for guest.

* **Structures** being used in test:
  * **```%guest_matrix```** stores networking info about guest. Example as below:
$VAR1 = {
          'sles-15-sp4-64-fv-xen' => {
                                       'netmode' => 'bridge',
                                       'nettype' => 'bridge',
                                       'macaddr' => '52:54:00:ef:05:09',
                                       'netname' => 'br123',
                                       'ipaddr' => '192.168.123.2',
                                       'staticip' => 'no'
                                     },
          'sles-15-sp4-64-pv-xen' => {
                                       'netmode' => 'nat',
                                       'nettype' => 'network',
                                       'macaddr' => '00:16:3e:04:5b:c2',
                                       'netname' => 'vnet_nat_virbr77',
                                       'ipaddr' => '192.168.124.103',
                                       'staticip' => 'no'
                                     }
        };
  * **%guest_network_matrix** stores info about network to be created for guest based on the type of network being used.
  * **%guest_migration_matrix** stores all migrate tests to be executed.
  * **%test_result** stores final test result for all migration tests.

* **Some** run-time settings being used by test:
  * **```LOCAL_IPADDR,LOCAL_FQDN,PEER_IPADDR and PEER_FQDN```** store ip address and FQDN of source and destination hots.
  * **```GUEST_UNDER_TEST```** stores guest to be tested.
  * **```GUEST_UNDER_TEST_MACADDR,GUEST_UNDER_TEST_IPADDR,GUEST_UNDER_TEST_NETTYPE,GUEST_UNDER_TEST_NETNAME, GUEST_UNDER_TEST_NETMODE and GUEST_UNDER_TEST_STATICIP```** are derived from ```%guest_matrix```. So destination host can have exactly the same piece of information about guest during test run.
  * **```TEST_RUN_PROGRESS```** stores current subroutine in action as progress. This is achieved by calling ```set_test_run_progress``` in subroutine. So peer test run can know state of each other, especially when one in ```post_fail_hook```, failed test run calls ```check_peer_test_run``` to get test result of peer test run by examining ```TEST_RUN_PROGRESS``` to determine whether it needs to wait for peer to finish operation after failure as well and avoid interrupting peer to finish as normal.
  * **```TEST_RUN_RESULT```** stores the final test run result.

* **```check_guest_network_config```** retrieves guest network info from its xml config and store in ```%guest_matrix``` which will be used by ```create_guest_network``` to create guest network together with ```%guest_network_matrix```. In order to be consistent and simple, the network name should take the following form:
  * **If** guest uses virtual network created by ```virsh net-define/net-created```, the network name should be like ```vnet_``` + ```nat/route/host``` + ```_other_strings``` if network uses nat, route or host bridge respectively. ```$guest_matrix{guest}{netmode}``` will be nat, route or host accordingly and ```$guest_matrix{guest}{nettype}``` will be 'network'. For guest uses default network, ```$guest_matrix{guest}{netmode}``` will be default as well.
  * **If** guest uses bridge device directly, both ```$guest_matrix{guest}{nettype}``` and ```$guest_matrix{guest}{netmode}``` will be 'bridge'. But if guest used br0 directly, ```$guest_matrix{guest}{netmode}``` will be 'host'.

* **The** detailed execution flow of this Guest Migration Test is as below:
<img width="604" alt="Screenshot 2023-03-27 at 21 15 06" src="https://user-images.githubusercontent.com/38779103/227949367-439e9adb-bf8d-463c-a0bb-84af4b3dc9ca.png">
<img width="549" alt="Screenshot 2023-03-27 at 21 16 58" src="https://user-images.githubusercontent.com/38779103/227949432-a0d2e1b2-3db6-4d9f-b9ac-c0197b70e676.png">
<img width="497" alt="Screenshot 2023-03-27 at 21 19 30" src="https://user-images.githubusercontent.com/38779103/227949499-428affc3-314b-4274-9f54-77c14086400f.png">

* **Verification runs:**
  * Passed xen migration 15sp5 guest from 15sp5 host to 15sp5 host with administration:
    * [source test run](http://10.163.28.134/tests/1204)
    * [destination test run](http://10.163.28.134/tests/1203)
  * Failed xen migration 15sp5 guest from 15sp5 host to 15sp5 host with administration and log for each failure:
    *  [source test run](http://10.163.28.134/tests/1206)
    * [destination test run](http://10.163.28.134/tests/1205)
  * Passed kvm migration 15sp5 guest from 15sp5 host to 15sp5 host with administration and two test failures/logs:
    * [source test run](http://10.163.28.134/tests/1222)
    * [destination test run](http://10.163.28.134/tests/1221)
  * Passed xen migration 12sp3 from 12sp3 host to 12sp3 host with administration:
    * [source test run](http://10.163.28.134/tests/1246) 
    * [destination test run](http://10.163.28.134/tests/1245)
  * Passed kvm migration 12sp3 from 12sp3 host to 12sp3 host without administration:
    * [source test run](http://10.163.28.134/tests/1266)
    * [destination test run](http://10.163.28.134/tests/1265)
  * Failed xen migration 15sp5 host to 15sp4 host:
    * [source test run](http://10.163.28.134/tests/1290)
    * [destination test run](http://10.163.28.134/tests/1289)
  * Passed xen migration 15sp4 guest from 15sp4 host to 15sp5 host without administration and logs:
    * [source test run](http://10.163.28.134/tests/1294)
    * [destination test run](http://10.163.28.134/tests/1293)
  * Passed kvm migration 15sp4 guest from 15sp4 host to 15sp5 host without administration and logs:
    * [source test run](http://10.163.28.134/tests/1322)
    * [destination test run](http://10.163.28.134/tests/1321)
  * MU Scenario - Passed 12sp3-15sp4 guest between 15sp4 kvm without administration:
    * [source test run](http://10.163.28.134/tests/1485)
    * [destination test run](http://10.163.28.134/tests/1484)
  * MU Scenario - Passed 12sp3-15sp4 guest between 15sp4 xen without administration:
    * [source test run](http://10.163.28.134/tests/1537)
    * [destination test run](http://10.163.28.134/tests/1536)
  * MU Scenario - Passed 12sp3-15sp4 guest between 12sp3 kvm without administration:
    * [source test run](http://10.163.28.134/tests/1645)
    * [destination test run](http://10.163.28.134/tests/1644)
  * MU Scenario - Passed 12sp3-15sp4 guest between 12sp3 xen without administration:
    * [source test run](http://10.163.28.134/tests/1633)
    * [destination test run](http://10.163.28.134/tests/1632)
  * [Guest Installation KVM](https://openqa.suse.de/tests/10796583)
  * [Guest Installation XEN](https://openqa.suse.de/tests/10796586)
  * [UEFI Guest Installation KVM](https://openqa.suse.de/tests/10819008)
  * [UEFI Guest Installation XEN](https://openqa.suse.de/tests/10825459)
  * [PRJ2 Verification Run](https://openqa.suse.de/tests/10853140)
  * Please refer to [this checklist](https://progress.opensuse.org/issues/124928) for full list of MU integration verification runs