### PR TITLE
Update autoyast profile of eula.xml to resolve module dependent issues

### DIFF
--- a/data/yam/autoyast/eula.xml
+++ b/data/yam/autoyast/eula.xml
@@ -12,8 +12,21 @@
             <timeout config:type="integer">-1</timeout>
         </global>
     </bootloader>
+    <suse_register>
+        <do_registration config:type="boolean">false</do_registration>
+    </suse_register>
     <add-on>
         <add_on_products config:type="list">
+             <listentry>
+                <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
+                <product>sle-module-server-applications</product>
+                <product_dir>/Module-Server-Applications</product_dir>
+             </listentry>
+             <listentry>
+                <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
+                <product>sle-module-desktop-applications</product>
+                <product_dir>/Module-Desktop-Applications</product_dir>
+             </listentry>
              <listentry>
                 <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
                 <product>sle-module-basesystem</product>


### PR DESCRIPTION
- Description: Update autoyast profile of data/yam/autoyast/eula.xml to resolve module dependent issues
- Related ticket: https://progress.opensuse.org/issues/134105
- Verification run: [Flavor full](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=manfredi%2Fos-autoinst-distri-opensuse%23issues-134105)
