### PR TITLE
[virtualization] Extend guest installation for generating guest profile from template for alp

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/alp_bedrock_kvm_hvm_x86_64_uefi_imported_qcow2_disk_vnet.xml
+++ b/data/virt_autotest/guest_params_xml_files/alp_bedrock_kvm_hvm_x86_64_uefi_imported_qcow2_disk_vnet.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>alp</guest_os_name>
-    <guest_version>0.1</guest_version>
+    <guest_version>bedrock-0.1</guest_version>
     <guest_version_major>0</guest_version_major>
     <guest_version_minor>1</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
@@ -33,7 +33,7 @@
     <guest_storage_format>qcow2</guest_storage_format>
     <guest_storage_label>gpt</guest_storage_label>
     <guest_storage_size>40</guest_storage_size>
-    <guest_storage_others>backing_store=/var/lib/libvirt/images/ALP-VM.x86_64-0.0.1-kvm-Snapshot##guest_build##-back.qcow2,backing_format=qcow2,bus=virtio,cache=none</guest_storage_others>
+    <guest_storage_others>backing_store=/var/lib/libvirt/images/ALP-Bedrock.x86_64-0.1-Default-qcow-Build##guest_build##-back.qcow2,backing_format=qcow2,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>virtual_network</guest_network_type>
     <guest_network_device>br123</guest_network_device>
     <guest_network_others></guest_network_others>

--- a/data/virt_autotest/guest_params_xml_files/alp_kvm_hvm_x86_64_imported_disk_vnet_template.xml
+++ b/data/virt_autotest/guest_params_xml_files/alp_kvm_hvm_x86_64_imported_disk_vnet_template.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>alp</guest_os_name>
-    <guest_version>0.1</guest_version>
-    <guest_version_major>0</guest_version_major>
-    <guest_version_minor>1</guest_version_minor>
+    <guest_version>##guest_version##</guest_version>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build></guest_build>
+    <guest_build>##guest_build##</guest_build>
     <host_hypervisor_uri></host_hypervisor_uri>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
@@ -17,6 +15,7 @@
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
     <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata></guest_metadata>
+    <guest_boot_settings>##guest_boot_settings##</guest_boot_settings>
     <guest_xpath></guest_xpath>
     <guest_installation_automation></guest_installation_automation>
     <guest_installation_automation_file></guest_installation_automation_file>
@@ -32,7 +31,7 @@
     <guest_storage_format>qcow2</guest_storage_format>
     <guest_storage_label>gpt</guest_storage_label>
     <guest_storage_size>40</guest_storage_size>
-    <guest_storage_others>backing_store=/var/lib/libvirt/images/ALP-VM.x86_64-0.0.1-kvm-Snapshot##guest_build##-back.qcow2,backing_format=qcow2,bus=virtio,cache=none</guest_storage_others>
+    <guest_storage_others>backing_store=/var/lib/libvirt/images/##backing_disk_name##,backing_format=##backing_format##,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>virtual_network</guest_network_type>
     <guest_network_device>br123</guest_network_device>
     <guest_network_others></guest_network_others>
@@ -68,7 +67,7 @@
     <guest_cputune></guest_cputune>
     <guest_memtune></guest_memtune>
     <guest_blkiotune></guest_blkiotune>
-    <guest_memorybacking></guest_memorybacking>
+    <guest_memorybacking>##guest_memorybacking##</guest_memorybacking>
     <guest_features></guest_features>
     <guest_clock></guest_clock>
     <guest_power_management></guest_power_management>
@@ -76,7 +75,7 @@
     <guest_resource></guest_resource>
     <guest_sysinfo>type=fwcfg,entry0.name="opt/com.coreos/config",entry0.file="/var/lib/libvirt/images/VIRT_TEST_VM_config.ign"</guest_sysinfo>
     <guest_qemu_command></guest_qemu_command>
-    <guest_launchSecurity></guest_launchSecurity>
+    <guest_launchsecurity>##guest_launchsecurity##</guest_launchsecurity>
     <guest_autostart></guest_autostart>
     <guest_transient></guest_transient>
     <guest_destroy_on_exit></guest_destroy_on_exit>

