### PR TITLE
Switch the transactional/enable_fips test module to serial terminal

### DIFF
--- a/tests/transactional/enable_fips.pm
+++ b/tests/transactional/enable_fips.pm
@@ -13,9 +13,10 @@ use testapi;
 use transactional;
 use bootloader_setup qw(change_grub_config);
 use version_utils qw(is_sle_micro);
+use serial_terminal 'select_serial_terminal';
 
 sub run {
-    select_console 'root-console';
+    select_serial_terminal;
 
     # make sure fips is not enabled
     assert_script_run("grep '^0\$' /proc/sys/crypto/fips_enabled");


### PR DESCRIPTION
- Verification run: [openqa.suse.de/t10605383](https://openqa.suse.de/tests/10605383)