### PR TITLE
Update autoyast profile for textmode installation

### DIFF
--- a/data/autoyast_sle15/autoyast_sle_powervm.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle_powervm.xml.ep
@@ -74,7 +74,7 @@
     <ntp_policy>auto</ntp_policy>
   </ntp-client>
   <services-manager config:type="map">
-    <default_target>graphical</default_target>
+    <default_target>multi-user</default_target>
     <services config:type="map">
       <enable config:type="list">
         <service>firewalld</service>
@@ -95,6 +95,9 @@
       <pattern>basesystem</pattern>
       <pattern>enhanced_base</pattern>
       <pattern>minimal_base</pattern>
+      <pattern>x11</pattern>
+      <pattern>x11_yast</pattern>
+      <pattern>yast2_basis</pattern>
     </patterns>
     <products config:type="list">
       <product>SLES</product>


### PR DESCRIPTION
Update the autoyast profile of textmode installation on spvm, the
pattern list is not the default pattern list, so add them; Under
the 'services-manager', the default_target should be 'multi-user'
for textmode.

- Related ticket: https://progress.opensuse.org/issues/127598
- Needles: n/a
- Verification run: 
- https://openqa.suse.de/tests/10991561
- https://openqa.suse.de/tests/10991563
- https://openqa.suse.de/tests/10991562
- Related MR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/500