### PR TITLE
Support installing host with autoyast

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_kvm_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_kvm_hvm_x86_64.xml
@@ -24,7 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://download.opensuse.org/tumbleweed/repo/oss</guest_installation_media>
+    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings></guest_boot_settings>
     <guest_secure_boot></guest_secure_boot>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
@@ -45,27 +45,7 @@
       <hostname>##Host-Name##</hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
     </dns>
-    <interfaces config:type="list">
-      <interface>
-        <bootproto>dhcp</bootproto>
-        <name>enp1s0</name>
-        <startmode>auto</startmode>
-      </interface>
-      <interface>
-        <bootproto>static</bootproto>
-        <broadcast>127.255.255.255</broadcast>
-        <name>lo</name>
-        <firewall>no</firewall>
-        <ipaddr>127.0.0.1</ipaddr>
-        <netmask>255.0.0.0</netmask>
-        <network>127.0.0.0</network>
-        <prefixlen>8</prefixlen>
-        <startmode>auto</startmode>
-      </interface>
-    </interfaces>
-    <ipv6 config:type="boolean">true</ipv6>
     <keep_install_network config:type="boolean">true</keep_install_network>
-    <managed config:type="boolean">false</managed>
     <routing>
       <ipv4_forward config:type="boolean">true</ipv4_forward>
       <ipv6_forward config:type="boolean">true</ipv6_forward>
@@ -113,21 +93,8 @@
         <product>openSUSE</product>
     </products>
     <packages config:type="list">
-      <package>openSUSE-release</package>
-      <package>less</package>
-      <package>wicked</package>
-      <package>openssh</package>
-      <package>numactl</package>
-      <package>kexec-tools</package>
-      <package>irqbalance</package>
-      <package>iproute2</package>
-      <package>grub2</package>
-      <package>glibc</package>
-      <package>e2fsprogs</package>
-      <package>chrony</package>
-      <package>btrfsprogs</package>
-      <package>biosdevname</package>
       <package>autoyast2</package>
+      <package>supportutils</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
@@ -143,20 +143,11 @@
   </users>
   <scripts>
     <!-- permit root login, password login and pubkeys login -->
