### PR TITLE
Refactor allow_openqa_port_selinux

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -18,8 +18,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_public_cloud get_version_id);
+use version_utils qw(is_sle is_public_cloud get_version_id is_transactional);
+use transactional qw(check_reboot_changes trup_call process_reboot);
 use registration;
+
+# Indicating if the openQA port has been already allowed via SELinux policies
+my $openqa_port_allowed = 0;
 
 our @EXPORT = qw(
   deregister_addon
@@ -41,6 +45,7 @@ our @EXPORT = qw(
   gcloud_install
   prepare_ssh_tunnel
   kill_packagekit
+  allow_openqa_port_selinux
 );
 
 # Get the current UTC timestamp as YYYY/mm/dd HH:MM:SS
@@ -297,6 +302,26 @@ sub kill_packagekit {
         $instance->ssh_script_run(cmd => "sudo systemctl disable packagekitd");
         $instance->ssh_script_run(cmd => "sudo systemctl mask packagekitd");
     }
+}
+
+
+sub allow_openqa_port_selinux {
+    # not needed to perform multiple times, also semanage would fail.
+    return if ($openqa_port_allowed);
+
+    # Additional packages required for semanage
+    my $pkgs = 'policycoreutils-python-utils';
+    if (is_transactional) {
+        trup_call("pkg install $pkgs");
+        check_reboot_changes;
+    } else {
+        zypper_call("in $pkgs");
+    }
+    # allow ssh tunnel port (to openQA)
+    my $upload_port = get_required_var('QEMUPORT') + 1;
+    assert_script_run("semanage port -a -t ssh_port_t -p tcp $upload_port");
+    process_reboot(trigger => 1) if (is_transactional);
+    $openqa_port_allowed = 1;
 }
 
 1;

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -12,7 +12,8 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use publiccloud::ssh_interactive "ssh_interactive_tunnel";
+use publiccloud::ssh_interactive qw(ssh_interactive_tunnel);
+use publiccloud::utils qw(allow_openqa_port_selinux);
 use version_utils;
 
 sub run {
@@ -25,6 +26,9 @@ sub run {
     # The serial terminal needs to be activated manually, as it requires the $self argument
     select_serial_terminal();
     enter_cmd('ssh -t sut');
+
+    # Allow openQA on instances where SELinux is in enforcing state by default
+    allow_openqa_port_selinux() if (is_public_cloud && is_sle_micro(">=5.4"));
 
     ## Test most important consoles to ensure they are working
     select_console('root-console');


### PR DESCRIPTION
Refactor the `allow_openqa_port_selinux` function to be used in `ssh_interactive_start`. This is needed to allow access to openQA resources from the moment the tunnel was established onwards, e.g. for `instance_overview`.

- Related ticket: https://progress.opensuse.org/issues/134450
- Verification run: https://duck-norris.qe.suse.de/tests/13480
