### PR TITLE
Implement SBD delay setup on premise tests

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -73,6 +73,8 @@ our @EXPORT = qw(
   activate_ntp
   script_output_retry_check
   calculate_sbd_start_delay
+  setup_sbd_delay
+  set_sbd_service_timeout
   collect_sbd_delay_parameters
   check_iscsi_failure
   cluster_status_matches_regex
@@ -1108,6 +1110,63 @@ sub calculate_sbd_start_delay {
         return $params{'sbd_delay_start'};
     }
     return $default_wait;
+}
+
+=head2 setup_sbd_delay
+    setup_sbd_delay()
+
+=cut
+
+sub setup_sbd_delay() {
+    my $delay = get_var('HA_SBD_START_DELAY', '');
+
+    if ($delay eq '') {
+        record_info('SBD delay', "Skipping, variable 'HA_SBD_START_DELAY' not defined");
+    }
+    else {
+        $delay =~ s/(?<![ye])s//g;
+        croak("<\$set_delay> value must be either 'yes', 'no' or an integer. Got value: $delay")
+          unless looks_like_number($delay) or grep /^$delay$/, qw(yes no);
+        file_content_replace('/etc/sysconfig/sbd', '^SBD_DELAY_START=.*', "SBD_DELAY_START=$delay");
+        record_info('SBD delay', "SBD delay set to: $delay");
+    }
+    # Calculate currently set delay
+    $delay = calculate_sbd_start_delay();
+
+    # set SBD service timeout to be higher (+30s) that calculated/set delay
+    my $sbd_service_timeout = set_sbd_service_timeout($delay + 30);
+    record_info('sbd.service', "Service start timeout for sbd.service set to: $sbd_service_timeout");
+
+    return ($delay);
+}
+
+=head2 set_sbd_service_timeout
+    set_sbd_service_timeout($service_timeout)
+
+=cut
+
+sub set_sbd_service_timeout {
+    my ($service_timeout) = @_;
+    croak "Argument 'service_timeout' not defined" unless defined($service_timeout);
+    croak "Argument 'service_timeout' is not a number" unless looks_like_number($service_timeout);
+    my $service_override_dir = "/etc/systemd/system/sbd.service.d/";
+    my $service_override_filename = "sbd_delay_start.conf";
+    my $service_override_path = $service_override_dir . $service_override_filename;
+
+    # CMD RC is converted to true/false
+    my $file_exists = script_run(join(" ", "test", "-e", $service_override_path, ";echo", "\$?"), quiet => 1) ? 1 : 0;
+
+    if ($file_exists) {
+        file_content_replace($service_override_path, '^TimeoutSec=.*', "TimeoutSec=$service_timeout");
+    }
+    else {
+        my @content = ('[Service]', "TimeoutSec=$service_timeout");
+        assert_script_run(join(" ", "mkdir", "-p", $service_override_dir));
+        assert_script_run(join(" ", "bash", "-c", "\"echo", "'$_'", ">>", $service_override_path, "\"")) foreach @content;
+    }
+    record_info("Systemd SBD", "Systemd unit timeout for 'sbd.service' set to '$service_timeout'");
+
+    return ($service_timeout);
 }
 
 =head2 check_iscsi_failure

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -45,7 +45,7 @@ our @EXPORT = qw(
   wait_for_pacemaker
   cloud_file_content_replace
   change_sbd_service_timeout
-  setup_sbd_delay
+  setup_sbd_delay_publiccloud
   sbd_delay_formula
   create_instance_data
   deployment_name
@@ -461,8 +461,8 @@ sub change_sbd_service_timeout() {
     record_info("Systemd SBD", "Systemd unit timeout for 'sbd.service' set to '$service_timeout'");
 }
 
-=head2 setup_sbd_delay
-     $self->setup_sbd_delay();
+=head2 setup_sbd_delay_publiccloud
+     $self->setup_sbd_delay_publiccloud();
 
      Set (activate or deactivate) SBD_DELAY_START setting in /etc/sysconfig/sbd.
      Delay is used in case of cluster VM joining cluster too quickly after fencing operation.
@@ -478,7 +478,7 @@ sub change_sbd_service_timeout() {
 
 =cut
 
-sub setup_sbd_delay() {
+sub setup_sbd_delay_publiccloud() {
     my ($self) = @_;
     my $delay = get_var('HA_SBD_START_DELAY') // '';
 

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -7,7 +7,7 @@ use Test::More;
 use sles4sap_publiccloud;
 
 
-subtest "Run 'setup_sbd_delay' with different values" => sub {
+subtest "Run 'setup_sbd_delay_publiccloud' with different values" => sub {
     my $self = sles4sap_publiccloud->new();
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { return; });
@@ -27,18 +27,18 @@ subtest "Run 'setup_sbd_delay' with different values" => sub {
 
     for my $input_value (@failok_values) {
         set_var('HA_SBD_START_DELAY', $input_value);
-        dies_ok { $self->setup_sbd_delay() } "Test expected failing 'HA_SBD_START_DELAY' value: $input_value";
+        dies_ok { $self->setup_sbd_delay_publiccloud() } "Test expected failing 'HA_SBD_START_DELAY' value: $input_value";
     }
 
     for my $value (keys %passing_values_vs_expected) {
         set_var('HA_SBD_START_DELAY', $value);
-        my $returned_value = $self->setup_sbd_delay();
+        my $returned_value = $self->setup_sbd_delay_publiccloud();
         is($returned_value, $passing_values_vs_expected{$value},
             "Test 'HA_SBD_START_DELAY' passing values:\ninput_value: $value\n result: $returned_value");
     }
 
     set_var('HA_SBD_START_DELAY', undef);
-    my $returned_delay = $self->setup_sbd_delay();
+    my $returned_delay = $self->setup_sbd_delay_publiccloud();
     is $returned_delay, 30, "Test with undefined 'HA_SBD_START_DELAY':\n Expected: 30\nGot: $returned_delay";
 
 };

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -74,7 +74,7 @@ sub run {
     systemctl 'list-units | grep iscsi', timeout => $default_timeout;
 
     if ((!defined $node_to_fence && check_var('HA_CLUSTER_INIT', 'yes')) || (defined $node_to_fence && get_hostname eq "$node_to_fence")) {
-        my $sbd_delay = calculate_sbd_start_delay;
+        my $sbd_delay = setup_sbd_delay();
         record_info("SBD delay $sbd_delay sec", "Calculated SBD start delay: $sbd_delay");
         # test should wait longer that startup delay set therefore adding 15s
         sleep $sbd_delay + 15;

--- a/tests/ha/ha_cluster_crash_test.pm
+++ b/tests/ha/ha_cluster_crash_test.pm
@@ -28,7 +28,7 @@ use hacluster qw(check_cluster_state
   get_node_index
   get_node_number
   ha_export_logs
-  calculate_sbd_start_delay
+  setup_sbd_delay
   wait_until_resources_started
 );
 use utils qw(zypper_call);
@@ -58,7 +58,7 @@ sub run {
     my @checks = qw(kill-sbd kill-corosync kill-pacemakerd split-brain-iptables);
     my $preflight_start_time = time;
     # Start delay after fencing to prevent node joining cluster too quickly
-    my $start_delay_after_fencing = calculate_sbd_start_delay();
+    my $start_delay_after_fencing = setup_sbd_delay();
 
     # Loop on each check
     foreach my $check (@checks) {

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -46,7 +46,7 @@ sub run {
     );
 
     # SBD delay related setup in case of crash OS to prevent cluster starting too quickly after reboot
-    $self->setup_sbd_delay() if $takeover_action eq 'crash';
+    $self->setup_sbd_delay_publiccloud() if $takeover_action eq 'crash';
     # Calculate SBD delay sleep time
     $sbd_delay = $self->sbd_delay_formula if $takeover_action eq 'crash';
 

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -48,7 +48,7 @@ sub run {
 
     if (($db_action eq 'crash')) {
         # SBD delay related setup in case of crash OS to prevent cluster starting too quickly after reboot
-        $self->setup_sbd_delay();
+        $self->setup_sbd_delay_publiccloud();
         record_info('Crash DB', "Crashing OS on Site B ('$site_b->{instance_id}')");
     }
     else {


### PR DESCRIPTION
This PR adds functions to set up SBD delay on HA cluster using parameter 
HA_SBD_START_DELAY. Functions do setup on HA clouster side but also increase 
timeout for systemd 'sbd' service.

- Related ticket: https://jira.suse.com/browse/TEAM-8151
- Verification run: 
- 2 node cluster - default values: http://openqaworker15.qa.suse.cz/tests/228022#step/check_after_reboot/41
- 3 node cluster - default values: https://openqaworker15.qa.suse.cz/tests/228030#step/check_after_reboot/48
- 2 node cluster - SBD set to 90s : https://openqaworker15.qa.suse.cz/tests/228031#step/check_after_reboot/43
- 3 node cluster - SBD set to 90s : https://openqaworker15.qa.suse.cz/tests/228023#step/check_after_reboot/42