### PR TITLE
Remove fatal flag on obs test

### DIFF
--- a/tests/qe-core/x11/openbroadcastersoftware.py
+++ b/tests/qe-core/x11/openbroadcastersoftware.py
@@ -40,7 +40,3 @@ def switch_to_root_console():
 def post_fail_hook(self):
     switch_to_root_console()
     assert_script_run('openqa-cli api experimental/search q=shutdown.pm')
-
-
-def test_flags(self):
-    return {'fatal': 1}


### PR DESCRIPTION
Remove fatal flag on obs test

- Related ticket: https://progress.opensuse.org/issues/109891
- Needles: none
- Verification run: https://openqa.opensuse.org/tests/3413239