### PR TITLE
prepare_instance update in P.C. to handle ssh connectivity errors

### DIFF
--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -37,7 +37,7 @@ sub run {
     my $provider = $self->provider_factory();
     my %instance_args;
     $instance_args{check_connectivity} = 1;
-    $instance_args{ignore_wrong_pubkey} //= 0;    # parameter set for wait_for_ssh: 0 = stop on publickey error.
+    $instance_args{ignore_wrong_pubkey} //= 1; # parameter set for wait_for_ssh: 0 = stop on publickey error; 1 = retry to connect until other events or timeout.
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     $args->{my_provider} = $provider;
     my $instance = $provider->create_instance(%instance_args);


### PR DESCRIPTION
publiccloud `prepare_instance` update to handle ssh connectivity errors.

As followup of previous PR#17227, in that PR at end we simply applied key rescan refresh only, skipping the retry on error.
But,as explained in the poo [note 11](https://progress.opensuse.org/issues/130444#note-11) the last new tests errors should be likely due to a rush condition of protocol checks in the multiple types of keys. In fact in those `journal` logs appeared 3 keys checks, where RSA is ok, but being last in the attempts sequence of instance VM, those tests failed due to stop at-first-error.

Therefore, the here reproposed retry on error should solve the issue.

- Related ticket: https://progress.opensuse.org/issues/130444
- Needles: none
- Verification run: TBD see next posts.
