### PR TITLE
lib/x11utils: ensure_unlocked_desktop: Don't wait until xscreensaver disappears

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -75,9 +75,9 @@ sub ensure_unlocked_desktop {
 
     # press key to update screen, wait shortly before and after to not match cached screen
     my $wait_time = get_var('UPGRADE') ? 10 : 3;
-    wait_still_screen($wait_time);
+    wait_still_screen($wait_time, timeout => 15);
     send_key 'ctrl';
-    wait_still_screen($wait_time);
+    wait_still_screen($wait_time, timeout => 15);
     while ($counter--) {
         my @tags = qw(displaymanager displaymanager-password-prompt generic-desktop screenlock screenlock-password authentication-required-user-settings authentication-required-modify-system guest-disabled-display oh-no-something-has-gone-wrong);
         push(@tags, 'blackscreen') if get_var("DESKTOP") =~ /minimalx|xfce/;    # Only xscreensaver and xfce have a blackscreen as screenlock


### PR DESCRIPTION
Previously it pressed a key to "update the screen" and then did a wait_still_screen which timed out because of the animated xscreensaver prompt. That caused the prompt to disappear again before it entered the password.

Ideally the second wait_still_screen gets removed, but to avoid introducing some regression somewhere the timeout is halved instead.

Verification run: https://openqa.opensuse.org/t3162560
