### PR TITLE
Avoid stop timer in Secure boot screen in aarch64 

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -988,7 +988,7 @@ sub tianocore_disable_secureboot {
     send_key_until_needlematch 'tianocore-devicemanager', 'esc';
     send_key_until_needlematch 'tianocore-mainmenu-reset', 'down';
     send_key 'ret';
-    send_key 'ret' if check_screen($neelle_sb_config_state, $timeout);
+    send_key 'ret' if (!is_aarch64() && check_screen($neelle_sb_config_state, $timeout));
     $basetest->wait_grub;
 }
 


### PR DESCRIPTION
In this sporadic issue there is a visual glitch not showing the lower half of this screen and some residual text as well, so the 'ret' key doesn't reach the SUT. Therefore we can allow the 5-seconds counter to proceed without stopping it, detecting successfully the grub.

- Related ticket: [poo#134384](https://progress.opensuse.org/issues/134384)
- Verification runs: [10x - aarch64_secureboot](https://openqa.suse.de/tests/overview?distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23test&version=15-SP3)
