### PR TITLE
Only test year_2038_detection on ALP

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -331,7 +331,7 @@ sub load_tests {
         load_common_tests;
         load_transactional_tests unless is_zvm;
     }
-    loadtest 'console/year_2038_detection';
+    loadtest 'console/year_2038_detection' if is_alp;
     load_journal_check_tests;
 }
 


### PR DESCRIPTION
We may not able set right permission for serial console with 'ROOTONLY' system. so right now I will only schedule the test on ALP.
I will try to find a way to enable the tests on Micro-OS later.

- Verification run: https://openqa.opensuse.org/tests/3208912