### PR TITLE
Remove redundant pipe from regex pattern

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -317,7 +317,7 @@
         "type": "ignore"
     },
     "health-check-typo": {
-        "description": "health-checker/fail.sh check\" failed|Failed to start MicroOS Health Checker.Machine didn't come up correct, do a rollback|",
+        "description": "health-checker/fail.sh check\" failed|Failed to start MicroOS Health Checker.Machine didn't come up correct, do a rollback",
         "products": {
             "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" , "5.5" ],
             "leap-micro": ["5.2", "5.3", "5.4"],


### PR DESCRIPTION
Bunch of error messages has been not caught most likely due to left over pipe. https://openqa.suse.de/tests/12122006#

- Verification run: http://kepler.suse.cz/tests/21887#
