### PR TITLE
Handle vendor change issues in automation for migration cases that with PackageHub installed

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -507,6 +507,7 @@ sub process_unsigned_files {
 # to deal with dependency issues, either work around it, or break dependency to continue with installation
 sub deal_with_dependency_issues {
     my ($self) = @_;
+    my $vendor_change = 0;
 
     return unless check_screen 'manual-intervention', 0;
 
@@ -527,13 +528,19 @@ sub deal_with_dependency_issues {
     elsif (check_var("BREAK_DEPS", '1')) {
         y2_logs_helper::break_dependency;
     }
+    elsif (check_var("VENDOR_CHG_DEPS", '1')) {
+        $vendor_change = 1;
+        y2_logs_helper::vendor_change_dependency;
+    }
     else {
         die 'Dependency problems';
     }
 
-    assert_screen 'dependency-issue-fixed';    # make sure the dependancy issue is fixed now
-    send_key 'alt-a';    # Accept
-    sleep 2;
+    if (!$vendor_change) {
+        assert_screen 'dependency-issue-fixed';    # make sure the dependancy issue is fixed now
+        send_key 'alt-a';    # Accept
+        sleep 2;
+    }
 
   DO_CHECKS:
     while (check_screen('accept-licence', 2)) {

--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -15,6 +15,7 @@ our @EXPORT_OK = qw(
   select_conflict_resolution
   workaround_dependency_issues
   break_dependency
+  vendor_change_dependency
   verify_license_has_to_be_accepted
   accept_license
   verify_license_translations
@@ -77,6 +78,25 @@ sub break_dependency {
             wait_still_screen(2);
         }
     }
+}
+
+# to fix vendor change dependency issues
+sub vendor_change_dependency {
+    return unless check_screen 'dependency-issue', 10;
+
+    while (check_screen('dependency-issue', 5)) {
+        # Cancel conflict
+        send_key 'alt-c';
+        # Refer ticket https://progress.opensuse.org/issues/48266
+        wait_still_screen(2);
+    }
+    assert_screen('software-dependency');
+    send_key 'alt-o';
+    assert_and_click('allow-vendor-change');
+    assert_and_click('accept-option-change');
+    assert_screen('automatic-change');
+    send_key 'alt-o';
+    assert_and_click('continue-unsupported-pkgs');
 }
 
 


### PR DESCRIPTION
Handle vendor change issues in automation for migration cases that with PackageHub installed.

- Related ticket: https://progress.opensuse.org/issues/128123
- Needles: N/A
- Verification run: 
  http://openqa.suse.de/tests/11215806#step/resolve_dependency_issues/23   # powerVM
  http://openqa.suse.de/tests/11215804#step/resolve_dependency_issues/23   # x86_64
