### PR TITLE
Clean args before script_output

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1008,6 +1008,11 @@ sub script_output_retry_check {
     my $ignore_failure = $args{ignore_failure} // "0";
     my $result;
 
+    # Get rid of args irrelevant to script_output
+    foreach my $key (keys %args) {
+        delete $args{$key} unless grep { $_ eq $key } qw(timeout wait type_command proceed_on_failure quiet);
+    }
+
     foreach (1 .. $retry) {
         $result = script_output($cmd, %args);
         return $result if $result =~ /$regex/;


### PR DESCRIPTION
This ticket clears the `args` hash of arguments not used in `script_output`, before `script_output` is called. The reason is, some failures were noticed before due to `script_output_retry_check` using some arguments contained in `%args` that are not used in the `script_output` function, however the same `%args` is internally passed to `script_output`. This can sometimes lead to wrong arguments taking the place of `timeout` in `script_output` leading to errors.

- Related ticket: https://jira.suse.com/browse/TEAM-8176
-  Verification Run:
https://openqa.suse.de/tests/12342121#details
https://openqa.suse.de/tests/12342122#details
https://openqa.suse.de/tests/12342123#details
https://openqa.suse.de/tests/12342124#details

