### PR TITLE
xfstests: Support nfs test on multi machine

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -104,6 +104,7 @@ sub analyze_result {
 
 sub run {
     select_serial_terminal;
+    return if get_var('XFSTESTS_NFS_SERVER');
     sleep 5;
 
     # Reload uploaded status log back to file


### PR DESCRIPTION
Support xfstests run nfs test on multi machine. Set XFSTESTS_NFS_SERVER=1 to setup nfs server, and set PARALLEL_WITH for nfs client.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/127478
- Needles: N/A
- Verification run: 
- https://openqa.suse.de/tests/11052962 (nfs server)
- https://openqa.suse.de/tests/11052963 (nfs client)
- https://openqa.suse.de/tests/10999022 (nfs test in one server)
- https://openqa.suse.de/tests/10999020 (generic test without nfs)
