### PR TITLE
pynfs: Add result to record_info()

### DIFF
--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -32,7 +32,7 @@ sub display_results {
     die 'failed to parse results.json' unless $results;
     die 'results.json is not array' unless (ref($results->{testcase}) eq 'ARRAY');
 
-    record_info('Results', "failures: $results->{failures}\nskipped: $results->{skipped}\ntime: $results->{time}");
+    record_info('Results', "failures: $results->{failures}\nskipped: $results->{skipped}\ntime: $results->{time}", result => $results->{failures} ? 'fail' : ($results->{skipped} ? 'softfail' : 'ok'));
 
     for my $test (@{$results->{testcase}}) {
         if (exists($test->{skipped})) {
@@ -43,7 +43,7 @@ sub display_results {
     }
 
     record_info('Passed', $pass);
-    record_info('Skipped', $skip);
+    record_info('Skipped', $skip, result => $results->{skipped} ? 'softfail' : 'ok');
 
     for my $test (@{$results->{testcase}}) {
         bmwqemu::fctinfo("code: $test->{code}");

--- a/tests/nfs/pynfs_result.pm
+++ b/tests/nfs/pynfs_result.pm
@@ -24,24 +24,29 @@ sub run {
     my $message = $data->{failure}->{message};
     my $is_v4 = get_required_var('PYNFS') eq 'nfs4.0';
     my $log = "$message\n\n$data->{failure}->{err}";
-
-    record_info('INFO', "name: $data->{name}\nclassname: $data->{classname}\ntime: $data->{time}\n");
-
-    die 'failure does not exist' unless (exists($data->{failure}));
-
+    my $softfail;
 
     if ($test eq 'LOCK24' && $message eq
         'OP_LOCK should return NFS4_OK, instead got NFS4ERR_BAD_SEQID') {
-        $self->record_soft_failure_result("LOCK24 failure is known, verriding to softfail: bsc#1192211\n\n" . $log);
+        $softfail = "LOCK24 failure is known, verriding to softfail: bsc#1192211";
     } elsif ($test eq 'RD5a' && is_sle && $is_v4 && $message eq
         "Reading file /b'exportdir/tree/file' should return NFS4_OK, instead got NFS4ERR_INVAL") {
-        $self->record_soft_failure_result("RD5a failure is known, verriding to softfail: bsc#1195957\n\n" . $log);
+        $softfail = "RD5a failure is known, verriding to softfail: bsc#1195957";
     } elsif (($test eq 'SATT15' || $test eq 'WRT18') && $is_v4 && (is_sle('<=15-sp3') or is_leap('<=15.3')) &&
         $message eq 'consecutive SETATTR(mode)\'s don\'t all change change attribute') {
-        $self->record_soft_failure_result("$test failure is known, verriding to softfail: bsc#1192210\n\n" . $log);
+        $softfail = "$test failure is known, verriding to softfail: bsc#1192210";
+    }
+
+    record_info('INFO', "name: $data->{name}\nclassname: $data->{classname}\ntime: $data->{time}\n",
+        result => $softfail ? 'softfail' : 'ok');
+
+    die 'failure does not exist' unless (exists($data->{failure}));
+
+    if ($softfail) {
+        $self->record_soft_failure_result("$softfail\n\n" . $log);
     } else {
         $self->{result} = 'fail';
-        record_info('ERROR', $log);
+        record_info('ERROR', $log, result => 'fail');
     }
 }
 


### PR DESCRIPTION
The default border color was always green (results == ok). Change the default color to suggest reviewer to see the content:

* 'Results' gets red border if there are failures, yellow if there are skip.
* 'Skipped' gets yellow if there are skipped.
* red in INFO and ERROR for errors
* yellow in INFO for soft failures ("Soft Failed" is already correctly formatted by record_soft_failure_result).

Verification run:
- fail: http://quasar.suse.cz/tests/2545, http://quasar.suse.cz/tests/2546
- soft failures: http://quasar.suse.cz/tests/2542
- pass: http://quasar.suse.cz/tests/2544