### PR TITLE
Update test suites that haven't applied default schedule for x86_64 and s390x

### DIFF
--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
@@ -5,31 +5,18 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/add_add_on_http_repo_url
-  - installation/add_on_product_installation/add_add_on_ftp_repo_url
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/select_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/consoletest_setup
-  - console/zypper_ref
-  - console/validate_addon_extension_repo_http
-  - console/validate_addon_extension_repo_ftp
+  add_on_product:
+    - installation/add_on_product/add_add_on_http_repo_url
+    - installation/add_on_product_installation/add_add_on_ftp_repo_url
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/select_role_text_mode
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/consoletest_setup
+    - console/zypper_ref
+  system_validation:
+    - console/validate_addon_extension_repo_http
+    - console/validate_addon_extension_repo_ftp

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
@@ -5,34 +5,18 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/add_add_on_http_repo_url
-  - installation/add_on_product_installation/add_add_on_ftp_repo_url
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/select_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/consoletest_setup
-  - console/zypper_ref
-  - console/validate_addon_extension_repo_http
-  - console/validate_addon_extension_repo_ftp
+  add_on_product:
+    - installation/add_on_product/add_add_on_http_repo_url
+    - installation/add_on_product_installation/add_add_on_ftp_repo_url
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/select_role_text_mode
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/consoletest_setup
+    - console/zypper_ref
+  system_validation:
+    - console/validate_addon_extension_repo_http
+    - console/validate_addon_extension_repo_ftp

--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -5,25 +5,13 @@ description:    >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/enable_autologin
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  local_user:
+    - installation/authentication/use_same_password_for_root
+    - installation/authentication/enable_autologin
+    - installation/authentication/default_user_simple_pwd
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
@@ -11,35 +11,16 @@ vars:
   FILESYSTEM: btrfs
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/warning/no_root
-  - installation/partitioning/warning/snapshots_small_root
-  - installation/partitioning/warning/no_boot
-  - installation/partitioning/warning/boot_small_for_kernel
-  - installation/partitioning/warning/bios_boot_small_for_bootloader
-  - installation/partitioning/warning/prep_small
-  - installation/partitioning/warning/zipl_small
-  - installation/partitioning/warning/rootfs_small
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
+  suggested_partitioning:
+    - installation/partitioning/warning/no_root
+    - installation/partitioning/warning/snapshots_small_root
+    - installation/partitioning/warning/no_boot
+    - installation/partitioning/warning/boot_small_for_kernel
+    - installation/partitioning/warning/bios_boot_small_for_bootloader
+    - installation/partitioning/warning/prep_small
+    - installation/partitioning/warning/zipl_small
+    - installation/partitioning/warning/rootfs_small
+    - installation/partitioning/accept_proposed_layout
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation: []

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -10,31 +10,21 @@ vars:
   LVM: 1
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/system_probing/activate_encrypted_volume
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup/accept_default_hard_disks_selection
-  - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
-  - installation/partitioning/guided_setup/accept_default_fs_options
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/boot_encrypt
-  - installation/first_boot
-  - console/validate_encrypt
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_probing:
+    - installation/system_probing/activate_encrypted_volume
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/accept_default_hard_disks_selection
+    - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_validation:
+    - console/validate_encrypt

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -7,42 +7,17 @@ name: activate_encrypted_volume+import_users
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/system_probing/activate_encrypted_volume
-  - console/validate_encrypted_volume_activation
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/import_users
-  - installation/authentication/root_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-test_data:
-  mapped_device: '/dev/mapper/cr-auto-1'
-  device_status:
-    message: 'is active and is in use.'
-    properties:
-      type: 'LUKS1'
-      cipher: 'aes-xts-plain64'
-      key_location: 'dm-crypt'
-      mode: 'read/write'
-  partitioning_deletion_entries:
-    - 'Delete btrfs on /dev/system/root'
-    - 'Delete swap on /dev/system/swap'
-    - 'Delete xfs on /dev/system/home'
-    - 'Delete volume group system'
-    - 'Delete partition'
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_probing:
+    - installation/system_probing/activate_encrypted_volume
+    - console/validate_encrypted_volume_activation
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/suggested_partitioning/verify_decrypted_partition_deleted
+  local_user:
+    - installation/authentication/import_users
+    - installation/authentication/root_simple_pwd
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
@@ -9,34 +9,22 @@ vars:
   FULL_LVM_ENCRYPT: 1
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/new_partitioning_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/boot_encrypt
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_lvm
-  - console/validate_encrypt
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  grub:
+    - installation/boot_encrypt
+    - installation/handle_reboot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -8,34 +8,20 @@ description: >
 vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1
