### PR TITLE
Use 15-SP4 as base container as suggested in bsc#1212429

### DIFF
--- a/tests/console/sssd_openldap_functional.pm
+++ b/tests/console/sssd_openldap_functional.pm
@@ -36,13 +36,13 @@ sub run {
     }
     zypper_call("in sssd sssd-ldap openldap2-client sshpass docker");
     systemctl('enable --now docker');
-    #Select container base image by specifying variable BASE_IMAGE_TAG. (for sles using sle15sp3 by default)
+    #Select container base image by specifying variable BASE_IMAGE_TAG. (for sles using sle15sp4 by default)
     my $pkgs = "openldap2 sudo";
     my $tag = get_var("BASE_IMAGE_TAG");
     my $maint_test_repo = get_var('MAINT_TEST_REPO');
     unless ($tag) {
         if (is_opensuse) { $tag = (is_tumbleweed) ? "opensuse/tumbleweed" : "opensuse/leap";
-        } else { $tag = "registry.suse.com/suse/sle15:15.3"; }
+        } else { $tag = "registry.suse.com/suse/sle15:15.4"; }
     }
     # build container
     # build image, create container, setup openldap database and import testing data


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/130919
- Verification run:
Unable to test properly, as with the change it fails in a different way:
https://openqa.suse.de/tests/11396340#step/sssd_openldap_functional/93

..which is also how it fails with openqa-clone-custom-git-refspec pointing to a repository which does not have a change to the test
https://openqa.suse.de/tests/11396848#step/sssd_openldap_functional/93

So currently not sure how to properly rerun it, but regardless it has been reported that 15-sp3 containers will no longer be available so a switch to 15-SP4 should be done.