### PR TITLE
Replace GUI host installation with autoyast for sle15

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -1,0 +1,268 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    % if (keys %$addons) {
+    <addons config:type="list">
+      % while (my ($key, $addon) = each (%$addons)) {
+      <addon>
+        <name><%= $addon->{name} %></name>
+        <version><%= $addon->{version} %></version>
+        <arch><%= $addon->{arch} %></arch>
+        % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sles')) {
+        <reg_code><%= $get_var->('SCC_REGCODE_WE') %></reg_code>
+        % }
+        % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sled')) {
+        <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+        % }
+        % if ($key eq 'rt') {
+        <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
+        % }
+        % if ($key eq 'ltss') {
+        <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+        % }
+        <release_type/>
+      </addon>
+      % }
+    </addons>
+    %}
+  </suse_register>
+  <!--add-on>
+    <add_on_products config:type="list">
+      % my $n =0;
+      % for my $repo (@$repos) {
+      <listentry>
+        <media_url><%= $repo %></media_url>
+        <alias>TEST_<%= $n++ %></alias>
+      </listentry>
+      % }
+    </add_on_products>
+  </add-on-->
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <serial>serial --speed=115200 --unit=<%= $get_var->('SERIALDEV') =~ s/ttyS//r %> --word=8 --parity=no --stop=1</serial>
+      <timeout config:type="integer">15</timeout>
+      <trusted_grub>false</trusted_grub>
+      <terminal>console</terminal>
+      % if ($check_var->('SYSTEM_ROLE', 'xen')) {
+      <xen_append>splash=silent quiet console=tty loglevel=5 <%= $check_var->('AMD', '1') ? "amd_iommu=on" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
+      <xen_kernel_append>console=com2,115200 vga=gfx-1024x768x16 loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
+      % } else {
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 <%= $check_var->('AMD', '1') ? "amd_iommu=on" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+      % }
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_reboot config:type="boolean">true</final_reboot>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">true</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>201M,high</crash_kernel>
+    <crash_xen_kernel>201M\&lt;4G</crash_xen_kernel>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <login_settings/>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <backend>wicked</backend>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <nameservers config:type="list">
+        <nameserver>10.162.0.1</nameserver>
+<!--gonzo and a another machine can not get nameserver from local dns server after autoyast installation. Put a static nameserver option above. If nameserver is retrived from dhcp they will be merged. Otherwise use the static -->
+      </nameservers>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+    </dns>
+    <virt_bridge_proposal config:type="boolean">true</virt_bridge_proposal>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+      <ntp_server>
+        <address>europe.pool.ntp.org</address>
+        <iburst config:type="boolean">true</iburst>
+        <offline config:type="boolean">false</offline>
+      </ntp_server>
+    </ntp_servers>
+    <ntp_sync>systemd</ntp_sync>
+  </ntp-client>
+  <partitioning config:type="list">
+  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745' 'openqaipmi5' => 'wwn-0x5000c5008711f2fc'};
+  % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
+  % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : ''; 
+    <drive>
+      <device><%= $device_id %></device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/var/lib/libvirt/images/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>120G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list">
+        <service>firewalld</service>
+      </disable>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>dhcp-client</package>
+      <package>guestfs-tools</package>
+      <package>nmap</package>
+    </packages>
+    <products config:type="list">
+      <product><%= uc $get_var->('SLE_PRODUCT') %></product>
+    </products>
+    <patterns config:type="list">
+      % my $patterns = $check_var->('SYSTEM_ROLE', 'kvm') ? ['base', 'enhanced_base', 'kvm_server', 'kvm_tools'] : ['base', 'enhanced_base', 'xen_server', 'xen_tools'];
+      % for my $pattern (@$patterns) {
+      <pattern><%= $pattern %></pattern>
+      % }
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>UTC</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <authorized_keys config:type="list"/>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bernhard</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$QSJG7nUenDgf$UcRX/Q6YWM2/S55RJ8Mgvu93oKEDlOs.7/rOTMYjjxXQPiZ/rq4ogx5EpkksVRZXoEF0kX8FeEa.gOTxl1l/t0</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <authorized_keys config:type="list"/>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <scripts>
+    <post-scripts config:type="list">
+      % if ($check_var->('SYSTEM_ROLE', 'xen') && $check_var->('XEN_DEFAULT_BOOT_IS_SET', 1)) {
+      <script>
+        <filename>default_xen_boot.sh</filename>
+        <interpreter>/bin/bash -x</interpreter>
+        <source><![CDATA[
+grub2-set-default 2
+]]>
+        </source>
+      </script>
+      % }
+      <script/>
+    </post-scripts>
+  </scripts>
+</profile>

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -849,19 +849,16 @@ elsif (get_var("VIRT_AUTOTEST")) {
     }
     else {
         if (!is_s390x) {
+            loadtest "autoyast/prepare_profile" if get_var("AUTOYAST_PREPARE_PROFILE");
             load_boot_tests();
             if (get_var("AUTOYAST")) {
                 loadtest "autoyast/installation";
-                loadtest "virt_autotest/reboot_and_wait_up_normal";
             }
             else {
                 load_inst_tests();
-                loadtest "virt_autotest/login_console";
             }
         }
-        else {
-            loadtest "virt_autotest/login_console";
-        }
+        loadtest "virt_autotest/login_console";
         loadtest "virt_autotest/install_package";
         loadtest "virt_autotest/update_package";
         loadtest "virt_autotest/reset_partition";

--- a/tests/virt_autotest/libvirt_extend_storage_lvm.pm
+++ b/tests/virt_autotest/libvirt_extend_storage_lvm.pm
@@ -69,7 +69,7 @@ sub prepare_lvm_storage_pool_source {
     # Use a unused hard disk for LVM volumes
     $dev = "/dev/";
     foreach my $disk (@disks) {
-        if (script_run("set -o pipefail;lsblk -rnoPKNAME,MOUNTPOINT | grep -i $disk | awk \'{print \$2}\'") ne '0') {
+        if (script_run("set -o pipefail;findmnt -n -o SOURCE / | grep $disk") != 0) {
             $lvm_disk_name = $dev . $disk;
             last;
         }


### PR DESCRIPTION
Create a autoyast template for sles15spx in order for product virtuallzation test to switch from GUI installation to autoyast

https://progress.opensuse.org/issues/112508

- Related ticket: https://progress.opensuse.org/issues/112508
- Needles: no
- Verification run: 
- sle15sp5 xen AMD: http://10.67.183.130/tests/3493
- sle15sp5 kvm: http://10.67.183.130/tests/3492
- sle15sp4 kvm: http://10.67.183.130/tests/3505#
 - gi-guest_developing-on-host_developing-kvm: https://openqa.suse.de/tests/11130833
 - uefi-gi-guest_developing-on-host_developing-xen: https://openqa.suse.de/tests/11132392 
- gi-guest_sles15sp4-on-host_developing-kvm: https://openqa.suse.de/tests/11132406
- prj2_host_upgrade_sles15sp4_to_developing_xen: https://openqa.suse.de/tests/11132409
- prj4_guest_upgrade_sles15sp4_on_sles15sp4-xen: https://openqa.suse.de/tests/11136940
- uefi-gi-guest_developing-on-host_sles15sp4: https://openqa.suse.de/tests/11137310#
- virt-guest-migration-developing-from-developing-to-developing-kvm-src:
 - https://openqa.suse.de/tests/11137008
- https://openqa.suse.de/tests/11137009
- sev-es-gi-guest_developing-on-host_developing-kvm: https://openqa.suse.de/tests/11146649
- virt-guest-migration-sles15sp4-from-sles15sp4-to-developing-xen-src: https://openqa.suse.de/tests/11154029