### PR TITLE
Get container storage

### DIFF
--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -34,4 +34,12 @@ sub configure_insecure_registries {
     systemctl('restart docker');
 }
 
+sub get_storage_driver {
+    my $json = shift->info(json => 1);
+    my $storage = $json->{Driver};
+    record_info 'Storage', "Detected storage driver=$storage";
+
+    return $storage;
+}
+
 1;

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -30,4 +30,12 @@ sub configure_insecure_registries {
     assert_script_run('echo -e \'[[registry]]\nlocation = "' . registry_url() . '"\ninsecure = true\' >> /etc/containers/registries.conf') if get_var('REGISTRY');
 }
 
+sub get_storage_driver {
+    my $json = shift->info(json => 1);
+    my $storage = $json->{store}->{graphDriverName};
+    record_info 'Storage', "Detected storage driver=$storage";
+
+    return $storage;
+}
+
 1;

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -22,7 +22,8 @@ use Mojo::Util 'trim';
 
 our @EXPORT = qw(test_seccomp runtime_smoke_tests basic_container_tests get_vars
   can_build_sle_base get_docker_version get_podman_version check_runtime_version
-  check_min_runtime_version container_ip container_route registry_url reset_container_network_if_needed);
+  check_min_runtime_version container_ip container_route registry_url reset_container_network_if_needed
+);
 
 sub test_seccomp {
     my $no_seccomp = script_run('docker info | tee /tmp/docker_info.txt | grep seccomp');


### PR DESCRIPTION
Rework container's engine::info to return plain output or `json` for
futher processing. Use the json output to select detected container's
storage drive that can be used in test modules.

- ticket: [[podman] Add check for storage engine](https://progress.opensuse.org/issues/134366)

### Verification runs: 

* [sle-15-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20230829-1-jeos-containers-docker@64bit-virtio-vga](http://kepler.suse.cz/tests/21722)
* [sle-15-SP6-JeOS-for-kvm-and-xen-x86_64-Build1.5-jeos-containers-podman@uefi-virtio-vga](http://kepler.suse.cz/tests/21721#step/rootless_podman/109)
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20230829-1-podman_tests@64bit](http://kepler.suse.cz/tests/21720#step/rootless_podman/119)
* [sle-15-SP5-Server-DVD-Updates-x86_64-Build20230829-1-docker_tests@64bit](http://kepler.suse.cz/tests/21719#step/validate_btrfs/87)
* [sle-15-SP2-Server-DVD-Updates-x86_64-Build20230829-1-docker_tests@64bit](http://kepler.suse.cz/tests/21715#step/validate_btrfs/87)
* [sle-15-SP3-Server-DVD-Updates-x86_64-Build20230829-1-docker_tests@64bit](http://kepler.suse.cz/tests/21717#step/validate_btrfs/87)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20230829-1-docker_tests@64bit](http://kepler.suse.cz/tests/21716#step/validate_btrfs/87)
* [sle-12-SP5-Server-DVD-Updates-x86_64-Build20230829-1-docker_tests@64bit](http://kepler.suse.cz/tests/21718#step/validate_btrfs/87)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20230829-1-podman_tests@64bit](http://kepler.suse.cz/tests/21725)
* [sle-15-SP2-Server-DVD-Updates-x86_64-Build20230829-1-podman_tests@64bit](http://kepler.suse.cz/tests/21724#step/rootless_podman/82)
* [sle-15-SP5-Server-DVD-Updates-x86_64-Build20230829-1-podman_tests@64bit](http://kepler.suse.cz/tests/21723#step/rootless_podman/115)
* [sle-15-SP4-Server-DVD-Updates-x86_64-Build20230829-1-podman_tests@64bit](http://kepler.suse.cz/tests/21727#step/rootless_podman/115)
* [sle-15-SP6-JeOS-for-kvm-and-xen-x86_64-Build1.11-jeos-containers-docker@uefi-virtio-vga](http://kepler.suse.cz/tests/21735#step/validate_btrfs/87)
* [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20230828-jeos-container_host@64bit_virtio-2G](http://kepler.suse.cz/tests/21728#step/rootless_podman/75)
* [microos-Tumbleweed-MicroOS-Image-ContainerHost-x86_64-Build20230828-container-host@64bit](http://kepler.suse.cz/tests/21729#step/rootless_podman/89)
* [sle-micro-5.4-Default-Updates-x86_64-Build20230829-1-slem_containers@64bit](http://kepler.suse.cz/tests/21733#step/rootless_podman/89)
* [sle-15-SP4-Server-DVD-Updates-x86_64-Build20230829-1-docker_tests@64bit](http://kepler.suse.cz/tests/21726#step/validate_btrfs/87)
* [sle-micro-5.1-MicroOS-Image-Updates-x86_64-Build20230829-1-slem_containers@64bit](http://kepler.suse.cz/tests/21731#step/rootless_podman/89)
* [sle-micro-5.5-Default-x86_64-Build16.1_3.6-slem_containers@64bit](http://kepler.suse.cz/tests/21730#step/rootless_podman/89)
* [sle-micro-5.2-MicroOS-Image-Updates-x86_64-Build20230829-1-slem_containers@64bit](http://kepler.suse.cz/tests/21732#step/rootless_podman/89)
