### PR TITLE
Fix serial terminal prompt handling

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -140,7 +140,8 @@ sub set_serial_prompt {
     die "Invalid prompt string '$serial_term_prompt'"
       unless $serial_term_prompt =~ s/\s*$//r;
     enter_cmd(qq/PS1="$serial_term_prompt"/);
-    wait_serial(qr/PS1="$serial_term_prompt"/);
+    wait_serial(qq/PS1="$serial_term_prompt"/, no_regex => 1);
+    $testapi::distri->{serial_term_prompt} = $serial_term_prompt;
 }
 
 =head2 login
@@ -388,7 +389,6 @@ sub select_serial_terminal {
     }
 
     die "No support for backend '$backend', add it" if (!defined $console) || ($console eq '');
-    $testapi::distri->{serial_term_prompt} = $prompt;
     select_console($console);
 }
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -761,6 +761,46 @@ sub console_nr {
     return $nr;
 }
 
+=head2 prompt_for_user
+
+  prompt_for_user($username)
+
+Returns the shell prompt that should be set for the given username
+=cut
+
+sub prompt_for_user {
+    my ($self, $username) = @_;
+
+    return $username eq 'root' ? '# ' : '$ ';
+}
+
+=head2 get_console_info
+
+  get_console_info($console)
+
+Returns a triplet describing the console: Session privilege level (root/user),
+username, console type.
+=cut
+
+sub get_console_info {
+    my ($self, $console) = @_;
+
+    $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell|serial-ssh)/;
+    my ($name, $user, $type) = ($1, $1, $2);
+    $name = $user //= '';
+    $type //= '';
+    if ($name eq 'user') {
+        $user = $testapi::username;
+    }
+    elsif ($name =~ /log|tunnel/) {
+        $user = 'root';
+    }
+
+    # Use ssh for generalhw(ssh/no VNC) for given consoles
+    $type = 'ssh' if (get_var('BACKEND', '') =~ /generalhw/ && !defined(get_var('GENERAL_HW_VNC_IP')) && $console =~ /root-console|install-shell|user-console|log-console/);
+    return ($name, $user, $type);
+}
+
 =head2 activate_console
 
   activate_console($console [, [ensure_tty_selected => 0|1] [, skip_set_standard_prompt => 0|1] [, skip_setterm => 0|1] [, timeout => $timeout]])
@@ -798,19 +838,7 @@ sub activate_console {
         }
     }
 
-    $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell|serial-ssh)/;
-    my ($name, $user, $type) = ($1, $1, $2);
-    $name = $user //= '';
-    $type //= '';
-    if ($name eq 'user') {
-        $user = $testapi::username;
-    }
-    elsif ($name =~ /log|tunnel/) {
-        $user = 'root';
-    }
-    # Use ssh for generalhw(ssh/no VNC) for given consoles
-    $type = 'ssh' if (get_var('BACKEND', '') =~ /generalhw/ && !defined(get_var('GENERAL_HW_VNC_IP')) && $console =~ /root-console|install-shell|user-console|log-console/);
-
+    my ($name, $user, $type) = $self->get_console_info($console);
     diag "activate_console, console: $console, type: $type";
     if ($type eq 'console') {
         # different handling for ssh consoles on s390x zVM
@@ -857,8 +885,7 @@ sub activate_console {
         }
     }
     elsif ($type =~ /^(virtio-terminal|sut-serial)$/) {
-        $self->{serial_term_prompt} = $user eq 'root' ? '# ' : '> ';
-        serial_terminal::login($user, $self->{serial_term_prompt});
+        serial_terminal::login($user, $self->prompt_for_user($user));
     }
     elsif ($console eq 'novalink-ssh') {
         assert_screen "password-prompt-novalink";
@@ -901,7 +928,7 @@ sub activate_console {
         assert_screen "text-logged-in-$user", 60;
     }
     elsif ($type eq 'serial-ssh') {
-        serial_terminal::set_serial_prompt($user eq 'root' ? '# ' : '$ ');
+        serial_terminal::set_serial_prompt($self->prompt_for_user($user));
     }
     else {
         diag 'activate_console called with generic type, no action';
@@ -951,6 +978,10 @@ sub console_selected {
         die $ret->{error} if $ret->{error};
         $autotest::selected_console = $console;
     }
+
+    my ($name, $user, $type) = $self->get_console_info($console);
+    $self->{serial_term_prompt} = $self->prompt_for_user($user);
+
     $args{await_console} //= 1;
     $args{tags} //= $console;
     $args{ignore} //= qr{sut|user-virtio-terminal|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary|serial-ssh};


### PR DESCRIPTION
The expected console prompt was switched inconsistently and could get out of sync with the actual SUT shell with the right sequence of console switching function calls. Move the automatic prompt setup logic to `susedistribution::activate_console()` and `susedistribution::console_selected()`. Also make sure that manual prompt changes using the appropriate helper function will update the console prompt expected by script_run().

- Related ticket: https://progress.opensuse.org/issues/126794
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/11574354
