### PR TITLE
Workaround system reboot due to pacemaker

### DIFF
--- a/tests/migration/online_migration/post_migration.pm
+++ b/tests/migration/online_migration/post_migration.pm
@@ -61,6 +61,8 @@ sub test_flags {
 sub add_maintenance_repos {
     set_var('PATCH_TEST_REPO', '');
     add_test_repositories();
+    # avoid reboot during fully_patch_system
+    zypper_call('in pacemaker') if is_sle('=15-sp1');
     fully_patch_system();
 }
 


### PR DESCRIPTION
Update first pacemaker and then rest of the packages, pacemaker or some dependency will trigger system reboot, the code does not expect reboot.
IMO it's simple workaround, better than expecting unexpected reboot.

- Verification run: https://openqa.suse.de/tests/11705396
https://openqa.suse.de/tests/overview?version=15-SP1&distri=sle&build=sap