### PR TITLE
fix Missing mandatory argument provider

### DIFF
--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -58,7 +58,7 @@ sub clean_up {
     my ($self) = @_;
     my @cmds_list;
     # Only run the Ansible deregister if the inventory is present
-    push(@cmds_list, 'ansible') if (!script_run 'test -f ' . qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER')));
+    push(@cmds_list, 'ansible') if (!script_run 'test -f ' . qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER')));
 
     # Terraform destroy can be executed in any case
     push(@cmds_list, 'terraform');


### PR DESCRIPTION
This PR is about to fix Missing mandatory argument **provider** , which is detected by GCP regression run
Regression from [PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17643)

Issue found @:http://openqaworker15.qa.suse.cz/tests/225423#step/deploy/59

- Related ticket: [TEAM-8006](https://jira.suse.com/browse/TEAM-8006)

- Verification run: GCP : http://openqaworker15.qa.suse.cz/tests/226071
                                AWS : http://openqaworker15.qa.suse.cz/t226072
                                Azure: http://openqaworker15.qa.suse.cz/tests/226073 (VR With Wrong reg code)
                                Azure : http://openqaworker15.qa.suse.cz/t226074 (Failed due to [TEAM-8532](https://jira.suse.com/browse/TEAM-8532))
