### PR TITLE
Move HanaSr qesap deployment to sec storage

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -8,9 +8,8 @@
 #   tests/sles4sap/publiccloud/qesap_ansible.pm
 
 provider: 'azure'
-apiver: 2
+apiver: 3
 terraform:
-  provider: 'azure'
   variables:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
@@ -28,7 +27,10 @@ terraform:
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 
 ansible:
-  hana_urls:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -8,9 +8,8 @@
 #   tests/sles4sap/publiccloud/qesap_ansible.pm
 
 provider: 'azure'
-apiver: 2
+apiver: 3
 terraform:
-  provider: 'azure'
   variables:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
@@ -28,7 +27,10 @@ terraform:
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 
 ansible:
-  hana_urls:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -172,6 +172,15 @@ sub run {
         record_info 'Resource Group', "Resource Group used for deployment: $workspace";
     }
 
+    if (get_var("HANA_TOKEN")) {
+        my $escaped_token = get_required_var("HANA_TOKEN");
+        # escape needed by 'sed'
+        # but not implemented in file_content_replace() yet poo#120690
+        $escaped_token =~ s/\&/\\\&/g;
+        set_var("HANA_TOKEN", $escaped_token);
+    }
+
+
     my $provider = $self->provider_factory();
     set_var('SLE_IMAGE', $provider->get_image_id());
     my $ansible_playbooks = create_playbook_section_list();


### PR DESCRIPTION
Adopt the qe-sap-deployment feature to use secure storage when accessing installers.

- Related ticket: TEAM-6943

- Verification run: 
15sp5 http://openqaworker15.qa.suse.cz/tests/152529 (failure is not related to this PR) http://openqaworker15.qa.suse.cz/tests/152530
15sp4 http://openqaworker15.qa.suse.cz/tests/152528
