### PR TITLE
Add IBS Mirror peering in qesap regression Azure

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -9,6 +9,8 @@ terraform:
     hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
     hana_instancetype: "%HANA_INSTANCE_TYPE%"
+    vnet_address_range: "%VNET_ADDRESS_RANGE%"
+    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
 
 ansible:
   az_storage_account_name: "%HANA_ACCOUNT%"

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -834,13 +834,13 @@ Run 00.050 net peering script
 sub cluster_trento_net_peering {
     my ($basedir) = @_;
     my $trento_rg = get_resource_group();
-    my $cluster_rg = qesap_get_az_resource_group(substring => TRENTO_QESAPDEPLOY_PREFIX);
+    my $cluster_rg = qesap_az_get_resource_group(substring => TRENTO_QESAPDEPLOY_PREFIX);
     my $cmd = join(' ',
         $basedir . '/00.050-trento_net_peering_tserver-sap_group.sh',
         '-s', $trento_rg,
-        '-n', qesap_get_vnet($trento_rg),
+        '-n', qesap_az_get_vnet($trento_rg),
         '-t', $cluster_rg,
-        '-a', qesap_get_vnet($cluster_rg));
+        '-a', qesap_az_get_vnet($cluster_rg));
     record_info('NET PEERING');
     assert_script_run($cmd, 360);
 }

--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -96,8 +96,8 @@ subtest '[cluster_trento_net_peering] cluster_trento_net_peering has to compose 
     @calls = ();
     my $expected_net_name = 'PIZZANET';
     $trento->redefine(get_resource_group => sub { return 'VALLUTATA'; });
