### PR TITLE
Create default yaml if applies for aarch64 and adapt test suites to use it if needed in YaST group

### DIFF
--- a/schedule/yast/btrfs/btrfs+warnings_aarch64.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_aarch64.yaml
@@ -1,0 +1,24 @@
+---
+name: btrfs+warnings
+description: >
+  Test suite verifies variety of warning which are expected to be shown when
+  something is missing during manual partitioning using Expert Partitioner.
+  Following warning are verified:
+    - Missing root partition;
+    - Minimal size for the root with btrfs and snapshots
+    - Missing boot partition (bios boot,/boot/zipl/,EFI, prep-boot).
+vars:
+  FILESYSTEM: btrfs
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/warning/no_root
+    - installation/partitioning/warning/snapshots_small_root
+    - installation/partitioning/warning/no_boot
+    - installation/partitioning/warning/boot_small_for_kernel
+    - installation/partitioning/warning/bios_boot_small_for_bootloader
+    - installation/partitioning/warning/prep_small
+    - installation/partitioning/warning/zipl_small
+    - installation/partitioning/warning/rootfs_small
+  software:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute_aarch64.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute_aarch64.yaml
@@ -1,0 +1,31 @@
+---
+description: >
+  Conduct installation activating encrypted partitions, but creating encrypted
+  lvm setup from scratch. Using pre-partitioned disk image to validate encrypted
+  partitions activation and that we can re-ecnrypt the disk.
+name: activate_encrypted_volume+force_recompute
+vars:
+  ENCRYPT: 1
+  ENCRYPT_FORCE_RECOMPUTE: 1
+  LVM: 1
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_probing:
+    - installation/system_probing/activate_encrypted_volume
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/accept_default_hard_disks_selection
+    - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  software:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_aarch64.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_aarch64.yaml
@@ -1,0 +1,24 @@
+---
+description: >
+  Conduct installation activating encrypted partitions and importing users created
+  in that installation. Using pre-partitioned disk image to validate encrypted
+  partitions activation and that we can re-ecnrypt the disk.
+name: activate_encrypted_volume+import_users
+vars:
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_probing:
+    - installation/system_probing/activate_encrypted_volume
+    - console/validate_encrypted_volume_activation
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  suggested_partitioning:
+    - installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted
+    - installation/partitioning/accept_proposed_layout
+  local_user:
+    - installation/authentication/import_users
+    - installation/authentication/root_simple_pwd
+  software:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/encryption/crypt_no_lvm_aarch64.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_aarch64.yaml
@@ -1,0 +1,32 @@
+---
+name: crypt_no_lvm
+description: >
+  Test installation with encrypted partitions but without lvm enabled.
+  This is supported only by storage-ng, hence, do NOT enable test suite on
+  distris without storage-ng.
+  Encrypted installations can take longer, especially on non-x86_64
+  architectures.
+vars:
+  DESKTOP: gnome
+  ENCRYPT: 1
+  LVM: 0
+  MAX_JOB_TIME: 14400
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/encrypt_simple_pwd
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  software:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/validate_encrypt

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_aarch64.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_aarch64.yaml
@@ -1,0 +1,28 @@
+---
+description: >
+  Conduct installation cancelling encrypted partitions activation, and creating
+  encrypted lvm setup from scratch. Using pre-partitioned disk image to validate
+  encrypted partitions activation and that we can re-ecnrypt the disk.
+name: cryptlvm+cancel_existing
+vars:
+  ENCRYPT: 1
+  LVM: 1
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_probing:
+    - installation/system_probing/cancel_encrypted_volume
+    - console/validate_encrypted_partition_not_activated
+  add_on_product: []
+  system_role: []
+  suggested_partitioning: []
+  clock_and_timezone: []
+  local_user: []
+  booting: []
+  installation_settings: []
+  installation: []
+  installation_logs: []
+  confirm_reboot: []
+  grub: []
+  first_login: []

