### PR TITLE
podman_pods: set replica count to 1 in hello-kubic.yaml

### DIFF
--- a/data/containers/hello-kubic.yaml
+++ b/data/containers/hello-kubic.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: hello-kubic
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: hello-kubic

--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -6,7 +6,7 @@
 # Package: podman
 # Summary: Test podman pods functionality
 # - Use data/containers/hello-kubic.yaml to run pods
-# - Confirm 3 pods are spawned
+# - Confirm 1 pod is spawned
 # - Clean up pods using hello-kubic.yaml
 # Maintainer: Richard Brown <rbrown@suse.com>
 
@@ -28,13 +28,12 @@ sub run {
 
     record_info('Test', 'Confirm pods are running');
     record_info('pod ps', script_output('podman pod ps'));
-    assert_script_run('podman pod ps | grep "Running" | wc -l | grep -q 3');
+    assert_script_run('podman pod ps | grep "Running" | wc -l | grep -q 1');
 
     record_info('Test', 'Killing one pod');
     assert_script_run('podman pod stop $(podman pod ps -q | head -n1)');
 
     record_info('Test', 'Confirm one pod has been killed');
-    assert_script_run('podman pod ps | grep "Running" | wc -l | grep -q 2');
     assert_script_run('podman pod ps | grep "Exited" | wc -l | grep -q 1');
 
     if (is_sle('15-SP3+') || is_opensuse()) {


### PR DESCRIPTION
Since version 4.4.0, podman will limit the number of replicas to 1 when using podman play kube. Thus it makes no sense anymore to have it set to 3 as that avoids additional branches depending on the podman version. (Also, supporting replicas was never really intended upstream and thus we shouldn't have tested it anyway.)

- Related ticket: fix for https://build.opensuse.org/request/show/1068441
- Needles: Not required
- Verification run: https://openqa.opensuse.org/tests/3161257
