### PR TITLE
Remove soft-failure for bsc 1186691 in docker-compose

### DIFF
--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -45,23 +45,6 @@ sub run {
         $ret = zypper_call "in docker-compose-switch";
     }
 
-    if ($ret == 4) {
-        # https://bugzilla.suse.com/show_bug.cgi?id=1186691#c29
-        # Possible outcomes:
-        #  nothing provides python-dockerpty >= 0.3.2 needed by docker-compose-1.2.0-5.1.noarch (12-SP5 s390x)
-        #  nothing provides python-docker-py >= 1.0.0 needed by docker-compose-1.2.0-5.1.noarch (12-SP4 s390x)
-        record_soft_failure "bsc#1186691 - docker-compose probably missing dependency";
-        return 0;
-    }
-
-    if (script_output('docker-compose --version', proceed_on_failure => 1) =~ /distribution was not found/) {
-        # Installation is ok, but when issuing docker-compose commands it throws:
-        # pkg_resources.DistributionNotFound: The 'PyYAML<4,>=3.10' distribution was not found and is required by docker-compose
-        # This happens only in 12-SP3 and 12-SP4 x86_64
-        record_soft_failure "bsc#1186691 - docker-compose probably missing dependency";
-        return 0;
-    }
-
     # Prepare docker-compose.yml and haproxy.cfg
     assert_script_run 'mkdir -p dcproject; cd dcproject';
     assert_script_run("curl -O " . data_url("containers/docker-compose.yml"));


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1186691 is resolved and tests are not soft-failing in this step. It's safe to be removed.