### PR TITLE
data/journal_check/bug_refs.json: Allow no-config-drive for Tumbleweed

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -359,7 +359,8 @@
         "products": {
             "leap-micro": ["5.3"],
             "sle-micro": ["5.3", "5.4" , "5.5"],
-            "microos":  ["Tumbleweed"]
+            "microos":  ["Tumbleweed"],
+            "opensuse":  ["Tumbleweed"]
         },
         "type": "ignore"
     },


### PR DESCRIPTION
Minimal has combustion now.

- Related ticket: https://build.opensuse.org/request/show/1110652#comment-1821250
- Verification run: https://openqa.opensuse.org/tests/3571943#live
