### PR TITLE
pc: Make sure kill_packagekitd runs as root

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -273,12 +273,12 @@ sub prepare_ssh_tunnel {
 
 sub kill_packagekit {
     my ($instance) = @_;
-    my $ret = $instance->ssh_script_run(cmd => "pkcon quit", timeout => 120);
+    my $ret = $instance->ssh_script_run(cmd => "sudo pkcon quit", timeout => 120);
     if ($ret) {
         # Older versions of systemd don't support "disable --now"
-        $instance->ssh_script_run(cmd => "systemctl stop packagekitd");
-        $instance->ssh_script_run(cmd => "systemctl disable packagekitd");
-        $instance->ssh_script_run(cmd => "systemctl mask packagekitd");
+        $instance->ssh_script_run(cmd => "sudo systemctl stop packagekitd");
+        $instance->ssh_script_run(cmd => "sudo systemctl disable packagekitd");
+        $instance->ssh_script_run(cmd => "sudo systemctl mask packagekitd");
     }
 }
 


### PR DESCRIPTION
`kill_packagekitd()` fails on Azure without root privileges.

- Related ticket: https://progress.opensuse.org/issues/131105
- Failing test: https://openqa.suse.de/tests/11388077#step/patch_and_reboot/19
- Verification run: https://openqa.suse.de/tests/11389656
