### PR TITLE
wait_for_ssh retry delay increased for long waiting cases

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -355,7 +355,7 @@ sub wait_for_ssh {
     # DMS will return normal user and error will be resolved: connection retry for that error.
 
     $args{username} //= $self->username();
-    my $delay = 1;
+    my $delay = $args{timeout} > 180 ? 5 : 1;
     my $start_time = time();
     my $instance_msg = "instance: $self->{instance_id}, public IP: $self->{public_ip}";
     my ($duration, $exit_code, $sshout, $sysout);
@@ -433,7 +433,7 @@ sub wait_for_ssh {
     # OK
     return $duration if (isok($exit_code) and not $args{wait_stop});
     # FAIL
-    croak($sshout . $sysout) unless ($args{proceed_on_failure});
+    croak(" results summary:\n" . $sshout . $sysout) unless ($args{proceed_on_failure});
     return;    # proceed_on_failure true
 }    # end sub
 


### PR DESCRIPTION
Description
- wait_for_ssh keep fast retrying 1s the only tests timeout set max 3min, all other delay is 5s
- Also die error message (croak command) improved readability.

References
- Related ticket: https://progress.opensuse.org/issues/130444
- Needles: none.
- Verification run: TBD, see next posts.
