### PR TITLE
seahorse_sshkey test fix

### DIFF
--- a/schedule/functional/sway.yaml
+++ b/schedule/functional/sway.yaml
@@ -1,0 +1,6 @@
+---
+name: message
+description: Sway wayland window manager
+schedule:
+  - sway/sway
+  - shutdown/shutdown

--- a/tests/sway/sway.pm
+++ b/tests/sway/sway.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: sway
+# Summary: Start Sway WM
+# Maintainer: rpalethorpe@suse.com
+
+use Mojo::Base qw(opensusebasetest);
+use testapi;
+use serial_terminal;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    $self->wait_boot;
+
+    select_serial_terminal;
+
+    zypper_call('in --type pattern --recommends sway');
+
+    select_console('user-console');
+
+    type_string("sway -d\n");
+    assert_screen('sway-workspace-1');
+}
+
+1;

--- a/tests/x11/seahorse_sshkey.pm
+++ b/tests/x11/seahorse_sshkey.pm
@@ -39,13 +39,13 @@ sub run {
     send_key 'alt-d';
     type_string "Keyring test";    # Name of new ssh key
     send_key 'alt-j';    # Just Create ssh key without setup
-    if (check_screen("seahorse-sshkey-inhibit", timeout => 3)) {
+    if (check_screen("seahorse-sshkey-inhibit", timeout => 6)) {
         assert_and_click "seahorse-sshkey-inhibit";
     }
     assert_screen 'seahorse-sshkey-passphrase';    # sshkey passphrase
     type_password;
     send_key 'ret';
-    if (check_screen("seahorse-sshkey-inhibit", timeout => 3)) {
+    if (check_screen("seahorse-sshkey-inhibit", timeout => 6)) {
         assert_and_click "seahorse-sshkey-inhibit";
     }
     assert_screen 'seahorse-sshkey-passphrase-retype';    # sshkey passphrase retype


### PR DESCRIPTION
Increased timeout for check screen. 3 seconds seemed often too short for passing this test.
 
- Related ticket: https://progress.opensuse.org/issues/130150
