### PR TITLE
Add basic testing for HPC papi module

### DIFF
--- a/data/hpc/papi_hw_info.c
+++ b/data/hpc/papi_hw_info.c
@@ -1,0 +1,47 @@
+ /****************************************************************************
+ * This is a simple low level example for getting information on the system *
+ * hardware. This function PAPI_get_hardware_info(), returns a pointer to a *
+ * structure of type PAPI_hw_info_t, which contains number of CPUs, nodes,  *
+ * vendor number/name for CPU, CPU revision, clock speed.                   *
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <papi.h> /* This needs to be included every time you use PAPI */
+
+int main()
+{
+   const PAPI_hw_info_t *hwinfo = NULL;
+   int retval;
+
+   /***************************************************************************
+   *  This part initializes the library and compares the version number of the*
+   * header file, to the version of the library, if these don't match then it *
+   * is likely that PAPI won't work correctly.If there is an error, retval    *
+   * keeps track of the version number.                                       *
+   ***************************************************************************/
+
+
+   if((retval = PAPI_library_init(PAPI_VER_CURRENT)) != PAPI_VER_CURRENT )
+   {
+      printf("Library initialization error! \n");
+      exit(1);
+   }
+
+   /* Get hardware info*/
+   if ((hwinfo = PAPI_get_hardware_info()) == NULL)
+   {
+      printf("PAPI_get_hardware_info error! \n");
+      exit(1);
+   }
+   /* when there is an error, PAPI_get_hardware_info returns NULL */
+
+
+   printf("%d CPU at %f Mhz.\n", hwinfo->totalcpus, hwinfo->mhz);
+   printf("Model string is %s \n", hwinfo->model_string);
+
+   /* clean up */
+   PAPI_shutdown();
+
+   exit(0);
+}

--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -52,6 +52,7 @@ sub get_mpi_src {
     return ('mpic++', 'sample_cplusplus.cpp') if ($libvar eq 'c++');
     return ('mpic++', 'sample_boost.cpp') if ($libvar eq 'boost');
     return ('', 'sample_scipy.py') if ($libvar eq 'scipy');
+    return ('mpicc', 'papi_hw_info.c') if (get_var('HPC_LIB') eq 'papi');
 }
 
 =head2 relogin_root
@@ -104,6 +105,11 @@ sub setup_scientific_module {
         my $mpi2load = ($mpi =~ /openmpi2|openmpi3|openmpi4/) ? 'openmpi' : $mpi;
         assert_script_run "module load gnu $mpi2load python3-scipy";
         assert_script_run("env MPICC=mpicc python3 -m pip install mpi4py", timeout => 1200);
+    }
+    if (get_var('HPC_LIB') eq 'papi') {
+        zypper_call("in papi-hpc papi-hpc-devel");
+        $self->relogin_root;
+        assert_script_run('module load gnu papi');
     }
     return 0;
 }


### PR DESCRIPTION
Introducing a basic test for HPC papi module by executing a c test file based on papi library.

Related ticket: https://jira.suse.com/browse/PED-3032

Verification Run: https://openqa.suse.de/tests/10957829#