### PR TITLE
Provider as mandatory argument for few qesapdeploy API

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -549,7 +549,7 @@ sub create_instance_data {
     my $class = ref($provider);
     die "Unexpected class type [$class]" unless ($class =~ /^publiccloud::(azure|ec2|gce)/);
     my @instances = ();
-    my $inventory_file = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my $inventory_file = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
     my $ypp = YAML::PP->new;
     my $raw_file = script_output("cat $inventory_file");
     my $inventory_data = $ypp->load_string($raw_file)->{all}{children};

--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -36,7 +36,7 @@ sub cleanup {
 
     my @cmd_list;
     # Only run the Ansible deregister if the inventory is present
-    push(@cmd_list, 'ansible') if (!script_run 'test -f ' . qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER')));
+    push(@cmd_list, 'ansible') if (!script_run 'test -f ' . qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER')));
 
     # Terraform destroy can be executed in any case
     push(@cmd_list, 'terraform');

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -437,7 +437,7 @@ sub cluster_deploy {
     die "'qesap.py terraform' return: $ret[0]" if ($ret[0]);
     @ret = qesap_execute(cmd => 'ansible', verbose => 1, timeout => bmwqemu::scale_timeout(3600));
     die "'qesap.py ansible' return: $ret[0]" if ($ret[0]);
-    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
     upload_logs($inventory);
 }
 
@@ -593,7 +593,7 @@ sub cluster_install_agent {
     }
     my $private_ip = get_trento_private_ip();
     $cmd = join(' ', 'ansible-playbook', '-vv',
-        '-i', qesap_get_inventory(lc get_required_var('PUBLIC_CLOUD_PROVIDER')),
+        '-i', qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER')),
         "$playbook_location/trento-agent.yaml",
         $local_rpm_arg,
         '-e', "api_key=$agent_api_key",

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -17,28 +17,28 @@ subtest '[qesap_get_inventory] upper case' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     $qesap->redefine(qesap_get_file_paths => sub {
             my %paths;
-            $paths{deployment_dir} = '/BRUCE';
+            $paths{terraform_dir} = '/BRUCE';
             return (%paths);
     });
 
-    my $inventory_path = qesap_get_inventory('NEMO');
+    my $inventory_path = qesap_get_inventory(provider => 'NEMO');
 
     note('inventory_path --> ' . $inventory_path);
-    is $inventory_path, '/BRUCE/terraform/nemo/inventory.yaml', "inventory_path:$inventory_path is the expected one";
+    is $inventory_path, '/BRUCE/nemo/inventory.yaml', "inventory_path:$inventory_path is the expected one";
 };
 
 subtest '[qesap_get_inventory] lower case' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     $qesap->redefine(qesap_get_file_paths => sub {
             my %paths;
-            $paths{deployment_dir} = '/BRUCE';
+            $paths{terraform_dir} = '/BRUCE';
             return (%paths);
     });
 
-    my $inventory_path = qesap_get_inventory('nemo');
+    my $inventory_path = qesap_get_inventory(provider => 'nemo');
 
     note('inventory_path --> ' . $inventory_path);
-    is $inventory_path, '/BRUCE/terraform/nemo/inventory.yaml', "inventory_path:$inventory_path is the expected one";
+    is $inventory_path, '/BRUCE/nemo/inventory.yaml', "inventory_path:$inventory_path is the expected one";
 };
 
 subtest '[qesap_create_folder_tree/qesap_get_file_paths] default' => sub {

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -110,6 +110,7 @@ sub create_hana_vars_section {
 
 sub run {
     my ($self, $run_args) = @_;
+    my $provider_setting = get_required_var('PUBLIC_CLOUD_PROVIDER');
 
     if (is_azure()) {
         my %maintenance_vars = qesap_az_calculate_address_range(slot => get_required_var('WORKER_ID'));
@@ -170,12 +171,12 @@ sub run {
     my $ansible_hana_vars = create_hana_vars_section();
 
     # Prepare QESAP deployment
-    qesap_prepare_env(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    qesap_prepare_env(provider => $provider_setting);
     qesap_create_ansible_section(ansible_section => 'create', section_content => $ansible_playbooks) if @$ansible_playbooks;
     qesap_create_ansible_section(ansible_section => 'hana_vars', section_content => $ansible_hana_vars) if %$ansible_hana_vars;
 
     # Regenerate config files (This workaround will be replaced with full yaml generator)
-    qesap_prepare_env(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'), only_configure => 1);
+    qesap_prepare_env(provider => $provider_setting, only_configure => 1);
 
     my @ret = qesap_execute(cmd => 'terraform', timeout => 3600, verbose => 1);
     die 'Terraform deployment FAILED. Check "qesap*" logs for details.' if ($ret[0]);

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -13,7 +13,7 @@ use qesapdeployment;
 sub run {
     my @ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => 1800);
     die "'qesap.py terraform' return: $ret[0]" if ($ret[0]);
-    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
     upload_logs($inventory, failok => 1);
     my @remote_ips = qesap_remote_hana_public_ips;
     record_info 'Remote IPs', join(' - ', @remote_ips);
@@ -50,7 +50,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     qesap_upload_logs();
-    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
     qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300) unless (script_run("test -e $inventory"));
     qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -13,10 +13,10 @@ use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
 
 sub run {
     my ($self) = @_;
-    my $inventory = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
-    my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
+    my $provider_setting = get_required_var('PUBLIC_CLOUD_PROVIDER');
+    my $inventory = qesap_get_inventory(provider => $provider_setting);
 
-    my $chdir = qesap_get_terraform_dir();
+    my $chdir = qesap_get_terraform_dir(provider => $provider_setting);
     assert_script_run("terraform -chdir=$chdir output");
     my @remote_cmd = (
         'pwd',
@@ -27,19 +27,19 @@ sub run {
         'zypper lr',
         'zypper in -f -y vim'
     );
-    qesap_ansible_cmd(cmd => $_, provider => $prov) for @remote_cmd;
-    qesap_ansible_cmd(cmd => 'ls -lai /hana/', provider => $prov, filter => 'hana');
+    qesap_ansible_cmd(cmd => $_, provider => $provider_setting) for @remote_cmd;
+    qesap_ansible_cmd(cmd => 'ls -lai /hana/', provider => $provider_setting, filter => 'hana');
     my $cmr_status = qesap_ansible_script_output(cmd => 'crm status',
-        provider => $prov,
+        provider => $provider_setting,
         host => '"hana[0]"',
         root => 1);
     record_info("crm status", $cmr_status);
-    qesap_ansible_cmd(cmd => $crm_mon_cmd, provider => $prov, filter => '"hana[0]"');
+    qesap_ansible_cmd(cmd => $crm_mon_cmd, provider => $provider_setting, filter => '"hana[0]"');
     qesap_cluster_logs();
-    if (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+    if ($provider_setting eq 'AZURE') {
         die 'Cluster resources throwing errors' if cluster_status_matches_regex($cmr_status);
     }
-    if (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+    if ($provider_setting eq 'AZURE') {
         if (get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP")) {
             my $rg = qesap_az_get_resource_group();
             my $ibs_mirror_rg = get_var('QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP');
@@ -47,7 +47,7 @@ sub run {
             qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));
             qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibs_mirror_rg);
         }
-    } elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
+    } elsif ($provider_setting eq 'EC2') {
         if (get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")) {
             my $deployment_name = qesap_calculate_deployment_name('qesapval');
             my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name);


### PR DESCRIPTION
Provider is a mandatory argument for the get_inventory and get_terraform_dir API. Terraform_dir calculated in a single place.

# Verification run: 

## Trento

 - sle-15-SP4-Trento-PremiumRolling-x86_64-BuildRolling2.1.0-build62.3-trento_test@64bit -> http://openqaworker15.qa.suse.cz/tests/217065

## HANASR

 - sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-08-23T04:03:13Z-hanasr_azure_test_sapconf@64bit -> http://openqaworker15.qa.suse.cz/tests/217061

## QESAP REGRESSION

 - GCP : sle-12-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE12_5_BYOS-qesap_gcp_saptune_test -> http://openqaworker15.qa.suse.cz/tests/217055 :green_circle: 

 - AZURE :
          - Image uploaded by `publiccloud_upload_img` sle-15-SP5-Qesap-Azure-Byos-Ibs-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS_IBS-qesap_azure_uri -> http://openqaworker15.qa.suse.cz/tests/217056
          - catalog images sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_sapconf_test -> http://openqaworker15.qa.suse.cz/tests/217057
          - with net peering sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ibsmirror_peering_test -> http://openqaworker15.qa.suse.cz/tests/217058

 - AWS :
          - with net peering  sle-15-SP4-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_4_BYOS-qesap_azure_ibsmirror_peering_test -> http://openqaworker15.qa.suse.cz/tests/217059
          - catalog images sle-15-SP4-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_4_BYOS-qesap_azure_sapconf_test -> http://openqaworker15.qa.suse.cz/tests/217060
