### PR TITLE
Switch to textmode to avoid first_boot fail

### DIFF
--- a/schedule/security/encryption/fips_lvm_encrypt_separate_boot.yaml
+++ b/schedule/security/encryption/fips_lvm_encrypt_separate_boot.yaml
@@ -9,6 +9,7 @@ vars:
   FULL_LVM_ENCRYPT: 1
   YUI_REST_API: 1
   MAX_JOB_TIME: '14400'
+  DESKTOP: textmode
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui


### PR DESCRIPTION
Set `DESKTOP: textmode` to avoid a fail in `first_boot` module.

- Related ticket: https://progress.opensuse.org/issues/124931
- Verification run: http://emiler-openqa.qe.suse.de/tests/156
