### PR TITLE
containers: Don't test CNI on ALP

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -94,7 +94,8 @@ sub load_host_tests_podman {
         load_image_test($run_args) unless is_public_cloud || is_alp;
         load_3rd_party_image_test($run_args);
         loadtest 'containers/podman_pods';
-        loadtest('containers/podman_network_cni');
+        # Default for ALP is Netavark
+        loadtest('containers/podman_network_cni') unless (is_alp);
         # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
         loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images


### PR DESCRIPTION
Don't test CNI on ALP

- Failing test: https://openqa.suse.de/tests/11975226#step/volumes_podman/20
- Verification run: https://openqa.suse.de/tests/11981054