### PR TITLE
Create new yaml schedule copied from yast2_ncurses.yaml for leap

### DIFF
--- a/schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
+++ b/schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
@@ -1,0 +1,38 @@
+---
+name:           yast2_ncurses_leap
+description:    >
+  Test for yast2 UI, ncurses only. Running on created gnome
+  images which provides both text console for ncurses UI tests
+  as well as the gnome environment for the GUI tests.
+vars:
+  YUI_REST_API: 1
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/setup_libyui_running_system
+  - console/yast2_rmt
+  - console/yast2_ntpclient
+  - console/yast2_tftp
+  - console/yast2_proxy
+  - console/yast2_vnc
+  - console/yast2_http
+  - console/yast2_ftp
+  - console/yast2_apparmor
+  - console/yast2_lan
+  - console/yast2_lan_device_settings
+  - console/yast2_lan_hostname/dhcp_no
+  - console/yast2_lan_hostname/dhcp_yes
+  - console/yast2_lan_hostname/dhcp_yes_eth
+  - console/yast2_dns_server_initial_setup
+  - console/yast2_dns_server_service_inactive_enabled
+  - console/yast2_dns_server_service_active_disabled
+  - console/yast2_dns_server_service_inactive_disabled
+  - console/yast2_dns_server_service_keep_inactive_disabled
+  - console/yast2_nfs_client
+  - console/yast2_snapper_ncurses
+test_data:
+  yast2_lan_hostname:
+    ui: ncurses
+    confirm_warning: 1


### PR DESCRIPTION
In Tumbleweed job group, the yast2_http,yast2-dns-server and yast2-dhcp-server will be removed from yast2_ncurses.yaml, to reserve these yast2 test in leap job group we create a new yaml schedule copied from yast2_ncurses.yaml for leap.

- Related ticket: https://progress.opensuse.org/issues/124433
- Related PR:  https://github.com/os-autoinst/opensuse-jobgroups/pull/285
- Needles: N/A
- Verification run: N/A (same content from yast2_ncurses.yaml)