-  MAX_JOB_TIME: '14400'
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/new_partitioning_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/handle_reboot
-  - installation/boot_encrypt
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_lvm
-  - console/validate_encrypt
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
@@ -8,37 +8,20 @@ description: >
 vars:
   ENCRYPT: 1
   FULL_LVM_ENCRYPT: 1
-  MAX_JOB_TIME: '14400'
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/new_partitioning_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/boot_encrypt
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_lvm
-  - console/validate_encrypt
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  grub:
+    - installation/boot_encrypt
+    - installation/handle_reboot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_lvm
+    - console/validate_encrypt

--- a/schedule/yast/installer_extended/installer_extended@s390x.yaml
+++ b/schedule/yast/installer_extended/installer_extended@s390x.yaml
@@ -13,81 +13,30 @@ vars:
   EXIT_AFTER_START_INSTALL: '1'
   EXTRABOOTPARAMS: Y2STRICTTEXTDOMAIN=1
   YUI_REST_API: 1
-conditional_schedule:
-  access_beta_distribution:
-    BETA:
-      1:
-        - installation/validate_beta_message
-        - installation/access_beta_distribution
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - '{{access_beta_distribution}}'
-  - installation/licensing/verify_license_translations
-  - installation/licensing/verify_license_has_to_be_accepted
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/view_development_versions
-  - installation/module_registration/verify_module_registration
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/releasenotes
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/default_user_simple_pwd
-  - installation/authentication/root_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-test_data:
-  license:
-    language: English (US)
-    translations:
-      - language: Czech
-        text: Licenční smlouva s koncovým uživatelem
-      - language: English (US)
-        text: End User License Agreement for SUSE Products
-      - language: French
-        text: Contrat de licence utilisateur final
-      - language: German
-        text: Endbenutzer-Lizenzvereinbarung
-      - language: Italian
-        text: Contratto di licenza
-      - language: Japanese
-        text: エンドユーザ使用許諾契約
-      - language: Korean
-        text: SUSE 제품에 관한
-      - language: Portuguese (Brazilian)
-        text: Contrato de Licença para Usuário Final
-      - language: Russian
-        text: Лицензионное соглашение
-      - language: Simplified Chinese
-        text: SUSE 产品
-      - language: Spanish
-        text: Acuerdo de licencia de usuario final
-      - language: Traditional Chinese
-        text: 最終使用者授權合約
-  beta_text: 'You are accessing our Beta Distribution'
-  modules:
-    - sle-ha
-    - sle-module-live-patching
-    - sle-we
-    - sle-module-basesystem
-    - sle-module-certifications
-    - sle-module-containers
-    - sle-module-desktop-applications
-    - sle-module-development-tools
-    - sle-module-legacy
-    - sle-module-public-cloud
-    - sle-module-python3
-    - PackageHub
-    - sle-module-server-applications
-    - sle-module-transactional-server
-    - sle-module-web-scripting
-  registered_modules:
-    - sle-module-basesystem
-    - sle-module-server-applications
+  license_agreement:
+    - installation/licensing/verify_license_translations
+    - installation/licensing/verify_license_has_to_be_accepted
+    - installation/licensing/accept_license
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/verify_module_registration
+    - installation/module_registration/skip_module_registration
+  clock_and_timezone:
+    - installation/releasenotes
+    - installation/clock_and_timezone/accept_timezone_configuration
+  local_user:
+    - installation/authentication/default_user_simple_pwd
+    - installation/authentication/root_simple_pwd
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  installation:
+    - installation/launch_installation
+    - installation/confirm_installation
+  stop_timeout_system_reboot: []
+  installation_logs: []
+  confirm_reboot: []
+  reconnect_svirt: []
+  grub: []
+  first_login: []
+  system_preparation: []

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -5,39 +5,21 @@ description: >
   wizard screen.
 name: cryptlvm
 vars:
