### PR TITLE
containers: Remove soft_failure for fixed issue

### DIFF
--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -48,7 +48,7 @@ sub registry_push_pull {
     if (script_run($engine->runtime . " images | grep '$image'") == 0) {
         assert_script_run $engine->runtime . " image rm -f $image", 90;
     } else {
-        record_soft_failure("Known issue - containers/podman#10685: podman image rm --force also untags other images (3.2.0 regression)");
+        die("rm --force untags other images");
     }
     assert_script_run "! " . $engine->runtime . " images | grep '$image'", 60;
     assert_script_run "! " . $engine->runtime . " images | grep 'localhost:5000/$image'", 60;


### PR DESCRIPTION
https://github.com/containers/podman/issues/10685 was fixed and backported to podman 3.2.2.

The soft-failure is unreachable anyway because the module is loaded only for SLE 15-SP4+ in `load_host_tests_docker()`: 

https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/lib/main_containers.pm#L130