### PR TITLE
Public Cloud: Remove '-v' from 'ssh' command

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -378,7 +378,7 @@ sub wait_for_ssh {
         sleep $sleep_period;
     }
 
-    script_run("ssh  -i /root/.ssh/id_rsa -v $args{username}\@$args{public_ip} true", timeout => 360);
+    script_run("ssh  -i /root/.ssh/id_rsa $args{username}\@$args{public_ip} true", timeout => 360);
     # Debug output: We have occasional error in 'journalctl -b' - see poo#96464 - this will be removed soon.
     # Exclude 'mr_test/saptune' test case as it will introduce random softreboot failures.
     if (!get_var('PUBLIC_CLOUD_SLES4SAP')) {


### PR DESCRIPTION
The `-v` parameter makes the SSH sometimes output debug messaged to serial console and to mess up with it.

If needed, we can add `LogLevel DEBUG` and `Log /tmp/ssh_error.log` to `data/publiccloud/ssh_config` later on.
