### PR TITLE
Change the way to define Terraform deployment_name

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -14,6 +14,7 @@ terraform:
   variables:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_maintenance.yaml
@@ -16,6 +16,7 @@ terraform:
     vnet_address_range: "%VNET_ADDRESS_RANGE%"
     subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
     az_region: '%PUBLIC_CLOUD_REGION%'
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -14,6 +14,7 @@ terraform:
   variables:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -5,6 +5,7 @@ terraform:
   variables:
     # GENERAL VARIABLES #
     aws_region: "%PUBLIC_CLOUD_REGION%"
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: "cloudadmin"
     public_key: "~/.ssh/id_rsa.pub"
     private_key: "~/.ssh/id_rsa"

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2_product.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2_product.yaml
@@ -5,6 +5,7 @@ terraform:
   variables:
     # GENERAL VARIABLES #
     aws_region: "%PUBLIC_CLOUD_REGION%"
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: "cloudadmin"
     public_key: "~/.ssh/id_rsa.pub"
     private_key: "~/.ssh/id_rsa"

--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -4,6 +4,7 @@ terraform:
   variables:
     project: "ei-sle-qa-sap-8469"
     region: "%PUBLIC_CLOUD_REGION%"
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: "cloudadmin"
     os_image: "%SLE_IMAGE%"
     private_key: "~/.ssh/id_rsa"

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -14,7 +14,7 @@ terraform:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
     admin_user: 'cloudadmin'
-    deployment_name: '%PUBLIC_CLOUD_RESOURCE_GROUP%'
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'


### PR DESCRIPTION
Change the way to define deployment_name for mr_test and HanaSR Drop the usage of the `terraform workspace`
Use a setting in the conf.yaml template and define it on the fly with `set_var`.

Related ticket: [TEAM-7850](https://jira.suse.com/browse/TEAM-7850)

Verification run:
 - HanaSR Azure https://openqa.suse.de/tests/11143744 generated `terraform.tfvars` has `deployment_name = "hanasr11143744"`. Terraform stage is called without `-w`
 
 ```
(exec_venv) # python3.10 /root/qe-sap-deployment/scripts/qesap/qesap.py --verbose -c /root/qe-sap-deployment/scripts/qesap/sles4sap_azure_generic_uri.yaml -b /root/qe-sap-deployment terraform  |& tee -a /tmp/qesap_exec_terraform.log.txt; echo Vq3bC-$?-
```
 
 - mr_test Azure https://openqa.suse.de/tests/11143745
 
 - mr_test Azure with PUBLIC_CLOUD_RESOURCE_GROUP  https://openqa.suse.de/tests/11143792  job triggered with `PUBLIC_CLOUD_RESOURCE_GROUP=goofy` results in generated terraform.tfvars with `deployment_name = "goofy11143792"`
 
 - mr_test Azure with QESAP_DEPLOYMENT_NAME https://openqa.suse.de/tests/11143793 job triggered with `QESAP_DEPLOYMENT_NAME=goofy` result in generated terraform.tfvars with `deployment_name = "goofy"`
 
- mr_test AWS https://openqa.suse.de/tests/11146908

 - mr_test GCP https://openqa.suse.de/tests/11147118