### PR TITLE
WIP: Introduce services health test run

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -45,6 +45,7 @@ sub load_config_tests {
     loadtest 'transactional/enable_selinux' if (get_var('ENABLE_SELINUX') && is_image);
     loadtest 'console/suseconnect_scc' if (is_sle_micro && get_var('SCC_REGISTER') && !is_dvd);
     loadtest 'transactional/install_updates' if (is_sle_micro && is_released);
+    loadtest 'microos/services_health';
 }
 
 sub load_boot_from_disk_tests {
@@ -114,6 +115,7 @@ sub load_installation_tests {
             loadtest 'microos/disk_boot';
         }
         loadtest 'console/textinfo';
+        loadtest 'microos/services_health';
     }
 }
 
@@ -226,10 +228,10 @@ sub load_rcshell_tests {
     loadtest 'microos/one_line_checks';
 }
 
-sub load_journal_check_tests {
+sub load_finalizing_check_tests {
     # Enclosing test cases
+    loadtest 'microos/services_health';
     loadtest 'console/journal_check';
-    loadtest 'shutdown/shutdown';
 }
 
 sub load_tests {
@@ -294,7 +296,9 @@ sub load_tests {
         load_common_tests;
         load_transactional_tests unless is_zvm;
     }
-    load_journal_check_tests;
+    load_finalizing_check_tests();
+    loadtest 'shutdown/shutdown';
+
 }
 
 1;

--- a/tests/microos/services_health.pm
+++ b/tests/microos/services_health.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2017-2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check that not failed services are present on the system
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+
+use strict;
+use warnings;
+use base "consoletest";
+use testapi;
+
+sub run {
+    # Yes. This test is an awesome oneliner.
+    # Please remove this comment when you are extending it.
+    validate_script_output("systemctl --failed", qr/0 loaded units listed./, fail_message => "There are failed systemd units present on the system");
+}
+
+1;


### PR DESCRIPTION
Adds a test run that checks for failing systemd services.

- Verification runs: [MicroOS](https://duck-norris.qe.suse.de/tests/12315)
