### PR TITLE
[qesap] Reuse infrastructure from previous test

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -14,7 +14,7 @@ terraform:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
     admin_user: 'cloudadmin'
-    deployment_name: '%PUBLIC_CLOUD_RESOURCE_GROUP%'
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     os_image: "%PUBLIC_CLOUD_IMAGE_ID%"

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -37,6 +37,8 @@ use publiccloud::utils qw(get_credentials);
 use mmapi 'get_current_job_id';
 use testapi;
 use Exporter 'import';
+use Scalar::Util 'looks_like_number';
+use File::Basename;
 
 my @log_files = ();
 
@@ -74,6 +76,8 @@ our @EXPORT = qw(
   qesap_az_vnet_peering_delete
   qesap_add_server_to_hosts
   qesap_calculate_deployment_name
+  qesap_export_instances
+  qesap_import_instances
 );
 
 =head1 DESCRIPTION
@@ -955,5 +959,55 @@ sub qesap_add_server_to_hosts {
         provider => $prov);
 }
 
+=head3 qesap_import_instances
+
+    Downloads assets required for re-using infrastructure from previously exported test.
+    qesap_import_instances(<$test_id>)
+
+=over 1
+
+=item B<$test_id> - OpenQA test ID from a test previously run with "QESAP_DEPLOYMENT_IMPORT=1" and infrastructure still being up and running
+
+=back
+=cut
+
+sub qesap_import_instances {
+    my ($test_id) = @_;
+    die("OpenQA test ID must be a number. Parameter 'QESAP_DEPLOYMENT_IMPORT' must contain ID of previously exported test")
+      unless looks_like_number($test_id);
+
+    my $inventory_file = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my %files = ('id_rsa' => '/root/.ssh/',
+        'id_rsa.pub' => '/root/.ssh/',
+        basename($inventory_file) => dirname($inventory_file) . '/');
+    my $test_url = join('', 'http://', get_required_var('OPENQA_URL'), '/tests/', $test_id);
+
+    assert_script_run('mkdir -m700 /root/.ssh');
+    assert_script_run('mkdir -p ' . dirname($inventory_file));
+
+    foreach my $key (keys %files) {
+        assert_script_run(join(' ', 'curl -v -fL', $test_url . '/file/' . $key, '-o', $files{$key} . $key),
+            fail_message => "Failed to download file log data '$key' from test '$test_url'");
+        record_info('IMPORT', "File '$key' imported from test '$test_url'");
+    }
+    assert_script_run('chmod -R 600 /root/.ssh/');
+}
+
+=head3 qesap_export_instances
+
+    Downloads assets required for re-using infrastructure from previously exported test.
+    qesap_export_instances()
+
+=cut
+
+sub qesap_export_instances {
+    my @upload_files = (
+        qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER')),
+        '/root/.ssh/id_rsa',
+        '/root/.ssh/id_rsa.pub');
+
+    upload_logs($_, log_name => basename($_)) for @upload_files;
+    record_info('EXPORT', "SSH keys and instances data uploaded to test results:\n" . join("\n", @upload_files));
+}
 
 1;

