### PR TITLE
Define python version via OpenQA parameter

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -19,6 +19,8 @@ terraform:
     private_key: '~/.ssh/id_rsa'
     os_image: "%PUBLIC_CLOUD_IMAGE_ID%"
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 
     # HANA
     hana_count: '%NODE_COUNT%'

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -18,6 +18,7 @@
 # _HANA_MASTER_PW (mandatory) - Hana master PW (secret)
 # INSTANCE_SID - SAP Sid
 # INSTANCE_ID - SAP instance id
+# ANSIBLE_REMOTE_PYTHON - define python version to be used for qesap-deploymnet (default '/usr/bin/python3')
 
 
 use strict;
@@ -127,6 +128,7 @@ sub run {
     die "HA cluster needs at least 2 nodes. Check 'NODE_COUNT' parameter." if ($ha_enabled && (get_var('NODE_COUNT') <= 1));
 
     set_var('FENCING_MECHANISM', 'native') unless ($ha_enabled);
+    set_var_output('ANSIBLE_REMOTE_PYTHON', '/usr/bin/python3');
 
     my $deployment_name = deployment_name();
     # Create a QESAP_DEPLOYMENT_NAME variable so it includes the random


### PR DESCRIPTION
HanaSR 12SP5 tests are currently failing because available python3
version does not meet ansible criteria. This PR adds option to define 
'ANSIBLE_REMOTE_PYTHON' python version in config.yml file 
and switch to supported python 2.7.

- Related ticket: Issue was blocking : https://jira.suse.com/browse/TEAM-8033

- Verification run: 
- 12SP5 (python ver. set to 2.7) - https://openqaworker15.qa.suse.cz/tests/215015/#step/deploy_qesap_terraform/137
- 15SP3 (default python3 ver.) - https://openqaworker15.qa.suse.cz/tests/215016#step/deploy_qesap_terraform/158