### PR TITLE
Change storage driver for newest docker

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -238,7 +238,7 @@ Otherwise it prints the output of info.
 =cut
 
 sub info {
-    my ($self, %args) = shift;
+    my ($self, %args) = @_;
     my $property = $args{property} ? qq(--format '{{.$args{property}}}') : '';
     my $expected = $args{value} ? qq( | grep $args{value}) : '';
     $self->_engine_assert_script_run(sprintf("info %s %s", $property, $expected));

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -42,9 +42,12 @@ sub test_seccomp {
 }
 
 sub get_docker_version {
-    my $v = script_output("docker --version");
-    record_info "$v", $v =~ /(\d{2}\.\d{2})/;
-    return $v =~ /(\d{2}\.\d{2})/;
+    my $raw = script_output("docker --version");
+    my ($v, undef) = split(',', $raw);
+    my @all = $v =~ /(\d+)/g;
+    $v = join('.', @all);
+    record_info "Docker version", "$v";
+    return $v;
 }
 
 sub get_podman_version {


### PR DESCRIPTION
New docker uses `overlayfs2` storage driver instead of `btrfs`. Change default settings for the `btrfs` storage driver validation.

- ticket: https://progress.opensuse.org/issues/128387
- Verification run: http://kepler.suse.cz/tests/20647#step/validate_btrfs/241
