### PR TITLE
Ensure to select bond port yast2_lan_restart_bond

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/BondSlavesTab.pm
@@ -39,6 +39,7 @@ sub select_bond_slave_in_list {
     assert_screen(BOND_SLAVES_TAB);
     apply_workaround_poo124652(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED) if (is_sle('>=15-SP4'));
     assert_and_click(BOND_SLAVE_DEVICE_CHECKBOX_UNCHECKED);
+    wait_still_screen;
 }
 
 sub select_continue_in_popup {


### PR DESCRIPTION
Ensure to select bond port yast2_lan_restart_bond

**Ticket:**

- https://progress.opensuse.org/issues/125999

**Verification run:**

- https://openqa.suse.de/t10825294 
- https://openqa.suse.de/t10825266
- https://openqa.suse.de/t10825278
- https://openqa.suse.de/t10825284
- https://openqa.suse.de/t10825286
- https://openqa.suse.de/t10825292
- https://openqa.suse.de/t10825296
- https://openqa.suse.de/t10825299
- https://openqa.suse.de/t10825301
- https://openqa.suse.de/t10825303
- https://openqa.suse.de/t10825340
