### PR TITLE
Remove stop_timeout_system_reboot test module

### DIFF
--- a/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_restapi.yaml
+++ b/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_restapi.yaml
@@ -13,4 +13,5 @@ schedule:
     - installation/security/select_security_module_none
   system_role:
     - installation/system_role/select_role_text_mode
+  stop_timeout_system_reboot: []
 ...


### PR DESCRIPTION
Remove stop_timeout_system_reboot test module

- Related ticket: https://progress.opensuse.org/issues/129799
- Verification run: https://openqa.suse.de/tests/11210580#
