### PR TITLE
Integrate yupdate script in openQA in order to get e2e playwright tests from a different repo

### DIFF
--- a/lib/yam/agama/patch_agama_base.pm
+++ b/lib/yam/agama/patch_agama_base.pm
@@ -1,0 +1,24 @@
+## Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: base class for Patch Agama tests
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package yam::agama::patch_agama_base;
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use y2_base 'save_upload_y2logs';
+
+sub pre_run_hook {
+    $testapi::password = 'linux';
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    select_console 'root-console';
+    y2_base::save_upload_y2logs($self, skip_logs_investigation => 1);
+}
+
+1;

--- a/schedule/yam/agama/agama_installation.yaml
+++ b/schedule/yam/agama/agama_installation.yaml
@@ -4,4 +4,5 @@ description: >
   Playwright test on agama
 schedule:
   - installation/bootloader_start
+  - yam/agama/patch_agama
   - yam/agama/agama_installation

--- a/tests/yam/agama/patch_agama.pm
+++ b/tests/yam/agama/patch_agama.pm
@@ -1,0 +1,23 @@
+## Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: This module use yupdate patch the Agama on Live Medium
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base yam::agama::patch_agama_base;
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    assert_screen('agama_product_selection', 120);
+
+    select_console 'root-console';
+
+    my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
+    assert_script_run("yupdate patch $repo $branch", timeout => 60);
+
+    select_console 'installation';
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -215,6 +215,7 @@ YUI_SERVER | string | | libyui REST API server name or ip address.
 YUI_START_PORT | integer | 39000 | Sets starting port for the libyui REST API, on qemu VNC port is then added to this port not to have conflicts.
 YUI_REST_API | boolean | false | Is used to setup environment for libyui REST API, as some parameters have to be set before the VM is started.
 YUI_PARAMS | string | | libyui REST API params required to open YaST modules
+YUPDATE_GIT | string | | Github link used by yast help script yupdate, format is repo#branch such as yast/agama#main.
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Comma separated list of repositories to be added/used for zypper dup call, defaults to SUSEMIRROR or attached media, e.g. ISO.
 ZFCP_ADAPTERS | string | | Comma separated list of available ZFCP adapters in the machine (usually 0.0.fa00 and/or 0.0.fc00)


### PR DESCRIPTION
Integrate yupdate script in openQA in order to get e2e playwright tests from a different repo

- Related ticket: https://progress.opensuse.org/issues/130000
- Needles: na
- Verification run: https://openqa.opensuse.org/tests/3346380

