### PR TITLE
Unschedule gpg for all arch and all SLE versions for QE-Core

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -10,7 +10,6 @@ schedule:
   - console/wget_ipv6
   - console/ca_certificates_mozilla
   - console/unzip
-  - console/gpg
   - console/rsync
   - console/shells
   - console/sudo


### PR DESCRIPTION
https://progress.opensuse.org/issues/134591

VR: N/A

We are safe to remove this single test module