### PR TITLE
Do not remove testuser if not created

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -16,16 +16,20 @@ use version_utils 'is_sle_micro';
 our $user = $testapi::username;
 our $password = $testapi::password;
 
+my $user_created = 0;
+
 sub cleanup {
     record_info 'Cleanup';
     clean_container_host(runtime => 'podman');
-    script_run "userdel -rf $user";    # script_run in case user has not been created yet
+    # Delete user only if created within the test run.
+    script_run "userdel -rf $user" if ($user_created);
 }
 
 sub create_user {
     if (script_run("getent passwd $user") != 0) {
         assert_script_run "useradd -m $user";
         assert_script_run "echo '$user:$password' | chpasswd";
+        $user_created = 1;
     }
 
     # Make sure user has access to tty group


### PR DESCRIPTION
Toolbox test run: Do not delete the testapi user, unless it has been created within the test run.

- Related ticket: https://progress.opensuse.org/issues/130141
- Verification run: [SLEM 5.4 on Azure](https://duck-norris.qe.suse.de/tests/12939) | [SLEM 5.4](https://duck-norris.qe.suse.de/tests/12952) | [SLEM 5.3](https://duck-norris.qe.suse.de/tests/12953) | [SLEM 5.2](https://duck-norris.qe.suse.de/tests/12950) | [SLEM 5.1](https://duck-norris.qe.suse.de/tests/12949) | [MicroOS](https://duck-norris.qe.suse.de/tests/12948)
