### PR TITLE
Exclude ssh from fips_env_mode tests

### DIFF
--- a/schedule/security/fips_crypt_core.yaml
+++ b/schedule/security/fips_crypt_core.yaml
@@ -20,8 +20,8 @@ schedule:
     - fips/openssl/openssl_pubkey_rsa
     - fips/openssl/openssl_pubkey_dsa
     - fips/openssh/openssh_fips
-    - console/sshd
-    - console/ssh_cleanup
+    # ssh disabled in env mode, see poo#125648
+    - '{{ssh}}'
 conditional_schedule:
     repo_setup:
         BETA:
@@ -34,3 +34,11 @@ conditional_schedule:
         BACKEND:
             pvm_hmc:
                 - console/yast2_vnc
+    ssh:
+        TEST_SUITE_NAME:
+            fips_ker_mode_tests_crypt_core:
+                - console/sshd
+                - console/ssh_cleanup
+            fips_ker_mode_tests_crypt_core_intel_ipmi:
+                - console/sshd
+                - console/ssh_cleanup


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/125648
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=20230314-1&groupid=431
