### PR TITLE
tests/installation/online_repos.pm: Enable on live cds if applicable

### DIFF
--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -10,8 +10,8 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(:VERSION :SCENARIO);
-use utils 'installwithaddonrepos_is_applicable';
+use version_utils qw(:VERSION :SCENARIO is_livecd);
+use utils qw(installwithaddonrepos_is_applicable get_netboot_mirror);
 
 sub open_online_repos_dialog {
     wait_screen_change { send_key 'alt-y' };
@@ -64,7 +64,7 @@ sub run {
     # Test online repos dialog explicitly
     if (get_var('DISABLE_ONLINE_REPOS')) {
         disable_online_repos_explicitly;
-    } elsif (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
+    } elsif ((is_livecd && !get_netboot_mirror) || installwithaddonrepos_is_applicable()) {
         # Acivate online repositories
         wait_screen_change { send_key 'alt-y' };
     } else {

--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -67,6 +67,8 @@ sub run {
     } elsif ((is_livecd && !get_netboot_mirror) || installwithaddonrepos_is_applicable()) {
         # Acivate online repositories
         wait_screen_change { send_key 'alt-y' };
+        assert_screen('list-of-online-repositories');
+        send_key $cmd{next};
     } else {
         # If click No, step is skipped, which is default behavior
         wait_screen_change { send_key 'alt-n' };


### PR DESCRIPTION
If the test does not explicitly specify repos to use for installation, enable online updates during live installation as well.

- Verification run: https://openqa.opensuse.org/tests/3221435
