### PR TITLE
Upload zypper log if any issue with test 'patterns'

### DIFF
--- a/tests/console/patterns.pm
+++ b/tests/console/patterns.pm
@@ -1,10 +1,10 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2017 SUSE LLC
+# Copyright 2016-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Test pattern selection for system role 'kvm host'
-# Maintainer: Christopher Hofmann <cwh@suse.de>
+# Maintainer: Christopher Hofmann <cwh@suse.de>, QE Core <qe-core@suse.de>
 # Tags: fate#317481 poo#16650
 
 use base 'consoletest';
@@ -20,7 +20,13 @@ sub run {
     # defines kvm_server as an additional pattern, xen_server defines 'xen host'.
     die "Only kvm|xen roles are supported" unless get_var('SYSTEM_ROLE', '') =~ /kvm|xen/;
     my $pattern_name = get_required_var('SYSTEM_ROLE') . '_server';
+    record_info('Show only installed patterns', script_output('zypper patterns -i'));
     assert_script_run("zypper patterns -i | grep $pattern_name");
+}
+
+sub post_fail_hook {
+    select_console 'log-console';
+    upload_logs "/var/log/zypper.log";
 }
 
 1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/127562

- Verification run: 
[VR](http://openqa.suse.de/t10912251)
zypper log can be seen at [link](http://openqa.suse.de/tests/10912251/file/patterns-zypper.log)after case failure.