### PR TITLE
Increase the timeout for enabling WSL feature

### DIFF
--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -92,12 +92,12 @@ sub run {
     # reboot the SUT
     $self->run_in_powershell(
         cmd => $powershell_cmds->{enable_wsl_feature}->{wsl},
-        timeout => 300
+        timeout => 600
     );
     if (get_var('WSL2')) {
         $self->run_in_powershell(
             cmd => $powershell_cmds->{enable_wsl_feature}->{vm_platform},
-            timeout => 300
+            timeout => 600
         );
     }
 


### PR DESCRIPTION
Seems like the time for the installation and activation of WSL features has been significantly increased

- Related ticket: https://progress.opensuse.org/issues/128309
- Verification runs:
  - http://openqa.suse.de/tests/10985950
  - http://openqa.suse.de/tests/10985952