### PR TITLE
kernel/bpftrace: kill after timeout

### DIFF
--- a/tests/kernel/bpftrace.pm
+++ b/tests/kernel/bpftrace.pm
@@ -71,7 +71,7 @@ sub run {
       old/tcpdrop.bt);
 
     foreach my $t (@assert_tests) {
-        my $ret = script_run("timeout --preserve-status -s SIGINT 10 bpftrace $tools_dir/$t");
+        my $ret = script_run("timeout --preserve-status -s SIGINT --kill-after=10 10 bpftrace $tools_dir/$t");
 
         if ($ret == 130) {
             record_info('timeout', "'bpftrace $t' did not handle SIGINT; system was probably too slow to attach probes");
@@ -81,7 +81,7 @@ sub run {
     }
 
     foreach my $t (@tests) {
-        script_run("timeout --preserve-status -s SIGINT 10 bpftrace $tools_dir/$t");
+        script_run("timeout --preserve-status -s SIGINT --kill-after=10 10 bpftrace $tools_dir/$t");
     }
 
     my $case_dir = get_required_var('CASEDIR');


### PR DESCRIPTION
Some timeouts of script_run have been observed where bpftrace appears to ignore the interrupt signal from the timeout command. If sending kill does not stop bpftrace then it could be a worse problem.

Waiting for verification.