### PR TITLE
Prevent warewulf client from booting

### DIFF
--- a/tests/hpc/ww4_await_pxe_install.pm
+++ b/tests/hpc/ww4_await_pxe_install.pm
@@ -18,6 +18,7 @@ use POSIX 'strftime';
 
 sub run ($self) {
     assert_screen('qemu-no-bootable-device', timeout => 90);
+    send_key('ctrl-B');
     mutex_wait "ww4_ready";
     barrier_wait('WWCTL_READY');
     record_info 'WWCTL_READY', strftime("\%H:\%M:\%S", localtime);


### PR DESCRIPTION
If ipxe fails tries to boot. assert qemu-no-bootable-device and make the sut waiting in the ipxe shell before try again.


- Related ticket: https://progress.opensuse.org/issues/135218
- Needles: https://openqa.suse.de/tests/12025143#step/ww4_await_pxe_install/1
- Verification run: https://openqa.suse.de/tests/12025143
