### PR TITLE
WIP: PC wait-ssh with 3 checks 

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -353,9 +353,15 @@ sub wait_for_ssh {
     my $check_port = 1;
     my $sleep_period = $args{ignore_wrong_pubkey} ? 20 : 1;
 
+    my $ana = get_var('PUBLIC_CLOUD_WAITSSH_SYSANA', 0);
+    my $command = $ana ? 'systemd-analyze time' : 'sudo systemctl is-system-running --wait';
+    my $output;
+    my $output2;
+
     # Looping until reaching timeout or passing two conditions :
     # - SSH port 22 is reachable
-    # - journalctl got message about reaching one of certain targets
+    # - Startup time successfully collected or is-system-running true
+    #   - journalctl got message about reaching one of certain targets
     while ((my $duration = time() - $start_time) < $args{timeout}) {
         if ($check_port) {
             $check_port = 0 if (script_run('nc -vz -w 1 ' . $self->{public_ip} . ' 22', quiet => 1) == 0);
@@ -363,29 +369,43 @@ sub wait_for_ssh {
         else {
             # On boottime test we do hard reboot which may change the instance address
             script_run("ssh-keyscan $args{public_ip} | tee -a ~/.ssh/known_hosts") if (get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME'));
-
-            my $output = $self->run_ssh_command(
+            $output = $self->run_ssh_command(
+                # cmd => 'sudo journalctl -b | grep -E "Reached target (Cloud-init|Default|Main User Target)"',
+                cmd => $command,
+                proceed_on_failure => 1,
+                username => $args{username});
+            $output2 = $self->run_ssh_command(
                 cmd => 'sudo journalctl -b | grep -E "Reached target (Cloud-init|Default|Main User Target)"',
                 proceed_on_failure => 1,
                 username => $args{username});
-            if ($output =~ m/Reached target.*/) {
+            if ($output2 =~ m/Reached target /) {
+                record_info("CHECK SSH J", "wait ssh journal OK " . $duration . "s\n" . "System: " . $output2);
+            }
+            if (($output =~ m/running|degraded/i and !$ana) or ($output =~ m/Startup finished in/ and $ana)) {
+                # DEBUG print
+                record_info("CHECK SSH", "wait ssh OK " . $duration . "s\n" . "System: " . $output);
+                $self->journal_upload("/tmp/waitssh_journal.txt", username => $args{username});
                 return $duration;
             }
             elsif ($output =~ m/Permission denied \(publickey\).*/) {
                 die "ssh permission denied (pubkey)" unless $args{ignore_wrong_pubkey};
             }
+            elsif (defined $output && length $output > 0 && !$ana) {
+                last;    # loop break error
+            }
         }
         sleep $sleep_period;
     }
 
+    # DEBUG print
+    record_info("CHECK SSH", "wait ssh NOK " . time() - $start_time . "s\n" . "System: " . $output);
     script_run("ssh  -i /root/.ssh/id_rsa -v $args{username}\@$args{public_ip} true", timeout => 360);
-    # Debug output: We have occasional error in 'journalctl -b' - see poo#96464 - this will be removed soon.
-    # Exclude 'mr_test/saptune' test case as it will introduce random softreboot failures.
-    if (!get_var('PUBLIC_CLOUD_SLES4SAP')) {
-        $self->run_ssh_command(cmd => 'sudo journalctl -b', proceed_on_failure => 1, username => $args{username}, timeout => 360);
-    }
 
     unless ($args{proceed_on_failure}) {
+        # Debug output: We have occasional error in 'journalctl -b' - see poo#96464 - this will be removed soon.
+        # Exclude 'mr_test/saptune' test case as it will introduce random softreboot failures.
+        $self->journal_upload("/tmp/waitssh_journal_ko.txt", username => $args{username});
+
         my $error_msg;
         if ($check_port) {
             $error_msg = sprintf("Unable to reach SSH port of instance %s with public IP:%s within %d seconds", $self->{instance_id}, $self->{public_ip},
@@ -399,6 +419,21 @@ sub wait_for_ssh {
     }
 
     return;
+}
+
+sub journal_upload {
+    my ($self, $log, %args) = @_;
+    my $usr = $args{username};
+    my $com = 'sudo journalctl -b --no-pager| grep -iE "Reached target" > ' . $log;
+    eval {
+        if (!get_var('PUBLIC_CLOUD_SLES4SAP')) {
+            $self->run_ssh_command(cmd => $com, proceed_on_failure => 1, username => $usr, timeout => 360);
+            $self->upload_log($log, failok => 1);
+        }
+    };
+    if ($@) {
+        print "ERR: $@\n";
+    }
 }
 
 =head2 softreboot


### PR DESCRIPTION
PR for inspection only.

P.C. `wait-for-ssh` has been almost rewitten, to detect the system-up condition, running 3 differents chk types, in sequence, from a `@command` array.
This draft PR has been created to show the strucutre and identify the best command to use.

Related ticket: https://progress.opensuse.org/issues/126218 poo
Needles:none
Verification run: [3814](http://10.168.4.117/tests/3814), [3816](http://10.168.4.117/tests/3816)
More tests coming soon
