### PR TITLE
x11/lxqt_reconfigure_openqa: Reconfigure the x11 console as well

### DIFF
--- a/tests/x11/lxqt_reconfigure_openqa.pm
+++ b/tests/x11/lxqt_reconfigure_openqa.pm
@@ -22,6 +22,8 @@ sub run {
     set_var('DISPLAYMANAGER', 'sddm');
     # sddm asks straight for PW with only one user; there is no need to type the username
     set_var('DM_NEEDS_USERNAME', 0);
+    # sddm might use a different tty for the session
+    console('x11')->set_tty(get_x11_console_tty());
 
     $self->result('ok');
 }


### PR DESCRIPTION
With the switch to SDDM, the graphical session might no longer be on tty7.

- Verification run: http://10.168.4.168/tests/1322
