### PR TITLE
Disabling Hyper V feature takes more time

### DIFF
--- a/tests/wsl/install_from_MSStore.pm
+++ b/tests/wsl/install_from_MSStore.pm
@@ -30,7 +30,8 @@ sub run {
         timeout => 300
     );
     $self->run_in_powershell(
-        cmd => 'Disable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V-Hypervisor -NoRestart'
+        cmd => 'Disable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V-Hypervisor -NoRestart',
+        timeout => 300
     ) if (get_var('WSL2'));
 
     # Reboot and wait for it


### PR DESCRIPTION
The default timeout is not enough in order to disable Hyper V feature.

- ticket: https://progress.opensuse.org/issues/132731
- Verification run: http://kepler.suse.cz/tests/21533#
