### PR TITLE
Fix autoyast pattern and user issues on qem test

### DIFF
--- a/data/autoyast_qam/12-common_base_installation.xml.ep
+++ b/data/autoyast_qam/12-common_base_installation.xml.ep
@@ -342,7 +342,7 @@
   <users config:type="list">
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <fullname>Bernhard M. Wiedemann</fullname>
+      <fullname>bernhard</fullname>
       <gid>100</gid>
       <home>/home/bernhard</home>
       <password_settings>

--- a/data/autoyast_qam/15-common_base_installation.xml.ep
+++ b/data/autoyast_qam/15-common_base_installation.xml.ep
@@ -313,7 +313,7 @@
   <users config:type="list">
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <fullname>Bernhard M. Wiedemann</fullname>
+      <fullname>bernhard</fullname>
       <gid>100</gid>
       <home>/home/bernhard</home>
       <password_settings>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -124,7 +124,12 @@ sub expand_patterns {
         }
         return [@all];
     }
-    return [split(/,/, get_var('PATTERNS') =~ s/\bminimal\b/minimal_base/r)] if is_sle('15+');
+    if (is_sle('15+')) {
+        my $patterns = get_var('PATTERNS');
+        $patterns =~ s/\bbase\b/enhanced_base/;
+        $patterns =~ s/\bminimal\b/minimal_base/;
+        return [split(/,/, $patterns)];
+    }
     return [split(/,/, get_var('PATTERNS') =~ s/\bminimal\b/Minimal/r)];
 }
 

--- a/schedule/qam/common/15-common_base_installation_ay.yaml
+++ b/schedule/qam/common/15-common_base_installation_ay.yaml
@@ -1,5 +1,5 @@
 ---
-name: 12-common_base_installation_autoyast
+name: 15-common_base_installation_autoyast
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start


### PR DESCRIPTION
https://progress.opensuse.org/issues/128732

Full name setting might impact needle matching
And if we define pattern in autoyast config files,
we need to use the exact name.

At the same time, fix a typo issue in schedule file

- Verification run: 
http://openqa.suse.de/tests/11039780
http://openqa.suse.de/tests/11040028