### PR TITLE
Test to install and verify kea dhcp4 server container

### DIFF
--- a/data/kea-dhcp/kea-dhcp4.conf
+++ b/data/kea-dhcp/kea-dhcp4.conf
@@ -1,0 +1,59 @@
+{
+
+"Dhcp4": {
+    "interfaces-config": {
+
+        // interface name (e.g. "eth0/192.0.2.1").
+        "interfaces": [ ]
+    },
+
+    "expired-leases-processing": {
+        "reclaim-timer-wait-time": 10,
+        "flush-reclaimed-timer-wait-time": 25,
+        "hold-reclaimed-time": 3600,
+        "max-reclaim-leases": 100,
+        "max-reclaim-time": 250,
+        "unwarned-reclaim-cycles": 5
+    },
+
+    "option-data": [
+        {
+            "name": "domain-name-servers",
+            "data": "10.0.2.1, 10.0.2.2"
+        },
+
+    ],
+
+    "subnet4": [
+        {
+            // subnet.
+            "subnet": "10.0.2.0/24",
+
+            "pools": [ { "pool": "10.0.2.120 - 10.0.2.125" } ],
+
+            "option-data": [
+                {
+                    // For each IPv4 subnet you most likely need to specify at
+                    // least one router.
+                    "name": "routers",
+                    "data": "10.0.2.1"
+                }
+            ]
+
+        }
+    ],
+
+    "loggers": [
+    {
+        "name": "kea-dhcp4",
+        "output_options": [
+          {
+                "output": "stdout"
+          },
+        ],
+        "severity": "INFO",
+        "debuglevel": 0
+    }
+  ]
+}
+}

--- a/schedule/alp/kea_dhcp4.yaml
+++ b/schedule/alp/kea_dhcp4.yaml
@@ -1,0 +1,14 @@
+---
+name: Kea DHCP
+description: >
+    Install and test Kea DHCP server container
+conditional_schedule:
+    kea_dhcp:
+        HOSTNAME:
+            'client':
+                - microos/workloads/kea-container/dhcp4_client
+            'server':
+                - microos/workloads/kea-container/setup_dhcp4_server
+schedule:
+    - microos/disk_boot
+    - '{{kea_dhcp}}'

--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -29,7 +29,8 @@ sub run {
         shift->wait_boot(bootloader_time => 300);
     }
     microos_login;
