### PR TITLE
Fix new server domain issue

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -109,7 +109,7 @@ sub test_network_interface {
     my $gate = $args{gate};
     my $isolated = $args{isolated} // 0;
     my $routed = $args{routed} // 0;
-    my $target = $args{target} // script_output("dig +short openqa.suse.de");
+    my $target = $args{target} // script_output("dig +short openqa.oqa.prg2.suse.org");
 
     check_guest_ip("$guest", net => $net) if ((is_sle('>15') || is_alp) && ($isolated == 1) && get_var('VIRT_AUTOTEST'));
 


### PR DESCRIPTION
The root cause of the problem is that the output of the 'dig +short openqa.suse.de' command has changed when OpenQA OSD (OpenQA On-Demand) moves to the 'prg2' environment.
poo: https://progress.opensuse.org/issues/135113



- Related ticket: https://progress.opensuse.org/issues/135113
- Needles: N/A
- Verification run: [sle-15-SP5-Server-DVD-Virt-XEN-Incidents-x86_64-Build:S:M:29955:305838:-qam-xen-networking@64bit-ipmi](http://openqa.qam.suse.cz/tests/59953), [sle-15-SP5-Server-DVD-Virt-KVM-Incidents-x86_64-Build:S:M:29955:305838:-qam-kvm-networking@64bit-ipmi](http://openqa.qam.suse.cz/tests/59949)