### PR TITLE
Check custom systemd service setup

### DIFF
--- a/data/jeos/g_cloudinit.cfg
+++ b/data/jeos/g_cloudinit.cfg
@@ -42,8 +42,24 @@ chpasswd:
 packages:
   - iotop
 
+write_files:
+  - content: |
+        [Unit]
+        Description=Simple test service
+
+        [Service]
+        Type=idle
+        ExecStart=/usr/bin/echo "Test service has started"
+        Restart=never
+
+        [Install]
+        WantedBy=multi-user.target
+    path: /etc/systemd/system/just_a_test.service
+    owner: root:root
+    permissions: '0644'
+
 # start services
 runcmd:
-  - systemctl enable qemu-guest-agent.service
-  - systemctl start --no-block qemu-guest-agent.service
-
+  - ['systemctl', 'daemon-reload']
+  - ['systemctl', 'enable', 'just_a_test.service']
+  - ['systemctl', 'start', '--no-block', 'just_a_test.service']

--- a/tests/jeos/verify_cloudinit.pm
+++ b/tests/jeos/verify_cloudinit.pm
@@ -36,12 +36,10 @@ sub run {
     }
     assert_script_run('SUSEConnect --status-text | grep -i active', timeout => 120);
 
-    # qemu-guest-agent service should be enabled and started
-    assert_script_run('rpm -q qemu-guest-agent');
-    systemctl('is-enabled qemu-guest-agent');
-    if (script_run('systemctl --no-pager is-active qemu-guest-agent')) {
-        record_soft_failure("bsc#1207135 - [Build 2.56] qemu-guest-agent.service: Job qemu-guest-agent.service/start failed with result 'dependency'");
-    }
+    # just_a_test.service should be enabled and executed
+    systemctl('is-enabled just_a_test.service');
+    assert_script_run('journalctl --no-pager -u just_a_test.service |grep "Test service has started"');
+    systemctl('disable just_a_test.service');
 
     # Package installation
     assert_script_run('rpm -q iotop');


### PR DESCRIPTION
Instead of checking `qemu-guest-agent.service` that requires a device to be added, try to write a custom systemd service and check whether it has executed correctly.

- Verification run: http://kepler.suse.cz/tests/21343#
