### PR TITLE
Make slurm installation versioning

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -24,7 +24,9 @@ sub run ($self) {
     $self->prepare_user_and_group();
 
     # Install slurm
-    zypper_call("in slurm slurm-munge slurm-slurmdbd");
+    my $ver = get_var('SLURM_VERSION') // '';
+    my $slurm = $ver ? "slurm_$ver" : 'slurm';
+    zypper_call("in $slurm slurm-munge slurm-slurmdbd");
     # install slurm-node if sle15, not available yet for sle12
     zypper_call('in slurm-node') if is_sle '15+';
 

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -433,7 +433,9 @@ sub run ($self) {
     # provision HPC cluster, so the proper rpms are installed,
     # munge key is distributed to all nodes, so is slurm.conf
     # and proper services are enabled and started
-    zypper_call('in slurm slurm-munge slurm-torque');
+    my $ver = get_var('SLURM_VERSION') // '';
+    my $slurm = $ver ? "slurm_$ver" : 'slurm';
+    zypper_call("in $slurm slurm-munge slurm-torque");
 
     if ($slurm_conf =~ /ha/) {
         $self->mount_nfs();

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -19,8 +19,9 @@ sub run ($self) {
     barrier_wait('CLUSTER_PROVISIONED');
 
     $self->prepare_user_and_group();
-    zypper_call('in slurm slurm-munge');
-
+    my $ver = get_var('SLURM_VERSION') // '';
+    my $slurm = $ver ? "slurm_$ver" : 'slurm';
+    zypper_call("in $slurm slurm-munge");
     $self->mount_nfs();
     barrier_wait("SLURM_SETUP_DONE");
     barrier_wait('SLURM_SETUP_DBD');

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -17,11 +17,12 @@ use utils;
 sub run ($self) {
     select_serial_terminal();
     my $nodes = get_required_var("CLUSTER_NODES");
-
+    my $ver = get_var('SLURM_VERSION') // '';
+    my $slurm = $ver ? "slurm_$ver" : 'slurm';
     barrier_wait('CLUSTER_PROVISIONED');
 
     $self->prepare_user_and_group();
-    zypper_call('in slurm slurm-munge');
+    zypper_call("in $slurm slurm-munge");
 
     # mount NFS shared directory specific
     # for this test /shared/slurm and provided by the


### PR DESCRIPTION
Slurm test needs to extended to be able to perform installation with the new packaging name which contains the versioning. The simpler way is via a job variable. When the variable is missing the old format will be used which it should still supported.

- Related ticket: https://progress.opensuse.org/issues/130838
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP4&build=b10n1k%2Fos-autoinst-distri-opensuse%2317278&distri=sle