-  DESKTOP: textmode
   LVM: '1'
-  MAX_JOB_TIME: '14400'
   OPT_KERNEL_PARAMS: console=%SERIALDEV% VNCSize=1024x768
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup/enable_lvm
-  - installation/partitioning/guided_setup/accept_default_fs_options
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/validate_lvm
-  - console/zypper_lr
-  - console/zypper_ref
-  - console/zypper_in
-  - console/firewall_enabled
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/enable_lvm
+    - installation/partitioning/guided_setup/accept_default_fs_options
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/validate_lvm
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/zypper_in
+    - console/firewall_enabled

--- a/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
@@ -8,32 +8,18 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/new_partitioning_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/hostname
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/lvm_thin_check
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/hostname
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/lvm_thin_check

--- a/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
+++ b/schedule/yast/minimal+base/minimal+base@yast-s390x.yaml
@@ -6,47 +6,22 @@ description:    >
   Grub is not displayed due to console reconnection.
 vars:
   DEPENDENCY_RESOLVER_FLAG: 1
-  DESKTOP: textmode
   PATTERNS: base,enhanced_base
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/select_patterns
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/security/select_security_module_none
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/installation_snapshots
-  - console/zypper_lr
-  - console/zypper_ref
-  - console/ncurses
-  - update/zypper_up
-  - console/zypper_lifecycle
-  - console/orphaned_packages_check
-  - console/validate_installed_patterns
-  - console/consoletest_finish
-test_data:
   software:
-    patterns:
-      - base
-      - enhanced_base
+    - installation/select_patterns
+  security:
+    - installation/security/select_security_module_none
+  system_preparation:
+    - console/system_prepare
+  system_validation:
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/ncurses
+    - update/zypper_up
+    - console/zypper_lifecycle
+    - console/orphaned_packages_check
+    - console/validate_installed_patterns
+    - console/consoletest_finish

--- a/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
+++ b/schedule/yast/minimal+role_minimal/minimal+role_minimal@s390x.yaml
@@ -6,44 +6,24 @@ description: >
   any issue.
 vars:
   BSC1167736: '1'
-  SYSTEM_ROLE: minimal
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/select_role_minimal
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/consoletest_setup
-  - console/zypper_lr
-  - console/zypper_ref
-  - console/zypper_in
-  - console/firewall_enabled
-  - console/ncurses
-  - console/sshd_running
-  - console/sshd
-  - console/verify_default_target
-  - console/validate_partition_table_via_blkid
-  - console/validate_blockdevices
-  - console/validate_installed_packages
-  - console/validate_installed_patterns
-  - console/orphaned_packages_check
+  system_role:
+    - installation/system_role/select_role_minimal
+  system_preparation:
+    - console/system_prepare
+    - console/consoletest_setup
+  system_validation:
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/zypper_in
+    - console/firewall_enabled
+    - console/ncurses
+    - console/sshd_running
+    - console/sshd
+    - console/verify_default_target
+    - console/validate_partition_table_via_blkid
+    - console/validate_blockdevices
+    - console/validate_installed_packages
+    - console/validate_installed_patterns
+    - console/orphaned_packages_check

--- a/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
@@ -6,30 +6,10 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/modify_existing_partition
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/validate_modify_existing_partition
-test_data:
-  <<: !include test_data/yast/modify_existing_partition/modify_existing_partition.yaml
+  suggested_partitioning:
+    - installation/partitioning/modify_existing_partition
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation: []
+  system_validation:
+    - console/validate_modify_existing_partition

