### PR TITLE
Create auto-installation for SLE12SP5 for autoyast migration aarch64

### DIFF
--- a/data/autoyast_sle12/create_hdd/create_hdd_sles_regression_aarch64.xml.ep
+++ b/data/autoyast_sle12/create_hdd/create_hdd_sles_regression_aarch64.xml.ep
@@ -348,7 +348,6 @@
           <pattern>documentation</pattern>
           <pattern>gnome-basic</pattern>
           <pattern>x11</pattern>
-	  <pattern>yast2_basis</pattern>
         </patterns>
 	% }
     </software>

--- a/schedule/yast/autoyast/autoyast_create_hdd_sdk_gnome.yaml
+++ b/schedule/yast/autoyast/autoyast_create_hdd_sdk_gnome.yaml
@@ -5,7 +5,6 @@ description: >
 vars:
   AUTOYAST_PREPARE_PROFILE: '1'
   DESKTOP: gnome
-  PUBLISH_HDD_1: autoyast-SLE%VERSION%-%ARCH%-GM-SDK-allpatterns-updated.qcow2
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start


### PR DESCRIPTION
For autoyast migration at aarch64, we need replace the use of image, SLES-12-SP5-aarch64-GM-SDK-gnome.qcow2

- Related ticket: https://progress.opensuse.org/issues/125345
- Related MR: [482](https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/482)
- Needles: N/A
- Verification run: 
  * https://openqa.suse.de/tests/10737760
  * https://openqa.suse.de/tests/10730545
