### PR TITLE
Public Cloud wait_for_ssh routine refactored and system-up check updated

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -298,6 +298,9 @@ publiccloud::instance objects.
 C<image>         defines the image_id to create the instance.
 C<instance_type> defines the flavor of the instance. If not specified, it will load it
                      from PUBLIC_CLOUD_INSTANCE_TYPE.
+C<timeout>             Parameter to pass to instance::wait_for_ssh.
+C<ignore_wrong_pubkey> Same as timeout.
+C<proceed_on_failure>  Same as timeout.
 
 =cut
 
@@ -310,7 +313,9 @@ sub create_instances {
     foreach my $instance (@vms) {
         record_info("INSTANCE", $instance->{instance_id});
         if ($args{check_connectivity}) {
-            $instance->wait_for_ssh();
+            $instance->wait_for_ssh(timeout => $args{timeout},
+                ignore_wrong_pubkey => $args{ignore_wrong_pubkey},
+                proceed_on_failure => $args{proceed_on_failure});
             # Install server's ssh publicckeys to prevent authenticity interactions
             assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
         }

--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -71,7 +71,7 @@ sub run {
     $instance->softreboot();
     $instance->run_ssh_command(cmd => 'sudo sestatus | grep disabled');
     $instance->run_ssh_command(cmd => 'sudo transactional-update -n setup-selinux');
-    $instance->softreboot();
+    $instance->softreboot(ignore_wrong_pubkey => 1);
 
     # SElinux and logging tests
     $instance->run_ssh_command(cmd => 'sudo sestatus | grep enabled');


### PR DESCRIPTION
Public cloud `wait_for_ssh` routine code has been refactored and updated.

The changes topics are:
* routine structure improved,split in 3 blocks,ssh-port check,system-up check,result report;
* system-up check improved using `systemctl is-system-running`, more reliable than journal inspection;
* report on final status improved, also returned when `die(croak)`, helping in debugging;
* description in head section improved, parameters meaning and usage detailed;
* start-up phases detailed in inner loop, providing precise details on the status detected;
* new option `systemup_check`, to check on-demand ssh-open only and skip system-up check;
* new option `wait_stop`, to wait until ssh-closed,instead of open,improving shutdown/reboot checks;
* new option `logs`, _journalctl_ uploaded to test logs, instead of printed on ouptput, _logs=0_ to skip;
* softreboot routine updated to use `wait_stop` option.
* slem_basic last SElinux reboot allowed to retry loop.
* create_instance error handling args added for eventual wait_for_ssh call setting.

Related ticket: poo [126218](https://progress.opensuse.org/issues/126218) 
Needles: no change
Verification run: see VRs in the next posts below.