### PR TITLE
Skip wait_boot for autoyast installations

### DIFF
--- a/tests/autoyast/console.pm
+++ b/tests/autoyast/console.pm
@@ -19,7 +19,7 @@ sub run {
     $pxe_boot_done = 1 if (check_var('IPXE', '1') || check_var('IPXE_UEFI', '1'));
 
     # If we didn't see pxe, the reboot is going now
-    $self->wait_boot if is_ipmi and not get_var('VIRT_AUTOTEST') and not $pxe_boot_done;
+    $self->wait_boot if is_ipmi && !get_var('VIRT_AUTOTEST') && !$pxe_boot_done;
 
     select_console 'root-console';
 }

--- a/tests/autoyast/console.pm
+++ b/tests/autoyast/console.pm
@@ -15,11 +15,9 @@ use Utils::Backends;
 sub run {
     my ($self) = @_;
     # IPXE boot does not provide boot menu so set pxe_boot_done equals 1 without checking needles
-    my $pxe_boot_done;
-    $pxe_boot_done = 1 if (check_var('IPXE', '1') || check_var('IPXE_UEFI', '1'));
 
     # If we didn't see pxe, the reboot is going now
-    $self->wait_boot if is_ipmi && !get_var('VIRT_AUTOTEST') && !$pxe_boot_done;
+    $self->wait_boot if is_ipmi && !check_var('IPXE', '1') && !check_var('IPXE_UEFI', '1');
 
     select_console 'root-console';
 }

--- a/tests/autoyast/console.pm
+++ b/tests/autoyast/console.pm
@@ -14,7 +14,13 @@ use Utils::Backends;
 
 sub run {
     my ($self) = @_;
-    $self->wait_boot if is_ipmi;
+    # IPXE boot does not provide boot menu so set pxe_boot_done equals 1 without checking needles
+    my $pxe_boot_done;
+    $pxe_boot_done = 1 if (check_var('IPXE', '1') || check_var('IPXE_UEFI', '1'));
+
+    # If we didn't see pxe, the reboot is going now
+    $self->wait_boot if is_ipmi and not get_var('VIRT_AUTOTEST') and not $pxe_boot_done;
+
     select_console 'root-console';
 }
 


### PR DESCRIPTION
When we deploy the system with autoyast, there is no reboot after the installation and wait_boot never sees a grub menu, so let's skip this in this case.

This will fix https://openqa.suse.de/tests/11998046 and similar