### PR TITLE
xfstests: Support ocfs2 test

### DIFF
--- a/lib/filesystem_utils.pm
+++ b/lib/filesystem_utils.pm
@@ -275,12 +275,24 @@ sub format_partition {
     if ($filesystem =~ /ext4/) {
         $options = $args{options} // "-F";
     }
+    elsif ($filesystem =~ /ocfs2/) {
+        $options = $args{options} // "-F --fs-features=local --fs-feature-level=max-features";
+    }
     else {
         $options = $args{options} // "-f";
     }
     script_run("umount -f $part");
     sleep 1;
-    assert_script_run("mkfs.$filesystem $options $part");
+    if ($filesystem =~ /ocfs2/) {
+        # mkfs.ocfs2 will still require input y even you used -F
+        background_script_run("mkfs.$filesystem $options $part");
+        sleep 1;
+        script_run('y');
+        wait_still_screen(10, 60);
+    }
+    else {
+        assert_script_run("mkfs.$filesystem $options $part");
+    }
 }
 
 =head2 df_command


### PR DESCRIPTION
Init ocfs2 test support. The plan is in related ticket. This is first step to test ocfs2 in 1 node without cluster setting. 

- Related ticket: https://progress.opensuse.org/issues/128918
- Verification run: 
- test ocfs2/001: http://10.67.133.133/tests/241
- test generic/001-100: http://10.67.133.133/tests/245#step/generate_report/423
- (the fail is expected, to check if new code would solve hung issue, fail tests and skip tests)
