### PR TITLE
Add setting in qesap for the Hana disk type

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -11,6 +11,7 @@ terraform:
     gcp_credentials_file: "/root/google_credentials.json"
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    hana_data_disk_type: "%HANA_DATA_DISK_TYPE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -11,6 +11,7 @@ terraform:
     gcp_credentials_file: "/root/google_credentials.json"
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    hana_data_disk_type: "%HANA_DATA_DISK_TYPE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -52,6 +52,7 @@ sub run {
     $variables{HANA_CLIENT_SAR} = get_required_var("QESAPDEPLOY_IMDB_CLIENT");
     $variables{HANA_SAPCAR} = get_required_var("QESAPDEPLOY_IMDB_SERVER");
     $variables{ANSIBLE_REMOTE_PYTHON} = get_var("QESAPDEPLOY_ANSIBLE_REMOTE_PYTHON", "/usr/bin/python3");
+    $variables{HANA_DATA_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DATA_DISK_TYPE", "pd-ssd");
     qesap_prepare_env(openqa_variables => \%variables, provider => $qesap_provider);
 }
 


### PR DESCRIPTION
Setting QESAPDEPLOY_HANA_DATA_DISK_TYPE with default value like in the qe-sap-deployment project pd-ssd

Related ticket: TEAM-7761
Verification run: 
- qesap regression GCP 12sp5 
  - http://openqaworker15.qa.suse.cz/tests/149882 pd-sdd
  - http://openqaworker15.qa.suse.cz/tests/151827 pd-standard (failure is about net quota, but tfvars get the right setting) https://openqaworker15.qa.suse.cz/tests/151845
- qesap regression GCP 15sp3 sapconf
  - http://openqaworker15.qa.suse.cz/tests/149881 pd-sdd
  - http://openqaworker15.qa.suse.cz/tests/151828 pd-standard
- qesap regression GCP 15sp3  saptune
  - http://openqaworker15.qa.suse.cz/tests/149880 pd-sdd
  - http://openqaworker15.qa.suse.cz/tests/151829 pd-standard (failure is about net quota, but tfvars get the right setting) https://openqaworker15.qa.suse.cz/tests/151846

What can be checked is generate .tfvars like http://openqaworker15.qa.suse.cz/tests/149882/file/configure-terraform.tfvars
