### PR TITLE
Workaround bsc#1209083 via reducing matched needle

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -341,6 +341,10 @@ sub run {
 
     check_screen \@needles, $check_time;
     @needles = qw(reboot-after-installation autoyast-postinstall-error autoyast-boot unreachable-repo warning-pop-up inst-bootmenu lang_and_keyboard encrypted-disk-password-prompt);
+    if (get_var('WORKAROUND_BSC1209083')) {
+        @needles = qw(reboot-after-installation autoyast-boot inst-bootmenu);
+        record_soft_failure "bsc#1209083 - In migration with AutoYaST setting grub2 timeout doesn't take effect";
+    }
     # Do not try to fail early in case of autoyast_error_dialog scenario
     # where we test that certain error are properly handled
     push @needles, 'autoyast-error' unless get_var('AUTOYAST_EXPECT_ERRORS');


### PR DESCRIPTION
Workaround bsc#1209083 via reducing matched needle
Workaround wrong entry selected in grub menu after migration with AutoYaST

- Related ticket: https://progress.opensuse.org/issues/119515
- Verification run: https://openqa.suse.de/tests/10825456#
