### PR TITLE
hyperV dynamic ip

### DIFF
--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -365,36 +365,28 @@ if (get_var("REGRESSION", '') =~ /xen/) {
 } elsif (get_var("REGRESSION", '') =~ /hyperv/) {
     %guests = (
         sles12sp3 => {
-            name => 'sles12sp3',
-            ip => 'win2k19-sle12-SP3.qa.suse.cz',
+            vm_name => 'sles-12.3_openQA-virtualization-maintenance',
         },
         sles12sp4 => {
-            name => 'sles12sp4',
-            ip => 'win2k19-sle12-SP4.qa.suse.cz',
+            vm_name => 'sles-12.4_openQA-virtualization-maintenance',
         },
         sles12sp5 => {
-            name => 'sles12sp5',
-            ip => 'win2k19-sle12-SP5.qa.suse.cz',
+            vm_name => 'sles-12.5_openQA-virtualization-maintenance',
         },
         sles15sp1 => {
-            name => 'sles15sp1',
-            ip => 'win2k19-sle15-SP1.qa.suse.cz',
+            vm_name => 'sles-15.1_openQA-virtualization-maintenance',
         },
         sles15sp2 => {
-            name => 'sles15sp2',
-            ip => 'win2k19-sle15-SP2.qa.suse.cz',
+            vm_name => 'sles-15.2_openQA-virtualization-maintenance',
         },
         sles15sp3 => {
-            name => 'sles15sp3',
-            ip => 'win2k19-sle15-SP3.qa.suse.cz',
+            vm_name => 'sles-15.3_openQA-virtualization-maintenance',
         },
         sles15sp4 => {
-            name => 'sles15sp4',
-            ip => 'win2k19-sle15-SP4.qa.suse.cz',
+            vm_name => 'sles-15.4_openQA-virtualization-maintenance',
         },
         sles15sp5 => {
-            name => 'sles15sp5',
-            ip => 'win2k19-sle15-SP5.qa.suse.cz',
+            vm_name => 'sles-15.5_openQA-virtualization-maintenance',
         },
     );
 

--- a/tests/virtualization/external/prepare.pm
+++ b/tests/virtualization/external/prepare.pm
@@ -29,7 +29,12 @@ sub run {
             assert_script_run(qq(echo "$ip $guest" >> /etc/hosts));
         }
     } else {
-        assert_script_run "echo \"\$(dig +short $virt_autotest::common::guests{$_}->{ip}) $_ # virtualization\" >> /etc/hosts" foreach (keys %virt_autotest::common::guests);
+        foreach my $guest (keys %virt_autotest::common::guests) {
+            my $vm_name = $virt_autotest::common::guests{$guest}->{vm_name};
+            my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no Administrator\@win2k19.qa.suse.cz 'powershell "get-vm -Name $vm_name | select -ExpandProperty networkadapters | select ipaddresses"' | awk -F '[{,]' '{print \$2}'));
+            record_info("$guest: $ip");
+            assert_script_run(qq(echo "$ip $guest" >> /etc/hosts));
+        }
     }
     assert_script_run "cat /etc/hosts";
 }

--- a/tests/virtualization/external/prepare.pm
+++ b/tests/virtualization/external/prepare.pm
@@ -31,7 +31,7 @@ sub run {
     } else {
         foreach my $guest (keys %virt_autotest::common::guests) {
             my $vm_name = $virt_autotest::common::guests{$guest}->{vm_name};
-            my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no Administrator\@win2k19.qa.suse.cz 'powershell "get-vm -Name $vm_name | select -ExpandProperty networkadapters | select ipaddresses"' | awk -F '[{,]' '{print \$2}'));
+            my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no Administrator\@win2k19.qa.suse.cz 'powershell "get-vm -Name $vm_name | select -ExpandProperty networkadapters | select ipaddresses"' | grep -oE '[0-9]+.[0-9]+.[0-9]+.[0-9]+'));
             record_info("$guest: $ip");
             assert_script_run(qq(echo "$ip $guest" >> /etc/hosts));
         }


### PR DESCRIPTION
Discover hyperV guests without using static IPs

- Related ticket: https://progress.opensuse.org/issues/111383
- Needles: N/A
- Verification run: 

[15-SP5](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=%3Atbaev%3A&groupid=322)
[15-SP3](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=%3Atbaev%3A&groupid=322)
[15-SP4](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=%3Atbaev%3A&groupid=322)
[12-SP5](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=%3Atbaev%3A&groupid=322)
[12-SP4](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP4&build=%3Atbaev%3A&groupid=322)
[12-SP3](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP3&build=%3Atbaev%3A&groupid=322)
