### PR TITLE
Add peering cleanup in base module

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -911,7 +911,7 @@ sub qesap_az_vnet_peering_delete {
         record_info("Peering deletion SUCCESS", "The peering was successfully destroyed");
         return;
     }
-    record_soft_failure("Peering destruction FAIL: There may be leftover peering connections, please check - jira#7487");
+    record_soft_failure("Peering destruction FAIL: There may be leftover peering connections, please check - jsc#7487");
 }
 
 =head3 qesap_az_get_peering_name

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -910,7 +910,7 @@ subtest '[qesap_az_vnet_peering_delete] delete failure' => sub {
     note("\n  SF-->  " . join("\n  SF-->  ", @soft_failure));
 
     # qesap_az_get_peering_name
-    ok((any { /jira#7487/ } @soft_failure), 'soft failure');
+    ok((any { /jsc#7487/ } @soft_failure), 'soft failure');
 };
 
 done_testing;


### PR DESCRIPTION
Add peering destruction to the `clenup` function of `sles4sap_publiccloud_basetest`.
Part of the https://jira.suse.com/browse/TEAM-7535 saga.

- Related ticket: https://jira.suse.com/browse/TEAM-7535
- Verification run: 
FAILING: http://openqaworker15.qa.suse.cz/tests/188749
PASSING: http://openqaworker15.qa.suse.cz/tests/188748 (well, should be passing but there's an unrelated registration error)
NO PEERING: http://openqaworker15.qa.suse.cz/tests/188747