### PR TITLE
lib/windowsbasetest.pm: Add support for WSL2 on aarch64

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -5,6 +5,7 @@
 
 package windowsbasetest;
 use Mojo::Base qw(basetest);
+use Utils::Architectures qw(is_aarch64);
 use testapi;
 
 sub windows_run {
@@ -152,6 +153,7 @@ sub post_fail_hook {
 sub install_wsl2_kernel {
     my $self = shift;
     my $ms_kernel_link = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi';
+    $ms_kernel_link = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_arm64.msi' if is_aarch64;
 
     # Download the WSL kernel and install it
     $self->run_in_powershell(

--- a/tests/wsl/prepare_wsl_feature.pm
+++ b/tests/wsl/prepare_wsl_feature.pm
@@ -33,8 +33,6 @@ q{New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppMod
 sub run {
     my ($self) = @_;
     my $wsl_appx_filename = (split /\//, get_required_var('ASSET_1'))[-1];
-    my $ms_kernel_link = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi';
-    $ms_kernel_link = 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_arm64.msi' if is_aarch64;
     my $certs = {
         opensuse => '/wsl/openSUSE-UEFI-CA-Certificate.crt',
         sle => '/wsl/SLES-UEFI-CA-Certificate.crt'


### PR DESCRIPTION
The verification for the previous run failed. Turns out the URL is set in a different place meanwhile...

- Verification run: https://openqa.opensuse.org/tests/3560743
