### PR TITLE
Change mr_test_azure config to be more generic

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -13,6 +13,8 @@ terraform:
   provider: 'azure'
   variables:
     # GENERAL VARIABLES #
+    vnet_address_range: "%VNET_ADDRESS_RANGE%"
+    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -802,7 +802,7 @@ sub cluster_hdbadm {
 
 This function allow to wait for a specific output
 for 'SAPHanaSR-showAttr', on one specific remote host.
-Remotly runs 'SAPHanaSR-showAttr' on $host.
+Remotely runs 'SAPHanaSR-showAttr' on $host.
 Runs 'SAPHanaSR-showAttr' multiple times in a loop,
 retying until the output PASS the test 'f_status'.
 The 'f_status' test is passed as a "function pointer".

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -111,12 +111,11 @@ sub create_hana_vars_section {
 sub run {
     my ($self, $run_args) = @_;
 
-    if (check_var('IS_MAINTENANCE', 1)) {
+    if (is_azure) {
         my %maintenance_vars = qesap_az_calculate_address_range(slot => get_required_var('WORKER_ID'));
         set_var("VNET_ADDRESS_RANGE", $maintenance_vars{vnet_address_range});
         set_var("SUBNET_ADDRESS_RANGE", $maintenance_vars{subnet_address_range});
     }
-
 
     # Select console on the host (not the PC instance) to reset 'TUNNELED',
     # otherwise select_serial_terminal() will be failed
@@ -154,7 +153,6 @@ sub run {
         $escaped_token =~ s/\&/\\\&/g;
         set_var("HANA_TOKEN", $escaped_token);
     }
-
 
     my $provider = $self->provider_factory();
     set_var('SLE_IMAGE', $provider->get_image_id());


### PR DESCRIPTION
Add VNET_ADDRESS_RANGE and SUBNET_ADDRESS_RANGE to the qesap config used in mr_tests that does not need network peering to IBS. Change the test module to populate these settings only for Azure tests and not only for IS_MAINTENANCE tests. This is a double step: 1. remove an `if` test that in any case will break when extending the test to AWS, 2. Implement slot IPs also for tests that does not need to perform net peering, it is useless but also harmless.


Related ticket: TEAM-7487 as follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17020/files


Verification run:
- mr_test with 15sp5 image from IBS (_uri config) https://openqa.suse.de/tests/11406964 https://openqa.suse.de/tests/11407265
- mr_test maintenance http://openqaworker15.qa.suse.cz/tests/192293
