### PR TITLE
Bump timeout for mediacheck in aarch64

### DIFF
--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -12,15 +12,17 @@ use strict;
 use warnings;
 use testapi;
 use bootloader_setup qw(ensure_shim_import select_bootmenu_more);
+use Utils::Architectures 'is_aarch64';
 
 sub run {
     my $self = shift;
     my $iterations = 0;
+    my $timeout = (is_aarch64) ? 600 : 300;
     ensure_shim_import;
     select_bootmenu_more('inst-onmediacheck', 1);
 
     while ($iterations++ < 3) {
-        assert_screen [qw(mediacheck-select-device mediacheck-ok mediacheck-checksum-wrong)], 300;
+        assert_screen [qw(mediacheck-select-device mediacheck-ok mediacheck-checksum-wrong)], $timeout;
         send_key "ret";
         if (match_has_tag('mediacheck-select-device')) {
             next;


### PR DESCRIPTION
Bump timeout for mediacheck in aarch64
- Related ticket: https://progress.opensuse.org/issues/127976
- Verification run:https://openqa.suse.de/tests/10952875#details