### PR TITLE
Cover unexpected values appearing in SBD calculation

### DIFF
--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -59,12 +59,12 @@ subtest '[script_output_retry_check] Check input values' => sub {
     $hacluster->redefine(script_output => sub { return $_[0]; });
 
     # Test mandatory args
-    dies_ok { script_output_retry_check(cmd => undef, regex_string => 'test') } "Die without cmd arg";
-    dies_ok { script_output_retry_check(cmd => 'rm -Rf /', regex_string => undef) } "Die without regex arg";
+    dies_ok { script_output_retry_check(cmd => undef, regex_string => 'test', sleep => '1') } "Die without cmd arg";
+    dies_ok { script_output_retry_check(cmd => 'rm -Rf /', regex_string => undef, sleep => '1') } "Die without regex arg";
 
     # Test regex
-    is script_output_retry_check(cmd => '42', regex_string => '^\d+$'), '42', "Test passing regex";
-    dies_ok { script_output_retry_check(cmd => 'rm -Rf /', regex_string => '^\d+$') } "Test failing regex";
+    is script_output_retry_check(cmd => '42', regex_string => '^\d+$', sleep => '1', retry => '2'), '42', "Test passing regex";
+    dies_ok { script_output_retry_check(cmd => 'rm -Rf /', regex_string => '^\d+$', sleep => '1', retry => '2') } "Test failing regex";
 };
 
 done_testing;


### PR DESCRIPTION
Module 'check_after_reboot' currently fails because of unexpected values 
appearing in SBD delay formula. This PR converts unexpected float parameters to 
int. It also sets default value in case 'pcmk_delay_max' is not obtainable. 

- Related ticket: https://jira.suse.com/browse/TEAM-8104
- Needles: N/A
- Verification run: 
http://openqa.suse.de/tests/11443306#step/check_after_reboot/35
http://openqa.suse.de/tests/11443643#step/check_after_reboot/36
