### PR TITLE
Optimize code in trento cluster_wait_status

### DIFF
--- a/tests/sles4sap/trento/test_hana_restore_stopped.pm
+++ b/tests/sles4sap/trento/test_hana_restore_stopped.pm
@@ -20,6 +20,8 @@ sub run {
 
     # "hana[0]" is more generic than vmhana01.
     my $primary_host = '"hana[0]"';
+
+    # Print cluster status at the beginning, just as reference
     cluster_print_cluster_status($primary_host);
 
     # Register the stopped DB to the new promoted primary
@@ -33,7 +35,8 @@ sub run {
 
     # Restart the stopped instance
     my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
-    # vmhana01 hardcoded in place of $primary_host as the second one is only valid for Ansible
+    # vmhana01 hard-coded in place of the generic Ansible filter from $primary_host.
+    # The Ansible generic filter is only valid for Ansible, here it is crm.
     qesap_ansible_cmd(cmd => "sudo crm resource refresh rsc_SAPHana_HDB_HDB00 vmhana01",
         provider => $prov,
         filter => $primary_host);


### PR DESCRIPTION
Align cluster_wait_status to latest fixes from
cluster_wait_status_by_regex.
Improve unit testing coverage in Trento cluster_wait_* API Change cypress_test_exec to return cumulative error score.

Related ticket: [TRNT-921](https://jira.suse.com/browse/TRNT-921)

Verification run: http://openqaworker15.qa.suse.cz/tests/181950 http://openqaworker15.qa.suse.cz/tests/181954

