### PR TITLE
Fix small iscsi server mistake

### DIFF
--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -32,6 +32,7 @@ sub run() {
         $count++;
     }
     foreach my $instance (@{$run_args->{instances}}) {
+        next if ($instance->{'instance_id'} !~ m/vmhana/);
         $instance->run_ssh_command(cmd => 'sudo zypper -n ref', username => 'cloudadmin', timeout => 1500);
     }
 }


### PR DESCRIPTION
Tests fail in `cluster_add_repos`, seemingly because even though only the hana nodes are amended with the test repository and the iscsi server is excluded, it is not excluded in the next loop which `zypper ref`s. That leads to a crash due to no repositories existing in the server.

- Related ticket: https://jira.suse.com/browse/TEAM-7535
- Verification run:
