### PR TITLE
Add kirk support

### DIFF
--- a/schedule/kernel/kirk.yaml
+++ b/schedule/kernel/kirk.yaml
@@ -1,0 +1,7 @@
+name:          kirk
+description:    >
+    Kirk is an all-in-one testing framework
+schedule:
+    - boot/boot_to_desktop
+    - kernel/kirk
+    - shutdown/shutdown

--- a/tests/kernel/kirk.pm
+++ b/tests/kernel/kirk.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Executes kirk testing framework
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use base 'opensusebasetest';
+use testapi qw(get_var get_required_var);
+use utils;
+use strict;
+use testapi;
+use warnings;
+use serial_terminal 'select_serial_terminal';
+
+our $result_file = 'result.json';
+
+sub run
+{
+    my ($self) = @_;
+    my $repo = get_var('KIRK_REPO', 'https://github.com/acerv/kirk.git');
+    my $branch = get_var('KIRK_BRANCH', 'master');
+    my $timeout = get_var('KIRK_TIMEOUT', '5400');
+    my $framework = get_required_var('KIRK_FRAMEWORK');
+    my $sut = get_var('KIRK_SUT', 'host');
+    my $skip = get_var('KIRK_SKIP', '');
+    my $envs = get_var('KIRK_ENVS', '');
+    my $opts = get_var('KIRK_OPTIONS', '');
+    my $suite = get_var('KIRK_SUITE', '');
+
+    select_serial_terminal;
+
+    zypper_call("in -y git");
+    assert_script_run("git clone -q --single-branch -b $branch --depth 1 $repo");
+
+    my $cmd = 'python3 kirk/kirk ';
+    $cmd .= "--verbose ";
+    $cmd .= "--suite-timeout $timeout ";
+    $cmd .= "--json-report $result_file ";
+    $cmd .= "--framework $framework " if $framework;
+    $cmd .= "--sut $sut " if $sut;
+    $cmd .= "--skip-tests $skip " if $skip;
+    $cmd .= "--env $envs " if $envs;
+    $cmd .= "--run-suite $suite " if $suite;
+    $cmd .= "$opts " if $opts;
+
+    assert_script_run($cmd, timeout => $timeout);
+}
+
+sub upload_kirk_logs
+{
+    my ($self) = @_;
+
+    assert_script_run("test -f /tmp/kirk.\$USER/latest/debug.log || echo No debug log");
+    upload_logs("/tmp/kirk.\$USER/latest/debug.log", failok => 1);
+
+    parse_extra_log('LTP', $result_file);
+}
+
+sub post_run_hook
+{
+    upload_kirk_logs;
+}
+
+sub post_fail_hook
+{
+    upload_kirk_logs;
+}
+
+1;


### PR DESCRIPTION
Kirk is a framework that aims to run mutiple Linux testing frameworks in a single application. With this patch we add support for scheduling it via yaml file.

- Related ticket: https://progress.opensuse.org/issues/130781
- Verification run: https://openqa.suse.de/tests/11406900
