### PR TITLE
pc: Use latest version of each CSP Terraform provider

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "= 3.5.0"
+      version = "= 3.48.0"
       source = "hashicorp/azurerm"
     }
     random = {

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "= 3.37.0"
+      version = "= 4.59.0"
       source = "hashicorp/aws"
     }
     random = {

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google = {
-      version = "= 3.65.0"
+      version = "= 4.57.0"
       source = "hashicorp/google"
     }
     random = {


### PR DESCRIPTION
Use latest version of each CSP Terraform provider

For aws we're using version 3.37.0 and the latest version is 4.59.0.  The same happens with other providers.

The changelog for these show many bugfixes that could avoid some issues with `terraform destroy` not working, for example.

Related ticket: https://progress.opensuse.org/issues/126242

Verification runs (**publiccloud_consoletests**):
- AWS: http://1b124.qa.suse.de/tests/352
- Azure: http://1b124.qa.suse.de/tests/353
- GCP: http://1b124.qa.suse.de/tests/354
- Azure-BYOS-ARM: https://openqa.suse.de/tests/10738403
- Azure-BYOS-gen2: https://openqa.suse.de/tests/10738404
- GCE-ARM: https://openqa.suse.de/tests/10738408
- publiccloud_smoketests@gce_n2d_standard_2_confidential: https://openqa.suse.de/tests/10738413
- publiccloud_smoketests@gce_n1_highmem_2: https://openqa.suse.de/tests/10738414
- publiccloud_smoketests@az_Standard_E2s_v4: https://openqa.suse.de/tests/10738415
- publiccloud_smoketests@az_Standard_F2s_v2: https://openqa.suse.de/tests/10738416