### PR TITLE
installation/bootloader_s390: Remove broken attempt at printing y2start.log

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -299,7 +299,6 @@ sub run {
     my $exception = $@;
 
     # add y2start/log output if exception is happening
-    die join("\n", '#', `cat /var/log/YaST2/y2start.log`) if $exception;
     die join("\n", '#' x 67, $exception, '#' x 67) if $exception;
 
     # activate console so we can call wait_serial later

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -297,8 +297,6 @@ sub run {
     }
 
     my $exception = $@;
-
-    # add y2start/log output if exception is happening
     die join("\n", '#' x 67, $exception, '#' x 67) if $exception;
 
     # activate console so we can call wait_serial later


### PR DESCRIPTION
That code runs on the worker, not the SUT.
It also terminates execution before printing $exception.

Verification run: https://openqa.opensuse.org/tests/3436187