### PR TITLE
lib/utils: Enable online repos on installations from live media if applicable

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -563,7 +563,7 @@ sub load_slepos_tests {
 sub load_system_role_tests {
     # This part is relevant only for openSUSE
     if (is_opensuse) {
-        if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
+        if (installwithaddonrepos_is_applicable()) {
             loadtest "installation/setup_online_repos";
         }
         # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
@@ -946,6 +946,7 @@ sub load_inst_tests {
         if (is_opensuse) {
             # See https://github.com/yast/yast-packager/pull/385
             loadtest "installation/online_repos";
+            loadtest "installation/setup_online_repos" if installwithaddonrepos_is_applicable;
         }
     }
     if (is_sle) {

--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -64,7 +64,7 @@ sub run {
     # Test online repos dialog explicitly
     if (get_var('DISABLE_ONLINE_REPOS')) {
         disable_online_repos_explicitly;
-    } elsif (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
+    } elsif (installwithaddonrepos_is_applicable()) {
         # Acivate online repositories
         wait_screen_change { send_key 'alt-y' };
     } else {

--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -10,8 +10,8 @@ use base 'y2_installbase';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(:VERSION :SCENARIO is_livecd);
-use utils qw(installwithaddonrepos_is_applicable get_netboot_mirror);
+use version_utils qw(:VERSION :SCENARIO);
+use utils 'installwithaddonrepos_is_applicable';
 
 sub open_online_repos_dialog {
     wait_screen_change { send_key 'alt-y' };
@@ -64,7 +64,7 @@ sub run {
     # Test online repos dialog explicitly
     if (get_var('DISABLE_ONLINE_REPOS')) {
         disable_online_repos_explicitly;
-    } elsif ((is_livecd && !get_netboot_mirror) || installwithaddonrepos_is_applicable()) {
+    } elsif (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
         # Acivate online repositories
         wait_screen_change { send_key 'alt-y' };
     } else {

--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -67,8 +67,6 @@ sub run {
     } elsif ((is_livecd && !get_netboot_mirror) || installwithaddonrepos_is_applicable()) {
         # Acivate online repositories
         wait_screen_change { send_key 'alt-y' };
-        assert_screen('list-of-online-repositories');
-        send_key $cmd{next};
     } else {
         # If click No, step is skipped, which is default behavior
         wait_screen_change { send_key 'alt-n' };


### PR DESCRIPTION
Revert the previous commits, implement it how it was meant to.

"addon repos" == "online repos" apparently, which is why I previously thought this would be the wrong approach.

- Related ticket: https://progress.opensuse.org/issues/127565
- Verification runs:
15.4 Incidents: https://openqa.opensuse.org/tests/3223992
15.4 Images (Upgrade from 15.2): https://openqa.opensuse.org/tests/3223991
15.4 Images (installation): https://openqa.opensuse.org/tests/3223999

CC @rfan1