### PR TITLE
xfstests: Solve aarch boot from qcow2 fails in alp

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -278,8 +278,8 @@ sub load_slem_on_pc_tests {
 }
 
 sub load_xfstests_tests {
-    load_boot_from_disk_tests;
     if (check_var('XFSTESTS', 'installation')) {
+        load_boot_from_disk_tests;
         loadtest 'transactional/host_config';
         loadtest 'xfstests/install';
         unless (check_var('NO_KDUMP', '1')) {
@@ -288,6 +288,7 @@ sub load_xfstests_tests {
         loadtest 'shutdown/shutdown';
     }
     else {
+        boot_hdd_image;
         loadtest 'xfstests/partition';
         loadtest 'xfstests/run';
         loadtest 'xfstests/generate_report';


### PR DESCRIPTION
Solve xfstests boot fail in aarch64 when using qcow2 HDD in alp. Using boot_hdd_image instead to boot from qcow2.

- Related ticket: https://progress.opensuse.org/issues/134099
- Verification run: 
- ALP
- aarch64: https://openqa.suse.de/tests/11835628
- x86_64: https://openqa.suse.de/tests/11835822
- SLE15SP6
- aarch64: https://openqa.suse.de/tests/11836023
- x86_64: https://openqa.suse.de/tests/11836039