### PR TITLE
Disable patterns smoke test in MicroOS

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -191,7 +191,7 @@ sub load_common_tests {
 sub load_transactional_tests {
     loadtest 'transactional/filesystem_ro';
     loadtest 'transactional/trup_smoke';
-    loadtest 'microos/patterns';
+    loadtest 'microos/patterns' unless is_microos;
     loadtest 'transactional/transactional_update';
     loadtest 'transactional/rebootmgr';
     loadtest 'transactional/health_check';


### PR DESCRIPTION
Conflicting patterns have appeared in MicroOS, which is expected by desgin. Keep the test for only minimal distros.

- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
