### PR TITLE
iPXE bootloader fixes

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -713,9 +713,6 @@ sub upload_profile {
     my $profile = $args{profile};
     my $path = $args{path};
 
-    if (check_var('IPXE', '1')) {
-        $path = get_required_var('SUT_IP') . $path;
-    }
     save_tmp_file($path, $profile);
     # Copy profile to ulogs directory, so profile is available in job logs
     make_path('ulogs');
@@ -843,6 +840,11 @@ sub prepare_ay_file {
     $profile = expand_version($profile);
     $profile = adjust_network_conf($profile);
     $profile = expand_variables($profile);
+
+    if (check_var('IPXE', '1')) {
+        $path = get_required_var('SUT_IP') . $path;
+    }
+
     upload_profile(profile => $profile, path => $path);
     return $path;
 }

--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -22,6 +22,7 @@ use bootloader_hyperv;
 use bootloader_svirt;
 use bootloader_zkvm;
 use bootloader_s390;
+use ipxe_install;
 use version_utils qw(:SCENARIO :BACKEND);
 use Utils::Architectures;
 use File::Basename;
@@ -32,7 +33,12 @@ use boot_from_pxe;
 
 sub run {
     my $self = shift;
-    if (uses_qa_net_hardware() || get_var("PXEBOOT")) {
+    if (check_var('IPXE', '1')) {
+        my $ipxe = ipxe_install->new($self->{category});
+        $ipxe->run();
+        return;
+    }
+    elsif (uses_qa_net_hardware() || get_var("PXEBOOT")) {
         record_info('boot_from_pxe');
         $self->boot_from_pxe::run();
         return;

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -212,6 +212,7 @@ sub run {
     if (get_var('AUTOYAST')) {
         # make sure to wait for a while befor changing the boot device again, in order to not change it too early
         sleep 120;
+        set_bootscript_hdd if get_var('IPXE_UEFI');
     }
     else {
         my $ssh_vnc_wait_time = 1500;

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -22,7 +22,6 @@ use virt_autotest::utils qw(is_kvm_host is_xen_host);
 
 use HTTP::Tiny;
 use IPC::Run;
-use Socket;
 use Time::HiRes 'sleep';
 
 
@@ -59,9 +58,6 @@ sub set_pxe_boot {
 
 sub set_bootscript {
     my $host = get_required_var('SUT_IP');
-    my $ip = inet_ntoa(inet_aton($host));
-    my $http_server = get_required_var('IPXE_HTTPSERVER');
-    my $url = "$http_server/v1/bootscript/script.ipxe/$ip";
     my $arch = get_required_var('ARCH');
     my $autoyast = get_var('AUTOYAST', '');
     my $regurl = get_var('SCC_URL', '');
@@ -69,7 +65,6 @@ sub set_bootscript {
     my $mirror_http = get_required_var('MIRROR_HTTP');
 
     # trim all strings from variables to get rid of bogus whitespaces
-    $url =~ s/^\s+|\s+$//g;
     $arch =~ s/^\s+|\s+$//g;
     $autoyast =~ s/^\s+|\s+$//g;
     $regurl =~ s/^\s+|\s+$//g;
@@ -141,8 +136,6 @@ initrd $initrd
 boot
 END_BOOTSCRIPT
 
-    diag "setting iPXE bootscript to: $bootscript";
-
     if ($autoyast ne '') {
         diag "===== BEGIN autoyast $autoyast =====";
         my $curl = `curl -s $autoyast`;
@@ -150,28 +143,16 @@ END_BOOTSCRIPT
         diag "===== END autoyast $autoyast =====";
     }
 
-    my $response = HTTP::Tiny->new->request('POST', $url, {content => $bootscript, headers => {'content-type' => 'text/plain'}});
-    diag "$response->{status} $response->{reason}\n";
-
-    # Comment out but keep the block for possible debug purpose.
-    #diag "\nThe bootscript from http server is: \n";
-    #$response = HTTP::Tiny->new->get($url);
-    #print "$response->{content}\n";
+    set_ipxe_bootscript($bootscript);
 }
 
 sub set_bootscript_hdd {
-    my $host = get_required_var('SUT_IP');
-    my $ip = inet_ntoa(inet_aton($host));
-    my $http_server = get_required_var('IPXE_HTTPSERVER');
-    my $url = "$http_server/v1/bootscript/script.ipxe/$ip";
-
     my $bootscript = <<"END_BOOTSCRIPT";
 #!ipxe
 exit
 END_BOOTSCRIPT
 
-    my $response = HTTP::Tiny->new->request('POST', $url, {content => $bootscript, headers => {'content-type' => 'text/plain'}});
-    diag "$response->{status} $response->{reason}\n";
+    set_ipxe_bootscript($bootscript);
 }
 
 sub enter_o3_ipxe_boot_entry {

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -6,6 +6,7 @@
 # Summary: Verify installation starts and is in progress
 # Maintainer: Michael Moese <mmoese@suse.de>
 
+package ipxe_install;
 use base 'y2_installbase';
 use strict;
 use warnings;


### PR DESCRIPTION
The `ipxe_install` bootloader currently doesn't work for AutoYaST installation jobs. Fix the issue, add iPXE support to `bootloader_start` job module and simplify iPXE boot script handling.

- Related ticket: https://progress.opensuse.org/issues/130219
- Needles: N/A
- Verification runs:
  - https://openqa.suse.de/tests/11998046 (note: `autoyast/installation` module is expected to fail after reboot due to unrelated AutoYaST profile issue)
  - https://openqa.suse.de/tests/11998047