### PR TITLE
MicroOS: Stop running zypper modules twice after boot

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -34,11 +34,6 @@ sub is_regproxy_required {
 }
 
 sub load_config_tests {
-    if (is_microos && !is_staging) {
-        loadtest 'update/zypper_clear_repos';
-        loadtest 'console/zypper_ar';
-        loadtest 'console/zypper_ref';
-    }
     loadtest 'transactional/tdup' if get_var('TDUP');
     loadtest 'transactional/host_config' unless is_dvd;
     loadtest 'rt/rt_is_realtime' if is_rt;


### PR DESCRIPTION
These are scheduled twice due to`replace_opensuse_repos_tests` and also scheduling it in `load_config_tests` function.

VR: https://openqa.opensuse.org/t3159229