### PR TITLE
Proceed on failures opt.add to influxdb_push_data

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -605,7 +605,8 @@ sub store_boottime_db() {
         tags => $tags,
         values => $results->{analyze}
     };
-    influxdb_push_data($url, $db, $org, $token, $data);
+    my $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1);
+    return unless ($res);
 
     record_info("STORE blame", $results->{type});
     $tags->{boottype} = $results->{type};
@@ -614,7 +615,8 @@ sub store_boottime_db() {
         tags => $tags,
         values => $results->{blame}
     };
-    influxdb_push_data($url, $db, $org, $token, $data);
+    $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1);
+    return $res;
 }
 
 sub systemd_time_to_second

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -371,7 +371,8 @@ sub store_in_db {
         tags => $tags,
         values => $results->{analyze}
     };
-    influxdb_push_data($url, $db, $org, $token, $data);
+    my $res = influxdb_push_data($url, $db, $org, $token, $data);
+    return unless ($res);
 
     for my $type (qw(first soft hard)) {
         $tags->{boottype} = $type;
@@ -380,7 +381,8 @@ sub store_in_db {
             tags => $tags,
             values => $results->{blame}->{$type}
         };
-        influxdb_push_data($url, $db, $org, $token, $data);
+        $res = influxdb_push_data($url, $db, $org, $token, $data);
+        return unless ($res);
     }
 }
 


### PR DESCRIPTION
`Proceed on failures` option added to `influxdb_push_data`, bottime measuring routines updated accordingly

- Related ticket: https://progress.opensuse.org/issues/129574
- Needles: none
- Verification run: coming soon.
