### PR TITLE
Azure CLI: Change the example image

### DIFF
--- a/tests/publiccloud/azure_cli.pm
+++ b/tests/publiccloud/azure_cli.pm
@@ -49,7 +49,7 @@ sub run {
     assert_script_run("az group create -n $resource_group --tags '$tags'");
 
     # Pint - command line tool to query pint.suse.com to get the current image name
-    my $image_name = script_output(qq/pint microsoft images --active --json | jq -r '[.images[] | select( .urn | contains("sles-15-sp4:gen2") )][0].urn'/);
+    my $image_name = script_output(qq/pint microsoft images --active --json | jq -r '[.images[] | select( .urn | contains("sles-15-sp5:gen2") )][0].urn'/);
     die("The pint query output is empty.") unless ($image_name);
     record_info("PINT", "Pint query: " . $image_name);
 


### PR DESCRIPTION
The 15-SP4 is not active any more. This is switching the image to 15-SP5.