### PR TITLE
Fix broken lockscreen on SLES

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -179,7 +179,8 @@ sub ensure_unlocked_desktop {
         die 'ensure_unlocked_desktop repeated too much. Check for X-server crash.' if ($counter eq 1);    # die loop when generic-desktop not matched
         if (match_has_tag('screenlock') || match_has_tag('blackscreen')) {
             wait_screen_change {
-                send_key 'ctrl';    # end screenlock
+                # ESC of KDE turns the monitor off and CTRL does not work on older SLES versions to unlock the screen
+                send_key(is_sle("<15-SP4") ? 'esc' : 'ctrl');    # end screenlock
                 diag("Screen lock present");
             };
             next;    # Go directly to assert_screen, skip wait_still_screen (and don't collect $200)


### PR DESCRIPTION
Fix the broken unlocking of the lockscreen on all SLES versions.

- Related ticket: https://progress.opensuse.org/issues/125414
- Verification run: [TW Gnome live](https://duck-norris.qe.suse.de/tests/12317) | [TW XFCE live](https://duck-norris.qe.suse.de/tests/12318) | [TW KDE live](https://duck-norris.qe.suse.de/tests/12316) | [12-SP5 consoletest_finish](https://duck-norris.qe.suse.de/tests/12319) | [12-SP5 shutdown](https://duck-norris.qe.suse.de/tests/12320) | [15-SP3 python_liblouis](https://duck-norris.qe.suse.de/tests/12321) (fails in different module) | [15-SP3 shutdown](https://duck-norris.qe.suse.de/tests/12320) | [15-SP5](https://duck-norris.qe.suse.de/tests/12323)
