### PR TITLE
xfstests: Support xfstests test on nfs

### DIFF
--- a/data/xfstests/wrapper.sh
+++ b/data/xfstests/wrapper.sh
@@ -5,8 +5,6 @@ SCRIPT_DIR=$(realpath $(dirname "$0"))
 OPTIONS=""
 if [ "$#" -gt 1 ]; then
     OPTIONS=$2
-fi
-if [ "$#" -gt 3 ]; then
     INJECT_LINE=$3
     INJECT_CODE=$4
 fi

--- a/data/xfstests/wrapper.sh
+++ b/data/xfstests/wrapper.sh
@@ -2,14 +2,18 @@
 XFSTESTS_DIR='/opt/xfstests'
 PROG="$XFSTESTS_DIR/check"
 SCRIPT_DIR=$(realpath $(dirname "$0"))
-if [ "$#" -gt 2 ]; then
-    INJECT_LINE=$2
-    INJECT_CODE=$3
+OPTIONS=""
+if [ "$#" -gt 1 ]; then
+    OPTIONS=$2
+fi
+if [ "$#" -gt 3 ]; then
+    INJECT_LINE=$3
+    INJECT_CODE=$4
 fi
 
 function usage()
 {
-    echo "Usage: $0 TEST [INJECT_LINE(for debug)] [INJECT_CODE(for debug)]"
+    echo "Usage: $0 TEST [OPTIONS for ./check] [INJECT_LINE(for debug)] [INJECT_CODE(for debug)]"
 }
 
 function unset_vars()
@@ -90,7 +94,7 @@ fi
 
 # Run test
 log_file="/tmp/xfstests-$(echo "$1" | tr '/' '_').tmp"
-./$(basename "$PROG") -d "$1" | tee "$log_file"
+./$(basename "$PROG") -d "$OPTIONS" "$1" | tee "$log_file"
 output=$(cat "$log_file")
 rm -f $log_file
 

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -255,7 +255,9 @@ sub tests_from_ranges {
 sub test_run {
     my $test = shift;
     my ($category, $num) = split(/\//, $test);
-    my $cmd = "\n$TEST_WRAPPER '$test' | tee $LOG_DIR/$category/$num; ";
+    my $run_options = '';
+    $run_options = '-nfs' if check_var('XFSTESTS', 'nfs');
+    my $cmd = "\n$TEST_WRAPPER '$test' $run_options | tee $LOG_DIR/$category/$num; ";
     $cmd .= "echo \${PIPESTATUS[0]} > $HB_DONE_FILE\n";
     type_string($cmd);
 }

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -257,7 +257,8 @@ sub test_run {
     my ($category, $num) = split(/\//, $test);
     my $run_options = '';
     $run_options = '-nfs' if check_var('XFSTESTS', 'nfs');
-    my $cmd = "\n$TEST_WRAPPER '$test' $run_options | tee $LOG_DIR/$category/$num; ";
+    my $inject_code = get_var('INJECT_INFO', '');
+    my $cmd = "\n$TEST_WRAPPER '$test' $run_options $inject_code | tee $LOG_DIR/$category/$num; ";
     $cmd .= "echo \${PIPESTATUS[0]} > $HB_DONE_FILE\n";
     type_string($cmd);
 }


### PR DESCRIPTION
Add support NFS test in xfstests, for now, Server and client test in a single VM.
Configure openqa parameter XFSTESTS=nfs to trigger tests under NFS filesystem. And 1 more parameter XFSTESTS_NFS_VERSION to set which NFS version to test, the default version is 4.1.

- Related ticket: https://progress.opensuse.org/issues/126464
- Verification run: 
1. xfstests for nfs
Run xfstests/nfs/001 in NFS4.1: http://10.67.133.133/tests/158
Run xfstests/generic/001-010 in NFS4.1: http://10.67.133.133/tests/157 (skip tests are known issue)

2. Verification run for inject code(in case some change in wrapper): http://10.67.133.133/tests/168 (inject a test code(free) in nfs/001:49)

3. Verification run for previous xfs/btrfs/ext4 tests
xfs/001-100: http://10.67.133.133/tests/164