-    <!-- /etc/ssh/sshd_config/sshd_config is not default installed in TW -->
-    <init-scripts config:type="list">
+    <init-scripts t="list">
       <script>
         <source><![CDATA[
-sshd_config_file="/etc/ssh/sshd_config"
-if [ ! -f $sshd_config_file ]; then
-    mkdir -p `dirname $sshd_config_file`
-    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
-else
-    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
-    for key in $keys; do
-        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
-    done
-fi
+sshd_config_file="/etc/ssh/sshd_config.d/permit_root_login.conf"
+echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
 [ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
 touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
 echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
@@ -180,16 +180,8 @@
     <init-scripts config:type="list">
       <script>
         <source><![CDATA[
-sshd_config_file="/etc/ssh/sshd_config"
-if [ ! -f $sshd_config_file ]; then
-    mkdir -p `dirname $sshd_config_file`
-    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
-else
-    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
-    for key in $keys; do
-        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
-    done
-fi
+sshd_config_file="/etc/ssh/sshd_config.d/permit_root_login.conf"
+echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
 [ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
 touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
 echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
@@ -180,16 +180,8 @@
     <init-scripts config:type="list">
       <script>
         <source><![CDATA[
-sshd_config_file="/etc/ssh/sshd_config"
-if [ ! -f $sshd_config_file ]; then
-    mkdir -p `dirname $sshd_config_file`
-    echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
-else
-    keys="PermitRootLogin PubkeyAuthentication PasswordAuthentication"
-    for key in $keys; do
-        sed -i "/^[# ]*$key */{h;s/^[# ]*$key *.*\$/$key yes/};\${x;/^\$/{s//$key yes/;H};x}" $sshd_config_file
-    done
-fi
+sshd_config_file="/etc/ssh/sshd_config.d/permit_root_login.conf"
+echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
 [ -d /root/.ssh ] || mkdir -p /root/.ssh; chmod 700 /root/.ssh
 touch /root/.ssh/authorized_keys; chmod 600 /root/.ssh/authorized_keys
 echo "##Authorized-Keys##" >> /root/.ssh/authorized_keys

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_sshd.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_sshd.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm t="boolean">false</confirm>
+      <final_reboot t="boolean">true</final_reboot>
+      <second_stage t="boolean">false</second_stage>
+    </mode>
+    <signature-handling>
+      <accept_file_without_checksum t="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key t="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key t="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file t="boolean">true</accept_unsigned_file>
+      <accept_verification_failed t="boolean">true</accept_verification_failed>
+      <import_gpg_key t="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <report>
+    <errors>
+      <show t="boolean">true</show>
+      <timeout t="integer">20</timeout>
+      <log t="boolean">true</log>
+    </errors>
+    <messages>
+      <show t="boolean">true</show>
+      <timeout t="integer">5</timeout>
+      <log t="boolean">true</log>
+    </messages>
+    <warnings>
+      <show t="boolean">true</show>
+      <timeout t="integer">10</timeout>
+      <log t="boolean">true</log>
+    </warnings>
+    <yesno_messages>
+      <show t="boolean">true</show>
+      <timeout t="integer">30</timeout>
+      <log t="boolean">true</log>
+    </yesno_messages>
+  </report>
+  <bootloader>
+    <loader_type>grub2</loader_type>
+    <global>
+      <activate>true</activate>
+      <boot_mbr>true</boot_mbr>
+      <gfxmode>auto</gfxmode>
+      <os_prober>true</os_prober>
+      <terminal>console serial</terminal>
+      <serial>serial --unit=1 --speed=115200 --word=8 --parity=no</serial>
+      <timeout t="integer">30</timeout>
+      <update_nvram>true</update_nvram>
+      <xen_kernel_append>console=com2,115200 loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
+      <xen_append>console=hvc0,115200 console=tty loglevel=5</xen_append>
+    </global>
+  </bootloader>
+  <partitioning t="list">
+    <drive>
+      <device>/dev/sda</device>
+      <initialize t="boolean">true</initialize>
+      <use>all</use>
+      <enable_snapshots t="boolean">false</enable_snapshots>
+    </drive>
+  </partitioning>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>America/New_York</timezone>
+  </timezone>
+  <networking>
+    <keep_install_network t="boolean">true</keep_install_network>
+    <backend>network_manager</backend>
+  </networking>
+  <software>
+    <products t="list">
+      <product>openSUSE</product>
+    </products>
+    <install_recommended t="boolean">true</install_recommended>
+    <patterns t="list">
+      <pattern>base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>enhanced_base</pattern>
+      <pattern>kvm_server</pattern>
+      <pattern>kvm_tools</pattern>
+    </patterns>
+    <packages t="list">
+      <package>autoyast2</package>
+      <package>supportutils</package>
+      <package>nmap</package>
+    </packages>
+  </software>
+  <users t="list">
+    <user>
+      <username>bernhard</username>
+      <user_password>$y$j9T$xsY9ubdI0jRF5JoSV8vvg1$03I5jIewyiCMm/EmkgRtYxvEYm83ZSJo0tl1rKP8Ad.</user_password>
+      <fullname>Bernhard M. Wiedemann</fullname>  
+      <encrypted t="boolean">true</encrypted>
+    </user>
+    <user>
+      <username>root</username>
+      <user_password>$y$j9T$Bc3oHTMRcmYxyzTlxEd7A/$jU0KChUccTna2tH9ItMRyRHC9fofibG37RGH4XkCxYD</user_password>
+      <encrypted t="boolean">true</encrypted>
+    </user>
+  </users>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable t="list">
+        <service>firewalld</service>
+      </disable>
+      <enable t="list">
+        <service>sshd</service>
+	<service>virtqemud</service>
+	<service>virtstoraged</service>
+	<service>virtnetworkd</service>
+	<service>virtnodedevd</service>
+	<service>virtsecretd</service>
+	<service>virtproxyd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <scripts>
+    <!-- permit root login, password login and pubkeys login -->
+    <!-- keep ssh session alive -->
+    <!-- /etc/ssh/sshd_config is not default installed in TW -->
+    <init-scripts t="list">
+      <script>
+        <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config.d/permit_root_login.conf"
+echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+sshd_config_file="/etc/ssh/sshd_config.d/keep_alive.conf"
+echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 480" > $sshd_config_file
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
+</profile>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_sshd.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_sshd.xml
@@ -114,6 +114,7 @@
 	<service>virtnodedevd</service>
 	<service>virtsecretd</service>
 	<service>virtproxyd</service>
+	<service>virtnwfilterd</service>
       </enable>
     </services>
   </services-manager>

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -1806,7 +1806,8 @@ sub get_guest_ipaddr {
     my @subnets_in_route = @_;
 
     $self->reveal_myself;
-    return $self if ((($self->{guest_ipaddr} ne '') and ($self->{guest_ipaddr} ne 'NO_IP_ADDRESS_FOUND_AT_THE_MOMENT')) or ($self->{guest_ipaddr_static} eq 'true'));
+    # Tumbleweed guest's IP will change after reboot, so we need check IP multiple times even if an IP has been detected.
+    return $self if ((!is_tumbleweed and ($self->{guest_ipaddr} ne '') and ($self->{guest_ipaddr} ne 'NO_IP_ADDRESS_FOUND_AT_THE_MOMENT')) or ($self->{guest_ipaddr_static} eq 'true'));
     @subnets_in_route = split(/\n+/, script_output("ip route show all | awk \'{print \$1}\' | grep -v default")) if (scalar(@subnets_in_route) eq 0);
     foreach (@subnets_in_route) {
         my $single_subnet = $_;
@@ -1894,7 +1895,7 @@ sub check_guest_installation_result_via_ssh {
     $self->reveal_myself;
     my $_guest_transient_hostname = '';
     record_info("Going to use guest $self->{guest_name} ip address to detect installation result directly.", "No any interested needle or text-login/guest-console-text-login needle is detected.Just a moment");
-    $self->get_guest_ipaddr if (($self->{guest_ipaddr_static} ne 'true') and (!($self->{guest_ipaddr} =~ /^\d+\.\d+\.\d+\.\d+$/im)));
+    $self->get_guest_ipaddr if (is_tumbleweed or (($self->{guest_ipaddr_static} ne 'true') and (!($self->{guest_ipaddr} =~ /^\d+\.\d+\.\d+\.\d+$/im))));
     save_screenshot;
     if ($self->{guest_ipaddr} =~ /^\d+\.\d+\.\d+\.\d+$/im) {
         if ($self->{guest_network_type} eq 'virtual_network') {

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -91,8 +91,8 @@ sub setup_console_in_grub {
             }
             $cmd
               = "sed -ri '/multiboot/ "
-              . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
-              . "/multiboot/ s/\$/ $dom0_options console=com2,115200 log_lvl=all guest_loglvl=all sync_console $com_settings/;}; "
+              . "{s/(console|loglevel|loglvl|guest_loglvl)=[^ ]*//g; "
+              . "/multiboot/ s/\$/ $dom0_options console=com2,115200 loglvl=all guest_loglvl=all sync_console $com_settings/;}; "
               . "' $grub_cfg_file";
             assert_script_run($cmd);
             save_screenshot;
@@ -122,7 +122,7 @@ sub setup_console_in_grub {
         $cmd
           = "cp $grub_cfg_file ${grub_cfg_file}.org "
           . "\&\& sed -ri '/($bootmethod\\s*.*$search_pattern)/ "
-          . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
+          . "{s/(console|loglevel|loglvl|guest_loglvl)=[^ ]*//g; "
           . "/$bootmethod\\s*.*$search_pattern/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5 $intel_option/;}; "
           . "s/timeout=-{0,1}[0-9]{1,}/timeout=30/g;"
           . "' $grub_cfg_file";

--- a/lib/parallel_guest_migration_base.pm
+++ b/lib/parallel_guest_migration_base.pm
@@ -54,7 +54,7 @@ use List::MoreUtils qw(firstidx);
 use List::Util 'first';
 use version_utils qw(is_opensuse is_sle is_alp is_microos get_os_release);
 use virt_utils qw(collect_host_and_guest_logs cleanup_host_and_guest_logs enable_debug_logging);
-use virt_autotest::utils qw(is_kvm_host is_xen_host check_host_health check_guest_health is_fv_guest is_pv_guest add_guest_to_hosts parse_subnet_address_ipv4 check_port_state setup_common_ssh_config);
+use virt_autotest::utils qw(is_kvm_host is_xen_host check_host_health check_guest_health is_fv_guest is_pv_guest add_guest_to_hosts parse_subnet_address_ipv4 check_port_state setup_common_ssh_config is_monolithic_libvirtd);
 use virt_autotest::domain_management_utils qw(construct_uri create_guest remove_guest shutdown_guest show_guest check_guest_state);
 use utils qw(zypper_call systemctl script_retry define_secret_variable);
 use virt_autotest::common;
@@ -443,7 +443,8 @@ sub check_host_virtualization {
         assert_script_run("lsmod | grep xen");
     }
 
-    if (!is_alp) {
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    if (!is_alp and is_monolithic_libvirtd) {
         if (script_run("systemctl is-active libvirtd") != 0) {
             systemctl("stop libvirtd", ignore_failure => 1);
             systemctl("start libvirtd");
@@ -1251,8 +1252,11 @@ EOF
                 $_temp = 0;
             }
             if (script_run("virsh $_uri net-start $guest_matrix{$_guest}{netname}") != 0) {
-                systemctl("restart libvirtd");
-                systemctl("status libvirtd");
+                # Note: TBD for modular libvirt. See poo#129086 for detail.
+                if (is_monolithic_libvirtd) {
+                    systemctl("restart libvirtd");
+                    systemctl("status libvirtd");
+                }
                 $_temp |= script_run("virsh $_uri net-start $guest_matrix{$_guest}{netname}");
             }
             else {

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -27,6 +27,7 @@ use IO::Socket::INET;
 use Carp;
 
 our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest guest_is_sle is_guest_ballooned is_xen_host is_kvm_host reset_log_cursor check_failures_in_journal check_host_health check_guest_health
+  is_monolithic_libvirtd turn_on_libvirt_debugging_log
   print_cmd_output_to_file ssh_setup ssh_copy_id create_guest import_guest install_default_packages upload_y2logs ensure_default_net_is_active ensure_guest_started
   ensure_online add_guest_to_hosts restart_libvirtd remove_additional_disks remove_additional_nic collect_virt_system_logs shutdown_guests wait_guest_online start_guests restore_downloaded_guests save_original_guest_xmls restore_original_guests
   is_guest_online wait_guests_shutdown remove_vm setup_common_ssh_config add_alias_in_ssh_config parse_subnet_address_ipv4 backup_file manage_system_service setup_rsyslog_host
@@ -55,8 +56,23 @@ sub restart_libvirtd {
     else {
         systemctl("restart libvirtd", timeout => 180);
     }
+    record_info("Libvirtd has been restarted!");
     save_screenshot;
-    record_info("Debug log for libvirtd has been enabled!");
+}
+
+# Usage: restart_modular_libvirt_daemons([daemon1_name daemon2_name ...]). For example:
+# to specify daemons which will be restarted: restart_modular_libvirt_daemons(virtqemud virtstoraged ...)
+# to restart all modular daemons without any daemons passed
+sub restart_modular_libvirt_daemons {
+    my @daemons = @_ == 0 ? qw(virtqemud virtstoraged virtnetworkd virtnodedevd virtsecretd virtproxyd virtnwfilterd) : split(" ", @_);
+    if (is_alp) {
+        record_soft_failure("Restaring modular libvirt daemons has not been implemented in ALP. See poo#129086");
+    }
+    else {
+        systemctl("restart $_\{,-ro,-admin\}.socket") foreach @daemons;
+        systemctl("restart $_.service") foreach @daemons;
+    }
+    record_info("Libvirt daemons restarted", join(' ', @daemons));
 }
 
 #return 1 if it is a VMware test judging by REGRESSION variable
@@ -114,6 +130,43 @@ sub is_guest_ballooned {
 #return 1 if test is expected to run on KVM hypervisor
 sub is_kvm_host {
     return check_var("SYSTEM_ROLE", "kvm") || check_var("HOST_HYPERVISOR", "kvm") || check_var("REGRESSION", "qemu-hypervisor");
+}
+
+#retrun 1 if libvirt 9.0- is running which monolithic libvirtd is the default service
+sub is_monolithic_libvirtd {
+    unless (is_alp) {
+        return 1 if script_run('rpm -q libvirt-libs | grep -e "libs-9\.0" -e "libs-[1-8]\."') == 0;
+    }
+    return 0;
+}
+
+# For legacy libvird, set debug level logging for libvirtd services
+# For modular libvirt, do the same settings to /etc/libvirt/virt{qemu,xen,driver}d.conf.
+# virt{qemu,xen}d daemons provide the most important libvirt log(sufficient for most issues).
+# virt{driver}.d daemons is only required by specific issues, eg virtual network failures may need virtnetworkd log.
+# But our automation is better to set them to collect more logs as we could as possible.
+# Developer asked to use different log file as log_output per daemon.
+sub turn_on_libvirt_debugging_log {
+
+    my @libvirt_daemons = is_monolithic_libvirtd ? "libvirtd" : qw(virtqemud virtstoraged virtnetworkd virtnodedevd virtsecretd virtproxyd virtnwfilterd virtlockd virtlogd);
+
+    #turn on debug and log filter for libvirt services
+    #set log_level = 1 'debug'
+    #the size of libvirtd with debug level and without any filter on sles15sp3 xen is over 100G,
+    #which consumes all the disk space. Now get comfirmation from virt developers,
+    #log filter is set to store component logs with different levels.
+    foreach my $daemon (@libvirt_daemons) {
+        my $conf_file = "/etc/libvirt/$daemon.conf";
+        if (script_run("ls $conf_file") == 0) {
+            script_run "sed -i '/^[# ]*log_level *=/{h;s/^[# ]*log_level *= *[0-9].*\$/log_level = 1/};\${x;/^\$/{s//log_level = 1/;H};x}' $conf_file";
+            script_run "sed -i '/^[# ]*log_outputs *=/{h;s%^[# ]*log_outputs *=.*[0-9].*\$%log_outputs = \"1:file:/var/log/libvirt/$daemon.log\"%};\${x;/^\$/{s%%log_outputs = \"1:file:/var/log/libvirt/$daemon.log\"%;H};x}' $conf_file";
+            script_run "sed -i '/^[# ]*log_filters *=/{h;s%^[# ]*log_filters *=.*[0-9].*\$%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%};\${x;/^\$/{s%%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%;H};x}' $conf_file";
+        }
+    }
+    script_run "grep -e 'log_level.*=' -e 'log_outputs.*=' -e 'log_filters.*=' /etc/libvirt/*d.conf";
+    save_screenshot;
+
+    is_monolithic_libvirtd ? restart_libvirtd : restart_modular_libvirt_daemons;
 }
 
 #return 1 if test is expected to run on XEN hypervisor
@@ -430,7 +483,8 @@ sub ensure_online {
             }
             # Check also if name resolution works - restart libvirtd if not
             if (script_run("ssh $guest ping -c 3 -w 120 $dns_host", timeout => 180) != 0) {
-                restart_libvirtd if (is_xen_host || is_kvm_host);
+                # Note: TBD for modular libvirt. See poo#129086 for detail.
+                restart_libvirtd if (is_monolithic_libvirtd and (is_xen_host || is_kvm_host));
                 die "name resolution failed for $guest" if (script_retry("ssh $guest ping -c 3 -w 120 $dns_host", delay => 1, retry => 10, timeout => 180) != 0);
             }
         }
@@ -446,7 +500,8 @@ sub upload_y2logs {
 
 sub ensure_default_net_is_active {
     if (script_run("virsh net-list --all | grep default | grep ' active'", 90) != 0) {
-        restart_libvirtd;
+        # Note: TBD for modular libvirt. See poo#129086 for detail.
+        restart_libvirtd if is_monolithic_libvirtd;
         if (script_run("virsh net-list --all | grep default | grep ' active'", 90) != 0) {
             assert_script_run "virsh net-start default";
         }
@@ -483,10 +538,11 @@ sub remove_additional_nic {
 }
 
 sub collect_virt_system_logs {
-    if (script_run("test -f /var/log/libvirt/libvirtd.log") == 0) {
-        upload_logs("/var/log/libvirt/libvirtd.log");
-    } else {
-        record_info "File /var/log/libvirt/libvirtd.log does not exist.";
+    if (script_run("test -f /var/log/libvirt/*d.log") == 0) {
+        upload_logs("/var/log/libvirt/*d.log");
+    }
+    else {
+        record_info "File /var/log/libvirt/*d.log does not exist.";
     }
 
     if (script_run("test -d /var/log/libvirt/libxl/") == 0) {

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -27,7 +27,7 @@ use virt_autotest::utils;
 
 our @EXPORT
   = qw(download_network_cfg prepare_network restore_standalone destroy_standalone restart_network
-  restore_guests restore_network destroy_vir_network restore_libvirt_default enable_libvirt_log pload_debug_log
+  restore_guests restore_network destroy_vir_network restore_libvirt_default pload_debug_log
   check_guest_status check_guest_module check_guest_ip save_guest_ip test_network_interface hosts_backup
   hosts_restore get_free_mem get_active_pool_and_available_space clean_all_virt_networks setup_vm_simple_dns_with_ip
   get_guest_ip_from_vnet_with_mac update_simple_dns_for_all_vm validate_guest_status);
@@ -286,13 +286,6 @@ sub restore_libvirt_default {
         assert_script_run("virsh net-define $default_path", 60);
         assert_script_run("rm -rf $default_path");
     }
-}
-
-sub enable_libvirt_log {
-    assert_script_run qq(echo 'log_level = 1
-    log_filters="3:remote 4:event 3:json 3:rpc"
-    log_outputs="1:file:/var/log/libvirt/libvirtd.log"' >> /etc/libvirt/libvirtd.conf);
-    restart_libvirtd;
 }
 
 sub upload_debug_log {

--- a/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
+++ b/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
@@ -4,8 +4,6 @@ description:    >
     Virtualization guest installation tests including extended feature tests schedule
 schedule:
     - '{{install_and_bootup}}'
-    - virt_autotest/switch_to_ssh_and_install_hypervisor
-    - '{{reboot}}'
     - '{{install_guest}}'
     - virt_autotest/set_config_as_glue
     - '{{virtual_network_test}}'
@@ -17,6 +15,13 @@ conditional_schedule:
         DO_NOT_INSTALL_HOST:
             0:
                 - installation/ipxe_install
+                - '{{install_host_with_needle_matching}}'
+    install_host_with_needle_matching:
+        HOST_INSTALL_AUTOYAST:
+            1:
+                - autoyast/installation
+                - virt_autotest/login_console
+            0:
                 - installation/welcome
                 - installation/online_repos
                 - installation/installation_mode
@@ -32,9 +37,7 @@ conditional_schedule:
                 - installation/start_install
                 - installation/await_install
                 - installation/reboot_after_installation
-    reboot:
-        DO_NOT_INSTALL_HOST:
-            0:
+                - virt_autotest/switch_to_ssh_and_install_hypervisor
                 - virt_autotest/reboot_and_wait_up_normal
     install_guest:
         SKIP_GUEST_INSTALL:

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -29,7 +29,7 @@ use testapi;
 use Utils::Architectures;
 use utils;
 use power_action_utils 'prepare_system_shutdown';
-use version_utils qw(is_sle is_microos is_released is_upgrade);
+use version_utils qw(is_sle is_microos is_tumbleweed is_released is_upgrade);
 use main_common 'opensuse_welcome_applicable';
 use x11utils 'untick_welcome_on_next_startup';
 use Utils::Backends;
@@ -106,7 +106,7 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
-    test_ayp_url;
+    test_ayp_url unless get_var('VIRT_AUTOTEST') and is_tumbleweed;
     my $test_data = get_test_suite_data();
     my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot package-notification nvidia-validation-failed import-untrusted-gpg-key);
 

--- a/tests/virt_autotest/cleanup_libvirtd_log.pm
+++ b/tests/virt_autotest/cleanup_libvirtd_log.pm
@@ -13,11 +13,14 @@ use base "virt_autotest_base";
 use testapi;
 
 sub run {
-    # Cleanup libvirtd.log
-    my $libvirtd_log_file = "/var/log/libvirt/libvirtd.log";
-    if (script_run("test -f $libvirtd_log_file") == 0) {
-        script_run("echo '' > $libvirtd_log_file");
-        record_info "Set file $libvirtd_log_file empty before every test.";
+    # Cleanup logs of libvirt daemons
+    my @libvirt_daemons = qw(libvirtd virtqemud virtstoraged virtnetworkd virtnodedevd virtsecretd virtproxyd virtnwfilterd virtlockd virtlogd);
+    foreach (@libvirt_daemons) {
+        my $log_file = "/var/log/libvirt/$_.log";
+        if (script_run("test -f $log_file") == 0) {
+            script_run("echo '' > $log_file");
+            record_info "Set file $log_file empty before every test.";
+        }
     }
 }
 

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -87,7 +87,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
-    virt_autotest::utils::restart_libvirtd();
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -83,7 +83,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
-    virt_autotest::utils::restart_libvirtd();
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -76,7 +76,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
-    virt_autotest::utils::restart_libvirtd();
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -114,7 +114,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
-    virt_autotest::utils::restart_libvirtd();
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -49,7 +49,7 @@ sub run_test {
         virt_autotest::virtual_network_utils::restore_standalone() if (is_sle('=11-sp4'));
 
         #Enable libvirt debug log
-        virt_autotest::virtual_network_utils::enable_libvirt_log();
+        turn_on_libvirt_debugging_log;
 
         #VM HOST SSH SETUP
         virt_autotest::utils::ssh_setup();
@@ -111,7 +111,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 
     #Restart libvirtd service
-    virt_autotest::utils::restart_libvirtd();
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
 
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -16,7 +16,7 @@ use Utils::Architectures;
 use Utils::Backends qw(use_ssh_serial_console is_remote_backend set_ssh_console_timeout);
 use version_utils qw(is_sle is_tumbleweed);
 use ipmi_backend_utils;
-use virt_autotest::utils qw(is_xen_host is_kvm_host check_port_state check_host_health);
+use virt_autotest::utils qw(is_xen_host is_kvm_host check_port_state check_host_health is_monolithic_libvirtd);
 use IPC::Run;
 
 sub set_ssh_console_timeout_before_use {
@@ -45,19 +45,29 @@ sub double_check_xen_role {
         die 'Double-check xen kernel failed';
     }
 
+    # for modular libvirt, virtxend is expected in "loaded: active or inactive" status.
+    # virtxend.socket seems to be always in "loaded: active" status
+    unless (is_monolithic_libvirtd) {
+        die 'virtxend.socket is not running!' unless script_run("systemctl is-active virtxend.socket") eq 0;
+    }
+
     record_info 'INFO', 'Check if start bootloader from a read-only snapshot';
     assert_script_run('touch /root/read-only.fs && rm -rf /root/read-only.fs');
     save_screenshot;
 }
 
 sub check_kvm_modules {
-    if (script_run('lsmod | grep "^kvm\b"') == 0 and script_run('lsmod | grep -e "^kvm_intel\b" -e "^kvm_amd\b"') == 0) {
+    unless (script_run('lsmod | grep "^kvm\b"') == 0 or script_run('lsmod | grep -e "^kvm_intel\b" -e "^kvm_amd\b"') == 0) {
         save_screenshot;
-        record_info("KVM", "kvm and kvm_intel/amd modules are loaded");
-    }
-    else {
         die "KVM modules are not loaded!";
     }
+
+    # for modular libvirt, virtqemud is expected in "loaded: active or inactive" status.
+    # virtqemud.socket seems to be always in "loaded: active" status
+    unless (is_monolithic_libvirtd) {
+        die 'virtqemud.socket is not running!' unless script_run("systemctl is-active virtqemud.socket") eq 0;
+    }
+    record_info("KVM", "kvm modules are loaded!");
 }
 
 #Explanation for parameters introduced to facilitate offline host upgrade:
@@ -211,12 +221,12 @@ sub login_to_console {
     # double-check xen role for xen host
     double_check_xen_role if (is_xen_host and !get_var('REBOOT_AFTER_UPGRADE'));
     check_kvm_modules if is_x86_64 and is_kvm_host and !get_var('REBOOT_AFTER_UPGRADE');
+    check_host_health();
 }
 
 sub run {
     my $self = shift;
     $self->login_to_console;
-    check_host_health();
 }
 
 sub post_fail_hook {

--- a/tests/virt_autotest/set_config_as_glue.pm
+++ b/tests/virt_autotest/set_config_as_glue.pm
@@ -13,6 +13,8 @@ use virt_autotest::common;
 use strict;
 use warnings;
 use testapi;
+use Utils::Backends 'use_ssh_serial_console';
+use ipmi_backend_utils;
 
 sub fufill_guests_in_setting {
     my $wait_script = "30";
@@ -28,6 +30,8 @@ sub fufill_guests_in_setting {
 }
 
 sub run {
+    select_console 'sol', await_console => 0;
+    use_ssh_serial_console;
     fufill_guests_in_setting;
 }
 

--- a/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
+++ b/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
@@ -48,7 +48,6 @@ sub run {
     zypper_call('--gpg-auto-import-keys ref');
     script_retry("zypper -n in -t pattern ${hypervisor}_server ${hypervisor}_tools", timeout => 1800, retry => 5, delay => 10);
     set_grub_on_vh('', '', $hypervisor);
-    systemctl 'enable libvirtd', ignore_failure => 1;
 
     virt_autotest::utils::install_default_packages();
     save_screenshot;

--- a/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
+++ b/tests/virt_autotest/switch_to_ssh_and_install_hypervisor.pm
@@ -3,8 +3,7 @@
 # Copyright 2021 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
-# Summary: For openSUSE virtualization test only. login in console, install kvm/xen patterns if needed.
-#  - Even if you'd like to run tests without host installation(DO_NOT_INSTALL_HOST=1), this module is still necessary as login console in this module is required.
+# Summary: For openSUSE virtualization tests which install hosts with needle matching. login in console, configure sshd, install kvm/xen patterns and set up br0. It is not required for tests which install hosts with autoyast, because all these configurations are written in its autoyast profiles.
 #  - This module is added for openSUSE TW because of the difference beteen SLE and TW. Meanwile, login_console, install_package and update_package from SLE are not needed. The reasons are listed below:
 #    -- login_console is not called after first boot in host installation in TW because kvm/xen patterns have not been installed at that time. reconnect_mgmt_console and first_boot take care of the login function.
 #    -- have to zypper install kvm/xen patterns in TW.
@@ -41,10 +40,8 @@ sub run {
     }
     assert_screen "text-logged-in-root";
     #skip TW host installation and directly login if you'd like to run test on an SUT with TW installed
-    permit_root_ssh_in_sol unless get_var('DO_NOT_INSTALL_HOST');
+    permit_root_ssh_in_sol;
     select_console('root-ssh');
-
-    return if get_var('DO_NOT_INSTALL_HOST');
 
     die 'Need one of both to be true: is_kvm_host || is_xen_host' unless is_kvm_host || is_xen_host;
     my $hypervisor = is_kvm_host ? 'kvm' : 'xen';

--- a/tests/virt_autotest/unified_guest_installation.pm
+++ b/tests/virt_autotest/unified_guest_installation.pm
@@ -51,10 +51,15 @@ use strict;
 use warnings;
 use testapi;
 use Carp;
+use Utils::Backends 'use_ssh_serial_console';
 use virt_autotest::utils qw(check_guest_health);
+use ipmi_backend_utils;
 
 sub run {
     my $self = shift;
+
+    select_console 'sol', await_console => 0;
+    use_ssh_serial_console;
 
     $self->reveal_myself;
     my @guest_names = split(/,/, get_required_var('UNIFIED_GUEST_LIST'));

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -21,7 +21,6 @@ use XML::Writer;
 use IO::File;
 use List::Util 'first';
 use LWP::Simple 'head';
-use version_utils 'is_sle';
 use virt_autotest::utils;
 use version_utils qw(is_sle is_alp get_os_release);
 
@@ -30,19 +29,7 @@ our @EXPORT
 
 sub enable_debug_logging {
 
-    #turn on debug and log filter for libvirtd
-    #set log_level = 1 'debug'
-    #the size of libvirtd with debug level and without any filter on sles15sp3 xen is over 100G,
-    #which consumes all the disk space. Now get comfirmation from virt developers,
-    #log filter is set to store component logs with different levels.
-    my $libvirtd_conf_file = "/etc/libvirt/libvirtd.conf";
-    if (!script_run "ls $libvirtd_conf_file") {
-        script_run "sed -i '/^[# ]*log_level *=/{h;s/^[# ]*log_level *= *[0-9].*\$/log_level = 1/};\${x;/^\$/{s//log_level = 1/;H};x}' $libvirtd_conf_file";
-        script_run "sed -i '/^[# ]*log_outputs *=/{h;s%^[# ]*log_outputs *=.*[0-9].*\$%log_outputs=\"1:file:/var/log/libvirt/libvirtd.log\"%};\${x;/^\$/{s%%log_outputs=\"1:file:/var/log/libvirt/libvirtd.log\"%;H};x}' $libvirtd_conf_file";
-        script_run "sed -i '/^[# ]*log_filters *=/{h;s%^[# ]*log_filters *=.*[0-9].*\$%log_filters=\"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%};\${x;/^\$/{s%%log_filters=\"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%;H};x}' $libvirtd_conf_file";
-        script_run "grep -e log_level -e log_outputs -e log_filters $libvirtd_conf_file";
-    }
-    save_screenshot;
+    turn_on_libvirt_debugging_log;
 
     # enable journal log with previous reboot
     my $journald_conf_file = "/etc/systemd/journald.conf";
@@ -61,8 +48,6 @@ sub enable_debug_logging {
     }
     save_screenshot;
 
-    #restart libvirtd to make debug level and coredump take effect
-    virt_autotest::utils::restart_libvirtd;
 }
 
 sub get_version_for_daily_build_guest {

--- a/tests/virtualization/universal/guest_management.pm
+++ b/tests/virtualization/universal/guest_management.pm
@@ -51,7 +51,8 @@ sub run {
     record_info "START", "Start all guests";
     foreach my $guest (keys %virt_autotest::common::guests) {
         if (script_retry("virsh start $guest", delay => 120, retry => 3, die => 0) != 0) {
-            restart_libvirtd;
+            # Note: TBD for modular libvirt. See poo#129086 for detail.
+            restart_libvirtd if is_monolithic_libvirtd;
             script_retry("virsh start $guest", delay => 120, retry => 3);
         }
         script_retry "nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12;

--- a/tests/virtualization/universal/patch_and_reboot.pm
+++ b/tests/virtualization/universal/patch_and_reboot.pm
@@ -35,7 +35,8 @@ sub run {
         save_screenshot;
         switch_from_ssh_to_sol_console(reset_console_flag => 'on');
     } else {
-        systemctl("restart libvirtd");
+        # Note: TBD for modular libvirt. See poo#129086 for detail.
+        systemctl("restart libvirtd") if is_monolithic_libvirtd;
         script_run("virsh list --all | grep -v Domain-0");
         # Check that all guests are still running
         script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -81,7 +81,8 @@ sub run {
     # Use serial terminal, unless defined otherwise. The unless will go away once we are certain this is stable
     #    select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
     select_console('root-console');
-    systemctl("restart libvirtd");
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    systemctl("restart libvirtd") if is_monolithic_libvirtd;
     assert_script_run('for i in $(virsh list --name|grep -v Domain-0);do virsh destroy $i;done');
     assert_script_run('for i in $(virsh list --name --inactive); do if [[ $i == win* ]]; then virsh undefine $i; else virsh undefine $i --remove-all-storage; fi; done');
     script_run("[ -f /root/.ssh/known_hosts ] && > /root/.ssh/known_hosts");

--- a/tests/virtualization/universal/virsh_start.pm
+++ b/tests/virtualization/universal/virsh_start.pm
@@ -22,7 +22,8 @@ sub run {
     }
 
     record_info "LIBVIRTD", "Restart libvirtd and expect all guests to boot up";
-    restart_libvirtd;
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    restart_libvirtd if is_monolithic_libvirtd;
 
 
     # Ensure all guests have network connectivity

--- a/tests/virtualization/universal/virsh_stop.pm
+++ b/tests/virtualization/universal/virsh_stop.pm
@@ -22,7 +22,8 @@ sub run {
     assert_script_run "virsh autostart --disable $_" foreach (keys %virt_autotest::common::guests);
 
     record_info "LIBVIRTD", "Restart libvirtd and expect all guests to stay down";
-    restart_libvirtd;
+    # Note: TBD for modular libvirt. See poo#129086 for detail.
+    restart_libvirtd if is_monolithic_libvirtd;
 }
 
 sub test_flags {


### PR DESCRIPTION
Put all commits in one PR because tests have to be verified in O3, downloading TW medium from download.opensuse.org always timeout and is not supported from O3 repo.

Autoyast profiles for KVM host has been done and for XEN host will available soon. but we need not wait for xen autoyast profiles, it will be in a seperate PR.

1. Support installing host with autoyast.  The normal path for host autoyast profiles, data/ or autoyast/ in openqa path, cannot be adoppted in O3 , because static ipxe installation command is used in O3. I commit the files at here but actually copy them manually to a location in O3, /var/lib/openqa/share/factory/other/autoyast_opensuse_kvm_sshd.xml. No installation.pm is used in O3 for the time being, it will be considered if it is implemented for SLE in the future.

2. Use sol console as it is used in other tests and it is said stable enough.

3. Determine modular libvirt by the version of libvirt package, libvirt 9.1.0. As Alice suggested, determine the version of libvirt by running command directly in SUT rather than by products and releases to prevent adaptions in the future. 

4. Provide a function to restart modular libvirt daemons for test owners to implement in their test in the future.

5. Enable debug logging for modular libvirt and output logs to seperate log files.

6. Install guests with medium from O3 repo. It is more stable to download kernel files from O3 repo than download.opensuse.org for guest. 

7.  Check guest more often as IP change after reboot. Unlike SLE15SP5 guests, the IP TW guest during installation is different with the one after guest reboot even with the identical MAC address. It took me a lot of time in this issue. I have tried configurations from both dhcp client side and server side, passing static IP to guest,  but all failed. Finally, I have to change test scripts to check guest IP more often. 

8. Remove "DISPLAY= " from yast.ssh install command. Installation with this system variable began to fail a few weeks ago. I don't find the reason.

- Related ticket: https://progress.opensuse.org/issues/124149 & https://progress.opensuse.org/issues/126092
- Verification run with the latest commits: 
[Passed TW kvm test](https://openqa.opensuse.org/tests/3284826#live) 
[Failed TW kvm test and logs uploaded](https://openqa.opensuse.org/tests/3282580)   // failed as expected and logs were uploaded in [virt_logs_all.tar.gz](https://openqa.opensuse.org/tests/3282580/file/virt_logs_all.tar.gz)
[Failed SLE 12sp5 xen host and libvirtd log uploaded](https://openqa.suse.de/tests/11109911)
[Passed SLE kvm test](https://openqa.suse.de/tests/11109919)

more verificat runs with previous commits
[uefi-gi-guest_developing-on-host_developing-kvm](http://openqa.suse.de/tests/11084741)  
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/11084731)  
[uefi-gi-guest_developing-on-host_sles15sp4-kvm](http://openqa.suse.de/t11083532) 
