### PR TITLE
Qesap collect logs in case of failure

### DIFF
--- a/data/sles4sap/script_output.yaml
+++ b/data/sles4sap/script_output.yaml
@@ -4,10 +4,12 @@
     cmd: ''
     out_path: '/tmp/ansible_script_output/'
     out_file: 'testout.txt'
+    failok: no
   tasks:
   - name: 'Run cmd'
     shell: "{{ cmd }} > /tmp/{{ out_file }}"
     register: crm_status_files
+    ignore_errors: "{{ failok }}"
   - name: fetch
     fetch:
       flat: yes

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -55,7 +55,15 @@ sub post_fail_hook {
     if (script_run("test -e $inventory") == 0)
     {
         # sleep bmwqemu::scale_timeout(300)
-        qesap_ansible_cmd(cmd => $_, provider => $prov, filter => 'hana') for ('crm status', 'crm configure show', 'lsblk -i -a', 'journalctl -b --no-pager -o short-precise', 'systemctl --no-pager --full status sbd');
+        foreach my $element (
+            ['crm status', 'crm_status.txt'],
+            ['crm configure show', 'crm_configure.txt'],
+            ['lsblk -i -a', 'lsblk.txt'],
+            ['journalctl -b --no-pager -o short-precise', 'journalctl.txt'],
+            ['systemctl --no-pager --full status sbd', 'sbd.txt']) {
+            my $out = qesap_ansible_script_output(cmd => @$element[0], provider => $prov, filter => 'hana', failok => 1);
+            save_tmp_file(@$element[1], $out);
+        }
         qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
     }
     qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -10,27 +10,6 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use qesapdeployment;
 
-sub wait_for_ssh {
-    my ($host) = @_;
-    my $timeout //= bmwqemu::scale_timeout(600);
-    my $start_time = time();
-    my $check_port = 1;
-
-    # Looping until reaching timeout or passing two conditions :
-    # - SSH port 22 is reachable
-    # - journalctl got message about reaching one of certain targets
-    while ((my $duration = time() - $start_time) < $timeout) {
-        if ($check_port) {
-            $check_port = 0 if (script_run('nc -vz -w 1 ' . $host . ' 22', quiet => 1) == 0);
-        }
-        else {
-            return $duration;
-        }
-        sleep 5;
-    }
-    die 'Timed out while waiting for ssh to be available in the CSP instances';
-}
-
 sub run {
     my $ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => 1800);
     die "'qesap.py terraform' return: $ret" if ($ret);
@@ -38,9 +17,15 @@ sub run {
     upload_logs($inventory, failok => 1);
     my @remote_ips = qesap_remote_hana_public_ips;
     record_info 'Remote IPs', join(' - ', @remote_ips);
-    foreach my $host (@remote_ips) { wait_for_ssh $host; }
+    foreach my $host (@remote_ips) {
+        die 'Timed out while waiting for ssh to be available in the CSP instances' if qesap_wait_for_ssh(host => $host) == -1;
+    }
     $ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
-    die "'qesap.py ansible' return: $ret" if ($ret);
+    if ($ret)
+    {
+        qesap_cluster_logs();
+        die "'qesap.py ansible' return: $ret";
+    }
 }
 
 sub test_flags {
@@ -50,22 +35,8 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     qesap_upload_logs();
-    my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
-    my $inventory = qesap_get_inventory($prov);
-    if (script_run("test -e $inventory") == 0)
-    {
-        # sleep bmwqemu::scale_timeout(300)
-        foreach my $element (
-            ['crm status', 'crm_status.txt'],
-            ['crm configure show', 'crm_configure.txt'],
-            ['lsblk -i -a', 'lsblk.txt'],
-            ['journalctl -b --no-pager -o short-precise', 'journalctl.txt'],
-            ['systemctl --no-pager --full status sbd', 'sbd.txt']) {
-            my $out = qesap_ansible_script_output(cmd => @$element[0], provider => $prov, filter => 'hana', failok => 1);
-            save_tmp_file(@$element[1], $out);
-        }
-        qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
-    }
+    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300) unless (script_run("test -e $inventory"));
     qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -50,7 +50,14 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     qesap_upload_logs();
-    qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
+    my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
+    my $inventory = qesap_get_inventory($prov);
+    if (script_run("test -e $inventory") == 0)
+    {
+        # sleep bmwqemu::scale_timeout(300)
+        qesap_ansible_cmd(cmd => $_, provider => $prov, filter => 'hana') for ('crm status', 'crm configure show', 'lsblk -i -a', 'journalctl -b --no-pager -o short-precise', 'systemctl --no-pager --full status sbd');
+        qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
+    }
     qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/qesapdeployment/destroy.pm
+++ b/tests/sles4sap/qesapdeployment/destroy.pm
@@ -14,10 +14,13 @@ use qesapdeployment;
 sub run {
     select_serial_terminal;
 
-    my $ret = qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
-    die "'qesap.py ansible -d' return: $ret" if ($ret);
-    $ret = qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
-    die "'qesap.py terraform -d' return: $ret" if ($ret);
+    my $ansible_ret = qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
+    if ($ansible_ret) {
+        qesap_cluster_logs();
+    }
+    my $terraform_ret = qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
+    die "'qesap.py ansible -d' return: $ansible_ret" if ($ansible_ret);
+    die "'qesap.py terraform -d' return: $terraform_ret" if ($terraform_ret);
 }
 
 sub post_fail_hook {

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -23,6 +23,7 @@ sub run {
     my $cmr_status = qesap_ansible_script_output(cmd => 'crm status', provider => $prov, host => 'vmhana01', root => 1);
     record_info("crm status", $cmr_status);
     qesap_ansible_cmd(cmd => $crm_mon_cmd, provider => $prov, filter => 'vmhana01');
+    qesap_cluster_logs();
 }
 
 sub post_fail_hook {

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -18,7 +18,7 @@ sub run {
 
     my $chdir = qesap_get_terraform_dir();
     assert_script_run("terraform -chdir=$chdir output");
-    qesap_ansible_cmd(cmd => $_, provider => $prov, $_) for ('pwd', 'uname -a', 'cat /etc/os-release');
+    qesap_ansible_cmd(cmd => $_, provider => $prov) for ('pwd', 'uname -a', 'cat /etc/os-release');
     qesap_ansible_cmd(cmd => 'ls -lai /hana/', provider => $prov, filter => 'hana');
     my $cmr_status = qesap_ansible_script_output(cmd => 'crm status', provider => $prov, host => 'vmhana01', root => 1);
     record_info("crm status", $cmr_status);


### PR DESCRIPTION
Collect logs from each HANA cluster node in case of failure
Change all the Ansible API in qesap lib to support failok mode
Change the script_output Ansible API in qesap also needs a change in the playbook
Move the wait_ssh from qesap regression test module to an API function in qesap
Align input validation in qesap_execute to all the other API of the qesap lib
Add tons of UT about these changes

Related ticket: TEAM-7152
Verification run: 

 - AZURE : 
 1. http://openqaworker15.qa.suse.cz/tests/138655 it is again a PASS and here again an example of log http://openqaworker15.qa.suse.cz/tests/138655/logfile?filename=test_cluster-crm_status.txt
 2. [LATEST CODE] http://openqaworker15.qa.suse.cz/tests/139091

 - GCP :  it is fail but it does not have logs. It is because the PR code is using fixed Ansible name for the two HANA hosts (like in [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16661/files#diff-23c988d39d71dc252bb5dce95a699047e93941078f2152ab4a6587286e9a4e47R671) ) but GCP Terraform wrongly include deployment name in them
 1. http://openqaworker15.qa.suse.cz/tests/138657
 2. http://openqaworker15.qa.suse.cz/tests/138661
 3. http://openqaworker15.qa.suse.cz/tests/138662
 2. [LATEST CODE] http://openqaworker15.qa.suse.cz/tests/139092
 
- AWS :
 1. http://openqaworker15.qa.suse.cz/tests/138654 it is a PASS one. Here an example of logs uploaded from the `run` of the test_cluster module http://openqaworker15.qa.suse.cz/tests/138654/logfile?filename=test_cluster-journalctl.txt
 2. http://openqaworker15.qa.suse.cz/tests/138658
 3. http://openqaworker15.qa.suse.cz/tests/138659
 4. http://openqaworker15.qa.suse.cz/tests/138660
 5. [LATEST CODE] http://openqaworker15.qa.suse.cz/tests/139090 
