### PR TITLE
Workaround for iscsi failure to connect after boot

### DIFF
--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -45,20 +45,7 @@ sub run {
 
     # Workaround network timeout issue during upgrade
     if (get_var('HDDVERSION')) {
-        assert_script_run 'journalctl -b --no-pager -o short-precise > bsc1129385-check-journal.log';
-        my $iscsi_fails = script_run 'grep -q "iscsid: cannot make a connection to" bsc1129385-check-journal.log';
-        my $csync_fails = script_run 'grep -q "corosync.service: Failed" bsc1129385-check-journal.log';
-        my $pcmk_fails = script_run 'grep -E -q "pacemaker.service.+failed" bsc1129385-check-journal.log';
-
-        if (defined $iscsi_fails and $iscsi_fails == 0 and defined $csync_fails
-            and $csync_fails == 0 and defined $pcmk_fails and $pcmk_fails == 0)
-        {
-            record_soft_failure "bsc#1129385";
-            upload_logs 'bsc1129385-check-journal.log';
-            $iscsi_fails = script_run 'grep -q LIO-ORG /proc/scsi/scsi';
-            systemctl 'restart iscsi' if ($iscsi_fails);
-            systemctl 'restart pacemaker';
-        }
+        check_iscsi_failure;
     }
 
     # Check iSCSI server is connected

--- a/tests/ha/migrate_clvmd_to_lvmlockd.pm
+++ b/tests/ha/migrate_clvmd_to_lvmlockd.pm
@@ -23,6 +23,9 @@ sub run {
     # We may execute this test after a reboot, so we need to log in
     select_console 'root-console';
 
+    # workaround for bsc#1129385
+    check_iscsi_failure;
+
     # Only perform clvm to lvmlockd migration if the cluster is up and has clvm resources
     assert_script_run $crm_mon_cmd;
     my $clvm_rsc = script_run "grep -wq clvm <($crm_mon_cmd)";


### PR DESCRIPTION
Workaround for issues found on migrate_clvmd_to_lvmlockd and check_after_reboot related 
to network starting to late and iscsi failing, causing a cascade effect that leads to pacemaker start failure.

fixes:_
TEAM-7786
TEAM-7788

Contains fixes from:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/master...lpalovsky:os-autoinst-distri-opensuse:Wait_for_supportserver

VR:
https://openqa.suse.de/tests/10953277
https://openqa.suse.de/tests/10953330
https://openqa.suse.de/tests/10953892
https://openqa.suse.de/tests/10953888
https://openqa.suse.de/tests/10953877
https://openqa.suse.de/tests/10954017

Failures:
https://openqa.suse.de/tests/10940657
https://openqa.suse.de/tests/10940659
https://openqa.suse.de/tests/10940612
https://openqa.suse.de/tests/10942056
https://openqa.suse.de/tests/10942058
https://openqa.suse.de/tests/10946404
