### PR TITLE
Workaround for timeouts on hana and netweaver

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -90,7 +90,8 @@ sub run {
     my ($proto, $path) = $self->fix_path(get_required_var('HANA'));
     my $sid = get_required_var('INSTANCE_SID');
     my $instid = get_required_var('INSTANCE_ID');
-    my $tout = get_var('HANA_INSTALLATION_TIMEOUT', 3600);    # Timeout for HANA installation commands.
+    # set timeout as 4800 as a temp workaround for slow nfs
+    my $tout = get_var('HANA_INSTALLATION_TIMEOUT', 4800);    # Timeout for HANA installation commands.
 
     select_serial_terminal;
     my $RAM = $self->get_total_mem();

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -23,7 +23,8 @@ sub run {
     my $sid = get_required_var('INSTANCE_SID');
     my $hostname = get_var('INSTANCE_ALIAS', '$(hostname)');
     my $params_file = "/sapinst/$instance_type.params";
-    my $timeout = bmwqemu::scale_timeout(900);    # Time out for NetWeaver's sources related commands
+    # set timeout as 1800 as workaround for slow nfs
+    my $timeout = bmwqemu::scale_timeout(1800);    # Time out for NetWeaver's sources related commands
     my $product_id = undef;
 
     # Set Product ID depending on the type of Instance


### PR DESCRIPTION
Raised timeout on install process to workaround nfs high load during 
hana and netweaver install.

Workaround for:
bsc#1206145

Failures:
https://openqa.suse.de/tests/10604465
https://openqa.suse.de/tests/10604463

VR:
https://openqa.suse.de/tests/10609831
https://openqa.suse.de/tests/10609829
