### PR TITLE
Increase timeout for spack installation

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -370,14 +370,14 @@ To do that run
 sub prepare_spack_env {
     my ($self, $mpi) = @_;
     $mpi //= 'mpich';
-    zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel", timeout => 480;
+    zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel", timeout => 1200;
     type_string('pkill -u root');    # this kills sshd
     select_serial_terminal(0);
     assert_script_run 'module load gnu $mpi';    ## TODO
     assert_script_run 'source /usr/share/spack/setup-env.sh';
 
     record_info 'spack', script_output 'zypper -q info spack';
-    record_info "$mpi spec", script_output("spack spec $mpi", timeout => 480);
+    record_info "$mpi spec", script_output("spack spec $mpi", timeout => 600);
     assert_script_run "spack install $mpi", timeout => 12000;
 
 }


### PR DESCRIPTION
Due to timeout failures on spack installation on aarch64, test needs additional time for some operations. `spack spec` is increased as precautious as a general measure against the poor performance on that arch.


- Related ticket: https://progress.opensuse.org/issues/126806
- Verification run: 
https://openqa.suse.de/tests/10912705#