### PR TITLE
Trim optional variable regurl only if set

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -71,7 +71,7 @@ sub set_bootscript {
     $url =~ s/^\s+|\s+$//g;
     $arch =~ s/^\s+|\s+$//g;
     $autoyast =~ s/^\s+|\s+$//g;
-    $regurl =~ s/^\s+|\s+$//g;
+    $regurl =~ s/^\s+|\s+$//g if defined $regurl;
     $console =~ s/^\s+|\s+$//g;
     $mirror_http =~ s/^\s+|\s+$//g;
 


### PR DESCRIPTION
Don't try to trim this variable if it is unset, which happens for maintenance tests.