### PR TITLE
xfstests: install nfs dependencies on client

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -349,6 +349,7 @@ sub run {
         }
         elsif (get_var('PARALLEL_WITH')) {
             setup_static_mm_network('10.0.2.102/24');
+            install_dependencies_nfs;
             assert_script_run('mkdir -p /nfs/test /nfs/scratch');
             $NFS_SERVER_IP = '10.0.2.101';
         }


### PR DESCRIPTION
We only install nfs4-acl-tools on nfs server, but nfs/001 requires this package on client.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/11181566