### PR TITLE
Add PackageHub on HPC autoyast

### DIFF
--- a/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
@@ -38,6 +38,15 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
+      % if ($check_var->('VERSION', '15-SP4')) {
+      <addon config:type="map">
+        <arch>{{ARCH}}</arch>
+        <name>PackageHub</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      % }
       % unless ($check_var->('VERSION', '15')) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>

--- a/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
@@ -38,6 +38,15 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
+      % if ($check_var->('VERSION', '15-SP4')) {
+      <addon config:type="map">
+        <arch>{{ARCH}}</arch>
+        <name>PackageHub</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      % }
       % unless ($check_var->('VERSION', '15')) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>


### PR DESCRIPTION
PackageHub is required to install warewulf on 15SP4. I edited aarch64 template as well even if warewulf is not scheduled there yet. (in fact is in the dev group)

- Verification run: https://openqa.suse.de/tests/11176838# + https://openqa.suse.de/tests/11176855#step/ww4/64 (although fails later and i havent checked why yet)
