### PR TITLE
gedit: ensure_installed before running it

### DIFF
--- a/tests/x11/gedit.pm
+++ b/tests/x11/gedit.pm
@@ -18,6 +18,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
+    ensure_installed('gedit');
     x11_start_program('gedit');
     $self->enter_test_text('gedit', slow => 1);
     assert_screen 'test-gedit-1';


### PR DESCRIPTION
Ensure gedit is installed before launching it
GNOME changes the default text-editor from gedit to gnome-text-editor

- Related ticket: https://build.opensuse.org/request/show/1079456
- Needles: N/A
- Verification run: N/A
