### PR TITLE
Enable FIPS testing for SLED - Core maintenance

### DIFF
--- a/schedule/qam/15-SP4/qam-regression-firefox_fips.yaml
+++ b/schedule/qam/15-SP4/qam-regression-firefox_fips.yaml
@@ -1,0 +1,30 @@
+---
+name: qam-regression-firefox with fips enabled for Vendor Affirmation
+schedule:
+- boot/boot_to_desktop
+- fips/fips_setup
+- console/prepare_test_data
+- x11/window_system
+- x11/disable_screensaver
+- x11/firefox/firefox_smoke
+- x11/firefox/firefox_urlsprotocols
+# https://progress.opensuse.org/issues/113435
+# - x11/firefox/firefox_downloading
+- x11/firefox/firefox_changesaving
+- x11/firefox/firefox_fullscreen
+- x11/firefox/firefox_localfiles
+- x11/firefox/firefox_headers
+- x11/firefox/firefox_pdf
+- x11/firefox/firefox_pagesaving
+- x11/firefox/firefox_private
+- x11/firefox/firefox_extensions
+- x11/firefox/firefox_appearance
+- x11/firefox/firefox_passwd
+- x11/firefox/firefox_html5
+- x11/firefox/firefox_developertool
+- x11/firefox/firefox_ssl
+- x11/firefox/firefox_emaillink
+- x11/firefox/firefox_plugins
+- x11/firefox/firefox_extcontent
+- x11/firefox_audio
+...

--- a/schedule/qam/15-SP4/qam-regression-other_fips.yaml
+++ b/schedule/qam/15-SP4/qam-regression-other_fips.yaml
@@ -1,0 +1,22 @@
+---
+name: qam regression other tests with fips enabled for Vendor Affirmation
+schedule:
+- boot/boot_to_desktop
+- fips/fips_setup
+- x11/window_system
+- console/consoletest_setup
+- x11/brasero/brasero_launch
+- x11/gnome_documents
+- x11/totem/totem_launch
+- x11/gnome_control_center
+- x11/gnome_tweak_tool
+- x11/seahorse
+- x11/gnome_music
+- x11/tracker/prep_tracker
+- x11/tracker/tracker_by_command
+- x11/tracker/tracker_info
+- x11/tracker/tracker_search_in_nautilus
+- x11/tracker/clean_tracker
+- fips/openjdk/openjdk_fips
+- fips/openjdk/openjdk_ssh
+...


### PR DESCRIPTION
https://progress.opensuse.org/issues/125195
https://bugzilla.suse.com/show_bug.cgi?id=1208951

- Verification run: 
[Firefox-with fips](https://openqa.suse.de/tests/10633356)
[Firefox-non-fips](http://openqa.suse.de/tests/10633358)
[SLED-others](http://openqa.suse.de/tests/10626751)