### PR TITLE
Assert tag 'grub2-agama' to avoid can't match in short time

### DIFF
--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -11,6 +11,7 @@ use warnings;
 
 use testapi qw(
   assert_script_run
+  assert_screen
   get_required_var
   enter_cmd
 );
@@ -20,6 +21,12 @@ sub run {
 
     assert_script_run("playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright tests/" . $test . ".spec.ts", timeout => 1200);
     enter_cmd 'reboot';
+}
+
+sub post_run_hook {
+    my ($self) = shift;
+    assert_screen([qw(grub2-agama encrypted-disk-password-prompt)], 120);
+    $self->SUPER::post_run_hook;
 }
 
 1;


### PR DESCRIPTION
Assert tag 'grub2-agama' to avoid can't match in short time.

- Related ticket: N/A
- Needles: N/A
- Verification run:  https://openqa.opensuse.org/tests/3531888#details       domolite_lvm          
                                 https://openqa.opensuse.org/tests/3531889#step/agama/3     full_encryption
