### PR TITLE
Fix assert_screen in apply_workaround_poo124652

### DIFF
--- a/lib/YaST/workarounds.pm
+++ b/lib/YaST/workarounds.pm
@@ -39,7 +39,7 @@ sub apply_workaround_poo124652 {
     if (!check_screen($mustmatch, %args)) {
         record_info('poo#124652', 'poo#124652 - gtk glitch not showing dialog window decoration on openQA');
         send_key('shift-f3', wait_screen_change => 1);
-        assert_screen('style-sheet-selection-popup');
+        check_screen('style-sheet-selection-popup', 10);
         send_key('esc', wait_screen_change => 1);
         # in some verification tests this didn't work, so let's check
         if (!check_screen($mustmatch)) {


### PR DESCRIPTION
- Related ticket:  https://progress.opensuse.org/issues/127499
- Needles: -
- Verification run: https://openqa.suse.de/tests/10912707

- Previous PR turned out to make some  test modules less stable.

