### PR TITLE
update_kernel: Fix LTP exclusion regex for livepatch heavy load generator

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -309,7 +309,7 @@ sub start_heavy_load {
     my @pids;
     my $root = get_ltproot;
 
-    script_run("grep -v 'module\|add_key' $root/runtest/syscalls >$root/runtest/syscalls.klp");
+    script_run("grep -v 'module\\|add_key' $root/runtest/syscalls >$root/runtest/syscalls.klp");
 
     for my $runfile (qw(syscalls.klp ltp-aiodio.part4)) {
         push @pids, background_script_run("yes | $root/runltp -f $runfile &>/dev/null");


### PR DESCRIPTION
The regex which disables LTP tests that load custom kernel modules and taint the kernel needs one more backslash after the move from separate shell script to Perl. Otherwise the module tests will be included in the temporary runfile and cause livepatch installation to randomly fail.

- Related ticket: N/A
- Needles: N/A
- Verification run: Pending
