### PR TITLE
Add preferences to disable first-run pop-ups in Firefox

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -547,8 +547,14 @@ EOF
 // https://firefox-source-docs.mozilla.org/browser/components/newtab/content-src/asrouter/docs/first-run.html
 pref("app.normandy.enabled", false);
 pref("browser.aboutwelcome.enabled", false);
+pref("browser.discovery.enabled", false);
+pref("browser.messaging-system.whatsNewPanel.enabled", false);
 pref("browser.startup.upgradeDialog.enabled", false);
+pref("browser.uitour.enabled", false);
+pref("datareporting.policy.firstRunURL", "");
+pref("messaging-system.rsexperimentloader.enabled", false);
 pref("privacy.restrict3rdpartystorage.rollout.enabledByDefault", false);
+pref("trailhead.firstrun.branches", "nofirstrun-empty");
 EOF
 });
 


### PR DESCRIPTION
Some parts of the "first-run experience" can be additionally disabled by specifying more user prefs in the AutoConfig. This will also prevent opening the Firefox Privacy Notice tab on first run.

- Related ticket: 
  * https://progress.opensuse.org/issues/125663
  * https://progress.opensuse.org/issues/125507
- Verification run:
  * https://openqa.suse.de/tests/10678624
  * https://openqa.suse.de/tests/10678236
  * https://openqa.suse.de/tests/10678261
  * https://openqa.opensuse.org/tests/3170786