### PR TITLE
Press down on textmode installation

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -78,6 +78,11 @@ sub run {
     wait_still_screen(1);
     # ncurses uses blocking modal dialog, so press return is needed
     send_key 'ret' if check_var('VIDEOMODE', 'text');
+    # make sure sure value is -1 not 0
+    if (check_var('VIDEOMODE', 'text') && $timeout eq '-1') {
+        wait_still_screen(1);
+        send_key 'down';
+    }
 
     wait_still_screen(1);
     save_screenshot;


### PR DESCRIPTION
Sometimes timeout is not set to -1, the typing is somehow interrupted
Typed is only '-' and this will set timeout to 0
Pressing down will decrease the value, 0 to -1, -1 is the lowest value

- Related ticket: https://progress.opensuse.org/issues/134183
- Verification run: https://openqa.suse.de/tests/overview?build=grub2_timeout