### PR TITLE
gpg: consider packages providing merged cabapilities

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -202,7 +202,7 @@ sub run {
     }
     else {
         foreach my $pkg_name (keys %$pkg_list) {
-            my $pkg_ver = script_output("rpm -q --qf '%{version}\n' $pkg_name");
+            my $pkg_ver = script_output("rpm -q --qf '%{version}\n' --whatprovides $pkg_name");
             record_info("$pkg_name version", "Version of Current package: $pkg_ver");
         }
     }


### PR DESCRIPTION
libgcrypt20-hmac has been merged into libgcrypt20 and can thus only
be verified using rpm -q --whatprovides libgcrypt20-hmac

for the test it is not important if the package exists as a separate
entity or is merged into the main package, we care for the functionality
being present.

- Related ticket: https://progress.opensuse.org/issues/130036
- Needles: N/A
- Verification run: [MicroOS](https://openqa.opensuse.org/tests/3337480) (openssl-fips-hash is unrelated and fails in all tests at the moment)
