### PR TITLE
Configure scipy module run properly with MPI modules

### DIFF
--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -38,8 +38,9 @@ is actually a source code where needs invoke _python_ interpreter.
 =cut
 
 sub single_node ($self, $bin) {
-    #my ($self, $bin) = @_;
     die unless $bin;
+    # Documentation gives `mpiexec -n numprocs python -m mpi4py pyfile`
+    # but it looks it works without defining the module in the command
     $bin = 'python3 ' . $bin if $self->need_interpreter;
     sprintf "%s %s", $self->mpirun, $bin;
 }
@@ -61,6 +62,8 @@ sub all_nodes ($self, $bin) {
     die unless $bin;
     my @cluster_nodes = $self->cluster_names();
     my $nodes = join(',', @cluster_nodes);
+    # Documentation gives `mpiexec -n numprocs python -m mpi4py pyfile`
+    # but it looks it works without defining the module in the command
     $bin = 'python3 ' . $bin if $self->need_interpreter;
     sprintf "%s --host %s %s", $self->mpirun, $nodes, $bin;
 }

--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -93,13 +93,17 @@ sub setup_scientific_module {
     my $mpi = get_required_var('MPI');
 
     if (get_var('HPC_LIB') eq 'scipy') {
-        zypper_call("in python3-scipy-gnu-hpc");
-        assert_script_run("env MPICC=mpicc python3 -m pip install mpi4py");
+        # $mpi-gnu-hpc-devel will be installed on compute nodes
+        # which is required to compile the mpi4py.
+        # This seems is not be shared by NFS
+        # If you have a better idea let me know.
+        zypper_call("in python3-scipy-gnu-hpc python3-devel $mpi-gnu-hpc-devel");
 
         # Make sure that env is updated. This will run scripts like 'source /usr/share/lmod/lmod/init/bash'
         $self->relogin_root;
-        # TODO smoke checks? (ex /MODULEPATH/)
-        assert_script_run('module load gnu python3-scipy');
+        my $mpi2load = ($mpi =~ /openmpi2|openmpi3|openmpi4/) ? 'openmpi' : $mpi;
+        assert_script_run "module load gnu $mpi2load python3-scipy";
+        assert_script_run("env MPICC=mpicc python3 -m pip install mpi4py");
     }
     return 0;
 }

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -37,7 +37,7 @@ sub run ($self) {
     my $prompt = $user_virtio_fixed ? $testapi::username . '@' . get_required_var('HOSTNAME') . ':~> ' : undef;
 
     script_run("sudo -u $testapi::username mkdir -p $exports_path{bin}");
-    zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel python3-devel imb-gnu-$mpi-hpc");
+    zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel imb-gnu-$mpi-hpc");
 
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
@@ -69,7 +69,9 @@ sub run ($self) {
     type_string('pkill -u root') unless $user_virtio_fixed;
     select_user_serial_terminal($prompt);
     # load mpi after all the relogins
-    assert_script_run "module load gnu $mpi2load";
+    my @load_modules = $mpi2load;
+    push @load_modules, 'python3-scipy' if check_var('HPC_LIB', 'scipy');
+    assert_script_run "module load gnu @load_modules";
     script_run "module av";
 
     barrier_wait('MPI_SETUP_READY');

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -26,7 +26,7 @@ sub run ($self) {
     barrier_wait('MPI_SETUP_READY');
     record_info 'MPI_SETUP_READY', strftime("\%H:\%M:\%S", localtime);
     $self->mount_nfs_exports(\%exports_path);
-
+    $self->setup_scientific_module();
     barrier_wait('MPI_BINARIES_READY');
     record_info 'MPI_BINARIES_READY', strftime("\%H:\%M:\%S", localtime);
     barrier_wait('MPI_RUN_TEST');


### PR DESCRIPTION
As for now the scipy test was configured incorrectly and was running with wrong source code. First we need to set HPC_LIB. Then the rest is on this PR.

- Related ticket: https://progress.opensuse.org/issues/126779
- Verification run: https://aquarius.suse.cz/tests/15687
