### PR TITLE
revert gpg keys import for phub

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -180,10 +180,6 @@ sub add_suseconnect_product {
     $version //= '${VERSION_ID}';
     $arch //= '${CPU}';
     $params //= '';
-    if (is_sle('=15-SP5') && $name =~ /PackageHub/) {
-        $params .= ' --gpg-auto-import-keys';
-        record_soft_failure 'bsc#1212134 - Package hub signing key verification failure';
-    }
     $retry //= 3;    # Times we retry the SUSEConnect command (besides first execution)
     $timeout //= 300;
 


### PR DESCRIPTION
Phub key fix has been provided, finally we can revert the previous changes introduced in (PR #17244).

VR: http://kepler.suse.cz/tests/21071#step/docker_compose/7
