### PR TITLE
Increased timeout for wait guest register

### DIFF
--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -28,7 +28,7 @@ sub run {
     select_serial_terminal();
     my $provider = $args->{my_provider};
     my $instance = $provider->create_instance();
-    $instance->wait_for_guestregister();
+    $instance->wait_for_guestregister([timeout => 400]);
     registercloudguest($instance) if is_byos();
 
     register_addons_in_pc($instance);


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: DMS - EC2 fails with
 Test died: guestregister didn't end in expected timeout=300 at sle/lib/publiccloud/instance.pm line 312.
- Verification run: In progress
