### PR TITLE
Make TW test more stable and faster

### DIFF
--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
@@ -6,7 +6,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>false</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_kvm_hvm_guest_x86_64.xml
@@ -10,7 +10,7 @@
       <secure_boot>false</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>gfxterm serial</terminal>
-      <timeout t="integer">8</timeout>
+      <timeout t="integer">1</timeout>
       <update_nvram>true</update_nvram>
     </global>
     <loader_type>grub2</loader_type>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
@@ -6,7 +6,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>false</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_hvm_guest_x86_64.xml
@@ -10,7 +10,7 @@
       <secure_boot>false</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>gfxterm serial</terminal>
-      <timeout t="integer">8</timeout>
+      <timeout t="integer">1</timeout>
       <update_nvram>true</update_nvram>
     </global>
     <loader_type>grub2</loader_type>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
@@ -6,7 +6,6 @@
       <append>console=tty console=hvc0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>false</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/opensuse_tumbleweed_xen_pv_guest_x86_64.xml
@@ -10,7 +10,7 @@
       <secure_boot>false</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>gfxterm serial</terminal>
-      <timeout t="integer">8</timeout>
+      <timeout t="integer">1</timeout>
       <update_nvram>true</update_nvram>
     </global>
     <loader_type>grub2</loader_type>

--- a/data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -38,7 +38,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>##Secure-Boot##</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -44,7 +44,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>      
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>serial</terminal>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_multi-user_x86_64.xml
@@ -44,7 +44,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>      
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>serial</terminal>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_graphical_x86_64.xml
@@ -44,7 +44,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>      
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>serial</terminal>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_multi-user_x86_64.xml
@@ -44,7 +44,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>      
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>serial</terminal>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_graphical_x86_64.xml
@@ -47,7 +47,6 @@
       <boot_root>true</boot_root>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>serial</terminal>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_multi-user_x86_64.xml
@@ -47,7 +47,6 @@
       <boot_root>true</boot_root>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>
       <terminal>serial</terminal>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -74,7 +74,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>##Secure-Boot##</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_multi-user_x86_64.xml
@@ -74,7 +74,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>##Secure-Boot##</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_graphical_x86_64.xml
@@ -74,7 +74,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>##Secure-Boot##</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_multi-user_x86_64.xml
@@ -74,7 +74,6 @@
       <append>console=tty console=ttyS0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>##Secure-Boot##</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_graphical_x86_64.xml
@@ -74,7 +74,6 @@
       <append>console=tty console=hvc0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>##Secure-Boot##</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_multi-user_x86_64.xml
@@ -74,7 +74,6 @@
       <append>console=tty console=hvc0,115200n8 mitigations=auto</append>
       <cpu_mitigations>auto</cpu_mitigations>
       <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>##Secure-Boot##</secure_boot>
       <serial>serial --unit=0 --speed=115200 --parity=no --word=8</serial>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_sshd.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_sshd.xml
@@ -68,6 +68,13 @@
   <networking>
     <keep_install_network t="boolean">true</keep_install_network>
     <backend>network_manager</backend>
+    <interfaces t="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <name>p3p1</name>
+        <startmode>manual</startmode>
+      </interface>
+    </interfaces>
   </networking>
   <software>
     <products t="list">
@@ -125,10 +132,10 @@
     <init-scripts t="list">
       <script>
         <source><![CDATA[
-sshd_config_file="/etc/ssh/sshd_config.d/permit_root_login.conf"
-echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
-sshd_config_file="/etc/ssh/sshd_config.d/keep_alive.conf"
-echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 480" > $sshd_config_file
+sshd_config_dir="/etc/ssh/sshd_config.d"
+echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > ${sshd_config_dir}/permit_root_login.conf
+echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 480" > ${sshd_config_dir}/keep_alive.conf
+echo -e "[Match]\nDriver=bridge\n\n[Link]\nMACAddressPolicy=none" > /etc/systemd/network/98-default-bridge.link
 ]]>
         </source>
       </script>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_sshd.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_sshd.xml
