### PR TITLE
Revert "Do not pipe output into a pager for wicked service"

### DIFF
--- a/tests/autoyast/wicked.pm
+++ b/tests/autoyast/wicked.pm
@@ -24,11 +24,10 @@ use strict;
 use warnings;
 use base 'consoletest';
 use testapi;
-use utils 'systemctl';
 
 sub run {
     # https://en.opensuse.org/openSUSE:Bugreport_wicked
-    systemctl 'status wickedd.service';
+    enter_cmd "systemctl status wickedd.service";
     enter_cmd "echo `wicked show all |cut -d ' ' -f 1` END | tee /dev/$serialdev";
     my $iflist = wait_serial("END", 10);
     # For poo#70453, to filter network link from mixed info of the output of wicked cmd


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#17050


https://openqa.suse.de/tests/11155748 | qam-gnome                                                                                                 | sle    | 15-SP4  | failed
https://openqa.suse.de/tests/11155747 | qam-allpatterns                                                                                           | sle    | 15-SP4  | failed
https://openqa.suse.de/tests/11155450 | qam-gnome                                                                                                 | sle    | 15-SP4  | failed
https://openqa.suse.de/tests/11155266 | qam-gnome                                                                                                 | sle    | 15-SP4  | failed
https://openqa.suse.de/tests/11155265 | qam-allpatterns                                                                                           | sle    | 15-SP4  | failed
https://openqa.suse.de/tests/11154902 | qam-gnome                                                                                                 | sle    | 15-SP4  | failed