### PR TITLE
install_ltp: Optimize installation of optional Git dependencies

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -46,6 +46,7 @@ our @EXPORT = qw(
   zypper_search
   zypper_repos
   zypper_patches
+  zypper_install_available
   set_zypper_lock_timeout
   workaround_type_encrypted_passphrase
   is_boot_encrypted
@@ -954,6 +955,22 @@ sub zypper_patches {
 
     my $output = script_output("zypper pch $params", 300);
     return parse_zypper_table($output, \@fields);
+}
+
+=head2
+
+ zypper_install_available(@packages);
+
+Install all available packages from the given list. Packages not found
+in enabled repositories will be skipped. Package availability is tested
+by exact name match.
+=cut
+
+sub zypper_install_available {
+    my $packlist = join(' ', @_);
+    my $result = zypper_search("-t package --match-exact $packlist");
+
+    return zypper_call('-t in ' . join(' ', map { $_->{name} } @$result));
 }
 
 =head2 set_zypper_lock_timeout

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -93,10 +93,7 @@ sub install_runtime_dependencies {
       wget
       xfsprogs
     );
-    for my $dep (@maybe_deps) {
-        # ignore failures due to missing packages (exit code 104)
-        zypper_call("in $dep", exitcode => [0, 104]);
-    }
+    zypper_install_available(@maybe_deps);
 }
 
 sub install_debugging_tools {
@@ -106,10 +103,7 @@ sub install_debugging_tools {
       ltrace
       strace
     );
-    for my $dep (@maybe_deps) {
-        # ignore failures due to missing packages (exit code 104)
-        zypper_call("in $dep", exitcode => [0, 104]);
-    }
+    zypper_install_available(@maybe_deps);
 }
 
 sub install_runtime_dependencies_network {
@@ -136,10 +130,7 @@ sub install_runtime_dependencies_network {
       wireguard-tools
       xinetd
     );
-    for my $dep (@maybe_deps) {
-        # ignore failures due to missing packages (exit code 104)
-        zypper_call("in $dep", exitcode => [0, 104]);
-    }
+    zypper_install_available(@maybe_deps);
 }
 
 sub install_build_dependencies {
@@ -187,11 +178,7 @@ sub install_build_dependencies {
     # libopenssl-devel-32bit is blocked by dependency mess on SLE-12 and we
     # don't use it anyway...
     push @maybe_deps, 'libopenssl-devel-32bit' if !is_sle('<15');
-
-    for my $dep (@maybe_deps) {
-        # ignore failures due to missing packages (exit code 104)
-        zypper_call("in $dep", exitcode => [0, 104]);
-    }
+    zypper_install_available(@maybe_deps);
 }
 
 sub prepare_ltp_git {


### PR DESCRIPTION
LTP installation from Git uses dependencies which are available only on some SLE versions. Zypper does not install anything in non-interactive mode if any package in the install list is missing and installing packages one by one is slow, especially on aarch64. Add a helper function which will search for available packages in the install list and then install only those that were found by exact name match. This speeds up aarch64 LTP installation from git by up to 12 minutes.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - SLE-12SP5 x86_64: https://openqa.suse.de/tests/11863069
  - SLE-15SP3 aarch64: https://openqa.suse.de/tests/11862537 (cloned from: https://openqa.suse.de/tests/11843610)