### PR TITLE
Remove duplicated logs from qesap_cluster_log_cmds

### DIFF
--- a/data/sles4sap/fetch_file.yaml
+++ b/data/sles4sap/fetch_file.yaml
@@ -2,11 +2,11 @@
 - hosts: all
   vars:
     remote_path: '/tmp/'
-    out_path: '/tmp/ansible_fetch_output/'
+    local_path: '/tmp/ansible_fetch_output/'
     file: 'testout.txt'
   tasks:
   - name: fetch
     fetch:
       flat: yes
       src: "{{ remote_path }}{{ file }}"
-      dest: "{{ out_path }}"
+      dest: "{{ local_path }}"

--- a/data/sles4sap/script_output.yaml
+++ b/data/sles4sap/script_output.yaml
@@ -8,5 +8,4 @@
   tasks:
   - name: 'Run cmd'
     shell: "{{ cmd }} > {{ remote_path }}{{ out_file }}"
-    register: crm_status_files
     ignore_errors: "{{ failok }}"


### PR DESCRIPTION
Remove logs that are already collected using `crm report`. Improve documentation of qesap functions using Ansible. Add unit testing about qesap_ansible_fetch_file.
This PR also solve some of the comments in the review of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17458

Related ticket: https://jira.suse.com/browse/TEAM-8138


Verification:
- sle-15-SP4-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_4_BYOS-qesap_azure_ibsmirror_peering_test@64bit -> http://openqaworker15.qa.suse.cz/tests/207786
 
- sle-15-SP4-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_4_BYOS-qesap_azure_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/207787 :green_circle: 

- sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-07-26T04:03:33Z-hanasr_azure_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/207788 :green_circle: 

- sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2023-07-26T04:03:33Z-hanasr_aws_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/207789 failure in a known later in the HanaSR test

- sle-15-SP3-Trento-PremiumRolling-x86_64-BuildRolling2.0.0-build58.6-trento_test@64bit -> http://openqaworker15.qa.suse.cz/tests/207791  http://openqaworker15.qa.suse.cz/tests/208221

