### PR TITLE
Fix mr_test sapconf not started softfail on 12sp4

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -48,10 +48,10 @@ sub setup {
     # Disable packagekit
     quit_packagekit;
     # Install saptune
-    zypper_call "-n in saptune";
+    zypper_call "in saptune";
+    zypper_call "in sapconf";
     if (systemctl("-q is-active sapconf.service", ignore_failure => 1)) {
         record_soft_failure("bsc#1190787 - sapconf is not started");
-        zypper_call "in sapconf";
     }
     # Install mr_test dependencies
     # 'zypper_call "-n in python3-rpm"' returns error message:


### PR DESCRIPTION
TEAM-7615 - Fix mr_test sapconf softfail on 12sp4: sapconf shows not started as sapconf pkg is not installed as a prerequisite
  Install sapconf for all OS version
  Remove the redundant `-n` parameter from `zypper_call ""`

- Related ticket: https://jira.suse.com/browse/TEAM-7615
- Needles: NA
- Verification run: 
  https://openqa.suse.de/tests/10715382 (passed without soft failure)