--- a/schedule/yast/msdos/msdos@s390x.yaml
+++ b/schedule/yast/msdos/msdos@s390x.yaml
@@ -5,31 +5,13 @@ description:    >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/msdos_partition_table
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/validate_partition_table_via_parted
-  - console/validate_blockdevices
-  - console/validate_free_space
-  - console/validate_read_write
+  suggested_partitioning:
+    - installation/partitioning/msdos_partition_table
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation: []
+  system_validation:
+    - console/validate_partition_table_via_parted
+    - console/validate_blockdevices
+    - console/validate_free_space
+    - console/validate_read_write

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -4,34 +4,19 @@ description:    >
   Tests successful detection of multipath and installation and
   validate multipath configuration and tools after booting.
 vars:
-  DESKTOP: gnome
   MULTIPATH: 1
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/multipath
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - console/validate_multipath
-test_data:
-  <<: !include test_data/yast/multipath.yaml
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  multipath:
+    - installation/multipath
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/system_prepare
+    - console/force_scheduled_tasks
+  system_validation:
+    - console/validate_multipath

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -7,33 +7,18 @@ vars:
   RAIDLEVEL: 0
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/raid_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - console/upload_y2logs_as_asset
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_md_raid
-  - console/validate_raid
-test_data:
-  <<: !include test_data/yast/raid/raid0_gpt_bios_boot.yaml
+  suggested_partitioning:
+    - installation/partitioning/raid_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  installation_logs:
+    - installation/logs_from_installation_system
+    - console/upload_y2logs_as_asset
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_md_raid
+    - console/validate_raid

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -7,33 +7,18 @@ vars:
   RAIDLEVEL: 10
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/raid_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_md_raid
-  - console/validate_raid
+  suggested_partitioning:
+    - installation/partitioning/raid_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_md_raid
+    - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -7,33 +7,18 @@ vars:
   RAIDLEVEL: 1
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/raid_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_md_raid
-  - console/validate_raid
+  suggested_partitioning:
+    - installation/partitioning/raid_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_md_raid
+    - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -7,33 +7,18 @@ vars:
   RAIDLEVEL: 5
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/raid_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_md_raid
-  - console/validate_raid
+  suggested_partitioning:
+    - installation/partitioning/raid_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_md_raid
+    - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -7,33 +7,18 @@ vars:
   RAIDLEVEL: 6
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/raid_gpt
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_md_raid
-  - console/validate_raid
+  suggested_partitioning:
+    - installation/partitioning/raid_gpt
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+  system_validation:
+    - console/validate_md_raid
+    - console/validate_raid
 test_data:
   <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
   mds:

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns@s390x.yaml
@@ -6,37 +6,22 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_nonconflicting_modules
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/select_guided_setup
-  - installation/partitioning/guided_setup/accept_default_part_scheme
-  - installation/partitioning/guided_setup/do_not_propose_separate_home
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/select_visible_patterns_from_bottom
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/consoletest_setup
-  - console/validate_installed_packages
-  - console/validate_installed_patterns
-  - console/yast2_i
-  - console/verify_no_separate_home
-  - console/validate_subvolumes
+  extension_module_selection:
+    - installation/module_registration/register_nonconflicting_modules
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  guided_partitioning:
+    - installation/partitioning/select_guided_setup
+    - installation/partitioning/guided_setup/accept_default_part_scheme
+    - installation/partitioning/guided_setup/do_not_propose_separate_home
+  software:
+    - installation/select_visible_patterns_from_bottom
+  system_preparation:
+    - console/system_prepare
+    - console/consoletest_setup
+  system_validation:
+    - console/validate_installed_packages
+    - console/validate_installed_patterns
+    - console/yast2_i
+    - console/verify_no_separate_home
+    - console/validate_subvolumes

