### PR TITLE
Update ec2imgutils version

### DIFF
--- a/data/publiccloud/venv/ec2uploadimg.txt
+++ b/data/publiccloud/venv/ec2uploadimg.txt
@@ -3,7 +3,7 @@ boto3==1.23.10
 botocore==1.26.10
 cffi==1.15.1
 cryptography==37.0.4
-ec2imgutils==10.0.1
+ec2imgutils==10.0.2
 jmespath==0.10.0
 paramiko==2.11.0
 pycparser==2.21


### PR DESCRIPTION
Update the required version of ec2imgutils to 10.0.2.

- Related ticket: https://progress.opensuse.org/issues/129397
- Verification run: https://duck-norris.qe.suse.de/tests/12972#step/prepare_tools/111
