### PR TITLE
containers: Restrict helm_rmt test to SLE 15-SP3+

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -21,7 +21,7 @@
 use Mojo::Base qw(consoletest);
 use XML::LibXML;
 use utils qw(zypper_call script_retry);
-use version_utils qw(get_os_release);
+use version_utils qw(get_os_release is_sle);
 use db_utils qw(push_image_data_to_db);
 use containers::common;
 use testapi;
@@ -80,12 +80,13 @@ sub run {
     # Wait for any zypper tasks in the background to finish
     assert_script_run('while pgrep -f zypp; do sleep 1; done', timeout => 300);
 
+    my ($version, $sp, $host_distri) = get_os_release;
+    return if (get_var('HELM_CONFIG') && !($host_distri == "sles" && $version == 15 && $sp >= 3));
+
     # CONTAINER_RUNTIME can be "docker", "podman" or both "podman,docker"
     my $engines = get_required_var('CONTAINER_RUNTIME');
     my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
     my $bci_tests_branch = get_var('BCI_TESTS_BRANCH');
-
-    my ($version, $sp, $host_distri) = get_os_release;
 
     record_info('Install', 'Install needed packages');
     my @packages = packages_to_install($version, $sp, $host_distri);

--- a/tests/containers/helm_rmt.pm
+++ b/tests/containers/helm_rmt.pm
@@ -16,13 +16,17 @@ use Mojo::Base 'publiccloud::basetest';
 use File::Basename qw(dirname);
 use testapi;
 use utils;
-use serial_terminal 'select_serial_terminal';
+use version_utils qw(get_os_release is_sle);
+use serial_terminal qw(select_serial_terminal);
 use containers::k8s;
 
 sub run {
     my ($self) = @_;
-
     select_serial_terminal;
+
+    my ($version, $sp, $host_distri) = get_os_release;
+    return if (get_var('HELM_CONFIG') && !($host_distri == "sles" && $version == 15 && $sp >= 3));
+
     systemctl 'stop firewalld';
     ensure_ca_certificates_suse_installed();
     install_k3s();


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/124385
- Failed jobs: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=9.46_rmt-server-image&groupid=445
- Verification run: sle-15-SP5-BCI-Updates-x86_64-Build9.46_rmt-server-image-_on_ubuntu@64bit -> https://openqa.suse.de/tests/12096338