### PR TITLE
Move autoyast var to testsuite/jobgroup.

### DIFF
--- a/schedule/security/create_hdd_autoyast/create_hdd_x86_64_uefi.yaml
+++ b/schedule/security/create_hdd_autoyast/create_hdd_x86_64_uefi.yaml
@@ -1,14 +1,20 @@
 name: autoyast_create_hdd_x86_64_uefi
 description:    >
   Test performs autoyast installation to generate qcow images for security tests
-vars:
-  AUTOYAST: security/create_hdd_%DESKTOP%_%ARCH%_uefi.xml
+conditional_schedule:
+  update_repos:
+    VERSION:
+      'Tumbleweed':
+        - update/zypper_clear_repos
+        - console/zypper_ar
+        - console/zypper_ref
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
   - installation/first_boot
   - console/system_prepare
+  - '{{update_repos}}'
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/128249
- Related PRs: https://github.com/os-autoinst/opensuse-jobgroups/pull/313
- Verification runs:
  - https://openqa.suse.de/tests/11023545
  - https://openqa.suse.de/tests/11023991
  - https://openqa.opensuse.org/tests/3260088
  - https://openqa.opensuse.org/tests/3260591