### PR TITLE
Fix Agama Dolomite auto installation fails due to product changes

### DIFF
--- a/data/yam/agama/auto/alp_dolomite.jsonnet
+++ b/data/yam/agama/auto/alp_dolomite.jsonnet
@@ -1,12 +1,12 @@
 local agama = import 'hw.libsonnet';
 local findBiggestDisk(disks) =
   local sizedDisks = std.filter(function(d) std.objectHas(d, 'size'), disks);
-  local sorted = std.sort(sizedDisks, function(x) x.size);
+  local sorted = std.sort(sizedDisks, function(x) -x.size);
   sorted[0].logicalname;
 
 {
   software: {
-    product: 'ALP-Micro',
+    product: 'ALP-Dolomite',
   },
   root: {
     password: 'nots3cr3t',

--- a/tests/yam/agama/agama_lvm.pm
+++ b/tests/yam/agama/agama_lvm.pm
@@ -12,6 +12,7 @@ use warnings;
 use testapi qw(
   assert_screen
   assert_script_run
+  enter_cmd
   get_required_var
   reset_consoles
   select_console
@@ -26,10 +27,10 @@ sub run {
     $testapi::password = 'linux';
     select_console 'root-console';
 
-    assert_script_run("RUN_INSTALLATION=1 PRODUCTNAME=\"$product_name\" playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright lvm", timeout => 1200);
-    upload_logs('./test-results/lvm-Use-logical-volume-management-LVM-as-storage-device-for-installation-chromium/trace.zip');
+    assert_script_run("RUN_INSTALLATION=1 PRODUCTNAME=\"$product_name\" playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright tests/lvm.spec.ts", timeout => 1200);
+    upload_logs('./test-results/lvm-The-main-page-Use-logical-volume-management-LVM-as-storage-device-for-installation-chromium/trace.zip');
 
-    assert_script_run('reboot');
+    enter_cmd "reboot";
     # For agama test, it is too short time to match the grub2, so we create
     # a new needle to avoid too much needles loaded.
     assert_screen('grub2-agama', 120);
@@ -39,6 +40,6 @@ sub run {
 }
 
 sub post_fail_hook {
-    upload_logs('./test-results/lvm-Use-logical-volume-management-LVM-as-storage-device-for-installation-chromium/trace.zip');
+    upload_logs('./test-results/lvm-The-main-page-Use-logical-volume-management-LVM-as-storage-device-for-installation-chromium/trace.zip');
 }
 1;


### PR DESCRIPTION
Update jsonnet profile to set product as 'Dolomite'.

- Related ticket: https://progress.opensuse.org/issues/134117
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3524946#details
  It shown installation finished successful but in fact failed to start installation.
