### PR TITLE
Do not install HANA from NFS. Copy media instead

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -108,8 +108,8 @@ sub run {
     # This installs HANA. Start by configuring the appropiate SAP profile
     $self->prepare_profile('HANA');
 
-    # Mount media
-    $self->mount_media($proto, $path, '/sapinst');
+    # Copy media
+    $self->copy_media($proto, $path, 1800, '/sapinst');
 
     # Mount points information: use the same paths and minimum sizes as the wizard (based on RAM size)
     my $full_size = ceil($RAM / 1024);    # Use the ceil value of RAM in GB


### PR DESCRIPTION
This partially reverts #14964, which replaced the `lib/sles4sap::copy_media` method for a `mount_media` method, enabling both HANA and NetWeaver installation tests to run the installers directly from the NFS mount. In this commit, the `copy_media` method has been added again to the library, and the HANA installation test has been modified to use `copy_media` instead of `mount_media`.

General purpose of the PR is to be able to more easily identify the root cause of some failures. With the current `mount_media` method, a failing installation could have its root in the performance of the SUT, network connection to the NFS server, NFS server performance and more. If we copy the media first and then install from the local copy, we are segmenting the steps, and we can more easily separate issues related to the network or the NFS servers versus those related to the worker and the SUT.

- Related ticket: https://jira.suse.com/browse/TEAM-8208
- Needles: N/A
- Verification run: [Single Machine Hana Installation](https://openqaworker15.qa.suse.cz/tests/223229#step/hana_install/38), Multi-Machine: [node 1](https://openqaworker15.qa.suse.cz/tests/223232#step/hana_install/38) & [node 2](https://openqaworker15.qa.suse.cz/tests/223231#step/hana_install/38) ~[node 1](https://openqaworker15.qa.suse.cz/tests/223215) & [node 2](https://openqaworker15.qa.suse.cz/tests/223214)~
- New Verification runs after NFS client Id was introduced: [node1](https://openqaworker15.qa.suse.cz/tests/223982) & [node 2](https://openqaworker15.qa.suse.cz/tests/223981), [Single Machine](https://openqaworker15.qa.suse.cz/tests/223979)
