### PR TITLE
Add base class for peering_destroy

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -453,7 +453,7 @@ sub setup_sbd_delay() {
         return;
     }
 
-    croak("<\$set_delay> value must be either 'yes', no or an integer. Got value: $delay")
+    croak("<\$set_delay> value must be either 'yes', 'no' or an integer. Got value: $delay")
       unless looks_like_number($delay) or grep /^$delay$/, qw(yes no);
 
     $self->cloud_file_content_replace('/etc/sysconfig/sbd', '^SBD_DELAY_START=.*', "SBD_DELAY_START=$delay");

--- a/tests/sles4sap/publiccloud/peering_destroy.pm
+++ b/tests/sles4sap/publiccloud/peering_destroy.pm
@@ -6,6 +6,7 @@
 
 use strict;
 use warnings;
+use base 'sles4sap_publiccloud_basetest';
 use sles4sap_publiccloud;
 
 sub run {


### PR DESCRIPTION
Bug in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17329


- Related ticket: [TEAM-8153](https://jira.suse.com/browse/TEAM-8153)

- Verification run: https://openqaworker15.qa.suse.cz/tests/199452

