### PR TITLE
Stop running year_2038_detection everywhere in MicroOS

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -179,6 +179,7 @@ sub load_common_tests {
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
     loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro || is_alp);
     loadtest 'console/kubeadm' if (check_var('SYSTEM_ROLE', 'kubeadm'));
+    loadtest 'console/year_2038_detection';
 }
 
 
@@ -350,7 +351,6 @@ sub load_tests {
         load_common_tests;
         load_transactional_tests unless is_zvm;
     }
-    loadtest 'console/year_2038_detection';
     load_journal_check_tests;
 }
 


### PR DESCRIPTION
It doesn't make sense to run this test everywhere. In the default list of tests should be enough.

VRs: 
- [microos](https://openqa.opensuse.org/tests/3299722)
- [container-host](https://openqa.opensuse.org/tests/3299740)
- [SLE Micro 5.4](https://openqa.suse.de/tests/11154779)