### PR TITLE
zypper_lifecycle: Skip EOS python2 module

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -37,10 +37,8 @@ our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 
 sub lifecycle_output_check {
     my $output = shift;
-    if ($output =~ /Legacy Module.*2021-(07|12)-30|Python 2 Module.*2021-(07|12)-30|Containers Module.*2021-12-31/) {
-        # https://chat.suse.de/channel/qem-openqa-review/thread/KLrXWR5Sy7zprLFcx?jump=e2dxZRDbkXHE5DXQt
-        # https://progress.opensuse.org/issues/95593
-        record_soft_failure 'bsc#1194294 zypper lifecycle wrong EOL for python2 and legacy module';
+    if (is_sle('=15-sp1') && $output =~ /Python 2 Module.*2021-07-31/) {
+        record_info 'poo#129026';
         return;
     }
     if (get_var('SCC_REGCODE_LTSS')) {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/129026
- Verification run:
https://openqa.suse.de/tests/11190286 x86_64
https://openqa.suse.de/tests/11190287 s390x
https://openqa.suse.de/tests/11190288 aarch64