### PR TITLE
Remove multipath and replace system_probing in default yaml 

### DIFF
--- a/schedule/yast/lvm_multipath_encrypted_x86_64.yaml
+++ b/schedule/yast/lvm_multipath_encrypted_x86_64.yaml
@@ -11,7 +11,7 @@ vars:
   HDDMODEL: scsi-hd
   YUI_REST_API: 1
 schedule:
-  multipath:
+  system_probing:
     - installation/multipath
   guided_partitioning:
     - installation/partitioning/select_guided_setup

--- a/schedule/yast/lvm_multipath_x86_64.yaml
+++ b/schedule/yast/lvm_multipath_x86_64.yaml
@@ -10,7 +10,7 @@ vars:
   HDDMODEL: scsi-hd
   YUI_REST_API: 1
 schedule:
-  multipath:
+  system_probing:
     - installation/multipath
   guided_partitioning:
     - installation/partitioning/select_guided_setup

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -9,7 +9,7 @@ vars:
 schedule:
   extension_module_selection:
     - installation/module_registration/register_module_desktop
-  multipath:
+  system_probing:
     - installation/multipath
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME

--- a/schedule/yast/sle/flows/default_x86_64.yaml
+++ b/schedule/yast/sle/flows/default_x86_64.yaml
@@ -15,7 +15,6 @@ registration:
 extension_module_selection:
   - installation/module_registration/skip_module_registration
 additional_products: []
-multipath: []
 system_probing: []
 add_on_product:
   - installation/add_on_product/skip_install_addons


### PR DESCRIPTION
- Description
Remove multipath key and replace reuse system_probing in default yaml schedule files for all arches.

- Ticket
https://progress.opensuse.org/issues/132266

- VR
[**system_probing**](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=&modules=&module_re=&distri=sle&version=15-SP5&build=hjluo%2Fos-autoinst-distri-opensuse%23system_probing)