### PR TITLE
Move BOOT_HDD_IMAGE to the OpenQA test suite

### DIFF
--- a/schedule/hpc/ww4.yaml
+++ b/schedule/hpc/ww4.yaml
@@ -7,7 +7,6 @@ description:    >
     '{{ww4}}' schedules the controller
 vars:
   DESKTOP: textmode
-  BOOT_HDD_IMAGE: 1
 
 conditional_schedule:
   bootmenu:


### PR DESCRIPTION
Remove BOOT_HDD_IMAGE from yml to set it up only for the controller of the cluster, and avoid run compute nodes with unwanted job variable.

- Related ticket: https://progress.opensuse.org/issues/128003
