### PR TITLE
Make sure that apparmor is disabled on HPC

### DIFF
--- a/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
@@ -349,9 +349,6 @@
     <gid_min>1000</gid_min>
     <hibernate_system>active_console</hibernate_system>
     <kernel.sysrq>184</kernel.sysrq>
-    % unless ($check_var->('VERSION', '15-SP3')) {
-    <lsm_select>apparmor</lsm_select>
-    % }
     <mandatory_services>secure</mandatory_services>
     <net.ipv4.ip_forward>0</net.ipv4.ip_forward>
     <net.ipv4.tcp_syncookies>0</net.ipv4.tcp_syncookies>
@@ -390,7 +387,6 @@
       <enable config:type="list">
         <service>YaST2-Firstboot</service>
         <service>YaST2-Second-Stage</service>
-        <service>apparmor</service>
         <service>auditd</service>
         <service>klog</service>
         <service>cron</service>
@@ -455,7 +451,6 @@
       <package>SLE_HPC-release</package>
     </packages>
     <patterns config:type="list">
-      <pattern>apparmor</pattern>
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>enhanced_base</pattern>

--- a/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
@@ -383,9 +383,6 @@
     <gid_min>1000</gid_min>
     <hibernate_system>active_console</hibernate_system>
     <kernel.sysrq>184</kernel.sysrq>
-    % unless ($check_var->('VERSION', '15-SP3')) {
-    <lsm_select>apparmor</lsm_select>
-    % }
     <mandatory_services>secure</mandatory_services>
     <net.ipv4.ip_forward>0</net.ipv4.ip_forward>
     <net.ipv4.tcp_syncookies>0</net.ipv4.tcp_syncookies>
@@ -424,7 +421,6 @@
       <enable config:type="list">
         <service>YaST2-Firstboot</service>
         <service>YaST2-Second-Stage</service>
-        <service>apparmor</service>
         <service>auditd</service>
         <service>klog</service>
         <service>cron</service>
@@ -490,7 +486,6 @@
       <package>SLE_HPC-release</package>
     </packages>
     <patterns config:type="list">
-      <pattern>apparmor</pattern>
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>enhanced_base</pattern>

--- a/tests/hpc/before_test.pm
+++ b/tests/hpc/before_test.pm
@@ -17,6 +17,7 @@ sub run ($self) {
 
     # disable packagekitd
     quit_packagekit();
+    ensure_apparmor_disabled();
 
     # Stop firewall
     systemctl 'stop ' . $self->firewall;
@@ -33,6 +34,13 @@ sub run ($self) {
 
         zypper_call("--gpg-auto-import-keys ref");
         zypper_call 'up';
+    }
+}
+
+sub ensure_apparmor_disabled () {
+    unless (systemctl "is-active apparmor", proceed_on_failure => 1) {    # 0 if active, unless to revert
+        systemctl "disable --now apparmor";
+        record_info "apparmor", "disabled";
     }
 }
 


### PR DESCRIPTION
As we are shifting towards selinux HPC team suggested that we do not need to be testing against apparmor, which there are not expectations for it to work without issues. This commit ensure that Apparmor is turned off, however we still testing installation where Apparmor comes as dependency of the diveded system roles


- Related ticket: https://progress.opensuse.org/issues/127670
- Verification run: 
https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2317162
https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2317162&version=15-SP3
