### PR TITLE
New test for checking systemd in WSL

### DIFF
--- a/schedule/wsl/wsl_main.yaml
+++ b/schedule/wsl/wsl_main.yaml
@@ -1,5 +1,5 @@
 ---
-name:         wsl_main.yaml
+name: wsl_main.yaml
 description:  >
       WSL smoke test on Windows 10 image
 
@@ -10,9 +10,14 @@ conditional_schedule:
         - wsl/install_from_MSStore
       'build':
         - wsl/prepare_wsl_feature
+  enable_systemd:
+    WSL_SYSTEMD:
+      '1':
+        - wsl/enable_systemd
 
 schedule:
   - wsl/boot_windows
   - '{{install_WSL}}'
   - wsl/firstrun
+  - '{{enable_systemd}}'
   - wsl/wsl_cmd_check

--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -1,0 +1,21 @@
+# SUSE's openQA tests
+#
+# Copyright 2012-2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Configure WSL users
+# Maintainer: qa-c  <qa-c@suse.de>
+
+use Mojo::Base qw(windowsbasetest);
+use testapi;
+use utils qw(enter_cmd_slow);
+
+sub run {
+    my $self = shift;
+
+    $self->open_powershell_as_admin();
+    $self->run_in_powershell(cmd => q(wsl /bin/bash -c "echo -e '[boot]\nsystemd=true' > /etc/wsl.conf"), timeout => 60);
+    $self->run_in_powershell(cmd => q(wsl --shutdown));
+    $self->run_in_powershell(cmd => q(wsl -c systemctl list-unit-files --type=service));
+    $self->run_in_powershell(cmd => q(wsl -c shutdown -h now));
+}


### PR DESCRIPTION
WSL now supports systemd, so there's need to check that we can enable and test it

- Related ticket: https://progress.opensuse.org/issues/133691
- Needles: *none*
- Verification run: *in_progress*
