### PR TITLE
Refactor spack to align with source code which is selected by get_mpi_src

### DIFF
--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -25,7 +25,7 @@ sub run ($self) {
     $self->setup_nfs_server(\%exports_path);
     $self->prepare_spack_env($mpi);
 
-    record_info 'boost info', script_output 'spack info boost';
+    record_info 'spack info', script_output "spack info $mpi";
     barrier_wait('CLUSTER_PROVISIONED');
 
     ## all nodes should be able to ssh to each other, as MPIs requires so
@@ -40,8 +40,8 @@ sub run ($self) {
     assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O $exports_path{'bin'}/$mpi_c");
 
     barrier_wait('MPI_SETUP_READY');
-
-    assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin -l boost_mpi -I \${BOOST_ROOT}/include/ -L \${BOOST_ROOT}/lib 2>&1 > /tmp/make.out");
+    assert_script_run "spack load $mpi";
+    assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin  2>&1 > /tmp/make.out");
     barrier_wait('MPI_BINARIES_READY');
 
     type_string "sudo systemctl restart sshd\n";
@@ -64,7 +64,7 @@ sub test_flags ($self) {
 }
 
 sub post_run_hook ($self) {
-    $self->uninstall_spack_module('boost');
+    $self->uninstall_spack_modules();
 }
 
 sub post_fail_hook ($self) {

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -25,6 +25,7 @@ sub run ($self) {
     type_string("$testapi::password\n");
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
+    assert_script_run "spack load $mpi";
     script_run "module av";
 
     record_info('ssh check', 'Validate sshd service status before mpirun');


### PR DESCRIPTION
boost is a special case which requires LD_LIBRARY_PATH which has been removed
and spack is not setting during its installation. A workaround causes problems
with the system packages and make its fix makes the test complicated. Instead,
some other basic source code can avoid this, as it should be able to be
compiled and run without additional hacks. Although this does not decrease the
execution time. Meaning that spack still takes some time to install its
dependencies, including the openssl which was causing the issues in the
previous implementation.
    
Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>

- Verification run: https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%23spack_openssl
