### PR TITLE
extra_tests_kernel: Add non fatal flags for various tests

### DIFF
--- a/tests/kernel/bcc.pm
+++ b/tests/kernel/bcc.pm
@@ -23,6 +23,10 @@ sub run {
     assert_script_run("$tools_dir/filetop -a 5 10");
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;
 
 =head1 Discussion

--- a/tests/kernel/bpftrace.pm
+++ b/tests/kernel/bpftrace.pm
@@ -100,6 +100,10 @@ sub run {
     assert_script_run("kill $pid");
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;
 
 =head1 Discussion

--- a/tests/kernel/fwupd.pm
+++ b/tests/kernel/fwupd.pm
@@ -29,4 +29,8 @@ sub run {
     assert_script_run "fwupdmgr get-remotes";
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -109,6 +109,10 @@ sub run {
     }
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;
 
 =head1 Discussion

--- a/tests/kernel/module_build.pm
+++ b/tests/kernel/module_build.pm
@@ -37,4 +37,8 @@ sub run {
     assert_script_run "cd .. && rm -rf data";
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/kernel/tuned.pm
+++ b/tests/kernel/tuned.pm
@@ -65,4 +65,9 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
     upload_logs '/var/log/tuned/tuned.log';
 }
+
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
Reason: when io_uring test fails, following tests are skipped. https://openqa.suse.de/tests/11114594#step/io_uring/52

Verification run:
- https://openqa.suse.de/tests/overview?build=extra_tests_kernel%2Fnon-fatal-flags
- https://openqa.opensuse.org/tests/overview?build=extra_tests_kernel%2Fnon-fatal-flags
- https://openqa.suse.de/tests/11120609 (example of the test where failed test due problem with repos did not block other tests to run)
