### PR TITLE
Handle conflicts in size monitoring

### DIFF
--- a/lib/db_utils.pm
+++ b/lib/db_utils.pm
@@ -177,6 +177,9 @@ sub push_image_data_to_db {
         record_info("DB", "Image data has been successfully pushed to the Database.");
     } elsif ($cmd_output =~ /(?=.*409 Conflict)/) {
         record_info("DB", "This image info already exists DB.");
+        # return to the caller that conflict has been found
+        # caller should exit the test case module immediately
+        return 409;
     } else {
         record_soft_failure("poo#113120 - There has been a problem pushing data to the DB.");
     }

--- a/tests/jeos/image_info.pm
+++ b/tests/jeos/image_info.pm
@@ -70,7 +70,9 @@ sub run {
 
     my $size_mb = $image_size / 1024 / 1024;
     record_info('Image', "Image: $image\nSize: $size_mb");
-    push_image_data_to_db('minimal-vm', $image, $size_mb, table => 'size', type => 'uncompressed');
+    my $is_conflict = push_image_data_to_db('minimal-vm', $image, $size_mb, table => 'size', type => 'uncompressed');
+
+    return 1 if ($is_conflict == 409);
 
     # Get list of packages installed in the system
     my $packages = script_output('rpm -qa --queryformat "%{SIZE} %{NAME}-%{VERSION}-%{RELEASE}\n" |sort -n -r');


### PR DESCRIPTION
If there is already existing record for the image, we can safely assume that all related records have been pushed before.

