### PR TITLE
podman: verify hostpid was set

### DIFF
--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -18,6 +18,43 @@ use serial_terminal 'select_serial_terminal';
 use version_utils qw(is_sle is_opensuse is_sle_micro);
 use containers::k8s qw(install_k3s uninstall_k3s);
 
+sub check_container_nspid {
+    # expect set hostpid
+    my $hostpid = shift;
+    my $config = 'hello-kubic.yaml';
+    my @errors = ();
+
+    record_info('NSPid', sprintf('Expect HostPid == %s', !!$hostpid ? 'True' : 'False'));
+
+    if ($hostpid) {
+        assert_script_run(qq[sed -i '/containers:/i\\      hostPID: true' $config]);
+    }
+
+    assert_script_run("podman play kube --replace $config");
+    my $pod = script_output(q[podman pod ps --format '{{ .Name }}']);
+    my $container = script_output(q[podman container ps --filter name=.*pod.* --format '{{ .Names }}']);
+    my $pid_on_host = script_output(qq[podman container inspect $container --format '{{ .State.Pid }}']);
+
+    my @pids = split(/\s+/, script_output("grep NSpid: /proc/$pid_on_host/status"));
+    shift @pids;
+    record_info('Detected', sprintf("%s", join(", ", @pids)));
+
+    my $pid_mode = script_output(qq[podman inspect $container --format '{{ .HostConfig.PidMode }}']);
+    if ($hostpid && $pid_mode ne 'host') {
+        push @errors, "HostConfig.PidMode should show 'host' when option 'hostPid: true' was used in the manifest file. Currently HostConfig.PidMore returns $pid_mode";
+    }
+
+    foreach (@pids) {
+        if ($_ == 1 && $hostpid) {
+            push @errors, "HostPid was set and PID=1 was found!";
+        }
+    }
+
+    if (@errors) {
+        die join("\n", @errors);
+    }
+}
+
 sub run {
     my ($self, $args) = @_;
     select_serial_terminal;
@@ -87,6 +124,11 @@ sub run {
             assert_script_run('kubectl wait --timeout=240s --for=condition=Ready pod/testing-pod', timeout => 260);
             validate_script_output('kubectl exec testing-pod -- cat /etc/os-release', sub { m/SUSE Linux Enterprise Server/ });
         }
+    }
+
+    if (check_min_runtime_version('4.4.4')) {
+        check_container_nspid();
+        check_container_nspid(1);
     }
 }
 


### PR DESCRIPTION
Verify that pod manifest HostPid option was set accordingly.

- ticket: https://progress.opensuse.org/issues/124604
- Verification run: http://kepler.suse.cz/tests/20623#
