### PR TITLE
Remove Java popup handling

### DIFF
--- a/tests/installation/confirm_installation.pm
+++ b/tests/installation/confirm_installation.pm
@@ -9,22 +9,9 @@
 
 use strict;
 use warnings;
-use testapi;
 use base 'y2_installbase';
-use version_utils 'is_sle';
 
 sub run {
-    # For SLE 15 SP4 tests that have the Legacy module added during installation, there is
-    # additional licence popup that is handled by the following function.
-    if ((get_var("PATTERNS", "") !~ /base,enhanced_base/) && (get_var("SCC_ADDONS") =~ /legacy/) && (is_sle("=15-SP4"))) {
-        my $package_license_popup = $testapi::distri->get_accept_popup_controller();
-        $package_license_popup->wait_accept_popup({
-                timeout => 3000,
-                interval => 2,
-                message => 'Accept license popup did not appear'});
-        save_screenshot;
-        $package_license_popup->accept();
-    }
     my $install_popup = $testapi::distri->get_ok_popup_controller();
     $install_popup->accept();
 }


### PR DESCRIPTION
On current maintenance updtaes, there is no update for java package , so the license popup does nto appear anymore and the java handling solution is causing new failures.

- Related ticket: https://progress.opensuse.org/issues/127529
- Verification runs: http://falafel.suse.cz/tests/overview?build=20230416-1&distri=sle&version=15-SP4
