### PR TITLE
Testing jeos-firstboot on s390x images 

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -415,6 +415,9 @@ sub load_boot_tests {
         loadtest "installation/data_integrity" if data_integrity_is_applicable;
         loadtest "installation/bootloader_uefi";
     }
+    elsif (is_jeos() && is_s390x()) {
+        loadtest "installation/bootloader_start";
+    }
     elsif (is_svirt_except_s390x()) {
         load_svirt_vm_setup_tests;
     }

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -48,16 +48,15 @@ sub load_config_tests {
 }
 
 sub load_boot_from_disk_tests {
-    if (is_s390x()) {
-        loadtest 'installation/bootloader_start';
+    loadtest 'installation/bootloader_start' if is_s390x();
+    if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
+        loadtest 'jeos/firstrun';
+    } elsif (is_s390x()) {
         loadtest 'boot/boot_to_desktop';
     } else {
-        if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
-            loadtest 'jeos/firstrun';
-        } else {
-            loadtest 'microos/disk_boot';
-        }
+        loadtest 'microos/disk_boot';
     }
+
     loadtest 'installation/system_workarounds' if (is_aarch64 && is_microos);
     replace_opensuse_repos_tests if is_repo_replacement_required;
 }


### PR DESCRIPTION
Wizard is activate on serial device `ttysclp0` as expected.
In order to interact with it, we need borrow the console from the serial
and attach it to already active VNC session on the host.

- Related ticket: https://progress.opensuse.org/issues/119080
- Verification run: https://openqa.suse.de/tests/10897979
