### PR TITLE
Set timeout to validate_default_target

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -79,7 +79,7 @@ sub validate_default_target {
 
     my $target_search = 'default target has been set';
     # default.target is not yet linked, so we parse logs and assert expectations
-    if (my $log_line = script_output("grep '$target_search' /var/log/YaST2/y2log | tail -1",
+    if (my $log_line = script_output("grep '$target_search' /var/log/YaST2/y2log | tail -1", timeout => 30,
             proceed_on_failure => 1)) {
         $log_line =~ /$target_search: (?<current_target>.*)/;
         assert_equals($expected_target, $+{current_target}, "Mismatch in default.target");


### PR DESCRIPTION
Adding a timeout for validating expected target because of some failures in s390x
failures: https://openqa.suse.de/tests/10846976 and https://openqa.suse.de/tests/10846980
VR: https://openqa.suse.de/tests/10853909
