### PR TITLE
salt_master: Check master log only on master node

### DIFF
--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -92,7 +92,7 @@ sub logs_from_salt {
     $error .= "| grep -vi 'has cached the public key for this node\\|Minion unable to successfully connect to a Salt Master'";
     $error .= "| grep -vi 'Error while bringing up minion for multi-master'";
     if (script_run("$error") != 1) {
-        if (script_run('grep "self.pusher.connect(timeout=timeout)" /var/log/salt/master') == 0) {
+        if (check_var('HOSTNAME', 'master') && script_run('grep "self.pusher.connect(timeout=timeout)" /var/log/salt/master') == 0) {
             record_soft_failure('bsc#1209248');
             return;
         }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/129496
- Verification run:
Before: https://openqa.suse.de/tests/11175440#step/salt_minion/98
After: https://openqa.suse.de/tests/11176159#step/salt_minion/95