### PR TITLE
Rework installation of k3s and kubectl 

### DIFF
--- a/data/containers/kubectl/deployment.yml
+++ b/data/containers/kubectl/deployment.yml
@@ -19,7 +19,7 @@ spec:
         # Use custom registry to avoid API rate limits on docker.io
         # The testing.registry must be registered in k8s
         # as private registry and point to REGISTRY variable.
-        image: testing.registry/library/nginx
+        image: docker.io/library/nginx
         ports:
         - containerPort: 80
         resources:

--- a/data/containers/registries.yaml
+++ b/data/containers/registries.yaml
@@ -1,4 +1,4 @@
 mirrors:
-  testing.registry:
+  docker.io:
     endpoint:
       - "http://REGISTRY"

--- a/tests/containers/kubectl.pm
+++ b/tests/containers/kubectl.pm
@@ -81,8 +81,8 @@ sub run {
     ## Test jobs
     record_info('Testing: jobs and pods', 'job and pod test runs');
     # The testing.registry must be registered in k8s as private registry and point to REGISTRY variable.
-    assert_script_run("kubectl create job sayhello --image=testing.registry/library/alpine -- echo 'Hello World'");
-    assert_script_run("kubectl create job gimme-date --image=testing.registry/library/busybox -- date");
+    assert_script_run("kubectl create job sayhello --image=docker.io/library/alpine -- echo 'Hello World'");
+    assert_script_run("kubectl create job gimme-date --image=docker.io/library/busybox -- date");
     validate_script_output("kubectl get jobs --no-headers", qr/sayhello/);
     validate_script_output("kubectl get jobs --no-headers", qr/gimme-date/);
     assert_script_run('kubectl wait jobs/sayhello --for=condition=complete --timeout=300s', timeout => 330);


### PR DESCRIPTION
k3s server might not have been fully operational and were not waiting long
enough to let it properly start before usage.
Installation of k3s got also complicated and for certain distros we need
to pull it from upstream whereas for TW, MicroOS or the k3s deployment
script is already packaged. For k3s usage, we do not need to
specifically install `kubenernetes-client` as this handled in the k3s
deployment script.

Allow installation of kubernetes-client either by version that should be
part of the test suite setup or pull the newest available in the distro.

- tickets:
  - https://progress.opensuse.org/issues/132284
  - https://progress.opensuse.org/issues/134726

#### Verification runs:

[sle-micro-5.1-MicroOS-Image-Updates-x86_64-Build20230906](http://kepler.suse.cz/tests/21787#step/podman_pods/199)
[sle-micro-5.3-MicroOS-Image-Updates-x86_64-Build20230906](http://kepler.suse.cz/tests/21786#step/podman_pods/199)
[sle-micro-5.4-Default-Updates-x86_64-Build20230906](http://kepler.suse.cz/tests/21784#step/podman_pods/199)
[sle-micro-5.2-Default-Updates-x86_64-Build20230906](http://kepler.suse.cz/tests/21785#step/podman_pods/199)
[opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20230907-jeos-container_host@64bit_virtio-2G](http://kepler.suse.cz/tests/21790#step/podman_pods/203)
[microos-Tumbleweed-MicroOS-Image-ContainerHost-x86_64-Build20230907-container-host-old2microosnext@64bit](http://kepler.suse.cz/tests/21789#step/podman_pods/245)
[microos-Tumbleweed-MicroOS-Image-ContainerHost-x86_64-Build20230907-container-host@64bit](http://kepler.suse.cz/tests/21788#step/podman_pods/245)
[helm](http://kepler.suse.cz/tests/21802#live)
[kubectl](http://kepler.suse.cz/tests/21806#live)
[microos-Tumbleweed-MicroOS-Image-ContainerHost-x86_64-Build20230917-container-host-old2microosnext@64bit](http://kepler.suse.cz/tests/21888#step/podman_pods/1)
[microos-Tumbleweed-MicroOS-Image-ContainerHost-x86_64-Build20230917-container-host2microosnext@64bit](http://kepler.suse.cz/tests/21891#step/podman_pods/1)
[microos-Tumbleweed-MicroOS-Image-ContainerHost-x86_64-Build20230917-container-host@64bit](http://kepler.suse.cz/tests/21889#step/podman_pods/1)
[opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20230917-jeos-container_host@64bit_virtio-2G](http://kepler.suse.cz/tests/21890#step/podman_pods/1)