### PR TITLE
Fix for poo#134177

### DIFF
--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -61,6 +61,7 @@ sub run {
 "$docker run -itd --shm-size=256m --name ds389_container --hostname ldapserver --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --restart=always ds389_image"
     ) if ($docker eq "docker");
     assert_script_run("$docker run -itd --shm-size=256m --name ds389_container --hostname ldapserver ds389_image") if ($docker eq "podman");
+    assert_script_run("$docker exec ds389_container chown dirsrv:dirsrv /var/lib/dirsrv");
     assert_script_run("$docker exec ds389_container sed -n '/ldapserver/p' /etc/hosts >> /etc/hosts");
     assert_script_run("$docker exec ds389_container dscreate from-file /tmp/instance_389.inf");
     assert_script_run('ldapadd -x -H ldap://ldapserver -D "cn=Directory Manager" -w opensuse -f user_389.ldif');


### PR DESCRIPTION
When doing manual installation of the package: 389_ds, the dir: /var/lib/dirsrv gets the proper ownership. However doing the zypper in while creating the container image results in improper ownership. Due to that the ns-slapd server does not start.

- Related ticket: https://progress.opensuse.org/issues/134177
- Verification run: https://openqa.suse.de/tests/12104508/modules/sssd_389ds_functional/steps/1/src

