### PR TITLE
Implement mr test on GCE: product + maintenance

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -11,6 +11,7 @@ terraform:
     monitoring_os_major_version: "%HANA_OS_MAJOR_VERSION%"
     drdb_os_major_version: "%HANA_OS_MAJOR_VERSION%"
     netweaver_os_major_version: "%HANA_OS_MAJOR_VERSION%"
+    bastion_os_major_version: "%HANA_OS_MAJOR_VERSION%"
     private_key: "~/.ssh/id_rsa"
     public_key: "~/.ssh/id_rsa.pub"
     gcp_credentials_file: "/root/google_credentials.json"

--- a/schedule/sles4sap/sles4sap_gnome_saptune_product.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_product.yaml
@@ -1,0 +1,26 @@
+---
+name: sles4sap_gnome_saptune
+description: >
+  saptune tests for SLES4SAP on VM's
+
+vars:
+  BOOTFROM: c
+  BOOT_HDD_IMAGE: '1'
+  NODE_COUNT: '1'
+  TEST_CONTEXT: 'OpenQA::Test::RunArgs'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
+  # START_AFTER_TEST: create_hdd_sles4sap_gnome
+schedule:
+  - boot/boot_to_desktop
+  - '{{PC_instance_ssh_interactive_start}}'
+  - sles4sap/saptune/mr_test
+conditional_schedule:
+  PC_instance_ssh_interactive_start:
+    PUBLIC_CLOUD_SLES4SAP:
+      '1':
+        - sles4sap/publiccloud/qesap_terraform
+        - sles4sap/publiccloud/mr_test_setup_env
+        - publiccloud/registration
+        - publiccloud/ssh_interactive_start
+        - publiccloud/instance_overview

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -21,6 +21,7 @@
 
 
 use base 'sles4sap_publiccloud_basetest';
+use publiccloud::ssh_interactive 'select_host_console';
 use strict;
 use warnings;
 use testapi;
@@ -154,6 +155,9 @@ sub run {
     my $workspace = get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qesapopenqa');
     $workspace .= sprintf("%04x", rand(0xffff));
 
+    # Select console on the host (not the PC instance) to reset 'TUNNELED',
+    # otherwise select_serial_terminal() will be failed
+    select_host_console();
     select_serial_terminal();
 
     # Collect OpenQA variables and default values


### PR DESCRIPTION
Implement mr test on GCE: product + maintenance

TEAM-6928 - [AC15+A16]Implement mr test on GCE
  AC15 - GCE product QA (incl. AC2+AC6+AC7)
  AC16 - GCE maintenance QA (incl. AC2+AC4+AC5)

Related MR (for 15sp5 scheduling part): https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1108

NOTE: 
1. Production 15sp5 use the latest Public Cloud tool "publiccloud_tools_0049.qcow2" not "*_0037.qcow2"
2. In test settings I used qe_sap_deployment version '0.6.0' so I have to set "bastion_os_major_version" again otherwise qesap_terraform will failed.

- Related ticket: https://jira.suse.com/browse/TEAM-6928
- Needles: NA
- Verification run:
  BYOS: http://openqa.suse.de/tests/10634611#dependencies (all passed)
  PAYG: http://openqa.suse.de/tests/10634828#dependencies (all passed)