--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -73,7 +73,7 @@ sub instantiate_guests_and_profiles {
         $_guest_profile->{guest_registration_code} = $_store_of_guests{$_element}{REG_CODE};
         $_guest_profile->{guest_registration_extensions_codes} = $_store_of_guests{$_element}{REG_EXTS_CODES};
         $guest_instances_profiles{$_element} = $_guest_profile;
-        $self->edit_guest_profile_with_template($_element) if ($_store_of_guests{$_element}{USE_TEMPLATE} eq '1');
+        $self->edit_guest_profile_with_template($_element, $_store_of_guests{$_element}) if ($_store_of_guests{$_element}{USE_TEMPLATE} eq '1');
         diag "Guest $_element is going to use profile" . Dumper($guest_instances_profiles{$_element});
     }
 

--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -73,10 +73,25 @@ sub instantiate_guests_and_profiles {
         $_guest_profile->{guest_registration_code} = $_store_of_guests{$_element}{REG_CODE};
         $_guest_profile->{guest_registration_extensions_codes} = $_store_of_guests{$_element}{REG_EXTS_CODES};
         $guest_instances_profiles{$_element} = $_guest_profile;
+        $self->edit_guest_profile_with_template($_element) if ($_store_of_guests{$_element}{USE_TEMPLATE} eq '1');
         diag "Guest $_element is going to use profile" . Dumper($guest_instances_profiles{$_element});
     }
 
     return $self;
+}
+
+# Motivation of the function:
+#   When multiple vms' profiles have great similarity and have some rules
+#   to follow to generate different profiles from a template, such a function
+#   will save a lot of static profile files in data/virt_autotest/guest_params_xml_files.
+# Usage:
+#   In testsuite settings, var UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS copes
+#   with var UNIFIED_GUEST_PROFILES. Both have values separated with comma.
+#   If at a position of UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS the value is '1',
+#   the UNIFIED_GUEST_PROFILES value at the same position will be the template profile for the vm.
+#   It's supported that some vms use template while some do not.
+sub edit_guest_profile_with_template {
+    # To be overloaded in child classes with customized needs.
 }
 
 #Create guest instance using $guest_instances{$_}->create(%{$guest_instances_profiles{$_}} and install it by calling $guest_instances{$_}->guest_installation_run.

--- a/schedule/virt_autotest/alp-virt-core-tests.yaml
+++ b/schedule/virt_autotest/alp-virt-core-tests.yaml
@@ -9,6 +9,7 @@ schedule:
     - "{{install_guest}}"
     - virt_autotest/set_config_as_glue
     - '{{uefi_guest_verification}}'
+    - '{{sev_es_guest_verification}}'
     - '{{virtual_network_test}}'
     - '{{hotplugging_test}}'
     - '{{storage_test}}'
@@ -18,11 +19,15 @@ conditional_schedule:
     install_guest:
         SKIP_GUEST_INSTALL:
             0:
-                - virt_autotest/unified_guest_installation
+                - virt_autotest/alp_guest_installation
     uefi_guest_verification:
         VIRT_UEFI_GUEST_INSTALL:
             1:
                 - virt_autotest/uefi_guest_verification
+    sev_es_guest_verification:
+        VIRT_SEV_ES_GUEST_INSTALL:
+            1:
+                - virt_autotest/sev_es_guest_verification
     virtual_network_test:
         ENABLE_VIR_NET:
             1:

