### PR TITLE
Import phub keys while registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -180,6 +180,10 @@ sub add_suseconnect_product {
     $version //= '${VERSION_ID}';
     $arch //= '${CPU}';
     $params //= '';
+    if ($name =~ /PackageHub/) {
+        $params .= ' --gpg-auto-import-keys';
+        record_soft_failure 'bsc#1212134 - Package hub signing key verification failure';
+    }
     $retry //= 3;    # Times we retry the SUSEConnect command (besides first execution)
     $timeout //= 300;
 


### PR DESCRIPTION
- ticket: [docker_tests fails in docker_compose](https://progress.opensuse.org/issues/130537)

```
2023-06-08 01:25:25 <5> susetest(19903) [zypp-core]
Exception.cc(log):186 FileChecker.cc(operator()):135 THROW:    Signature
verification failed for repomd.xml
2023-06-08 01:25:25 <5> susetest(19903) [zypp-core]
Exception.cc(log):186 Fetcher.cc(provideToDest):571 RETHROW:  Signature
verification failed for repomd.xml
2023-06-08 01:25:25 <5> susetest(19903) [zypp-core]
Exception.cc(log):186 RepoManager.cc(refreshMetadata):1263 CAUGHT:
Signature verification failed for repomd.xml
2023-06-08 01:25:25 <5> susetest(19903) [zypp-core]
Exception.cc(log):186 RepoManager.cc(refreshMetadata):1277 THROW:
[SUSE_Package_Hub_15_SP5_s390x:SUSE-PackageHub-15-SP5-Backports-Pool|https://updates.suse.com/SUSE/Backports/SLE-15-SP5_s390x/standard?M98wM8a0VUOrVZDgeL66rnSVA01BrLMC9WurmNz6LK7Nlu5skg_-tcp0ns17G5o2yFV4Bc1IiGiMAOwCZLCm3VqLVdX4p5fiZOYiZMltdDXgABcWqpSiTsvRqqO9cxqoC6Von1tGqg]
Valid metadata not found at specified URL
2023-06-08 01:25:25 <5> susetest(19903) [zypp-core]
Exception.cc(log):186 repos.cc(build_cache):456 CAUGHT:
[SUSE_Package_Hub_15_SP5_s390x:SUSE-PackageHub-15-SP5-Backports-Pool|https://updates.suse.com/SUSE/Backports/SLE-15-SP5_s390x/standard?M98wM8a0VUOrVZDgeL66rnSVA01BrLMC9WurmNz6LK7Nlu5skg_-tcp0ns17G5o2yFV4Bc1IiGiMAOwCZLCm3VqLVdX4p5fiZOYiZMltdDXgABcWqpSiTsvRqqO9cxqoC6Von1tGqg]
Valid metadata not found at specified URL
```

#### Verification runs

* [docker-compose@jeos](http://kepler.suse.cz/tests/21051#step/docker_compose/6)
* [ansible](http://kepler.suse.cz/tests/21050#step/ansible/20)
* [sle-15-SP5-Server-DVD-Updates-x86_64-Build20230607-1-docker_tests@64bit](http://kepler.suse.cz/tests/21049#)
* [sle-15-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20230607-1-jeos-filesystem@uefi-virtio-vga](http://kepler.suse.cz/tests/21048#)