### PR TITLE
push boottime data updated proceed on failure option

### DIFF
--- a/lib/db_utils.pm
+++ b/lib/db_utils.pm
@@ -75,7 +75,7 @@ sub influxdb_push_data {
     $out =~ s/$token/<redacted>/;
     record_info('curl POST', $out);
 
-    my $output = script_output($cmd, quiet => $args{quiet});
+    my $output = script_output($cmd, quiet => $args{quiet}, proceed_on_failure => $args{proceed_on_failure});
     my ($return_code) = $output =~ /RETURN_CODE:(\d+)/;
     unless ($return_code >= 200 && $return_code < 300) {
         my $msg = "Failed pushing data into Influx DB:\n$output\n";


### PR DESCRIPTION
In publiccloud the routine to push boottime data to InfluxDB  the _proceed on failure_ option has been updated in order to handle script_output errors and _timeout_ cases too.

- Related ticket: https://progress.opensuse.org/issues/133871
- Needles: N/A
- Verification run: TDB, see next posts
