### PR TITLE
Fix dns resolve failure on sle12sp5 by moving testvirt.net forward in resov.conf

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -1193,7 +1193,7 @@ sub config_guest_network_bridge_services {
     my $_detect_name_server = script_output("cat /etc/resolv.conf | grep \"nameserver $_guest_network_ipaddr_gw\"", proceed_on_failure => 1);
     my $_detect_domain_name = script_output("cat /etc/resolv.conf | grep $self->{guest_domain_name}", proceed_on_failure => 1);
     assert_script_run("awk -v dnsvar=$_guest_network_ipaddr_gw \'done != 1 && /^nameserver.*\$/ { print \"nameserver \"dnsvar\"\"; done=1 } 1\' /etc/resolv.conf > /etc/resolv.conf.tmp") if ($_detect_name_server eq '');
-    assert_script_run("sed -i -r \'/^search/ s/\$/ $self->{guest_domain_name}/\' /etc/resolv.conf.tmp") if ($_detect_domain_name eq '');
+    assert_script_run("sed -i -r \'s/^search/search $self->{guest_domain_name}/\' /etc/resolv.conf.tmp") if ($_detect_domain_name eq '');
     if ($_detect_signature eq '') {
         assert_script_run("cp /etc/resolv.conf /etc/resolv_backup.conf && mv /etc/resolv.conf.tmp /etc/resolv.conf");
         assert_script_run("echo \'#Modified by guest_installation_and_configuration_base module\' >> /etc/resolv.conf");


### PR DESCRIPTION
"Could not resolve guest name" was found in unified guest installation tests too, https://openqa.suse.de/tests/11222650#step/unified_guest_installation/530. Similiar change is supposed to be applied to thoes tests.

Related ticket: https://progress.opensuse.org/issues/129544

Verification run: 
[uefi-gi-guest_developing-on-host_sles12sp5-xen](https://openqa.suse.de/tests/11228540#)
[uefi-gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.suse.de/tests/11228828#)
[uefi-gi-guest_developing-on-host_sles15sp4-xen](https://openqa.suse.de/tests/11228830#)
[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/11228827#)
[sev-es-gi-guest_developing-on-host_sles15sp4-kvm](https://openqa.suse.de/tests/11228878)