### PR TITLE
Revert "MicroOS: Stop running zypper modules twice after boot"

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -34,6 +34,11 @@ sub is_regproxy_required {
 }
 
 sub load_config_tests {
+    if (is_microos && !is_staging) {
+        loadtest 'update/zypper_clear_repos';
+        loadtest 'console/zypper_ar';
+        loadtest 'console/zypper_ref';
+    }
     loadtest 'transactional/tdup' if get_var('TDUP');
     loadtest 'transactional/host_config' unless is_dvd;
     loadtest 'rt/rt_is_realtime' if is_rt;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16543

Breaks DVD installation:
https://openqa.opensuse.org/tests/3162305#

https://progress.opensuse.org/issues/125555