### PR TITLE
Enable softfail for bsc#1212977

### DIFF
--- a/tests/console/steamcmd.pm
+++ b/tests/console/steamcmd.pm
@@ -22,6 +22,10 @@ sub run {
     # see https://github.com/ValveSoftware/steam-for-linux/issues/4341
     my $allow_exit_codes = [qw(0 6 7 8)];
     my $ret = script_run '/usr/bin/steamcmd +login anonymous +app_update 90 validate +quit', 1200;
+    if ($ret == 139) {
+        record_soft_failure("boo#1212977 steamcmd segfaults");
+        return 1;
+    }
     if ($ret == 8) {
         # Steam bug: HL needs multiple download attempts:
         # https://developer.valvesoftware.com/wiki/SteamCMD#Downloading_an_app


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/131306
- Needles: NO
- Verification run: [opensuse-15.4]( https://openqa.opensuse.org/tests/3450757#step/steamcmd/6 
) | [opensuse-15.5](https://openqa.opensuse.org/tests/3450626#step/steamcmd/6)


