### PR TITLE
Allow perl and python extensions in yaml schedule

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -138,8 +138,11 @@ sub init_main {
 
 sub loadtest {
     my ($test, %args) = @_;
-    croak "extensions are not allowed here '$test'" if $test =~ /\.pm$/;
-    autotest::loadtest("tests/$test.pm", %args);
+    if ($test =~ /\.p[my]$/) {
+        autotest::loadtest("tests/$test", %args);
+    } else {
+        autotest::loadtest("tests/$test.pm", %args);
+    }
 }
 
 sub load_testdir {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -138,11 +138,7 @@ sub init_main {
 
 sub loadtest {
     my ($test, %args) = @_;
-    if ($test =~ /\.p[my]$/) {
-        autotest::loadtest("tests/$test", %args);
-    } else {
-        autotest::loadtest("tests/$test.pm", %args);
-    }
+    autotest::loadtest('tests/' . ($test =~ /\.p[my]$/ ? $test : "$test.pm"), %args);
 }
 
 sub load_testdir {


### PR DESCRIPTION
Accept perl and python extensions in yaml schedule, still defaults to perl when extension is missing

This will allow running python tests from a yaml schedule.


- Related ticket: https://progress.opensuse.org/issues/126590
- Needles: none
- Verification run: 
  - https://openqa.suse.de/tests/10860639# (see https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/master...michaelgrifalconi:os-autoinst-distri-opensuse:pyaml-testing?expand=1 for the code used for validation run)
  

YAML Schedule used for validation run:
```
---
name: mgrifalconi-test
description: try out stuff
schedule:
  - installation/bootloader_start
  - boot/boot_to_desktop
  - console/prepare_test_data
  - console/consoletest_setup
  - console/curl_ipv6
  - console/curl_ipv6.py
  - console/curl_ipv6.pm
...
```

Python test used for validation run:
```
from testapi import *

def run(self):
    assert_script_run('echo "Hey, I am running on Python!"')
    assert_script_run('curl www3.zq1.de/test.txt')
    assert_script_run('rpm -q curl libcurl4')
```