### PR TITLE
Automate auto-installation of SUSE ALP Micro

### DIFF
--- a/data/yam/agama/auto/alp.sh
+++ b/data/yam/agama/auto/alp.sh
@@ -5,4 +5,3 @@ set -ex
 /usr/bin/agama config set root.password=nots3cr3t
 /usr/bin/sleep 30
 /usr/bin/agama install
-/sbin/reboot

--- a/data/yam/agama/auto/alp_micro.jsonnet
+++ b/data/yam/agama/auto/alp_micro.jsonnet
@@ -1,0 +1,33 @@
+local agama = import 'hw.libsonnet';
+local findBiggestDisk(disks) =
+  local sizedDisks = std.filter(function(d) std.objectHas(d, 'size'), disks);
+  local sorted = std.sort(sizedDisks, function(x) x.size);
+  sorted[0].logicalname;
+
+{
+  description: |||
+        Install agama Micro with jsonnet on
+        x86_64 and aarch64.
+      |||,
+  software: {
+    product: 'ALP-Micro',
+  },
+  root: {
+    password: 'nots3cr3t',
+  },
+  user: {
+    fullName: 'Jane Doe',
+    password: '123456',
+    userName: 'jane.doe',
+  },
+  localization: {
+    language: 'en_US',
+  },
+  storage: {
+    devices: [
+      {
+        name: findBiggestDisk(agama.disks),
+      },
+    ],
+  },
+}

--- a/tests/yam/agama/auto.pm
+++ b/tests/yam/agama/auto.pm
@@ -8,12 +8,20 @@ use base yam::agama::agama_base;
 use strict;
 use warnings;
 
-use testapi 'assert_screen';
-
+use testapi;
+use utils 'clear_console';
 
 sub run {
     assert_screen('agama-main-page', 120);
-    assert_screen('agama-installing', 60);
+    assert_screen('agama-installing', 120);
+    assert_screen('agama-install-finished', 900);
+
+    select_console 'root-console';
+    clear_console;
+    enter_cmd "reboot";
+
+    assert_screen('grub2', 120);
+    wait_screen_change { send_key 'ret' };
 
     my @tags = ("welcome-to", "login");
     assert_screen \@tags, 960;


### PR DESCRIPTION
 - Description
   * Automate auto-installation of SUSE ALP Micro with Jasonnet.
   * Fixed agama_auto_bedrock with installation finished check.

- Related ticket: 
  * https://progress.opensuse.org/issues/126848
- Needles: 
  * agama-install-finished

- Verification run: 
   * [**agama_auto_bedrock**](https://openqa.opensuse.org/tests/overview?arch=&flavor=&machine=&test=agama_auto_bedrock&modules=&module_re=&distri=alp&version=agama-0.9&build=4.35&groupid=96#)
   * [**agama_auto_micro**](https://openqa.opensuse.org/tests/overview?arch=&flavor=&machine=&test=agama_auto_micro&modules=&module_re=&distri=alp&version=agama-0.9&build=4.35&groupid=96#)