### PR TITLE
Use agama_base as base package to avoid password issue

### DIFF
--- a/tests/yam/agama/agama_installation.pm
+++ b/tests/yam/agama/agama_installation.pm
@@ -5,7 +5,7 @@
 # run playwright tests directly from the Live ISO.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-use base 'y2_installbase';
+use base Yam::agama::agama_base;
 use strict;
 use warnings;
 

--- a/tests/yam/agama/agama_lvm.pm
+++ b/tests/yam/agama/agama_lvm.pm
@@ -5,7 +5,7 @@
 # run playwright tests directly from the Live ISO.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-use base 'y2_installbase';
+use base Yam::agama::agama_base;
 use strict;
 use warnings;
 


### PR DESCRIPTION
Use agama_base as base package to avoid the password issue after reboot.

- Failed job: https://openqa.opensuse.org/tests/3432170#step/validate_lvm/4
- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3434416#
