### PR TITLE
Add basic Sway WM test

### DIFF
--- a/schedule/functional/sway.yaml
+++ b/schedule/functional/sway.yaml
@@ -1,0 +1,6 @@
+---
+name: message
+description: Sway wayland window manager
+schedule:
+  - sway/sway
+  - shutdown/shutdown

--- a/tests/sway/sway.pm
+++ b/tests/sway/sway.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: sway
+# Summary: Start Sway WM
+# Maintainer: rpalethorpe@suse.com
+
+use Mojo::Base qw(opensusebasetest);
+use testapi;
+use serial_terminal;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    $self->wait_boot;
+
+    select_serial_terminal;
+
+    zypper_call('in --type pattern --recommends sway');
+
+    select_console('user-console');
+
+    type_string("sway -d\n");
+    assert_screen('sway-workspace-1');
+}
+
+1;


### PR DESCRIPTION
This should just be enough to catch the Mesa issue reported here: https://bugzilla.suse.com/show_bug.cgi?id=1212345

I can't create the required needle(s) yet because the active TW image still seems to have the above issue.

Example job group YAML to schedule it.

```yaml
defaults:
  x86_64:
    machine: 64bit
    priority: 50

products:
  sle-15-sp5:
    distri: sle
    flavor: Online
    version: 15-SP5
  opensuse-Tumbleweed-DVD-x86_64:
    distri: opensuse
    flavor: DVD
    version: Tumbleweed

scenarios:
  x86_64:
    opensuse-Tumbleweed-DVD-x86_64:
      - sway:
          testsuite: null
          settings:
            BOOT_HDD_IMAGE: "1"
            VIDEOMODE: text
            DESKTOP: textmode
            HDD_1: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2"
            UEFI_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"
            QEMU_VIDEO_DEVICE: virtio-vga
            START_AFTER_TEST: create_hdd_textmode
            YAML_SCHEDULE: schedule/functional/sway.yaml
```