### PR TITLE
Validate STIG rules remediated by YaST

### DIFF
--- a/schedule/security/autoyast_stig_hardening.yaml
+++ b/schedule/security/autoyast_stig_hardening.yaml
@@ -15,3 +15,42 @@ schedule:
   - installation/boot_encrypt
   - installation/first_boot
   - security/stig/upload_stig_logs
+  - security/stig/validate_stig_rules_applied_by_yast
+test_data:
+  stig_rules_applied_by_yast:
+    CCE-85719-3:
+      name: Encrypt Partitions
+      sles_ref: SLES-15-010330
+      result: notchecked
+    CCE-85639-3:
+      name: Ensure /home Located On Separate Partition
+      sles_ref: SLES-15-040200
+      result: pass
+    CCE-85640-1:
+      name: Ensure /var Located On Separate Partition
+      sles_ref: SLES-15-040210
+      result: pass
+    CCE-85618-7:
+      name: Ensure /var/log/audit Located On Separate Partition
+      sles_ref: SLES-15-030810
+      result: pass
+    CCE-85697-1:
+      name: Configure a Sufficiently Large Partition for Audit Logs
+      sles_ref: SLES-15-030660
+      result: notchecked
+    CCE-83275-8:
+      name: Set the UEFI Boot Loader Password
+      sles_ref: SLES-15-010200
+      result: notapplicable
+    CCE-83274-1:
+      name: Set Boot Loader Password in grub2 (non-UEFI)
+      sles_ref: SLES-15-010190
+      result: pass
+    CCE-85751-6:
+      name: Verify firewalld Enabled
+      sles_ref: SLES-15-010220
+      result: pass
+    CCE-83286-5:
+      name: Deactivate Wireless Network Interfaces
+      sles_ref: SLES-15-010380
+      result: pass

--- a/tests/security/stig/validate_stig_rules_applied_by_yast.pm
+++ b/tests/security/stig/validate_stig_rules_applied_by_yast.pm
@@ -1,0 +1,30 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: validate STIG rules checked by YaST during installation
+#
+# Maintainer: QE Security <none@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my @errors;
+    my $expected_stig_rules = get_test_suite_data()->{stig_rules_applied_by_yast};
+    for my $rule (keys %$expected_stig_rules) {
+        my $name = $expected_stig_rules->{$rule}{name};
+        my $result = $expected_stig_rules->{$rule}{result};
+        my $sles_ref = $expected_stig_rules->{$rule}{sles_ref};
+
+        if (script_run("grep -A 1 -B 2 $rule /var/log/ssg-apply/*.out | grep 'Result.*$result'") != 0) {
+            push @errors, "For STIG rule \"$name\" ($rule, $sles_ref), the expected result is '$result'";
+        }
+    }
+    die "Evaluation of STIG rules after installation revealed that the Installer did not apply the following:\n" .
+      join("\n", @errors) . "\nSee logs under /var/log/ssg-apply/*.out for further information\n" if @errors;
+}
+
+1;


### PR DESCRIPTION
Introduce validation for STIG rules that YaST should apply in the installed system.

- Related ticket: [poo#135311](https://progress.opensuse.org/issues/135311)
- Verification runs: 
  - [autoyast_stig_remediation in QU SLE15SP5](https://openqa.suse.de/tests/12080529)
  - [autoyast_stig_remediation in SLE15SP5](https://openqa.suse.de/tests/12091834)
  
  example of [error](https://openqa.suse.de/tests/12080164#step/validate_stig_rules_applied_by_yast/20)