### PR TITLE
Update sudo for HA public cloud tests

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -14,6 +14,7 @@ use publiccloud::utils;
 use sles4sap_publiccloud;
 use qesapdeployment;
 use serial_terminal 'select_serial_terminal';
+use version_utils 'is_sle';
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
@@ -48,6 +49,11 @@ sub run {
         # Check ssh connection for all hosts
         $instance->wait_for_ssh;
 
+        # Update sudo package as a temporary fix for bsc#1205325
+        if (is_sle('=15-sp2')) {
+            $instance->run_ssh_command(cmd => 'sudo zypper up -y sudo');
+            record_soft_failure('bsc#1205325 - update sudo pkg');
+        }
         # Skip instances without HANA db or setup without cluster
         next if ($instance_id !~ m/vmhana/) or !$ha_enabled;
         $self->wait_for_sync();


### PR DESCRIPTION
Due to bsc#1205325 15SP2 tests are faling on PC because outdated 'sudo' package.
This PR updates the package after ansible deployment is finished. 

- Related ticket: https://jira.suse.com/browse/TEAM-7865
- Verification run:
- 15SP2 (SUSE:sles-sap-15-sp2-byos:gen2:2022.11.08) - https://openqaworker15.qa.suse.cz/tests/214622#step/deploy_qesap_ansible/28
- 15SP2 (latest img) - https://openqaworker15.qa.suse.cz/tests/214620#step/deploy_qesap_ansible/75
- 15SP3 - https://openqaworker15.qa.suse.cz/tests/214624#

