### PR TITLE
selinux on ALP is already enabled and in enforcing mode by default

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -234,8 +234,9 @@ sub load_fips_tests {
 sub load_selinux_tests {
     loadtest 'security/selinux/selinux_setup';
     loadtest 'security/selinux/sestatus';
-    loadtest 'security/selinux/selinux_smoke';
-    loadtest 'security/selinux/enforcing_mode_setup';
+    # ALP has selinux enabled and in enforcing mode by default
+    loadtest 'security/selinux/selinux_smoke' unless is_alp;
+    loadtest 'security/selinux/enforcing_mode_setup' unless is_alp;
     loadtest 'security/selinux/semanage_fcontext';
     loadtest 'security/selinux/semanage_boolean';
     loadtest 'security/selinux/fixfiles';


### PR DESCRIPTION
These two modules were already skipped in the YAML schedule version of this.

- Related ticket: https://progress.opensuse.org/issues/126359
- Verification run: https://openqa.opensuse.org/tests/3186924
