### PR TITLE
netconfig force update and add new name server if network failure

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -13,10 +13,11 @@ use warnings;
 use File::Basename;
 use testapi;
 use Utils::Architectures;
-use Utils::Backends qw(use_ssh_serial_console is_remote_backend set_ssh_console_timeout);
+use Utils::Backends qw(use_ssh_serial_console is_remote_backend set_ssh_console_timeout update_ssh_console_netconfig);
 use ipmi_backend_utils;
 use virt_autotest::utils qw(is_xen_host is_kvm_host check_port_state check_host_health);
 use IPC::Run;
+use version_utils;
 
 sub set_ssh_console_timeout_before_use {
     reset_consoles;
@@ -209,6 +210,7 @@ sub login_to_console {
     # double-check xen role for xen host
     double_check_xen_role if (is_xen_host and !get_var('REBOOT_AFTER_UPGRADE'));
     check_kvm_modules if is_x86_64 and is_kvm_host and !get_var('REBOOT_AFTER_UPGRADE');
+    update_ssh_console_netconfig if (is_x86_64 and (is_sle or is_sle_micro) and get_var('VIRT_AUTOTEST', ''));
 }
 
 sub run {


### PR DESCRIPTION
* **Sometimes** SUT machine can not communicate with system outside, for example, the worker machine or openQA website. Root cause is file /etc/resolv.conf can not be populated successfully on reboot. This happens frequently recently due to unclear reasons, detailed info can be found in [poo#126188](https://progress.opensuse.org/issues/126188). 

* **In** order to mitigate the issue, using "netconfig update -f" to refresh network configuration after ssh console is opened.

* **If** netconfig update -f does not help, remove existing and add new name servers provided by worker machine.

* **Verification Runs:**
  * [guest installation on 12sp5](http://openqa.suse.de/tests/10917129)
  * [guest installation on 15sp5](http://openqa.suse.de/tests/10917134)
  * [guest installation on sle micro](http://openqa.suse.de/tests/10917132)
  * [guest installation on 12sp5 with empty /etc/resolv.conf and using netconfig update -f followed by adding nameserver into /etc/resolv.conf](http://openqa.suse.de/tests/10957562)
  * [guest installation on 15sp5 with empty /etc/resolv.conf and using netconfig update -f followed by adding nameserver into /etc/resolv.conf](http://openqa.suse.de/tests/10991605)
  * [guest installation on 15sp4 with empty /etc/resolv.conf and using netconfig update -f followed by adding nameserver into /etc/resolv.conf](http://openqa.suse.de/tests/10991606)
  * [guest installation on sle-micro with empty /etc/resolv.conf and using netconfig update -f followed by adding nameserver into /etc/resolv.conf](http://openqa.suse.de/tests/10918426)
  * [uefi guest installation on sles with empty /etc/resolv.conf and using netconfig update -f followed by adding nameserver into /etc/resolv.conf](http://openqa.suse.de/tests/10929535)
  * [host upgrade with empty /etc/resolv.conf and using netconfig update -f](https://openqa.suse.de/tests/10891525)
  * [add nameserver into /etc/resolv.conf on local SLES host](http://10.163.28.134/tests/1866)
  * [add nameserver into /etc/resolv.conf on remote SLES host](http://10.163.28.134/tests/1880)
  * [netconfig update -f followed by adding nameserver into /etc/resolv.conf on localhost](http://10.163.28.134/tests/1868)
  * [netconfig update -f followed by adding nameserver into /etc/resolv.conf on remote SLE-Micro hot](http://10.163.28.134/tests/1869)
  * [netconfig update -f followed by adding nameserver into /etc/resolv.conf on local SLE-Micro host](http://10.163.28.134/tests/1873)
  * [host network failure and test run die](http://10.163.28.134/tests/1876)