### PR TITLE
Update create_hdd_gnome_sdk_allpatterns_s390x.xml

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_sdk_allpatterns_s390x.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_sdk_allpatterns_s390x.xml
@@ -300,10 +300,6 @@
       <package>xorg-x11-Xvnc</package>
       <package>wicked</package>
       <package>snapper</package>
-      <package>sle-module-server-applications-release</package>
-      <package>sle-module-basesystem-release</package>
-      <package>sle-module-development-tools-release</package>
-      <package>sle-module-desktop-applications-release</package>
       <package>openssh</package>
       <package>kexec-tools</package>
       <package>kdump</package>


### PR DESCRIPTION
Adding -release files is no longer necessary now that https://bugzilla.suse.com/show_bug.cgi?id=1202234 is fixed

VR https://openqa.suse.de/tests/11567313