--- a/schedule/yast/encryption/cryptlvm_sle_15_aarch64.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_aarch64.yaml
@@ -1,0 +1,29 @@
+---
+description: >
+  Conduct installation with encrypted LVM selected during installation.
+  Generated disk image used in downstream jobs. (crypt-)LVM installations can
+  take longer, especially on non-x86_64 architectures.
+name: cryptlvm
+vars:
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  software:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt
+    - console/zypper_lr
+    - console/yast2_i
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_aarch64.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_aarch64.yaml
@@ -1,0 +1,30 @@
+---
+name: lvm-encrypt-separate-boot
+description: >
+  Same as lvm-full-encrypt, but with separate boot not encrypted partition, only
+  installation to not repeat everything again with small risk.
+vars:
+  UNENCRYPTED_BOOT: 1
+  ENCRYPT: 1
+  FULL_LVM_ENCRYPT: 1
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  software:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/encryption/lvm_full_encrypt_aarch64.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_aarch64.yaml
@@ -1,0 +1,27 @@
+---
+name: lvm-full-encrypt
+description: >
+  Installation with encrypted root and swap logical volumes and encrypted
+  boot partition outside of volume group as plain partition.
+  Partitioning is validated in the booted system after the installation,
+  including check for separate boot partition.
+vars:
+  ENCRYPT: 1
+  FULL_LVM_ENCRYPT: 1
+  YUI_REST_API: 1
+schedule:
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  software:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/schedule/yast/installer_extended/installer_extended_aarch64.yaml
@@ -1,0 +1,44 @@
+---
+name: installer_extended
+description: >
+  Test suite performs additional UI checks. As of now following is tested:
+     - Switch keyboard layout and test it (only when is not VNC installation)
+     - License has to be accepted and there is pop-up with a hint.
+     - License translations (except SLE 15 due to missing translations in the
+       beta phase).
+     - Check available and selected by default modules for installation.
+vars:
+  CHECK_PRESELECTED_MODULES: '1'
+  CHECK_RELEASENOTES: '1'
+  EXIT_AFTER_START_INSTALL: '1'
+  EXTRABOOTPARAMS: Y2STRICTTEXTDOMAIN=1
+  YUI_REST_API: 1
+schedule:
+  bootloader:
+    - installation/isosize
+    - installation/data_integrity
+    - installation/bootloader_start
+  setup_libyui:
+    - installation/setup_libyui
+    - installation/language_keyboard/switch_keyboard_layout
+  license_agreement:
+    - installation/licensing/verify_license_translations
+    - installation/licensing/verify_license_has_to_be_accepted
+    - installation/licensing/accept_license
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/verify_module_registration
+    - installation/module_registration/skip_module_registration
+  release_notes:
+    - installation/releasenotes
+  local_user:
+    - installation/authentication/default_user_simple_pwd
+    - installation/authentication/root_simple_pwd
+  software:
+    - installation/installation_settings/validate_default_target
+  installation:
+    - installation/confirm_installation
+  installation_logs: []
+  confirm_reboot: []
+  grub: []
+  first_login: []

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_aarch64.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_aarch64.yaml
@@ -1,0 +1,28 @@
+---
+description: >
+  Test suite cancels encrypted partitions activation and performs installation
+  with unencrypted lvm.
+name: lvm+cancel_existing_cryptlvm
+vars:
+  LVM: 1
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_probing:
+    - installation/system_probing/cancel_encrypted_volume
+    - console/validate_encrypted_partition_not_activated
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/lvm_ignore_existing
+  software:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/system_prepare
+    - console/force_scheduled_tasks
+  system_validation:
+    - console/validate_lvm

--- a/schedule/yast/lvm/lvm_sle_aarch64.yaml
+++ b/schedule/yast/lvm/lvm_sle_aarch64.yaml
@@ -1,0 +1,27 @@
+---
+description: >
+  Conduct installation with LVM selected during installation using guided setup.
+  In comparison to SLE 12 we register the installation and have system roles
+  wizard screen.
+name: cryptlvm
+vars:
+  DESKTOP: textmode
+  LVM: '1'
+  MAX_JOB_TIME: '14400'
+  OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
+  YUI_REST_API: 1
+schedule:
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/enable_lvm
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/validate_lvm
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/zypper_in
+    - console/firewall_enabled

--- a/schedule/yast/lvm/lvm_thin_provisioning_aarch64.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning_aarch64.yaml
@@ -1,0 +1,27 @@
+---
+name: lvm_thin_provisioning
+description: >
+  Complete OS deployment with unencrypted LVM drive management. Test creates
+  2 LVM and BIOS boot partitions. Thin pool and thin lv reside on the second
+  LVM partition, where /home (XFS) is being mounted. Partitioning is validated
+  in the booted system after the installation.
+vars:
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  software:
+    - installation/installation_settings/validate_default_target
+  grub:
+    - installation/handle_reboot
+  system_preparation:
+    - console/system_prepare
+    - console/hostname
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/lvm_thin_check

