### PR TITLE
installation/mediacheck: Reduce the timeout from 1h to 5min

### DIFF
--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -20,9 +20,7 @@ sub run {
     select_bootmenu_more('inst-onmediacheck', 1);
 
     while ($iterations++ < 3) {
-        # the timeout is insane - but some old DVDs took almost forever, could
-        # recheck with all current one and lower again
-        assert_screen [qw(mediacheck-select-device mediacheck-ok mediacheck-checksum-wrong)], 3600;
+        assert_screen [qw(mediacheck-select-device mediacheck-ok mediacheck-checksum-wrong)], 300;
         send_key "ret";
         if (match_has_tag('mediacheck-select-device')) {
             next;


### PR DESCRIPTION
Neither on TW, Leap nor SLE this takes more than 2-3 minutes.
Due to boo#1192829, sometimes mediacheck doesn't start and openQA just wastes
1h of worker time (2h on aarch64 due to TIMEOUT_SCALE).

- Two hours wasted: https://openqa.opensuse.org/tests/3209137
- Verification runs:
Early failure: https://openqa.opensuse.org/tests/3225739
Success: https://openqa.opensuse.org/tests/3225736