### PR TITLE
Skip repo check for ALP

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -13,7 +13,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro is_vmware);
+use version_utils qw(is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro is_vmware is_alp);
 use Utils::Architectures;
 use Utils::Backends;
 use jeos qw(expect_mount_by_uuid);
@@ -252,7 +252,7 @@ sub run {
     verify_mounts unless is_leap('<15.2') && is_aarch64;
 
     verify_hypervisor unless is_generalhw;
-    verify_norepos unless is_opensuse;
+    verify_norepos unless is_opensuse || is_alp;
     verify_bsc if is_jeos;
 }
 


### PR DESCRIPTION
Usually images come with empty repo list, but there is an exception for opensuse and ALP.

- Verification run: [alp-1.0-Dolomite-Default-x86_64-Build6.8-alp_image_wizard@64bit](https://openqa.suse.de/tests/12098751)
