### PR TITLE
samba_adcli: Use script_retry for network cmds

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -61,7 +61,7 @@ sub samba_sssd_install {
     validate_script_output("cat /etc/resolv.conf", qr/nameserver $AD_ip/, fail_message => "Domain controller not present in /etc/resolv.conf");
 
     # Ensure DNS name resolution works for the AD host
-    assert_script_run("ping -c 2 $AD_hostname");
+    script_retry("ping -c 2 $AD_hostname", retry => 3, timeout => 60, die => 1, fail_message => "$AD_hostname is unreachable");
     assert_script_run("dig srv _kerberos._tcp.$AD_hostname", fail_message => "failed to resolved the required kerberos host entry for AD controller");
     assert_script_run("dig srv _ldap._tcp.$AD_hostname", fail_message => "failed to resolved the required LDAP SRV entry for AD controller");
 }
@@ -81,7 +81,7 @@ sub join_domain {
     # if something is not working in the future: i.e authentication is not working, switching to using expect
     # would be a better idea
     # TODO: REMOVED: -S '$AD_hostname'
-    assert_script_run("echo \"\$AD_DOMAIN_PASSWORD\" | net ads join --domain '$AD_domain' -U Administrator --no-dns-updates -i", timeout => 60, fail_message => "Error joining domain (poo#96986)");
+    script_retry("echo \"\$AD_DOMAIN_PASSWORD\" | net ads join --domain '$AD_domain' -U Administrator --no-dns-updates -i", retry => 3, timeout => 60, die => 1, fail_message => "Error joining domain (poo#96986)");
 
     # Enable pam authentication
     assert_script_run "pam-config -a --mkhomedir";


### PR DESCRIPTION
- Occasional failures:
https://openqa.suse.de/tests/11149974#step/samba_adcli/150 | samba_adcli_5   | sle    | 15-SP4  | failed
https://openqa.suse.de/tests/11149209#step/samba_adcli/150 | mau-extratests2 | sle    | 15-SP3  | failed
https://openqa.suse.de/tests/11144887#step/samba_adcli/122 | mau-extratests2 | sle    | 15-SP1  | failed
https://openqa.suse.de/tests/11126435#step/samba_adcli/119 | mau-extratests2 | sle    | 15-SP2  | failed
https://openqa.suse.de/tests/11112805#step/samba_adcli/119 | mau-extratests2 | sle    | 15-SP4  | failed
https://openqa.suse.de/tests/11079462#step/samba_adcli/153 | mau-extratests2 | sle    | 15-SP2  | failed
https://openqa.suse.de/tests/11071809#step/samba_adcli/156 | mau-extratests2 | sle    | 15-SP1  | failed
https://openqa.suse.de/tests/11068874#step/samba_adcli/122 | mau-extratests2 | sle    | 15-SP1  | failed
https://openqa.suse.de/tests/11063127#step/samba_adcli/156 | mau-extratests2 | sle    | 15-SP2  | failed
https://openqa.suse.de/tests/11062005#step/samba_adcli/122 | mau-extratests2 | sle    | 15-SP2  | failed
https://openqa.suse.de/tests/11045981#step/samba_adcli/153 | mau-extratests2 | sle    | 15-SP2  | failed
https://openqa.suse.de/tests/11042887#step/samba_adcli/119 | mau-extratests2 | sle    | 15-SP4  | failed
https://openqa.suse.de/tests/11017176#step/samba_adcli/119 | mau-extratests2 | sle    | 15-SP4  | failed
- Verification run:
https://openqa.suse.de/tests/overview?&distri=sle&build=samba_adcli
