### PR TITLE
data/journal_check/bug_refs.json: Add 15.5 to an entry

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -397,7 +397,7 @@
     "boo#1196618": {
         "description": "error -110 whilst initialising SD card",
         "products": {
-            "opensuse": ["Tumbleweed", "15.4"]
+            "opensuse": ["Tumbleweed", "15.4", "15.5"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/3197659#step/journal_check/10

No verification run, this message occurs only sometimes.