### PR TITLE
Fix setup_dns failure on sle12sp5 xen host

### DIFF
--- a/tests/virt_autotest/setup_dns_service.pm
+++ b/tests/virt_autotest/setup_dns_service.pm
@@ -34,10 +34,6 @@ sub post_fail_hook {
 
     diag("There is something wrong with establishing dns service for vm guest or ssh connection to vm guest without inputting login password.");
     diag("Module setup_dns_service post fail hook starts.");
-    for (my $i = 0; $i < 4; $i++) {
-        script_run("head -n \$((($i+1)*50)) /etc/named.conf");
-        save_screenshot;
-    }
     script_run("cat /var/lib/named/testvirt.net.zone");
     save_screenshot;
     script_run("cat /var/lib/named/123.168.192.zone");


### PR DESCRIPTION
- move testvirt domain at the beginning of 'search' field in /etc/resolv.conf
- better match "fowarders" in /etc/named.conf
- move outputing file content in setup_dns  log to ease copy text and debug

Related ticket: https://progress.opensuse.org/issues/129544

Verification run: 
https://openqa.suse.de/tests/11173132
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/11175443)
[gi-guest_sles12sp5-on-host_developing-xen](https://openqa.suse.de/tests/11175354)
[gi-guest_developing-on-host_sles12sp5-xen](http://openqa.suse.de/tests/11175385)     //it failed previously without this PR. it passed with the PR now.