### PR TITLE
Add new disk encryption tests

### DIFF
--- a/schedule/security/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/security/encryption/lvm_encrypt_separate_boot.yaml
@@ -1,0 +1,39 @@
+---
+name: lvm-encrypt-separate-boot
+description: >
+  Installation of a system with root on an encrypted logical volume
+  and with /boot on a separate unencrypted partition.
+vars:
+  UNENCRYPTED_BOOT: 1
+  ENCRYPT: 1
+  FULL_LVM_ENCRYPT: 1
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_module_desktop
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/partitioning/new_partitioning_gpt
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/handle_reboot
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_lvm
+  - console/validate_encrypt

--- a/schedule/security/encryption/lvm_encrypt_separate_boot_s390x.yaml
+++ b/schedule/security/encryption/lvm_encrypt_separate_boot_s390x.yaml
@@ -1,0 +1,47 @@
+---
+name: lvm-encrypt-separate-boot
+description: >
+  Installation of a system with root on an encrypted logical volume
+  and with /boot on a separate unencrypted partition.
+vars:
+  UNENCRYPTED_BOOT: 1
+  ENCRYPT: 1
+  FULL_LVM_ENCRYPT: 1
+  YUI_REST_API: 1
+  # Used by `installation/edit_optional_kernel_cmd_parameters`.
+  # Setting `boot=/edev/vda2` fixes poo#116281
+  # We have to set `fips=1` again, since all parameters get overwritten.
+  OPT_KERNEL_PARAMS: 'fips=1 boot=/dev/vda2'
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/register_module_desktop
+  - installation/add_on_product/skip_install_addons
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/partitioning/new_partitioning_gpt
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+  - installation/installation_settings/validate_default_target
+  - installation/edit_optional_kernel_cmd_parameters
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/performing_installation/stop_timeout_system_reboot_now
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/performing_installation/reconnect_after_reboot
+  - installation/boot_encrypt
+  - installation/handle_reboot
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_lvm
+  - console/validate_encrypt

--- a/test_data/security/encryption/lvm_encrypt_separate_boot.yaml
+++ b/test_data/security/encryption/lvm_encrypt_separate_boot.yaml
@@ -1,0 +1,32 @@
+---
+disks:
+  - name: vda
+    partitions:
+      - size: 2MiB
+        role: raw-volume
+        id: bios-boot
+      - size: 500MiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot
+      - role: raw-volume
+        id: linux-lvm
+        encrypt_device: 1
+lvm:
+  volume_groups:
+    - name: vg-system
+      devices:
+        - /dev/vda3
+      logical_volumes:
+        - name: lv-swap
+          size: 2000MiB
+          role: swap
+        - name: lv-root
+          role: operating-system
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/security/encryption/default.yaml

--- a/test_data/security/encryption/lvm_encrypt_separate_boot_s390x.yaml
+++ b/test_data/security/encryption/lvm_encrypt_separate_boot_s390x.yaml
@@ -1,0 +1,37 @@
+---
+disks:
+  - name: vda
+    partitions:
+      - size: 300MiB
+        role: raw-volume
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot/zipl
+      - size: 500MiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot
+      - role: raw-volume
+        id: linux-lvm
+        encrypt_device: 1
+lvm:
+  volume_groups:
+    - name: vg-system
+      devices:
+        - /dev/vda3
+      logical_volumes:
+        - name: lv-swap
+          size: 2000MiB
+          role: swap
+        - name: lv-root
+          role: operating-system
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/security/encryption/default.yaml

--- a/test_data/security/encryption/lvm_encrypt_separate_boot_uefi.yaml
+++ b/test_data/security/encryption/lvm_encrypt_separate_boot_uefi.yaml
@@ -1,0 +1,38 @@
+---
+disks:
+  - name: vda
+    partitions:
+      - size: 300MiB
+        role: raw-volume
+        id: efi
+        formatting_options:
+          should_format: 1
+          filesystem: fat
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot/efi
+      - size: 500MiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot
+      - role: raw-volume
+        id: linux-lvm
+        encrypt_device: 1
+lvm:
+  volume_groups:
+    - name: vg-system
+      devices:
+        - /dev/vda3
+      logical_volumes:
+        - name: lv-swap
+          size: 2000MiB
+          role: swap
+        - name: lv-root
+          role: operating-system
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/security/encryption/default.yaml


### PR DESCRIPTION
New security tests for encrypted installation testing with separate `/boot` partition and running in FIPS mode. So far it doesn't cover testing on `ppc64le`.

The tests are derived from YaST team and patched to run in FIPS mode, since some platforms require special steps in such case. This was done after consulting with the YaST team.

- Related tickets:
    - https://progress.opensuse.org/issues/113162
    - https://progress.opensuse.org/issues/116281
- Verification runs:
    - s390x: https://openqa.suse.de/tests/11211502
    - x86_64: https://openqa.suse.de/tests/11217049
    - aarch64: https://openqa.suse.de/tests/11217050
