### PR TITLE
P.C. create_instance guestregister triggrering update

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -580,7 +580,7 @@ sub store_boottime_db() {
     }
 
     my $org = get_var('PUBLIC_CLOUD_PERF_DB_ORG', 'qec');
-    my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf');
+    my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf_2');
 
     my $tags = {
         instance_type => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -30,7 +30,7 @@ sub run {
         $provider = $args->{my_provider};
     } else {
         $provider = $self->provider_factory();
-        $instance = $provider->create_instance();
+        $instance = $provider->create_instance(check_guestregister => is_ondemand ? 1 : 0);
 
         $instance->wait_for_guestregister() if is_ondemand();
     }

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -99,7 +99,7 @@ sub run {
         $provider = $self->{provider} = $args->{my_provider};    # required for cleanup
     } else {
         $provider = $self->provider_factory();
-        $instance = $self->{my_instance} = $provider->create_instance();
+        $instance = $self->{my_instance} = $provider->create_instance(check_guestregister => is_openstack ? 0 : 1);
         unless (is_openstack) {
             $instance->wait_for_guestregister();
         }


### PR DESCRIPTION
Publiccloud **create_instance**, `guestregister` check triggering updated cases:
1) in img_proof, do if ondemand,
2) in run_ltp, skip if openstack.

Moreover the remote DB `perf` _default target_ (used when `PUBLIC_CLOUD_PERF_COLLECT=1` 
 and `_PUBLIC_CLOUD_PERF_PUSH_DATA=1`  only) has been changed to be the new `perf_2`, being additional tags used. This update was also tested in VRs of previous PR#16577. A new _token_ is used for r/w.


- Related ticket: https://progress.opensuse.org/issues/118027#note-13
- Needles: None
- Verification run: TBD
