### PR TITLE
Enable existing libyui-rest-api modules in migration 

### DIFF
--- a/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
+++ b/lib/Installation/InstallationSettings/InstallationSettingsPage.pm
@@ -60,7 +60,7 @@ sub is_loaded_completely {
     eval {
         $result = YuiRestClient::Wait::wait_until(object => sub {
                 my $overview_content = $self->get_overview_content();
-                return ($overview_content =~ m/SSH port will be/);
+                return ($overview_content =~ m/Boot Loader Type/);
         }, timeout => 60, message => "Overview content is not loaded.");
     };
     $result ? 1 : 0;

--- a/schedule/migration/migration_offline_media_x86_64.yaml
+++ b/schedule/migration/migration_offline_media_x86_64.yaml
@@ -24,7 +24,7 @@ schedule:
   - installation/upgrade/accept_remove_previous_repos
   - installation/addon_products_sle
   - installation/resolve_dependency_issues
-  - installation/bootloader_settings/disable_boot_menu_timeout_navigating_tabs
+  - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation
@@ -32,4 +32,3 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
-  

--- a/schedule/migration/migration_offline_media_x86_64.yaml
+++ b/schedule/migration/migration_offline_media_x86_64.yaml
@@ -1,6 +1,6 @@
 name: migration_offline_x86_64.yaml
 description: |
-  This is for offline migraiton tests on x86_64.
+  This is for offline migration tests on x86_64.
 vars:
   ORIGIN_SYSTEM_VERSION: '%HDDVERSION%'
   UPGRADE_TARGET_VERSION: '%VERSION%'
@@ -18,18 +18,18 @@ schedule:
   - migration/version_switch_upgrade_target
   - installation/bootloader
   - installation/setup_libyui
-  - installation/welcome
+  - installation/upgrade/accept_keyboard_layout
   - installation/upgrade/select_for_update
   - installation/licensing/accept_license
   - installation/upgrade/accept_remove_previous_repos
-  - installation/scc_registration
   - installation/addon_products_sle
   - installation/resolve_dependency_issues
-  - installation/installation_overview
-  - installation/disable_grub_timeout
-  - installation/start_install
-  - installation/await_install
+  - installation/bootloader_settings/disable_boot_menu_timeout_navigating_tabs
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
+  

--- a/tests/installation/upgrade/accept_keyboard_layout.pm
+++ b/tests/installation/upgrade/accept_keyboard_layout.pm
@@ -1,0 +1,18 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles page for keyboard layout selection.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    $testapi::distri->get_language_keyboard()->get_keyboard_test();
+    $testapi::distri->get_navigation()->proceed_next_screen();
+}
+
+1;


### PR DESCRIPTION
1a71a734586260e13d889341da429964075309cf  Enable existing libyui-rest-api modules in migration 

See https://progress.opensuse.org/issues/131048

Updates of the yaml schedule schedule/migration/migration_offline_media_x86_64.yaml

50ffb933603d2c3123ef4090109062e674c69efe Modify InstallationSettingsPage to work in migration

The string "SSH port will be" is not visible if ssh is not enabled, so
the subroutine is_loaded_completely can fail in this case.
On the other hand "Boot Loader Type" is always present, so we can use it
in all cases.

f10b0bee1ec13dc19bd00df959552156530bfe69 Add a module to accept keyboard layout

VR https://openqa.suse.de/tests/overview?version=15-SP5&distri=sle&build=JRivrain%2Fos-autoinst-distri-opensuse%2317421