### PR TITLE
Add workaround for bsc#1213991

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -199,6 +199,7 @@ sub trup_call {
 
     $args{timeout} //= 180;
     $args{exit_code} //= 0;
+    $args{proceed_on_failure} //= 0;
     $script .= "-n " unless $args{interactive};
     $script .= $cmd;
 
@@ -232,6 +233,11 @@ sub trup_call {
         $ret = script_run($script, timeout => $args{timeout}, die_on_timeout => 0);
     }
 
+    if ($args{proceed_on_failure}) {
+        diag("transactional-update $cmd call returned: $ret");
+        return $ret;
+    }
+
     die "transactional-update didn't finish" unless defined($ret);
     die "transactional-update returned with $ret, expected $args{exit_code}" unless $ret == $args{exit_code};
 }
@@ -262,12 +268,13 @@ sub trup_install {
 sub trup_shell {
     my ($cmd, %args) = @_;
     $args{reboot} //= 1;
+    $args{timeout} //= 90;
 
     enter_cmd("transactional-update shell; echo trup_shell-status-\$? > /dev/$serialdev");
     wait_still_screen;
     enter_cmd("$cmd");
     enter_cmd("exit");
-    wait_serial('trup_shell-status-0') || die "'transactional-update shell' didn't finish";
+    wait_serial('trup_shell-status-0', timeout => $args{timeout}) || die "'transactional-update shell' didn't finish";
 
     process_reboot(trigger => 1) if $args{reboot};
 }

--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -16,6 +16,19 @@ use version_utils 'is_sle_micro';
 use serial_terminal;
 use utils qw(script_retry);
 
+sub soft_fail_rt_scriptlet {
+    return if (get_var('FLAVOR') !~ /rt/i);
+
+    if (script_run("grep '%post(kernel-rt-5.14.21-150400.15.46.1.x86_64) scriptlet failed, exit status 1' /var/log/zypp/history") == 0) {
+        record_soft_failure('bsc#1213991 - %post(kernel-rt-5.14.21-150400.15.40.1.x86_64) scriptlet failed');
+        select_console 'root-console';
+        trup_shell 'zypper -n update', timeout => 1800;
+    } else {
+        die "Transactional update failed with different error cause";
+    }
+}
+
+
 sub run {
     my ($self) = @_;
 
@@ -34,7 +47,8 @@ sub run {
     }
     add_test_repositories;
     record_info 'Updates', script_output('zypper lu');
-    trup_call 'up', timeout => 1800;
+    my $ret = trup_call 'up', timeout => 1800, proceed_on_failure => 1;
+    soft_fail_rt_scriptlet if ($ret != 0);
     process_reboot(trigger => 1);
 }
 


### PR DESCRIPTION
RT kernel's scriptlet is failing therefore the whole snapshot is discarded and the rest of the testing is without other updates that are currently in the queue.

- Related ticket: https://progress.opensuse.org/issues/134240
- VRs
  * http://kepler.suse.cz/tests/21523#
  * http://kepler.suse.cz/tests/21522#
