### PR TITLE
Increase default timeout in script_output

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -72,7 +72,7 @@ sub record_avc_selinux_alerts {
         return;
     }
 
-    my @logged = split(/\n/, script_output('ausearch -m avc -r', proceed_on_failure => 1));
+    my @logged = split(/\n/, script_output('ausearch -m avc -r', timeout => 300, proceed_on_failure => 1));
 
     # no new messages are registered
     if (scalar @logged <= $avc_record{start}) {


### PR DESCRIPTION
The short default timeout (90) causes some tests to fail. This has been implemented after internal discussion in #eng-testing.

- Related ticket: https://progress.opensuse.org/issues/125033
- Test run: http://emiler-openqa.qe.suse.de/tests/118#