### PR TITLE
Move the files under lib/yam to lib/Yam

### DIFF
--- a/lib/Yam/agama/agama_base.pm
+++ b/lib/Yam/agama/agama_base.pm
@@ -4,7 +4,7 @@
 # Summary: base class for Agama tests
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-package yam::agama::agama_base;
+package Yam::agama::agama_base;
 use base 'opensusebasetest';
 use strict;
 use warnings;

--- a/lib/Yam/agama/patch_agama_base.pm
+++ b/lib/Yam/agama/patch_agama_base.pm
@@ -4,7 +4,7 @@
 # Summary: base class for Patch Agama tests
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-package yam::agama::patch_agama_base;
+package Yam::agama::patch_agama_base;
 use base 'opensusebasetest';
 use strict;
 use warnings;

--- a/tests/yam/agama/auto.pm
+++ b/tests/yam/agama/auto.pm
@@ -4,7 +4,7 @@
 # Summary: First installation using D-Installer current CLI (only for development purpose)
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-use base yam::agama::agama_base;
+use base Yam::agama::agama_base;
 use strict;
 use warnings;
 

--- a/tests/yam/agama/patch_agama.pm
+++ b/tests/yam/agama/patch_agama.pm
@@ -4,7 +4,7 @@
 # Summary: This module use yupdate patch the Agama on Live Medium
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-use base yam::agama::patch_agama_base;
+use base Yam::agama::patch_agama_base;
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION
There are 'Yam' and 'yam' folders under /lib/, actually Yam is the correct one, so we need move files under /lib/yam to /lib/Yam.

- Related ticket: https://progress.opensuse.org/issues/130579
- Needles: n/a
- Verification run: https://openqa.opensuse.org/tests/3365502#
