### PR TITLE
Fix schedule for MicroOS and SLE-Micro

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -34,11 +34,6 @@ sub is_regproxy_required {
 }
 
 sub load_config_tests {
-    if (is_microos && !is_staging) {
-        loadtest 'update/zypper_clear_repos';
-        loadtest 'console/zypper_ar';
-        loadtest 'console/zypper_ref';
-    }
     loadtest 'transactional/tdup' if get_var('TDUP');
     loadtest 'transactional/host_config' unless is_dvd;
     loadtest 'rt/rt_is_realtime' if is_rt;
@@ -118,6 +113,7 @@ sub load_installation_tests {
             loadtest 'microos/disk_boot';
         }
         loadtest 'console/textinfo';
+        replace_opensuse_repos_tests if is_repo_replacement_required;
     }
 }
 
@@ -342,6 +338,7 @@ sub load_tests {
     } elsif (check_var('EXTRA', 'provisioning')) {
         # This module fails in MicroOS, never been run before. Need to investigate.
         loadtest 'microos/verify_setup' unless is_microos;
+        load_transactional_tests;
     } elsif (check_var('EXTRA', 'virtualization')) {
         load_qemu_tests;
     } elsif (check_var('EXTRA', 'fips')) {


### PR DESCRIPTION
Run repo replacement only it is needed after booting an image or finishing the deployment of the system from DVD.

Schedule additional transactional tests for ignition/combustion test suites.

#### Verification runs: 

* [dvd-staging](http://kepler.suse.cz/tests/20590#)
* [microos-Staging:D-Staging-DVD-x86_64-BuildD.499.2-container-host-microos@64bit-2G-HD40G](http://kepler.suse.cz/tests/20590#)
* [microos-Staging:D-Staging-MicroOS-Image-ContainerHost-x86_64-BuildD.1.8-container-host@64bit](http://kepler.suse.cz/tests/20591#)
* [microos-Tumbleweed-MicroOS-Image-x86_64-Build20230419-microos-combustion@64bit](http://kepler.suse.cz/tests/20592#)
* [microos-Tumbleweed-MicroOS-Image-x86_64-Build20230419-microos-ignition@64bit](http://kepler.suse.cz/tests/20593#)
* [sle-micro-5.3-MicroOS-Image-Updates-x86_64-Build20230419-1-slem_ignition@64bit](http://kepler.suse.cz/tests/20594#)
* [microos-Tumbleweed-DVD-x86_64-Build20230419-container-host@64bit](http://kepler.suse.cz/tests/20595#)