### PR TITLE
Mask purge-kernels service then not to race with PackageKit

### DIFF
--- a/tests/update/prepare_system_for_update_tests.pm
+++ b/tests/update/prepare_system_for_update_tests.pm
@@ -1,10 +1,11 @@
-# Copyright 2017-2018 SUSE LLC
+# Copyright 2017-2023 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Package: PackageKit
 # Summary: Prepare system for actual desktop specific updates
 # - Disable delta rpms if system is not sle
 # - Unmask packagekit service
+# - Mask purge-kernels service, see poo#133016
 # - Run "pkcon refresh"
 # Maintainer: Stephan Kulow <coolo@suse.de>
 
@@ -21,6 +22,7 @@ sub run {
     # default is true, for legacy reasons we were running this on openSUSE only
     assert_script_run "echo \"download.use_deltarpm = false\" >> /etc/zypp/zypp.conf" if !is_sle;
     systemctl 'unmask packagekit';
+    systemctl 'mask purge-kernels';
 
     assert_script_run "pkcon refresh", 400;
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/133016

After installing new kernel package, purge-kernels service may take sometime to purge the old kernels, it can block PackageKit to start.

- Verification run:https://openqa.opensuse.org/tests/3440335
