### PR TITLE
Add link for released 15-SP5 base container

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -107,7 +107,7 @@ our %images_list = (
             available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
         },
         '15-SP5' => {
-            released => sub { },
+            released => sub { 'registry.suse.com/suse/sle15:15.5' },
             totest => sub {
                 'registry.suse.de/suse/sle-15-sp5/ga/test/containers/suse/sle15:15.5';
             },


### PR DESCRIPTION
The registry link to released 15-SP5 container was missing.

- ticket: https://progress.opensuse.org/issues/134465
- VR: http://kepler.suse.cz/tests/21564
