### PR TITLE
Boottime measures triggered at P.C. instance creation

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -22,6 +22,7 @@ use utils;
 use db_utils;
 use Mojo::Util 'trim';
 use Data::Dumper;
+use mmapi qw(get_current_job_id);
 
 use constant SSH_TIMEOUT => 90;
 
@@ -555,14 +556,16 @@ sub store_boottime_db() {
     my $token = get_var('_PUBLIC_CLOUD_PERF_DB_TOKEN');
     unless ($url && $token) {
         record_info("WARN", "PUBLIC_CLOUD_PERF_DB_URI or _PUBLIC_CLOUD_PERF_DB_TOKEN is missing ", result => 'fail');
-        return;
+        return -1;
     }
+
     my $org = get_var('PUBLIC_CLOUD_PERF_DB_ORG', 'qec');
     my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf');
 
     my $tags = {
         instance_type => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
-        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
+        job_id => get_current_job_id(),
+        os_provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
         os_build => get_required_var('BUILD'),
         os_flavor => get_required_var('FLAVOR'),
         os_version => get_required_var('VERSION'),

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -18,6 +18,10 @@ use Utils::Backends qw(set_sshserial_dev unset_sshserial_dev);
 use publiccloud::ssh_interactive qw(ssh_interactive_tunnel ssh_interactive_leave select_host_console);
 use version_utils;
 use utils;
+# for boottime checks
+use db_utils;
+use Mojo::Util 'trim';
+use Data::Dumper;
 
 use constant SSH_TIMEOUT => 90;
 
@@ -486,5 +490,203 @@ sub network_speed_test() {
     record_info("ping 1.1.1.1", $self->run_ssh_command(cmd => "ping -c30 1.1.1.1", proceed_on_failure => 1, timeout => 600));
     record_info("curl $rmt_host", $self->run_ssh_command(cmd => "curl -w '$write_out' -o /dev/null -v https://$rmt_host/", proceed_on_failure => 1));
 }
+
+=head2 measure_boottime
+
+    measure_boottime();
+
+Perfomrance measurement of the system Boot time. 
+Mainly used C<systemd-analyze> command for the data extraction.
+Data is then collected in an internal record, ready for storing in a DB.
+- when PUBLIC_CLOUD_PERF_COLLECT=0 boottime measurement disabled;
+- when bit-0 ON,First reboot only enabled =1;
+- when bit-1 ON, first,softreboot enabled =3 [2 too];
+- when bit-2 ON, first,hardreboot enabled =5 [4 too];
+- when all bits ON,all 3 measures enabled =7 [6 too].
+
+=cut
+
+sub measure_boottime() {
+    my ($self, $instance) = @_;
+    my $perf = get_var('PUBLIC_CLOUD_PERF_COLLECT');
+    return 0 unless ($perf);
+
+    my $softreboot = $perf & 2;    # bit-1 check
+    my $hardreboot = $perf & 4;    # bit-2 check
+
+    my $ret = {
+        kernel_release => undef,
+        kernel_version => undef,
+        analyze => {},
+        blame => {
+            first => {}, soft => {}, hard => {}
+        },
+    };
+    record_info("BOOT TIME", 'systemd_analyze');
+    # first deployment analysis
+    my ($systemd_analyze, $systemd_blame) = do_systemd_analyze($instance);
+    $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
+    $ret->{blame}->{first} = $systemd_blame;
+
+    # Collect kernel version
+    $ret->{kernel_release} = $instance->run_ssh_command(cmd => 'uname -r');
+    $ret->{kernel_version} = $instance->run_ssh_command(cmd => 'uname -v');
+
+    if ($softreboot) {
+        # Do soft reboot
+        my ($shutdown_time, $startup_time) = $instance->softreboot();
+        $ret->{analyze}->{ssh_access_soft} = $startup_time;
+
+        ($systemd_analyze, $systemd_blame) = do_systemd_analyze($instance);
+        $ret->{analyze}->{$_ . '_soft'} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
+        $ret->{blame}->{soft} = $systemd_blame;
+    }
+
+    if ($hardreboot) {
+        # Do hard reboot
+        $instance->stop();
+        $ret->{analyze}->{ssh_access_hard} = $instance->start();
+
+        ($systemd_analyze, $systemd_blame) = do_systemd_analyze($instance);
+        $ret->{analyze}->{$_ . '_hard'} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
+        $ret->{blame}->{hard} = $systemd_blame;
+    }
+
+    # Do logging to openqa UI
+    $Data::Dumper::Sortkeys = 1;
+    record_info("RESULTS", Dumper($ret));
+
+    $instance->run_ssh_command(cmd => 'sudo tar -czvf /tmp/sle_cloud.tar.gz /var/log/cloudregister /var/log/cloud-init.log /var/log/cloud-init-output.log /var/log/messages /var/log/NetworkManager', proceed_on_failure => 1);
+    $instance->upload_log('/tmp/sle_cloud.tar.gz');
+
+    return $ret;
+}
+
+
+=head2 store_in_db
+
+    store_in_db();
+
+Save data collected with measure_boottime in a DB;
+Mainly stored on a remote InfluxDB on a Grafana server.
+
+=cut
+
+sub store_in_db() {
+    my ($self, $results) = @_;
+    return unless (get_var('_PUBLIC_CLOUD_PERF_PUSH_DATA') && $results);
+
+    my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI');
+    return unless ($url);
+
+    my $token = get_var('_PUBLIC_CLOUD_PERF_DB_TOKEN');
+    return unless ($token);
+
+    my $org = get_var('PUBLIC_CLOUD_PERF_DB_ORG', 'qec');
+    my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf');
+
+    my $softreboot = (get_var('PUBLIC_CLOUD_PERF_COLLECT', 0) & 2) or get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME');  # bit-1 check
+    my $hardreboot = (get_var('PUBLIC_CLOUD_PERF_COLLECT', 0) & 4) or get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME');  # bit-2 check
+
+    my $tags = {
+        instance_type => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
+        os_build => get_required_var('BUILD'),
+        os_flavor => get_required_var('FLAVOR'),
+        os_version => get_required_var('VERSION'),
+
+        os_kernel_release => $results->{kernel_release},
+        os_kernel_version => $results->{kernel_version},
+    };
+
+    $tags->{os_pc_build} = get_var('PUBLIC_CLOUD_QAM') ? 'N/A' : get_required_var('PUBLIC_CLOUD_BUILD');
+    $tags->{os_pc_kiwi_build} = get_var('PUBLIC_CLOUD_QAM') ? 'N/A' : get_required_var('PUBLIC_CLOUD_BUILD_KIWI');
+
+    record_info("STORE DATA", 'bootup');
+    # Store values in influx-db
+    my $data = {
+        table => 'bootup',
+        tags => $tags,
+        values => $results->{analyze}
+    };
+    influxdb_push_data($url, $db, $org, $token, $data);
+
+    record_info("STORE DATA", 'bootup_blame');
+    for my $type (qw(first soft hard)) {
+        if ($type == 'soft' && !$softreboot) {
+            next;
+        }
+        if ($type == 'hard' && !$hardreboot) {
+            next;
+        }
+        $tags->{boottype} = $type;
+        $data = {
+            table => 'bootup_blame',
+            tags => $tags,
+            values => $results->{blame}->{$type}
+        };
+        influxdb_push_data($url, $db, $org, $token, $data);
+    }
+}
+
+sub systemd_time_to_sec
+{
+    my $str = trim(shift);
+    if ($str !~ /^(?<check_min>(?<min>\d{1,2})\s*min\s*)?((?<sec>\d{1,2}\.\d{1,3})s|(?<ms>\d+)ms)$/) {
+        die("Unable to parse systemd time '$str'");
+    }
+    my $sec = $+{sec} // $+{ms} / 1000;
+    $sec += $+{min} * 60 if (defined($+{check_min}));
+    return $sec;
+}
+
+sub extract_analyze {
+    my $string = shift;
+    my $res = {};
+    ($string) = split(/\r?\n/, $string, 2);
+    $string =~ s/Startup finished in\s*//;
+    $string =~ s/=(.+)$/+$1 (overall)/;
+    for my $time (split(/\s*\+\s*/, $string)) {
+        $time = trim($time);
+        my ($time, $type) = $time =~ /^(.+)\s*\((\w+)\)$/;
+        $res->{$type} = systemd_time_to_sec($time);
+    }
+    map { die("Fail to detect $_ timing") unless exists($res->{$_}) } qw(kernel initrd userspace overall);
+    return $res;
+}
+
+sub extract_blame {
+    my $string = shift;
+    my $ret = {};
+    for my $line (split(/\r?\n/, $string)) {
+        $line = trim($line);
+        my ($time, $service) = $line =~ /^(.+)\s+(\S+)$/;
+        $ret->{$service} = systemd_time_to_sec($time);
+    }
+    return $ret;
+}
+
+sub do_systemd_analyze {
+    my ($instance, %args) = @_;
+    $args{timeout} = 120;
+    my $start_time = time();
+    my $output = "";
+    my @ret;
+
+    # Wait for guest register, before calling syastemd-analyze
+    $instance->wait_for_guestregister();
+    while ($output !~ /Startup finished in/ && time() - $start_time < $args{timeout}) {
+        $output = $instance->run_ssh_command(cmd => 'systemd-analyze time', proceed_on_failure => 1);
+        sleep 5;
+    }
+
+    die("Unable to get system-analyze in $args{timeout} seconds") unless (time() - $start_time < $args{timeout});
+    push @ret, extract_analyze($output);
+
+    $output = $instance->run_ssh_command(cmd => 'systemd-analyze blame');
+    push @ret, extract_blame($output);
+
+    return @ret;
+}
+
 
 1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -313,6 +313,9 @@ sub create_instances {
             # Install server's ssh publicckeys to prevent authenticity interactions
             assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
         }
+        # Performance data: boottime
+        my $btime = $instance->measure_boottime($instance);
+        $instance->store_in_db($btime);
     }
     return @vms;
 }

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -314,8 +314,8 @@ sub create_instances {
             assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
         }
         # Performance data: boottime
