### PR TITLE
Prevent test fail on 15SP1 with mvapich2

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -134,6 +134,10 @@ sub run ($self) {
             if (script_run('grep \'Caught error: Floating point exception (signal 8)\' /tmp/mpi_bin.log') == 0) {
                 record_soft_failure('bsc#1175679 Floating point exception should be fixed on mvapich2/2.3.4');
             }
+        } elsif ($return == 1) {
+            if (script_run('grep \'failure occurred while posting a receive for message data\' /tmp/mpi_bin.log') == 0) {
+                record_soft_failure('bsc#1209130 MPI Benchmarks unable to run on 15SP1 with imb-gnu-mvapich2-hpc');
+            }
         } else {
             ##TODO: condider more rebust handling of various errors
             die("echo $return - not expected errorcode") unless $return == 0;


### PR DESCRIPTION
Test fails with `failure occurred while posting a receive for message data` and `Out of memory (unable to allocate 1 bytes)` with imb test. Show this as a softfail as it likely wont be fixed.


https://openqa.suse.de/tests/10652016#step/mpi_master/132