### PR TITLE
SLE Micro: whitelist "Failed to start MicroOS Health Checker"

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -317,7 +317,7 @@
         "type": "ignore"
     },
     "health-check-typo": {
-        "description": "health-checker/fail.sh check\" failed|Machine didn't come up correct, do a rollback",
+        "description": "health-checker/fail.sh check\" failed|Failed to start MicroOS Health Checker.Machine didn't come up correct, do a rollback|",
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" ],
             "leap-micro": ["5.2", "5.3", "5.4"],


### PR DESCRIPTION
There is a new failure which is expected but we didn't record it before, it might be due to the addition of new packages.
https://openqa.suse.de/tests/10689169#step/journal_check/21

VR: https://openqa.suse.de/tests/10690205