### PR TITLE
lib/main_common.pm: Skip snapper_jeos_cli in staging

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1841,7 +1841,8 @@ sub load_extra_tests_filesystem {
     if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
         loadtest 'console/snapper_undochange';
         loadtest 'console/snapper_create';
-        loadtest "console/snapper_jeos_cli" if is_jeos;
+        # Needs zsh, not available in staging
+        loadtest "console/snapper_jeos_cli" if is_jeos && !is_staging;
         loadtest "console/btrfs_autocompletion";
         if (get_var("NUMDISKS", 0) > 1) {
             loadtest "console/btrfs_qgroups";


### PR DESCRIPTION
No zsh in there.

- Verification run: https://openqa.opensuse.org/tests/3532597
