### PR TITLE
Enable Tumbleweed feature tests and automation changes after guest installation

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_two_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_two_disk.xml
@@ -120,6 +120,7 @@
         <service>firewalld</service>
       </disable>
       <enable t="list">
+	<service>NetworkManager</service>
 	<service>sshd</service>
 	<service>virtqemud</service>
 	<service>virtstoraged</service>

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -22,7 +22,7 @@ use XML::Writer;
 use IO::File;
 use utils 'script_retry';
 use upload_system_log 'upload_supportconfig_log';
-use version_utils qw(is_sle is_alp);
+use version_utils qw(is_sle is_alp is_tumbleweed);
 use virt_autotest::utils;
 
 our @EXPORT
@@ -111,7 +111,7 @@ sub test_network_interface {
     my $routed = $args{routed} // 0;
     my $target = $args{target} // script_output("dig +short google.com");
 
-    check_guest_ip("$guest", net => $net) if ((is_sle('>15') || is_alp) && ($isolated == 1) && get_var('VIRT_AUTOTEST'));
+    check_guest_ip("$guest", net => $net) if ((is_sle('>15') || is_alp || is_tumbleweed) && ($isolated == 1) && get_var('VIRT_AUTOTEST'));
 
     save_guest_ip("$guest", name => $net);
 
@@ -365,14 +365,14 @@ sub setup_vm_simple_dns_with_ip {
     my $_dns_file = '/etc/hosts';
 
     # Workaround for directly editing file issue: resource busy
-    if (is_alp) {
+    if (is_alp || is_tumbleweed) {
         $_dns_file = '/etc/hosts.wip';
         assert_script_run "cp /etc/hosts $_dns_file";
     }
 
     script_run "sed -i '/$_vm/d' $_dns_file";
     assert_script_run "echo '$_ip $_vm' >> $_dns_file";
-    assert_script_run "cp $_dns_file /etc/hosts" if (is_alp);
+    assert_script_run "cp $_dns_file /etc/hosts" if (is_alp || is_tumbleweed);
     save_screenshot;
     record_info("Simple DNS setup in /etc/hosts for $_ip $_vm is successful!", script_output("cat /etc/hosts"));
 }

--- a/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
+++ b/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
@@ -56,13 +56,14 @@ conditional_schedule:
     hotplugging_test:
         ENABLE_HOTPLUGGING:
             1:
-                - virtualization/universal/hotplugging_guest_preparation
                 - virtualization/universal/hotplugging_network_interfaces
                 - virtualization/universal/hotplugging_HDD
                 - virtualization/universal/hotplugging_vCPUs
                 - virtualization/universal/hotplugging_memory
+            0:
+                - virtualization/universal/hotplugging_guest_preparation
                 - virtualization/universal/hotplugging_cleanup
     storage_test:
         ENABLE_STORAGE:
-            1:
+            0:
                 - virtualization/universal/storage

--- a/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_host_bridge_virtual_network.pm
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_alp);
+use version_utils qw(is_sle is_alp is_tumbleweed);
 
 our $virt_host_bridge = 'br0';
 our $based_guest_dir = 'tmp';
@@ -25,7 +25,7 @@ sub run_test {
     my ($self) = @_;
 
     # ALP has done this in earlier setup
-    unless (is_alp) {
+    unless (is_alp || is_tumbleweed) {
         #Prepare VM HOST SERVER Network Interface Configuration
         #for libvirt virtual network testing
         virt_autotest::virtual_network_utils::prepare_network($virt_host_bridge, $based_guest_dir);

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_alp);
+use version_utils qw(is_sle is_alp is_tumbleweed);
 use virt_autotest::utils qw(is_xen_host);
 
 sub run_test {
@@ -76,7 +76,7 @@ sub run_test {
         check_guest_health($guest);
 
         # ALP guest uses networkmanager to control network, no /etc/sysconfig/network/ifcfg*
-        next if ($guest =~ /alp/i);
+        next if ($guest =~ /alp/i || is_tumbleweed);
         #Prepare the new guest network interface files for libvirt virtual network
         #for some guests, interfaces are named eth0, eth1, eth2, ...
         #for TW kvm guest, they are enp1s0, enp2s0, enp3s0, ...


### PR DESCRIPTION
- Description
To enable Feature Tests and automation fixes after guest installation and test runs to support OpenSUSE Tumbleweed.
**virtual_network_test:**
                - virt_autotest/libvirt_virtual_network_init
                - virt_autotest/libvirt_nated_virtual_network
                - virt_autotest/libvirt_host_bridge_virtual_network

- Related ticket: 
Epic: https://progress.opensuse.org/issues/94801
Sub-tasks:
https://progress.opensuse.org/issues/136157
https://progress.opensuse.org/issues/137123

- Verification run: 
[KVM](https://openqa.opensuse.org/tests/3592430#):  libvirt_nated_virtual_network

[KVM](https://openqa.opensuse.org/tests/3617766#): libvirt_virtual_network_init and libvirt_nated_virtual_network [PASSED]

[XEN](https://openqa.opensuse.org/tests/3617939#): libvirt_virtual_network_init [PASS] and libvirt_nated_virtual_network [FAIL]