--- a/schedule/yast/sle/flows/default_s390x_zfcp.yaml
+++ b/schedule/yast/sle/flows/default_s390x_zfcp.yaml
@@ -1,0 +1,57 @@
+---
+# Default ordered sequence of steps to be optionally overwritten for this product
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+access_beta: []
+license_agreement:
+  - installation/licensing/accept_license
+configure_zfcp_disks:
+  - installation/disk_activation/select_configure_zfcp_disks
+  - installation/disk_activation/select_add_zfcp_device
+  - installation/disk_activation/configure_zfcp_device
+  - installation/disk_activation/accept_configured_zfcp_devices
+  - installation/disk_activation/finish_disk_activation
+multipath: []
+registration:
+  - installation/registration/register_via_scc
+extension_module_selection:
+  - installation/module_registration/skip_module_registration
+add_on_product:
+  - installation/add_on_product/skip_install_addons
+add_on_product_installation: []
+system_role:
+  - installation/system_role/accept_selected_role_text_mode
+guided_partitioning: []
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+security:
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+default_systemd_target: []
+installation_settings:
+  - installation/launch_installation
+installation:
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+stop_timeout_system_reboot:
+  - installation/performing_installation/stop_timeout_system_reboot_now
+installation_logs:
+  - installation/logs_from_installation_system
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+grub:
+  - installation/handle_reboot
+first_login:
+  - installation/first_boot
+system_preparation: []
+system_validation: []

--- a/schedule/yast/textmode/ha_textmode.yaml
+++ b/schedule/yast/textmode/ha_textmode.yaml
@@ -4,24 +4,8 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/view_development_versions
-  - installation/module_registration/register_extensions_and_modules
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/select_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/handle_reboot
-  - installation/first_boot
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/register_extensions_and_modules
+  system_role:
+    - installation/system_role/select_role_text_mode

--- a/schedule/yast/textmode/ha_textmode_minimal_base.yaml
+++ b/schedule/yast/textmode/ha_textmode_minimal_base.yaml
@@ -4,25 +4,10 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/view_development_versions
-  - installation/module_registration/register_extensions_and_modules
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/select_role_minimal
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/handle_reboot
-  - installation/first_boot
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/register_extensions_and_modules
+  system_role:
+    - installation/system_role/select_role_minimal
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/ha_textmode_minimal_base_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_minimal_base_s390x.yaml
@@ -4,24 +4,11 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/view_development_versions
-  - installation/module_registration/register_extensions_and_modules
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/select_role_minimal
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/register_extensions_and_modules
+  system_role:
+    - installation/system_role/select_role_minimal
+  installation_settings: []
+  stop_timeout_system_reboot: []
+  system_preparation: []

--- a/schedule/yast/textmode/ha_textmode_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_s390x.yaml
@@ -4,24 +4,11 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/view_development_versions
-  - installation/module_registration/register_extensions_and_modules
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/select_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
+  extension_module_selection:
+    - installation/module_registration/view_development_versions
+    - installation/module_registration/register_extensions_and_modules
+  system_role:
+    - installation/system_role/select_role_text_mode
+  installation_settings: []
+  stop_timeout_system_reboot: []
+  system_preparation: []

--- a/schedule/yast/textmode/ha_textmode_skip_registration.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration.yaml
@@ -4,24 +4,13 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/skip_registration
-  - installation/module_selection/select_extension_ha
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/select_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_extension_ha
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/select_role_text_mode
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base.yaml
@@ -4,24 +4,13 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/product_selection/install_SLES
-  - installation/licensing/accept_license
-  - installation/registration/skip_registration
-  - installation/module_selection/select_extension_ha
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/select_role_minimal
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/grub_test
-  - installation/first_boot
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_extension_ha
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/select_role_minimal
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base_s390x.yaml
@@ -4,24 +4,16 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/skip_registration
-  - installation/module_selection/select_extension_ha
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/select_role_minimal
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_extension_ha
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/select_role_minimal
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  installation_settings: []
+  stop_timeout_system_reboot: []
+  system_preparation: []

