### PR TITLE
Handle java license popup during installation

### DIFF
--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -40,6 +40,7 @@ use Installation::SystemProbing::EncryptedVolumeActivationController;
 use Installation::SystemRole::SystemRoleController;
 use Installation::Popups::OKPopupController;
 use Installation::Popups::YesNoPopupController;
+use Installation::Popups::AcceptPopupController;
 use YaST::Bootloader::BootloaderSettingsController;
 use YaST::Firstboot::ConfigurationCompletedController;
 use YaST::Firstboot::HostNameController;
@@ -174,6 +175,10 @@ sub get_ok_popup_controller {
 
 sub get_yes_no_popup_controller {
     return Installation::Popups::YesNoPopupController->new();
+}
+
+sub get_accept_popup_controller {
+    return Installation::Popups::AcceptPopupController->new();
 }
 
 sub get_encrypted_volume_activation {

--- a/lib/Installation/Popups/AcceptPopup.pm
+++ b/lib/Installation/Popups/AcceptPopup.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces methods to handle
+# an Accept license popup.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Installation::Popups::AcceptPopup;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        app => $args->{app}
+    }, $class;
+    return $self->init();
+}
+
+sub init {
+    my $self = shift;
+    $self->{btn_accept} = $self->{app}->button({id => 'accept'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    $self->{btn_accept}->exist();
+}
+
+sub press_accept {
+    my ($self) = @_;
+    $self->{btn_accept}->click();
+}
+
+1;

--- a/lib/Installation/Popups/AcceptPopupController.pm
+++ b/lib/Installation/Popups/AcceptPopupController.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# # SPDX-License-Identifier: FSFAP
+
+# Summary: The class introduces business actions for Popups with Accept option
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Installation::Popups::AcceptPopupController;
+use strict;
+use warnings;
+use YuiRestClient;
+use YuiRestClient::Wait;
+use Installation::Popups::AcceptPopup;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init();
+}
+
+sub init {
+    my ($self) = @_;
+    $self->{AcceptPopup} = Installation::Popups::AcceptPopup->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub wait_accept_popup {
+    my ($self, $args) = @_;
+    YuiRestClient::Wait::wait_until(object => sub {
+            $self->{AcceptPopup}->is_shown({timeout => 0});
+    }, %$args);
+}
+
+sub get_accept_popup {
+    my ($self) = @_;
+    die 'Accept Popup is not displayed' unless $self->{AcceptPopup}->is_shown();
+    return $self->{AcceptPopup};
+}
+
+sub accept {
+    my ($self) = @_;
+    $self->get_accept_popup()->press_accept();
+}
+
+1;

--- a/tests/installation/confirm_installation.pm
+++ b/tests/installation/confirm_installation.pm
@@ -9,9 +9,22 @@
 
 use strict;
 use warnings;
+use testapi;
 use base 'y2_installbase';
+use version_utils 'is_sle';
 
 sub run {
+    # For SLE 15 SP4 tests that have the Legacy module added during installation, there is
+    # additional licence popup that is handled by the following function.
+    if ((get_var("SCC_ADDONS") =~ /legacy/) && (is_sle("=15-SP4"))) {
+        my $package_license_popup = $testapi::distri->get_accept_popup_controller();
+        $package_license_popup->wait_accept_popup({
+                timeout => 3000,
+                interval => 2,
+                message => 'Accept license popup did not appear'});
+        save_screenshot;
+        $package_license_popup->accept();
+    }
     my $install_popup = $testapi::distri->get_ok_popup_controller();
     $install_popup->accept();
 }


### PR DESCRIPTION
For SP4 there is an extra java license popup that breaks installation tests. This PR is adding a way to handle it in confirm_installation.pm

- Related ticket: https://progress.opensuse.org/issues/124140
- Verification run: http://falafel.suse.cz/tests/overview?build=20230411-1&distri=sle&version=15-SP4
OSD: https://openqa.suse.de/tests/10902903#next_previous
