### PR TITLE
Update invalid link during installation

### DIFF
--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -32,7 +32,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             macaddress => '52:54:00:78:73:a3',
             ip => '192.168.122.102',
             distro => 'SLE_15',
-            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-LATEST/x86_64/DVD1/',
+            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-GM/x86_64/DVD1/',    # SLE-15-Installer-latest link is not avaiable any more
             linuxrc => 'ifcfg="eth0=192.168.122.102/24,192.168.122.1,192.168.122.1"',
         },
         sles15HVM => {
@@ -42,7 +42,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             macaddress => '52:54:00:78:73:a4',
             ip => '192.168.122.101',
             distro => 'SLE_15',
-            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-LATEST/x86_64/DVD1/',
+            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-GM/x86_64/DVD1/',    # SLE-15-Installer-latest link is not avaiable any more
             linuxrc => 'ifcfg="eth0=192.168.122.101/24,192.168.122.1,192.168.122.1"',
         },
         sles12sp4PV => {
@@ -198,7 +198,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             macaddress => '52:54:00:78:73:a4',
             ip => '192.168.122.101',
             distro => 'SLE_15',
-            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-LATEST/x86_64/DVD1/',
+            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-GM/x86_64/DVD1/',    # SLE-15-Installer-latest link is not avaiable any more
             linuxrc => 'ifcfg="eth0=192.168.122.101/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp1 => {


### PR DESCRIPTION
poo# https://progress.opensuse.org/issues/127307
http://mirror.suse.cz/install/SLP/SLE-15-Installer-LATEST/x86_64/DVD1/ is invalid,
http://mirror.suse.cz/install/SLP/SLE-15-Installer-GM/x86_64/DVD1/ is avaiable.



- Related ticket: https://progress.opensuse.org/issues/127307
- Needles: N/A
- Verification run: http://openqa.qam.suse.cz/tests/52336
