### PR TITLE
Handle return values which assign undef

### DIFF
--- a/tests/hpc/conman.pm
+++ b/tests/hpc/conman.pm
@@ -45,7 +45,7 @@ sub run ($self) {
     # do not restart conmand after starting netcat!
 
     # start conman on this socket
-    $rt = enter_cmd("conman socket1 &");
+    $rt = (enter_cmd("conman socket1 &")) ? 1 : 0;
     test_case('Config socket', 'conman socket', $rt);
 
     # test from netcat side

--- a/tests/hpc/genders.pm
+++ b/tests/hpc/genders.pm
@@ -43,7 +43,7 @@ sub run ($self) {
     assert_script_run('cat $cfile');
 
     # Compare test files, file must have same content, difference means test failure
-    $rt = assert_script_run('diff $tmpfile $cfile');
+    $rt = (assert_script_run('diff $tmpfile $cfile')) ? 1 : 0;
     test_case('Compare test files', 'genders smoke test', $rt);
 }
 

--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -53,10 +53,10 @@ sub run {
         enter_cmd("exit");
         sleep(1);
         assert_script_run('hostname|grep mrsh-master');
-        $rt = assert_script_run("mrsh ${node_name}  rm -f /tmp/hello");
+        $rt = (assert_script_run("mrsh ${node_name}  rm -f /tmp/hello")) ? 1 : 0;
         test_case('Delete file remotely', 'mrsh test remote deletion', $rt);
         assert_script_run("echo \"Hello world!\" >/tmp/hello");
-        $rt = assert_script_run("mrcp /tmp/hello ${node_name}:/tmp/hello");
+        $rt = (assert_script_run("mrcp /tmp/hello ${node_name}:/tmp/hello")) ? 1 : 0;
         test_case('Create file remotely', 'mrsh test remote copy', $rt);
         assert_script_run("mrsh ${node_name}  cat /tmp/hello");
     }

--- a/tests/hpc/munge_master.pm
+++ b/tests/hpc/munge_master.pm
@@ -36,9 +36,9 @@ sub run ($self) {
     barrier_wait("MUNGE_SERVICE_ENABLED");
 
     # Test if munge works fine
-    $rt = assert_script_run('munge -n');
+    $rt = (assert_script_run('munge -n')) ? 1 : 0;
     test_case('Run munge', 'munge test', $rt);
-    $rt = assert_script_run('munge -n | unmunge');
+    $rt = (assert_script_run('munge -n | unmunge')) ? 1 : 0;
     test_case('Check unmunge output', 'munge test', $rt);
     for (my $node = 1; $node < $nodes; $node++) {
         my $node_name = sprintf("munge-slave%02d", $node);
@@ -48,7 +48,7 @@ sub run ($self) {
         };
         test_case("Check ssh $node_name", 'test munge config', $rt);
     }
-    $rt = assert_script_run('remunge');
+    $rt = (assert_script_run('remunge')) ? 1 : 0;
     test_case('Run remunge', 'test remunge', $rt);
     barrier_wait('MUNGE_DONE');
 }

--- a/tests/hpc/pdsh_slave.pm
+++ b/tests/hpc/pdsh_slave.pm
@@ -39,7 +39,7 @@ sub run ($self) {
 
     $self->switch_user('nobody');
     my $genders_plugin = get_var('PDSH_GENDER_TEST') ? '-g type=genders-test' : '';
-    $rt = assert_script_run("pdsh -R mrsh $genders_plugin -w $server_hostname ls / &> /tmp/pdsh.log");
+    $rt = (assert_script_run("pdsh -R mrsh $genders_plugin -w $server_hostname ls / &> /tmp/pdsh.log")) ? 1 : 0;
     test_case('Run remotelly mrsh module on the server', 'pdsh remote invocation', $rt);
     assert_script_run("test -s /tmp/pdsh.log");
     upload_logs '/tmp/pdsh.log';

--- a/tests/hpc/powerman.pm
+++ b/tests/hpc/powerman.pm
@@ -58,16 +58,16 @@ EOF
     test_case('Test powerman -l', 'powerman can find nodes', $rt);
 
     # check if target can be turned on
-    $rt = assert_script_run("powerman -1 \$(hostname)");
+    $rt = (assert_script_run("powerman -1 \$(hostname)")) ? 1 : 0;
     test_case('powerman on', 'powerman can turn on nodes', $rt);
 
     $rt = validate_script_output("powerman -Q \$(hostname)", sub { /on:\s+$hostname.*/ });
     test_case('powerman list online nodes', 'powerman can find nodes', $rt);
 
     # check if target can be turned off
-    $rt = assert_script_run("powerman -0 \$(hostname)");
+    $rt = (assert_script_run("powerman -0 \$(hostname)")) ? 1 : 0;
     test_case('powerman off', 'powerman can turn off nodes', $rt);
-    $rt = validate_script_output("powerman -Q \$(hostname)", sub { /off:\s+$hostname.*/ });
+    $rt = (validate_script_output("powerman -Q \$(hostname)", sub { /off:\s+$hostname.*/ })) ? 1 : 0;
     test_case('powerman list online nodes', 'powerman can turn off nodes', $rt);
 
     # check if command can be handled by power control device
@@ -75,7 +75,7 @@ EOF
     # Power cycle is not supported by *bashfun*.
     if (exists $$powerman_dev_caps{cycle}) {
         record_info('skip cycle', 'cycle is supported but check is not implemented');
-        $rt = assert_script_run("powerman -c \$(hostname)");
+        $rt = (assert_script_run("powerman -c \$(hostname)")) ? 1 : 0;
         test_case('powerman cycle', 'powerman can show node cycle', $rt);
     } else {
         $rt = validate_script_output("powerman -c \$(hostname)", sub { /.*cannot be handled by power control device.*/ }, proceed_on_failure => 1);


### PR DESCRIPTION
Some invocations are not return a value of 0 or 1 so need to be handled in order to pass the return value to test_case.


- Verification run: https://openqa.suse.de/tests/overview?version=15-SP5&build=b10n1k%2Fos-autoinst-distri-opensuse%2317106&distri=sle