--- a/schedule/yast/lvm_multipath_aarch64.yaml
+++ b/schedule/yast/lvm_multipath_aarch64.yaml
@@ -1,0 +1,23 @@
+---
+name:           lvm_multipath
+description:    >
+  Textmode installation test for lvm partitioning with no spearate home, on multipath with lvm validation.
+vars:
+  YUI_REST_API: 1
+schedule:
+  system_probing:
+    - installation/multipath
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/enable_lvm
+    - installation/partitioning/guided_setup/do_not_propose_separate_home
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_multipath
+    - console/validate_lvm

--- a/schedule/yast/lvm_multipath_encrypted_aarch64.yaml
+++ b/schedule/yast/lvm_multipath_encrypted_aarch64.yaml
@@ -1,0 +1,27 @@
+---
+name:           lvm_multipath_encrypted
+description:    >
+  Textmode installation test for encrypted lvm partitioning on multipath with lvm and encryption validation.
+vars:
+  YUI_REST_API: 1
+schedule:
+  system_probing:
+    - installation/multipath
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  software:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_multipath
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_aarch64.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_aarch64.yaml
@@ -1,0 +1,18 @@
+---
+name:           lvm+raid1
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+  YUI_REST_API: 1
+schedule:
+  suggested_partitioning:
+    - installation/partitioning/setup_raid1_lvm
+  software:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_lvm_raid1
+test_data:
+  <<: !include test_data/yast/lvm_raid1/lvm+raid1.yaml

--- a/schedule/yast/minimal+base/minimal+base@yast_aarch64.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast_aarch64.yaml
@@ -1,0 +1,26 @@
+---
+name:           minimal+base@yast
+description:    >
+  Select a minimal textmode installation by starting with the default and unselecting all patterns
+  except for "base" and "minimal". Not to be confused with the new system role "minimal" introduced with SLE15.
+vars:
+  DEPENDENCY_RESOLVER_FLAG: 1
+  DESKTOP: textmode
+  PATTERNS: base,enhanced_base
+  YUI_REST_API: 1
+schedule:
+  software:
+    - installation/select_only_visible_patterns_from_top
+  security:
+    - installation/security/select_security_module_none
+  system_validation:
+    - console/system_prepare
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - update/zypper_up
+    - console/zypper_lifecycle
+    - console/orphaned_packages_check
+    - console/validate_installed_patterns
+    - console/consoletest_finish

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal_aarch64.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal_aarch64.yaml
@@ -1,0 +1,30 @@
+---
+name: minimal+role_minimal
+description: >
+  SLE 15 specific registered installation with minimal role selected.
+  Installation is validated by successful boot and that YaST does not report
+  any issue.
+vars:
+  YUI_REST_API: 1
+schedule:
+  system_role:
+    - installation/system_role/select_role_minimal
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/consoletest_setup
+  system_validation:
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/zypper_in
+    - console/firewall_enabled
+    - console/ncurses
+    - console/sshd_running
+    - console/sshd
+    - console/verify_default_target
+    - console/validate_partition_table_via_blkid
+    - console/validate_blockdevices
+    - console/validate_installed_packages
+    - console/validate_installed_patterns
+    - console/orphaned_packages_check

--- a/schedule/yast/modify_existing_partition/modify_existing_partition_aarch64.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition_aarch64.yaml
@@ -1,0 +1,14 @@
+---
+name: modify_existing_partition
+description: >
+  Installation where we modify some pre-existing partitions. Must depend on some
+  create_hdd test suite.
+vars:
+  YUI_REST_API: 1
+schedule:
+  suggested_partitioning:
+    - installation/partitioning/modify_existing_partition
+  software:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_modify_existing_partition

--- a/schedule/yast/raid/raid0_sle_gpt_uefi_aarch64.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt_uefi_aarch64.yaml
@@ -1,0 +1,22 @@
+name:           RAID0_gpt_uefi
+description:    >
+  Configure RAID 0 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates EFI boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 0.
+vars:
+  RAIDLEVEL: 0
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/raid_gpt
+  suggested_partitioning: []
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_md_raid
+    - console/validate_raid

