### PR TITLE
Change hard coded product names in playwright test specs

### DIFF
--- a/tests/yam/agama/agama_full_disk_encryption.pm
+++ b/tests/yam/agama/agama_full_disk_encryption.pm
@@ -12,6 +12,7 @@ use warnings;
 use testapi qw(
   assert_screen
   assert_script_run
+  get_required_var
   select_console
   upload_logs
 );
@@ -19,11 +20,12 @@ use power_action_utils 'power_action';
 use transactional 'process_reboot';
 
 sub run {
+    my $product_name = get_required_var('AGAMA_PRODUCT');
     assert_screen('agama_product_selection', 120);
     $testapi::password = 'linux';
     select_console 'root-console';
 
-    assert_script_run('playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright full-disk-encryption', timeout => 600);
+    assert_script_run("PRODUCTNAME=\"$product_name\" playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright full-disk-encryption", timeout => 600);
 
     $testapi::password = 'nots3cr3t';
     assert_script_run('reboot');

--- a/tests/yam/agama/agama_lvm.pm
+++ b/tests/yam/agama/agama_lvm.pm
@@ -12,6 +12,7 @@ use warnings;
 use testapi qw(
   assert_screen
   assert_script_run
+  get_required_var
   reset_consoles
   select_console
   upload_logs
@@ -20,11 +21,12 @@ use power_action_utils 'power_action';
 use transactional 'process_reboot';
 
 sub run {
+    my $product_name = get_required_var('AGAMA_PRODUCT');
     assert_screen('agama_product_selection', 120);
     $testapi::password = 'linux';
     select_console 'root-console';
 
-    assert_script_run('RUN_INSTALLATION=1 playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright lvm', timeout => 1200);
+    assert_script_run("RUN_INSTALLATION=1 PRODUCTNAME=\"$product_name\" playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright lvm", timeout => 1200);
     upload_logs('./test-results/lvm-Use-logical-volume-management-LVM-as-storage-device-for-installation-chromium/trace.zip');
 
     assert_script_run('reboot');


### PR DESCRIPTION
Change hard coded product names in playwright test specs, add upload trace file for tests/yam/agama/agama_full_disk_encryption.pm.

- Related ticket: https://progress.opensuse.org/issues/133562
- Related Playwright PR: https://github.com/jknphy/e2e-agama-playwright/pull/9
- Needles: N/A
- Verification run:  https://openqa.opensuse.org/tests/3478043#step/agama_lvm/5
  https://openqa.opensuse.org/tests/3478044#step/agama_full_disk_encryption/5
The failures are for https://bugzilla.suse.com/show_bug.cgi?id=1213836
