### PR TITLE
Containers: use httpd image instead of fedora/apache

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -75,7 +75,7 @@ sub run {
         subnet_v6 => 'fd00::1:8:0/112'
     };
     my $ctr1 = {
-        image => get_required_var('REGISTRY') . '/fedora/apache',
+        image => registry_url('httpd'),
         name => 'apache_ctr',
         ip => '10.90.0.8',
         mac => '76:22:33:44:55:66',


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/129910
VRs:
- https://openqa.suse.de/tests/11199934
- https://openqa.suse.de/tests/11200094
- https://openqa.suse.de/tests/11200095