### PR TITLE
extra_tests_kernel: Add BCC tools test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2539,7 +2539,11 @@ sub load_extra_tests_kernel {
     loadtest "kernel/module_build";
     loadtest "kernel/tuned";
     loadtest "kernel/fwupd" if is_sle('15+');
-    loadtest "kernel/bpftrace" if is_tumbleweed || is_sle('>=15-sp5');
+
+    if (is_tumbleweed || is_sle('>=15-sp5')) {
+        loadtest "kernel/bpftrace";
+        loadtest "kernel/bcc";
+    }
 }
 
 # Scheduling set for validation of specific installation

--- a/tests/kernel/bcc.pm
+++ b/tests/kernel/bcc.pm
@@ -1,0 +1,30 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Package: bpftrace
+# Summary: Compile and attach eBPF probes with BCC tools
+# Maintainer: kernel-qa@suse.de
+
+use Mojo::Base qw(opensusebasetest);
+use testapi;
+use utils 'zypper_call';
+use version_utils 'is_sle';
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+
+    zypper_call('in bcc-tools');
+
+    my $tools_dir = '/usr/share/bcc/tools';
+
+    assert_script_run("$tools_dir/btrfsdist 5 2");
+    assert_script_run("$tools_dir/btrfsslower -d 10");
+    assert_script_run("$tools_dir/filetop -a 5 10");
+}
+
+1;
+
+=head1 Discussion
+
+Smoke test for a small selection of BCC tools.


### PR DESCRIPTION
Add smoke test for BCC. There are many BCC tools and they all are different. So this just selects a few which might be interesting to us.

Note that it doesn't check the output yet because I want to figure out how to properly do that with bpftrace first. Also a lot of these tools have upstream issues and are inherently flaky. We are only running them to make sure the compiler framework and kernel work.

@czerw @pevik 