### PR TITLE
Check status of ipsec client before connecting

### DIFF
--- a/tests/security/cc/ipsec/ipsec_ciphers.pm
+++ b/tests/security/cc/ipsec/ipsec_ciphers.pm
@@ -30,7 +30,7 @@ sub run {
     # Test ike
     my $ike_output = script_output('bash test_basic_ipsec_eval_ike.bash');
 
-    mutex_create('IPSEC_CLEINT_DONE');
+    mutex_create('IPSEC_CLIENT_DONE');
 
     my @results = (split(/\n/, "$esp_output\n$ike_output"));
     my $expect_failures = {

--- a/tests/security/cc/ipsec/ipsec_client.pm
+++ b/tests/security/cc/ipsec/ipsec_client.pm
@@ -26,9 +26,8 @@ sub run {
     my $netdev = get_var('NETDEV', 'eth0');
     assert_script_run("ip addr add $atsec_test::client_ip/24 dev $netdev") if (is_s390x);
 
-    mutex_wait('IPSEC_SERVER_READY');
-
     assert_script_run("cd $audit_test::test_dir/ipsec_configuration/toe");
+    mutex_wait('IPSEC_SERVER_READY');
 
     # Setup the ipip tunnel to the IPSec gateway and test it
     # 192.168.100.1 is configured in the server by ipsec_setup_tunnel_server.sh
@@ -42,8 +41,14 @@ sub run {
     # Test the IPSec connection
     assert_script_run('ipsec start');
     assert_script_run('stime=$(date +\'%H:%M:%S\')');
-    record_soft_failure("poo#117208 - The addition of the sleep command is a temporary workaround");
-    sleep 60;
+
+    # ipsec start can take some time to start charon daemon,
+    # so we wait until we get some status output
+    my $inc = 0;
+    while (scalar(split(/\n/, script_output('ipsec statusall', proceed_on_failure => 1)) <= 5) && $inc < 10) {
+        sleep(++$inc);
+    }
+
     assert_script_run('ipsec up ikev2suse');
 
     # Test the IPSec connection
@@ -53,7 +58,9 @@ sub run {
     assert_script_run('ausearch -ts $stime | grep --color -e \'MAC_IPSEC_EVENT\' -e \'SPD-add\' -e \'SAD-add\'');
 
     assert_script_run('stime=$(date +\'%H:%M:%S\')');
-    assert_script_run('ipsec down ikev2suse');
+
+    my $timeout = is_s390x() ? 180 : 90;
+    assert_script_run('ipsec down ikev2suse', $timeout);
 
     # Search for AUDIT SPD/SAD delete records
     assert_script_run('ausearch -ts $stime | grep --color -e \'MAC_IPSEC_EVENT\' -e \'SPD-delete\' -e \'SAD-delete\'');

--- a/tests/security/cc/ipsec/ipsec_server.pm
+++ b/tests/security/cc/ipsec/ipsec_server.pm
@@ -54,7 +54,7 @@ sub run {
     # Restart the strongswan service
     assert_script_run('systemctl restart strongswan');
 
-    mutex_wait('IPSEC_CLEINT_DONE', (keys %$children)[0]);
+    mutex_wait('IPSEC_CLIENT_DONE', (keys %$children)[0]);
 
     # Stop StrongSWAN
     assert_script_run('systemctl stop strongswan');

--- a/tests/security/cc/ipsec/weak_ipsec_ciphers.pm
+++ b/tests/security/cc/ipsec/weak_ipsec_ciphers.pm
@@ -13,13 +13,15 @@ use warnings;
 use testapi;
 use utils;
 use lockapi;
+use Utils::Architectures;
 
 sub run {
     my ($self) = @_;
     select_console 'root-console';
 
     assert_script_run('cd /usr/local/atsec/ipsec/IPSEC_basic_eval');
-    my $output = script_output('bash test_basic_ipsec_eval_weak.bash');
+    my $timeout = is_s390x() ? 180 : 90;
+    my $output = script_output('bash test_basic_ipsec_eval_weak.bash', $timeout);
 
     my @lines = split(/\n/, $output);
     foreach my $line (@lines) {


### PR DESCRIPTION
- ipsec client depends on a daemon to be started; on the first time it can take some time due to key generation. Some weeks ago We introduced a sleep with softfail as a workaround, with this change we wait for ipsec status to be stable before checking the tunnel connection.

- This also fixes a typo in the mutex name



- Related tickets: 
   - https://progress.opensuse.org/issues/124005
   - https://progress.opensuse.org/issues/117208
- Verification runs:
    - 15sp4 x86_64:     
    https://openqa.suse.de/tests/10604665 [client]
    https://openqa.suse.de/tests/10604663 [server]
    - 15sp4 s390:
    https://openqa.suse.de/tests/10605746 [client]            
    https://openqa.suse.de/tests/10605747 [server]
    - 15sp4 aarch64:
    https://openqa.suse.de/tests/10609787 [client]
    https://openqa.suse.de/tests/10609788 [server]
    - 15sp5 x86_64: 
    https://openqa.suse.de/tests/10604669 [client]          
    https://openqa.suse.de/tests/10604670 [server]
    - 15sp5 aarch64:
    https://openqa.suse.de/tests/10609664 [client]
    https://openqa.suse.de/tests/10609663 [server]
    - 15sp5 s390:
    https://openqa.suse.de/tests/10609690 [client]
    https://openqa.suse.de/tests/10609691 [server]