### PR TITLE
Change the way to populate os_image_uri

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -16,7 +16,7 @@ terraform:
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
+    os_image_uri: '%OS_URI%'
 
     # HANA
     hana_count: '%NODE_COUNT%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -17,7 +17,7 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image_uri: 'https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/sle-images/%SLE_IMAGE%'
+    os_image_uri: '%OS_URI%'
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
 
     # HANA

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -154,7 +154,7 @@ sub run {
     }
 
     my $provider = $self->provider_factory();
-    set_var('SLE_IMAGE', $provider->get_image_id());
+    set_var('OS_URI', $provider->get_os_vhd_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION')));
     my $ansible_playbooks = create_playbook_section_list();
     my $ansible_hana_vars = create_hana_vars_section();
 


### PR DESCRIPTION
Related ticket: [TEAM-8211](https://jira.suse.com/browse/TEAM-8211)

Note: content of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17549/ is useful to understand this PR

Verification run

- HanaSR with OS image from CSP catalog (so should not use code I changed) http://openqaworker15.qa.suse.cz/tests/212573
- sle-15-SP5-Azure-SAP-BYOS-x86_64-Build0290-azure_sap_byos_hanasr_sapconf  https://openqa.suse.de/tests/11787078
- sle-15-SP5-Azure-SAP-BYOS-x86_64-Build0290-sles4sap_gnome_saptune_notes https://openqa.suse.de/tests/11787084
- sle-15-SP5-Azure-SAP-BYOS-x86_64-Build0290-azure_sap_byos_qesap_saptune (qesap regression on OSD, should not be influenced by code changes in this PR) https://openqa.suse.de/tests/11787080
- 