### PR TITLE
Add missing runtime dependencies, vol. 2

### DIFF
--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -27,12 +27,15 @@ use registration 'add_suseconnect_product';
 sub run {
     select_serial_terminal;
 
+    # Install runtime dependencies
+    zypper_call("in sudo nscd");
+
     my $docker = "podman";
     if (is_sle) {
         $docker = "docker";
         is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
     }
-    zypper_call("in nscd sssd sssd-ldap openldap2-client $docker");
+    zypper_call("in sssd sssd-ldap openldap2-client $docker");
 
     #For released sle versions use sle15sp3 base image by default. For developing sle use corresponding image in registry.suse.de
     my $pkgs = "awk systemd systemd-sysvinit 389-ds openssl";

--- a/tests/console/sssd_openldap_functional.pm
+++ b/tests/console/sssd_openldap_functional.pm
@@ -26,11 +26,15 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 
 sub run {
     select_serial_terminal;
+
+    # Install runtime dependencies
+    zypper_call("in sudo nscd");
+
     if (is_sle) {
         add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
         is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
     }
-    zypper_call("in nscd sssd sssd-ldap openldap2-client sshpass docker");
+    zypper_call("in sssd sssd-ldap openldap2-client sshpass docker");
     systemctl('enable --now docker');
     #Select container base image by specifying variable BASE_IMAGE_TAG. (for sles using sle15sp3 by default)
     my $pkgs = "openldap2 sudo";

--- a/tests/console/wget_https.pm
+++ b/tests/console/wget_https.pm
@@ -13,6 +13,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use utils 'zypper_call';
 
 sub run {
     select_console "root-console";

--- a/tests/security/grub_auth/grub_authorization.pm
+++ b/tests/security/grub_auth/grub_authorization.pm
@@ -20,6 +20,7 @@ use warnings;
 use testapi;
 use base 'consoletest';
 use version_utils 'is_sle';
+use utils 'zypper_call';
 
 my $sup_user = 'admin';
 my $sup_passwd = 'pw_admin';


### PR DESCRIPTION
Some dependencies were missed in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16997.

- Related ticket: https://progress.opensuse.org/issues/128735
- Verification runs:
  - https://openqa.suse.de/tests/11043004
  - https://openqa.suse.de/tests/11043005

Some tests were also failing due to missing library `utils`.

- Verification run: https://openqa.suse.de/tests/11043538