### PR TITLE
Fixes for LTP installation on ALP

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -127,7 +127,7 @@ sub add_custom_grub_entries {
         $distro = "SLES" . ' \\?' . get_required_var('VERSION');
     }
     elsif (is_alp()) {
-        $distro = "Adaptable Linux Platform";
+        $distro = "ALP";
     }
     elsif (is_sle_micro()) {
         $distro = "SLE Micro" . ' \\?' . get_required_var('VERSION');

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -302,6 +302,7 @@ sub load_tests {
 
     if (is_kernel_test()) {
         load_kernel_tests;
+        return 1;
     } elsif (is_container_test || check_var('SYSTEM_ROLE', 'container-host')) {
         if (is_microos) {
             # MicroOS Container-Host image runs all tests.


### PR DESCRIPTION
ALP changed grub menuentry from Adaptable Linux Platform to ALP Micro/Bedrock.

`load_journal_check_test` was  scheduled after `load_kernel_tests`,

- Failures:
 grub config: https://openqa.opensuse.org/tests/3195013#step/install_ltp/157
 schedule: https://openqa.opensuse.org/tests/3195516
- Needles: none
- Verification run:
ALP Micro: https://openqa.opensuse.org/tests/3195521
ALP Bedrock: https://openqa.opensuse.org/tests/3195522
