### PR TITLE
ntp_client.pm: reinstall chrony if pool.conf is empty

### DIFF
--- a/tests/console/ntp_client.pm
+++ b/tests/console/ntp_client.pm
@@ -45,6 +45,16 @@ sub run {
     systemctl 'is-enabled chronyd';
     systemctl 'is-active chronyd';
     systemctl 'status chronyd';
+
+    # due to bsc#1214141, we need to remove and install again chrony and chrony-pool-suse (just reinstalling doesn't work)
+    if (script_run('cat /etc/chrony.d/pool.conf | grep -q ^pool') != 0) {
+        record_info 'workaround for bsc#1214141';
+        zypper_call 'rm chrony-pool-suse';
+        zypper_call 'in chrony-pool-suse';
+        systemctl 'enable chronyd';
+        systemctl 'start chronyd';
+    }
+
     # ensure and wait until time is actually synced before checking status
     # otherwise we could get a transient *503 No such source* on listing sources
     assert_script_run 'chronyc makestep';


### PR DESCRIPTION
This is a workaround for bsc#1214141.

- Related ticket: https://progress.opensuse.org/issues/133763
- Verification runs:
  - https://openqa.suse.de/tests/11792552
  - https://openqa.suse.de/tests/11792553