--- a/schedule/yast/raid/raid10_sle_gpt_uefi_aarch64.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt_uefi_aarch64.yaml
@@ -1,0 +1,21 @@
+name:           RAID10_gpt_uefi
+description:    >
+  Configure RAID 10 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates EFI boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 10.
+vars:
+  RAIDLEVEL: 10
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/raid_gpt
+  suggested_partitioning: []
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - console/validate_md_raid
+    - console/validate_raid

--- a/schedule/yast/raid/raid1_sle_gpt_uefi_aarch64.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi_aarch64.yaml
@@ -1,0 +1,21 @@
+name:           RAID1_gpt_uefi
+description:    >
+  Configure RAID 1 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates EFI boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 1.
+vars:
+  RAIDLEVEL: 1
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/raid_gpt
+  suggested_partitioning: []
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - console/validate_md_raid
+    - console/validate_raid

--- a/schedule/yast/raid/raid5_sle_gpt_uefi_aarch64.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt_uefi_aarch64.yaml
@@ -1,0 +1,21 @@
+name:           RAID5_gpt_uefi
+description:    >
+  Configure RAID 5 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates EFI boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 5.
+vars:
+  RAIDLEVEL: 5
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/raid_gpt
+  suggested_partitioning: []
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - console/validate_md_raid
+    - console/validate_raid

--- a/schedule/yast/raid/raid6_sle_gpt_uefi_aarch64.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi_aarch64.yaml
@@ -1,0 +1,21 @@
+name:           RAID6_gpt_uefi
+description:    >
+  Configure RAID 6 on the disks with GPT partition tables and UEFI using Expert Partitioner.
+  Creates EFI boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 6.
+vars:
+  RAIDLEVEL: 6
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/raid_gpt
+  suggested_partitioning: []
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - console/validate_md_raid
+    - console/validate_raid

--- a/schedule/yast/releasenotes_origin+unregistered_aarch64.yaml
+++ b/schedule/yast/releasenotes_origin+unregistered_aarch64.yaml
@@ -1,0 +1,22 @@
+---
+name: releasenotes_origin+unregistered
+description: >
+  Test fate#323273 - Check the origin (rpm or url) of the showed release notes.
+vars:
+  YUI_REST_API: 1
+schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_module_desktop
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/release_notes_from_url
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  installation:
+    - installation/confirm_installation
+  installation_logs: []
+  confirm_reboot: []
+  grub: []
+  first_login: []

--- a/schedule/yast/select_disk/select_disk_aarch64.yaml
+++ b/schedule/yast/select_disk/select_disk_aarch64.yaml
@@ -1,0 +1,18 @@
+---
+description: >
+  Test the selection of "first" disk with the guided setup in partitioning.
+  This is also used as a prerequisite for real hardware tests to select
+  the right disk for installation and not a "random" one.
+name: select_disk
+vars:
+  YUI_REST_API: 1
+schedule:
+  expert_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/select_disks
+    - installation/partitioning/guided_setup/accept_default_part_scheme
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  software:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_first_disk_selection

--- a/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration_aarch64.yaml
+++ b/schedule/yast/select_modules_and_patterns+registration/select_modules_and_patterns+registration_aarch64.yaml
@@ -1,0 +1,41 @@
+---
+name: select_modules_and_patterns+registration
+description: >
+  Full Medium installation that covers the following cases:
+     1. Additional modules enabled using SCC (Legacy, Development Tools,
+        Web and Scripting, Containers, Desktop Applications);
+     2. Yast patterns installed;
+     3. System registration is skipped during installation;
+     4. Installation is validated by successful boot and that YaST does not
+        report any issues;
+     5. Registration is performed on the installed system.
+vars:
+  YUI_REST_API: 1
+schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_nonconflicting_modules
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  software:
+    - installation/select_visible_patterns_from_bottom
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_installed_packages
+    - console/validate_installed_patterns
+    - console/scc_cleanup_reregister
+    - console/install_packages_simple
+    - console/scc_deregistration
+    - console/firewalld_add_port
+    - console/setup_libyui_running_system
+    - x11/addon_products_via_SCC_yast2
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_aarch64.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_aarch64.yaml
@@ -1,0 +1,27 @@
+---
+name: select_modules_and_patterns
+description: |
+  Perform an installation enabling some modules and selecting some
+  patterns.This test suite always registers to have access to some modules.
+vars:
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/register_nonconflicting_modules
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/accept_default_part_scheme
+    - installation/partitioning/guided_setup/do_not_propose_separate_home
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/consoletest_setup
+    - console/validate_installed_packages
+    - console/validate_installed_patterns
+    - console/yast2_i
+    - console/verify_no_separate_home
+    - console/validate_subvolumes

