### PR TITLE
containers: ensure k3s has the default serviceaccount

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -62,6 +62,8 @@ sub install_k3s {
     script_run("mkdir -p ~/.kube");
     script_run("rm -f ~/.kube/config");
     assert_script_run("ln -s /etc/rancher/k3s/k3s.yaml ~/.kube/config");
+    sleep 60;
+    script_retry("kubectl get serviceaccount default -o name", delay => 60, retry => 3);
     record_info('k3s', "k3s installed");
 }
 


### PR DESCRIPTION
When k3s is installed (utils::install_k3s) it needs some time to be ready to accept the creation of pods.

- Related ticket: https://progress.opensuse.org/issues/127955
- Verification run: http://openqa.suse.de/tests/10948319
