### PR TITLE
Replace NFS server 1c119 FQHN with its IP address

### DIFF
--- a/schedule/kernel/sles4sap/install_sles4sap_baremetal.yaml
+++ b/schedule/kernel/sles4sap/install_sles4sap_baremetal.yaml
@@ -9,7 +9,7 @@ vars:
   GRUB_TIMEOUT: 300
   IPXE: 1
   IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
-  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
+  HANA: nfs://10.162.31.119/srv/nfs/sap/HANA2/SPS04rev46/x86_64
   INSTANCE_SID: NDB
   INSTANCE_ID: '00'
   SEPARATE_HOME: 0

--- a/schedule/kernel/sles4sap/setup_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/setup_hana_baremetal.yaml
@@ -7,7 +7,7 @@ description: >
 vars:
   DESKTOP: textmode
   GRUB_TIMEOUT: 300
-  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
+  HANA: nfs://10.162.31.119/srv/nfs/sap/HANA2/SPS04rev46/x86_64
   INSTANCE_SID: NDB
   INSTANCE_ID: '00'
   INSTANCE_TYPE: HBD

--- a/schedule/kernel/sles4sap/setup_netweaver_baremetal.yaml
+++ b/schedule/kernel/sles4sap/setup_netweaver_baremetal.yaml
@@ -7,7 +7,7 @@ vars:
   INSTANCE_ID: '00'
   INSTANCE_SID: QAD
   INSTANCE_TYPE: ASCS
-  NW: nfs://1c119.qa.suse.de/srv/nfs/sap/NW75_CLUSTER
+  NW: nfs://10.162.31.119/srv/nfs/sap/NW75_CLUSTER
   ROOTONLY: '1'
   START_AFTER_TEST: install_sles4sap_baremetal
 schedule:

--- a/schedule/kernel/sles4sap/wmp_simple_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/wmp_simple_hana_baremetal.yaml
@@ -6,7 +6,7 @@ description: >
 vars:
   DESKTOP: textmode
   GRUB_TIMEOUT: 300
-  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
+  HANA: nfs://10.162.31.119/srv/nfs/sap/HANA2/SPS04rev46/x86_64
   INSTANCE_SID: NDB
   INSTANCE_ID: '00'
   INSTANCE_TYPE: HDB

--- a/schedule/kernel/sles4sap/wmp_simple_netweaver_baremetal.yaml
+++ b/schedule/kernel/sles4sap/wmp_simple_netweaver_baremetal.yaml
@@ -6,7 +6,7 @@ description: >
 vars:
   DESKTOP: textmode
   GRUB_TIMEOUT: 300
-  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
+  HANA: nfs://10.162.31.119/srv/nfs/sap/HANA2/SPS04rev46/x86_64
   INSTANCE_SID: QAD
   INSTANCE_ID: '00'
   INSTANCE_TYPE: ASCS

--- a/schedule/migration/migration_offline_sap.yaml
+++ b/schedule/migration/migration_offline_sap.yaml
@@ -3,7 +3,7 @@ name: migration_offline_sap
 description: >
   SAP offline migration with netweaver
 vars:
-  NW: 'nfs://1c119.qa.suse.de/srv/nfs/sap/NW75_CLUSTER'
+  NW: 'nfs://10.162.31.119/srv/nfs/sap/NW75_CLUSTER'
   INSTANCE_ID: '00'
   INSTANCE_SID: 'QAD'
   INSTANCE_TYPE: 'ASCS'

--- a/schedule/migration/migration_online_sap.yaml
+++ b/schedule/migration/migration_online_sap.yaml
@@ -3,7 +3,7 @@ name: migration_online_sap
 description: >
   SAP online migration with netweaver
 vars:
-  NW: 'nfs://1c119.qa.suse.de/srv/nfs/sap/NW75_CLUSTER'
+  NW: 'nfs://10.162.31.119/srv/nfs/sap/NW75_CLUSTER'
   INSTANCE_ID: '00'
   INSTANCE_SID: 'QAD'
   INSTANCE_TYPE: 'ASCS'

--- a/schedule/sles4sap/netweaver/netweaver_single_systemd.yaml
+++ b/schedule/sles4sap/netweaver/netweaver_single_systemd.yaml
@@ -8,7 +8,6 @@ vars:
   INSTANCE_ID: '00'
   INSTANCE_SID: QAD
   INSTANCE_TYPE: ASCS
-  NW: nfs://1c119.qa.suse.de/srv/nfs/sap/NW753
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-%DESKTOP%.qcow2
 schedule:

--- a/schedule/sles4sap/netweaver/test_netweaver.yaml
+++ b/schedule/sles4sap/netweaver/test_netweaver.yaml
@@ -8,7 +8,6 @@ vars:
   INSTANCE_ID: '00'
   INSTANCE_SID: QAD
   INSTANCE_TYPE: ASCS
-  NW: nfs://1c119.qa.suse.de/srv/nfs/sap/NW75_CLUSTER
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-%DESKTOP%.qcow2
 schedule:

--- a/schedule/yast/autoyast/autoyast_sap.yaml
+++ b/schedule/yast/autoyast/autoyast_sap.yaml
@@ -6,7 +6,7 @@ description: >
 vars:
   AUTOYAST: autoyast_sle15/create_hdd/create_hdd_sap.xml.ep
   AUTOYAST_PREPARE_PROFILE: '1'
-  NW: 'nfs://1c119.qa.suse.de/srv/nfs/sap/NW75_CLUSTER'
+  NW: 'nfs://10.162.31.119/srv/nfs/sap/NW75_CLUSTER'
   INSTANCE_ID: '00'
   INSTANCE_SID: 'QAD'
   INSTANCE_TYPE: 'ASCS'


### PR DESCRIPTION
As part of ongoing works in our internal network, the FQHN `1c119.qa.suse.de` has been decommissioned so NFS access to this server is currently only possible using its IP address. This PR removes the setting from the sles4sap schedules, as it makes more sense to have such a setting in a Test Suite or in the Job Group configuration; setting is to be added in the Job Groups YAML configuration for tests using:

- schedule/sles4sap/netweaver/netweaver_single_systemd.yaml
- schedule/sles4sap/netweaver/test_netweaver.yaml

While also replacing the IP address instead of the FQHN in other team's schedules.

- Related ticket: N/A
- Related MR: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/437 https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/509
- Needles: N/A

Pinging @frankenmichl @schlad @JRivrain @badboywj to review the non SLES for SAP Applications schedules.