### PR TITLE
 wait_for_guestregister external calls removed

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -261,9 +261,9 @@ sub upload_log {
     assert_script_run("test -d '$tmpdir' && rm -rf '$tmpdir'");
 }
 
-=head2 wait_for_guestregister_chk
+=head2 wait_for_guestregister
 
-    wait_for_guestregister_chk([timeout => 300]);
+    wait_for_guestregister([timeout => 300]);
 
 Run command C<systemctl is-active guestregister> on the instance in a loop and
 wait till guestregister is ready. If guestregister finish with state failed,
@@ -271,10 +271,10 @@ a soft-failure will be recorded.
 If guestregister will not finish within C<timeout> seconds, job dies.
 In case of BYOS images we checking that service is inactive and quit
 Returns the time needed to wait for the guestregister to complete.
-C<wait_for_guestregister_chk> is called inside C<create_instance()>, enabled by C<check_guestregister>
+C<wait_for_guestregister> is called inside C<create_instance()>, enabled by C<check_guestregister>
 =cut
 
-sub wait_for_guestregister_chk {
+sub wait_for_guestregister {
     my ($self, %args) = @_;
     $args{timeout} //= 300;
     my $start_time = time();
@@ -312,24 +312,6 @@ sub wait_for_guestregister_chk {
 
     $self->upload_log($log, log_name => $name);
     die('guestregister didn\'t end in expected timeout=' . $args{timeout});
-}
-
-
-=head2 wait_for_guestregister
-
-    wait_for_guestregister([timeout => 300]);
-
-The previous functionality has been migrated into wait_for_guestregister_chk above, for logic refactoring 
-planned to run directly when publiccloud create_instances executed. 
-This function is now a temporary placeholder without effects, to quickly proof the new logic, 
-but passing the existing calls still present in many modules,reducing the changes of deleting those ones.
-After the new logic will be consilidated, this function and related calls will be removed. 
-=cut
-
-sub wait_for_guestregister {
-    my ($self, %args) = @_;
-    my $out = $self->run_ssh_command(cmd => 'sudo systemctl is-active guestregister', proceed_on_failure => 1, quiet => 1);
-    return;
 }
 
 =head2 wait_for_ssh

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -322,7 +322,7 @@ sub create_instances {
             assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));
         }
         # check guestregister conditional, default yes:
-        $instance->wait_for_guestregister_chk() if ($args{check_guestregister});
+        $instance->wait_for_guestregister() if ($args{check_guestregister});
         # Performance data: boottime
         my $btime = $instance->measure_boottime($instance, 'first');
         $instance->store_boottime_db($btime);

--- a/tests/publiccloud/ahb.pm
+++ b/tests/publiccloud/ahb.pm
@@ -35,7 +35,6 @@ sub run {
 
     my $provider = $self->provider_factory();
     my $instance = $provider->create_instance();
-    $instance->wait_for_guestregister();
     # resource group
     # get instance resource group
     my $resource_group_command = "curl -s -H Metadata:true --noproxy \"*\" \"$azure_endpoint/resourceGroupName?api-version=$api_version&format=text\"";

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -273,8 +273,6 @@ sub do_systemd_analyze {
     my $output = "";
     my @ret;
 
-    # Wait for guest register, before calling syastemd-analyze
-    $instance->wait_for_guestregister();
     while ($output !~ /Startup finished in/ && time() - $start_time < $args{timeout}) {
         $output = $instance->run_ssh_command(cmd => 'systemd-analyze time', proceed_on_failure => 1);
         sleep 5;

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -31,8 +31,6 @@ sub run {
     } else {
         $provider = $self->provider_factory();
         $instance = $provider->create_instance(check_guestregister => is_ondemand ? 1 : 0);
-
-        $instance->wait_for_guestregister() if is_ondemand();
     }
 
     if ($tests eq "default") {

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -40,7 +40,6 @@ sub run {
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     $args->{my_provider} = $provider;
     my $instance = $provider->create_instance(%instance_args);
-    $instance->wait_for_guestregister();
     $args->{my_instance} = $instance;
     $instance->ssh_opts("");    # Clear $instance->ssh_opts which ombit the known hosts file and strict host checking by default
 

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -100,9 +100,6 @@ sub run {
     } else {
         $provider = $self->provider_factory();
         $instance = $self->{my_instance} = $provider->create_instance(check_guestregister => is_openstack ? 0 : 1);
-        unless (is_openstack) {
-            $instance->wait_for_guestregister();
-        }
     }
 
     assert_script_run("cd $root_dir");

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -176,7 +176,6 @@ sub run {
 
     my $provider = $self->provider_factory();
     my $instance = $provider->create_instance(use_extra_disk => {size => $disk_size, type => $disk_type});
-    $instance->wait_for_guestregister();
 
     $tags->{os_kernel_release} = $instance->run_ssh_command(cmd => 'uname -r');
     $tags->{os_kernel_version} = $instance->run_ssh_command(cmd => 'uname -v');


### PR DESCRIPTION
Being the `wait_for_guestregister` routine no-more-operational and replaced by the new `wait_for_guestregister_chk`, as explained in its (removed)  _head2_, in this cleanup all related calls have been removed where existing in Public cloud modules and the new routine has been then renamed as the original name `wait_for_guestregister`, in place. 
This PR is a followup of previous merged PR#16577.

- Related ticket: https://progress.opensuse.org/issues/118027
- Needles: N/A
- Verification run: TBD see next posts.