### PR TITLE
Introduce BCI_SKIP setting

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -210,7 +210,7 @@ sub load_container_tests {
     if (is_container_image_test() && !(is_jeos || is_sle_micro || is_microos || is_leap_micro) && $runtime !~ /k8s|openshift/) {
         # Container Image tests common
         loadtest 'containers/host_configuration';
-        loadtest 'containers/bci_prepare' if (get_var('BCI_TESTS'));
+        loadtest 'containers/bci_prepare' if (get_var('BCI_TESTS') && !get_var('BCI_SKIP'));
     }
 
     if (get_var('CONTAINER_SLEM_RANCHER')) {
@@ -228,9 +228,11 @@ sub load_container_tests {
         $run_args->{runtime} = $_;
         if (is_container_image_test()) {
             if (get_var('BCI_TESTS')) {
-                loadtest('containers/bci_test', run_args => $run_args, name => 'bci_test_' . $run_args->{runtime});
-                # For Base image we also run traditional image.pm test
-                load_image_test($run_args) if (is_sle(">=15-SP3") && check_var('BCI_TEST_ENVS', 'base'));
+                unless (get_var('BCI_SKIP')) {
+                    loadtest('containers/bci_test', run_args => $run_args, name => 'bci_test_' . $run_args->{runtime});
+                    # For Base image we also run traditional image.pm test
+                    load_image_test($run_args) if (is_sle(">=15-SP3") && check_var('BCI_TEST_ENVS', 'base'));
+                }
             } elsif (is_sle_micro || is_alp) {
                 # Test toolbox image updates
                 loadtest 'microos/toolbox';
@@ -257,6 +259,6 @@ sub load_container_tests {
             loadtest 'containers/apptainer' if (/apptainer/i);
         }
     }
-    loadtest 'containers/bci_logs' if (get_var('BCI_TESTS'));
+    loadtest 'containers/bci_logs' if (get_var('BCI_TESTS') && !get_var('BCI_SKIP'));
     loadtest 'console/coredump_collect' unless (is_public_cloud || is_jeos || is_sle_micro || is_microos || is_leap_micro || is_alp || get_var('BCI_TESTS') || is_ubuntu_host || is_expanded_support_host);
 }

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -81,6 +81,11 @@ sub run {
     my ($self, $args) = @_;
     select_serial_terminal;
 
+    if (get_var('BCI_SKIP')) {
+        record_info('BCI skipped', 'BCI test skipped due to BCI_SKIP=1 setting');
+        return;
+    }
+
     $error_count = 0;
 
     my $engine = $args->{runtime};

--- a/variables.md
+++ b/variables.md
@@ -32,6 +32,7 @@ BCI_TESTS_REPO | string | | Location of the bci-tests repository to be cloned. U
 BCI_TESTS_BRANCH | string | | Branch to be cloned from bci-tests. Used by `bci_prepare.pm`.
 BCI_TIMEOUT | string | | Timeout given to the command to test each environment. Used by `bci_test.pm`.
 BCI_TARGET | string | ibs-cr | Container project to be tested. `ibs-cr` is the CR project, `ibs` is the released images project
+BCI_SKIP | boolean | false | Switch to disable BCI test runs. Necessary for fine-granular test disablement
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.
 CASEDIR | string | | Path to the directory which contains tests.


### PR DESCRIPTION
Introduce the BCI_SKIP setting to allow to skip certain BCI test runs more granular than the job group settings allow.

- Related ticket: https://progress.opensuse.org/issues/129301
- Verification run: [normal test run](https://duck-norris.qe.suse.de/tests/13254) | [BCI_SKIP=1](https://duck-norris.qe.suse.de/tests/13255)
