### PR TITLE
Support install hosts via iPXE for virt and hana test

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -112,7 +112,7 @@
     </dns>
   </networking>
   <partitioning config:type="list">
-  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745'};
+  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'ph052' => 'wwn-0x5000c500e28a91bb', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0'};
   % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
   % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : '';
     <drive>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -118,7 +118,7 @@
     <ntp_sync>systemd</ntp_sync>
   </ntp-client>
   <partitioning config:type="list">
-  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc'};
+  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'ph052' => 'wwn-0x5000c500e28a91bb', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0'};
   % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
   % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : ''; 
     <drive>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -425,6 +425,9 @@ sub load_boot_tests {
         loadtest "boot/boot_from_pxe";
         set_var("DELAYED_START", get_var("PXEBOOT"));
     }
+    elsif (get_var("IPXE")) {
+        loadtest "installation/ipxe_install";
+    }
     else {
         loadtest "installation/data_integrity" if data_integrity_is_applicable;
         loadtest "installation/bootloader" unless load_bootloader_s390x();

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -129,7 +129,7 @@ sub run {
     # So push a needle to check upcoming reboot on zVM that is a way to indicate the stage done
     push @needles, 'autoyast-stage1-reboot-upcoming' if is_s390x || (is_pvm && !is_upgrade);
     # Similar situation over IPMI backend, we can check against PXE menu
-    push @needles, qw(prague-pxe-menu qa-net-selection) if is_ipmi;
+    push @needles, qw(prague-pxe-menu qa-net-selection) if is_ipmi and !get_var('IPXE');
     # Import untrusted certification for SMT
     push @needles, 'untrusted-ca-cert' if get_var('SMT_URL');
     # Workaround for removing package error during upgrade
@@ -354,7 +354,7 @@ sub run {
     # match openSUSE Welcome dialog on matching distros
     push(@needles, 'opensuse-welcome') if opensuse_welcome_applicable;
     # There will be another reboot for IPMI backend
-    push @needles, qw(prague-pxe-menu qa-net-selection) if is_ipmi;
+    push @needles, qw(prague-pxe-menu qa-net-selection) if is_ipmi and !get_var('IPXE');
     until (match_has_tag('reboot-after-installation')
           || match_has_tag('opensuse-welcome'))
     {


### PR DESCRIPTION
- Schedule installation/ipxe_install.pm for tests with IPXE=1.
- Add more kernel and linuxrc arguments in bootscript for virt and hana tests.
- Finally don't touch the prefixing in autoyast profile path with SUT_IP in lib/autoyast.pm as it will be fixed in another PR. It breaks IPXE autoyast installation, fg. http://openqa.suse.de/tests/11712594#step/installation/1. 
- Prevent warnings `Use of uninitialized value...`, fg. https://openqa.suse.de/tests/11712594/logfile?filename=autoinst-log.txt
- "Boot flag" is not required anymore after vh015 firmwire upgrade
- Support passing "EXTRA_PXE_CMDLINE" to bootscripts.
- Enable sshd during autoyast installation for sake of debugging and post_fail_hook().
- Allow to install other SLE release with '+MIRROR_HTTP' as always.
- Be able to install TW with installer DVD outside O3. fg.[TW in my own openqa server](http://10.67.129.27/tests/77)
- Differentiate iPXE server on baremental-support service and static
  iPXE server by introducing a new setting, IPXE_STATIC(O3 and OSD share same ipxe menu)
- Add hard disk's wwns of two machines to autoyast profiles for virt test s in a seperate commit


Related ticket: https://progress.opensuse.org/issues/128060
Needles MR: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1647

Verification run: 
[xen tests with autoyast](http://10.67.129.27/tests/66)
[sle12sp5 with autoyast](http://10.67.129.27/tests/65)
[sle12sp5 xen without autoyast](http://10.67.129.27/tests/64)
[kvm without autoyast on OSD](https://openqa.suse.de/tests/11626483#)
[kvm with autoyast on OSD](https://openqa.suse.de/tests/11895292)
[prj2 tests with autoyast](http://10.67.129.27/tests/67)
[TW kvm test on O3](https://openqa.opensuse.org/tests/3522659)
[UEFI test with autoyast](http://10.67.129.27/tests/70)
[TW in my own openqa server](http://10.67.129.27/tests/77)