### PR TITLE
[WIP] kernel/nfs: Add mutex to wait for barrier creation

### DIFF
--- a/tests/kernel/nfs_barriers.pm
+++ b/tests/kernel/nfs_barriers.pm
@@ -17,6 +17,7 @@ sub run {
     barrier_create("NFS_SERVER_ENABLED", $nodes);
     barrier_create("NFS_CLIENT_ENABLED", $nodes);
     barrier_create("NFS_SERVER_CHECK", $nodes);
+    mutex_create("NFS_BARRIERS_CREATED");
     record_info("barriers initialized");
 }
 

--- a/tests/kernel/nfs_client.pm
+++ b/tests/kernel/nfs_client.pm
@@ -22,7 +22,9 @@ sub run {
     my $local_nfs3_async = "/home/localNFS3async";
     my $local_nfs4_async = "/home/localNFS4async";
 
+    mutex_wait('NFS_BARRIERS_CREATED');
     barrier_wait("NFS_SERVER_ENABLED");
+
     record_info("showmount", script_output("showmount -e server-node00"));
 
     assert_script_run("mkdir $local_nfs3 $local_nfs4 $local_nfs3_async $local_nfs4_async");

--- a/tests/kernel/nfs_server.pm
+++ b/tests/kernel/nfs_server.pm
@@ -64,6 +64,7 @@ sub run {
     #my $nfsstat = script_output("nfsstat -s");
     record_info("NFS stat for server", script_output("nfsstat -s"));
 
+    mutex_wait('NFS_BARRIERS_CREATED');
     barrier_wait("NFS_SERVER_ENABLED");
     barrier_wait("NFS_CLIENT_ENABLED");
     barrier_wait("NFS_SERVER_CHECK");


### PR DESCRIPTION
Currently there is a race between support server and the NFS client/server. So add a mutex to wait for the barriers and support server to be setup.

No validation yet because it fails for another reason.

@schlad 