--- a/tests/virt_autotest/alp_guest_installation.pm
+++ b/tests/virt_autotest/alp_guest_installation.pm
@@ -1,0 +1,65 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: This file handles the guest installation for ALP.
+#          It supports configuring vm profiles with template.
+#
+# Maintainer: Alice <xlai@suse.com>, or VT squad <qe-virt@suse.de>
+
+package alp_guest_installation;
+
+use base unified_guest_installation;
+use strict;
+use warnings;
+use testapi;
+use Data::Dumper;
+
+sub edit_guest_profile_with_template {
+    my ($self, $guest_name) = @_;
+
+    # Initialize config
+    my %_guest_profile = %{$concurrent_guest_installations::guest_instances_profiles{$guest_name}};
+
+    # Handle guest_boot_settings
+    my $_boot_value = '';
+    $_boot_value = 'uefi' if (get_var('VIRT_UEFI_GUEST_INSTALL', ''));
+    $_boot_value = 'firmware=efi' if (get_var('VIRT_SEV_ES_GUEST_INSTALL', ''));
+    $_guest_profile{guest_boot_settings} =~ s/##guest_boot_settings##/$_boot_value/g;
+
+    # Handle guest_storage_others
+    my $_backing_disk_name = get_var('HDD_1', '');
+    $_backing_disk_name =~ /([^\/]+)\.([^\/\.]+)$/m;
+    my $_new_back_name = "$1-back.$2";
+    my $_back_format = $2;
+    $_guest_profile{guest_storage_others} =~ s/##backing_disk_name##/$_new_back_name/g;
+    $_guest_profile{guest_storage_others} =~ s/##backing_format##/$_back_format/g;
+
+    # Handle version
+    my $_version = get_var('VERSION', '');
+    $_version =~ /[a-zA-Z]+-([0-9\.]+)/m;
+    $_version = $1;
+    $_guest_profile{guest_version} =~ s/##guest_version##/$_version/g;
+
+    # Handle build
+    my $_build = get_var('BUILD', '');
+    $_guest_profile{guest_build} =~ s/##guest_build##/$_build/g;
+
+    # Handle SEV-ES realted settings
+    my $_memory_back = '';
+    my $_launch_security = '';
+    if (get_var('VIRT_SEV_ES_GUEST_INSTALL', '')) {
+        $_memory_back = 'locked=yes';
+        $_launch_security = 'sev,policy=0x07';
+    }
+    $_guest_profile{guest_memorybacking} =~ s/##guest_memorybacking##/$_memory_back/g;
+    $_guest_profile{guest_launchsecurity} =~ s/##guest_launchsecurity##/$_launch_security/g;
+
+    # TODO: when alp products other than bedrock/micro need to test,
+    #       more extensions may be needed here
+
+    # Overwrite $guest_instances_profiles
+    $concurrent_guest_installations::guest_instances_profiles{$guest_name} = \%_guest_profile;
+    record_info("$guest_name profile has been created from template.", "Content is:\n" . Dumper($concurrent_guest_installations::guest_instances_profiles{$guest_name}));
+}
+
+1;

