### PR TITLE
Add apache2 version setting to SLES12-SP5

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -38,7 +38,8 @@ sub setup_apache2 {
     my %args = @_;
     my $mode = uc $args{mode} || "";
     # package hostname is available on sle15+ and openSUSE, on <15 it's net-tools
-    my @packages = qw(apache2 /bin/hostname);
+    my @packages = qw(/bin/hostname);
+    push @packages, get_var('APACHE2_PKG', "apache2");
 
     # For gensslcert
     push @packages, 'apache2-utils', 'openssl' if is_tumbleweed;

--- a/lib/services/apache.pm
+++ b/lib/services/apache.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020 SUSE LLC
+# Copyright 2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Package for apache2 service tests
@@ -13,9 +13,11 @@ use testapi;
 use utils;
 use strict;
 use warnings;
+use version_utils 'is_sle';
 
 sub install_service {
-    zypper_call('in apache2 apache2-utils');
+    my $apache = get_var('APACHE2_PKG', "apache2");
+    zypper_call("in $apache $apache-utils");
 }
 
 sub enable_service {

--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -1,6 +1,6 @@
 # SUSE's Apache regression test
 #
-# Copyright 2019-2021 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: apache2 apache2-mod_php72 php72-php72-curl
@@ -22,6 +22,9 @@ use version_utils qw(is_sle is_jeos);
 sub run {
     select_serial_terminal;
 
+    # On SLES12-SP5 apache2 and apache2-tls13 are supported
+    my $apache2 = get_var('APACHE2_PKG', "apache2");
+
     # installation of docs and manpages is excluded in zypp.conf
     # enable full package installation, and clean up previous apache2 deployment
     if (is_jeos) {
@@ -32,16 +35,10 @@ sub run {
     # Even before the installation there should be htdocs so we can create the index
     assert_script_run 'echo "index" > /srv/www/htdocs/index.html';
 
-    # Ensure apache2 is installed and stopped
-    if (script_run('rpm -q apache2') == 0) {
-        systemctl('stop apache2');
-    } else {
-        zypper_call 'in apache2';
-    }
-
-    # Check if the unit is enabled (and if not, enable it), started (and if not, start it) and display its status
-    systemctl 'enable apache2';
-    systemctl 'start apache2';
+    # Install and start apache
+    zypper_call "in $apache2";
+    systemctl 'enable apache2';    # Note: The systemd service is always apache2, not apache2-tls13.
+    systemctl 'restart apache2';    # apache2 could be already running from previous test runs
     systemctl 'status apache2';
 
     # Check if apache is working when php module is enabled
@@ -127,7 +124,7 @@ sub run {
         else {
             # Create directory for the new instance and prepare config
             assert_script_run 'mkdir -p /tmp/prefork';
-            assert_script_run 'sed "s_\(/var/log/apache2\|/var/run\)_/tmp/prefork_; s/80/8080/" /usr/share/doc/packages/apache2/httpd.conf.default > /tmp/prefork/httpd.conf';
+            assert_script_run "sed 's_\(/var/log/apache2\|/var/run\)_/tmp/prefork_; s/80/8080/' /usr/share/doc/packages/$apache2/httpd.conf.default > /tmp/prefork/httpd.conf";
 
             # httpd.default.conf contains wrong service userid and groupid
             assert_script_run q{sed -ie 's/^User daemon$/User wwwrun/' /tmp/prefork/httpd.conf};

--- a/tests/console/shibboleth.pm
+++ b/tests/console/shibboleth.pm
@@ -22,7 +22,8 @@ use utils;
 sub run {
     select_console 'root-console';
 
-    zypper_call "in shibboleth-sp apache2";
+    my $apache2 = get_var('APACHE2_PKG', "apache2");
+    zypper_call "in shibboleth-sp $apache2";
     assert_script_run "a2enmod shib";
     systemctl 'restart apache2';
 

--- a/variables.md
+++ b/variables.md
@@ -12,6 +12,7 @@ For a better overview some domain-specific values have been moved to their own s
 
 Variable        | Type      | Default value | Details
 ---             | ---       | ---           | ---
+`APACHE2_PKG` | string | `apache` | Apache2 package under test (e.g. `apache2` or `apache2-tls13`)
 AARCH64_MTE_SUPPORTED | boolean | false     | Set to 1 if your machine supports Memory Tagging Extension (MTE)
 ADDONS          | string    |               | Comma separated list of addons to be added using DVD. Also used to indicate addons in the SUT.
 ADDONURL        | string    |               | Comma separated list of addons. Includes addon names to get url defined in ADDONURL_*. For example: ADDONURL=sdk,we ADDONURL_SDK=https://url ADDONURL_WE=ftp://url


### PR DESCRIPTION
Introduce the `APACHE2_PKG` setting to select `apache` or `apache2-tls13`, as we need to test both on SLES12-SP5.

- Related ticket: https://progress.opensuse.org/issues/126146
- Verification run: [12-SP5 with apache2](https://duck-norris.qe.suse.de/tests/12480) | [12-SP5 with apache2-tls13](https://duck-norris.qe.suse.de/tests/12481) | [15-SP4](https://duck-norris.qe.suse.de/tests/12482) | [Tumbleweed](https://duck-norris.qe.suse.de/tests/12483)
