### PR TITLE
Create new libyui-rest-api based test modules for ntp_config_settings

### DIFF
--- a/lib/Distribution/Sle/15_current.pm
+++ b/lib/Distribution/Sle/15_current.pm
@@ -30,6 +30,7 @@ use Installation::SystemRole::Sle::SystemRoleController;
 use Installation::ModuleRegistration::SeparateRegCodesController;
 use YaST::DNSServer::Sle::DNSServerController;
 use YaST::DNSServer::Sle::DNSServerSetupController;
+use Installation::NTPConfiguration::NTPConfigurationPage;
 
 =head2 get_license_agreement
 
@@ -96,6 +97,10 @@ sub get_dns_server {
 
 sub get_dns_server_setup {
     return YaST::DNSServer::Sle::DNSServerSetupController->new();
+}
+
+sub get_ntp_configuration {
+    return Installation::NTPConfiguration::NTPConfigurationPage->new();
 }
 
 1;

--- a/lib/Installation/NTPConfiguration/NTPConfigurationPage.pm
+++ b/lib/Installation/NTPConfiguration/NTPConfigurationPage.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The module provides interface to act on the
+#          ntp Configuration page.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Installation::NTPConfiguration::NTPConfigurationPage;
+use parent 'Yam::PageBase';
+use strict;
+use warnings;
+
+sub init {
+    my $self = shift;
+    $self->{txb_ntp_server} = $self->{app}->textbox({id => '"Y2Caasp::Widgets::NtpServer"'});
+    $self->{btn_next} = $self->{app}->button({id => 'next'});
+    return $self;
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{txb_ntp_server}->exist({timeout => 200});
+}
+
+sub get_ntp_servers {
+    my ($self) = @_;
+    $self->get_ntp_configuration_page();
+    return $self->{txb_ntp_server}->value();
+}
+
+sub get_ntp_configuration_page {
+    my ($self) = @_;
+    die "Ntp configuration page is not displayed" unless $self->is_shown();
+}
+
+sub press_next {
+    my ($self) = @_;
+    $self->get_ntp_configuration_page();
+    return $self->{btn_next}->click();
+}
+
+1;

--- a/schedule/yast/sle/flows/default_slem.yaml
+++ b/schedule/yast/sle/flows/default_slem.yaml
@@ -12,7 +12,7 @@ registration:
   - installation/registration/register_via_scc
 addons: []
 ntp_configuration:
-  - installation/ntp_config_settings
+  - yam/ntp_configuration
 authentication:
   - installation/authentication/root_simple_pwd
 software:

--- a/tests/yam/ntp_configuration.pm
+++ b/tests/yam/ntp_configuration.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This test module launches the installation from
+#          the installation settings page.
+
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use Test::Assert 'assert_matches';
+
+sub run {
+    my $ntp_settings = $testapi::distri->get_ntp_configuration()->get_ntp_servers();
+    assert_matches(qr/suse\.pool\.ntp\.org|10\.160\.0\.45\ 10\.160\.0\.44\ 10\.160\.255\.254/, $ntp_settings, "NTP setting is not correct");
+    $testapi::distri->get_ntp_configuration()->press_next();
+}
+
+1;


### PR DESCRIPTION
Create new libyui-rest-api based test modules for ntp_config_settings

- Related ticket: https://progress.opensuse.org/issues/133001
- Verification run: https://openqa.suse.de/tests/11857438
   s390x: https://openqa.suse.de/tests/11820003#step/ntp_configuration/1
   aarch64: https://openqa.suse.de/tests/11821383#step/ntp_configuration/1

