### PR TITLE
Remove IP settings from InfiniBand tests

### DIFF
--- a/schedule/kernel/ibtest-master-autoyast.yaml
+++ b/schedule/kernel/ibtest-master-autoyast.yaml
@@ -8,8 +8,6 @@ vars:
     IBTESTS: 1
     IBTEST_GITBRANCH: master
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
-    IBTEST_IP1: 10.162.2.93
-    IBTEST_IP2: 10.162.2.94
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -7,8 +7,6 @@ vars:
     IBTESTS: 1
     IBTEST_GITBRANCH: master
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
-    IBTEST_IP1: 10.162.2.93
-    IBTEST_IP2: 10.162.2.94
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080

--- a/schedule/kernel/ibtest-master-tumbleweed.yaml
+++ b/schedule/kernel/ibtest-master-tumbleweed.yaml
@@ -7,8 +7,6 @@ vars:
     IBTESTS: 1
     IBTEST_GITBRANCH: master
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
-    IBTEST_IP1: 10.162.2.93
-    IBTEST_IP2: 10.162.2.94
     IBTEST_ROLE: IBTEST_MASTER
     PATTERNS: base,minimal
     ROOTONLY: 1

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -7,8 +7,6 @@ vars:
     IBTESTS: 1
     IBTEST_GITBRANCH: master
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
-    IBTEST_IP1: 10.162.2.93
-    IBTEST_IP2: 10.162.2.94
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080

--- a/schedule/kernel/ibtest-slave-autoyast.yaml
+++ b/schedule/kernel/ibtest-slave-autoyast.yaml
@@ -9,8 +9,6 @@ vars:
     IBTESTS: 1
     IBTEST_GITBRANCH: master
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
-    IBTEST_IP1: 10.162.2.93
-    IBTEST_IP2: 10.162.2.94
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -7,8 +7,6 @@ vars:
     IBTESTS: 1
     IBTEST_GITBRANCH: master
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
-    IBTEST_IP1: 10.162.2.93
-    IBTEST_IP2: 10.162.2.94
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080

--- a/schedule/kernel/ibtest-slave-tumbleweed.yaml
+++ b/schedule/kernel/ibtest-slave-tumbleweed.yaml
@@ -7,8 +7,6 @@ vars:
     IBTESTS: 1
     IBTEST_GITBRANCH: master
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
-    IBTEST_IP1: 10.162.2.93
-    IBTEST_IP2: 10.162.2.94
     IBTEST_ROLE: IBTEST_SLAVE
     ROOTONLY: 1
     SCC_ADDONS: sdk

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -7,8 +7,6 @@ vars:
     IBTESTS: 1
     IBTEST_GITBRANCH: master
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
-    IBTEST_IP1: 10.162.2.93
-    IBTEST_IP2: 10.162.2.94
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080


### PR DESCRIPTION
Remove IBTEST_IP1 and IBTEST_IP2 from InfiniBand schedules. These should be set elsewhere, so the schedules don't contain actual dependencies to infrastructure.
