### PR TITLE
Retry script_output with sanity check

### DIFF
--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -53,4 +53,18 @@ subtest '[calculate_sbd_start_delay] Return default on non numeric value' => sub
     $sbd_delay_params{'corosync_token'} = $corosync_token_original;
 };
 
+subtest '[script_output_retry_check] Check input values' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    $hacluster->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $hacluster->redefine(script_output => sub { return $_[0]; });
+
+    # Test mandatory args
+    dies_ok { script_output_retry_check(cmd => undef, regex_string => 'test') } "Die without cmd arg";
+    dies_ok { script_output_retry_check(cmd => 'rm -Rf /', regex_string => undef) } "Die without regex arg";
+
+    # Test regex
+    is script_output_retry_check(cmd => '42', regex_string => '^\d+$'), '42', "Test passing regex";
+    dies_ok { script_output_retry_check(cmd => 'rm -Rf /', regex_string => '^\d+$') } "Test failing regex";
+};
+
 done_testing;


### PR DESCRIPTION
SAP/HA tests are currently failing because of kernel messages creeping into 
'script_output' output. This PR adds "script_output_retry_check" subroutine 
which checks result against expected regex and retries command couple of times 
upon failure. 

- Related ticket: https://jira.suse.com/browse/TEAM-8076
- Needles: N/A
- Verification run: 
Replicated issue: https://openqa.suse.de/tests/11406510#step/check_after_reboot/31
Issue did not occur: http://openqa.suse.de/tests/11406907#step/check_after_reboot/31 
