### PR TITLE
Replace script_ouput by script_ouput_retry in iscsi_configuration

### DIFF
--- a/tests/installation/iscsi_configuration.pm
+++ b/tests/installation/iscsi_configuration.pm
@@ -12,13 +12,14 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
+use utils 'script_output_retry';
 
 # In order to have clear expectations about state of the disk we need to erase it.
 # As it could be encrypted or non-encrypted (with or without partitions) making UI to
 # react in different ways. It assumes only one iscsi disk already mounted.
 sub wipe_iscsi_disk {
     select_console 'install-shell';
-    my $disk = script_output("lsscsi | grep 'disk' | awk 'NF>1{print \$NF}'");
+    my $disk = script_output_retry("lsscsi | grep 'disk' | awk 'NF>1{print \$NF}'");
     assert_script_run("wipefs -a $disk");
     select_console 'installation';
 }


### PR DESCRIPTION
Should fix a sporadic failure where the command is not executed in time, probably due to slow network.
See https://progress.opensuse.org/issues/125753

VRs (not passed yet, please check before merging.)
 https://openqa.suse.de/t10717973
 https://openqa.suse.de/t10717974
 https://openqa.suse.de/t10717975
 https://openqa.suse.de/t10717976
 https://openqa.suse.de/t10717977
 https://openqa.suse.de/t10717978
 https://openqa.suse.de/t10717979
 https://openqa.suse.de/t10717980
 https://openqa.suse.de/t10717981
 https://openqa.suse.de/t10717982