### PR TITLE
Split derigister_dropped_modules test module

### DIFF
--- a/schedule/migration/migration_offline_media_all_patterns_x86_64.yaml
+++ b/schedule/migration/migration_offline_media_all_patterns_x86_64.yaml
@@ -14,7 +14,8 @@ schedule:
   - migration/setup_sle
   - migration/install_all_patterns
   - migration/query_all_rpm
-  - migration/drop_unavailable_product_modules
+  - migration/deregister_ltss
+  - migration/deregister_python2
   - migration/deregister_system
   - migration/record_disk_info
   - migration/reboot_to_upgrade

--- a/tests/migration/deregister_ltss.pm
+++ b/tests/migration/deregister_ltss.pm
@@ -1,0 +1,19 @@
+# SLE15 migration tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: LTSS is not supported to do migration, need to deregiter it before migration
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use registration qw(remove_suseconnect_product);
+
+sub run {
+    remove_suseconnect_product('SLES-LTSS');
+}
+
+1;
+

--- a/tests/migration/deregister_python2.pm
+++ b/tests/migration/deregister_python2.pm
@@ -1,0 +1,19 @@
+# SLE15 migration tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Python2 module doesn't exist since SLE15SP3, need to remove it before migration
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use registration qw(remove_suseconnect_product get_addon_fullname);
+
+sub run {
+    remove_suseconnect_product(get_addon_fullname('python2'));
+}
+
+1;
+


### PR DESCRIPTION
This PR is to split derigister_dropped_modules test module by creating two new test module to deregister ltss and python2 module. Because the supported hpc migration path doesn't include older scenarios, so we don't have ltss in hpc cases, so I didn't add SLE_HPC-LTSS to the deregister_ltss text module.

- Related ticket: https://progress.opensuse.org/issues/132920
- Needles: n/a
- Verification run: 
- https://openqa.suse.de/tests/12051316#step/deregister_ltss/1
- https://openqa.suse.de/tests/12051316#step/deregister_python2/1