### PR TITLE
Bump timeout in yast2_kdump_use_fadump

### DIFF
--- a/lib/YaST/RestartInfoPage.pm
+++ b/lib/YaST/RestartInfoPage.pm
@@ -28,4 +28,12 @@ sub confirm_reboot_needed {
     $self->get_restart_info_page()->{btn_ok}->click();
 }
 
+sub wait_restart_info_popup {
+    my ($self) = @_;
+
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->{btn_ok}->exist({timeout => 0});
+    }, timeout => 180, message => "btn_ok does not exist");
+}
+
 1;

--- a/tests/console/yast2_kdump_use_fadump.pm
+++ b/tests/console/yast2_kdump_use_fadump.pm
@@ -29,6 +29,7 @@ sub run {
     save_screenshot;
     $fadump->get_navigation->ok();
     save_screenshot;
+    $restartinfo->wait_restart_info_popup();
     $restartinfo->confirm_reboot_needed();
     save_screenshot;
 


### PR DESCRIPTION
Spvm is not particularly slow so we could bump the timeout for all arch in the point where we expect the popup. We need wait the restart info page shown then check the page is existed.

- Related ticket: https://progress.opensuse.org/issues/125957
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/10716015
