### PR TITLE
PC: Do not define cpu_options when not needed

### DIFF
--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -120,8 +120,11 @@ resource "aws_instance" "openqa" {
         create = var.vm_create_timeout
     }
 
-    cpu_options {
-        amd_sev_snp = var.enable_confidential_vm
+    dynamic "cpu_options" {
+        for_each = var.enable_confidential_vm == "disabled" ? [] : [1]
+        content {
+            amd_sev_snp = var.enable_confidential_vm
+        }
     }
 }
 

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -168,6 +168,12 @@ sub upload_img {
     record_info('INFO', "AMI: $ami");    # Show the ami-* number, could be useful
 }
 
+sub terraform_apply {
+    my ($self, %args) = @_;
+    $args{confidential_compute} = get_var("PUBLIC_CLOUD_CONFIDENTIAL_VM", 0);
+    return $self->SUPER::terraform_apply(%args);
+}
+
 sub img_proof {
     my ($self, %args) = @_;
 


### PR DESCRIPTION
- Coninues after: #17676
- Related ticket: [poo#134738](https://progress.opensuse.org/issues/134738)
- Verification run: [ec2-m6a.large](https://pdostal-server.suse.cz/tests/5200), [ec2-c5.large](https://pdostal-server.suse.cz/tests/5198), [Azure](https://pdostal-server.suse.cz/tests/5195), [GCE](https://pdostal-server.suse.cz/tests/5193)