### PR TITLE
Harmonize qe-sap-deployment config.yaml

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -1,36 +1,41 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'aws'
 apiver: 3
 terraform:
   variables:
-    aws_region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%OS_VER%"
-    os_owner: "%OS_OWNER%"
-    private_key: "%SSH_KEY_PRIV%"
-    public_key: "%SSH_KEY_PUB%"
-    aws_credentials: "/root/amazon_credentials"
-    hana_instancetype: "%HANA_INSTANCE_TYPE%"
-    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-
+    aws_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    os_owner: '%OS_OWNER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    aws_credentials: '/root/amazon_credentials'
+    hana_instancetype: '%HANA_INSTANCE_TYPE%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code=${REG_CODE} -e email_address=testing@suse.com
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address=testing@suse.com
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml
     - sap-hana-storage.yaml
@@ -41,5 +46,3 @@ ansible:
     - sap-hana-cluster.yaml -e use_sbd=false
   destroy:
     - deregister.yaml
-  variables:
-    REG_CODE: "%SCC_REGCODE_SLES4SAP%"

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -1,36 +1,41 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'aws'
 apiver: 3
 terraform:
   variables:
-    aws_region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%OS_VER%"
-    os_owner: "%OS_OWNER%"
-    private_key: "%SSH_KEY_PRIV%"
-    public_key: "%SSH_KEY_PUB%"
-    aws_credentials: "/root/amazon_credentials"
-    hana_instancetype: "%HANA_INSTANCE_TYPE%"
-    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-
+    aws_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    os_owner: '%OS_OWNER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    aws_credentials: '/root/amazon_credentials'
+    hana_instancetype: '%HANA_INSTANCE_TYPE%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=true
     - sap-hana-storage.yaml
@@ -41,6 +46,3 @@ ansible:
     - sap-hana-cluster.yaml -e use_sbd=false
   destroy:
     - deregister.yaml
-  variables:
-    REG_CODE: "%SCC_REGCODE_SLES4SAP%"
-    EMAIL: testing@suse.com

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -1,35 +1,40 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'azure'
 apiver: 3
 terraform:
   variables:
-    az_region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%OS_VER%"
-    public_key: "%SSH_KEY_PUB%"
-    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    hana_instancetype: "%HANA_INSTANCE_TYPE%"
-    vnet_address_range: "%VNET_ADDRESS_RANGE%"
-    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
-
+    az_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    public_key: '%SSH_KEY_PUB%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    hana_instancetype: '%HANA_INSTANCE_TYPE%'
+    vnet_address_range: '%VNET_ADDRESS_RANGE%'
+    subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_reboottimeout=900
     - cluster_sbd_prep.yaml
@@ -41,7 +46,3 @@ ansible:
     - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml
-  variables:
-    REG_CODE: "%SCC_REGCODE_SLES4SAP%"
-    EMAIL: testing@suse.com
-

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -1,32 +1,38 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'azure'
 apiver: 3
 terraform:
   variables:
-    az_region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%OS_VER%"
-    public_key: "%SSH_KEY_PUB%"
-    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    az_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    public_key: '%SSH_KEY_PUB%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=true -e use_reboottimeout=900
     - cluster_sbd_prep.yaml
@@ -38,6 +44,3 @@ ansible:
     - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml
-  variables:
-    REG_CODE: "%SCC_REGCODE_SLES4SAP%"
-    EMAIL: testing@suse.com

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
@@ -1,28 +1,34 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'azure'
 apiver: 3
 terraform:
   variables:
-    az_region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%OS_VER%"
-    public_key: "%SSH_KEY_PUB%"
-    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    az_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    public_key: '%SSH_KEY_PUB%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -1,35 +1,41 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'azure'
 apiver: 3
 terraform:
   variables:
-    az_region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    public_key: "%SSH_KEY_PUB%"
-    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
+    az_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    public_key: '%SSH_KEY_PUB%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%OS_VER%'
-    hana_instancetype: "%HANA_INSTANCE_TYPE%"
+    hana_instancetype: '%HANA_INSTANCE_TYPE%'
 
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_sapconf=${SAPCONF}
+    - sap-hana-preconfigure.yaml -e use_sapconf=%USE_SAPCONF%
     - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml
@@ -39,7 +45,3 @@ ansible:
     - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml
-  variables:
-    REG_CODE: "%SCC_REGCODE_SLES4SAP%"
-    EMAIL: testing@suse.com
-    SAPCONF: "%USE_SAPCONF%"

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -1,37 +1,43 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'gcp'
 apiver: 3
 terraform:
   variables:
-    project: "ei-sle-qa-sap-8469"
-    region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%OS_VER%"
-    private_key: "%SSH_KEY_PRIV%"
-    public_key: "%SSH_KEY_PUB%"
-    gcp_credentials_file: "/root/google_credentials.json"
-    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    hana_data_disk_type: "%HANA_DATA_DISK_TYPE%"
-    hana_log_disk_type: "%HANA_LOG_DISK_TYPE%"
+    project: 'ei-sle-qa-sap-8469'
+    region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    gcp_credentials_file: '/root/google_credentials.json'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    hana_data_disk_type: '%HANA_DATA_DISK_TYPE%'
+    hana_log_disk_type: '%HANA_LOG_DISK_TYPE%'
 
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml
     - sap-hana-storage.yaml
