### PR TITLE
Set sbd service timeout above sbd delay

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1100,8 +1100,8 @@ sub calculate_sbd_start_delay {
           $params{'corosync_token'} +
           $params{'corosync_consensus'} +
           $params{'pcmk_delay_max'} +
-          $params{'sbd_watchdog_timeout'} * 2 +    # msgwait = sbd_watchdog_timeout * 2
-          30;    # wait time should be greater than formula therefore adding 30s
+          $params{'sbd_watchdog_timeout'} * 2;    # msgwait = sbd_watchdog_timeout * 2
+
         record_info('SBD start delay', "SBD delay calculated: $sbd_delay_start_time");
         return ($sbd_delay_start_time);
     }

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -44,6 +44,7 @@ our @EXPORT = qw(
   wait_for_sync
   wait_for_pacemaker
   cloud_file_content_replace
+  change_sbd_service_timeout
   setup_sbd_delay
   sbd_delay_formula
   create_instance_data
@@ -427,6 +428,39 @@ sub wait_for_pacemaker {
     return 1;
 }
 
+=head2 change_sbd_service_timeout
+     $self->change_sbd_service_timeout(timeout => $timeout);
+
+     Overrides timeout for sbd systemd service to a value provided by argument.
+     This is done by creating or changing file "/etc/systemd/system/sbd.service.d/sbd_delay_start.conf"
+
+=cut
+
+sub change_sbd_service_timeout() {
+    my ($self, $service_timeout) = @_;
+    die if !defined($service_timeout);
+    my $service_override_dir = "/etc/systemd/system/sbd.service.d/";
+    my $service_override_filename = "sbd_delay_start.conf";
+    my $service_override_path = $service_override_dir . $service_override_filename;
+    my $file_exists = $self->run_cmd(cmd => join(" ", "test", "-e", $service_override_path, ";echo", "\$?"),
+        proceed_on_failure => 1,
+        quiet => 1);
+
+    # bash return code has inverted value: 0 = file exists
+    if (!$file_exists) {
+        $self->cloud_file_content_replace($service_override_path,
+            '^TimeoutSec=.*',
+            "TimeoutSec=$service_timeout");
+    }
+    else {
+        my @content = ('[Service]', "TimeoutSec=$service_timeout");
+
+        $self->run_cmd(cmd => join(" ", "mkdir", "-p", $service_override_dir), quiet => 1);
+        $self->run_cmd(cmd => join(" ", "bash", "-c", "\"echo", "'$_'", ">>", $service_override_path, "\""), quiet => 1) foreach @content;
+    }
+    record_info("Systemd SBD", "Systemd unit timeout for 'sbd.service' set to '$service_timeout'");
+}
+
 =head2 setup_sbd_delay
      $self->setup_sbd_delay();
 
@@ -446,18 +480,25 @@ sub wait_for_pacemaker {
 
 sub setup_sbd_delay() {
     my ($self) = @_;
-    my $delay = get_var('HA_SBD_START_DELAY');
-    $delay =~ s/(?<![ye])s//g;
+    my $delay = get_var('HA_SBD_START_DELAY') // '';
+
     if ($delay eq '') {
         record_info('SBD delay', 'Skipping, parameter without value');
-        return;
+        # Ensure service timeout is higher than sbd delay time
+        $delay = $self->sbd_delay_formula();
+        $self->change_sbd_service_timeout($delay + 30);
+    }
+    else {
+        $delay =~ s/(?<![ye])s//g;
+        croak("<\$set_delay> value must be either 'yes', 'no' or an integer. Got value: $delay")
+          unless looks_like_number($delay) or grep /^$delay$/, qw(yes no);
+
+        $self->cloud_file_content_replace('/etc/sysconfig/sbd', '^SBD_DELAY_START=.*', "SBD_DELAY_START=$delay");
+        # service timeout must be higher that startup delay
+        $self->change_sbd_service_timeout($self->sbd_delay_formula() + 30);
+        record_info('SBD delay', "SBD delay set to: $delay");
     }
 
-    croak("<\$set_delay> value must be either 'yes', 'no' or an integer. Got value: $delay")
-      unless looks_like_number($delay) or grep /^$delay$/, qw(yes no);
-
-    $self->cloud_file_content_replace('/etc/sysconfig/sbd', '^SBD_DELAY_START=.*', "SBD_DELAY_START=$delay");
-    record_info('SBD delay', "SBD delay set to: $delay");
     return $delay;
 }
 

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -17,8 +17,8 @@ my %sbd_delay_params = (
 subtest '[calculate_sbd_start_delay] Check sbd_delay_start values' => sub {
     my $sbd_delay;
     my %value_vs_expected = (
-        'yes' => 55,
-        '1' => 55,
+        'yes' => 25,
+        '1' => 25,
         'no' => 0,
         '0' => 0,
         '120' => 120,

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -13,6 +13,8 @@ subtest "Run 'setup_sbd_delay' with different values" => sub {
     $sles4sap_publiccloud->redefine(record_info => sub { return; });
     $sles4sap_publiccloud->redefine(cloud_file_content_replace => sub { return; });
     $sles4sap_publiccloud->redefine(croak => sub { die; });
+    $sles4sap_publiccloud->redefine(change_sbd_service_timeout => sub { return; });
+    $sles4sap_publiccloud->redefine(sbd_delay_formula => sub { return 30; });
 
     my %passing_values_vs_expected = (
         '1' => '1',
@@ -36,6 +38,9 @@ subtest "Run 'setup_sbd_delay' with different values" => sub {
     }
 
     set_var('HA_SBD_START_DELAY', undef);
+    my $returned_delay = $self->setup_sbd_delay();
+    is $returned_delay, 30, "Test with undefined 'HA_SBD_START_DELAY':\n Expected: 30\nGot: $returned_delay";
+
 };
 
 done_testing;

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -76,7 +76,8 @@ sub run {
     if ((!defined $node_to_fence && check_var('HA_CLUSTER_INIT', 'yes')) || (defined $node_to_fence && get_hostname eq "$node_to_fence")) {
         my $sbd_delay = calculate_sbd_start_delay;
         record_info("SBD delay $sbd_delay sec", "Calculated SBD start delay: $sbd_delay");
-        sleep $sbd_delay;
+        # test should wait longer that startup delay set therefore adding 15s
+        sleep $sbd_delay + 15;
     }
     # Barrier for fenced nodes to wait for start delay.
     barrier_wait("SBD_START_DELAY_$cluster_name");

--- a/tests/ha/ha_cluster_crash_test.pm
+++ b/tests/ha/ha_cluster_crash_test.pm
@@ -79,8 +79,8 @@ sub run {
                 # Wait for boot and reconnect to root console
                 $self->wait_boot;
                 select_serial_terminal;
-                # Wait for fencing delay and resources to start
-                sleep $start_delay_after_fencing;
+                # Wait for fencing delay and resources to start. Test should wait a little longer than startup delay.
+                sleep $start_delay_after_fencing + 15;
                 wait_until_resources_started();
                 $node_was_fenced = 1;
                 last;

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -45,8 +45,8 @@ sub run {
         join(' ', ucfirst($takeover_action) . 'DB on', ucfirst($site_name), "('", $target_site->{instance_id}, "')")
     );
 
-    # Setup sbd delay if defined by variable in case of crash OS to prevent cluster starting too quickly after reboot
-    $self->setup_sbd_delay() if $takeover_action eq 'crash' and defined(get_var('HA_SBD_START_DELAY'));
+    # SBD delay related setup in case of crash OS to prevent cluster starting too quickly after reboot
+    $self->setup_sbd_delay() if $takeover_action eq 'crash';
     # Calculate SBD delay sleep time
     $sbd_delay = $self->sbd_delay_formula if $takeover_action eq 'crash';
 
@@ -57,7 +57,8 @@ sub run {
     # SBD delay is active only after reboot
     if ($takeover_action eq 'crash' and $sbd_delay != 0) {
         record_info('SBD SLEEP', "Waiting $sbd_delay sec for SBD delay timeout.");
-        sleep($sbd_delay);
+        # test needs to wait a little more than sbd delay
+        sleep($sbd_delay + 30);
         $self->wait_for_pacemaker();
     }
 

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -46,8 +46,8 @@ sub run {
     my $db_action = get_var('DB_ACTION', $run_args->{hana_test_definitions}{$self->{name}});
     croak('Database action unknown or not defined.') if ($db_action !~ /^(stop|kill|crash)$/);
 
-    if (($db_action eq 'crash') && defined(get_var('HA_SBD_START_DELAY'))) {
-        # Setup sbd delay in case of crash OS to prevent cluster starting too quickly after reboot.
+    if (($db_action eq 'crash')) {
+        # SBD delay related setup in case of crash OS to prevent cluster starting too quickly after reboot
         $self->setup_sbd_delay();
         record_info('Crash DB', "Crashing OS on Site B ('$site_b->{instance_id}')");
     }
@@ -66,7 +66,8 @@ sub run {
     # SBD delay is active only after reboot
     if ($db_action eq 'crash' and $sbd_delay != 0) {
         record_info('SBD SLEEP', "Waiting $sbd_delay sec for SBD delay timeout.");
-        sleep($sbd_delay);
+        # sleep needs to be a little longer than sbd start delay
+        sleep($sbd_delay + 30);
         $self->wait_for_pacemaker();
     }
 


### PR DESCRIPTION
This PR adjusts sbd systemd service timeout so it is always above sbd start 
delay to prevent service failure before pacemaker even starts. SBD calculation 
now returns only exact calculated delay without adding extra seconds. This is 
moved outside of the function. 

- Related ticket: https://jira.suse.com/browse/TEAM-8175
- Verification run: 

Public cloud:
15SP3:
default value - https://openqaworker15.qa.suse.cz/tests/201957#step/Crash_site_a-primary/29
** test failed with default values but that might possibly be due to timeout not being high enough. Test below has value increased to 300s and PASSED which previously did not happen. 

defined value 300s - https://openqaworker15.qa.suse.cz/tests/201369#step/Crash_site_a-primary/29

15SP4:
default values - https://openqaworker15.qa.suse.cz/tests/201359#step/Crash_site_a-primary/27
defined value 300s - https://openqaworker15.qa.suse.cz/tests/201360#step/Crash_site_a-primary/27

15SP5:
default values: https://openqaworker15.qa.suse.cz/tests/201358#step/Crash_site_a-primary/27
defined value 300s: https://openqaworker15.qa.suse.cz/tests/201357#step/Crash_site_a-primary/27

On premise:
15SP3: https://openqa.suse.de/tests/11560682
15SP4: https://openqa.suse.de/tests/11560676
15SP5: http://openqa.suse.de/tests/11560689

