### PR TITLE
Skip postgresql on RHEL7

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -86,6 +86,14 @@ sub run {
         return;
     }
 
+    # Skip the postgresql test runs on RHEL7 due to poo#129301
+    my ($os_version, $sp, $host_distri) = get_os_release;
+    my $is_rhel7 = ($host_distri eq 'rhel' && $os_version == 7);
+    if (get_var('BCI_TEST_ENVS') eq 'postgres' && $is_rhel7) {
+        record_soft_failure("poo#129301 unsupported authentication for postgresql on RHEL7");
+        return;
+    }
+
     $error_count = 0;
 
     my $engine = $args->{runtime};


### PR DESCRIPTION
Adds a softfailure for skipping the postgresql test run on RHEL7.

- Related ticket: https://progress.opensuse.org/issues/129301
- Verification run: [rhel7-postgres14](https://duck-norris.qe.suse.de/tests/13267#step/bci_test_podman/9) | [SLES15-SP4 postgres14](https://duck-norris.qe.suse.de/tests/13263#step/bci_test_docker/61) | [rhel7-pcp](https://duck-norris.qe.suse.de/tests/13264#step/bci_test_podman/40) | [rhel8-postgres14](https://duck-norris.qe.suse.de/tests/13268#step/bci_test_podman/55)
