### PR TITLE
Add softfail for bsc#1211591 to salt test

### DIFF
--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -96,6 +96,10 @@ sub logs_from_salt {
             record_soft_failure('bsc#1209248');
             return;
         }
+        if (script_run('grep "ModuleNotFoundError.*\'salt.ext.six\'" /var/log/salt/minion') == 0) {
+            record_soft_failure('bsc#1211591');
+            return;
+        }
         die "Salt logs are containing errors!";
     }
 }


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1211591
https://progress.opensuse.org/issues/129595

- Verification run: 
[15SP1/SP4/SP5](https://openqa.suse.de/tests/overview?distri=sle&build=rfan0523)

15SP2/SP3 will not hit the issue for now, since the salt package version is at older `3004`