### PR TITLE
Recover only yast logs in Agama auto-install

### DIFF
--- a/lib/yam/agama/agama_base.pm
+++ b/lib/yam/agama/agama_base.pm
@@ -1,0 +1,23 @@
+## Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: base class for Agama tests
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package yam::agama::agama_base;
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi 'select_console';
+use y2_base 'save_upload_y2logs';
+use Utils::Logging 'save_and_upload_log';
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $testapi::password = 'linux';
+    select_console 'root-console';
+    y2_base::save_upload_y2logs($self, skip_logs_investigation => 1);
+    save_and_upload_log('journalctl -u agama-auto', "/tmp/agama-auto-log.txt");
+}
+
+1;

--- a/tests/yam/agama/auto.pm
+++ b/tests/yam/agama/auto.pm
@@ -4,7 +4,7 @@
 # Summary: First installation using D-Installer current CLI (only for development purpose)
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-use base 'y2_installbase';
+use base yam::agama::agama_base;
 use strict;
 use warnings;
 


### PR DESCRIPTION
See https://progress.opensuse.org/issues/128489

    Adding a post_fail_hook directly in the module to use the default
    installer password and just upload y2logs, as it seems like there
    is nothing that does only that in the libs.

VRs
https://openqa.opensuse.org/tests/overview?distri=alp&build=JRivrain%2Fos-autoinst-distri-opensuse%2316994&version=1.0.0
https://openqa.opensuse.org/tests/overview?version=agama-0.9&build=JRivrain%2Fos-autoinst-distri-opensuse%2316994&distri=alp