### PR TITLE
Also use postgresql-server-devel on openSUSE

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -67,7 +67,7 @@ sub packages_to_install {
             push @packages, ('go', 'skopeo');
         }
     } elsif ($host_distri =~ /opensuse/) {
-        push @packages, qw(python3-devel go skopeo postgresql-devel);
+        push @packages, qw(python3-devel go skopeo postgresql-server-devel);
     } else {
         die("Host is not supported for running BCI tests.");
     }


### PR DESCRIPTION
Also on openSUSE, use the postgresql-server-devel package instead of postgresql-devel.

- Related ticket: https://progress.opensuse.org/issues/128900
- Verification run: https://openqa.suse.de/tests/11076233 (failure due to outdated BCI repo)
