### PR TITLE
Revert "containers: Test rmt image by repo/tag"

### DIFF
--- a/tests/containers/containerd_rmt.pm
+++ b/tests/containers/containerd_rmt.pm
@@ -29,14 +29,12 @@ sub run {
     install_kubectl();
     install_helm();
 
-    my $rmt_helm = get_var('RMTTEST_CHART', 'https://github.com/SUSE/helm-charts/archive/refs/heads/main.tar.gz');
+    my $rmt_helm = get_var('RMTTEST_REPO', 'https://github.com/SUSE/helm-charts/archive/refs/heads/main.tar.gz');
     # pull in the testsuite
     assert_script_run("curl -sSLk $rmt_helm | tar -zxf -");
     my $rmt_config = get_var('RMTTEST_CONFIG', 'https://gitlab.suse.de/QA-APAC-I/testing/-/raw/master/data/rmtcontainer/myvalue.yaml');
     assert_script_run("curl -sSLOk $rmt_config");
-    my $rmt_repo = get_required_var('RMTTEST_REPO');
-    my $rmt_tag = get_var('RMTTEST_TAG', 'latest');
-    assert_script_run("helm install --set app.image.repository=$rmt_repo --set app.image.tag=$rmt_tag rmt ./helm-charts-main/rmt-helm/ -f myvalue.yaml");
+    assert_script_run("helm install rmt ./helm-charts-main/rmt-helm -f myvalue.yaml");
     assert_script_run("helm list");
     my @out = split(' ', script_output("kubectl get pods | grep rmt-app"));
     my $counter = 0;


### PR DESCRIPTION
This reverts commit c417f3a033de8504dacd299526b67b5e6eb300a4.

Too much time wasted on something that should be run on container-release-bot anyway.  In the mean time we have this test failing blocking updates...

Closing https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17647

- Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1311
- Related ticket: https://progress.opensuse.org/issues/134594
- Verification run: https://openqa.suse.de/t11952671
