### PR TITLE
Revert "add suseconnect test in 15-SP4 and 15-SP5"

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -137,7 +137,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/ansible
-        - console/suseconnect
   arch_specific15_sp5:
     ARCH:
       x86_64:


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#17547

Planning to move suseconnect test to a separate job.