### PR TITLE
[virt_autotest] Fix up check with openqa domain problem

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -109,7 +109,7 @@ sub test_network_interface {
     my $gate = $args{gate};
     my $isolated = $args{isolated} // 0;
     my $routed = $args{routed} // 0;
-    my $target = $args{target} // script_output("dig +short openqa.oqa.prg2.suse.org");
+    my $target = $args{target} // script_output("dig +short google.com");
 
     check_guest_ip("$guest", net => $net) if ((is_sle('>15') || is_alp) && ($isolated == 1) && get_var('VIRT_AUTOTEST'));
 


### PR DESCRIPTION
Current, our OSD domain use with openqa.oqa.prg2.suse.org instead due to our MOVE PLAN from NUE TO PRG. 
Meanwhile, suppose that there was the network(DNS) performance problem from our current OSD network. 
FYI
```
# Test died: command 'ssh root@10.168.193.25 ip r a openqa.oqa.prg2.suse.org.
10.145.10.207 via 10.168.195.254 dev eth1' failed at /usr/lib/os-autoinst/testapi.pm line 926.
testapi::assert_script_run("ssh root\@10.168.193.25 ip r a openqa.oqa.prg2.suse.org.\x{a}10.14"...) called at sle/lib/virt_autotest/virtual_network_utils.pm line 156
virt_autotest::virtual_network_utils::test_network_interface("sles-15-sp5-64-fv-uefi-kvm", "mac", "00:16:3e:32:66:24", "gate", "10.168.195.254", "net", "vnet_host_bridge") called at sle/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm line 72
```
So, we have to use with google.com instead. 

- Related ticket: https://progress.opensuse.org/issues/135242
- Verification run:
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/12079987) PASS
WIP QAM test run