### PR TITLE
Fix mr_test random "ssh" timed out on Public Cloud

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -504,6 +504,8 @@ sub softreboot {
 
     $self->ssh_assert_script_run(cmd => 'sudo /sbin/shutdown -r +1');
     sleep 60;    # wait for the +1 in the previous command
+    # add more time to wait for the system to turn off for SLES4SAP test cases
+    # sleep 120 if (get_var('PUBLIC_CLOUD_SLES4SAP'));
     my $start_time = time();
 
     # wait till ssh disappear
@@ -517,6 +519,7 @@ sub softreboot {
     my $bootup_time = $self->wait_for_ssh(timeout => $args{timeout} - $shutdown_time,
         username => $args{username},
         ignore_wrong_pubkey => $args{ignore_wrong_pubkey});
+    #record_info('UPTIME', $self->ssh_assert_script_run(cmd => 'uptime'));
 
     # ensure the tunnel-console is healthy, usefuly to early detect possible issues with the serial terminal
     assert_script_run("true", fail_message => "console is broken");

--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -66,7 +66,7 @@ sub ssh_interactive_tunnel {
     # because this only happens the first time the console is activated
     if ($args{reconnect}) {
         establish_tunnel_console("root-console");
-        establish_tunnel_console("user-console");
+        establish_tunnel_console("user-console", timeout => 120);
         establish_tunnel_console("root-virtio-terminal");
     }
 


### PR DESCRIPTION
This PR is fixing 3 kinds of random failures happened on Public Cloud mr_test test cases:
- 1. For example: https://openqa.suse.de/tests/11138281#step/1_saptune_notes/758
  The random failure is "no candidate needle with tag(s) 'user-console' matched".
  The ssh tunnel was not setup well.
- 2. For example: https://openqa.suse.de/tests/11152681#step/1_saptune_solutions/130
  The random failure is "command 'echo ... >> /var/log.txt' timed out". 
  It seems the 'ssh -t sut' failed and then ssh tunnel was not setup well.
- 3. For example: ttps://openqa.suse.de/tests/11156384#step/1_saptune_notes/384
  The random failure is: command 'ssh -t  -i ... $instance" -- $'sudo /sbin/shutdown -r +1'' timed out
   It seems the system is very slow to turn off.
  
TEAM-7322 - Fix saptune (mr_test) test module "mr_test_setup_env" random "ssh" timed out


- Related ticket: https://jira.suse.com/browse/TEAM-7322
- Needles: NA
- Verification run: 
12sp5 EC2: https://openqa.suse.de/tests/11198988# (passed)
15sp5 EC2: https://openqa.nue.suse.com/tests/11199086#  (passed)
15sp3 Azure: https://openqa.nue.suse.com/tests/11199074#details  (passed)

NOTE:
Since the issues are sporadic so I did many verification runs (40+),  above 3 issues can not be reproduced now with this PR. but can still reproduce one known issue (for example: https://openqa.nue.suse.com/tests/11195101#step/1_saptune_solutions/624), this issue can be tracked by another JIRA ticket: ([TEAM-7836](https://jira.suse.com/browse/TEAM-7836)
Fix/Investigate wait_for_ssh() random failed after softreboot() on Public Cloud).