### PR TITLE
Fix failure in repetitive upload_image calls

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -261,8 +261,7 @@ sub get_image_uri {
     my $image_uri = get_var("PUBLIC_CLOUD_IMAGE_URI");
     die 'The PUBLIC_CLOUD_IMAGE_URI variable makes sense only for Azure' if ($image_uri && !is_azure);
     if (!!$image_uri && $image_uri =~ /^auto$/mi) {
-        my $gen = (check_var('PUBLIC_CLOUD_AZURE_SKU', 'gen2')) ? 'V2' : 'V1';
-        my $definition = get_required_var('DISTRI') . '-' . get_required_var('FLAVOR') . '-' . get_var('PUBLIC_CLOUD_ARCH', 'x86_64') . '-' . get_required_var('VERSION') . '-' . $gen;
+        my $definition = $self->generate_azure_image_definition();
         my $version = $self->calc_img_version();    # PUBLIC_CLOUD_BUILD PUBLIC_CLOUD_BUILD_KIWI
         my $subscriptions = $self->provider_client->subscription;
         my $resource_group = $self->resource_group;


### PR DESCRIPTION
Adds the architecture to the image definition name to allow x86_64 and aarch64 images in parallel.
Also prevent a failure due to multiple image definitions, if the given image is already defined (see related failure above)

- Related failure: https://openqa.suse.de/tests/11610662
- Related ticket: https://progress.opensuse.org/issues/133013
- Verification runs:
* [x86_64 (new image)](https://duck-norris.qe.suse.de/tests/13363#step/upload_image/97) | [x86_64 (reusing existing image)](https://duck-norris.qe.suse.de/tests/13365#step/upload_image/97)
* [aarch64 (new image)](https://duck-norris.qe.suse.de/tests/13364#step/upload_image/97) | [aarch64 (using existing image)](https://duck-norris.qe.suse.de/tests/13366#step/upload_image/97)
* [slem-basic](https://duck-norris.qe.suse.de/tests/13367) | [slem_containers](https://duck-norris.qe.suse.de/tests/13369)