--- a/schedule/yast/textmode/ha_textmode_skip_registration_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_s390x.yaml
@@ -4,24 +4,16 @@ description: >
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/skip_registration
-  - installation/module_selection/select_extension_ha
-  - installation/add_on_product_installation/accept_add_on_installation
-  - installation/system_role/select_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
+  registration:
+    - installation/registration/skip_registration
+  extension_module_selection:
+    - installation/module_selection/select_extension_ha
+  add_on_product:
+    - installation/add_on_product_installation/accept_add_on_installation
+  system_role:
+    - installation/system_role/select_role_text_mode
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  installation_settings: []
+  stop_timeout_system_reboot: []
+  system_preparation: []

--- a/schedule/yast/textmode/textmode@s390x_svirt.yaml
+++ b/schedule/yast/textmode/textmode@s390x_svirt.yaml
@@ -5,40 +5,22 @@ description: |
 vars:
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/registration/register_via_scc
-  - installation/module_registration/skip_module_registration
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_text_mode
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/performing_installation/reconnect_after_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/system_prepare
-  - console/prepare_test_data
-  - console/consoletest_setup
-  - console/validate_product_installed_SLES
-  - console/verify_network
-  - locale/keymap_or_locale
-  - console/validate_installed_patterns
-  - console/force_scheduled_tasks
-  - console/textinfo
-  - console/orphaned_packages_check
-  - console/consoletest_finish
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  stop_timeout_system_reboot: []
+  system_preparation:
+    - console/system_prepare
+    - console/prepare_test_data
+    - console/consoletest_setup
+  system_validation:
+    - console/validate_product_installed_SLES
+    - console/verify_network
+    - locale/keymap_or_locale
+    - console/validate_installed_patterns
+    - console/force_scheduled_tasks
+    - console/textinfo
+    - console/orphaned_packages_check
+    - console/consoletest_finish
 test_data:
   software:
     patterns:

--- a/schedule/yast/transactional_server/create_hdd_transactional_server@s390x.yaml
+++ b/schedule/yast/transactional_server/create_hdd_transactional_server@s390x.yaml
@@ -1,37 +1,19 @@
 ---
 name: create_hdd_transactional_server
 description: >
-    Installation of a Transactional Server which uses a read-only
-    root filesystem to provide atomic, automatic updates of a
-    system without interfering with the running system.
+  Installation of a Transactional Server which uses a read-only
+  root filesystem to provide atomic, automatic updates of a
+  system without interfering with the running system.
 vars:
-    SCC_ADDONS: tsm
-    HDDSIZEGB: 40
-    YUI_REST_API: 1
+  SCC_ADDONS: tsm
+  HDDSIZEGB: 40
+  YUI_REST_API: 1
 schedule:
-    - installation/bootloader_start
-    - installation/setup_libyui
-    - installation/licensing/accept_license
-    - installation/registration/register_via_scc
+  extension_module_selection:
     - installation/module_registration/register_module_transactional
-    - installation/add_on_product/skip_install_addons
+  system_role:
     - installation/system_role/accept_selected_role_transactional_server
-    - installation/partitioning/accept_proposed_layout
-    - installation/clock_and_timezone/accept_timezone_configuration
-    - installation/authentication/use_same_password_for_root
-    - installation/authentication/default_user_simple_pwd
-    - installation/installation_settings/validate_ssh_service_enabled
-    - installation/installation_settings/open_ssh_port
-    - installation/bootloader_settings/disable_boot_menu_timeout
-    - installation/launch_installation
-    - installation/confirm_installation
-    - installation/performing_installation/perform_installation
-    - installation/performing_installation/stop_timeout_system_reboot_now
-    - installation/logs_from_installation_system
-    - installation/performing_installation/confirm_reboot
-    - installation/performing_installation/reconnect_after_reboot
-    - installation/handle_reboot
-    - installation/first_boot
+  system_preparation:
     - console/hostname
     - console/system_prepare
     - console/force_scheduled_tasks

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -4,94 +4,18 @@ description: >
   Only tests succesful detection of multipath and installation.
   No functional testing of multipath itself.
 vars:
-  DESKTOP: gnome
   YUI_REST_API: 1
 schedule:
