### PR TITLE
Add new validate_repos test module

### DIFF
--- a/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
@@ -19,6 +19,7 @@ conditional_schedule:
   PC_instance_ssh_interactive_start:
     PUBLIC_CLOUD_SLES4SAP:
       '1':
+        - publiccloud/validate_repos
         - sles4sap/publiccloud/qesap_terraform
         - sles4sap/publiccloud/network_peering
         - sles4sap/publiccloud/add_server_to_hosts

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -14,8 +14,8 @@ use testapi;
 use strict;
 use utils;
 use publiccloud::ssh_interactive "select_host_console";
-use publiccloud::utils "is_embargo_update";
-use List::MoreUtils qw(uniq);
+use publiccloud::utils "validate_repo";
+
 
 # Get the status of the update repos
 # 0 = no repo, 1 = repos already downloaded, 2 = repos downloading
@@ -56,18 +56,17 @@ sub run {
         my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
         assert_script_run('touch /tmp/repos.list.txt');
 
+        # Failsafe: Fail if there are no test repositories, otherwise we have the wrong template link
+        my $count = scalar @repos;
+        my $check_empty_repos = get_var('PUBLIC_CLOUD_IGNORE_EMPTY_REPO', 0) == 0;
+        die "No test repositories" if ($check_empty_repos && $count == 0);
+
         my $ret = 0;
         my $reject = "'robots.txt,*.ico,*.png,*.gif,*.css,*.js,*.htm*'";
         my $regex = "'s390x\\/|ppc64le\\/|kernel*debuginfo*.rpm|src\\/'";
         my ($incident, $type);
         for my $maintrepo (@repos) {
-            ($incident, $type) = ($2, $1) if ($maintrepo =~ /\/(PTF|Maintenance):\/(\d+)/g);
-            die "We did not detect incident number for URL \"$maintrepo\". We detected \"$incident\"" unless $incident =~ /\d+/;
-            if (is_embargo_update($incident, $type)) {
-                record_info("EMBARGOED", "The repository \"$maintrepo\" belongs to embargoed incident number \"$incident\"");
-                script_run("echo 'The repository \"$maintrepo\" belongs to embargoed incident number \"$incident\"'");
-                next;
-            }
+            next unless validate_repo($maintrepo);
             script_run("echo 'Downloading $maintrepo ...' >> ~/repos/qem_download_status.txt");
             my ($parent) = $maintrepo =~ 'https?://(.*)$';
             my ($domain) = $parent =~ '^([a-zA-Z.]*)';
@@ -89,10 +88,6 @@ sub run {
                 }
             }
         }
-        # Failsafe: Fail if there are no test repositories, otherwise we have the wrong template link
-        my $count = scalar @repos;
-        my $check_empty_repos = get_var('PUBLIC_CLOUD_IGNORE_EMPTY_REPO', 0) == 0;
-        die "No test repositories" if ($check_empty_repos && $count == 0);
 
         assert_script_run("echo 'Download completed' >> ~/repos/qem_download_status.txt");
         upload_logs('/tmp/repos.list.txt');

--- a/tests/publiccloud/validate_repos.pm
+++ b/tests/publiccloud/validate_repos.pm
@@ -1,0 +1,58 @@
+# SUSE's openQA tests
+#
+# Copyright 2019-2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Download repositores from the internal server
+#
+# Maintainer: qa-c <qa-c@suse.de>
+
+use base 'consoletest';
+use registration;
+use warnings;
+use testapi;
+use strict;
+use utils;
+use publiccloud::ssh_interactive "select_host_console";
+use publiccloud::utils "validate_repo";
+
+sub run {
+    my ($self, $args) = @_;
+    select_host_console();    # select console on the host, not the PC instance
+
+    if (get_var('PUBLIC_CLOUD_SKIP_MU')) {
+        # Skip maintenance updates. This is useful for debug runs
+        record_info('Skip validation', 'Skipping maintenance update validation (triggered by setting)');
+        return;
+    } else {
+        # In Incidents there is INCIDENT_REPO instead of MAINT_TEST_REPO
+        # Those two variables contain list of repositories separated by comma
+        set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) unless get_var('MAINT_TEST_REPO');
+        my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
+        # Failsafe: Fail if there are no test repositories, otherwise we have the wrong template link
+        my $count = scalar @repos;
+        my $check_empty_repos = get_var('PUBLIC_CLOUD_IGNORE_EMPTY_REPO', 0) == 0;
+        die "No test repositories" if ($check_empty_repos && $count == 0);
+
+        my $repo_count = 0;
+        my ($incident, $type);
+        for my $maintrepo (@repos) {
+            next unless validate_repo($maintrepo);
+            $repo_count++;
+        }
+        die "No usable test repositories" if ($repo_count == 0);
+    }
+}
+
+sub post_fail_hook {
+}
+
+sub test_flags {
+    return {
+        fatal => 1,
+        milestone => 1,
+        publiccloud_multi_module => 1
+    };
+}
+
+1;

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -26,6 +26,9 @@ sub run {
         loadtest('sles4sap/publiccloud/qesap_ansible', name => 'verify_infrastructure', run_args => $run_args, @_);
     }
     else {
+        if (check_var('IS_MAINTENANCE', 1)) {
+            loadtest('publiccloud/validate_repos', name => 'validate_repos', run_args => $run_args, @_);
+        }
         loadtest('sles4sap/publiccloud/qesap_terraform', name => 'deploy_qesap_terraform', run_args => $run_args, @_);
         if (check_var('IS_MAINTENANCE', 1)) {
             loadtest('sles4sap/publiccloud/network_peering', name => 'network_peering', run_args => $run_args, @_);


### PR DESCRIPTION
Create validate_repos derived from download_repos. Add this new test module in HanaSr and mr_test scheduled when IS_MAINTENANCE is enabled

- Related ticket: https://jira.suse.com/browse/TEAM-8322
- Verification run: 
WITH EMBARGOED: http://openqaworker15.qa.suse.cz/tests/208684#step/validate_repos/46
NO REPO: http://openqaworker15.qa.suse.cz/tests/208685#step/validate_repos/26

