### PR TITLE
Revert "Remove ubi7-init container image"

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -338,10 +338,10 @@ sub get_3rd_party_images {
     ) unless (is_arm || is_s390x || is_ppc64le);
 
     # RedHat UBI7 images are not built for aarch64 and 32-bit arm
-    # ubi7/ubi-init fails with "requested source is not authorized"
     push @images, (
         "registry.access.redhat.com/ubi7/ubi",
-        "registry.access.redhat.com/ubi7/ubi-minimal"
+        "registry.access.redhat.com/ubi7/ubi-minimal",
+        "registry.access.redhat.com/ubi7/ubi-init"
     ) unless (is_arm || is_aarch64 || check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
 
     return (\@images);


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#16981

ubi-init is back to life:
```
podman pull registry.access.redhat.com/ubi7/ubi-init
Trying to pull registry.access.redhat.com/ubi7/ubi-init:latest...
Getting image source signatures
Copying blob dc611367a437 done  
Copying blob ec121c671d0c done  
Copying config e597c5043a done  
Writing manifest to image destination
Storing signatures
e597c5043a71a0b18da54d03ba9f9c67059ab6a3388419880e0d19a4aac54e3c
```