--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -24,37 +24,37 @@ sub cleanup {
     return if ($self->{cleanup_called});
     $self->{cleanup_called} = 1;
 
-    for my $command ("ansible", "terraform") {
+    for my $command ('ansible', 'terraform') {
         # Skip cleanup if ansible inventory is not present (deployment could not have been done without it)
         next if (script_run 'test -f ' . qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER')));
 
-        record_info("Cleanup", "Executing $command cleanup");
+        record_info('Cleanup', "Executing $command cleanup");
         # 3 attempts for both terraform and ansible cleanup
         for (1 .. 3) {
-            my $cleanup_cmd_rc = qesap_execute(verbose => "--verbose", cmd => $command, cmd_options => "-d", timeout => 1200);
+            my $cleanup_cmd_rc = qesap_execute(verbose => '--verbose', cmd => $command, cmd_options => '-d', timeout => 1200);
             if ($cleanup_cmd_rc == 0) {
                 diag(ucfirst($command) . " cleanup attempt # $_ PASSED.");
-                record_info("Clean $command", ucfirst($command) . " cleanup PASSED.");
+                record_info("Clean $command", ucfirst($command) . ' cleanup PASSED.');
                 last;
             }
             else {
                 diag(ucfirst($command) . " cleanup attempt # $_ FAILED.");
                 sleep 10;
             }
-            record_info("Cleanup FAILED", "Cleanup $command FAILED", result => "fail") if $_ == 3 && $cleanup_cmd_rc;
+            record_info('Cleanup FAILED', "Cleanup $command FAILED", result => 'fail') if $_ == 3 && $cleanup_cmd_rc;
             $self->{result} = "fail" if $_ == 3 && $cleanup_cmd_rc;
         }
     }
     $args->{my_provider}->terraform_applied(0) if ((defined $args) &&
         (ref($args->{my_provider}) =~ /^publiccloud::(azure|ec2|gce)/) &&
         (defined $self->{result}) && ($self->{result} ne 'fail'));
-    record_info("Cleanup finished");
+    record_info('Cleanup finished');
 }
 
 sub post_fail_hook {
     my ($self) = @_;
-    if (get_var("PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE")) {
-        diag("Skip post fail", "Variable 'PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE' defined.");
+    if (get_var('QESAP_NO_CLEANUP_ON_FAILURE')) {
+        diag('Skip post fail', "Variable 'QESAP_NO_CLEANUP_ON_FAILURE' defined.");
         return;
     }
     $self->cleanup();
@@ -62,8 +62,8 @@ sub post_fail_hook {
 
 sub post_run_hook {
     my ($self) = @_;
-    if ($self->test_flags()->{publiccloud_multi_module} or get_var("PUBLIC_CLOUD_NO_CLEANUP")) {
-        diag("Skip post run", "Skipping post run hook. \n Variable 'PUBLIC_CLOUD_NO_CLEANUP' defined or test_flag 'publiccloud_multi_module' active");
+    if ($self->test_flags()->{publiccloud_multi_module} or get_var('QESAP_NO_CLEANUP')) {
+        diag('Skip post run', "Skipping post run hook. \n Variable 'QESAP_NO_CLEANUP' defined or test_flag 'publiccloud_multi_module' active");
         return;
     }
     $self->cleanup();

--- a/schedule/sles4sap/publiccloud_hanasr.yml
+++ b/schedule/sles4sap/publiccloud_hanasr.yml
@@ -11,8 +11,7 @@ vars:
   TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
   - boot/boot_to_desktop
-  - sles4sap/publiccloud/qesap_terraform
-  - sles4sap/publiccloud/qesap_ansible
+  - sles4sap/publiccloud/hana_sr_schedule_deployment
   - sles4sap/publiccloud/hana_sr_schedule_primary_tests
   - sles4sap/publiccloud/hana_sr_schedule_replica_tests
   - sles4sap/publiccloud/hana_sr_schedule_cleanup

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Test module for scheduling qesap-deployment related modules.
+
+package hana_sr_schedule_deployment;
+
+use base 'sles4sap_publiccloud_basetest';
+use main_common 'loadtest';
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    if (get_var('QESAP_DEPLOYMENT_IMPORT')) {
+        loadtest('sles4sap/publiccloud/qesap_reuse_infra', name => 'prepare_existing_infrastructure', run_args => $run_args, @_);
+        loadtest('sles4sap/publiccloud/qesap_ansible', name => 'verify_infrastructure', run_args => $run_args, @_);
+    }
+    else {
+        loadtest('sles4sap/publiccloud/qesap_terraform', name => 'deploy_qesap_terraform', run_args => $run_args, @_);
+        loadtest('sles4sap/publiccloud/qesap_ansible', name => 'deploy_qesap_ansible', run_args => $run_args, @_);
+    }
+}
+
+1;

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
@@ -26,8 +26,8 @@ sub run {
     # 'HANASR_PRIMARY_ACTIONS' - define to override test flow
     my @database_actions = split(",", get_var("HANASR_PRIMARY_ACTIONS", 'stop,kill,crash'));
     for my $action (@database_actions) {
-        for my $site ("site_a", "site_b") {
-            my $test_name = join(" ", ucfirst($action), $site, "-", "primary");
+        for my $site ('site_a', 'site_b') {
+            my $test_name = join('_', ucfirst($action), "$site-primary");
             $run_args->{hana_test_definitions}{$test_name}{action} = $action;
             $run_args->{hana_test_definitions}{$test_name}{site_name} = $site;
             loadtest('sles4sap/publiccloud/hana_sr_takeover', name => $test_name, run_args => $run_args, @_);

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_replica_tests.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_replica_tests.pm
@@ -27,7 +27,7 @@ sub run {
     my @database_actions = split(",", get_var("HANASR_SECONDARY_ACTIONS", 'stop,kill,crash'));
 
     for my $action (@database_actions) {
-        my $test_name = ucfirst($action) . " replica";
+        my $test_name = ucfirst($action) . "_replica";
         $run_args->{hana_test_definitions}{$test_name} = $action;
         loadtest('sles4sap/publiccloud/hana_sr_test_secondary', name => $test_name, run_args => $run_args, @_);
     }

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -23,20 +23,32 @@ sub test_flags {
 sub run {
     my ($self, $run_args) = @_;
     select_serial_terminal;
-    my $ha_enabled = get_required_var("HA_CLUSTER") =~ /false|0/i ? 0 : 1;
+    my $ha_enabled = get_required_var('HA_CLUSTER') =~ /false|0/i ? 0 : 1;
     my $instances = $run_args->{instances};
 
-    die("Ansible deploymend FAILED. Check 'qesap*' logs for details.") if qesap_execute(cmd => 'ansible', timeout => 3600, verbose => 1) > 0;
-    record_info("FINISHED", "Ansible deployment process finished successfully.");
-    return unless $ha_enabled;
+    # skip ansible deploymnt in case of reusing infrastructure
+    unless (get_var('QESAP_DEPLOYMENT_IMPORT')) {
+        die("Ansible deploymend FAILED. Check 'qesap*' logs for details.") if qesap_execute(cmd => 'ansible', timeout => 3600, verbose => 1) > 0;
+        record_info('FINISHED', 'Ansible deployment process finished successfully.');
+    }
 
-    # In case of Hana/HA deployment, detect initial primary and secondary site location
-    record_info("HANA chk", "Ansible deployment process finished successfully.");
+    # export instance data and disable cleanup
+    if (get_var('QESAP_DEPLOYMENT_EXPORT')) {
+        qesap_export_instances();
+        record_info('CLEANUP OFF', "'QESAP_DEPLOYMENT_EXPORT' enabled, turning cleanup functions off.");
+        set_var('QESAP_NO_CLEANUP', '1');
+        set_var('QESAP_NO_CLEANUP_ON_FAILURE', '1');
+    }
+
+    # Check connectivity to all instances and status of the cluster in case of HA deployment
     foreach my $instance (@$instances) {
         $self->{my_instance} = $instance;
         my $instance_id = $instance->{'instance_id'};
-        # Skip instances without HANA db
-        next if ($instance_id !~ m/vmhana/);
+        # Check ssh connection for all hosts
+        $instance->wait_for_ssh;
+
+        # Skip instances without HANA db or setup without cluster
+        next if ($instance_id !~ m/vmhana/) or !$ha_enabled;
         $self->wait_for_sync();
 
         # Define initial state for both sites
@@ -46,7 +58,14 @@ sub run {
         $run_args->{site_a} = $instance if ($instance_id eq $master_node);
         $run_args->{site_b} = $instance if ($instance_id ne $master_node);
     }
-    record_info("Instances:", "Detected HANA instances:
+
+    get_var('QESAP_DEPLOYMENT_IMPORT') ?
+      record_info('IMPORT OK', 'Importing infrastructure successfull.') :
+      record_info('DEPLOY OK', 'Ansible deployment process finished successfully.');
+
+    return unless $ha_enabled;
+
+    record_info('Instances:', "Detected HANA instances:
     Site A (PRIMARY): $run_args->{site_a}{instance_id}
     Site B: $run_args->{site_b}{instance_id}");
     return 1;

--- a/tests/sles4sap/publiccloud/qesap_cleanup.pm
+++ b/tests/sles4sap/publiccloud/qesap_cleanup.pm
@@ -15,7 +15,11 @@ use testapi;
 
 sub run {
     my ($self, $args) = @_;
-    return if get_var("PUBLIC_CLOUD_NO_CLEANUP");
+    if (get_var('QESAP_NO_CLEANUP')) {
+        record_info('SKIP CLEANUP',
+            "Variable 'QESAP_NO_CLEANUP' set to value " . get_var('QESAP_NO_CLEANUP'));
+        return 1;
+    }
     $self->cleanup($args);
 }
 

--- a/tests/sles4sap/publiccloud/qesap_reuse_infra.pm
+++ b/tests/sles4sap/publiccloud/qesap_reuse_infra.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Reuse qe-sap-deployment infrastructure preserved from previous test run.
+# https://github.com/SUSE/qe-sap-deployment
+
+use base 'sles4sap_publiccloud_basetest';
+use strict;
+use warnings;
+use testapi;
+use publiccloud::ssh_interactive 'select_host_console';
+use serial_terminal 'select_serial_terminal';
+use sles4sap_publiccloud;
+use qesapdeployment;
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    my $test_id = get_required_var('QESAP_DEPLOYMENT_IMPORT');
+
+    # Disable cleanup to keep resources running
+    set_var('QESAP_NO_CLEANUP', '1');
+    set_var('QESAP_NO_CLEANUP_ON_FAILURE', '1');
+    # This prevents variable being inherited from cloned job
+    set_var('QESAP_DEPLOYMENT_EXPORT', '');
+    set_var('SAP_SIDADM', lc(get_var('INSTANCE_SID') . 'adm'));
+
+    # Select console on the host (not the PC instance) to reset 'TUNNELED',
+    # otherwise select_serial_terminal() will be failed
+    select_host_console();
+    select_serial_terminal();
+
+    qesap_import_instances($test_id);
+
+    my $provider = $self->provider_factory();
+    my $instances = create_instance_data($provider);
+    $self->{instances} = $run_args->{instances} = $instances;
+
+    record_info('IMPORT OK', 'Instance data imported.');
+}
+
+1;


### PR DESCRIPTION
This PR allows reuse infrastructure created by qesap-deployment project between 
multiple tests. Running test with parameter QESAP_DEPLOYMENT_EXPORT=1 disables 
cleanup and exports data from testrun. Next test run with 
QESAP_DEPLOYMENT_IMPORT=<test id> will connect to the existing infrastructure. 
This is meant mostly for development or keeping infrastructure for bug 
reporting.

- Related ticket: https://jira.suse.com/browse/TEAM-6902
- Needles: N/A
- Verification runs: 
Without export (cleanup should happen): https://openqaworker15.qa.suse.cz/tests/179826#
Export infra (Cleanup skipped): https://openqaworker15.qa.suse.cz/tests/179825#
Import infra (Cleanup skipped, hosts have same IPs): https://openqaworker15.qa.suse.cz/tests/179827#step/verify_infrastructure/33