### PR TITLE
Exclude python3-module from 15-SP6 AY profile

### DIFF
--- a/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
@@ -38,7 +38,7 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
-      % unless ($check_var->('VERSION', '15')) {
+      % unless ($check_var->('VERSION', '15') || $check_var->('VERSION', '15-SP6')) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
         % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
@@ -424,7 +424,7 @@
       <package>sle-module-development-tools-release</package>
       <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
-      % unless ($check_var->('VERSION', '15')) {
+      % unless ($check_var->('VERSION', '15') || $check_var->('VERSION', '15-SP6')) {
       % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
       % } else {

--- a/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
@@ -38,10 +38,10 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
-      % unless ($check_var->('VERSION', '15')) {
+      % unless ($check_var->('VERSION', '15') || $check_var->('VERSION', '15-SP6')) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
-        % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
+        % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION','15-SP5')) {
         <name>sle-module-python2</name>
         % } else {
         <name>sle-module-python3</name>
@@ -464,8 +464,8 @@
       <package>sle-module-development-tools-release</package>
       <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
-      % unless ($check_var->('VERSION', '15')) {
-      % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
+      % unless ($check_var->('VERSION', '15') || $check_var->('VERSION', '15-SP6')) {
+      % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5') || $check_var->('VERSION', '15-SP6')) {
       <package>sle-module-python2-release</package>
       % } else {
       <package>sle-module-python3-release</package>


### PR DESCRIPTION
This is a workaround as the `sle-module-python3` is not available and blocks the installation. This obviously needs to be addressed and be reverted asap we get the expectations/requirements.

- Related ticket: https://progress.opensuse.org/issues/134192
- Verification run: https://aquarius.suse.cz/tests/18171