### PR TITLE
Apply workaround and umount before ending iscsi session

### DIFF
--- a/lib/YaST/workarounds.pm
+++ b/lib/YaST/workarounds.pm
@@ -12,7 +12,7 @@ use utils;
 use version_utils;
 
 
-our @EXPORT = qw(apply_workaround_poo124652 apply_workaround_bsc1207157);
+our @EXPORT = qw(apply_workaround_poo124652 apply_workaround_bsc1206132);
 
 =head1 Workarounds for known issues
 
@@ -49,19 +49,19 @@ sub apply_workaround_poo124652 {
     }
 }
 
-=head2 apply_workaround_bsc1207157 ():
+=head2 apply_workaround_bsc1206132 ():
 
 Workaround for the iscsi return code issue.
 
-Records a soft failure with a reference to bsc#1207157
+Records a soft failure with a reference to bsc#1206132
 
 Changes the iscsid service file to require and start after the iscsid socket.
 Then reloads systemd, in order to scan for the changed unit.
 
 =cut
 
-sub apply_workaround_bsc1207157 {
-    record_soft_failure('bsc#1207157 - openQA test fails in iscsi_client - launched then no response');
+sub apply_workaround_bsc1206132 {
+    record_soft_failure('bsc#1206132 - openQA test fails in iscsi_client - launched then no response');
     my $service_unit = '/usr/lib/systemd/system/iscsid.service';
     # append the two lines at the end of the [Unit] section of the service file, as specified in bsc#1206132
     my $cmd = q(awk -i inplace 'BEGIN {c=1}; /^$/ {if (c){print("Requires=iscsid.socket\nAfter=iscsid.socket")} c=0}; {print}' );

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -108,7 +108,7 @@ sub run {
     zypper_call("in open-iscsi yast2-iscsi-client");
     mutex_wait('iscsi_target_ready', undef, 'Target configuration in progress!');
     record_info 'Target Ready!', 'iSCSI target is configured, start initiator configuration';
-    apply_workaround_bsc1207157() if (is_sle('=15-SP3'));
+    apply_workaround_bsc1206132() if ((is_sle('=15-SP3')) || (is_sle('=15-SP5')));
     my $module_name = y2_module_guitest::launch_yast2_module_x11('iscsi-client', target_match => 'iscsi-client');
     initiator_service_tab;
     initiator_discovered_targets_tab;
@@ -152,8 +152,8 @@ sub run {
     mutex_create('iscsi_initiator_ready');
     mutex_wait('iscsi_display_sessions', undef, 'Verifying sessions on target');
     record_info 'Logout iSCSI', 'Logout iSCSI sessions & unmount LUN';
-    assert_script_run 'iscsiadm --mode node --logoutall=all';
     assert_script_run 'umount /mnt';
+    assert_script_run 'iscsiadm --mode node --logoutall=all';
     enter_cmd "killall xterm";
 }
 


### PR DESCRIPTION
We need apply workaround and unmount before ending iscsi session following https://bugzilla.suse.com/show_bug.cgi?id=1206132#c31.

- Related ticket: https://progress.opensuse.org/issues/125741
- Needles: N/A
- Verification run: 
15SP5: http://openqa.nue.suse.com/tests/10689325#
15SP4: http://openqa.nue.suse.com/tests/10689359#
15SP3: http://openqa.nue.suse.com/tests/10689348#
