### PR TITLE
Install libyui-rest-api16 at 15sp5 for yast2_expert_partitioner

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_maintenance.xml.ep
+++ b/data/autoyast_sle15/create_hdd/create_hdd_maintenance.xml.ep
@@ -216,7 +216,7 @@ cd /etc/zypp/repos.d
 sed -i 's/enabled=1/enabled=0/' $(ls|grep -i nvidia)
 zypper lr
 
-% if ( $get_var->('VERSION') =~ /15-SP[34]/ ) {
+% if ( $get_var->('VERSION') =~ /15-SP[3-5]/ ) {
     # Regarding rpm lock see Q9@ https://documentation.suse.com/de-de/sles/15-SP1/html/SLES-all/app-ay-faq.html
     # quote : "during the post-script phase, YaST still has an exclusive lock on the RPM database."
     # the package cannot be installed the autoyast way, because of the changing package name (eg libyui-rest-api15)


### PR DESCRIPTION
Install libyui-rest-api16 at 15sp5 for yast2_expert_partitioner

- Related ticket: https://progress.opensuse.org/issues/129997
- Verification run: https://openqa.suse.de/tests/11215645
  15sp4 VR: https://openqa.suse.de/tests/11215661#step/setup_libyui_running_system/8
