### PR TITLE
Install NFS dir before exportfs on Spack

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -428,6 +428,7 @@ sub setup_nfs_server {
     my ($self, $exports) = @_;
     zypper_call 'in nfs-kernel-server';
     foreach my $dir (values %$exports) {
+        assert_script_run "install -d -o $testapi::username -g users $dir" unless script_run("test -f $dir", quiet => 1) == 0;
         assert_script_run "echo $dir *(rw,no_root_squash,sync,no_subtree_check) >> /etc/exports";
     }
     assert_script_run 'exportfs -a';


### PR DESCRIPTION
Spack fails to find and export the expected directories. For some reason this was not a problem on SLE15 before SP3. Now we need to create it explicitly.


- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP3&build=b10n1k%2Fos-autoinst-distri-opensuse%23fix_spack_sp3&distri=sle