### PR TITLE
Increase timeout for seahorse_sshkey

### DIFF
--- a/tests/x11/seahorse_sshkey.pm
+++ b/tests/x11/seahorse_sshkey.pm
@@ -39,13 +39,13 @@ sub run {
     send_key 'alt-d';
     type_string "Keyring test";    # Name of new ssh key
     send_key 'alt-j';    # Just Create ssh key without setup
-    if (check_screen("seahorse-sshkey-inhibit", timeout => 6)) {
+    if (check_screen("seahorse-sshkey-inhibit", timeout => 8)) {
         assert_and_click "seahorse-sshkey-inhibit";
     }
     assert_screen 'seahorse-sshkey-passphrase';    # sshkey passphrase
     type_password;
     send_key 'ret';
-    if (check_screen("seahorse-sshkey-inhibit", timeout => 6)) {
+    if (check_screen("seahorse-sshkey-inhibit", timeout => 8)) {
         assert_and_click "seahorse-sshkey-inhibit";
     }
     assert_screen 'seahorse-sshkey-passphrase-retype';    # sshkey passphrase retype


### PR DESCRIPTION
This should prevent any occasional timeout failures. It has been increased from 3 to 6 in the past, but still sometimes happens, so we can set this to 8 for good measure.

Related ticket: https://progress.opensuse.org/issues/130150