### PR TITLE
Skip test run on s390x

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -136,6 +136,12 @@ sub run {
     my $password = get_required_var("_SECRET_AD_DOMAIN_PASSWORD");
     define_secret_variable("AD_DOMAIN_PASSWORD", $password);
 
+    # Check for poo#126866
+    if (is_s390x && script_run("ping -c 2 $AD_hostname") != 0) {
+        record_soft_failure("poo#126866 - Can't contact domain controller (infra issue)");
+        return;
+    }
+
     samba_sssd_install();
     randomize_hostname();    # Prevent race condition with parallel test runs
     disable_ipv6();    # AD host is not reachable via IPv6 on some of our workers


### PR DESCRIPTION
Skip the test run on s390x is the host can not be reached (poo#126866).

- Related ticket: https://progress.opensuse.org/issues/126866
- Verification run: [s390x](https://openqa.suse.de/tests/10817119) | [x86_64](https://openqa.suse.de/tests/10817120)
