### PR TITLE
Public Cloud: Repair the repository syncing process

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -169,7 +169,8 @@ sub is_hardened() {
 }
 
 sub is_embargo_update {
-    my ($incident) = @_;
+    my ($incident, $type) = @_;
+    return 0 if ($type =~ /PTF/);
     script_retry("curl -sSf https://build.suse.de/attribs/SUSE:Maintenance:$incident -o /tmp/$incident.txt");
     return 1 if (script_run("grep 'OBS:EmbargoDate' /tmp/$incident.txt") == 0);
     return 0;

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -32,6 +32,10 @@ sub run {
 
     ssh_fully_patch_system($remote);
 
+    record_info('UNAME', $args->{my_instance}->ssh_script_output(cmd => 'uname -a'));
+    $args->{my_instance}->ssh_assert_script_run(cmd => 'rpm -qa > /tmp/rpm-qa.txt');
+    $args->{my_instance}->upload_log('/tmp/rpm-qa.txt');
+
     $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
 }
 


### PR DESCRIPTION
Issues fixed:
1) The `rsync` command in `transfer_repos.pm` was lacking `--recorsive` parameter. (Introduced in #16117)
2) The `PTF:/` directory is now supported in the same way as the `Maintenance:/` directory.

- Verification run: [SLE 15-SP4 Azure BYOS aarch64](https://pdostal-server.suse.cz/tests/4452), [SLE 12-SP4 GCE BYOS x86_64](https://pdostal-server.suse.cz/tests/4460), [SLE 15-SP1 EC2 x86_64](https://pdostal-server.suse.cz/tests/4461)
