### PR TITLE
pc: Lowercase openqa_var_SERVER & openqa_var_JOB_ID

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -627,9 +627,9 @@ sub terraform_param_tags
     $openqa_var_server =~ s@^https?://|/$@@gm;
     my $tags = {
         openqa_ttl => get_var('MAX_JOB_TIME', 7200) + get_var('PUBLIC_CLOUD_TTL_OFFSET', 300),
-        openqa_var_JOB_ID => get_current_job_id(),
-        openqa_var_NAME => get_var(NAME => ''),
-        openqa_var_SERVER => $openqa_var_server
+        openqa_var_job_id => get_current_job_id(),
+        openqa_var_name => get_var(NAME => ''),
+        openqa_var_server => $openqa_var_server
     };
 
     return encode_json($tags);

--- a/tests/publiccloud/aws_cli.pm
+++ b/tests/publiccloud/aws_cli.pm
@@ -45,7 +45,7 @@ sub run {
     my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
     my $tag = "{Key=openqa-cli-test-tag,Value=$job_id},{Key=openqa_created_by,Value=$created_by},{Key=openqa_ttl,Value=$openqa_ttl}";
-    $tag .= ",{Key=openqa_var_SERVER,Value=$openqa_url},{Key=openqa_var_JOB_ID,Value=$job_id}";
+    $tag .= ",{Key=openqa_var_server,Value=$openqa_url},{Key=openqa_var_job_id,Value=$job_id}";
 
     my $create_security_group = "aws ec2 create-security-group --group-name $security_group_name --description 'aws_cli openqa test security group'";
     $create_security_group .= " --tag-specifications 'ResourceType=security-group,Tags=[$tag]'";

--- a/tests/publiccloud/azure_cli.pm
+++ b/tests/publiccloud/azure_cli.pm
@@ -42,7 +42,7 @@ sub run {
     my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
     my $tags = "openqa-cli-test-tag=$job_id openqa_created_by=$created_by openqa_ttl=$openqa_ttl";
-    $tags .= " openqa_var_SERVER=$openqa_url openqa_var_JOB_ID=$job_id";
+    $tags .= " openqa_var_server=$openqa_url openqa_var_job_id=$job_id";
 
     # Configure default location and create Resource group
     assert_script_run("az configure --defaults location=southeastasia");

--- a/tests/publiccloud/azure_more_cli.pm
+++ b/tests/publiccloud/azure_more_cli.pm
@@ -96,7 +96,7 @@ sub run {
     my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
     my $created_by = "$openqa_url/t$job_id";
     my $tags = "openqa-cli-test-tag=$job_id openqa_created_by=$created_by openqa_ttl=$openqa_ttl";
-    $tags .= " openqa_var_SERVER=$openqa_url openqa_var_JOB_ID=$job_id";
+    $tags .= " openqa_var_server=$openqa_url openqa_var_job_id=$job_id";
     my $location = "southeastasia";
     my $sshkey = "~/.ssh/id_rsa.pub";
 

--- a/tests/publiccloud/google_cli.pm
+++ b/tests/publiccloud/google_cli.pm
@@ -51,7 +51,7 @@ sub run {
     $openqa_hostname =~ tr/./_/;
     # Only hyphens (-), underscores (_), lowercase characters, and numbers are allowed.
     my $labels = "openqa-cli-test-label=$job_id,openqa_created_by=$openqa_hostname,openqa_ttl=$openqa_ttl";
-    $labels .= ",openqa_var_SERVER=$openqa_hostname,openqa_var_JOB_ID=$job_id";
+    $labels .= ",openqa_var_server=$openqa_hostname,openqa_var_job_id=$job_id";
     my $metadata = 'ssh-keys=susetest:$(cat ~/.ssh/id_rsa.pub | sed "s/[[:blank:]]*$//") susetest';
     my $create_instance = "gcloud compute instances create $machine_name --image-family=sles-15 --image-project=suse-cloud";
     $create_instance .= " --machine-type=e2-micro --labels='$labels' --metadata=\"$metadata\"";


### PR DESCRIPTION
Use lowercase `openqa_var_SERVER` & `openqa_var_JOB_ID` because `gcloud` doesn't support uppercase keys.

- Related ticket: https://progress.opensuse.org/issues/132611
- Related PR: https://github.com/SUSE/pcw/pull/278
- Verification run: https://openqa.suse.de/tests/11650292