### PR TITLE
Add softfailure for bsc#1211917

### DIFF
--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -55,8 +55,14 @@ sub run {
 
     # install and enable SELinux if not done by default
     if (!is_enforcing) {
-        die("SELinux should be enabled by default on " . get_required_var("DISTRI") . " " . get_required_var("VERSION"))
-          if (is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos);
+        if (is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos) {
+            if (is_sle_micro('=5.4')) {
+                record_soft_failure("bsc#1211917 - SELinux not in enforcing mode on SLEM 5.4");
+            } else {
+                die("SELinux should be enabled by default on " . get_required_var("DISTRI") . " " . get_required_var("VERSION"));
+            }
+        }
+
         trup_call('setup-selinux');
         upload_logs($trup_log, log_name => $trup_log . ".txt");
         save_and_upload_log('rpm -qa', 'installed_pkgs.txt');


### PR DESCRIPTION
Adds a softfailure for bsc#1211917 until it is resolved.

- Related ticket: https://progress.opensuse.org/issues/110791
- Verification run: [SLEM 5.4](https://duck-norris.qe.suse.de/tests/12969#step/enable_selinux/6) | [SLEM 5.3](https://duck-norris.qe.suse.de/tests/12973#) | [SLEM 5.2](https://duck-norris.qe.suse.de/tests/12974#) | [SLEM 5.1](https://duck-norris.qe.suse.de/tests/12975#) - fails due to [poo#130507](https://progress.opensuse.org/issues/130507)
