### PR TITLE
Fix public cloud ansible python version failure

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -21,6 +21,8 @@ terraform:
     private_key: '~/.ssh/id_rsa'
     os_image: "%PUBLIC_CLOUD_OS_IMAGE%"
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 
     # HANA
     hana_count: '%NODE_COUNT%'


### PR DESCRIPTION
Fix failure "ansible-core requires a minimum of Python2 version 2.7 or Python3 version 3.5. Current version: 3.4.10" in pulbic cloud cases 

TEAM-8361 - Only use cloud catalog images in MU JobGroups

- Related ticket: https://jira.suse.com/browse/TEAM-8361
- Needles: NA
- Verification run:

**sap12sp5**: 
    https://openqaworker15.qa.suse.cz/tests/225386#
    The failure can be tracked by new ticket [TEAM-8533](https://sd.suse.com/browse/SD-8533) - "SAPHanaSR-ScaleUp-PerfOpt" failed on "deploy_qesap_ansible": "zypper lr" returns 6 on "vmiscsi01"
  
**sap15sp1**:  
    https://openqaworker15.qa.suse.cz/tests/224668#step/deploy_qesap_ansible/7
**sap15sp3**:  
    https://openqaworker15.qa.suse.cz/tests/224660#step/deploy_qesap_ansible/7
    The failures on sap15sp1 and sap15sp3 can be tracked by new ticket [TEAM-8532](https://sd.suse.com/browse/SD-8532) - "SAPHanaSR-ScaleUp-PerfOpt" failed on "deploy_qesap_ansible": "registercloudguest" returns 1 on "vmiscsi01"
  