### PR TITLE
wsl/prepare_wsl_feature.pm: Add support for WSL2 on aarch64

### DIFF
--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -34,6 +34,7 @@ sub run {
     my ($self) = @_;
     my $wsl_appx_filename = (split /\//, get_required_var('ASSET_1'))[-1];
     my $ms_kernel_link = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi';
+    $ms_kernel_link = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_arm64.msi' if is_aarch64;
     my $certs = {
         opensuse => '/wsl/openSUSE-UEFI-CA-Certificate.crt',
         sle => '/wsl/SLES-UEFI-CA-Certificate.crt'


### PR DESCRIPTION
Add the URL for Arm64.

This test is incredibly slow but it does work with a patched QEMU.

- Related ticket: https://progress.opensuse.org/issues/126083
- Verification run: https://openqa.opensuse.org/tests/3560340#live

CC @pablo-herranz @ggardet
