### PR TITLE
Fix nfs-server exportfs timeout issue

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -257,8 +257,6 @@ sub config_service {
 
 sub start_service {
     my ($rw, $ro) = @_;
-    # Back on the console
-    clear_console;
 
     # Server is up and running, client can use it now!
     check_nfs_ready($rw, $ro);


### PR DESCRIPTION
The clear_console in serial terminal is unexpected which blocked the system and not returned which caused exportfs timeout.

- Related ticket: https://progress.opensuse.org/issues/128648
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=lemon-suse%2Fos-autoinst-distri-opensuse%23fix-nfs-server-exports-timeout-issue&flavor=Online&arch=aarch64&arch=x86_64
