### PR TITLE
Skip the samba_adcli test on <12-SP3

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -125,6 +125,11 @@ sub enable_ipv6 {
 }
 
 sub run {
+    # Don't run on 12-SP2. This is much easier than a conditional schedule in the yaml file.
+    if (is_sle('<12-SP3')) {
+        record_info("Not available", "this test run is not available for SLES version older than 12-SP3.");
+        return;
+    }
     select_serial_terminal;
 
     # Ensure the required variables are set


### PR DESCRIPTION
SLES version older than 12-SP3 are not supported by this test run and we should skip them.

- Related ticket: https://progress.opensuse.org/issues/96512
- Verification run: [12-SP2](https://duck-norris.qe.suse.de/tests/12401) | [15-SP4](https://duck-norris.qe.suse.de/tests/12403)
