### PR TITLE
mr_test get the os_image from PUBLIC_CLOUD_IMAGE_ID

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -10,7 +10,7 @@ terraform:
     public_key: "~/.ssh/id_rsa.pub"
     private_key: "~/.ssh/id_rsa"
     aws_credentials: "/root/amazon_credentials"
-    os_image: "%QESAP_CLUSTER_OS_VER%"
+    os_image: "%PUBLIC_CLOUD_IMAGE_ID%"
 
     hana_os_major_version: "%VERSION%"
     iscsi_os_major_version: "%VERSION%"


### PR DESCRIPTION
Change the qe-sap-deployment used by mr_test in AWS to get the value for the Terraform variable os_image from the PUBLIC_CLOUD_IMAGE_ID setting. It will be in the form of the ami- and no more the image name.

- Related ticket: TEAM-8098
- Verification run: 
