### PR TITLE
containers: helm could be disabled during the k3s installation

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -49,10 +49,13 @@ sub install_k3s {
         # k3s doesn't like long hostnames like the ones being used in publiccloud
         assert_script_run("export K3S_NODE_NAME=k3s-node") if (is_public_cloud);
 
+        my $disables = '--disable=metrics-server';
+        $disables .= ' --disable-helm-controller' unless (get_var('K3S_ENABLE_HELM_CONTROLLER'));
+
         # github.com/k3s-io/k3s#5946 - The kubectl delete namespace helm-ns-413 command freezes and does nothing
         # Note: The install script starts a k3s-server by default, unless INSTALL_K3S_SKIP_START is set to true
         script_retry("curl -sfL https://get.k3s.io  -o install_k3s.sh", timeout => 180, delay => 60, retry => 3);
-        assert_script_run("INSTALL_K3S_SKIP_START=true sh install_k3s.sh --disable=metrics-server", timeout => 300);
+        assert_script_run("INSTALL_K3S_SKIP_START=true sh install_k3s.sh $disables", timeout => 300);
         script_run("rm -f install_k3s.sh");
     }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/129541
- Verification run:
- http://openqa.suse.de/tests/11165062
- https://openqa.suse.de/tests/11176573 (with helm)
