### PR TITLE
Increase reboot timeout value for Public Cloud

### DIFF
--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: zypper
@@ -30,7 +30,7 @@ sub run {
 
     ssh_fully_patch_system($remote);
 
-    $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
+    $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 1200));
 }
 
 sub test_flags {


### PR DESCRIPTION
Fix patch_and_reboot failure: reboot need more wait time, for some special instances such as "ec2_r5b.metal" the reboot needs about 15 minutes.

From the serial_terminal log of VR you can see the reboot need at least 15 minutes:
```
  Reboot scheduled for Tue 2023-04-25 10:51:49 UTC, use 'shutdown -c' to cancel.   
  ...   
  Apr 25 11:06:10 vmhana01 systemd[2491]: Reached target Main User Target.   
```

[TEAM-7834](https://jira.suse.com/browse/TEAM-7834) - Fix mr_test failed on "patch_and_reboot" on AWS "r5b.metal" instance type

- Related ticket: https://jira.suse.com/browse/TEAM-7834
- Needles: NA
- Verification run: http://openqa.nue.suse.com/t10980695