### PR TITLE
Improve libvirt checks for login_console test module

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -159,6 +159,7 @@ sub is_kvm_host {
 
 #retrun 1 if libvirt 9.0- is running which monolithic libvirtd is the default service
 sub is_monolithic_libvirtd {
+    record_info('WARNING', 'Libvirt package is not installed', result => 'fail') if (script_run('rpm -q libvirt-libs'));
     unless (is_alp) {
         return 1 if script_run('rpm -q libvirt-libs | grep -e "libs-9\.0" -e "libs-[1-8]\."') == 0;
     }

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -65,7 +65,9 @@ sub check_kvm_modules {
     # for modular libvirt, virtqemud is expected in "loaded: active or inactive" status.
     # virtqemud.socket seems to be always in "loaded: active" status
     unless (is_monolithic_libvirtd) {
-        die 'virtqemud.socket is not running!' unless script_run("systemctl is-active virtqemud.socket") eq 0;
+        unless (get_var('TEST_SUITE_NAME') =~ /kubevirt-tests/ or script_run("systemctl is-active virtqemud.socket") eq 0) {
+            die 'virtqemud.socket is not running!';
+        }
     }
     record_info("KVM", "kvm modules are loaded!");
 }


### PR DESCRIPTION
1. To improve the function 'is_monolithic_libvirtd()', adding a warning message for checking whether libvirt package installed or not. (lib/virt_autotest/utils.pm)
2. Skip libvirt service checks for kubevirt tests. (tests/virt_autotest/login_console.pm)

- Related ticket: https://progress.opensuse.org/issues/132608
- Verification run: https://openqa.suse.de/tests/11760650
