### PR TITLE
Handling Inaccessible NVIDIA Repository during Unified Guest Installation

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -774,8 +774,9 @@ sub setup_rsyslog_host {
     $log_host_protocol //= 'udp';
     $log_host_port //= '514';
 
+    # Add --gpg-auto-import-keys to zypper_call("in rsyslog")
     zypper_call("--gpg-auto-import-keys ref");
-    zypper_call("in rsyslog");
+    zypper_call("--gpg-auto-import-keys in rsyslog");
     assert_script_run("mkdir -p $log_host_folder");
     my $log_host_protocol_directive = ($log_host_protocol eq 'udp' ? '\$UDPServerRun' : '\$InputTCPServerRun');
     if (script_output("cat /etc/rsyslog.conf | grep \"#Setup centralized rsyslog host\"", proceed_on_failure => 1) eq '') {


### PR DESCRIPTION
Description:
-- Handling Inaccessible NVIDIA Repository during Unified Guest Installation for Virtualization
-- This PR addresses an issue with repository refresh and GPG key trust logic for the NVIDIA repository which is not accessible.

The following is done:
-- Open a bug to report Nvidia repo is inaccessible for OpenSUSE Tumbleweed: [BUGZILLA](https://bugzilla.suse.com/show_bug.cgi?id=1214592)
-- By adding zypper in with "--import...key" option works and this fixes the Nvidia repo issue.

- Related ticket: https://progress.opensuse.org/issues/134333
- Verification run: [KVM_rebel6](https://openqa.opensuse.org/tests/3536968) , [KVM_rebel5](https://openqa.opensuse.org/tests/3536704) and [XEN_rebel6](https://openqa.opensuse.org/tests/3537217#comments)

Small change, Welcome review!! Thanks :) 
@Julie-CAO @guoxuguang @waynechen55 @alice-suse @RoyCai7 @tonyyuan1 @tbaev 