### PR TITLE
data/zvm.xml: Drop use of removed kdump options

### DIFF
--- a/data/zvm.xml
+++ b/data/zvm.xml
@@ -505,12 +505,10 @@
     <crash_kernel>220M</crash_kernel>
     <crash_xen_kernel>220M\&lt;4G</crash_xen_kernel>
     <general t="map">
-      <KDUMPTOOL_FLAGS/>
       <KDUMP_AUTO_RESIZE>no</KDUMP_AUTO_RESIZE>
       <KDUMP_COMMANDLINE/>
       <KDUMP_COMMANDLINE_APPEND/>
       <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
-      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
       <KDUMP_CPUS/>
       <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
       <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>


### PR DESCRIPTION
They were removed in kdump 1.9 and yast-kdump no longer accepts them.

Failure: https://openqa.opensuse.org/tests/3420135

Verification run: https://openqa.opensuse.org/tests/3422145#live