### PR TITLE
[HPC] Exclude python2 modules from 15sp6 autoyast

### DIFF
--- a/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
@@ -43,7 +43,7 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
-      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
+      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5') or $check_var->('VERSION', '15-SP6')) {
       <addon>
         <name>sle-module-python2</name>
         <version>{{VERSION}}</version>
@@ -110,7 +110,7 @@
       <package>sle-module-basesystem-release</package>
       <package>sle-module-web-scripting-release</package>
       <package>sle-module-hpc-release</package>
-      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
+      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5') or $check_var->('VERSION', '15-SP5')) {
       <package>sle-module-python2-release</package>
       % }
     </packages>

--- a/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
@@ -43,7 +43,7 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
-      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
+      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5') or $check_var->('VERSION', '15-SP6')) {
       <addon>
         <name>sle-module-python2</name>
         <version>{{VERSION}}</version>
@@ -96,7 +96,7 @@
       <package>sle-module-basesystem-release</package>
       <package>sle-module-web-scripting-release</package>
       <package>sle-module-hpc-release</package>
-      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5')) {
+      % unless ($check_var->('VERSION', '15-SP4') or $check_var->('VERSION', '15-SP5') or $check_var->('VERSION', '15-SP6')) {
       <package>sle-module-python2-release</package>
       % }
     </packages>


### PR DESCRIPTION
We had fixed this for the other installations which use yaml profiles. that should be the only one which need to get updated.

