### PR TITLE
Remove DEVEL_TOOLS_REPO from schedules

### DIFF
--- a/schedule/kernel/ibtest-master-autoyast.yaml
+++ b/schedule/kernel/ibtest-master-autoyast.yaml
@@ -4,7 +4,6 @@ description:    >
 vars:
     AUTOYAST: autoyast_mlx_con5.xml
     AUTOYAST_PREPARE_PROFILE: 1
-    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -3,7 +3,6 @@ description:    >
     The master node for the infiniband testsuite (hpc-testing)
 vars:
     DESKTOP: textmode
-    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -3,7 +3,6 @@ description:    >
     The master node for the infiniband testsuite (hpc-testing)
 vars:
     DESKTOP: textmode
-    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/15.4/devel:tools.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -3,7 +3,6 @@ description:    >
     The slave node for the infiniband testsuite (hpc-testing)
 vars:
     DESKTOP: textmode
-    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -3,7 +3,6 @@ description:    >
     The slave node for the infiniband testsuite (hpc-testing)
 vars:
     DESKTOP: textmode
-    DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/SLE_15_SP2/devel:tools.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
     IBTEST_GITBRANCH: master


### PR DESCRIPTION
This is a variable we have to change every now and then to match the version of the distro we are testing, so we should not define it in the schedule but on the testsuite level.
