### PR TITLE
Temporally disable ansible-test package on SLE

### DIFF
--- a/tests/console/ansible.pm
+++ b/tests/console/ansible.pm
@@ -93,6 +93,9 @@ sub run {
     # Call the zypper module properly (depends on version)
     file_content_replace('roles/test/tasks/main.yaml', COMMUNITYGENERAL => ((is_tumbleweed) ? 'community.general.' : ''));
 
+    # https://bugzilla.suse.com/show_bug.cgi?id=1210875 Package ansible-test requires Python2.7
+    script_run('echo "[defaults]\ninterpreter_python = /usr/bin/python3" | tee ansible.cfg') if (is_sle('<15-SP5'));
+
     # 2. Ansible basics
 
     # Check Ansible version

--- a/tests/console/ansible.pm
+++ b/tests/console/ansible.pm
@@ -25,8 +25,10 @@ use transactional qw(trup_call check_reboot_changes);
 # git-core needed by ansible-galaxy
 # sudo is used by ansible to become root
 # python3-yamllint needed by ansible-test
-my $pkgs = 'ansible ansible-test git-core';
+my $pkgs = 'ansible git-core';
 $pkgs .= ' python3-yamllint' unless is_alp;
+# https://bugzilla.suse.com/show_bug.cgi?id=1210876 Nothing provides 'python3-virtualenv'
+$pkgs .= ' ansible-test' unless is_sle('=15-SP5');
 
 sub run {
     select_serial_terminal;
@@ -132,8 +134,10 @@ sub run {
     assert_script_run "ansible-playbook -i hosts main.yaml --check $skip_tags", timeout => 300;
 
     # Run the ansible sanity test
-    script_run 'ansible-test --help';
-    assert_script_run 'ansible-test sanity';
+    unless (is_sle('=15-SP5')) {
+        script_run 'ansible-test --help';
+        assert_script_run 'ansible-test sanity';
+    }
 
     # 5. Ansible playbook execution
 


### PR DESCRIPTION
- Previous pull request: #16933

* **Package ansible-test requires Python2.7** [poo#128300](https://progress.opensuse.org/issues/128300), [bsc#1210875](https://bugzilla.suse.com/show_bug.cgi?id=1210875)
    Enforcing `python3` in `ansible.cfg` on **SLE 15-SP5**.
* **Nothing provides 'python3-virtualenv** [poo#128327](https://progress.opensuse.org/issues/128327), [bsc#1210876](https://bugzilla.suse.com/show_bug.cgi?id=1210876)
    Skipping `ansible-test` on **SLE 15-SP54**.
- Verification run: [Leap 15.5](https://pdostal-server.suse.cz/tests/4373), [SLE 15-SP5](https://pdostal-server.suse.cz/tests/4372), [SLE 15-SP4](https://pdostal-server.suse.cz/tests/4374)