### PR TITLE
Fix 32bit compat mode LTP test activation

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -57,9 +57,9 @@ sub shutdown_ltp {
 sub want_ltp_32bit {
     my $pkg = shift // get_var('LTP_PKG');
 
-    # TEST_SUITE_NAME is for running 32bit tests (e.g. ltp_syscalls_m32),
-    # checking LTP_PKG is for install_ltp.pm which also uses prepare_ltp_env()
-    return (get_required_var('TEST_SUITE_NAME') =~ m/[-_]m32$/
+    # TEST is for running 32bit tests (e.g. ltp_syscalls_m32), checking
+    # LTP_PKG is for install_ltp.pm which also uses prepare_ltp_env()
+    return (get_required_var('TEST') =~ m/[-_]m32$/
           || $pkg =~ m/-32bit$/
           || is_32bit);
 }


### PR DESCRIPTION
The `TEST_SUITE_NAME` variable is always defined but when the job was defined in jobgroup YAML with `testsuite: null`, it will be empty. Check the actual job name to decide whether LTP jobs should use the default LTP package or the 32bit one.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - ltp_math: https://openqa.suse.de/tests/11223299
  - ltp_math_m32: https://openqa.suse.de/tests/11223300
