### PR TITLE
Run playwright installation with encryption

### DIFF
--- a/schedule/yam/agama/agama_full_disk_encryption.yaml
+++ b/schedule/yam/agama/agama_full_disk_encryption.yaml
@@ -1,0 +1,11 @@
+---
+name: agama_install_full_disk_encryption.yaml
+description: >
+  Playwright test on agama
+schedule:
+  - installation/bootloader_start
+  - yam/agama/patch_agama
+  - yam/agama/agama_full_disk_encryption
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/validate_encrypt

--- a/test_data/yam/agama_full_disk_encryption.yaml
+++ b/test_data/yam/agama_full_disk_encryption.yaml
@@ -1,0 +1,13 @@
+---
+crypttab:
+  num_devices_encrypted: 1
+cryptsetup:
+  device_status:
+    message: is active and is in use.
+    properties:
+      type: LUKS2
+      cipher: aes-xts-plain64
+      key_location: keyring
+      mode: read/write
+backup_file_info: 'LUKS encrypted file, ver 2, header size 16384, ID 3, algo sha256'
+backup_path: '/root/bkp_luks_header'

--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -13,16 +13,15 @@ use warnings;
 use base "installbasetest";
 use utils;
 use testapi qw(check_var get_var record_info);
-use version_utils qw(is_leap is_sle is_leap_micro is_sle_micro);
+use version_utils qw(is_leap is_sle is_leap_micro is_sle_micro is_alp);
 
 sub run {
     # With newer grub2 (in TW only currently), entering the passphrase in GRUB2
     # is enough. The key is passed on during boot, so it's not asked for
     # a second time.
-    return if is_boot_encrypted && !is_leap && !is_sle && !is_leap_micro && !is_sle_micro;
+    return if is_boot_encrypted && !is_leap && !is_sle && !is_leap_micro && !is_sle_micro && !is_alp;
 
     unlock_if_encrypted(check_typed_password => 1);
 }
 
 1;
-

--- a/tests/yam/agama/agama_full_disk_encryption.pm
+++ b/tests/yam/agama/agama_full_disk_encryption.pm
@@ -1,0 +1,32 @@
+## Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Run interactive installation with Agama,
+# run playwright tests directly from the Live ISO.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+use testapi qw(
+  assert_screen
+  assert_script_run
+  select_console
+  upload_logs
+);
+use power_action_utils 'power_action';
+use transactional 'process_reboot';
+
+sub run {
+    assert_screen('agama_product_selection', 120);
+    $testapi::password = 'linux';
+    select_console 'root-console';
+
+    assert_script_run('playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright full-disk-encryption', timeout => 600);
+
+    $testapi::password = 'nots3cr3t';
+    assert_script_run('reboot');
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/130003
- Related PR for Playwright stuff: https://github.com/jknphy/e2e-agama-playwright/pull/2
- Verification runs: 
  - x86_64: https://openqa.opensuse.org/tests/3418668
  - aarch64: https://openqa.opensuse.org/tests/3419297
