### PR TITLE
Adapt autoyast profile path for migration misc group

### DIFF
--- a/schedule/migration/autoyast_regression_test_offline_pre@pvm.yaml
+++ b/schedule/migration/autoyast_regression_test_offline_pre@pvm.yaml
@@ -2,10 +2,6 @@
 name: autoyast_regression_test_offline_pre@pvm
 description: >
   autoYaST installation and prepare base system
-vars:
-  AUTOYAST: autoyast_sle15/autoyast_sle_powervm.xml.ep
-  AUTOYAST_PREPARE_PROFILE: '1'
-  DESKTOP: textmode
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start


### PR DESCRIPTION
The autoyast profile path is changed and wrote in setting, need to remove the old path from schedule file.

- Verification run: https://openqa.suse.de/tests/11896939#
