### PR TITLE
Fix docker rm call

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -324,7 +324,9 @@ sub cleanup_system_host {
 
     # all containers should be stopped before running prune
     # https://github.com/containers/podman/issues/19038
-    $self->_engine_assert_script_run("rm --force --all", 120);
+    if ($self->runtime eq 'podman') {
+        $self->_engine_assert_script_run("rm --force --all", 120);
+    }
     $self->_engine_assert_script_run("system prune -a -f", 300);
 
     if ($assert) {


### PR DESCRIPTION
`all` option in `docker-rm` is unknown. Run `rm --all force` only in case of podman before `system prune`


- Related ticket: https://progress.opensuse.org/issues/133031
#### Verification runs

* [docker](http://kepler.suse.cz/tests/21306#)
* [podman](http://kepler.suse.cz/tests/21307)
