### PR TITLE
Use ovmf xen firmware for uefi guest on SLE 15 host

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -26,7 +26,7 @@
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>http://dist.suse.de/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms.bin,loader_type=pflash</guest_boot_settings>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant></guest_os_variant>
     <guest_storage_path></guest_storage_path>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -26,7 +26,7 @@
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms.bin,loader_type=pflash</guest_boot_settings>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant></guest_os_variant>
     <guest_storage_path></guest_storage_path>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -26,7 +26,7 @@
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP5-Full-x86_64-Build12345-Media1</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms.bin,loader_type=pflash</guest_boot_settings>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant></guest_os_variant>
     <guest_storage_path></guest_storage_path>


### PR DESCRIPTION
* **Recent** uefi guest installation on 15-SP4/SP5 xen host failed because text console can not be opened for yast2 installation, which has something to do with ovmf firmware used, for example, [this one](https://openqa.suse.de/tests/10929519#step/unified_guest_installation/1015).

* **After** looking into ovmf firmware definition, it seems that ```ovmf-x86_64-xen-4m.bin``` is the right one to be used because it is used for xenfv virtual machine specifically.

* **The** firmware auto-selection feature for Xen virtual machine also prefers ```ovmf-x86_64-xen-4m.bin```.

* **Verification runs:**
  * [uefi 15sp5 on 15sp5](https://openqa.suse.de/tests/10932004)
  * [uefi 15sp4 on 15sp5](https://openqa.suse.de/tests/10932007)
  * [uefi 15sp5 on 15sp4](https://openqa.suse.de/tests/10937285)
  * [uefi 12sp5 on 15sp5](https://openqa.suse.de/tests/10937308)
