### PR TITLE
xfstests: More stable in log collection steps

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -32,7 +32,7 @@ sub log_end {
     my $file = shift;
     my $cmd = "echo '\nTest run complete' >> $file";
     send_key 'ret';
-    assert_script_run($cmd);
+    script_run($cmd, proceed_on_failure => 1);
 }
 
 # Compress all sub directories under $dir and upload them.
@@ -107,10 +107,10 @@ sub run {
     sleep 5;
 
     # Reload uploaded status log back to file
-    script_run('curl -O ' . autoinst_url . "/files/status.log; cat status.log > $STATUS_LOG");
+    script_run('df -h; curl -O ' . autoinst_url . "/files/status.log; cat status.log > $STATUS_LOG", die_on_timeout => 0);
 
     # Reload test logs if check missing
-    script_run("if [ ! -d $LOG_DIR ]; then mkdir -p $LOG_DIR; curl -O " . autoinst_url . '/files/opt_logs.tar.gz; tar zxvfP opt_logs.tar.gz; fi');
+    script_run("if [ ! -d $LOG_DIR ]; then mkdir -p $LOG_DIR; curl -O " . autoinst_url . '/files/opt_logs.tar.gz; tar zxvfP opt_logs.tar.gz; fi', die_on_timeout => 0);
 
     # Finalize status log and upload it
     log_end($STATUS_LOG);

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -158,7 +158,7 @@ sub log_add {
     send_key 'ret';
     assert_script_run($cmd);
     sleep 5;
-    my $ret = script_output("cat $file", 20);
+    my $ret = script_output("cat $file", 60);
     return $ret;
 }
 


### PR DESCRIPTION
Recent s390x keep fail by curl log part, and this PR first accept some log missing to make whole tests complete. Then add a little bit timeout time, to adapt recent low performance in aarch64 in osd.
- Set no die on some log collection steps to workaround s390x fails in generate_report steps
- Check disk usage before download log
- Enlarge wait time to adopt lower performance in aarch64 worker

- Related ticket: 
https://progress.opensuse.org/issues/122539
https://progress.opensuse.org/issues/126203
- Verification run: 
s390x: https://openqa.suse.de/tests/10730560
aarch64: http://openqa.suse.de/tests/10730566