### PR TITLE
ibus: type language to add slower

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1076,7 +1076,7 @@ sub add_input_resource {
 
     assert_and_click 'ibus-input-source-add';
     assert_and_click 'ibus-input-language-list';
-    type_string $tag;
+    type_string_slow $tag;
 
     assert_and_click "ibus-input-$tag";
     if ($tag eq "japanese") {


### PR DESCRIPTION
Trying to counter mistypes like in https://openqa.opensuse.org/tests/3450441#step/ibus_test_cn/8

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3450843 (still far from good, but the mis-typing at least is gone, which makes the current bug reports against g-c-c at least valid again)

