### PR TITLE
Move the network peering cleanup in the baseclass

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -527,21 +527,21 @@ sub qesap_ansible_script_output {
 
     my $inventory = qesap_get_inventory($args{provider});
 
-    my $pb = 'script_output.yaml';
+    my $playbook = 'script_output.yaml';
     my $local_path = $args{local_path} // '/tmp/ansible_script_output/';
     my $local_file = $args{local_file} // 'testout.txt';
     my $local_tmp = $local_path . $local_file;
     my $return_string = ((not exists $args{local_path}) && (not exists $args{local_file}));
 
-    if (script_run "test -e $pb") {
+    if (script_run "test -e $playbook") {
         my $cmd = join(' ',
             'curl', '-v', '-fL',
-            data_url("sles4sap/$pb"),
-            '-o', $pb);
+            data_url("sles4sap/$playbook"),
+            '-o', $playbook);
         assert_script_run($cmd);
     }
 
-    my @ansible_cmd = ('ansible-playbook', '-vvvv', $pb);
+    my @ansible_cmd = ('ansible-playbook', '-vvvv', $playbook);
     push @ansible_cmd, ('-l', $args{host}, '-i', $inventory);
     push @ansible_cmd, ('-u', $args{user});
     push @ansible_cmd, ('-b', '--become-user', 'root') if ($args{root});
@@ -867,7 +867,7 @@ sub qesap_az_vnet_peering {
 
     record_info("Checking peering status");
     assert_script_run("az network vnet peering show --name $peering_name --resource-group $args{target_group} --vnet-name $target_vnet --output table");
-    record_info("PEERING STATUS SUCCESS");
+    record_info("AZURE PEERING SUCCESS");
 }
 
 =head3 qesap_az_vnet_peering_delete
@@ -1307,7 +1307,7 @@ sub qesap_aws_vnet_peering {
         target_ip_net => $args{target_ip},
         trans_gw_id => $trans_gw_id);
 
-    record_info('AWS PEERING', 'SUCCESS');
+    record_info('AWS PEERING SUCCESS');
     return 1;
 }
 

--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -14,6 +14,7 @@ use warnings FATAL => 'all';
 use Exporter 'import';
 use testapi;
 use qesapdeployment;
+use sles4sap_publiccloud;
 use publiccloud::utils;
 
 our @EXPORT = qw(cleanup);
