### PR TITLE
Do not pipe output into a pager for wicked service

### DIFF
--- a/tests/autoyast/wicked.pm
+++ b/tests/autoyast/wicked.pm
@@ -24,10 +24,11 @@ use strict;
 use warnings;
 use base 'consoletest';
 use testapi;
+use utils 'systemctl';
 
 sub run {
     # https://en.opensuse.org/openSUSE:Bugreport_wicked
-    enter_cmd "systemctl status wickedd.service";
+    systemctl 'status wickedd.service';
     enter_cmd "echo `wicked show all |cut -d ' ' -f 1` END | tee /dev/$serialdev";
     my $iflist = wait_serial("END", 10);
     # For poo#70453, to filter network link from mixed info of the output of wicked cmd


### PR DESCRIPTION
Do not pipe output into a pager for wicked service

- Related ticket: https://progress.opensuse.org/issues/128150
- Verification run: https://openqa.suse.de/tests/11146505#step/wicked/1