### PR TITLE
Let warewulf controller boot when controller is ready

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -91,8 +91,9 @@ sub destroy_test_barriers {
         barrier_destroy('MPI_RUN_TEST');
     }
     elsif (check_var('HPC', 'ww4_controller') || check_var('HPC', 'ww4_compute')) {
-        barrier_create('WWCTL_DONE');
-        barrier_create('COMPUTE_BOOT_DONE');
+        barrier_destroy('WWCTL_READY');
+        barrier_destroy('WWCTL_DONE');
+        barrier_destroy('COMPUTE_BOOT_DONE');
     }
 }
 

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -64,6 +64,7 @@ sub run ($self) {
         barrier_create('IMB_TEST_DONE', $nodes);
     }
     elsif (check_var('HPC', 'ww4_controller')) {
+        barrier_create('WWCTL_READY', $nodes);
         barrier_create('WWCTL_DONE', $nodes);
         barrier_create('WWCTL_COMPUTE_DONE', $nodes);
     }


### PR DESCRIPTION
Add mutex to remove controllers rebooting until the controller is ready. Fix also the tear down operations which destroy the barriers.

Previously, as we implementated the loop, it could have finished before the
controller is ready to boot the nodes or the nodes would have to wait even if
the server was done.

- Related ticket: https://progress.opensuse.org/issues/128003
- Verification run: https://aquarius.suse.cz/tests/16626
