### PR TITLE
Fix rmt-chinese issue

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -295,11 +295,7 @@ sub handle_login {
     handle_additional_polkit_windows($mypwd) if check_screen([qw(authentication-required-user-settings authentication-required-modify-system)], 15);
     assert_screen([qw(generic-desktop gnome-activities opensuse-welcome)], 180);
     if (match_has_tag('gnome-activities')) {
-        send_key_until_needlematch [qw(generic-desktop opensuse-welcome language-change-required-update-folder)], 'esc';
-        if (match_has_tag('language-change-required-update-folder')) {
-            assert_and_click('reserve_old_folder_name');
-            assert_screen([qw(generic-desktop opensuse-welcome)]);
-        }
+        send_key_until_needlematch [qw(generic-desktop opensuse-welcome)], 'esc', 5, 10;
     }
 }
 

--- a/tests/x11/rmt/rmt_chinese.pm
+++ b/tests/x11/rmt/rmt_chinese.pm
@@ -29,7 +29,7 @@ sub set_language_to_Chinese {
     select_console 'x11', await_console => 0;
     wait_still_screen 15;
     ensure_unlocked_desktop;
-    assert_screen "generic-desktop";
+    assert_screen 'generic-desktop';
 
     x11_start_program('xterm');
     wait_still_screen 2, 2;
@@ -52,6 +52,11 @@ sub set_language_to_Chinese {
 
     # Logout and login to ensure the configuration for Chinese language take effect.
     handle_relogin;
+
+    # Reserve old folder name and close dialog of requirement for language change to update folder
+    assert_screen 'language-change-required-update-folder';
+    assert_and_click('reserve_old_folder_name');
+    assert_screen 'generic-desktop';
 
     x11_start_program('gnome-terminal');
     wait_still_screen 2, 2;


### PR DESCRIPTION
 Update code to select 'reserve_old_folder_name' and close the dialog of language-change-required-update-folder to fix rmt_test issue.

- Related ticket: https://progress.opensuse.org/issues/125351
- Needles: needles related already merged in OSD.
- Verification run:http://openqa.nue.suse.com/tests/10647288#