### PR TITLE
Fix timeout while booting ppc64le

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -277,7 +277,7 @@ sub boot_local_disk {
             push @tags, 'displaymanager' if check_var('DESKTOP', 'gnome');
         }
 
-        assert_screen(\@tags, 60);
+        assert_screen(\@tags, 120);
         if (match_has_tag 'grub2') {
             diag 'already in grub2, returning from boot_local_disk';
             stop_grub_timeout;


### PR DESCRIPTION
ppc64le is taking more than 60 seconds to boot, therefore is not able to match bootloader screen.

Failure:
https://openqa.suse.de/tests/11131033

VR:
https://openqa.suse.de/tests/11131517

Fixes:
TEAM-7973 ppc64le is taking too long to show grub screen
