### PR TITLE
Add GitHub CODEOWNERS for Public Cloud and Containers tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# GitHub CODEOWNERS https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+lib/publiccloud/ @pdostal @grisu48
+tests/publiccloud/ @pdostal @grisu48
+
+lib/containers/ @pdostal @grisu48 @asmorodskyi
+tests/containers/ @pdostal @grisu48 @asmorodskyi
+


### PR DESCRIPTION
The [GitHub CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file basically notifies all the people interested in particular file in case that file has been changed.

Also, if given file has code owners then at least one of them needs to approve every pull request before it can be merged.

This should be valid after we merge this pull request.
