### PR TITLE
Test registration role use

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -64,8 +64,20 @@ sub create_playbook_section_list {
     my @hana_playbook_list;
 
     # Add registration module as first element - "QESAP_SCC_NO_REGISTER" skips scc registration via ansible
-    push @playbook_list, 'registration.yaml -e reg_code=' . get_required_var('SCC_REGCODE_SLES4SAP') . " -e email_address=''"
-      unless (get_var('QESAP_SCC_NO_REGISTER'));
+    if ( check_var( 'USE_ROLES', 1 ) ) {
+        push @playbook_list,
+            'registration_role.yaml -e reg_code='
+          . get_required_var('SCC_REGCODE_SLES4SAP')
+          . " -e email_address=''"
+          unless ( get_var('QESAP_SCC_NO_REGISTER') );
+    }
+    else {
+        push @playbook_list,
+            'registration.yaml -e reg_code='
+          . get_required_var('SCC_REGCODE_SLES4SAP')
+          . " -e email_address=''"
+          unless ( get_var('QESAP_SCC_NO_REGISTER') );
+    }
 
     # SLES4SAP/HA related playbooks
     if ($ha_enabled) {


### PR DESCRIPTION
This PR adds conditional clauses for the use of the registration role from Steven's repo () in qe-sap-deployment. See https://github.com/SUSE/qe-sap-deployment/pull/164 for details.


- Related ticket: https://jira.suse.com/browse/TEAM-8142
- Verification runs:

run double vrs with+without `USE_ROLES` openqa var for `hanasr regression` and `qesap_regression`:
for qesap_regression the repo was downloaded, but since the ansible create section is hardcoded in the config file and not dynamically created, the old registration.yaml is used, so both VRs are identical and have the same behaviour as before.
for hanasr regression, with USE_ROLES the new registration role is used, and without USE_ROLES the behaviour is the same as it was before.
**qesap regression**:
- with `USE_ROLES`: http://openqaworker15.qa.suse.cz/tests/201365
- without: http://openqaworker15.qa.suse.cz/tests/201366
(same behavior for both)
**hanasr regression**:
- with `USE_ROLES`: https://openqaworker15.qa.suse.cz/tests/201367 (the registration role from steven's repo is used)
- without: http://openqaworker15.qa.suse.cz/tests/201364 (our old registration.yaml task-based playbook is used)
