### PR TITLE
Fix kubectl test timeouts

### DIFF
--- a/tests/containers/kubectl.pm
+++ b/tests/containers/kubectl.pm
@@ -122,7 +122,13 @@ sub run {
     validate_script_output('kubectl describe services/web-load-balancer', sub { $_ =~ m/.*Port:.*8080\/TCP.*/ });
     validate_script_output('kubectl describe services/web-load-balancer', sub { $_ =~ m/.*TargetPort:.*80\/TCP.*/ });
     validate_script_output('kubectl describe services/web-load-balancer', sub { $_ =~ m/.*Endpoints:.*10.*/ });
-    validate_script_output_retry("curl http://localhost:8080/index.html", qr/I am Groot/, retry => 6, delay => 20, timeout => 10);
+    $pid = background_script_run('kubectl port-forward deploy/nginx-deployment 8008:80');
+    validate_script_output_retry("curl http://localhost:8008/index.html", qr/I am Groot/, retry => 6, delay => 20, timeout => 10);
+    assert_script_run("kill $pid");    # terminate port-forwarding
+    my $ip = script_output("kubectl get services | awk '/web-load-balancer/ {print \$4}'s");
+    record_info('Balancer IP', $ip);
+    validate_script_output_retry("curl http://$ip:8080/index.html", qr/I am Groot/, retry => 6, delay => 20, timeout => 10);
+
     assert_script_run('kubectl delete -f service.yml');
 
     assert_script_run('kubectl delete -f deployment.yml');


### PR DESCRIPTION
Calling to the balancer using localhost doesn't work.
So the good way is to extract the IP from the services
and use this ip instead of localhost

- Related ticket: https://progress.opensuse.org/issues/126926
- VR: http://openqa.suse.de/tests/10844960