### PR TITLE
FIPS encrypted install tests optimizations

### DIFF
--- a/schedule/security/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/security/encryption/lvm_encrypt_separate_boot.yaml
@@ -14,14 +14,15 @@ schedule:
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
+  - installation/module_registration/skip_module_registration
   - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/system_role/accept_selected_role_text_mode
   - installation/partitioning/new_partitioning_gpt
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_plymouth
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
@@ -31,9 +32,5 @@ schedule:
   - installation/handle_reboot
   - installation/boot_encrypt
   - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
   - console/validate_lvm
   - console/validate_encrypt

--- a/schedule/security/encryption/lvm_encrypt_separate_boot_s390x.yaml
+++ b/schedule/security/encryption/lvm_encrypt_separate_boot_s390x.yaml
@@ -17,17 +17,16 @@ schedule:
   - installation/setup_libyui
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/module_registration/register_module_desktop
+  - installation/module_registration/skip_module_registration
   - installation/add_on_product/skip_install_addons
-  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/system_role/accept_selected_role_text_mode
   - installation/partitioning/new_partitioning_gpt
   - installation/clock_and_timezone/accept_timezone_configuration
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
-  - installation/installation_settings/validate_ssh_service_enabled
-  - installation/installation_settings/open_ssh_port
   - installation/installation_settings/validate_default_target
   - installation/edit_optional_kernel_cmd_parameters
+  - installation/bootloader_settings/disable_plymouth
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
@@ -39,9 +38,5 @@ schedule:
   - installation/boot_encrypt
   - installation/handle_reboot
   - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
   - console/validate_lvm
   - console/validate_encrypt


### PR DESCRIPTION
Changing `DESKTOP` from `gnome` to `textmode` in encrypted installation tests and removing unused modules.
This should be merged in parallel with changes in our security job groups.

- Related ticket: https://progress.opensuse.org/issues/130898
- Verification runs:
  - x86_64: https://openqa.suse.de/tests/11358606
  - aarch64: https://openqa.suse.de/tests/11360835
  - s390x: https://openqa.suse.de/tests/11360845
