### PR TITLE
Increase timeout

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -291,7 +291,7 @@ sub install_from_repo {
     my @pkgs = split(/\s* \s*/, get_var('LTP_PKG', get_default_pkg));
 
     if (is_transactional) {
-        assert_script_run("transactional-update -n -c pkg install " . join(' ', @pkgs), 90);
+        assert_script_run("transactional-update -n -c pkg install " . join(' ', @pkgs), 180);
     } else {
         zypper_call("in --recommends " . join(' ', @pkgs));
     }


### PR DESCRIPTION
In case of some architectures for a transactional systems, like ARM, we see 90 sec isn't enough to run the installation
