### PR TITLE
Run prune after all containers are stopped

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -321,6 +321,10 @@ sub cleanup_system_host {
     my ($self, $assert) = @_;
     $assert //= 1;
     $self->_engine_assert_script_run("ps -q | xargs -r " . $self->runtime . " stop", 180);
+
+    # all containers should be stopped before running prune
+    # https://github.com/containers/podman/issues/19038
+    $self->_engine_assert_script_run("rm --force --all", 120);
     $self->_engine_assert_script_run("system prune -a -f", 300);
 
     if ($assert) {


### PR DESCRIPTION
`podman-prune` might run while containers are stopping.

- ticket: https://progress.opensuse.org/issues/133031
- Verification run: [sle-micro-5.3-BYOS-Azure-x86_64-Build0468-slem_containers@64bit](http://kepler.suse.cz/tests/21305#)
