### PR TITLE
Integrate Slurm versioned installation

### DIFF
--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -14,6 +14,9 @@ use utils;
 use version_utils 'is_sle';
 use serial_terminal 'select_serial_terminal';
 use version;
+use Exporter 'import';
+
+our @EXPORT = qw(get_slurm_version);
 
 sub get_mpi() {
     my $mpi = get_required_var('MPI');
@@ -27,6 +30,20 @@ sub get_mpi() {
     }
 
     return $mpi;
+}
+
+=head2 get_slurm_version
+
+ get_slurm_version();
+
+Returns the slurm package to be installed. C<SLURM_VERSION> takes the form of I<Major_Minor>.
+for instance: 23_02.
+
+=cut
+
+sub get_slurm_version {
+    my $pkg_version = shift;
+    return $pkg_version ? 'slurm_' . $pkg_version : 'slurm';
 }
 
 =head2 get_mpi_src

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -5,7 +5,8 @@
 
 # Summary: Slurm master node
 #    This test is setting up slurm master node and runs tests depending
-#    on the slurm cluster configuration
+#    on the slurm cluster configuration.
+#    SLURM_VERSIONED_TEST enables installation of the versioned Slurm.
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 use Mojo::Base qw(hpcbase hpc::configs), -signatures;
@@ -420,11 +421,34 @@ sub extended_hpc_tests ($master_ip, $slave_ip) {
     parse_extra_log('XUnit', './results/TEST-hpc-test.xml');
 }
 
