### PR TITLE
Increase timeout value for startupdate

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -31,9 +31,9 @@ sub run {
     # Also, virtual machines for testing can be really slow in this step
     my $started_timeout = get_var('LIVECD') ? 1200 : 300;
     if (is_upgrade) {
+        wait_still_screen 2;
         send_key $cmd{update};
-        sleep 1;
-        assert_screen [qw(startupdate startupdate-conflict license-popup)], 5;
+        assert_screen [qw(startupdate startupdate-conflict license-popup)], 10;
 
         while (match_has_tag("startupdate-conflict") || match_has_tag("license-popup")) {
             if (match_has_tag("startupdate-conflict")) {


### PR DESCRIPTION
We need wait more time for 'startupdate'.

- Related ticket: https://progress.opensuse.org/issues/127715
- Needles: N/A
- Verification run: 
  http://openqa.suse.de/tests/10932788#
  http://openqa.suse.de/tests/10932789#
  http://openqa.suse.de/tests/10932790#
  http://openqa.suse.de/tests/10932791#
  http://openqa.suse.de/tests/10932793#