--- a/schedule/yast/skip_registration/skip_registration_aarch64.yaml
+++ b/schedule/yast/skip_registration/skip_registration_aarch64.yaml
@@ -1,0 +1,26 @@
+---
+name:           skip_registration
+description:    >
+  Skipping registration for SLE 15, as requires network connection.
+  This is default behavior for SLE 12.
+vars:
+  ADDONS: all-packages
+  YUI_REST_API: 1
+schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_module_desktop
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/yast/sle/flows/default_x86_64.yaml
+++ b/schedule/yast/sle/flows/default_x86_64.yaml
@@ -16,6 +16,7 @@ extension_module_selection:
   - installation/module_registration/skip_module_registration
 additional_products: []
 multipath: []
+system_probing: []
 add_on_product:
   - installation/add_on_product/skip_install_addons
 add_on_product_installation: []

--- a/schedule/yast/textmode/ha_textmode_aarch64.yaml
+++ b/schedule/yast/textmode/ha_textmode_aarch64.yaml
@@ -1,0 +1,11 @@
+name: ha_textmode
+description: |
+  Installation sles with ha in textmode which selects System Role 'Text Mode'.
+vars:
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/register_extensions_and_modules
+  system_role:
+    - installation/system_role/select_role_text_mode

--- a/schedule/yast/textmode/ha_textmode_minimal_base_aarch64.yaml
+++ b/schedule/yast/textmode/ha_textmode_minimal_base_aarch64.yaml
@@ -1,0 +1,13 @@
+name: ha_textmode_minimal_base
+description: |
+  Installation sles with ha in textmode which selects System Role 'Text Mode'.
+vars:
+  YUI_REST_API: 1
+schedule:
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/register_extensions_and_modules
+  system_role:
+    - installation/system_role/select_role_minimal
+  software:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/ha_textmode_skip_registration_aarch64.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_aarch64.yaml
@@ -1,0 +1,16 @@
+name: ha_textmode_skip_registration
+description: >
+  Installation SLES + HA in textmode which selects System Role 'Text Mode'.
+vars:
+  YUI_REST_API: 1
+schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_extension_ha
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/select_role_text_mode
+  software:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base_aarch64.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base_aarch64.yaml
@@ -1,0 +1,16 @@
+name: ha_textmode_skip_registration_minimal_base
+description: >
+  Installation SLES + HA in textmode which selects System Role 'Minimal'.
+vars:
+  YUI_REST_API: 1
+schedule:
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_extension_ha
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/select_role_minimal
+  software:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/textmode_aarch64.yaml
+++ b/schedule/yast/textmode/textmode_aarch64.yaml
@@ -1,0 +1,22 @@
+---
+name: textmode
+description: |
+  Installation in textmode which selects System Role 'Text Mode'.
+vars:
+  YUI_REST_API: 1
+schedule:
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/prepare_test_data
+    - console/consoletest_setup
+  system_validation:
+    - console/validate_product_installed_SLES
+    - console/verify_network
+    - locale/keymap_or_locale
+    - console/validate_installed_patterns
+    - console/force_scheduled_tasks
+    - console/textinfo
+    - console/orphaned_packages_check
+    - console/consoletest_finish

--- a/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role_aarch64.yaml
+++ b/schedule/yast/textmode_installation_minimal_role/textmode_installation_minimal_role_aarch64.yaml
@@ -1,0 +1,26 @@
+---
+name:           textmode_installation_minimal_role
+description:    >
+  Full Medium installation that covers the following cases:
+    1. Installation in textmode;
+    2. "Minimal" role is selected;
+    3. Boot to command-line mode;
+    4. Installation is validated by default set of smoke tests.
+vars:
+  VIDEOMODE: text
+  YUI_REST_API: 1
+schedule:
+  system_role:
+    - installation/system_role/select_role_minimal
+  software:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - update/zypper_up
+    - console/zypper_lifecycle
+    - console/orphaned_packages_check
+    - console/consoletest_finish

