### PR TITLE
Update journal check whitelist for SLE Micro 5.5

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -57,7 +57,7 @@
     "bsc#1126272": {
         "description": "Failed unmounting \/\\S+\\.|-- Reboot --|pam_systemd.*Failed to release session",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" , "5.4"],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" , "5.4" , "5.5"],
             "leap-micro": [ "5.2", "5.3", "5.4" ],
             "microos":  ["Tumbleweed"],
             "alp":  ["0.1", "0.1:S:A", "0.1:S:B"]
@@ -67,7 +67,7 @@
     "bsc#1022525|bsc#1177461": {
         "description": ".*rpcbind.*cannot(.*open file.*rpcbind.xdr.*|.*open file.*portmap.xdr.*|.*save any registration.*)",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" , "5.5" ],
             "leap-micro": ["5.2", "5.3"],
             "microos":  ["Tumbleweed"]
         },
@@ -85,7 +85,7 @@
     "bsc#1182500": {
         "description": "Failed to transition into init label 'system_u:system_r:init_t:s0'",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" , "5.5" ],
             "leap-micro": [ "5.2" ],
             "microos":  ["Tumbleweed"],
             "alp":  ["0.1", "0.1:S:A", "0.1:S:B"]
@@ -103,7 +103,7 @@
     "bsc#1178033": {
         "description": "kernel: ITS@0x8080000: Unable to locate ITS domain handle",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" , "5.5" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
             "microos":  ["Tumbleweed"],
             "sle": ["15-SP2", "15-SP3", "15-SP4", "15-SP5"]
@@ -135,7 +135,7 @@
     "bsc#1190662": {
         "description": "/etc/udev/rules.d/41-qeth-.*Failed to write ATTR",
         "products": {
-            "sle-micro": [ "5.1", "5.2", "5.3", "5.4" ]
+            "sle-micro": [ "5.1", "5.2", "5.3", "5.4" , "5.5" ]
         },
         "type": "bug"
     },
@@ -319,7 +319,7 @@
     "health-check-typo": {
         "description": "health-checker/fail.sh check\" failed|Failed to start MicroOS Health Checker.Machine didn't come up correct, do a rollback|",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" , "5.5" ],
             "leap-micro": ["5.2", "5.3", "5.4"],
             "microos":  ["Tumbleweed"],
             "alp":  ["0.1", "0.1:S:A", "0.1:S:B"]
@@ -347,7 +347,7 @@
     "ssh-connection-close-by-remote": {
         "description": "error: kex_exchange_identification: Connection closed by remote host",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" , "5.5" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3", "15.4", "15.5"],
             "microos":  ["Tumbleweed"],
             "sle": ["15-SP2", "15-SP3", "15-SP4", "15-SP5"]
@@ -358,7 +358,7 @@
         "description": "Timed out waiting for device (/dev/disk/by-label/ignition|/dev/combustion/config)",
         "products": {
             "leap-micro": ["5.3"],
-            "sle-micro": ["5.3", "5.4"],
+            "sle-micro": ["5.3", "5.4" , "5.5"],
             "microos":  ["Tumbleweed"]
         },
         "type": "ignore"
@@ -383,7 +383,7 @@
         "products": {
             "opensuse": ["Tumbleweed"],
             "microos":  ["Tumbleweed"],
-            "sle-micro": ["5.1", "5.2", "5.3", "5.4"]
+            "sle-micro": ["5.1", "5.2", "5.3", "5.4" , "5.5"]
         },
         "type": "ignore"
     },
@@ -404,7 +404,7 @@
     "boo#1203899": {
         "description": "NetworkManager.*kill child process 'helper'.* failed due to unexpected return value -1 by waitpid",
         "products": {
-            "sle-micro": ["5.4"],
+            "sle-micro": ["5.4" , "5.5"],
             "alp":  ["0.1", "0.1:S:A", "0.1:S:B"]
         },
         "type": "bug"
@@ -412,7 +412,7 @@
     "bsc#1200490": {
         "description": "Unable to open /dev/kvm: No such file or directory",
         "products": {
-            "sle-micro": ["5.2", "5.3", "5.4"],
+            "sle-micro": ["5.2", "5.3", "5.4" , "5.5"],
             "leap-micro": ["5.3"]
         },
         "type": "ignore"


### PR DESCRIPTION
https://progress.opensuse.org/issues/133586
https://progress.opensuse.org/issues/133544


- Verification run: [SLE-Micro](https://openqa.suse.de/tests/overview?distri=sle-micro&build=rfan08091&version=5.5)
