### PR TITLE
Ansible deployment state

### DIFF
--- a/lib/mr_test_lib.pm
+++ b/lib/mr_test_lib.pm
@@ -65,8 +65,10 @@ sub load_mr_tests {
     #   [debug] ||| finished ssh_interactive_end publiccloud
     #   [debug] ||| starting 1_saptune_notes .../mr_test_run.pm
     #   [debug] ||| finished 1_saptune_notes lib
-    loadtest_mr_test('tests/publiccloud/ssh_interactive_end', run_args => $args) if get_var('PUBLIC_CLOUD_SLES4SAP');
-    loadtest_mr_test('tests/sles4sap/publiccloud/peering_destroy', run_args => $args) if get_var('IS_MAINTENANCE');
+    if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
+        loadtest_mr_test('tests/publiccloud/ssh_interactive_end', run_args => $args);
+        loadtest_mr_test('tests/sles4sap/publiccloud/qesap_cleanup', run_args => $args);
+    }
 }
 
 1;

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -50,6 +50,8 @@ our @EXPORT = qw(
   create_instance_data
   deployment_name
   delete_network_peering
+  create_playbook_section_list
+  create_hana_vars_section
 );
 
 =head2 run_cmd
@@ -606,6 +608,60 @@ sub delete_network_peering {
     elsif (is_ec2) {
         qesap_aws_delete_transit_gateway_vpc_attachment(name => deployment_name() . '*');
     }
+}
+
+=head2 create_ansible_playbook_list
+
+    Detects HANA/HA scenario from openQA variables and returns a list of ansible playbooks to include
+    in the "ansible: create:" section of config.yaml file.
+
+=cut
+
+sub create_playbook_section_list {
+    my ($ha_enabled) = @_;
+    my @playbook_list;
+
+    # Add registration module as first element - "QESAP_SCC_NO_REGISTER" skips scc registration via ansible
+    push @playbook_list, 'registration.yaml -e reg_code=' . get_required_var('SCC_REGCODE_SLES4SAP') . " -e email_address=''"
+      unless (get_var('QESAP_SCC_NO_REGISTER'));
+
+    # SLES4SAP/HA related playbooks
+    if ($ha_enabled) {
+        push @playbook_list, 'pre-cluster.yaml', 'sap-hana-preconfigure.yaml -e use_sapconf=' . get_required_var('USE_SAPCONF');
+        push @playbook_list, 'cluster_sbd_prep.yaml' if (check_var('FENCING_MECHANISM', 'sbd'));
+        push @playbook_list, qw(
+          sap-hana-storage.yaml
+          sap-hana-download-media.yaml
+          sap-hana-install.yaml
+          sap-hana-system-replication.yaml
+          sap-hana-system-replication-hooks.yaml
+          sap-hana-cluster.yaml
+        );
+    }
+    return (\@playbook_list);
+}
+
+=head2 create_hana_vars_section
+
+    Detects HANA/HA scenario from openQA variables and creates "terraform: variables:" section in config.yaml file.
+
+=cut
+
+sub create_hana_vars_section {
+    my ($ha_enabled) = @_;
+    # Cluster related setup
+    my %hana_vars;
+    if ($ha_enabled == 1) {
+        $hana_vars{sap_hana_install_software_directory} = get_required_var('HANA_MEDIA');
+        $hana_vars{sap_hana_install_master_password} = get_required_var('_HANA_MASTER_PW');
+        $hana_vars{sap_hana_install_sid} = get_required_var('INSTANCE_SID');
+        $hana_vars{sap_hana_install_instance_number} = get_required_var('INSTANCE_ID');
+        $hana_vars{sap_domain} = get_var('SAP_DOMAIN', 'qesap.example.com');
+        $hana_vars{primary_site} = get_var('HANA_PRIMARY_SITE', 'site_a');
+        $hana_vars{secondary_site} = get_var('HANA_SECONDARY_SITE', 'site_b');
+        set_var('SAP_SIDADM', lc(get_var('INSTANCE_SID') . 'adm'));
+    }
+    return (\%hana_vars);
 }
 
 1;

--- a/tests/sles4sap/publiccloud/add_server_to_hosts.pm
+++ b/tests/sles4sap/publiccloud/add_server_to_hosts.pm
@@ -15,11 +15,9 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    my $instances = $run_args->{instances};
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
-    record_info('CONTEXT LOG', "instances:$instances network_peering_present:$self->{network_peering_present}");
+    $self->import_context($run_args);
 
