### PR TITLE
Adapt function test for taa and mds problem

### DIFF
--- a/tests/cpu_bugs/xen_domu_mitigation_test.pm
+++ b/tests/cpu_bugs/xen_domu_mitigation_test.pm
@@ -583,7 +583,7 @@ my $mitigations_off_on_hvm_haswell = {"mitigations=off" => {
     }
 };
 
-my $corss_testcase_mds_taa_off = {"mds=off tsx_async_abort=off" => {
+my $corss_testcase_mds_taa_off = {"mds=off tsx_async_abort=off mmio_stale_data=off" => {
         default => {
             expected => {'cat /proc/cmdline' => ['mds=off tsx_async_abort=off'], 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Vulnerable; SMT Host state unknown'], 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Vulnerable']},
             unexpected => {}
@@ -591,7 +591,7 @@ my $corss_testcase_mds_taa_off = {"mds=off tsx_async_abort=off" => {
     }
 };
 
-my $corss_testcase_mds_taa_off_on_haswell = {"mds=off tsx_async_abort=off" => {
+my $corss_testcase_mds_taa_off_on_haswell = {"mds=off tsx_async_abort=off mmio_stale_data=off" => {
         default => {
             expected => {'cat /proc/cmdline' => ['mds=off tsx_async_abort=off'], 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Vulnerable; SMT Host state unknown'], 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Not affected']},
             unexpected => {}


### PR DESCRIPTION
15SP5 have some change on kernel,So it needs to adapt,refer to the bug https://bugzilla.suse.com/show_bug.cgi?id=1205618.
Modify the file xen_domu_mitigation.pm.

- Verification run:http://10.67.129.4/tests/57559
                              http://10.67.129.7/tests/overview?result=passed&distri=sle&version=15-SP5&build=88.1&groupid=14