### PR TITLE
Introduce BCI_TARGET setting

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -86,6 +86,7 @@ sub run {
     my $engine = $args->{runtime};
     my $bci_devel_repo = get_var('BCI_DEVEL_REPO');
     my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
+    my $bci_target = get_var('BCI_TARGET', 'ibs-cr');
     my $version = get_required_var('VERSION');
     my $test_envs = get_required_var('BCI_TEST_ENVS');
     return if ($test_envs eq '-');
@@ -98,7 +99,7 @@ sub run {
     assert_script_run("export CONTAINER_RUNTIME=$engine");
     $version =~ s/-SP/./g;
     assert_script_run("export OS_VERSION=$version");
-    assert_script_run("export TARGET=ibs-cr");
+    assert_script_run("export TARGET=$bci_target");
     assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;
 
     # Run common tests from test_all.py

--- a/variables.md
+++ b/variables.md
@@ -31,6 +31,7 @@ BCI_TEST_ENVS | string | | The list of environments to be tested, e.g. `base,ini
 BCI_TESTS_REPO | string | | Location of the bci-tests repository to be cloned. Used by `bci_prepare.pm`.
 BCI_TESTS_BRANCH | string | | Branch to be cloned from bci-tests. Used by `bci_prepare.pm`.
 BCI_TIMEOUT | string | | Timeout given to the command to test each environment. Used by `bci_test.pm`.
+BCI_TARGET | string | ibs-cr | Container project to be tested. `ibs-cr` is the CR project, `ibs` is the released images project
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.
 CASEDIR | string | | Path to the directory which contains tests.


### PR DESCRIPTION
Introduce the BCI_TARGET setting to allow configuration of the BCI target project for debugging and development.

- Related ticket: https://progress.opensuse.org/issues/131441
- Verification run: [aarch64 BCI_TARGET=ibs-cr](https://openqa.suse.de/tests/11452660) | [x86_64](https://openqa.suse.de/tests/11453626) | [aarch64](https://openqa.suse.de/tests/11453625)
