### PR TITLE
ulp_openposix: Fix libc version regex

### DIFF
--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -59,7 +59,7 @@ sub prepare_repo {
     }
 
     my $provides = script_output("zypper -n info --provides $repo_args $packname");
-    my @versions = $provides =~ m/^\s*libc_([^_]+)_livepatch\d+\.so\(\)\([^)]+\)\s*$/gm;
+    my @versions = $provides =~ m/^\s*libc_([^_()]+)_livepatch\d+\.so\(\)\([^)]+\)\s*$/gm;
 
     die "Package $packname contains no libc livepatches"
       unless scalar @versions;


### PR DESCRIPTION
If the livepatch filename is libc_livepatch*.so, the old regex could match across multiple lines. Exclude parantheses which are added to the RPM filename list to prevent matching across lines.

- Related ticket: https://progress.opensuse.org/issues/112004
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/10745529
