### PR TITLE
Fix an autoyast profile to make it install

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_disabled_firewall.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_disabled_firewall.xml
@@ -50,6 +50,12 @@
       </zone>
     </zones>
   </firewall>
+  <general t="map">
+    <cio_ignore t="boolean">false</cio_ignore>
+    <mode t="map">
+      <confirm t="boolean">false</confirm>
+    </mode>
+  </general>
   <groups t="list">
     <group t="map">
       <gid>100</gid>
@@ -140,4 +146,26 @@
       <username>root</username>
     </user>
   </users>
+  <report>
+    <errors t="map">
+      <log t="boolean">true</log>
+      <show t="boolean">true</show>
+      <timeout t="integer">0</timeout>
+    </errors>
+    <messages t="map">
+      <log t="boolean">true</log>
+      <show t="boolean">true</show>
+      <timeout t="integer">0</timeout>
+    </messages>
+    <warnings t="map">
+      <log t="boolean">true</log>
+      <show t="boolean">true</show>
+      <timeout t="integer">0</timeout>
+    </warnings>
+    <yesno_messages t="map">
+      <log t="boolean">true</log>
+      <show t="boolean">true</show>
+      <timeout t="integer">0</timeout>
+    </yesno_messages>
+  </report>
 </profile>


### PR DESCRIPTION
The autoyast profile added by pr#16382 has some problems, the cases don't start to install. Add the "report" and "general" section to make the profile work.

- Related ticket: https://progress.opensuse.org/issues/121912
- Needles: n/a
- Verification run: 
- https://openqa.suse.de/tests/10605943 (x86_64)
- https://openqa.suse.de/tests/10609495 (aarch64）