### PR TITLE
Use deafult value if pcmk_delay_max is not defined in resource

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -73,6 +73,7 @@ our @EXPORT = qw(
   activate_ntp
   script_output_retry_check
   calculate_sbd_start_delay
+  collect_sbd_delay_parameters
   check_iscsi_failure
 );
 
@@ -1015,7 +1016,7 @@ sub script_output_retry_check {
     }
 
     die('Pattern did not match') unless $ignore_failure;
-    return $result;
+    return undef;
 }
 
 =head2 collect_sbd_delay_parameters
@@ -1037,9 +1038,9 @@ sub collect_sbd_delay_parameters {
           script_output_retry_check(cmd => $sbd_watchdog_timeout, regex_string => '^\d+$', sleep => '3', retry => '3'),
         'sbd_delay_start' =>
           script_output_retry_check(cmd => $sbd_delay_start, regex_string => '^\d+$|yes|no', sleep => '3', retry => '3'),
-        # pcmk_delay_max is not always present for example in diskless SBD scenario
+        # pcmk_delay_max is not always present for example in 3 node clusters or diskless SBD scenario
         'pcmk_delay_max' => get_var('USE_DISKLESS_SBD') ? 30 :
-          script_output_retry_check(cmd => $pcmk_delay_max, regex_string => '^\d+$', sleep => '3', retry => '3')
+          script_output_retry_check(cmd => $pcmk_delay_max, regex_string => '^\d+$', sleep => '3', retry => '3', ignore_failure => 1) // 0
     );
 
     return (%params);

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -4,6 +4,7 @@ use Test::More;
 use Test::Exception;
 use Test::MockModule;
 use hacluster;
+use testapi;
 use Scalar::Util 'looks_like_number';
 
 my %sbd_delay_params = (
@@ -56,6 +57,7 @@ subtest '[calculate_sbd_start_delay] Return default on non numeric value' => sub
 subtest '[script_output_retry_check] Check input values' => sub {
     my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
     $hacluster->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    # Just returns whatever you put as command
     $hacluster->redefine(script_output => sub { return $_[0]; });
 
     # Test mandatory args
@@ -65,6 +67,27 @@ subtest '[script_output_retry_check] Check input values' => sub {
     # Test regex
     is script_output_retry_check(cmd => '42', regex_string => '^\d+$', sleep => '1', retry => '2'), '42', "Test passing regex";
     dies_ok { script_output_retry_check(cmd => 'rm -Rf /', regex_string => '^\d+$', sleep => '1', retry => '2') } "Test failing regex";
+};
+
+subtest '[script_output_retry_check] Diskless SBD scenario' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    $hacluster->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    # Just returns whatever you put as command
+    $hacluster->redefine(script_output => sub { return $_[0]; });
+
+    $corosync_token = 1;
+    $corosync_consensus = 2;
+    $sbd_watchdog_timeout = 3;
+    $sbd_delay_start = 4;
+    $pcmk_delay_max = "asdf";
+
+    my %params = collect_sbd_delay_parameters();
+    is $params{'pcmk_delay_max'}, 0, "Test pcmk_delay_max undefined: pcmk_delay_max = $params{'pcmk_delay_max'}";
+
+    set_var('USE_DISKLESS_SBD', 1);
+    my %params = collect_sbd_delay_parameters();
+    is $params{'pcmk_delay_max'}, 30, "Test diskless scenario: pcmk_delay_max = $params{'pcmk_delay_max'}";
+    set_var('USE_DISKLESS_SBD', undef);
 };
 
 done_testing;


### PR DESCRIPTION
Some tests use default value 'pcmk_delay_max' which does not appear in stonith resource. 
This PR changes function for getting sbd start delay parameters as follows:
- if disk based fencing is used and parameter  'pcmk_delay_max' is defined - use the value
- if 'pcmk_delay_max' is not defined - default value is 0s 
- in case of diskless SBD - use static value 30s

- Related ticket: https://jira.suse.com/browse/TEAM-8266

- Verification run: 
2 node SBD fencing: http://openqa.suse.de/tests/11617429
3 node cluster - param undefined : https://openqa.suse.de/tests/11623974#
3 node diskless SBD:  https://openqa.suse.de/tests/11623982