### PR TITLE
lib/x11utils: Use Ctrl instead of Esc to show the lockscreen

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -179,7 +179,7 @@ sub ensure_unlocked_desktop {
         die 'ensure_unlocked_desktop repeated too much. Check for X-server crash.' if ($counter eq 1);    # die loop when generic-desktop not matched
         if (match_has_tag('screenlock') || match_has_tag('blackscreen')) {
             wait_screen_change {
-                send_key 'esc';    # end screenlock
+                send_key 'ctrl';    # end screenlock
                 diag("Screen lock present");
             };
             next;    # Go directly to assert_screen, skip wait_still_screen (and don't collect $200)


### PR DESCRIPTION
Plasma 5.27 introduced that Esc turns the monitor off. With 5.27.2, it no longer causes the lockscreen UI to show, so we can't use it here anymore. Ctrl appears to work fine.

Verification runs:

KDE Live: https://openqa.opensuse.org/tests/3154656
GNOME Live: https://openqa.opensuse.org/tests/3154657
Xfce Live: https://openqa.opensuse.org/tests/3154662

Any other VRs needed? The lxde and the otherDE tests apparently don't trigger the lockscreen.