### PR TITLE
Switch from az_Standard_A2_v2 to az_Standard_B2s

### DIFF
--- a/data/publiccloud/azure_more_cli/azure_vn.sh
+++ b/data/publiccloud/azure_more_cli/azure_vn.sh
@@ -77,7 +77,9 @@ echo "Created container ${storage_cont}"
 count=$(( ${number_of_nics} - 1 ))
 while [ $count -ge 0 ]
 do
+    # shellcheck disable=2004
     subnet_names[${count}]=${base_subnet}"${count}"
+    # shellcheck disable=2004
     nic_names[${count}]=${base_nic}"${count}"
     # shellcheck disable=2004
     count=$(( ${count} - 1 ))

--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -24,7 +24,7 @@ variable "name" {
 }
 
 variable "type" {
-    default = "Standard_A2_v2"
+    default = "Standard_B2s"
 }
 
 variable "region" {

--- a/data/publiccloud/terraform/azure_nfstest.tf
+++ b/data/publiccloud/terraform/azure_nfstest.tf
@@ -38,7 +38,7 @@ variable "instance_count" {
     default = "1"
 }
 variable "type" {
-    default = "Standard_A2_v2"
+    default = "Standard_B2s"
 }
 
 variable "image_id" {


### PR DESCRIPTION
In Azure, we're using [Standard_A2_v2](https://azureprice.net/vm/Standard_A2_v2) VM by default but it is old and expensive. I'd like to switch to [Standard_B2s](https://azureprice.net/vm/Standard_B2s) instead.

- Related merge request: [gitlab.suse.de/qac/qac-openqa-yaml!1249](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1249)
- Verification run: [12-SP4](https://pdostal-server.suse.cz/tests/4599), [15-SP5](https://pdostal-server.suse.cz/tests/4595)