--- a/schedule/yast/transactional_server/create_hdd_transactional_server_aarch64.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server_aarch64.yaml
@@ -1,0 +1,22 @@
+---
+name: create_hdd_transactional_server
+description: >
+    Installation of a Transactional Server which uses a read-only
+    root filesystem to provide atomic, automatic updates of a
+    system without interfering with the running system.
+vars:
+    YUI_REST_API: 1
+schedule:
+    extension_module_selection:
+        - installation/module_registration/register_module_transactional
+    system_role:
+        - installation/system_role/accept_selected_role_transactional_server
+    software:
+        - installation/installation_settings/validate_default_target
+    system_preparation:
+        - console/hostname
+        - console/system_prepare
+        - console/force_scheduled_tasks
+        - shutdown/grub_set_bootargs
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown

--- a/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname_aarch64.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+dhcp_hostname_aarch64.yaml
@@ -1,0 +1,20 @@
+---
+name: yast_hostname+dhcp_hostname
+description: >
+  Test suite uses default option to set dhcp (using ifgf=*=dhcp), hostname.
+  Test validates if installation can successfully start in case of usage of
+  these parameters.
+vars:
+  YUI_REST_API: 1
+schedule:
+  local_user: []
+  booting: []
+  installation_settings: []
+  installation: []
+  installation_logs: []
+  confirm_reboot: []
+  grub: []
+  first_login: []
+  clock_and_timezone:
+    - installation/clock_and_timezone/accept_timezone_configuration
+    - installation/hostname_inst

--- a/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname_aarch64.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname+linuxrc_hostname_aarch64.yaml
@@ -1,0 +1,23 @@
+---
+name: yast_hostname+linuxrc_hostname
+description: >
+  Test suite uses default option to set hostname=linuxrchostname.
+  Test validates if installation can successfully start in case of usage of
+  these parameters.
+vars:
+  EXIT_AFTER_START_INSTALL: '1'
+  EXPECTED_INSTALL_HOSTNAME: linuxrchostname
+  EXTRABOOTPARAMS: hostname=linuxrchostname
+  YUI_REST_API: 1
+schedule:
+  local_user: []
+  booting: []
+  installation_settings: []
+  installation: []
+  installation_logs: []
+  confirm_reboot: []
+  grub: []
+  first_login: []
+  clock_and_timezone:
+    - installation/clock_and_timezone/accept_timezone_configuration
+    - installation/hostname_inst

--- a/schedule/yast/yast_hostname/yast_hostname_aarch64.yaml
+++ b/schedule/yast/yast_hostname/yast_hostname_aarch64.yaml
@@ -1,0 +1,20 @@
+---
+name: yast_hostname
+description: >
+  Test suite uses default option to set hostname. Test validates if installation
+  can successfully start in case of usage of these parameters.
+vars:
+  EXIT_AFTER_START_INSTALL: '1'
+  YUI_REST_API: 1
+schedule:
+  local_user: []
+  booting: []
+  installation_settings: []
+  installation: []
+  installation_logs: []
+  confirm_reboot: []
+  grub: []
+  first_login: []
+  clock_and_timezone:
+    - installation/clock_and_timezone/accept_timezone_configuration
+    - installation/hostname_inst

--- a/schedule/yast/yast_no_self_update/yast_no_self_update_aarch64.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update_aarch64.yaml
@@ -1,0 +1,16 @@
+---
+name: yast_no_self_update
+description:    >
+  Test suite conducts installation with self-update explicitly disabled. No
+  hard checks are done that the self-updating is really disabled.
+  Installation is validated by successful boot and that YaST does not report
+  any issue.
+vars:
+  INSTALLER_NO_SELF_UPDATE: 1
+  YUI_REST_API: 1
+schedule:
+  license_agreement:
+    - installation/validate_no_self_update
+    - installation/licensing/accept_license
+  software:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/yast_self_update/yast_self_update_aarch64.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update_aarch64.yaml
@@ -1,0 +1,16 @@
+---
+name: yast_self_update
+description:    >
+  Test suite conducts installation with self-update explicitly enabled. No hard
+  checks are done that the self-updating is really disabled.
+  Installation is validated by successful boot and that YaST does not report
+  any issue.
+vars:
+  INSTALLER_SELF_UPDATE: 'http://openqa.suse.de/assets/repo/%REPO_SLE_PRODUCT_SLES%'
+  YUI_REST_API: 1
+schedule:
+  license_agreement:
+    - installation/validate_self_update
+    - installation/licensing/accept_license
+  software:
+    - installation/installation_settings/validate_default_target

