### PR TITLE
Add basic installation test for Elemental

### DIFF
--- a/data/elemental/cloud-config.yaml
+++ b/data/elemental/cloud-config.yaml
@@ -1,0 +1,10 @@
+name: "Default user"
+stages:
+   initramfs:
+     - name: "Setup users"
+       ensure_entities:
+       - path: /etc/shadow
+         entity: |
+            kind: "shadow"
+            username: "root"
+            password: "%TEST_PASSWORD%"

--- a/products/elemental
+++ b/products/elemental
@@ -1,0 +1,1 @@
+./sle-micro

--- a/schedule/elemental/iso.yaml
+++ b/schedule/elemental/iso.yaml
@@ -1,0 +1,8 @@
+name: elemental_iso
+description: >
+  Test installation and boot of Elemental ISO.
+  Maintainer: elemental@suse.de
+schedule:
+  - elemental/installation
+  - console/journal_check
+  - elemental/shutdown

--- a/tests/elemental/installation.pm
+++ b/tests/elemental/installation.pm
@@ -1,0 +1,98 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test boot of Elemental OS
+# Maintainer: elemental@suse.de
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+
+use testapi;
+use power_action_utils qw(power_action);
+use serial_terminal qw(select_serial_terminal);
+use utils qw(file_content_replace);
+
+sub run {
+    my ($self) = @_;
+    my $cloudconfig = "/tmp/cloud-config.yaml";
+    my %boot_entries = (
+        active => {
+            tag => 'elemental-bootmenu-default'
+        },
+        passive => {
+            tag => 'elemental-bootmenu-fallback'
+        },
+        recovery => {
+            tag => 'elemental-bootmenu-recovery'
+        }
+    );
+
+
+    # Wait for GRUB
+    $self->wait_grub(bootloader_time => 120);
+    send_key('ret', wait_screen_change => 1);
+    wait_still_screen(timeout => 90);
+    save_screenshot();
+
+    ## No GUI, easier and quicker to use the serial console
+    select_serial_terminal();
+
+    # Add a simple cloud-config
+    my $rootpwd = script_output('openssl passwd -6 ' . get_var('TEST_PASSWORD'));
+    assert_script_run('curl ' . data_url('elemental/cloud-config.yaml') . ' -o ' . $cloudconfig);
+    file_content_replace($cloudconfig, '%TEST_PASSWORD%' => $rootpwd);
+
+    # Install Elemental OS on HDD
+    assert_script_run('elemental install /dev/vda --cloud-init ' . $cloudconfig);
+
+    # Reboot after installation
+    power_action('reboot', keepconsole => 1, textmode => 1);
+
+    # Use new root password
+    $testapi::password = get_var('TEST_PASSWORD');
+
+    # Loop on all entries to test them
+    foreach my $boot_entry (keys %boot_entries) {
+        my $state = $boot_entries{$boot_entry};
+        my $state_file = "/run/cos/${boot_entry}_mode";
+
+        # Select SUT for bootloader
+        select_console('sut');
+
+        # Wait for GRUB
+        $self->wait_grub(bootloader_time => 120);
+
+        # Choose entry to test
+        send_key_until_needlematch($state->{tag}, 'down');
+        send_key('ret', wait_screen_change => 1);
+        wait_still_screen(timeout => 120);
+        save_screenshot();
+
+        # No GUI, easier and quicker to use the serial console
+        select_serial_terminal();
+
+        # Check that we are booted in the correct entry
+        # NOTE: Shell and Perl return code are inverted!
+        if (!script_run("[[ -f ${state_file} ]]")) {
+            record_info("$boot_entry detected!", "$state_file has been detected!");
+        } else {
+            die("Not booted in $boot_entry!");
+        }
+
+        # Check the installed OS
+        assert_script_run('cat /etc/os-release');
+
+        # Reboot to test the next entry
+        power_action('reboot', keepconsole => 1, textmode => 1);
+
+        # Record boot
+        record_info('OS boot', "$boot_entry: successfully tested!");
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/elemental/shutdown.pm
+++ b/tests/elemental/shutdown.pm
@@ -1,0 +1,29 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Power off Elemental OS server
+# Maintainer: elemental@suse.de
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+
+use testapi;
+use power_action_utils qw(power_action);
+use serial_terminal qw(select_serial_terminal);
+
+sub run {
+    my ($self) = @_;
+
+    # No GUI, easier and quicker to use the serial console
+    select_serial_terminal();
+
+    # It's the end, power off!
+    power_action('poweroff', keepconsole => 1, textmode => 1);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
This PR adds a basic installation test for Elemental ISO.

Elemental is a very small OS based on SLEM for Rancher intended to be used with Rancher Manager to provision edge cluster. See [Elemental docs](https://elemental.docs.rancher.com) for more information.

This test will be used mainly by QAM to validate SLEM fixes pushed to Elemental image. More complete E2E tests are done in the [Elemental GitHub project](https://github.com/rancher/elemental).

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1641
- Add new product in OBS: https://gitlab.suse.de/openqa/openqa-trigger-from-ibs-plugin/-/merge_requests/128 and https://gitlab.suse.de/openqa/salt-states-openqa/-/merge_requests/868
- Job Group definition: https://github.com/rancher/elemental/pull/878

Verification runs:
- http://ldevulder.udp.ovpn1.nue.suse.de/tests/104