### PR TITLE
Add users in slurm compute nodes

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -225,10 +225,10 @@ sub t01_accounting() {
     my $description = 'Basic check for slurm accounting cmd';
     my $result = 0;
     my %users = (
-        'user_1' => 'Sebastian',
-        'user_2' => 'Egbert',
-        'user_3' => 'Christina',
-        'user_4' => 'Jose',
+        'user_1' => 'sebastian',
+        'user_2' => 'egbert',
+        'user_3' => 'christina',
+        'user_4' => 'jose',
     );
 
     ##Add users TODO: surely this should be abstracted

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -28,7 +28,18 @@ sub run ($self) {
         zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);
         zypper_call('in iputils python');
     }
+    my %users = (
+        'user_1' => 'sebastian',
+        'user_2' => 'egbert',
+        'user_3' => 'christina',
+        'user_4' => 'jose',
+    );
 
+    ##Add users TODO: surely this should be abstracted
+    script_run("useradd $users{user_1}");
+    script_run("useradd $users{user_2}");
+    script_run("useradd $users{user_3}");
+    script_run("useradd $users{user_4}");
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait("SLURM_SETUP_DONE");
     barrier_wait('SLURM_SETUP_DBD');


### PR DESCRIPTION
Users should appear among all the nodes of the cluster and their uid/gid should match. It seems that the uid/gid are assigned correctly.

This used to work without the creation of the users on compute nodes for SLE15SP4 and below but apparently it shouldnt. This commit just makes things right.


- Related ticket: https://progress.opensuse.org/issues/127487
- Verification run: https://aquarius.suse.cz/tests/15865
