### PR TITLE
sudo asks for invoking user's password on Azure

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -20,6 +20,7 @@ use warnings;
 use testapi;
 use utils 'zypper_call';
 use version_utils qw(is_sle);
+use publiccloud::utils qw(is_azure);
 
 sub sudo_with_pw {
     my ($command, %args) = @_;
@@ -49,7 +50,8 @@ sub run {
     zypper_call 'in sudo expect';
     select_console 'user-console';
     # Defaults targetpw -> asks for root PW
-    assert_script_run("expect -c 'spawn sudo id -un;expect \"password for root\" {send \"$testapi::password\\r\";interact} default {exit 1}' | grep ^root");
+    my $exp_user = (is_azure && is_sle('=15-SP5')) ? 'bernhard' : 'root';
+    assert_script_run("expect -c 'spawn sudo id -un;expect \"password for $exp_user\" {send \"$testapi::password\\r\";interact} default {exit 1}' | grep ^$exp_user");
     select_console 'root-console';
     # Prepare a file with content '1' for later IO redirection test
     assert_script_run 'echo 1 >/run/openqa_sudo_test';


### PR DESCRIPTION
As per https://bugzilla.suse.com/show_bug.cgi?id=1205325#c29 sudo is configured on Azure images to ask for invoking user's password instead of target's user password. This change will eventually hit all supported Azure images.

- ticket: [publiccloud_consoletests fail in sudo](https://progress.opensuse.org/issues/130432)

#### Verification runs

* [sle-12-SP5-AZURE-Standard-Updates-x86_64-Build20230607-1-publiccloud_consoletests@64bit](http://kepler.suse.cz/tests/21060#step/sudo/16)
* [sle-15-SP4-AZURE-BYOS-Updates-x86_64-Build20230607-1-publiccloud_consoletests@64bit](http://kepler.suse.cz/tests/21059#step/sudo/16)
* [sle-15-SP5-Azure-BYOS-x86_64-Build0333-publiccloud_consoletests@az_Standard_B2s](http://kepler.suse.cz/tests/21058#step/sudo/16)