### PR TITLE
containers: Add tests for volumes

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -332,6 +332,7 @@ sub cleanup_system_host {
         }
         $self->_engine_assert_script_run("rm --force --all", 120);
     }
+    $self->_engine_assert_script_run("volume prune -f", 300);
     $self->_engine_assert_script_run("system prune -a -f", 300);
 
     if ($assert) {

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -100,6 +100,7 @@ sub load_host_tests_podman {
         # exclude rootless poman on public cloud because of cgroups2 special settings
         loadtest 'containers/rootless_podman' unless (is_sle('=15-sp1') || is_openstack || is_public_cloud);
     }
+    loadtest 'containers/volumes';
 }
 
 sub load_host_tests_docker {
@@ -127,6 +128,7 @@ sub load_host_tests_docker {
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro) {
         loadtest 'containers/validate_btrfs';
     }
+    loadtest 'containers/volumes';
 }
 
 sub load_host_tests_containerd_rmt {

--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -1,0 +1,132 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: podman network
+# Summary: Test podman network
+# Maintainer: qac team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use version_utils;
+use containers::utils qw(get_docker_version get_podman_version);
+
+
+sub run {
+    my $runtime = get_required_var("CONTAINER_RUNTIME");
+
+    select_serial_terminal();
+
+    # From https://docs.docker.com/storage/bind-mounts/
+    # The --mount flag does not support z or Z options for modifying selinux labels.
+    my $Z = $runtime eq "podman" ? ",Z" : "";
+
+    my $test_dir = "test_dir";
+    my $test_file = "test_file";
+    my $test_image = "test_image";
+    my $test_container = "test_container";
+    my $test_volume = "test_volume";
+
+    assert_script_run("mkdir $test_dir");
+
+    # Create Dockerfile with VOLUME defined
+    assert_script_run("echo -e 'FROM busybox\nVOLUME /$test_dir' > $test_dir/Dockerfile");
+
+    # Build image
+    assert_script_run("$runtime build -t $test_image -f $test_dir/Dockerfile $test_dir/");
+
+    # Test --volumes-from
+    # Case 1: Check that the volume from container is visible in another container
+    assert_script_run("$runtime run -d --name $test_container $test_image");
+    assert_script_run("$runtime run --rm --volumes-from $test_container $test_image ls /$test_dir");
+    assert_script_run("$runtime rm -vf $test_container");
+
+    # Case 2: Check that the volume from container is visible in another container, but the
+    # first container is mounting it in the directory specified as VOLUME in the Dockerfile
+    assert_script_run("touch $test_dir/$test_file");
+    assert_script_run("$runtime run -d --name $test_container -v \$PWD/$test_dir:/$test_dir:Z $test_image");
+    # NOTE: When https://github.com/containers/podman/issues/19529 is solved we must add a version check here
+    my $ret = script_run("$runtime run --rm --volumes-from $test_container $test_image ls /$test_dir/$test_file");
+    if ($ret != 0) {
+        if ($runtime eq "podman") {
+            record_soft_failure("gh#19529 - Unexpected error with --volumes-from") if ($ret != 0 && $runtime == "podman");
+        } else {
+            die("--volumes-from failed");
+        }
+    }
+
+    assert_script_run("$runtime rm -vf $test_container");
+
+    # Test --volume option with directory (read-only)
+    assert_script_run("! $runtime run --rm --volume \$PWD/$test_dir:/$test_dir:ro,Z $test_image rm /$test_dir/$test_file");
+    assert_script_run("test -f $test_dir/$test_file");
+
+    # Equivalent --mount option to above
+    assert_script_run("! $runtime run --rm --mount type=bind,source=\$PWD/$test_dir,destination=/$test_dir,readonly$Z $test_image rm /$test_dir/$test_file");
+    assert_script_run("test -f $test_dir/$test_file");
+
+    assert_script_run("rm $test_dir/$test_file");
+
+    # Test --volume option with directory (read-write)
+    assert_script_run("$runtime run --rm --volume \$PWD/$test_dir:/$test_dir:Z $test_image touch /$test_dir/$test_file");
+    assert_script_run("test -f $test_dir/$test_file");
+
+    assert_script_run("rm $test_dir/$test_file");
+
+    # Equivalent --mount option to above
+    assert_script_run("$runtime run --rm --mount type=bind,source=\$PWD/$test_dir,destination=/${test_dir}$Z $test_image touch /$test_dir/$test_file");
+    assert_script_run("test -f $test_dir/$test_file");
+
+    # Test volume subcommands
+    assert_script_run("$runtime volume create $test_volume");
+    assert_script_run("$runtime volume ls --format '{{.Name}}' | grep -Fx $test_volume");
+    assert_script_run("$runtime volume inspect --format '{{.Name}}' $test_volume | grep -Fx $test_volume");
+    # Other subcommands supported only by podman: mount unmount reload
+    if ($runtime eq "podman") {
+        assert_script_run("$runtime volume exists $test_volume");
+        assert_script_run("tar cf - $test_dir | $runtime volume import $test_volume -");
+        assert_script_run("$runtime volume export $test_volume | tar tf - | grep -Fx $test_dir/$test_file");
+    }
+    assert_script_run("$runtime volume rm $test_volume");
+    assert_script_run("! $runtime volume inspect $test_volume");
+
+    for (my $i = 1; $i <= 10; $i++) {
+        assert_script_run("$runtime volume create $test_volume");
+
+        # Test --volume option with volume (read-write)
+        assert_script_run("$runtime run --rm --volume $test_volume:/$test_dir $test_image touch /$test_dir/$test_file");
+        assert_script_run("test -f $test_dir/$test_file");
+
+        # Equivalent --mount option to above
+        # NOTE: ",Z" in --mount is known to work on 4.6.0+ but not 4.4.4
+        my $optionalZ = ($runtime eq "podman" && version->parse(get_podman_version()) < version->parse('4.6.0')) ? "" : $Z;
+        assert_script_run("$runtime run --rm --mount type=volume,source=$test_volume,destination=/$test_dir$optionalZ $test_image touch /$test_dir/$test_file");
+
+        # Test --volume option with volume (read-only)
+        assert_script_run("! $runtime run --rm --volume $test_volume:/$test_dir:ro $test_image rm /$test_dir/$test_file");
+        assert_script_run("test -f $test_dir/$test_file");
+
+        # Equivalent --mount option to above
+        assert_script_run("! $runtime run --rm --mount type=volume,source=$test_volume,destination=/$test_dir,readonly$optionalZ $test_image rm /$test_dir/$test_file");
+
+        assert_script_run("$runtime volume rm $test_volume");
+        assert_script_run("! $runtime volume inspect $test_volume");
+    }
+
+    my $all = "";
+    if ($runtime eq "docker") {
+        $all = "-a";
+        # The -a option to docker volume prune was added to 23.0.5 according to:
+        # https://docs.docker.com/engine/release-notes/23.0/#2305
+        return if (version->parse(get_docker_version()) < version->parse('23.0.5'));
+    }
+    # Create a dangling (not used by any container) volume and test its removal
+    assert_script_run("$runtime volume create $test_volume");
+    assert_script_run("$runtime volume prune $all -f | grep -Fx $test_volume");
+    assert_script_run("! $runtime volume inspect $test_volume");
+    assert_script_run("[ \$($runtime volume ls --quiet --filter dangling=true | wc -l\) -eq 0 ]");
+}
+
+1;


### PR DESCRIPTION
Add tests for volumes

- Related ticket: https://progress.opensuse.org/issues/133910
- Verification runs:
  - sle-15-SP4-Server-DVD-Updates-x86_64-Build20230814-1-docker_tests@64bit -> https://openqa.suse.de/t11851425
  - sle-15-SP4-Server-DVD-Updates-x86_64-Build20230814-1-podman_tests@64bit -> https://openqa.suse.de/t11851093
  - sle-15-SP2-Server-DVD-Updates-x86_64-Build20230815-1-docker_tests@64bit -> https://openqa.suse.de/t11851118
  - opensuse-Tumbleweed-DVD-x86_64-Build20230814-containers_host_podman@64bit -> https://openqa.opensuse.org/t3511540
  - opensuse-Tumbleweed-DVD-x86_64-Build20230814-containers_host_docker@64bit -> https://openqa.opensuse.org/t3511560