### PR TITLE
Add qesap regression test on Azure: 15-SP5 PAYG

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -29,7 +29,7 @@ ansible:
   create:
     - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
     - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
+    - sap-hana-preconfigure.yaml -e use_sapconf=${SAPCONF}
     - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml
@@ -42,3 +42,4 @@ ansible:
   variables:
     REG_CODE: "%SCC_REGCODE_SLES4SAP%"
     EMAIL: testing@suse.com
+    SAPCONF: "%USE_SAPCONF%"

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -34,6 +34,7 @@ sub run {
     }
     $variables{OS_OWNER} = get_var('QESAP_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 
+    $variables{USE_SAPCONF} = get_required_var('USE_SAPCONF');
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';
     $variables{SCC_REGCODE_SLES4SAP} = get_required_var('SCC_REGCODE_SLES4SAP');


### PR DESCRIPTION
Add qesap regression tests: saptune enabled and sapconf enabled 
 
TEAM-8000 - [OSD] qesap regression test on Azure using 15-SP5 PAYG images

- Related ticket: https://jira.suse.com/browse/TEAM-8000
- Needles: NA
- Verification run:
  saptune enabled: https://openqa.suse.de/tests/11216912 (passed)
  sapconf enabled: https://openqa.suse.de/tests/11216913 (failed on ansible part as it doesn't work on 15-SP5 PAYG images yet)
