### PR TITLE
Bump timeout for patterns installation in sle-micro

### DIFF
--- a/tests/microos/patterns.pm
+++ b/tests/microos/patterns.pm
@@ -23,7 +23,7 @@ sub run {
     my @patterns = map { m/\|\s+(.*?)\s+\|.*pattern$/ } @available_patterns;
 
     # install new patterns
-    trup_call('pkg install -t pattern ' . join(" ", @patterns), timeout => 600);
+    trup_call('pkg install -t pattern ' . join(" ", @patterns), timeout => 720);
     process_reboot(trigger => 1);
 
     # expect empty list therefore ZYPPER_EXIT_INF_CAP_NOT_FOUND


### PR DESCRIPTION
This module is timing out frequently in `aarch64` machines in the updates test group.

- ticket: https://progress.opensuse.org/issues/131036
- Verification run:


```Created job #11443494: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443494
Created job #11443495: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443495
Created job #11443496: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443496
Created job #11443499: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443499
Created job #11443501: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443501
Created job #11443503: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443503
Created job #11443504: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443504
Created job #11443505: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443505
Created job #11443506: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443506
Created job #11443508: sle-micro-5.4-DVD-Updates-aarch64-Build20230625-1-slem_installation_autoyast@aarch64 -> https://openqa.suse.de/t11443508
```

