### PR TITLE
Fix podman_exec call in trento lib.

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -1024,7 +1024,7 @@ sub podman_wait {
         podman_exec(name => $args{name}, cmd => 'pgrep cypress');
 
         # Kill cypress within the container ...
-        podman_exec(name => $args{container_name}, cmd => 'pkill -15 cypress');
+        podman_exec(name => $args{name}, cmd => 'pkill -15 cypress');
         # ... give podman few more seconds to terminate ...
         sleep bmwqemu::scale_timeout(10);
         enter_cmd('pkill -9 podman');


### PR DESCRIPTION
Fix for bug introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17159 (I added a couple of comments in that PR on `lib/trento.pm` and `t/08_trento.t` to explain why the bugs has not been detected by the UT


Related ticket: [TRNT-921](https://jira.suse.com/browse/TRNT-921)

Verification run: 
- http://openqaworker15.qa.suse.cz/tests/197257 from here the part is using the fixed code http://openqaworker15.qa.suse.cz/tests/197257#step/test_trento_web/131  :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/197255 triggered with no more existing Trento web image tag :red_circle: 
