### PR TITLE
install_ltp: Don't install kernel-default-extra on SLE-12

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -78,7 +78,6 @@ sub install_runtime_dependencies {
       exfat-utils
       fuse-exfat
       ibmtss
-      kernel-default-extra
       lvm2
       net-tools
       net-tools-deprecated
@@ -93,6 +92,13 @@ sub install_runtime_dependencies {
       wget
       xfsprogs
     );
+
+    # SLE-15 allows loading unsupported modules from kernel-default-extra
+    # via modprobe config file but SLE-12 does not. LTP tests for those
+    # modules then fail on SLE-12 because the required driver is available but
+    # modprobe refuses to load it.
+    push @maybe_deps, 'kernel-default-extra' unless is_sle('<15');
+
     zypper_install_available(@maybe_deps);
 }
 


### PR DESCRIPTION
LTP tests for unsupported (by SUSE) kernel modules fail on SLE-12SP5 because the required modules are provided through the `kernel-default-extra` package but unlike SLE-15, there is no modprobe config file allowing them to be loaded. Skip installing `kernel-default-extra` on SLE-12 and earlier.

- Related ticket: https://progress.opensuse.org/issues/129577
- Needles: N/A
- Verification run:
  - SLE-12SP5: https://openqa.suse.de/tests/11977706#step/install_ltp/179 (should not be installed)
  - SLE-15SP1: https://openqa.suse.de/tests/11977708#step/install_ltp/179 (should be installed)
