### PR TITLE
xfstests: Init xfstests in alp main file

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -277,6 +277,23 @@ sub load_slem_on_pc_tests {
     loadtest("publiccloud/ssh_interactive_end", run_args => $args);
 }
 
+sub load_xfstests_tests {
+    load_boot_from_disk_tests;
+    if (check_var('XFSTESTS', 'installation')) {
+        loadtest 'transactional/host_config';
+        loadtest 'xfstests/install';
+        unless (check_var('NO_KDUMP', '1')) {
+            loadtest 'xfstests/enable_kdump';
+        }
+        loadtest 'shutdown/shutdown';
+    }
+    else {
+        loadtest 'xfstests/partition';
+        loadtest 'xfstests/run';
+        loadtest 'xfstests/generate_report';
+    }
+}
+
 sub load_tests {
     # SLEM on PC
     if (is_public_cloud()) {
@@ -286,6 +303,11 @@ sub load_tests {
 
     if (is_kernel_test()) {
         load_kernel_tests;
+        return 1;
+    }
+
+    if (get_var('XFSTESTS')) {
+        load_xfstests_tests;
         return 1;
     }
 

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -45,7 +45,10 @@ sub install_xfstests_from_repo {
     zypper_call('--gpg-auto-import-keys ref');
     record_info('repo info', script_output('zypper lr -U'));
     if (is_transactional) {
-        trup_call('pkg install xfstests fio');
+        trup_call('pkg install xfstests');
+        unless (is_alp) {
+            trup_call('--continue pkg install fio');
+        }
         reboot_on_changes;
     }
     else {


### PR DESCRIPTION
Init xfstests in alp main file, and makes it install success remove fio package first, because one of fio dependency build fails in alp.

- Related ticket: https://progress.opensuse.org/issues/132533
- Verification run: 

> Use create_hdd_xfstests to create qcow2 which xfstests installed, and runs other tests based on that as  HDD_1
> - create_hdd_xfstests http://10.67.133.133/tests/278
> - example for normal sub tests:
> - xfstests_xfs-generic-001-100 http://10.67.133.133/tests/280
> - xfstests_xfs-xfs-001-100 http://10.67.133.133/tests/281
> - xfstests_btrfs-btrfs-001-050 http://10.67.133.133/tests/282
> - xfstests_btrfs-generic-001-100 http://10.67.133.133/tests/283
> - xfstests_ext4-ext4 http://10.67.133.133/tests/284
> - xfstests_ext4-generic-001-100 http://10.67.133.133/tests/285