### PR TITLE
Set password in pre_run_hook for agama_base

### DIFF
--- a/lib/yam/agama/agama_base.pm
+++ b/lib/yam/agama/agama_base.pm
@@ -12,9 +12,12 @@ use testapi 'select_console';
 use y2_base 'save_upload_y2logs';
 use Utils::Logging 'save_and_upload_log';
 
+sub pre_run_hook {
+    $testapi::password = 'linux';
+}
+
 sub post_fail_hook {
     my ($self) = @_;
-    $testapi::password = 'linux';
     select_console 'root-console';
     y2_base::save_upload_y2logs($self, skip_logs_investigation => 1);
     save_and_upload_log('journalctl -u agama-auto', "/tmp/agama-auto-log.txt");


### PR DESCRIPTION
- basically the livecd settings clear the password (and that might change once we move to IBS) but once we are in agama we should match password with the system to linux, and when we finish without failure we should match password to running system password.


