### PR TITLE
Simplify cypress exec API

### DIFF
--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -775,6 +775,21 @@ subtest '[cypress_test_exec] new CY' => sub {
     ok((any { /podman run.*cypress\/e2e\/FARINATA\// } @calls), 'Podman get test file in new folder');
 };
 
+subtest '[cypress_exec]' => sub {
+    my $trento = Test::MockModule->new('trento', no_auto => 1);
+    @calls = ();
+
+    $trento->redefine(script_run => sub { push @calls, $_[0]; });
+    $trento->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    cypress_exec(cypress_test_dir => 'TEST_DIR',
+        cmd => 'FARINATA',
+        log_prefix => 'FARINATA');
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok((any { /podman images/ } @calls), 'Podman run');
+    ok((any { /podman rm/ } @calls), 'Podman run');
+    ok((any { /podman run.*/ } @calls), 'Podman run');
+};
+
 subtest '[cluster_wait_status_by_regex] not enough arguments' => sub {
     dies_ok { cluster_wait_status_by_regex() } "Expected croak for missing arguments host.";
     dies_ok { cluster_wait_status_by_regex('hana') } "Expected croak for missing arguments regexp.";

--- a/tests/sles4sap/trento/test_hana_unregister_node.pm
+++ b/tests/sles4sap/trento/test_hana_unregister_node.pm
@@ -63,7 +63,7 @@ sub run {
 
     my $cypress_test_dir = "/root/test/test";
     enter_cmd "cd $cypress_test_dir";
-    cypress_test_exec($cypress_test_dir, 'unregister', bmwqemu::scale_timeout(900));
+    cypress_test_exec($cypress_test_dir, 'unregister', bmwqemu::scale_timeout(1800));
     trento_support();
     trento_collect_scenarios('test_hana_unregister');
 }

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -25,7 +25,11 @@ sub run {
     assert_script_run "mkdir " . CYPRESS_LOG_DIR;
 
     #  Cypress verify: cypress.io self check about the framework installation
-    cypress_exec($cypress_test_dir, 'verify', bmwqemu::scale_timeout(120), 'verify', 1);
+    cypress_exec(cypress_test_dir => $cypress_test_dir,
+        cmd => 'verify',
+        log_prefix => 'verify',
+        timeout => bmwqemu::scale_timeout(120));
+
     cypress_log_upload(('.txt'));
 
     # test about first visit: login and eula


### PR DESCRIPTION
Remove unused parameter and better arguments validation in CY related API of the trento lib.
Add UT.
Increase the timeout for the CY execution of the unregistered test.
 
Related ticket: [TRNT-921](https://jira.suse.com/browse/TRNT-921)

Verification run: 
http://openqaworker15.qa.suse.cz/tests/181959 fails in the new test due to script_run(podman ...cy) timeout
 http://openqaworker15.qa.suse.cz/tests/181960 fails in eula  test due to script_run(podman ...cy) timeout 
http://openqaworker15.qa.suse.cz/tests/182576
http://openqaworker15.qa.suse.cz/tests/182593 timeout in new test after 1800secs http://openqaworker15.qa.suse.cz/tests/182593#step/test_hana_unregister_node/179  (so quite like it is not a test duration problem)
