### PR TITLE
Disable 2038 year detection in SLE Micro

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -179,7 +179,9 @@ sub load_common_tests {
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
     loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro || is_alp);
     loadtest 'console/kubeadm' if (check_var('SYSTEM_ROLE', 'kubeadm'));
-    loadtest 'console/year_2038_detection' unless is_s390x;
+    # SLE Micro is not 2038-proof, so it doesn't apply here, but it does for ALP.
+    # On s390x zvm setups we need more time to wait for system to boot up.
+    loadtest 'console/year_2038_detection' unless (is_s390x || is_sle_micro || is_leap_micro);
 }
 
 


### PR DESCRIPTION
SLE15 will not be 2038-proof, that should only go to ALP base.
