### PR TITLE
Fix assert_screen for agama_installation

### DIFF
--- a/schedule/yam/agama/agama_installation.yaml
+++ b/schedule/yam/agama/agama_installation.yaml
@@ -4,5 +4,5 @@ description: >
   Playwright test on agama
 schedule:
   - installation/bootloader_start
-  - yam/agama/patch_agama
+  - yam/agama/patch_agama_opensuse
   - yam/agama/agama_installation

--- a/tests/yam/agama/patch_agama_opensuse.pm
+++ b/tests/yam/agama/patch_agama_opensuse.pm
@@ -1,0 +1,23 @@
+## Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: This module use yupdate patch the Agama on Opensuse Live Medium
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base Yam::agama::patch_agama_base;
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    assert_screen('agama_product_selection', 120);
+
+    select_console 'root-console';
+
+    my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
+    assert_script_run("yupdate patch $repo $branch", timeout => 60);
+
+    select_console 'installation';
+}
+
+1;


### PR DESCRIPTION
Fixing failure caused by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17586
VR: http://falafel.suse.cz/tests/1295

The new failure is due to the agama_base. We decided to create a new test: https://progress.opensuse.org/issues/134228
