### PR TITLE
ww4: Change compute node boot logic

### DIFF
--- a/tests/hpc/ww4_await_pxe_install.pm
+++ b/tests/hpc/ww4_await_pxe_install.pm
@@ -17,17 +17,13 @@ use mm_tests;
 use POSIX 'strftime';
 
 sub run ($self) {
-    if (check_screen('pxe-start')) {
-        send_key "ctrl-B";
-        save_screenshot();
-        record_info "pxe", "wait for controller";
-    }
+    assert_screen('qemu-no-bootable-device', timeout => 90);
     mutex_wait "ww4_ready";
     barrier_wait('WWCTL_READY');
     record_info 'WWCTL_READY', strftime("\%H:\%M:\%S", localtime);
-    type_string("reboot", lf => 1);
+    send_key('ctrl-alt-delete');
     save_screenshot();
-    check_screen('ww4-ready', 180);
+    assert_screen('ww4-ready', 180);
     save_screenshot();
     barrier_wait('WWCTL_DONE');
     record_info 'WWCTL_DONE', strftime("\%H:\%M:\%S", localtime);


### PR DESCRIPTION
Fix poo#131207: We were trying to enter PXE console by CTRL+B during system boot, but it was not reliable on heavy loaded workers. PXE needle was usually missed and system booted to attached ISO image. This change will solve boot issues. Node will just wait after failed boot. When is controller configuration done, we will continue on compute node by reset(send key comination CTRL-ALT-DELETE). Node will boot via PXE without issue. Test suite settings must not contain HDD_1 or ISO variable to avoid booting from them.

- Related ticket: https://progress.opensuse.org/issues/131207
- Needles: none
- Verification run (on loaded workers):  https://openqa.suse.de/tests/11438147#step/ww4_await_pxe_install/1

Logic also works on aarch64 https://openqa.suse.de/tests/11433964#step/ww4_await_pxe_install/1 , but this architecture has own problems, not related to PXE boot.