### PR TITLE
Standardize variable name in the conf.yaml for qesap

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -4,8 +4,8 @@ terraform:
   variables:
     aws_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%QESAP_CLUSTER_OS_VER%"
-    os_owner: "%QESAP_CLUSTER_OS_OWNER%"
+    os_image: "%OS_VER%"
+    os_owner: "%OS_OWNER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     aws_credentials: "/root/amazon_credentials"

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -4,8 +4,8 @@ terraform:
   variables:
     aws_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%QESAP_CLUSTER_OS_VER%"
-    os_owner: "%QESAP_CLUSTER_OS_OWNER%"
+    os_image: "%OS_VER%"
+    os_owner: "%OS_OWNER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     aws_credentials: "/root/amazon_credentials"

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -4,7 +4,7 @@ terraform:
   variables:
     az_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%QESAP_CLUSTER_OS_VER%"
+    os_image: "%OS_VER%"
     public_key: "%SSH_KEY_PUB%"
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -4,7 +4,7 @@ terraform:
   variables:
     az_region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%QESAP_CLUSTER_OS_VER%"
+    os_image: "%OS_VER%"
     public_key: "%SSH_KEY_PUB%"
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -7,7 +7,7 @@ terraform:
     public_key: "%SSH_KEY_PUB%"
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
+    os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%OS_VER%'
     hana_instancetype: "%HANA_INSTANCE_TYPE%"
 
 ansible:

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -5,7 +5,7 @@ terraform:
     project: "ei-sle-qa-sap-8469"
     region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%QESAP_CLUSTER_OS_VER%"
+    os_image: "%OS_VER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     gcp_credentials_file: "/root/google_credentials.json"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -5,7 +5,7 @@ terraform:
     project: "ei-sle-qa-sap-8469"
     region: "%REGION%"
     deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%QESAP_CLUSTER_OS_VER%"
+    os_image: "%OS_VER%"
     private_key: "%SSH_KEY_PRIV%"
     public_key: "%SSH_KEY_PUB%"
     gcp_credentials_file: "/root/google_credentials.json"

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -27,13 +27,13 @@ sub run {
     $variables{REGION} = $provider->provider_client->region;
     $variables{DEPLOYMENTNAME} = $resource_group_postfix;
     if (get_var('QESAP_CLUSTER_OS_VER')) {
-        $variables{QESAP_CLUSTER_OS_VER} = get_var('QESAP_CLUSTER_OS_VER');
+        $variables{OS_VER} = get_var('QESAP_CLUSTER_OS_VER');
     }
     else {
         $variables{STORAGE_ACCOUNT_NAME} = get_required_var('STORAGE_ACCOUNT_NAME');
-        $variables{SLE_IMAGE} = $provider->get_image_id();
+        $variables{OS_VER} = $provider->get_image_id();
     }
-    $variables{QESAP_CLUSTER_OS_OWNER} = get_var('QESAP_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    $variables{OS_OWNER} = get_var('QESAP_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';


### PR DESCRIPTION
Always use OS_VER in all the qesap regression conf.yaml templates. This is used for tests using image from the cloud catalog and for tests using custom builds.

- Related ticket: TEAM-7693

- Verification run:
AWS 15sp5 (the one that this  PR is mind to fix) http://openqaworker15.qa.suse.cz/tests/154807 **os_image** is fine in http://openqaworker15.qa.suse.cz/tests/154807/file/configure-terraform.tfvars Test fails for similar reason as before. Probably it is due to `os_owner`. Second VR with proper OS_OWNER setting http://openqaworker15.qa.suse.cz/tests/154814
AWS 15sp3 http://openqaworker15.qa.suse.cz/tests/154808 PASS
AZ 15sp5 http://openqaworker15.qa.suse.cz/tests/154810 PASS
AZ 15sp4 http://openqaworker15.qa.suse.cz/tests/154811 PASS
