### PR TITLE
Remove multiline scripts

### DIFF
--- a/tests/fips/gnutls/gnutls_server.pm
+++ b/tests/fips/gnutls/gnutls_server.pm
@@ -39,7 +39,8 @@ ca
 cert_signing_key
 EOF
     assert_script_run "certtool --generate-privkey > $pri_ca_key";
-    assert_script_run "echo '$ca_tmpl_cont' > $ca_tmpl";
+    $ca_tmpl_cont =~ s/\n/\\n/g;
+    assert_script_run "echo -e '$ca_tmpl_cont' > $ca_tmpl";
     assert_script_run "certtool --generate-self-signed --load-privkey $pri_ca_key --template $ca_tmpl --outfile $pri_ca_out";
 
     # Generate a server certificate
@@ -55,7 +56,8 @@ signing_key
 dns_name = test.gnutls.org
 EOF
     assert_script_run "certtool --generate-privkey > $ser_pri_key";
-    assert_script_run "echo '$ser_tmpl_cont' > $ser_tmpl";
+    $ser_tmpl_cont =~ s/\n/\\n/g;
+    assert_script_run "echo -e '$ser_tmpl_cont' > $ser_tmpl";
     assert_script_run
 "certtool --generate-certificate --load-privkey $ser_pri_key --load-ca-certificate $pri_ca_out --load-ca-privkey $pri_ca_key --template $ser_tmpl --outfile $ser_ca_out";
 
@@ -70,7 +72,8 @@ encryption_key
 signing_key
 EOF
     assert_script_run "certtool --generate-privkey > $cli_pri_key";
-    assert_script_run "echo '$cli_tmpl_cont' > $cli_tmpl";
+    $cli_tmpl_cont =~ s/\n/\\n/g;
+    assert_script_run "echo -e '$cli_tmpl_cont' > $cli_tmpl";
     assert_script_run
 "certtool --generate-certificate --load-privkey $cli_pri_key --load-ca-certificate $pri_ca_out --load-ca-privkey $pri_ca_key --template $cli_tmpl --outfile $cli_out";
 


### PR DESCRIPTION
Replace newlines with escaped newlines to avoid multiline scripts in openQA.

- Verification runs: [s390x](https://openqa.suse.de/tests/11913033) | [aarch64](https://openqa.suse.de/tests/11913035) | [x86_64](https://duck-norris.qe.suse.de/tests/13486)
