### PR TITLE
epiphany: handle the new 'set as default browser' dialog

### DIFF
--- a/tests/x11/gnomeapps/epiphany.pm
+++ b/tests/x11/gnomeapps/epiphany.pm
@@ -14,7 +14,11 @@ use testapi;
 use utils;
 
 sub run {
-    assert_gui_app('epiphany');
+    assert_gui_app('epiphany', remain => 1);
+    if (match_has_tag 'epiphany-set-default-browser') {
+        send_key('alt-n');
+    }
+    send_key('alt-f4');
 }
 
 1;


### PR DESCRIPTION
- Related ticket: N/A (identified as part of GNOME Next live testing)
- Needles: Created on o3 during VR
- Verification run: https://openqa.opensuse.org/tests/3171206
