### PR TITLE
Enable automation for YaST in Container in ALP

### DIFF
--- a/schedule/alp/alp_yast.yaml
+++ b/schedule/alp/alp_yast.yaml
@@ -1,0 +1,9 @@
+---
+name: alp_yast
+description: >
+    Enable YaST automation test for ALP
+vars:
+    YUI_REST_API: 1
+schedule:
+    - microos/disk_boot
+    - shutdown/shutdown


### PR DESCRIPTION
Enable automation for YaST in Container in ALP

**Ticket:**

- https://progress.opensuse.org/issues/128117

**Verification run:**
- [Development ALP Micro](https://openqa.opensuse.org/tests/overview?distri=alp&version=micro-0.1&build=3.5&groupid=110)
- [Development ALP Bedrock](https://openqa.opensuse.org/tests/overview?distri=alp&version=bedrock-0.1&build=5.1&groupid=111)

**Related PR:**
- [# 318](https://github.com/os-autoinst/opensuse-jobgroups/pull/318)