### PR TITLE
Create support images with modules for sles12sp5 default pattern

### DIFF
--- a/schedule/yam/create_support_image_module_combinations_updated.yaml
+++ b/schedule/yam/create_support_image_module_combinations_updated.yaml
@@ -1,0 +1,17 @@
+name: create_support_image_module_combinations_updated
+description:    >
+  Create support images with module combinations.
+conditional_schedule:
+  svirt_upload_assets:
+    ARCH:
+      s390x:
+        - shutdown/svirt_upload_assets
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - update/patch_sle
+  - console/scc_deregistration
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+  - '{{svirt_upload_assets}}'


### PR DESCRIPTION
- Description:
    * Create support images with modules for the sles12sp5 default pattern

- Related ticket: [**132704**](https://progress.opensuse.org/issues/132704)
- Needles: N/A
- Verification run: 
     *  [**VRS**](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=20230912-1&groupid=520)
     - sle_autoyast_support_image_gnome_12sp5_ids-idu@ppc64le
        * https://openqa.suse.de/tests/12133691
     -   sle_autoyast_support_image_gnome_12sp5_lp@ppc64le
         * https://openqa.suse.de/tests/12116127
     -  sle_autoyast_support_image_gnome_12sp5_lp@s390x-kvm-sle12
        * https://openqa.suse.de/tests/12116482
     -   sle_autoyast_support_image_gnome_12sp5_phub@64bit
        *  https://openqa.suse.de/tests/12116113
     -  sle_autoyast_support_image_gnome_12sp5_we_lp@64bit
        *  https://openqa.suse.de/tests/12116911