### PR TITLE
Upload slurm logs

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -131,6 +131,13 @@ sub get_remote_logs {
     upload_logs("/tmp/$machine\@$logs", failok => 1);
 }
 
+sub get_slurm_logs {
+    my ($self) = @_;
+    $self->upload_service_log('slurmd');
+    $self->upload_service_log('munge');
+    $self->upload_service_log('slurmctld') if get_var('HPC') =~ /slurm_master/;
+}
+
 sub switch_user {
     my ($self, $username) = @_;
     enter_cmd("su - $username");

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -493,12 +493,14 @@ sub test_flags ($self) {
     return {fatal => 1, milestone => 1};
 }
 
+sub post_run_hook ($self) {
+    $self->SUPER::get_slurm_logs();
+    $self->SUPER::post_run_hook();
+}
+
 sub post_fail_hook ($self) {
     $self->destroy_test_barriers();
     select_serial_terminal;
-    $self->upload_service_log('slurmd');
-    $self->upload_service_log('munge');
-    $self->upload_service_log('slurmctld');
     export_logs_basic;
     $self->get_remote_logs('slave-node02', 'slurmdbd.log');
     upload_logs('/var/log/slurmctld.log');


### PR DESCRIPTION
Slurm logs are missing when job is successful and they are fetched only when job is failing.


- Verification run: 

[slurm_master_backup_db](https://aquarius.suse.cz/tests/18399)
[slurm_master](https://aquarius.suse.cz/tests/18396)