### PR TITLE
Add Playwright automation test 

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -59,7 +59,7 @@ sub handle_password_prompt {
     my ($console) = @_;
     $console //= '';
 
-    return if (get_var("LIVETEST") || get_var('LIVECD')) && get_var('FLAVOR') !~ /d-installer/;
+    return if (get_var("LIVETEST") || get_var('LIVECD')) && (get_var('VERSION') !~ /agama/);
     if (is_serial_terminal()) {
         wait_serial(qr/Password:\s*$/i, timeout => 30);
     } else {

--- a/schedule/yam/agama/agama_installation.yaml
+++ b/schedule/yam/agama/agama_installation.yaml
@@ -1,0 +1,7 @@
+---
+name: agama_installation
+description: >
+  Playwright test on agama
+schedule:
+  - installation/bootloader_start
+  - yam/agama/agama_installation

--- a/tests/yam/agama/agama_installation.pm
+++ b/tests/yam/agama/agama_installation.pm
@@ -1,0 +1,35 @@
+## Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Run interactive installation with Agama,
+# run playwright tests directly from the Live ISO.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+use testapi qw(
+  assert_screen
+  assert_script_run
+  select_console
+  upload_logs
+);
+use power_action_utils 'power_action';
+use transactional 'process_reboot';
+
+sub run {
+    assert_screen('agama_product_selection', 120);
+    $testapi::password = 'linux';
+    select_console 'root-console';
+
+    assert_script_run('RUN_INSTALLATION=1 playwright test --trace on --project chromium --config /usr/share/agama-playwright take_screenshots', timeout => 600);
+
+    upload_logs('./test-results/take_screenshots-The-Installer-installs-the-system-chromium/trace.zip');
+    assert_script_run('reboot');
+    assert_screen('grub2', 120);
+    my @tags = ("welcome-to", "login");
+    assert_screen(\@tags, 300);
+}
+
+1;


### PR DESCRIPTION
We need run Playwright tests directly from the Live ISO in openQA.

- Related ticket: https://progress.opensuse.org/issues/124550
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/overview?distri=alp&version=agama-0.9&build=4.35&groupid=96
