### PR TITLE
Ensure 'Add' button clicked in Network Settings

### DIFF
--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -17,6 +17,7 @@ use warnings;
 use testapi;
 use y2_module_basetest 'is_network_manager_default';
 use version_utils 'is_sle';
+use YaST::workarounds;
 
 sub run {
 
@@ -57,12 +58,14 @@ sub run {
     unless (is_network_manager_default) {
         send_key $cmd{overview_tab};
         assert_screen 'yast2-network-settings_overview';
+        wait_still_screen 2;
         send_key $cmd{add_device};
         # Older than 15-SP2 versions require two steps to select device type: expand the list and then select the option.
         # On 15-SP2 it is a list of radio buttons, so only one step with selecting the radio is needed.
         if (is_sle('<15-SP2')) {
             assert_and_click 'yast2-network-settings_overview_hardware-dialog_device-type';
         }
+        apply_workaround_poo124652('yast2-network-settings_overview_hardware-dialog_device-type_bridge');
         assert_and_click 'yast2-network-settings_overview_hardware-dialog_device-type_bridge';
         send_key $cmd{next};
         assert_screen 'yast2-network-settings_overview_network-card-setup';


### PR DESCRIPTION
We need ensure 'Add' button clicked in Network Settings, and there is refreshment issue for ' yast2-network-settings_overview_hardware-dialog_device-type_bridge', so add workaround for it.

- Related ticket: https://progress.opensuse.org/issues/127607
- Needles: N/A
- Verification run:  https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=lemon-suse%2Fos-autoinst-distri-opensuse%23ensure-add-button-clicked-network-setting&flavor=Online
 job for the glitch issue:  https://openqa.suse.de/tests/10971316#step/yast2_network_settings/18
