### PR TITLE
[virt_autotest] Add ALP Host Bridge Network Test Support

### DIFF
--- a/data/virt_autotest/alp_host_bridge_init.sh
+++ b/data/virt_autotest/alp_host_bridge_init.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Print commands and abort script on failure
+set -ex
+#
+# PREPARATION
+# --------------------
+. /etc/os-release
+# Variables Definition
+# --------------------
+BRIDGEIF_NAME="br0"
+ACTIVE_DEVICE=$(ip a|awk -F': ' '/state UP/ {print $2}'|head -n1)
+CONNECTION_NAME=$(nmcli -f DEVICE,CONNECTION dev status| grep ${ACTIVE_DEVICE} | awk '{print $4}')
+ACTIVE_CONNECTION="Wired connection ${CONNECTION_NAME}"
+ACTIVE_UUID=$(nmcli -g UUID,DEVICE con | grep ${ACTIVE_DEVICE} | cut -d: -f1)
+IPV4_ADDRESS=$(nmcli -g IP4.ADDRESS con show "${ACTIVE_UUID}")
+IPV4_GATEWAY=$(nmcli -g IP4.GATEWAY con show "${ACTIVE_UUID}")
+IPV4_DNS_A=$(nmcli -g IP4.DNS con show "${ACTIVE_UUID}"| awk '{print $1}')
+IPV4_DNS_B=$(nmcli -g IP4.DNS con show "${ACTIVE_UUID}"| awk '{print $3}')
+
+# Function Definitions
+# --------------------
+# Add Host Bridge Network Interface via nmcli
+setup_host_bridge_network_interface() {
+    # Add bridge type
+    nmcli con add type bridge con-name ${BRIDGEIF_NAME} ifname ${BRIDGEIF_NAME} \
+         autoconnect yes ipv4.method manual ipv4.address ${IPV4_ADDRESS} \
+         ipv4.gateway ${IPV4_GATEWAY} ipv4.dns ${IPV4_DNS_A} +ipv4.dns ${IPV4_DNS_B} \
+    # Add bridge-slave type
+    nmcli con add type bridge-slave con-name ${BRIDGEIF_NAME}-slave ifname ${ACTIVE_DEVICE} master ${BRIDGEIF_NAME}
+}
+
+# Enable Host Bridge Network Interface via nmcli
+enable_host_bridge_network_interface() {
+    nmcli con up ${BRIDGEIF_NAME}
+    # refer to bsc#1208005 for more details
+    nmcli con down "${ACTIVE_CONNECTION}"
+}
+
+# ==== #
+# MAIN # Testing starts here ...
+# ==== #
+if [[ $ID =~ 'alp' ]]; then
+    echo "Confirm Test Environment: ALP"
+else
+    echo "Error: Please perform this Tool on ALP! Exit... now"
+    exit 1
+fi
+
+setup_host_bridge_network_interface
+enable_host_bridge_network_interface

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -30,8 +30,7 @@ our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest i
   print_cmd_output_to_file ssh_setup ssh_copy_id create_guest import_guest install_default_packages upload_y2logs ensure_default_net_is_active ensure_guest_started
   ensure_online add_guest_to_hosts restart_libvirtd remove_additional_disks remove_additional_nic collect_virt_system_logs shutdown_guests wait_guest_online start_guests restore_downloaded_guests save_original_guest_xmls restore_original_guests
   is_guest_online wait_guests_shutdown remove_vm setup_common_ssh_config add_alias_in_ssh_config parse_subnet_address_ipv4 backup_file manage_system_service setup_rsyslog_host
-  check_port_state subscribe_extensions_and_modules download_script download_script_and_execute is_sev_es_guest upload_virt_logs recreate_guests
-  download_vm_import_disks);
+  check_port_state subscribe_extensions_and_modules download_script download_script_and_execute is_sev_es_guest upload_virt_logs recreate_guests download_vm_import_disks enable_nm_debug check_activate_network_interface set_host_bridge_interface_with_nm upload_nm_debug_log);
 
 my %log_cursors;
 
@@ -943,5 +942,44 @@ sub download_vm_import_disks {
     record_info("All imported disk download is done.");
 }
 
