### PR TITLE
Remove testing of sap-b1/sap-bone pattern in 15-SP5+

### DIFF
--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -19,7 +19,7 @@ use warnings;
 
 sub run {
     my @sappatterns = qw(sap-nw sap-b1 sap-hana);
-    $sappatterns[1] =~ s/b1/bone/ if (is_sle('15-SP5+'));
+    splice(@sappatterns, 1, 1) if (is_sle('15-SP5+'));    # sap-bone pattern is no longer part of SLES4SAP starting on 15-SP5
     my $output = '';
 
     select_serial_terminal;


### PR DESCRIPTION
`sap-b1` pattern will no longer be available in 15-SP5, so no need to check for it.

- Related ticket: https://jira.suse.com/browse/TEAM-7438 & https://build.suse.de/request/show/290910
- Needles: N/A
- Verification run: [15-SP5](https://openqa.suse.de/tests/10609865), [15-SP4](https://openqa.suse.de/t10610127)