### PR TITLE
firefox_nss: fixes for SLES <= 15.3

### DIFF
--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -206,6 +206,12 @@ sub run {
 
         firefox_crashreporter;
     }
+
+    if (is_sle('<=15-SP3') && check_screen("firefox-password-required-prompt")) {
+        type_string($fips_strong_password, timeout => 10, max_interval => 30);
+        send_key "ret";
+    }
+
     assert_screen("firefox-url-loaded", $waittime);
 
     # Firefox Preferences


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/125705
Verification runs: 
* 15-sp2 http://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=20230402-1&groupid=431
* 15-sp3 http://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=20230402-1&groupid=431
* 15-sp4: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=20230402-1&groupid=431