### PR TITLE
Fix disabling clock sync test failure for svirt backend

### DIFF
--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -174,7 +174,7 @@ sub init_guest_time {
     # Set the guest time by using the variable $last_day
     if (is_svirt) {
         $last_day = script_output("date -u -d '$h_datetime last day' +'\%F \%T'");
-        $g_datetime = script_output("date -u -d '$last_day last day' +'\%F \%T'");
+        $g_datetime = script_output("date -u -s '$last_day' +'\%F \%T'");
     }
     elsif (is_qemu) {
         $last_day = script_output(qq($ssh_vm "date -u -d '$h_datetime last day' +'\%F \%T'"));


### PR DESCRIPTION
Disabling clock sync test failed while running on svirt backend. For the fix, using the same date set command with qemu backend.

- Related ticket: https://progress.opensuse.org/issues/127553
- Verification run: http://10.67.129.96/tests/2148
