### PR TITLE
installation/setup_online_repos: Don't expect the beta warning

### DIFF
--- a/tests/installation/setup_online_repos.pm
+++ b/tests/installation/setup_online_repos.pm
@@ -85,10 +85,6 @@ sub run {
     send_key $cmd{next};    # Next
 
     if (get_var("WITH_MAIN_REPO")) {
-        if (get_var('BETA')) {
-            assert_screen "inst-betawarning", 500;
-            send_key 'alt-o';
-        }
         # older product versions check for same license multiple times so we
         # need to check that
         if (is_sle('<15') || is_leap('<15.0')) {


### PR DESCRIPTION
The beta warning is only shown at the welcome screen.

- Failure: https://openqa.opensuse.org/tests/3225320#step/setup_online_repos/19
- Verification run: https://openqa.opensuse.org/tests/3225707
