### PR TITLE
Adapt kvm mitigations on spectre_v2 for passthrough

### DIFF
--- a/tests/cpu_bugs/mitigations.pm
+++ b/tests/cpu_bugs/mitigations.pm
@@ -149,6 +149,10 @@ sub run {
                     $mitigations_list{sysfs}->{auto}->{'spectre_v2'} = 'Mitigation: Retpolines,.*IBPB: conditional, IBRS_FW*';
                     $mitigations_list{sysfs}->{'auto,nosmt'}->{'spectre_v2'} = 'Mitigation: Retpolines,.*IBPB: conditional, IBRS_FW*';
                 }
+                if (get_var('MACHINE', '') =~ /^qemu-skylake.*-passthrough$/ && $item eq 'spectre_v2') {
+                    $mitigations_list{sysfs}->{auto}->{'spectre_v2'} = 'Mitigation: IBRS, IBPB: conditional, RSB filling.*';
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{'spectre_v2'} = 'Mitigation: IBRS, IBPB: conditional, RSB filling.*';
+                }
                 #NO-IBRS
                 if (get_var('MACHINE') =~ /^qemu-.*-NO-IBRS$/ && $item eq 'mds') {
                     $mitigations_list{sysfs}->{auto}->{mds} = 'Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown';


### PR DESCRIPTION
modify mitigations.pm for kvm passthrough of spectre_v2 cases on skylake machine.
http://10.67.129.4/tests/56928#

Verification run: http://10.67.129.4/tests/56989