-    $trento->redefine(qesap_get_az_resource_group => sub { return 'ZUPPA'; });
-    $trento->redefine(qesap_get_vnet => sub {
+    $trento->redefine(qesap_az_get_resource_group => sub { return 'ZUPPA'; });
+    $trento->redefine(qesap_az_get_vnet => sub {
             push @calls, $_[0];
             return "PIATTO_DI_VALLUTATA" if ($_[0] =~ /VALLUTATA/);
             return "PIATTO_DI_ZUPPA" if ($_[0] =~ /ZUPPA/);

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -150,14 +150,14 @@ sub run {
     my ($self, $run_args) = @_;
 
     if (check_var('IS_MAINTENANCE', 1)) {
-        my %maintenance_vars = qesap_calculate_az_address_range(slot => get_var("WORKER_INSTANCE"));
+        my %maintenance_vars = qesap_calculate_az_address_range(slot => get_required_var('WORKER_ID'));
         set_var("VNET_ADDRESS_RANGE", $maintenance_vars{vnet_address_range});
         set_var("SUBNET_ADDRESS_RANGE", $maintenance_vars{subnet_address_range});
     }
 
     # Let's define a workspace for terraform. We use PUBLIC_CLOUD_RESOURCE_GROUP
     # if defined, otherwise we use qesaposd
-    my $workspace = get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qesaposd') . get_current_job_id();
+    my $workspace = qesap_calculate_deployment_name(get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qesaposd'));
 
     # Select console on the host (not the PC instance) to reset 'TUNNELED',
     # otherwise select_serial_terminal() will be failed

--- a/tests/sles4sap/qesapdeployment/cluster_add_repos.pm
+++ b/tests/sles4sap/qesapdeployment/cluster_add_repos.pm
@@ -34,11 +34,11 @@ sub run() {
 
 sub delete_peering {
     # destroy the network peering, if it was created
-    my $rg = qesap_get_az_resource_group();
-    my $vn = qesap_get_vnet($rg);
+    my $rg = qesap_az_get_resource_group();
+    my $vn = qesap_az_get_vnet($rg);
     my $target_rg = get_required_var('QESAP_TARGET_RESOURCE_GROUP');
-    my $target_vn = qesap_get_vnet($target_rg);
-    qesap_delete_az_peering(source_group => $rg, source_vnet => $vn, target_group => $target_rg, target_vnet => $target_vn);
+    my $target_vn = qesap_az_get_vnet($target_rg);
+    qesap_az_vnet_peering_delete(source_group => $rg, source_vnet => $vn, target_group => $target_rg, target_vnet => $target_vn);
 }
 
 sub test_flags {

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -19,13 +19,12 @@ sub run {
     # Init al the PC gears (ssh keys)
     my $provider = $self->provider_factory();
 
-    my $resource_group_postfix = 'qesapval' . get_current_job_id();
     my $qesap_provider = lc get_required_var('PUBLIC_CLOUD_PROVIDER');
 
     my %variables;
     $variables{PROVIDER} = $qesap_provider;
     $variables{REGION} = $provider->provider_client->region;
-    $variables{DEPLOYMENTNAME} = $resource_group_postfix;
+    $variables{DEPLOYMENTNAME} = qesap_calculate_deployment_name('qesapval');
     if (get_var('QESAP_CLUSTER_OS_VER')) {
         $variables{OS_VER} = get_var('QESAP_CLUSTER_OS_VER');
     }
@@ -56,6 +55,11 @@ sub run {
         $variables{HANA_DATA_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DISK_TYPE", "pd-ssd");
         $variables{HANA_LOG_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DISK_TYPE", "pd-ssd");
     }
+
+    my %peering_settings = qesap_calculate_az_address_range(slot => get_required_var('WORKER_ID'));
+    $variables{VNET_ADDRESS_RANGE} = $peering_settings{vnet_address_range};
+    $variables{SUBNET_ADDRESS_RANGE} = $peering_settings{subnet_address_range};
+
     qesap_prepare_env(openqa_variables => \%variables, provider => $qesap_provider);
 }
 

--- a/tests/sles4sap/qesapdeployment/network_peering.pm
+++ b/tests/sles4sap/qesapdeployment/network_peering.pm
@@ -15,7 +15,7 @@ sub run {
     my ($self, $run_args) = @_;
     my $instance = $run_args->{my_instance};
     record_info("$instance");
-    my $rg = qesap_get_az_resource_group();
+    my $rg = qesap_az_get_resource_group();
     my $target_rg = get_required_var('QESAP_TARGET_RESOURCE_GROUP');
     qesap_az_vnet_peering(source_group => $rg, target_group => $target_rg);
     qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("IBSM_IP"));
@@ -30,11 +30,11 @@ sub post_fail_hook {
     qesap_upload_logs();
 
     # destroy the network peering, if it was created
-    my $rg = qesap_get_az_resource_group();
-    my $vn = qesap_get_vnet($rg);
+    my $rg = qesap_az_get_resource_group();
+    my $vn = qesap_az_get_vnet($rg);
     my $target_rg = get_required_var('QESAP_TARGET_RESOURCE_GROUP');
-    my $target_vn = qesap_get_vnet($target_rg);
-    qesap_delete_az_peering(source_group => $rg, source_vnet => $vn, target_group => $target_rg, target_vnet => $target_vn);
+    my $target_vn = qesap_az_get_vnet($target_rg);
+    qesap_az_vnet_peering_delete(source_group => $rg, source_vnet => $vn, target_group => $target_rg, target_vnet => $target_vn);
 
     my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
     qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300) unless (script_run("test -e $inventory"));

--- a/tests/sles4sap/qesapdeployment/peering_destroy.pm
+++ b/tests/sles4sap/qesapdeployment/peering_destroy.pm
@@ -12,9 +12,9 @@ use testapi;
 use qesapdeployment;
 
 sub run {
-    my $rg = qesap_get_az_resource_group();
+    my $rg = qesap_az_get_resource_group();
     my $target_rg = get_required_var('QESAP_TARGET_RESOURCE_GROUP');
-    qesap_delete_az_peering(source_group => $rg, target_group => $target_rg);
+    qesap_az_vnet_peering_delete(source_group => $rg, target_group => $target_rg);
 }
 
 1;

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -24,6 +24,13 @@ sub run {
     record_info("crm status", $cmr_status);
     qesap_ansible_cmd(cmd => $crm_mon_cmd, provider => $prov, filter => '"hana[0]"');
     qesap_cluster_logs();
+
+    if (get_var("QESAP_IBSMIRROR_RESOURCE_GROUP")) {
+        my $rg = qesap_az_get_resource_group();
+        my $ibs_mirror_rg = get_var('QESAP_IBSMIRROR_RESOURCE_GROUP');
+        qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_rg);
+        qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibs_mirror_rg);
+    }
 }
 
 sub post_fail_hook {
@@ -31,6 +38,11 @@ sub post_fail_hook {
     qesap_upload_logs();
     qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
     qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
+    if (get_var("QESAP_IBSMIRROR_RESOURCE_GROUP")) {
+        my $rg = qesap_az_get_resource_group();
+        my $ibs_mirror_rg = get_required_var('QESAP_IBSMIRROR_RESOURCE_GROUP');
+        qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibs_mirror_rg);
+    }
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Add a simple test about network peering in qesap regression for Azure. Increase the timeout for the az peering cmds.
Minor fixes in qesapdeployment and unit testing about peering functions.

Related ticket: [TEAM-7704](https://jira.suse.com/browse/TEAM-7704)

Verification run: Azure 15sp4

 - saptune without QESAP_IBSMIRROR_RESOURCE_GROUP http://openqaworker15.qa.suse.cz/tests/156456 PASS http://openqaworker15.qa.suse.cz/tests/156470 PASS

 - saptune with QESAP_IBSMIRROR_RESOURCE_GROUP and longer timeout http://openqaworker15.qa.suse.cz/tests/156462 and http://openqaworker15.qa.suse.cz/tests/156469 PASS WITH PEERING

 - sapconf http://openqaworker15.qa.suse.cz/tests/156458 PASS

 - mr_test https://openqa.suse.de/tests/11099115

 - mr_test with IS_MAINTENANCE , YAML_SCHEDULE=schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml , QESAP_TARGET_RESOURCE_GROUP and  IBSM_IP  https://openqa.suse.de/tests/11099559 and https://openqa.suse.de/tests/11099805 and https://openqa.suse.de/tests/11100807 and https://openqa.suse.de/tests/11103488 and https://openqa.suse.de/tests/11103804 and https://openqa.suse.de/tests/11111558

 - trento http://openqaworker15.qa.suse.cz/tests/156471 and http://openqaworker15.qa.suse.cz/tests/156473 and http://openqaworker15.qa.suse.cz/tests/156474# all of them fails, but failure is in the last Cypress part, this PR can affect deployment that is PASS

