### PR TITLE
Use needle to click on save password as aarch64 misses shortcut keypress

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -628,8 +628,7 @@ sub adminer_database_delete {
     send_key "tab";
     send_key "tab";
     send_key "ret";
-    assert_screen("adminer-save-passwd");
-    send_key "alt-s";
+    assert_and_click("adminer-save-passwd", timeout => 180);
     assert_screen("adminer-select-database");
     assert_and_click("adminer-click-database-test");
     assert_and_click("adminer-click-drop-database-test");


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/129044
- Verification runs:
  - https://openqa.suse.de/tests/11255114#step/apache2_changehat/113
  - https://openqa.suse.de/tests/11255132#step/apache2_changehat/113 
