### PR TITLE
Autoyast profile for XEN Host with Install guest medium from O3 repo

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_hvm_x86_64.xml
@@ -24,7 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://download.opensuse.org/tumbleweed/repo/oss</guest_installation_media>
+    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings></guest_boot_settings>
     <guest_secure_boot></guest_secure_boot>

--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_pv_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_pv_x86_64.xml
@@ -24,7 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=nots3cr3t#console=hvc0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://download.opensuse.org/tumbleweed/repo/oss</guest_installation_media>
+    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT</guest_installation_media>
     <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings></guest_boot_settings>
     <guest_secure_boot></guest_secure_boot>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
@@ -45,27 +45,7 @@
       <hostname>##Host-Name##</hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
     </dns>
-    <interfaces config:type="list">
-      <interface>
-        <bootproto>dhcp</bootproto>
-        <name>eth0</name>
-        <startmode>auto</startmode>
-      </interface>
-      <interface>
-        <bootproto>static</bootproto>
-        <broadcast>127.255.255.255</broadcast>
-        <name>lo</name>
-        <firewall>no</firewall>
-        <ipaddr>127.0.0.1</ipaddr>
-        <netmask>255.0.0.0</netmask>
-        <network>127.0.0.0</network>
-        <prefixlen>8</prefixlen>
-        <startmode>auto</startmode>
-      </interface>
-    </interfaces>
-    <ipv6 config:type="boolean">true</ipv6>
     <keep_install_network config:type="boolean">true</keep_install_network>
-    <managed config:type="boolean">false</managed>
     <routing>
       <ipv4_forward config:type="boolean">true</ipv4_forward>
       <ipv6_forward config:type="boolean">true</ipv6_forward>
@@ -113,21 +93,8 @@
         <product>openSUSE</product>
     </products>
     <packages config:type="list">
-      <package>openSUSE-release</package>
-      <package>less</package>
-      <package>wicked</package>
-      <package>openssh</package>
-      <package>numactl</package>
-      <package>kexec-tools</package>
-      <package>irqbalance</package>
-      <package>iproute2</package>
-      <package>grub2</package>
-      <package>glibc</package>
-      <package>e2fsprogs</package>
-      <package>chrony</package>
-      <package>btrfsprogs</package>
-      <package>biosdevname</package>
       <package>autoyast2</package>
+      <package>supportutils</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
@@ -45,27 +45,7 @@
       <hostname>##Host-Name##</hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
     </dns>
-    <interfaces config:type="list">
-      <interface>
-        <bootproto>dhcp</bootproto>
-        <name>eth0</name>
-        <startmode>auto</startmode>
-      </interface>
-      <interface>
-        <bootproto>static</bootproto>
-        <broadcast>127.255.255.255</broadcast>
-        <name>lo</name>
-        <firewall>no</firewall>
-        <ipaddr>127.0.0.1</ipaddr>
-        <netmask>255.0.0.0</netmask>
-        <network>127.0.0.0</network>
-        <prefixlen>8</prefixlen>
-        <startmode>auto</startmode>
-      </interface>
-    </interfaces>
-    <ipv6 config:type="boolean">true</ipv6>
     <keep_install_network config:type="boolean">true</keep_install_network>
-    <managed config:type="boolean">false</managed>
     <routing>
       <ipv4_forward config:type="boolean">true</ipv4_forward>
       <ipv6_forward config:type="boolean">true</ipv6_forward>
@@ -113,21 +93,8 @@
         <product>openSUSE</product>
     </products>
     <packages config:type="list">
-      <package>openSUSE-release</package>
-      <package>less</package>
-      <package>wicked</package>
-      <package>openssh</package>
-      <package>numactl</package>
-      <package>kexec-tools</package>
-      <package>irqbalance</package>
-      <package>iproute2</package>
-      <package>grub2</package>
-      <package>glibc</package>
-      <package>e2fsprogs</package>
-      <package>chrony</package>
-      <package>btrfsprogs</package>
-      <package>biosdevname</package>
       <package>autoyast2</package>
