### PR TITLE
[virt_autotest] Adapt SLE automation from monolithic to modular libvirt on 15SP6

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2022 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: virtual_network_utils:
@@ -26,7 +26,7 @@ use version_utils qw(is_sle is_alp);
 use virt_autotest::utils;
 
 our @EXPORT
-  = qw(download_network_cfg prepare_network restore_standalone destroy_standalone restart_network
+  = qw(download_network_cfg prepare_network restore_standalone destroy_standalone
   restore_guests restore_network destroy_vir_network restore_libvirt_default pload_debug_log
   check_guest_status check_guest_module check_guest_ip save_guest_ip test_network_interface hosts_backup
   hosts_restore get_free_mem get_active_pool_and_available_space clean_all_virt_networks setup_vm_simple_dns_with_ip
@@ -253,10 +253,6 @@ sub destroy_standalone {
     #File cleanup was installed from qa_test_virtualization package
     my $cleanup_path = "/usr/share/qa/qa_test_virtualization/cleanup";
     assert_script_run("source $cleanup_path", 60) if (script_run("[[ -f $cleanup_path ]]") == 0);
-}
-
-sub restart_network {
-    is_sle('=11-sp4') ? script_run("service network restart") : systemctl 'restart network';
 }
 
 sub restore_guests {

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2022 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: HOST bridge virtual network test:
@@ -89,18 +89,8 @@ sub post_fail_hook {
 
     $self->SUPER::post_fail_hook;
 
-    #Restart libvirtd service
-    # Note: TBD for modular libvirt. See poo#129086 for detail.
-    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
-
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();
-
-    #Restore br123 for virt_autotest
-    virt_autotest::virtual_network_utils::restore_standalone();
-
-    #Restore Guest systems
-    virt_autotest::virtual_network_utils::restore_guests();
 
     #Restore Network setting
     virt_autotest::virtual_network_utils::restore_network($virt_host_bridge, $based_guest_dir);

--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2022 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Isolated virtual network test:
@@ -71,10 +71,6 @@ sub run_test {
 
     #After finished all virtual network test, need to restore file /etc/hosts from backup
     virt_autotest::virtual_network_utils::hosts_restore();
-
-    #Skip restart network service due to bsc#1166570
-    #Restart network service
-    #virt_autotest::virtual_network_utils::restart_network();
 }
 
 sub post_fail_hook {
@@ -82,18 +78,8 @@ sub post_fail_hook {
 
     $self->SUPER::post_fail_hook;
 
-    #Restart libvirtd service
-    # Note: TBD for modular libvirt. See poo#129086 for detail.
-    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
-
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();
-
-    #Restore br123 for virt_autotest
-    virt_autotest::virtual_network_utils::restore_standalone();
-
-    #Restore Guest systems
-    virt_autotest::virtual_network_utils::restore_guests();
 }
 
 1;

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2022 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: NAT based virtual network test:
@@ -22,6 +22,8 @@ use version_utils qw(is_sle is_alp);
 sub run_test {
     my ($self) = @_;
 
+    #Refer to bsc#1214223 more details
+    record_soft_failure('bsc#1214223 - Failed to attach NAT virtual network interface to guest system') if (is_xen_host && !is_monolithic_libvirtd);
     #Download libvirt host bridge virtual network configuration file
     my $vnet_nated_cfg_name = "vnet_nated.xml";
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_nated_cfg_name);
@@ -75,21 +77,11 @@ sub post_fail_hook {
 
     $self->SUPER::post_fail_hook;
 
-    #Restart libvirtd service
-    # Note: TBD for modular libvirt. See poo#129086 for detail.
-    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
-
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();
 
     #Restore default(NATed Network)
     virt_autotest::virtual_network_utils::restore_libvirt_default();
-
-    #Restore br123 for virt_autotest
-    virt_autotest::virtual_network_utils::restore_standalone();
-
-    #Restore Guest systems
-    virt_autotest::virtual_network_utils::restore_guests();
 }
 
 1;

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2022 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Routed virtual network test:
@@ -112,18 +112,8 @@ sub post_fail_hook {
 
     $self->SUPER::post_fail_hook;
 
-    #Restart libvirtd service
-    # Note: TBD for modular libvirt. See poo#129086 for detail.
-    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
-
     #Destroy created virtual networks
     virt_autotest::virtual_network_utils::destroy_vir_network();
-
-    #Restore br123 for virt_autotest
-    virt_autotest::virtual_network_utils::restore_standalone();
-
-    #Restore Guest systems
-    virt_autotest::virtual_network_utils::restore_guests();
 }
 
 1;

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2022 SUSE LLC
+# Copyright 2019-2023 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Initialize testing environment for Libvirt Virtual Networks
@@ -99,10 +99,6 @@ sub run_test {
             assert_script_run("time ssh -v root\@$guest systemctl restart wickedd", 120);
         }
     }
-
-    #Skip restart network service due to bsc#1166570
-    #Restart network service
-    #virt_autotest::virtual_network_utils::restart_network();
 }
 
 sub post_fail_hook {
@@ -110,18 +106,6 @@ sub post_fail_hook {
 
     $self->SUPER::post_fail_hook;
 
-    #Restart libvirtd service
-    # Note: TBD for modular libvirt. See poo#129086 for detail.
-    virt_autotest::utils::restart_libvirtd() if is_monolithic_libvirtd;
-
-    #Destroy created virtual networks
-    virt_autotest::virtual_network_utils::destroy_vir_network();
-
-    #Restore br123 for virt_autotest
-    virt_autotest::virtual_network_utils::restore_standalone();
-
-    #Restore Guest systems
-    virt_autotest::virtual_network_utils::restore_guests();
 }
 
 1;

--- a/tests/virtualization/universal/guest_management.pm
+++ b/tests/virtualization/universal/guest_management.pm
@@ -52,7 +52,7 @@ sub run {
     foreach my $guest (keys %virt_autotest::common::guests) {
         if (script_retry("virsh start $guest", delay => 120, retry => 3, die => 0) != 0) {
             # Note: TBD for modular libvirt. See poo#129086 for detail.
-            restart_libvirtd if is_monolithic_libvirtd;
+            restart_libvirtd;
             script_retry("virsh start $guest", delay => 120, retry => 3);
         }
         script_retry "nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12;

--- a/tests/virtualization/universal/patch_and_reboot.pm
+++ b/tests/virtualization/universal/patch_and_reboot.pm
@@ -36,7 +36,7 @@ sub run {
         switch_from_ssh_to_sol_console(reset_console_flag => 'on');
     } else {
         # Note: TBD for modular libvirt. See poo#129086 for detail.
-        systemctl("restart libvirtd") if is_monolithic_libvirtd;
+        restart_libvirtd;
         script_run("virsh list --all | grep -v Domain-0");
         # Check that all guests are still running
         script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -82,7 +82,7 @@ sub run {
     #    select_serial_terminal unless get_var('_VIRT_SERIAL_TERMINAL', 1) == 0;
     select_console('root-console');
     # Note: TBD for modular libvirt. See poo#129086 for detail.
-    systemctl("restart libvirtd") if is_monolithic_libvirtd;
+    restart_libvirtd;
     assert_script_run('for i in $(virsh list --name|grep -v Domain-0);do virsh destroy $i;done');
     assert_script_run('for i in $(virsh list --name --inactive); do if [[ $i == win* ]]; then virsh undefine $i; else virsh undefine $i --remove-all-storage; fi; done');
     script_run("[ -f /root/.ssh/known_hosts ] && > /root/.ssh/known_hosts");

--- a/tests/virtualization/universal/virsh_start.pm
+++ b/tests/virtualization/universal/virsh_start.pm
@@ -21,9 +21,9 @@ sub run {
         }
     }
 
-    record_info "LIBVIRTD", "Restart libvirtd and expect all guests to boot up";
+    record_info "LIBVIRTD", "Restart libvirt daemon and expect all guests to boot up";
     # Note: TBD for modular libvirt. See poo#129086 for detail.
-    restart_libvirtd if is_monolithic_libvirtd;
+    restart_libvirtd;
 
 
     # Ensure all guests have network connectivity

--- a/tests/virtualization/universal/virsh_stop.pm
+++ b/tests/virtualization/universal/virsh_stop.pm
@@ -21,9 +21,9 @@ sub run {
     record_info "AUTOSTART DISABLE", "Disable autostart for all guests";
     assert_script_run "virsh autostart --disable $_" foreach (keys %virt_autotest::common::guests);
 
-    record_info "LIBVIRTD", "Restart libvirtd and expect all guests to stay down";
+    record_info "LIBVIRTD", "Restart libvirt daemon and expect all guests to stay down";
     # Note: TBD for modular libvirt. See poo#129086 for detail.
-    restart_libvirtd if is_monolithic_libvirtd;
+    restart_libvirtd;
 }
 
 sub test_flags {


### PR DESCRIPTION
- Description
Refer to [PED-4804](https://jira.suse.com/browse/PED-4804), In SLES15SP6, we should consider enabling libvirt modular daemons by default on new installations.
So, adapt SLE automation from monolithic to modular libvirt from 15SP6 for this PR purpose. 

- New changes
- New func `check_modular_libvirt_daemons()`
After enabled modular libvirt daemons as the default in SLES15SP6, meanwhile, we should check with each modular libvirt daemons are working properly before our SLE automation test 

- Enhancement
- Update func `restart_libvirtd()` 

- Remove func `restart_network()`

- Remove the step of restarting the service when each virtualization network type test fails
After a lot of research and investigation, when performing each virtualization network type test and found errors, we should better keep the error scene in order to accurately find the root cause of the error, rather than restarting the libvirt daemons will break the error on site

- Related ticket: https://progress.opensuse.org/issues/130769
- Verification run: 
- Modular Libvirt:
prj1 15SP6 x86_64
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/12226316#step/libvirt_nated_virtual_network/62) FAIL [bsc#1214223](https://bugzilla.suse.com/show_bug.cgi?id=1214223)  - [XEN][MODULAR LIBVIRT] error: Failed to attach NAT virtual network interface to guest system
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/12193008#) PASS
prj2 
[prj2_host_upgrade_sles15sp5_to_developing_kvm](https://openqa.suse.de/tests/12156659#) PASS
prj3
[virt-guest-migration-sles15sp5-from-sles15sp5-to-developing-kvm-src](https://openqa.suse.de/tests/12156501#) PASS
[virt-guest-migration-sles15sp5-from-sles15sp5-to-developing-kvm-dst](https://openqa.suse.de/tests/12156502#) PASS
[virt-guest-migration-developing-from-developing-to-developing-kvm-src](https://openqa.suse.de/tests/12193114#) PASS
[virt-guest-migration-developing-from-developing-to-developing-kvm-dst](https://openqa.suse.de/tests/12193113#) PASS
[virt-guest-migration-developing-from-developing-to-developing-xen-src](https://openqa.suse.de/tests/12211195#) PASS
[virt-guest-migration-developing-from-developing-to-developing-xen-dst](https://openqa.suse.de/tests/12211196#) PASS
prj4 
[prj4_guest_upgrade_sles15sp5_on_developing-kvm](http://10.67.129.59/tests/228) PASS

- Monolithic Libvirt: 
prj1 15SP6 x86_64
[gi-guest_developing-on-host_developing-xen](http://openqa.suse.de/tests/12184698) PASS
[gi-guest_developing-on-host_developing-kvm](http://openqa.suse.de/tests/12185754) PASS
[gi-guest_sles15sp5-on-host_developing-kvm](http://10.67.129.59/tests/216) PASS
prj2 
[prj2_host_upgrade_sles15sp5_to_developing_kvm](https://openqa.suse.de/tests/12155899#) PASS
prj3
[virt-guest-migration-sles15sp5-from-sles15sp5-to-developing-kvm-src](http://openqa.suse.de/tests/12148936) PASS
[virt-guest-migration-sles15sp5-from-sles15sp5-to-developing-kvm-dst](http://openqa.suse.de/tests/12148935) PASS
[virt-guest-migration-sles15sp5-from-sles15sp5-to-developing-xen-src](http://openqa.suse.de/tests/12184711) PASS
[virt-guest-migration-sles15sp5-from-sles15sp5-to-developing-xen-dst](http://openqa.suse.de/tests/12184712) PASS
prj4
[prj4_guest_upgrade_sles15sp5_on_developing-kvm](http://10.67.129.59/tests/224#) PASS
[QAM](http://openqa.qam.suse.cz/tests/overview?build=:javor:15-SP3:testforPR&distri=sle&version=15-SP3&groupid=156) PASS
prj1 15SP6 aarch64
[gi-guest_sles15sp5-on-host_developing-kvm](http://10.67.129.59/tests/238#) PASS
[LTSS-gi-guest_sles15sp_2-4_-on-host_developing-kvm](http://10.67.129.59/tests/239#) PASS