### PR TITLE
BCI: Skip metadata tests if the public image is not available

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -104,7 +104,7 @@ sub run {
     $self->run_tox_cmd('all');
 
     # Run metadata tests when needed
-    $self->run_tox_cmd('metadata') if get_var('BCI_TEST_METADATA');
+    $self->run_tox_cmd('metadata') if check_var('BCI_TEST_METADATA', '1');
 
     # Run environment specific tests
     for my $env (split(/,/, $test_envs)) {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/126158
- Failure: https://openqa.suse.de/tests/10716006#step/_root_BCI-tests_metadata_podman/6
- VRs: 
    https://openqa.suse.de/tests/10717366 (from failed test)
    https://openqa.suse.de/tests/10717367 (from already green test)
