### PR TITLE
Add yaml schedule files for SLE Micro testsuite

### DIFF
--- a/schedule/sle-micro/yam/slem_installation_autoyast.yaml
+++ b/schedule/sle-micro/yam/slem_installation_autoyast.yaml
@@ -1,0 +1,14 @@
+name:           sle_micro_autoyast
+description:    >
+  Maintainer: QE Yam <qe-yam at suse de>
+  SUSE Linux Enterprise Micro tests
+schedule:
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/logs
+  - console/textinfo
+  - microos/cockpit_service
+  - shutdown/shutdown

--- a/schedule/sle-micro/yam/slem_installation_default_aarch64.yaml
+++ b/schedule/sle-micro/yam/slem_installation_default_aarch64.yaml
@@ -1,0 +1,21 @@
+name:           sle_micro_default
+description:    >
+  Maintainer: QE Yam <qe-yam at suse de>
+  SUSE Linux Enterprise Micro installation on aarch64
+schedule:
+  - installation/bootloader_uefi
+  - installation/welcome
+  - installation/scc_registration
+  - installation/ntp_config_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - microos/disk_boot
+  - console/textinfo
+  - microos/cockpit_service
+  - shutdown/shutdown

--- a/schedule/sle-micro/yam/slem_installation_default_s390x.yaml
+++ b/schedule/sle-micro/yam/slem_installation_default_s390x.yaml
@@ -1,0 +1,22 @@
+name:           sle_micro_default
+description:    >
+  Maintainer: QE Yam <qe-yam at suse de>
+  SUSE Linux Enterprise Micro installation on s390x
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/scc_registration
+  - installation/ntp_config_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - console/textinfo
+  - microos/cockpit_service
+  - shutdown/shutdown

--- a/schedule/sle-micro/yam/slem_installation_default_x86_64.yaml
+++ b/schedule/sle-micro/yam/slem_installation_default_x86_64.yaml
@@ -1,0 +1,21 @@
+name:           sle_micro_default
+description:    >
+  Maintainer: QE Yam <qe-yam at suse de>
+  SUSE Linux Enterprise Micro installation on x86_64
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/scc_registration
+  - installation/ntp_config_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - microos/disk_boot
+  - console/textinfo
+  - microos/cockpit_service
+  - shutdown/shutdown


### PR DESCRIPTION
Add yaml schedule files for SLE Micro testsuite of slem_installation_autoyast and slem_installation_default.

- Related ticket: https://progress.opensuse.org/issues/132992
- Verification run: 
- https://openqa.suse.de/tests/11657764# (autoyast on aarch64)
- https://openqa.suse.de/tests/11657762# (autoyast on s390x)
- https://openqa.suse.de/tests/11657763# (autoyast on x86_64)
- https://openqa.suse.de/tests/11657780# (default on aarch64)
- https://openqa.suse.de/tests/11657781# (default on s390x)
- https://openqa.suse.de/tests/11657782# (default on x86_64)