### PR TITLE
Adapt check for bsc#1210587

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -95,7 +95,7 @@ sub run {
         upload_logs('/var/tmp/toolbox_zypper_up.txt');
         # Test for bsc#1210587
         my $output = script_output('cat /var/tmp/toolbox_zypper_up.txt');
-        if ($output =~ m/Installation of timezone-2023c-.* failed/) {
+        if ($output =~ m/Installation of timezone-.* failed/ && is_sle_micro) {
             record_soft_failure("bsc#1210587 installation of timezone failed");
         } else {
             die "zypper up failed within toolbox";


### PR DESCRIPTION
bsc#1210587 is affecting all SLEM versions.
This commit updates the check for this bsc accordingly.

- Verification run: [SLEM 5.3](https://duck-norris.qe.suse.de/tests/12686#step/toolbox/67) | [SLEM 5.2](https://duck-norris.qe.suse.de/tests/12687#step/toolbox/67) | [SLEM 5.1](https://duck-norris.qe.suse.de/tests/12688#step/toolbox/67)
