### PR TITLE
remote_python Terraform variable for AWS and GCP

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -10,6 +10,8 @@ terraform:
     public_key: "%SSH_KEY_PUB%"
     aws_credentials: "/root/amazon_credentials"
     hana_instancetype: "%HANA_INSTANCE_TYPE%"
+    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -10,6 +10,8 @@ terraform:
     public_key: "%SSH_KEY_PUB%"
     aws_credentials: "/root/amazon_credentials"
     hana_instancetype: "%HANA_INSTANCE_TYPE%"
+    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -6,15 +6,11 @@ terraform:
     region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    hana_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    iscsi_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    monitoring_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    drdb_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    netweaver_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    bastion_os_major_version: "%QESAP_CLUSTER_OS_VER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     gcp_credentials_file: "/root/google_credentials.json"
+    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -6,15 +6,11 @@ terraform:
     region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    hana_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    iscsi_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    monitoring_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    drdb_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    netweaver_os_major_version: "%QESAP_CLUSTER_OS_VER%"
-    bastion_os_major_version: "%QESAP_CLUSTER_OS_VER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     gcp_credentials_file: "/root/google_credentials.json"
+    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"


### PR DESCRIPTION
Related ticket: TEAM-6956

Verification run:

GCP SLE12SP5 http://openqaworker15.qa.suse.cz/tests/136022 test fails for other reason but the usage of the setting *QESAPDEPLOY_ANSIBLE_REMOTE_PYTHON=/usr/bin/python2* results in the generated .tfvars like http://openqaworker15.qa.suse.cz/tests/136022/file/configure-terraform.tfvars

```
hana_remote_python = "/usr/bin/python2"
iscsi_remote_python = "/usr/bin/python2"
```

AWS SLE12SP5 http://openqaworker15.qa.suse.cz/tests/136581 the same of the other one
