### PR TITLE
Add missing runtime dependencies

### DIFF
--- a/tests/console/openvswitch_ssl.pm
+++ b/tests/console/openvswitch_ssl.pm
@@ -19,6 +19,9 @@ use version_utils 'is_sle';
 sub run {
     select_console 'root-console';
 
+    # Install runtime dependencies
+    zypper_call("in wget");
+
     if (is_sle("<=12-SP5")) {
         zypper_call('in python python-base openvswitch');
     } else {

--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -32,7 +32,7 @@ sub run {
         $docker = "docker";
         is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
     }
-    zypper_call("in sssd sssd-ldap openldap2-client $docker");
+    zypper_call("in nscd sssd sssd-ldap openldap2-client $docker");
 
     #For released sle versions use sle15sp3 base image by default. For developing sle use corresponding image in registry.suse.de
     my $pkgs = "awk systemd systemd-sysvinit 389-ds openssl";

--- a/tests/console/sssd_openldap_functional.pm
+++ b/tests/console/sssd_openldap_functional.pm
@@ -30,7 +30,7 @@ sub run {
         add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
         is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
     }
-    zypper_call("in sssd sssd-ldap openldap2-client sshpass docker");
+    zypper_call("in nscd sssd sssd-ldap openldap2-client sshpass docker");
     systemctl('enable --now docker');
     #Select container base image by specifying variable BASE_IMAGE_TAG. (for sles using sle15sp3 by default)
     my $pkgs = "openldap2 sudo";

--- a/tests/console/syslog.pm
+++ b/tests/console/syslog.pm
@@ -23,6 +23,9 @@ use version_utils;
 sub run {
     select_serial_terminal;
 
+    # Install runtime dependencies
+    zypper_call("in rsyslog");
+
     my $test_log_msg = 'Test Log Message FOOBAR123';
     assert_script_run "logger $test_log_msg";
 

--- a/tests/console/wget_https.pm
+++ b/tests/console/wget_https.pm
@@ -16,6 +16,10 @@ use testapi;
 
 sub run {
     select_console "root-console";
+
+    # Install runtime dependencies
+    zypper_call("in wget");
+
     assert_script_run("rpm -q wget");
     assert_script_run("wget -c https://build.opensuse.org -O opensuse.html");
     assert_script_run("wget -c https://www.google.com -O google.html");

--- a/tests/fips/strongswan/strongswan_client.pm
+++ b/tests/fips/strongswan/strongswan_client.pm
@@ -20,7 +20,9 @@ use lockapi;
 sub run {
     my $self = shift;
     select_console 'root-console';
-    zypper_call 'in strongswan strongswan-hmac tcpdump';
+
+    # Install runtime dependencies
+    zypper_call("in strongswan strongswan-hmac tcpdump wget");
 
     my $remote_ip = get_var('SERVER_IP', '10.0.2.101');
     my $local_ip = get_var('CLIENT_IP', '10.0.2.102');

--- a/tests/network/openvpn_client.pm
+++ b/tests/network/openvpn_client.pm
@@ -26,6 +26,9 @@ sub run {
     barrier_wait 'SETUP_DONE';
     select_serial_terminal;
 
+    # Install runtime dependencies
+    zypper_call("in iputils");
+
     # Install openvpn
     zypper_call('in openvpn');
     assert_script_run('cd /etc/openvpn');

--- a/tests/network/openvpn_server.pm
+++ b/tests/network/openvpn_server.pm
@@ -34,6 +34,9 @@ sub run {
     barrier_wait 'SETUP_DONE';
     select_serial_terminal;
 
+    # Install runtime dependencies
+    zypper_call("in iputils");
+
     # Install openvpn, generate static key
     add_qa_head_repo unless is_opensuse();
     zypper_call('in openvpn easy-rsa');

--- a/tests/security/389ds/tls_389ds_server.pm
+++ b/tests/security/389ds/tls_389ds_server.pm
@@ -19,6 +19,9 @@ use services::389ds_server;
 sub run {
     select_console("root-console");
 
+    # Install runtime dependencies
+    zypper_call("in wget");
+
     services::389ds_server::install_service();
     services::389ds_server::config_service();
     services::389ds_server::enable_service();

--- a/tests/security/check_kernel_config/dm_crypt.pm
+++ b/tests/security/check_kernel_config/dm_crypt.pm
@@ -22,6 +22,9 @@ sub run {
     my $self = shift;
     select_serial_terminal;
 
+    # Install runtime dependencies
+    zypper_call("in sudo");
+
     # Make sure the code changes are there
     if (is_sle) {
         assert_script_run("rpm -q kernel-default --changelog | grep 'dm crypt' | grep 'kcryptd workqueues'");

--- a/tests/security/create_swtpm_hdd/build_hdd.pm
+++ b/tests/security/create_swtpm_hdd/build_hdd.pm
@@ -20,6 +20,9 @@ use power_action_utils 'power_action';
 sub run {
     select_serial_terminal;
 
+    # Install runtime dependencies
+    zypper_call("in wget");
+
     # Install tpm and tpm2 related packages, then we can verify the swtpm function
     zypper_call("in tpm-tools tpm-quote-tools tpm2-0-tss tpm2-tss-engine tpm2.0-abrmd tpm2.0-tools trousers");
     assert_script_run("systemctl enable tcsd");

--- a/tests/security/ebpf/check_cap_bpf.pm
+++ b/tests/security/ebpf/check_cap_bpf.pm
@@ -16,6 +16,10 @@ sub run {
     my $f_bpf_test = '/tmp/bpf_test';
 
     select_console 'root-console';
+
+    # Install runtime dependencies
+    zypper_call("in wget");
+
     # Set 'unprivileged_bpf_disabled' to 1
     validate_script_output('sysctl kernel.unprivileged_bpf_disabled=1', sub { m/kernel.unprivileged_bpf_disabled = 1/ });
     validate_script_output("cat /proc/sys/kernel/unprivileged_bpf_disabled", sub { m/1/ });

--- a/tests/security/grub_auth/grub_authorization.pm
+++ b/tests/security/grub_auth/grub_authorization.pm
@@ -86,6 +86,9 @@ sub grub_auth_oper {
 sub run {
     select_console("root-console");
 
+    # Install runtime dependencies
+    zypper_call("in wget");
+
     # Check disk name, partition number and fs_type for root file system,
     # then create a new custom grub config file based on the users/passwords we definded
     assert_script_run "wget --quiet " . data_url("grub_auth/create_custom_grub.sh");

--- a/tests/security/mariadb/mariadb_ssl_client.pm
+++ b/tests/security/mariadb/mariadb_ssl_client.pm
@@ -23,6 +23,9 @@ sub run {
 
     select_console 'root-console';
 
+    # Install runtime dependencies
+    zypper_call("in iputils");
+
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV.
     my $netdev = get_var('NETDEV', 'eth0');

--- a/tests/security/openscap/oscap_setup.pm
+++ b/tests/security/openscap/oscap_setup.pm
@@ -15,7 +15,7 @@ use version_utils 'is_opensuse';
 
 sub run {
 
-    zypper_call('in openscap-utils libxslt-tools');
+    zypper_call("in openscap-utils libxslt-tools wget");
 
     oscap_get_test_file("oval.xml");
     oscap_get_test_file("xccdf.xml");

--- a/tests/security/oscap_stig/baseline_comparison.pm
+++ b/tests/security/oscap_stig/baseline_comparison.pm
@@ -31,6 +31,9 @@ sub run {
 
     select_console 'root-console';
 
+    # Install runtime dependencies
+    zypper_call("in wget");
+
     # Download python script for baseline comparison
     assert_script_run('wget --quiet ' . data_url("$py_script"));
 

--- a/tests/security/pam/pam_mount.pm
+++ b/tests/security/pam/pam_mount.pm
@@ -20,8 +20,8 @@ sub run {
     # so switch to root-console here
     select_console 'root-console';
 
-    # Install the pam-mount package, since this service package is not installed by default
-    zypper_call 'in pam_mount';
+    # Install runtime dependencies
+    zypper_call("in pam_mount cryptsetup");
 
     # Define the uesr and encrypt key for the volume
     my $user = 'bernhard';

--- a/tests/security/postgresql_ssl/postgresql_ssl_client.pm
+++ b/tests/security/postgresql_ssl/postgresql_ssl_client.pm
@@ -22,6 +22,9 @@ sub run {
 
     select_console 'root-console';
 
+    # Install runtime dependencies
+    zypper_call("in iputils");
+
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV
     my $netdev = get_var('NETDEV', 'eth0');

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -32,7 +32,7 @@ sub run {
         assert_script_run('transactional-update --non-interactive pkg install policycoreutils');
     }
     else {
-        zypper_call("in policycoreutils");
+        zypper_call("in policycoreutils wget");
     }
     # Program 'semanage' is found in:
     #  - policycoreutils-python-utils pkgs on ALP, TW and SLES 15-SP4

--- a/tests/security/swtpm/swtpm_env_setup.pm
+++ b/tests/security/swtpm/swtpm_env_setup.pm
@@ -31,7 +31,7 @@ sub run {
 
     # Install the required packages for libvirt environment setup,
     # "expect" is used for later remote login test, so install here as well
-    zypper_call("in qemu libvirt swtpm expect virt-install virt-manager");
+    zypper_call("in qemu libvirt swtpm expect virt-install virt-manager wget");
 
     # Start libvirtd daemon and start the default libvirt network
     assert_script_run("systemctl start libvirtd");

--- a/tests/security/usbguard/usbguard.pm
+++ b/tests/security/usbguard/usbguard.pm
@@ -41,7 +41,7 @@ sub run {
 
     # 0. Set up environment
     # Install usbguard packages
-    zypper_call('in libusbguard1 usbguard usbguard-devel usbguard-tools', timeout => 900);
+    zypper_call('in libusbguard1 usbguard usbguard-devel usbguard-tools usbutils', timeout => 900);
 
     # Start audit service
     systemctl('restart auditd.service');

--- a/tests/security/vsftpd/vsftpd_setup.pm
+++ b/tests/security/vsftpd/vsftpd_setup.pm
@@ -26,7 +26,7 @@ sub run {
     select_console 'root-console';
 
     # Install vsftpd, expect for Tumbleweed
-    zypper_call('in vsftpd expect openssl');
+    zypper_call("in vsftpd expect openssl wget");
 
     # Create self-signed certificate
     assert_script_run("mkdir $vsftpd_path && cd $vsftpd_path");


### PR DESCRIPTION
Some tests have started failing due to migrations to autoyast, eg. https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16919. This PR adds missing dependencies to relevant tests.

Related ticket: https://progress.opensuse.org/issues/128735

## Verification runs:

- 15-SP4:
  - `security/create_swtpm_hdd/build_hdd.pm` https://openqa.suse.de/tests/11041761
  - `security/ebpf/check_cap_bpf` https://openqa.suse.de/tests/11041779
  - `console/openvswitch_ssl.pm` https://openqa.suse.de/tests/11041895
  - `console/syslog.pm` https://openqa.suse.de/tests/11041895
  - `console/wget_https.pm` https://openqa.suse.de/tests/11041937
  - `security/postgresql_ssl/postgresql_ssl_client.pm` https://openqa.suse.de/tests/11042045
  - `security/mariadb/mariadb_ssl_client.pm` https://openqa.suse.de/tests/11042069
  - `console/openvswitch_ssl.pm` https://openqa.suse.de/tests/11042079
  - `console/wget_https.pm` https://openqa.suse.de/tests/11042081
  - `security/postgresql_ssl/postgresql_ssl_client.pm` https://openqa.suse.de/tests/11042085
  - `fips/strongswan/strongswan_client.pm` https://openqa.suse.de/tests/11042118
  - `network/openvpn_client.pm`
  - `network/openvpn_server.pm`
  - `security/openscap/oscap_setup.pm` https://openqa.suse.de/tests/11042130
  - `security/389ds/tls_389ds_server.pm` https://openqa.suse.de/tests/11042149
  - `security/check_kernel_config/dm_crypt.pm` https://openqa.suse.de/tests/11042383
  - `security/grub_auth/grub_authorization.pm` https://openqa.suse.de/tests/11042166
  - `security/swtpm/swtpm_env_setup.pm` https://openqa.suse.de/tests/11042174
  - `security/selinux/selinux_setup.pm` https://openqa.suse.de/tests/11042224
  - `security/oscap_stig/baseline_comparison.pm` https://openqa.suse.de/tests/11042238
  - `security/usbguard/usbguard.pm` https://openqa.suse.de/tests/11042243
  - `security/vsftpd/vsftpd_setup.pm` https://openqa.suse.de/tests/11042247
  - `console/sssd_389ds_functional.pm`
- 15-SP3:
  - `security/create_swtpm_hdd/build_hdd.pm` https://openqa.suse.de/tests/11042279
  - `security/openscap/oscap_setup.pm` https://openqa.suse.de/tests/11042280
  - `network/openvpn_client.pm`
  - `network/openvpn_server.pm`
  - `security/389ds/tls_389ds_server.pm` https://openqa.suse.de/tests/11042290
  - `security/check_kernel_config/dm_crypt.pm`
  - `security/grub_auth/grub_authorization.pm` https://openqa.suse.de/tests/11042332
  - `security/swtpm/swtpm_env_setup.pm` https://openqa.suse.de/tests/11042366
  - `security/selinux/selinux_setup.pm` https://openqa.suse.de/tests/11042370
  - `console/sssd_389ds_functional.pm` https://openqa.suse.de/tests/11042375
  - `console/sssd_openldap_functional.pm` https://openqa.suse.de/tests/11042376
  - `security/vsftpd/vsftpd_setup.pm` https://openqa.suse.de/tests/11042373