### PR TITLE
Set USE_SAPCONF=false to fix qesap_saptune failure

### DIFF
--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -34,7 +34,7 @@ sub run {
     }
     $variables{OS_OWNER} = get_var('QESAP_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 
-    $variables{USE_SAPCONF} = get_required_var('USE_SAPCONF');
+    $variables{USE_SAPCONF} = get_var('USE_SAPCONF', 'false');
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';
     $variables{SCC_REGCODE_SLES4SAP} = get_required_var('SCC_REGCODE_SLES4SAP');


### PR DESCRIPTION
Set USE_SAPCONF=false to fix test case "qec2_sap_byos_qesap_saptune" test module "configure" error.   
The error message is "Could not retrieve required variable USE_SAPCONF" it was introduced by [PR#17176](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17176)

- Related ticket: NA
- Needles: NA
- Verification run (passed): [openqa.mypersonalinstance.de/tests/xyz#step/module/x
](https://openqa.suse.de/tests/11222535#details)