### PR TITLE
Move fips tests from main_common to yaml

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2222,140 +2222,9 @@ sub load_security_console_prepare {
     loadtest "console/yast2_vnc" if (get_var("FIPS_ENABLED") && is_pvm);
 }
 
-# The function name load_security_tests_crypt_* is to avoid confusing
-# since openSUSE does NOT have FIPS mode
-# Some tests are valid only for FIPS Regression testing. Use
-# "FIPS_ENABLED" to control whether to run these "FIPS only" cases
-sub load_security_tests_crypt_core {
-    load_security_console_prepare;
-
-    if (get_var('FIPS_ENABLED')) {
-        loadtest "fips/openssl/openssl_fips_alglist";
-        loadtest "fips/openssl/openssl_fips_hash";
-        loadtest "fips/openssl/openssl_fips_cipher";
-        loadtest "fips/openssl/dirmngr_setup";
-        loadtest "fips/openssl/dirmngr_daemon";    # dirmngr_daemon needs to be tested after dirmngr_setup
-        loadtest "fips/gnutls/gnutls_base_check";
-        loadtest "fips/gnutls/gnutls_server";
-        loadtest "fips/gnutls/gnutls_client";
-    }
-    loadtest "fips/openssl/openssl_tlsv1_3";
-    loadtest "fips/openssl/openssl_pubkey_rsa";
-    loadtest "fips/openssl/openssl_pubkey_dsa";
-    loadtest "fips/openssh/openssh_fips" if get_var("FIPS_ENABLED");
-    loadtest "console/sshd";
-    loadtest "console/ssh_cleanup";
-}
-
-
-sub load_security_tests_crypt_web {
-    load_security_console_prepare;
-
-    loadtest "console/curl_https";
-    loadtest "console/wget_https";
-    loadtest "console/w3m_https";
-    if (is_sle('15+') || is_tumbleweed) {
-        loadtest "console/links_https";
-        loadtest "console/lynx_https";
-    }
-    loadtest "console/apache_ssl";
-    if (get_var('FIPS_ENABLED')) {
-        loadtest "fips/mozilla_nss/apache_nssfips";
-        loadtest "console/libmicrohttpd" if is_sle('<15');
-    }
-}
-
-sub load_security_tests_crypt_kernel {
-    load_security_console_prepare;
-
-    loadtest "console/cryptsetup";
-    loadtest "security/dm_crypt";
-}
-
-sub load_security_tests_crypt_x11 {
-    set_var('SECTEST_REQUIRE_WE', 1);
-    load_security_console_prepare;
-
-    # In SLE, hexchat and seahorse are provided only in WE addon which is for
-    # x86_64 platform only.
-    if (is_x86_64) {
-        loadtest "x11/seahorse_sshkey";
-        loadtest "x11/hexchat_ssl";
-    }
-    loadtest "x11/x3270_ssl";
-}
-
-sub load_security_tests_crypt_firefox {
-    load_security_console_prepare;
-
-    loadtest "fips/mozilla_nss/firefox_nss" if get_var('FIPS_ENABLED');
-}
-
-sub load_security_tests_crypt_openjdk {
-    load_security_console_prepare;
-
-    if (get_var('FIPS_ENABLED')) {
-        loadtest "fips/openjdk/openjdk_fips";
-        loadtest "fips/openjdk/openjdk_ssh";
-    }
-}
-
-sub load_security_tests_crypt_tool {
-    load_security_console_prepare;
-
-    if (get_var('FIPS_ENABLED')) {
-        loadtest "fips/curl_fips_rc4_seed";
-        loadtest "console/aide_check";
-    }
-    loadtest "console/gpg";
-    loadtest "console/journald_fss";
-    loadtest "console/git";
-    loadtest "console/clamav";
-    loadtest "console/openvswitch_ssl";
-    loadtest "console/ntp_client";
-    loadtest "console/cups";
-    loadtest "console/syslog";
-    loadtest "x11/evolution/evolution_prepare_servers";
-    loadtest "console/mutt";
-}
-
-sub load_security_tests_crypt_libtool {
-    load_security_console_prepare;
-
-    loadtest "fips/libtool/liboauth";
-}
-
 sub load_security_tests_fips_setup {
     # Setup system into fips mode
     loadtest "fips/fips_setup";
-}
-
-sub load_security_tests_ipsec {
-    load_security_console_prepare;
-
-    loadtest "console/ipsec_tools_h2h";
-}
-
-sub load_security_tests_mmtest {
-    load_security_console_prepare;
-
-    # Load client tests by APPTESTS variable
-    load_applicationstests;
-}
-
-sub load_security_tests_yast2_users {
-    load_security_console_prepare;
-
-    loadtest "security/yast2_users/add_users";
-}
-
-sub load_security_tests_cc_audit_remote_libvirt {
-    # Setup environment for cc testing: 'audit-test' test suite setup
-    # Such as: download code branch; install needed packages
-    loadtest 'security/cc/cc_audit_test_setup';
-
-    # Run test cases of 'audit-test' test suite which do NOT need SELinux env
-    loadtest 'security/cc/audit_remote_libvirt';
 }
 
 sub load_security_tests_mok_enroll {
@@ -2452,12 +2321,8 @@ sub load_mitigation_tests {
 
 sub load_security_tests {
     my @security_tests = qw(
-      fips_setup crypt_core crypt_web crypt_kernel crypt_x11 crypt_firefox crypt_tool crypt_openjdk
-      crypt_libtool
-      ipsec mmtest
-      yast2_users
+      fips_setup
       mok_enroll
-      cc_audit_remote_libvirt
     );
 
     # Check SECURITY_TEST and call the load functions iteratively.

--- a/schedule/security/cc_audit_remote_libvirt.yaml
+++ b/schedule/security/cc_audit_remote_libvirt.yaml
@@ -1,0 +1,7 @@
+name: cc_audit_remote_libvirt
+description:    >
+    This is for audit-remote-libvirt test in CC system role
+schedule:
+    - boot/boot_to_desktop
+    - security/cc/cc_audit_test_setup
+    - security/cc/audit_remote_libvirt

--- a/schedule/security/fips_crypt_core.yaml
+++ b/schedule/security/fips_crypt_core.yaml
@@ -1,0 +1,45 @@
+name: fips_crypt_core
+description:    >
+    This is for the crypt_core fips tests.
+schedule:
+    - '{{bootloader_s390}}'
+    - '{{bootloader_ppc}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - '{{y2_vnc_pvm}}'
+    - fips/openssl/openssl_fips_alglist
+    - fips/openssl/openssl_fips_hash
+    - fips/openssl/openssl_fips_cipher
+    - fips/openssl/dirmngr_setup
+    - fips/openssl/dirmngr_daemon
+    - fips/gnutls/gnutls_base_check
+    - fips/gnutls/gnutls_server
+    - fips/gnutls/gnutls_client
+    - fips/openssl/openssl_tlsv1_3
+    - fips/openssl/openssl_pubkey_rsa
+    - fips/openssl/openssl_pubkey_dsa
+    - fips/openssh/openssh_fips
+    - console/sshd
+    - console/ssh_cleanup
+conditional_schedule:
+    bootloader_s390:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    bootloader_ppc:
+        BACKEND:
+            pvm_hmc:
+                - installation/bootloader
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup
+    y2_vnc_pvm:
+        BACKEND:
+            pvm_hmc:
+                - console/yast2_vnc

--- a/schedule/security/fips_crypt_firefox.yaml
+++ b/schedule/security/fips_crypt_firefox.yaml
@@ -1,0 +1,32 @@
+name: fips_crypt_firefox
+description:    >
+    This is for the crypt_firefox fips tests.
+schedule:
+    - '{{bootloader_s390}}'
+    - '{{bootloader_ppc}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - '{{y2_vnc_pvm}}'
+    - fips/mozilla_nss/firefox_nss
+conditional_schedule:
+    bootloader_s390:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    bootloader_ppc:
+        BACKEND:
+            pvm_hmc:
+                - installation/bootloader
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup
+    y2_vnc_pvm:
+        BACKEND:
+            pvm_hmc:
+                - console/yast2_vnc

--- a/schedule/security/fips_crypt_kernel.yaml
+++ b/schedule/security/fips_crypt_kernel.yaml
@@ -1,0 +1,33 @@
+name: fips_crypt_kernel
+description:    >
+    This is for the crypt_kernel fips tests.
+schedule:
+    - '{{bootloader_s390}}'
+    - '{{bootloader_ppc}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - '{{y2_vnc_pvm}}'
+    - console/cryptsetup
+    - security/dm_crypt
+conditional_schedule:
+    bootloader_s390:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    bootloader_ppc:
+        BACKEND:
+            pvm_hmc:
+                - installation/bootloader
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup
+    y2_vnc_pvm:
+        BACKEND:
+            pvm_hmc:
+                - console/yast2_vnc

--- a/schedule/security/fips_crypt_openjdk.yaml
+++ b/schedule/security/fips_crypt_openjdk.yaml
@@ -1,0 +1,33 @@
+name: fips_crypt_openjdk
+description:    >
+    This is for the crypt_openjdk fips tests.
+schedule:
+    - '{{bootloader_s390}}'
+    - '{{bootloader_ppc}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - '{{y2_vnc_pvm}}'
+    - fips/openjdk/openjdk_fips
+    - fips/openjdk/openjdk_ssh
+conditional_schedule:
+    bootloader_s390:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    bootloader_ppc:
+        BACKEND:
+            pvm_hmc:
+                - installation/bootloader
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup
+    y2_vnc_pvm:
+        BACKEND:
+            pvm_hmc:
+                - console/yast2_vnc

--- a/schedule/security/fips_crypt_tool.yaml
+++ b/schedule/security/fips_crypt_tool.yaml
@@ -1,0 +1,43 @@
+name: fips_crypt_tool
+description:    >
+    This is for the crypt_tool fips tests.
+schedule:
+    - '{{bootloader_s390}}'
+    - '{{bootloader_ppc}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - '{{y2_vnc_pvm}}'
+    - fips/curl_fips_rc4_seed
+    - console/aide_check
+    - console/gpg
+    - console/journald_fss
+    - console/git
+    - console/clamav
+    - console/openvswitch_ssl
+    - console/ntp_client
+    - console/cups
+    - console/syslog
+    - x11/evolution/evolution_prepare_servers
+    - console/mutt
+conditional_schedule:
+    bootloader_s390:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    bootloader_ppc:
+        BACKEND:
+            pvm_hmc:
+                - installation/bootloader
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup
+    y2_vnc_pvm:
+        BACKEND:
+            pvm_hmc:
+                - console/yast2_vnc

--- a/schedule/security/fips_crypt_web.yaml
+++ b/schedule/security/fips_crypt_web.yaml
@@ -1,0 +1,38 @@
+name: fips_crypt_web
+description:    >
+    This is for the crypt_web fips tests.
+schedule:
+    - '{{bootloader_s390}}'
+    - '{{bootloader_ppc}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - '{{y2_vnc_pvm}}'
+    - console/curl_https
+    - console/wget_https
+    - console/w3m_https
+    - console/links_https
+    - console/lynx_https
+    - console/apache_ssl
+    - fips/mozilla_nss/apache_nssfips
+conditional_schedule:
+    bootloader_s390:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    bootloader_ppc:
+        BACKEND:
+            pvm_hmc:
+                - installation/bootloader
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup
+    y2_vnc_pvm:
+        BACKEND:
+            pvm_hmc:
+                - console/yast2_vnc

--- a/schedule/security/fips_crypt_x11.yaml
+++ b/schedule/security/fips_crypt_x11.yaml
@@ -1,0 +1,38 @@
+name: fips_crypt_x11
+description:    >
+    This is for the crypt_x11 fips tests.
+schedule:
+    - '{{bootloader_s390}}'
+    - '{{bootloader_ppc}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - '{{y2_vnc_pvm}}'
+    - '{{tests_for_64bit}}'
+    - x11/x3270_ssl
+conditional_schedule:
+    bootloader_s390:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    bootloader_ppc:
+        BACKEND:
+            pvm_hmc:
+                - installation/bootloader
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup
+    y2_vnc_pvm:
+        BACKEND:
+            pvm_hmc:
+                - console/yast2_vnc
+    tests_for_64bit:
+        ARCH:
+            x86_64:
+                - x11/seahorse_sshkey
+                - x11/hexchat_ssl

--- a/schedule/security/yast2_users.yaml
+++ b/schedule/security/yast2_users.yaml
@@ -1,0 +1,18 @@
+name: yast2_users
+description:    >
+    This is for the yast2_users test.
+schedule:
+    - '{{bootloader_s390}}'
+    - '{{bootloader_ppc}}'
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - security/yast2_users/add_users
+conditional_schedule:
+    bootloader_s390:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm
+    bootloader_ppc:
+        BACKEND:
+            pvm_hmc:
+                - installation/bootloader


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/124253
- Verification runs:
  - 15sp5: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=77.1&groupid=431
    - aarch64 didn't run due to an unrelated issue
  - 15sp4: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=20230308-1&groupid=431