### PR TITLE
Increase timeout for boot log collection

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -387,7 +387,7 @@ sub cleanup {
 
     my $id = $args->{my_instance}->{instance_id};
 
-    script_run("az vm boot-diagnostics get-boot-log --ids $id | jq -r '.' > bootlog.txt");
+    script_run("az vm boot-diagnostics get-boot-log --ids $id | jq -r '.' > bootlog.txt", timeout => 120, die_on_timeout => 0);
     upload_logs("bootlog.txt", failok => 1);
 
     $self->SUPER::cleanup();


### PR DESCRIPTION
Increase the timeout for collecting the boot-diagnostics (i.e. serial terminal) log on Azure.

- Related failure: https://openqa.suse.de/tests/10929910#step/ssh_interactive_end/31
- Verification run: https://openqa.suse.de/tests/10932333
