### PR TITLE
Not allow wait_for_ssh to die early due to wrong pubkey error

### DIFF
--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -56,7 +56,8 @@ sub run {
 
     record_info('system reboots');
     my ($shutdown_time, $startup_time) = $instance->softreboot(
-        timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 400)
+        timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 400),
+        ignore_wrong_pubkey => 1
     );
 
     # Upload distro_migration.log


### PR DESCRIPTION
DMS migration (tests/publiccloud/migration.pm) is running under user migration
until it is not over we will recieve ssh permission denied (pubkey) error
but it is not good reason to die early because after it will be over DMS will return normal
user and error will be resolved.