### PR TITLE
Defer hostname test until installation end

### DIFF
--- a/schedule/security/create_hdd_ntlm.yaml
+++ b/schedule/security/create_hdd_ntlm.yaml
@@ -11,7 +11,6 @@ schedule:
   - '{{no_sep_home}}'
   - installation/partitioning_finish
   - installation/installer_timezone
-  - installation/hostname_inst
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
@@ -24,6 +23,7 @@ schedule:
   - boot/reconnect_mgmt_console
   - '{{grub_test}}'
   - installation/first_boot
+  - console/hostname
 conditional_schedule:
   no_sep_home:
     ARCH:


### PR DESCRIPTION
A leftout from last refactoring, emerged only after latest ppc64le fixes; we check for proper hostname setting after the installation finishes.

- Related ticket: https://progress.opensuse.org/issues/127544
- Verification run: https://openqa.suse.de/tests/10932795

note: the test `create_hdd_textmode_hmc_ntlm` currently is scheduled only on [ppc64le](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=93.1&groupid=268) 