### PR TITLE
Check Python3 module for 3.11 instead of 3.10

### DIFF
--- a/tests/console/check_migration_features.pm
+++ b/tests/console/check_migration_features.pm
@@ -40,20 +40,20 @@ sub check_python2_dropped {
 # SLE-23610: Python3 module
 # test steps:
 # 1) activate the python3 module
-# 2) install the python310 package
-# 3) check python3.10's version which should be 3.10.X
+# 2) install the python311 package
+# 3) check python3.11's version which should be 3.11
 # 4) check python3's version
-# 5) check python310's lifecycle
+# 5) check python311's lifecycle
 sub check_python3_module {
     record_info('SLE-23610', 'Check Python3 Module');
     my $OS_VERSION = script_output("grep VERSION_ID /etc/os-release | cut -c13- | head -c -2");
     my $ARCH = get_required_var('ARCH');
     assert_script_run("SUSEConnect -p sle-module-python3/$OS_VERSION/$ARCH", timeout => 180);
-    zypper_call("se python310");
-    zypper_call("in python310");
-    assert_script_run("python3.10 --version | grep Python | grep 3.10.");
+    zypper_call("se python311");
+    zypper_call("in python311");
+    assert_script_run("python3.11 --version | grep Python | grep 3.11.");
     assert_script_run("python3 --version | grep Python | grep 3.6.");
-    assert_script_run("zypper lifecycle python310");
+    assert_script_run("zypper lifecycle python311");
 }
 
 # function to check all the features after migration


### PR DESCRIPTION
python 3.10 is not shipped with SLE15 SP5 any more as it's been upgraded to python 3.11

- Related ticket: https://progress.opensuse.org/issues/128690
- Verification run: https://openqa.suse.de/tests/11111616#step/check_migration_features/29
  https://openqa.suse.de/tests/11130644#step/check_migration_features/27
