### PR TITLE
[hpc] Add setup-env.sh to the .bashrc

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -381,6 +381,7 @@ sub prepare_spack_env {
     my ($self, $mpi) = @_;
     $mpi //= 'mpich';
     zypper_call "in spack", timeout => 1200;
+    assert_script_run "echo source /usr/share/spack/setup-env.sh >> /home/$testapi::username/.bashrc";
     type_string('pkill -u root');    # this kills sshd
     select_serial_terminal(0);
 
@@ -391,7 +392,6 @@ sub prepare_spack_env {
         assert_script_run "spack install boost+mpi^$mpi", timeout => 12000;
         assert_script_run "source spack_get_libs.sh boost^$mpi";
     } else {
-        assert_script_run 'source /usr/share/spack/setup-env.sh';
         record_info "$mpi spec", script_output("spack spec $mpi", timeout => 600);
         assert_script_run "spack install $mpi", timeout => 12000;
     }

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -43,7 +43,6 @@ sub run ($self) {
 
     barrier_wait('MPI_SETUP_READY');
     if (check_var('HPC_LIB', 'boost')) {
-        assert_script_run 'source /usr/share/spack/setup-env.sh';
         assert_script_run "spack load boost^$mpi";
         assert_script_run 'spack find --loaded';
         assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin -l boost_mpi -I \${BOOST_ROOT}/include/ -L \${BOOST_ROOT}/lib 2>&1 > /tmp/make.out");

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -26,7 +26,6 @@ sub run ($self) {
     barrier_wait('CLUSTER_PROVISIONED');
     barrier_wait('MPI_SETUP_READY');
     if (check_var('HPC_LIB', 'boost')) {
-        assert_script_run 'source /usr/share/spack/setup-env.sh';
         assert_script_run "spack load boost^$mpi";
     } else {
         assert_script_run "spack load $mpi";


### PR DESCRIPTION
Because test switches between consoles add the setup-env.sh to the .bashrc of the user. it will help also in manual interversion avoiding to run it every time.

- Verification run: https://aquarius.suse.cz/tests/18209
