### PR TITLE
Fix dud bootloader connection timeout issue

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -787,7 +787,12 @@ sub specific_bootmenu_params {
             elsif ($dud =~ /^ASSET_\d+$/) {
                 # In case dud is uploaded as an ASSET we need just filename
                 $dud = basename(get_required_var($dud));
-                push @params, 'dud=' . shorten_url(autoinst_url("/assets/other/$dud"));
+                if (check_var('DUD_NO_SHORTEN_URL', '1')) {
+                    push @params, 'dud=' . autoinst_url("/assets/other/$dud");
+                }
+                else {
+                    push @params, 'dud=' . shorten_url(autoinst_url("/assets/other/$dud"));
+                }
             }
             else {
                 push @params, 'dud=' . data_url($dud);


### PR DESCRIPTION
Short url is not work for dud bootloader parameters, we would add a setting of 'DUD_NO_SHORTEN_URL' for the using of short url or not.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/11550109#
                                http://openqa.suse.de/tests/11550156#details
- Related MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/564
