### PR TITLE
Split patch_sle to several modules

### DIFF
--- a/schedule/migration/migration_offline_media_x86_64.yaml
+++ b/schedule/migration/migration_offline_media_x86_64.yaml
@@ -1,0 +1,32 @@
+name:           migration_offline_x86_64.yaml
+description:    |
+  This is for offline migraiton tests on x86_64.
+vars:
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - migration/SUSEConnect_register_system
+  - migration/patch_and_reboot_system
+  - migration/setup_sle
+  - migration/install_patterns
+  - migration/drop_unavailable_product_modules
+  - migration/deregister_system
+  - migration/record_disk_info
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - installation/bootloader
+  - installation/welcome
+  - installation/upgrade_select
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot

--- a/schedule/migration/migration_offline_scc_x86_64.yaml
+++ b/schedule/migration/migration_offline_scc_x86_64.yaml
@@ -1,0 +1,30 @@
+name:           migration_offline_x86_64.yaml
+description:    |
+  This is for offline migraiton tests on x86_64.
+vars:
+  ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
+  UPGRADE_TARGET_VERSION: '%VERSION%'
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - migration/SUSEConnect_register_system
+  - migration/patch_and_reboot_system
+  - migration/setup_sle
+  - migration/install_patterns
+  - migration/record_disk_info
+  - migration/reboot_to_upgrade
+  - migration/version_switch_upgrade_target
+  - installation/bootloader
+  - installation/welcome
+  - installation/upgrade_select
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot

--- a/tests/migration/SUSEConnect_register_system.pm
+++ b/tests/migration/SUSEConnect_register_system.pm
@@ -1,0 +1,23 @@
+# SLE15 migration tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Register the original system before migration
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "y2_module_consoletest";
+use strict;
+use warnings;
+use testapi;
+use registration;
+
+sub run {
+    select_console 'root-console';
+
+    register_product();
+    register_addons_cmd();
+    set_var('IN_PATCH_SLE', 0);
+}
+
+1;

--- a/tests/migration/deregister_system.pm
+++ b/tests/migration/deregister_system.pm
@@ -1,0 +1,18 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Deregister from the SUSE Customer Center
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use strict;
+use warnings;
+use base "consoletest";
+use testapi;
+use registration "scc_deregistration";
+
+sub run {
+    select_console 'root-console';
+    scc_deregistration;
+}
+
+1;

--- a/tests/migration/drop_unavailable_product_modules.pm
+++ b/tests/migration/drop_unavailable_product_modules.pm
@@ -1,0 +1,20 @@
+# SLE15 migration tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Some modules don't exist on the target product, need to remove these modules before migration
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use migration;
+
+sub run {
+    select_console 'root-console';
+    deregister_dropped_modules;
+}
+
+1;

--- a/tests/migration/install_patterns.pm
+++ b/tests/migration/install_patterns.pm
@@ -1,0 +1,26 @@
+# SLE15 migration tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Install patterns for allpatterns cases before conducting migration
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use migration;
+use y2_base;
+
+sub run {
+    select_console 'root-console';
+    install_patterns() if (get_var('PATTERNS'));
+
+    # Record the installed rpm list
+    assert_script_run 'rpm -qa > /tmp/rpm-qa.txt';
+    upload_logs '/tmp/rpm-qa.txt';
+}
+
+1;

--- a/tests/migration/patch_and_reboot_system.pm
+++ b/tests/migration/patch_and_reboot_system.pm
@@ -1,0 +1,28 @@
+# SLE15 migration tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Fully patch the system before conducting migration and then reboot
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils qw(is_desktop_installed is_upgrade);
+use migration;
+
+sub run {
+    select_console 'root-console';
+
+    my ($self) = @_;
+
+    fully_patch_system();
+    enter_cmd "reboot";
+    $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 300);
+    select_console 'root-console';
+}
+
+1;

--- a/tests/migration/setup_sle.pm
+++ b/tests/migration/setup_sle.pm
@@ -1,0 +1,19 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: After reboot, setup the system again and set HDD as registered.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use strict;
+use warnings;
+use base "consoletest";
+use testapi;
+use migration;
+
+sub run {
+    setup_sle;
+    # Need to set HDD as registered for offline cases
+    set_var('HDD_SCC_REGISTERED', 1) if get_var('KEEP_REGISTERED');
+}
+
+1;


### PR DESCRIPTION
Too many functions are integrated in patch_sle test module. To make it clear to understand the steps, split it to several test modules based on the steps: migration_setup; register_origin_system; patch_system; remove_dropped_modules; deregistration_system.

- Related ticket: https://progress.opensuse.org/issues/125594
- Needles: n/a
- Verification run: 
- https://openqa.suse.de/tests/11313896
- https://openqa.suse.de/tests/11313897
- Related MR: https://gitlab.suse.de/coolgw/wegao-test/-/merge_requests/284