### PR TITLE
Enable logs upload for agama playwright tests

### DIFF
--- a/lib/Yam/agama/agama_base.pm
+++ b/lib/Yam/agama/agama_base.pm
@@ -23,6 +23,7 @@ sub post_fail_hook {
     select_console 'root-console';
     y2_base::save_upload_y2logs($self, skip_logs_investigation => 1);
     save_and_upload_log('journalctl -u agama-auto', "/tmp/agama-auto-log.txt");
+    upload_traces();
 }
 
 sub post_run_hook {
@@ -33,6 +34,12 @@ sub post_run_hook {
 
 sub test_flags {
     return {fatal => 1};
+}
+
+sub upload_traces {
+    my ($dest, $sources) = ("/tmp/traces.tar.gz", "test-results/");
+    script_run("tar czf $dest $sources");
+    upload_logs($dest, failok => 1);
 }
 
 1;

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -16,9 +16,11 @@ use testapi qw(
 );
 
 sub run {
+    my $self = shift;
     my $test = get_required_var('AGAMA_TEST');
 
     assert_script_run("playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright tests/" . $test . ".spec.ts", timeout => 1200);
+    $self->upload_traces();
     enter_cmd 'reboot';
 }
 


### PR DESCRIPTION
- Description: Enable logs upload for agama playwright tests
- Related ticket: https://progress.opensuse.org/issues/134690
- Verification run: [overview](https://openqa.opensuse.org/tests/overview?build=manfredi%2Fos-autoinst-distri-opensuse%23issues-134690&distri=alp&version=agama-3.0-staging)
