### PR TITLE
Revert "Skip 'registercloudguest' on SLE15-SP5"

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -92,12 +92,10 @@ sub run {
     if (is_byos()) {
         $instance->ssh_assert_script_run(cmd => 'sudo SUSEConnect --version');
         $instance->ssh_assert_script_run(cmd => "sudo SUSEConnect $regcode_param");
-        # The registercloudguest tool is not yet part of 15-SP5 as the infrastructure is not yet ready for it.
-        $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean") if (get_var('PUBLIC_CLOUD_QAM'));
+        $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
     }
 
-    # The registercloudguest tool is not yet part of 15-SP5 as the infrastructure is not yet ready for it.
-    $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest $regcode_param") if (get_var('PUBLIC_CLOUD_QAM'));
+    $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest $regcode_param");
     if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
         die('The list of zypper repositories is empty.');
     }
@@ -105,15 +103,12 @@ sub run {
         die('Directory /etc/zypp/credentials.d/ is empty.');
     }
 
-    # The registercloudguest tool is not yet part of 15-SP5 as the infrastructure is not yet ready for it.
-    if (get_var('PUBLIC_CLOUD_QAM')) {
-        $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest $regcode_param --force-new");
-        if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
-            die('The list of zypper repositories is empty.');
-        }
-        if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') == 0) {
-            die('Directory /etc/zypp/credentials.d/ is empty.');
-        }
+    $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest $regcode_param --force-new");
+    if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
+        die('The list of zypper repositories is empty.');
+    }
+    if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') == 0) {
+        die('Directory /etc/zypp/credentials.d/ is empty.');
     }
 
     register_addons_in_pc($instance);


### PR DESCRIPTION
This reverts commit 4f6196a9e2f3e7a7ffdafe629e03127fe72670ed (#16046).

As we already have SCC infra ready, we should properly register the system.

- Related ticket: [bsc#1209198](https://bugzilla.suse.com/show_bug.cgi?id=1209198)
- Verification run: [pdostal-server.suse.cz/t4079](https://pdostal-server.suse.cz/t4079)
