### PR TITLE
Enable saptune/mr_test Tests in OSD for Azure

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#   Settings are meant to be controlled via OpenQA variables and managed by test:
+#   tests/sles4sap/publiccloud/qesap_ansible.pm
+
+provider: 'azure'
+apiver: 3
+terraform:
+  provider: 'azure'
+  variables:
+    # GENERAL VARIABLES #
+    az_region: '%PUBLIC_CLOUD_REGION%'
+    admin_user: 'cloudadmin'
+    public_key: '~/.ssh/id_rsa.pub'
+    private_key: '~/.ssh/id_rsa'
+    os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
+
+    # HANA
+    hana_count: '%NODE_COUNT%'
+    hana_ha_enabled: '%HA_CLUSTER%'
+    vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+
+ansible:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  hana_media:
+    - "%HANA_SAR%"
+    - "%HANA_CLIENT_SAR%"
+    - "%HANA_SAPCAR%"
+  destroy:
+    - deregister.yaml

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -415,7 +415,7 @@ sub terraform_apply {
         my $storage_account_name = get_var('STORAGE_ACCOUNT_NAME');
         my $storage_account_key = get_var('STORAGE_ACCOUNT_KEY');
         # Enable specifying resource group name to allow running multiple tests simultaneously
-        my $resource_group = get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qashapopenqa');
+        my $resource_group = get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qesaposd');
         my $sle_version = get_var('FORCED_DEPLOY_REPO_VERSION') ? get_var('FORCED_DEPLOY_REPO_VERSION') : get_var('VERSION');
         $sle_version =~ s/-/_/g;
         my $ha_sap_repo = get_var('HA_SAP_REPO') ? get_var('HA_SAP_REPO') . '/SLE_' . $sle_version : '';

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -72,8 +72,7 @@ sub create_playbook_section_list {
 
     # SLES4SAP/HA related playbooks
     if ($ha_enabled) {
-        push @hana_playbook_list, 'pre-cluster.yaml',
-          'sap-hana-preconfigure.yaml -e use_sapconf=' . set_var_output('USE_SAPCONF', 'true');
+        push @hana_playbook_list, 'pre-cluster.yaml', 'sap-hana-preconfigure.yaml -e use_sapconf=' . set_var_output('USE_SAPCONF', 'true');
         push @hana_playbook_list, 'cluster_sbd_prep.yaml' if (check_var('FENCING_MECHANISM', 'sbd'));
         push @hana_playbook_list, qw(
           sap-hana-storage.yaml
@@ -139,8 +138,7 @@ sub create_instance_data {
                 provider => $provider,
                 region => $provider->provider_client->region,
                 type => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
-                image_id => $provider->get_image_id()
-            );
+                image_id => $provider->get_image_id());
             push @instances, $instance;
         }
     }
@@ -152,8 +150,8 @@ sub run {
     my ($self, $run_args) = @_;
 
     # Let's define a workspace for terraform. We use PUBLIC_CLOUD_RESOURCE_GROUP
-    # if defined, otherwise we use qesapopenqa
-    my $workspace = get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qesapopenqa') . get_current_job_id();
+    # if defined, otherwise we use qesaposd
+    my $workspace = get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qesaposd') . get_current_job_id();
 
     # Select console on the host (not the PC instance) to reset 'TUNNELED',
     # otherwise select_serial_terminal() will be failed

--- a/variables.md
+++ b/variables.md
@@ -312,7 +312,7 @@ PUBLIC_CLOUD_PROVIDER | string | "" | The type of the CSP (e.g. AZURE, EC2, GCE)
 PUBLIC_CLOUD_QAM | boolean | false |  1 : to identify jobs running to test "Maintenance" updates; 0 : for jobs testing "Latest" (in development). Used to control all behavioral implications which this brings.
 PUBLIC_CLOUD_REBOOT_TIMEOUT | integer | 600 | Number of seconds we wait for instance to reboot.
 PUBLIC_CLOUD_REGION | string | "" | The region to use. (default-azure: westeurope, default-ec2: eu-central-1, default-gcp: europe-west1-b). In `upload-img` for Azure Arm64 images, multiple comma-separated regions are supported (see `lib/publiccloud/azure.pm`)
-PUBLIC_CLOUD_RESOURCE_GROUP | string | "qashapopenqa" | Allows to specify resource group name on SLES4SAP PC tests.
+PUBLIC_CLOUD_RESOURCE_GROUP | string | "qesaposd" | Allows to specify resource group name on SLES4SAP PC tests.
 PUBLIC_CLOUD_RESOURCE_NAME | string | "openqa-vm" | The name we use when creating our VM.
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Debug variable used to run test without maintenance updates repository being applied.
 PUBLIC_CLOUD_REDOWNLOAD_MU | boolean | false | Debug variable used to redownload the maintenance repositories (as they might be downloaded by parent test)


### PR DESCRIPTION
Add `mr_test_azure_uri.yaml` file to support customer images on Azure. 
This file is copied from `mr_test_azure.yaml` but replaced "`os_image`" with "`os_image_uri`".
Revised some tidy errors.
Revised the default value of **PUBLIC_CLOUD_RESOURCE_GROUP** to a short one '**qesaposd**' as a work around of:
`https://openqa.suse.de/tests/10880299#step/qesap_terraform/260 (Error: name ("stdiagqesapopenqa10880299") can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long) `
VR of **PUBLIC_CLOUD_RESOURCE_GROUP=qesaposd**: https://openqa.suse.de/tests/10897218# ([qesap_terraform](https://openqa.suse.de/tests/10897218/modules/qesap_terraform/steps/1/src) passed on **OSD**)

TEAM-7633 - Enable saptune/mr_test Tests in osd for Azure

- Related ticket: https://jira.suse.com/browse/TEAM-7633
- Needles: NA
- Verification run: 
**15SP5 VRs:**
  15sp5 BYOS: https://openqaworker15.qa.suse.cz/tests/144737#dependencies  
  15sp5 PAYG: https://openqaworker15.qa.suse.cz/tests/144742#dependencies  
**QEM VRs (all passed, softfails are known):**
  15sp4 passed: https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP4&build=%3Awhatever%3Atest-15sp4&groupid=42  
  15sp3 passed: https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP3&build=%3Awhatever%3Atest-15sp3&groupid=42  
  15sp2 passed: https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP2&build=%3Awhatever%3Atest-15sp2&groupid=42  
  15sp1 passed: https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP1&build=%3Awhatever%3Atest-15sp1&groupid=42  
  12sp5 passed: https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=12-SP5&build=%3Awhatever%3Atest-12sp5&groupid=42  
  12sp4 passed: https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=12-SP4&build=%3Awhatever%3Atest-12sp4&groupid=42  