### PR TITLE
Setup FIPS squid tests

### DIFF
--- a/data/squid/apache_vhost.conf
+++ b/data/squid/apache_vhost.conf
@@ -1,0 +1,14 @@
+<VirtualHost *:8080>
+    DocumentRoot /srv/www/vhosts/Test
+    <Directory "/srv/www/vhosts/Test">
+        Options Indexes MultiViews
+        AllowOverride None
+        <IfModule !mod_access_compat.c>
+                Require all granted
+        </IfModule>
+        <IfModule mod_access_compat.c>
+                Order allow,deny
+                Allow from all
+        </IfModule>
+    </Directory>
+</VirtualHost>

--- a/data/squid/hello.html
+++ b/data/squid/hello.html
@@ -1,0 +1,16 @@
+<html>
+
+<head>
+    <title>
+        Test Page
+    </title>
+</head>
+
+<body>
+    <h2>
+        Hello
+    </h2>
+    SUSE Linux
+</body>
+
+</html>

--- a/data/squid/squid_authdigest.conf
+++ b/data/squid/squid_authdigest.conf
@@ -1,0 +1,82 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 1025-65535 # unregistered ports
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+visible_hostname localhost
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+#http_access allow localnet
+#http_access allow localhost
+auth_param digest program /usr/lib/squid/digest_file_auth -c /etc/squid/passwd.txt
+auth_param digest children 20 startup=0 idle=1
+auth_param digest realm Squid proxy-caching web server
+auth_param digest nonce_garbage_interval 5 minutes
+auth_param digest nonce_max_duration 30 minutes
+auth_param digest nonce_max_count 50
+auth_param digest realm SUSE
+acl UserAuth proxy_auth REQUIRED
+http_access allow UserAuth
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /var/cache/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/cache/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320
+
+# enable debugging
+debug_options ALL,1

--- a/data/squid/squid_reverse.conf
+++ b/data/squid/squid_reverse.conf
@@ -1,0 +1,83 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 0.0.0.1-0.255.255.255  # RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8             # RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10          # RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16         # RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12          # RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16         # RFC 1918 local private network (LAN)
+acl localnet src fc00::/7               # RFC 4193 local private network range
+acl localnet src fe80::/10              # RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl Safe_ports port 80          # http
+acl Safe_ports port 21          # ftp
+acl Safe_ports port 443         # https
+acl Safe_ports port 70          # gopher
+acl Safe_ports port 210         # wais
+acl Safe_ports port 1025-65535  # unregistered ports
+acl Safe_ports port 280         # http-mgmt
+acl Safe_ports port 488         # gss-http
+acl Safe_ports port 591         # filemaker
+acl Safe_ports port 777         # multiling http
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+visible_hostname localhost
+
+http_port 8888 accel 
+https_port 8443 accel cert=/etc/squid/squid.cert key=/etc/squid/squid.key
+cache_peer 127.0.0.1 parent 8080 0 no-query default
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+http_access allow localnet
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /var/cache/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/cache/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:           1440    20%     10080
+refresh_pattern ^gopher:        1440    0%      1440
+refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+refresh_pattern .               0       20%     4320
+
+# enable debugging
+debug_options ALL,1

--- a/data/squid/squid_sslbump.conf
+++ b/data/squid/squid_sslbump.conf
@@ -1,0 +1,78 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+visible_hostname localhost
+
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+http_access allow localnet
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128 ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=4MB cert=/etc/squid/ssl_cert/myCA.pem
+ssl_bump bump all
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /var/cache/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/cache/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320

--- a/schedule/security/fips_crypt_squid.yaml
+++ b/schedule/security/fips_crypt_squid.yaml
@@ -1,0 +1,25 @@
+name: fips_crypt_squid
+description:    >
+    This is for the crypt_squid fips tests.
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - '{{y2_vnc_pvm}}'
+    - fips/squid/squid_init
+    - fips/squid/squid_web_proxy
+    - fips/squid/squid_reverse_proxy
+conditional_schedule:
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup
+    y2_vnc_pvm:
+        BACKEND:
+            pvm_hmc:
+                - console/yast2_vnc

