### PR TITLE
Doubling the timeout for seahorse-sshkey-inhibit.

### DIFF
--- a/tests/x11/seahorse_sshkey.pm
+++ b/tests/x11/seahorse_sshkey.pm
@@ -39,13 +39,13 @@ sub run {
     send_key 'alt-d';
     type_string "Keyring test";    # Name of new ssh key
     send_key 'alt-j';    # Just Create ssh key without setup
-    if (check_screen("seahorse-sshkey-inhibit", timeout => 3)) {
+    if (check_screen("seahorse-sshkey-inhibit", timeout => 6)) {
         assert_and_click "seahorse-sshkey-inhibit";
     }
     assert_screen 'seahorse-sshkey-passphrase';    # sshkey passphrase
     type_password;
     send_key 'ret';
-    if (check_screen("seahorse-sshkey-inhibit", timeout => 3)) {
+    if (check_screen("seahorse-sshkey-inhibit", timeout => 6)) {
         assert_and_click "seahorse-sshkey-inhibit";
     }
     assert_screen 'seahorse-sshkey-passphrase-retype';    # sshkey passphrase retype


### PR DESCRIPTION
openQA logs revelaed that 3 seconds is often too short for this dialog to appear and then the button to be clicked.

6 seconds seems to be enough for this test to pass.

Commit fixes poo#130150

- Related ticket: https://progress.opensuse.org/issues/130150
