### PR TITLE
Set milestone test flag to agama_base.pm

### DIFF
--- a/lib/Yam/agama/agama_base.pm
+++ b/lib/Yam/agama/agama_base.pm
@@ -33,4 +33,8 @@ sub post_run_hook {
     ensure_serialdev_permissions;
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;


### PR DESCRIPTION
Set milestone test flag to agama_base.pm

- Related ticket: https://progress.opensuse.org/issues/131483
- Needles: na
- Verification run: https://openqa.opensuse.org/tests/3420599#