### PR TITLE
Fix mismatched parameter error in boot parameters

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -785,7 +785,7 @@ sub specific_bootmenu_params {
             elsif ($dud =~ /^ASSET_\d+$/) {
                 # In case dud is uploaded as an ASSET we need just filename
                 $dud = basename(get_required_var($dud));
-                push @params, 'dud=' . autoinst_url("/assets/other/$dud");
+                push @params, 'dud=' . shorten_url(autoinst_url("/assets/other/$dud"));
             }
             else {
                 push @params, 'dud=' . data_url($dud);


### PR DESCRIPTION
On specific tests the bootloader parameters check finds a mismatch between the expected and received boot params.
This happens because, while all the parameters have been typed in the boot options command line in the grub menu (max char length is 512) only 477 of those characters are recorded in the /proc/cmdline of the system (you could check it during installation). The reason is that the system will automatically add the initrd and splash parameters, and even then, /proc/cmdline only allows for 506 characters.
Given these findings the only way to avoid characters being cropped, due to exceeding the 477 limit, is to shorten the urls added as parameters. Since the system installation [complains if the self_update url is shortened](https://openqa.suse.de/tests/10708519#step/bootloader_start/14), the solution was to shorten the dud url. This solution makes sense because it seems to be the introduction of the dud url parameter that causes this mismatch compared to other tests that do not display parameter mismatch.

- Related ticket: https://progress.opensuse.org/issues/125018
- Needles: No
- Verification run: 
[shortened dud url](https://openqa.suse.de/tests/10708995#step/bootloader_start/9), we no longer have a mismatch
[test without dud url](https://openqa.suse.de/tests/10709765#step/bootloader_start/9)
