### PR TITLE
Enhance how we open/close YaST modules in containers to detect potential problems

### DIFF
--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -11,24 +11,32 @@ our @EXPORT_OK = qw(yast2_console_exec);
 
 sub yast2_console_exec {
     my %args = @_;
-    die "Yast2 module has not been found among function arguments!\n" unless (defined($args{yast2_module}));
-    my $y2_start = y2_module_basetest::with_yast_env_variables($args{extra_vars}) . ' yast2 ';
-    my $module_name = 'yast2-' . $args{yast2_module} . '-status';
-    $y2_start .= (defined($args{yast2_opts})) ?
-      $args{yast2_opts} . ' ' . $args{yast2_module} :
-      $args{yast2_module};
-    $y2_start .= " $args{args}" if (defined($args{args}));
-    $y2_start .= ';';
-    # poo#40715: Hyper-V 2012 R2 serial console is unstable (a Hyper-V product bug)
-    # and is in many cases loosing the 15th character, so e.g. instead of the expected
-    # 'yast2-scc-status-0' we get 'yast2-scc-statu-0' (sic, see the missing 's').
-    # Kepp only the first 10 characters of a magic string plus a dash ('-')
-    # and up to a three digit exit code.
-    $module_name = substr($module_name, 0, 10) if is_hyperv('2012r2');
-    if (!script_run($y2_start . " echo $module_name-\$? > /dev/$serialdev", 0)) {
+    die "Yast2 module has not been found among function arguments!\n" unless (defined($args{yast2_module} || defined($args{podman})));
+    my $cmd_start;
+    my $module_name;
+    if (defined($args{yast2_module})) {
+        $cmd_start = y2_module_basetest::with_yast_env_variables($args{extra_vars}) . ' yast2 ';
+        $module_name = 'yast2-' . $args{yast2_module} . '-status';
+        $cmd_start .= (defined($args{yast2_opts})) ?
+          $args{yast2_opts} . ' ' . $args{yast2_module} :
+          $args{yast2_module};
+        $cmd_start .= " $args{args}" if (defined($args{args}));
+        $cmd_start .= ';';
+        # poo#40715: Hyper-V 2012 R2 serial console is unstable (a Hyper-V product bug)
+        # and is in many cases loosing the 15th character, so e.g. instead of the expected
+        # 'yast2-scc-status-0' we get 'yast2-scc-statu-0' (sic, see the missing 's').
+        # Kepp only the first 10 characters of a magic string plus a dash ('-')
+        # and up to a three digit exit code.
+        $module_name = substr($module_name, 0, 10) if is_hyperv('2012r2');
+    }
+    if (defined($args{podman})) {
+        $cmd_start = y2_module_basetest::with_yast_env_variables($args{extra_vars}) . $args{podman};
+        $module_name = 'podman-status';
+    }
+    if (!script_run($cmd_start . " echo $module_name-\$? > /dev/$serialdev", 0)) {
         return $module_name;
     } else {
-        die "Yast2 module failed to execute!\n";
+        die "$cmd_start failed to execute!\n";
     }
 }
 

--- a/tests/yam/yast_modules/control_center.pm
+++ b/tests/yam/yast_modules/control_center.pm
@@ -10,12 +10,14 @@
 use base 'y2_installbase';
 use strict;
 use warnings;
-use testapi qw(select_console enter_cmd wait_still_screen save_screenshot get_var);
+use y2_module_consoletest;
+use testapi qw(select_console wait_serial save_screenshot get_var);
 
 sub run {
-    my $podman_cmd = "podman container runlabel run registry.opensuse.org/suse/alp/workloads/tumbleweed_containerfiles/suse/alp/workloads/yast-mgmt-ncurses-test-api";
     select_console('root-console');
-    enter_cmd(get_var('YUI_PARAMS') . " $podman_cmd");
+
+    my $podman_cmd = " podman container runlabel run registry.opensuse.org/suse/alp/workloads/tumbleweed_containerfiles/suse/alp/workloads/yast-mgmt-ncurses-test-api;";
+    my $module_name = y2_module_consoletest::yast2_console_exec(extra_vars => get_var('YUI_PARAMS'), podman => $podman_cmd);
     my $control_center = $testapi::distri->get_control_center();
     my $release_notes = $testapi::distri->get_release_notes();
     $control_center->open_release_notes();
@@ -23,6 +25,8 @@ sub run {
     $release_notes->close();
     save_screenshot();
     $control_center->quit();
+    wait_serial("$module_name-0", timeout => 60) ||
+      die "Fail! $podman_cmd is not closed or non-zero code returned.";
 }
 
 1;


### PR DESCRIPTION
Enhance how we open/close YaST modules in containers to detect potential problems

-  Related ticket: https://progress.opensuse.org/issues/131069
-  Verification run: https://openqa.suse.de/tests/11615686#step/control_center/4
   https://openqa.suse.de/tests/11623715

