### PR TITLE
Check status of Linux Security Modules for respective products as a basic validation for installations

### DIFF
--- a/schedule/yam/agama_auto_tumbleweed.yaml
+++ b/schedule/yam/agama_auto_tumbleweed.yaml
@@ -1,5 +1,5 @@
 ---
-name: agama_auto
+name: agama_auto_tumbleweed
 description: >
   Prepare url for agama.auto boot parameter, boot, perform auto-installation with agama.
 schedule:
@@ -7,4 +7,4 @@ schedule:
   - yam/agama/auto
   - yam/validate/validate_product
   - yam/validate/validate_user
-  - security/selinux/sestatus
+  - yam/validate/validate_apparmor

--- a/tests/yam/validate/validate_apparmor.pm
+++ b/tests/yam/validate/validate_apparmor.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate apparmor status after agama installation.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi qw(select_console);
+use services::apparmor;
+
+sub run {
+    select_console 'root-console';
+
+    services::apparmor::check_service();
+    services::apparmor::check_aa_status();
+}
+
+1;


### PR DESCRIPTION
Utilize tests/security/selinux/sestatus.pm to check selinux in test suite agama_auto_dolomite.
Utilize tests/security/apparmor/aa_status.pm to check apparmor in test suite agama_auto_tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/133046
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3445906#
                                https://openqa.opensuse.org/tests/3531862#
