### PR TITLE
ulp_openposix: Use libpulp-load-default instead of LD_PRELOAD

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -291,9 +291,6 @@ sub parse_openposix_runfile {
     my $ulp_test = get_var('LIBC_LIVEPATCH', 0);
     my $whitelist = LTP::WhiteList->new();
 
-    assert_script_run('export LD_PRELOAD=/usr/lib64/libpulp.so.0')
-      if ($ulp_test);
-
     for my $line (@$cmds) {
         chomp($line);
         my $testname = basename($line, '.run-test') . $suffix;

--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -23,6 +23,11 @@ sub parse_incident_repo {
     my @repos = split(",", $repo);
     my @repo_names;
     my $packname;
+    my %ulp_tools = (
+        libpulp0 => 1,
+        'libpulp-tools' => 1,
+        'libpulp-load-default' => 1
+    );
 
     while ((my ($i, $url)) = (each(@repos))) {
         push @repo_names, "ULP_$i";
@@ -36,7 +41,7 @@ sub parse_incident_repo {
         record_info('Livepatch tests', "Incident $incident_id contains userspace livepatches.");
         $packname = 'glibc-livepatches';
     }
-    elsif (grep { $$_{name} eq 'libpulp0' || $$_{name} eq 'libpulp-tools' } @$packlist) {
+    elsif (grep { exists($ulp_tools{$$_{name}}) } @$packlist) {
         record_info('Tools tests', "Incident $incident_id contains livepatching tools.");
 
         my $patches = get_patches($incident_id, $repo);
@@ -63,7 +68,7 @@ sub setup_ulp {
     my $repo_args = '';
 
     install_klp_product;
-    zypper_call('in libpulp0 libpulp-tools');
+    zypper_call('in libpulp0 libpulp-tools libpulp-load-default');
 
     if (get_var('INCIDENT_REPO')) {
         my $repo_data = parse_incident_repo();


### PR DESCRIPTION
The `libpulp-load-default` package should be installed to enable livepatching in real-world use cases. Use it in testing as well.

- Related ticket: https://progress.opensuse.org/issues/112004
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/11361465#step/ulp_openposix/36