### PR TITLE
Install common package for slem version in PC

### DIFF
--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -22,25 +22,37 @@ sub run {
     my $provider = $self->provider_factory();
     $provider->{username} = 'suse';
     my $instance = $self->{my_instance} = $provider->create_instance(check_guestregister => 0);
-    my $test_package = 'strace';
+    my $test_package = get_var('TEST_PACKAGE', 'jq');
     registercloudguest($instance);
     $instance->run_ssh_command(cmd => 'zypper lr -d', timeout => 600);
     $instance->run_ssh_command(cmd => 'systemctl is-enabled issue-generator');
     $instance->run_ssh_command(cmd => 'systemctl is-enabled transactional-update.timer');
     $instance->run_ssh_command(cmd => 'systemctl is-enabled issue-add-ssh-keys');
+
+    # package installation test
+    my $ret = $instance->run_ssh_command(cmd => 'rpm -q ' . $test_package, rc_only => 1);
+    if ($ret) {
+        die("Testing package \'$test_package\' is already installed, choose a different package!");
+    }
     $instance->run_ssh_command(cmd => 'sudo transactional-update -n pkg install ' . $test_package, timeout => 600);
     $instance->softreboot();
     $instance->run_ssh_command(cmd => 'rpm -q ' . $test_package);
+
+    # cockpit test
     $instance->run_ssh_command(cmd => '! curl localhost:9090');
     $instance->run_ssh_command(cmd => 'sudo systemctl enable --now cockpit.socket');
     $instance->run_ssh_command(cmd => 'systemctl status cockpit.service | grep inactive');
     $instance->run_ssh_command(cmd => 'curl http://localhost:9090');
     $instance->run_ssh_command(cmd => 'systemctl status cockpit.service | grep active');
+
+    # additional tr-up tests
     $instance->run_ssh_command(cmd => 'sudo transactional-update -n up', timeout => 360);
     $instance->softreboot();
     $instance->run_ssh_command(cmd => 'sudo sestatus | grep disabled');
     $instance->run_ssh_command(cmd => 'sudo transactional-update -n setup-selinux');
     $instance->softreboot();
+
+    # SElinux and logging tests
     $instance->run_ssh_command(cmd => 'sudo sestatus | grep enabled');
     $instance->run_ssh_command(cmd => 'sudo dmesg');
     $instance->run_ssh_command(cmd => 'sudo journalctl -p err');


### PR DESCRIPTION
`strace` package is not available for slem 5.1. We need to find a common package that is available across all supported versions

- [SLEM 5.1 needs to be enabled for AWS (only !!!!) both archs ( x86_64 and aarch64 )](https://progress.opensuse.org/issues/121363)

### Verification runs

- sle-micro-15-SP3-Micro-5-1-BYOS-EC2-HVM-x86_64-Build0002-slem_basic@64bit -> https://openqa.suse.de/t10747171
- sle-micro-15-SP3-Micro-5-2-BYOS-Azure-x86_64-Build0363-slem_basic@64bit -> https://openqa.suse.de/t10747172
- sle-micro-15-SP4-Micro-5-3-BYOS-GCE-x86_64-Build0278-slem_basic@64bit -> https://openqa.suse.de/t10747173
- sle-micro-15-SP4-Micro-5-4-BYOS-GCE-ARM-x86_64-Build0001-slem_basic@64bit -> https://openqa.suse.de/tests/10747596#details
