### PR TITLE
wip [virt_autotest] fix up scc_url problem for sles15sp6 guest system installation

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2012-2016 SUSE LLC
+# Copyright 2012-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: guest_installation_run: This test is used to verify if different products can be installed successfully as guest on specify host.
@@ -12,6 +12,7 @@ use warnings;
 use testapi;
 use Utils::Architectures;
 use virt_utils;
+use virt_autotest::utils qw(is_xen_host);
 
 sub get_script_run {
     my $pre_test_cmd = "";
@@ -63,6 +64,17 @@ sub post_execute_script_assertion {
 
 sub run {
     my $self = shift;
+
+    # refer to poo#135431 for more details
+    my $proxyscc = get_var('SCC_URL');
+    if ($proxyscc) {
+        my $fv_guest = "fv";
+        my $pv_guest = "pv";
+        my $autoyast_dir = script_output("find /usr/share/qa/virtautolib/data/autoinstallation/sles/15/ -maxdepth 1 | tail -1");
+	$autoyast_dir = $autoyast_dir . "/64/";
+        my $guest_autoyast = "$autoyast_dir" + (is_xen_host ? $pv_guest : $fv_guest ) + "/def";
+        script_run("sed -i '8i\ <reg_server>$proxyscc</reg_server>' $guest_autoyast");
+    }
 
     # Add option to keep guest after successful installation
     # Only for x86_64 now


### PR DESCRIPTION
- Current problem
Repositories for SP6 are not yet published on updates.suse.com 
The product is only in alpha release to be tested with qa-proxy.

- Solution
So, we  have to use the qa-proxy (e.g [http://all-${BUILD NUM}.proxy.scc.suse.de/) instead as the workaround for current 15SP6 guest installation failure. 

- Related ticket: https://progress.opensuse.org/issues/135431

- Verification run: 
gi-guest_developing-on-host_developing-kvm
wip gi-guest_developing-on-host_developing-kvm
wip gi-guest_developing-on-host_15sp5-kvm
wip gi-guest_developing-on-host_12sp5-kvm
wip gi-guest_12sp5-on-host_developing-kvm
wip gi-guest_15sp5-on-host_developing-kvm
