### PR TITLE
Adjust schedules to avoid processing beta popup

### DIFF
--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
@@ -4,10 +4,15 @@ description: |
   Test verifies that extensions can be added as addons via http and ftp.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@pvm.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@pvm.yaml
@@ -4,10 +4,15 @@ description: |
     Test verifies that adding addons using http and ftp works fine.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
@@ -4,10 +4,15 @@ description: |
    Test verifies that adding addons using http and ftp works fine.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/btrfs/btrfs+warnings.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings.yaml
@@ -10,10 +10,15 @@ description: >
 vars:
   FILESYSTEM: btrfs
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/btrfs/btrfs+warnings@pvm.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@pvm.yaml
@@ -10,10 +10,15 @@ description: >
 vars:
   FILESYSTEM: btrfs
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
@@ -10,10 +10,15 @@ description: >
 vars:
   FILESYSTEM: btrfs
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/clone_system/clone_system_pvm.yaml
+++ b/schedule/yast/clone_system/clone_system_pvm.yaml
@@ -4,10 +4,15 @@ description: >
   generated and no error reported by YaST. No validation of the profile is done.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -9,10 +9,15 @@ vars:
   ENCRYPT_FORCE_RECOMPUTE: 1
   LVM: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute_pvm.yaml
@@ -11,10 +11,15 @@ vars:
   ENCRYPT_FORCE_RECOMPUTE: 1
   LVM: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -6,10 +6,15 @@ description: >
 name: activate_encrypted_volume+import_users
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users_pvm.yaml
@@ -10,10 +10,15 @@ vars:
   ETC_PASSWD: "bernhard:x:1000:100:bernhard:/home/bernhard:/bin/bash"
   ETC_SHADOW: "bernhard:$6$ZQ2QptdwejF6$QAEuGvFZJCsyA0oWlrFsWXcMSNcgkU4y3oVPGHhoOjuEHU7BhKAm8DN5L8FnwQlngmNheB.vZqyz1HripbwKL0:18435:0:99999:7:::"
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/crypt_no_lvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm.yaml
@@ -12,10 +12,15 @@ vars:
   LVM: 0
   MAX_JOB_TIME: 14400
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_pvm.yaml
@@ -14,10 +14,15 @@ vars:
   LVM: 0
   MAX_JOB_TIME: 14400
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -8,10 +8,15 @@ vars:
   ENCRYPT: 1
   LVM: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -8,10 +8,15 @@ vars:
   ENCRYPT: 1
   LVM: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm_sle_15.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15.yaml
@@ -6,10 +6,15 @@ description: >
 name: cryptlvm
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_spvm.yaml
@@ -10,10 +10,15 @@ name: cryptlvm
 vars:
   DESKTOP: textmode
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot.yaml
@@ -8,10 +8,15 @@ vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
@@ -8,10 +8,15 @@ vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_module_desktop

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_pvm.yaml
@@ -12,9 +12,14 @@ vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -10,10 +10,15 @@ vars:
   FULL_LVM_ENCRYPT: 1
   MAX_JOB_TIME: '14400'
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
@@ -10,10 +10,15 @@ vars:
   FULL_LVM_ENCRYPT: 1
   MAX_JOB_TIME: '14400'
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_pvm.yaml
@@ -11,10 +11,15 @@ vars:
   FULL_LVM_ENCRYPT: 1
   MAX_JOB_TIME: '14400'
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm.yaml
@@ -6,10 +6,15 @@ name: lvm+cancel_existing_cryptlvm
 vars:
   LVM: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_pvm.yaml
@@ -6,10 +6,15 @@ name: lvm+cancel_existing_cryptlvm
 vars:
   LVM: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -10,10 +10,15 @@ vars:
   MAX_JOB_TIME: '14400'
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm_sle_spvm.yaml
+++ b/schedule/yast/lvm/lvm_sle_spvm.yaml
@@ -10,10 +10,15 @@ vars:
   DESKTOP: textmode
   MAX_JOB_TIME: '14400'
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm_thin_provisioning.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning.yaml
@@ -7,10 +7,15 @@ description: >
   in the booted system after the installation.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
@@ -7,10 +7,15 @@ description: >
   in the booted system after the installation.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_module_desktop

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -7,10 +7,15 @@ vars:
   RAIDLEVEL: 1
   LVM: 1
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+base/minimal+base@pvm.yaml
+++ b/schedule/yast/minimal+base/minimal+base@pvm.yaml
@@ -8,10 +8,15 @@ vars:
   DESKTOP: textmode
   PATTERNS: base,enhanced_base
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -9,10 +9,15 @@ vars:
   DESKTOP: textmode
   PATTERNS: base,enhanced_base
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/minimal+base/minimal+base@yast.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast.yaml
@@ -8,10 +8,15 @@ vars:
   DESKTOP: textmode
   PATTERNS: base,enhanced_base
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal.yaml
@@ -8,10 +8,15 @@ vars:
   BSC1167736: '1'
   SYSTEM_ROLE: minimal
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal@pvm.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal@pvm.yaml
@@ -8,10 +8,15 @@ vars:
   BSC1167736: '1'
   SYSTEM_ROLE: minimal
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
@@ -8,10 +8,15 @@ vars:
   BSC1167736: '1'
   SYSTEM_ROLE: minimal
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/modify_existing_partition/modify_existing_partition.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition.yaml
@@ -5,10 +5,15 @@ description: >
   create_hdd test suite.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
@@ -5,10 +5,15 @@ description: >
   create_hdd test suite.
 vars:
   YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/access_beta_distribution
+  - '{{access_beta_distribution}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/skip_module_registration

--- a/schedule/yast/sle/flows/default_x86_64.yaml
+++ b/schedule/yast/sle/flows/default_x86_64.yaml
@@ -4,8 +4,7 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta:
-  - installation/access_beta_distribution
+access_beta: []
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:


### PR DESCRIPTION
Adjust schedules to avoid processing beta popup when the product will not contain it in GMC in all the job groups owned by Yam.

- Related ticket: https://progress.opensuse.org/issues/129020
- Needles: n/a
- Verification run: n/a
