### PR TITLE
LTP Whitelist: Add support for other job variables

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -18,13 +18,18 @@ use Mojo::UserAgent;
 use Mojo::File 'path';
 use YAML::PP;
 
-sub new {
-    my $class = shift;
-    my $self = bless({}, $class);
-    my $path = get_var('LTP_KNOWN_ISSUES_LOCAL');
+my %file_cache;
 
-    if (!defined($path) && get_var('LTP_KNOWN_ISSUES')) {
-        $path = _download_whitelist();
+sub new {
+    my ($class, $url) = @_;
+    my $self = bless({}, $class);
+    my $path;
+
+    $path = get_var('LTP_KNOWN_ISSUES_LOCAL') unless defined($url);
+    $url //= get_var('LTP_KNOWN_ISSUES');
+
+    if (!defined($path) && defined($url)) {
+        $path = _download_whitelist($url);
     }
 
     $self->{whitelist} = _load_whitelist_file($path) if $path;
@@ -33,13 +38,15 @@ sub new {
 }
 
 sub _download_whitelist {
-    my $path = get_var('LTP_KNOWN_ISSUES');
+    my $path = shift;
     return undef unless defined($path);
+
+    return $file_cache{$path} if exists($file_cache{$path});
 
     my $res = Mojo::UserAgent->new(max_redirects => 5)->get($path)->result;
     unless ($res->is_success) {
         record_info("$path not downloaded!", $res->message, result => 'softfail');
-        set_var('LTP_KNOWN_ISSUES_LOCAL', '');
+        $file_cache{$path} = '';
         return;
     }
 
@@ -50,7 +57,7 @@ sub _download_whitelist {
     save_tmp_file($basename, $res->body);
     copy($lfile, "ulogs/$basename");
 
-    set_var('LTP_KNOWN_ISSUES_LOCAL', $lfile);
+    $file_cache{$path} = $lfile;
     return $lfile;
 }
 


### PR DESCRIPTION
LTP Whitelist implementation is generic enough for non-LTP use but the LTP_KNOWN_ISSUES job variable is specific to run_ltp test module. Allow creating new LTP::Whitelist instances with custom URL passed as constructor argument.

The LTP_KNOWN_ISSUES_LOCAL variable was replaced with private class attribute cache but kept in case some tests use it explicitly.

The new argument will be used in PR #16825.

- Related ticket: N/A
- Needles: N/A
- Verification run: Pending