### PR TITLE
Add testuite for suseconnect test

### DIFF
--- a/schedule/qam/common/mau-registration-stack.yaml
+++ b/schedule/qam/common/mau-registration-stack.yaml
@@ -1,0 +1,10 @@
+---
+name: registration_stack
+description: suseconnect
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - console/suseconnect
+...

--- a/tests/console/suseconnect.pm
+++ b/tests/console/suseconnect.pm
@@ -49,4 +49,8 @@ sub run {
 
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Introduce suseconnect test in a new testsuite in SLE 15-SP4 and 15-SP5
MR:  https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/586

- Related ticket:  https://progress.opensuse.org/issues/129205
- Needles: No
- Verification run:  
