### PR TITLE
tests: openqa: Update to use openqa-cli instead of deprecated old client

### DIFF
--- a/tests/openqa/osautoinst/start_test.pm
+++ b/tests/openqa/osautoinst/start_test.pm
@@ -18,11 +18,11 @@ sub run {
     # aarch64 does not support nested virt, huge pages are not configured and 'gic_version=host' and host cpu options are only usable with KVM
     my $clone_options = ($arch =~ /aarch64/) ? "QEMU_NO_KVM=1 QEMU_HUGE_PAGES_PATH='' QEMUMACHINE=virt QEMUCPU='cortex-a72'" : "";
     my $cmd = <<"EOF";
-last_tw_build=\$(openqa-client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-$arch-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
+last_tw_build=\$(openqa-cli api --host $openqa_url assets | sed -n 's/^.*name.*Tumbleweed-NET-$arch-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
 echo "Last Tumbleweed build on openqa.opensuse.org: \$last_tw_build"
 [ ! -z \$last_tw_build ]
 command -v jq >/dev/null || zypper -n in jq
-job_id=\$(openqa-client --host $openqa_url --json-output jobs get version=Tumbleweed scope=relevant arch=$arch build=\$last_tw_build flavor=NET latest=1 | jq '.jobs | .[] | select(.test == "$ttest") | .id')
+job_id=\$(openqa-cli api --host $openqa_url jobs version=Tumbleweed scope=relevant arch=$arch build=\$last_tw_build flavor=NET latest=1 | jq '.jobs | .[] | select(.test == "$ttest") | .id')
 echo "Job Id: \$job_id"
 [ ! -z \$job_id  ]
 echo "Scenario: $arch-$ttest-NET: \$job_id"

--- a/tests/openqa/osautoinst/test_running.pm
+++ b/tests/openqa/osautoinst/test_running.pm
@@ -12,7 +12,7 @@ use base "consoletest";
 use testapi;
 
 sub run {
-    assert_script_run ' ret=false; for i in {1..5} ; do openqa-client jobs state=running | grep --color -z running && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ] ; echo $? ', 300;
+    assert_script_run ' ret=false; for i in {1..5} ; do openqa-cli api jobs state=running | grep --color -z running && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ] ; echo $? ', 300;
 }
 
 sub post_fail_hook {

--- a/tests/openqa/webui/test_results.pm
+++ b/tests/openqa/webui/test_results.pm
@@ -15,10 +15,10 @@ use testapi;
 my $tutorial_disabled;
 
 sub upload_autoinst_log {
-    assert_script_run 'openqa-client jobs/1/cancel post';
+    assert_script_run 'openqa-cli api -X post jobs/1/cancel';
     for my $i (1 .. 10) {
         # wait for test to finish and upload
-        last if (script_run('openqa-client jobs/1 | grep state | grep done', 40) == 0);
+        last if (script_run('openqa-cli api jobs/1 | grep state | grep done', 40) == 0);
         sleep 5;
     }
     if (script_run('wget http://localhost/tests/1/file/autoinst-log.txt') != 0) {


### PR DESCRIPTION
Verification run:
* opensuse-Tumbleweed-DVD-x86_64-Build20230425-openqa_bootstrap@64bit -> https://openqa.opensuse.org/tests/3248358