### PR TITLE
Enable SAP HANA SR Perf-Opt test on AWS for 15SP5

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#   Settings are meant to be controlled via OpenQA variables and managed by test:
+#   tests/sles4sap/publiccloud/qesap_ansible.pm
+
+provider: 'aws'
+apiver: 3
+terraform:
+  variables:
+    # GENERAL VARIABLES #
+    aws_region: "%PUBLIC_CLOUD_REGION%"
+    aws_credentials: "/root/amazon_credentials"
+    admin_user: "cloudadmin"
+    deployment_name: "%QESAP_DEPLOYMENT_NAME%"
+    public_key: "~/.ssh/id_rsa.pub"
+    private_key: "~/.ssh/id_rsa"
+    os_image: "%SLE_IMAGE%"
+    os_owner: "self"
+    hana_os_major_version: "%HANA_OS_MAJOR_VERSION%"
+
+    # HANA
+    hana_count: "%NODE_COUNT%"
+    hana_ha_enabled: "%HA_CLUSTER%"
+    hana_instancetype: "%PUBLIC_CLOUD_INSTANCE_TYPE%"
+    hana_cluster_fencing_mechanism: "%FENCING_MECHANISM%"
+
+ansible:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name: "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
+    - "%HANA_SAR%"
+    - "%HANA_CLIENT_SAR%"
+    - "%HANA_SAPCAR%"
+  destroy:
+    - deregister.yaml
+


### PR DESCRIPTION
 Enable SAP HANA SR Perf-Opt Scenario on AWS for 15SP5  
TEAM-7755 - Enable SAP HANA SR Perf-Opt Scenario on AWS for 15SP5

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1211

- Related ticket: https://jira.suse.com/browse/TEAM-7755
- Needles: NA
- Verification run:
  https://openqa.suse.de/tests/11146601#step/qesap_terraform/367 (test case failed on "Kill site_a - primary" test module, it is other issues)