### PR TITLE
Document sbd_delay_formula function for SAP PC tests

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -464,6 +464,9 @@ sub setup_sbd_delay() {
 =head2 sbd_delay_formula
     $self->sbd_delay_formula();
 
+    Collects required data from OS to calculate startup delay for pacemaker (and sbd) service after reboot.
+    Parameters are passed to 'calculate_sbd_start_delay' to calculate delay in sec. using defined formula.
+    Returns number of seconds for services start delay.
 
 =cut
 


### PR DESCRIPTION
PR adds documentation for 'sbd_delay_formula' function used for sles4sap public cloud tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: - No functional code changes
