### PR TITLE
Get openQA hostname

### DIFF
--- a/tests/publiccloud/aws_cli.pm
+++ b/tests/publiccloud/aws_cli.pm
@@ -42,7 +42,7 @@ sub run {
     my $machine_name = "openqa-cli-test-vm-$job_id";
     my $security_group_name = "openqa-cli-test-sg-$job_id";
     my $openqa_ttl = get_var('MAX_JOB_TIME', 7200) + get_var('PUBLIC_CLOUD_TTL_OFFSET', 300);
-    my $openqa_url = get_required_var('OPENQA_URL');
+    my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
     my $tag = "{Key=openqa-cli-test-tag,Value=$job_id},{Key=openqa_created_by,Value=$created_by},{Key=openqa_ttl,Value=$openqa_ttl}";
 

--- a/tests/publiccloud/azure_cli.pm
+++ b/tests/publiccloud/azure_cli.pm
@@ -39,7 +39,7 @@ sub run {
     my $machine_name = "openqa-cli-test-vm-$job_id";
 
     my $openqa_ttl = get_var('MAX_JOB_TIME', 7200) + get_var('PUBLIC_CLOUD_TTL_OFFSET', 300);
-    my $openqa_url = get_required_var('OPENQA_URL');
+    my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
     my $tags = "openqa-cli-test-tag=$job_id openqa_created_by=$created_by openqa_ttl=$openqa_ttl";
 

--- a/tests/publiccloud/azure_more_cli.pm
+++ b/tests/publiccloud/azure_more_cli.pm
@@ -93,10 +93,9 @@ sub run {
 
     my $openqa_ttl = get_var('MAX_JOB_TIME', 7200) +
       get_var('PUBLIC_CLOUD_TTL_OFFSET', 300);
-    my $openqa_url = get_required_var('OPENQA_URL');
+    my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
-    my $tags =
-      "openqa-cli-test-tag=$job_id openqa_created_by=$created_by openqa_ttl=$openqa_ttl";
+    my $tags = "openqa-cli-test-tag=$job_id openqa_created_by=$created_by openqa_ttl=$openqa_ttl";
     my $location = "southeastasia";
     my $sshkey = "~/.ssh/id_rsa.pub";
 

--- a/tests/publiccloud/google_cli.pm
+++ b/tests/publiccloud/google_cli.pm
@@ -48,7 +48,7 @@ sub run {
     my $openqa_ttl = get_var('MAX_JOB_TIME', 7200) + get_var('PUBLIC_CLOUD_TTL_OFFSET', 300);
     my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $openqa_hostname = get_required_var('OPENQA_HOSTNAME');
-    $openqa_hostname =~ tr/./-/;
+    $openqa_hostname =~ tr/./_/;
     # Only hyphens (-), underscores (_), lowercase characters, and numbers are allowed.
     my $labels = "openqa-cli-test-label=$job_id,openqa_created_by=$openqa_hostname,openqa_ttl=$openqa_ttl";
     my $metadata = 'ssh-keys=susetest:$(cat ~/.ssh/id_rsa.pub | sed "s/[[:blank:]]*$//") susetest';

--- a/tests/publiccloud/google_cli.pm
+++ b/tests/publiccloud/google_cli.pm
@@ -46,6 +46,7 @@ sub run {
 
     my $machine_name = "openqa-cli-test-vm-$job_id";
     my $openqa_ttl = get_var('MAX_JOB_TIME', 7200) + get_var('PUBLIC_CLOUD_TTL_OFFSET', 300);
+    my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $openqa_hostname = get_required_var('OPENQA_HOSTNAME');
     $openqa_hostname =~ tr/./-/;
     # Only hyphens (-), underscores (_), lowercase characters, and numbers are allowed.


### PR DESCRIPTION
This PR:
- Uses `OPENQA_HOSTNAME` if `OPENQA_URL` is not available.
- Use underscores instead of hyphens to mask dots in hostname (hyphens are valid characters in hostnames unlke underscores).