### PR TITLE
Apply workaround for bsc#1202234 for autoyast install

### DIFF
--- a/data/autoyast_qam/12-common_base_installation.xml.ep
+++ b/data/autoyast_qam/12-common_base_installation.xml.ep
@@ -315,6 +315,13 @@
     % if ($get_var->('SCC_ADDONS') =~ m/\brt\b/) {
     <kernel>kernel-rt</kernel>
     % }
+    <packages config:type="list">
+      <!-- Workaround for bsc#1202234: [addon]-release packages are missing after autoyast installation. -->
+      % foreach (values %$addons) {
+      <package><%= lc($_->{name}) %>-release</package>
+      % }
+      <!-- end of workaround -->
+    </packages>
     <patterns config:type="list">
       % for my $pattern (@$patterns) {
       <pattern><%= $pattern %></pattern>

--- a/data/autoyast_qam/15-common_base_installation.xml.ep
+++ b/data/autoyast_qam/15-common_base_installation.xml.ep
@@ -280,12 +280,17 @@
     % if ($get_var->('SCC_ADDONS') =~ m/\brt\b/) {
     <kernel>kernel-rt</kernel>
     % }
-    % if ($check_var->('VERSION', '15-SP3') or $check_var->('VERSION', '15-SP4')) {
     <packages config:type="list">
+      <!-- Workaround for bsc#1202234: [addon]-release packages are missing after autoyast installation. -->
+      % foreach (values %$addons) {
+      <package><%= lc($_->{name}) %>-release</package>
+      % }
+      <!-- end of workaround -->
+    % if ($check_var->('VERSION', '15-SP3') or $check_var->('VERSION', '15-SP4')) {
       <package>openssh</package>
       <package>firewalld</package>
-    </packages>
     % }
+    </packages>
     <patterns config:type="list">
       % for my $pattern (@$patterns) {
       <pattern><%= $pattern %></pattern>

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -37,14 +37,6 @@ sub run {
 
     quit_packagekit unless check_var('DESKTOP', 'textmode');
 
-    # We need to activated SLES-LTSS product again on system installed via autoyast
-    # https://progress.opensuse.org/issues/128840
-    # https://bugzilla.suse.com/show_bug.cgi?id=1211154
-    if (get_var('AUTOYAST') && get_var('SCC_ADDONS') =~ /ltss/ && script_run('test -f /etc/products.d/SLES-LTSS.prod') != 0) {
-        record_soft_failure('bsc#1211154');
-        add_suseconnect_product('SLES-LTSS', undef, undef, '-r ' . get_var('SCC_REGCODE_LTSS'), 150);
-    }
-
     zypper_call(q{mr -d $(zypper lr | awk -F '|' '{IGNORECASE=1} /nvidia/ {print $2}')}, exitcode => [0, 3]);
 
     add_test_repositories;


### PR DESCRIPTION
Remove the old workaround at the same time:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17004

- Related ticket: https://progress.opensuse.org/issues/128846

- Verification run: [sle12sp2-15sp3](https://openqa.suse.de/tests/overview?&distri=sle&build=rfan_ltss_new)