### PR TITLE
lib/main_common: CR-DVD does not need_clear_repos

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -737,6 +737,7 @@ sub need_clear_repos {
       && !get_var('DUALBOOT')
       && (is_opensuse && !is_updates_tests)
       && !(is_jeos && !is_staging)
+      && !(is_opensuse && check_var("FLAVOR", "CR-DVD"))
       || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
 }
 

--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -31,8 +31,8 @@ sub send_key_and_wait {
 }
 
 sub run {
-    # install-shell is tty2 by default, but that's where our session might be.
-    # Use the same logic as for the root console.
+    # Adjust the installation consoles, they can differ from what the instsys uses
+    # (install-shell -> tty2, installation -> tty7).
     console('install-shell')->set_tty(get_root_console_tty());
     console('installation')->set_tty(get_x11_console_tty());
 


### PR DESCRIPTION
This flavor uses published repos during testing.

+ Bonus improvement to a comment I had lying around in my checkout but didn't want to open a separate PR for.

- Related ticket: https://progress.opensuse.org/issues/131186
- Verification run: https://openqa.opensuse.org/tests/3440543
