### PR TITLE
Switch to python3.10 from python3.9

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -32,7 +32,7 @@ use warnings;
 use Carp qw(croak);
 use Mojo::JSON qw(decode_json);
 use YAML::PP;
-use utils qw(file_content_replace zypper_call);
+use utils qw(file_content_replace);
 use publiccloud::utils qw(get_credentials);
 use testapi;
 use Exporter 'import';
@@ -158,10 +158,9 @@ sub qesap_create_ansible_section {
 =cut
 
 sub qesap_pip_install {
-    zypper_call('in python39');
-    assert_script_run("python3.9 -m venv " . QESAPDEPLOY_VENV . " && source " . QESAPDEPLOY_VENV . "/bin/activate");
-    enter_cmd 'pip3.9 config --site set global.progress_bar off';
-    my $pip_ints_cmd = 'pip3.9 install --no-color --no-cache-dir ';
+    assert_script_run("python3.10 -m venv " . QESAPDEPLOY_VENV . " && source " . QESAPDEPLOY_VENV . "/bin/activate");
+    enter_cmd 'pip3.10 config --site set global.progress_bar off';
+    my $pip_ints_cmd = 'pip3.10 install --no-color --no-cache-dir ';
     my $pip_install_log = '/tmp/pip_install.txt';
     my %paths = qesap_get_file_paths();
 
@@ -285,7 +284,7 @@ sub qesap_execute {
     # activate virtual environment
     script_run("source " . QESAPDEPLOY_VENV . "/bin/activate");
 
-    my $qesap_cmd = join(' ', 'python3.9', $paths{deployment_dir} . '/scripts/qesap/qesap.py',
+    my $qesap_cmd = join(' ', 'python3.10', $paths{deployment_dir} . '/scripts/qesap/qesap.py',
         $verbose,
         '-c', $paths{qesap_conf_trgt},
         '-b', $paths{deployment_dir},


### PR DESCRIPTION
There was a problem with the old public cloud images (ver <51) and the installation and use of `python3.9` by sap tests. This pr replaces `python3.9` with `python3.10` to use with the updated public cloud images (>=51).

Sister gitlab pr: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/422

- Related ticket: https://jira.suse.com/browse/TEAM-7506
- Verification runs: 
azure: http://openqaworker15.qa.suse.cz/tests/140794
gcp: http://openqaworker15.qa.suse.cz/tests/140795 (fails on test cluster, not python ver related)
aws: http://openqaworker15.qa.suse.cz/tests/140796
