### PR TITLE
add suseconnect test in 15-SP4 and 15-SP5

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -137,6 +137,7 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/ansible
+        - console/suseconnect
   arch_specific15_sp5:
     ARCH:
       x86_64:


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/129205
- Needles: N0
- Verification run:  
[15-SP4](http://openqa.suse.de/tests/11860047#step/suseconnect/1)  | [15-SP5]( http://openqa.suse.de/tests/11869515)