### PR TITLE
Add arch_only key for extra repos

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -86,12 +86,12 @@ sub add_extra_customer_repositories {
     my @repo_list = (
         {cond => '=12-SP2', name => '12-SP2-LTSS-ERICSSON-Updates', uri => "http://dist.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP2-LTSS-ERICSSON/$arch/update/"},
         {cond => '=12-SP3', name => '12-SP3-LTSS-TERADATA-Updates', uri => "http://dist.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP3-LTSS-TERADATA/$arch/update/"},
-        {cond => '=15-SP3', name => '15-SP3-ERICSSON-Updates', uri => "http://dist.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-ERICSSON/$arch/update/"},
-        {cond => '=15-SP4', name => '15-SP4-ERICSSON-Updates', uri => "http://dist.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP4-ERICSSON/$arch/update/"}
+        {cond => '=15-SP3', name => '15-SP3-ERICSSON-Updates', uri => "http://dist.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-ERICSSON/$arch/update/", arch_only => 'x86_64'},
+        {cond => '=15-SP4', name => '15-SP4-ERICSSON-Updates', uri => "http://dist.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP4-ERICSSON/$arch/update/", arch_only => 'x86_64'}
     );
 
     for my $repo (@repo_list) {
-        add_repo_if_not_present($repo->{uri}, $repo->{name}) if is_sle($repo->{cond});
+        add_repo_if_not_present($repo->{uri}, $repo->{name}) if is_sle($repo->{cond}) && defined($repo->{arch_only}) eq 'x86_64';
     }
 }
 


### PR DESCRIPTION
Right now the extra customer repos are only for x86_64, other architectures are failing as they can't add not existing repo

- Related ticket:  #17196
- Verification run:
https://openqa.suse.de/tests/11234928 aarch64 jeos
https://openqa.suse.de/tests/11234920 aarch64 jeos
https://openqa.suse.de/tests/11234918 s390x sle
https://openqa.suse.de/tests/11234919 aarch64 sle
