### PR TITLE
Remove "Public Cloud Devel" repo

### DIFF
--- a/tests/sles4sap/trento/setup_jumphost.pm
+++ b/tests/sles4sap/trento/setup_jumphost.pm
@@ -42,6 +42,8 @@ sub run {
 
     # Cypress.io installation
     cypress_install_container();
+
+    zypper_call 'rr "Public Cloud Devel"';
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Add `zypper rr` as creating the tool qcow2 for Trento test

- Related ticket: [TRNT-2018](https://jira.suse.com/browse/TRNT-2018)
- Verification run:  https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP4&build=PREVIEW&groupid=4 and in particular https://openqaworker15.qa.suse.cz/tests/140828#step/setup_jumphost/59 Here a Trento test using the new qcow2 https://openqaworker15.qa.suse.cz/tests/141284
