### PR TITLE
Add option for testing nginx proxy instead of apache in openqa_bootstrap

### DIFF
--- a/tests/openqa/install/openqa_bootstrap.pm
+++ b/tests/openqa/install/openqa_bootstrap.pm
@@ -21,7 +21,8 @@ sub run {
     }
 
     zypper_call('in openQA-bootstrap');
-    assert_script_run('/usr/share/openqa/script/openqa-bootstrap', 4000);
+    my $proxy_var = get_var('OPENQA_WEB_PROXY') ? 'setup_web_proxy=' . get_var('OPENQA_WEB_PROXY') . ' ' : '';
+    assert_script_run($proxy_var . "/usr/share/openqa/script/openqa-bootstrap", 4000);
 }
 
 sub test_flags {


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/131024

PR for enabling nginx in openQA RPMs: https://github.com/os-autoinst/openQA/pull/5232