### PR TITLE
tests/container: PR review follow-up for #16567

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -161,7 +161,7 @@ sub verify_userid_on_container {
     # https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16567
     my $podman_version = get_podman_version();
     if (package_version_cmp($podman_version, '4.4.0') >= 0) {
-        my $huser_name = script_output "whoami";
+        my $huser_name = $testapi::username;
         validate_script_output "podman top $cid user huser", sub { /${huser_name}\s+${id}/ };
     } else {
         validate_script_output "podman top $cid user huser", sub { /1000\s+${id}/ };


### PR DESCRIPTION
Follows-up with left-over reviews for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16567
