### PR TITLE
Change hotkey for SLES 15-SP5 back

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -66,8 +66,7 @@ sub get_product_shortcuts {
         # Full (15-SP4)     s
         return (sles => 's') if (get_var('ISO') =~ /Full/ && is_ppc64le() && get_var('NTLM_AUTH_INSTALL'));
         return (
-            sles => (is_sle '15-SP5+') ? 's'    # for now treat 15-SP5+ as if they would have new shortcuts
-            : (is_ppc64le() || is_s390x()) ? 'u'    # s390 doesn't have a product selection screen for now
+            (is_ppc64le() || is_s390x()) ? 'u'    # s390 doesn't have a product selection screen for now
             : is_aarch64() ? 's'
             : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/) && (get_var('FLAVOR') =~ /Full-QR/)) ? 'i'    # this is used by QU/QR
             : ((is_sle '=15-SP4') && (get_var('ISO') =~ /Full/)) ? 's'    # this is used be Maintenance Test Repo


### PR DESCRIPTION
* **SLES** 15-SP5 hotkey changed in PublicBeta with yast installation, which was fixed by the following two pull requests consecutively: [pr#16368](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16368) and [pr#16366](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16366).

* **Recently** I tried to do verification run with a personal test branch with Build73.2, it seems that the installer of which updates itself again to use "alt+i" to select SLES prodcut, although a [previous run](https://openqa.suse.de/tests/10562859#step/welcome/5) passed. 

* **But** the latest re-run with the same build [failed at "welcome" step](https://openqa.suse.de/tests/10636153#step/welcome/6) again.

* **I** think we may need to way a new build to see whether there is really a change. So it is not urgent to merge this pull request at the moment. I opened this pull request to track this issue.

* **Welcome** have a look @foursixnine  @rakoenig Joaquin Rivera

* **Verification runs:** TO BE DONE