### PR TITLE
bootloader_uefi decrease chance of needle match timeout

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -379,10 +379,8 @@ sub get_bootmenu_console_params {
 sub uefi_bootmenu_params {
     # assume bios+grub+anim already waited in start.sh
     # in grub2 it's tricky to set the screen resolution
-    #send_key_until_needlematch('grub2-enter-edit-mode', 'e', 6, 0.5);
-    (is_jeos)
-      ? send_key_until_needlematch('grub2-enter-edit-mode', 'e', 6, 0.5)
-      : send_key 'e';
+    send_key 'e';
+    assert_screen("grub2-enter-edit-mode", 30) if is_jeos;
     # Kiwi in TW uses grub2-mkconfig instead of the custom kiwi config
     # Locate gfxpayload parameter and update it
     if (is_jeos && (is_tumbleweed || is_sle('>=15-sp1') || is_leap('>=15.1'))) {

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -86,6 +86,11 @@ sub run {
     if (get_var('UEFI_HTTP_BOOT') || get_var('UEFI_HTTPS_BOOT')) {
         tianocore_http_boot;
     }
+
+    # Some aach64 JeOS jobs take too long to match the first grub2 needle.
+    # By pressing a random key, we stop the grub timeout
+    send_key 'backspace' if (is_jeos && is_aarch64);
+
     assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2)], $bootloader_timeout);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";


### PR DESCRIPTION
The first needle bootloader-grub2 might take already some seconds,
and send_key_until_needlematch is checking first for a needle and
then pressing the key.
By pressing the key first, we reduce the chance that we go into boot
mode before matchin the uefi edit screen.


Related ticket: https://progress.opensuse.org/issues/129601
VRs:

- [Multiple runs of JeOS 15-SP4](https://openqa.suse.de/tests/overview?version=15-SP4&build=jlausuch%2Fos-autoinst-distri-opensuse%23bootloader_uefi_fix&distri=sle) -> 100% success.
- [20 runs of openSUSE JeOS aarch64](https://openqa.opensuse.org/tests/overview?build=jlausuch%2Fos-autoinst-distri-opensuse%23bootloader_uefi_fix&version=Tumbleweed&distri=opensuse) -> 100% success
- [single JeOS 12-SP5 x86_64 uefi](https://openqa.suse.de/tests/11161307#)
- [random 15-SP5 aarch64 job](https://openqa.suse.de/tests/11161767)