### PR TITLE
PC migration issue 

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -287,16 +287,17 @@ sub wait_for_guestregister_chk {
     while (time() - $start_time < $args{timeout}) {
         my $out = $self->run_ssh_command(cmd => 'sudo systemctl is-active guestregister', proceed_on_failure => 1, quiet => 1);
         # guestregister is expected to be inactive because it runs only once
-        if ($out eq 'inactive') {
+        # the tests match the expected string at end of the cmd output
+        if ($out =~ m/inactive$/) {
             $self->upload_log($log, log_name => $name);
             return time() - $start_time;
         }
-        elsif ($out eq 'failed') {
+        elsif ($out =~ m/failed$/) {
             $self->upload_log($log, log_name => $name);
             $out = $self->run_ssh_command(cmd => 'sudo systemctl status guestregister', quiet => 1);
             return time() - $start_time;
         }
-        elsif ($out eq 'active') {
+        elsif ($out =~ m/active$/) {
             $self->upload_log($log, log_name => $name);
             die "guestregister should not be active on BYOS" if (is_byos);
         }

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -27,7 +27,7 @@ sub run {
     my ($self, $args) = @_;
     select_serial_terminal();
     my $provider = $args->{my_provider};
-    my $instance = $provider->create_instance(check_guestregister => 0);
+    my $instance = $provider->create_instance();
     registercloudguest($instance) if is_byos();
 
     register_addons_in_pc($instance);


### PR DESCRIPTION
The `instance::wait_for_guestregister_chk` modified in order to match the expected result as _substring_ at _end_ of the proper command _output_.

In the `migration.pm` the original _default input_ of crete_instance restored.
 
- Related ticket: https://progress.opensuse.org/issues/127277
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/10865573 PASS

