### PR TITLE
tw: JeOS firstboot does not offer wifi configuration anymore

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -142,7 +142,7 @@ sub run {
         send_key 'ret';
     }
 
-    if (is_generalhw && is_aarch64 && !is_leap("<15.4")) {
+    if (is_generalhw && is_aarch64 && !is_leap("<15.4") && !is_tumbleweed) {
         assert_screen 'jeos-please-configure-wifi';
         send_key 'n';
     }


### PR DESCRIPTION
Due to https://build.opensuse.org/request/show/1087172 - [boo#1207419](https://bugzilla.suse.com/show_bug.cgi?id=1207419)
- Verification run: https://openqa.opensuse.org/tests/3292715
