### PR TITLE
Add support for userspace livepatching tests without incident repo

### DIFF
--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -89,7 +89,8 @@ sub run {
     record_info('glibc version', $libver);
     zypper_call("in --oldpackage glibc-$libver");
     schedule_tests('openposix', "_glibc-$libver");
-    loadtest_kernel('ulp_threads', name => "ulp_threads_glibc-$libver");
+    loadtest_kernel('ulp_threads', name => "ulp_threads_glibc-$libver",
+        run_args => $tinfo);
     zypper_call("in " . $tinfo->{packname});
 
     # Run tests again with the next untested glibc version

--- a/tests/kernel/ulp_threads.pm
+++ b/tests/kernel/ulp_threads.pm
@@ -12,11 +12,13 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $tinfo) = @_;
+
+    die 'ulp_threads must be scheduled by ulp_openposix' unless defined($tinfo);
 
     my $threadcount = get_var('ULP_THREAD_COUNT', 1000);
     my $threadsleep = get_var('ULP_THREAD_SLEEP', 100);
-    my $livepatch_list = script_output('rpm -ql glibc-livepatches');
+    my $livepatch_list = script_output("rpm -ql " . $tinfo->{packname});
     assert_script_run('export LD_PRELOAD=/usr/lib64/libpulp.so.0');
 
     # Do not use background_script_run() here. The actual test runs inside


### PR DESCRIPTION
Allow ulp_openposix to run without incident repo. In that case, test latest libpulp from product repos using openposix livepatches. Also fix ulp_threads to use livepatch package designated by ulp_openposix.

- Related ticket: https://progress.opensuse.org/issues/112004
- Needles: N/A
- Verification run:
  - Incident test: https://openqa.suse.de/tests/10810290
  - Product test: https://openqa.suse.de/tests/10810299