### PR TITLE
Fix a few yaml schedule files for yast cases

### DIFF
--- a/schedule/yast/autoyast/autoyast_rules_and_classes.yaml
+++ b/schedule/yast/autoyast/autoyast_rules_and_classes.yaml
@@ -3,7 +3,7 @@ name: autoyast_rules_and_classes
 description: >
   For future testing of AutoYaST rules and classes
 vars:
-  AUTOYAST: autoyast_sle15/rule-based_example/
+  AUTOYAST: yam/autoyast/rule-based_example/
 schedule:
   - autoyast/prepare_rules_and_classes
   - installation/bootloader_start

--- a/schedule/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/schedule/yast/installer_extended/installer_extended_aarch64.yaml
@@ -18,9 +18,9 @@ schedule:
     - installation/isosize
     - installation/data_integrity
     - installation/bootloader_start
-  setup_libyui:
-    - installation/setup_libyui
+  product_selection:
     - installation/language_keyboard/switch_keyboard_layout
+    - installation/product_selection/install_SLES
   license_agreement:
     - installation/licensing/verify_license_translations
     - installation/licensing/verify_license_has_to_be_accepted


### PR DESCRIPTION
Fix a few yaml schedule files for yast cases.

- Verification run: 
- https://openqa.suse.de/tests/11820454# (updated the autoyast profile path to yam/autoyast/)
- https://openqa.suse.de/tests/11820453#step/switch_keyboard_layout/1 (to correct the test module sequence)
