### PR TITLE
xfstests: Change test folder and add repo for alp

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -27,11 +27,14 @@ use mm_network;
 use nfs_common;
 use Utils::Systemd 'disable_and_stop_service';
 use registration;
+use version_utils 'is_alp';
 
 my $INST_DIR = '/opt/xfstests';
 my $CONFIG_FILE = "$INST_DIR/local.config";
 my $NFS_VERSION = get_var('XFSTESTS_NFS_VERSION', '4.1');
 my $NFS_SERVER_IP;
+my $TEST_FOLDER = '/opt/test';
+my $SCRATCH_FOLDER = '/opt/scratch';
 
 # Number of SCRATCH disk in SCRATCH_DEV_POOL, other than btrfs has only 1 SCRATCH_DEV, xfstests specific
 sub partition_amount_by_homesize {
@@ -127,12 +130,12 @@ sub do_partition_for_xfstests {
     }
     parted_print(dev => $para{dev});
     # Create mount points
-    script_run('mkdir /mnt/test /mnt/scratch');
+    script_run("mkdir $TEST_FOLDER $SCRATCH_FOLDER");
     # Setup configure file xfstests/local.config
     script_run("echo 'export TEST_DEV=$test_dev' >> $CONFIG_FILE");
     set_var('XFSTESTS_TEST_DEV', $test_dev);
-    script_run("echo 'export TEST_DIR=/mnt/test' >> $CONFIG_FILE");
-    script_run("echo 'export SCRATCH_MNT=/mnt/scratch' >> $CONFIG_FILE");
+    script_run("echo 'export TEST_DIR=$TEST_FOLDER' >> $CONFIG_FILE");
+    script_run("echo 'export SCRATCH_MNT=$SCRATCH_FOLDER' >> $CONFIG_FILE");
     if ($para{amount} == 1) {
         script_run("echo 'export SCRATCH_DEV=$scratch_dev[0]' >> $CONFIG_FILE");
         set_var('XFSTESTS_SCRATCH_DEV', $scratch_dev[0]);
@@ -187,12 +190,12 @@ sub create_loop_device_by_rootsize {
     script_run("losetup -a");
     format_with_options("$INST_DIR/test_dev", $para{fstype});
     # Create mount points
-    script_run('mkdir /mnt/test /mnt/scratch');
+    script_run("mkdir $TEST_FOLDER $SCRATCH_FOLDER");
     # Setup configure file xfstests/local.config
     script_run("echo 'export TEST_DEV=/dev/loop0' >> $CONFIG_FILE");
     set_var('XFSTESTS_TEST_DEV', '/dev/loop0');
-    script_run("echo 'export TEST_DIR=/mnt/test' >> $CONFIG_FILE");
-    script_run("echo 'export SCRATCH_MNT=/mnt/scratch' >> $CONFIG_FILE");
+    script_run("echo 'export TEST_DIR=$TEST_FOLDER' >> $CONFIG_FILE");
+    script_run("echo 'export SCRATCH_MNT=$SCRATCH_FOLDER' >> $CONFIG_FILE");
     if ($amount == 1) {
         script_run("echo 'export SCRATCH_DEV=/dev/loop1' >> $CONFIG_FILE");
         set_var('XFSTESTS_SCRATCH_DEV', '/dev/loop1');


### PR DESCRIPTION
The xfstest in alp will default install in /opt/xfstests, so no need to link here.
Also add the alp xfstests repo and denepency repo.

- Related ticket: https://progress.opensuse.org/issues/132533
- Verification run: 
> Verify previous tests OK with the changes:
> - create_hdd_xfstests: http://10.67.133.133/tests/258
> - xfstests_btrfs-btrfs-001-050: http://10.67.133.133/tests/260