### PR TITLE
Fix boot timeout and NTP sync issues for year_2038_detection

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -179,7 +179,7 @@ sub load_common_tests {
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
     loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro || is_alp);
     loadtest 'console/kubeadm' if (check_var('SYSTEM_ROLE', 'kubeadm'));
-    loadtest 'console/year_2038_detection';
+    loadtest 'console/year_2038_detection' unless is_s390x;
 }
 
 

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -49,6 +49,7 @@ conditional_schedule:
         - '{{arch_specific}}'
         - '{{arch_specific15_sp4}}'
         - console/valgrind
+        - '{{arch_specific15_sp5}}'
       15-SP4:
         - console/osinfo_db
         - console/ovn
@@ -136,4 +137,10 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/ansible
+  arch_specific15_sp5:
+    ARCH:
+      x86_64:
+        - console/year_2038_detection
+      aarch64:
+        - console/year_2038_detection
 ...


### PR DESCRIPTION
https://progress.opensuse.org/issues/129139

At the same time, add the test in sle15-sp5 qem

- Verification run:
[zvm](https://openqa.suse.de/tests/11255202#next_previous)
[tw](https://openqa.opensuse.org/tests/3340000#next_previous)
[sle](https://openqa.suse.de/tests/overview?&build=rfan0606)
[micro-os](https://openqa.opensuse.org/tests/3339989)