### PR TITLE
Add PAYG support for qesap regression

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_no_reg.yaml
@@ -1,0 +1,42 @@
+provider: "%PROVIDER%"
+apiver: 3
+terraform:
+  variables:
+    az_region: "%REGION%"
+    deployment_name: "%DEPLOYMENTNAME%"
+    os_image: "%OS_VER%"
+    public_key: "%SSH_KEY_PUB%"
+    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    hana_instancetype: "%HANA_INSTANCE_TYPE%"
+    vnet_address_range: "%VNET_ADDRESS_RANGE%"
+    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
+
+ansible:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
+    - "%HANA_SAR%"
+    - "%HANA_CLIENT_SAR%"
+    - "%HANA_SAPCAR%"
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HDB'
+    sap_hana_install_instance_number: '00'
+    sap_domain: "qe-test.example.com"
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+  create:
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+    - cluster_sbd_prep.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml
+  destroy:
+

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
@@ -1,0 +1,39 @@
+provider: "%PROVIDER%"
+apiver: 3
+terraform:
+  variables:
+    az_region: "%REGION%"
+    deployment_name: "%DEPLOYMENTNAME%"
+    os_image: "%OS_VER%"
+    public_key: "%SSH_KEY_PUB%"
+    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+
+ansible:
+  az_storage_account_name: "%HANA_ACCOUNT%"
+  az_container_name:  "%HANA_CONTAINER%"
+  az_sas_token: "%HANA_TOKEN%"
+  hana_media:
+    - "%HANA_SAR%"
+    - "%HANA_CLIENT_SAR%"
+    - "%HANA_SAPCAR%"
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HDB'
+    sap_hana_install_instance_number: '00'
+    sap_domain: "qe-test.example.com"
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+  create:
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml -e use_sapconf=true -e use_reboottimeout=900
+    - cluster_sbd_prep.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml
+  destroy:
+

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -37,7 +37,9 @@ sub run {
     $variables{USE_SAPCONF} = get_var('QESAPDEPLOY_USE_SAPCONF', 'false');
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';
-    $variables{SCC_REGCODE_SLES4SAP} = get_required_var('SCC_REGCODE_SLES4SAP');
+
+    # Only BYOS images needs it
+    $variables{SCC_REGCODE_SLES4SAP} = get_var('SCC_REGCODE_SLES4SAP', '');
     $variables{HANA_INSTANCE_TYPE} = get_var('QESAPDEPLOY_HANA_INSTANCE_TYPE', 'r6i.xlarge');
 
     $variables{HANA_ACCOUNT} = get_required_var('QESAPDEPLOY_HANA_ACCOUNT');

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -18,7 +18,16 @@ sub run {
 
     my $chdir = qesap_get_terraform_dir();
     assert_script_run("terraform -chdir=$chdir output");
-    qesap_ansible_cmd(cmd => $_, provider => $prov) for ('pwd', 'uname -a', 'cat /etc/os-release');
+    my @remote_cmd = (
+        'pwd',
+        'uname -a',
+        'cat /etc/os-release',
+        'sudo SUSEConnect --status-text',
+        'zypper ref',
+        'zypper lr',
+        'zypper in -f -y vim'
+    );
+    qesap_ansible_cmd(cmd => $_, provider => $prov) for @remote_cmd;
     qesap_ansible_cmd(cmd => 'ls -lai /hana/', provider => $prov, filter => 'hana');
     my $cmr_status = qesap_ansible_script_output(cmd => 'crm status', provider => $prov, host => '"hana[0]"', root => 1);
     record_info("crm status", $cmr_status);


### PR DESCRIPTION
Add some more steps in the test module, about zypper. Add a config.yaml Azure template that is not calling the Ansible registration playbook.

- Related ticket: [TEAM-8059](https://jira.suse.com/browse/TEAM-8059)

- Verification run:
AZURE BYOS http://openqaworker15.qa.suse.cz/tests/188257  http://openqaworker15.qa.suse.cz/tests/188261 :heavy_check_mark: 
AZURE PAYG SAPTUNE
- http://openqaworker15.qa.suse.cz/tests/188259  "No provider of '+saptune>=3.0' found." :red_circle: 
-  http://openqaworker15.qa.suse.cz/tests/188260 "No provider of '+saptune>=3.0' found." :red_circle: 
AZURE PAYG SAPCONF 
  - http://openqaworker15.qa.suse.cz/tests/188263  : Could not find the requested service sbd: host :red_circle: 
  - http://openqaworker15.qa.suse.cz/tests/188266 : Could not find the requested service sbd: host :red_circle: 
  - http://openqaworker15.qa.suse.cz/tests/188750 : Could not find the requested service sbd: host :red_circle: 
