### PR TITLE
usr_sbin_smbd: use 'assert_and_click' instead of 'send_key'

### DIFF
--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -97,7 +97,7 @@ sub samba_client_access {
 
     # Connect to samba server
     assert_and_click("nautilus-other-locations");
-    send_key_until_needlematch("nautilus-connect-to-server", 'tab', 21, 2);
+    assert_and_click("nautilus-connect-to-server");
     type_string("smb://$ip");
     send_key "ret";
     wait_still_screen(2);


### PR DESCRIPTION
It is faster and more accurate to use `assert_and_click` to focus on the address bar.

- Related ticket: https://progress.opensuse.org/issues/134330
- Needles: None
- Verification run: https://openqa.opensuse.org/tests/3515713#step/usr_sbin_smbd/61
