### PR TITLE
Change force_scheduled_tasks order for s390 migration tests

### DIFF
--- a/schedule/migration/s390x_regression_test_offline.yaml
+++ b/schedule/migration/s390x_regression_test_offline.yaml
@@ -40,6 +40,7 @@ conditional_schedule:
     QCOW_GENERATION:
       0:
         - console/system_prepare
+        - console/force_scheduled_tasks
         - console/check_os_release
         - console/check_system_info
         - '{{check_migration_features}}'
@@ -72,7 +73,6 @@ conditional_schedule:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/force_scheduled_tasks
         - console/hostname
         - console/upgrade_snapshots
         - console/zypper_lr

--- a/schedule/migration/s390x_regression_test_online.yaml
+++ b/schedule/migration/s390x_regression_test_online.yaml
@@ -23,6 +23,7 @@ conditional_schedule:
       0:
         - console/check_upgraded_service
         - console/system_prepare
+        - console/force_scheduled_tasks
         - console/check_os_release
         - console/check_system_info
         - '{{check_migration_features}}'
@@ -55,7 +56,6 @@ conditional_schedule:
     REGRESSION_TEST:
       1:
         - locale/keymap_or_locale
-        - console/force_scheduled_tasks
         - console/hostname
         - console/upgrade_snapshots
         - console/zypper_lr


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/126344

Verification run: https://openqa.suse.de/tests/10844663
https://openqa.suse.de/tests/10844668
https://openqa.suse.de/tests/10844673
https://openqa.suse.de/tests/10844674
https://openqa.suse.de/tests/10844675
https://openqa.suse.de/tests/10844676
https://openqa.suse.de/tests/10844677

Some Vrs fail but not in force_scheduled_tasks