### PR TITLE
Open the update flag for hpc installation autoyast profiles

### DIFF
--- a/data/yam/autoyast/support_images/create_hdd_hpc_development_node_aarch64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_development_node_aarch64.xml.ep
@@ -395,7 +395,7 @@
   </ssh_import>
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
-    <install_updates config:type="boolean">false</install_updates>
+    <install_updates config:type="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
     <slp_discovery t="boolean">false</slp_discovery>
     % if (keys %$addons) {

--- a/data/yam/autoyast/support_images/create_hdd_hpc_development_node_x86_64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_development_node_x86_64.xml.ep
@@ -397,7 +397,7 @@
   </ssh_import>
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
-    <install_updates config:type="boolean">false</install_updates>
+    <install_updates config:type="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
     <slp_discovery t="boolean">false</slp_discovery>
     % if (keys %$addons) {

--- a/data/yam/autoyast/support_images/create_hdd_hpc_management_server_aarch64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_management_server_aarch64.xml.ep
@@ -398,7 +398,7 @@
   </ssh_import>
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
-    <install_updates config:type="boolean">false</install_updates>
+    <install_updates config:type="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
     <slp_discovery t="boolean">false</slp_discovery>
     % if (keys %$addons) {

--- a/data/yam/autoyast/support_images/create_hdd_hpc_management_server_x86_64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_management_server_x86_64.xml.ep
@@ -398,7 +398,7 @@
   </ssh_import>
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
-    <install_updates config:type="boolean">false</install_updates>
+    <install_updates config:type="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
     <slp_discovery t="boolean">false</slp_discovery>
     % if (keys %$addons) {

--- a/data/yam/autoyast/support_images/create_hdd_hpc_textmode_aarch64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_textmode_aarch64.xml.ep
@@ -383,7 +383,7 @@
   </ssh_import>
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
-    <install_updates config:type="boolean">false</install_updates>
+    <install_updates config:type="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
     <slp_discovery t="boolean">false</slp_discovery>
     % if (keys %$addons) {

--- a/data/yam/autoyast/support_images/create_hdd_hpc_textmode_x86_64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_textmode_x86_64.xml.ep
@@ -385,7 +385,7 @@
   </ssh_import>
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
-    <install_updates config:type="boolean">false</install_updates>
+    <install_updates config:type="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_HPC}}</reg_code>
     <slp_discovery t="boolean">false</slp_discovery>
     % if (keys %$addons) {


### PR DESCRIPTION
Open the update flag for hpc installation autoyast profiles to recieve the latest update during installation.

- Related ticket: https://progress.opensuse.org/issues/134222
- Verification run:
[Jobs of installation](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=20230814-1&groupid=251)
[Job to confirm the installation above](http://openqa.suse.de/tests/11839243#step/zypper_patch/6)  received the latest updates
- Related mr: [mr1](https://gitlab.suse.de/coolgw/wegao-test/-/merge_requests/324#970720112fbd10d6a14a624c984af6d5c29432d2) and [mr2](https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/584)
