### PR TITLE
Open ssh port during installation

### DIFF
--- a/schedule/security/encryption/lvm_encrypt_separate_boot.yaml
+++ b/schedule/security/encryption/lvm_encrypt_separate_boot.yaml
@@ -22,6 +22,8 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_settings/validate_default_target
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
   - installation/bootloader_settings/disable_plymouth
   - installation/bootloader_settings/disable_boot_menu_timeout
   - installation/launch_installation

--- a/schedule/security/encryption/lvm_encrypt_separate_boot_s390x.yaml
+++ b/schedule/security/encryption/lvm_encrypt_separate_boot_s390x.yaml
@@ -25,6 +25,8 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/installation_settings/validate_default_target
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
   - installation/edit_optional_kernel_cmd_parameters
   - installation/bootloader_settings/disable_plymouth
   - installation/bootloader_settings/disable_boot_menu_timeout


### PR DESCRIPTION
New defaults for installation have been set to not open port 22, which causes test fails in several modules. This PR ensures the SSH service and port are enabled in installation settings.

- Related ticket: https://progress.opensuse.org/issues/133982
- Verification run: https://openqa.suse.de/tests/11858115
