### PR TITLE
Configure HANA disk type in mr_test

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -1,4 +1,4 @@
-provider: 'gce'
+provider: 'gcp'
 apiver: 3
 terraform:
   variables:
@@ -6,19 +6,15 @@ terraform:
     region: "%PUBLIC_CLOUD_REGION%"
     admin_user: "cloudadmin"
     os_image: "%SLE_IMAGE%"
-    hana_os_major_version: "%HANA_OS_MAJOR_VERSION%"
-    iscsi_os_major_version: "%HANA_OS_MAJOR_VERSION%"
-    monitoring_os_major_version: "%HANA_OS_MAJOR_VERSION%"
-    drdb_os_major_version: "%HANA_OS_MAJOR_VERSION%"
-    netweaver_os_major_version: "%HANA_OS_MAJOR_VERSION%"
-    bastion_os_major_version: "%HANA_OS_MAJOR_VERSION%"
     private_key: "~/.ssh/id_rsa"
     public_key: "~/.ssh/id_rsa.pub"
     gcp_credentials_file: "/root/google_credentials.json"
 
     # HANA
     hana_count: '1'
-    hana_ha_enabled: '%HA_CLUSTER%'
+    hana_ha_enabled: "%HA_CLUSTER%"
+    hana_data_disk_type: "%HANA_DISK_TYPE%"
+    hana_log_disk_type: "%HANA_DISK_TYPE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -12,6 +12,7 @@ terraform:
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     hana_data_disk_type: "%HANA_DATA_DISK_TYPE%"
+    hana_log_disk_type: "%HANA_LOG_DISK_TYPE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -12,6 +12,7 @@ terraform:
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     hana_data_disk_type: "%HANA_DATA_DISK_TYPE%"
+    hana_log_disk_type: "%HANA_LOG_DISK_TYPE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -52,7 +52,10 @@ sub run {
     $variables{HANA_CLIENT_SAR} = get_required_var("QESAPDEPLOY_IMDB_CLIENT");
     $variables{HANA_SAPCAR} = get_required_var("QESAPDEPLOY_IMDB_SERVER");
     $variables{ANSIBLE_REMOTE_PYTHON} = get_var("QESAPDEPLOY_ANSIBLE_REMOTE_PYTHON", "/usr/bin/python3");
-    $variables{HANA_DATA_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DATA_DISK_TYPE", "pd-ssd");
+    if (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE')) {
+        $variables{HANA_DATA_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DISK_TYPE", "pd-ssd");
+        $variables{HANA_LOG_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DISK_TYPE", "pd-ssd");
+    }
     qesap_prepare_env(openqa_variables => \%variables, provider => $qesap_provider);
 }
 


### PR DESCRIPTION
Configure hana data and log disk in mr_test on GCP. Configure hana log disk in qesap for gcp and unify setting to configure both data and log disk.


- Related ticket: [TEAM-7761](https://jira.suse.com/browse/TEAM-7761)

Verification run: 
-  qesap regression GCP sapconf http://openqaworker15.qa.suse.cz/tests/153201 and with `QESAPDEPLOY_HANA_DISK_TYPE=pd-standard` http://openqaworker15.qa.suse.cz/tests/153202
-  qesap regression GCP saptune
- mr_test 
   - with no additional settings https://openqa.suse.de/tests/11040669 it fails as expected with `Could not retrieve required variable HANA_DISK_TYPE `  (this change require a JobGroup change),
   -  with HANA_DISK_TYPE=pd-ssd https://openqa.suse.de/tests/11040725 , with HANA_DISK_TYPE=pd-standard https://openqa.suse.de/tests/11040741
