### PR TITLE
Replace record_softfailure by record_info in zypper_lifecycle

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -45,7 +45,7 @@ sub lifecycle_output_check {
     }
     if (get_var('SCC_REGCODE_LTSS')) {
         if ($output =~ /No products.*before/) {
-            record_soft_failure('poo#95593 https://jira.suse.com/browse/MSC-70');
+            record_info('Softfail', "poo#95593 https://jira.suse.com/browse/MSC-70");
             return;
         }
         die "SUSE Linux Enterprise Server is end of support\nOutput: '$output'" unless $output =~ /SUSE Linux Enterprise Server/;


### PR DESCRIPTION
Replace record_softfailure by record_info in zypper_lifecycle.

- Related ticket: https://progress.opensuse.org/issues/126605
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/10869645#step/zypper_lifecycle/49
