### PR TITLE
Increase NVIDIA drivers screen timeout

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -95,9 +95,9 @@ sub register_via_scc {
     wait_screen_change(sub { send_key 'alt-c' }, 10);
     wait_screen_change { type_string $reg_code, max_interval => 125, wait_screen_change => 2 };
     send_key 'alt-n';
-    assert_screen ['trust_nvidia_gpg_keys', 'wsl-registration-repository-offer'], timeout => 60;
+    assert_screen ['trust_nvidia_gpg_keys', 'wsl-registration-repository-offer'], timeout => 240;
     send_key 'alt-t' if (match_has_tag 'trust_nvidia_gpg_keys');
-    assert_screen 'wsl-registration-repository-offer', timeout => 60;
+    assert_screen 'wsl-registration-repository-offer', timeout => 240;
     send_key 'alt-y';
     assert_screen 'wsl-extension-module-selection';
     send_key 'alt-n';
@@ -136,7 +136,7 @@ sub run {
         # SLED Workstation license agreement
         license if (check_var('SLE_PRODUCT', 'sled'));
         # And done!
-        assert_screen ['trust_nvidia_gpg_keys', 'wsl-installation-completed'], timeout => 60;
+        assert_screen ['trust_nvidia_gpg_keys', 'wsl-installation-completed'], timeout => 240;
         send_key 'alt-t' if (match_has_tag 'trust_nvidia_gpg_keys');
         assert_screen 'wsl-installation-completed', 240;
         send_key 'alt-f';


### PR DESCRIPTION
The 60s timeout after accepting the NVIDIA license is not enough to complete the installation

- Related ticket: https://progress.opensuse.org/issues/128798
