### PR TITLE
Do not fail when 'az sig image-version show'

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -95,7 +95,7 @@ sub find_img {
         my $definition = get_required_var('DISTRI') . '-' . get_required_var('FLAVOR') . '-' . get_required_var('VERSION');
         $definition = get_var("PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION", uc($definition));
         $json = script_output("az sig image-version show --resource-group '$resource_group' --gallery-name '$gallery' " .
-              "--gallery-image-definition '$definition' --gallery-image-version '$version'", timeout => 60 * 30);
+              "--gallery-image-definition '$definition' --gallery-image-version '$version'", proceed_on_failure => 1, timeout => 60 * 30);
     } else {
         $json = script_output("az image show --resource-group " . $self->resource_group . " --name $name", 60, proceed_on_failure => 1);
         record_info('IMG INFO', $json);


### PR DESCRIPTION
When the image version does not exists in Azure shared image galery it will be created later.

- Related ticket: [poo#130213](https://progress.opensuse.org/issues/130213)
- Related pull request: #16886
- Related error: [openqa.suse.de/t11229560](https://openqa.suse.de/tests/11229560)
- Verification run: [pdostal-server.suse.cz/t4428](https://pdostal-server.suse.cz/tests/4428)
