### PR TITLE
Wicked: ignore bonding_masters interface on ppc64le

### DIFF
--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -59,7 +59,8 @@ Return first NIC which is not loopback
 sub iface {
     my ($quantity) = @_;
     $quantity ||= 1;
-    return script_output('ls /sys/class/net/ | grep -v lo | head -' . $quantity);
+    # bonding_masters showing up in ppc64le jobs in 15-SP5: bsc#1210641
+    return script_output('ls /sys/class/net/ | grep -v lo | grep -v bonding_masters | head -' . $quantity);
 }
 
 =head2 can_upload_logs

--- a/tests/wicked/basic/sut/t01_basic.pm
+++ b/tests/wicked/basic/sut/t01_basic.pm
@@ -51,7 +51,7 @@ sub run {
     if (arrays_differ(\@wicked_all_ifaces, \@ls_all_ifaces)) {
         diag "expected list of interfaces: @wicked_all_ifaces";
         diag "actual list of interfaces: @ls_all_ifaces";
-        die "Wrong list of interfaces from wicked";
+        die "Wrong list of interfaces from wicked @ls_all_ifaces";
     }
     record_info('Test 6', 'Bring an interface down with wicked');
     $self->wicked_command('ifdown', $ctx->iface());


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/120127
- VR: https://openqa.suse.de/tests/10947641

bug reported: https://bugzilla.suse.com/show_bug.cgi?id=1210641
