### PR TITLE
New test for checking systemd in WSL

### DIFF
--- a/schedule/wsl/wsl_main.yaml
+++ b/schedule/wsl/wsl_main.yaml
@@ -1,11 +1,18 @@
 ---
-name:         wsl_main.yaml
+name: wsl_main.yaml
 description:  >
       WSL smoke test on Windows 10 image
+
+conditional_schedule:
+  enable_systemd:
+    WSL_SYSTEMD:
+      '1':
+        - wsl/enable_systemd
 
 schedule:
   - wsl/boot_windows
   - wsl/prepare_wsl
   - wsl/install_wsl
   - wsl/firstrun
+  - '{{enable_systemd}}'
   - wsl/wsl_cmd_check

--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enable and test that systemd is running in WSL
+# Maintainer: qa-c  <qa-c@suse.de>
+
+use Mojo::Base qw(windowsbasetest);
+use testapi;
+use utils qw(enter_cmd_slow);
+use version_utils qw(is_opensuse);
+use wsl qw(is_fake_scc_url_needed);
+
+sub run {
+    my $self = shift;
+
+    assert_screen(['windows_desktop', 'powershell-as-admin-window']);
+    $self->open_powershell_as_admin if match_has_tag('windows_desktop');
+    # In openSUSE the WSL shell is not root, so there's need to run become_root
+    # in order to write in the /etc/wsl.conf file
+    $self->run_in_powershell(
+        cmd => q(wsl),
+        code => sub {
+            become_root if (is_opensuse);
+            enter_cmd("ps 1 | grep '/init'");
+            enter_cmd("stat /init | grep 'init'");
+            enter_cmd("echo -e '[boot]\nsystemd=true' > /etc/wsl.conf");
+            wait_still_screen stilltime => 3, timeout => 10;
+            save_screenshot;
+            enter_cmd("exit");
+            # In openSUSE there's need to exit twice, one from the root and another
+            # one from the WSL
+            enter_cmd("exit") if (is_opensuse);
+        }
+    );
+    $self->run_in_powershell(cmd => q(wsl --shutdown));
+    $self->run_in_powershell(cmd => q(wsl /bin/bash -c "ps 1 | grep '/sbin/init'"));
+    $self->run_in_powershell(cmd => q(wsl /bin/bash -c "stat /sbin/init | grep 'systemd'"));
+    $self->run_in_powershell(cmd => q(wsl /bin/bash -c "systemctl list-unit-files --type=service | head -n 20"));
+    $self->run_in_powershell(cmd => q(wsl /bin/bash -c "exit"));
+}
+
+1;


### PR DESCRIPTION
WSL now supports systemd, so there's need to check that we can enable and test it

- Paired with: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1309
- Related ticket: [poo#133691](https://progress.opensuse.org/issues/133691)
- Needles: *not_needed*
- Verification runs:
  - SLE:
    - https://openqa.suse.de/tests/12855059
    - https://openqa.suse.de/tests/12867495
    - https://openqa.suse.de/tests/12855057
    - https://openqa.suse.de/tests/12867496
    - https://openqa.suse.de/tests/12855055
    - https://openqa.suse.de/tests/12867497
  - TW:
    - https://openqa.opensuse.org/tests/3744420
    - https://openqa.opensuse.org/tests/3747994
    - https://openqa.opensuse.org/tests/3744422
    - https://openqa.opensuse.org/tests/3747995
    - https://openqa.opensuse.org/tests/3744424
    - https://openqa.opensuse.org/tests/3800853
  - Leap:
    - https://openqa.opensuse.org/tests/3800615
    - https://openqa.opensuse.org/tests/3800635
    - https://openqa.opensuse.org/tests/3800617
    - https://openqa.opensuse.org/tests/3800618
    - https://openqa.opensuse.org/tests/3800619
    - https://openqa.opensuse.org/tests/3800760