### PR TITLE
wait_for_ssh update in P.C. to handle check retry for other errors

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -324,12 +324,11 @@ Then by default also checks that system is up, unless systemup_check false/0.
 
 Wnen a remote pc instance is stopping in shutdown, we set input param. wait_stop=1(true),
 to expect until ssh is closed; automatic defaults systemup_check=0 and proceed_on_failure=1 applied.
-Status values of exit_code: 0 = pass; 1 = fail; 2 = fail,but on-demand can retry,till timeout.
+Status values of exit_code: 0 = pass; 1 = fail; 2 = fail,but retry,till timeout or valid outcome.
 
 Parameters:
  timeout => total wait timeout; default: 600.
  wait_stop => If true waits for ssh port to become unreachable, if false waits for ssh reachable; default: false.
- ignore_wrong_pubkey => for eventual publickey issue or unpredicted 'else' sysout, if true, lets retry in loop, false let routine fail.
  proceed_on_failure => in case of fail, if false exit test with error, if true let calling code to continue; default: wait_stop.
  username => default: username().
  public_ip => default: public_ip().
@@ -353,10 +352,10 @@ sub wait_for_ssh {
     # DMS migration (tests/publiccloud/migration.pm) is running under user "migration"
     # until it is not over we will receive "ssh permission denied (pubkey)" error
     # but it is not good reason to die early because after it will be over
-    # DMS will return normal user and error will be resolved.
-    $args{ignore_wrong_pubkey} //= 0;
+    # DMS will return normal user and error will be resolved: connection retry for that error.
+
     $args{username} //= $self->username();
-    my $delay = $args{ignore_wrong_pubkey} ? 5 : 1;
+    my $delay = 1;
     my $start_time = time();
     my $instance_msg = "instance: $self->{instance_id}, public IP: $self->{public_ip}";
     my ($duration, $exit_code, $sshout, $sysout);
@@ -366,7 +365,7 @@ sub wait_for_ssh {
         $exit_code = script_run('nc -vz -w 1 ' . $self->{public_ip} . ' 22', quiet => 1);
         last if (isok($exit_code) and not $args{wait_stop});    # ssh port open ok
         last if (not isok($exit_code) and $args{wait_stop});    # ssh port closed ok
-        sleep 1;
+        sleep $delay;
     }    # endloop
 
     # exit_code is 0 when shell script is ok
@@ -379,6 +378,7 @@ sub wait_for_ssh {
     }    # endif
 
     # check also remote system is up and running:
+    my $retry = 0;    # count retries of unexpected sysout
     if ($args{systemup_check} and isok($exit_code)) {
         # Install server's ssh publicckeys to prevent authentication interactions
         # or instance address changes during VM reboots.
@@ -388,11 +388,7 @@ sub wait_for_ssh {
             $sysout = $self->ssh_script_output(cmd => 'sudo systemctl is-system-running',
                 timeout => $args{timeout} - $duration, proceed_on_failure => 1, username => $args{username});
             # result check
-            if ($sysout =~ m/Permission denied \(publickey\).*/) {
-                $exit_code = 2;
-                last unless $args{ignore_wrong_pubkey};    # ondemand retry
-            }
-            elsif ($sysout =~ m/initializing|starting/) {    # still starting
+            if ($sysout =~ m/initializing|starting/) {    # still starting
                 $exit_code = undef;
             }
             elsif ($sysout =~ m/running/) {    # startup OK
@@ -412,10 +408,9 @@ sub wait_for_ssh {
                 $sysout .= "\nCan not reach systemd target";
                 last;
             }
-            else {    # FAIL: Connection refused or else
+            else {    # other outcome or connection refused: retry/reloop
                 $exit_code = 2;
-                $sysout .= "\nCan not reach systemd target";
-                last unless ($args{proceed_on_failure} or $args{ignore_wrong_pubkey});    # ondemand retry until timeout
+                ++$retry;
             }    # endif
             sleep $delay;
         }    # end loop
@@ -433,6 +428,7 @@ sub wait_for_ssh {
     $sysout .= "\nTimeout $args{timeout} sec. expired" if ($duration >= $args{timeout});
     $instance_msg = "Check" . ($args{systemup_check} ? " SYSTEM " : " SSH ") . ($args{wait_stop} ? "DOWN" : "UP") .
       ", $instance_msg, Duration: $duration sec.\nResult: $sshout . $sysout";
+    $instance_msg .= "\nRetries on failure: $retry" if ($retry);
     record_info("WAIT CHECK", $instance_msg);
     # OK
     return $duration if (isok($exit_code) and not $args{wait_stop});
@@ -472,7 +468,6 @@ sub softreboot {
     $args{timeout} //= 600;
     $args{username} //= $self->username();
     # see detailed explanation inside wait_for_ssh
-    $args{ignore_wrong_pubkey} //= 0;
 
     my $duration;
 
@@ -496,9 +491,7 @@ sub softreboot {
 
     my $shutdown_time = time() - $start_time;
     die("Waiting for system down failed!") unless ($shutdown_time < $args{timeout});
-    my $bootup_time = $self->wait_for_ssh(timeout => $args{timeout} - $shutdown_time,
-        username => $args{username},
-        ignore_wrong_pubkey => $args{ignore_wrong_pubkey});
+    my $bootup_time = $self->wait_for_ssh(timeout => $args{timeout} - $shutdown_time, username => $args{username});
 
     # ensure the tunnel-console is healthy, usefuly to early detect possible issues with the serial terminal
     assert_script_run("true", fail_message => "console is broken");

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -301,7 +301,6 @@ C<image>         defines the image_id to create the instance.
 C<instance_type> defines the flavor of the instance. If not specified, it will load it
                      from PUBLIC_CLOUD_INSTANCE_TYPE.
 C<timeout>             Parameter to pass to instance::wait_for_ssh.
-C<ignore_wrong_pubkey> Same as timeout.
 C<proceed_on_failure>  Same as timeout.
 
 =cut
@@ -316,7 +315,6 @@ sub create_instances {
         record_info("INSTANCE", $instance->{instance_id});
         if ($args{check_connectivity}) {
             $instance->wait_for_ssh(timeout => $args{timeout},
-                ignore_wrong_pubkey => $args{ignore_wrong_pubkey},
                 proceed_on_failure => $args{proceed_on_failure});
             # Install server's ssh publicckeys to prevent authenticity interactions
             assert_script_run(sprintf('ssh-keyscan %s >> ~/.ssh/known_hosts', $instance->public_ip));

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -101,9 +101,7 @@ sub run {
 
     record_info('system reboots');
     my ($shutdown_time, $startup_time) = $instance->softreboot(
-        timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 400),
-        ignore_wrong_pubkey => 1
-    );
+        timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 400));
 
     # Upload distro_migration.log
     $instance->upload_log("/var/log/distro_migration.log", failok => 1);

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -37,7 +37,6 @@ sub run {
     my $provider = $self->provider_factory();
     my %instance_args;
     $instance_args{check_connectivity} = 1;
-    $instance_args{ignore_wrong_pubkey} //= 1; # parameter set for wait_for_ssh: 0 = stop on publickey error; 1 = retry to connect until other events or timeout.
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     $args->{my_provider} = $provider;
     my $instance = $provider->create_instance(%instance_args);

--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -71,7 +71,7 @@ sub run {
     $instance->softreboot();
     $instance->run_ssh_command(cmd => 'sudo sestatus | grep disabled');
     $instance->run_ssh_command(cmd => 'sudo transactional-update -n setup-selinux');
-    $instance->softreboot(ignore_wrong_pubkey => 1);
+    $instance->softreboot();
 
     # SElinux and logging tests
     $instance->run_ssh_command(cmd => 'sudo sestatus | grep enabled');


### PR DESCRIPTION
Description:
- `wait_for_ssh` updated in P.C. to handle retries on _other errors_, i.e. for any _else_ error occurred, not managed by proper `if` branch, we retry the remote command in loop, eventually until timeout;
- removed option `ignore_wrong_pubkey` and related error handling: always retry check on error, in loop;
- `ignore_wrong_pubkey` option cleaned, removed from any module where it was used in `wait_for_ssh` calls parameters.

References:
  - Related ticket: https://progress.opensuse.org/issues/130444
  - Needles:None
  - Verification run:  TBD, see next
