### PR TITLE
Ensure BCI directory doesn't exist

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -116,6 +116,7 @@ sub run {
 
     record_info('Clone', "Clone BCI tests repository: $bci_tests_repo");
     my $branch = $bci_tests_branch ? "-b $bci_tests_branch" : '';
+    script_run('rm -rf /root/BCI-tests');
     assert_script_run("git clone $branch -q --depth 1 $bci_tests_repo /root/BCI-tests");
 
     # Pull the image in advance


### PR DESCRIPTION
Remove the BCI-tests directory before a test run to ensure it does not already exist.

- Related failure: https://duck-norris.qe.suse.de/tests/13746#step/bci_prepare/69
- Verification run: https://duck-norris.qe.suse.de/tests/13781#step/bci_prepare/68
