### PR TITLE
Don't add development-tools on maintenance tests

### DIFF
--- a/schedule/qam/common/mau-extratests-desktop.yaml
+++ b/schedule/qam/common/mau-extratests-desktop.yaml
@@ -8,10 +8,10 @@ schedule:
   - x11/disable_screensaver
   - x11/vnc_two_passwords
   - x11/user_defined_snapshot
-  - x11/remote_desktop/screensharing_available
   - x11/libqt5_qtbase
   - x11/rrdtool_x11
   - x11/yast2_lan_restart
+  - x11/remote_desktop/screensharing_available
   - console/yast2_lan_device_settings
   - '{{version_specific}}'
   - console/coredump_collect

--- a/tests/x11/libqt5_qtbase.pm
+++ b/tests/x11/libqt5_qtbase.pm
@@ -21,9 +21,10 @@ use x11utils 'ensure_unlocked_desktop';
 use version_utils 'is_sle';
 use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
 use Utils::Architectures 'is_aarch64';
+use main_common qw(is_updates_tests);
 
 sub run {
-    if (is_sle('>=15-sp4')) {
+    if (is_sle('>=15-sp4') && !main_common::is_updates_tests) {
         select_serial_terminal;
         # Activating development-tools module to install libqt5-qttools package
         add_suseconnect_product("sle-module-development-tools");


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/129658
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=x11_129658&version=15-SP5
