### PR TITLE
Add preparation step for SELinux

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -269,7 +269,7 @@ sub load_slem_on_pc_tests {
     loadtest("publiccloud/ssh_interactive_start", run_args => $args);
     loadtest("publiccloud/instance_overview", run_args => $args);
     loadtest("publiccloud/slem_prepare", run_args => $args);
-
+    loadtest("transactional/enable_selinux") if (get_var('ENABLE_SELINUX'));
     if (get_var("PUBLIC_CLOUD_CONTAINERS")) {
         load_container_tests() if is_container_test;
     }

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -23,6 +23,7 @@ use version_utils;
 use utils 'reconnect_mgmt_console';
 use Utils::Backends;
 use Utils::Architectures;
+use publiccloud::instances;
 
 our @EXPORT = qw(
   process_reboot
@@ -74,6 +75,12 @@ sub process_reboot {
     $args{trigger} //= 0;
     $args{automated_rollback} //= 0;
     $args{expected_grub} //= 1;
+
+    if (is_public_cloud) {
+        my $instance = publiccloud::instances::get_instance();
+        $instance->softreboot();    # Handled re-establishing of the required ssh tunnel and consoles
+        return;
+    }
 
     # Switch to root-console as we need VNC to check for grub and for login prompt
     my $prev_console = current_console();

--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -13,26 +13,46 @@ use strict;
 use warnings;
 use testapi;
 use transactional qw(process_reboot);
-use version_utils qw(is_sle_micro);
+use version_utils qw(is_sle_micro is_public_cloud);
 use Utils::Systemd qw(systemctl);
 use Utils::Logging 'save_and_upload_log';
+use transactional qw(trup_call check_reboot_changes process_reboot);
 
 sub run {
     select_console 'root-console';
+
+    # Until bsc#1211058 is resolved, we cannot enable SELinux via `transactional-update setup-selinux`.
+    if (is_sle_micro('=5.2')) {
+        record_soft_failure("bsc#1211058 Enabling SELinux broken via transactional-update setup-selinux");
+        return;
+    }
+
     my $audit_log = "/var/log/audit/audit.log";
 
     # auditd should be enabled
     systemctl 'is-enabled auditd';
 
     # install and enable SELinux if not done by default
-    if (script_run('test -d /sys/fs/selinux && test -e /etc/selinux/config') != 0) {
-        assert_script_run('transactional-update setup-selinux');
+    if (script_run('test -d /sys/fs/selinux && test -e /etc/selinux/config && getenforce | grep -i "enforcing" >/dev/null') != 0) {
+        trup_call('setup-selinux');
         upload_logs('/var/log/transactional-update.log');
         save_and_upload_log('rpm -qa', 'installed_pkgs.txt');
-        process_reboot(trigger => 1);
+        check_reboot_changes;
+        if (is_public_cloud) {
+            # Additional packages required for semanage
+            trup_call('pkg install policycoreutils-python-utils');
+            check_reboot_changes;
+            # allow ssh tunnel port (to openQA)
+            my $upload_port = get_required_var('QEMUPORT') + 1;
+            assert_script_run("semanage port -a -t ssh_port_t -p tcp $upload_port");
+            process_reboot(trigger => 1);
+        }
     }
 
     assert_script_run('selinuxenabled');
+    validate_script_output("getenforce", sub { m/Enforcing/ });
+    validate_script_output("sestatus", sub { m/Current mode:.*enforcing/ });
+    validate_script_output("sestatus", sub { m/Mode from config file:.*enforcing/ });
     record_info('SELinux', script_output('sestatus'));
     record_info('Audit report', script_output('aureport'));
     record_info('Audit denials', script_output('aureport -a', proceed_on_failure => 1));


### PR DESCRIPTION
Eanble SELinux testing for SLEM on PC. We add additional preparation setps to install and configure SELinux, as well as to allow the ssh tunnel port to make sure we have access to openQA.

This PR enabled the code part. Job group settings will be added after merge.

- Related ticket: https://progress.opensuse.org/issues/110791
- Verification runs:
* [SLEM 5.1 slem_selinux](https://duck-norris.qe.suse.de/tests/12919)
* [SLEM 5.1 containers_selinux](https://duck-norris.qe.suse.de/tests/12917)
* [SLEM 5.2 slem_selinux](https://duck-norris.qe.suse.de/tests/12926)
* [SLEM 5.2 containers_selinux](https://duck-norris.qe.suse.de/tests/12922)
* [SLEM 5.3 slem_selinux](https://duck-norris.qe.suse.de/tests/12916)
* [SLEM 5.3 containers_selinux](https://duck-norris.qe.suse.de/tests/12918)
* [SLEM 5.4 default](https://duck-norris.qe.suse.de/tests/12924)
* [SLEM 5.4 containers](https://duck-norris.qe.suse.de/tests/12925)