### PR TITLE
Modify guest installation schedule for guest migration

### DIFF
--- a/schedule/qam/common/virt/qam_virt_install_guest.yaml
+++ b/schedule/qam/common/virt/qam_virt_install_guest.yaml
@@ -1,11 +1,11 @@
 ---
 name: qam_virt_install_guest
 description:    >
+  Maintainer: roy.cai@suse.com, qe-virt@suse.de
   Install guest VMs for virtualization tests.
 schedule:
   - virt_autotest/login_console
-  - virtualization/universal/prepare_guests
-  - virtualization/universal/waitfor_guests
+  - '{{install_guests}}'
   - '{{patch_host_guest_zypper}}'
   - virtualization/universal/kernel
   - virtualization/universal/finish
@@ -27,3 +27,8 @@ conditional_schedule:
       'qemu':
         - virt_autotest/login_console
         - virtualization/universal/list_guests
+  install_guests:
+    INSTALL_GUEST:
+      '1':
+        - virtualization/universal/prepare_guests
+        - virtualization/universal/waitfor_guests


### PR DESCRIPTION
poo#https://progress.opensuse.org/issues/124928
Modify guest installation schedule for guest migration to keep job running well.

- Related ticket: https://progress.opensuse.org/issues/124928
- Needles: N/A
- Verification run: [kvm test](http://openqa.qam.suse.cz/tests/52715), [xen test](http://openqa.qam.suse.cz/tests/52713), [kvm migration test](http://openqa.qam.suse.cz/tests/overview?build=:S:M:28650:295434:64bit-guest-mi-ipmi:12-SP5:g_m_test:&distri=sle&version=12-SP5&groupid=149),  [xen migration test](http://openqa.qam.suse.cz/tests/overview?build=:S:M:28650:295434:64bit-guest-mi-ipmi-group2:12-SP5:g_m_test:&distri=sle&version=12-SP5&groupid=160)
