### PR TITLE
Add des3 and des-ede3 as approved Ciphers in s390x

### DIFF
--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -6,10 +6,10 @@
 # Package: openssl
 # Summary: FIPS: openssl_fips_cipher
 #          In fips mode, openssl only works with the FIPS
-#          approved Cihper algorithms: AES and DES3
+#          approved Cipher algorithms: AES and DES3
 #
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#44837
+# Tags: poo#44837, bsc#1209271, poo#134321
 
 use base "consoletest";
 use testapi;
@@ -36,9 +36,7 @@ sub run {
     assert_script_run "mkdir fips-test && cd fips-test && echo Hello > $file_raw";
 
     # With FIPS approved Cipher algorithms, openssl should work
-    my @approved_cipher = ("aes128", "aes192", "aes256");
-    # https://bugzilla.suse.com/show_bug.cgi?id=1209271#c8
-    push @approved_cipher, qw(des3 des-ede3) unless (is_sle_micro('5.4+') && is_s390x);
+    my @approved_cipher = ("aes128", "aes192", "aes256", "des3", "des-ede3");
     for my $cipher (@approved_cipher) {
         assert_script_run "openssl enc -$cipher -e -pbkdf2 -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg";
         assert_script_run "openssl enc -$cipher -d -pbkdf2 -in $file_enc -out $file_dec -k $enc_passwd -md $hash_alg";
@@ -49,7 +47,10 @@ sub run {
     # With FIPS non-approved Cipher algorithms, openssl shall report failure
     my @invalid_cipher = ("bf", "cast", "rc4", "seed", "des", "desx");
     push @invalid_cipher, "des-ede" if is_sle('12-SP2+');
-    push @invalid_cipher, qw(des3 des-ede3) if (is_sle_micro('5.4+') && is_s390x);
+    # des3 des-ede3 were reporting failure in SLE Micro 5.4 (see # https://bugzilla.suse.com/show_bug.cgi?id=1209271#c8),
+    # but in 5.5 behaviour is different, possible cause:
+    # (1) different worker used z13 vs linuxone (2) or libica not correctly activated
+    # In any case with normal s390x kvm worker we don't need to exclude them anymore.
     for my $cipher (@invalid_cipher) {
         validate_script_output
           "openssl enc -$cipher -e -pbkdf2 -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 || true",


### PR DESCRIPTION
des3 and des-ede3 were reporting failure in SLE Micro 5.4 (see # https://bugzilla.suse.com/show_bug.cgi?id=1209271#c8), but in 5.5 behavior is different, possible cause: (1) different worker used z13 vs linuxone (2) or libica not correctly activated In any case with normal s390x kvm worker we don't need to exclude them anymore and from QE perspective we don't have fixed expectations to do it.

- Related ticket: [poo#134321](https://progress.opensuse.org/issues/134321)
- Verification run: [slem_installation_fips](https://openqa.suse.de/tests/12046799)