### PR TITLE
Avoid adding openqa repo in leap

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -79,7 +79,7 @@ sub start_online_update {
             if (is_tumbleweed()) {
                 zypper_call("ar -f http://download.opensuse.org/ports/$repo_arch/update/tumbleweed repo-update");
             } else {
-                 zypper_call("ar -f http://download.opensuse.org/ports/update/$update_name repo-update");
+                zypper_call("ar -f http://download.opensuse.org/ports/update/$update_name repo-update");
             }
         }
         select_console 'x11', await_console => 0;

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -79,18 +79,19 @@ sub start_online_update {
             if (is_tumbleweed()) {
                 zypper_call("ar -f http://download.opensuse.org/ports/$repo_arch/update/tumbleweed repo-update");
             } else {
-                zypper_call("ar -f http://download.opensuse.org/ports/update/$update_name repo-update");
+                 zypper_call("ar -f http://download.opensuse.org/ports/update/$update_name repo-update");
             }
         }
         select_console 'x11', await_console => 0;
     }
     assert_and_click 'yast2_control-center_online-update';
-    my @tags = qw(yast2_control-center_update-repo-dialogue yast2_control-center_online-update_close yast2_control-center-ask_packagekit_to_quit);
+    my @tags = qw(yast2_control-center_update-repo-dialogue yast2_control-center_online-update_close yast2_control-center-ask_packagekit_to_quit yast2_control-center-no-update-repo);
     do {
         assert_screen \@tags;
         wait_screen_change { send_key 'alt-n' } if match_has_tag('yast2_control-center_update-repo-dialogue');
         # Let it kill PackageKit, in case it is running.
         wait_screen_change { send_key 'alt-y' } if match_has_tag('yast2_control-center-ask_packagekit_to_quit');
+        wait_screen_change { send_key 'alt-y' } if match_has_tag('yast2_control-center-no-update-repo');
     } until (match_has_tag('yast2_control-center_online-update_close'));
 
     send_key 'alt-c';


### PR DESCRIPTION
Avoid removing official repos and add openQA repos twice in aarch Leap 15.5 through set KEEP_ONLINE_REPOS=1.

- Related ticket: https://progress.opensuse.org/issues/124889
- Needles: yast2_control-center-no-update-repo, yast2_control-center_online-update_close already merged in OSD.
-  Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/283
- Verification run:  https://openqa.opensuse.org/tests/3161815#step/yast2_control_center/39