### PR TITLE
OS image selector in HanaSR qesap config file

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -18,7 +18,7 @@ terraform:
     deployment_name: '%PUBLIC_CLOUD_RESOURCE_GROUP%'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image: "%QESAP_CLUSTER_OS_VER%"
+    os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
 
     # HANA


### PR DESCRIPTION
Move from specific HANA setting sles4sap_uri to the generic one os_image_uri available from qe-sap-deployment version 0.7.0 Rename the existing file to _uri.
Create a new config.yaml for HanaSR to be able to use OS images from the cloud provider catalog (using os_image setting).

Related ticket: https://jira.suse.com/browse/TEAM-7340

Verification run:
