### PR TITLE
Fix typo for system_validation

### DIFF
--- a/schedule/yast/clone_system/clone_system_pvm.yaml
+++ b/schedule/yast/clone_system/clone_system_pvm.yaml
@@ -8,6 +8,6 @@ schedule:
   system_preparation:
     - console/system_prepare
     - console/consoletest_setup
-  system_validateion:
+  system_validation:
     - console/yast2_clone_system
     - console/consoletest_finish


### PR DESCRIPTION
We need to fix the typo for system_validation in clone_system_pvm.yaml

- Related ticket:  Quick PR
- Needles: N/A
- Verification run: 
  * https://openqa.suse.de/t11889071