-    record_kernel_audit_messages(log_upload => 1);
+    # Avoid uploading logs in multimachine tests as no ip address is currently assigned to the interface
+    record_kernel_audit_messages(log_upload => 1) unless (get_var('NICTYPE') eq 'tap');
 }
 
 sub test_flags {

--- a/tests/microos/workloads/kea-container/dhcp4_client.pm
+++ b/tests/microos/workloads/kea-container/dhcp4_client.pm
@@ -1,0 +1,45 @@
+# SUSE"s openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: podman kea-container
+# Summary: install and verify Kea DHCP server container.
+# Maintainer: QE Core <qe-core@suse.de>
+
+use base "consoletest";
+use warnings;
+use strict;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use lockapi;
+use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
+
+sub run {
+    my ($self) = @_;
+
+    mutex_wait 'barrier_setup_done';
+    barrier_wait 'DHCP_SERVER_READY';
+
+    select_serial_terminal;
+    # Configure static network, disable firewall
+    disable_and_stop_service($self->firewall) if check_unit_file($self->firewall);
+
+    assert_script_run('nmcli conn');
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    my ($device, $nm_id) = split(':', $nm_list);
+    assert_script_run "nmcli connection modify '$nm_id' ipv4.method auto";
+    assert_script_run("nmcli conn up '$nm_id'");
+    assert_script_run('nmcli conn');
+
+    record_info("ip a", script_output("ip a"));
+    assert_script_run('ping -c 1 10.0.2.101');
+
+    $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    ($device, $nm_id) = split(':', $nm_list);
+    validate_script_output("ip -4 addr show dev $device | sed -rne '/inet/s/[[:blank:]]*inet ([0-9\\.]*).*/\\1/p'", sub { m/10.0.2.12[0-5]/ });
+    #validate_script_output("$addr",  sub {m/10.0.2.12[0-5]/});
+    barrier_wait 'DHCP_SERVER_FINISHED';
+}
+1;
+

--- a/tests/microos/workloads/kea-container/setup_dhcp4_server.pm
+++ b/tests/microos/workloads/kea-container/setup_dhcp4_server.pm
@@ -1,0 +1,82 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: install and verify Kea DHCP server container.
+# Maintainer:  QE Core <qe-core@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use utils qw(set_hostname);
+use testapi;
+use lockapi;
+use serial_terminal 'select_serial_terminal';
+use mm_network 'setup_static_mm_network';
+use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
+
+sub run {
+    my ($self) = @_;
+    my $hostname = get_var('HOSTNAME');
+
+    barrier_create('DHCP_SERVER_READY', 2);
+    barrier_create('DHCP_SERVER_FINISHED', 2);
+    mutex_create 'barrier_setup_done';
+
+    select_serial_terminal;
+    record_info("ip a", script_output("ip a"));
+
+    # Do not use external DNS for our internal hostnames
+    assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');
+
+    # Configure static network, disable firewall
+    disable_and_stop_service($self->firewall) if check_unit_file($self->firewall);
+
+    setup_static_mm_network('10.0.2.101/24');
+    record_info("ip a", script_output("ip a"));
+
+    # Set the hostname
+    set_hostname $hostname;
+
+    install_dhcp_container();
+
+    barrier_wait 'DHCP_SERVER_READY';
+    barrier_wait 'DHCP_SERVER_FINISHED';
+    # Kill the container running on background
+    script_run("podman kill kea-dhcp4");
+    script_output("podman logs kea-dhcp4 | tee server.log");
+    upload_logs 'server.log';
+
+}
+
+sub install_dhcp_container {
+    my $image = get_var('CONTAINER_IMAGE_TO_TEST', 'registry.opensuse.org/suse/alp/workloads/tumbleweed_containerfiles/suse/alp/workloads/kea:latest');
+    # Instaling the container image
+    assert_script_run("podman container runlabel install $image");
+
+    # Copy the configured kea-dhcp4 config file to the container host and add the network interface name to listen on DHCP4 server
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    my ($device, $nm_id) = split(':', $nm_list);
+    assert_script_run('curl -v -o /etc/kea/kea-dhcp4.conf  ' . data_url('kea-dhcp/kea-dhcp4.conf'));
+    assert_script_run("cat  /etc/kea/kea-dhcp4.conf");
+    assert_script_run("sed -i -e 's/\"interfaces\": \\[ \\]/\"interfaces\": \[ \" $device \" \]/' /etc/kea/kea-dhcp4.conf");
+
+    # Start the dhcp4 container in the background
+    assert_script_run("podman run -itd --replace --name kea-dhcp4 --privileged --network=host -v /etc/kea:/etc/kea $image  kea-dhcp4 -c /etc/kea/kea-dhcp4.conf");
+    validate_script_output('podman ps ', sub { m/kea-dhcp4/ });
+    # cni-podman0 interface is created when running the first container
+    validate_script_output('ip a s cni-podman0', sub { /,UP/ });
+    validate_script_output('ss -lnp', sub { /10.0.2.101:67/ });
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    script_run("podman kill kea-dhcp4");
+    script_output("podman logs kea-dhcp4 | tee server.log");
+    upload_logs 'server.log';
+
+    $self->SUPER::post_fail_hook;
+}
+1;
+


### PR DESCRIPTION
Add a multi-machine test to install and verify the ISC Kea DHCP4 server.

- Related ticket: https://progress.opensuse.org/issues/124209
- Needles: NO
- Verification run: [DHCP4_server](http://deepthi-openqa.qe.suse.de/tests/4773) | [DHCP4_client](http://deepthi-openqa.qe.suse.de/tests/4774#)

Latest VRs:
[setup_dhcp4_server](http://deepthi-openqa.qe.suse.de/tests/4855) | [DHCP4_client](http://deepthi-openqa.qe.suse.de/tests/4856#)
