### PR TITLE
Add modules maintained by @pdostal to .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,3 +22,16 @@ tests/jeos/ @mloviska @jlausuch
 tests/transactional/ @mloviska @jlausuch
 lib/main_micro_alp.pm @mloviska @jlausuch
 
+# pdostal
+tests/console/sshd.pm @pdostal
+tests/console/ansible.pm @pdostal
+tests/console/nginx.pm @pdostal
+lib/services/nginx.pm @pdostal
+tests/console/irqbalance.pm @pdostal
+tests/console/rpm.pm @pdostal
+tests/network/wireguard.pm @pdostal
+tests/network/openvpn_client.pm @pdostal
+tests/network/openvpn_server.pm @pdostal
+tests/network/setup_multimachine.pm @pdostal
+lib/Utils/Logging.pm @pdostal
+

--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -1,5 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
+# Summary: All the logging related subroutines
+# Maintainer: Pavel Dostál <pdostal@suse.cz>, QE Core <qe-core@suse.com>
 
 =head1 Utils::Logging
 

--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Helper package for common virt operations
-# Maintainer: Pavel Dostal <pdostal@suse.cz>
+# Maintainer: qe-virt <qe-virt@suse.de>
 
 package virt_autotest::common;
 

--- a/lib/virt_autotest/kernel.pm
+++ b/lib/virt_autotest/kernel.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Virtualization kernel functions
-# Maintainer: Pavel Dostal <pdostal@suse.cz>
+# Maintainer: qe-virt <qe-virt@suse.de>
 
 package virt_autotest::kernel;
 


### PR DESCRIPTION
 * Make QE Core team and Pavel Dostál as maintainer of lib/Utils/Logging.pm
 * Return lib/virt_autotest/kernel.pm and lib/virt_autotest/common.pm to qe-virt team
 * Add test modules maintained by pdostal to .github/CODEOWNERS

What is [GITHUB CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)