### PR TITLE
HANA install/test now reads actuall pmem devices

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -196,11 +196,11 @@ sub run {
         # Read all configured pmem devices on the system
         my @pmem_devices_all = split("\n", script_output("find /dev/pmem*"));
         foreach my $pmem_device (@pmem_devices_all) {
-            $pmem_device =~ s:/dev/(.*):$1:;
+            $pmem_device =~ s:/dev/(pmem.+):$1:;
             assert_script_run "mkdir -p $pmempath/$pmem_device";
             assert_script_run "mkfs.xfs -f /dev/$pmem_device";
             assert_script_run "echo /dev/$pmem_device $pmempath/$pmem_device xfs defaults,noauto,dax 0 0 >> /etc/fstab";
-            assert_script_run "mount $pmempath/$pmem_device"; my $nvddevs = get_var('NVDIMM_NAMESPACES_TOTAL', 2);
+            assert_script_run "mount $pmempath/$pmem_device";
         }
 
         assert_script_run 'mkdir -p /etc/systemd/system/systemd-udev-settle.service.d';

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -196,7 +196,7 @@ sub run {
         # Read all configured pmem devices on the system
         my @pmem_devices_all = split("\n", script_output("find /dev/pmem*"));
         foreach my $pmem_device (@pmem_devices_all) {
-            $pmem_device =~ s:/dev/(pmem.+):$1:;
+            $pmem_device =~ s:/dev/(pmem\S+).*:$1:;
             assert_script_run "mkdir -p $pmempath/$pmem_device";
             assert_script_run "mkfs.xfs -f /dev/$pmem_device";
             assert_script_run "echo /dev/$pmem_device $pmempath/$pmem_device xfs defaults,noauto,dax 0 0 >> /etc/fstab";

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -1,6 +1,6 @@
 # SUSE's SLES4SAP openQA tests
 #
-# Copyright 2019-2021 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: lvm2 util-linux parted device-mapper
@@ -193,12 +193,14 @@ sub run {
     # Configure NVDIMM devices only when running on a BACKEND with NVDIMM
     my $pmempath = get_var('HANA_PMEM_BASEPATH', "/hana/pmem/$sid");
     if (get_var('NVDIMM')) {
-        my $nvddevs = get_var('NVDIMM_NAMESPACES_TOTAL', 2);
-        foreach my $i (0 .. ($nvddevs - 1)) {
-            assert_script_run "mkdir -p $pmempath/pmem$i";
-            assert_script_run "mkfs.xfs -f /dev/pmem$i";
-            assert_script_run "echo /dev/pmem$i $pmempath/pmem$i xfs defaults,noauto,dax 0 0 >> /etc/fstab";
-            assert_script_run "mount $pmempath/pmem$i";
+        # Read all configured pmem devices on the system
+        my @pmem_devices_all = split("\n", script_output("find /dev/pmem*"));
+        foreach my $pmem_device (@pmem_devices_all) {
+            $pmem_device =~ s:/dev/(.*):$1:;
+            assert_script_run "mkdir -p $pmempath/$pmem_device";
+            assert_script_run "mkfs.xfs -f /dev/$pmem_device";
+            assert_script_run "echo /dev/$pmem_device $pmempath/$pmem_device xfs defaults,noauto,dax 0 0 >> /etc/fstab";
+            assert_script_run "mount $pmempath/$pmem_device"; my $nvddevs = get_var('NVDIMM_NAMESPACES_TOTAL', 2);
         }
 
         assert_script_run 'mkdir -p /etc/systemd/system/systemd-udev-settle.service.d';

--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -1,6 +1,6 @@
 # SUSE's SLES4SAP openQA tests
 #
-# Copyright 2018 SUSE LLC
+# Copyright 2018-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: HANA installation smoke test
@@ -85,11 +85,14 @@ sub run {
         $output = script_output "$hdbsql \"SELECT * FROM M_INIFILE_CONTENTS where file_name = 'global.ini' and section = 'persistence' and key = 'basepath_persistent_memory_volumes'\"";
         my $pmempath = get_var('HANA_PMEM_BASEPATH', "/hana/pmem/$sid");
         my $nvddevs = get_var('NVDIMM_NAMESPACES_TOTAL', 2);
-        foreach my $i (0 .. ($nvddevs - 1)) {
-            die "hdbsql: HANA not configured with NVDIMM\n\n$output" unless ($output =~ /pmem$i/);
-            assert_script_run "grep -q -w pmem$i /hana/shared/$sid/global/hdb/custom/config/global.ini";
-            assert_script_run "ls $pmempath/pmem$i";
-            assert_script_run "test -n \"\$(ls $pmempath/pmem$i)\"";
+        # Read all configured pmem devices on the system
+        my @pmem_devices_all = split("\n", script_output("find /dev/pmem*"));
+        foreach my $pmem_device (@pmem_devices_all) {
+            $pmem_device =~ s:/dev/(.*):$1:;
+            die "hdbsql: HANA not configured with NVDIMM\n\n$output" unless ($output =~ /$pmem_device/);
+            assert_script_run "grep -q -w $pmem_device /hana/shared/$sid/global/hdb/custom/config/global.ini";
+            assert_script_run "ls $pmempath/$pmem_device";
+            assert_script_run "test -n \"\$(ls $pmempath/$pmem_device)\"";
         }
     }
 

--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -87,7 +87,7 @@ sub run {
         # Read all configured pmem devices on the system
         my @pmem_devices_all = split("\n", script_output("find /dev/pmem*"));
         foreach my $pmem_device (@pmem_devices_all) {
-            $pmem_device =~ s:/dev/(pmem.+):$1:;
+            $pmem_device =~ s:/dev/(pmem\S+).*:$1:;
             die "hdbsql: HANA not configured with NVDIMM\n\n$output" unless ($output =~ /$pmem_device/);
             assert_script_run "grep -q -w $pmem_device /hana/shared/$sid/global/hdb/custom/config/global.ini";
             assert_script_run "ls $pmempath/$pmem_device";

--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -84,11 +84,10 @@ sub run {
     if (get_var('NVDIMM') and !get_var('SKIP_HANADB_QUERY')) {
         $output = script_output "$hdbsql \"SELECT * FROM M_INIFILE_CONTENTS where file_name = 'global.ini' and section = 'persistence' and key = 'basepath_persistent_memory_volumes'\"";
         my $pmempath = get_var('HANA_PMEM_BASEPATH', "/hana/pmem/$sid");
-        my $nvddevs = get_var('NVDIMM_NAMESPACES_TOTAL', 2);
         # Read all configured pmem devices on the system
         my @pmem_devices_all = split("\n", script_output("find /dev/pmem*"));
         foreach my $pmem_device (@pmem_devices_all) {
-            $pmem_device =~ s:/dev/(.*):$1:;
+            $pmem_device =~ s:/dev/(pmem.+):$1:;
             die "hdbsql: HANA not configured with NVDIMM\n\n$output" unless ($output =~ /$pmem_device/);
             assert_script_run "grep -q -w $pmem_device /hana/shared/$sid/global/hdb/custom/config/global.ini";
             assert_script_run "ls $pmempath/$pmem_device";


### PR DESCRIPTION
HANA install/test modules had hard written to pmem devices starts from 0, which is now chnaged to thle list of exact devices on the system

- Related ticket: https://jira.suse.com/browse/TEAM-8077
- Verification run:  https://openqa.suse.de/tests/11387562