### PR TITLE
disable_kdump fix for new security option

### DIFF
--- a/tests/installation/disable_kdump.pm
+++ b/tests/installation/disable_kdump.pm
@@ -29,7 +29,8 @@ sub run {
     }
     else {
         # Select section kdump on Installation Settings overview (video mode)
-        send_key_until_needlematch 'kdump-section-selected', 'tab';
+        send_key_until_needlematch 'kdump-section-selected', 'tab', 30;
+
         send_key 'ret';
     }
 


### PR DESCRIPTION
Because of new security option added on settings screen, send_key_until_needlematch
is reaching its default keystroke limit.

Failure:
https://openqa.suse.de/tests/10652132

VR:
https://openqa.suse.de/tests/10659994
Fixes: 
poo#125774
