### PR TITLE
console/valgrind: Call cachegrind with --cache-sim=yes

### DIFF
--- a/tests/console/valgrind.pm
+++ b/tests/console/valgrind.pm
@@ -102,7 +102,7 @@ sub run {
     assert_present($output, 'totals: ', "'callgrind totals' mismatch");
 
     # cachegrind tool checks
-    assert_script_run('valgrind --tool=cachegrind --cachegrind-out-file="cachegrind.out" ./valgrind-test');
+    assert_script_run('valgrind --tool=cachegrind --cachegrind-out-file="cachegrind.out" --cache-sim=yes ./valgrind-test');
     $output = script_output('cat cachegrind.out');
     script_run('rm -f cachegrind.out');
     assert_present($output, "desc: I1", "'cachegrind desc I1' mismatch");


### PR DESCRIPTION
Valgrind 3.21 disables cache-sim by default. We check that its output is present, so just enable it explicitly again.

- Related ticket: https://progress.opensuse.org/issues/129622
- Verification run: http://10.168.4.168/tests/1323
