### PR TITLE
Enable automation for YaST in Container in ALP in OSD

### DIFF
--- a/schedule/alp/yast_as_workload.yaml
+++ b/schedule/alp/yast_as_workload.yaml
@@ -1,0 +1,12 @@
+---
+name: yast_as_workload
+description: >
+    Run YaST as a workload for ALP
+vars:
+    YUI_REST_API: 1
+schedule:
+    - installation/bootloader_uefi
+    - microos/selfinstall
+    - console/setup_libyui_running_system
+    - yam/yast_modules/control_center
+    - shutdown/shutdown


### PR DESCRIPTION
Enable automation for YaST in Container in ALP in OSD

- Related ticket: https://progress.opensuse.org/issues/130384
- Verification run: https://openqa.suse.de/tests/overview?distri=alp&version=1.0&build=4.1&groupid=496
- MR: https://gitlab.suse.de/qsf-y/qa-sle-functional-y/-/merge_requests/509
