### PR TITLE
Add pipefail

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -36,6 +36,7 @@ sub run_tox_cmd {
     $cmd .= " --reruns $bci_reruns --reruns-delay $bci_reruns_delay";
     $cmd .= "| tee $tox_out";
     record_info("tox", "Running command: $cmd");
+    script_run("set -o pipefail");    # required because we don't want to rely on consoletest_setup for BCI tests.
     my $ret = script_run("timeout $bci_timeout $cmd", timeout => ($bci_timeout + 3));
     if ($ret == 124) {
         # man timeout: If  the command times out, and --preserve-status is not set, then exit with status 124.


### PR DESCRIPTION
Fail the test run, if the `tox` command fails.

- Related ticket: https://progress.opensuse.org/issues/128900
- Verification run: https://openqa.suse.de/tests/11063925
