### PR TITLE
Fix guest power reboot failure for open-vm-tools tests

### DIFF
--- a/lib/virt_autotest/esxi_utils.pm
+++ b/lib/virt_autotest/esxi_utils.pm
@@ -33,15 +33,16 @@ my $hypervisor = get_var('HYPERVISOR') // 'esxi7.qa.suse.cz';
 
 sub esxi_vm_get_vmid {
     my $vm_name = shift;
-    my $vim_cmd = "vim-cmd vmsvc/getallvms | grep -i $vm_name | cut -d' ' -f1";
+    my $vim_cmd = "vim-cmd vmsvc/getallvms | grep -iw $vm_name | cut -d' ' -f1";
     my $vmid;
+
     if (is_svirt) {
         (undef, $vmid) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
     }
     elsif (is_qemu) {
         $vmid = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd"));
-        chomp($vmid);
     }
+    chomp($vmid);
     return $vmid;
 }
 
@@ -49,6 +50,7 @@ sub esxi_vm_power_getstate {
     my $vmid = shift;
     my $vim_cmd = "vim-cmd vmsvc/power.getstate";
     my $power_state;
+
     if (is_svirt) {
         (undef, $power_state) = console('svirt')->run_cmd("$vim_cmd $vmid", domain => 'sshVMwareServer', wantarray => 1);
     }
@@ -61,6 +63,7 @@ sub esxi_vm_power_getstate {
 sub esxi_vm_power_ops {
     my ($vmid, $powerops) = @_;
     my $vim_cmd = "vim-cmd vmsvc/$powerops";
+
     if (is_svirt) {
         return console('svirt')->run_cmd("$vim_cmd $vmid", domain => 'sshVMwareServer', wantarray => 1);
     }
@@ -71,12 +74,15 @@ sub esxi_vm_power_ops {
 
 sub esxi_vm_network_binding {
     my $vmid = shift;
-    my $vim_cmd = qq(vim-cmd vmsvc/get.environment $vmid | grep vswitch | sed -n 1p | cut -d'\\"' -f2);
+    my $vim_cmd;
     my $vswitch;
+
     if (is_svirt) {
+        $vim_cmd = qq(vim-cmd vmsvc/get.environment $vmid | grep vswitch | sed -n 1p | cut -d'\"' -f2);
         (undef, $vswitch) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
     }
     elsif (is_qemu) {
+        $vim_cmd = qq(vim-cmd vmsvc/get.environment $vmid | grep vswitch | sed -n 1p | cut -d'\\"' -f2);
         $vswitch = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd"));
     }
     return $vswitch;
@@ -84,12 +90,15 @@ sub esxi_vm_network_binding {
 
 sub esxi_vm_public_ip {
     my $vmid = shift;
-    my $vim_cmd = qq(vim-cmd vmsvc/get.guest $vmid | grep ipAddress | sed -n 1p | cut -d'\\"' -f2);
+    my $vim_cmd;
     my $vm_ip;
+
     if (is_svirt) {
+        $vim_cmd = qq(vim-cmd vmsvc/get.guest $vmid | grep ipAddress | sed -n 1p | cut -d'\"' -f2);
         (undef, $vm_ip) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
     }
     elsif (is_qemu) {
+        $vim_cmd = qq(vim-cmd vmsvc/get.guest $vmid | grep ipAddress | sed -n 1p | cut -d'\\"' -f2);
         $vm_ip = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd"));
     }
     return $vm_ip;
@@ -98,6 +107,7 @@ sub esxi_vm_public_ip {
 sub get_host_timestamp {
     my $date_cmd = shift // "date -u +'\%F \%T'";    # Default to get UTC time
     my $host_time;
+
     if (is_svirt) {
         (undef, $host_time) = console('svirt')->run_cmd($date_cmd, domain => 'sshVMwareServer', wantarray => 1);
     }
@@ -105,49 +115,6 @@ sub get_host_timestamp {
         $host_time = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$date_cmd"));
     }
     return $host_time;
-}
-
-sub disable_vm_time_synchronization {
-    my $vm_name = shift;
-    my $vmx_file;
-
-    # Set all time synchronization properties to FALSE
-    if (is_svirt) {
-        $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/openQA/$vm_name.vmx";
-        console('svirt')->run_cmd("sed -ie 's/tools.syncTime.*/tools.syncTime=\"FALSE\"/' $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-        console('svirt')->run_cmd("echo time.synchronize.continue=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-        console('svirt')->run_cmd("echo time.synchronize.restore=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-        console('svirt')->run_cmd("echo time.synchronize.resume.disk=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-        console('svirt')->run_cmd("echo time.synchronize.shrink=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-        console('svirt')->run_cmd("echo time.synchronize.tools.startup=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-        console('svirt')->run_cmd("echo time.synchronize.resume.host=\"FALSE\" >> $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-    }
-    elsif (is_qemu) {
-        $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/$vm_name/$vm_name.vmx";
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "sed -ie 's/tools.syncTime.*/tools.syncTime=\"FALSE\"/' $vmx_file"));
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.continue=\"FALSE\" >> $vmx_file"));
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.restore=\"FALSE\" >> $vmx_file"));
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.resume.disk=\"FALSE\" >> $vmx_file"));
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.shrink=\"FALSE\" >> $vmx_file"));
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.tools.startup=\"FALSE\" >> $vmx_file"));
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "echo time.synchronize.resume.host=\"FALSE\" >> $vmx_file"));
-    }
-}
-
-sub revert_vm_timesync_setting {
-    my $vm_name = shift;
-    my $vmx_file;
-
-    # Remove time synchronization properties
-    if (is_svirt) {
-        $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/openQA/$vm_name.vmx";
-        console('svirt')->run_cmd("sed -i '/time.synchronize/d' $vmx_file", domain => 'sshVMwareServer', wantarray => 1);
-    }
-    elsif (is_qemu) {
-        $vmx_file = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/$vm_name/$vm_name.vmx";
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "sed -i 's/tools.syncTime.*/tools.syncTime=\"FALSE\"/' $vmx_file"));
-        assert_script_run(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "sed -i '/time.synchronize/d' $vmx_file"));
-    }
 }
 
 1;

