### PR TITLE
Add new needle instead of generic grub2

### DIFF
--- a/tests/yam/agama/agama_installation.pm
+++ b/tests/yam/agama/agama_installation.pm
@@ -27,7 +27,9 @@ sub run {
     upload_logs('./test-results/take_screenshots-The-Installer-installs-the-system-chromium/trace.zip');
 
     assert_script_run('reboot');
-    assert_screen('grub2', 120);
+    # For agama test, it is too short time to match the grub2, so we create
+    # a new needle to avoid too much needles loaded.
+    assert_screen('grub2-agama', 120);
     my @tags = ("welcome-to", "login");
     assert_screen(\@tags, 300);
 }

--- a/tests/yam/agama/agama_lvm.pm
+++ b/tests/yam/agama/agama_lvm.pm
@@ -28,7 +28,9 @@ sub run {
     upload_logs('./test-results/lvm-Use-logical-volume-management-LVM-as-storage-device-for-installation-chromium/trace.zip');
 
     assert_script_run('reboot');
-    assert_screen('grub2', 120);
+    # For agama test, it is too short time to match the grub2, so we create
+    # a new needle to avoid too much needles loaded.
+    assert_screen('grub2-agama', 120);
     my @tags = ("welcome-to", "login");
     assert_screen(\@tags, 300);
     reset_consoles;


### PR DESCRIPTION
Failed job: https://openqa.opensuse.org/tests/3422058#step/agama_installation/13 , we need add new needle instead of generic grub2. 

- Related ticket: N/A
- Needles: grub2-agama
- Verification run: [openqa.mypersonalinstance.de/tests/xyz#step/module/x](https://openqa.opensuse.org/tests/overview?version=agama-2.1-staging&build=lemon-suse%2Fos-autoinst-distri-opensuse%23use-new-needle-instead-generic-grub2&distri=alp)
 https://openqa.opensuse.org/tests/3422192#step/agama_installation/7 failed for slow caused missed character.
