### PR TITLE
btrfs_autocomplete: btrfsprogs-bash-autocompletion is split into sep package

### DIFF
--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -38,7 +38,10 @@ sub run {
     # On JeOS 'bash-completion' is not expected to be present. On general
     # SLES installation it is. Thus on JeOS we have to enable it manually.
     if (is_jeos) {
-        zypper_call('in bash-completion');
+        # btrfsprogs split bash-completion into a sub-package; JeOS using no-recommends does
+        # not trigger this sub-package to be auto-installed. Attempt to install, accept non-
+        # existing package on case it is not yet split (exitcode 104)
+        zypper_call('in bash-completion btrfsprogs-bash-completion', exitcode => [0, 104]);
         assert_script_run('source $(rpmquery -l bash-completion | grep bash_completion.sh)');
     }
 


### PR DESCRIPTION
Attempt to install the new package together with bash-autocompletion
If the package does not yet exist (stable distros without the split), accept
exit code 104 (package not found) as valid return code.

- Related ticket: https://progress.opensuse.org/issues/126944
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3199379
