### PR TITLE
xfstests: Add QEMURAM to Size record_info

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -252,7 +252,8 @@ sub post_env_info {
             $size_info = $size_info . $_ . "    $size\n";
         }
     }
-    $size_info = $size_info . "PAGE_SIZE    " . script_output("getconf PAGE_SIZE");
+    $size_info = $size_info . "PAGE_SIZE     " . script_output("getconf PAGE_SIZE") . "\n";
+    $size_info = $size_info . "QEMURAM       " . get_var("QEMURAM") . "\n";
     record_info('Size', $size_info);
 }
 


### PR DESCRIPTION
print RAM size of the VM for debug

- Related ticket: https://progress.opensuse.org/issues/135299
- Needles: N/A
- Verification run: http://10.67.129.54/tests/845#step/partition/57
