### PR TITLE
Avoid Mojo::File::spurt() deprecation warning

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -103,7 +103,7 @@ $filename = "my-test.log";
 sub save_ulog {
     my ($out, $filename) = @_;
     mkdir('ulogs') if (!-d 'ulogs');
-    path("ulogs/$filename")->spurt($out);    # save the logs to the ulogs directory on the worker directly
+    path("ulogs/$filename")->spew($out);    # save the logs to the ulogs directory on the worker directly
 }
 
 =head2 export_healthcheck_basic

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -260,8 +260,8 @@ sub write_extra_test_result {
         }],
         result => $result,
     };
-    path($dir, 'result-' . $filename . '.json')->spurt(Mojo::JSON::encode_json($result_file));
-    path($dir, $filename . '.txt')->spurt($details->{test}->{log});
+    path($dir, 'result-' . $filename . '.json')->spew(Mojo::JSON::encode_json($result_file));
+    path($dir, $filename . '.txt')->spew($details->{test}->{log});
 
     push @{$self->{details}}, $result_file->{details}->[0];
 }

--- a/tests/kernel/virtio_console_long_output.pm
+++ b/tests/kernel/virtio_console_long_output.pm
@@ -43,7 +43,7 @@ sub run {
 
     my $filename = "original_$size.txt";
     my $testdata = create_test_data($size);
-    path('ulogs/' . $filename)->spurt($testdata);
+    path('ulogs/' . $filename)->spew($testdata);
     save_tmp_file($filename, $testdata);
     assert_script_run('curl -O ' . autoinst_url . "/files/" . $filename);
     my $sha1sum = sha1_sum(trim($testdata));    # cause script_output() trim the data
@@ -69,7 +69,7 @@ sub run {
         } else {
             script_run("cat /sys/kernel/debug/virtio-ports/*");
             record_info("FAILED $i", "ORIG: $sha1sum\nFAIL: $sha1sum_2", result => 'fail');
-            path('ulogs/failed')->spurt($output);
+            path('ulogs/failed')->spew($output);
             record_info('DIFF', scalar(`diff  ulogs/$filename ulogs/failed`)) if (system('diff --help') == 0);
             die("OUTPUT MISSMATCH");
         }

--- a/tests/wicked/sysctl/sut/t02_sysctl_check_defaults.pm
+++ b/tests/wicked/sysctl/sut/t02_sysctl_check_defaults.pm
@@ -71,7 +71,7 @@ EOT
     $self->record_console_test_result("Sysctl Wicked", $out_wicked, result => 'ok');
 
     mkdir "ulogs";
-    path(sprintf('ulogs/%s_%s@%s_sysctl_wicked.txt', get_var('DISTRI'), get_var('VERSION'), get_var('ARCH')))->spurt($out_wicked);
+    path(sprintf('ulogs/%s_%s@%s_sysctl_wicked.txt', get_var('DISTRI'), get_var('VERSION'), get_var('ARCH')))->spew($out_wicked);
 
     # Disable wicked and reboot to get "systemd-sysctl" defaults
     script_run('systemctl disable --now wicked', die_on_timeout => 1);
@@ -83,7 +83,7 @@ EOT
     my $out_native = script_output($cmd);
 
     $self->record_console_test_result("Sysctl Native", $out_native, result => 'ok');
-    path(sprintf('ulogs/%s_%s@%s_sysctl_native.txt', get_var('DISTRI'), get_var('VERSION'), get_var('ARCH')))->spurt($out_native);
+    path(sprintf('ulogs/%s_%s@%s_sysctl_native.txt', get_var('DISTRI'), get_var('VERSION'), get_var('ARCH')))->spew($out_native);
 
     # Wicked set `ipv4.arp_notify = 1` by default.
     my $except_diff = {'net.ipv4.conf.' . $ctx->iface() . '.arp_notify' => 1};


### PR DESCRIPTION
As of Mojolicious v9.34 Mojo::File::spurt() has been deprecated in favor of spew() (see
https://github.com/mojolicious/mojo/commit/45f1e6091a724ef6380492d751afb9863c324b0d).

---

I'm adding the "notready" label because we should not merge this until the new Mojolicious version has been deployed on o3 and OSD workers. At this point v9.34 hasn't even made it to Tumbleweed yet. Note that you can easily test whether this works via e.g. `perl -e "use Mojo::File qw(path); path('/tmp/foo')->spew('test')"`.