### PR TITLE
Add test suite of autoyast_mini for s390x and aarch64

### DIFF
--- a/data/autoyast_sle15/mini_s390x.xml
+++ b/data/autoyast_sle15/mini_s390x.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- minimal autoyast profile -->
+    <suse_register>
+      <do_registration config:type="boolean">true</do_registration>
+      <email/>
+      <reg_code>{{SCC_REGCODE}}</reg_code>
+      <install_updates config:type="boolean">true</install_updates>
+      <reg_server>{{SCC_URL}}</reg_server>
+      <addons config:type="list">
+        <addon>
+          <name>sle-module-basesystem</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+      </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+	    <cpu_mitigations>auto</cpu_mitigations>
+	    <gfxmode>auto</gfxmode>
+	    <hiddenmenu>false</hiddenmenu>
+	    <os_prober>false</os_prober>
+	    <secure_boot>false</secure_boot>
+	    <terminal>console</terminal>
+	    <timeout t="integer">0</timeout>
+	    <trusted_grub>false</trusted_grub>
+	    <update_nvram>true</update_nvram>
+	    <xen_kernel_append>crashkernel=147M\&lt;4G</xen_kernel_append>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+</profile>

--- a/schedule/yast/autoyast/autoyast_mini_aarch64.yaml
+++ b/schedule/yast/autoyast/autoyast_mini_aarch64.yaml
@@ -1,0 +1,54 @@
+---
+name: autoyast_mini
+description: >
+  The schedule for the common installation with AutoYaST control file.
+  Could be used by variety of AutoYaST test suites with different set of openQA
+  variables. The variables are specified in Job Group or in Test Suite settings.
+vars:
+  AUTOYAST_PREPARE_PROFILE: 1
+  AUTOYAST_CONFIRM: 1
+  DESKTOP: textmode
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - update/zypper_up
+  - console/zypper_in
+  - console/zypper_log
+  - console/orphaned_packages_check
+  - autoyast/verify_cloned_profile
+test_data:
+  disks:
+    - name: vda
+      table_type: gpt
+      partitions:
+        - name: vda2
+          formatting_options:
+            filesystem: btrfs
+          mounting_options:
+            mount_point: /
+        - name: vda3
+          formatting_options:
+            filesystem: xfs
+          mounting_options:
+            mount_point: /home
+        - name: vda4
+          formatting_options:
+            filesystem: swap
+          mounting_options:
+            mount_point: '[SWAP]'
+  <<: !include test_data/yast/autoyast/profiles/mini_aarch64.yaml

--- a/schedule/yast/autoyast/autoyast_mini_s390x.yaml
+++ b/schedule/yast/autoyast/autoyast_mini_s390x.yaml
@@ -1,0 +1,53 @@
+---
+name: autoyast_mini
+description: >
+  The schedule for the common installation with AutoYaST control file.
+  Could be used by variety of AutoYaST test suites with different set of openQA
+  variables. The variables are specified in Job Group or in Test Suite settings.
+vars:
+  AUTOYAST_PREPARE_PROFILE: 1
+  AUTOYAST_CONFIRM: 1
+  DESKTOP: textmode
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/first_boot
+  - console/validate_partition_table_via_blkid
+  - console/validate_blockdevices
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - update/zypper_up
+  - console/zypper_in
+  - console/zypper_log
+  - console/orphaned_packages_check
+  - autoyast/verify_cloned_profile
+test_data:
+  disks:
+    - name: vda
+      table_type: gpt
+      partitions:
+        - name: vda2
+          formatting_options:
+            filesystem: btrfs
+          mounting_options:
+            mount_point: /
+        - name: vda3
+          formatting_options:
+            filesystem: xfs
+          mounting_options:
+            mount_point: /home
+        - name: vda4
+          formatting_options:
+            filesystem: swap
+          mounting_options:
+            mount_point: '[SWAP]'
+  <<: !include test_data/yast/autoyast/profiles/mini_s390x.yaml

--- a/test_data/yast/autoyast/profiles/mini_aarch64.yaml
+++ b/test_data/yast/autoyast/profiles/mini_aarch64.yaml
@@ -1,0 +1,32 @@
+---
+profile:
+  partitioning:
+    drive:
+      - device: /dev/vda
+        disklabel: gpt
+        enable_snapshots: 'true'
+        partitions:
+          __count: 4
+          partition:
+            - filesystem: btrfs
+              mount: /
+              subvolumes:
+                subvolume:
+                  - copy_on_write: 'true'
+                    path: usr/local
+                  - copy_on_write: 'false'
+                    path: var
+                  - copy_on_write: 'true'
+                    path: srv
+                  - copy_on_write: 'true'
+                    path: root
+                  - copy_on_write: 'true'
+                    path: opt
+                  - copy_on_write: 'true'
+                    path: tmp
+              subvolumes_prefix: '@'
+            - filesystem: xfs
+              mount: /home
+            - filesystem: swap
+              mount: swap
+        type: CT_DISK

--- a/test_data/yast/autoyast/profiles/mini_s390x.yaml
+++ b/test_data/yast/autoyast/profiles/mini_s390x.yaml
@@ -1,0 +1,32 @@
+---
+profile:
+  partitioning:
+    drive:
+      - device: /dev/disk/by-path/ccw-0.0.0000
+        disklabel: gpt
+        enable_snapshots: 'true'
+        partitions:
+          __count: 4
+          partition:
+            - filesystem: btrfs
+              mount: /
+              subvolumes:
+                subvolume:
+                  - copy_on_write: 'true'
+                    path: usr/local
+                  - copy_on_write: 'false'
+                    path: var
+                  - copy_on_write: 'true'
+                    path: srv
+                  - copy_on_write: 'true'
+                    path: root
+                  - copy_on_write: 'true'
+                    path: opt
+                  - copy_on_write: 'true'
+                    path: tmp
+              subvolumes_prefix: '@'
+            - filesystem: xfs
+              mount: /home
+            - filesystem: swap
+              mount: swap
+        type: CT_DISK


### PR DESCRIPTION
Add test suite of autoyast_mini for s390x and aarch64

- Related ticket: https://progress.opensuse.org/issues/131342
- Needles: na
- Verification run: 
    s390x:   https://openqa.suse.de/t11614211
    aarch64: https://openqa.suse.de/tests/11609007#step/verify_cloned_profile/6
