### PR TITLE
PC: Adjust xfsprepare repositories

### DIFF
--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -26,12 +26,12 @@ my $CONFIG_FILE = "$INST_DIR/local.config";
 sub get_filesystem_repo {
     my $version = get_required_var('VERSION');
     # The naming scheme of the filesystems repo depens on the version. See https://download.opensuse.org/repositories/filesystems/
-    # For SLE<15-SP3 -     e.g. https://download.opensuse.org/repositories/filesystems/SLE_15_SP1
-    # From 15-SP3 onwards: e.g. https://download.opensuse.org/repositories/filesystems/15.3
-    if (is_sle("<15-SP3")) {
+    # For SLE<15-SP4 -     e.g. https://download.opensuse.org/repositories/filesystems/SLE_15_SP3
+    # From 15-SP4 onwards: e.g. https://download.opensuse.org/repositories/filesystems/15.4
+    if (is_sle("<15-SP4")) {
         $version =~ s/-/_/g;    # Version in repo-path needs an underscore instead of a dash
         return "https://download.opensuse.org/repositories/filesystems/SLE_${version}/";
-    } elsif (is_sle(">=15-SP3")) {
+    } elsif (is_sle(">=15-SP4")) {
         $version =~ s/-SP/./g;    # Unified versions with dot (e.g. 15.3)
         return "https://download.opensuse.org/repositories/filesystems/${version}/";
     } else {


### PR DESCRIPTION
The repositories for 15-SP2 and 15-SP3 have been disabled for some time and yesterday reenabled.
 * Please see the list of all available versions: https://download.opensuse.org/repositories/filesystems/
 * You may see the OBS project as well: https://build.opensuse.org/package/show/home:pdostal:branches:filesystems/xfstests

- Related ticket: [poo#130645](https://progress.opensuse.org/issues/130645)
