### PR TITLE
Add a new test to select installation device

### DIFF
--- a/schedule/yam/agama/agama_install_on_second_disk.yaml
+++ b/schedule/yam/agama/agama_install_on_second_disk.yaml
@@ -1,0 +1,17 @@
+---
+name: agama_install_on_second_disk.yaml
+description: >
+  Playwright test: Install system on second disk using Agama.
+schedule:
+  - installation/bootloader_start
+  - yam/agama/patch_agama
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_first_disk_selection
+test_data:
+  guided_partitioning:
+    disks:
+      - vdb
+  unused_disks:
+    - vda


### PR DESCRIPTION
See https://progress.opensuse.org/issues/133073

Agama allows to choose between several installation devices (disks) so we want to test it. Related to https://github.com/jknphy/e2e-agama-playwright/pull/19

VR 
staging https://openqa.opensuse.org/tests/overview?version=agama-3.0-staging&build=JRivrain%2Fos-autoinst-distri-opensuse%2317660&distri=alp

Fails in devel because of recent UI changes. It is necessary to assert that the disk size is detected, as otherwise fails in next step because the locator then says "no devices detected" unless we refresh the page. I included those VRs anyway.
devel https://openqa.opensuse.org/tests/overview?version=agama-3.0-devel&distri=alp&build=JRivrain%2Fos-autoinst-distri-opensuse%2317660
