### PR TITLE
console/java: Install openjdk packages more explicitly

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -49,7 +49,7 @@ sub run {
     # java-11-openjdk                   -> Basesystem
     # java-10-openjdk & java-1_8_0-ibm  -> Legacy
     my $cmd = 'install --auto-agree-with-licenses ';
-    $cmd .= (is_sle('15+') || is_sle('=12-SP5') || is_leap) ? 'java-11-openjdk* java-1_*' : 'java-*';
+    $cmd .= (is_sle('15+') || is_sle('=12-SP5') || is_leap) ? 'java-11-openjdk{,-demo,-devel} java-1_*' : 'java-*';
 
     if (is_transactional) {
         select_console 'root-console';


### PR DESCRIPTION
java-11-openjdk* does not work anymore, that also matches the obsoleted -accessibility subpackage. Mention the actually needed ones explicitly.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1209404
- Verification runs:
Leap 15.4: https://openqa.opensuse.org/tests/3186085
SLE 12 SP5: http://10.168.4.168/tests/1302
SLE 15 SP1: http://10.168.4.168/tests/1298
SLE 15 SP4: http://10.168.4.168/tests/1301
