### PR TITLE
Reintroduce Samba adcli

### DIFF
--- a/data/supportserver/samba/kinit.exp
+++ b/data/supportserver/samba/kinit.exp
@@ -45,6 +45,6 @@ if {$force_conservative} {
 set timeout -1
 spawn kinit Administrator
 match_max 100000
-expect -exact "Password for Administrator@GEEKO.COM: "
-send -- "Nots3cr3t\r"
+expect -exact "Password for Administrator@$AD_DOMAIN: "
+send -- "$AD_DOMAIN_PASSWORD\r"
 expect eof

--- a/data/supportserver/samba/krb5.conf
+++ b/data/supportserver/samba/krb5.conf
@@ -1,5 +1,5 @@
 [libdefaults]
-        default_realm = GEEKO.COM
+        default_realm = $AD_DOMAIN
         default_ccache_name = FILE:/tmp/krb5cc_%{uid}
         dns_canonicalize_hostname = false
         clockskew = 500
@@ -9,8 +9,8 @@
         forwardable = true
 
 [domain_realm]
-        .geeko.com = GEEKO.COM
-        geeko.com = GEEKO.COM
+        .$AD_HOSTNAME = $AD_DOMAIN
+        $AD_HOSTNAME = $AD_DOMAIN
 
 [logging]
         kdc = FILE:/var/log/krb5/krb5kdc.log
@@ -18,12 +18,14 @@
         default = SYSLOG:NOTICE:DAEMON
 
 [realms]
-GEEKO.COM = {
-        kdc = win2019dcadprovider.phobos.qa.suse.de
-        admin_server = win2019dcadprovider.phobos.qa.suse.de
-        default_domain = geeko.com
-        auth_to_local = RULE:[1:$1@$0]
-}
+        $AD_DOMAIN = {
+                kdc = $AD_HOSTNAME
+                admin_server = $AD_HOSTNAME
+                default_domain = $AD_DOMAIN
+                auth_to_local = RULE:[1:$1@$0]
+        }
+        default_domain = $AD_DOMAIN
+
 [appdefaults]
         pam = {
                 ticket_lifetime = 1d

--- a/data/supportserver/samba/smb.conf
+++ b/data/supportserver/samba/smb.conf
@@ -1,7 +1,7 @@
 [global]
-        workgroup = geeko
+        workgroup = $AD_WORKGROUP
         kerberos method = secrets and keytab
-        realm = GEEKO.COM
+        realm = $AD_DOMAIN
         security = ADS
         template homedir = /home/%D/%U
         template shell = /bin/bash
@@ -12,6 +12,10 @@
         winbind enum users = yes
         idmap gid = 10000-20000
         idmap uid = 10000-20000
+
+        # https://bugzilla.samba.org/show_bug.cgi?id=15240
+        client schannel = yes
+        
         #add machine script = /usr/sbin/useradd  -c Machine -d /var/lib/nobody -s /bin/false %m$
         # netbios name = SLES-VM
 

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -31,6 +31,7 @@ schedule:
   - console/gd
   - console/systemtap
   - console/vsftpd
+  - network/samba/samba_adcli
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:

--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -1,12 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright 2012-2020 SUSE LLC
+# Copyright 2012-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: samba test conecting with Active Directory using adcli
 # package: samba adcli samba-winbind krb5-client
 #
-# Maintainer: Marcelo Martins <mmartins@suse.com>
+# Maintainer: QE Core <qe-core@suse.de>
+# Remote server: https://confluence.suse.com/display/qasle/AD+configuration+for+testing
 
 use strict;
 use warnings;
@@ -17,8 +18,22 @@ use utils;
 use version_utils 'is_sle';
 use Utils::Architectures;
 
-my $AD_hostname = 'win2019dcadprovider.phobos.qa.suse.de';
-my $AD_ip = '10.162.30.119';
+my $AD_hostname = get_required_var("AD_HOSTNAME");
+my $AD_ip = get_required_var("AD_HOST_IP");
+my $AD_domain = get_required_var("AD_DOMAIN");
+my $AD_workgroup = get_required_var("AD_WORKGROUP");
+my $domain_joined = 0;
+
+sub get_supportserver_file {
+    my ($filename, $location) = @_;
+
+    assert_script_run('curl -f ' . autoinst_url . "/data/supportserver/samba/$filename  > $location");
+    assert_script_run("sed -i 's/\$AD_HOSTNAME/$AD_hostname/' $location");
+    assert_script_run("sed -i 's/\$AD_HOST_IP/$AD_ip/' $location");
+    assert_script_run("sed -i \"s/\\\$AD_DOMAIN_PASSWORD/\$AD_DOMAIN_PASSWORD/\" $location");
+    assert_script_run("sed -i 's/\$AD_DOMAIN/$AD_domain/' $location");
+    assert_script_run("sed -i 's/\$AD_WORKGROUP/$AD_workgroup/' $location");
+}
 
 sub samba_sssd_install {
     zypper_call('in expect samba adcli samba-winbind krb5-client sssd-ad');
@@ -29,174 +44,123 @@ sub samba_sssd_install {
     my $sssd_config_location = "/etc/sssd/conf.d/suse.conf";
     $sssd_config_location = "/etc/sssd/sssd.conf" if is_sle('<=12-sp4');
 
-    record_info($sssd_config_location);
-
-    #Copy config files enviroment.
-    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/kinit.exp  > ~/kinit.exp";
-    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/smb.conf  >/etc/samba/smb.conf";
-    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/krb5.conf  >/etc/krb5.conf";
-    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/nsswitch.conf  >/etc/nsswitch.conf";
-    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/sssd/conf.d/suse.conf  >$sssd_config_location";
+    # Copy config files enviroment.
+    get_supportserver_file("kinit.exp", '$HOME/kinit.exp');
+    get_supportserver_file("smb.conf", "/etc/samba/smb.conf");
+    get_supportserver_file("krb5.conf", "/etc/krb5.conf");
+    get_supportserver_file("nsswitch.conf", "/etc/nsswitch.conf");
+    get_supportserver_file("sssd/conf.d/suse.conf", $sssd_config_location);
     assert_script_run "chmod go-rwx $sssd_config_location";
     assert_script_run 'sed -i -E \'s/\tenable-cache(.*)(passwd|group)(.*)yes/\tenable-cache\1\2\3no/g\' /etc/nscd.conf';
 
-    # ensure we can resolve the ip addresses of the Active Directory Server
-    script_run('echo NETCONFIG_DNS_STATIC_SEARCHLIST="geeko.com" >> /etc/sysconfig/network/config');
-    script_run('echo NETCONFIG_DNS_STATIC_SERVERS="' . $AD_ip . '" >> /etc/sysconfig/network/config');
+    # Update the DNS configuration to use the Domain controller as primary source
+    assert_script_run("echo NETCONFIG_DNS_STATIC_SEARCHLIST='$AD_hostname' >> /etc/sysconfig/network/config");
+    assert_script_run("echo NETCONFIG_DNS_STATIC_SERVERS='$AD_ip' >> /etc/sysconfig/network/config");
     assert_script_run('netconfig update -f');
+    validate_script_output("cat /etc/resolv.conf", qr/nameserver $AD_ip/, fail_message => "Domain controller not present in /etc/resolv.conf");
 
-    record_info('Check the DNS config file');
-    script_run('cat /etc/resolv.conf');
-
-    script_run('dig srv _kerberos._tcp.geeko.com');
-    script_run('dig srv _ldap._tcp.geeko.com');
+    # Ensure DNS name resolution works for the AD host
+    assert_script_run("ping -c 2 $AD_hostname");
+    assert_script_run("dig srv _kerberos._tcp.$AD_hostname", fail_message => "failed to resolved the required kerberos host entry for AD controller");
+    assert_script_run("dig srv _ldap._tcp.$AD_hostname", fail_message => "failed to resolved the required LDAP SRV entry for AD controller");
 }
 
-sub update_password {
-    # Array @params contains tuples with [$params-for-adcli, $adcli-output-substring]
-    # first  tuple: no extra parameter for adcli so '', look for the string 'WBC_ERR_AUTH_ERROR'
-    # second tuple: add the extra parameter for adcli '--add-samba-data', look for the string 'succeeded'
-    my @params = (['', 'WBC_ERR_AUTH_ERROR'], ['--add-samba-data', 'succeeded']);
-
-    my $retries = 15;
-
-    # First invalidate the password, then update/restore it using --add-samba-data
-    for my $i (0 .. $#params) {
-        my $cmd = 'adcli update --verbose --computer-password-lifetime=0 --domain geeko.com ' . $params[$i][0];
-
-        # If the command fails, re-join as Administrator and retry the command (max 15 times)
-        for (1 .. $retries) {
-            my $ret = script_run($cmd);
-            if ($ret eq "0") {
-                # if the adcli command returned succesfully, stop retrying and break out of the loop
-                last;
-            } else {
-                # adcli update failed, check bsc#1188390
-                record_soft_failure("bsc#1188390");
-
-                # Retrying the adcli join is needed, probably due to https://bugs.freedesktop.org/show_bug.cgi?id=55487
-                if (script_retry('adcli join -v -W --domain geeko.com -U Administrator -C', delay => 10, retry => 15, timeout => 60, die => 0) != 0) {
-                    record_soft_failure('poo#96983');
-                    return;
-                }
-            }
-        }
-
-        # Check the trust secret for the domain
-        my $output = script_output('wbinfo -tP', proceed_on_failure => 1);
-        my $substr = $params[$i][1];
-
-        if (index($output, $substr) == -1) {
-            # If the output of the 1st command is not expected, and SUT is 12-SP3 or 12-SP4
-            if (($i == 0) && (is_sle('=12-SP3') || is_sle('=12-SP4'))) {
-                # Known issue, adcli update does not invalidate password (bsc#1188575)
-                record_soft_failure("bsc#1188575");
-                last;
-            } else {
-                die("wbinfo output does not contain $substr");
-            }
-        }
-    }
-}
-
-sub disable_ipv6 {
-    select_serial_terminal;
-    assert_script_run("sysctl -w net.ipv6.conf.all.disable_ipv6=1");
-    set_var('SYSCTL_IPV6_DISABLED', '1');
-}
-
-sub enable_ipv6 {
-    select_serial_terminal;
-    assert_script_run("sysctl -w net.ipv6.conf.all.disable_ipv6=0");
-    systemctl('restart network');
-    set_var('SYSCTL_IPV6_DISABLED', '0');
-}
-
-sub run {
-    # select_console 'root-console';
-    select_serial_terminal;
-    disable_ipv6;
-    samba_sssd_install;
-
-    #Join the Active Directory
+sub join_domain {
+    # Join the Active Directory via `kinit`
     script_retry("expect kinit.exp", retry => 3, timeout => 120, die => 1);
+    validate_script_output("klist", qr/$AD_domain/, fail_message => "Kerberos ticket for domain not listed");
 
-    # Retrying the adcli join is needed, probably due to https://bugs.freedesktop.org/show_bug.cgi?id=55487
-    if (script_retry('adcli join -v -W --domain geeko.com -U Administrator -C', delay => 10, retry => 15, timeout => 60, die => 0) != 0) {
-        record_soft_failure('poo#96983');
-        return;
-    }
+    # Retrying the adcli join is needed, due to https://bugs.freedesktop.org/show_bug.cgi?id=55487
+    # Joining the domain can take some time.
+    script_retry("adcli join -v --no-password --domain $AD_domain -U Administrator -C", delay => 30, retry => 3, timeout => 300, fail_message => "Joining AD domain failed (poo#96983)");
+    record_info("adcli info", script_output("adcli info -D '$AD_domain' -S '$AD_hostname' -v"));
 
-    #Verify if machine already added
-    assert_script_run "adcli info -D geeko.com  -S $AD_hostname -v";
-
-    #test samba with AD
+    # Test samba with AD
     # the wait_serial possibly could enter into a race condition, however for now this solution is good enough
     # if something is not working in the future: i.e authentication is not working, switching to using expect
     # would be a better idea
-    assert_script_run "klist";
-    if (script_run("echo Nots3cr3t  | net ads join --domain geeko.com -U Administrator --no-dns-updates -i") != 0) {
-        record_soft_failure('poo#96986');
-        return;
-    }
+    # TODO: REMOVED: -S '$AD_hostname'
+    assert_script_run("echo \"\$AD_DOMAIN_PASSWORD\" | net ads join --domain '$AD_domain' -U Administrator --no-dns-updates -i", timeout => 60, fail_message => "Error joining domain (poo#96986)");
 
-    #systemctl('restart nmb');
-    #systemctl('restart winbind');
-    #Enable pam authentication
-    # assert_script_run "pam-config -a --winbind"; We'll only use sss to authenticate for now
+    # Enable pam authentication
     assert_script_run "pam-config -a --mkhomedir";
     assert_script_run "pam-config -a --sss";
 
     foreach my $service (qw(smb nmb winbind sssd)) {
         systemctl("enable --now $service");
     }
-
     systemctl('restart nscd');
+}
 
-    #Verify users and groups  from AD
-    my $wbinfo_ret = 0;
-    $wbinfo_ret += script_run "wbinfo -u | grep foursixnine";
-    $wbinfo_ret += script_run "wbinfo -g | grep dnsupdateproxy";
-    $wbinfo_ret += script_run "wbinfo -D geeko.com";
-    $wbinfo_ret += script_run "wbinfo -i geekouser\@geeko.com";
-    $wbinfo_ret += script_run "wbinfo -i Administrator\@geeko.com";
+sub update_password {
+    # Invalidate the password of the local computer account on AD
+    script_retry("adcli update --verbose --computer-password-lifetime=0 --domain '$AD_domain'", retry => 3, delay => 60, fail_message => "Error invalidating local password");
+    # Restore the password with --add-samba-data as requested by poo#91950
+    script_retry("adcli update --verbose --computer-password-lifetime=0 --domain '$AD_domain' --add-samba-data", retry => 3, delay => 60, fail_message => "Error re-adding password with samba data");
 
-    # If any of the wbinfo commands did not return successfully, softfail
-    if ($wbinfo_ret != 0) {
-        record_soft_failure('poo#96513');
+    # Check the trust secret for the domain
+    if (script_run("wbinfo -tP") != 0) {
+        my $output = script_output('wbinfo -tP', proceed_on_failure => 1);
+
+        # Check for bsc#1188575
+        if ($output =~ "WBC_ERR_AUTH_ERROR") {
+            die("wbinfo output failed") unless (is_sle('=12-SP3') || is_sle('=12-SP4'));
+            record_soft_failure("bsc#1188575");
+        }
     }
+}
 
-    if (script_run("expect -c 'spawn ssh -l geekouser\@geeko.com localhost -t;expect sword:;send Nots3cr3t\\n;expect geekouser>;send exit\\n;interact'") != 0) {
-        record_soft_failure('poo#96512');
-    }
+sub randomize_hostname {
+    my $hostname = "openqa-" . random_string(length => 8);
+    assert_script_run("hostnamectl set-hostname '$hostname'");
+}
 
-    # poo#91950 (update machine password with adcli --add-samba-data option)
-    update_password() unless is_sle('=15');    # sle 15 does not support the `--add-samba-data` option
+sub run {
+    select_serial_terminal;
 
-    if ((script_run "echo Nots3cr3t  | net ads leave --domain geeko.com -U Administrator -i") != 0) {
-        record_soft_failure('poo#96986');
-        return;
-    }
+    # Ensure the required variables are set
+    my $password = get_required_var("_SECRET_AD_DOMAIN_PASSWORD");
+    define_secret_variable("AD_DOMAIN_PASSWORD", $password);
+
+    samba_sssd_install();
+    randomize_hostname();    # Prevent race condition with parallel test runs
+    join_domain();
+    $domain_joined = 1;
+
+    # Verify users and groups from AD via winbind.
+    # Note: The following checks are subject to sporadic failures (poo#96513)
+    record_soft_failure("poo#96513 - Failed to get AD domain") if (script_run("wbinfo -D $AD_domain", timeout => 120) != 0);
+    record_soft_failure("poo#96513 - Failed to get AD username") if (script_run("wbinfo -u | grep 'geekotest'", timeout => 120) != 0);
+    record_soft_failure("poo#96513 - Failed to get AD groups") if (script_run("wbinfo -g | grep 'openqa'", timeout => 120) != 0);
+    record_soft_failure("poo#96513 Failed to get AD user info for geekotest") if (script_run("wbinfo -i geekotest\@$AD_domain", timeout => 120) != 0);
+
+    # poo#91950 (update password with adcli --add-samba-data option)
+    update_password() unless (is_sle("=15") || is_sle("<12-SP4"));    # sle 15 and 12-SP3 do not support the `--add-samba-data` option
+
+    assert_script_run("echo \"\$AD_DOMAIN_PASSWORD\" | net ads leave --domain '$AD_hostname' -U Administrator -i", fail_message => "Failed to leave the domain (poo#96986)");
+    $domain_joined = 0;
 
     # For futher extensions
-    # - Mount //GEEKO
-    # - smbclient //10.162.30.119/openQA as geekouser will be denied, as berhard is the owner
+    # - smbclient //$AD_hostname/openQA as geekouser is permitted (read-only), but as berhard it is denied
     # - delete the computer OU after the test is done in post_run_hook
     # - test winbind (samba?) authentication
 }
 
 sub post_run_hook {
     my ($self) = shift;
-    $self->enable_ipv6;
 }
 
 sub post_fail_hook {
     my ($self) = shift;
     $self->SUPER::post_fail_hook;
-    select_serial_terminal;
+
     script_run 'tar Jcvf samba_adcli.tar.xz /etc/sssd /var/log/samba /var/log/sssd /var/log/krb5';
     upload_logs('./samba_adcli.tar.xz');
-    $self->enable_ipv6;
+
+    # Leave domain, if joined
+    if ($domain_joined) {
+        script_run("echo \"\$AD_DOMAIN_PASSWORD\" | net ads leave --domain '$AD_hostname' -U Administrator -i");
+    }
 }
 
 1;

--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -1,0 +1,202 @@
+# SUSE's openQA tests
+#
+# Copyright 2012-2020 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: samba test conecting with Active Directory using adcli
+# package: samba adcli samba-winbind krb5-client
+#
+# Maintainer: Marcelo Martins <mmartins@suse.com>
+
+use strict;
+use warnings;
+use base "consoletest";
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use version_utils 'is_sle';
+use Utils::Architectures;
+
+my $AD_hostname = 'win2019dcadprovider.phobos.qa.suse.de';
+my $AD_ip = '10.162.30.119';
+
+sub samba_sssd_install {
+    zypper_call('in expect samba adcli samba-winbind krb5-client sssd-ad');
+
+    # sssd versions prior to 1.14 don't support conf.d
+    # https://github.com/SSSD/sssd/issues/3289
+    # 12-SP4 ships libini 1.2, and version 1.3.0 is required for this feature to be available in sssd
+    my $sssd_config_location = "/etc/sssd/conf.d/suse.conf";
+    $sssd_config_location = "/etc/sssd/sssd.conf" if is_sle('<=12-sp4');
+
+    record_info($sssd_config_location);
+
+    #Copy config files enviroment.
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/kinit.exp  > ~/kinit.exp";
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/smb.conf  >/etc/samba/smb.conf";
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/krb5.conf  >/etc/krb5.conf";
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/nsswitch.conf  >/etc/nsswitch.conf";
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/samba/sssd/conf.d/suse.conf  >$sssd_config_location";
+    assert_script_run "chmod go-rwx $sssd_config_location";
+    assert_script_run 'sed -i -E \'s/\tenable-cache(.*)(passwd|group)(.*)yes/\tenable-cache\1\2\3no/g\' /etc/nscd.conf';
+
+    # ensure we can resolve the ip addresses of the Active Directory Server
+    script_run('echo NETCONFIG_DNS_STATIC_SEARCHLIST="geeko.com" >> /etc/sysconfig/network/config');
+    script_run('echo NETCONFIG_DNS_STATIC_SERVERS="' . $AD_ip . '" >> /etc/sysconfig/network/config');
+    assert_script_run('netconfig update -f');
+
+    record_info('Check the DNS config file');
+    script_run('cat /etc/resolv.conf');
+
+    script_run('dig srv _kerberos._tcp.geeko.com');
+    script_run('dig srv _ldap._tcp.geeko.com');
+}
+
+sub update_password {
+    # Array @params contains tuples with [$params-for-adcli, $adcli-output-substring]
+    # first  tuple: no extra parameter for adcli so '', look for the string 'WBC_ERR_AUTH_ERROR'
+    # second tuple: add the extra parameter for adcli '--add-samba-data', look for the string 'succeeded'
+    my @params = (['', 'WBC_ERR_AUTH_ERROR'], ['--add-samba-data', 'succeeded']);
+
+    my $retries = 15;
+
+    # First invalidate the password, then update/restore it using --add-samba-data
+    for my $i (0 .. $#params) {
+        my $cmd = 'adcli update --verbose --computer-password-lifetime=0 --domain geeko.com ' . $params[$i][0];
+
+        # If the command fails, re-join as Administrator and retry the command (max 15 times)
+        for (1 .. $retries) {
+            my $ret = script_run($cmd);
+            if ($ret eq "0") {
+                # if the adcli command returned succesfully, stop retrying and break out of the loop
+                last;
+            } else {
+                # adcli update failed, check bsc#1188390
+                record_soft_failure("bsc#1188390");
+
+                # Retrying the adcli join is needed, probably due to https://bugs.freedesktop.org/show_bug.cgi?id=55487
+                if (script_retry('adcli join -v -W --domain geeko.com -U Administrator -C', delay => 10, retry => 15, timeout => 60, die => 0) != 0) {
+                    record_soft_failure('poo#96983');
+                    return;
+                }
+            }
+        }
+
+        # Check the trust secret for the domain
+        my $output = script_output('wbinfo -tP', proceed_on_failure => 1);
+        my $substr = $params[$i][1];
+
+        if (index($output, $substr) == -1) {
+            # If the output of the 1st command is not expected, and SUT is 12-SP3 or 12-SP4
+            if (($i == 0) && (is_sle('=12-SP3') || is_sle('=12-SP4'))) {
+                # Known issue, adcli update does not invalidate password (bsc#1188575)
+                record_soft_failure("bsc#1188575");
+                last;
+            } else {
+                die("wbinfo output does not contain $substr");
+            }
+        }
+    }
+}
+
+sub disable_ipv6 {
+    select_serial_terminal;
+    assert_script_run("sysctl -w net.ipv6.conf.all.disable_ipv6=1");
+    set_var('SYSCTL_IPV6_DISABLED', '1');
+}
+
+sub enable_ipv6 {
+    select_serial_terminal;
+    assert_script_run("sysctl -w net.ipv6.conf.all.disable_ipv6=0");
+    systemctl('restart network');
+    set_var('SYSCTL_IPV6_DISABLED', '0');
+}
+
+sub run {
+    # select_console 'root-console';
+    select_serial_terminal;
+    disable_ipv6;
+    samba_sssd_install;
+
+    #Join the Active Directory
+    script_retry("expect kinit.exp", retry => 3, timeout => 120, die => 1);
+
+    # Retrying the adcli join is needed, probably due to https://bugs.freedesktop.org/show_bug.cgi?id=55487
+    if (script_retry('adcli join -v -W --domain geeko.com -U Administrator -C', delay => 10, retry => 15, timeout => 60, die => 0) != 0) {
+        record_soft_failure('poo#96983');
+        return;
+    }
+
+    #Verify if machine already added
+    assert_script_run "adcli info -D geeko.com  -S $AD_hostname -v";
+
+    #test samba with AD
+    # the wait_serial possibly could enter into a race condition, however for now this solution is good enough
+    # if something is not working in the future: i.e authentication is not working, switching to using expect
+    # would be a better idea
+    assert_script_run "klist";
+    if (script_run("echo Nots3cr3t  | net ads join --domain geeko.com -U Administrator --no-dns-updates -i") != 0) {
+        record_soft_failure('poo#96986');
+        return;
+    }
+
+    #systemctl('restart nmb');
+    #systemctl('restart winbind');
+    #Enable pam authentication
+    # assert_script_run "pam-config -a --winbind"; We'll only use sss to authenticate for now
+    assert_script_run "pam-config -a --mkhomedir";
+    assert_script_run "pam-config -a --sss";
+
+    foreach my $service (qw(smb nmb winbind sssd)) {
+        systemctl("enable --now $service");
+    }
+
+    systemctl('restart nscd');
+
+    #Verify users and groups  from AD
+    my $wbinfo_ret = 0;
+    $wbinfo_ret += script_run "wbinfo -u | grep foursixnine";
+    $wbinfo_ret += script_run "wbinfo -g | grep dnsupdateproxy";
+    $wbinfo_ret += script_run "wbinfo -D geeko.com";
+    $wbinfo_ret += script_run "wbinfo -i geekouser\@geeko.com";
+    $wbinfo_ret += script_run "wbinfo -i Administrator\@geeko.com";
+
+    # If any of the wbinfo commands did not return successfully, softfail
+    if ($wbinfo_ret != 0) {
+        record_soft_failure('poo#96513');
+    }
+
+    if (script_run("expect -c 'spawn ssh -l geekouser\@geeko.com localhost -t;expect sword:;send Nots3cr3t\\n;expect geekouser>;send exit\\n;interact'") != 0) {
+        record_soft_failure('poo#96512');
+    }
+
+    # poo#91950 (update machine password with adcli --add-samba-data option)
+    update_password() unless is_sle('=15');    # sle 15 does not support the `--add-samba-data` option
+
+    if ((script_run "echo Nots3cr3t  | net ads leave --domain geeko.com -U Administrator -i") != 0) {
+        record_soft_failure('poo#96986');
+        return;
+    }
+
+    # For futher extensions
+    # - Mount //GEEKO
+    # - smbclient //10.162.30.119/openQA as geekouser will be denied, as berhard is the owner
+    # - delete the computer OU after the test is done in post_run_hook
+    # - test winbind (samba?) authentication
+}
+
+sub post_run_hook {
+    my ($self) = shift;
+    $self->enable_ipv6;
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->SUPER::post_fail_hook;
+    select_serial_terminal;
+    script_run 'tar Jcvf samba_adcli.tar.xz /etc/sssd /var/log/samba /var/log/sssd /var/log/krb5';
+    upload_logs('./samba_adcli.tar.xz');
+    $self->enable_ipv6;
+}
+
+1;


### PR DESCRIPTION
This PR reintroduced the samba AD test run. It consists of two commits, one where we revert the test to the old state and one where we adapt it to the new Domain-Controller.

- Related ticket: https://progress.opensuse.org/issues/96512
- Verification runs: [15-SP4](https://duck-norris.qe.suse.de/tests/12387) | [15-SP3](https://duck-norris.qe.suse.de/tests/12381) | [15-SP2](https://duck-norris.qe.suse.de/tests/12382) | [15-SP1](https://duck-norris.qe.suse.de/tests/12383) | [12-SP5](https://duck-norris.qe.suse.de/tests/12384) | [12-SP4](https://duck-norris.qe.suse.de/tests/12385) | [12-SP3](https://duck-norris.qe.suse.de/tests/12386)