### PR TITLE
Revert "lib/x11utils: Use Ctrl instead of Esc to show the lockscreen"

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -179,7 +179,7 @@ sub ensure_unlocked_desktop {
         die 'ensure_unlocked_desktop repeated too much. Check for X-server crash.' if ($counter eq 1);    # die loop when generic-desktop not matched
         if (match_has_tag('screenlock') || match_has_tag('blackscreen')) {
             wait_screen_change {
-                send_key 'ctrl';    # end screenlock
+                send_key 'esc';    # end screenlock
                 diag("Screen lock present");
             };
             next;    # Go directly to assert_screen, skip wait_still_screen (and don't collect $200)


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16536

This breaks current SLES tests. Let's revert and find a better way.

Examples:

* https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=12-SP3&build=20230305-1&groupid=414
* https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=12-SP4&build=20230305-1&groupid=414
* https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP3&build=20230305-1&groupid=414
* https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP1&build=20230305-1&groupid=414
* https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=12-SP5&build=20230305-1&groupid=414