### PR TITLE
Nvidia trust drivers screen moved in WSL YaST install

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -94,7 +94,11 @@ sub register_via_scc {
     wait_screen_change(sub { send_key 'alt-c' }, 10);
     wait_screen_change { type_string $reg_code, max_interval => 125, wait_screen_change => 2 };
     send_key 'alt-n';
-    assert_screen 'wsl-registration-repository-offer', 180;
+    if (is_sle('>=15-SP5')) {
+        assert_screen 'trust_nvidia_gpg_keys', timeout => 240;
+        send_key 'alt-t';
+    }
+    assert_screen 'wsl-registration-repository-offer', timeout => 240;
     send_key 'alt-y';
     assert_screen 'wsl-extension-module-selection';
     send_key 'alt-n';
@@ -127,7 +131,7 @@ sub run {
         enter_user_details([$realname, undef, $password, $password]);
         send_key 'alt-n';
         # wsl-gui pattern installation (only in SLE15-SP4+ by now)
-        wsl_gui_pattern if (is_sle('15-SP4+'));
+        wsl_gui_pattern if (is_sle('>=15-SP4'));
         # Registration
         is_sle && register_via_scc();
         # SLED Workstation license agreement and trust nVidia GPG keys


### PR DESCRIPTION
While installing WSL, the order of the screens have changed so now there's a Nvidia driver trust screen before choosing the repos. This only happens in 15-SP5.

- Related ticket: https://progress.opensuse.org/issues/127010
- Verification run: 
  - https://openqa.suse.de/tests/10948602
  - https://openqa.suse.de/tests/10948601