### PR TITLE
alp: Fix schedule of kernel tests

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -8,7 +8,7 @@ use base 'Exporter';
 use Exporter;
 use testapi qw(check_var get_required_var get_var);
 use utils;
-use main_common qw(boot_hdd_image load_bootloader_s390x load_kernel_baremetal_tests);
+use main_common qw(boot_hdd_image load_bootloader_s390x load_kernel_baremetal_tests replace_opensuse_repos_tests is_repo_replacement_required);
 use 5.018;
 use Utils::Backends;
 use version_utils qw(is_opensuse is_alp);
@@ -32,6 +32,12 @@ sub load_kernel_tests {
     loadtest_kernel "../installation/bootloader" if is_pvm;
 
     if (get_var('INSTALL_LTP')) {
+        if (is_alp) {
+            loadtest 'microos/disk_boot';
+            replace_opensuse_repos_tests if is_repo_replacement_required;
+            loadtest 'transactional/host_config';
+        }
+
         if (get_var('INSTALL_KOTD')) {
             loadtest_kernel 'install_kotd';
         }

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -266,6 +266,11 @@ sub load_journal_check_tests {
 }
 
 sub load_tests {
+    if (is_kernel_test()) {
+        load_kernel_tests;
+        return 1;
+    }
+
     if (get_var('REMOTE_TARGET')) {
         load_remote_target_tests;
         return 1;
@@ -300,10 +305,7 @@ sub load_tests {
 
     load_config_tests;
 
-    if (is_kernel_test()) {
-        load_kernel_tests;
-        return 1;
-    } elsif (is_container_test || check_var('SYSTEM_ROLE', 'container-host')) {
+    if (is_container_test || check_var('SYSTEM_ROLE', 'container-host')) {
         if (is_microos) {
             # MicroOS Container-Host image runs all tests.
             load_common_tests;


### PR DESCRIPTION
Basically reverts https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16700 and adds more configuration modules.

- Fail: https://openqa.opensuse.org/tests/3195539#
- Needles: none
- Verification runs:
 1. ALP Micro:
  installation: https://openqa.opensuse.org/tests/3196124
  run: https://openqa.opensuse.org/tests/3196128
 2. ALP Bedrock:
  installation: https://openqa.opensuse.org/tests/3195953
  run: https://openqa.opensuse.org/tests/3195946

