### PR TITLE
Stop iscsid before iscsi

### DIFF
--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -89,7 +89,9 @@ sub run {
 
     if (is_sle('=15-SP1') && systemctl('-q is-active iscsi', ignore_failure => 1)) {
         record_soft_failure('iscsi issue: bug bsc#1162078');
+        systemctl('stop iscsid');
         systemctl('start iscsi');
+        systemctl('start iscsid');
     }
 
     # iSCSI LUN must be present


### PR DESCRIPTION
On 15SP1 iscsi serivce is  attempted to start in case of being down. However it 
does not stop first the iscsid service and fails. This PR stops iscsid.service 
first and then started both serivces in order. 

- Related ticket: https://jira.suse.com/browse/TEAM-8115
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/11482568#step/iscsi_client/34
https://openqa.suse.de/tests/11482566#step/iscsi_client/34
