### PR TITLE
Rearrange the test matrix

### DIFF
--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -162,10 +162,45 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             linuxrc => 'ifcfg="eth0=192.168.122.120/24,192.168.122.1,192.168.122.1"'
         }
     );
-
-    delete($guests{sles12sp4PV}) if (!is_sle('=12-SP4'));
-    delete($guests{sles12sp5HVM}) if (!is_sle('=12-SP5'));
-    delete($guests{sles15sp1HVM}) if (!is_sle('=15-SP1'));
+    # Filter out guests not allowed for the detected SLE version
+    if (is_sle('=12-SP5')) {
+        my @allowed_guests = qw(sles12sp5HVM sles12sp5PV sles15sp1HVM sles15sp1PV sles15sp5HVM sles15sp5PV);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=12-SP4')) {
+        my @allowed_guests = qw(sles12sp4HVM sles12sp4PV sles12sp5HVM sles12sp5PV);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP1')) {
+        my @allowed_guests = qw(sles15sp1HVM sles15sp1PV sles15sp2HVM sles15sp2PV);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP2')) {
+        my @allowed_guests = qw(sles15sp2HVM sles15sp2PV sles15sp3HVM sles15sp3PV);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP3')) {
+        my @allowed_guests = qw(sles15sp3HVM sles15sp3PV sles15sp4HVM sles15sp4PV);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP4')) {
+        my @allowed_guests = qw(sles12sp5HVM sles12sp5PV sles15sp4HVM sles15sp4PV sles15sp5HVM sles15sp5PV);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP5')) {
+        my @allowed_guests = qw(sles12sp5HVM sles12sp5PV sles15sp5HVM sles15sp5PV);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } else {
+        %guests = ();
+    }
 } elsif (get_var("REGRESSION", '') =~ /kvm|qemu/) {
     %guests = (
         sles12sp3 => {
@@ -247,6 +282,50 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             linuxrc => 'ifcfg="eth0=192.168.122.109/24,192.168.122.1,192.168.122.1"'
         }
     );
+    # Filter out guests not allowed for the detected SLE version
+    if (is_sle('=12-SP3')) {
+        my @allowed_guests = qw(sles12sp3);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=12-SP4')) {
+        my @allowed_guests = qw(sles12sp4 sles12sp5);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=12-SP5')) {
+        my @allowed_guests = qw(sles12sp5 sles15sp1 sles15sp5);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP1')) {
+        my @allowed_guests = qw(sles15sp1 sles15sp2);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP2')) {
+        my @allowed_guests = qw(sles15sp2 sles15sp3);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP3')) {
+        my @allowed_guests = qw(sles15sp3 sles15sp4);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP4')) {
+        my @allowed_guests = qw(sles12sp5 sles15sp4 sles15sp5);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('=15-SP5')) {
+        my @allowed_guests = qw(sles12sp5 sles15sp5);
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } else {
+        %guests = ();
+    }
 } elsif (get_var("REGRESSION", '') =~ /vmware/) {
     %guests = (
         sles12sp3 => {


### PR DESCRIPTION
Optimize test matrix to improve test efficiency
progress ticket: https://progress.opensuse.org/issues/132503

- Related ticket: https://progress.opensuse.org/issues/132530
- Needles: N/A
- Verification run:

XEN tests:
[XEN 12-sp4](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:xen:hansolo:12-SP4:test:&distri=sle&version=12-SP4&groupid=161)
[XEN 12-sp5](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:xen:hansolo:12-SP5:test:&distri=sle&version=12-SP5&groupid=160)
[XEN 15-sp1](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:xen:javor:15-SP1:test:&distri=sle&version=15-SP1&groupid=158)
[XEN 15-sp2](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:xen:yoda:15-SP2:test:&distri=sle&version=15-SP2&groupid=157)
[XEN 15-sp3](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:xen:witch:15-SP3:test:&distri=sle&version=15-SP3&groupid=156)
[XEN 15-sp4](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:xen:hansolo:15-SP4:test:&distri=sle&version=15-SP4&groupid=163)
[XEN 15-sp5](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:xen:darthvader:15-SP5:test:&distri=sle&version=15-SP5&groupid=168)

KVM tests
[KVM 12-sp3](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:jarjarbinks:12-SP3:test:&distri=sle&version=12-SP3&groupid=143)
[KVM 12-sp4](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:darthvader:12-SP4:test:&distri=sle&version=12-SP4&groupid=142)
[KVM 12-sp5](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:darthvader:12-SP5:test:&distri=sle&version=12-SP5&groupid=149)
[KVM 15-sp1](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:javor:15-SP1:test:&distri=sle&version=15-SP1&groupid=147)
[KVM 15-sp2](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:witch:15-SP3:test:&distri=sle&version=15-SP3&groupid=154)
[KVM 15-sp3](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:inara:15-SP2:test:&distri=sle&version=15-SP2&groupid=152)
[KVM 15-sp4](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:hansolo:15-SP4:test:&distri=sle&version=15-SP4&groupid=164)
[KVM 15-sp5](http://openqa.qam.suse.cz/tests/overview?build=:S:M:29711:302738:river:15-SP5:test:&distri=sle&version=15-SP5&groupid=167)

Hyper-V test
[Hyper-v test on 15-sp5](https://openqa.suse.de/tests/11572089)


VMware test
[VMware test on 15-sp5](https://openqa.suse.de/tests/11572090)