### PR TITLE
openQA: Fix finished results hidden out of screen

### DIFF
--- a/tests/openqa/webui/test_results.pm
+++ b/tests/openqa/webui/test_results.pm
@@ -46,7 +46,11 @@ sub run {
     handle_notify_popup;
     assert_screen 'openqa-tests';
     assert_and_click 'openqa-tests';
-    assert_and_click 'openqa-job-minimalx';
+    # At this point the openQA job might still be running or already finished.
+    # Ensure to show finished results at the bottom of the screen whenever the
+    # page finished loading
+    send_key_until_needlematch 'openqa-job-minimalx', 'end';
+    click_lastmatch;
     assert_and_click 'openqa-job-details';
     assert_screen 'openqa-testresult', 600;
 }


### PR DESCRIPTION
1 job has been created:
 - opensuse-Tumbleweed-DVD-x86_64-Build20230604-openqa_bootstrap@64bit -> https://openqa.opensuse.org/tests/3336705

https://openqa.opensuse.org/tests/3336705#step/test_results/14 shows how the openQA is detected on a scrolled down page despite the job actually still running.