-    foreach my $instance (@{$instances}) {
+    foreach my $instance (@{$self->{instances}}) {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
         record_info("$instance");
 

--- a/tests/sles4sap/publiccloud/check_ibsm_embargoed.pm
+++ b/tests/sles4sap/publiccloud/check_ibsm_embargoed.pm
@@ -16,9 +16,8 @@ sub test_flags {
 
 sub run() {
     my ($self, $run_args) = @_;
+    $self->import_context($run_args);
     my $instance = $run_args->{my_instance};
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
-    record_info('CONTEXT LOG', "instance:$instance network_peering_present:$self->{network_peering_present}");
 
     my @repos = split(/,/, get_var('INCIDENT_REPO'));
     my $count = 0;

--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -13,27 +13,24 @@ sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
 }
 
-sub run() {
+sub run {
     my ($self, $run_args) = @_;
-    my $instance = $run_args->{my_instance};
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
-    record_info('CONTEXT LOG', "instance:$instance network_peering_present:$self->{network_peering_present}");
+    $self->import_context($run_args);
 
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) if get_var('INCIDENT_REPO');
-    my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
     my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
     my $count = 0;
 
     while (defined(my $maintrepo = shift @repos)) {
         next if $maintrepo =~ /^\s*$/;
-        foreach my $instance (@{$run_args->{instances}}) {
+        foreach my $instance (@{$self->{instances}}) {
             next if ($instance->{'instance_id'} !~ m/vmhana/);
             $instance->run_ssh_command(cmd => "sudo zypper --no-gpg-checks ar -f -n TEST_$count $maintrepo TEST_$count",
                 username => 'cloudadmin');
         }
         $count++;
     }
-    foreach my $instance (@{$run_args->{instances}}) {
+    foreach my $instance (@{$self->{instances}}) {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
         $instance->run_ssh_command(cmd => 'sudo zypper -n ref', username => 'cloudadmin', timeout => 1500);
     }

--- a/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
+++ b/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
@@ -15,7 +15,7 @@ use testapi;
 use registration;
 use utils;
 use publiccloud::ssh_interactive qw(select_host_console);
-use publiccloud::utils qw(kill_packagekit);
+use publiccloud::utils qw(kill_packagekit is_azure);
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
@@ -23,17 +23,17 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+    $self->import_context($run_args);
     select_host_console();    # select console on the host, not the PC instance
 
-    foreach my $instance (@{$run_args->{instances}}) {
+    foreach my $instance (@{$self->{instances}}) {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
         record_info("$instance");
 
         my $remote = '-o ControlMaster=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ' . $instance->username . '@' . $instance->public_ip;
 
         my $cmd_time = time();
-        my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;
+        my $ref_timeout = is_azure ? 3600 : 240;
         kill_packagekit($instance);
         $instance->ssh_script_retry("sudo zypper -n --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
         record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_cleanup.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_cleanup.pm
@@ -10,8 +10,8 @@ package hana_sr_schedule_cleanup;
 use strict;
 use warnings FATAL => 'all';
 use base 'sles4sap_publiccloud_basetest';
-use main_common 'loadtest';
 use testapi;
+use main_common 'loadtest';
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
@@ -19,9 +19,16 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
 
     record_info("Schedule", "Schedule cleanup job");
+    # A test module only to schedule another test module
+    # It is needed to be sure that qesap_cleanup is executed as last test step
+    # Direct schedule of qesap_cleanup is not possible
+    # due to the fact that hana_sr_schedule_cleanup is scheduled
+    # with other test modules that are also using loadtest
     loadtest('sles4sap/publiccloud/qesap_cleanup', name => "Cleanup resources", run_args => $run_args, @_);
 }
 

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -10,8 +10,8 @@ package hana_sr_schedule_deployment;
 use strict;
 use warnings FATAL => 'all';
 use base 'sles4sap_publiccloud_basetest';
-use main_common 'loadtest';
 use testapi;
+use main_common 'loadtest';
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
@@ -19,7 +19,9 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
 
     if (get_var('QESAP_DEPLOYMENT_IMPORT')) {
         loadtest('sles4sap/publiccloud/qesap_reuse_infra', name => 'prepare_existing_infrastructure', run_args => $run_args, @_);

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
@@ -13,8 +13,8 @@ package hana_sr_schedule_primary_tests;
 use strict;
 use warnings FATAL => 'all';
 use base 'sles4sap_publiccloud_basetest';
-use main_common 'loadtest';
 use testapi;
+use main_common 'loadtest';
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
@@ -22,7 +22,9 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
 
     record_info("Schedule", "Executing tests on master Hana DB");
     # 'HANASR_PRIMARY_ACTIONS' - define to override test flow

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_replica_tests.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_replica_tests.pm
@@ -13,8 +13,8 @@ package hana_sr_schedule_replica_tests;
 use strict;
 use warnings FATAL => 'all';
 use base 'sles4sap_publiccloud_basetest';
-use main_common 'loadtest';
 use testapi;
+use main_common 'loadtest';
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
@@ -22,7 +22,9 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
 
     record_info("Schedule", "Executing tests on secondary site (replica)");
     # 'HANASR_SECONDARY_ACTIONS' - define to override test flow

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -9,8 +9,8 @@ use strict;
 use warnings FATAL => 'all';
 use base 'sles4sap_publiccloud_basetest';
 use testapi;
-use publiccloud::utils;
 use sles4sap_publiccloud;
+use publiccloud::utils;
 use serial_terminal 'select_serial_terminal';
 
 sub test_flags {
@@ -19,8 +19,9 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
-    $self->{instances} = $run_args->{instances};
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
 
     select_serial_terminal;
     my $test_name = $self->{name};

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -12,8 +12,8 @@
 use strict;
 use warnings FATAL => 'all';
 use base 'sles4sap_publiccloud_basetest';
-use sles4sap_publiccloud;
 use testapi;
+use sles4sap_publiccloud;
 use serial_terminal 'select_serial_terminal';
 use Time::HiRes 'sleep';
 
@@ -23,8 +23,9 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
-    $self->{instances} = $run_args->{instances};
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
     croak('site_b is missing or undefined in run_args') if (!$run_args->{site_b});
 
     my $hana_start_timeout = bmwqemu::scale_timeout(600);

--- a/tests/sles4sap/publiccloud/mr_test_setup_env.pm
+++ b/tests/sles4sap/publiccloud/mr_test_setup_env.pm
@@ -10,10 +10,8 @@
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use publiccloud::ssh_interactive qw(select_host_console);
-use testapi;
-use Mojo::File 'path';
 use publiccloud::utils;
-use Data::Dumper;
+use testapi;
 
 sub test_flags {
     return {
@@ -25,8 +23,22 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
     my $mr_test_tar = 'mr_test-master.tar.gz';
     my $instance = $run_args->{my_instance};
+
+    # This test module is using publiccloud::basetest and not sles4sap_publiccloud_basetest
+    # as base class. network_peering_present and ansible_present are propagated here
+    # to a different context than usual
+    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+    $self->{ansible_present} = 1 if ($run_args->{ansible_present});
+    record_info('MR_TEST CONTEXT', join(' ',
+            'cleanup_called:', $self->{cleanup_called} // 'undefined',
+            'instance:', $instance // 'undefined',
+            'network_peering_present:', $self->{network_peering_present} // 'undefined',
+            'ansible_present:', $self->{ansible_present} // 'undefined')
+    );
 
     # Select console on the host, not the PC instance
     select_host_console();

--- a/tests/sles4sap/publiccloud/network_peering.pm
+++ b/tests/sles4sap/publiccloud/network_peering.pm
@@ -11,11 +11,15 @@ use testapi;
 use qesapdeployment;
 use publiccloud::utils qw(is_azure is_ec2);
 
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
-    my $instance = $run_args->{my_instance};
-    record_info('CONTEXT LOG', "instance:$instance network_peering_present:$self->{network_peering_present}");
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
 
     die 'Network peering already in place' if ($self->{network_peering_present});
     my $ibs_mirror_resource_group = get_required_var('IBSM_RG');
@@ -28,10 +32,6 @@ sub run {
         die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
     }
     $run_args->{network_peering_present} = $self->{network_peering_present} = 1;
-}
-
-sub test_flags {
-    return {fatal => 1, publiccloud_multi_module => 1};
 }
 
 1;

--- a/tests/sles4sap/publiccloud/peering_destroy.pm
+++ b/tests/sles4sap/publiccloud/peering_destroy.pm
@@ -11,8 +11,8 @@ use sles4sap_publiccloud;
 
 sub run {
     my ($self, $run_args) = @_;
-    if ($run_args->{network_peering_present}) {
-        $self->{network_peering_present} = 1;
+    $self->import_context($run_args);
+    if ($self->{network_peering_present}) {
         delete_network_peering();
         $run_args->{network_peering_present} = $self->{network_peering_present} = 0;
     }

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -22,11 +22,16 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
-    my $instances = $run_args->{instances};
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
 
     my $ha_enabled = get_required_var('HA_CLUSTER') =~ /false|0/i ? 0 : 1;
     select_serial_terminal;
+    # mark as done in advance and also in case of
+    # QESAP_DEPLOYMENT_IMPORT as the status flag is mostly
+    # used to decide if to call the cleanup
+    $run_args->{ansible_present} = $self->{ansible_present} = 1;
     # skip ansible deployment in case of reusing infrastructure
     unless (get_var('QESAP_DEPLOYMENT_IMPORT')) {
         my @ret = qesap_execute(cmd => 'ansible', timeout => 3600, verbose => 1);
@@ -43,7 +48,7 @@ sub run {
     }
 
     # Check connectivity to all instances and status of the cluster in case of HA deployment
-    foreach my $instance (@$instances) {
+    foreach my $instance (@{$self->{instances}}) {
         $self->{my_instance} = $instance;
         my $instance_id = $instance->{'instance_id'};
         # Check ssh connection for all hosts
@@ -60,7 +65,8 @@ sub run {
 
         # Define initial state for both sites
         # Site A is always PROMOTED (Master node) after deployment
-        my $resource_output = $self->run_cmd(cmd => "crm status full", quiet => 1); record_info("crm out", $resource_output);
+        my $resource_output = $self->run_cmd(cmd => "crm status full", quiet => 1);
+        record_info("crm out", $resource_output);
         my $master_node = $self->get_promoted_hostname();
         $run_args->{site_a} = $instance if ($instance_id eq $master_node);
         $run_args->{site_b} = $instance if ($instance_id ne $master_node);

--- a/tests/sles4sap/publiccloud/qesap_cleanup.pm
+++ b/tests/sles4sap/publiccloud/qesap_cleanup.pm
@@ -3,7 +3,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Cleanup test meant to be used with multimodule setup with qe-sap-deployment project.
+# Summary: Cleanup cloud resources meant to be used with multimodule setup with qe-sap-deployment project.
 # https://github.com/SUSE/qe-sap-deployment
 
 use base 'sles4sap_publiccloud_basetest';
@@ -14,15 +14,17 @@ use testapi;
 
 sub run {
     my ($self, $run_args) = @_;
-    $self->{network_peering_present} = 1 if ($run_args->{network_peering_present});
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
+
     if (get_var('QESAP_NO_CLEANUP')) {
-        delete_network_peering() if ($run_args->{network_peering_present});
         record_info('SKIP CLEANUP',
             "Variable 'QESAP_NO_CLEANUP' set to value " . get_var('QESAP_NO_CLEANUP'));
         return 1;
     }
     $self->cleanup($run_args);
-    $run_args->{network_peering_present} = $self->{network_peering_present} = 0;
+    $run_args->{network_peering_present} = $self->{network_peering_present};
+    $run_args->{ansible_present} = $self->{ansible_present};
 }
 
 1;


### PR DESCRIPTION
Create flag in the base class to record if Ansible has been executed or not and only to call Ansible deregister when needed. mr_test schedule to use qesap_cleanup in place of peering_destroy Both peering_destroy and qesap_cleanup are doing exactly the same from the point of view of the network peering to the IBSm. qesap_cleanup has cluster destruction after that.

- Related ticket: [TEAM-8153](https://jira.suse.com/browse/TEAM-8153)

- Verification run: 

    - sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-08-24T04:03:11Z-hanasr_azure_test_sapconf@64bit -> http://openqaworker15.qa.suse.cz/tests/219884 . Here after the `qesap_ansible` test module execution  http://openqaworker15.qa.suse.cz/tests/219884#step/Stop_site_a-primary/1 you can see `network_peering_present: undefined ansible_present: 1`

    - sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-08-24T04:03:11Z-hanasr_azure_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/219883 with an example of final cleanup http://openqaworker15.qa.suse.cz/tests/219883#step/Cleanup%20resources/2

    - sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2023-08-24T04:03:11Z-hanasr_aws_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/219882 here with an example of failure http://openqaworker15.qa.suse.cz/tests/219882#step/Crash_site_a-primary/165

    - sle-15-SP5-Azure-SAP-BYOS-x86_64-Buildmpagot_VR-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/234036