### PR TITLE
Resurrect Azure Accelerated Network testing

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -260,7 +260,7 @@ sub get_image_uri {
     my ($self) = @_;
     my $image_uri = get_var("PUBLIC_CLOUD_IMAGE_URI");
     die 'The PUBLIC_CLOUD_IMAGE_URI variable makes sense only for Azure' if ($image_uri && !is_azure);
-    if ($image_uri =~ /^auto$/mi) {
+    if (!!$image_uri && $image_uri =~ /^auto$/mi) {
         my $definition = get_required_var('DISTRI') . '-' . get_required_var('FLAVOR') . '-' . get_required_var('VERSION');
         my $version = $self->calc_img_version();    # PUBLIC_CLOUD_BUILD PUBLIC_CLOUD_BUILD_KIWI
         my $subscriptions = $self->provider_client->subscription;
@@ -269,8 +269,10 @@ sub get_image_uri {
         $image_uri = "/subscriptions/$subscriptions/resourceGroups/$resource_group/providers/";
         $image_uri .= "Microsoft.Compute/galleries/$image_gallery/images/$definition/versions/$version";
         record_info 'IMAGE_URI', "Calculated IMAGE_URI=$image_uri";
-    } else {
+    } elsif (!!$image_uri) {
         record_info 'IMAGE_URI', "Provided IMAGE_URI=$image_uri";
+    } else {
+        record_info 'IMAGE_URI', 'IMAGE_URI not found!';
     }
     return $image_uri;
 }

--- a/tests/publiccloud/az_accelerated_net.pm
+++ b/tests/publiccloud/az_accelerated_net.pm
@@ -14,23 +14,25 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use Data::Dumper;
 
 =head2 prepare_vm
 
 Creates a VM in Azure and installs IPERF binaries on it
 
 =cut
-sub prepare_vm {
+sub prepare_vms {
     my ($self, $provider) = @_;
-    my $iperf = get_required_var('IPERF_FILE');
-    record_info('INFO', 'Create VM');
-    my $instance = $provider->create_instance(check_guestregister => 0);
-    record_info('Instance', 'Instance ' . $instance->instance_id . ' created');
-    record_info('Iperf', 'Install IPerf binaries in VM');
-    $instance->run_ssh_command(cmd => "wget https://iperf.fr/download/opensuse/$iperf");
-    $instance->run_ssh_command(cmd => "sudo rpm -i  $iperf");
-    return $instance;
+    my $repo = get_required_var('IPERF_REPO');
+    record_info('INFO', "Create VM\nInstalling iperf package from $repo");
+    my @instances = $provider->create_instances(check_guestregister => 0, count => 2);
+    foreach my $instance (@instances) {
+        record_info('Instance', 'Instance ' . $instance->instance_id . ' created');
+        record_info('Iperf', 'Install IPerf binaries in VM');
+        $instance->run_ssh_command(cmd => "sudo zypper -n ar --no-gpgcheck $repo net_perf");
+        $instance->run_ssh_command(cmd => "sudo zypper -n in -r net_perf iperf");
+    }
+
+    return \@instances;
 }
 
 =head2 get_new_ip
@@ -40,9 +42,13 @@ a VM again, since the IPs will differ.
 
 =cut
 sub get_new_ip {
-    my ($self, $instance) = @_;
-    assert_script_run('az vm list -g ' . $instance->instance_id . ' -d');
-    my $cmd = 'az vm list -g ' . $instance->instance_id . q( -d|grep -i publicip|awk '{print $2}'| tr -d '"'| tr -d ',');
+    my ($instance, $need_pub) = @_;
+    my $resgroup = (split('/', $instance->instance_id))[4];
+    assert_script_run("az vm list -g $resgroup -d");
+    my $cmd = 'az vm list-ip-addresses --ids ' . $instance->instance_id . ' --query "[].virtualMachine.network.privateIpAddresses[]" -o tsv';
+    if (!!$need_pub) {
+        $cmd = 'az vm list-ip-addresses --ids ' . $instance->instance_id . ' --query "[].virtualMachine.network.publicIpAddresses[].ipAddress" -o tsv';
+    }
     my $ip = script_output($cmd);
     record_info('Instance', "VM has new IP: $ip");
     return $ip;
@@ -56,12 +62,16 @@ It follows the instructions in https://goo.gl/Px6kou
 =cut
 sub enable_accelerated_net {
     my ($self, $instance) = @_;
-    my $name = $instance->{instance_id};
-    assert_script_run("az vm deallocate --resource-group $name --name $name", timeout => 60 * 10);
-    assert_script_run("az network nic update --name $name-nic --resource-group $name --accelerated-networking true", timeout => 60 * 10);
-    assert_script_run("az vm start --resource-group $name --name $name", timeout => 60 * 20);
+    my $inst_id = $instance->{instance_id};
+    my $name = (split('/', $inst_id))[-1];
+    my $resgroup = (split('/', $inst_id))[4];
+    my $subs = $instance->{provider}->{provider_client}->{subscription};
+    assert_script_run("az vm deallocate --ids $inst_id", timeout => 60 * 10);
+    assert_script_run("az network nic update --resource-group $resgroup --name $name-nic --accelerated-networking true", timeout => 60 * 10);
+    assert_script_run("az vm start --ids $inst_id", timeout => 60 * 20);
     sleep 60 * 3;    # Sometimes, IP is not reachable after the restart and 5 minutes is enough.
-    $instance->public_ip($self->get_new_ip($instance));
+    $instance->{private_ip} = get_new_ip($instance);
+    $instance->public_ip(get_new_ip($instance, 1));
     die('SR-IOV flags not found') if (!$self->check_sriov($instance));
 }
 
@@ -80,7 +90,7 @@ sub check_sriov {
     my $ethtool_output = $instance->run_ssh_command(cmd => "sudo ethtool -S eth0 | grep vf_");
     record_info('lspci', $lspci_output);
     record_info('ethtool', $ethtool_output);
-    if ($lspci_output =~ m/Mellanox/ && $ethtool_output !~ m/vf_rx_bytes: 0/) {
+    if (($lspci_output =~ m/Mellanox/) && ($ethtool_output !~ m/^\s+vf_rx_bytes: 0$/)) {
         record_info('sr-iov', 'SR-IOV is enabled');
         return 1;
     }
@@ -96,11 +106,12 @@ test on the client side. The test runs TEST_TIME seconds.
 =cut
 sub run_test {
     my ($self, $client, $server) = @_;
-    record_info('server', 'Start IPERF in server' . $server->public_ip);
-    $server->run_ssh_command(cmd => 'nohup iperf -s -D &', no_quote => 1);
+    record_info('server', 'Start IPERF in server ' . $server->public_ip);
+    $server->run_ssh_command(cmd => 'nohup iperf3 -s -D &', no_quote => 1);
     sleep 60;    # Wait 60 seconds so that the server starts up safely and the clinet can connect to it
     record_info('client', 'Start IPERF in client');
-    my $output = $client->run_ssh_command(cmd => 'iperf -t ' . get_required_var('TEST_TIME') . ' -c ' . $server->public_ip);
+    my $ttime = get_required_var('TEST_TIME');
+    my $output = $client->run_ssh_command(cmd => 'iperf3 -t ' . $ttime . ' -c ' . $server->{private_ip}, timeout => $ttime * 3);
     record_info('RESULTS', $output);
 }
 
@@ -110,8 +121,7 @@ sub run {
     select_serial_terminal;
 
     my $provider = $self->provider_factory();
-    my $client = $self->prepare_vm($provider);
-    my $server = $self->prepare_vm($provider);
+    my ($client, $server) = @{$self->prepare_vms($provider)};
 
     $self->enable_accelerated_net($client);
     $self->enable_accelerated_net($server);

--- a/variables.md
+++ b/variables.md
@@ -87,6 +87,7 @@ INSTALL_SOURCE | string | | Specify network protocol to be used as installation 
 INSTALLATION_VALIDATION | string | | Comma separated list of modules to be used for installed system validation, should be used in combination with INSTALLONLY, to schedule only relevant test modules.
 INSTALLONLY | boolean | false | Indicates that test suite conducts only installation. Is recommended to be used for all jobs which create and publish images
 INSTLANG | string | en_US | Installation locale settings.
+IPERF_REPO | string | | Link to repository with iperf tool for network performance testing. Currently used in Public Cloud Azure test
 IPXE | boolean | false | Indicates ipxe boot.
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
@@ -182,6 +183,7 @@ SYSTEMD_TESTSUITE | boolean | undef | Enable schedule of systemd upstream tests
 SYSTEMD_UNIFIED_CGROUP | string | "yes", "no", "hybrid", "default" | systemd currently supports 3 (unified,legacy,hybrid) cgroups configurations
 TEST | string | | Name of the test suite.
 TEST_CONTEXT | string | | Defines the class name to be used as the context instance of the test. This is used in the scheduler to pass the `run_args` into the loadtest function. If it is not given it will be undef.
+TEST_TIME | integer | | Set time parameter for `iperf -t N` option. Used in Azure Public Cloud testing of Accelerated NICs
 TOGGLEHOME | boolean | false | Changes the state of partitioning to have or not to have separate home partition in the proposal.
 TUNNELED | boolean | false | Enables the use of normal consoles like "root-consoles" on a remote SUT while configuring the tunnel in a local "tunnel-console"
 TYPE_BOOT_PARAMS_FAST | boolean | false | When set, forces `bootloader_setup::type_boot_parameters` to use the default typing interval.


### PR DESCRIPTION
The test module was not used for a while and needed to be updated
accordingly. Test suite creates 2 instances of type `Standard_D2_v4`
and measures network throuput using `iperf3`.
In order to install the package, we need to use opensuse repos or devel
repos in OBS as for SLE the `iperf` is provided by package hub and in
older versions only.

- ticket: [enable network performance test](https://progress.opensuse.org/issues/126224)
- Verification run: https://openqa.suse.de/tests/11242895#
