### PR TITLE
[WIP] Add a sample hello world test in virt_autotest

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-zypper -n --gpg-auto-import-keys install os-autoinst-distri-opensuse-deps
+#zypper -n --gpg-auto-import-keys install os-autoinst-distri-opensuse-deps

--- a/schedule/virt_autotest/textmode_svirt.yaml
+++ b/schedule/virt_autotest/textmode_svirt.yaml
@@ -3,48 +3,5 @@ description:    >
     Maintainer: nan.zhang@suse.com
     Textmode installation with integration services and open-vm-tools test modules
 schedule:
+    - installation/hello_world
     - installation/isosize
-    - '{{bootloader}}'
-    - installation/welcome
-    - installation/scc_registration
-    - installation/addon_products_sle
-    - installation/system_role
-    - installation/partitioning
-    - installation/partitioning_finish
-    - installation/installer_timezone
-    - installation/user_settings
-    - installation/user_settings_root
-    - installation/resolve_dependency_issues
-    - installation/installation_overview
-    - installation/disable_grub_timeout
-    - installation/start_install
-    - installation/await_install
-    - installation/add_serial_console
-    - installation/logs_from_installation_system
-    - installation/reboot_after_installation
-    - installation/grub_test
-    - installation/first_boot
-    - console/system_prepare
-    - console/check_network
-    - console/system_state
-    - console/integration_services
-    - '{{open_vm_tools}}'
-conditional_schedule:
-    bootloader:
-        VIRSH_VMM_FAMILY:
-            vmware:
-                - installation/bootloader_svirt
-                - '{{uefi}}'
-            hyperv:
-                - installation/bootloader_hyperv
-                - '{{uefi}}'
-    uefi:
-        UEFI:
-            1:
-                - installation/bootloader_uefi
-            0:
-                - installation/bootloader
-    open_vm_tools:
-        VIRSH_VMM_FAMILY:
-            vmware:
-                - virt_autotest/esxi_open_vm_tools

--- a/tests/installation/hello_world.pm
+++ b/tests/installation/hello_world.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This test module is a simple hello world program for 
+# testing the workflow of openqa.
+
+# Maintainer: Sudarshan Mhalas <sudarshan.mhalas@suse.com>
+
+package helloworld;
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = $class->SUPER::new($args);
+    return $self;
+}
+
+sub run {
+    my ($self) = @_;
+
+    if (get_var('HW')) {
+        # Print a greeting message
+        record_info("Hello World", "********** Hello World! **********");
+    } else {
+        record_info("Hello World", "Hello World message skipped");
+    }
+}
+
+sub test_flags {
+    return { fatal => 1 };
+}
+
+1;


### PR DESCRIPTION
This PR contains a very basic hello world test module added in the virt_autotest.  
And for speeding up the testing of this module, I have removed all other tests from the yaml file.  

- Related ticket: Not related to any ticket.
- Needles: No corresponding needles.
- Verification run: This modules is testes on my local openqa setup : 
  Pass Job : http://10.67.129.155/tests/75
  Fail Job : http://10.67.129.155/tests/72

Please Note : This PR is just for learning the PR process. And would be repaired back immediately. We are also committing these changes in a private branch.
