### PR TITLE
Fix timeout issue on iscsi_client and nfs client_common_tests

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -170,7 +170,7 @@ sub client_common_tests {
     assert_script_run "rm /tmp/nfs/client/symlinkedfile";
 
     # Copy large file from NFS and test it's checksum
-    assert_script_run "time cp /tmp/nfs/client/random /var/tmp/", 300;
+    assert_script_run "time cp /tmp/nfs/client/random /var/tmp/", 600;
     assert_script_run "md5sum /var/tmp/random | cut -d' ' -f1 > /var/tmp/random.md5sum";
     assert_script_run "diff /tmp/nfs/client/random.md5sum /var/tmp/random.md5sum";
 }

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -141,7 +141,7 @@ sub run {
         $iscsi_drive .= '1';
     }
     sleep 3;
-    assert_script_run "mkfs.ext4 $iscsi_drive";
+    assert_script_run "mkfs.ext4 $iscsi_drive", 180;
     sleep 2;
     # try mount remote partition to /mnt
     assert_script_run "mount $iscsi_drive /mnt";


### PR DESCRIPTION
Enlarge timeout value to fix timeout issue on iscsi_client and nfs client_common_tests.

- Related ticket: N/A
- Failed jobs: https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP1&build=20230806-1&groupid=421
  https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP3&build=20230806-1&groupid=421
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/11755996#step/yast2_nfs_client/149
   https://openqa.nue.suse.com/tests/11756075#details
  https://openqa.nue.suse.com/tests/11756077#details
  
