### PR TITLE
Manage failok in all qesap_ansible functions

### DIFF
--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -29,7 +29,10 @@ sub run {
     );
     qesap_ansible_cmd(cmd => $_, provider => $prov) for @remote_cmd;
     qesap_ansible_cmd(cmd => 'ls -lai /hana/', provider => $prov, filter => 'hana');
-    my $cmr_status = qesap_ansible_script_output(cmd => 'crm status', provider => $prov, host => '"hana[0]"', root => 1);
+    my $cmr_status = qesap_ansible_script_output(cmd => 'crm status',
+        provider => $prov,
+        host => '"hana[0]"',
+        root => 1);
     record_info("crm status", $cmr_status);
     qesap_ansible_cmd(cmd => $crm_mon_cmd, provider => $prov, filter => '"hana[0]"');
     qesap_cluster_logs();


### PR DESCRIPTION
Always provide a 0 default for failok.
Export qesap_upload_crm_report.
Create an utility function to download the fetch and command playbooks. Remove some argument to local variable translations. Remove not necessary tests on mandatory arguments. Add all relevant unit testing.

- Related ticket: https://jira.suse.com/browse/TEAM-8138

Verification run:
- qesap deployment http://openqaworker15.qa.suse.cz/tests/209586 http://openqaworker15.qa.suse.cz/tests/209587

- qesap deployment with an artificial Ansible failure http://openqaworker15.qa.suse.cz/tests/209589. The failure is intentionally even before that the cluster is initialized. The `crm report` is called as part of other logs collected at each Ansible failure: http://openqaworker15.qa.suse.cz/tests/209589#step/deploy/191  . The `crm report` fails as expected as the cluster is not configured. The fetching of the report fails too http://openqaworker15.qa.suse.cz/tests/209589#step/deploy/203 (here the code could be further improved and this comment in the code refer to it https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17518/files#diff-23c988d39d71dc252bb5dce95a699047e93941078f2152ab4a6587286e9a4e47R674 ). But even if the `crm report` fails (here the point of this PR), other logs are properly collected later http://openqaworker15.qa.suse.cz/tests/209589#step/deploy/218
 
- hanasr https://openqaworker15.qa.suse.cz/tests/209591

- trento http://openqaworker15.qa.suse.cz/tests/209592
