### PR TITLE
os_owner configurable in AWS qesap regression

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -5,7 +5,7 @@ terraform:
     aws_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    os_owner: "amazon"
+    os_owner: "%QESAP_CLUSTER_OS_OWNER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     aws_credentials: "/root/amazon_credentials"

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -5,7 +5,7 @@ terraform:
     aws_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
     os_image: "%QESAP_CLUSTER_OS_VER%"
-    os_owner: "amazon"
+    os_owner: "%QESAP_CLUSTER_OS_OWNER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     aws_credentials: "/root/amazon_credentials"

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -33,6 +33,7 @@ sub run {
         $variables{STORAGE_ACCOUNT_NAME} = get_required_var('STORAGE_ACCOUNT_NAME');
         $variables{SLE_IMAGE} = $provider->get_image_id();
     }
+    $variables{QESAP_CLUSTER_OS_OWNER} = get_var('QESAP_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';


### PR DESCRIPTION
Add QESAP_CLUSTER_OS_OWNER setting to configure the os_owner terraform variable from job settings.
Add more logs in qesap_cluster_log_cmds.
Remove no more used DEPLOYMENT_DIR alias for  QESAP_DEPLOYMENT_DIR setting.
Add a user warning about ignored QESAP_INSTALL_GITHUB variables. Split qesap_get_variables culr/grep command composition to have more readable test code.


- Related ticket: [TEAM-7693](https://jira.suse.com/browse/TEAM-7693)
- Verification run: 

qesap regression AWS: http://openqaworker15.qa.suse.cz/tests/147327
mr_test Azure: https://openqa.suse.de/tests/10954414
