### PR TITLE
switch_to_wicked: configure dhcp after switching to wicked

### DIFF
--- a/tests/console/switch_to_wicked.pm
+++ b/tests/console/switch_to_wicked.pm
@@ -11,6 +11,7 @@ use y2_module_basetest;
 use strict;
 use warnings;
 use testapi;
+use mm_network;
 
 sub run {
     my ($self) = shift;
@@ -18,6 +19,7 @@ sub run {
     ensure_installed 'wicked';
     select_console 'root-console';
     $self->use_wicked_network_manager;
+    configure_dhcp;
 }
 
 1;


### PR DESCRIPTION
Switching from NetworkManager to wicked requires also wicked to be configured

- Related ticket: https://progress.opensuse.org/issues/125864
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3230050
