### PR TITLE
Ensure installed before invoking gedit

### DIFF
--- a/tests/x11/gb18030.pm
+++ b/tests/x11/gb18030.pm
@@ -49,6 +49,7 @@ sub test_gb18030_file {
 sub run {
     my ($self) = @_;
 
+    ensure_installed('gedit');
     # download test text file from x11 data directory
     x11_start_program("xterm");
     enter_cmd("wget " . autoinst_url . "/data/x11/gb18030/{double,four}.txt");

--- a/tests/x11/gnomecase/gnome_window_switcher.pm
+++ b/tests/x11/gnomecase/gnome_window_switcher.pm
@@ -19,6 +19,7 @@ use testapi;
 
 sub run {
     # Launch 3 applications
+    ensure_installed('gedit');
     x11_start_program('nautilus');
     send_key "super-h";    # Minimize the window
     x11_start_program('gedit');

--- a/tests/x11/ibus/ibus_test_cn.pm
+++ b/tests/x11/ibus/ibus_test_cn.pm
@@ -15,6 +15,7 @@ use testapi;
 use utils;
 
 sub test_cn {
+    ensure_installed('gedit');
     x11_start_program('gedit');
     hold_key 'super';
     send_key_until_needlematch 'ibus_switch_cn', 'spc', 7;

--- a/tests/x11/ibus/ibus_test_jp.pm
+++ b/tests/x11/ibus/ibus_test_jp.pm
@@ -15,6 +15,7 @@ use testapi;
 use utils;
 
 sub test_jp {
+    ensure_installed('gedit');
     x11_start_program('gedit');
     hold_key('super');
     send_key_until_needlematch 'ibus_switch_jp', 'spc', 7;

--- a/tests/x11/ibus/ibus_test_kr.pm
+++ b/tests/x11/ibus/ibus_test_kr.pm
@@ -15,6 +15,7 @@ use testapi;
 use utils;
 
 sub test_kr {
+    ensure_installed('gedit');
     x11_start_program('gedit');
     hold_key 'super';
     send_key_until_needlematch 'ibus_switch_kr', 'spc', 7;


### PR DESCRIPTION
- Related ticket: 
> https://progress.opensuse.org/issues/127964 [desktop] test fails in gb18030: gedit no longer installed by default
> https://progress.opensuse.org/issues/127967 [desktop] test fails in gnome_window_switcher

- Needles: N/A
- Verification run: 

> https://openqa.opensuse.org/tests/3235288# desktopapps-gb18030
> https://openqa.opensuse.org/tests/3241502# desktopapps-gnome
The ibus related VR is not provided due to [boo#1206230](https://bugzilla.opensuse.org/show_bug.cgi?id=1206230) and [boo#1197719](https://bugzilla.opensuse.org/show_bug.cgi?id=1197719)