### PR TITLE
Remove unused needle & update record_info syntax

### DIFF
--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -80,9 +80,6 @@ sub run {
     background_script_run("x3270 -trace $noverifycert -tracefile $tracelog_file L:localhost:8443");
     wait_still_screen;
 
-    # This needle can be removed in the future (poo#127730):
-    # assert_screen 'x3270_fips_launched_with_TLS_SSL';
-
     # Exit and back to generic desktop
     send_key "ctrl-c";
     send_key "alt-tab";
@@ -94,7 +91,8 @@ sub run {
     send_key "ctrl-c";
     clear_console;
 
-    record_info 'SSL Trace', 'x3270-trace.log contains passed SSL negotiation data';
+    # Check trace log
+    record_info("SSL Trace", "x3270-trace.log contains passed SSL negotiation data");
     assert_script_run("grep 'Cipher: TLS_AES_256_GCM_SHA384' /tmp/x3270-trace.log");
     assert_script_run("grep 'SSL_connect trace: SSLOK  SSL negotiation finished successfully' /tmp/x3270-trace.log");
 


### PR DESCRIPTION
Removing unused needle. The syntax of `record_info` has also been changed to be the same as the rest in the entire document.

- Related ticket: https://progress.opensuse.org/issues/127814
- Verification run: https://openqa.suse.de/tests/10937670

Since no significant logic changes were made, one test run is sufficient (only checking syntax, not test itself).
