### PR TITLE
Update autoyast profile of autoyast_bcache.xml

### DIFF
--- a/data/autoyast_sle15/autoyast_bcache.xml
+++ b/data/autoyast_sle15/autoyast_bcache.xml
@@ -38,7 +38,7 @@
       <enable_snapshots config:type="boolean">true</enable_snapshots>
       <partitions config:type="list">
         <partition>
-          <mount>/swap</mount>
+          <mount>swap</mount>
           <create config:type="boolean">true</create>
           <filesystem config:type="symbol">swap</filesystem>
           <size>auto</size>


### PR DESCRIPTION
Errors on validation of AutoYaST profile, need to fix to /mount instead of mount.

- Related ticket: https://progress.opensuse.org/issues/127583
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/10917174#
