### PR TITLE
Fix GCP sporadic "missing sudo passwd" failure

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -95,6 +95,7 @@ our @EXPORT = qw(
   qesap_export_instances
   qesap_import_instances
   qesap_ansible_log_find_timeout
+  qesap_ansible_log_find_missing_sudo_password
 );
 
 =head1 DESCRIPTION
@@ -436,6 +437,19 @@ sub qesap_ansible_log_find_timeout
     my $search_string = 'Timed out waiting for last boot time check';
     my $timeout_match = script_output("grep \"$search_string\" $file || exit 0");
     return $timeout_match ? 1 : 0;
+}
+
+=head3 qesap_ansible_log_find_missing_sudo_password
+
+    Return the '"msg": "Missing sudo password"' error found in the Ansible log or not
+=cut
+
+sub qesap_ansible_log_find_missing_sudo_password
+{
+    my ($file) = @_;
+    my $search_string = 'Missing sudo password';
+    my $missing_sudo_pwd_match = script_output("grep \"$search_string\" $file || exit 0");
+    return $missing_sudo_pwd_match ? 1 : 0;
 }
 
 =head3 qesap_get_inventory


### PR DESCRIPTION
Fix GCP sporadic "missing sudo passwd" failure on test module "deploy.pm" when executing ansible playbook, retry the ansible command when hit "missing sudo passwd".

This issue described in "TEAM-8479 - qesap regression GCP 15sp5 failure in Ansible - Missing sudo password" seems to be a race condition.

- Related ticket: https://jira.suse.com/browse/TEAM-8479
- Needles: NA
Verification run:
1. Detected '"msg": "Missing sudo password"' at step: https://openqaworker15.qa.suse.cz/tests/223965#step/deploy/48 and "ansible retry pass" at step: https://openqaworker15.qa.suse.cz/tests/223965#step/deploy/64
2. Here is a normal test cases passed: https://openqaworker15.qa.suse.cz/tests/223966#details

  
