### PR TITLE
Revert "Add zypper_lifecycle test to livepatch LTP jobs"

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -87,8 +87,6 @@ sub load_kernel_tests {
             is_opensuse) {
             loadtest_kernel 'install_klp_product';
         }
-
-        loadtest 'console/zypper_lifecycle' if get_var('KGRAFT');
     }
     elsif (get_var('INSTALL_KLP_PRODUCT')) {
         loadtest_kernel 'boot_ltp';

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -12,7 +12,6 @@ use base 'opensusebasetest';
 use testapi;
 use utils;
 use power_action_utils 'power_action';
-use serial_terminal;
 use upload_system_log;
 
 sub export_to_json {
@@ -32,7 +31,6 @@ sub run {
         export_to_json($tinfo->test_result_export);
     }
 
-    select_serial_terminal;
     script_run('df -h');
 
     if (get_var('LTP_COMMAND_FILE')) {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#17513

- Related ticket: https://progress.opensuse.org/issues/133514
- Needles: N/A
- Verification runs: N/A

Running the `zypper_lifecycle` test on kernel-livepatch package updates is pointless, the lifecycle data has its own package which gets updated in separate incidents.