### PR TITLE
Add TW test data for lvm+raid1

### DIFF
--- a/test_data/yast/opensuse/lvm+raid1.yaml
+++ b/test_data/yast/opensuse/lvm+raid1.yaml
@@ -1,0 +1,79 @@
+---
+mds:
+  - raid_level: 1
+    chunk_size: '64 KiB'
+    devices:
+      - vda2
+      - vdb2
+      - vdc2
+      - vdd2
+    partition:
+      role: raw-volume
+      formatting_options:
+        should_format: 0
+      mounting_options:
+        should_mount: 0
+  - raid_level: 0
+    chunk_size: '64 KiB'
+    devices:
+      - vda3
+      - vdb3
+      - vdc3
+      - vdd3
+    partition:
+      role: swap
+      formatting_options:
+        should_format: 1
+        filesystem: swap
+      mounting_options:
+        should_mount: 1
+lvm: !include test_data/yast/lvm_raid1/lvm+raid1_lvm.yaml
+disks:
+  - name: vda
+    partitions:
+      - size: 2mb
+        id: bios-boot
+        role: raw-volume
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdb
+    partitions:
+      - size: 2mb
+        id: bios-boot
+        role: raw-volume
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdc
+    partitions:
+      - size: 2mb
+        id: bios-boot
+        role: raw-volume
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdd
+    partitions:
+      - size: 2mb
+        id: bios-boot
+        role: raw-volume
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 100mb
+        role: raw-volume
+        id: linux-raid
+raid1:
+  disk_to_fail: /dev/vdd2
+  level: raid1
+  name: /dev/md0


### PR DESCRIPTION
fixes failure : https://openqa.opensuse.org/tests/3278116#step/setup_raid1_lvm/4
- Verification run: https://openqa.opensuse.org/tests/3278733
combined with https://github.com/os-autoinst/opensuse-jobgroups/pull/324
