### PR TITLE
export_healthcheck_basic: fix debug output to reference df instead of dh

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -125,9 +125,9 @@ echo -e "\nvmstat" >> $health_log_file
 vmstat >> $health_log_file
 echo -e "\nfdisk -l" >> $health_log_file
 fdisk -l >> $health_log_file
-echo -e "\ndh -h" >> $health_log_file
+echo -e "\ndf -h" >> $health_log_file
 df -h >> $health_log_file
-echo -e "\ndh -i" >> $health_log_file
+echo -e "\ndf -i" >> $health_log_file
 df -i >> $health_log_file
 echo -e "\nTop 10 CPU Processes" >> $health_log_file
 ps axwwo %cpu,pid,user,cmd | sort -k 1 -r -n | head -11 | sed -e '/^%/d' >> $health_log_file


### PR DESCRIPTION
Simple debug output: the basic_health_check.txt references the command
dh -h and dh -i, but actually the logger calls df -h/-i.

Clarify the log file to use show the correct commands

- Related ticket: N/A - quickfix identified while reading some log files
- Needles: N/A
- Verification run: N/A
