### PR TITLE
Activate LTSS product due to bsc#1211154

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -29,12 +29,21 @@ use power_action_utils qw(power_action);
 use version_utils qw(is_sle);
 use serial_terminal qw(add_serial_console);
 use version_utils qw(is_jeos);
+use registration qw(add_suseconnect_product);
 
 sub run {
     my $self = shift;
     select_serial_terminal;
 
     quit_packagekit unless check_var('DESKTOP', 'textmode');
+
+    # We need to activated SLES-LTSS product again on system installed via autoyast
+    # https://progress.opensuse.org/issues/128840
+    # https://bugzilla.suse.com/show_bug.cgi?id=1211154
+    if (get_var('AUTOYAST') && get_var('SCC_ADDONS') =~ /ltss/ && script_run('test -f /etc/products.d/SLES-LTSS.prod') != 0) {
+        record_soft_failure('bsc#1211154');
+        add_suseconnect_product('SLES-LTSS', undef, undef, '-r ' . get_var('SCC_REGCODE_LTSS'), 150);
+    }
 
     zypper_call(q{mr -d $(zypper lr | awk -F '|' '{IGNORECASE=1} /nvidia/ {print $2}')}, exitcode => [0, 3]);
 


### PR DESCRIPTION
Workaround:
https://progress.opensuse.org/issues/128840
https://bugzilla.suse.com/show_bug.cgi?id=1211154

- Verification run: 
[VRs for sles15sp1-p3](https://openqa.suse.de/tests/overview?&distri=sle&build=rfan_ltss)