### PR TITLE
Apply workaround of bsc#1195046 for all arches

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -36,7 +36,7 @@ sub setup_sle {
     select_console 'root-console';
 
     # https://bugzilla.suse.com/show_bug.cgi?id=1205290#c3
-    if (is_ppc64le && is_sle('<12-sp5')) {
+    if (is_sle('<=12-SP5')) {
         systemctl('restart systemd-vconsole-setup.service');
     }
 


### PR DESCRIPTION
We need apply workaround of bsc#1195046 for all arches.

- Related ticket:  https://progress.opensuse.org/issues/125891
- Needles: N/A
- Verification run:  http://openqa.nue.suse.com/tests/10677781#step/patch_sle/19
