### PR TITLE
autoyast_rules_and_classes: specify expected desktop to be GNOME

### DIFF
--- a/schedule/yast/opensuse/autoyast/autoyast_rules_and_classes.yaml
+++ b/schedule/yast/opensuse/autoyast/autoyast_rules_and_classes.yaml
@@ -4,6 +4,7 @@ description: >
   For future testing of AutoYaST rules and classes
 vars:
   AUTOYAST: autoyast_opensuse/rule-based_example/
+  DESKTOP: gnome
 schedule:
   - autoyast/prepare_rules_and_classes
   - installation/bootloader_start


### PR DESCRIPTION
The referenced autoyast profiles select GNOME as the desktop to be
installed. Ensure, openQA expects the same.

- Related ticket: https://progress.opensuse.org/issues/130042
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3492187
