### PR TITLE
qesap_terraform only call get_blob_uri for uploaded images tests

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -19,7 +19,7 @@
 # INSTANCE_SID - SAP Sid
 # INSTANCE_ID - SAP instance id
 # ANSIBLE_REMOTE_PYTHON - define python version to be used for qesap-deploymnet (default '/usr/bin/python3')
-
+# PUBLIC_CLOUD_IMAGE_LOCATION - needed by get_blob_uri
 
 use strict;
 use warnings;
@@ -155,11 +155,18 @@ sub run {
     }
 
     my $provider = $self->provider_factory();
-    if (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
-        set_var('OS_URI', $provider->get_blob_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION')));
-    } else {
-        set_var('SLE_IMAGE', $provider->get_image_id());
+
+    # This section is only needed by tests using images uploaded
+    # with publiccloud_upload_img so using conf.yaml templates
+    # with OS_URI or SLE_IMAGE
+    if (get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) {
+        if (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+            set_var('OS_URI', $provider->get_blob_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION')));
+        } else {
+            set_var('SLE_IMAGE', $provider->get_image_id());
+        }
     }
+
     my $ansible_playbooks = create_playbook_section_list();
     my $ansible_hana_vars = create_hana_vars_section();
 


### PR DESCRIPTION
Avoid to call the API when the job is not configured to use and image uploaded from IBS
 
- Related ticket: [TEAM-8211](https://jira.suse.com/browse/TEAM-8211)
- Verification run: 

URI IMAGE sle-15-SP5-Azure-SAP-x86_64-Build0296-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/216177  http://openqaworker15.qa.suse.cz/tests/216575

CATALOG IMAGE sle-15-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:30243:rpm-sles4sap_gnome_saptune_solutions@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/216178 http://openqaworker15.qa.suse.cz/tests/216574
