### PR TITLE
wicked: fix sysctl error for sysctl.conf broken link test

### DIFF
--- a/tests/wicked/sysctl/sut/t01_sysctl_load_files.pm
+++ b/tests/wicked/sysctl/sut/t01_sysctl_load_files.pm
@@ -118,7 +118,7 @@ sub check {
 
     # Exceptional behavior for /etc/sysctl.conf, it is silently ignored
     my $file = "/etc/sysctl.conf";
-    assert_script_run("rm $file");
+    assert_script_run("rm -f $file");
     assert_script_run("ln -s /I_do_not_exists $file");
     check_load_order();
     die("Wrongly showing broken '$file' in logs") if grep { $_ eq $file } @{wicked_get_file_order()};


### PR DESCRIPTION
Newer version of openSUSE do not have `/etc/sysctl.conf` by default.

- failed: http://openqa.wicked.suse.de/tests/133517#step/t01_sysctl_load_files/10
- Verification run: http://openqa.wicked.suse.de/tests/133518#
