### PR TITLE
Update code for Teradata flavor without SCC reg

### DIFF
--- a/data/autoyast_qam/15-common_base_installation.xml.ep
+++ b/data/autoyast_qam/15-common_base_installation.xml.ep
@@ -2,7 +2,12 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
+    % unless ($check_var->('FLAVOR', 'Server-DVD-Updates-TERADATA') or $check_var->('FLAVOR', 'Server-DVD-Incidents-TERADATA')) {
     <do_registration config:type="boolean">true</do_registration>
+    % }
+    % if ($check_var->('FLAVOR', 'Server-DVD-Updates-TERADATA') or $check_var->('FLAVOR', 'Server-DVD-Incidents-TERADATA')) {
+    <do_registration config:type="boolean">false</do_registration>
+    % }
     <email><%= $get_var->('SCC_EMAIL') %></email>
     <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
     <install_updates config:type="boolean">true</install_updates>

--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -2,7 +2,12 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
+    % unless ($check_var->('FLAVOR', 'Server-DVD-Updates-TERADATA') or $check_var->('FLAVOR', 'Server-DVD-Incidents-TERADATA')) {
     <do_registration config:type="boolean">true</do_registration>
+    % }
+    % if ($check_var->('FLAVOR', 'Server-DVD-Updates-TERADATA') or $check_var->('FLAVOR', 'Server-DVD-Incidents-TERADATA')) {
+    <do_registration config:type="boolean">false</do_registration>
+    % }
     <email><%= $get_var->('SCC_EMAIL') %></email>
     <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
     <install_updates config:type="boolean">true</install_updates>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -312,7 +312,7 @@ sub is_updates_tests {
     my $flavor = get_var('FLAVOR');
     return 0 unless $flavor;
     # Incidents might be also Incidents-Gnome or Incidents-Kernel
-    return $flavor =~ /-Updates$/ || $flavor =~ /-Incidents/;
+    return $flavor =~ /-Updates/ || $flavor =~ /-Incidents/;
 }
 
 sub is_migration_tests {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -795,6 +795,8 @@ sub skip_registration {
     }
     elsif (match_has_tag('scc-skip-reg-warning-yes')) {
         send_key "alt-y";    # confirmed skip SCC registration
+        wait_still_screen;
+        send_key $cmd{next};
     }
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -578,7 +578,7 @@ sub is_using_system_role {
       && (install_this_version() || install_to_other_at_least('12-SP2'))
       || (is_sles4sap() && main_common::is_updates_test_repo())
       || is_sle('=15')
-      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
+      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL') || get_var('FLAVOR') =~ /TERADATA/))
       || (is_sle('15-SP2+') && check_var('FLAVOR', 'Full'))
       || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW, MicroOS
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -355,7 +355,7 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
     my $repos = join_incidents_to_repo(\%incidents);
 
     set_var('MAINT_TEST_REPO', $repos);
-    set_var('SCC_REGISTER', 'installation');
+    set_var('SCC_REGISTER', 'installation') unless get_var('FLAVOR') =~ /TERADATA/;
 }
 
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_ADDONS')) {

--- a/tests/boot/grub2_test.pm
+++ b/tests/boot/grub2_test.pm
@@ -96,7 +96,7 @@ sub run {
         select_console 'root-console';
     }
 
-    if (is_sle('15+')) {
+    if (is_sle('15+') && get_var('FLAVOR') !~ /TERADATA/) {
         record_info 'grub2 zfs', 'ensure that zfs in grub2 is not available on SLE 15+ but on openSUSE';
         assert_script_run 'zypper se grub2- | grep extras ; test "$?" == "1"';
         assert_script_run 'rpm -qa | grep grub2 | xargs rpm -ql | grep zfs ; test "$?" == "1"';

--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -20,8 +20,16 @@ sub run() {
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
 
-    assert_screen('inst-addon', 60);
-    send_key 'alt-k';    # install with a maint update repo
+    if (!check_var('SCC_REGISTER', 'installation')) {
+        assert_screen('module-selection');
+        send_key $cmd{next};
+        assert_screen('addon-products');
+        send_key 'alt-a';
+    }
+    else {
+        assert_screen('inst-addon', 60);
+        send_key 'alt-k';    # install with a maint update repo
+    }
 
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) if get_var('INCIDENT_REPO');
     my @repos = split(/,/, get_var('MAINT_TEST_REPO'));

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -38,6 +38,7 @@ sub run {
     quit_packagekit unless check_var('DESKTOP', 'textmode');
 
     zypper_call(q{mr -d $(zypper lr | awk -F '|' '{IGNORECASE=1} /nvidia/ {print $2}')}, exitcode => [0, 3]);
+    zypper_call(q{mr -e $(zypper lr | awk -F '|' '/Basesystem-Module/ {print $2}')}, exitcode => [0, 3]) if get_var('FLAVOR') =~ /TERADATA/;
 
     add_test_repositories;
 

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -30,6 +30,8 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
+    zypper_call(q{mr -e $(zypper lr | awk -F '|' '/Basesystem-Module/ {print $2}')}, exitcode => [0, 3]) if get_var('FLAVOR') =~ /TERADATA/;
+
     # shim update will fail with old grub2 due to old signature
     if (get_var('MACHINE') =~ /uefi/ && !is_transactional) {
         zypper_call('up grub2 grub2-x86_64-efi kernel-default');

--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -114,6 +114,7 @@ sub run {
     my $zypper_version = script_output(q(rpm -q zypper|awk -F. '{print$2}'));
 
     zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);
+    zypper_call(q{mr -f $(zypper lr | awk -F '|' '/SLES15-SP4-15.4-0/ {print $2}')}, exitcode => [0, 3]) if get_var('FLAVOR') =~ /TERADATA/;
     zypper_call("ar -f http://dist.suse.de/ibs/SUSE/Updates/SLE-Live-Patching/12-SP3/" . get_var('ARCH') . "/update/ sle-module-live-patching:12-SP3::update") if is_sle('=12-SP3');
 
     # Extract module name from repo url.


### PR DESCRIPTION
-disable SCC registration for Teradata in autoyast profiles
-update condition in is_updates_tests to accept Teradata Updates
-update condition in is_using_system_role to schedule system_role
-add next key in registration test when registration is skipper &
 update behavior add_update_test_repo
-don't auto set SCC_REGISTER=installation for Teradata FLAVOR
-enable basesystem ISO repo after installation in patch_and_reboot
 and install_update

- Related ticket: https://progress.opensuse.org/issues/131498
- Verification run:
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=20230904-1&groupid=414 Aggregates
https://openqa.suse.de/tests/overview?distri=sle&build=%3A30538%3Afrr&groupid=521 Incidents
