### PR TITLE
lib/main_common: Refactor online_repos configuration

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -563,9 +563,6 @@ sub load_slepos_tests {
 sub load_system_role_tests {
     # This part is relevant only for openSUSE
     if (is_opensuse) {
-        if (installwithaddonrepos_is_applicable()) {
-            loadtest "installation/setup_online_repos";
-        }
         # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
         if ((!get_var('BACKEND', 'ipmi') || !is_pvm) && !is_hyperv_in_gui && !get_var("LIVECD")) {
             loadtest "installation/logpackages";
@@ -933,21 +930,17 @@ sub load_inst_tests {
     if (!is_sle('15-SP4+') && !get_var('WITHISCSI') && (get_var('MULTIPATH') or get_var('MULTIPATH_CONFIRM'))) {
         loadtest "installation/multipath";
     }
-    if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {
-        # See https://github.com/yast/yast-packager/pull/385
-        loadtest "installation/online_repos";
-        loadtest "installation/installation_mode";
-    }
     if (is_upgrade) {
         loadtest "installation/upgrade_select";
         if (check_var("UPGRADE", "LOW_SPACE")) {
             loadtest "installation/disk_space_fill";
         }
-        if (is_opensuse) {
-            # See https://github.com/yast/yast-packager/pull/385
-            loadtest "installation/online_repos";
-            loadtest "installation/setup_online_repos" if installwithaddonrepos_is_applicable;
-        }
+    }
+    if (is_opensuse) {
+        # See https://github.com/yast/yast-packager/pull/385
+        loadtest "installation/online_repos";
+        loadtest "installation/setup_online_repos" if installwithaddonrepos_is_applicable;
+        loadtest "installation/installation_mode";
     }
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
@@ -964,12 +957,6 @@ sub load_inst_tests {
         loadtest "installation/addon_products_sle";
     }
     if (noupdatestep_is_applicable()) {
-        # On Leap 15.2/TW Lives and Argon there is no network configuration stage
-        if (get_var("LIVECD") && is_leap("<=15.1") && !is_krypton_argon) {
-            loadtest "installation/livecd_network_settings";
-        }
-        # See https://github.com/yast/yast-packager/pull/385
-        loadtest "installation/online_repos" if is_opensuse && is_livecd;
         # Run system_role/desktop selection tests if using the new openSUSE installation flow
         if (is_using_system_role_first_flow && requires_role_selection) {
             load_system_role_tests;

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -21,7 +21,7 @@ sub run {
         assert_screen 'Common-Criteria-Evaluated-Configuration-RN-Next';
         send_key 'alt-n';
     }
-    assert_screen 'partitioning-edit-proposal-button', 40;
+    assert_screen 'partitioning-edit-proposal-button', 180;
     if (check_var('PARTITION_EDIT', 'ext4_btrfs')) {
         send_key 'alt-g';
         send_key 'alt-n';


### PR DESCRIPTION
Instead of calling it in multiple places with various complex conditions and getting it wrong in some cases, just call it in one place that works for all scenarios.

- Verification runs:

TW NET: https://openqa.opensuse.org/tests/3225684
TW DVD offline: https://openqa.opensuse.org/tests/3225683#live
Argon: https://openqa.opensuse.org/tests/3225682#live
Backports 15.4 Incidents: https://openqa.opensuse.org/tests/3225681