### PR TITLE
Fix encrypted drive detection for ALP

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -17,10 +17,11 @@ sub run {
     select_console 'root-console';
 
     # Disk which /var resides on
-    my $disk = script_output 'lsblk -rnoPKNAME $(findmnt -nrvoSOURCE /var)';
-    if (!$disk && check_var('FLAVOR', 'Default-encrypted')) {
-        $disk = (split('/', script_output 'blkid -l -t TYPE="crypto_LUKS" -o device'))[-1];
+    my $device = script_output 'findmnt -nrvoSOURCE /var';
+    if (index($device, "/dev/mapper/") != -1) {
+        $device = script_output 'blkid -l -t TYPE="crypto_LUKS" -o device';
     }
+    my $disk = script_output "lsblk -rndoPKNAME $device";
 
     # Verify that openQA resized the disk image
     my $disksize = script_output "sfdisk --show-size /dev/$disk";


### PR DESCRIPTION
Follow up for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16728 as previous PR wrongly used partition to check the size.

Adding `-d` switch to the `lsblk` call as without it the output is as follows.

```
vda3 253:3 0 4G 0 part
luks 254:0 0 4G 0 crypt /usr/local\x0a/srv\x0a/opt\x0a/home\x0a/boot/writable\x0a/boot/grub2/x86_64-efi\x0a/boot/grub2/i386-pc\x0a/.snapshots\x0a/var\x0a/root\x0a/
```

- Verification run: http://kepler.suse.cz/tests/20511#step/image_checks/14
