### PR TITLE
Add pattern condition for accepting java popup

### DIFF
--- a/tests/installation/confirm_installation.pm
+++ b/tests/installation/confirm_installation.pm
@@ -16,7 +16,7 @@ use version_utils 'is_sle';
 sub run {
     # For SLE 15 SP4 tests that have the Legacy module added during installation, there is
     # additional licence popup that is handled by the following function.
-    if (!(get_var("PATTERNS") =~ /minimal/) && (get_var("SCC_ADDONS") =~ /legacy/) && (is_sle("=15-SP4"))) {
+    if ((get_var("PATTERNS", "") !~ /base,enhanced_base/) && (get_var("SCC_ADDONS") =~ /legacy/) && (is_sle("=15-SP4"))) {
         my $package_license_popup = $testapi::distri->get_accept_popup_controller();
         $package_license_popup->wait_accept_popup({
                 timeout => 3000,


### PR DESCRIPTION
This test fails because of the java popup missing: 
https://openqa.suse.de/tests/10917246

- Related ticket: https://progress.opensuse.org/issues/124140
- Verification run: http://falafel.suse.cz/tests/overview?build=20230412-1&distri=sle&version=15-SP4
http://falafel.suse.cz/tests/1099