### PR TITLE
Fix multiline commands in aa_easyprof, rsync_server, tomcat and tpm2_env_setup

### DIFF
--- a/data/console/rsyncd.conf
+++ b/data/console/rsyncd.conf
@@ -1,0 +1,14 @@
+max connections = 2
+log file = /var/log/rsync.log
+timeout = 300
+
+[pub]
+     comment = Testing files available for download
+     read only = yes
+     list = yes
+     path = /srv/rsync_test/pub
+     uid = nobody
+     gid = nobody
+     auth users = test42
+     secrets file = /etc/rsyncd.secrets
+

--- a/data/lib/tomcat/tomcat-users.xml
+++ b/data/lib/tomcat/tomcat-users.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+<role rolename="manager-gui"/>
+<user name="admin" password="admin" roles="manager-gui,tomcat"/>
+</tomcat-users>

--- a/data/security/tpm2/emulator.conf
+++ b/data/security/tpm2/emulator.conf
@@ -1,0 +1,6 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/tpm2-abrmd --tcti=libtss2-tcti-mssim.so
+
+[Unit]
+ConditionPathExistsGlob=

--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -35,17 +35,6 @@ sub browse_with_keyboard {
 
 # Install tomcat and set initial configuration
 sub tomcat_setup() {
-    my $tomcat_users_xml = <<'EOF';
-<?xml version="1.0" encoding="UTF-8"?>
-<tomcat-users xmlns="http://tomcat.apache.org/xml"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
-              version="1.0">
-<role rolename="manager-gui"/>
-<user name="admin" password="admin" roles="manager-gui,tomcat"/>
-</tomcat-users>
-EOF
-
     # log in to root console
     select_console('root-console');
 
@@ -64,7 +53,8 @@ EOF
     assert_script_run('lsof -i :8080 | grep tomcat');
 
     # create manager-gui role
-    assert_script_run("echo '$tomcat_users_xml' > /etc/tomcat/tomcat-users.xml");
+    assert_script_run('curl -v -o /etc/tomcat/tomcat-users.xml ' .
+          data_url('lib/tomcat/tomcat-users.xml'));
 
     # restart tomcat in order to take into account new role
     systemctl('restart tomcat');

--- a/tests/console/rsync_server.pm
+++ b/tests/console/rsync_server.pm
@@ -27,24 +27,7 @@ sub run {
     select_console 'root-console';
 
     #preparation of rsync config files
-    script_run 'cat > /etc/rsyncd.conf <<EOF
-max connections = 2
-log file = /var/log/rsync.log
-timeout = 300
-
-[pub]
-     comment = Testing files available for download
-     read only = yes
-     list = yes
-     path = /srv/rsync_test/pub
-     uid = nobody
-     gid = nobody
-     auth users = test42
-     secrets file = /etc/rsyncd.secrets
-
-EOF
-true';
-
+    assert_script_run('curl -v -o /etc/rsyncd.conf ' . data_url('console/rsyncd.conf'));
     assert_script_run 'echo "test42:424242" > /etc/rsyncd.secrets';
 
     if (is_sle('<12-sp5')) {    #using xinetd on sle 12

--- a/tests/security/apparmor/aa_easyprof.pm
+++ b/tests/security/apparmor/aa_easyprof.pm
@@ -24,18 +24,19 @@ sub run {
     my $output_result = "/tmp/output";
     my $output_json = "/tmp/manifest.json";
 
-    my $easyprof_cmd = "aa-easyprof \\
---template=user-application \\
---policy-groups=opt-application,user-application \\
---abstractions=\"python,audio\" \\
---read-path=\"/usr/share/foo/*\" \\
---write-path=\"/opt/foo/tmp/\" \\
---write-path=\"/opt/foo/log/\" \\
---template-var=\"\@{APPNAME}=foo\" \\
---author=\"SUSE Tester\" \\
---copyright=\"Copyright 2018, SUSE Tester\" \\
---comment=\"AppArmor is easy with aa-easyprof\" \\
+    my $easyprof_cmd = "aa-easyprof
+--template=user-application
+--policy-groups=opt-application,user-application
+--abstractions=\"python,audio\"
+--read-path=\"/usr/share/foo/*\"
+--write-path=\"/opt/foo/tmp/\"
+--write-path=\"/opt/foo/log/\"
+--template-var=\"\@{APPNAME}=foo\"
+--author=\"SUSE Tester\"
+--copyright=\"Copyright 2018, SUSE Tester\"
+--comment=\"AppArmor is easy with aa-easyprof\"
 /usr/bin/foo ";
+    $easyprof_cmd =~ s/\n/ /g;
 
     my $easyprof_args_json = "--output-format=json ";
 

--- a/tests/security/tpm2/tpm2_env_setup.pm
+++ b/tests/security/tpm2/tpm2_env_setup.pm
@@ -53,17 +53,7 @@ sub run {
     # and make it connect to "--tcti=libtss2-tcti-mssim.so"
     if (get_var('QEMUTPM', '') ne 'instance' || get_var('QEMUTPM_VER', '') ne '2.0') {
         assert_script_run("mkdir /etc/systemd/system/tpm2-abrmd.service.d");
-        assert_script_run(
-            "echo \"\$(cat <<EOF
-[Service]
-ExecStart=
-ExecStart=/usr/sbin/tpm2-abrmd --tcti=libtss2-tcti-mssim.so
-
-[Unit]
-ConditionPathExistsGlob=
-EOF
-            )\" > /etc/systemd/system/tpm2-abrmd.service.d/emulator.conf"
-        );
+        assert_script_run('curl -v -o /etc/systemd/system/tpm2-abrmd.service.d/emulator.conf ' . data_url('security/tpm2/emulator.conf'));
         assert_script_run("systemctl daemon-reload");
 
         # Start the emulator


### PR DESCRIPTION
Move test config files into the data directory to avoid running multiline commands with `script_run` just to create a static text file.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
  - aa_easyprof: https://openqa.opensuse.org/tests/3528949
  - rsync_server: https://openqa.opensuse.org/tests/3528950
  - tomcat: https://openqa.opensuse.org/tests/3528952
  - tpm2_env_setup: https://openqa.opensuse.org/tests/3528953
