### PR TITLE
Give additional timeout to build mpi4py on aarch64

### DIFF
--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -103,7 +103,7 @@ sub setup_scientific_module {
         $self->relogin_root;
         my $mpi2load = ($mpi =~ /openmpi2|openmpi3|openmpi4/) ? 'openmpi' : $mpi;
         assert_script_run "module load gnu $mpi2load python3-scipy";
-        assert_script_run("env MPICC=mpicc python3 -m pip install mpi4py");
+        assert_script_run("env MPICC=mpicc python3 -m pip install mpi4py", timeout => 600);
     }
     return 0;
 }


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/126779
- Verification run: https://openqa.suse.de/tests/10888875#details
