### PR TITLE
Workaround for boo#1211628

### DIFF
--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -28,6 +28,18 @@ sub run {
         handle_welcome_screen;
     }
 
+    # Workaround for boo#1211628
+    if (check_var('DESKTOP', 'kde') && match_has_tag('boo1211628')) {
+        # plasmashell crashed and openSUSE theme is not fully applied
+        # Workaround that
+        x11_start_program('rm ~/.config/plasma-org.kde.plasma.desktop-appletsrc', valid => 0);
+        x11_start_program('konsole', valid => 0);
+        x11_start_program('plasmashell --replace', valid => 0);
+        x11_start_program('pkill konsole', valid => 0);
+        assert_screen 'generic-desktop';
+        die 'Workaround for boo#1211628 did not work' if (match_has_tag('boo1211628'));
+    }
+
     turn_off_plasma_tooltips;
 }
 


### PR DESCRIPTION
plasmashell crashed and openSUSE theme is not fully applied
Relaunch plasmashell to fix the theme

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1211628
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/bd6156b9c06ecf49be556c8995f2d55d22d3ba72
- Verification run: https://openqa.opensuse.org/tests/3345638