### PR TITLE
Move ansible test to avoid conflict with busybox-ed

### DIFF
--- a/schedule/jeos/sle/jeos-extratest.yaml
+++ b/schedule/jeos/sle/jeos-extratest.yaml
@@ -51,6 +51,7 @@ schedule:
     - console/curl_ipv6
     - console/wget_ipv6
     - console/ca_certificates_mozilla
+    - console/ansible
     - x11/evolution/evolution_prepare_servers
     - console/unzip
     - console/salt
@@ -60,4 +61,3 @@ schedule:
     - console/dstat
     - console/journalctl
     - console/procps
-    - console/ansible


### PR DESCRIPTION
Ansible test case installs `ed` as part of its test playbook. A conflict in installation can occur as `x11/evolution/evolution_prepare_servers` installs `busybox-ed` package when deploying `postfix`

VR: http://kepler.suse.cz/tests/20474#step/ansible/1
