### PR TITLE
[WIP] kernel/run_ltp.pm: Improve timeout capabilities

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -20,6 +20,7 @@ use Utils::Architectures;
 
 our @EXPORT = qw(
   get_ltproot
+  get_ltp_mul
   get_ltp_openposix_test_list_file
   get_ltp_version_file
   init_ltp_tests
@@ -132,12 +133,21 @@ sub log_versions {
     script_run('aa-enabled; aa-status');
 }
 
+sub get_ltp_mul {
+    # default timeout multiplicator, e.g. LTP_TIMEOUT_MUL_aarch64
+    my $mul = get_var('LTP_TIMEOUT_MUL') || 1;
+
+    # arch specific timeout multiplicator, e.g. LTP_TIMEOUT_MUL_aarch64
+    $mul = get_var('LTP_TIMEOUT_MUL_' . get_required_var('ARCH')) || $mul;
+
+    return $mul;
+}
 
 # Set up basic shell environment for running LTP tests
 sub prepare_ltp_env {
     my $ltp_env = get_var('LTP_ENV');
 
-    assert_script_run('export LTPROOT=' . get_ltproot() . '; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
+    assert_script_run('export LTPROOT=' . get_ltproot() . '; export LTP_COLORIZE_OUTPUT=n LTP_TIMEOUT_MUL=' . get_ltp_mul() . ' TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 
     # setup for LTP networking tests
     assert_script_run("export PASSWD='$testapi::password'");


### PR DESCRIPTION
Add new variables to specify timeout for particular arch or test only.

* `LTP_TIMEOUT_test` (e.g.  `LTP_TIMEOUT_zram01`) Test specific timeout in sec (overrides `LTP_TIMEOUT`).

* `LTP_TIMEOUT_MUL` Multiplies the timeout. Also exported as environment variable for LTP (originally LTP variable).

* `LTP_TIMEOUT_MUL_arch` (e.g. `LTP_TIMEOUT_MUL_aarch64`) Multiplicator for specific arch (overrides `LTP_TIMEOUT_MUL`, also exported as `LTP_TIMEOUT_MUL` for LTP).

=> I would add `LTP_TIMEOUT_MUL_aarch64=3` to aarch64 workers we use or to aarch64 media type.
Also add test specific timeout to testsuites, e.g. `LTP_TIMEOUT_zram01=1800`.

Also it's a question if use somehow `TIMEOUT_SCALE` (used in `ltp_syscalls_baremetal` in http://openqa.qam.suse.cz/tests/52619#settings).

Verification run: TODO
