### PR TITLE
Fix dpdk module for openSUSE

### DIFF
--- a/tests/console/dpdk.pm
+++ b/tests/console/dpdk.pm
@@ -23,10 +23,16 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils qw(is_sle is_leap is_tumbleweed is_leap is_opensuse);
 
 
 sub install_ovs_dpdk {
-    zypper_call('in openvswitch3 dpdk22 dpdk22-tools', timeout => 300);
+    if (is_sle('>=15-sp5')) {
+        zypper_call('in openvswitch3 dpdk22 dpdk22-tools', timeout => 300);
+    }
+    else {
+        zypper_call('in openvswitch dpdk dpdk-tools', timeout => 300);
+    }
     # export PATH for later usage
     assert_script_run 'export PATH=$PATH:/usr/share/openvswitch/scripts';
 }
@@ -46,7 +52,8 @@ sub load_bind_kernel_module {
 ip a | grep -i 'br0 state UP' | awk '{print \$2}' | sed -e 's/://'
 EOF
     assert_script_run 'modprobe "vfio-pci"';    # load required vfio-pci at first
-    assert_script_run 'dpdk_nic_bind -u eth0';    # unbind the device 'eth0' at first
+    assert_script_run 'dpdk_nic_bind -u eth0' if (is_sle || is_leap);    # unbind the device 'eth0' at first
+    assert_script_run 'dpdk_nic_bind -u ens4' if (is_tumbleweed);    # ens4 is the active network device name on Tumbleweed
     record_soft_failure 'bsc#1205702, cannot bind to network device: dpdk_nic_bind --bind=vfio-pci eth0' unless assert_script_run 'dpdk_nic_bind --bind="vfio-pci" 0000:00:04.0'; # bind vfio-pci
 }
 
@@ -64,8 +71,9 @@ sub test_ovs_dpdk {
     # check dpdk_nic_bind --status-dev net
     assert_script_run 'dpdk_nic_bind --status-dev net';
 
-    # check dpdk-hugenpages
-    assert_script_run 'dpdk-hugepages.py -s';
+    # check dpdk-hugepages
+    # we have issue with missing python script dpdk-hugepages.py, see boo#1212113
+    assert_script_run 'which dpdk-hugepages.py -s' if (is_sle || is_tumbleweed);
     assert_script_run 'grep -i  "dpdk enabled" /var/log/openvswitch/ovs-vswitchd.log';
 }
 


### PR DESCRIPTION
we have different package name for dpdk and openvswitch for openSUSE so dpdk test failed.

see https://progress.opensuse.org/issues/130498
VRs:
http://10.161.8.50/tests/163#step/dpdk (Leap)
http://10.161.8.50/tests/161#step/dpdk (Tumbleweed)

