### PR TITLE
Minor improvement on logging

### DIFF
--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
@@ -138,7 +138,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
@@ -138,7 +138,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
@@ -138,7 +138,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -160,7 +160,7 @@
   </software>
   <timezone t="map">
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults t="map">
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -182,7 +182,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_multi-user_x86_64.xml
@@ -183,7 +183,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_graphical_x86_64.xml
@@ -186,7 +186,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_multi-user_x86_64.xml
@@ -186,7 +186,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_graphical_x86_64.xml
@@ -187,7 +187,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_multi-user_x86_64.xml
@@ -187,7 +187,7 @@
   </software>
   <timezone>
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults>
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -232,7 +232,7 @@
   </software>
   <timezone t="map">
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults t="map">
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_multi-user_x86_64.xml
@@ -232,7 +232,7 @@
   </software>
   <timezone t="map">
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults t="map">
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_graphical_x86_64.xml
@@ -234,7 +234,7 @@
   </software>
   <timezone t="map">
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults t="map">
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_multi-user_x86_64.xml
@@ -234,7 +234,7 @@
   </software>
   <timezone t="map">
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults t="map">
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_graphical_x86_64.xml
@@ -235,7 +235,7 @@
   </software>
   <timezone t="map">
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults t="map">
     <expire/>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_multi-user_x86_64.xml
@@ -235,7 +235,7 @@
   </software>
   <timezone t="map">
     <hwclock>UTC</hwclock>
-    <timezone>America/Denver</timezone>
+    <timezone>America/New_York</timezone>
   </timezone>
   <user_defaults t="map">
     <expire/>

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -381,7 +381,7 @@ sub prepare_common_environment {
         virt_autotest::utils::backup_file(\@stuff_to_backup);
         script_run("rm -f -r /root/.ssh/config");
         virt_autotest::utils::setup_common_ssh_config('/root/.ssh/config');
-        script_run("sed -i -r -n \'s/^.*IdentityFile.*\$/#&/\' /etc/ssh/ssh_config");
+        script_run("[ -f /etc/ssh/ssh_config ] && sed -i -r -n \'s/^.*IdentityFile.*\$/#&/\' /etc/ssh/ssh_config");
         enable_debug_logging;
         $self->prepare_non_transactional_environment;
         $common_environment_prepared = 'true';

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -140,7 +140,7 @@ sub reset_log_cursor {
 #support x86_64 only
 #welcome everybody to extend this function
 sub check_failures_in_journal {
-    return unless is_x86_64;
+    return unless is_x86_64 and (is_sle or is_opensuse);
     my $machine = shift;
     $machine //= 'localhost';
 
@@ -149,7 +149,7 @@ sub check_failures_in_journal {
     $cmd .= defined($cursor) ? "--cursor='$cursor'" : "-b";
     $cmd = "ssh root\@$machine " . "\"$cmd\"" if $machine ne 'localhost';
 
-    my $log = script_output($cmd);
+    my $log = script_output($cmd, type_command => 1, proceed_on_failure => 1);
     my $failures = "";
     my @warnings = ('Started Process Core Dump', 'Call Trace');
 
@@ -235,7 +235,7 @@ sub download_script {
     my $script_url = $args{script_url} // data_url("virt_autotest/$script_name");
     my $machine = $args{machine} // 'localhost';
 
-    my $cmd = "curl -s -o ~/$script_name $script_url";
+    my $cmd = "curl -o ~/$script_name $script_url";
     $cmd = "ssh root\@$machine " . "\"$cmd\"" if ($machine ne 'localhost');
     unless (script_retry($cmd, retry => 2, die => 0) == 0) {
         # Add debug codes as the url only exists in a dynamic openqa URL

--- a/tests/virt_autotest/validate_system_health.pm
+++ b/tests/virt_autotest/validate_system_health.pm
@@ -28,7 +28,7 @@ sub prepare_run_test {
 }
 
 sub run_test {
-    return unless is_x86_64;
+    return unless is_x86_64 || is_alp;
 
     my $self = shift;
     my %health_status = ();


### PR DESCRIPTION
- To continue the test even if test run to logging failures, fg. https://openqa.suse.de/tests/10685378#step/validate_system_health/24
- Correct timezone settings of guests
- '/etc/ssh/ssh_config' file does not exist in TW

- Verification run:
[guest-migration-sles15sp4-from-sles15sp4-to-developing-xen-src](https://openqa.suse.de/tests/10744978)
[gi-guest_developing-on-host_sles12sp5-xen](https://openqa.suse.de/tests/10752905)
