### PR TITLE
Increase timeout for pattern installation

### DIFF
--- a/tests/microos/patterns.pm
+++ b/tests/microos/patterns.pm
@@ -23,7 +23,7 @@ sub run {
     my @patterns = map { m/\|\s+(.*?)\s+\|.*pattern$/ } @available_patterns;
 
     # install new patterns
-    trup_call('pkg install -t pattern ' . join(" ", @patterns), timeout => 300);
+    trup_call('pkg install -t pattern ' . join(" ", @patterns), timeout => 600);
     process_reboot(trigger => 1);
 
     # expect empty list therefore ZYPPER_EXIT_INF_CAP_NOT_FOUND


### PR DESCRIPTION
Increase the timeout to 10 minutes for package installation due to timeout failures in aarch64 test runs.

- Related ticket: https://progress.opensuse.org/issues/130546
- Verification run: https://duck-norris.qe.suse.de/tests/12994#step/patterns/67
