### PR TITLE
Fix a few failures in post_fail_hook which make guests failed to be restored

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -547,7 +547,8 @@ sub remove_additional_nic {
 
 sub collect_virt_system_logs {
     if (script_run("test -f /var/log/libvirt/*d.log") == 0) {
-        upload_logs("/var/log/libvirt/*d.log");
+        script_run('tar czvf /tmp/libvirt_daemons.tar.gz /var/log/libvirt/*d.log');
+        upload_asset("/tmp/libvirt_daemons.tar.gz");
     }
     else {
         record_info "File /var/log/libvirt/*d.log does not exist.";
@@ -930,6 +931,8 @@ sub restore_original_guests {
             record_info("Fail to restore guest!", "$guest", result => 'softfail');
         }
     }
+    script_run("virsh list --all");
+    save_screenshot;
 }
 
 sub upload_virt_logs {

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -10,7 +10,6 @@ package reboot_and_wait_up;
 use strict;
 use warnings;
 use testapi;
-use login_console;
 use ipmi_backend_utils;
 use base "proxymode";
 use power_action_utils 'power_action';

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -117,7 +117,7 @@ sub run_test {
         #reboot the guest
         record_info("VM reboot", "$guest");
         script_run "ssh root\@$guest 'reboot'";    #don't use assert_script_run, or may fail on xen guests
-        wait_guest_online($guest);
+        wait_guest_online($guest, 30);
         save_network_device_status_logs($log_dir, $guest, $passthru_vf_count + 3 . '-after_guest_reboot');
 
         #check host and guest to make sure they work well


### PR DESCRIPTION
- Fix a few failures in post_fail_hook which blocks consequent tests running after sriov tests. 
  - publishing unit log failed due to no command history. In this case, [uefi-gi-guest_developing-on-host_sles12sp5-xen](https://openqa.suse.de/tests/11163170#) , guests were not restored after sriov failure which stopped consequent tests.  
  - correct errors in uploading logs in post_fail_hook.
  - stop SLE test going into ALP environment. fg. http://10.67.129.102/tests/634#step/sriov_network_card_pci_passthrough/461
  - remove duplicate collecting virt logs from product tests as it has been uploaded in collect_host_and_guest_logs().
- remove Perl warnings in autoinst.txt, https://openqa.suse.de/tests/11181432/logfile?filename=autoinst-log.txt
```
Subroutine set_ssh_console_timeout_before_use redefined at sle/tests/virt_autotest/login_console.pm line 22.
```



Related ticket: https://progress.opensuse.org/issues/120750
Verification run: 
[storage_tests_continued_after_sriov_test_fail](https://openqa.suse.de/tests/11194705)
[logs_uploaded_correctly_in_post_fail_hook](http://10.67.129.102/tests/634)
