### PR TITLE
pc: Fix newline issue with transfer_repos

### DIFF
--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -50,9 +50,9 @@ sub run {
         s/https?:\/\/// for @repos;
 
         # Create list of directories for rsync
-        my $directories;
-        $directories .= "$_\n" foreach @repos;
-        assert_script_run("echo -en '$directories' | tee /tmp/transfer_repos.txt");
+        foreach my $repo (@repos) {
+            assert_script_run("echo $repo | tee -a /tmp/transfer_repos.txt");
+        }
 
         # Mitigate occasional CSP network problems (especially one CSP is prone to those issues!)
         # Delay of 2 minutes between the tries to give their network some time to recover after a failure


### PR DESCRIPTION
Fix newline issue with transfer_repos

- Related ticket: https://progress.opensuse.org/issues/134597
- Failing job: https://openqa.suse.de/tests/11904992#step/transfer_repos/333
- Verification run: sle-15-SP4-AZURE-BYOS-Updates-x86_64-Build20230823-1-publiccloud_ahb@64bit -> https://openqa.suse.de/t11911831