### PR TITLE
Save y2logs in test 'patterns' if any issue

### DIFF
--- a/tests/console/patterns.pm
+++ b/tests/console/patterns.pm
@@ -26,7 +26,8 @@ sub run {
 
 sub post_fail_hook {
     select_console 'log-console';
-    upload_logs "/var/log/zypper.log";
+    assert_script_run 'save_y2logs /tmp/patterns_y2logs.tar.bz2';
+    upload_logs '/tmp/patterns_y2logs.tar.bz2';
 }
 
 1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/129436
Enhance the current logic which uploads the zypper log only

- Verification run: [VR](https://openqa.suse.de/tests/11146735)
 logs can be uploaded if test fails: [y2logs](https://openqa.suse.de/tests/11146735/file/patterns-patterns_y2logs.tar.bz2)