### PR TITLE
Update test path for systemd-testsuite

### DIFF
--- a/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
+++ b/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
@@ -19,7 +19,7 @@ sub run {
         TEST_PREFER_NSPAWN => get_var('SYSTEMD_NSPAWN', 1),
         UNIFIED_CGROUP_HIERARCHY => get_var('SYSTEMD_UNIFIED_CGROUP', 'yes')
     };
-    my $testdir = '/usr/lib/systemd/tests/test/';
+    my $testdir = '/usr/lib/systemd/tests/integration-tests/';
     my @pkgs = qw(
       lz4
       busybox


### PR DESCRIPTION
Tests paths has change in the package. Update the test code in order to schedule integration tests in openQA

- Verification run: http://kepler.suse.cz/tests/21337#
