### PR TITLE
Add 12sp5 autoyast with default pattern image

### DIFF
--- a/data/autoyast_sle12/create_hdd/create_hdd_sles_regression_aarch64.xml.ep
+++ b/data/autoyast_sle12/create_hdd/create_hdd_sles_regression_aarch64.xml.ep
@@ -348,7 +348,6 @@
           <pattern>documentation</pattern>
           <pattern>gnome-basic</pattern>
           <pattern>x11</pattern>
-	  <pattern>yast2_basis</pattern>
         </patterns>
 	% }
     </software>


### PR DESCRIPTION
When create autoyast for ARM SLES12SP5 we need remove pattern yast2_basis for default pattern installation.

- Related ticket: https://progress.opensuse.org/issues/125345
- Related MR:  [477](https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/477)
- Needles: N/A
- Verification run: 
   * https://openqa.suse.de/tests/10659005
   * https://openqa.suse.de/tests/10677313