### PR TITLE
Put softfail check inside error code check

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -156,9 +156,9 @@ sub run ($self) {
         } elsif ($return == 1 || $return == 139 || $return == 255) {
             if (script_run('grep \'Caught error: Segmentation fault (signal 11)\' /tmp/mpi_bin.log') == 0) {
                 record_soft_failure('bsc#1144000 MVAPICH2: segfault while executing without ib_uverbs loaded');
+            } elsif (script_run('grep \'failure occurred while posting a receive for message data\' /tmp/mpi_bin.log') == 0) {
+                record_soft_failure('bsc#1209130 MPI Benchmarks unable to run on 15SP1 with imb-gnu-mvapich2-hpc');
             }
-        } elsif (script_run('grep \'failure occurred while posting a receive for message data\' /tmp/mpi_bin.log') == 0) {
-            record_soft_failure('bsc#1209130 MPI Benchmarks unable to run on 15SP1 with imb-gnu-mvapich2-hpc');
         } else {
             ##TODO: consider more robust handling of various errors
             die("echo $return - not expected errorcode") unless $return == 0;


### PR DESCRIPTION
Before the if was executed correctly but the bsc#1209130 check was never
reached as it was in the else condition of this block and it was skipped.
    
Signed-off-by: Ioannis Bonatakis <ybonatakis@suse.com>