### PR TITLE
Remove softfail from firefox_nss test

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -87,7 +87,6 @@ sub run {
     }
     clear_console;
     select_console 'x11';
-    return record_soft_failure('bsc#1200325 - firefox_nss can no longer open https webpages in FIPS Mode') if (is_sle('=15-sp4') && get_var('FIPS_ENABLED'));
     x11_start_program('firefox https://html5test.opensuse.org', target_match => 'firefox-html-test', match_timeout => 360);
 
     # Firefox Preferences
@@ -171,7 +170,8 @@ sub run {
 
         # Add max_interval while type password and extend time of click needle match
         type_string($fips_password, timeout => 10, max_interval => 30);
-        assert_and_click('firefox-enter-password-OK', timeout => 120);
+        send_key 'ret', wait_screen_change => 1;    # Confirm password
+
         wait_still_screen 30;
 
         # Add a condition to avoid the password missed input


### PR DESCRIPTION
Also replace a needle-based click with a simple keypress, because on password input the dialog box has the focus 

- Related ticket: https://progress.opensuse.org/issues/125198
- Verification runs: 
  - https://openqa.suse.de/tests/10636154
  - https://openqa.suse.de/tests/10636233
  - https://openqa.suse.de/tests/10636234
  - https://openqa.suse.de/tests/10636236
  - https://openqa.suse.de/tests/10636542
  - https://openqa.suse.de/tests/10636542 
  - https://openqa.suse.de/tests/10636154
  - https://openqa.suse.de/tests/10641011
