### PR TITLE
Add new workaround for nvidia repo not reliable with new hot-key

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -544,8 +544,9 @@ sub process_scc_register_addons {
             }
             elsif (match_has_tag('nvidia-validation-failed')) {
                 # nvidia repos unreliable
-                send_key 'alt-y';
-                record_soft_failure 'bsc#1144831';
+                record_soft_failure 'bsc#1214234';
+                wait_still_screen { send_key 'alt-o' };
+                send_key 'alt-n';
                 next;
             }
             elsif (match_has_tag('yast_scc-pkgtoinstall')) {
@@ -644,8 +645,9 @@ sub handle_scc_popups {
             }
             elsif (match_has_tag('nvidia-validation-failed')) {
                 # sometimes nvidia driver repos are unreliable
-                send_key 'alt-y';
-                record_soft_failure 'bsc#1144831';
+                record_soft_failure 'bsc#1214234';
+                wait_still_screen { send_key 'alt-o' };
+                send_key 'alt-n';
                 next;
             }
             elsif (match_has_tag('contacting-registration-server')) {


### PR DESCRIPTION
https://progress.opensuse.org/issues/134423
https://bugzilla.suse.com/show_bug.cgi?id=1214234

- Verification run: 
[SLES](https://openqa.suse.de/tests/11888696)
[SLED](https://openqa.suse.de/tests/11888689)

Based on the test result, the workaround can not work perfectly on sled tests, we may need to file a new ticket.