### PR TITLE
Add NIC to the default firewall zone 'public' in AutoYaST

### DIFF
--- a/data/autoyast_qam/15-common_base_installation.xml.ep
+++ b/data/autoyast_qam/15-common_base_installation.xml.ep
@@ -244,6 +244,7 @@
         <device>eth0</device>
         <dhclient_set_default_route>yes</dhclient_set_default_route>
         <startmode>auto</startmode>
+        <zone>public</zone>
       </interface>
     </interfaces>
   </networking>


### PR DESCRIPTION
https://progress.opensuse.org/issues/128843

The NIC 'eth0' is added to firewall zone 'public' by default during
interactive installation. so add the same configuration in AutoYaST

- Verification run:
[SLE15-SP1---SLES15-SP4](https://openqa.suse.de/tests/overview?distri=sle&build=rfan_x86)

**This PR only fixes the issue mentioned in [poo#128843](https://progress.opensuse.org/issues/128843), I will try to enhance the firewall configuration settings via [poo#129083](https://progress.opensuse.org/issues/129083) **
