### PR TITLE
Refresh container's storage.conf

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -47,6 +47,15 @@ sub run {
         assert_script_run "usermod -a -G systemd-journal $testapi::username";
     }
 
+    if (get_var('TDUP')) {
+        my $unresolved_config = script_output('rpmconfigcheck');
+        my $cont_storage = '/etc/containers/storage.conf';
+        if ($unresolved_config =~ m|$cont_storage|) {
+            assert_script_run(sprintf('mv  %s.rpmnew %s', $cont_storage, $cont_storage));
+            assert_script_run('podman system reset -f');
+        }
+    }
+
     # Prepare for Podman 3.4.4 and CGroups v2
     if (is_sle('15-SP3+') || is_leap('15.3+')) {
         record_info 'cgroup v2', 'Switching to cgroup v2';


### PR DESCRIPTION
Check unresolved configuration files in distro upgrade test suite as old MicroOS used btrfs instead of overlay as storage driver.

- ticket: https://progress.opensuse.org/issues/135017
#### Verification runs
- [Build20230902-container-host-old2microosnext@64bit](http://kepler.suse.cz/tests/21761#step/rootless_podman/103)
- [Build20230902-container-host@64bit](http://kepler.suse.cz/tests/21758#step/rootless_podman/89)
