### PR TITLE
Check systemd depemdencies required from shutdown test module

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(
   power_action
   assert_shutdown_and_restore_system
   assert_shutdown_with_soft_timeout
+  check_bsc1215132
 );
 
 =head2 prepare_system_shutdown
@@ -436,4 +437,17 @@ sub assert_shutdown_with_soft_timeout {
         record_info('Softfail', "$args->{soft_failure_reason}", result => 'softfail');
     }
     assert_shutdown($args->{timeout} - $args->{soft_timeout});
+}
+
+
+=head2 check_bsc1215132
+
+  Validate dependencies which provides shutdown/poweroff/reboot commands.
+  Use this in the post_fail_hook to raise a softfail of the reported bug.
+=cut
+
+sub check_bsc1215132 {
+    record_soft_failure("bsc1215132: Possible missing dependency on systemd")
+      if (script_run("rpm -q --provides systemd | grep systemd-sysvinit") ||
+        script_run("rpm -q --provides systemd | grep shutdown"));
 }

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use power_action_utils 'power_action';
+use power_action_utils qw(power_action check_bsc1215132);
 use utils;
 
 sub run {
@@ -25,6 +25,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    check_bsc1215132();
     $self->SUPER::post_fail_hook;
     select_console('log-console');
     # check systemd jobs still running in background, these jobs


### PR DESCRIPTION
Provide visibility when bsc1215132 will hit again raising a softfail.

VR: https://openqa.suse.de/tests/12056939#step/shutdown/10