### PR TITLE
Restart firewalld on 15-SP5

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -65,7 +65,7 @@ sub reset_engines {
     my ($self, $current_engine) = @_;
     my ($version, $sp, $host_distri) = get_os_release;
     my $sp_version = "$version.$sp";
-    if ($sp_version =~ /15.3|15.4/) {
+    if ($sp_version =~ /15.3|15.4|15.5/) {
         # This workaround is only needed in SLE 15-SP3 and 15-SP4 (and Leap 15.3 and 15.4)
         # where we need to restart docker and firewalld before running podman, otherwise
         # the podman containers won't have access to the outside world.

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -47,8 +47,8 @@ sub run {
     install_podman_when_needed($host_distri) if ($engine =~ 'podman');
 
     # It has been observed that after system update, the ip forwarding doesn't work.
-    # In 15.3/15.4 there is a need to restart the firewall and docker daemon.
-    if ($host_distri =~ /sles|opensuse-leap/ && $version eq '15' && $sp =~ /3|4/) {
+    # In 15.3/15.4/15.5 there is a need to restart the firewall and docker daemon.
+    if ($host_distri =~ /sles|opensuse-leap/ && $version eq '15' && $sp =~ /3|4|5/) {
         systemctl("restart docker") if ($engine =~ 'docker');
         systemctl("restart firewalld");
     }


### PR DESCRIPTION
Apply the known workaround to fix not working ip-forwarding on 15-SP5.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1213811
- Verification run: https://duck-norris.qe.suse.de/tests/13382
