### PR TITLE
ALP test profile for automated installation of Bedrock

### DIFF
--- a/data/yam/agama/auto/alp.sh
+++ b/data/yam/agama/auto/alp.sh
@@ -1,0 +1,8 @@
+set -ex
+
+/usr/bin/agama config set software.product=ALP-Bedrock
+/usr/bin/agama config set user.userName=joe user.password=doe
+/usr/bin/agama config set root.password=nots3cr3t
+/usr/bin/sleep 30
+/usr/bin/agama install
+/sbin/reboot

--- a/schedule/yast/opensuse/agama_autoinst.yaml
+++ b/schedule/yast/opensuse/agama_autoinst.yaml
@@ -1,0 +1,10 @@
+---
+name: agama_auto
+description: >
+  First test for autoinstallation wit agama
+vars:
+  AGAMA_AUTO: yam/agama/auto/alp.sh
+schedule:
+  - yam/agama/auto/url_prepare
+  - installation/bootloader_start
+  - yam/agama/auto/auto

--- a/tests/yam/agama/auto/auto.pm
+++ b/tests/yam/agama/auto/auto.pm
@@ -1,0 +1,23 @@
+## Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: First installation using D-Installer current CLI (only for development purpose)
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+use testapi;
+
+
+sub run {
+
+    assert_screen('alp-installer-ui', 120);
+
+    assert_screen('alp-installing', 60);
+
+    assert_screen('bedrock-login', 960);
+}
+
+1;

--- a/tests/yam/agama/auto/url_prepare.pm
+++ b/tests/yam/agama/auto/url_prepare.pm
@@ -1,0 +1,19 @@
+## Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: First installation using D-Installer current CLI (only for development purpose)
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+use testapi;
+use utils;
+
+sub run {
+    my $path = data_url(get_var('AGAMA_AUTO'));
+    set_var('EXTRABOOTPARAMS', "agama.auto=\"$path\"");
+}
+
+1;


### PR DESCRIPTION
- Related tickets: https://progress.opensuse.org/issues/126857
  (also included parts of): https://progress.opensuse.org/issues/127349
- Needles: 3 new needles created with needle editor
- [Verification runs for aarch64 and x86_64 on O3](https://openqa.opensuse.org/tests/overview?distri=alp&version=1.0.0&build=4.26&groupid=96)


- Using `agama.auto` boot parameter to launch the automatic installation
- Currently using a shell skript to execute agama commands

