### PR TITLE
Re-evaluate return value of Ansible retry cmd

### DIFF
--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -23,13 +23,23 @@ sub run {
     @ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
     if ($ret[0])
     {
-        qesap_cluster_logs();
         my $rec_timeout = qesap_ansible_log_find_timeout($ret[1]);
         if ($rec_timeout) {
             record_info('DETECTED ANSIBLE TIMEOUT ERROR');
             @ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
+            if ($ret[0])
+            {
+                qesap_cluster_logs();
+                die "'qesap.py ansible' return: $ret[0]";
+            }
+            record_info('ANSIBLE RETRY PASS');
         }
-        die "'qesap.py ansible' return: $ret[0]";
+        else
+        {
+            qesap_cluster_logs();
+            die "'qesap.py ansible' return: $ret[0]";
+        }
+
     }
 }
 


### PR DESCRIPTION
This PR is about Re-evaluating the result of Ansible retry cmd when Timeout error is captured in the log.
It is implemented in qesap deploy.pm

- Related ticket: [TEAM-8006](https://jira.suse.com/browse/TEAM-8006)

- Verification run:  **Azure**:  http://openqaworker15.qa.suse.cz/tests/211672
                               **Azure** : with wrong reg_code : http://openqaworker15.qa.suse.cz/tests/211673 (Failure is expected to check other return codes and result in case of other failures except for timeout errors.)
                               **AWS** : http://openqaworker15.qa.suse.cz/tests/211674
