### PR TITLE
Move the container to the devel project

### DIFF
--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -52,7 +52,7 @@ sub run {
     # TODO: Use another namespace using team group name
     # Docker image source in https://github.com/ricardobranco777/hawk_test
     # It will be eventually moved to https://github.com/ClusterLabs/hawk/e2e_test
-    my $docker_image = "registry.opensuse.org/home/rbranco/branches/opensuse/templates/images/15.4/containers/hawk_test:latest";
+    my $docker_image = "registry.opensuse.org/devel/openqa/ci/tooling/containers_15_4/hawk_test:latest";
 
     assert_script_run("docker pull $docker_image", 240);
 


### PR DESCRIPTION
The container needed for this was in Ricardo Branco's home OBS project and would eventually be garbage collected.

This uses the same container that has been submitted to the CI subproject in the devel namespace and is for this reason not going to be garbage collected.

- Related ticket: https://jira.suse.com/browse/TEAM-7428
- Verification run: https://openqa.suse.de/tests/10807780
