### PR TITLE
Switch to openvswitch3* packages for ovs-server test on sles 15 sp5

### DIFF
--- a/tests/console/ovs_client.pm
+++ b/tests/console/ovs_client.pm
@@ -27,7 +27,7 @@ use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
 use console::ovs_utils;
-
+use version_utils;
 
 my $server_ip = "10.0.2.101";
 my $client_ip = "10.0.2.102";
@@ -48,7 +48,13 @@ sub run {
     mutex_wait 'barrier_setup_done';
 
     # Install the needed packages
-    zypper_call('in openvswitch-ipsec openvswitch-pki tcpdump openvswitch-vtep', timeout => 300);
+    # At moment we have opnvswitch3* packages on sles 15 sp5 only
+    if (is_sle('>=15-SP5')) {
+        zypper_call('in openvswitch3-ipsec tcpdump openvswitch3-pki openvswitch3-vtep', timeout => 300);
+    }
+    else {
+        zypper_call('in openvswitch-ipsec tcpdump openvswitch-pki openvswitch-vtep', timeout => 300);
+    }
 
     # Start the openvswitch and openvswitch-ipsec services
     systemctl 'start openvswitch', timeout => 200;

--- a/tests/console/ovs_server.pm
+++ b/tests/console/ovs_server.pm
@@ -28,6 +28,7 @@ use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
 use console::ovs_utils;
+use version_utils;
 
 my $server_ip = "10.0.2.101";
 my $client_ip = "10.0.2.102";
@@ -62,7 +63,13 @@ sub run {
     mutex_create 'barrier_setup_done';
 
     # Install the needed packages
-    zypper_call('in openvswitch-ipsec tcpdump openvswitch-pki openvswitch-vtep', timeout => 300);
+    # At moment we have opnvswitch3* packages on sles 15 sp5 only
+    if (is_sle('>=15-SP5')) {
+        zypper_call('in openvswitch3-ipsec tcpdump openvswitch3-pki openvswitch3-vtep', timeout => 300);
+    }
+    else {
+        zypper_call('in openvswitch-ipsec tcpdump openvswitch-pki openvswitch-vtep', timeout => 300);
+    }
     systemctl 'start openvswitch', timeout => 200;
     systemctl 'start openvswitch-ipsec', timeout => 200;
 


### PR DESCRIPTION
we have now openvswitch3* packages and current packages of openvswitch belong to repository SLE-Module-Legacy15-SP5-Pool, that is why zypper_call failed

see https://progress.opensuse.org/issues/127799 for more details

