### PR TITLE
pc: Add kill_packagekit() routine and use it in patch_and_reboot

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -39,6 +39,7 @@ our @EXPORT = qw(
   register_addons_in_pc
   gcloud_install
   prepare_ssh_tunnel
+  kill_packagekit
 );
 
 # Get the current UTC timestamp as YYYY/mm/dd HH:MM:SS
@@ -267,6 +268,17 @@ sub prepare_ssh_tunnel {
     # Create log file for ssh tunnel
     my $ssh_sut = '/var/tmp/ssh_sut.log';
     assert_script_run "touch $ssh_sut; chmod 777 $ssh_sut";
+}
+
+sub kill_packagekit {
+    my ($instance) = @_;
+    my $ret = $instance->ssh_script_run(cmd => "pkcon quit", timeout => 120);
+    if ($ret) {
+        # Older versions of systemd don't support "disable --now"
+        $instance->ssh_script_run(cmd => "systemctl stop packagekitd");
+        $instance->ssh_script_run(cmd => "systemctl disable packagekitd");
+        $instance->ssh_script_run(cmd => "systemctl mask packagekitd");
+    }
 }
 
 1;

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -15,6 +15,7 @@ use testapi;
 use strict;
 use utils;
 use publiccloud::ssh_interactive qw(select_host_console);
+use publiccloud::utils qw(kill_packagekit);
 
 sub run {
     my ($self, $args) = @_;
@@ -24,6 +25,7 @@ sub run {
 
     my $cmd_time = time();
     my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;
+    kill_packagekit($args->{my_instance});
     $args->{my_instance}->ssh_script_retry("sudo zypper -n --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
     record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');
     record_soft_failure('bsc#1195382 - Considerable decrease of zypper performance and increase of registration times') if ((time() - $cmd_time) > 240);


### PR DESCRIPTION
pc: Add kill_packagekit() routine and use it in patch_and_reboot

- Related ticket: https://progress.opensuse.org/issues/120883
- Verification run: TBD
