### PR TITLE
Increase maximum waiting time for xrdp_client test.

### DIFF
--- a/tests/x11/remote_desktop/xrdp_client.pm
+++ b/tests/x11/remote_desktop/xrdp_client.pm
@@ -58,7 +58,7 @@ sub run {
     assert_and_click 'auth_credentials-ok';
 
     wait_still_screen 3;
-    assert_screen [qw(connection-failed windows-desktop-on-remmina)];
+    assert_screen [qw(connection-failed windows-desktop-on-remmina)], 180;
 
     if (match_has_tag 'connection-failed') {
         record_soft_failure 'bsc#1117402 - Remmina is not able to connect to the windows server';


### PR DESCRIPTION
The maximum waiting time for assert_screen [qw(connection-failed windows-desktop-on-remmina)] is too small and leads to xrdp_client fails frequently.

Increase the maximum waiting time to fix the issue.

- Related ticket: https://progress.opensuse.org/issues/91575
- Needles: N/A
- Verification run: 
  > [remote-desktop-xrdp-server1](https://openqa.suse.de/tests/10854082)
  > [remote-desktop-xrdp-client1](https://openqa.suse.de/tests/10854081)
  > [remote-desktop-xrdp-server2](https://openqa.suse.de/tests/10868829)
  > [remote-desktop-xrdp-client2](https://openqa.suse.de/tests/10868830)