### PR TITLE
Add new needle to match grub2 after installation for agama

### DIFF
--- a/tests/yam/agama/auto.pm
+++ b/tests/yam/agama/auto.pm
@@ -20,7 +20,9 @@ sub run {
     clear_console;
     enter_cmd "reboot";
 
-    assert_screen('grub2', 120);
+    # For agama test, it is too short time to match the grub2, so we create
+    # a new needle to avoid too much needles loaded.
+    assert_screen('grub2-agama', 120);
     wait_screen_change { send_key 'ret' };
 
     my @tags = ("welcome-to", "login");


### PR DESCRIPTION
Sometimes it can't match grub2 after installation in a short time on aarch64 for agama, we add new needle to fix it.

- Failed job:  https://openqa.opensuse.org/tests/3418306#step/auto/15
- Related ticket: N/A
- Needles:  grub2-agama
- Verification run: https://openqa.opensuse.org/tests/overview?version=agama-2.1-staging&distri=alp&build=lemon-suse%2Fos-autoinst-distri-opensuse%23match-grub2-after-installation-for-agama
