### PR TITLE
Fix desktopapps-documentation failure on TW

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -969,7 +969,7 @@ sub gnote_search_and_close {
     type_string $string;
     assert_screen $needle, 5;
 
-    send_key "ctrl-w";
+    send_key "alt-f4";
 }
 
 # remove the created new note
@@ -979,7 +979,7 @@ sub cleanup_gnote {
     assert_and_click($needle, button => 'right');
     assert_and_click "delete-new-note";
     assert_and_click "really-delete-note";
-    send_key 'ctrl-w';
+    send_key 'alt-f4';
 }
 
 sub gnote_start_with_new_note {

--- a/tests/x11/gedit/gedit_launch.pm
+++ b/tests/x11/gedit/gedit_launch.pm
@@ -19,6 +19,7 @@ use warnings;
 use testapi;
 
 sub run {
+    ensure_installed('gedit');
     x11_start_program('gedit');
     assert_and_click 'gedit-x-button';
 

--- a/tests/x11/gnote/gnote_first_run.pm
+++ b/tests/x11/gnote/gnote_first_run.pm
@@ -26,7 +26,7 @@ sub run {
         select_console('x11');
     }
     x11_start_program('gnote');
-    send_key "ctrl-w";
+    send_key "ctrl-q";
 }
 
 # add milestone flag to save gnote installation in lastgood vm snapshot

--- a/tests/x11/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11/libreoffice/libreoffice_open_specified_file.pm
@@ -46,6 +46,10 @@ sub run {
         # close document
         send_key "ctrl-f4";
         wait_still_screen(2);
+        if (check_screen("libreoffice-test-$tag")) {
+            record_soft_failure("bsc#1209179 ctrl+f4 can't close libreoffice document");
+            assert_and_click("close-document");
+        }
         if (check_screen('generic-desktop')) {
             record_soft_failure 'bsc#1196648';
             $self->libreoffice_start_program('libreoffice');


### PR DESCRIPTION
Change short cuts to close gnote to fix gnote failures
Ensure installed gedit before invoking
Use a stable way to close libreoffice document
Add a softfailure for TW due to bsc#1209179

- Related ticket: https://progress.opensuse.org/issues/126635
- Needles: already added when debugging on osd and o3
- Verification run: 

>  TW: 
[desktopapps-documentation](https://openqa.opensuse.org/tests/3328460#details)
> SLE: 
[wayland-desktopapps-documentation](https://openqa.suse.de/tests/11228632#details)
[x11-desktopapps-documentation](https://openqa.suse.de/tests/11228633#details)