@@ -21,33 +22,26 @@ our @EXPORT = qw(cleanup);
 
 sub cleanup {
     my ($self, $args) = @_;
+
+    record_info('Cleanup',
+        join(' ',
+            'cleanup_called:', $self->{cleanup_called} // 'undefined',
+            'network_peering_present:', $self->{network_peering_present} // 'undefined'));
     # Do not run destroy if already executed
     return if ($self->{cleanup_called});
     $self->{cleanup_called} = 1;
 
-    for my $command ('ansible', 'terraform') {
-        # Skip cleanup if ansible inventory is not present (deployment could not have been done without it)
-        next if (script_run 'test -f ' . qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER')));
+    qesap_upload_logs();
+    delete_network_peering() if ($self->{network_peering_present});
 
-        if (check_var('IS_MAINTENANCE', 1)) {
-            record_info('Cleanup', `Executing peering cleanup (if peering is present)`);
-            if (is_azure) {
-                my $rg = qesap_az_get_resource_group();
-                my $ibsm_rg = get_required_var('IBSM_RG');
-                # Check that required vars are available befor delleting the peering
-                if (defined $rg && $rg ne '' && defined $ibsm_rg && $ibsm_rg ne '') {
-                    qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibsm_rg);
-                }
-                else {
-                    record_info('No peering', 'No peering exists, peering destruction skipped');
-                }
-            }
-            elsif (is_ec2) {
-                my $deployment_name = qesap_calculate_deployment_name();
-                qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
-            }
-        }
+    my @cmd_list;
+    # Only run the Ansible deregister if the inventory is present
+    push(@cmd_list, 'ansible') if (!script_run 'test -f ' . qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER')));
 
+    # Terraform destroy can be executed in any case
+    push(@cmd_list, 'terraform');
+
+    for my $command (@cmd_list) {
         record_info('Cleanup', "Executing $command cleanup");
         # 3 attempts for both terraform and ansible cleanup
         for (1 .. 3) {

--- a/tests/sles4sap/publiccloud/add_server_to_hosts.pm
+++ b/tests/sles4sap/publiccloud/add_server_to_hosts.pm
@@ -2,17 +2,24 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Deployment steps for qe-sap-deployment
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use strict;
 use warnings;
-use Mojo::Base 'publiccloud::basetest';
+use base 'sles4sap_publiccloud_basetest';
 use testapi;
-use qesapdeployment;
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
 
 sub run {
     my ($self, $run_args) = @_;
-    foreach my $instance (@{$run_args->{instances}}) {
+    my $instances = $run_args->{instances};
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+    record_info('CONTEXT LOG', "instances:$instances network_peering_present:$self->{network_peering_present}");
+
+    foreach my $instance (@{$instances}) {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
         record_info("$instance");
 
@@ -20,24 +27,6 @@ sub run {
         $instance->run_ssh_command(cmd => "echo \"$ibsm_ip download.suse.de\" | sudo tee -a /etc/hosts", username => 'cloudadmin');
         $instance->run_ssh_command(cmd => 'cat /etc/hosts', username => 'cloudadmin');
     }
-}
-
-sub test_flags {
-    return {fatal => 1};
-}
-
-sub post_fail_hook {
-    my ($self) = shift;
-    qesap_upload_logs();
-
-    # destroy the network peering, if it was created
-    qesap_az_vnet_peering_delete(source_group => qesap_az_get_resource_group(),
-        target_group => get_required_var('IBSM_RG'));
-
-    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
-    qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300) unless (script_run("test -e $inventory"));
-    qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
+++ b/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
@@ -8,17 +8,22 @@
 #
 # Maintainer: qa-c <qa-c@suse.de>
 
-use Mojo::Base 'publiccloud::basetest';
-use registration;
-use warnings;
-use testapi;
 use strict;
+use warnings;
+use base 'sles4sap_publiccloud_basetest';
+use testapi;
+use registration;
 use utils;
 use publiccloud::ssh_interactive qw(select_host_console);
 use publiccloud::utils qw(kill_packagekit);
 
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
 sub run {
     my ($self, $run_args) = @_;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
     select_host_console();    # select console on the host, not the PC instance
 
     foreach my $instance (@{$run_args->{instances}}) {
@@ -38,10 +43,6 @@ sub run {
 
         $instance->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
     }
-}
-
-sub test_flags {
-    return {fatal => 1, publiccloud_multi_module => 1};
 }
 
 1;

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_cleanup.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_cleanup.pm
@@ -6,10 +6,11 @@
 # Summary: Test module schedules cleanup at the end of the test queue.
 
 package hana_sr_schedule_cleanup;
-use base 'sles4sap_publiccloud_basetest';
-use main_common 'loadtest';
+
 use strict;
 use warnings FATAL => 'all';
+use base 'sles4sap_publiccloud_basetest';
+use main_common 'loadtest';
 use testapi;
 
 sub test_flags {
@@ -18,6 +19,8 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+
     record_info("Schedule", "Schedule cleanup job");
     loadtest('sles4sap/publiccloud/qesap_cleanup', name => "Cleanup resources", run_args => $run_args, @_);
 }

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -7,10 +7,10 @@
 
 package hana_sr_schedule_deployment;
 
-use base 'sles4sap_publiccloud_basetest';
-use main_common 'loadtest';
 use strict;
 use warnings FATAL => 'all';
+use base 'sles4sap_publiccloud_basetest';
+use main_common 'loadtest';
 use testapi;
 
 sub test_flags {
@@ -19,6 +19,8 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+
     if (get_var('QESAP_DEPLOYMENT_IMPORT')) {
         loadtest('sles4sap/publiccloud/qesap_reuse_infra', name => 'prepare_existing_infrastructure', run_args => $run_args, @_);
         loadtest('sles4sap/publiccloud/qesap_ansible', name => 'verify_infrastructure', run_args => $run_args, @_);

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
@@ -10,10 +10,10 @@
 
 package hana_sr_schedule_primary_tests;
 
-use base 'sles4sap_publiccloud_basetest';
-use main_common 'loadtest';
 use strict;
 use warnings FATAL => 'all';
+use base 'sles4sap_publiccloud_basetest';
+use main_common 'loadtest';
 use testapi;
 
 sub test_flags {
@@ -22,6 +22,8 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+
     record_info("Schedule", "Executing tests on master Hana DB");
     # 'HANASR_PRIMARY_ACTIONS' - define to override test flow
     my @database_actions = split(",", get_var("HANASR_PRIMARY_ACTIONS", 'stop,kill,crash'));

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_replica_tests.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_replica_tests.pm
@@ -10,10 +10,10 @@
 
 package hana_sr_schedule_replica_tests;
 
-use base 'sles4sap_publiccloud_basetest';
-use main_common 'loadtest';
 use strict;
 use warnings FATAL => 'all';
+use base 'sles4sap_publiccloud_basetest';
+use main_common 'loadtest';
 use testapi;
 
 sub test_flags {
@@ -22,6 +22,8 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+
     record_info("Schedule", "Executing tests on secondary site (replica)");
     # 'HANASR_SECONDARY_ACTIONS' - define to override test flow
     my @database_actions = split(",", get_var("HANASR_SECONDARY_ACTIONS", 'stop,kill,crash'));

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -5,14 +5,12 @@
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Test module for performing database takeover using various methods on "master" HANA database.
 
-use base 'sles4sap_publiccloud_basetest';
 use strict;
 use warnings FATAL => 'all';
+use base 'sles4sap_publiccloud_basetest';
 use testapi;
 use publiccloud::utils;
-use utils qw(zypper_call);
 use sles4sap_publiccloud;
-use Data::Dumper;
 use serial_terminal 'select_serial_terminal';
 
 sub test_flags {
@@ -21,8 +19,10 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    select_serial_terminal;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
     $self->{instances} = $run_args->{instances};
+
+    select_serial_terminal;
     my $test_name = $self->{name};
     my $takeover_action = $run_args->{hana_test_definitions}{$test_name}{action};
     my $site_name = $run_args->{hana_test_definitions}{$test_name}{site_name};

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -5,20 +5,26 @@
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Test module for performing database stop using various methods on secondary HANA database site.
 
-use base 'sles4sap_publiccloud_basetest';
 use strict;
 use warnings FATAL => 'all';
+use base 'sles4sap_publiccloud_basetest';
 use sles4sap_publiccloud;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use Time::HiRes 'sleep';
 
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
 sub run {
     my ($self, $run_args) = @_;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
     $self->{instances} = $run_args->{instances};
+    croak('site_b is missing or undefined in run_args') if (!$run_args->{site_b});
+
     my $hana_start_timeout = bmwqemu::scale_timeout(600);
     # $site_b = $instance of secondary instance located in $run_args->{$instances}
-    croak('site_b is missing or undefined in run_args') if (!$run_args->{site_b});
     my $site_b = $run_args->{site_b};
     select_serial_terminal;
 
@@ -65,10 +71,6 @@ sub run {
       if $self->get_promoted_hostname() eq $site_b->{instance_id};
 
     record_info("Done", "Test finished");
-}
-
-sub test_flags {
-    return {fatal => 1, publiccloud_multi_module => 1};
 }
 
 1;

--- a/tests/sles4sap/publiccloud/network_peering.pm
+++ b/tests/sles4sap/publiccloud/network_peering.pm
@@ -2,53 +2,36 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Deployment steps for qe-sap-deployment
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use strict;
 use warnings;
-use mmapi 'get_current_job_id';
-use Mojo::Base 'publiccloud::basetest';
+use base 'sles4sap_publiccloud_basetest';
 use testapi;
 use qesapdeployment;
 use publiccloud::utils qw(is_azure is_ec2);
 
 sub run {
     my ($self, $run_args) = @_;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
     my $instance = $run_args->{my_instance};
-    record_info("$instance");
+    record_info('CONTEXT LOG', "instance:$instance network_peering_present:$self->{network_peering_present}");
+
+    die 'Network peering already in place' if ($self->{network_peering_present});
     my $ibs_mirror_resource_group = get_required_var('IBSM_RG');
     if (is_azure) {
         my $rg = qesap_az_get_resource_group();
         qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_resource_group);
     } elsif (is_ec2) {
-        my $deployment_name = qesap_calculate_deployment_name(get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qesaposd'));
-        my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name . '*');
+        my $vpc_id = qesap_aws_get_vpc_id(resource_group => $self->deployment_name() . '*');
         my $ibs_mirror_target_ip = get_required_var('IBSM_IPRANGE');    # '10.254.254.240/28'
         die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
     }
+    $run_args->{network_peering_present} = $self->{network_peering_present} = 1;
 }
 
 sub test_flags {
-    return {fatal => 1};
-}
-
-sub post_fail_hook {
-    my ($self) = shift;
-    qesap_upload_logs();
-
-    if (is_azure) {
-        # destroy the network peering, if it was created
-        qesap_az_vnet_peering_delete(source_group => qesap_az_get_resource_group(),
-            target_group => get_required_var('IBSM_RG'));
-    } elsif (is_ec2) {
-        my $deployment_name = qesap_calculate_deployment_name();
-        qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
-    }
-
-    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
-    qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300) unless (script_run("test -e $inventory"));
-    qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
-    $self->SUPER::post_fail_hook;
+    return {fatal => 1, publiccloud_multi_module => 1};
 }
 
 1;

--- a/tests/sles4sap/publiccloud/peering_destroy.pm
+++ b/tests/sles4sap/publiccloud/peering_destroy.pm
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Deployment steps for qe-sap-deployment
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use strict;
 use warnings;
-use mmapi 'get_current_job_id';
-use Mojo::Base 'publiccloud::basetest';
-use testapi;
-use qesapdeployment;
+use sles4sap_publiccloud;
 
 sub run {
-    qesap_az_vnet_peering_delete(source_group => qesap_az_get_resource_group(),
-        target_group => get_required_var('IBSM_RG'));
+    my ($self, $run_args) = @_;
+    if ($run_args->{network_peering_present}) {
+        $self->{network_peering_present} = 1;
+        delete_network_peering();
+        $run_args->{network_peering_present} = $self->{network_peering_present} = 0;
+    }
 }
 
 1;

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -6,11 +6,10 @@
 # Summary: Execute ansible deployment using qe-sap-deployment project.
 # https://github.com/SUSE/qe-sap-deployment
 
-use base 'sles4sap_publiccloud_basetest';
 use strict;
 use warnings;
+use base 'sles4sap_publiccloud_basetest';
 use testapi;
-use Mojo::File 'path';
 use publiccloud::utils;
 use sles4sap_publiccloud;
 use qesapdeployment;
@@ -22,11 +21,12 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    select_serial_terminal;
-    my $ha_enabled = get_required_var('HA_CLUSTER') =~ /false|0/i ? 0 : 1;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
     my $instances = $run_args->{instances};
 
-    # skip ansible deploymnt in case of reusing infrastructure
+    my $ha_enabled = get_required_var('HA_CLUSTER') =~ /false|0/i ? 0 : 1;
+    select_serial_terminal;
+    # skip ansible deployment in case of reusing infrastructure
     unless (get_var('QESAP_DEPLOYMENT_IMPORT')) {
         die("Ansible deploymend FAILED. Check 'qesap*' logs for details.") if qesap_execute(cmd => 'ansible', timeout => 3600, verbose => 1) > 0;
         record_info('FINISHED', 'Ansible deployment process finished successfully.');
@@ -60,7 +60,7 @@ sub run {
     }
 
     get_var('QESAP_DEPLOYMENT_IMPORT') ?
-      record_info('IMPORT OK', 'Importing infrastructure successfull.') :
+      record_info('IMPORT OK', 'Importing infrastructure successfully.') :
       record_info('DEPLOY OK', 'Ansible deployment process finished successfully.');
 
     return unless $ha_enabled;

--- a/tests/sles4sap/publiccloud/qesap_cleanup.pm
+++ b/tests/sles4sap/publiccloud/qesap_cleanup.pm
@@ -7,20 +7,22 @@
 # https://github.com/SUSE/qe-sap-deployment
 
 use base 'sles4sap_publiccloud_basetest';
-use sles4sap_publiccloud_basetest;
 use strict;
 use warnings FATAL => 'all';
 use testapi;
 
 
 sub run {
-    my ($self, $args) = @_;
+    my ($self, $run_args) = @_;
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
     if (get_var('QESAP_NO_CLEANUP')) {
+        delete_network_peering() if ($run_args->{network_peering_present});
         record_info('SKIP CLEANUP',
             "Variable 'QESAP_NO_CLEANUP' set to value " . get_var('QESAP_NO_CLEANUP'));
         return 1;
     }
-    $self->cleanup($args);
+    $self->cleanup($run_args);
+    $run_args->{network_peering_present} = $self->{network_peering_present} = 0;
 }
 
 1;

--- a/tests/sles4sap/publiccloud/qesap_reuse_infra.pm
+++ b/tests/sles4sap/publiccloud/qesap_reuse_infra.pm
@@ -6,9 +6,9 @@
 # Summary: Reuse qe-sap-deployment infrastructure preserved from previous test run.
 # https://github.com/SUSE/qe-sap-deployment
 
-use base 'sles4sap_publiccloud_basetest';
 use strict;
 use warnings;
+use base 'sles4sap_publiccloud_basetest';
 use testapi;
 use publiccloud::ssh_interactive 'select_host_console';
 use serial_terminal 'select_serial_terminal';

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -20,17 +20,16 @@
 # INSTANCE_ID - SAP instance id
 
 
-use base 'sles4sap_publiccloud_basetest';
-use publiccloud::ssh_interactive 'select_host_console';
 use strict;
 use warnings;
+use base 'sles4sap_publiccloud_basetest';
+use publiccloud::ssh_interactive 'select_host_console';
 use testapi;
-use Mojo::File 'path';
 use publiccloud::utils;
 use publiccloud::instance;
 use publiccloud::instances;
-use qesapdeployment;
 use sles4sap_publiccloud;
+use qesapdeployment;
 use serial_terminal 'select_serial_terminal';
 
 our $ha_enabled = set_var_output('HA_CLUSTER', '0') =~ /false|0/i ? 0 : 1;
@@ -130,7 +129,7 @@ sub run {
 
     set_var('FENCING_MECHANISM', 'native') unless ($ha_enabled);
 
-    my $deployment_name = qesap_calculate_deployment_name(get_var('PUBLIC_CLOUD_RESOURCE_GROUP', 'qesaposd'));
+    my $deployment_name = deployment_name();
     # Create a QESAP_DEPLOYMENT_NAME variable so it includes the random
     # string appended to the PUBLIC_CLOUD_RESOURCE_GROUP
     #
@@ -141,7 +140,7 @@ sub run {
     #     resulting deployment_name: goofy123456
     #  * define QESAP_DEPLOYMENT_NAME=goofy
     #     resulting deployment_name: goofy
-    #     PUBLIC_CLOUD_RESOURCE_GROUP is completly ignored and
+    #     PUBLIC_CLOUD_RESOURCE_GROUP is completely ignored and
     #     the job_id is not included in the deployment name
     set_var('QESAP_DEPLOYMENT_NAME', get_var('QESAP_DEPLOYMENT_NAME', $deployment_name));
     record_info 'Resource Group', "Resource Group used for deployment: $deployment_name";
@@ -159,7 +158,7 @@ sub run {
     my $ansible_playbooks = create_playbook_section_list();
     my $ansible_hana_vars = create_hana_vars_section();
 
-    # Prepare QESAP deplyoment
+    # Prepare QESAP deployment
     qesap_prepare_env(provider => lc(get_required_var('PUBLIC_CLOUD_PROVIDER')));
     qesap_create_ansible_section(ansible_section => 'create', section_content => $ansible_playbooks) if @$ansible_playbooks;
     qesap_create_ansible_section(ansible_section => 'hana_vars', section_content => $ansible_hana_vars) if %$ansible_hana_vars;
@@ -188,12 +187,6 @@ sub run {
     $self->{provider} = $run_args->{my_provider} = $provider;    # Required for cleanup
     record_info('Deployment OK',);
     return 1;
-}
-
-sub post_fail_hook {
-    my ($self, $run_args) = @_;
-    qesap_upload_logs();
-    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
Move and unify code for the IBSm Network Peering cleanup  to the
sles4sap_publiccloud basetest class.
Variable name change in qesapdeploy.

Related ticket: 

Verification run: 
## Azure HanaSR without peering : 
- http://openqaworker15.qa.suse.cz/tests/195021 : the cleanup is properly executed by the `Cleanup resources` test module http://openqaworker15.qa.suse.cz/tests/195021#step/Cleanup%20resources/5 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195475 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195480 but Ansible deregister is not called http://openqaworker15.qa.suse.cz/tests/195480#step/Cleanup%20resources/12 :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195936  :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195944   :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195956  :green_circle: 

## Azure 15sp4 HanaSR with peering
- http://openqaworker15.qa.suse.cz/tests/195520 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195945 failure in NetworkPeering due to bug in previous VR job that does not delete the peering :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195951  failure in NetworkPeering  :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/196620 and  http://openqaworker15.qa.suse.cz/tests/196626 Zypper error in `general_patch_and_reboot` with zypper as package to test  :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/196635 Peering failure http://openqaworker15.qa.suse.cz/tests/196635#step/network_peering/47 :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/196646
- http://openqaworker15.qa.suse.cz/tests/196630 with a different MU and patching works http://openqaworker15.qa.suse.cz/tests/196630#step/general_patch_and_reboot/76 At the end the Azure peering is properly deleted http://openqaworker15.qa.suse.cz/tests/196630#step/Cleanup%20resources/47 :green_heart: 

## AWS 15sp4 mr_Test without peering
 - https://openqa.suse.de/tests/11470342 :  this one seems not schedule the `Cleanup resources` test module, seems like it is not using the `qesap_exec` API from qesapdeploy.pm to call the glue script to perform the deployment destruction. But at some point terraform destroy is called here https://openqa.suse.de/tests/11470342#step/ssh_interactive_end/58 (destroy is performed but not using code in this PR) :green_circle: 

## AWS 15sp4 mr_test with peering

### r5b machine type
-  https://openqa.suse.de/tests/11470343 Terraform `Error launching source instance: InsufficientInstanceCapacity`   :red_circle: 
-  https://openqa.suse.de/tests/11474622 Terraform `Error launching source instance: InsufficientInstanceCapacity`     :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195437  Terraform `Error launching source instance: InsufficientInstanceCapacity`     :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195438 Terraform `Error launching source instance: InsufficientInstanceCapacity`     :red_circle: 

### r4.8xlarge machine type
-  http://openqaworker15.qa.suse.cz/tests/195463 Terraform `Error: Error launching source instance: InvalidIPAddress.InUse: Address 10.0.1.10 is in use.` :red_circle: 
- a different incident id http://openqaworker15.qa.suse.cz/tests/195482   not expected and fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/4662ad5431d5ef70d1ee7620916b4307b20ccb4e..04e21a52603925c1f5f9228d14948323129214ab)   and [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/04e21a52603925c1f5f9228d14948323129214ab..3880c868762f3dabf14c1e8811572ec6e27370f0) :red_circle:
- http://openqaworker15.qa.suse.cz/tests/195505 :red_circle:  peering failure
- http://openqaworker15.qa.suse.cz/tests/195934 error in `cluster_add_repos` that is not expected. After that the deployment destroy is properly called but the Peering delete is not :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195940 `InvalidIPAddress.InUse: Address 10.0.1.10 is in use.` :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/196621  `InvalidIPAddress.InUse: Address 10.0.1.10 is in use.` :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/196647

## AWS 15sp4 HanaSR without peering 
- http://openqaworker15.qa.suse.cz/tests/195943 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195958 :green_circle: 

## Error handling

### Azure 15sp4 HanaSR with peering and artificial failure before the peering 
- http://openqaworker15.qa.suse.cz/tests/195434 Cleanup in post_fail_hook is called http://openqaworker15.qa.suse.cz/tests/195434#step/network_peering/8 (notice that as peering was not completed the cleanup for the peering is not performed. :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195959 :green_circle: 

### Intentionally cloned with a setting to create an error during Terraform 
- http://openqaworker15.qa.suse.cz/tests/195518 Ansible called too and should not :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195521 cleanup called only with Terraform destroy  :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195946  cleanup called only with Terraform destroy  :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195960 Terraform destroy error http://openqaworker15.qa.suse.cz/tests/195960#step/deploy_qesap_terraform/327 :red_circle: 

### Intentionally cloned with a setting to create an error during Ansible
- http://openqaworker15.qa.suse.cz/tests/195519 Cleanup called but without Ansible deregister, it is not expected :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195522 Cleanuup called and Ansible deregister called as part of it. Ansible fails 3 times (that is not fine) but later terraform destroy is called in any case :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195947 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/195961 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/196651


### Handling of generic Ansible failure
- http://openqaworker15.qa.suse.cz/tests/195932 Ansible timeout issue TEAM-8006 / TEAM-6829. The Cleanup procedure starts but the Ansible Deregister procedure fails http://openqaworker15.qa.suse.cz/tests/195932#step/deploy_qesap_ansible/29 It attemps to run Ansible 3 times that all fails. Then in any cases it calls Terraform http://openqaworker15.qa.suse.cz/tests/195932#step/deploy_qesap_ansible/73 .  :green_circle:  
- http://openqaworker15.qa.suse.cz/tests/195941 :green_circle: 

### Handling a IBSm connection error
Trigger with wrong IBSm IP address:
- http://openqaworker15.qa.suse.cz/tests/196631 :green_circle: 

### without INCIDENT_REPO setting
- http://openqaworker15.qa.suse.cz/tests/195517 and Terraform destroy properly called http://openqaworker15.qa.suse.cz/tests/195517#step/network_peering/61 :green_apple: 

## Intermediate VR with bugs in the intermediate PR code

### bug in the cleanup, missing test flag
-  http://openqaworker15.qa.suse.cz/tests/195435 fail as ssh fails, but it is quite like due to peering deleted at the end of the execution of the network_peering test module: it is not expected and fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/4662ad5431d5ef70d1ee7620916b4307b20ccb4e..04e21a52603925c1f5f9228d14948323129214ab)  and [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/04e21a52603925c1f5f9228d14948323129214ab..3880c868762f3dabf14c1e8811572ec6e27370f0) :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195464   not expected and fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/4662ad5431d5ef70d1ee7620916b4307b20ccb4e..04e21a52603925c1f5f9228d14948323129214ab)  and [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/04e21a52603925c1f5f9228d14948323129214ab..3880c868762f3dabf14c1e8811572ec6e27370f0) :red_circle:
- http://openqaworker15.qa.suse.cz/tests/195481  not expected and fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/4662ad5431d5ef70d1ee7620916b4307b20ccb4e..04e21a52603925c1f5f9228d14948323129214ab)  and [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/04e21a52603925c1f5f9228d14948323129214ab..3880c868762f3dabf14c1e8811572ec6e27370f0) :red_circle:
- http://openqaworker15.qa.suse.cz/tests/195490  not expected and fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/4662ad5431d5ef70d1ee7620916b4307b20ccb4e..04e21a52603925c1f5f9228d14948323129214ab)  and [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/04e21a52603925c1f5f9228d14948323129214ab..3880c868762f3dabf14c1e8811572ec6e27370f0) :red_circle:

### bug in the record_info of the clean let post_fail_hook to die
- http://openqaworker15.qa.suse.cz/tests/195504 fails and cleanup is not called due to an exception in the post_fail_hook fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/3880c868762f3dabf14c1e8811572ec6e27370f0..d0849cf572d56e0a491ce4ba62e514cecc6cd2df) :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195507 fails and cleanup is not called due to an exception in the post_fail_hook fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/3880c868762f3dabf14c1e8811572ec6e27370f0..d0849cf572d56e0a491ce4ba62e514cecc6cd2df) :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195508 fails and cleanup is not called due to an exception in the post_fail_hook fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/3880c868762f3dabf14c1e8811572ec6e27370f0..d0849cf572d56e0a491ce4ba62e514cecc6cd2df) :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195506 fails and cleanup is not called due to an exception in the post_fail_hook fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/3880c868762f3dabf14c1e8811572ec6e27370f0..d0849cf572d56e0a491ce4ba62e514cecc6cd2df) :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195515 fails and cleanup is not called due to an exception in the post_fail_hook fixed by [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/3880c868762f3dabf14c1e8811572ec6e27370f0..d0849cf572d56e0a491ce4ba62e514cecc6cd2df) :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195516 [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/6040546ad59b3406f4a0f1623b69a0473e759da3..9ed935f5f54590c57158cac86e5688d4d14749e6) :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195523 [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/6040546ad59b3406f4a0f1623b69a0473e759da3..9ed935f5f54590c57158cac86e5688d4d14749e6) :red_circle: 

### bug network_peering_present not propagated across test modules
- http://openqaworker15.qa.suse.cz/tests/195950 : executed mostly in parallel with 195951 but using a different MU than 195951 and 195945. It fails in `add_server_to_hosts`. Notice as `network_peering_present`  is not set in http://openqaworker15.qa.suse.cz/tests/195950#step/add_server_to_hosts/1 and it should. Should be fixed as [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/854c648c4616990f048d71a761b072cb88307fc5..8b2587defe6319c489303e766e5933d3eee42310) :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/195948  Notice as `network_peering_present`  is not set in http://openqaworker15.qa.suse.cz/tests/195950#step/add_server_to_hosts/1 and it should. Should be fixed as [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/854c648c4616990f048d71a761b072cb88307fc5..8b2587defe6319c489303e766e5933d3eee42310) :red_circle: 

### bug in add_server_to_host
VR failing due to a bug in the PR solved in  [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/79904bedce13d989fc74b516b84b28171dd0c9d6..946d501c52d63010b2a7e1394858d73bc0a78e31)
- http://openqaworker15.qa.suse.cz/tests/195957
- http://openqaworker15.qa.suse.cz/tests/195955
- http://openqaworker15.qa.suse.cz/tests/195962