-        my $btime = $instance->measure_boottime($instance);
-        $instance->store_in_db($btime);
+        my $btime = $instance->measure_boottime($instance, 'first');
+        $instance->store_boottime_db($btime);
     }
     return @vms;
 }

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -304,6 +304,7 @@ C<instance_type> defines the flavor of the instance. If not specified, it will l
 sub create_instances {
     my ($self, %args) = @_;
     $args{check_connectivity} //= 1;
+    $args{check_guestregister} //= 1;
 
     my @vms = $self->terraform_apply(%args);
     foreach my $instance (@vms) {
@@ -313,6 +314,8 @@ sub create_instances {
             # Install server's ssh publicckeys to prevent authenticity interactions
             assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
         }
+        # check guestregister conditional, default yes:
+        $instance->wait_for_guestregister_chk() if ($args{check_guestregister});
         # Performance data: boottime
         my $btime = $instance->measure_boottime($instance, 'first');
         $instance->store_boottime_db($btime);

--- a/tests/jeos/prepare_openstack.pm
+++ b/tests/jeos/prepare_openstack.pm
@@ -16,7 +16,7 @@ sub run {
     select_host_console();
 
     my $provider = $self->provider_factory();
-    my $instance = $provider->create_instance();
+    my $instance = $provider->create_instance(check_guestregister => 0);
     $self->{provider} = $args->{my_provider} = $provider;
     $args->{my_instance} = $instance;
     $args->{ssh_log_file} = '/var/tmp/ssh_sut.log';

--- a/tests/publiccloud/az_accelerated_net.pm
+++ b/tests/publiccloud/az_accelerated_net.pm
@@ -25,7 +25,7 @@ sub prepare_vm {
     my ($self, $provider) = @_;
     my $iperf = get_required_var('IPERF_FILE');
     record_info('INFO', 'Create VM');
-    my $instance = $provider->create_instance();
+    my $instance = $provider->create_instance(check_guestregister => 0);
     record_info('Instance', 'Instance ' . $instance->instance_id . ' created');
     record_info('Iperf', 'Install IPerf binaries in VM');
     $instance->run_ssh_command(cmd => "wget https://iperf.fr/download/opensuse/$iperf");

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -308,11 +308,8 @@ sub measure_timings {
         $provider = $args->{my_provider};
     } else {
         $provider = $self->provider_factory();
-        $instance = $self->{my_instance} = $provider->create_instance(check_connectivity => 0);
+        $instance = $self->{my_instance} = $provider->create_instance();
     }
-
-    $ret->{analyze}->{ssh_access} = $instance->wait_for_ssh(timeout => 300);
-    assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
 
     my ($systemd_analyze, $systemd_blame) = do_systemd_analyze($instance);
     $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -228,25 +228,71 @@ our $thresholds_by_flavor = {
     },
 };
 
-sub provider_instance {
-    my ($self, $args) = @_;
-    my $provider;
-    my $instance;
 
-    if (get_var('PUBLIC_CLOUD_QAM')) {
-        $provider = $args->{my_provider};
-        $instance = $args->{my_instance};
-    } else {
-        $provider = $self->provider_factory();
-        $instance = $self->{my_instance} = $provider->create_instance(check_connectivity => 0);
+sub systemd_time_to_sec
+{
+    my $str = trim(shift);
+    if ($str !~ /^(?<check_min>(?<min>\d{1,2})\s*min\s*)?((?<sec>\d{1,2}\.\d{1,3})s|(?<ms>\d+)ms)$/) {
+        die("Unable to parse systemd time '$str'");
     }
-    die("Provider instance error") unless ($provider and $instance);
+    my $sec = $+{sec} // $+{ms} / 1000;
+    $sec += $+{min} * 60 if (defined($+{check_min}));
+    return $sec;
+}
 
-    return $instance;
+sub extract_analyze {
+    my $string = shift;
+    my $res = {};
+    ($string) = split(/\r?\n/, $string, 2);
+    $string =~ s/Startup finished in\s*//;
+    $string =~ s/=(.+)$/+$1 (overall)/;
+    for my $time (split(/\s*\+\s*/, $string)) {
+        $time = trim($time);
+        my ($time, $type) = $time =~ /^(.+)\s*\((\w+)\)$/;
+        $res->{$type} = systemd_time_to_sec($time);
+    }
+    map { die("Fail to detect $_ timing") unless exists($res->{$_}) } qw(kernel initrd userspace overall);
+    return $res;
+}
+
+sub extract_blame {
+    my $string = shift;
+    my $ret = {};
+    for my $line (split(/\r?\n/, $string)) {
+        $line = trim($line);
+        my ($time, $service) = $line =~ /^(.+)\s+(\S+)$/;
+        $ret->{$service} = systemd_time_to_sec($time);
+    }
+    return $ret;
+}
+
+sub do_systemd_analyze {
+    my ($instance, %args) = @_;
+    $args{timeout} = 120;
+    my $start_time = time();
+    my $output = "";
+    my @ret;
+
+    # Wait for guest register, before calling syastemd-analyze
+    $instance->wait_for_guestregister();
+    while ($output !~ /Startup finished in/ && time() - $start_time < $args{timeout}) {
+        $output = $instance->run_ssh_command(cmd => 'systemd-analyze time', proceed_on_failure => 1);
+        sleep 5;
+    }
+
+    die("Unable to get system-analyze in $args{timeout} seconds") unless (time() - $start_time < $args{timeout});
+    push @ret, extract_analyze($output);
+
+    $output = $instance->run_ssh_command(cmd => 'systemd-analyze blame');
+    push @ret, extract_blame($output);
+
+    return @ret;
 }
 
 sub measure_timings {
-    my ($self, $instance) = @_;
+    my ($self, $args) = @_;
+    my $provider;
+    my $instance;
 
     my $ret = {
         kernel_release => undef,
@@ -256,6 +302,14 @@ sub measure_timings {
             first => {}, soft => {}, hard => {}
         },
     };
+
+    if (get_var('PUBLIC_CLOUD_QAM')) {
+        $instance = $args->{my_instance};
+        $provider = $args->{my_provider};
+    } else {
+        $provider = $self->provider_factory();
+        $instance = $self->{my_instance} = $provider->create_instance(check_connectivity => 0);
+    }
 
     $ret->{analyze}->{ssh_access} = $instance->wait_for_ssh(timeout => 300);
     assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
@@ -294,6 +348,45 @@ sub measure_timings {
     return $ret;
 }
 
+sub store_in_db {
+    my ($self, $results) = @_;
+    my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI');
+    return unless ($url);
+    my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf');
+    my $token = get_required_var('_PUBLIC_CLOUD_PERF_DB_TOKEN');
+    my $org = get_var('PUBLIC_CLOUD_PERF_DB_ORG', 'qec');
+
+    my $tags = {
+        instance_type => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
+        os_flavor => get_required_var('FLAVOR'),
+        os_version => get_required_var('VERSION'),
+        os_build => get_required_var('BUILD'),
+        os_kernel_release => $results->{kernel_release},
+        os_kernel_version => $results->{kernel_version},
+    };
+
+    $tags->{os_pc_build} = get_var('PUBLIC_CLOUD_QAM') ? 'N/A' : get_required_var('PUBLIC_CLOUD_BUILD');
+    $tags->{os_pc_kiwi_build} = get_var('PUBLIC_CLOUD_QAM') ? 'N/A' : get_required_var('PUBLIC_CLOUD_BUILD_KIWI');
+
+    # Store values in influx-db
+    my $data = {
+        table => 'bootup',
+        tags => $tags,
+        values => $results->{analyze}
+    };
+    influxdb_push_data($url, $db, $org, $token, $data);
+
+    for my $type (qw(first soft hard)) {
+        $tags->{boottype} = $type;
+        $data = {
+            table => 'bootup_blame',
+            tags => $tags,
+            values => $results->{blame}->{$type}
+        };
+        influxdb_push_data($url, $db, $org, $token, $data);
+    }
+}
+
 sub check_threshold_values
 {
     my ($self, $results, $thresholds) = @_;
@@ -311,7 +404,7 @@ sub check_threshold_values
 
 sub check_thresholds {
     my ($self, $results) = @_;
-    return unless ($results);
+
     my $flavor = get_required_var('FLAVOR');
     die("Missing thresholds for flavor $flavor") unless (exists($thresholds_by_flavor->{$flavor}));
     my $thresholds = $thresholds_by_flavor->{$flavor};
@@ -326,11 +419,10 @@ sub check_thresholds {
 
 sub run {
     my ($self, $args) = @_;
-    my $results;
     select_host_console();
-    my $instance = $self->provider_instance($args);
-    $results = $instance->measure_timings($args) unless (get_required_var('PUBLIC_CLOUD_PERF_COLLECT'));
-    $instance->store_in_db($results) if (check_var('_PUBLIC_CLOUD_PERF_PUSH_DATA', 1));
+
+    my $results = $self->measure_timings($args);
+    $self->store_in_db($results) if (check_var('_PUBLIC_CLOUD_PERF_PUSH_DATA', 1));
     $self->check_thresholds($results) if (get_var('PUBLIC_CLOUD_PERF_THRESH_CHECK'));
 }
 
@@ -339,7 +431,6 @@ sub run {
 =head1 Discussion
 
 This module collect boot time statistics from publiccloud images.
-This code is executed only if not already elsewhere executed (PUBLIC_CLOUD_PERF_COLLECT).
 It collect systemd_analyze and ssh access time for three states:
 1) After first deployment
 2) After a soft reboot

--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -21,7 +21,7 @@ sub run {
     select_serial_terminal();
     my $provider = $self->provider_factory();
     $provider->{username} = 'suse';
-    my $instance = $self->{my_instance} = $provider->create_instance();
+    my $instance = $self->{my_instance} = $provider->create_instance(check_guestregister => 0);
     my $test_package = 'strace';
     registercloudguest($instance);
     $instance->run_ssh_command(cmd => 'zypper lr -d', timeout => 600);

--- a/tests/publiccloud/sles4sap.pm
+++ b/tests/publiccloud/sles4sap.pm
@@ -170,7 +170,7 @@ sub run {
     select_serial_terminal;
 
     my $provider = $self->provider_factory();
-    my @instances = $provider->create_instances(check_connectivity => 1);
+    my @instances = $provider->create_instances(check_connectivity => 1, check_guestregister => 0);
 
     # Upload all TF/SALT logs first!
     foreach my $instance (@instances) {

--- a/variables.md
+++ b/variables.md
@@ -308,7 +308,7 @@ PUBLIC_CLOUD_PERF_THRESH_CHECK | boolean | "" | If set to `1` or any not empty v
 PUBLIC_CLOUD_PREPARE_TOOLS | boolean | false | Activate prepare_tools test module by setting this variable.
 PUBLIC_CLOUD_GOOGLE_PROJECT_ID | string | "" | GCP only, used to specify the project id.
 PUBLIC_CLOUD_PROVIDER | string | "" | The type of the CSP (e.g. AZURE, EC2, GCE).
-PUBLIC_CLOUD_QAM | boolean | false | Used to select Maintenance jobs (true/1) or "Latest" jobs (false/0). The 1st prepare a cloud instance in top module before any other test, the 2nd prepare instance in other different phases. This param. also used to trigger creation or reuse of an instance.
+PUBLIC_CLOUD_QAM | boolean | false |  1 : to identify jobs running to test "Maintenance" updates; 0 : for jobs testing "Latest" (in development). Used to control all behavioral implications which this brings.
 PUBLIC_CLOUD_REBOOT_TIMEOUT | integer | 600 | Number of seconds we wait for instance to reboot.
 PUBLIC_CLOUD_REGION | string | "" | The region to use. (default-azure: westeurope, default-ec2: eu-central-1, default-gcp: europe-west1-b). In `upload-img` for Azure Arm64 images, multiple comma-separated regions are supported (see `lib/publiccloud/azure.pm`)
 PUBLIC_CLOUD_RESOURCE_GROUP | string | "qashapopenqa" | Allows to specify resource group name on SLES4SAP PC tests.

--- a/variables.md
+++ b/variables.md
@@ -308,7 +308,7 @@ PUBLIC_CLOUD_PERF_THRESH_CHECK | boolean | "" | If set to `1` or any not empty v
 PUBLIC_CLOUD_PREPARE_TOOLS | boolean | false | Activate prepare_tools test module by setting this variable.
 PUBLIC_CLOUD_GOOGLE_PROJECT_ID | string | "" | GCP only, used to specify the project id.
 PUBLIC_CLOUD_PROVIDER | string | "" | The type of the CSP (e.g. AZURE, EC2, GCE).
-PUBLIC_CLOUD_QAM | boolean | false | Previously used to recognize maintenance jobs - now deprecated - should be removed.
+PUBLIC_CLOUD_QAM | boolean | false | Used to select Maintenance jobs (true/1) or "Latest" jobs (false/0). The 1st prepare a cloud instance in top module before any other test, the 2nd prepare instance in other different phases. This param. also used to trigger creation or reuse of an instance.
 PUBLIC_CLOUD_REBOOT_TIMEOUT | integer | 600 | Number of seconds we wait for instance to reboot.
 PUBLIC_CLOUD_REGION | string | "" | The region to use. (default-azure: westeurope, default-ec2: eu-central-1, default-gcp: europe-west1-b). In `upload-img` for Azure Arm64 images, multiple comma-separated regions are supported (see `lib/publiccloud/azure.pm`)
 PUBLIC_CLOUD_RESOURCE_GROUP | string | "qashapopenqa" | Allows to specify resource group name on SLES4SAP PC tests.


### PR DESCRIPTION
Primary Target of this PR in publiccloud is to trigger the boot time measurements collection  in the VM instance creation phase, instead of running in a separate module.
And as the collection as pushing data to InfluxDB are enabled by means of proper parmeters setting.
The _data push_ has been tested in a new created `perf_2` bucket and also in the existing one `perf` ( see param. `PUBLIC_CLOUD_PERF_DB`), successfully.

More details are in the [note-8](https://progress.opensuse.org/issues/118027#note-8) of the  poo.

- Related ticket: https://progress.opensuse.org/issues/118027
- Needles: N/A
- Verification run:   
[x86_64 AZURE 3715](http://10.168.4.117/tests/3715)  
[aarch64 GCE 3716](http://10.168.4.117/tests/3716)  
[x86_64 GCE 3718](http://10.168.4.117/tests/3718)  

This PR  to replace of the [16476](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16476)