--- a/tests/fips/squid/squid_init.pm
+++ b/tests/fips/squid/squid_init.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests - FIPS tests
+#
+# Copyright 2016-2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: SquidInit
+# Summary: FIPS tests for squid proxy
+#
+# Maintainer: QE Security <none@suse.de>
+
+use base "basetest";
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils qw(zypper_call systemctl);
+
+sub run {
+    my $self = shift;
+    select_serial_terminal;
+    # install squid package with default config
+    zypper_call("in squid");
+    systemctl 'enable squid';
+    # Check squid status: active is the expected result
+    systemctl 'start squid';
+    validate_script_output('systemctl status --no-pager squid.service', sub { m/Active: active/ });
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/fips/squid/squid_reverse_proxy.pm
+++ b/tests/fips/squid/squid_reverse_proxy.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests - FIPS tests
+#
+# Copyright 2016-2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: SquidReverseProxy
+# Summary: FIPS tests for squid as reverse web proxy providing SSL encrypt connection for HTTP web site
+#
+# Maintainer: QE Security <none@suse.de>
+
+use base "basetest";
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils qw(systemctl zypper_call);
+
+sub configure_apache {
+    zypper_call 'in apache2';
+    # configure apache as a webserver on port 8080
+    assert_script_run 'mkdir -p /srv/www/vhosts/Test';
+    assert_script_run 'curl ' . data_url('squid/apache_vhost.conf') . ' -o /etc/apache2/vhosts.d/vhost.conf';
+    assert_script_run 'curl ' . data_url('squid/hello.html') . ' -o /srv/www/vhosts/Test/hello.html';
+    assert_script_run "sed -i -e 's/^Listen 80/Listen 8080/' /etc/apache2/listen.conf";
+    systemctl 'start apache2';
+    # ensure apache is working
+    validate_script_output 'curl http://localhost:8080/hello.html', sub { m/Test Page/ };
+}
+
+sub configure_squid {
+    # generate self-signed X509 cert for squid https
+    assert_script_run("openssl req -x509 -nodes -days 365 -newkey rsa:2048"
+          . " -subj '/C=DE/ST=Bayern/L=Nuremberg/O=Suse/OU=QA/CN=localhost/emailAddress=admin\@localhost'"
+          . " -keyout /etc/squid/squid.key -out /etc/squid/squid.cert ");
+    # install certificate system-wide
+    assert_script_run 'cp /etc/squid/squid.cert /usr/share/pki/trust/anchors ; update-ca-certificates';
+    # configure squid as reverse proxy
+    assert_script_run 'curl ' . data_url('squid/squid_reverse.conf') . ' -o /etc/squid/squid.conf';
+    systemctl 'reload squid';
+}
+
+sub run {
+    select_serial_terminal;
+    configure_apache;
+    configure_squid;
+    # use squid as https reverse proxy to access content served by apache.
+    # Ensure reply contains certificate info, HTTP 200 and test page content
+    validate_script_output 'curl -v --proxy https://localhost:8443 http://localhost:8080/hello.html',
+      sub { m/subject:.+O=Suse.+CN=localhost.+HTTP\/1.1 200 OK.+Test Page/s };
+}
+
+sub post_fail_hook {
+    upload_logs('/var/log/squid/access.log', log_name => 'squid_access.log');
+    upload_logs('/var/log/squid/cache.log', log_name => 'squid_cache.log');
+}
+
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/fips/squid/squid_web_proxy.pm
+++ b/tests/fips/squid/squid_web_proxy.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests - FIPS tests
+#
+# Copyright 2016-2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: SquidWebProxy
+# Summary: FIPS tests for squid, test squid as a web proxy
+#
+# Maintainer: QE Security <none@suse.de>
+
+use base "basetest";
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils qw(systemctl);
+
+sub configure_squid {
+    # configure squid as a web proxy cache
+    assert_script_run 'curl ' . data_url('squid/squid_authdigest.conf') . ' -o /etc/squid/squid.conf';
+    # digest is for proxyuser:proxypassword with realm SUSE
+    assert_script_run 'echo "proxyuser:SUSE:7935d7d2f866548295f9b3c5400b97e6" > /etc/squid/passwd.txt';
+    systemctl 'reload squid';
+}
+
+sub run {
+    select_serial_terminal;
+    configure_squid;
+    my $testfile = data_url('squid/hello.html');
+    # try to download file without authentication, should fail
+    validate_script_output 'curl --head --proxy http://localhost:3128 ' . $testfile,
+      sub { m/HTTP\/1.1 407 Proxy Authentication Required.+Server: squid/s, proceed_on_failure => 1, };
+    # try to download file with authentication, should success
+    validate_script_output 'curl --head --proxy-digest -U proxyuser:proxypassword --proxy http://localhost:3128 ' . $testfile,
+      sub { m/HTTP\/1.1 200 OK/ };
+}
+
+sub post_fail_hook {
+    upload_logs('/var/log/squid/access.log', log_name => 'squid_access.log');
+    upload_logs('/var/log/squid/cache.log', log_name => 'squid_cache.log');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Schedule first tests for squid web proxy, both in forward and reverse mode.

- Related ticket: https://progress.opensuse.org/issues/125585
- Verification run: https://openqa.suse.de/tests/10739929
