### PR TITLE
Fix kubectl test when loadbalancer is pending

### DIFF
--- a/tests/containers/kubectl.pm
+++ b/tests/containers/kubectl.pm
@@ -125,7 +125,8 @@ sub run {
     $pid = background_script_run('kubectl port-forward deploy/nginx-deployment 8008:80');
     validate_script_output_retry("curl http://localhost:8008/index.html", qr/I am Groot/, retry => 6, delay => 20, timeout => 10);
     assert_script_run("kill $pid");    # terminate port-forwarding
-    my $ip = script_output("kubectl get services | awk '/web-load-balancer/ {print \$4}'s");
+    my $output = script_output("kubectl describe services/web-load-balancer");
+    my ($ip) = $output =~ /IP:\s+([^\s]+)/;
     record_info('Balancer IP', $ip);
     validate_script_output_retry("curl http://$ip:8080/index.html", qr/I am Groot/, retry => 6, delay => 20, timeout => 10);
 


### PR DESCRIPTION
If the LB is pending, the current code gets pending as the IP. Changed the way to obtain the IP to solve the problem

- Related ticket: https://progress.opensuse.org/issues/126926
- Verification run: [openqa.mypersonalinstance.de/tests/xyz#step/module/x](https://openqa.suse.de/tests/10933038#step/kubectl/227)
