### PR TITLE
Change naming convention of qesap regression settings

### DIFF
--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -32,9 +32,9 @@ sub run {
         $variables{STORAGE_ACCOUNT_NAME} = get_required_var('STORAGE_ACCOUNT_NAME');
         $variables{OS_VER} = $provider->get_image_id();
     }
-    $variables{OS_OWNER} = get_var('QESAP_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    $variables{OS_OWNER} = get_var('QESAPDEPLOY_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 
-    $variables{USE_SAPCONF} = get_required_var('USE_SAPCONF');
+    $variables{USE_SAPCONF} = get_var('QESAPDEPLOY_USE_SAPCONF');
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';
     $variables{SCC_REGCODE_SLES4SAP} = get_required_var('SCC_REGCODE_SLES4SAP');


### PR DESCRIPTION
Enforce naming convention for settings used in qesap regression testing.

Verification
- http://openqaworker15.qa.suse.cz/tests/184653
- http://openqaworker15.qa.suse.cz/tests/185060
-  http://openqaworker15.qa.suse.cz/tests/185061

