### PR TITLE
Add system_prepare to extra_test_{gnome,textmode} schedule

### DIFF
--- a/schedule/functional/extra_tests_gnome.yaml
+++ b/schedule/functional/extra_tests_gnome.yaml
@@ -55,6 +55,7 @@ conditional_schedule:
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
+    - console/system_prepare
     - console/prepare_test_data
     - console/consoletest_setup
     - x11/x11_setup

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -99,6 +99,7 @@ conditional_schedule:
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
+    - console/system_prepare
     - console/prepare_test_data
     - console/consoletest_setup
     - '{{update_repos}}'


### PR DESCRIPTION
At least on PPC, the serial device (dev/hvc0) does not retain permission
post reboot and we fail to write to it as normal user.

system_prepare takes care of setting the right permissions for us.

- Related ticket: https://progress.opensuse.org/issues/123791
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3246598
