### PR TITLE
Public Cloud: azure upload_img: Add DISTRI and VERSION to offer

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -177,7 +177,7 @@ sub upload_img {
     assert_script_run("az storage blob update --account-key $key --container-name '$container' --account-name '$storage_account' --name $img_name --content-md5 $file_md5");
 
     my $publisher = get_var("PUBLIC_CLOUD_AZURE_PUBLISHER", "qe-c");
-    my $offer = get_var("PUBLIC_CLOUD_AZURE_OFFER", get_var('FLAVOR') . '-' . get_var('PUBLIC_CLOUD_ARCH', 'x86_64'));
+    my $offer = get_var("PUBLIC_CLOUD_AZURE_OFFER", get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('FLAVOR') . '-' . get_var('PUBLIC_CLOUD_ARCH', 'x86_64'));
     my $definition = get_required_var('DISTRI') . '-' . get_required_var('FLAVOR') . '-' . get_var('PUBLIC_CLOUD_ARCH', 'x86_64') . '-' . get_required_var('VERSION') . '-' . $gen;
     $definition = get_var("PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION", uc($definition));
     my $sku = get_var("PUBLIC_CLOUD_AZURE_SKU", 'gen2');

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -262,7 +262,7 @@ sub get_image_uri {
     die 'The PUBLIC_CLOUD_IMAGE_URI variable makes sense only for Azure' if ($image_uri && !is_azure);
     if (!!$image_uri && $image_uri =~ /^auto$/mi) {
         my $gen = (check_var('PUBLIC_CLOUD_AZURE_SKU', 'gen2')) ? 'V2' : 'V1';
-        my $definition = get_required_var('DISTRI') . '-' . get_required_var('FLAVOR') . '-' . get_required_var('PUBLIC_CLOUD_ARCH', 'x86_64') . '-' . get_required_var('VERSION') . '-' . $gen;
+        my $definition = get_required_var('DISTRI') . '-' . get_required_var('FLAVOR') . '-' . get_var('PUBLIC_CLOUD_ARCH', 'x86_64') . '-' . get_required_var('VERSION') . '-' . $gen;
         my $version = $self->calc_img_version();    # PUBLIC_CLOUD_BUILD PUBLIC_CLOUD_BUILD_KIWI
         my $subscriptions = $self->provider_client->subscription;
         my $resource_group = $self->resource_group;


### PR DESCRIPTION
In my previous pull request I forgot about SLEM. We have multiple versions of SLEM and the `--offer` needs to be unique. That's why I do this:

- Related ticket: [poo#114517](https://progress.opensuse.org/issues/114517)
- Previous pull request: #17310
- Related merge request: [gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1269](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1269)
- Related failure: https://openqa.suse.de/tests/11600399#downloads
- Verification run: [upload_img](https://pdostal-server.suse.cz/tests/4707), [slem_containers](https://pdostal-server.suse.cz/tests/4711)
