### PR TITLE
Un-schedule upgrade_snapshots in sle-15-SP5-Regression-on-Migration-f…

### DIFF
--- a/schedule/migration/ppc64le_regression_test_offline.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline.yaml
@@ -76,7 +76,6 @@ conditional_schedule:
         - locale/keymap_or_locale
         - console/force_scheduled_tasks
         - console/hostname
-        - console/upgrade_snapshots
         - console/zypper_lr
         - console/zypper_ref
         - console/check_system_info


### PR DESCRIPTION
…rom-SLE12-SPx-ppc64le-offline_sles12sp5_media_sdk-lp-asmm-contm-lgm-tcm-wsm-pcm_all_full@ppc64le-2g

The test causes an OOM situation. It is a bug, but this backend is no longer supported. Adding memory allows other modules to pass, but is resource consuming, and the test module itself is still failing anyway. I tested the same commands on a powervm machine, the bug was not appearing there. Un-scheduling this module will allow the other test modules to pass.

VR https://openqa.suse.de/tests/10611328
with more memory: https://openqa.suse.de/tests/10617298
