### PR TITLE
Force remove pods before containers

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -13,6 +13,8 @@ use Carp 'croak';
 use Test::Assert 'assert_equals';
 use containers::utils qw(registry_url);
 use utils qw(systemctl file_content_replace script_retry);
+use version_utils qw(package_version_cmp);
+use containers::utils qw(get_podman_version);
 use overload
   '""' => sub { return shift->runtime },
   bool => sub { return 1 },
@@ -325,6 +327,9 @@ sub cleanup_system_host {
     # all containers should be stopped before running prune
     # https://github.com/containers/podman/issues/19038
     if ($self->runtime eq 'podman') {
+        if (package_version_cmp(get_podman_version(), '4.0.0') < 0) {
+            $self->_engine_script_run("pod rm --force --all", 120);
+        }
         $self->_engine_assert_script_run("rm --force --all", 120);
     }
     $self->_engine_assert_script_run("system prune -a -f", 300);


### PR DESCRIPTION
In older podman versions e.g. `2.1.1` we need to force remove pods before containers.

- ticket: https://progress.opensuse.org/issues/133031

### Verification runs

* [sle-15-SP4-JeOS-for-kvm-and-xen-Updates-x86_64-Build20230719-1-jeos-containers-podman@uefi-virtio-vga](http://kepler.suse.cz/tests/21318#step/podman_pods/373)
* [http://kepler.suse.cz/tests/21316#step/podman_pods/373](http://kepler.suse.cz/tests/21316#step/podman_pods/373)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20230719-1-podman_tests@64bit](http://kepler.suse.cz/tests/21317#step/podman_pods/87)
* [sle-15-SP2-Server-DVD-Updates-x86_64-Build20230719-1-podman_tests@64bit](http://kepler.suse.cz/tests/21315#step/podman_pods/87)
* [sle-15-SP1-AZURE-BYOS-Updates-x86_64-Build20230719-1-publiccloud_containers@64bit](http://kepler.suse.cz/tests/21319#live)
* [sle-15-SP2-EC2-BYOS-Updates-x86_64-Build20230719-1-publiccloud_containers@64bit](http://kepler.suse.cz/tests/21320#live)
* [sle-15-SP3-GCE-BYOS-Updates-x86_64-Build20230719-1-publiccloud_containers@64bit](http://kepler.suse.cz/tests/21321)

