### PR TITLE
Add container schedule for SLEM on PC

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -14,7 +14,7 @@ use Exporter;
 use main_common;
 use main_containers qw(load_container_tests is_container_test);
 use testapi qw(check_var get_required_var get_var set_var);
-use version_utils qw(is_microos is_sle_micro is_leap_micro is_alp is_staging is_released is_transactional is_rt);
+use version_utils;
 use utils;
 use Utils::Architectures;
 use Utils::Backends;
@@ -266,7 +266,29 @@ sub load_journal_check_tests {
     loadtest 'shutdown/shutdown';
 }
 
+sub load_slem_on_pc_tests {
+    my $args = OpenQA::Test::RunArgs->new();
+
+    loadtest("boot/boot_to_desktop");
+    loadtest("publiccloud/prepare_instance", run_args => $args);
+    loadtest("publiccloud/registration", run_args => $args);
+    loadtest("publiccloud/ssh_interactive_start", run_args => $args);
+    loadtest("publiccloud/instance_overview", run_args => $args);
+    loadtest("publiccloud/slem_prepare", run_args => $args);
+
+    if (get_var("PUBLIC_CLOUD_CONTAINERS")) {
+        load_container_tests() if is_container_test;
+    }
+    loadtest("publiccloud/ssh_interactive_end", run_args => $args);
+}
+
 sub load_tests {
+    # SLEM on PC
+    if (is_public_cloud()) {
+        load_slem_on_pc_tests;
+        return 1;
+    }
+
     if (is_kernel_test()) {
         load_kernel_tests;
         return 1;

--- a/tests/publiccloud/slem_prepare.pm
+++ b/tests/publiccloud/slem_prepare.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Prepare SLEM on PC for testing
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use transactional qw(trup_call process_reboot);
+
+sub run {
+    my ($self, $args) = @_;
+    my $instance = $args->{my_instance};
+    select_serial_terminal;
+
+    if (get_var("PUBLIC_CLOUD_CONTAINERS")) {
+        my $runtime = get_required_var('CONTAINER_RUNTIME');
+        # Install packages for container test runs
+        trup_call("pkg install $runtime toolbox");
+        $instance->softreboot();
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+


### PR DESCRIPTION
Adds code to allow scheduling of container test runs for SLEM on PC.

- Related ticket: https://progress.opensuse.org/issues/110791
- Verification run: [podman](https://duck-norris.qe.suse.de/tests/12581) | [docker](https://duck-norris.qe.suse.de/tests/12583)
