### PR TITLE
Fix Mojo::File::spurt() deprecation warning in LTP unit test

### DIFF
--- a/t/07_ltp_whitelist.t
+++ b/t/07_ltp_whitelist.t
@@ -77,7 +77,7 @@ subtest override_known_failures => sub {
         }
     };
 
-    Mojo::File::path('test_known_issues.json')->spurt(Mojo::JSON::encode_json($known_issues_json));
+    Mojo::File::path('test_known_issues.json')->spew(Mojo::JSON::encode_json($known_issues_json));
 
     my $env = {product => 'sle:15', retval => 0};
     my $whitelist = LTP::WhiteList->new();


### PR DESCRIPTION
`Mojo::File::spurt()` is deprecated, replace it with `Mojo::File::spew()`.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
