### PR TITLE
Test that SELinux can be enabled after being disabled on SLEM

### DIFF
--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -13,10 +13,31 @@ use strict;
 use warnings;
 use testapi;
 use transactional qw(process_reboot);
-use version_utils qw(is_sle_micro is_public_cloud);
+use version_utils qw(is_leap_micro is_microos is_sle_micro is_public_cloud);
 use Utils::Systemd qw(systemctl);
 use Utils::Logging 'save_and_upload_log';
 use transactional qw(trup_call check_reboot_changes process_reboot);
+
+sub check_enforcing {
+    assert_script_run('selinuxenabled');
+    validate_script_output("getenforce", sub { m/Enforcing/ });
+    validate_script_output("sestatus", sub { m/Current mode:.*enforcing/ });
+    validate_script_output("sestatus", sub { m/Mode from config file:.*enforcing/ });
+    record_info('SELinux', script_output('sestatus'));
+    record_info('Audit report', script_output('aureport'));
+    record_info('Audit denials', script_output('aureport -a', proceed_on_failure => 1));
+}
+
+sub check_disabled {
+    record_info('SELinux', script_output('sestatus'));
+    assert_script_run('! selinuxenabled');
+    validate_script_output("getenforce", sub { m/Disabled/ });
+    validate_script_output("sestatus", sub { m/SELinux status:.*disabled/ });
+}
+
+sub is_enforcing {
+    return (script_run('test -d /sys/fs/selinux && test -e /etc/selinux/config && getenforce | grep -i "enforcing" >/dev/null') == 0);
+}
 
 sub run {
     select_console 'root-console';
@@ -27,15 +48,17 @@ sub run {
         return;
     }
 
-    my $audit_log = "/var/log/audit/audit.log";
+    my $trup_log = "/var/log/transactional-update.log";
 
     # auditd should be enabled
     systemctl 'is-enabled auditd';
 
     # install and enable SELinux if not done by default
-    if (script_run('test -d /sys/fs/selinux && test -e /etc/selinux/config && getenforce | grep -i "enforcing" >/dev/null') != 0) {
+    if (!is_enforcing) {
+        die("SELinux should be enabled by default on " . get_required_var("DISTRI") . " " . get_required_var("VERSION"))
+          if (is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos);
         trup_call('setup-selinux');
-        upload_logs('/var/log/transactional-update.log');
+        upload_logs($trup_log, log_name => $trup_log . ".txt");
         save_and_upload_log('rpm -qa', 'installed_pkgs.txt');
         check_reboot_changes;
         if (is_public_cloud) {
@@ -49,18 +72,28 @@ sub run {
         }
     }
 
-    assert_script_run('selinuxenabled');
-    validate_script_output("getenforce", sub { m/Enforcing/ });
-    validate_script_output("sestatus", sub { m/Current mode:.*enforcing/ });
-    validate_script_output("sestatus", sub { m/Mode from config file:.*enforcing/ });
-    record_info('SELinux', script_output('sestatus'));
-    record_info('Audit report', script_output('aureport'));
-    record_info('Audit denials', script_output('aureport -a', proceed_on_failure => 1));
-    upload_logs($audit_log);
+    check_enforcing;
+
+    # disable and re-enable SELinux
+    assert_script_run "sed -i -e 's/^SELINUX=.*/SELINUX=disabled/g' /etc/selinux/config";
+    # See "Note: Relabeling your system after switching from the disabled mode" section on:
+    # https://documentation.suse.com/sle-micro/5.4/html/SLE-Micro-all/cha-selinux-slemicro.html
+    assert_script_run "touch /etc/selinux/.autorelabel";
+    process_reboot(trigger => 1);
+    check_disabled;
+    trup_call('setup-selinux');
+    process_reboot(trigger => 1);
+    check_enforcing;
+    assert_script_run "test -f /etc/selinux/.relabelled";
 }
 
 sub test_flags {
     return {fatal => 1, milestone => 1};
+}
+
+sub post_run_hook {
+    my $audit_log = "/var/log/audit/audit.log";
+    upload_logs($audit_log, log_name => $audit_log . ".txt");
 }
 
 1;


### PR DESCRIPTION
This PR:
- Adds a test that SELinux can be enabled after being disabled on SLEM.
- Checks that SELinux is enabled on SLEM 15.4+

---

- Related ticket: https://progress.opensuse.org/issues/129394
- Verification runs:
   - microos-Tumbleweed-MicroOS-Image-x86_64-Build20230531-microos@64bit -> https://openqa.opensuse.org/tests/3328840
  - sle-micro-5.1-MicroOS-Image-Updates-x86_64-Build20230531-1-slem_selinux@64bit -> https://openqa.suse.de/tests/11229117 
  - sle-micro-5.2-MicroOS-Image-Updates-x86_64-Build20230531-1-slem_selinux@64bit -> https://openqa.suse.de/tests/11229118 
  - sle-micro-5.3-MicroOS-Image-Updates-x86_64-Build20230531-1-slem_selinux@64bit -> https://openqa.suse.de/tests/11229119
