### PR TITLE
Add Github Shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: shellcheck
+on:
+  push:
+    paths:
+      - 'data/publiccloud/**'
+  pull_request:
+    paths:
+      - 'data/publiccloud/**'
+permissions: {}
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: './data/publiccloud' 


### PR DESCRIPTION
There are many bash scripts in this repository and Shellcheck would be useful.

My plan is to enable this workflow but exclude most of the directories so people can individually choose to "opt-in".
