### PR TITLE
Increase timeout for spack installation

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -352,7 +352,7 @@ downloading and installing all bits required for whatever package or compiler.
 sub prepare_spack_env {
     my ($self, $mpi) = @_;
     $mpi //= 'mpich';
-    zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel";
+    zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel", timeout => 480;
     type_string('pkill -u root');    # this kills sshd
     select_serial_terminal(0);
     assert_script_run 'module load gnu $mpi';    ## TODO


### PR DESCRIPTION
spack by its own takes some time to complete as it runs scripts which takes some time and the default timeout is not limited. This commit gives enough time to avoid unecessary timeouts during installation.


- Related ticket: https://progress.opensuse.org/issues/126806
- Verification run: NA