### PR TITLE
Add PATTERNS condition for accepting java popup

### DIFF
--- a/tests/installation/confirm_installation.pm
+++ b/tests/installation/confirm_installation.pm
@@ -16,7 +16,7 @@ use version_utils 'is_sle';
 sub run {
     # For SLE 15 SP4 tests that have the Legacy module added during installation, there is
     # additional licence popup that is handled by the following function.
-    if ((get_var("SCC_ADDONS") =~ /legacy/) && (is_sle("=15-SP4"))) {
+    if (!(get_var("PATTERNS") =~ /minimal/) && (get_var("SCC_ADDONS") =~ /legacy/) && (is_sle("=15-SP4"))) {
         my $package_license_popup = $testapi::distri->get_accept_popup_controller();
         $package_license_popup->wait_accept_popup({
                 timeout => 3000,


### PR DESCRIPTION
After merging https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16830
the SP4 tests with legacy and minimal pattern fail : https://openqa.suse.de/tests/10911585#step/confirm_installation/1
This extra condition, fixes the new issue that has appeared

- Verification run: 
SP4,minimal,legacy : http://falafel.suse.cz/tests/1078
SP4,legacy :  http://falafel.suse.cz/tests/1081
SP4 : http://falafel.suse.cz/tests/1082
