### PR TITLE
Increase timeout on spack spec command

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -378,8 +378,7 @@ sub prepare_spack_env {
 
     record_info 'spack', script_output 'zypper -q info spack';
     record_info "$mpi spec", script_output("spack spec $mpi", timeout => 480);
-    assert_script_run "spack install $mpi", timeout => 12000;
-
+    assert_script_run "spack install $mpi", timeout => 7200;
 }
 
 =head2 uninstall_spack_modules


### PR DESCRIPTION
This is intent to fix the timeout on aarch64 which getting slower and slower


- Related ticket: https://progress.opensuse.org/issues/126806
- Verification run: https://openqa.suse.de/tests/10827843
