### PR TITLE
Disable Netavark test on staging

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -90,7 +90,7 @@ sub load_host_tests_podman {
         load_3rd_party_image_test($run_args);
         loadtest 'containers/podman_pods';
         loadtest('containers/podman_network_cni');
-        loadtest 'containers/podman_netavark';
+        loadtest 'containers/podman_netavark' unless (is_staging);
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
         loadtest 'containers/podman_firewall' unless (is_public_cloud || is_openstack || is_microos || is_alp);
         # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
Staging jobs are showing the following:
`'aardvark-dns' not found in package names. Trying capabilities. `
due to repository configuration

https://openqa.opensuse.org/tests/3318594