### PR TITLE
Install available patterns for sle-micro

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -191,6 +191,7 @@ sub load_common_tests {
 sub load_transactional_tests {
     loadtest 'transactional/filesystem_ro';
     loadtest 'transactional/trup_smoke';
+    loadtest 'microos/patterns';
     loadtest 'transactional/transactional_update';
     loadtest 'transactional/rebootmgr';
     loadtest 'transactional/health_check';

--- a/tests/microos/patterns.pm
+++ b/tests/microos/patterns.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Smoke pattern installation check
+# Maintainer: QA-c Team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use transactional qw(trup_call process_reboot);
+use utils qw(zypper_call);
+use serial_terminal qw(select_serial_terminal);
+
+sub run {
+    shift->select_serial_terminal();
+
+    # display all patterns
+    record_info('patterns', script_output 'zypper se -t pattern');
+
+    # collect available not yet installed patterns
+    my @available_patterns = split(/\n/, script_output "zypper -q se -t pattern -u");
+    my @patterns = map { m/\|\s+(.*?)\s+\|.*pattern$/ } @available_patterns;
+
+    # install new patterns
+    trup_call('pkg install -t pattern ' . join(" ", @patterns));
+    process_reboot(trigger => 1);
+
+    # expect empty list therefore ZYPPER_EXIT_INF_CAP_NOT_FOUND
+    zypper_call "-q se -t pattern -u", exitcode => [104];
+}
+
+sub post_fail_hook {
+    select_console 'log-console';
+
+    upload_logs '/var/log/zypper.log';
+    upload_logs '/var/log/zypp/history';
+}
+
+1;


### PR DESCRIPTION
There are only few available patterns that we are not regularly installing.

- ticket: [New test to check and install patterns in SLEM](https://progress.opensuse.org/issues/108356)
- VR: http://kepler.suse.cz/tests/20507#step/patterns/28
