### PR TITLE
Update timeout widget following yast-bootloader changes

### DIFF
--- a/lib/YaST/Bootloader/BootloaderOptionsPage.pm
+++ b/lib/YaST/Bootloader/BootloaderOptionsPage.pm
@@ -15,7 +15,7 @@ use warnings;
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{txb_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::TimeoutWidget\""});
+    $self->{txb_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::Grub2Widget::TimeoutWidget\""});
     return $self;
 }
 


### PR DESCRIPTION
Following a change in yast-bootloader (see https://github.com/yast/yast-bootloader/pull/686/files#diff-673d66967f8d7a2a143e4a776ed743e81346e947c1e6d58b8f2657235902718e)
This test needeed to be adjusted.

- Related ticket: https://progress.opensuse.org/issues/135512
- Verification run: https://openqa.opensuse.org/tests/3570013
                    https://openqa.suse.de/tests/12114085#step/disable_boot_menu_timeout/1
                    https://openqa.suse.de/tests/12113447#step/disable_boot_menu_timeout/1
