### PR TITLE
Fix wrong mount point for swap

### DIFF
--- a/data/autoyast_sle15/autoyast_home_encrypted.xml
+++ b/data/autoyast_sle15/autoyast_home_encrypted.xml
@@ -63,7 +63,7 @@
       <enable_snapshots config:type="boolean">true</enable_snapshots>
       <partitions config:type="list">
         <partition>
-          <mount>/swap</mount>
+          <mount>swap</mount>
           <create config:type="boolean">true</create>
           <filesystem config:type="symbol">swap</filesystem>
           <size>auto</size>


### PR DESCRIPTION
Fix wrong mount point for swap in autoyast_home_encrypted.xml

**Ticket:**

- https://progress.opensuse.org/issues/126227

**Verification run:**

- https://openqa.suse.de/tests/10744985
