### PR TITLE
Fix terraform destroy sporadic timed out failure

### DIFF
--- a/tests/sles4sap/qesapdeployment/destroy.pm
+++ b/tests/sles4sap/qesapdeployment/destroy.pm
@@ -16,7 +16,7 @@ sub run {
 
     my $ansible_ret = qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
     qesap_cluster_logs() if ($ansible_ret);
-    my $terraform_ret = qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
+    my $terraform_ret = qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1800);
     die "'qesap.py ansible -d' return: $ansible_ret" if ($ansible_ret);
     die "'qesap.py terraform -d' return: $terraform_ret" if ($terraform_ret);
 }


### PR DESCRIPTION
Fix terraform destroy sporadic timed out failure via increasing the time out value to 1800 seconds though generally the destroy will be finished in 1200 minutes

I hit this sporadic timed out issue (http://openqaworker15.qa.suse.cz/tests/187769#step/destroy/22) when I am working on this ticket [TEAM-8002](https://jira.suse.com/browse/TEAM-8002) - [OW15] qesap regression test on Azure using 12-SP5 BYOS images (PAYG done)
You can see test module "destroy" took 20+ minutes and exited with timed out.

- Related ticket: https://jira.suse.com/browse/TEAM-8002
- Needles: NA
- Verification run:
http://openqaworker15.qa.suse.cz/tests/188230# (passed)