### PR TITLE
Add chunk size for RAID1 opensuse15.4 test_data

### DIFF
--- a/schedule/yast/opensuse/raid/raid1_gpt_opensuse15.4.yaml
+++ b/schedule/yast/opensuse/raid/raid1_gpt_opensuse15.4.yaml
@@ -1,0 +1,74 @@
+name:           RAID1_gpt
+description:    >
+  Configure RAID 1 on the disks with GPT partition tables using Expert Partitioner.
+  Creates BIOS boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 1.
+vars:
+  RAIDLEVEL: 1
+  YUI_REST_API: 1
+conditional_schedule:
+  access_beta_distribution:
+    BETA:
+      1:
+        - installation/access_beta_distribution
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - '{{access_beta_distribution}}'
+  - installation/licensing/accept_license
+  - installation/online_repos/disable_online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role/select_role_generic_desktop
+  - installation/partitioning/raid_gpt
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/disable_autologin
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_overview
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_md_raid
+  - console/validate_raid
+test_data:
+  <<: !include test_data/yast/raid/raid_gpt_disks_with_bios-boot.yaml
+  mds:
+    - raid_level: 1
+      name: md0
+      chunk_size: '64 KiB'
+      devices:
+        - vda2
+        - vdb2
+        - vdc2
+        - vdd2
+      device_selection_step: 2
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 0
+      name: md1
+      chunk_size: '64 KiB'
+      devices:
+        - vda3
+        - vdb3
+        - vdc3
+        - vdd3
+      partition:
+        role: swap
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/test_data/yast/raid/raid0_prep_boot_opensuse15.4.yaml
+++ b/test_data/yast/raid/raid0_prep_boot_opensuse15.4.yaml
@@ -1,0 +1,48 @@
+---
+<<: !include test_data/yast/raid/raid_disks_prep_boot.yaml
+mds:
+  - raid_level: 0
+    name: md0
+    chunk_size: '64 KiB'
+    devices:
+      - vda2
+      - vdb2
+      - vdc2
+      - vdd2
+    partition:
+      role: operating-system
+      formatting_options:
+        should_format: 1
+      mounting_options:
+        should_mount: 1
+  - raid_level: 1
+    name: md1
+    chunk_size: '64 KiB'
+    devices:
+      - vda3
+      - vdb3
+      - vdc3
+      - vdd3
+    partition:
+      role: data
+      formatting_options:
+        should_format: 1
+        filesystem: ext4
+      mounting_options:
+        should_mount: 1
+        mount_point: '/boot'
+  - raid_level: 0
+    name: md2
+    chunk_size: '64 KiB'
+    devices:
+      - vda4
+      - vdb4
+      - vdc4
+      - vdd4
+    partition:
+      role: swap
+      formatting_options:
+        should_format: 1
+      filesystem: swap
+      mounting_options:
+        should_mount: 1


### PR DESCRIPTION
Add chunk size for RAID1 opensuse15.4 test_data
- Related ticket: https://progress.opensuse.org/issues/131183
- Needles: na
- Verification run: https://openqa.opensuse.org/tests/3450746
Jobgroup PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/355

NOTE:
This PR ONLY can fix following cases:
opensuse-15.4-CR-DVD-ppc64le-Build32.1-RAID0@ppc64le  https://openqa.opensuse.org/tests/3450746
opensuse-15.4-CR-DVD-x86_64-Build32.2-RAID1_gpt@64bit https://openqa.opensuse.org/tests/3455294  (But this case not stable such as https://openqa.opensuse.org/tests/3450790#step/first_boot/1)

Need further check how to fix following case:
opensuse-15.4-CR-DVD-aarch64-Build32.2-RAID1_gpt_uefi@USBboot_aarch64 https://openqa.opensuse.org/tests/3450791
