### PR TITLE
Set plain text output in curl for matching on squid test

### DIFF
--- a/tests/fips/squid/squid_reverse_proxy.pm
+++ b/tests/fips/squid/squid_reverse_proxy.pm
@@ -45,7 +45,7 @@ sub run {
     configure_squid;
     # use squid as https reverse proxy to access content served by apache.
     # Ensure reply contains certificate info, HTTP 200 and test page content
-    validate_script_output 'curl -v --proxy https://localhost:8443 http://localhost:8080/hello.html',
+    validate_script_output 'curl -v  --no-styled-output --proxy https://localhost:8443 http://localhost:8080/hello.html',
       sub { m/subject:.+O=Suse.+CN=localhost.+HTTP\/1.1 200 OK.+Test Page/s };
 }
 

--- a/tests/fips/squid/squid_web_proxy.pm
+++ b/tests/fips/squid/squid_web_proxy.pm
@@ -28,10 +28,11 @@ sub run {
     configure_squid;
     my $testfile = data_url('squid/hello.html');
     # try to download file without authentication, should fail
-    validate_script_output 'curl --head --proxy http://localhost:3128 ' . $testfile,
-      sub { m/HTTP\/1.1 407 Proxy Authentication Required.+Server: squid/s, proceed_on_failure => 1, };
+    validate_script_output('curl --no-styled-output --head --proxy http://localhost:3128 ' . $testfile,
+        sub { m/HTTP\/1.1 407 Proxy Authentication Required.+Server: squid/s },
+        proceed_on_failure => 1);
     # try to download file with authentication, should success
-    validate_script_output 'curl --head --proxy-digest -U proxyuser:proxypassword --proxy http://localhost:3128 ' . $testfile,
+    validate_script_output 'curl --no-styled-output --head --proxy-digest -U proxyuser:proxypassword --proxy http://localhost:3128 ' . $testfile,
       sub { m/HTTP\/1.1 200 OK/ };
 }
 


### PR DESCRIPTION
New version of `curl` has bold output by default, so to use in `validate_script_output` it needs an extra option to switch to plain text  

- Related ticket: https://progress.opensuse.org/issues/125585
- Verification runs:
  - s390x https://openqa.suse.de/tests/10856031
  - x86_64 https://openqa.suse.de/tests/10856033
  - aarch64 https://openqa.suse.de/tests/10856034
