### PR TITLE
pc: Add openqa_var_SERVER & openqa_var_JOB_ID tags to ${provider}_cli tests

### DIFF
--- a/tests/publiccloud/aws_cli.pm
+++ b/tests/publiccloud/aws_cli.pm
@@ -45,6 +45,7 @@ sub run {
     my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
     my $tag = "{Key=openqa-cli-test-tag,Value=$job_id},{Key=openqa_created_by,Value=$created_by},{Key=openqa_ttl,Value=$openqa_ttl}";
+    $tag .= ",{Key=openqa_var_SERVER,Value=$openqa_url},{Key=openqa_var_JOB_ID,Value=$job_id}";
 
     my $create_security_group = "aws ec2 create-security-group --group-name $security_group_name --description 'aws_cli openqa test security group'";
     $create_security_group .= " --tag-specifications 'ResourceType=security-group,Tags=[$tag]'";

--- a/tests/publiccloud/azure_cli.pm
+++ b/tests/publiccloud/azure_cli.pm
@@ -42,6 +42,7 @@ sub run {
     my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
     my $tags = "openqa-cli-test-tag=$job_id openqa_created_by=$created_by openqa_ttl=$openqa_ttl";
+    $tags .= " openqa_var_SERVER=$openqa_url openqa_var_JOB_ID=$job_id";
 
     # Configure default location and create Resource group
     assert_script_run("az configure --defaults location=southeastasia");

--- a/tests/publiccloud/azure_more_cli.pm
+++ b/tests/publiccloud/azure_more_cli.pm
@@ -96,6 +96,7 @@ sub run {
     my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
     my $tags = "openqa-cli-test-tag=$job_id openqa_created_by=$created_by openqa_ttl=$openqa_ttl";
+    $tags .= " openqa_var_SERVER=$openqa_url openqa_var_JOB_ID=$job_id";
     my $location = "southeastasia";
     my $sshkey = "~/.ssh/id_rsa.pub";
 

--- a/tests/publiccloud/google_cli.pm
+++ b/tests/publiccloud/google_cli.pm
@@ -51,6 +51,7 @@ sub run {
     $openqa_hostname =~ tr/./_/;
     # Only hyphens (-), underscores (_), lowercase characters, and numbers are allowed.
     my $labels = "openqa-cli-test-label=$job_id,openqa_created_by=$openqa_hostname,openqa_ttl=$openqa_ttl";
+    $labels .= ",openqa_var_SERVER=$openqa_hostname,openqa_var_JOB_ID=$job_id";
     my $metadata = 'ssh-keys=susetest:$(cat ~/.ssh/id_rsa.pub | sed "s/[[:blank:]]*$//") susetest';
     my $create_instance = "gcloud compute instances create $machine_name --image-family=sles-15 --image-project=suse-cloud";
     $create_instance .= " --machine-type=e2-micro --labels='$labels' --metadata=\"$metadata\"";


### PR DESCRIPTION
 Add openqa_var_SERVER & openqa_var_JOB_ID tags to VM's created by `${provider}_cli` tests so pcw is aware of them.

- Related ticket: https://progress.opensuse.org/issues/132611
- Related PR: https://github.com/SUSE/pcw/pull/278
- Verification run: https://openqa.suse.de/tests/11650015