### PR TITLE
PC: Set terraform instance creation timeout to 1 hour

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -76,6 +76,10 @@ variable "tags" {
     default = {}
 }
 
+variable "vm_create_timeout" {
+    default = "20m"
+}
+
 resource "random_id" "service" {
     count = var.instance_count
     keepers = {
@@ -217,6 +221,10 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
   boot_diagnostics {
     /* Passing a null value will utilize a Managed Storage Account to store Boot Diagnostics */
     storage_account_uri = null
+  }
+
+  timeouts {
+    create = var.vm_create_timeout
   }
 }
 

--- a/data/publiccloud/terraform/azure_nfstest.tf
+++ b/data/publiccloud/terraform/azure_nfstest.tf
@@ -53,6 +53,10 @@ variable "sku" {
     default="gen1"
 }
 
+variable "vm_create_timeout" {
+    default = "20m"
+}
+
 ## ---- data ---------------------------------------------------------------- ##
 
 // IP address of the client
@@ -236,6 +240,10 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
       sku       = var.image_id != "" ? "" : var.sku
       version   = var.image_id != "" ? "" : "latest"
     }
+  }
+
+  timeouts {
+    create = var.vm_create_timeout
   }
 }
 

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -52,6 +52,10 @@ variable "tags" {
     default = {}
 }
 
+variable "vm_create_timeout" {
+    default = "20m"
+}
+
 resource "random_id" "service" {
     count = var.instance_count
     keepers = {
@@ -106,6 +110,10 @@ resource "aws_instance" "openqa" {
     ebs_block_device {
         device_name = "/dev/sda1"
         volume_size = 20
+    }
+
+    timeouts {
+        create = var.vm_create_timeout
     }
 }
 

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -84,6 +84,10 @@ variable "gpu" {
   default = false
 }
 
+variable "vm_create_timeout" {
+    default = "20m"
+}
+
 resource "random_id" "service" {
     count = var.instance_count
     keepers = {
@@ -144,6 +148,10 @@ resource "google_compute_instance" "openqa" {
             enable_vtpm = "true"
             enable_integrity_monitoring = "true"
         }
+    }
+
+    timeouts {
+        create = var.vm_create_timeout
     }
 }
 

--- a/variables.md
+++ b/variables.md
@@ -335,3 +335,4 @@ PUBLIC_CLOUD_INSTANCE_IP | string | "" | If defined, no instance will be created
 _SECRET_PUBLIC_CLOUD_INSTANCE_SSH_KEY | string | "" | The `~/.ssh/id_rsa` existing key allowed by `PUBLIC_CLOUD_INSTANCE_IP` instance
 PUBLIC_CLOUD_TERRAFORM_DIR | string | "/root/terraform" | Override default root path to terraform directory
 PUBLIC_CLOUD_SCC_ENDPOINT | string | "registercloudguest" | Name of binary which will be used to register image . Except default value only possible value is "SUSEConnect" anything else will lead to test failure!
+TERRAFORM_VM_CREATE_TIMEOUT | string | "20m" | Terraform timeout for creating the virtual machine resource.


### PR DESCRIPTION
- Terraform documentation: [developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts)
- Example failure: [openqa.suse.de/t10784510](https://openqa.suse.de/t10784510)
- Related ticket: [bsc#1209382](https://bugzilla.suse.com/show_bug.cgi?id=1209382)
- Verification run (default): [EC2](https://pdostal-server.suse.cz/tests/4173), [GCE](https://pdostal-server.suse.cz/tests/4172), [Azure](https://pdostal-server.suse.cz/tests/4180)
- Verification run (default): [EC2](https://pdostal-server.suse.cz/tests/4176), [GCE](https://pdostal-server.suse.cz/tests/4175), [Azure](https://pdostal-server.suse.cz/tests/4181)
