### PR TITLE
Enhance filter function to get uniq vm ID

### DIFF
--- a/lib/virt_autotest/esxi_utils.pm
+++ b/lib/virt_autotest/esxi_utils.pm
@@ -33,7 +33,7 @@ my $hypervisor = get_var('HYPERVISOR') // 'esxi7.qa.suse.cz';
 
 sub esxi_vm_get_vmid {
     my $vm_name = shift;
-    my $vim_cmd = "vim-cmd vmsvc/getallvms | grep -i $vm_name | cut -d' ' -f1";
+    my $vim_cmd = "vim-cmd vmsvc/getallvms | grep -w $vm_name | cut -d' ' -f1";
     my $vmid;
     if (is_svirt) {
         (undef, $vmid) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);


### PR DESCRIPTION
poo#https://progress.opensuse.org/issues/127334
In order to get uniq vm ID by updating command



- Related ticket: https://progress.opensuse.org/issues/127334
- Needles:
- Verification run:  http://openqa.suse.de/tests/10879601
