### PR TITLE
console/steamcmd.pm: Fix order of return code checks

### DIFF
--- a/tests/console/steamcmd.pm
+++ b/tests/console/steamcmd.pm
@@ -22,14 +22,14 @@ sub run {
     # see https://github.com/ValveSoftware/steam-for-linux/issues/4341
     my $allow_exit_codes = [qw(0 6 7 8)];
     my $ret = script_run '/usr/bin/steamcmd +login anonymous +app_update 90 validate +quit', 1200;
-    if ($ret == 139) {
-        record_soft_failure("boo#1212977 steamcmd segfaults");
-        return 1;
-    }
     if ($ret == 8) {
         # Steam bug: HL needs multiple download attempts:
         # https://developer.valvesoftware.com/wiki/SteamCMD#Downloading_an_app
         $ret = script_run '/usr/bin/steamcmd +login anonymous +app_update 90 validate +quit', 1200;
+    }
+    if ($ret == 139) {
+        record_soft_failure("boo#1212977 steamcmd segfaults");
+        return 1;
     }
     die "'steamcmd' failed with exit code $ret" unless (grep { $_ == $ret } @$allow_exit_codes);
     assert_script_run 'test -f Steam/steamapps/common/Half-Life/hlds_run';


### PR DESCRIPTION
The retry might also fail with 139.

- Failure: https://openqa.opensuse.org/tests/3462243#step/steamcmd/8
- Verification run: https://openqa.opensuse.org/tests/3462877
