### PR TITLE
Create nested condition for installation_node scheduling

### DIFF
--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -24,8 +24,14 @@ conditional_schedule:
     HPC:
       server:
         - installation/user_settings
+  installation_node_conf:
+    SYSTEM_ROLE:
+      hpc-node:
+        - installation/user_settings_root
   user_settings_root:
     VERSION:
+      15-SP1:
+        - '{{installation_node_conf}}'
       15-SP2:
         - installation/user_settings_root
       15-SP3:


### PR DESCRIPTION
The hpc_installation_node and hpc_installation_server share the same scheduling file but there is a condition which takes place when the VERSION is 15SP1. For that particular version the `installation/user_settings_root` should be scheduled only for the
hpc_installation_node. hpc_installation_server is not making use of root setup despite all the other versions bigger than SP1


- Verification run: 

https://aquarius.suse.cz/tests/14996
https://aquarius.suse.cz/tests/14997
https://aquarius.suse.cz/tests/14998
https://aquarius.suse.cz/tests/14999