+our $slurm_pkg = 'slurm';
+
 sub run ($self) {
     select_serial_terminal();
     my $nodes = get_required_var('CLUSTER_NODES');
     my $slurm_conf = get_required_var('SLURM_CONF');
     my $version = get_required_var('VERSION');
+
+    if (get_var('SLURM_VERSIONED_TEST', '0') == '1') {
+        if (is_sle('<15-SP4')) {
+            record_info 'No testing', 'versioned Slurm not used';
+            return;
+        }
+        my $query_output = script_output(qq{zypper se slurm | awk '{print \$2}' | grep -E '^slurm_[0-9]{1,2}_[0-9]{1,2}\$' | uniq});
+        my @slurm_vers = split(/(\ |\n)/, $query_output);
+        my $higher_slurm_ver = 0;
+        record_info "@slurm_vers", 'slurm packages found';
+        foreach my $v (@slurm_vers) {
+            my ($slurm_version_tmp) = $v =~ /([0-9]{1,2}_[0-9]{1,2})/;
+            $slurm_version_tmp =~ s/_/\./;
+            if ($higher_slurm_ver < $slurm_version_tmp) {
+                $higher_slurm_ver = $slurm_version_tmp;
+            }
+        }
+        $higher_slurm_ver =~ s/\./_/;    # restore format
+        record_info "Latest $higher_slurm_ver", "This should be the latest/higher slurm version";
+        $slurm_pkg = 'slurm_' . $higher_slurm_ver;
+    }
 
     barrier_wait('CLUSTER_PROVISIONED');
     $self->prepare_user_and_group();
@@ -433,7 +457,13 @@ sub run ($self) {
     # provision HPC cluster, so the proper rpms are installed,
     # munge key is distributed to all nodes, so is slurm.conf
     # and proper services are enabled and started
-    zypper_call('in slurm slurm-munge slurm-torque');
+    if ($slurm_pkg =~ /slurm_/) {
+        # $slurm_pkg-munge is installed explicitly since slurm_23_02
+        # bsc1214094
+        zypper_call("in $slurm_pkg $slurm_pkg-munge");
+    } else {
+        zypper_call("in slurm slurm-munge slurm-torque");
+    }
 
     if ($slurm_conf =~ /ha/) {
         $self->mount_nfs();

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -11,15 +11,17 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
+use hpc::utils 'get_slurm_version';
 
 sub run ($self) {
     select_serial_terminal();
     my $nodes = get_required_var("CLUSTER_NODES");
+    my $slurm_pkg = get_slurm_version(get_var('SLURM_VERSION', ''));
 
     barrier_wait('CLUSTER_PROVISIONED');
 
     $self->prepare_user_and_group();
-    zypper_call('in slurm slurm-munge');
+    zypper_call("in $slurm_pkg $slurm_pkg-munge");
 
     $self->mount_nfs();
     barrier_wait("SLURM_SETUP_DONE");

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -13,15 +13,18 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
+use hpc::utils 'get_slurm_version';
 
 sub run ($self) {
     select_serial_terminal();
     my $nodes = get_required_var("CLUSTER_NODES");
+    my $slurm_pkg = get_slurm_version(get_var('SLURM_VERSION', ''));
 
     barrier_wait('CLUSTER_PROVISIONED');
 
     $self->prepare_user_and_group();
-    zypper_call('in slurm slurm-munge');
+    # $slurm_pkg-munge is installed explicitly since slurm_23_02
+    zypper_call("in $slurm_pkg $slurm_pkg-munge");
 
     # mount NFS shared directory specific
     # for this test /shared/slurm and provided by the

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -13,16 +13,19 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
+use hpc::utils 'get_slurm_version';
 use version_utils 'is_sle';
 
 sub run ($self) {
     select_serial_terminal();
     $self->prepare_user_and_group();
+    my $slurm_pkg = get_slurm_version(get_var('SLURM_VERSION', ''));
 
     # Install slurm
-    zypper_call('in slurm-munge');
+    # $slurm_pkg-munge is installed explicitly since slurm_23_02
+    zypper_call("in $slurm_pkg-munge");
     # install slurm-node if sle15, not available yet for sle12
-    zypper_call('in slurm-node') if is_sle '15+';
+    zypper_call("in $slurm_pkg-node") if is_sle '15+';
 
     if (get_required_var('EXT_HPC_TESTS')) {
         zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);

--- a/variables.md
+++ b/variables.md
@@ -174,7 +174,7 @@ SES5_CEPH_QA_HEALTH_OK | string | | URL for repo containing ceph-qa-health-ok pa
 SKIP_CERT_VALIDATION | boolean | false | Enables linuxrc parameter to skip certificate validation of the remote source, e.g. when using self-signed https url.
 SET_CUSTOM_PROMPT | boolean | false | Set a custom, shorter prompt in shells. Saves screen space but can take time to set repeatedly in all shell sessions.
 SLE_PRODUCT | string | | Defines SLE product. Possible values: `sles`, `sled`, `sles4sap`. Is mainly used for SLE 15 installation flow.
-SLURM_VERSIONED_TEST | string | | If 1, slurm will try to find the latest versioned package instead the default package.
+SLURM_VERSION | string | | Defines slurm version (ex: 23_02) for installation. If not set, installation uses the base Slurm version.
 SOFTFAIL_BSC1063638 | boolean | false | Enable bsc#1063638 detection.
 STAGING | boolean | false | Indicates staging environment.
 SPECIFIC_DISK | boolean | false | Enables installation/partitioning_olddisk test module.

--- a/variables.md
+++ b/variables.md
@@ -174,6 +174,7 @@ SES5_CEPH_QA_HEALTH_OK | string | | URL for repo containing ceph-qa-health-ok pa
 SKIP_CERT_VALIDATION | boolean | false | Enables linuxrc parameter to skip certificate validation of the remote source, e.g. when using self-signed https url.
 SET_CUSTOM_PROMPT | boolean | false | Set a custom, shorter prompt in shells. Saves screen space but can take time to set repeatedly in all shell sessions.
 SLE_PRODUCT | string | | Defines SLE product. Possible values: `sles`, `sled`, `sles4sap`. Is mainly used for SLE 15 installation flow.
+SLURM_VERSIONED_TEST | string | | If 1, slurm will try to find the latest versioned package instead the default package.
 SOFTFAIL_BSC1063638 | boolean | false | Enable bsc#1063638 detection.
 STAGING | boolean | false | Indicates staging environment.
 SPECIFIC_DISK | boolean | false | Enables installation/partitioning_olddisk test module.


### PR DESCRIPTION
Make possible to install and test latest version of the Slurm package. As for now, Slurm is explicitly invoked. But now test should be able to get the latest available versioned Slurm in the system, install it and run the tests.

Those changes are not apply to all the test cases at the moment. Verifications run only against a basic scenario (see hpc_EPSILON) and the test requires a new job variable, SLURM_VERSIONED_TEST.


- Related ticket: https://progress.opensuse.org/issues/130838

- Verification run: 
https://aquarius.suse.cz/tests/18805# current version
https://aquarius.suse.cz/tests/18763# versioned slurm
