### PR TITLE
Set host name when NetworkManager is active

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -77,6 +77,7 @@ our @EXPORT = qw(
   exec_and_insert_password
   shorten_url
   reconnect_mgmt_console
+  print_ip_info
   set_hostname
   show_tasks_in_blocked_state
   show_oom_info
@@ -1052,6 +1053,21 @@ sub set_bridged_networking {
     }
     # Some needles match hostname which we can't set permanently with bridge.
     set_var('BRIDGED_NETWORKING', 1) if $ret;
+}
+
+=head2 print_ip_info
+
+  print_ip_info();
+
+Print the interface addresses, routes and adjacent network nodes (that
+have been seen). Especially useful for multi-machine test debugging.
+
+=cut
+
+sub print_ip_info {
+    script_run('ip addr');
+    script_run('ip route');
+    script_run('ip neigh');
 }
 
 =head2 set_hostname

--- a/tests/kernel/before_nfs_test.pm
+++ b/tests/kernel/before_nfs_test.pm
@@ -25,4 +25,8 @@ sub test_flags {
 }
 sub post_run_hook { }
 
+sub post_fail_hook {
+    print_ip_info;
+}
+
 1;


### PR DESCRIPTION
Firstly restarting the network service doesn't seem to cause NetworkManager to renew the DHCP lease. If we use `nmcli` instead then it doesn't wait for the lease to be renewed. So we have to wait for DNS to come back or perhaps use ping.

I'm not sure whether we should just switch to Wicked or if these are bugs with the NetworkManager setup. 