### PR TITLE
Remove non-default package from autoyast file

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_textmode_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_textmode_aarch64.xml
@@ -292,7 +292,6 @@
       <package>wicked</package>
       <package>snapper</package>
       <package>sle-module-server-applications-release</package>
-      <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
       <package>shim</package>
       <package>openssh</package>


### PR DESCRIPTION
Pacckage 'sle-module-desktop-applications-release' is not installed by default in textmode. We can remove it and install it by tester's requirement.

- Verification run: http://openqa.suse.de/tests/10831905#