### PR TITLE
btrfs_autocomplete: instruct zypper to ignore missing packages

### DIFF
--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -41,7 +41,8 @@ sub run {
         # btrfsprogs split bash-completion into a sub-package; JeOS using no-recommends does
         # not trigger this sub-package to be auto-installed. Attempt to install, accept non-
         # existing package on case it is not yet split (exitcode 104)
-        zypper_call('in bash-completion btrfsprogs-bash-completion', exitcode => [0, 104]);
+        # use zypper -n -i install: -i ignores missing packages
+        zypper_call('-i in bash-completion btrfsprogs-bash-completion', exitcode => [0, 104]);
         assert_script_run('source $(rpmquery -l bash-completion | grep bash_completion.sh)');
     }
 


### PR DESCRIPTION
btrfsprogs-bash-autocompletion has been split out, but does not yet exist
in all versions.

- Related ticket: Fixup to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16750
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3202800