--- a/tests/virt_autotest/alp_guest_installation.pm
+++ b/tests/virt_autotest/alp_guest_installation.pm
@@ -15,7 +15,8 @@ use testapi;
 use Data::Dumper;
 
 sub edit_guest_profile_with_template {
-    my ($self, $guest_name) = @_;
+    my ($self, $guest_name, $_guest_config) = @_;
+    my %_guest_config_from_testsuite = %$_guest_config;
 
     # Initialize config
     my %_guest_profile = %{$concurrent_guest_installations::guest_instances_profiles{$guest_name}};
@@ -27,7 +28,7 @@ sub edit_guest_profile_with_template {
     $_guest_profile{guest_boot_settings} =~ s/##guest_boot_settings##/$_boot_value/g;
 
     # Handle guest_storage_others
-    my $_backing_disk_name = get_var('HDD_1', '');
+    my $_backing_disk_name = $_guest_config_from_testsuite{BACKING_DISK};
     $_backing_disk_name =~ /([^\/]+)\.([^\/\.]+)$/m;
     my $_new_back_name = "$1-back.$2";
     my $_back_format = $2;
@@ -35,13 +36,13 @@ sub edit_guest_profile_with_template {
     $_guest_profile{guest_storage_others} =~ s/##backing_format##/$_back_format/g;
 
     # Handle version
-    my $_version = get_var('VERSION', '');
+    my $_version = $_guest_config_from_testsuite{VM_VERSION};
     $_version =~ /[a-zA-Z]+-([0-9\.]+)/m;
     $_version = $1;
     $_guest_profile{guest_version} =~ s/##guest_version##/$_version/g;
 
     # Handle build
-    my $_build = get_var('BUILD', '');
+    my $_build = $_guest_config_from_testsuite{VM_BUILD};
     $_guest_profile{guest_build} =~ s/##guest_build##/$_build/g;
 
     # Handle SEV-ES realted settings

--- a/tests/virt_autotest/sev_es_guest_verification.pm
+++ b/tests/virt_autotest/sev_es_guest_verification.pm
@@ -22,7 +22,7 @@ use utils;
 use virt_utils;
 use virt_autotest::common;
 use virt_autotest::utils;
-use version_utils qw(is_sle is_tumbleweed);
+use version_utils qw(is_sle is_tumbleweed is_alp);
 use Utils::Architectures;
 
 sub run_test {
@@ -30,7 +30,7 @@ sub run_test {
 
     $self->check_sev_es_on_host;
     foreach (keys %virt_autotest::common::guests) {
-        virt_autotest::utils::wait_guest_online($_, 180, 1);
+        virt_autotest::utils::wait_guest_online($_, 50, 1);    # 50 retries * ~7 seconds/retry, long enough
         $self->check_sev_es_on_guest(guest_name => "$_");
     }
     return $self;
@@ -49,10 +49,10 @@ additional argument supported by this subroutine.
 sub check_sev_es_on_host {
     my $self = shift;
 
-    record_info('Check SEV/SEV-ES support status on host', 'Only 15-SP2+ host supports AMD SEV and only 15-SP4+ supports AMD SEV-ES.');
+    record_info('Check SEV/SEV-ES support status on host', 'Only 15-SP2+ host supports AMD SEV, and only 15-SP4+/Tumbleweed/ALP support AMD SEV-ES.');
     if (is_x86_64) {
-        if (is_sle('>=15-SP4') or is_tumbleweed) {
-            record_info('No AMD SEV or SEV-ES feature available on host', 'Host is a 15-SP4 or newer produdct') unless ($self->check_sev_es_parameter(params_to_check => 'sev sev_es') == 0);
+        if (is_sle('>=15-SP4') or is_tumbleweed or is_alp) {
+            record_info('No AMD SEV or SEV-ES feature available on host', 'Host is a 15-SP4+/Tumbleweed/ALP produdct') unless ($self->check_sev_es_parameter(params_to_check => 'sev sev_es') == 0);
         }
         elsif (is_sle('>=15-SP2')) {
             record_info('No AMD SEV feature available on host', 'Host is a 15-SP2 or newer produdct but older than 15-SP4') unless ($self->check_sev_es_parameter(params_to_check => 'sev') == 0);

--- a/tests/virt_autotest/uefi_guest_verification.pm
+++ b/tests/virt_autotest/uefi_guest_verification.pm
@@ -49,6 +49,9 @@ sub run_test {
     if (is_sle('>=15')) {
         $self->check_guest_pmsuspend_enabled;
     }
+    elsif (is_alp) {
+        record_info("Skip power management check on ALP", "The uefi firmware does not support pm well.");
+    }
     else {
         record_info("SLES that is eariler than 15 does not support power management functionality with uefi", "Skip check_guest_pmsuspend_enabled");
     }

--- a/tests/virt_autotest/unified_guest_installation.pm
+++ b/tests/virt_autotest/unified_guest_installation.pm
@@ -41,6 +41,11 @@
 # will be assigned to guest parameters [guest_registration_code] and
 # [guest_registration_extensions_codes], so please refer to base module
 # lib/concurrent_guest_installations for detailed information about them.
+# TEMPLATE_VM_BACKING_DISKS, TEMPLATE_VM_BUILDS, and TEMPLATE_VM_VERSIONS
+# are 3 additional testsuite settings to help with template based guest
+# installation. They work together with UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS.
+# Only VMs configured with profile template will use the 3 settings to edit
+# profile in code.
 # Installation progress monitoring,result validation, junit log provision,
 # environment cleanup and failure handling are also included and supported
 # by calling other subroutines:
@@ -72,15 +77,21 @@ sub run {
     my @guest_profiles = split(/,/, get_required_var('UNIFIED_GUEST_PROFILES'));
     croak("Guest names and profiles must be given to create, configure and install guests.") if ((scalar(@guest_names) eq 0) or (scalar(@guest_profiles) eq 0));
     my %store_of_guests;
-    my @guest_registration_codes = my @guest_registration_extensions_codes = my @guest_profile_template_flags = ('') x scalar @guest_names;
+    my @guest_registration_codes = my @guest_registration_extensions_codes = my @guest_profile_template_flags = my @template_vm_backing_disks = my @template_vm_versions = my @template_vm_builds = ('') x scalar @guest_names;
     @guest_registration_codes = split(/,/, get_var('UNIFIED_GUEST_REG_CODES', '')) if (get_var('UNIFIED_GUEST_REG_CODES', '') ne '');
     @guest_registration_extensions_codes = split(/,/, get_var('UNIFIED_GUEST_REG_EXTS_CODES', '')) if (get_var('UNIFIED_GUEST_REG_EXTS_CODES', '') ne '');
     @guest_profile_template_flags = split(/,/, get_var('UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS', '')) if (get_var('UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS', '') ne '');
+    @template_vm_backing_disks = split(/,/, get_var('TEMPLATE_VM_BACKING_DISKS', '')) if (get_var('TEMPLATE_VM_BACKING_DISKS', '') ne '');
+    @template_vm_versions = split(/,/, get_var('TEMPLATE_VM_VERSIONS', '')) if (get_var('TEMPLATE_VM_VERSIONS', '') ne '');
+    @template_vm_builds = split(/,/, get_var('TEMPLATE_VM_BUILDS', '')) if (get_var('TEMPLATE_VM_BUILDS', '') ne '');
     while (my ($index, $element) = each @guest_names) {
         $store_of_guests{$element}{PROFILE} = $guest_profiles[$index];
         $store_of_guests{$element}{REG_CODE} = $guest_registration_codes[$index];
         $store_of_guests{$element}{REG_EXTS_CODES} = $guest_registration_extensions_codes[$index];
         $store_of_guests{$element}{USE_TEMPLATE} = $guest_profile_template_flags[$index];
+        $store_of_guests{$element}{BACKING_DISK} = $template_vm_backing_disks[$index];
+        $store_of_guests{$element}{VM_VERSION} = $template_vm_versions[$index];
+        $store_of_guests{$element}{VM_BUILD} = $template_vm_builds[$index];
     }
 
     $self->concurrent_guest_installations_run(\%store_of_guests);

--- a/tests/virt_autotest/unified_guest_installation.pm
+++ b/tests/virt_autotest/unified_guest_installation.pm
@@ -15,6 +15,17 @@
 # vm_profile_2,vm_profile_3".Then vm_name_1 will be created and installed
 # using vm_profile_1 and so on by calling instantiate_guests_and_profiles
 # and install_guest_instances.
+# This module also supports to use guest profile templates to dynamically
+# generate profiles. The function can be switched on or off, on per-vm basis.
+# If UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS is set to '1' at the vm's position
+# (separated by ',' from string), the UNIFIED_GUEST_PROFILES's value at the same position,
+# will be used as the guest profile template, which will then be updated in code
+# to generate the final profile for vm installation. The purpose for this is to
+# save too many similar profiles in data/virt_autotest/guest_params_xml_files folder.
+# For example, if UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS is set to '0,1,0',
+# the second vm's profile will be generated based on template file given in
+# UNIFIED_GUEST_PROFILES[1], while the other two vms use static profiles
+# specified in UNIFIED_GUEST_PROFILES[0]/[2].
 # UNIFIED_GUEST_REG_CODES and UNIFIED_GUEST_REG_EXTS_CODES are two other
 # test suite level settings which are given guest os registration codes
 # and codes for additional modules/extensions/products to be used by guests.
@@ -61,14 +72,17 @@ sub run {
     my @guest_profiles = split(/,/, get_required_var('UNIFIED_GUEST_PROFILES'));
     croak("Guest names and profiles must be given to create, configure and install guests.") if ((scalar(@guest_names) eq 0) or (scalar(@guest_profiles) eq 0));
     my %store_of_guests;
-    my @guest_registration_codes = my @guest_registration_extensions_codes = ('') x scalar @guest_names;
+    my @guest_registration_codes = my @guest_registration_extensions_codes = my @guest_profile_template_flags = ('') x scalar @guest_names;
     @guest_registration_codes = split(/,/, get_var('UNIFIED_GUEST_REG_CODES', '')) if (get_var('UNIFIED_GUEST_REG_CODES', '') ne '');
     @guest_registration_extensions_codes = split(/,/, get_var('UNIFIED_GUEST_REG_EXTS_CODES', '')) if (get_var('UNIFIED_GUEST_REG_EXTS_CODES', '') ne '');
+    @guest_profile_template_flags = split(/,/, get_var('UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS', '')) if (get_var('UNIFIED_GUEST_PROFILE_TEMPLATE_FLAGS', '') ne '');
     while (my ($index, $element) = each @guest_names) {
         $store_of_guests{$element}{PROFILE} = $guest_profiles[$index];
         $store_of_guests{$element}{REG_CODE} = $guest_registration_codes[$index];
         $store_of_guests{$element}{REG_EXTS_CODES} = $guest_registration_extensions_codes[$index];
+        $store_of_guests{$element}{USE_TEMPLATE} = $guest_profile_template_flags[$index];
     }
+
     $self->concurrent_guest_installations_run(\%store_of_guests);
     check_guest_health($_) foreach (@guest_names);
     return $self;


### PR DESCRIPTION
Motivation of the PR:
- alp will have quite several different products, and each product will have several images. If using static guest profile, there will be a lot of similar profile files in openqa code directory `data/virt_autotest/guest_params_xml_files/`. 
- To avoid it, give limited template files in the data dir, and let code handles dynamic profile generation based on it.

The design:
  - please read the requirement in https://progress.opensuse.org/issues/126905
 
What will be supported with the PR merged: 
- creation of different types of alp guests with mixture of below
    - using alp micro and alp bedrock products (if newer alp products follow similar configuration and have no extra special handling, it will work seamlessly too)
   - with each product's  Default-qcow(qcow2) and Default-encrypted(raw) images// note: for encrypted image, the generated profile will be ok, but for others, poo@122737 will handle )
   - with vms configured to be uefi, sev-es, general/non-uefi
- in one testsuite, support mixed guest installation: some with static profile and some with dynamic profile from template (fully switchable on testsuite setting)

What are included in the PR:
- the main implementation of dynamic guest creation from template
- alp sev-es fixes and enablement (Leon can start from here easier for poo#123199)
- other minor fixes to support different alp products/images
 
Related ticket: 
    -  https://progress.opensuse.org/issues/126905
    - partially cover sev-es in https://progress.opensuse.org/issues/123199

Verification run: 

- one alp uefi bedrock default-qcow guest with tempalte, with all feature: http://10.67.129.185/tests/596#
- two uefi vms, one alp guest(alp-bedrock, default-qcow) with template, one sles guest without template, pass: http://10.67.129.185/tests/570, key verified parts:
  - http://10.67.129.185/tests/570#step/alp_guest_installation/1
  - http://10.67.129.185/tests/570#step/alp_guest_installation/7
  - http://10.67.129.185/tests/570#step/alp_guest_installation/243
- two uefi vms, one alp guest(alp-micro, Default-encrypted, raw) with template, one sles guest without template, pass: http://10.67.129.185/tests/577#, key verified parts:
  - please note: it is known that encrypted disk would fail in guest installation because disk key is not set, will be solved in poo#122737 which is blocked now
  - http://10.67.129.185/tests/577#step/alp_guest_installation/1
  - http://10.67.129.185/tests/577#step/alp_guest_installation/7
- sev-es alp guest (alp-bedrock, default-qcow) with template, pass :http://10.67.129.185/tests/589#step/alp_guest_installation/7
- two regular/non-uefi vms, one alp guest(alp-micro, default-qcow) with template, one sles guest without template, pass : http://10.67.129.185/tests/611
- one alp uefi bedrock default-qcow guest without template, with all feature: pass  http://10.67.129.185/tests/608
- regression test on sles:
  - uefi xen 15sp4, uefi-gi-guest_developing-on-host_sles15sp4-xen, https://openqa.suse.de/t10911890
  - uefi kvm, uefi-gi-guest_developing-on-host_developing-kvm, https://openqa.suse.de/tests/10917156
  - sev-es, sev-es-gi-guest_developing-on-host_developing-kvm, https://openqa.suse.de/t10911136
