### PR TITLE
Fix usage of validate_script_output

### DIFF
--- a/lib/openscaptest.pm
+++ b/lib/openscaptest.pm
@@ -59,7 +59,7 @@ sub validate_result {
         assert_script_run "xmllint --noout $xml_args $result_file";
     }
 
-    validate_script_output "cat $result_file", sub { $match }, timeout => 300;
+    validate_script_output "cat $result_file", $match, timeout => 300;
     upload_logs($result_file);
 }
 

--- a/tests/security/openscap/oscap_generating_fix.pm
+++ b/tests/security/openscap/oscap_generating_fix.pm
@@ -16,9 +16,9 @@ use openscaptest;
 sub run {
     my $fix_script = "fix-script.sh";
 
-    my $fix_script_match = 'm/
+    my $fix_script_match = qr/
         echo\s*>\s*\/etc\/securetty.*
-        echo\s+0\s*>\s*\/proc\/sys\/kernel\/sysrq/sxx';
+        echo\s+0\s*>\s*\/proc\/sys\/kernel\/sysrq/sxx;
 
     assert_script_run "oscap xccdf generate fix --template urn:xccdf:fix:script:sh --profile standard --output $fix_script xccdf.xml";
 

--- a/tests/security/openscap/oscap_generating_report.pm
+++ b/tests/security/openscap/oscap_generating_report.pm
@@ -19,31 +19,31 @@ sub run {
     my $oval_report = "oval_report.html";
     my $xccdf_oval_report = "xccdf_oval_report.html";
 
-    my $xccdf_guide_match = 'm/
+    my $xccdf_guide_match = qr/
             Checklist.*
             contains 2 rules.*
             Restrict Root Logins.*
             Direct root Logins Not Allowed.*
-            sysctl kernel.sysrq must be 0.*/sxx';
+            sysctl kernel.sysrq must be 0.*/sxx;
 
-    my $xccdf_report_match = 'm/
+    my $xccdf_report_match = qr/
             with profile.*Standard System Security Profile.*
             The target system did not satisfy the conditions of 2 rules.*
             Hardening SUSE Linux Enterprise.*2x fail.*
             Restrict Root Logins.*1x fail.*
             Direct root Logins Not Allowed.*
-            sysctl kernel.sysrq must be 0/sxx';
+            sysctl kernel.sysrq must be 0/sxx;
 
-    my $oval_report_match = 'm/
+    my $oval_report_match = qr/
             OVAL Results Generator Information.*
             OVAL Definition Generator Information.*
             System Information.*
             cpe:\/a:open-scap:oscap.*
             OVAL Definition Results.*
             oval:rule_misc_sysrq:def:1.*false.*
-            oval:no_direct_root_logins:def:1.*false/sxx';
+            oval:no_direct_root_logins:def:1.*false/sxx;
 
-    my $xccdf_oval_report_match = 'm/
+    my $xccdf_oval_report_match = qr/
             with profile.*Standard System Security Profile.*
             Evaluation Characteristics.*
             CPE Platforms.*cpe:\/o:suse.*
@@ -53,7 +53,7 @@ sub run {
             Severity of failed rules.*1 other.*
             Score.*
             Rule Overview.*
-    ';
+    /;
 
     ensure_generated_file($oval_result);
     ensure_generated_file($xccdf_result);

--- a/tests/security/openscap/oscap_oval_scanning.pm
+++ b/tests/security/openscap/oscap_oval_scanning.pm
@@ -15,12 +15,12 @@ use openscaptest;
 
 sub run {
 
-    my $scanning_match = 'm/
+    my $scanning_match = qr/
         Definition\ oval:rule_misc_sysrq:def:[0-9]:\ false.*
         Definition\ oval:no_direct_root_logins:def:[0-9]:\ false.*
-        Evaluation\ done/sxx';
+        Evaluation\ done/sxx;
 
-    my $result_match = 'm/
+    my $result_match = qr/
         encoding="UTF-8".*
         <oval_results\ xmlns:xsi.*XMLSchema-instance.*
         xmlns:oval=.*oval-common-5.*xmlns=.*oval-results-5.*
@@ -38,24 +38,24 @@ sub run {
         definition_id="oval:rule_misc_sysrq:def:1".*
         result="false".*
         definition_id="oval:no_direct_root_logins:def:1".*
-        result="false"/sxx';
+        result="false"/sxx;
 
-    my $scanning_match_single = 'm/
+    my $scanning_match_single = qr/
         Definition\ oval:rule_misc_sysrq:def:[0-9]:\ false.*
-        Evaluation\ done/sxx';
+        Evaluation\ done/sxx;
 
-    my $result_match_single = 'm/
+    my $result_match_single = qr/
         encoding="UTF-8".*
         <results.*<system.*<definitions.*
         definition_id="oval:rule_misc_sysrq:def:1".*
         result="false".*
         definition_id="oval:no_direct_root_logins:def:1".*
-        result="not\ evaluated"/sxx';
+        result="not\ evaluated"/sxx;
 
-    validate_script_output "oscap oval eval --results $oval_result oval.xml", sub { $scanning_match };
+    validate_script_output "oscap oval eval --results $oval_result oval.xml", $scanning_match;
     validate_result($oval_result, $result_match);
 
-    validate_script_output "oscap oval eval --id oval:rule_misc_sysrq:def:1 --results $oval_result_single oval.xml", sub { $scanning_match_single };
+    validate_script_output "oscap oval eval --id oval:rule_misc_sysrq:def:1 --results $oval_result_single oval.xml", $scanning_match_single;
     validate_result($oval_result_single, $result_match_single);
 }
 

--- a/tests/security/openscap/oscap_remediating_offline.pm
+++ b/tests/security/openscap/oscap_remediating_offline.pm
@@ -15,11 +15,11 @@ use openscaptest;
 sub run {
     my $remediate_result = "scan-xccdf-remediate-results.xml";
 
-    my $remediate_match = 'm/
+    my $remediate_match = qr/
               Rule.*no_direct_root_logins.*Result.*fixed.*
-              Rule.*rule_misc_sysrq.*Result.*fixed/sxx';
+              Rule.*rule_misc_sysrq.*Result.*fixed/sxx;
 
-    my $remediate_result_match = 'm/
+    my $remediate_result_match = qr/
               <\?xml\s+version="[0-9]+\.[0-9]+"\s+encoding="UTF-8".*
               <Benchmark.*<Profile\s+id="standard".*
               select.*no_direct_root_logins.*selected="true".*
@@ -33,12 +33,12 @@ sub run {
               rule-result.*idref="no_direct_root_logins".*result.*fixed.*
               rule-result.*idref="rule_misc_sysrq".*result.*fixed.*
               score\s+system="urn:xccdf:scoring:default".*
-              maximum="[0-9]+/sxx';
+              maximum="[0-9]+/sxx;
 
     ensure_generated_file($xccdf_result);
     prepare_remediate_validation;
 
-    validate_script_output("oscap xccdf remediate --results $remediate_result $xccdf_result", sub { $remediate_match });
+    validate_script_output("oscap xccdf remediate --results $remediate_result $xccdf_result", $remediate_match);
     validate_result($remediate_result, $remediate_result_match);
 
     # Verify the remediate action result

--- a/tests/security/openscap/oscap_remediating_online.pm
+++ b/tests/security/openscap/oscap_remediating_online.pm
@@ -15,14 +15,14 @@ use openscaptest;
 sub run {
     my $remediate_result = "scan-xccdf-remediate-results.xml";
 
-    my $remediate_match = 'm/
+    my $remediate_match = qr/
                       Rule.*no_direct_root_logins.*Result.*fail.*
                       Rule.*rule_misc_sysrq.*Result.*fail.*
                       Starting\s+Remediation.*
                       Rule.*no_direct_root_logins.*Result.*fixed.*
-                      Rule.*rule_misc_sysrq.*Result.*fixed/sxx';
+                      Rule.*rule_misc_sysrq.*Result.*fixed/sxx;
 
-    my $remediate_result_match = 'm/
+    my $remediate_result_match = qr/
               version="[0-9]+\.[0-9]+"\s+encoding="UTF-8".*
               <Benchmark.*<Profile\s+id="standard".*
               select.*no_direct_root_logins.*selected="true".*
@@ -33,12 +33,12 @@ sub run {
               rule-result.*idref="no_direct_root_logins".*result.*fixed.*
               rule-result.*idref="rule_misc_sysrq".*result.*fixed.*
               score\s+system="urn:xccdf:scoring:default".*
-              maximum="[0-9]+/sxx ';
+              maximum="[0-9]+/sxx;
 
     prepare_remediate_validation;
 
     # Remediate
-    validate_script_output "oscap xccdf eval --remediate --profile standard --results $remediate_result xccdf.xml", sub { $remediate_match };
+    validate_script_output "oscap xccdf eval --remediate --profile standard --results $remediate_result xccdf.xml", $remediate_match;
     validate_result($remediate_result, $remediate_result_match);
 
     # Verify the remediate action result

--- a/tests/security/openscap/oscap_result_datastream.pm
+++ b/tests/security/openscap/oscap_result_datastream.pm
@@ -14,7 +14,7 @@ use openscaptest;
 
 sub run {
 
-    my $arf_result_match = 'm/
+    my $arf_result_match = qr/
         version="[0-9]+\.[0-9]+"\s+encoding="UTF-8".*
         <arf:asset-report-collection.*<ns0:definitions.*
         <ns0:criteria\s+operator="AND".*
@@ -29,7 +29,7 @@ sub run {
         check="all"\s+result="not\sevaluated".*
         <test\s+test_id="oval:rule_misc_sysrq:tst:1".*
         check="at\sleast\sone"\s+result="not\sevaluated".*
-        \/arf:asset-report-collection>/sxx';
+        \/arf:asset-report-collection>/sxx;
 
     ensure_generated_file($source_ds);
 

--- a/tests/security/openscap/oscap_source_datastream.pm
+++ b/tests/security/openscap/oscap_source_datastream.pm
@@ -16,7 +16,7 @@ sub run {
 
     my $xccdf_12 = 'xccdf-1.2.xml';
 
-    my $source_ds_match = 'm/
+    my $source_ds_match = qr/
         <ds:data-stream-collection.*
         <ds:component\s+id=.*xml.*
         <ns0:definition.*oval:no_direct_root_logins:def:1.*class.*compliance.*
@@ -25,10 +25,10 @@ sub run {
         <Benchmark.*xccdf_com.suse_benchmark_test.*
         <Profile.*xccdf_com.suse_profile_standard.*
         <Rule.*xccdf_com.suse_rule_no_direct_root_logins.*selected.*false.*
-        <Rule.*xccdf_com.suse_rule_rule_misc_sysrq.*selected.*false/sxx';
+        <Rule.*xccdf_com.suse_rule_rule_misc_sysrq.*selected.*false/sxx;
 
 
-    my $source_ds_result_match = 'm/
+    my $source_ds_result_match = qr/
         version="[0-9]+\.[0-9]+"\s+encoding="UTF-8".*
         <Benchmark.*<Profile\s+id="xccdf_com\.suse_profile_standard".*
         select.*xccdf_com\.suse_rule_no_direct_root_logins".*selected="true".*
@@ -37,7 +37,7 @@ sub run {
         Rule.*xccdf_com\.suse_rule_rule_misc_sysrq".*selected="false".*
         <TestResult.*<benchmark.*id="xccdf_com\.suse_benchmark_test".*
         rule-result.*xccdf_com\.suse_rule_no_direct_root_logins".*notselected.*
-        rule-result.*xccdf_com\.suse_rule_rule_misc_sysrq.*notselected/sxx';
+        rule-result.*xccdf_com\.suse_rule_rule_misc_sysrq.*notselected/sxx;
 
     # Convert to XCCDF version 1.2 and validate
     assert_script_run "xsltproc --stringparam reverse_DNS com.suse /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl xccdf.xml > $xccdf_12";

--- a/tests/security/openscap/oscap_xccdf_scanning.pm
+++ b/tests/security/openscap/oscap_xccdf_scanning.pm
@@ -16,11 +16,11 @@ use version_utils qw(is_sle is_leap);
 
 sub run {
 
-    my $scanning_match = 'm/
+    my $scanning_match = qr/
         Rule.*no_direct_root_logins.*fail.*
-        Rule.*rule_misc_sysrq.*fail/sxx';
+        Rule.*rule_misc_sysrq.*fail/sxx;
 
-    my $result_match = 'm/
+    my $result_match = qr/
         encoding="UTF-8".*
         <Benchmark.*<Profile\s+id="standard".*<select.*
         idref="no_direct_root_logins"\ selected="true".*
@@ -31,13 +31,13 @@ sub run {
         <rule-result.*idref="no_direct_root_logins".*<result.*fail.*
         <rule-result.*idref="rule_misc_sysrq".*<result.*fail.*
         <score\s+system="urn:xccdf:scoring:default".*
-        maximum="[0-9]+/sxx';
+        maximum="[0-9]+/sxx;
 
-    my $scanning_match_single = 'm/
+    my $scanning_match_single = qr/
         Title.*Direct\ root\ Logins\ Not\ Allowed.*
-        Rule.*no_direct_root_logins.*fail/sxx';
+        Rule.*no_direct_root_logins.*fail/sxx;
 
-    my $result_match_single = 'm/
+    my $result_match_single = qr/
         encoding="UTF-8".*
         <Benchmark.*<Profile\s+id="standard".*<select.*
         idref="no_direct_root_logins"\ selected="true".*
@@ -48,17 +48,17 @@ sub run {
         <rule-result.*idref="no_direct_root_logins".*<result.*fail.*
         <rule-result.*idref="rule_misc_sysrq".*<result.*notselected.*
         <score\s+system="urn:xccdf:scoring:default".*
-        maximum="[0-9]+/sxx';
+        maximum="[0-9]+/sxx;
 
     # Always return failed here, so we use "||true" as workaround
-    validate_script_output "oscap xccdf eval --profile standard --results $xccdf_result xccdf.xml || true", sub { $scanning_match };
+    validate_script_output "oscap xccdf eval --profile standard --results $xccdf_result xccdf.xml || true", $scanning_match;
     validate_result($xccdf_result, $result_match);
 
     # Single rule testing only available on the higher version for
     # openscap-utils
     if (!(is_sle('<15') or is_leap('<15.0'))) {    # openscap >= 1.2.16
         validate_script_output "oscap xccdf eval --profile standard --rule no_direct_root_logins --results $xccdf_result_single xccdf.xml || true",
-          sub { $scanning_match_single };
+          $scanning_match_single;
         validate_result($xccdf_result_single, $result_match_single);
     }
 }


### PR DESCRIPTION
I was just pointed to this code by @vtrubovics, and that it does not work as expected.

This should do what was oriinally intended.

Maybe someone familiar with this test can do a verification run?

http://open.qa/api/testapi/#_validate_script_output

validate_script_output can take a callback subroutine, where you can write your own code to match the output stored in `$_`. Alternatively it takes a regex object, which you can create with `qr//`.

If you use

    $something = 'm/regex/';

then the variable will just contain an ordinary string starting with the characters 'm' and a forward slash.

- Verification run: tbd