### PR TITLE
Fix select_role_text_mode when DESKTOP is textmode for yast-mru-install-minimal-with-addons

### DIFF
--- a/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_restapi.yaml
+++ b/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_restapi.yaml
@@ -5,6 +5,8 @@ vars:
   YUI_REST_API: 1
 schedule:
   additional_products: []
+  system_role:
+    - installation/system_role/select_role_text_mode
   add_on_product:
     - installation/add_on_product/add_maintenance_repos
   software:


### PR DESCRIPTION
For test  `yast-mru-install-minimal-with-addons`, we set `DESKTOP=textmode` but 
we scheduled `accept_selected_role_SLES_with_GNOME` to let the test choose gnome, which cause the first_boot to fail.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/10647383
  https://openqa.suse.de/tests/10647409
  https://openqa.suse.de/tests/10647439
