### PR TITLE
Stop pacemaker before migration

### DIFF
--- a/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
+++ b/schedule/ha/bv/migration/migration_offline_sles_ha.yaml
@@ -26,6 +26,7 @@ schedule:
   - migration/version_switch_origin_system
   - '{{bootloader_zkvm}}'
   - boot/boot_to_desktop
+  - ha/stop_pacemaker
   - update/patch_sle
   - migration/record_disk_info
   - migration/reboot_to_upgrade

--- a/tests/ha/stop_pacemaker.pm
+++ b/tests/ha/stop_pacemaker.pm
@@ -10,9 +10,11 @@
 use base 'opensusebasetest';
 use strict;
 use warnings;
+use testapi;
 use Utils::Systemd qw(systemctl);
 
 sub run {
+    select_console("root-console");
     systemctl 'stop pacemaker';
 }
 


### PR DESCRIPTION
Migration tests are failing sporadically because cluster services are not stopped on non clustered test.
This produces unwanted message about pacemaker service failing.
This PR adds ha/stop_pacemaker module to stop this service at the beginning of the test.

- Related ticket: https://jira.suse.com/browse/TEAM-7665
- Needles: N/A
- Verification run: 

Offline migrations (previously failing):
https://openqa.suse.de/tests/10832433#
https://openqa.suse.de/tests/10832196#
https://openqa.suse.de/tests/10832177     #15SP4 failure not related to pacemaker.
https://openqa.suse.de/tests/10832665#
https://openqa.suse.de/tests/10832669#

Online migrations (currently using the module - proof change does not break anything):
https://openqa.suse.de/tests/10832211#step/stop_pacemaker/1
https://openqa.suse.de/tests/10832205#step/stop_pacemaker/1
https://openqa.suse.de/tests/10832216#step/stop_pacemaker/1
* 15SP2 - 15SP3 fail because of a known bug