### PR TITLE
ALP: move kernel tests after image boot

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -32,11 +32,6 @@ sub load_kernel_tests {
     loadtest_kernel "../installation/bootloader" if is_pvm;
 
     if (get_var('INSTALL_LTP')) {
-        if (is_alp) {
-            loadtest('microos/disk_boot');
-            loadtest('transactional/host_config');
-        }
-
         if (get_var('INSTALL_KOTD')) {
             loadtest_kernel 'install_kotd';
         }

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -265,10 +265,6 @@ sub load_journal_check_tests {
 }
 
 sub load_tests {
-    if (is_kernel_test()) {
-        load_kernel_tests;
-        return 1;
-    }
     if (get_var('REMOTE_TARGET')) {
         load_remote_target_tests;
         return 1;
@@ -299,12 +295,13 @@ sub load_tests {
             loadtest 'transactional/check_phub';
             return;
         }
-
     }
 
     load_config_tests;
 
-    if (is_container_test || check_var('SYSTEM_ROLE', 'container-host')) {
+    if (is_kernel_test()) {
+        load_kernel_tests;
+    } elsif (is_container_test || check_var('SYSTEM_ROLE', 'container-host')) {
         if (is_microos) {
             # MicroOS Container-Host image runs all tests.
             load_common_tests;


### PR DESCRIPTION
This way, the image boot will be done in the main scheduler and the rest in the kernel scheduler.

failure: https://openqa.opensuse.org/tests/3189603#step/install_ltp/128
VR: https://openqa.opensuse.org/tests/3189672
