### PR TITLE
Remove chunk_size from RAID1 settings on 15-SP5

### DIFF
--- a/schedule/qam/15-SP5/qam-minimal-RAID1.yaml
+++ b/schedule/qam/15-SP5/qam-minimal-RAID1.yaml
@@ -34,7 +34,6 @@ test_data:
   mds:
     - raid_level: 1
       name: md0
-      chunk_size: '64 KiB'
       devices:
         - vda2
         - vdb2


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/129562
- Verification run:
https://openqa.suse.de/tests/overview?distri=sle&build=raid_129562