### PR TITLE
Give more tries for script_retry for journalctl module

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -218,7 +218,7 @@ sub run {
         die "journal lists less than 2 boots";
     }
     is_journal_empty('--boot=-1', "journalctl-1.txt");
-    script_retry('journalctl --identifier=batman --boot=-1| grep "The batman is going to sleep"', retry => 5, delay => 2);
+    script_retry('journalctl --identifier=batman --boot=-1| grep "The batman is going to sleep"', retry => 8, delay => 4);
     script_run('echo -e "Reboot time:  `cat /var/tmp/reboottime`\nCurrent time: `date -u \'+%F %T\'`"');
     die "journalctl after reboot empty" if is_journal_empty('-S "`cat /var/tmp/reboottime`"', "journalctl-after.txt");
     # Basic journalctl tests: Export journalctl with various arguments and ensure they are not empty


### PR DESCRIPTION
we have sporadic issue with journalctl on Tumbleweed. One possible reason is performance. So increase re-tries for script_retry and check wether this is enough to make the test stabile.

see https://progress.opensuse.org/issues/129304
