### PR TITLE
Fix needle match timeout for firefox_appearance test

### DIFF
--- a/tests/x11/firefox/firefox_appearance.pm
+++ b/tests/x11/firefox/firefox_appearance.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2016 SUSE LLC
+# Copyright 2012-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: MozillaFirefox
@@ -13,7 +13,7 @@
 # - Open url "addons.mozilla.org/en-US/firefox/addon/opensuse" and check
 # - Install opensuse theme and check
 # - Exit firefox
-# Maintainer: wnereiz <wnereiz@gmail.com>
+# Maintainer: wnereiz <wnereiz@gmail.com>, QE Core <qe-core@suse.de>
 
 use strict;
 use warnings;
@@ -31,15 +31,9 @@ sub run {
 
     $self->firefox_open_url('addons.mozilla.org/en-US/firefox/addon/opensuse');
     assert_screen('firefox-appearance-mozilla_addons');
-    for (1 .. 3) {
-        assert_and_click 'firefox-appearance-addto';
-        if (check_screen("firefox-appearance-addto-permissions_requested", 10)) {
-            assert_and_click "firefox-appearance-addto-permissions_requested";
-            # poo#124095, sporadic issue for matching 'firefox-appearance-installed'
-            wait_still_screen 60;
-        }
-        last if check_screen 'firefox-appearance-installed', 90;
-    }
+    assert_and_click('firefox-appearance-addto');
+    assert_and_click('firefox-appearance-addto-permissions_requested');
+    assert_screen 'firefox-appearance-installed', 120;
     # on SLE 12 window gets unselected after pop-up is handled
     assert_and_click 'firefox-appearance-mozilla_addons' if is_sle('<15');
     $self->exit_firefox;


### PR DESCRIPTION
https://progress.opensuse.org/issues/127511

At the same time, remove the loop to match the needle
- Verification run:
[QEM](https://openqa.suse.de/tests/overview?distri=sle&build=rfan0417)
[SLE15SP5](https://openqa.suse.de/tests/overview?build=rfan0417_1&version=15-SP5&distri=sle&test=firefox_desktop)
- Needles: Added via openQA webUI