### PR TITLE
Public Cloud: Make sure the openqa_var_SERVER tag does not contain slash

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -623,11 +623,14 @@ c<{"key": "value"}> where c<value> must be a string.
 sub terraform_param_tags
 {
     my ($self) = @_;
+    my $openqa_var_server = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
+    # Remove the http:// https:// and/or the slash at the end
+    $openqa_var_server =~ s@^https?://|/$@@gm;
     my $tags = {
         openqa_ttl => get_var('MAX_JOB_TIME', 7200) + get_var('PUBLIC_CLOUD_TTL_OFFSET', 300),
         openqa_var_JOB_ID => get_current_job_id(),
         openqa_var_NAME => get_var(NAME => ''),
-        openqa_var_SERVER => get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'))
+        openqa_var_SERVER => $openqa_var_server
     };
 
     return encode_json($tags);


### PR DESCRIPTION
- Verification run: [openqa.suse.de](https://openqa.suse.de/tests/11609478), [pdostal-server.suse.cz](https://pdostal-server.suse.cz/tests/4712)
