### PR TITLE
Add agama auto install sh script for Tumbleweed

### DIFF
--- a/data/yam/agama/auto/alp_tw.sh
+++ b/data/yam/agama/auto/alp_tw.sh
@@ -1,0 +1,8 @@
+set -ex
+
+/usr/bin/agama config set software.product=Tumbleweed
+/usr/bin/agama config set user.userName=joe user.password=doe
+/usr/bin/agama config set root.password=nots3cr3t
+/usr/bin/sleep 30
+/usr/bin/agama install
+/sbin/reboot


### PR DESCRIPTION
Add agama auto install sh script for Tumbleweed
- Related ticket: https://progress.opensuse.org/issues/128183
- Needles: na
- Verification run: https://openqa.opensuse.org/tests/3247743 