### PR TITLE
Add qesap_add_server_to_hosts to qesap regression

### DIFF
--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -29,6 +29,7 @@ sub run {
         my $rg = qesap_az_get_resource_group();
         my $ibs_mirror_rg = get_var('QESAP_IBSMIRROR_RESOURCE_GROUP');
         qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_rg);
+        qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAP_IBSMIRROR_IP"));
         qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibs_mirror_rg);
     }
 }


### PR DESCRIPTION
Add Ansible to touch /etc/hosts during qesap regression as it seems critical in mr_test.
Rename az based qesapdeploy function
Add timeout and verbosity to qesap_ansible_cmd

Related ticket: [TEAM-7704](https://jira.suse.com/browse/TEAM-7704)

Verification run: Azure 15sp4
https://openqaworker15.qa.suse.cz/tests/180441
