### PR TITLE
Use logs_from_installation_system on HPC installation

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -783,6 +783,10 @@ sub activate_console {
             # login as root, who does not have a password on Live-CDs
             wait_screen_change { enter_cmd "root" };
         }
+        elsif (check_screen('tty2-selected')) {
+            enter_cmd "root";
+            handle_password_prompt;
+        }
         else {
             # on s390x we need to login here by providing a password
             handle_password_prompt if is_s390x;

--- a/schedule/hpc/autoyast_create_hdd_textmode.yaml
+++ b/schedule/hpc/autoyast_create_hdd_textmode.yaml
@@ -23,6 +23,7 @@ schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
+  - installation/logs_from_installation_system
   - installation/first_boot
   - console/system_prepare
   - console/hostname

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -82,7 +82,11 @@ sub run {
     # We don't change network setup here, so should work
     # We don't parse logs unless it's detect_yast2_failures scenario
     $self->save_upload_y2logs(no_ntwrk_recovery => 1, skip_logs_investigation => !get_var('ASSERT_Y2LOGS'));
-    select_console 'installation' unless get_var('REMOTE_CONTROLLER');
+    if (check_var('SLE_PRODUCT', 'hpc')) {
+        type_string('exit', lf => 1);
+    } else {
+        select_console 'installation' unless get_var('REMOTE_CONTROLLER');
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
This PR allows logs_from_installation_system to collect logs from HPC autoyast installation. I think this module should be applicable to be used without modification but the installation console which used here was an obstacle. When we use installation shell first we have to login and then we have to exit, instead of return to it.
The changes do not provide a general solution but it just makes it work for the HPC AY installation particular.


- Related ticket: https://progress.opensuse.org/issues/124032
- https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1645
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2317267
