### PR TITLE
Improve the check of the PowerShell screen

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base qw(windowsbasetest);
 use testapi;
+use utils qw(enter_cmd_slow);
 use version_utils qw(is_sle);
 use wsl qw(is_sut_reg is_fake_scc_url_needed);
 
@@ -165,17 +166,17 @@ sub run {
     # Nothing to do in WSL2 pts w/o serialdev support
     # https://github.com/microsoft/WSL/issues/4322
     if (get_var('WSL2')) {
-        enter_cmd "exit";
+        enter_cmd_slow "exit\n";
         return;
     }
 
     is_fake_scc_url_needed || become_root;
     assert_script_run 'cd ~';
     assert_script_run "zypper ps";
-    enter_cmd 'exit';
+    enter_cmd_slow "exit\n";
     sleep 3;
     save_screenshot;
-    is_fake_scc_url_needed || enter_cmd 'exit';
+    is_fake_scc_url_needed || enter_cmd_slow "exit\n";
 }
 
 sub post_fail_hook {

--- a/tests/wsl/wsl_cmd_check.pm
+++ b/tests/wsl/wsl_cmd_check.pm
@@ -19,8 +19,6 @@ my %expected = (
 sub run {
     my $self = shift;
 
-    assert_and_click 'powershell-as-admin-window';
-    enter_cmd 'exit';
     $self->open_powershell_as_admin();
     $self->run_in_powershell(cmd => 'wsl --list --verbose', timeout => 60);
     $self->run_in_powershell(cmd => "wsl mount | Select-String -Pattern $expected{mount}", timeout => 60);


### PR DESCRIPTION
The PowerShell screen sometimes stays at the background and creates an incorrect scenario, because the commands are not being typed

- Related ticket: https://progress.opensuse.org/issues/126725
- Verification run:
  - https://openqa.suse.de/tests/10953266
