### PR TITLE
Podman Pods: increase timeout for kubectl wait

### DIFF
--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -83,8 +83,8 @@ sub run {
             install_k3s();
             record_info('Test', 'kube apply');
             assert_script_run('podman kube apply --kubeconfig ~/.kube/config -f pod.yaml');
-            assert_script_run('kubectl wait --timeout=240s --for=condition=Ready pod/testing-pod', timeout => 260);
-            validate_script_output('kubectl exec testing-pod -- cat /etc/os-release', sub { m/SUSE Linux Enterprise Server/ });
+            assert_script_run('kubectl wait --timeout=600s --for=condition=Ready pod/testing-pod', timeout => 610);
+            validate_script_output('kubectl exec testing-pod -- cat /etc/os-release', sub { m/SUSE Linux Enterprise Server/ }, timeout => 300);
         }
     }
 }


### PR DESCRIPTION
There are still a lot of timeouts in aarch64 jobs.
VRs:
https://openqa.suse.de/tests/11006810
https://openqa.suse.de/tests/11006811
https://openqa.suse.de/tests/11006812
