### PR TITLE
Add code for hanasr scaleup maintenance jobs

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#   Settings are meant to be controlled via OpenQA variables and managed by test:
+#   tests/sles4sap/publiccloud/qesap_ansible.pm
+
+provider: 'azure'
+apiver: 3
+terraform:
+  variables:
+    # GENERAL VARIABLES #
+    vnet_address_range: "%VNET_ADDRESS_RANGE%"
+    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
+    az_region: '%PUBLIC_CLOUD_REGION%'
+    admin_user: 'cloudadmin'
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
+    public_key: '~/.ssh/id_rsa.pub'
+    private_key: '~/.ssh/id_rsa'
+    os_image: "%PUBLIC_CLOUD_OS_IMAGE%"
+    hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
+
+    # HANA
+    hana_count: '%NODE_COUNT%'
+    hana_ha_enabled: '%HA_CLUSTER%'
+    vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+
+ansible:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  destroy:
+    - deregister.yaml
+

--- a/tests/sles4sap/publiccloud/add_server_to_hosts.pm
+++ b/tests/sles4sap/publiccloud/add_server_to_hosts.pm
@@ -12,12 +12,14 @@ use qesapdeployment;
 
 sub run {
     my ($self, $run_args) = @_;
-    my $instance = $run_args->{my_instance};
-    record_info("$instance");
+    foreach my $instance (@{$run_args->{instances}}) {
+        next if ($instance->{'instance_id'} !~ m/vmhana/);
+        record_info("$instance");
 
-    my $ibsm_ip = get_required_var('IBSM_IP');
-    $instance->run_ssh_command(cmd => "echo \"$ibsm_ip download.suse.de\" | sudo tee -a /etc/hosts", username => 'cloudadmin');
-    $instance->run_ssh_command(cmd => 'cat /etc/hosts', username => 'cloudadmin');
+        my $ibsm_ip = get_required_var('IBSM_IP');
+        $instance->run_ssh_command(cmd => "echo \"$ibsm_ip download.suse.de\" | sudo tee -a /etc/hosts", username => 'cloudadmin');
+        $instance->run_ssh_command(cmd => 'cat /etc/hosts', username => 'cloudadmin');
+    }
 }
 
 sub test_flags {

--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -24,12 +24,16 @@ sub run() {
 
     while (defined(my $maintrepo = shift @repos)) {
         next if $maintrepo =~ /^\s*$/;
-        $instance->run_ssh_command(cmd => "sudo zypper --no-gpg-checks ar -f -n TEST_$count $maintrepo TEST_$count",
-            username => 'cloudadmin');
+        foreach my $instance (@{$run_args->{instances}}) {
+            next if ($instance->{'instance_id'} !~ m/vmhana/);
+            $instance->run_ssh_command(cmd => "sudo zypper --no-gpg-checks ar -f -n TEST_$count $maintrepo TEST_$count",
+                username => 'cloudadmin');
+        }
         $count++;
     }
-
-    $instance->run_ssh_command(cmd => 'sudo zypper -n ref', username => 'cloudadmin');
+    foreach my $instance (@{$run_args->{instances}}) {
+        $instance->run_ssh_command(cmd => 'sudo zypper -n ref', username => 'cloudadmin', timeout => 1500);
+    }
 }
 
 sub delete_peering {

--- a/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
+++ b/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright 2019 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: zypper
+# Summary: Refresh repositories, apply patches and reboot
+#
+# Maintainer: qa-c <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use registration;
+use warnings;
+use testapi;
+use strict;
+use utils;
+use publiccloud::ssh_interactive qw(select_host_console);
+use publiccloud::utils qw(kill_packagekit);
+
+sub run {
+    my ($self, $run_args) = @_;
+    select_host_console();    # select console on the host, not the PC instance
+
+    foreach my $instance (@{$run_args->{instances}}) {
+        next if ($instance->{'instance_id'} !~ m/vmhana/);
+        record_info("$instance");
+
+        my $remote = '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ' . $instance->username . '@' . $instance->public_ip;
+
+        my $cmd_time = time();
+        my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;
+        kill_packagekit($instance);
+        $instance->ssh_script_retry("sudo zypper -n --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
+        record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');
+        record_soft_failure('bsc#1195382 - Considerable decrease of zypper performance and increase of registration times') if ((time() - $cmd_time) > 240);
+
+        ssh_fully_patch_system($remote);
+
+        $instance->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
+    }
+}
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+1;

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -25,6 +25,11 @@ sub run {
     }
     else {
         loadtest('sles4sap/publiccloud/qesap_terraform', name => 'deploy_qesap_terraform', run_args => $run_args, @_);
+        if (check_var('IS_MAINTENANCE', 1)) {
+            loadtest('sles4sap/publiccloud/network_peering', name => 'network_peering', run_args => $run_args, @_);
+            loadtest('sles4sap/publiccloud/add_server_to_hosts', name => 'add_server_to_hosts', run_args => $run_args, @_);
+            loadtest('sles4sap/publiccloud/cluster_add_repos', name => 'cluster_add_repos', run_args => $run_args, @_);
+        }
         loadtest('sles4sap/publiccloud/qesap_ansible', name => 'deploy_qesap_ansible', run_args => $run_args, @_);
     }
 }


### PR DESCRIPTION
This pr is adding the necessary maintenance-specific code, fixes previous errors and is enabling the `SAPHanaSR-ScaleUp-PerfOpt` jobs for maintenance. Scheduling changes needed on Gitlab.

**NOTE**: `patch_and_reboot` module causes problems, and is to be tackled in another ticket (https://jira.suse.com/browse/TEAM-8035), so it's ommited.

- Related ticket: https://jira.suse.com/browse/TEAM-7535
- Verification runs:
**SAPHanaSR-ScaleUp-PerfOpt**: https://openqaworker15.qa.suse.cz/tests/186747
**mr_test** (modules used in that were changed): http://openqaworker15.qa.suse.cz/tests/186350

Scheduling gitlab mr: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/462