### PR TITLE
Add test support for os_image from uri

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -5,10 +5,10 @@ terraform:
     az_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    hana_instancetype: "%HANA_INSTANCE_TYPE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -4,10 +4,11 @@ terraform:
   variables:
     az_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%QESAP_CLUSTER_OS_VER%"
     public_key: "%SSH_KEY_PUB%"
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
+    hana_instancetype: "%HANA_INSTANCE_TYPE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"
@@ -28,7 +29,7 @@ ansible:
   create:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_sapconf=true
+    - sap-hana-preconfigure.yaml
     - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -26,16 +26,23 @@ sub run {
     $variables{PROVIDER} = $qesap_provider;
     $variables{REGION} = $provider->provider_client->region;
     $variables{DEPLOYMENTNAME} = $resource_group_postfix;
-    $variables{QESAP_CLUSTER_OS_VER} = get_required_var("QESAP_CLUSTER_OS_VER");
+    if (get_var('QESAP_CLUSTER_OS_VER')) {
+        $variables{QESAP_CLUSTER_OS_VER} = get_var('QESAP_CLUSTER_OS_VER');
+    }
+    else {
+        $variables{STORAGE_ACCOUNT_NAME} = get_required_var('STORAGE_ACCOUNT_NAME');
+        $variables{SLE_IMAGE} = $provider->get_image_id();
+    }
+
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';
     $variables{SCC_REGCODE_SLES4SAP} = get_required_var('SCC_REGCODE_SLES4SAP');
     $variables{HANA_INSTANCE_TYPE} = get_var('QESAP_HANA_INSTANCE_TYPE', 'r6i.xlarge');
 
-    $variables{HANA_ACCOUNT} = get_required_var("QESAPDEPLOY_HANA_ACCOUNT");
-    $variables{HANA_CONTAINER} = get_required_var("QESAPDEPLOY_HANA_CONTAINER");
+    $variables{HANA_ACCOUNT} = get_required_var('QESAPDEPLOY_HANA_ACCOUNT');
+    $variables{HANA_CONTAINER} = get_required_var('QESAPDEPLOY_HANA_CONTAINER');
     if (get_var("QESAPDEPLOY_HANA_TOKEN")) {
-        $variables{HANA_TOKEN} = get_required_var("QESAPDEPLOY_HANA_TOKEN");
+        $variables{HANA_TOKEN} = get_required_var('QESAPDEPLOY_HANA_TOKEN');
         # escape needed by 'sed'
         # but not implemented in file_content_replace() yet poo#120690
         $variables{HANA_TOKEN} =~ s/\&/\\\&/g;


### PR DESCRIPTION
- Add Azure config.yaml to support image from uri
- Fix setting management in configure test module
- Remove no needed Terraform setting

Related ticket: TEAM-7514

Verification run:

- qesap regression Azure With os image from uri (using custom JobGroup, special post variables) http://openqaworker15.qa.suse.cz/tests/139943 and parent http://openqaworker15.qa.suse.cz/tests/139942
On emore attempt fails due to a cloud problem http://openqaworker15.qa.suse.cz/tests/139944 http://openqaworker15.qa.suse.cz/tests/139945#step/deploy/7 and one more attempt http://openqaworker15.qa.suse.cz/tests/139950 Errors are not related to PR, they are some sort of problem that qe-sap-deployment seems to have with sles15-sp5
- qesap regression Azure with os from the catalogue http://openqaworker15.qa.suse.cz/tests/139947 PASS
- qesap regression GCP with os from the catalogue http://openqaworker15.qa.suse.cz/tests/139951 failure is not related to this PR, it is a known issue http://openqaworker15.qa.suse.cz/tests/139951#step/test_cluster/39  terraform fromqe-sap-deployment,  in gcp, add prefix to hana node name. Test code is expecting generic name like vmhana01, like for Az and AWS. To be fixed in qe-sap-deployment
- qesap regression AWS with os from the catalogue http://openqaworker15.qa.suse.cz/tests/139952 PASS

