### PR TITLE
Remove stop_timeout_system_reboot_now test module at default 15sp4 aarch64 yaml file

### DIFF
--- a/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_restapi.yaml
+++ b/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_restapi.yaml
@@ -13,5 +13,4 @@ schedule:
     - installation/security/select_security_module_none
   system_role:
     - installation/system_role/select_role_text_mode
-  stop_timeout_system_reboot: []
 ...

--- a/schedule/yast/sle/flows/default_sle15sp4_aarch64.yaml
+++ b/schedule/yast/sle/flows/default_sle15sp4_aarch64.yaml
@@ -33,8 +33,6 @@ installation_settings:
 installation:
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
-stop_timeout_system_reboot:
-  - installation/performing_installation/stop_timeout_system_reboot_now
 installation_logs:
   - installation/logs_from_installation_system
 confirm_reboot:


### PR DESCRIPTION
The 'stop_timeout_system_reboot' test module should be added at 15sp3 aarch64 but 15sp4 don't need it.

- VR: SP4: https://openqa.suse.de/tests/11214412#
         SP3: https://openqa.suse.de/tests/11210354
         SP5: https://openqa.suse.de/tests/11214778