### PR TITLE
[HPC] Add user_settings_root on yaml schedulers for 15-SP6

### DIFF
--- a/schedule/hpc/installation_node_dev.yaml
+++ b/schedule/hpc/installation_node_dev.yaml
@@ -17,6 +17,8 @@ conditional_schedule:
         - installation/bootloader
   user_settings_root:
     VERSION:
+      15-SP6:
+        - installation/user_settings_root
       15-SP5:
         - installation/user_settings_root
       15-SP4:

--- a/schedule/hpc/installation_server.yaml
+++ b/schedule/hpc/installation_server.yaml
@@ -40,6 +40,8 @@ conditional_schedule:
         - installation/user_settings_root
       15-SP5:
         - installation/user_settings_root
+      15-SP6:
+        - installation/user_settings_root
   add_update_test_repo:
     FLAVOR:
       Server-DVD-HPC-Incidents:


### PR DESCRIPTION
New SLE version is missing the proper scheduling for HPC.

