### PR TITLE
Add cloud_init_log in Azure to capture timeout error root cause

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -721,6 +721,12 @@ sub qesap_cluster_log_cmds {
             Output => 'aws_config.txt',
         };
     }
+    if (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+        push @log_list, {
+            Cmd => 'cat /var/log/cloud-init.log > azure_cloud_init_log.txt',
+            Output => 'azure_cloud_init_log.txt',
+        };
+    }
     return @log_list;
 }
 


### PR DESCRIPTION
Capturing Cloud init logs in Azure to find out root cause of timeout error. cat /var/log/cloud-init.log > azure_cloud_init_log.txt in lib/qesapdeployment.pm

- Related ticket: [TEAM-8006](https://jira.suse.com/browse/TEAM-8006)
- Verification run: Azure: http://openqaworker15.qa.suse.cz/tests/207043
                     AWS : http://openqaworker15.qa.suse.cz/tests/207044
