### PR TITLE
kernel/bpftrace: Try to increase timeout reliability

### DIFF
--- a/tests/kernel/bpftrace.pm
+++ b/tests/kernel/bpftrace.pm
@@ -71,17 +71,11 @@ sub run {
       old/tcpdrop.bt);
 
     foreach my $t (@assert_tests) {
-        my $ret = script_run("timeout --preserve-status -s SIGINT --kill-after=10 10 bpftrace $tools_dir/$t");
-
-        if ($ret == 130) {
-            record_info('timeout', "'bpftrace $t' did not handle SIGINT; system was probably too slow to attach probes");
-        } elsif ($ret) {
-            die "'bpftrace $t' failed";
-        }
+        assert_script_run(qq%echo -e "\\ninterval:s:5 { exit(); }" | cat $tools_dir/$t - | bpftrace -%);
     }
 
     foreach my $t (@tests) {
-        script_run("timeout --preserve-status -s SIGINT --kill-after=10 10 bpftrace $tools_dir/$t");
+        script_run(qq%echo -e "\\ninterval:s:5 { exit(); }" | cat $tools_dir/$t - | bpftrace -%);
     }
 
     my $case_dir = get_required_var('CASEDIR');


### PR DESCRIPTION
Instead of using the timeout utility to send an interrupt signal we can append a timeout probe to the script we are executing.

If the interrupt signal gets ignored, which appears to happen under stress, it is hard to say if it is a bug or not. If the interval probe fails to fire or exit this seems like a more concrete bug.

Awaiting validation: https://openqa.opensuse.org/tests/3358777

https://progress.opensuse.org/issues/130772
@czerw 
