### PR TITLE
Add default gnome and kde badges to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 os-autoinst/openQA tests for openSUSE and SUSE Linux Enterprise [![Build Status](https://github.com/os-autoinst/os-autoinst-distri-opensuse/workflows/ci/badge.svg)](https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions)
+
+
+- Gnome on Tumbleweed: [![Gnome on Tumbleweed](https://openqa.opensuse.org/tests/latest/badge?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=gnome&version=Tumbleweed)](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=gnome&version=Tumbleweed)
+- KDE on Tumbleweed: [![KDE on Tumbleweed](https://openqa.opensuse.org/tests/latest/badge?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=kde&version=Tumbleweed)](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=kde&version=Tumbleweed)
+
 =================================================================================================================================================================================================================================
 os-autoinst-distri-opensuse is repo which contains tests, which are executed
 by openQA for openSUSE and SLE distributions.


### PR DESCRIPTION
Since https://github.com/os-autoinst/openQA/pull/5022 enables badges on o3, we can now add that to multiple places, not only to showcase but also as a visual aid, especially on PR.

z![image](https://user-images.githubusercontent.com/229240/223724591-d6f7f7f0-7796-431a-b51a-ddf732a56640.png)
