### PR TITLE
ALP-Micro first test fixes

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -183,7 +183,7 @@ sub load_common_tests {
     loadtest 'microos/cockpit_service' unless is_staging || (is_microos('Tumbleweed') && get_var('HDD_1') =~ /-old/);
     # Staging has no access to repos and the MicroOS-DVD does not contain ansible
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
-    loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro);
+    loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro || is_alp);
     loadtest 'console/kubeadm' if (check_var('SYSTEM_ROLE', 'kubeadm'));
 }
 

--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -44,7 +44,7 @@ sub run {
     }
 
 
-    unless (is_sle_micro('<5.2') || is_leap_micro('<5.2')) {
+    unless (is_sle_micro('<5.2') || is_leap_micro('<5.2') || is_alp) {
         push @pkgs, qw(cockpit-machines cockpit-tukit);
     }
 

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -28,10 +28,8 @@ sub run {
     record_info('REPOS (Default)', script_output('zypper lr --url', proceed_on_failure => 1));
 
     if (is_alp) {
-        change_grub_config('=.*', '=1024x768', 'GRUB_GFXMODE=');
-        zypper_call('mr -e ALP-Build');
-
-        add_staging_repos() if (get_var("STAGING"));
+        zypper_call('ar -c ' . get_required_var('MIRROR_PREFIX') . '/' . get_required_var('REPO_ALP') . ' alp');
+        zypper_call('--gpg-auto-import-keys ref');
         record_info('REPOS (all)', script_output('zypper lr --url', proceed_on_failure => 1));
     }
 


### PR DESCRIPTION
ALP repos are synced in openQA using OBS sync and the directory is in REPO_ALP variable, we can easily add the repo using openQA assets url.

Ansible is not available in ALP repos.

cockpit-machines cockpit-tukit not available either.
