### PR TITLE
Patch and Reboot for Maintenance hanasr jobs

### DIFF
--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -29,7 +29,6 @@ sub cleanup {
         # Skip cleanup if ansible inventory is not present (deployment could not have been done without it)
         next if (script_run 'test -f ' . qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER')));
 
-
         if (is_azure && check_var('IS_MAINTENANCE', 1)) {
             record_info('Cleanup', `Executing peering cleanup (if peering is present)`);
             my $rg = qesap_az_get_resource_group();

--- a/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
+++ b/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
@@ -25,7 +25,7 @@ sub run {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
         record_info("$instance");
 
-        my $remote = '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ' . $instance->username . '@' . $instance->public_ip;
+        my $remote = '-o ControlMaster=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ' . $instance->username . '@' . $instance->public_ip;
 
         my $cmd_time = time();
         my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -29,6 +29,7 @@ sub run {
             loadtest('sles4sap/publiccloud/network_peering', name => 'network_peering', run_args => $run_args, @_);
             loadtest('sles4sap/publiccloud/add_server_to_hosts', name => 'add_server_to_hosts', run_args => $run_args, @_);
             loadtest('sles4sap/publiccloud/cluster_add_repos', name => 'cluster_add_repos', run_args => $run_args, @_);
+            loadtest('sles4sap/publiccloud/general_patch_and_reboot', name => 'general_patch_and_reboot', run_args => $run_args, @_);
         }
         loadtest('sles4sap/publiccloud/qesap_ansible', name => 'deploy_qesap_ansible', run_args => $run_args, @_);
     }


### PR DESCRIPTION
This solves the problem of `qesap_ansible` failing if `patch_and_reboot` runs before it.

The problem was in the ssh settings: `patch_and_reboot` runs a couple of commands via ssh on the node, and due to the ssh settings and some problem this created a multiplexed ssh connection that broke after the command was executed, leaving a stale ssh socket file behind. Later, ansible ssh command tried to re-use that socket file which lead to failure.

Adding `-o ControlMaster=no` to the ssh command in `patch_and_reboot` disables the ssh multiplexing for that command, which leads to the job succeeding.

- Related ticket: https://jira.suse.com/browse/TEAM-8035
- Verification run: http://openqaworker15.qa.suse.cz/tests/193006
