### PR TITLE
Increase update timeout to 30min

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -34,7 +34,7 @@ sub run {
     }
     add_test_repositories;
     record_info 'Updates', script_output('zypper lu');
-    trup_call 'up', timeout => 1200;
+    trup_call 'up', timeout => 1800;
     process_reboot(trigger => 1);
 }
 


### PR DESCRIPTION
Occasional timeouts when installing updates motivate to increase the update time from 20 to 30 minutes.

- Related ticket: https://progress.opensuse.org/issues/126428
- Verification run: https://duck-norris.qe.suse.de/tests/12397#step/await_install/15
