### PR TITLE
jeos/firstrun: Leap 15.5 does not need explicit EULA acceptance

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -108,7 +108,7 @@ sub run {
     send_key 'ret';
 
     # Accept EULA if required
-    unless (is_tumbleweed || is_microos) {
+    unless (is_tumbleweed || is_microos || is_leap('>=15.5')) {
         assert_screen 'jeos-doyouaccept';
         send_key 'ret';
     }


### PR DESCRIPTION
jeos-firstboot got updated.

- Failure: https://openqa.opensuse.org/tests/3195374#step/firstrun/1
- Verification run: https://openqa.opensuse.org/tests/3195651
