### PR TITLE
Add azure ibsm embargo test

### DIFF
--- a/schedule/sles4sap/sles4sap_ibsm_embargo_check.yml
+++ b/schedule/sles4sap/sles4sap_ibsm_embargo_check.yml
@@ -1,0 +1,20 @@
+---
+name: sles4sap_ibsm_embargo_check
+description: >
+  Checks for embargoed updates on IBSM
+
+vars:
+  BOOTFROM: c
+  BOOT_HDD_IMAGE: '1'
+  NODE_COUNT: '1'
+  TEST_CONTEXT: 'OpenQA::Test::RunArgs'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
+  # START_AFTER_TEST: create_hdd_sles4sap_gnome
+schedule:
+  - boot/boot_to_desktop
+  - sles4sap/publiccloud/qesap_terraform
+  - sles4sap/publiccloud/network_peering
+  - sles4sap/publiccloud/add_server_to_hosts
+  - sles4sap/publiccloud/check_ibsm_embargoed
+  - sles4sap/publiccloud/qesap_cleanup

--- a/tests/sles4sap/publiccloud/check_ibsm_embargoed.pm
+++ b/tests/sles4sap/publiccloud/check_ibsm_embargoed.pm
@@ -1,0 +1,40 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Checks for embargoed updates on IBSM
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use strict;
+use warnings;
+use base 'sles4sap_publiccloud_basetest';
+use publiccloud::utils "validate_repo";
+use testapi;
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run() {
+    my ($self, $run_args) = @_;
+    my $instance = $run_args->{my_instance};
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+    record_info('CONTEXT LOG', "instance:$instance network_peering_present:$self->{network_peering_present}");
+
+    my @repos = split(/,/, get_var('INCIDENT_REPO'));
+    my $count = 0;
+
+    while (defined(my $maintrepo = shift @repos)) {
+        next if $maintrepo =~ /^\s*$/;
+        # validate_repo returns 0 if an embargoed update is found, so it's reversed to enter the loop
+        if (!validate_repo($maintrepo)) {
+            $instance->run_ssh_command(cmd => "sudo zypper --no-gpg-checks ar -f -n TEST_$count $maintrepo TEST_$count",
+                username => 'cloudadmin');
+            my $rc = $instance->run_ssh_command(cmd => "sudo zypper -n ref TEST_$count", username => 'cloudadmin', timeout => 1500, rc_only => 1);
+            die "EMBARGOED REPOSITORY IN IBSM: $maintrepo" if !$rc;
+            $count++;
+        }
+    }
+    record_info('NO EMBARGOED', 'No embargoed updates found on the IBSMirror.');
+}
+
+1;


### PR DESCRIPTION
A new test is added, using a single node with peering to azure IBSM, that fails with an appropriate message if an embargoed update exists on the IBSMirror.

- Related ticket: https://jira.suse.com/browse/TEAM-8325
- Verification runs:
WITHOUT EMBARGOED UPDATE: http://openqaworker15.qa.suse.cz/tests/217441
WITH EMBARGOED UPDATE: http://openqaworker15.qa.suse.cz/tests/217440
