### PR TITLE
Add a test to verify kea dhcp6 server container in ALP

### DIFF
--- a/data/kea-dhcp/kea-dhcp6.conf
+++ b/data/kea-dhcp/kea-dhcp6.conf
@@ -1,0 +1,48 @@
+{
+# DHCPv6 configuration starts on the next line
+"Dhcp6": {
+
+# First we set up global values
+    "valid-lifetime": 4000,
+    "renew-timer": 1000,
+    "rebind-timer": 2000,
+    "preferred-lifetime": 3000,
+
+# Next we set up the interfaces to be used by the server.
+    "interfaces-config": {
+        "interfaces": [ ]
+    },
+
+# And we specify the type of lease database
+    "lease-database": {
+        "type": "memfile",
+        "persist": true,
+        "name": "/var/lib/kea/dhcp6.leases"
+    },
+
+# Finally, we list the subnets from which we will be leasing addresses.
+    "subnet6": [
+        {
+            "subnet": "fe12:3456:789a::/48",
+            "pools": [
+                {
+                    "pool": "fe12:3456:789a::4-fe12:3456:789a::9"
+                }
+             ],
+              "interface": "eth0"
+        }
+    ],
+"loggers": [
+        {
+            "name": "kea-dhcp6",
+            "output_options": [
+                {
+                    "output": "stdout"
+                }
+            ],
+            "debuglevel": 0,
+            "severity": "INFO"
+        }
+    ]
+  }
+}

--- a/schedule/alp/kea_dhcp6.yaml
+++ b/schedule/alp/kea_dhcp6.yaml
@@ -1,0 +1,14 @@
+---
+name: Kea DHCP
+description: >
+    Install and test Kea DHCP6 server container
+conditional_schedule:
+    kea_dhcp:
+        HOSTNAME:
+            'client':
+                - microos/workloads/kea-container/dhcp6_client
+            'server':
+                - microos/workloads/kea-container/setup_dhcp6_server
+schedule:
+    - microos/disk_boot
+    - '{{kea_dhcp}}'

--- a/tests/microos/workloads/kea-container/dhcp6_client.pm
+++ b/tests/microos/workloads/kea-container/dhcp6_client.pm
@@ -1,0 +1,44 @@
+# SUSE"s openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: podman kea-container
+# Summary: install and verify Kea DHCP server container.
+# Maintainer: QE Core <qe-core@suse.de>
+
+use base "consoletest";
+use warnings;
+use strict;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use lockapi;
+use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
+
+sub run {
+    my ($self) = @_;
+
+    mutex_wait 'barrier_setup_done';
+    barrier_wait 'DHCP_SERVER_READY';
+
+    select_serial_terminal;
+    # Configure static network, disable firewall
+    disable_and_stop_service($self->firewall) if check_unit_file($self->firewall);
+
+    assert_script_run('nmcli conn');
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    my ($device, $nm_id) = split(':', $nm_list);
+    assert_script_run "nmcli connection modify '$nm_id' ipv6.method dhcp";
+    assert_script_run("nmcli conn up '$nm_id'");
+    assert_script_run('nmcli conn');
+
+    record_info("ip a", script_output("ip a"));
+    record_info("ip -6 route", script_output("ip -6 route"));
+
+    assert_script_run("ip -6 route add  fe12:3456:789a::1/48 dev $device");
+    assert_script_run('ping -c 1 fe12:3456:789a::2');
+    validate_script_output("ip -6 addr show dev $device || sed -nE 's/^.*inet6 ([^/]+)\/.*$/\1/p'", sub { m/fe12:3456:789a::[4-9]/ });
+    barrier_wait 'DHCP_SERVER_FINISHED';
+}
+1;
+

