### PR TITLE
Fix os_release_name in Agama auto installation

### DIFF
--- a/test_data/yam/agama_auto_micro.yaml
+++ b/test_data/yam/agama_auto_micro.yaml
@@ -1,2 +1,2 @@
 ---
-os_release_name: ALP Micro
+os_release_name: ALP-Dolomite


### PR DESCRIPTION
- Description: quick PR to fix `os_release_name` in Agama auto installation
- Issues: [overview](https://openqa.opensuse.org/tests/overview?distri=alp&version=agama-3.0-staging&build=4.62&groupid=96)
- Verification run: [overview](https://openqa.opensuse.org/tests/overview?distri=alp&build=manfredi%2Fos-autoinst-distri-opensuse%23issues-product-name&version=agama-3.0-staging)
