### PR TITLE
Disable disruptive timers

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -186,6 +186,7 @@ sub load_common_tests {
 
 
 sub load_transactional_tests {
+    loadtest 'transactional/disable_timers';
     loadtest 'transactional/filesystem_ro';
     loadtest 'transactional/trup_smoke';
     loadtest 'microos/patterns' if is_sle_micro;

--- a/tests/transactional/disable_timers.pm
+++ b/tests/transactional/disable_timers.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Disable various timers that sometimes cause test interruptions
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils qw(systemctl);
+use mm_network qw(is_networkmanager);
+use version_utils qw(is_microos is_sle_micro);
+use serial_terminal;
+
+sub run {
+    my ($self) = @_;
+
+    select_serial_terminal;
+
+    # Disable disruptive timers
+    my @timers = qw(snapper-cleanup.timer fstrim.timer transactional-update.timer btrfs-balance.timer btrfs-defrag.timer btrfs-scrub.timer btrfs-trim.timer);
+    push(@timers, "snapper-timeline.timer") unless (is_microos);
+    push(@timers, "transactional-update-cleanup.timer") if (is_sle_micro(">5.1"));
+    foreach my $timer (@timers) {
+        systemctl("disable --now '$timer'");
+    }
+}
+
+1;

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright 2020-2021 SUSE LLC
+# Copyright 2020-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Package: transactional-update
 # Summary: Host configuration operations (e.g. disable grub timeout,
 #              kernel params, etc)
 #
-# Maintainer: Jose Lausuch <jalausuch@suse.com>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base qw(consoletest);
 use testapi;


### PR DESCRIPTION
To avoid test run interruptions, disable possible disruptive timers on the test host. This must happen only selectively, and if applied after `services_enabled.pm` is executed.

- Related ticket: https://progress.opensuse.org/issues/134999
- Verification run: [SLEM 5.3 autoyast](https://duck-norris.qe.suse.de/tests/13508#step/disable_timers/1) | [SLEM 5.3 selinux](https://duck-norris.qe.suse.de/tests/13509#step/disable_timers/1) | [MicroOS](https://duck-norris.qe.suse.de/tests/13512#step/disable_timers/1)
