### PR TITLE
Fix sporadic takeover failed to complete on AWS

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -391,8 +391,8 @@ sub wait_for_sync {
         $output_pass-- if $output_pass == 1 && $ret !~ /SOK/ && $ret !~ /PRIM/ && $ret =~ /SFAIL/;
         $output_fail++ if $ret =~ /SFAIL/;
         $output_fail-- if $output_fail >= 1 && $ret !~ /SFAIL/;
-        next if $output_pass < 3;
-        last if $output_pass == 3;
+        next if $output_pass < 5;
+        last if $output_pass == 5;
         if (time - $start_time > $timeout) {
             record_info("Cluster status", $self->run_cmd(cmd => $crm_mon_cmd));
             record_info("Sync FAIL", "Host replication status: " . $self->run_cmd(cmd => 'SAPHanaSR-showAttr'));

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -50,12 +50,26 @@ sub run {
     # Calculate SBD delay sleep time
     $sbd_delay = $self->sbd_delay_formula if $takeover_action eq 'crash';
 
+    # SBD delay related setup for 'stop' to fix sporadic 'takeover failed to complete' issue on EC2
+    if ($takeover_action eq 'stop' and check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
+        $self->setup_sbd_delay();
+        $sbd_delay = $self->sbd_delay_formula();
+    }
+
     # Stop/kill/crash HANA DB and wait till SSH is again available with pacemaker running.
     $self->stop_hana(method => $takeover_action);
     $self->{my_instance}->wait_for_ssh(username => 'cloudadmin');
 
     # SBD delay is active only after reboot
     if ($takeover_action eq 'crash' and $sbd_delay != 0) {
+        record_info('SBD SLEEP', "Waiting $sbd_delay sec for SBD delay timeout.");
+        # test needs to wait a little more than sbd delay
+        sleep($sbd_delay + 30);
+        $self->wait_for_pacemaker();
+    }
+
+    # Add SBD delay for 'stop' to fix sporadic 'takeover failed to complete' issue on EC2
+    if ($takeover_action eq 'stop' and check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
         record_info('SBD SLEEP', "Waiting $sbd_delay sec for SBD delay timeout.");
         # test needs to wait a little more than sbd delay
         sleep($sbd_delay + 30);


### PR DESCRIPTION
Fix hanasr sporadic takeover failed to complete on AWS  
TEAM-8371 - [HANA SR - PC AWS] - "Stop_site_a-primary" failed on "takeover failed to complete"

- Related ticket: https://jira.suse.com/browse/TEAM-8371
- Needles: NA
- Verification run:
  I ran for many times and did not hit the "takeover failed to complete":  
  https://openqaworker15.qa.suse.cz/tests/214200#step/Stop_site_a-primary/85
  (The "Fenced database 'vmhana01' is not offline" error can be tracked by other ticket https://jira.suse.com/browse/TEAM-8139)