### PR TITLE
Fix lib/sles4sap openssl legacy regex

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -832,7 +832,7 @@ SLES and HANA versions whether B<libopenssl1_0_0> must be installed.
 sub install_libopenssl_legacy {
     my ($self, $hana_path) = @_;
 
-    if ($hana_path =~ s/.*\/SPS([0-9]+)rev[0-9]\/.*/$1/r) {
+    if ($hana_path =~ s/.*\/SPS([0-9]+)rev[0-9]+\/.*/$1/r) {
         my $hana_version = $1;
         if (is_sle('15+') && ($hana_version <= 2)) {
             # The old libopenssl is in Legacy Module


### PR DESCRIPTION
Broken regex in lib/sles4sap install_libopenssl_legacy function causes 
libopenssl1_0_0 installed on all HANA installation. This PR makes regex to apply 
legacy module only on HANA SPS < 3.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
Broken (legacy module added) :  
https://openqa.suse.de/tests/10641386#step/hana_install/7

VR (No legacy module applied):
https://openqa.suse.de/tests/10648987#step/hana_install/7