### PR TITLE
Add recognition of 'disabled for FIPS' error msg

### DIFF
--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -45,7 +45,7 @@ sub run {
     my @invalid_hash = ("md4", "md5", "mdc2", "rmd160", "ripemd160", "whirlpool", "md5-sha1");
     for my $hash (@invalid_hash) {
         eval {
-            validate_script_output "openssl dgst -$hash $tmp_file 2>&1 || true", sub { m/$hash is not a known digest|unknown option|Unknown digest|dgst: Unrecognized flag/ };
+            validate_script_output "openssl dgst -$hash $tmp_file 2>&1 || true", sub { m/$hash is not a known digest|unknown option|Unknown digest|dgst: Unrecognized flag|disabled for FIPS|disabled for fips/ };
         };
         if ($@) {
             record_soft_failure 'bsc#1193859';


### PR DESCRIPTION
OpenSSL versions have different messages about crypto/hashing algorithms disabled in FIPS mode. We try to match all with a single regular expression

- Related ticket: https://progress.opensuse.org/issues/125456
- Verification runs: 
   - https://openqa.suse.de/tests/10629764#step/openssl_fips_hash/28
   - https://openqa.suse.de/tests/10629787#step/openssl_fips_hash/28
   - https://openqa.suse.de/tests/10629788#step/openssl_fips_hash/28
   - https://openqa.suse.de/tests/10629789#step/openssl_fips_hash/28
   - https://openqa.suse.de/tests/10629790#step/openssl_fips_hash/28
   - https://openqa.suse.de/tests/10629791#step/openssl_fips_hash/28
   - https://openqa.suse.de/tests/10629792#step/openssl_fips_hash/28

    
    
    

