### PR TITLE
Run upstream libica's build testsuite in FIPS mode

### DIFF
--- a/schedule/security/fips_crypt_libica.yaml
+++ b/schedule/security/fips_crypt_libica.yaml
@@ -1,0 +1,19 @@
+name: fips_crypt_libica
+description:    >
+    This is for the crypt_libica fips tests.
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - fips/libica_upstream_testsuite
+    - fips/libica
+conditional_schedule:
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup

--- a/tests/fips/libica_upstream_testsuite.pm
+++ b/tests/fips/libica_upstream_testsuite.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests - FIPS tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: run upstream libica testsuite (build time) on s390x with enabled FIPS mode
+# Maintainer: QE Security <none@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use Utils::Architectures 'is_s390x';
+use registration qw(cleanup_registration register_product add_suseconnect_product);
+
+sub run {
+    return unless is_s390x();
+    select_serial_terminal;
+    # we need to add development tools to compile
+    add_suseconnect_product('sle-module-desktop-applications');
+    add_suseconnect_product('sle-module-development-tools');
+    zypper_call('in libica rpmbuild autoconf automake fipscheck gcc-c++ libtool openssl-devel');
+    my $version = get_required_var('VERSION');
+    my $repourl = "https://download.suse.de/ibs/SUSE:/SLE-$version:/GA/standard/SUSE:SLE-$version:GA.repo";
+    assert_script_run("cd /etc/zypp/repos.d ; curl -k $repourl -O");
+    zypper_call('si libica');
+    # build output should have FAIL: 0 and ERROR: 0, as example:
+    #============================================================================
+    #Testsuite summary for libica 4.2.1
+    #============================================================================
+    # TOTAL: 55
+    # PASS:  33
+    # SKIP:  22
+    # XFAIL: 0
+    # FAIL:  0
+    # XPASS: 0
+    # ERROR: 0
+    #============================================================================
+    validate_script_output 'rpmbuild -ba /usr/src/packages/SPECS/libica.spec',
+      sub { m/Testsuite summary for libica.+XFAIL:\s+0.+FAIL:\s+0.+ERROR:\s+0/s },
+      timeout => 600;
+}
+
+sub post_run_hook {
+    zypper_call("rr libica-tests");
+}
+
+1;


### PR DESCRIPTION
We schedule the upstream build testsuite and a simple 'smoke' test to check libica functionality in the system. Libica is s390x only

- Related ticket: https://progress.opensuse.org/issues/120558 
- Verification run: https://openqa.suse.de/tests/10855924#
