### PR TITLE
Fix and expand SBD delay code

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -19,12 +19,19 @@ use lockapi;
 use isotovideo;
 use x11utils 'ensure_unlocked_desktop';
 use Utils::Logging 'export_logs';
+use Carp qw(croak);
+use Data::Dumper;
 
 our @EXPORT = qw(
   $crm_mon_cmd
   $softdog_timeout
   $join_timeout
   $default_timeout
+  $corosync_token
+  $corosync_consensus
+  $sbd_watchdog_timeout
+  $sbd_delay_start
+  $pcmk_delay_max
   exec_csync
   add_file_in_csync
   get_cluster_name
@@ -90,11 +97,17 @@ Extension (HA or HAE) tests.
 =back
 
 =cut
+
 our $crm_mon_cmd = 'crm_mon -R -r -n -N -1';
 our $softdog_timeout = bmwqemu::scale_timeout(60);
 our $prev_console;
 our $join_timeout = bmwqemu::scale_timeout(60);
 our $default_timeout = bmwqemu::scale_timeout(30);
+our $corosync_token = q@corosync-cmapctl | awk -F " = " '/runtime.config.totem.token\s/ {print $2/1000}'@;
+our $corosync_consensus = q@corosync-cmapctl | awk -F " = " '/runtime.config.totem.consensus\s/ {print $2/1000}'@;
+our $sbd_watchdog_timeout = q@grep -oP '(?<=^SBD_WATCHDOG_TIMEOUT=)[[:digit:]]+' /etc/sysconfig/sbd@;
+our $sbd_delay_start = q@grep -oP '(?<=^SBD_DELAY_START=)([[:digit:]]+|yes|no)+' /etc/sysconfig/sbd@;
+our $pcmk_delay_max = q@crm resource param stonith-sbd show pcmk_delay_max| sed 's/[^0-9]*//g'@;
 
 # Private functions
 sub _just_the_ip {
@@ -968,55 +981,73 @@ sub activate_ntp {
 
 =head2 calculate_sbd_start_delay
 
-  calculate_sbd_start_delay();
+  calculate_sbd_start_delay(\%sbd_parameters);
 
 Calculates start time delay after node is fenced.
 Prevents cluster failure if fenced node restarts too quickly.
 Delay time is used either if specified in sbd config variable "SBD_DELAY_START"
 or calculated:
-"corosync_token + corosync_consensus + SBD_WATCHDOG_TIMEOUT * 2"
+"corosync token timeout + consensus timeout + pcmk_delay_max + msgwait"
 Variables 'corosync_token' and 'corosync_consensus' are converted to seconds.
+For diskless SBD pcmk_delay_max is set to static 30s.
+
+%sbd_parameters = {
+    'corosync_token' => <runtime.config.totem.token>,
+    'corosync_consensus' => <runtime.config.totem.consensus>,
+    'sbd_watchdog_timeout' => <SBD_WATCHDOG_TIMEOUT>,
+    'sbd_delay_start' => <SBD_DELAY_START>,
+    'pcmk_delay_max' => <pcmk_delay_max>
+}
+
+If C<%sbd_parameters> argument is omitted, then function will
+try to obtain the values from the configuration files.
+
 =cut
 
 sub calculate_sbd_start_delay {
-    my %params;
-    my $default_wait = 35 * get_var('TIMEOUT_SCALE', 1);
-
-    %params = (
-        'corosync_token' => script_output("corosync-cmapctl | awk -F \" = \" '/config.totem.token\\s/ {print \$2}'"),
-        'corosync_consensus' => script_output("corosync-cmapctl | awk -F \" = \" '/totem.consensus\\s/ {print \$2}'"),
-        'sbd_watchdog_timeout' => script_output("awk -F \"=\" '/SBD_WATCHDOG_TIMEOUT/ {print \$2}' /etc/sysconfig/sbd"),
-        'sbd_delay_start' => script_output("awk -F \"=\" '/SBD_DELAY_START/ {print \$2}' /etc/sysconfig/sbd")
+    my ($sbd_parameters) = @_;
+    my %params = (ref($sbd_parameters) eq 'HASH') ? %$sbd_parameters : (
+        'corosync_token' => script_output($corosync_token),
+        'corosync_consensus' => script_output($corosync_consensus),
+        'sbd_watchdog_timeout' => script_output($sbd_watchdog_timeout),
+        'sbd_delay_start' => script_output($sbd_delay_start),
+        'pcmk_delay_max' => get_var('USE_DISKLESS_SBD') ? 30 :
+          script_output($pcmk_delay_max)
     );
 
+    my $default_wait = 35 * get_var('TIMEOUT_SCALE', 1);
+
+    record_info('SBD Params', Dumper(\%params));
+
     # if delay is false return 0sec wait
-    if ($params{'sbd_delay_start'} == 'no' || $params{'sbd_delay_start'} == 0) {
-        record_info("SBD start delay", "SBD delay disabled in config file");
+    if (grep /^$params{'sbd_delay_start'}$/, qw(no 0)) {
+        record_info('SBD start delay', 'SBD delay disabled either in /etc/sysconfig/sbd or by provided function arguments');
         return 0;
     }
 
     # if delay is only true, calculate according to default equation
-    if ($params{'sbd_delay_start'} == 'yes' || $params{'sbd_delay_start'} == 1) {
+    if (grep /^$params{'sbd_delay_start'}$/, qw(yes 1)) {
         for my $param_key (keys %params) {
-            if (!looks_like_number($params{$param_key})) {
-                record_soft_failure("SBD start delay",
-                    "Parameter '$param_key' returned non numeric value:\n$params{$param_key}");
-                return $default_wait;
-            }
-            my $sbd_delay_start_time =
-              $params{'corosync_token'} / 1000 +
-              $params{'corosync_consensus'} / 1000 +
-              $params{'sbd_watchdog_timeout'} * 2;
-            record_info("SBD start delay", "SBD delay calculated: $sbd_delay_start_time");
-            return ($sbd_delay_start_time);
+            croak("Parameter '$param_key' returned non numeric value: $params{$param_key}\n
+                This might indicate test issue or unexpected HA configuration value.")
+              if !looks_like_number($params{$param_key}) and $param_key ne 'sbd_delay_start';
         }
+        my $sbd_delay_start_time =
+          $params{'corosync_token'} +
+          $params{'corosync_consensus'} +
+          $params{'pcmk_delay_max'} +
+          $params{'sbd_watchdog_timeout'} * 2 +    # msgwait = sbd_watchdog_timeout * 2
+          30;    # wait time should be greater than formula therefore adding 30s
+        record_info('SBD start delay', "SBD delay calculated: $sbd_delay_start_time");
+        return ($sbd_delay_start_time);
     }
 
     # if sbd_delay_stat is specified by number explicitly
     if (looks_like_number($params{'sbd_delay_start'})) {
-        record_info("SBD start delay", "Specified explicitly in config: $params{'sbd_delay_start'}");
+        record_info('SBD start delay', "Specified explicitly in config: $params{'sbd_delay_start'}");
         return $params{'sbd_delay_start'};
     }
+    return $default_wait;
 }
 
 =head2 check_iscsi_failure

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::MockModule;
+use hacluster;
+use Scalar::Util 'looks_like_number';
+
+my %sbd_delay_params = (
+    'sbd_delay_start' => 'yes',
+    'corosync_token' => 5,
+    'corosync_consensus' => 5,
+    'sbd_watchdog_timeout' => 5,
+    'pcmk_delay_max' => 5
+);
+
+subtest '[calculate_sbd_start_delay] Check sbd_delay_start values' => sub {
+    my $sbd_delay;
+    my %value_vs_expected = (
+        'yes' => 55,
+        '1' => 55,
+        'no' => 0,
+        '0' => 0,
+        '120' => 120,
+    );
+
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    $hacluster->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $hacluster->redefine(record_soft_failure => sub { note(join(' ', 'RECORD_SOFT_FAILURE -->', @_)); });
+    $hacluster->redefine(script_output => sub { note(join(' ', 'SCRIPT_OUTPUT -->', @_)); });
+
+    for my $input_value (keys %value_vs_expected) {
+        my $expected = $value_vs_expected{$input_value};
+        $sbd_delay_params{'sbd_delay_start'} = $input_value;
+        $sbd_delay = calculate_sbd_start_delay(\%sbd_delay_params);
+        is $sbd_delay, $expected, "Testing 'sbd_delay_start' value: $input_value";
+    }
+    $sbd_delay_params{'sbd_delay_start'} = 'yes';
+};
+
+subtest '[calculate_sbd_start_delay] Return default on non numeric value' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    $hacluster->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $hacluster->redefine(record_soft_failure => sub { note(join(' ', 'RECORD_SOFT_FAILURE -->', @_)); });
+    $hacluster->redefine(script_output => sub { note(join(' ', 'SCRIPT_OUTPUT -->', @_)); });
+    $hacluster->redefine(croak => sub { die; });
+
+    my $corosync_token_original = $sbd_delay_params{'corosync_token'};
+    $sbd_delay_params{'corosync_token'} = 'asdf';
+    $sbd_delay_params{'sbd_delay_start'} = 'yes';
+
+    dies_ok { calculate_sbd_start_delay(\%sbd_delay_params) } "Test should die with unexpected values";
+    $sbd_delay_params{'corosync_token'} = $corosync_token_original;
+};
+
+done_testing;

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use testapi;
+use Test::MockModule;
+use Test::Exception;
+use Test::More;
+use sles4sap_publiccloud;
+
+
+subtest "Run 'setup_sbd_delay' with different values" => sub {
+    my $self = sles4sap_publiccloud->new();
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
+    $sles4sap_publiccloud->redefine(record_info => sub { return; });
+    $sles4sap_publiccloud->redefine(cloud_file_content_replace => sub { return; });
+    $sles4sap_publiccloud->redefine(croak => sub { die; });
+
+    my %passing_values_vs_expected = (
+        '1' => '1',
+        'yes' => 'yes',
+        'no' => 'no',
+        '0' => '0',
+        '100' => '100',
+        '100s' => '100');
+    my @failok_values = qw(aasd 100asd 100S "" undef);
+
+    for my $input_value (@failok_values) {
+        set_var('HA_SBD_START_DELAY', $input_value);
+        dies_ok { $self->setup_sbd_delay() } "Test expected failing 'HA_SBD_START_DELAY' value: $input_value";
+    }
+
+    for my $value (keys %passing_values_vs_expected) {
+        set_var('HA_SBD_START_DELAY', $value);
+        my $returned_value = $self->setup_sbd_delay();
+        is($returned_value, $passing_values_vs_expected{$value},
+            "Test 'HA_SBD_START_DELAY' passing values:\ninput_value: $value\n result: $returned_value");
+    }
+
+    set_var('HA_SBD_START_DELAY', undef);
+};
+
+done_testing;

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -11,46 +11,46 @@ use warnings FATAL => 'all';
 use sles4sap_publiccloud;
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use Time::HiRes 'sleep';
 
 sub run {
     my ($self, $run_args) = @_;
     $self->{instances} = $run_args->{instances};
     my $hana_start_timeout = bmwqemu::scale_timeout(600);
     # $site_b = $instance of secondary instance located in $run_args->{$instances}
-    croak("site_b is missing or undefined in run_args") if (!$run_args->{site_b});
+    croak('site_b is missing or undefined in run_args') if (!$run_args->{site_b});
     my $site_b = $run_args->{site_b};
     select_serial_terminal;
 
     # Switch to control Site B (currently replica mode)
     $self->{my_instance} = $site_b;
-    my $cluster_status = $self->run_cmd(cmd => "crm status");
-    record_info("Cluster status", $cluster_status);
+    my $cluster_status = $self->run_cmd(cmd => 'crm status');
+    record_info('Cluster status', $cluster_status);
     # Check initial state: 'site B' = replica mode
     die("Site B '$site_b->{instance_id}' is NOT in replication mode.") if
       $self->get_promoted_hostname() eq $site_b->{instance_id};
 
     # Stop DB
     # check variable DB_ACTION in case of separate usage of the test.
-    my $db_action = get_var("DB_ACTION", $run_args->{hana_test_definitions}{$self->{name}});
-    croak("Database action unknown or not defined.") if ($db_action !~ /^(stop|kill|crash)$/);
+    my $db_action = get_var('DB_ACTION', $run_args->{hana_test_definitions}{$self->{name}});
+    croak('Database action unknown or not defined.') if ($db_action !~ /^(stop|kill|crash)$/);
 
-    if ($db_action eq "crash") {
+    if (($db_action eq 'crash') && get_var('HA_SBD_START_DELAY')) {
         # Setup sbd delay in case of crash OS to prevent cluster starting too quickly after reboot.
-        $self->setup_sbd_delay("30s");
-        record_info("Crash DB", "Crashing OS on Site B ('$site_b->{instance_id}')");
+        $self->setup_sbd_delay(get_var('HA_SBD_START_DELAY'));
+        record_info('Crash DB', "Crashing OS on Site B ('$site_b->{instance_id}')");
     }
     else {
-        my $action = $db_action eq "stop" ? "stopp" : $db_action;
+        # 'stopp' is not a typo - 'ing' is appended later
+        my $action = $db_action eq 'stop' ? 'stopp' : $db_action;
         record_info(ucfirst($db_action) . ' DB', ucfirst($action) . "ing Site B ('$site_b->{instance_id}')");
     }
-
     $self->stop_hana(method => $db_action);
+    $self->{my_instance}->wait_for_ssh(username => 'cloudadmin');
 
-    if ($db_action eq "crash") {
-        $self->{my_instance}->wait_for_ssh(username => 'cloudadmin');
-        sleep 10;
-        $self->wait_for_pacemaker();
-    }
+    # SBD delay is active only after reboot
+    sleep $self->sbd_delay_formula if $db_action eq "crash";
+    $self->wait_for_pacemaker();
 
     # wait for DB to start with resources
     $self->is_hana_online(wait_for_start => 'true');


### PR DESCRIPTION
This PR fixes sbd delay calculation formula used by "on premise" tests and allows 
this function to be used by HANA SR as well. It adds as well ability to change 
the SBD_DELAY_START value for public cloud based tests.

- Related ticket: https://jira.suse.com/browse/TEAM-7914
- Needles: N/A
- Verification run: 

15SP5 default value on prem:
SBD 2nodes: https://openqa.suse.de/tests/11216985#step/check_after_reboot/32
Diskless SBD 3 nodes: https://openqa.suse.de/tests/11216991#step/check_after_reboot/30

Public cloud:
Timeout default:
15SP5: https://openqa.suse.de/tests/11217582#step/Crash_site_b-primary/22
15SP4: https://openqaworker15.qa.suse.cz/tests/184194#step/Crash_site_a-primary/22
15SP3: https://openqaworker15.qa.suse.cz/tests/184195#step/Crash_site_a-primary/22

Timeout set to "150s" or "120s":
15SP5: https://openqa.suse.de/tests/11217304#step/Crash_site_a-primary/41
15SP4: https://openqaworker15.qa.suse.cz/tests/184196#step/Crash_site_a-primary/24
15SP3: https://openqaworker15.qa.suse.cz/tests/184212#step/Crash_site_a-primary/24

Timeout "yes":
15SP5:  http://mordor.suse.cz/tests/6041#step/Crash_site_a-primary/25
15SP4: https://openqaworker15.qa.suse.cz/tests/184645#step/Crash_site_a-primary/25
15SP3: https://openqaworker15.qa.suse.cz/tests/184644#step/Crash_site_b-primary/24

Timeout "no":
** Failures are expected since SBD timeout is 0.
15SP5: https://openqa.suse.de/tests/11217337#step/Crash_site_a-primary/25
15SP4: https://openqaworker15.qa.suse.cz/tests/184200#step/Crash_site_a-primary/24
15SP3: https://openqaworker15.qa.suse.cz/tests/184201#step/Crash_site_a-primary/24