### PR TITLE
Use ip address instead of DNS name before joining to domain

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -137,7 +137,7 @@ sub run {
     define_secret_variable("AD_DOMAIN_PASSWORD", $password);
 
     # Check for poo#126866
-    if (is_s390x && script_run("ping -c 2 $AD_hostname") != 0) {
+    if (is_s390x && script_run("ping -c 2 $AD_ip") != 0) {
         record_soft_failure("poo#126866 - Can't contact domain controller (infra issue)");
         return;
     }


### PR DESCRIPTION
https://progress.opensuse.org/issues/126866

We can't remove the workaround so far due to
https://sd.suse.com/servicedesk/customer/portal/1/SD-119612

- Verification run: 
[s390x](https://openqa.suse.de/tests/overview?build=rfan0425&distri=sle)