### PR TITLE
Disable qemu/kvm specific test for SLE Micro RT

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -204,8 +204,8 @@ sub load_network_tests {
 sub load_qemu_tests {
     loadtest 'microos/rebuild_initrd' if is_s390x;
     loadtest 'qemu/info';
-    loadtest 'qemu/qemu';
-    loadtest 'qemu/kvm' unless is_aarch64;
+    loadtest 'qemu/qemu' unless is_rt;
+    loadtest 'qemu/kvm' unless (is_aarch64 or is_rt);
     # qemu-linux-user package not available in SLEM
     loadtest 'qemu/user' unless (is_sle_micro || is_leap_micro);
 }


### PR DESCRIPTION
* **SLE Micro RT** has no kvm support, so disable relevant tests, otherwise it will fail like [this](https://openqa.suse.de/tests/11713080#step/qemu/4).

* **Please** refer to [SLE Micro 5.5 Test Plan](https://confluence.suse.com/display/qasle/Master+Test+Plan+for+SLE+Micro+5.5)

*  **Verification runs:**
    * [Loaded slem_installation_virt on x86_64 DVD](http://10.163.28.134/tests/1927)
    * [Loaded slem_installation_virt on aarch64 DVD](http://10.163.28.134/tests/1931)
    * [Loaded slem_installation_virt on s390x DVD](http://10.163.28.134/tests/1932)
    * [Loaded slem_virtualization on x86_64 Default](http://10.163.28.134/tests/1933)
    * [Loaded slem_virtualization on aarch64 Default](http://10.163.28.134/tests/1934)
    * [Loaded slem_virtualizaiton on s390x Default](http://10.163.28.134/tests/1935)
    * [Loaded slem_virtualization on x86_64 Default-RT](http://10.163.28.134/tests/1926)
    OR
    * [Loaded slem_installation_virt on x86_64 DVD](http://10.67.18.153/tests/1927)
    * [Loaded slem_installation_virt on aarch64 DVD](http://10.67.18.153/tests/1931)
    * [Loaded slem_installation_virt on s390x DVD](http://10.67.18.153/tests/1932)
    * [Loaded slem_virtualization on x86_64 Default](http://10.67.18.153/tests/1933)
    * [Loaded slem_virtualization on aarch64 Default](http://10.67.18.153/tests/1934)
    * [Loaded slem_virtualizaiton on s390x Default](http://10.67.18.153/tests/1935)
    * [Loaded slem_virtualization on x86_64 Default-RT](http://10.67.18.153/tests/1926)

