### PR TITLE
To set the default boot to Xen during host installation where grub2 is modified

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -18,7 +18,7 @@ use utils;
 use power_action_utils 'prepare_system_shutdown';
 use Utils::Architectures;
 use Carp;
-use virt_autotest::utils qw(check_port_state);
+use virt_autotest::utils qw(is_xen_host check_port_state);
 
 our @EXPORT = qw(set_grub_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot ipmitool enable_sev_in_kernel add_kernel_options set_grub_terminal_and_timeout reconnect_when_ssh_console_broken);
 
@@ -96,6 +96,14 @@ sub setup_console_in_grub {
               . "' $grub_cfg_file";
             assert_script_run($cmd);
             save_screenshot;
+
+            # setting grub menuentry selection on sol console with grub2-set-default as xen, during host installation
+            if (is_xen_host && get_var('XEN_DEFAULT_BOOT_IS_SET')) {
+                $cmd = "sed -i '/### END \\\/etc\\\/grub.d\\\/00_header ###/iset default=2' $grub_cfg_file";
+                assert_script_run($cmd);
+            }
+
+
         }
         elsif (${virt_type} eq "kvm") {
             $bootmethod = "linux";


### PR DESCRIPTION
[virtualization] Replace grub menu-entry selection on sol console with grub2-set-default

To set the default boot to Xen during host installation where grub2 is modified, https://openqa.suse.de/tests/10679635#step/logs_from_installation_system/25

- Related ticket: https://progress.opensuse.org/issues/122947
- Verification runs with XEN_DEFAULT_BOOT_IS_SET: 
http://10.137.0.177/tests/80
https://openqa.suse.de/tests/10810302

- Verification runs without XEN_DEFAULT_BOOT_IS_SET:
http://openqa.suse.de/tests/10815502
http://10.137.0.177/tests/84

Screenshots: 
http://10.137.0.177/tests/80#step/logs_from_installation_system/16
http://10.137.0.177/tests/80#step/login_console/2

https://openqa.suse.de/tests/10810302#step/logs_from_installation_system/16
https://openqa.suse.de/tests/10810302#step/login_console/2

Xen test on #vh001. such as gi-guest_developing-on-host_sles12sp5-xen, no feature tests on them are needed.

@alice-suse @guoxuguang @waynechen55 @Julie-CAO Welcome review!