### PR TITLE
Filter only CRITICAL and ERROR sections

### DIFF
--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -87,7 +87,7 @@ sub logs_from_salt {
 
     upload_logs '/var/log/salt/minion', log_name => 'salt-minion.txt';
 
-    my $error = "cat /var/log/salt/* | grep -i 'CRITICAL\\|ERROR\\|Traceback' ";
+    my $error = "cat /var/log/salt/* | grep -i '\\[.*CRITICAL.*\\]\\|\\[.*ERROR.*\\]\\|Traceback' ";
     $error .= "| grep -vi 'Error while parsing IPv\\|Error loading module\\|Unable to resolve address\\|SaltReqTimeoutError' ";
     $error .= "| grep -vi 'has cached the public key for this node\\|Minion unable to successfully connect to a Salt Master'";
     $error .= "| grep -vi 'Error while bringing up minion for multi-master'";


### PR DESCRIPTION
Filter only CRITICAL and ERROR sections, instead of word. This prevents a false positive when reporting the error module has been loaded.

- Related ticket: https://progress.opensuse.org/issues/125834
- Verification run: https://duck-norris.qe.suse.de/tests/12355
