### PR TITLE
zypper_lifecycle: Force reinstall release-notes

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -65,6 +65,8 @@ sub run {
     # files. this cause the zypper lifecycle failed when building cache for non-root user.
     assert_script_run('chmod -R u+rwX,og+rX /var/cache/zypp');
     zypper_call('in curl') if (script_run('rpm -qi curl') == 1);
+    # force reinstall release notes, package must not come from expected SLE-Product repo e.g. GMC
+    zypper_call('in -f release-notes*');
 
     select_console 'user-console';
     my $overview = script_output('zypper lifecycle', 600);


### PR DESCRIPTION
Package can come from ISO and then test will fail because it expects repo

- Related ticket: https://progress.opensuse.org/issues/129466
- Verification run: https://openqa.suse.de/tests/overview?build=lifecycle_package&distri=sle