### PR TITLE
HPC: Fix expansion of $mpi in assert_script_run

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -373,7 +373,7 @@ sub prepare_spack_env {
     zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel", timeout => 1200;
     type_string('pkill -u root');    # this kills sshd
     select_serial_terminal(0);
-    assert_script_run 'module load gnu $mpi';    ## TODO
+    assert_script_run "module load gnu $mpi";
     assert_script_run 'source /usr/share/spack/setup-env.sh';
 
     record_info 'spack', script_output 'zypper -q info spack';


### PR DESCRIPTION
The variable is called inside the function which setups spack. Side note that this used to work so far until recently. Which sle15sp3 began to fail. So this should fix the issue with the missing libraries but the flow needs some investigation.


- Related ticket: https://progress.opensuse.org/issues/128597
- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%23spack_expansion

https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%23spack_expansion