### PR TITLE
Add FLAVOR specific QR fix for welcome

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,7 +69,8 @@ sub get_product_shortcuts {
             sles => (is_sle '15-SP5+') ? 's'    # for now treat 15-SP5+ as if they would have new shortcuts
             : (is_ppc64le() || is_s390x()) ? 'u'    # s390 doesn't have a product selection screen for now
             : is_aarch64() ? 's'
-            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'
+            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/) && (get_var('FLAVOR') =~ /Full-QR/)) ? 'i'    # this is used by QU/QR
+            : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'    # this is used be Maintenance Test Repo
             : 'i',
             sled => 'x',
             hpc => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
This time try to avoid causing anything to change besides Full-QR flavor exactly.

- Related ticket: https://progress.opensuse.org/issues/124206
- Verification runs:
15-SP4 QR:
https://openqa.suse.de/tests/10604089 - now again 'i' for SLES
https://openqa.suse.de/tests/10604090 - --""--
15-SP4 Maintenance: Test Repo:
https://openqa.suse.de/tests/10604091 - still 's' for SLES (regressed with the previous attempt) even though "ISO" has "Full" in it
