### PR TITLE
Use default timeout for MicroOS boot in aarch64

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -24,7 +24,7 @@ sub run {
     # already have disabled grub timeout in order to install updates and reboot
     # therefore *aarch64* images would hang in GRUB2
     if ((get_var('HDD_1') !~ /GM-Updated/ && (is_sle_micro || is_leap_micro || is_alp)) && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
-        shift->wait_boot_past_bootloader(textmode => 1, ready_time => 300);
+        shift->wait_boot_past_bootloader(textmode => 1);
     } else {
         shift->wait_boot(bootloader_time => 300);
     }


### PR DESCRIPTION
By removing it, we will be using the default one (500), which is higher than current one.
We are hitting this 300s timeout sporadically.

- Related ticket: https://progress.opensuse.org/issues/127211
- VR: http://openqa.suse.de/tests/10864238
