### PR TITLE
Add Ansible cmd to retry if Azure reboot timeout error found

### DIFF
--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -27,6 +27,7 @@ sub run {
         my $rec_timeout = qesap_ansible_log_find_timeout($ret[1]);
         if ($rec_timeout) {
             record_info('DETECTED ANSIBLE TIMEOUT ERROR');
+            @ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
         }
         die "'qesap.py ansible' return: $ret[0]";
     }


### PR DESCRIPTION
Add Ansible cmd to re-trigger run if it find Azure reboot time out in qesapdeployment/deploy.pm
Add Fail_ok = 1 flag in qesap_upload_crm_report to avoid log collecting failures

- Related ticket: [TEAM-8006](https://jira.suse.com/browse/TEAM-8006)
- Verification run: AZURE :  http://openqaworker15.qa.suse.cz/t208688
VR with wrong reg_code : http://openqaworker15.qa.suse.cz/tests/209145 (Expected failure)
-VR for Fail_ok flag : http://openqaworker15.qa.suse.cz/tests/209144
- AWS VR : http://openqaworker15.qa.suse.cz/t208689