+      <package>supportutils</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_sshd.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_sshd.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm t="boolean">false</confirm>
+      <final_reboot t="boolean">true</final_reboot>
+      <second_stage t="boolean">false</second_stage>
+    </mode>
+    <signature-handling>
+      <accept_file_without_checksum t="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key t="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key t="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file t="boolean">true</accept_unsigned_file>
+      <accept_verification_failed t="boolean">true</accept_verification_failed>
+      <import_gpg_key t="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <report>
+    <errors>
+      <show t="boolean">true</show>
+      <timeout t="integer">20</timeout>
+      <log t="boolean">true</log>
+    </errors>
+    <messages>
+      <show t="boolean">true</show>
+      <timeout t="integer">5</timeout>
+      <log t="boolean">true</log>
+    </messages>
+    <warnings>
+      <show t="boolean">true</show>
+      <timeout t="integer">10</timeout>
+      <log t="boolean">true</log>
+    </warnings>
+    <yesno_messages>
+      <show t="boolean">true</show>
+      <timeout t="integer">30</timeout>
+      <log t="boolean">true</log>
+    </yesno_messages>
+  </report>
+  <bootloader>
+    <loader_type>grub2</loader_type>
+    <global>
+      <activate>true</activate>
+      <boot_mbr>true</boot_mbr>
+      <gfxmode>auto</gfxmode>
+      <os_prober>true</os_prober>
+      <terminal>console serial</terminal>
+      <serial>serial --unit=1 --speed=115200 --word=8 --parity=no</serial>
+      <timeout t="integer">30</timeout>
+      <update_nvram>true</update_nvram>
+      <xen_kernel_append>console=com2,115200 loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
+      <xen_append>console=hvc0,115200 console=tty loglevel=5</xen_append>
+    </global>
+  </bootloader>
+  <partitioning t="list">
+    <drive>
+      <device>/dev/sda</device>
+      <initialize t="boolean">true</initialize>
+      <use>all</use>
+      <enable_snapshots t="boolean">false</enable_snapshots>
+    </drive>
+  </partitioning>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>America/New_York</timezone>
+  </timezone>
+  <networking>
+    <keep_install_network t="boolean">true</keep_install_network>
+    <backend>network_manager</backend>
+  </networking>
+  <software>
+    <products t="list">
+      <product>openSUSE</product>
+    </products>
+    <install_recommended t="boolean">true</install_recommended>
+    <patterns t="list">
+      <pattern>base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>enhanced_base</pattern>
+      <pattern>xen_server</pattern>
+      <pattern>xen_tools</pattern>
+    </patterns>
+    <packages t="list">
+      <package>autoyast2</package>
+      <package>supportutils</package>
+      <package>nmap</package>
+    </packages>
+  </software>
+  <users t="list">
+    <user>
+      <username>bernhard</username>
+      <user_password>$y$j9T$xsY9ubdI0jRF5JoSV8vvg1$03I5jIewyiCMm/EmkgRtYxvEYm83ZSJo0tl1rKP8Ad.</user_password>
+      <fullname>Bernhard M. Wiedemann</fullname>  
+      <encrypted t="boolean">true</encrypted>
+    </user>
+    <user>
+      <username>root</username>
+      <user_password>$y$j9T$Bc3oHTMRcmYxyzTlxEd7A/$jU0KChUccTna2tH9ItMRyRHC9fofibG37RGH4XkCxYD</user_password>
+      <encrypted t="boolean">true</encrypted>
+    </user>
+  </users>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable t="list">
+        <service>firewalld</service>
+      </disable>
+      <enable t="list">
+        <service>sshd</service>
+	<!--  suse supports the virtqemud and virtxend hypervisor daemons, xend or libvirtd is not needed for modular libvirt -->
+	<service>virtxend</service>
+	<service>virtstoraged</service>
+	<service>virtnetworkd</service>
+	<service>virtnodedevd</service>
+	<service>virtsecretd</service>
+	<service>virtproxyd</service>
+	<service>virtnwfilterd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <scripts>
+  <!-- permit root login, password login, and pubkeys login -->
+  <!-- keep SSH session alive -->
+  <!-- /etc/ssh/sshd_config is not default installed in TW -->
+  <init-scripts t="list">
+    <script>
+      <source><![CDATA[
+sshd_config_file="/etc/ssh/sshd_config.d/permit_root_login.conf"
+echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
+sshd_config_file="/etc/ssh/sshd_config.d/keep_alive.conf"
+echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 480" > $sshd_config_file
+echo "Below lines modify the /etc/default/grub file to set the GRUB_DEFAULT parameter to Xen hypervisor and then regenerate the GRUB configuration file using grub2-mkconfig"         
+sed -i 's/^GRUB_DEFAULT=.*/GRUB_DEFAULT=2/' /etc/default/grub
+grub2-mkconfig -o /boot/grub2/grub.cfg
+      ]]></source>
+    </script>
+  </init-scripts>
+ </scripts>
+</profile>


### PR DESCRIPTION
In continuation to Autoyast profiles for the KVM host which has been done PR: #16625 and this PR is for XEN hosts.

This PR will 
1. support installing a host with autoyast profile for TumbleWeed.
2. Install guests with medium from O3 repo. 

- Related ticket: https://progress.opensuse.org/issues/128675
- Verification run: 
[GuestInstallationXEN](https://openqa.opensuse.org/tests/3318567)
[GuestInstallaionKVM](https://openqa.opensuse.org/tests/3323699) : PASSED

Latest Run [KVM](https://openqa.opensuse.org/tests/3330711#): PASSED