### PR TITLE
SLEM: increase timeout to install patterns

### DIFF
--- a/tests/microos/patterns.pm
+++ b/tests/microos/patterns.pm
@@ -23,7 +23,7 @@ sub run {
     my @patterns = map { m/\|\s+(.*?)\s+\|.*pattern$/ } @available_patterns;
 
     # install new patterns
-    trup_call('pkg install -t pattern ' . join(" ", @patterns));
+    trup_call('pkg install -t pattern ' . join(" ", @patterns), timeout => 300);
     process_reboot(trigger => 1);
 
     # expect empty list therefore ZYPPER_EXIT_INF_CAP_NOT_FOUND


### PR DESCRIPTION
Example of timeout: https://openqa.suse.de/tests/11173313#step/patterns/29
VR: http://openqa.suse.de/tests/11175839