### PR TITLE
Fixed shellcheck issues

### DIFF
--- a/data/publiccloud/azure_more_cli/azure_arm_grp.sh
+++ b/data/publiccloud/azure_more_cli/azure_arm_grp.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -u
 set -o pipefail
 # This bash source is for reporting
-# shellcheck disable=2046
 # shellcheck disable=1091
-. $(dirname "${BASH_SOURCE[0]}")/azure_lib_fn.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/azure_lib_fn.sh
 #######################################################################
 # File: azure_arm_grp.sh
 # Command: azure_arm_grp.sh <resource groupname> <location> ..........

--- a/data/publiccloud/azure_more_cli/azure_arm_mg.sh
+++ b/data/publiccloud/azure_more_cli/azure_arm_mg.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -u
 set -o pipefail
 # This bash source is for reporting
-# shellcheck disable=2046
 # shellcheck disable=1091
-. $(dirname "${BASH_SOURCE[0]}")/azure_lib_fn.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/azure_lib_fn.sh
 #######################################################################
 # File: azure_arm_mg.sh
 # Command: azure_arm_mg.sh <resource groupname> <location> ..........

--- a/data/publiccloud/azure_more_cli/azure_arm_sub.sh
+++ b/data/publiccloud/azure_more_cli/azure_arm_sub.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -u
 set -o pipefail
 # This bash source is for reporting
-# shellcheck disable=2046
 # shellcheck disable=1091
-. $(dirname "${BASH_SOURCE[0]}")/azure_lib_fn.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/azure_lib_fn.sh
 #######################################################################
 # File: azure_arm_sub.sh
 # Command: azure_arm_sub.sh <resource groupname> <location> ..........

--- a/data/publiccloud/azure_more_cli/azure_lb.sh
+++ b/data/publiccloud/azure_more_cli/azure_lb.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -u
 set -o pipefail
 # This bash source is for reporting
-# shellcheck disable=2046
 # shellcheck disable=1091
-. $(dirname "${BASH_SOURCE[0]}")/azure_lib_fn.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/azure_lib_fn.sh
 #######################################################################
 # File: azure_lb.sh
 # Command: azure_lb.sh <resource groupname> <location> ..........
@@ -261,7 +260,7 @@ case "${rid}" in
             ;;
       *"disks"* )
             # shellcheck disable=2179
-            diskids+=${rid}
+	    diskids+=${rid}
             ;;
       *"networkSecurityGroups"*)
             echo "Deleting nsg ${rid}"

--- a/data/publiccloud/azure_more_cli/azure_lib_fn.sh
+++ b/data/publiccloud/azure_more_cli/azure_lib_fn.sh
@@ -56,18 +56,15 @@ fcmd=0
 final_exit_status=0
  for ind in "${!TEST_STATUS[@]}"
  do
-    # shellcheck disable=2219
-    let "tcmd+=1"
+    (( tcmd++ ))
     if  (( ${TEST_STATUS[${ind}]} > 0 ))
     then
       echo "  Test ${ind} FAILED "
-      # shellcheck disable=2219
-      let "fcmd+=1"
+      (( fcmd++ ))
       final_exit_status=1
     else
       echo "  Test ${ind} Passed "
-      # shellcheck disable=2219
-      let "pcmd+=1"
+      (( pcmd++ ))
     fi
  done
 echo "${tcmd} tests run, ${pcmd} tests passed and ${fcmd} failed"

--- a/data/publiccloud/azure_more_cli/azure_rbac.sh
+++ b/data/publiccloud/azure_more_cli/azure_rbac.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -u
 set -o pipefail
 # This bash source is for reporting
-# shellcheck disable=2046
 # shellcheck disable=1091
-. $(dirname "${BASH_SOURCE[0]}")/azure_lib_fn.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/azure_lib_fn.sh
 ############################################################################
 # File: azure_rbac.sh
 # Description: Tests a rbac azure cli's.

--- a/data/publiccloud/azure_more_cli/azure_runcmd.sh
+++ b/data/publiccloud/azure_more_cli/azure_runcmd.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -u
 set -o pipefail
 # This bash source is for reporting
-# shellcheck disable=2046
 # shellcheck disable=1091
-. $(dirname "${BASH_SOURCE[0]}")/azure_lib_fn.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/azure_lib_fn.sh
 #######################################################################
 # File: azure_runcmd.sh
 # Command: azure_runcmd.sh <resource groupname> <location> ..........

--- a/data/publiccloud/azure_more_cli/azure_vmss.sh
+++ b/data/publiccloud/azure_more_cli/azure_vmss.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -u
 set -o pipefail
 # This bash source is for reporting
-# shellcheck disable=2046
 # shellcheck disable=1091
-. $(dirname "${BASH_SOURCE[0]}")/azure_lib_fn.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/azure_lib_fn.sh
 ############################################################################
 # File: azure_vmss.sh
 # Description: Tests a VM scaleset azure cli's.

--- a/data/publiccloud/azure_more_cli/azure_vn.sh
+++ b/data/publiccloud/azure_more_cli/azure_vn.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -u
 set -o pipefail
-# This bash source is for reporting
-# shellcheck disable=2046
+# This bash source is for reporting which is common
+# for all azure_more_cli testing
 # shellcheck disable=1091
-. $(dirname "${BASH_SOURCE[0]}")/azure_lib_fn.sh
+. "$(dirname "${BASH_SOURCE[0]}")"/azure_lib_fn.sh
 ##########################################################################
 # File: azure_vn.sh
 # Description: Tests Azure Virtual Network cli create vm with muliple subnets
@@ -73,16 +73,12 @@ echo "Created container ${storage_cont}"
 
 #based on number of nics
 #store subnet name and nic names in array
-# shellcheck disable=2004
-count=$(( ${number_of_nics} - 1 ))
+count=$(( number_of_nics - 1 ))
 while [ $count -ge 0 ]
 do
-    # shellcheck disable=2004
-    subnet_names[${count}]=${base_subnet}"${count}"
-    # shellcheck disable=2004
-    nic_names[${count}]=${base_nic}"${count}"
-    # shellcheck disable=2004
-    count=$(( ${count} - 1 ))
+    subnet_names["$count"]="$base_subnet$count"
+    nic_names["$count"]="$base_nic$count"
+    count=$(( count - 1 ))
 done
 
 # Create VNET
@@ -107,8 +103,7 @@ do
         --vnet-name "${vnet}" \
         --output table
     echo "Done creating subnet ${subnet_names[$i]} with prefix ${prefix} and ${i}"
-    # shellcheck disable=2219
-    let "i+=1"
+    (( i++ ))
 done
 
 #
@@ -185,8 +180,7 @@ do
             --output table
         echo "Created NIC ${nic}..."
     fi
-    # shellcheck disable=2219
-    let "i+=1"
+    (( i++ ))
 done
 
 #


### PR DESCRIPTION
Fixed shellcheck issues for the following
 shellcheck disable=2219
 shellcheck disable=2004
removed the disable

VR - for this currently not possible the clone job will fail due to repo does have the latest packages for latest CLI.
To test this changes, I manually execute the shell scripts and will share the output 

Updated output in https://etherpad.opensuse.org/p/yoga-pr_%2317336