### PR TITLE
Introduce BCI tests for tumbleweed based images

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -105,8 +105,8 @@ sub run {
         foreach my $pkg (@packages) {
             zypper_call("--quiet in $pkg", timeout => 300);
         }
-        assert_script_run('pip3.6 --quiet install --upgrade pip', timeout => 600);
-        assert_script_run("pip3.6 --quiet install tox --ignore-installed six", timeout => 600);
+        assert_script_run('pip --quiet install --upgrade pip', timeout => 600);
+        assert_script_run("pip --quiet install tox --ignore-installed six", timeout => 600);
     } else {
         die "Unexpected distribution ($host_distri) has been used";
     }

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -111,6 +111,7 @@ sub run {
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
     assert_script_run("export CONTAINER_RUNTIME=$engine");
     $version =~ s/-SP/./g;
+    $version = lc($version);
     assert_script_run("export OS_VERSION=$version");
     assert_script_run("export TARGET=$bci_target");
     assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;


### PR DESCRIPTION
Following subset of images can be found in development group. In order to proceed with testing we need to adapt the BCI openQA modules.

- Images: init, minimal, micro, busybox, golang, rust, ruby and postgres14
- Related ticket: https://progress.opensuse.org/issues/132338

#### Verification runs:

* [init](http://kepler.suse.cz/tests/21195)
* [golang](http://kepler.suse.cz/tests/21197#step/_root_BCI-tests_all_podman/8)
* [postgres](http://kepler.suse.cz/tests/21196)
* [sle-15-SP5-BCI-Updates-x86_64-Build11.5_minimal-image-bci-minimal_15.5_on_SLES_15-SP4@64bit](http://kepler.suse.cz/tests/21203)
* [sle-15-SP5-BCI-Updates-x86_64-Build11.5_minimal-image-bci-minimal_15.5_on_SLES_15-SP2@64bit](http://kepler.suse.cz/tests/21204)
* [sle-15-SP5-BCI-Updates-x86_64-Build11.5_minimal-image-bci-minimal_15.5_on_SLES_12-SP5@64bit](http://kepler.suse.cz/tests/21202)