### PR TITLE
Fix for Rootless podman

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -159,13 +159,8 @@ sub verify_userid_on_container {
     # when using `user` descriptor with `podman top`, handle
     # conditionally.
     # https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16567
-    my $podman_version = get_podman_version();
-    if (package_version_cmp($podman_version, '4.4.0') >= 0) {
-        my $huser_name = $testapi::username;
-        validate_script_output "podman top $cid user huser", sub { /${huser_name}\s+${id}/ };
-    } else {
-        validate_script_output "podman top $cid user huser", sub { /1000\s+${id}/ };
-    }
+    my $huser_name = $testapi::username;
+    validate_script_output "podman top $cid user huser", sub { /${huser_name}\s+${id}|1000\s+${id}/ };
     validate_script_output "podman top $cid capeff", sub { /none/ };
 
     record_info "root with keep-id", "the default user(root) starts process with the same uid as host user";


### PR DESCRIPTION
Failure: [15-SP2 s390x](https://openqa.suse.de/tests/10672353#step/rootless_podman/194)
Verification Runs:
-[15-SP2 s390x](https://openqa.suse.de/tests/10682291)
-[15-SP2 aarch64](https://openqa.suse.de/tests/10680778)
-[15-SP2 x86_64](https://openqa.suse.de/tests/10680779)
-[15-SP4 aarch64](https://openqa.suse.de/tests/10680780)
-[15-SP4 x86_64](https://openqa.suse.de/tests/10680781#)
-[Tumbleweed](https://openqa.opensuse.org/tests/3171405)
-[15-SP2 s390x](https://openqa.suse.de/tests/10682291)
