### PR TITLE
Remove LTSS ends sles15

### DIFF
--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -25,26 +25,6 @@ use version_utils 'is_sle';
 our %guests = ();
 if (get_var("REGRESSION", '') =~ /xen/) {
     %guests = (
-        sles15PV => {
-            name => 'sles15PV',
-            autoyast => 'autoyast_xen/sles15PV_PRG.xml',
-            extra_params => '--connect xen:/// --virt-type xen --paravirt --os-variant sle15',
-            macaddress => '52:54:00:78:73:a3',
-            ip => '192.168.122.102',
-            distro => 'SLE_15',
-            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-GM/x86_64/DVD1/',    # SLE-15-Installer-latest link is not avaiable any more
-            linuxrc => 'ifcfg="eth0=192.168.122.102/24,192.168.122.1,192.168.122.1"',
-        },
-        sles15HVM => {
-            name => 'sles15HVM',
-            autoyast => 'autoyast_xen/sles15HVM_PRG.xml',
-            extra_params => '--connect xen:/// --virt-type xen --hvm --os-variant sle15',
-            macaddress => '52:54:00:78:73:a4',
-            ip => '192.168.122.101',
-            distro => 'SLE_15',
-            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-GM/x86_64/DVD1/',    # SLE-15-Installer-latest link is not avaiable any more
-            linuxrc => 'ifcfg="eth0=192.168.122.101/24,192.168.122.1,192.168.122.1"',
-        },
         sles12sp4PV => {
             name => 'sles12sp4PV',
             autoyast => 'autoyast_xen/sles12sp4PV_PRG.xml',
@@ -185,7 +165,6 @@ if (get_var("REGRESSION", '') =~ /xen/) {
 
     delete($guests{sles12sp4PV}) if (!is_sle('=12-SP4'));
     delete($guests{sles12sp5HVM}) if (!is_sle('=12-SP5'));
-    delete($guests{sles15PV}) if (!is_sle('=15'));
     delete($guests{sles15sp1HVM}) if (!is_sle('=15-SP1'));
 } elsif (get_var("REGRESSION", '') =~ /kvm|qemu/) {
     %guests = (
@@ -208,16 +187,6 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             distro => 'SLE_12_SP4',
             location => 'http://mirror.suse.cz/install/SLP/SLE-12-SP4-Server-GM/x86_64/DVD1/',
             linuxrc => 'ifcfg="eth0=192.168.122.103/24,192.168.122.1,192.168.122.1"',
-        },
-        sles15 => {
-            name => 'sles15',
-            autoyast => 'autoyast_kvm/sles15_PRG.xml',
-            extra_params => '--os-variant sle15',
-            macaddress => '52:54:00:78:73:a4',
-            ip => '192.168.122.101',
-            distro => 'SLE_15',
-            location => 'http://mirror.suse.cz/install/SLP/SLE-15-Installer-GM/x86_64/DVD1/',    # SLE-15-Installer-latest link is not avaiable any more
-            linuxrc => 'ifcfg="eth0=192.168.122.101/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp1 => {
             name => 'sles15sp1',
@@ -289,9 +258,6 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles12sp5 => {
             name => 'sles12sp5',
         },
-        sles15 => {
-            name => 'sles15',
-        },
         sles15sp1 => {
             name => 'sles15sp1',
         },
@@ -312,7 +278,6 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     delete($guests{sles12sp3}) if (!is_sle('=12-SP3'));
     delete($guests{sles12sp4}) if (!is_sle('=12-SP4'));
     delete($guests{sles12sp5}) if (!is_sle('=12-SP5'));
-    delete($guests{sles15}) if (!is_sle('=15'));
     delete($guests{sles15sp1}) if (!is_sle('=15-SP1'));
     delete($guests{sles15sp2}) if (!is_sle('=15-SP2'));
     delete($guests{sles15sp3}) if (!is_sle('=15-SP3'));
@@ -331,10 +296,6 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles12sp5 => {
             name => 'sles12sp5',
             ip => 'win2k19-sle12-SP5.qa.suse.cz',
-        },
-        sles15 => {
-            name => 'sles15',
-            ip => 'win2k19-sle15.qa.suse.cz',
         },
         sles15sp1 => {
             name => 'sles15sp1',
@@ -361,7 +322,6 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     delete($guests{sles12sp3}) if (!is_sle('=12-SP3'));
     delete($guests{sles12sp4}) if (!is_sle('=12-SP4'));
     delete($guests{sles12sp5}) if (!is_sle('=12-SP5'));
-    delete($guests{sles15}) if (!is_sle('=15'));
     delete($guests{sles15sp1}) if (!is_sle('=15-SP1'));
     delete($guests{sles15sp2}) if (!is_sle('=15-SP2'));
     delete($guests{sles15sp3}) if (!is_sle('=15-SP3'));


### PR DESCRIPTION
poo# https://progress.opensuse.org/issues/129985
SUSE Linux Enterprise Server 15 has exceeded its long-term support (LTSS) end date of December 31, 2022. This means that it is no longer receiving official support or updates from SUSE.
So it is unnecessary to test it again.


- Related ticket: https://progress.opensuse.org/issues/129985
- Needles: N/A
- Verification run:[XEN test]( http://openqa.qam.suse.cz/tests/54270), [KVM test](http://openqa.qam.suse.cz/tests/54100)
