### PR TITLE
susedistribution: bootloader_setup: Add user-sut-serial

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -19,7 +19,7 @@ use version_utils qw(is_microos is_sle_micro is_jeos is_leap is_sle is_tumblewee
 use mm_network;
 use Utils::Backends;
 
-use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_CONSOLE_DEFAULT_DEVICE SERIAL_CONSOLE_DEFAULT_PORT);
+use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_CONSOLE_DEFAULT_DEVICE SERIAL_CONSOLE_DEFAULT_PORT SERIAL_USER_TERMINAL_DEFAULT_DEVICE SERIAL_USER_TERMINAL_DEFAULT_PORT);
 
 our @EXPORT = qw(
   add_custom_grub_entries
@@ -1134,13 +1134,22 @@ sub zkvm_add_pty {
             target_port => SERIAL_CONSOLE_DEFAULT_PORT
         });
 
-    # sut-serial (serial terminal: emulation of QEMU's virtio console for svirt)
+    # ssh-virtsh-serial for root (serial terminal: emulation of QEMU's virtio console for svirt)
     $svirt->add_pty(
         {
             pty_dev => SERIAL_TERMINAL_DEFAULT_DEVICE,
             pty_dev_type => 'pty',
             target_type => 'virtio',
             target_port => SERIAL_TERMINAL_DEFAULT_PORT
+        });
+
+    # ssh-virtsh-serial for user (serial terminal: emulation of QEMU's virtio console for svirt)
+    $svirt->add_pty(
+        {
+            pty_dev => SERIAL_USER_TERMINAL_DEFAULT_DEVICE,
+            pty_dev_type => 'pty',
+            target_type => 'virtio',
+            target_port => SERIAL_USER_TERMINAL_DEFAULT_PORT
         });
 }
 

--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -379,7 +379,7 @@ sub select_serial_terminal {
         if (check_var('SERIAL_CONSOLE', 0)) {
             $console = $root ? 'root-console' : 'user-console';
         } else {
-            $console = $root ? 'root-sut-serial' : 'sut-serial';
+            $console = $root ? 'root-sut-serial' : 'user-sut-serial';
         }
     } elsif (has_serial_over_ssh) {
         $console = 'root-ssh';

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -18,7 +18,9 @@ use utils qw(
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_opensuse);
 use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop x11_start_program_xterm);
 use Utils::Backends;
-use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
+
+use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_USER_TERMINAL_DEFAULT_DEVICE SERIAL_USER_TERMINAL_DEFAULT_PORT);
+
 use Cwd;
 use autotest 'query_isotovideo';
 use isotovideo;
@@ -476,10 +478,15 @@ sub init_consoles {
             });
         set_var('SVIRT_VNC_CONSOLE', 'sut');
     } else {
-        # sut-serial (serial terminal: emulation of QEMU's virtio console for svirt)
+        # ssh-virtsh-serial for root (serial terminal: emulation of QEMU's virtio console for svirt)
         $self->add_console('root-sut-serial', 'ssh-virtsh-serial', {
                 pty_dev => SERIAL_TERMINAL_DEFAULT_DEVICE,
                 target_port => SERIAL_TERMINAL_DEFAULT_PORT});
+
+        # ssh-virtsh-serial for user (serial terminal: emulation of QEMU's virtio console for svirt)
+        $self->add_console('user-sut-serial', 'ssh-virtsh-serial', {
+                pty_dev => SERIAL_USER_TERMINAL_DEFAULT_DEVICE,
+                target_port => SERIAL_USER_TERMINAL_DEFAULT_PORT});
     }
 
     if ((get_var('BACKEND', '') =~ /qemu|ikvm/


### PR DESCRIPTION
user-serial is svirt serial console for user. Adding a link helps switching between root and non root user in `select_serial_terminal()`. This commit is similar to 4a89bfb0f.

Verification run:
with updated os-autoinst https://github.com/os-autoinst/os-autoinst/pull/2330 (API version 39)
- https://openqa.suse.de/tests/overview?build=sut-serial-for-user
- https://openqa.opensuse.org/tests/overview?build=sut-serial-for-user (please ignore s390x, because virtio console test does not work on z/VM)
- https://openqa.suse.de/tests/11441410#step/zypper_lifecycle/1 (sle-15-SP4-Server-DVD-Updates-s390x-Buildlifecycle-qam-minimal+base@s390x-kvm-sle12, thanks to @dzedro)

Ticket: [poo#131258](https://progress.opensuse.org/issues/131258)

NOTE: WIP is due waiting API version 39 being installed to all workers.