### PR TITLE
Add workaround for verify correct capabilities

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -103,7 +103,7 @@ sub load_host_tests_podman {
         loadtest 'containers/buildah' unless (is_sle_micro || is_microos || is_leap_micro || is_alp || is_staging);
         # https://github.com/containers/podman/issues/5732#issuecomment-610222293
         # exclude rootless poman on public cloud because of cgroups2 special settings
-        loadtest 'containers/rootless_podman' unless (is_sle('<15-sp3') || is_openstack || is_public_cloud);
+        loadtest 'containers/rootless_podman' unless (is_sle('<15-sp2') || is_openstack || is_public_cloud);
         load_volume_tests($run_args);
     }
 }


### PR DESCRIPTION
A container spawned with `keep-id` option lists capabilities. The original workaround has disappeared, however the issue is still tracked in the same report - https://bugzilla.suse.com/show_bug.cgi?id=1182428

- [sle15-sp2 + podman v3.4.7](http://kepler.suse.cz/tests/21561#step/rootless_podman/214)
- [sle15-sp2 + podman v2.1.1](http://kepler.suse.cz/tests/21565#)

