### PR TITLE
Fix agama micro install timeout issue

### DIFF
--- a/tests/yam/agama/auto.pm
+++ b/tests/yam/agama/auto.pm
@@ -13,8 +13,8 @@ use utils 'clear_console';
 
 sub run {
     assert_screen('agama-main-page', 120);
-    assert_screen('agama-installing', 120);
-    assert_screen('agama-install-finished', 900);
+    assert_screen('agama-installing', 320);
+    assert_screen('agama-install-finished', 1200);
 
     select_console 'root-console';
     clear_console;


### PR DESCRIPTION
Sometimes 900s is not enough for agama micro to finish the installation, so we need increase the timeout value for it.

- Failed job: https://openqa.opensuse.org/tests/3418101#step/auto/12
                     https://openqa.opensuse.org/tests/3409587#step/auto/3
- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3418125#
