### PR TITLE
Prevent conditiom to run when return code is success code

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -131,7 +131,7 @@ sub run ($self) {
             }
         } else {
             ##TODO: condider more rebust handling of various errors
-            die("echo $return - not expected errorcode");
+            die("echo $return - not expected errorcode") unless $return == 0;
         }
     } else {
         record_info 'testing IMB', 'Run all IMB-MPI1 components';


### PR DESCRIPTION
The softfail should run only on return error code and the else should never run when the code is success. Instead should continue to the outter else statement.


- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
