### PR TITLE
Use the job id as resource group postfix

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -418,7 +418,7 @@ sub terraform_apply {
         my $sle_version = get_var('FORCED_DEPLOY_REPO_VERSION') ? get_var('FORCED_DEPLOY_REPO_VERSION') : get_var('VERSION');
         $sle_version =~ s/-/_/g;
         my $ha_sap_repo = get_var('HA_SAP_REPO') ? get_var('HA_SAP_REPO') . '/SLE_' . $sle_version : '';
-        my $suffix = sprintf("%04x", rand(0xffff));
+        my $suffix = get_current_job_id();
         my $fencing_mechanism = get_var('FENCING_MECHANISM', 'sbd');
         file_content_replace('terraform.tfvars',
             q(%MACHINE_TYPE%) => $instance_type,


### PR DESCRIPTION
Using it could allow to correlate resources running in the cloud with openQA jobs that generated them, at least better than using rand numbers.
Keep the hex encoding to short the name and not to hit the limitation imposed on the name length from each cloud API.


Related ticket: TEAM-7595

Verification run: 
- Azure mr_test http://openqaworker15.qa.suse.cz/tests/139953 http://openqaworker15.qa.suse.cz/tests/139958. This one with latest code and id without hex encoding http://openqaworker15.qa.suse.cz/tests/140357
- GCP mr_test http://openqaworker15.qa.suse.cz/tests/139954 http://openqaworker15.qa.suse.cz/tests/139959. This one with latest code and id without hex encoding http://openqaworker15.qa.suse.cz/tests/140358
- EC2 mr_test http://openqaworker15.qa.suse.cz/tests/139955 http://openqaworker15.qa.suse.cz/tests/139956. This one with latest code and id without hex encoding http://openqaworker15.qa.suse.cz/tests/140359
