### PR TITLE
Fix multiline commands in saltbase, wireguard and vnc_two_passwords

### DIFF
--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -54,7 +54,7 @@ sub minion_prepare {
     assert_script_run("grep 'master:\\\|ipv6:\\\|log_' /etc/salt/minion");
 
     assert_script_run("grep -B9 -A9 'disable_modules' /etc/salt/minion");
-    assert_script_run("echo -en 'disable_modules:\n  - boto3_elasticsearch\n' >> /etc/salt/minion");
+    assert_script_run('echo -en "disable_modules:\n  - boto3_elasticsearch\n" >> /etc/salt/minion');
     assert_script_run("grep -B9 -A9 'disable_modules' /etc/salt/minion");
     upload_logs '/etc/salt/minion';
 

--- a/tests/network/wireguard.pm
+++ b/tests/network/wireguard.pm
@@ -121,7 +121,7 @@ sub run {
         assert_script_run('ip a && ip r');
         exec_and_insert_password("scp -o StrictHostKeyChecking=no server.pub client* $remote:/etc/wireguard/");
         # Prepare configuration script
-        assert_script_run('echo -e "[Interface]\nPrivateKey = `cat /etc/wireguard/server`\nAddress = ' . "$vpn_local\n" . 'ListenPort = 51820\n" > /etc/wireguard/wg0.conf');
+        assert_script_run('echo -e "[Interface]\nPrivateKey = `cat /etc/wireguard/server`\nAddress = ' . $vpn_local . '\nListenPort = 51820\n" > /etc/wireguard/wg0.conf');
         assert_script_run('echo -e "[Peer]\nPublicKey = `cat /etc/wireguard/client1.pub`\nAllowedIPs = 192.168.2.2\nPersistentKeepalive = 25\n" >> /etc/wireguard/wg0.conf');
         assert_script_run('echo -e "[Peer]\nPublicKey = `cat /etc/wireguard/client2.pub`\nAllowedIPs = 192.168.2.3\nPersistentKeepalive = 25\n" >> /etc/wireguard/wg0.conf');
         script_run('cat /etc/wireguard/wg0.conf');

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -107,9 +107,9 @@ sub configure_vnc_server {
     # Config done following this guide:
     # https://github.com/TigerVNC/tigervnc/blob/master/unix/vncserver/HOWTO.md
     #   1. Add a user mapping
-    assert_script_run("echo -e \'$display=root\n\' >> /etc/tigervnc/vncserver.users");
+    assert_script_run("echo -e \"$display=root\\n\" >> /etc/tigervnc/vncserver.users");
     #   2. Configure Xvnc options
-    assert_script_run("echo -e \'session=gnome\ngeometry=1024x768\ndepth=16\' >> /etc/tigervnc/vncserver-config-defaults");
+    assert_script_run('echo -e "session=gnome\ngeometry=1024x768\ndepth=16" >> /etc/tigervnc/vncserver-config-defaults');
     #   3. Set VNC password
     #     Already created in start_vnc_server()
     #   4. Start the TigerVNC server


### PR DESCRIPTION
Trivial replacement of newlines in `script_run()` commands with escape sequences which will be interpreted by the shell instead.

- Related ticket: N/A
- Needles: N/A
- Verification runs: 
  - salt_minion: https://openqa.opensuse.org/tests/3528834
  - wireguard: https://openqa.opensuse.org/tests/3528836
  - vnc_two_passwords: https://openqa.opensuse.org/tests/3528837