### PR TITLE
Increse s390x boot timeout on SLEM

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -94,7 +94,7 @@ sub process_reboot {
     } elsif (is_backend_s390x) {
         prepare_system_shutdown;
         enter_cmd "reboot";
-        opensusebasetest::wait_boot(opensusebasetest->new(), bootloader_time => 200);
+        opensusebasetest::wait_boot(opensusebasetest->new(), bootloader_time => 300);
         record_kernel_audit_messages();
     } else {
         power_action('reboot', observe => !$args{trigger}, keepconsole => 1);


### PR DESCRIPTION
- Occasional failures:
https://openqa.suse.de/tests/11159973#step/year_2038_detection/48 | slem_installation_default  |  5.4     | failed
https://openqa.suse.de/tests/11157712#step/year_2038_detection/48 | slem_installation_default  |  5.2     | failed
https://openqa.suse.de/tests/11157483#step/year_2038_detection/48 | slem_installation_default  |  5.2     | failed
https://openqa.suse.de/tests/11157177#step/year_2038_detection/48 | slem_installation_default  |  5.2     | failed
https://openqa.suse.de/tests/11155723#step/year_2038_detection/48 | slem_installation_default  |  5.4     | failed
https://openqa.suse.de/tests/11149033#step/year_2038_detection/48 | slem_installation_default  |  5.2     | failed
https://openqa.suse.de/tests/11143743#step/year_2038_detection/48 | slem_installation_default  |  5.2     | failed
https://openqa.suse.de/tests/11139240#step/year_2038_detection/48 | slem_installation_default  |  5.3     | failed
https://openqa.suse.de/tests/11138665#step/year_2038_detection/48 | slem_installation_default  |  5.4     | failed
https://openqa.suse.de/tests/11138654#step/year_2038_detection/48 | slem_installation_default  |  5.3     | failed
https://openqa.suse.de/tests/11138644#step/year_2038_detection/48 | slem_installation_default  |  5.2     | failed
- Verification run: 
https://openqa.suse.de/tests/11161095#step/year_2038_detection/58
https://openqa.suse.de/tests/11159857#step/year_2038_detection/58
https://openqa.suse.de/tests/11149421#step/year_2038_detection/58
