### PR TITLE
Reintroduce reset_container_network_if_needed

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -22,7 +22,7 @@ use Mojo::Util 'trim';
 
 our @EXPORT = qw(test_seccomp runtime_smoke_tests basic_container_tests get_vars
   can_build_sle_base get_docker_version get_podman_version check_runtime_version
-  check_min_runtime_version container_ip container_route registry_url);
+  check_min_runtime_version container_ip container_route registry_url reset_container_network_if_needed);
 
 sub test_seccomp {
     my $no_seccomp = script_run('docker info | tee /tmp/docker_info.txt | grep seccomp');
@@ -292,6 +292,27 @@ sub can_build_sle_base {
     # script_run returns 0 if true, but true is 1 on perl
     my $has_sle_registration = !script_run("test -e /etc/zypp/credentials.d/SCCcredentials");
     return check_os_release('sles', 'ID') && $has_sle_registration;
+}
+
+sub reset_container_network_if_needed {
+    my ($current_engine) = @_;
+    my ($version, $sp, $host_distri) = get_os_release;
+    my $sp_version = "$version.$sp";
+
+    # This workaround is only needed from SLE 15-SP3 (and Leap 15.3) onwards.
+    # See https://bugzilla.suse.com/show_bug.cgi?id=1213811
+    if ($version eq "15" && $sp >= 3) {
+        my $runtime = get_required_var('CONTAINER_RUNTIME');
+        if ($host_distri =~ /sles|opensuse/ && $runtime =~ /docker/) {
+            if ($current_engine eq 'podman') {
+                # Only stop docker, if docker is active. This is also a free check if docker is present
+                systemctl("stop docker") if (script_run("systemctl is-active docker") == 0);
+            } elsif ($current_engine eq 'docker') {
+                systemctl("start docker");
+            }
+            systemctl("restart firewalld");
+        }
+    }
 }
 
 1;

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -18,6 +18,7 @@ use Mojo::Base qw(consoletest);
 use XML::LibXML;
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use containers::utils qw(reset_container_network_if_needed);
 use File::Basename;
 use utils qw(systemctl);
 use version_utils qw(get_os_release);
@@ -61,22 +62,6 @@ sub run_tox_cmd {
     script_run('mv junit_' . $env . '.xml junit_' . $env . '_${CONTAINER_RUNTIME}.xml');
 }
 
-sub reset_engines {
-    my ($self, $current_engine) = @_;
-    my ($version, $sp, $host_distri) = get_os_release;
-    my $sp_version = "$version.$sp";
-    if ($sp_version =~ /15.3|15.4|15.5/) {
-        # This workaround is only needed in SLE 15-SP3 and 15-SP4 (and Leap 15.3 and 15.4)
-        # where we need to restart docker and firewalld before running podman, otherwise
-        # the podman containers won't have access to the outside world.
-        my $engines = get_required_var('CONTAINER_RUNTIME');
-        if ($engines =~ /docker/ && $host_distri =~ /sles|opensuse/ && $host_distri =~ /sles|opensuse/) {
-            ($current_engine eq 'podman') ? systemctl("stop docker") : systemctl("start docker");
-            script_run('systemctl --no-pager restart firewalld');
-        }
-    }
-}
-
 sub run {
     my ($self, $args) = @_;
     select_serial_terminal;
@@ -107,7 +92,7 @@ sub run {
     my $test_envs = get_required_var('BCI_TEST_ENVS');
     return if ($test_envs eq '-');
 
-    $self->reset_engines($engine);
+    reset_container_network_if_needed($engine);
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     assert_script_run("cd /root/BCI-tests");

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -15,6 +15,7 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils qw(check_os_release get_os_release is_sle);
 use containers::common;
+use containers::utils qw(reset_container_network_if_needed);
 
 sub run {
     select_serial_terminal;
@@ -45,13 +46,7 @@ sub run {
     # Install engines in case they are not installed
     install_docker_when_needed($host_distri) if ($engine =~ 'docker');
     install_podman_when_needed($host_distri) if ($engine =~ 'podman');
-
-    # It has been observed that after system update, the ip forwarding doesn't work.
-    # In 15.3/15.4/15.5 there is a need to restart the firewall and docker daemon.
-    if ($host_distri =~ /sles|opensuse-leap/ && $version eq '15' && $sp =~ /3|4|5/) {
-        systemctl("restart docker") if ($engine =~ 'docker');
-        systemctl("restart firewalld");
-    }
+    reset_container_network_if_needed($engine);
 
     # Record podman|docker version
     foreach my $eng (split(',\s*', $engine)) {

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -16,6 +16,7 @@ use containers::common;
 use containers::container_images;
 use containers::urls qw(get_image_uri);
 use db_utils qw(push_image_data_to_db);
+use containers::utils qw(reset_container_network_if_needed);
 
 sub run {
     my ($self, $args) = @_;
@@ -23,6 +24,8 @@ sub run {
 
     my $runtime = $args->{runtime};
     my $engine = $self->containers_factory($runtime);
+    reset_container_network_if_needed($runtime);
+
 
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE') && $runtime eq 'docker');
 


### PR DESCRIPTION
Reintroduced the reset_container_network_if_needed subroutine after reverting it in 19fbd63a897718ec9df92970c3706839a49ae587 and 55b7e3c0aef659b368b2688eebf764cc96c1c03a, and adds a check if docker is present to fix it on Leap 15.5 and other systems.

- Related ticket: https://progress.opensuse.org/issues/133808
- Verification runs: [15.5 container image on Leap 15.3](https://duck-norris.qe.suse.de/tests/13393) | [bci-base on Leap 15.4](https://duck-norris.qe.suse.de/tests/13395) | [bci-base on SLES 12-SP5](https://duck-norris.qe.suse.de/tests/13396) | [bci-base on 15-SP4](https://duck-norris.qe.suse.de/tests/13398) | [sle base on 15-SP5](https://duck-norris.qe.suse.de/tests/13400) | [Tumbleweed](https://duck-norris.qe.suse.de/tests/13401#)