### PR TITLE
Disable low space warning when testing SAP installation wizard

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -16,6 +16,15 @@ use utils qw(file_content_replace type_string_slow);
 use x11utils qw(turn_off_gnome_screensaver);
 use version_utils qw(package_version_cmp is_sle);
 
+sub turn_off_low_disk_warning {
+    enter_cmd q@VAL=$(gsettings get org.gnome.settings-daemon.plugins.housekeeping ignore-paths | sed -e "s,.$,\, '/hana/shared'\, '/hana/data'\, '/hana/log'],")@;
+    enter_cmd 'echo $VAL';
+    enter_cmd 'gsettings get org.gnome.settings-daemon.plugins.housekeeping ignore-paths';
+    enter_cmd 'gsettings set org.gnome.settings-daemon.plugins.housekeeping ignore-paths "$VAL"';
+    enter_cmd 'gsettings get org.gnome.settings-daemon.plugins.housekeeping ignore-paths';
+    save_screenshot;
+}
+
 sub run {
     my ($self) = @_;
     my ($proto, $path) = $self->fix_path(get_required_var('HANA'));
@@ -51,6 +60,7 @@ sub run {
         mouse_hide;    # Hide the mouse so no needle will fail because of the mouse pointer appearing
         x11_start_program('xterm');
         turn_off_gnome_screensaver;    # Disable screensaver
+        turn_off_low_disk_warning;
         enter_cmd "killall xterm";
         assert_screen 'generic-desktop';
         x11_start_program('yast2 sap-installation-wizard', target_match => 'sap-installation-wizard');


### PR DESCRIPTION
Depending on the disk size used during testing, the SAP Installation Wizard test module can cause a Low Disk Space warning to be shown on gnome which causes troubles when detecting with `assert_screen()` that the wizard has finished, as it checks for a clean gnome desktop. This commit adds the expected HANA filesystems to the ignore-paths key in `org.gnome.settings-daemon.plugins.housekeeping` so these paths are ignored and the warning not shown.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/11064820#step/wizard_hana_install/21
