### PR TITLE
Automate auto-installation of openSUSE Leap 16.0 on Agama

### DIFF
--- a/data/yam/agama/auto/leap16.json
+++ b/data/yam/agama/auto/leap16.json
@@ -1,0 +1,13 @@
+{
+   "software": {
+      "product": "Leap16"
+   },
+   "user": {
+      "fullName": "Bernhard M. Wiedemann",
+      "password": "nots3cr3t",
+      "userName": "bernhard"
+   },
+   "root": {
+      "password": "nots3cr3t"
+   }
+}

--- a/data/yam/agama/auto/leap16.sh
+++ b/data/yam/agama/auto/leap16.sh
@@ -1,0 +1,7 @@
+set -ex
+
+/usr/bin/agama config set software.product=Leap16
+/usr/bin/agama config set user.userName=bernhard user.password=nots3cr3t
+/usr/bin/agama config set root.password=nots3cr3t
+/usr/bin/sleep 30
+/usr/bin/agama install


### PR DESCRIPTION
Automate auto-installation of openSUSE Leap 16.0 on Agama using json and shell format.

- Related ticket: https://progress.opensuse.org/issues/128186
- Needles: n/a
- Verification run: 
- https://openqa.opensuse.org/tests/3330797#
- https://openqa.opensuse.org/tests/3330796#
The installation is block by bsc#1211506
