### PR TITLE
Use bootloader_start only on s390x and ppc64le

### DIFF
--- a/schedule/security/fips_crypt_core.yaml
+++ b/schedule/security/fips_crypt_core.yaml
@@ -2,7 +2,7 @@ name: fips_crypt_core
 description:    >
     This is for the crypt_core fips tests.
 schedule:
-    - installation/bootloader_start
+    - '{{boot}}'
     - boot/boot_to_desktop
     - console/consoletest_setup
     - '{{repo_setup}}'
@@ -23,6 +23,12 @@ schedule:
     # ssh disabled in env mode, see poo#125648
     - '{{ssh}}'
 conditional_schedule:
+    boot:
+        ARCH:
+            s390x:
+                - installation/bootloader_start
+            ppc64le:
+                - installation/bootloader_start
     repo_setup:
         BETA:
             1:

--- a/schedule/security/fips_crypt_kernel.yaml
+++ b/schedule/security/fips_crypt_kernel.yaml
@@ -2,7 +2,7 @@ name: fips_crypt_kernel
 description:    >
     This is for the crypt_kernel fips tests.
 schedule:
-    - installation/bootloader_start
+    - '{{boot}}'
     - boot/boot_to_desktop
     - console/consoletest_setup
     - '{{repo_setup}}'
@@ -11,6 +11,12 @@ schedule:
     - console/cryptsetup
     - security/dm_crypt
 conditional_schedule:
+    boot:
+        ARCH:
+            s390x:
+                - installation/bootloader_start
+            ppc64le:
+                - installation/bootloader_start
     repo_setup:
         BETA:
             1:

--- a/schedule/security/fips_crypt_tool.yaml
+++ b/schedule/security/fips_crypt_tool.yaml
@@ -2,7 +2,7 @@ name: fips_crypt_tool
 description:    >
     This is for the crypt_tool fips tests.
 schedule:
-    - installation/bootloader_start
+    - '{{boot}}'
     - boot/boot_to_desktop
     - console/consoletest_setup
     - '{{repo_setup}}'
@@ -21,6 +21,12 @@ schedule:
     - x11/evolution/evolution_prepare_servers
     - console/mutt
 conditional_schedule:
+    boot:
+        ARCH:
+            s390x:
+                - installation/bootloader_start
+            ppc64le:
+                - installation/bootloader_start
     repo_setup:
         BETA:
             1:

--- a/schedule/security/fips_crypt_web.yaml
+++ b/schedule/security/fips_crypt_web.yaml
@@ -2,7 +2,7 @@ name: fips_crypt_web
 description:    >
     This is for the crypt_web fips tests.
 schedule:
-    - installation/bootloader_start
+    - '{{boot}}'
     - boot/boot_to_desktop
     - console/consoletest_setup
     - '{{repo_setup}}'
@@ -16,6 +16,12 @@ schedule:
     - console/apache_ssl
     - fips/mozilla_nss/apache_nssfips
 conditional_schedule:
+    boot:
+        ARCH:
+            s390x:
+                - installation/bootloader_start
+            ppc64le:
+                - installation/bootloader_start
     repo_setup:
         BETA:
             1:


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/127664
- Verification runs:
  - a
  - b