--- a/test_data/yast/encryption/full_lvm_enc_cancel.yaml
+++ b/test_data/yast/encryption/full_lvm_enc_cancel.yaml
@@ -1,0 +1,1 @@
+enc_disk_part: vda2

--- a/test_data/yast/encryption/full_lvm_enc_import_user.yaml
+++ b/test_data/yast/encryption/full_lvm_enc_import_user.yaml
@@ -1,0 +1,14 @@
+mapped_device: '/dev/mapper/cr-auto-1'
+device_status:
+  message: 'is active and is in use.'
+  properties:
+    type: 'LUKS1'
+    cipher: 'aes-xts-plain64'
+    key_location: 'dm-crypt'
+    mode: 'read/write'
+partitioning_deletion_entries:
+  - 'Delete btrfs on /dev/system/root'
+  - 'Delete swap on /dev/system/swap'
+  - 'Delete xfs on /dev/system/home'
+  - 'Delete volume group system'
+  - 'Delete partition'

--- a/test_data/yast/installation/network_config.yaml
+++ b/test_data/yast/installation/network_config.yaml
@@ -1,4 +1,12 @@
 ---
+software:
+  patterns:
+    - apparmor
+    - base
+    - enhanced_base
+    - x11
+    - x11_yast
+    - yast2_basis
 network:
   network_manager: wicked
   device: eth0

--- a/test_data/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/test_data/yast/installer_extended/installer_extended_aarch64.yaml
@@ -45,3 +45,6 @@ modules:
 selected_modules:
   - sle-module-basesystem
   - sle-module-server-applications
+registered_modules:
+  - sle-module-basesystem
+  - sle-module-server-applications

--- a/test_data/yast/minimal_base_aarch64.yaml
+++ b/test_data/yast/minimal_base_aarch64.yaml
@@ -1,0 +1,4 @@
+software:
+  patterns:
+    - base
+    - enhanced_base

--- a/test_data/yast/multipath_encrypted.yaml
+++ b/test_data/yast/multipath_encrypted.yaml
@@ -1,0 +1,70 @@
+---
+crypttab:
+  num_devices_encrypted: 1
+cryptsetup:
+  device_status:
+    message: is active and is in use.
+    properties:
+      type: LUKS1
+      cipher: aes-xts-plain64
+      device: /dev/mapper/0QEMU_QEMU_HARDDISK_hd0-part2
+      key_location: dm-crypt
+      mode: read/write
+backup_file_info: 'LUKS encrypted file, ver 1 \[aes, xts-plain64, sha256\]'
+backup_path: '/root/bkp_luks_header_cr_home'
+software:
+  packages:
+    # Device Mapper Tools
+    device-mapper:
+      installed: 1
+    # Tools to Manage Multipathed Devices with the device-mapper
+    multipath-tools:
+      installed: 1
+    # Manages partition tables on device-mapper devices
+    kpartx:
+      installed: 1
+multipath:
+  attributes:
+    # Specifies whether to use world-wide IDs (WWIDs) or to use the /var/lib/multipath/bindings file
+    # to assign a persistent and unique alias to the multipath devices in the form of /dev/mapper/mpathN.
+    user_friendly_names: 'no'
+    # Specifies whether to monitor the failed path recovery, and indicates the timing for group failback
+    # after failed paths return to service.
+    failback: manual
+    # Determines the state of the path.
+    #   tur: Issues an SCSI test unit ready command to the device.
+    path_checker: tur
+    # Specifies the path grouping policy for a multipath device hosted by a given controller.
+    #   failover: One path is assigned per priority group so that only one path at a time is used.
+    path_grouping_policy: failover
+    # Specifies the path-selector algorithm to use for load balancing
+    #   service-time 0: A service-time oriented load balancer that balances I/O on paths according
+    #                   to the latency.
+    path_selector: 'service-time 0'
+    # Specifies the time in seconds between the end of one path checking cycle and the beginning
+    # of the next path checking cycle.
+    polling_interval: 5
+    # Specifies the number of I/O requests to route to a path before switching to the next path
+    # in the current path group.
+    rr_min_io_rq: 1
+    # Specifies the weighting method to use for paths.
+    #   uniform: All paths have the same round-robin weights.
+    rr_weight: uniform
+    # A udev attribute that provides a unique path identifier
+    uid_attribute: ID_SERIAL
+  topology:
+    vendor_product_revision: 'QEMU,QEMU HARDDISK'
+    features: 0
+    hwhandler: 0
+    wp: rw
+    priority_groups:
+      - prio: 1
+        status: active
+        paths:
+          - name: sda
+            status: 'active ready running'
+      - prio: 1
+        status: enabled
+        paths:
+          - name: sdb
+            status: 'active ready running'

