### PR TITLE
Create test modules for reboot_before_migration  and stop_grub_timeout

### DIFF
--- a/schedule/migration/migration_offline_media_all_patterns_x86_64.yaml
+++ b/schedule/migration/migration_offline_media_all_patterns_x86_64.yaml
@@ -18,7 +18,7 @@ schedule:
   - migration/deregister_python2
   - migration/deregister_system
   - migration/record_disk_info
-  - migration/reboot_to_upgrade
+  - migration/reboot_to_migration
   - migration/version_switch_upgrade_target
   - installation/bootloader
   - installation/setup_libyui

--- a/schedule/migration/migration_offline_media_x86_64.yaml
+++ b/schedule/migration/migration_offline_media_x86_64.yaml
@@ -14,7 +14,7 @@ schedule:
   - migration/drop_unavailable_product_modules
   - migration/deregister_system
   - migration/record_disk_info
-  - migration/reboot_to_upgrade
+  - migration/reboot_to_migration
   - migration/version_switch_upgrade_target
   - installation/bootloader
   - installation/setup_libyui

--- a/schedule/migration/migration_offline_scc_all_patterns_x86_64.yaml
+++ b/schedule/migration/migration_offline_scc_all_patterns_x86_64.yaml
@@ -14,7 +14,7 @@ schedule:
   - migration/install_all_patterns
   - migration/query_all_rpm
   - migration/record_disk_info
-  - migration/reboot_to_upgrade
+  - migration/reboot_to_migration
   - migration/version_switch_upgrade_target
   - installation/bootloader
   - installation/welcome

--- a/schedule/migration/migration_offline_scc_x86_64.yaml
+++ b/schedule/migration/migration_offline_scc_x86_64.yaml
@@ -11,7 +11,7 @@ schedule:
   - migration/patch_and_reboot_system
   - migration/setup_sle
   - migration/record_disk_info
-  - migration/reboot_to_upgrade
+  - migration/reboot_to_migration
   - migration/version_switch_upgrade_target
   - installation/bootloader
   - installation/welcome

--- a/tests/migration/reboot_to_migration.pm
+++ b/tests/migration/reboot_to_migration.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Reboot machine to perform upgrade
+#       Just trigger reboot action, afterwards tests will be
+#       incepted by later test modules, such as tests in
+#       load_boot_tests or wait_boot in setup_zdup.pm
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi qw(select_console set_var assert_script_run send_key assert_screen);
+use Utils::Architectures;
+use Utils::Backends 'is_pvm';
+use power_action_utils 'power_action';
+use version_utils;
+use utils qw(quit_packagekit wait_for_purge_kernels);
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    # Mark the hdd has been patched
+    set_var('PATCHED_SYSTEM', 1);
+
+    assert_script_run "sync", 300;
+    power_action('reboot', textmode => 1, keepconsole => 1);
+
+    assert_screen('inst-bootmenu', 300) unless (is_s390x || is_pvm);
+
+    send_key 'up' if is_x86_64;
+}
+
+sub pre_run_hook {
+    quit_packagekit;
+    wait_for_purge_kernels;
+}
+
+1;
+


### PR DESCRIPTION
- Description:
  * Create test modules for reboot_before_migration and stop_grub_timeout.
  
- Related ticket: https://progress.opensuse.org/issues/132950
- Needles: N/A
- Verification run: 
  * https://openqa.suse.de/tests/12615294
  * https://openqa.suse.de/tests/12615295
  * https://openqa.suse.de/tests/12615296
  * https://openqa.suse.de/tests/12615297