### PR TITLE
Skip netavark testing on ppc64le

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -91,7 +91,7 @@ sub load_host_tests_podman {
         loadtest 'containers/podman_pods';
         loadtest('containers/podman_network_cni');
         # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
-        loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3"));
+        loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
         loadtest 'containers/podman_firewall' unless (is_public_cloud || is_openstack || is_microos || is_alp);
         # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
Due to missing package, skip schedule of `podman_netavark` test module on `ppc64` architecture.

- ticket: [podman_netavark: package does not exist on ppc64le](https://progress.opensuse.org/issues/130255)
- Verification run: https://openqa.opensuse.org/tests/3336695#
