### PR TITLE
Remove 'IN_PATCH_SLE' in tests/migration/SUSEConnect_register_system.pm

### DIFF
--- a/schedule/migration/migration_offline_media_x86_64.yaml
+++ b/schedule/migration/migration_offline_media_x86_64.yaml
@@ -7,7 +7,7 @@ vars:
 schedule:
   - migration/version_switch_origin_system
   - boot/boot_to_desktop
-  - migration/SUSEConnect_register_system
+  - migration/suseconnect_register_system
   - migration/patch_and_reboot_system
   - migration/setup_sle
   - migration/install_patterns

--- a/schedule/migration/migration_offline_scc_x86_64.yaml
+++ b/schedule/migration/migration_offline_scc_x86_64.yaml
@@ -7,7 +7,7 @@ vars:
 schedule:
   - migration/version_switch_origin_system
   - boot/boot_to_desktop
-  - migration/SUSEConnect_register_system
+  - migration/suseconnect_register_system
   - migration/patch_and_reboot_system
   - migration/setup_sle
   - migration/install_patterns

--- a/tests/migration/suseconnect_register_system.pm
+++ b/tests/migration/suseconnect_register_system.pm
@@ -17,7 +17,6 @@ sub run {
 
     register_product();
     register_addons_cmd();
-    set_var('IN_PATCH_SLE', 0);
 }
 
 1;


### PR DESCRIPTION
- Description: Remove the set for `IN_PATCH_SLE` in `tests/migration/SUSEConnect_register_system.pm`
  + update the name of the file `SUSEConnect_register_system.pm` to make it lowercase
- Related ticket: https://progress.opensuse.org/issues/132737
- Verification run:
  + [sles15sp3_media](https://openqa.suse.de/tests/11619212)
  + [sles15sp4_pscc](https://openqa.suse.de/tests/11619213)
