### PR TITLE
zypper_lifecycle: Use select_(user_)?serial_terminal

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -901,7 +901,7 @@ sub activate_console {
         assert_screen "text-logged-in-$user", 60;
     }
     elsif ($type eq 'serial-ssh') {
-        serial_terminal::set_serial_prompt($user eq 'root' ? '# ' : '$ ');
+        serial_terminal::set_serial_prompt($user eq 'root' ? '# ' : '> ');
     }
     else {
         diag 'activate_console called with generic type, no action';

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -32,6 +32,7 @@ use testapi;
 use utils;
 use version_utils qw(is_sle is_jeos is_upgrade);
 use Utils::Architectures;
+use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
 
 our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 
@@ -61,7 +62,7 @@ sub lifecycle_output_check {
 sub run {
     diag('fate#320597: Introduce \'zypper lifecycle\' to provide information about life cycle of individual products and packages');
 
-    select_console 'root-console';
+    select_serial_terminal;
     # First we'd make sure that we have a clean zypper cache env and all dirs have
     # 0755 and all files have 0644 pemmission.
     # For some reason the system will change the permission on /var/cache/zypp/{solv,raw}
@@ -71,7 +72,7 @@ sub run {
     # force reinstall release notes, package must not come from expected SLE-Product repo e.g. GMC
     zypper_call('in -f release-notes*');
 
-    select_console 'user-console';
+    select_user_serial_terminal;
     my $overview = script_output('zypper lifecycle', 600);
     die "Missing header line:\nOutput: '$overview'" unless $overview =~ /Product end of support/;
     die "Missing link to lifecycle page:\nOutput: '$overview'"
@@ -117,7 +118,7 @@ sub run {
     my $testdate_after = '2620-02-04';
     my $testdate_before = '2620-02-02';
     # backup and create our lifecycle data with known content
-    select_console 'root-console';
+    select_serial_terminal;
     assert_script_run "
     if [ -f /var/lib/lifecycle/data/$prod.lifecycle ] ; then
         mv /var/lib/lifecycle/data/$prod.lifecycle /var/lib/lifecycle/data/$prod.lifecycle.orig
@@ -125,7 +126,7 @@ sub run {
     mkdir -p /var/lib/lifecycle/data
     echo '$package, *, $testdate' > /var/lib/lifecycle/data/$prod.lifecycle";
     # verify eol from lifecycle data
-    select_console 'user-console';
+    select_user_serial_terminal;
     $output = script_output "zypper lifecycle $package", 300;
     die "$package lifecycle entry incorrect:\nOutput: '$output'" unless $output =~ /$package(-\S+)?\s+$testdate/;
 
@@ -139,7 +140,7 @@ sub run {
     die "$package reported for date $testdate_before:\nOutput: '$output'" if $output =~ /$package(-\S+)?\s+$testdate/;
 
     # delete lifecycle data - package eol should default to product eol
-    select_console 'root-console';
+    select_serial_terminal;
     assert_script_run "rm -f /var/lib/lifecycle/data/$prod.lifecycle";
 
     # get product eol
@@ -157,7 +158,7 @@ sub run {
     }
     die "baseproduct eol not found in overview\nOutput: '$product_name'" unless $product_eol;
 
-    select_console 'user-console';
+    select_user_serial_terminal;
     # verify that package eol defaults to product eol
     # dash is accepted in prod EOL, despite it does not match zypper lifecycle, see poo#126794
     $output = script_output "zypper lifecycle $package", 300;
@@ -166,13 +167,13 @@ sub run {
     }
 
     # restore original data, if any
-    select_console 'root-console';
+    select_serial_terminal;
     assert_script_run "
     if [ -f /var/lib/lifecycle/data/$prod.lifecycle.orig ] ; then
         mv /var/lib/lifecycle/data/$prod.lifecycle.orig /var/lib/lifecycle/data/$prod.lifecycle
     fi";
     #
-    select_console 'user-console';
+    select_user_serial_terminal;
     # 4. verify that "zypper lifecycle --days N" and "zypper lifecycle --date
     # D" shows correct results
     assert_script_run 'zypper lifecycle --help';

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -161,7 +161,7 @@ sub run {
     # verify that package eol defaults to product eol
     # dash is accepted in prod EOL, despite it does not match zypper lifecycle, see poo#126794
     $output = script_output "zypper lifecycle $package", 300;
-    unless ($output =~ /$package(-\S+)?\s+($product_eol|-)/) {
+    unless ($output =~ /$package(-\S+)?\s+($product_eol|-$)/) {
         die "$package lifecycle entry incorrect:\nOutput: '$output', expected: '/$package-\\S+\\s+$product_eol'";
     }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/126794 https://github.com/os-autoinst/os-autoinst/pull/2295
- Verification run: https://openqa.suse.de/tests/overview?build=lifecycle&version=15-SP5&distri=sle