### PR TITLE
Find encrypted partition for ALP full disk encrypted image

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -18,6 +18,9 @@ sub run {
 
     # Disk which /var resides on
     my $disk = script_output 'lsblk -rnoPKNAME $(findmnt -nrvoSOURCE /var)';
+    if (!$disk && check_var('FLAVOR', 'Default-encrypted')) {
+        $disk = (split('/', script_output 'blkid -l -t TYPE="crypto_LUKS" -o device'))[-1];
+    }
 
     # Verify that openQA resized the disk image
     my $disksize = script_output "sfdisk --show-size /dev/$disk";


### PR DESCRIPTION
When the drive is encrypted, the previous code [did not find](https://openqa.opensuse.org/tests/3195032#step/image_checks/6) the partition that holds `/var`.

- VR: http://kepler.suse.cz/tests/20487#step/image_checks/8