-  - installation/bootloader_start
-  - installation/setup_libyui
-  - installation/licensing/accept_license
-  - installation/disk_activation/select_configure_zfcp_disks
-  - installation/disk_activation/select_add_zfcp_device
-  - installation/disk_activation/configure_zfcp_device
-  - installation/disk_activation/accept_configured_zfcp_devices
-  - installation/disk_activation/finish_disk_activation
-  - installation/activate_multipath
-  - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
-  - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
-  - installation/partitioning/accept_proposed_layout
-  - installation/clock_and_timezone/accept_timezone_configuration
-  - installation/authentication/use_same_password_for_root
-  - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
-  - installation/installation_settings/validate_default_target
-  - installation/bootloader_settings/disable_boot_menu_timeout
-  - installation/launch_installation
-  - installation/confirm_installation
-  - installation/performing_installation/perform_installation
-  - installation/performing_installation/stop_timeout_system_reboot_now
-  - installation/logs_from_installation_system
-  - installation/performing_installation/confirm_reboot
-  - installation/handle_reboot
-  - installation/first_boot
-  - console/validate_zfcp
-  - console/validate_zfcp_multipath
-  # Unscheduling due to poo#99267
-  # - console/validate_multipath
-test_data:
-  software:
-    packages:
-      # Device Mapper Tools
-      device-mapper:
-        installed: 1
-      # Tools to Manage Multipathed Devices with the device-mapper
-      multipath-tools:
-        installed: 1
-      # Manages partition tables on device-mapper devices
-      kpartx:
-        installed: 1
-  zfcp:
-    fcp_devices:
-      - fcp_channel: '0.0.fa00'
-        attributes:
-          online: 1
-          port_type: 'NPIV VPORT'
-        fcp_luns:
-          - wwpn: '0x500507630708d3b3'
-            scsi:
-              peripheral_type: disk
-              vendor_model_revision: 'IBM'
-          - wwpn: '0x500507630703d3b3'
-            scsi:
-              peripheral_type: disk
-              vendor_model_revision: 'IBM'
-      - fcp_channel: '0.0.fc00'
-        attributes:
-          online: 0
   multipath:
-    attributes:
-      user_friendly_names: 'no'
-      failback: manual
-      path_checker: tur
-      path_grouping_policy: failover
-      path_selector: 'service-time 0'
-      polling_interval: 5
-      rr_min_io_rq: 1
-      rr_weight: uniform
-      uid_attribute: ID_SERIAL
-    topology:
-      vendor_product_revision: IBM
-      features: '1 queue_if_no_path'
-      hwhandler: '1 alua'
-      wp: rw
-      priority_groups:
-        - prio: 50
-          status: active
-          paths:
-            - name: sda
-              status: 'active ready running'
-            - name: sdb
-              status: 'active ready running'
-  multipath_activation_message: 'The system seems to have multipath hardware'
+    - installation/activate_multipath
+  extension_module_selection:
+    - installation/module_registration/register_module_desktop
+  system_role:
+    - installation/system_role/accept_selected_role_SLES_with_GNOME
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_zfcp
+    - console/validate_zfcp_multipath
+    # Unscheduling due to poo#99267
+    # - console/validate_multipath

--- a/test_data/yast/encryption/activate_encrypted_volume+import_use_x86_64.yaml
+++ b/test_data/yast/encryption/activate_encrypted_volume+import_use_x86_64.yaml
@@ -1,0 +1,15 @@
+---
+mapped_device: '/dev/mapper/cr-auto-1'
+device_status:
+  message: 'is active and is in use.'
+  properties:
+    type: 'LUKS1'
+    cipher: 'aes-xts-plain64'
+    key_location: 'dm-crypt'
+    mode: 'read/write'
+partitioning_deletion_entries:
+  - 'Delete btrfs on /dev/system/root'
+  - 'Delete swap on /dev/system/swap'
+  - 'Delete xfs on /dev/system/home'
+  - 'Delete volume group system'
+  - 'Delete partition'

