### PR TITLE
Create test for later gnu-compilers-hpc later toolchain

### DIFF
--- a/schedule/hpc/gnu-compilers-hpc.yml
+++ b/schedule/hpc/gnu-compilers-hpc.yml
@@ -1,0 +1,11 @@
+---
+name: gnu-compilers-hpc
+description:    >
+    Maintainer: kernel-qa
+    Test for gnu-compilers-hpc to toolchain upgrades
+vars:
+  DESKTOP: textmode
+
+schedule:
+  - boot/boot_to_desktop
+  - hpc/gnu_compilers_hpc

--- a/tests/hpc/gnu_compilers_hpc.pm
+++ b/tests/hpc/gnu_compilers_hpc.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: Verify latest gnu-compilers-hpc installation
+#
+# Test later toolchain versions that are made available for SLE.
+#
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base qw(hpcbase), -signatures;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use Utils::Logging qw(export_logs);
+
+sub run ($self) {
+    select_serial_terminal();
+    my $version = get_required_var('GNU_COMPILERS_HPC_VERSION');
+    zypper_call("in gnu$version-compilers-hpc");
+    type_string('pkill -u root', lf => 1);
+    $self->{serial_term_prompt} = '# ';
+    serial_terminal::login('root', $self->{serial_term_prompt});
+
+    assert_script_run qq{module av | grep gnu/$version};
+    assert_script_run 'module load gnu';
+    assert_script_run qq{env |grep "MODULEPATH=/usr/share/lmod/moduledeps/gnu-$version"};
+    if (zypper_call("in gnu$version-compilers-hpc-devel", exitcode => [107]) == 107) {
+        record_soft_failure 'bsc#1212351 Type in posttrans script for the non-base Compiler Version cause Script to fail';
+    }
+    assert_script_run 'module load gnu';
+    assert_script_run qq{env |grep "PATH=/usr/lib/hpc/compiler/gnu/$version/bin"};
+    assert_script_run qq{gcc --version | grep $version};
+
+}
+
+sub post_fail_hook ($self) {
+    export_logs();
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -77,6 +77,7 @@ FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DV
 FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only.
 FULL_LVM_ENCRYPT | boolean | false | Enables/indicates encryption using lvm. boot partition may or not be encrypted, depending on the product default behavior.
 FUNCTION | string | | Specifies SUT's role for MM test suites. E.g. Used to determine which SUT acts as target/server and initiator/client for iscsi test suite
+GNU_COMPILERS_HPC_VERSION | string | | Define the gnu-N-compilers-hpc version to be tested.
 GRUB_PARAM | string | | A semicolon-separated list of extra boot options. Adds 2 grub meny entries per each item in main grub (2nd entry is the "Advanced options ..." submenu). See `add_custom_grub_entries()`.
 GRUB_BOOT_NONDEFAULT | boolean | false | Boot grub menu entry added by `add_custom_grub_entries` (having setup `GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb;slub_debug=FZPU`, `GRUB_BOOT_NONDEFAULT=1` selects 3rd entry, which contains `debug_pagealloc=on`, `GRUB_BOOT_NONDEFAULT=2` selects 5th entry, which contains `ima_policy=tcb`). NOTE: ARCH=s390x on BACKEND=s390x is not supported. See `boot_grub_item()`, `handle_grub()`.
 GRUB_SELECT_FIRST_MENU | integer | | Select grub menu entry in main grub menu, used together with GRUB_SELECT_SECOND_MENU. GRUB_BOOT_NONDEFAULT has higher preference when both set. NOTE: ARCH=s390x on BACKEND=s390x is not supported. See `boot_grub_item()`, `handle_grub()`.


### PR DESCRIPTION
Test gnu-compilers-hpc packages for later GNU toolchain that are released available for SLE.

- Related ticket: https://progress.opensuse.org/issues/130844
- Verification run: 
https://aquarius.suse.cz/tests/17753