### PR TITLE
Add IBS Mirror peering in qesap regression Azure

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -9,6 +9,8 @@ terraform:
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     hana_instancetype: "%HANA_INSTANCE_TYPE%"
+    vnet_address_range: "%VNET_ADDRESS_RANGE%"
+    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -769,8 +769,6 @@ subtest '[qesap_get_az_resource_group]' => sub {
 };
 
 subtest '[qesap_calculate_az_address_range]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
-
     my %result_1 = qesap_calculate_az_address_range(slot => 1);
     my %result_2 = qesap_calculate_az_address_range(slot => 2);
     my %result_64 = qesap_calculate_az_address_range(slot => 64);
@@ -787,6 +785,5 @@ subtest '[qesap_calculate_az_address_range]' => sub {
     dies_ok { qesap_calculate_az_address_range(slot => 0); } "Expected die for slot < 1";
     dies_ok { qesap_calculate_az_address_range(slot => 8193); } "Expected die for slot > 8192";
 };
-
 
 done_testing;

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -56,6 +56,11 @@ sub run {
         $variables{HANA_DATA_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DISK_TYPE", "pd-ssd");
         $variables{HANA_LOG_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DISK_TYPE", "pd-ssd");
     }
+
+    my %peering_settings = qesap_calculate_az_address_range(slot => get_var("WORKER_INSTANCE"));
+    $variables{VNET_ADDRESS_RANGE} = $peering_settings{vnet_address_range};
+    $variables{SUBNET_ADDRESS_RANGE} = $peering_settings{subnet_address_range};
+
     qesap_prepare_env(openqa_variables => \%variables, provider => $qesap_provider);
 }
 


### PR DESCRIPTION
Add network peering in qesap regression for Azure. Minor fixes in qesapdeployment and unit testing about peering functions.


Related ticket: [TEAM-7704](https://jira.suse.com/browse/TEAM-7704)

Verification run: Azure 15sp4
- saptune http://openqaworker15.qa.suse.cz/tests/153896#step/configure/85 (without QESAP_IBSMIRROR_RESOURCE_GROUP) generated .tfvars is http://openqaworker15.qa.suse.cz/tests/153896/file/configure-terraform.tfvars

```
vnet_address_range = "10.2.64.0/21"
subnet_address_range = "10.2.64.0/24"
```
`az` commands for peering are not called due to missing **QESAP_IBSMIRROR_RESOURCE_GROUP** setting

- saptune http://openqaworker15.qa.suse.cz/tests/153897 (with QESAP_IBSMIRROR_RESOURCE_GROUP) generated .tfvars is http://openqaworker15.qa.suse.cz/tests/153897/file/configure-terraform.tfvars

```
vnet_address_range = "10.2.88.0/21"
subnet_address_range = "10.2.88.0/24"
```

The `az` peering create command is in http://openqaworker15.qa.suse.cz/tests/153897#step/test_cluster/346 and it is fine

The peering delete one is in http://openqaworker15.qa.suse.cz/tests/153897#step/test_cluster/372  and it fails for `timed out`

- saptune with QESAP_IBSMIRROR_RESOURCE_GROUP and longer `az` timeout http://openqaworker15.qa.suse.cz/tests/153916

- sapconf http://openqaworker15.qa.suse.cz/tests/153901#live (this is using the config.yaml not edited by this PR)


One more set of VR after the alignment to the master content:

saptune without QESAP_IBSMIRROR_RESOURCE_GROUP :: clone of VR 153896 ---> http://openqaworker15.qa.suse.cz/tests/156435

saptune with QESAP_IBSMIRROR_RESOURCE_GROUP and longer timeout :: clone of VR 153916 ---> http://openqaworker15.qa.suse.cz/tests/156435

sapconf :: clone of VR 153901 ---> http://openqaworker15.qa.suse.cz/tests/156435