--- a/test_data/yast/installer_extended/installer_extended_s390x.yaml
+++ b/test_data/yast/installer_extended/installer_extended_s390x.yaml
@@ -1,0 +1,46 @@
+license:
+  language: English (US)
+  translations:
+    - language: Czech
+      text: Licenční smlouva s koncovým uživatelem
+    - language: English (US)
+      text: End User License Agreement for SUSE Products
+    - language: French
+      text: Contrat de licence utilisateur final
+    - language: German
+      text: Endbenutzer-Lizenzvereinbarung
+    - language: Italian
+      text: Contratto di licenza
+    - language: Japanese
+      text: エンドユーザ使用許諾契約
+    - language: Korean
+      text: SUSE 제품에 관한
+    - language: Portuguese (Brazilian)
+      text: Contrato de Licença para Usuário Final
+    - language: Russian
+      text: Лицензионное соглашение
+    - language: Simplified Chinese
+      text: SUSE 产品
+    - language: Spanish
+      text: Acuerdo de licencia de usuario final
+    - language: Traditional Chinese
+      text: 最終使用者授權合約
+beta_text: 'You are accessing our Beta Distribution'
+modules:
+  - sle-ha
+  - sle-module-live-patching
+  - sle-module-basesystem
+  - sle-module-certifications
+  - sle-module-containers
+  - sle-module-desktop-applications
+  - sle-module-development-tools
+  - sle-module-legacy
+  - sle-module-public-cloud
+  - sle-module-python3
+  - PackageHub
+  - sle-module-server-applications
+  - sle-module-transactional-server
+  - sle-module-web-scripting
+registered_modules:
+  - sle-module-basesystem
+  - sle-module-server-applications

--- a/test_data/yast/minimal+base_yast@s390x.yaml
+++ b/test_data/yast/minimal+base_yast@s390x.yaml
@@ -1,0 +1,5 @@
+---
+software:
+  patterns:
+    - base
+    - enhanced_base

--- a/test_data/yast/zfcp@s390x.yaml
+++ b/test_data/yast/zfcp@s390x.yaml
@@ -1,0 +1,56 @@
+---
+test_data:
+  software:
+    packages:
+      # Device Mapper Tools
+      device-mapper:
+        installed: 1
+      # Tools to Manage Multipathed Devices with the device-mapper
+      multipath-tools:
+        installed: 1
+      # Manages partition tables on device-mapper devices
+      kpartx:
+        installed: 1
+  zfcp:
+    fcp_devices:
+      - fcp_channel: '0.0.fa00'
+        attributes:
+          online: 1
+          port_type: 'NPIV VPORT'
+        fcp_luns:
+          - wwpn: '0x500507630708d3b3'
+            scsi:
+              peripheral_type: disk
+              vendor_model_revision: 'IBM'
+          - wwpn: '0x500507630703d3b3'
+            scsi:
+              peripheral_type: disk
+              vendor_model_revision: 'IBM'
+      - fcp_channel: '0.0.fc00'
+        attributes:
+          online: 0
+  multipath:
+    attributes:
+      user_friendly_names: 'no'
+      failback: manual
+      path_checker: tur
+      path_grouping_policy: failover
+      path_selector: 'service-time 0'
+      polling_interval: 5
+      rr_min_io_rq: 1
+      rr_weight: uniform
+      uid_attribute: ID_SERIAL
+    topology:
+      vendor_product_revision: IBM
+      features: '1 queue_if_no_path'
+      hwhandler: '1 alua'
+      wp: rw
+      priority_groups:
+        - prio: 50
+          status: active
+          paths:
+            - name: sda
+              status: 'active ready running'
+            - name: sdb
+              status: 'active ready running'
+  multipath_activation_message: 'The system seems to have multipath hardware'


### PR DESCRIPTION
On x86_64 and s390x, there are some test cases haven't applied default schedule, update these cases.

- Related ticket: https://progress.opensuse.org/issues/129364
- Needles: n/a
- Verification run: 
- https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=102.1&groupid=251
- https://openqa.suse.de/tests/11367115
- https://openqa.suse.de/tests/11367118
- Related mr: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/507