+sub enable_nm_debug {
+    # Enable Network Manager Debug Log Level
+    assert_script_run("nmcli general logging level DEBUG domains ALL", 60);
+    record_info("Enable Network Manager in Debug Level successfully for automation test.");
+}
+
+sub check_activate_network_interface {
+    # Check with activate network interface as required
+    my ($network_interface, $target_name) = @_;
+    $network_interface //= "br0";
+    $target_name //= get_required_var('OPENQA_URL');
+    assert_script_run("ping -I $network_interface -c 3 $target_name", 60);
+    assert_script_run("nmcli device show $network_interface", 60);
+    save_screenshot;
+    record_info("Activate Network Interface check successfully for automation test.");
+}
+
+sub set_host_bridge_interface_with_nm {
+    # Setup Host Bridge Network Interface with nmcli(NetworkManager) as needed
+    my $_host_bridge_cfg = "/etc/NetworkManager/system-connections/br0.nmconnection";
+
+    # Change the NetworkManager log-level as DEBUG at runtime
+    enable_nm_debug;
+
+    if (script_run("[[ -f $_host_bridge_cfg ]]") != 0) {
+        my $_alp_host_bridge = "/root/alp_host_bridge_init.sh";
+        assert_script_run("curl " . data_url("virt_autotest/alp_host_bridge_init.sh") . " -o $_alp_host_bridge");
+        assert_script_run("chmod +rx $_alp_host_bridge && $_alp_host_bridge");
+        save_screenshot;
+        record_info("Host Bridge Network Interface is set successfully for automation test.", script_output("ip a; ip route show all"));
+    }
+    check_activate_network_interface;
+}
+
+sub upload_nm_debug_log {
+    script_run("journalctl -u NetworkManager.service > /tmp/NetworkManager.logs");
+    upload_virt_logs("/tmp/NetworkManager.logs", "NetworkManager-debug-logs");
+    script_run("rm -rf /tmp/NetworkManager.logs");
+}
 
 1;

--- a/schedule/virt_autotest/alp-virt-core-tests.yaml
+++ b/schedule/virt_autotest/alp-virt-core-tests.yaml
@@ -32,6 +32,7 @@ conditional_schedule:
         ENABLE_VIR_NET:
             1:
                 - virt_autotest/libvirt_virtual_network_init
+                - virt_autotest/libvirt_host_bridge_virtual_network
                 - virt_autotest/libvirt_nated_virtual_network
                 - virt_autotest/libvirt_routed_virtual_network
                 - virt_autotest/libvirt_isolated_virtual_network

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -17,16 +17,19 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_alp);
 
 our $virt_host_bridge = 'br0';
 our $based_guest_dir = 'tmp';
 sub run_test {
     my ($self) = @_;
 
-    #Prepare VM HOST SERVER Network Interface Configuration
-    #for libvirt virtual network testing
-    virt_autotest::virtual_network_utils::prepare_network($virt_host_bridge, $based_guest_dir);
+    # ALP has done this in earlier setup
+    unless (is_alp) {
+        #Prepare VM HOST SERVER Network Interface Configuration
+        #for libvirt virtual network testing
+        virt_autotest::virtual_network_utils::prepare_network($virt_host_bridge, $based_guest_dir);
+    }
 
     #Download libvirt host bridge virtual network configuration file
     my $vnet_host_bridge_cfg_name = "vnet_host_bridge.xml";

--- a/tests/virt_autotest/prepare_alp_host.pm
+++ b/tests/virt_autotest/prepare_alp_host.pm
@@ -32,6 +32,9 @@ sub run {
     save_screenshot;
     assert_script_run("ls -latr /var/lib/libvirt/images/");
     record_info("Ignition file is successfully downloaded.");
+
+    # Setup Host Bridge Network Interface as required
+    virt_autotest::utils::set_host_bridge_interface_with_nm;
 }
 
 sub test_flags {
@@ -41,6 +44,8 @@ sub test_flags {
 sub post_fail_hook {
     # Let it empty now.
     # Need to let parent one called after yast team modifies the parent class to fit alp.
+    # Upload expected NetworkManager debug log
+    virt_autotest::utils::upload_nm_debug_log;
 }
 
 1;


### PR DESCRIPTION
Add ALP Host Bridge Network Test Support

- Related ticket: https://progress.opensuse.org/issues/122731
- Verification run: 
[use existed host bridge network interface](http://10.67.129.218/tests/395)
[setup new host bridge network interface](http://10.67.129.218/tests/393#)
[call post_fail_hook](http://10.67.129.218/tests/381)