@@ -42,6 +48,3 @@ ansible:
     - sap-hana-cluster.yaml -e use_sbd=false
   destroy:
     - deregister.yaml
-  variables:
-    REG_CODE: "%SCC_REGCODE_SLES4SAP%"
-    EMAIL: testing@suse.com

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -1,37 +1,43 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'gcp'
 apiver: 3
 terraform:
   variables:
-    project: "ei-sle-qa-sap-8469"
-    region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%OS_VER%"
-    private_key: "%SSH_KEY_PRIV%"
-    public_key: "%SSH_KEY_PUB%"
-    gcp_credentials_file: "/root/google_credentials.json"
-    hana_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    iscsi_remote_python: "%ANSIBLE_REMOTE_PYTHON%"
-    hana_data_disk_type: "%HANA_DATA_DISK_TYPE%"
-    hana_log_disk_type: "%HANA_LOG_DISK_TYPE%"
+    project: 'ei-sle-qa-sap-8469'
+    region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    gcp_credentials_file: '/root/google_credentials.json'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    hana_data_disk_type: '%HANA_DATA_DISK_TYPE%'
+    hana_log_disk_type: '%HANA_LOG_DISK_TYPE%'
 
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=true
     - sap-hana-storage.yaml
@@ -42,6 +48,3 @@ ansible:
     - sap-hana-cluster.yaml -e use_sbd=false
   destroy:
     - deregister.yaml
-  variables:
-    REG_CODE: "%SCC_REGCODE_SLES4SAP%"
-    EMAIL: testing@suse.com

--- a/data/sles4sap/qe_sap_deployment/trento_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/trento_azure.yaml
@@ -1,34 +1,39 @@
-provider: "%PROVIDER%"
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'azure'
 apiver: 3
 terraform:
   variables:
-    az_region: "%REGION%"
-    deployment_name: "%DEPLOYMENTNAME%"
-    os_image: "%TRENTO_CLUSTER_OS_VER%"
-    private_key: "%SSH_KEY_PRIV%"
-    public_key: "%SSH_KEY_PUB%"
-    admin_user: "%CLUSTER_USER%"
-
+    az_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%TRENTO_CLUSTER_OS_VER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    admin_user: '%CLUSTER_USER%'
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
-    - "%HANA_SAR%"
-    - "%HANA_CLIENT_SAR%"
-    - "%HANA_SAPCAR%"
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HDB'
     sap_hana_install_instance_number: '00'
-    sap_domain: "qe-test.example.com"
+    sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_sapconf=${SAPCONF}
+    - sap-hana-preconfigure.yaml -e use_sapconf=true
     - cluster_sbd_prep.yaml
     - sap-hana-storage.yaml
     - sap-hana-download-media.yaml
@@ -38,7 +43,3 @@ ansible:
     - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml
-  variables:
-    REG_CODE: "%SCC_REGCODE_SLES4SAP%"
-    EMAIL: testing@suse.com
-    SAPCONF: true

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -22,7 +22,6 @@ sub run {
     my $qesap_provider = lc get_required_var('PUBLIC_CLOUD_PROVIDER');
 
     my %variables;
-    $variables{PROVIDER} = $qesap_provider;
     $variables{REGION} = $provider->provider_client->region;
     $variables{DEPLOYMENTNAME} = qesap_calculate_deployment_name('qesapval');
     if (get_var('QESAPDEPLOY_CLUSTER_OS_VER')) {


### PR DESCRIPTION
Made conf.yaml templates used by Trento and qesap regressio more consisten.
 - Copyright file header
 - Hardcoded provider: as in any case each config.yaml is specific to one CPS
 - Remove Ansible variables
 - String quotations


Related ticket: [TEAM-8049](https://jira.suse.com/browse/TEAM-8049)

Verification run:
 -  Results for sle-15-SP4-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_4_BYOS-qesap_azure_sapconf_test http://openqaworker15.qa.suse.cz/tests/200686 :green_circle: 
 -  Results for sle-15-SP4-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_4_BYOS-qesap_azure_saptune_test http://openqaworker15.qa.suse.cz/tests/200687 :green_circle: 
 -  Results for sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_4_BYOS-qesap_azure_saptune_test  `os_image_uri:`  http://openqaworker15.qa.suse.cz/tests/200698 :green_circle: using image uploaded by http://openqaworker15.qa.suse.cz/tests/200692
 - Result for sle-15-SP4-Qesap-Aws-Byos-x86_64-qesap_aws_sapconf_test http://openqaworker15.qa.suse.cz/tests/200694  :green_circle: 
 - Result for sle-15-SP4-Qesap-Aws-Byos-x86_64-qesap_aws_saptune_test http://openqaworker15.qa.suse.cz/tests/200695 :green_circle: 
 - Trento http://openqaworker15.qa.suse.cz/tests/200697 http://openqaworker15.qa.suse.cz/tests/200720 :green_circle: (the qe-sap-deployment part is OK)