### PR TITLE
Add wait_quit_zypper in zdup

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -15,6 +15,7 @@ use testapi;
 use utils qw(OPENQA_FTP_URL zypper_call);
 use Utils::Backends 'is_pvm';
 use Utils::Logging 'export_logs';
+use zypper 'wait_quit_zypper';
 
 sub run {
     my $self = shift;
@@ -37,6 +38,9 @@ sub run {
     script_run "ip addr show";
     save_screenshot;
     assert_script_run('modprobe nvram') if is_pvm;
+
+    # poo#126425, sometimes we have issue with zypper progress in background, so we just need to wait a little bit
+    wait_quit_zypper;
 
     # Disable all repos, so we do not need to remove one by one
     # beware PackageKit!


### PR DESCRIPTION
we have sporadic issue with zypper process running in background, see poo#126425, so add wait_quit_zypper can avoid this issue.

verification test run: http://10.161.8.50/tests/59
