### PR TITLE
Add workstation extension before seahorse installation

### DIFF
--- a/tests/x11/seahorse_sshkey.pm
+++ b/tests/x11/seahorse_sshkey.pm
@@ -12,9 +12,21 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
+use version_utils 'is_sle';
+use registration qw(add_suseconnect_product get_addon_fullname);
+
+sub prepare_repositories {
+    # add workstation extension
+    add_suseconnect_product(get_addon_fullname('we'), undef, undef, "-r " . get_var('SCC_REGCODE_WE'), 300, 1);
+    # disable nvidia repository to avoid the 'doesn't contain public key data' error
+    zypper_call(q{mr -d $(zypper lr | awk -F '|' '{IGNORECASE=1} /nvidia/ {print $2}')}, exitcode => [0, 3]);
+}
 
 sub run {
     select_console 'root-console';
+
+    prepare_repositories if is_sle();
+
     zypper_call "in seahorse";
     select_console 'x11';
 


### PR DESCRIPTION
as https://bugzilla.suse.com/show_bug.cgi?id=1211416 , some desktop programs have been moved to the *SLE-WE* repository, so we need to add extension before installing packages

- Related ticket: https://progress.opensuse.org/issues/129334
- Verification run: https://openqa.suse.de/tests/11183052
