### PR TITLE
jeos/firstrun: Leap 15.4 does not need explicit EULA acceptance

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -121,7 +121,7 @@ sub run {
     send_key 'ret';
 
     # Accept EULA if required
-    unless (is_tumbleweed || is_microos || is_leap('>=15.5')) {
+    unless (is_tumbleweed || is_microos || is_leap('>=15.4')) {
         assert_screen 'jeos-doyouaccept';
         send_key 'ret';
     }


### PR DESCRIPTION
jeos-firstboot got updated there as well now.

- Verification run: https://openqa.opensuse.org/tests/3282110
