### PR TITLE
Restart firewalld only if active

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -310,7 +310,7 @@ sub reset_container_network_if_needed {
             } elsif ($current_engine eq 'docker') {
                 systemctl("start docker");
             }
-            systemctl("restart firewalld");
+            systemctl("restart firewalld") if (script_run("systemctl is-active firewalld") == 0);
         }
     }
 }


### PR DESCRIPTION
Restart the firewall only if it was previously already active to avoid (bsc#1214080)[https://bugzilla.suse.com/show_bug.cgi?id=1214080]

- Related ticket: https://progress.opensuse.org/issues/133808
- Verification run: https://openqa.opensuse.org/tests/3492898
