### PR TITLE
Hotfix for phub key workaround

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -180,7 +180,7 @@ sub add_suseconnect_product {
     $version //= '${VERSION_ID}';
     $arch //= '${CPU}';
     $params //= '';
-    if ($name =~ /PackageHub/) {
+    if (is_sle('=15-SP5') && $name =~ /PackageHub/) {
         $params .= ' --gpg-auto-import-keys';
         record_soft_failure 'bsc#1212134 - Package hub signing key verification failure';
     }


### PR DESCRIPTION
Introduced in 69f78a887fec69a5b2ca1a5ff90951984725efd0, add version checking as not all version of SUSEConnect has key import feature.

VR:

- [15sp1](http://kepler.suse.cz/tests/21061#step/add_phub_extension/6)
- [15sp5](http://kepler.suse.cz/tests/21062#step/add_phub_extension/7)