### PR TITLE
Increase log collection timeout on post_run for hpc

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -97,7 +97,7 @@ sub post_run_hook {
     select_console('log-console');
     my $hname = get_var('HOSTNAME', 'susetest');
     foreach (keys %log_files) {
-        save_and_upload_log($log_files{$_}{cmd}, "/tmp/$hname-" . $log_files{$_}{logfile}, {screenshot => 1});
+        save_and_upload_log($log_files{$_}{cmd}, "/tmp/$hname-" . $log_files{$_}{logfile}, {timeout => 1200, screenshot => 1});
     }
     $self->upload_service_log("wicked");
     if ($hname =~ /master/) {


### PR DESCRIPTION
Somehow this start failing for sle15sp1. make sure that post_run is not destructing. Number is huge and maybe needs more investigation why tests are not finding default number sufficient. But sp1 is quite old so i guess this is ok for now.


- Verification run: https://openqa.suse.de/tests/10856747#details