### PR TITLE
Swap order of kernel parameters for new grub entries

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -151,7 +151,7 @@ sub add_custom_grub_entries {
         my $script_new_esc = $script_new =~ s~/~\\/~rg;
         assert_script_run("cp -v $script_old $script_new");
 
-        my $cmd = "sed -i -e 's/\\(args=.\\)\\(\\\$4\\)/\\1$grub_param \\2/'";
+        my $cmd = "sed -i -e 's/\\(args=.\\)\\(\\\$4[^\"]*\\)/\\1\\2 $grub_param/'";
         $cmd .= " -e 's/\\(Advanced options for %s\\)/\\1 ($grub_param)/'";
         $cmd .= " -e 's/\\(menuentry .\\\$(echo .\\\$title\\)/\\1 ($grub_param)/'";
         $cmd .= " -e 's/\\(menuentry .\\\$(echo .\\\$os\\)/\\1 ($grub_param)/' $script_new";
@@ -165,7 +165,7 @@ sub add_custom_grub_entries {
         die("Unexpected number of grub entries: $cnt_new, expected: $cnt_old") if ($cnt_old != $cnt_new);
         $cnt_new = script_output("$run_cmd grep -c 'menuentry .$distro.*($grub_param)' " . GRUB_CFG_FILE);
         die("Unexpected number of new grub entries: $cnt_new, expected: " . ($cnt_old)) if ($cnt_old != $cnt_new);
-        $cnt_new = script_output("$run_cmd grep -c -E 'linux.*(/boot|/vmlinu[xz]-).* $grub_param ' " . GRUB_CFG_FILE);
+        $cnt_new = script_output("$run_cmd grep -c -E 'linux.*(/boot|/vmlinu[xz]-).* $grub_param' " . GRUB_CFG_FILE);
         die("Unexpected number of new grub entries with '$grub_param': $cnt_new, expected: " . ($cnt_old)) if ($cnt_old != $cnt_new);
     }
 }


### PR DESCRIPTION
New custom grub entries added parameters to the beginning of kernel command line. This change will add them at the end of command line to allow overwriting (by order) existing parameters.

Alternative approach to  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17593. New solution is more simple and more powerful and extends already existing functionality.

- Related ticket:  none
- Needles: none
- Verification run: 
 GRUB_PARAM=debug_pagealloc=on;ima_policy=tcb;selinux=0;enforcing=0
adds two new options to disable SELinux, one entry will disable completely, the other one will permissive mode on
installation: https://openqa.suse.de/tests/11897495#
boot (GRUB_BOOT_NONDEFAULT= 3): https://openqa.suse.de/tests/11897572#step/boot_ltp/5


Comparison of test result:
With SELinux: https://openqa.suse.de/tests/11849701#step/memcg_subgroup_charge/8
Without SELinux (GRUB_BOOT_NONDEFAULT= 3): https://openqa.suse.de/tests/11891059#step/memcg_subgroup_charge/8