### PR TITLE
Including scc_deregistration in the zvm media migration.

### DIFF
--- a/schedule/migration/s390x-zVM-Media-Upgrade.yaml
+++ b/schedule/migration/s390x-zVM-Media-Upgrade.yaml
@@ -1,0 +1,32 @@
+name:           s390x-zVM-Media-Upgrade.yaml
+description:    >
+    This is for s390x zVM media upgrade migration.
+schedule:
+  - installation/bootloader_s390
+  - installation/welcome
+  - installation/disk_activation
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/select_patterns
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - console/system_prepare
+  - console/hostname
+  - console/force_scheduled_tasks
+  - console/scc_deregistration
+  - update/patch_sle
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
Optimize test coverage for default module (base) in migrations from SLE 12 SP5

**Ticket:**

- https://progress.opensuse.org/issues/131120

**Verification run:**

- [my VRs](https://openqa.suse.de/tests/overview?arch=&flavor=Migration-from-SLE12-SPx&machine=&test=&modules=&module_re=&distri=sle&version=15-SP5&build=102.1&groupid=466)
