### PR TITLE
Adapt yast2_control_center for start_directory_server

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -294,6 +294,10 @@ sub start_wake_on_lan {
 sub start_directory_server {
     search 'directory server';
     assert_and_click 'yast2_control-center_authentication-server';
+    if (check_screen('deprecated_info', 60)) {
+        record_info('Deprecated Info', 'The tool is deprecated.');
+        send_key 'alt-o';
+    }
     do {
         assert_screen [
             qw(yast2_control-center-authentication-server_install yast2_control-center-authentication-server_configuration yast2_control-center-authentication-server_empty_first_page)


### PR DESCRIPTION
Adapt yast2_control_center for start_directory_server

- Related ticket: https://progress.opensuse.org/issues/134444
- Verification run: https://openqa.suse.de/tests/12088500#step/yast2_control_center/91