### PR TITLE
Increase timeout in 'nmcli device disconnect $dev' for qemu no kvm

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1113,7 +1113,9 @@ sub set_hostname {
                 next if ($dev eq 'lo');
                 next if !($line =~ /connected/);
 
-                assert_script_run 'nmcli device disconnect ' . $dev;
+                # Default timeout (10 seconds) may be too short with qemu NO kvm, so increase to 20s - poo#131366
+                my $nmcli = get_var('QEMU_NO_KVM') ? 'nmcli -w 20' : 'nmcli';
+                assert_script_run "$nmcli device disconnect $dev";
                 assert_script_run 'nmcli device connect ' . $dev;
             }
 


### PR DESCRIPTION
Default timeout (10 seconds) may be too short with qemu NO kvm so increase to 20s - poo#131366

- Related ticket: https://progress.opensuse.org/issues/131366
- Verification run:  https://openqa.opensuse.org/tests/3448590#step/hostname/21
