### PR TITLE
Avoid duplicate configuration in update_package.pm

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -862,7 +862,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/install_package";
         loadtest "virt_autotest/update_package";
         loadtest "virt_autotest/reset_partition";
-        loadtest "virt_autotest/reboot_and_wait_up_normal" if get_var('REPO_0_TO_INSTALL');
+        loadtest "virt_autotest/reboot_and_wait_up_normal" if (!get_var('AUTOYAST') && get_var('REPO_0_TO_INSTALL'));
         loadtest "virt_autotest/download_guest_assets" if get_var("SKIP_GUEST_INSTALL") && is_x86_64;
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -103,7 +103,7 @@ sub install_package {
     if (get_var('GUEST_LIST', '') =~ /^win-.*/ && (is_xen_host)) { zypper_call '--no-refresh --no-gpg-checks in mkisofs' }
 
     #Subscribing packagehub from SLE 15-SP4 onwards that enables access to many useful software tools
-    virt_autotest::utils::subscribe_extensions_and_modules(reg_exts => 'PackageHub') if (is_sle('>=15-sp4') and !is_s390x);
+    virt_autotest::utils::subscribe_extensions_and_modules(reg_exts => 'PackageHub') if (!get_var('AUTOYAST') and is_sle('>=15-sp4') and !is_s390x);
 }
 
 sub run {

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -123,11 +123,11 @@ sub login_to_console {
         }
     }
 
-    unless (is_tumbleweed or check_screen([qw(grub2 grub1 prague-pxe-menu)], 210)) {
+    unless (is_tumbleweed or check_screen([qw(grub2 grub1 prague-pxe-menu)], get_var('AUTOYAST') && !get_var("NOT_DIRECT_REBOOT_AFTER_AUTOYAST") ? 1 : 180)) {
         ipmitool("chassis power reset");
         reset_consoles;
         select_console 'sol', await_console => 0;
-        check_screen([qw(grub2 grub1 prague-pxe-menu)], 90);
+        check_screen([qw(grub2 grub1 prague-pxe-menu)], 120);
     }
 
     # If a PXE menu will appear just select the default option (and save us the time)

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -81,7 +81,9 @@ sub reboot_and_wait_up {
         reset_consoles;
 
         #wait boot finish and relogin
+        set_var('NOT_DIRECT_REBOOT_AFTER_AUTOYAST', '1');
         login_console::login_to_console($self, $reboot_timeout);
+
     }
 }
 

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -48,10 +48,13 @@ sub update_package {
 sub run {
     my $self = shift;
     #workaroud: skip update package for registered aarch64 tests and because there are conflicts on sles15sp2 XEN
-    $self->update_package() unless (is_registered_sles && is_aarch64);
-    unless ((is_registered_sles && is_aarch64) || is_s390x) {
+    $self->update_package() unless (!!get_var('AUTOYAST') || is_registered_sles && is_aarch64);
+    unless (!!get_var('AUTOYAST') || (is_registered_sles && is_aarch64) || is_s390x) {
         set_grub_on_vh('', '', 'xen') if is_xen_host;
         set_grub_on_vh('', '', 'kvm') if is_kvm_host;
+    } else {
+        my @files_to_upload = ("/boot/grub2/grub.cfg", "/etc/default/grub");
+        upload_logs($_, failok => 1) foreach (@files_to_upload);
     }
     update_guest_configurations_with_daily_build();
 


### PR DESCRIPTION
With host installation by autoyast, some configuration functionalities of install_package and update_package get duplicate so adding conditional statements to avoid their execution.

https://progress.opensuse.org/issues/132836

- Related ticket: https://progress.opensuse.org/issues/132836
- Needles: no
- Verification run: 
- prj2_host_upgrade_sles12sp5_to_developing_kvm, http://10.67.183.130/tests/3787
- prj2_host_upgrade_sles12sp5_to_developing_xen, http://10.67.183.130/tests/3803
- prj2_host_upgrade_sles15sp4_to_developing_xen (GUI install), https://openqa.suse.de/tests/11641701
- prj2_host_upgrade_sles15sp4_to_developing_xen, https://openqa.suse.de/tests/11637657
- prj2_host_upgrade_sles15sp4_to_developing_kvm, https://openqa.suse.de/tests/11739188
- -gi-guest_developing-on-host_developing-xen, http://10.67.183.130/tests/3775
- gi-guest_developing-on-host_developing-kvm, http://10.67.183.130/tests/3770
- uefi-gi-guest_sles15sp4-on-host_developing-xen,  https://openqa.suse.de/tests/11765772
- sev-es-gi-guest_developing-on-host_sles15sp4-kvm,  https://openqa.suse.de/tests/11777628
