### PR TITLE
update_kernel: Apply kernel-source version exception to RT packages

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -205,8 +205,10 @@ sub install_lock_kernel {
     my @lpackages = @packages;
     my %packver = (
         'kernel-devel' => $src_version,
+        'kernel-devel-rt' => $src_version,
         'kernel-macros' => $src_version,
-        'kernel-source' => $src_version
+        'kernel-source' => $src_version,
+        'kernel-source-rt' => $src_version
     );
 
     if (check_var('SLE_PRODUCT', 'slert')) {


### PR DESCRIPTION
The kernel-source-rt and kernel-devel-rt package minor versions can also differ from the corresponding kernel-rt package. Apply the same exception as for kernel-source.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/11242896