### PR TITLE
Deal with no bounce back on powerKVM

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -881,6 +881,9 @@ sub wait_boot {
         #
         $self->handle_pxeboot(bootloader_time => $bootloader_time, pxemenu => 'pxe-custom-kernel', pxeselect => 'pxe-custom-kernel-selected');
     }
+    # When no bounce back on power KVM, we need skip bootloader process and go ahead when 'displaymanager' matched.
+    elsif (get_var('OFW') && (check_screen('displaymanager', 5))) {
+    }
     else {
         assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600) if (uses_qa_net_hardware() || get_var("PXEBOOT"));
         $self->handle_grub(bootloader_time => $bootloader_time, in_grub => $in_grub);


### PR DESCRIPTION
We have workaround the situation when no bounce back happened on powerkvm, but it is not work when online_migration_setup loaded after bootloader module. Because when showed 'display manager' but test still used wait_boot -> boot_local_disk which will match from the point of bootloader.

We need ensure if no bounce back happend it won't go back to grub2 for the test process, and go ahead, that handle_grub shouldn't be called anymore after dispaly-mananger selected in bootloader module.

- Related ticket: https://progress.opensuse.org/issues/129649
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/11286593#
   VR for SLEM micro image testing: http://openqa.suse.de/tests/11286602#
   VR for powerVM: http://openqa.suse.de/tests/11354720#details