@@ -68,6 +68,13 @@
   <networking>
     <keep_install_network t="boolean">true</keep_install_network>
     <backend>network_manager</backend>
+    <interfaces t="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <name>p3p1</name>
+        <startmode>manual</startmode>
+      </interface>
+    </interfaces>
   </networking>
   <software>
     <products t="list">
@@ -126,10 +133,10 @@
   <init-scripts t="list">
     <script>
       <source><![CDATA[
-sshd_config_file="/etc/ssh/sshd_config.d/permit_root_login.conf"
-echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > $sshd_config_file
-sshd_config_file="/etc/ssh/sshd_config.d/keep_alive.conf"
-echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 480" > $sshd_config_file
+sshd_config_dir="/etc/ssh/sshd_config.d"
+echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes" > ${sshd_config_dir}/permit_root_login.conf
+echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 480" > ${sshd_config_dir}/keep_alive.conf
+echo -e "[Match]\nDriver=bridge\n\n[Link]\nMACAddressPolicy=none" > /etc/systemd/network/98-default-bridge.link
 echo "Below lines modify the /etc/default/grub file to set the GRUB_DEFAULT parameter to Xen hypervisor and then regenerate the GRUB configuration file using grub2-mkconfig"         
 sed -i 's/^GRUB_DEFAULT=.*/GRUB_DEFAULT=2/' /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg

--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -112,6 +112,8 @@ sub install_guest_instances {
         else {
             $guest_instances{$_}->guest_installation_run(@_);
         }
+        # Abort current guest installation if dry run failed
+        next if $guest_instances{$_}->{guest_installation_result} eq 'FAILED';
         if ($guest_instances{$_}->has_noautoconsole_for_sure) {
             assert_screen('text-logged-in-root');
             $guest_instances{$_}->do_attach_guest_installation_screen_without_session;

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -121,7 +121,7 @@ sub login_to_console {
         }
     }
 
-    unless (check_screen([qw(grub2 grub1 prague-pxe-menu)], 210) or is_tumbleweed) {
+    unless (is_tumbleweed or check_screen([qw(grub2 grub1 prague-pxe-menu)], 210)) {
         ipmitool("chassis power reset");
         reset_consoles;
         select_console 'sol', await_console => 0;
@@ -201,7 +201,7 @@ sub login_to_console {
         set_var('AFTER_UPGRADE', '1');
     }
     save_screenshot;
-    send_key 'ret';
+    send_key 'ret' unless is_tumbleweed;
 
     sleep 30;    # Wait for the GRUB to disappier (there's no chance for the system to boot faster
     save_screenshot;


### PR DESCRIPTION
1. type key again to ensure to enter the particular ipxe entry.
2.  reduce timeout of grub2 menu of guest to prevent recieving keys from outside accidently
3.  decrease host installation time(ipxe_install + autoyast_install + login_console) from 30 min to 20 min by optimizing some needle matching
4. stop guest installation when dry run failed. (it will be droppend when the PR is ready to merge)
5. remove `<hiddenmenu>` attribute as it is not found in TW/SLE15SP4/SLE12SP5 autoyast guide.
6. deactivate the 2nd network interface to avoid networking issues
7. add udev rule to make br0 have same MAC with em1 to be able to get an IP from dhcp server

Related ticket: 
https://progress.opensuse.org/issues/130108
https://progress.opensuse.org/issues/130111

Verification run: 
// item 1 is not verified in this test because they have not been reproduced successully.
[virt-guest-installation-kvm](https://openqa.opensuse.org/tests/3330864)    //successful one. to verify change item 2, 3, 5
[dry run failed](https://openqa.opensuse.org/tests/3345200)  //to verify item 4
[dry fun failed](https://openqa.opensuse.org/tests/3345811#)  //to verify item4
[login successful on rebel:5](https://openqa.opensuse.org/tests/3352726)  //to verify item 6 & 7
[kvm test on rebel:5](https://openqa.opensuse.org/tests/3352909)  //PASS
[xen test on rebel:6](https://openqa.opensuse.org/tests/3352901)  //Fail as expected