### PR TITLE
Set WONTFIX to soft failure in cc tests on 15-SP3

### DIFF
--- a/tests/security/cc/filter.pm
+++ b/tests/security/cc/filter.pm
@@ -25,7 +25,7 @@ sub run {
         my $test_dir = $audit_test::test_dir;
         assert_script_run("sed -i 's/+ class_exec//' $test_dir/audit-test/filter/run.conf") if !is_aarch64;
         assert_script_run("sed -i 's/+ class_attr//' $test_dir/audit-test/filter/run.conf");
-        record_soft_failure("poo#116683 - class_exec and class_attr fail on 15-SP3");
+        record_soft_failure("poo#116683 WONTFIX, class_exec and class_attr fail on 15-SP3");
     }
 
     run_testcase('filter', (make => 1, timeout => 180));


### PR DESCRIPTION
This prevents the openqa_review bot from reopening [poo#116683](https://progress.opensuse.org/issues/116683), since the issue will not be fixed upstream.
