### PR TITLE
Remove not needed setting condition from mr_test

### DIFF
--- a/tests/sles4sap/publiccloud/mr_test_setup_env.pm
+++ b/tests/sles4sap/publiccloud/mr_test_setup_env.pm
@@ -32,10 +32,8 @@ sub run {
     select_host_console();
 
     # Download mr_test and extract it to '/root' later
-    if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
-        my $tarball = get_var('MR_TEST_TARBALL', "https://gitlab.suse.de/qa/mr_test/-/archive/master/$mr_test_tar");
-        assert_script_run "curl -sk $tarball -o /root/$mr_test_tar";
-    }
+    my $tarball = get_var('MR_TEST_TARBALL', "https://gitlab.suse.de/qa/mr_test/-/archive/master/$mr_test_tar");
+    assert_script_run "curl -sk $tarball -o /root/$mr_test_tar";
 
     # Copy the code to instance
     my $remote = $run_args->{my_instance}->username . '@' . $run_args->{my_instance}->public_ip;


### PR DESCRIPTION
Remove PUBLIC_CLOUD_SLES4SAP from mr_test .tar download. This condition of PUBLIC_CLOUD_SLES4SAP can be deleted as non-public and public mr_test env setup use different test module:
- non-cloud env setup use: ./tests/sles4sap/saptune/mr_test.pm
- cloud env setup uses: ./tests/sles4sap/publiccloud/mr_test_setup_env.pm


Related ticket: [TEAM-6798](https://jira.suse.com/browse/TEAM-6798)

Verification run: 
- Cloud mr_test https://openqa.suse.de/tests/11076569
- non cloud mr_test https://openqa.suse.de/tests/11076579
