### PR TITLE
Fix expected kernel package for all SLE-11 service packs

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -408,7 +408,7 @@ sub run {
         $incident_id = get_required_var('INCIDENT_ID');
     }
 
-    $kernel_package = 'kernel-default-base' if is_sle('=11-SP4');
+    $kernel_package = 'kernel-default-base' if is_sle('<12');
     $kernel_package = 'kernel-rt' if check_var('SLE_PRODUCT', 'slert');
 
     if (get_var('KGRAFT')) {


### PR DESCRIPTION
SLE-11SP3 kernel files also belong to the kernel-default-base package. Change the expected kernel package name for all SLE versions before SLE-12GA.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - SLE-11SP3: https://openqa.suse.de/tests/10832338
  - SLE-11SP4: https://openqa.suse.de/tests/10832385
  - SLE-12SP2: https://openqa.suse.de/tests/10832386
