### PR TITLE
Add yast2-migration-sle for leap to SLE migration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -768,7 +768,7 @@ sub yast_scc_registration {
     # and start/enable rollback.service before running yast2 registration module.
     my $client_module = 'scc';
     if (is_leap_migration) {
-        zypper_call('in yast2-registration rollback-helper');
+        zypper_call('in yast2-migration-sle rollback-helper');
         systemctl("enable rollback");
         systemctl("start rollback");
         $client_module = 'registration';


### PR DESCRIPTION
As of leap 15.5, we'd use the yast2-migration-sle tools as default leap to SLE migration tool. So We'd use it for our leap to SLE migration in the Misc.

- Related ticket:  [**124964**](https://progress.opensuse.org/issues/124964)
- Related MR: [**278**](https://gitlab.suse.de/coolgw/wegao-test/-/merge_requests/278)
- Needles: added during tests
    *  yast2-migration-leap_to_sle-20230329
    *  yast2_migration-license-agreement-leap2sle-20230329
    *  yast2-migration-upgrading-leap-20230330
    *  yast2_migration-manual-intervention-leap-20230330
    *  yast2_migration-desktop-runner-KDE-20230406
- Verification run:
 - textmode 
    * https://openqa.suse.de/tests/10855139
 - gnome: 
   * https://openqa.suse.de/tests/10854819
 - KDE: 
   * https://openqa.suse.de/tests/10868805
 - Regression:
    *   https://openqa.suse.de/t10868824
    *   https://openqa.suse.de/t10868825
    *   https://openqa.suse.de/t10868826
    *   https://openqa.suse.de/t10868827
   