### PR TITLE
Podman pods: Get rid of podman kube generate '-f' parameter

### DIFF
--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -49,7 +49,7 @@ sub run {
         my $image = "registry.suse.com/bci/bci-busybox:latest";
         script_retry("podman pull $image", timeout => 300, delay => 60, retry => 3);
         assert_script_run("podman container create --pod testing_pod --name container $image sh -c \"sleep 3600\"");
-        assert_script_run("podman kube generate testing_pod -f pod.yaml");
+        assert_script_run("podman kube generate testing_pod | tee pod.yaml");
         assert_script_run("grep 'image: $image' pod.yaml");
         assert_script_run("podman pod rm testing_pod");
 


### PR DESCRIPTION
That parameter was suggested by me in #16560

- Related ticket: [poo#126992](https://progress.opensuse.org/issues/126992)
- Verification run: [pdostal-server.suse.cz/t4211](https://pdostal-server.suse.cz/tests/4211)
