### PR TITLE
Enable Cockpit for Staging in SLE Micro when SCC is available

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -174,7 +174,7 @@ sub load_common_tests {
     loadtest 'microos/one_line_checks';
     loadtest 'microos/services_enabled';
     # MicroOS -old images use wicked, but cockpit-wicked is no longer supported in TW
-    loadtest 'microos/cockpit_service' unless is_staging || (is_microos('Tumbleweed') && get_var('HDD_1') =~ /-old/);
+    loadtest 'microos/cockpit_service' unless (is_microos('Tumbleweed') && is_staging) || (is_microos('Tumbleweed') && get_var('HDD_1') =~ /-old/) || !get_var('SCC_REGISTER');
     # Staging has no access to repos and the MicroOS-DVD does not contain ansible
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
     loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro || is_alp);


### PR DESCRIPTION
This test was disabled in staging because at the beginning we don't
have SCC and we need to install some cockpit packages. With this
new condition, we can run the test according to SCC variable,
so it's also useful for staging after SCC is in place.