### PR TITLE
Parameters added to instance record pushed to InfluxDB

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -590,6 +590,9 @@ sub store_boottime_db() {
         os_build => get_required_var('BUILD'),
         os_flavor => get_required_var('FLAVOR'),
         os_version => get_required_var('VERSION'),
+        os_distri => get_required_var('DISTRI'),
+        os_arch => get_required_var('ARCH'),
+        os_region => get_required_var('PUBLIC_CLOUD_REGION'),
         os_kernel_release => $results->{kernel_release},
         os_kernel_version => $results->{kernel_version},
     };


### PR DESCRIPTION
3 more parameters added to instance record pushed to InfluxDB for P.C. boottime measures in `perf_2` bucket, 
from test settings: `ARCH`, `DISTRI`, `REGION`

- Related ticket: https://progress.opensuse.org/issues/118027
- Needles: N/A
- Verification run: Coming soon
