### PR TITLE
Add check for NetworkManager or wicked

### DIFF
--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -13,7 +13,17 @@ use serial_terminal 'select_serial_terminal';
 use publiccloud::utils qw(is_byos registercloudguest);
 use publiccloud::ssh_interactive 'select_host_console';
 use utils qw(zypper_call systemctl);
-use version_utils 'is_sle';
+use version_utils qw(is_sle_micro check_version);
+
+sub has_wicked {
+    # Check if the image is expected to have wicked
+    return 0 if (is_sle_micro('5.3+'));
+
+    # Helper to check (wrong SLES) version due to poo#128681
+    my $version = get_var('VERSION');
+    return 1 if check_version("<15-SP4", $version, qr/\d{2}(?:-sp\d)?/);
+    return 0;
+}
 
 sub run {
     my ($self) = @_;
@@ -28,6 +38,17 @@ sub run {
     $instance->run_ssh_command(cmd => 'systemctl is-enabled issue-generator');
     $instance->run_ssh_command(cmd => 'systemctl is-enabled transactional-update.timer');
     $instance->run_ssh_command(cmd => 'systemctl is-enabled issue-add-ssh-keys');
+
+    # Ensure NetworkManager is used on SLEM 5.3+
+    unless (has_wicked()) {
+        # Remove this softfailure after bsc#1211084 is resolved.
+        # Currently the images still contain NetworkManager.
+        if ($instance->ssh_script_run('systemctl is-active NetworkManager') != 0) {
+            record_soft_failure("bsc#1211084 - Image uses wicked instead of NetworkManager");
+        }
+    } else {
+        $instance->ssh_assert_script_run('systemctl is-active wicked', fail_message => "wicked is not active");
+    }
 
     # package installation test
     my $ret = $instance->run_ssh_command(cmd => 'rpm -q ' . $test_package, rc_only => 1);


### PR DESCRIPTION
Check if NetworkManager (SLEM 5.3+) or wicked (< SLEM 5.3) is active to ensure, the right network daemon is running on the images.

- Related issue: https://bugzilla.suse.com/show_bug.cgi?id=1211084
- Verification run: [SLEM 5.1](https://duck-norris.qe.suse.de/tests/12830#step/slem_basic/109) | [SLEM 5.2](https://duck-norris.qe.suse.de/tests/12829#step/slem_basic/91) | [SLEM 5.3](https://duck-norris.qe.suse.de/tests/12827#step/slem_basic/91) | [SLEM 5.4](https://duck-norris.qe.suse.de/tests/12828#step/slem_basic/91)
