### PR TITLE
Add zypper_lifecycle test to livepatch LTP jobs

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -87,6 +87,8 @@ sub load_kernel_tests {
             is_opensuse) {
             loadtest_kernel 'install_klp_product';
         }
+
+        loadtest 'console/zypper_lifecycle' if get_var('KGRAFT');
     }
     elsif (get_var('INSTALL_KLP_PRODUCT')) {
         loadtest_kernel 'boot_ltp';

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -12,6 +12,7 @@ use base 'opensusebasetest';
 use testapi;
 use utils;
 use power_action_utils 'power_action';
+use serial_terminal;
 use upload_system_log;
 
 sub export_to_json {
@@ -31,6 +32,7 @@ sub run {
         export_to_json($tinfo->test_result_export);
     }
 
+    select_serial_terminal;
     script_run('df -h');
 
     if (get_var('LTP_COMMAND_FILE')) {


### PR DESCRIPTION
Kernel livepatches don't have the basic incident tests. Add `zypper_lifecycle` test to one of the kernel jobs.

- Related ticket: https://progress.opensuse.org/issues/133514
- Needles: N/A
- Verification runs:
  - SLE-12SP5: https://openqa.suse.de/tests/11712913
  - SLE-15SP5: https://openqa.suse.de/tests/11712919 (expected to fail due to broken metadata in a released package)