### PR TITLE
Remove search softfail on our registries

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -231,14 +231,13 @@ sub test_search_registry {
 
     foreach my $rlink (@registries) {
         record_info("URL", "Scanning: $rlink");
-        my $res = script_run(sprintf(qq[set -o pipefail; %s search %s/busybox --format="{{.Name}}" |& tee ./out], $engine, $rlink), timeout => 200);
-        if (script_run('grep "requested access to the resource is denied" ./out') == 0) {
-            record_soft_failure("bsc#1178214 Podman search doesn't work with SUSE Registry");
-            record_soft_failure("bsc#1198974 [sle15sp1,sle15sp2] podman search wrong return code") if ($res != 125);
+        my $start = time;
+        assert_script_run(sprintf('%s --log-level=debug search %s/busybox --format="{{.Name}}"', $engine, $rlink), timeout => 200);
+        my $duration = time - $start;
+        record_info('Response', "Registry $rlink responded in $duration seconds");
+        if ($duration > 60) {
+            record_info('Softfail', 'Searching registry.suse.com is too slow (sdsc#SD-106252 https://sd.suse.com/servicedesk/customer/portal/1/SD-106252)');
         }
-        die 'Unexpected error during search!' if ($res && $res != 125);
-        # This should be conditional based on the needed time, but that's currently not possible.
-        record_info('Softfail', 'Searching registry.suse.com is too slow (sdsc#SD-106252 https://sd.suse.com/servicedesk/customer/portal/1/SD-106252)');
     }
 }
 


### PR DESCRIPTION
As described in https://bugzilla.suse.com/show_bug.cgi?id=1178214 search command was not working properly on oS/SUSE registries. This has been fixed meanwhile, therefore we do not need this softfailure anymore.

- Related ticket: https://progress.opensuse.org/issues/77035
#### Verification runs

* [sle-15-SP5-Server-DVD-Updates-x86_64-Build20230605-1-podman_tests@64bit](http://kepler.suse.cz/tests/21017#step/podman/373)
* [sle15sp5-docker](http://kepler.suse.cz/tests/21016#step/docker/378)
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20230606-1-podman_tests@64bit](http://kepler.suse.cz/tests/21015#step/podman/394)
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20230606-1-docker_tests@64bit](http://kepler.suse.cz/tests/21021#step/docker/384)
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20230606-1-podman_tests@64bit](http://kepler.suse.cz/tests/21022#step/podman/376)
* [sle-15-SP4-Server-DVD-Updates-x86_64-Build20230606-1-podman_tests@64bit](http://kepler.suse.cz/tests/21018#step/podman/368)
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20230606-1-docker_tests@64bit](http://kepler.suse.cz/tests/21019#step/docker/393)
* [sle-15-SP4-Server-DVD-Updates-x86_64-Build20230606-1-docker_tests@64bit](http://kepler.suse.cz/tests/21020#step/docker/390)
* [sle-15-SP2-Server-DVD-Updates-x86_64-Build20230606-1-podman_tests@64bit](http://kepler.suse.cz/tests/21023#step/podman/345)
* [sle-15-SP2-Server-DVD-Updates-x86_64-Build20230606-1-docker_tests@64bit](http://kepler.suse.cz/tests/21024#step/docker/393)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20230606-1-podman_tests@64bit](http://kepler.suse.cz/tests/21027#step/podman/347)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20230606-1-docker_tests@64bit](http://kepler.suse.cz/tests/21026#step/docker/384)
* [sle-12-SP4-Server-DVD-Updates-x86_64-Build20230606-1-docker_tests@64bit](http://kepler.suse.cz/tests/21025#step/docker/381)
* [sle-12-SP5-Server-DVD-Updates-x86_64-Build20230606-1-docker_tests@64bit](http://kepler.suse.cz/tests/21028#step/docker/378)
* [sle-12-SP3-Server-DVD-Updates-x86_64-Build20230606-1-docker_tests@64bit](http://kepler.suse.cz/tests/21029#step/docker/381)