### PR TITLE
Bump up timeout in yast2_software_management

### DIFF
--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -19,7 +19,7 @@ sub run {
     # Accept => Exit, or get to the installation report
     send_key 'alt-a';
     # Installation may take some time
-    assert_screen [qw(sw_single_ui_installation_report generic-desktop)], timeout => 300;
+    assert_screen [qw(sw_single_ui_installation_report generic-desktop)], timeout => 350;
     if (match_has_tag('sw_single_ui_installation_report')) {
         # Press finish
         send_key 'alt-f';


### PR DESCRIPTION
This issue has appeared just once and seems sporadic, therefore slightly increasing timeout should prevent it from reoccurring in the future

- Related ticket: https://progress.opensuse.org/issues/127604
- Verification run: https://openqa.suse.de/tests/10912372#next_previous
