### PR TITLE
Fix unexpected description issue for agama jsonnet

### DIFF
--- a/data/yam/agama/auto/default_alp_micro.jsonnet
+++ b/data/yam/agama/auto/default_alp_micro.jsonnet
@@ -5,10 +5,6 @@ local findBiggestDisk(disks) =
   sorted[0].logicalname;
 
 {
-  description: |||
-        Install agama Micro with jsonnet on
-        x86_64 and aarch64.
-      |||,
   software: {
     product: 'ALP-Micro',
   },


### PR DESCRIPTION
Remove the description part from agama jsonnet as it is 'Additional properties are not allowed ('description' was unexpected)'.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/overview?distri=alp&version=agama-2.1-staging&build=lemon-suse%2Fos-autoinst-distri-opensuse%23Fix-unexpected-description-agama-jsonet