### PR TITLE
Use writeback to fast qemu-img convert

### DIFF
--- a/tests/shutdown/svirt_upload_assets.pm
+++ b/tests/shutdown/svirt_upload_assets.pm
@@ -25,7 +25,7 @@ sub extract_assets {
     enter_cmd("test -e $svirt_img_name && echo 'OK'");
     assert_screen('svirt-asset-upload-hdd-image-exists');
 
-    my $cmd = "nice ionice qemu-img convert -p -O $format $svirt_img_name $image_storage/$name";
+    my $cmd = "nice ionice qemu-img convert -t writeback -p -O $format $svirt_img_name $image_storage/$name";
     if (get_var('QEMU_COMPRESS_QCOW2')) {
         $cmd .= ' -c';
     }


### PR DESCRIPTION
Use writeback to fast qemu-img convert

- Related ticket:  https://progress.opensuse.org/issues/125804
- Needles: N/A
- Verification run:   [**svirt_upload_assets**](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=hjluo%2Fos-autoinst-distri-opensuse%23svirt_upload)

