### PR TITLE
prepare_instance updated to retry on error in wait_for_ssh

### DIFF
--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -37,6 +37,7 @@ sub run {
     my $provider = $self->provider_factory();
     my %instance_args;
     $instance_args{check_connectivity} = 1;
+    $instance_args{ignore_wrong_pubkey} //= 0;    # parameter set for wait_for_ssh: 0 = stop on publickey error.
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     $args->{my_provider} = $provider;
     my $instance = $provider->create_instance(%instance_args);

--- a/variables.md
+++ b/variables.md
@@ -303,8 +303,9 @@ PUBLIC_CLOUD_IMG_PROOF_EXCLUDE | string | "" | Tests to be excluded by img-proof
 PUBLIC_CLOUD_INSTANCE_TYPE | string | "" | Specify the instance type. Which instance types exists depends on the CSP. (default-azure: Standard_A2, default-ec2: t2.large )
 PUBLIC_CLOUD_LTP | boolean | false | If set, the run_ltp test module is added to the job.
 PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE | boolean | false | Do not remove the instance when the test fails.
+PUBLIC_CLOUD_PERF_COLLECT | boolean | false | Enable `boottime` measures collection, at end of `create_instance` routine.
 PUBLIC_CLOUD_PERF_DB_URI | string | "" | If set, the bootup times get stored in the influx database. (e.g. PUBLIC_CLOUD_PERF_DB_URI=http://publiccloud-ng.qe.suse.de:8086)
-PUBLIC_CLOUD_PERF_DB | string | "perf" | If `PUBLIC_CLOUD_PERF_DB_URI` is defined, this variable defines the bucket in which the performance metrics are stored
+PUBLIC_CLOUD_PERF_DB | string | "perf_2" | If `PUBLIC_CLOUD_PERF_DB_URI` is defined, this variable defines the bucket in which the performance metrics are stored
 PUBLIC_CLOUD_PERF_DB_ORG | string | "qec" | If `PUBLIC_CLOUD_PERF_DB_URI` is defined, this variable defines the organization in which the performance metrics are stored
 _PUBLIC_CLOUD_PERF_DB_TOKEN | string | "" | If `PUBLIC_CLOUD_PERF_DB_URI` is defined, this required variable is the access token
 _PUBLIC_CLOUD_PERF_PUSH_DATA | boolean | "" | If set to `1`, then the test run will push it's metrics to the InfluxDB. This variable is used as secret variable, so that cloned jobs by default do not push metrics to avoid accidental database contamination.


### PR DESCRIPTION
P.C. module `prepare_instance` updated to allow check for system up to _retry_ in case of _publickey_ or _unknown_ errors in `wait_for_ssh`

- Related ticket: https://progress.opensuse.org/issues/130444
- Needles: No change
- Verification run: see next posts
