### PR TITLE
Add partition for autoyast_sle_powervm.xml.ep

### DIFF
--- a/data/autoyast_sle15/autoyast_sle_powervm.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle_powervm.xml.ep
@@ -113,6 +113,12 @@
       </interface>
     </interfaces>
   </networking>
+  <partitioning config:type="list">
+     <drive>
+        <device>/dev/sda</device>
+        <initialize config:type="boolean">true</initialize> 
+     </drive>
+  </partitioning>
   <firewall config:type="map">
     <default_zone>public</default_zone>
     <enable_firewall config:type="boolean">true</enable_firewall>


### PR DESCRIPTION
Sometimes when we install on the slice that has installed encrypted OS, then it
 will wait for us to confirm to [**continue**](https://openqa.suse.de/tests/11130609#step/installation/2). We need to add a partition for the autoyast_sle_powervm.xml.ep

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/11130950
