### PR TITLE
Use spack_get_libs.sh to setup LD_LIBRARY_PATH

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -355,44 +355,43 @@ After C<prepare_spack_env> run, C<spack> should be ready to build entire tool st
 downloading and installing all bits required for whatever package or compiler.
 
 This sub is designed to install one of the mpi implementations. Although there are
-thousands packages to be used.
+thousands packages to be used. Spack will check if any mpi is installed and it will
+build the package if it is not found. In case you want to make the runtime of the
+test faster you can install C<$mpi-gnu-hpc $mpi-gnu-hpc-devel> packages in advanced.
 
 LD_LIBRARY_PATH is removed and spack is not exported. In case LD_LIBRARY_PATH is required
-it has to be add it in the F<.spack/modules.yaml>.
+it has to be added in the F<.spack/modules.yaml>.
 
 =begin text
   See bsc#1208751 for details
 =end text
 
-To do that run
+The workaround of that requires to run
 
 =begin text
   spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH]
   spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]
 =end text
 
+however the newest spack updates contain C<spack_get_libs.sh>.
+
 =cut
 
 sub prepare_spack_env {
     my ($self, $mpi) = @_;
     $mpi //= 'mpich';
-    zypper_call "in spack $mpi-gnu-hpc $mpi-gnu-hpc-devel", timeout => 1200;
+    zypper_call "in spack", timeout => 1200;
     type_string('pkill -u root');    # this kills sshd
     select_serial_terminal(0);
-    assert_script_run "module load gnu $mpi";
-    assert_script_run 'source /usr/share/spack/setup-env.sh';
-    if (check_var('HPC_LIB', 'boost')) {
-        # Workaround for bsc#1208751
-        assert_script_run "spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH]";
-        assert_script_run "spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]";
-    }
+
     record_info 'spack', script_output 'zypper -q info spack';
     record_info "$mpi spec", script_output("spack spec $mpi", timeout => 600);
     if (check_var('HPC_LIB', 'boost')) {
         record_info "boost spec", script_output("spack spec boost", timeout => 600);
         assert_script_run "spack install boost+mpi^$mpi", timeout => 12000;
-        #assert_script_run 'spack load boost';
+        assert_script_run "source spack_get_libs.sh boost^$mpi";
     } else {
+        assert_script_run 'source /usr/share/spack/setup-env.sh';
         record_info "$mpi spec", script_output("spack spec $mpi", timeout => 600);
         assert_script_run "spack install $mpi", timeout => 12000;
     }

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -40,8 +40,13 @@ sub run ($self) {
     assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O $exports_path{'bin'}/$mpi_c");
 
     barrier_wait('MPI_SETUP_READY');
-    assert_script_run "spack load $mpi";
-    assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin  2>&1 > /tmp/make.out");
+    if (check_var('HPC_LIB', 'boost')) {
+        assert_script_run 'spack load boost';
+        assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin -l boost_mpi -I \${BOOST_ROOT}/include/ -L \${BOOST_ROOT}/lib 2>&1 > /tmp/make.out");
+    } else {
+        assert_script_run "spack load $mpi";
+        assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin  2>&1 > /tmp/make.out");
+    }
     barrier_wait('MPI_BINARIES_READY');
 
     type_string "sudo systemctl restart sshd\n";

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -5,6 +5,8 @@
 # Summary: HPC_Module: Test Spack package installation and features
 #
 # Acts as the master node of the cluster to execute parallel executions
+# The flow is impacted by HPC_LIB job variable. When is ommitted it will
+# use simple_mpi.c. if the value is boost C<sample_boost.cpp> will be used.
 #
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
@@ -41,7 +43,9 @@ sub run ($self) {
 
     barrier_wait('MPI_SETUP_READY');
     if (check_var('HPC_LIB', 'boost')) {
-        assert_script_run 'spack load boost';
+        assert_script_run 'source /usr/share/spack/setup-env.sh';
+        assert_script_run "spack load boost^$mpi";
+        assert_script_run 'spack find --loaded';
         assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin -l boost_mpi -I \${BOOST_ROOT}/include/ -L \${BOOST_ROOT}/lib 2>&1 > /tmp/make.out");
     } else {
         assert_script_run "spack load $mpi";

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -25,9 +25,13 @@ sub run ($self) {
     type_string("$testapi::password\n");
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
-    assert_script_run "spack load $mpi";
-    script_run "module av";
-
+    if (check_var('HPC_LIB', 'boost')) {
+        assert_script_run 'source /usr/share/spack/setup-env.sh';
+        assert_script_run "spack load boost^$mpi";
+    } else {
+        assert_script_run "spack load $mpi";
+    }
+    assert_script_run 'spack find --loaded';
     record_info('ssh check', 'Validate sshd service status before mpirun');
     systemctl 'status sshd';
     barrier_wait('MPI_BINARIES_READY');


### PR DESCRIPTION
Spack doesnt set LD_LIBRARY_PATH and libraries cant be found. Apply workaround
from bsc#1208751. This is supposed is gonna be fixed and this workaround would
be needed.

Update: Second commit overrides workaround. 

Signed-off-by: Ioannis Bonatakis ybonatakis@suse.com

https://progress.opensuse.org/issues/127481
http://aquarius.suse.cz/tests/17841 - w/o HPC_LIB
http://aquarius.suse.cz/tests/17835 - with HPC_LIB