--- a/tests/microos/workloads/kea-container/setup_dhcp6_server.pm
+++ b/tests/microos/workloads/kea-container/setup_dhcp6_server.pm
@@ -1,0 +1,99 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: install and verify Kea DHCP server container.
+# Maintainer:  QE Core <qe-core@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use utils qw(set_hostname);
+use testapi;
+use lockapi;
+use mm_network 'setup_static_mm_network';
+use serial_terminal 'select_serial_terminal';
+use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
+
+my ($device, $nm_id);
+sub run {
+    my ($self) = @_;
+    my $hostname = get_var('HOSTNAME');
+
+    barrier_create('DHCP_SERVER_READY', 2);
+    barrier_create('DHCP_SERVER_FINISHED', 2);
+    mutex_create 'barrier_setup_done';
+
+    select_serial_terminal;
+    record_info("ip a", script_output("ip a"));
+
+    # Do not use external DNS for our internal hostnames
+    assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');
+
+    # Configure static network, disable firewall
+    disable_and_stop_service($self->firewall) if check_unit_file($self->firewall);
+
+    setup_static_mm_network('10.0.2.101/24');
+    setup_static_mm_network_ipv6('fe12:3456:789a::2/48');
+    record_info("ip a", script_output("ip a"));
+
+    # Set the hostname
+    set_hostname $hostname;
+
+    install_dhcp_container();
+
+    barrier_wait 'DHCP_SERVER_READY';
+    barrier_wait 'DHCP_SERVER_FINISHED';
+    # Kill the container running on background
+    script_run("podman kill kea-dhcp6");
+    script_output("podman logs kea-dhcp6 | tee server.log");
+    upload_logs 'server.log';
+
+}
+
+sub install_dhcp_container {
+    my $image = get_var('CONTAINER_IMAGE_TO_TEST', 'registry.opensuse.org/suse/alp/workloads/tumbleweed_containerfiles/suse/alp/workloads/kea:latest');
+    # Instaling the container image
+    assert_script_run("podman container runlabel install $image");
+
+    # Copy the configured kea-dhcp6 config file to the container host and add the network interface name to listen on DHCP4 server
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    ($device, $nm_id) = split(':', $nm_list);
+    assert_script_run('curl -v -o /etc/kea/kea-dhcp6.conf  ' . data_url('kea-dhcp/kea-dhcp6.conf'));
+    assert_script_run("cat  /etc/kea/kea-dhcp6.conf");
+    assert_script_run("sed -i -e 's/\"interfaces\": \\[ \\]/\"interfaces\": \[ \"$device\" \]/' /etc/kea/kea-dhcp6.conf");
+    assert_script_run("sed -i -e 's/\"interface\": \"eth0\"/\"interface\":  \"$device\" /' /etc/kea/kea-dhcp6.conf");
+    assert_script_run("cat /etc/kea/kea-dhcp6.conf");
+
+
+    # Start the dhcp6 container in the background
+    assert_script_run("podman run -itd --replace --name kea-dhcp6 --privileged --network=host -v /etc/kea:/etc/kea $image  kea-dhcp6 -c /etc/kea/kea-dhcp6.conf");
+    validate_script_output('podman ps ', sub { m/kea-dhcp6/ });
+    # cni-podman0 interface is created when running the first container
+    validate_script_output('ip a s cni-podman0', sub { /,UP/ });
+}
+
+sub setup_static_mm_network_ipv6 {
+    my $ip = shift;
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    ($device, $nm_id) = split(':', $nm_list);
+    record_info('set_ip', "Device: $device\n NM ID: $nm_id\nIP: $ip");
+    assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip6 $ip ipv6.method manual";
+    assert_script_run 'nmcli networking off';
+    assert_script_run 'nmcli networking on';
+    # Wait until the connections are configured
+    assert_script_run 'nmcli networking connectivity check';
+
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    script_run("podman kill kea-dhcp6");
+    script_output("podman logs kea-dhcp6 | tee server.log");
+    upload_logs 'server.log';
+
+    $self->SUPER::post_fail_hook;
+}
+1;
+


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/124209
- Needles: No
- Verification run: [DHCP-client](http://deepthi-openqa.qe.suse.de/tests/4926) | [DHCP-server](http://deepthi-openqa.qe.suse.de/tests/4925)

Latest VRs:
[DHCP6-client](http://deepthi-openqa.qe.suse.de/tests/4948) | [DHCP6-server](http://deepthi-openqa.qe.suse.de/tests/4947#)