### PR TITLE
Two new API to Azure provider about image names

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -13,7 +13,7 @@ terraform:
     public_key: '%SSH_KEY_PUB%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
-    os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%OS_VER%'
+    os_image_uri: '%OS_URI%'
 
 ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use testapi 'set_var';
+
+use publiccloud::azure;
+
+subtest '[get_image_name]' => sub {
+    my $provider = publiccloud::azure->new();
+    set_var('PUBLIC_CLOUD_AZURE_SKU', 'gen2');
+    my $res = $provider->get_image_name('SOMETHING.vhdfixed.xz');
+    set_var('PUBLIC_CLOUD_AZURE_SKU', undef);
+    is $res, 'SOMETHING-V2.vhd', "The image name is properly composed";
+};
+
+subtest '[get_image_name] without .xz' => sub {
+    my $provider = publiccloud::azure->new();
+    set_var('PUBLIC_CLOUD_AZURE_SKU', 'gen2');
+    my $res = $provider->get_image_name('SOMETHING.vhdfixed');
+    set_var('PUBLIC_CLOUD_AZURE_SKU', undef);
+    is $res, 'SOMETHING-V2.vhd', "The image name is properly composed";
+};
+
+subtest '[get_image_name] with URL' => sub {
+    my $provider = publiccloud::azure->new();
+    set_var('PUBLIC_CLOUD_AZURE_SKU', 'gen2');
+    my $res = $provider->get_image_name('https://download.somewhere.org/SUSE:/SLE-15-SP5:/Update:/PubClouds/images/SOMETHING.vhdfixed.xz');
+    set_var('PUBLIC_CLOUD_AZURE_SKU', undef);
+    is $res, 'SOMETHING-V2.vhd', "The image name is properly composed";
+};
+
+subtest '[get_os_vhd_uri]' => sub {
+    my $provider = publiccloud::azure->new();
+    set_var('PUBLIC_CLOUD_AZURE_SKU', 'gen2');
+    set_var('PUBLIC_CLOUD_STORAGE_ACCOUNT', 'SOMEWHERE');
+    my $res = $provider->get_os_vhd_uri('SOMETHING.vhdfixed.xz');
+    set_var('PUBLIC_CLOUD_AZURE_SKU', undef);
+    set_var('PUBLIC_CLOUD_STORAGE_ACCOUNT', undef);
+    is $res, 'https://SOMEWHERE.blob.core.windows.net/sle-images/SOMETHING-V2.vhd', "The image uri is properly composed";
+};
+
+done_testing;

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -28,7 +28,7 @@ sub run {
     }
     else {
         $variables{STORAGE_ACCOUNT_NAME} = get_required_var('STORAGE_ACCOUNT_NAME');
-        $variables{OS_VER} = $provider->get_image_id();
+        $variables{OS_URI} = $provider->get_os_vhd_uri(get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
     }
     $variables{OS_OWNER} = get_var('QESAPDEPLOY_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 


### PR DESCRIPTION
Add two new function in the Azure provider of publiccloud library.
 - `get_image_name` to get the filename of the image uploaded in Azure
 - `get_os_vhd_uri` to get the uri of the image on the Azure blob server

Add unit tests file for PC
Change qesap regression to use the new API to get image from the blob server.

- Related ticket: [TEAM-8211](https://jira.suse.com/browse/TEAM-8211)
Verification run:

- qesap regression test using `get_os_vhd_uri` and `PUBLIC_CLOUD_IMAGE_LOCATION` that match an image uploaded this morning by some job on OSD  http://openqaworker15.qa.suse.cz/tests/212118 : the overall test is failing for some other reason. The value for `os_image_uri` is ok in the composed `terraform.tfvars` file.  The Terraform deployment is fine http://openqaworker15.qa.suse.cz/tests/212118#step/deploy/7 

- publiccloud_upload_img of an already uploaded image https://openqa.suse.de/tests/11770696

- publiccloud_upload_img with a "new" image https://openqa.suse.de/tests/11770695

-  sle-micro-5.4-BYOS-Azure-x86_64 https://openqa.suse.de/tests/11782160

-  sle-micro-5.4-BYOS-Azure-ARM-x86_64 https://openqa.suse.de/tests/11782165