### PR TITLE
Remove soft-failure bsc#1195046

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -35,11 +35,6 @@ our @EXPORT = qw(
 sub setup_sle {
     select_console 'root-console';
 
-    if (is_ppc64le && is_sle('<=12-sp5')) {
-        record_soft_failure('bsc#1195046 - ncurses display a wrong checker board character');
-        systemctl('restart systemd-vconsole-setup.service');
-    }
-
     # Stop packagekitd
     if (is_sle('12+')) {
         quit_packagekit;


### PR DESCRIPTION
Remove soft-failure bsc#1195046

**Ticket:**

- https://progress.opensuse.org/issues/125069

**Verification run:**
- https://openqa.suse.de/tests/10609677
- https://openqa.suse.de/tests/10610216
- https://openqa.suse.de/tests/10610836
- https://openqa.suse.de/tests/10611327
- https://openqa.suse.de/tests/10614085
- https://openqa.suse.de/tests/10614158
- https://openqa.suse.de/tests/10614778
- https://openqa.suse.de/tests/10614861
- https://openqa.suse.de/tests/10614871
- https://openqa.suse.de/tests/10614928
- https://openqa.suse.de/tests/10614950
- https://openqa.suse.de/tests/10615011