--- a/tests/installation/add_serial_console.pm
+++ b/tests/installation/add_serial_console.pm
@@ -33,7 +33,11 @@ sub run {
     assert_script_run('sed -ie \'s/GRUB_TERMINAL.*//\' /etc/default/grub');
     # VMware needs to always stop in Grub and wait for interaction.
     # Migration seems to reset it.
-    assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub');
+    if (get_var('KEEP_GRUB_TIMEOUT')) {
+        assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=8/\' /etc/default/grub');
+    } else {
+        assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub');
+    }
     assert_script_run('echo GRUB_TERMINAL_OUTPUT=\"serial gfxterm\" >> /etc/default/grub');
     assert_script_run('echo GRUB_SERIAL_COMMAND=\"serial\" >> /etc/default/grub');
     # Set expected resolution for GRUB and kernel


### PR DESCRIPTION
Guest power reboot command failed, because the machine doesn't boot into the OS. To fix the issue, this PR will enable the grub timeout for checking the VM power state.
http://10.67.129.96/tests/2085#step/esxi_open_vm_tools/76

1. Fix getting vm_id failure
2. Provide a option 'KEEP_GRUB_TIMEOUT' to enable grub timeout
3. Use open-vm-tools command to disable VM time sync

- Related ticket: 
   https://progress.opensuse.org/issues/126860
   https://progress.opensuse.org/issues/127334
- Verification run: 
   svirt backend:  http://10.67.129.96/tests/2130
   qemu backend:  https://openqa.suse.de/tests/10825316
