### PR TITLE
Update pgsql dependencies

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -46,9 +46,8 @@ sub packages_to_install {
         push @packages, ('python3-devel', 'python3-pip', 'golang', 'postgresql-devel');
     } elsif ($host_distri eq 'sles') {
         # SDK is needed for postgresql
-
         my $version = "$version.$sp";
-        push @packages, ('python3-devel', 'postgresql-devel');
+        push @packages, ('python3-devel', 'postgresql-server-devel');
         if ($version eq "12.5") {
             script_retry("SUSEConnect -p sle-sdk/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             # PackageHub is needed for jq


### PR DESCRIPTION
The `pg_config` package is present in `postgresql-server-devel`, not in `postgresql-devel`.

- Related ticket: https://progress.opensuse.org/issues/128900
- Verification run: [15-SP4](https://openqa.suse.de/tests/11073975#step/bci_prepare/38) | [12-SP5](https://openqa.suse.de/tests/11074493#step/bci_prepare/38) (both fail in a different subsequent step)
