### PR TITLE
Podman Netavark fixes for SLE

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -90,7 +90,8 @@ sub load_host_tests_podman {
         load_3rd_party_image_test($run_args);
         loadtest 'containers/podman_pods';
         loadtest('containers/podman_network_cni');
-        loadtest 'containers/podman_netavark' unless (is_staging);
+        # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
+        loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3"));
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
         loadtest 'containers/podman_firewall' unless (is_public_cloud || is_openstack || is_microos || is_alp);
         # Buildah is not available in SLE Micro, MicroOS and staging projects

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -139,7 +139,7 @@ sub run {
             'http://localhost:8080',
             'http://localhost:8888'
     )) {
-        validate_script_output("curl --retry 5 --retry-all-errors --head --silent $req", sub { /HTTP.* 200 OK/ }, timeout => 120);
+        validate_script_output("curl --retry 5 --head --silent $req", sub { /HTTP.* 200 OK/ }, timeout => 120);
     }
 
     assert_script_run("podman container inspect $ctr1->{name} --format {{.NetworkSettings.Networks.$net1->{name}.IPAddress}}");


### PR DESCRIPTION
- don't execute it in 15-SP1 and 15-SP2
- remove --retry-all-errors in curl

VRs:
- [sle-15-SP3-GCE-CHOST-BYOS-Updates](https://openqa.suse.de/tests/11204907#)
- [sle-15-SP3-JeOS-for-kvm-and-xen-Updates](https://openqa.suse.de/tests/11204906#)
- [sle-15-SP3-Server-DVD-Updates](https://openqa.suse.de/tests/11204905#)
- [sle-15-SP1-GCE-CHOST-BYOS-Updates](https://openqa.suse.de/tests/11204904#)
- [sle-15-SP1-JeOS-for-kvm-and-xen-Updates](https://openqa.suse.de/tests/11204903#)
- [sle-15-SP1-Server-DVD-Updates](https://openqa.suse.de/tests/11204902#)
- [sle-15-SP3-GCE-CHOST-BYOS-Updates](https://openqa.suse.de/tests/11204907#)
- [sle-15-SP3-JeOS-for-kvm-and-xen-Updates](https://openqa.suse.de/tests/11204906#)
- [sle-15-SP3-AZURE-BYOS-Updates](https://openqa.suse.de/tests/11204898#)
- [sle-15-SP3-AZURE-CHOST-BYOS-Updates](https://openqa.suse.de/tests/11204897#)


