### PR TITLE
Add bsc#1213635 soft-failure for salt test

### DIFF
--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -92,14 +92,20 @@ sub logs_from_salt {
     $error .= "| grep -vi 'has cached the public key for this node\\|Minion unable to successfully connect to a Salt Master'";
     $error .= "| grep -vi 'Error while bringing up minion for multi-master'";
     if (script_run("$error") != 1) {
+        my $softfail_flag = 0;
         if (check_var('HOSTNAME', 'master') && script_run('grep "self.pusher.connect(timeout=timeout)" /var/log/salt/master') == 0) {
             record_soft_failure('bsc#1209248');
-            return;
+            $softfail_flag = 1;
         }
         if (script_run('grep "ModuleNotFoundError.*\'salt.ext.six\'" /var/log/salt/minion') == 0) {
             record_soft_failure('bsc#1211591');
-            return;
+            $softfail_flag = 1;
         }
+        if (script_run('grep "Encountered StreamClosedException" /var/log/salt/master') == 0) {
+            record_soft_failure('bsc#1213635');
+            $softfail_flag = 1;
+        }
+        return if $softfail_flag;
         die "Salt logs are containing errors!";
     }
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/133304
- Needles: NO
- Verification run: [salt_mater](https://openqa.suse.de/tests/11658932) | [salt_minion](https://openqa.suse.de/tests/11658931#)

Latest VRs:

[salt_master](https://openqa.suse.de/tests/11674943#step/salt_master/167) | [salt_minion](https://openqa.suse.de/tests/11674944#step/salt_minion/1)