### PR TITLE
Revert 2ee46ad8cf to solve aarch boot fail

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -10,7 +10,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle_micro is_leap_micro is_alp);
+use version_utils qw(is_sle_micro is_leap_micro);
 use Utils::Architectures qw(is_aarch64);
 use microos "microos_login";
 use transactional "record_kernel_audit_messages";
@@ -23,7 +23,7 @@ sub run {
     # SLEM updated GM images from https://openqa.suse.de/group_overview/377
     # already have disabled grub timeout in order to install updates and reboot
     # therefore *aarch64* images would hang in GRUB2
-    if ((get_var('HDD_1') !~ /GM-Updated/ && (is_sle_micro || is_leap_micro || is_alp)) && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
+    if ((get_var('HDD_1') !~ /GM-Updated/ && (is_sle_micro || is_leap_micro)) && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
         shift->wait_boot_past_bootloader(textmode => 1);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
aarch64 xfstests all fail to boot in alp when using qcow2 as HDD_1. I checked the log it skip the bootloader part in the previous commit 2ee46ad8cf in tests/microos/disk_boot.pm.
Pass in x86_64: https://openqa.suse.de/tests/11732109#step/disk_boot/1
Fails in aarch64: https://openqa.suse.de/tests/11782227#step/disk_boot/4
Shall we consider reverting this behavior in aarch64 alp? I can't find which test fails before made this change.

- Related ticket: https://progress.opensuse.org/issues/134099
- Verification run: WIP