--- a/test_data/yast/raid/raid1_gpt_uefi_aarch64.yaml
+++ b/test_data/yast/raid/raid1_gpt_uefi_aarch64.yaml
@@ -1,0 +1,79 @@
+disks:
+  - name: vda
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        formatting_options:
+          should_format: 1
+          filesystem: fat
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot/efi'
+      - size: 12500mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdb
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 12500mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdc
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 12500mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdd
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 12500mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+mds:
+  - raid_level: 1
+    name: md0
+    devices:
+      - vda2
+      - vdb2
+      - vdc2
+      - vdd2
+    partition:
+      role: operating-system
+      formatting_options:
+        should_format: 1
+      mounting_options:
+        should_mount: 1
+  - raid_level: 0
+    name: md1
+    chunk_size: '64 KiB'
+    devices:
+      - vda3
+      - vdb3
+      - vdc3
+      - vdd3
+    partition:
+      role: swap
+      formatting_options:
+        should_format: 1
+        filesystem: swap
+      mounting_options:
+        should_mount: 1

--- a/test_data/yast/raid/raid6_gpt_uefi_aarch64.yaml
+++ b/test_data/yast/raid/raid6_gpt_uefi_aarch64.yaml
@@ -1,0 +1,82 @@
+disks:
+  - name: vda
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        formatting_options:
+          should_format: 1
+          filesystem: fat
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot/efi'
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdb
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdc
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdd
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+mds:
+  - raid_level: 6
+    name: md0
+    chunk_size: '64 KiB'
+    devices:
+      - vda2
+      - vdb2
+      - vdc2
+      - vdd2
+    device_selection_step: 2
+    partition:
+      role: operating-system
+      formatting_options:
+        should_format: 1
+      mounting_options:
+        should_mount: 1
+  - raid_level: 0
+    name: md1
+    chunk_size: '64 KiB'
+    devices:
+      - vda3
+      - vdb3
+      - vdc3
+      - vdd3
+    device_selection_step: 1
+    partition:
+      role: operating-system
+      formatting_options:
+        should_format: 1
+        filesystem: swap
+      mounting_options:
+        should_mount: 1

--- a/test_data/yast/select_disk_aarch64.yaml
+++ b/test_data/yast/select_disk_aarch64.yaml
@@ -1,0 +1,5 @@
+guided_partitioning:
+  disks:
+    - vda
+unused_disks:
+  - vdb

--- a/test_data/yast/select_modules_and_patterns/select_modules_and_patterns_aarch64.yaml
+++ b/test_data/yast/select_modules_and_patterns/select_modules_and_patterns_aarch64.yaml
@@ -1,0 +1,25 @@
+---
+default_target: graphical.target
+software:
+  packages:
+    bash:
+      installed: 1
+  patterns:
+    - apparmor
+    - base
+    - devel_yast
+    - enhanced_base
+    - fonts
+    - gnome_basic
+    - x11
+    - x11_yast
+    - yast2_basis
+    - yast2_desktop
+    - yast2_server
+validate_subvolumes:
+  - subvolume: home
+    mount_point: /
+install_packages:
+  - libyui-rest-api
+port: 30000-50000
+zone: public


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/124035
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=102.1&groupid=220&version=15-SP5
- MR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/506
