### PR TITLE
Prevent hot-corner invocation by mouse movement

### DIFF
--- a/tests/x11/hexchat_ssl.pm
+++ b/tests/x11/hexchat_ssl.pm
@@ -53,12 +53,7 @@ sub run {
     my $name = ('hexchat');
     zypper_call("in $name");
 
-    # we need to move the mouse in the top left corner as hexchat
-    # opens it's window where the mouse is. mouse_hide() would move
-    # it to the lower right where the pk-update-icon's passive popup
-    # may suddenly cover parts of the dialog ... o_O
     select_console "x11";
-    mouse_set(0, 0);
 
     if (my $url = get_var("XCHAT_URL")) {
         # Start up hexchat client and try to login into server


### PR DESCRIPTION
The test opened overview mode by moving the cursor to `0,0`, which invoked the Gnome hot-corner feature. This mouse movement is now redundant and can be removed.

- Related ticket: https://progress.opensuse.org/issues/128960
- Verification run: https://openqa.suse.de/tests/11072699
