### PR TITLE
Add btrfs subvolumes on qem autoyast file

### DIFF
--- a/data/autoyast_qam/12-common_base_installation.xml.ep
+++ b/data/autoyast_qam/12-common_base_installation.xml.ep
@@ -69,51 +69,85 @@
     </mode>
     <final_reboot config:type="boolean">true</final_reboot>
   </general>
-  <partitioning config:type="list">
-    <drive>
-      <_id config:type="integer">0</_id>
+  <partitioning t="list">
+    <drive t="map">
       <device>/dev/disk/by-path/ccw-0.0.0000</device>
       <disklabel>gpt</disklabel>
-      <enable_snapshots config:type="boolean">true</enable_snapshots>
-      <partitions config:type="list">
-        <partition>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">ext2</filesystem>
-          <format config:type="boolean">true</format>
-          <fstopt>acl,user_xattr</fstopt>
+      <enable_snapshots t="boolean">true</enable_snapshots>
+      <partitions t="list">
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">ext2</filesystem>
+          <format t="boolean">true</format>
           <mount>/boot/zipl</mount>
-          <mountby config:type="symbol">uuid</mountby>
-          <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">1</partition_nr>
-          <partition_type>primary</partition_type>
-          <resize config:type="boolean">false</resize>
-          <size>300M</size>
+	  <fstopt>acl,user_xattr</fstopt>
+          <mountby t="symbol">uuid</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">1</partition_nr>
+          <resize t="boolean">false</resize>
+          <size>314572800</size>
         </partition>
-        <partition>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">btrfs</filesystem>
-          <format config:type="boolean">true</format>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <create_subvolumes t="boolean">true</create_subvolumes>
+          <filesystem t="symbol">btrfs</filesystem>
+          <format t="boolean">true</format>
           <mount>/</mount>
-          <mountby config:type="symbol">uuid</mountby>
-          <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">2</partition_nr>
-          <partition_type>primary</partition_type>
-          <resize config:type="boolean">false</resize>
+          <mountby t="symbol">uuid</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">2</partition_nr>
+          <quotas t="boolean">true</quotas>
+          <resize t="boolean">false</resize>
+          <size>max</size>
+          <subvolumes t="list">
+            <subvolume t="map">
+              <copy_on_write t="boolean">false</copy_on_write>
+              <path>var</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>usr/local</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>tmp</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>srv</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>root</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>opt</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>home</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>boot/grub2/s390x-emu</path>
+            </subvolume>
+          </subvolumes>
+          <subvolumes_prefix>@</subvolumes_prefix>
         </partition>
-        <partition>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">swap</filesystem>
-          <format config:type="boolean">true</format>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">swap</filesystem>
+          <format t="boolean">true</format>
           <mount>swap</mount>
-          <mountby config:type="symbol">uuid</mountby>
-          <partition_id config:type="integer">130</partition_id>
-          <partition_nr config:type="integer">3</partition_nr>
-          <partition_type>primary</partition_type>
-          <resize config:type="boolean">false</resize>
-          <size>2G</size>
+          <mountby t="symbol">uuid</mountby>
+          <partition_id t="integer">130</partition_id>
+          <partition_nr t="integer">3</partition_nr>
+          <resize t="boolean">false</resize>
+          <size>2148515328</size>
         </partition>
       </partitions>
-      <type config:type="symbol">CT_DISK</type>
+      <type t="symbol">CT_DISK</type>
       <use>all</use>
     </drive>
   </partitioning>

--- a/data/autoyast_qam/15-common_base_installation.xml.ep
+++ b/data/autoyast_qam/15-common_base_installation.xml.ep
@@ -68,50 +68,84 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
-  <partitioning config:type="list">
-    <drive>
+  <partitioning t="list">
+    <drive t="map">
       <device>/dev/disk/by-path/ccw-0.0.0000</device>
       <disklabel>gpt</disklabel>
-      <enable_snapshots config:type="boolean">true</enable_snapshots>
-      <partitions config:type="list">
-        <partition>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">ext2</filesystem>
-          <format config:type="boolean">true</format>
-          <fstopt>acl,user_xattr</fstopt>
+      <enable_snapshots t="boolean">true</enable_snapshots>
+      <partitions t="list">
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">ext2</filesystem>
+          <format t="boolean">true</format>
           <mount>/boot/zipl</mount>
-          <mountby config:type="symbol">uuid</mountby>
-          <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">1</partition_nr>
-          <partition_type>primary</partition_type>
-          <resize config:type="boolean">false</resize>
-          <size>300M</size>
+          <mountby t="symbol">uuid</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">1</partition_nr>
+          <resize t="boolean">false</resize>
+          <size>314572800</size>
         </partition>
-        <partition>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">btrfs</filesystem>
-          <format config:type="boolean">true</format>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <create_subvolumes t="boolean">true</create_subvolumes>
+          <filesystem t="symbol">btrfs</filesystem>
+          <format t="boolean">true</format>
           <mount>/</mount>
-          <mountby config:type="symbol">uuid</mountby>
-          <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">2</partition_nr>
-          <partition_type>primary</partition_type>
-          <resize config:type="boolean">false</resize>
+          <mountby t="symbol">uuid</mountby>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">2</partition_nr>
+          <quotas t="boolean">true</quotas>
+          <resize t="boolean">false</resize>
+          <size>max</size>
+          <subvolumes t="list">
+            <subvolume t="map">
+              <copy_on_write t="boolean">false</copy_on_write>
+              <path>var</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>usr/local</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>tmp</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>srv</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>root</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>opt</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>home</path>
+            </subvolume>
+            <subvolume t="map">
+              <copy_on_write t="boolean">true</copy_on_write>
+              <path>boot/grub2/s390x-emu</path>
+            </subvolume>
+          </subvolumes>
+          <subvolumes_prefix>@</subvolumes_prefix>
         </partition>
-        <partition>
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">swap</filesystem>
-          <format config:type="boolean">true</format>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">swap</filesystem>
+          <format t="boolean">true</format>
           <mount>swap</mount>
-          <mountby config:type="symbol">uuid</mountby>
-          <partition_id config:type="integer">130</partition_id>
-          <partition_nr config:type="integer">3</partition_nr>
-          <partition_type>primary</partition_type>
-          <resize config:type="boolean">false</resize>
-          <size>2G</size>
+          <mountby t="symbol">uuid</mountby>
+          <partition_id t="integer">130</partition_id>
+          <partition_nr t="integer">3</partition_nr>
+          <resize t="boolean">false</resize>
+          <size>2148515328</size>
         </partition>
       </partitions>
-      <type config:type="symbol">CT_DISK</type>
+      <type t="symbol">CT_DISK</type>
       <use>all</use>
     </drive>
   </partitioning>


### PR DESCRIPTION
https://progress.opensuse.org/issues/128990

- Verification run: 
 **The changes are happening on s390x only**
[create_hdd](https://openqa.suse.de/tests/overview?distri=sle&build=rfan_s390x_btrfs)
[btrfs](https://openqa.suse.de/tests/11082079)

[12-SP5-15-SP4](https://openqa.suse.de/tests/overview?result=passed&arch=&flavor=&machine=&test=&modules=&module_re=&build=rfan_s390x_btrfs&distri=sle#)