### PR TITLE
Remove IPXE setting in SLE-Micro job yaml

### DIFF
--- a/schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml
+++ b/schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml
@@ -14,7 +14,6 @@ vars:
   SYSTEM_ROLE: kvm
   HOST_HYPERVISOR: kvm
   PATTERNS: default,kvm
-  IPXE: 0
   MAX_JOB_TIME: 10800
 schedule:
   - "{{bootup_and_install}}"


### PR DESCRIPTION
* **There** is no need to give IPXE setting in job yaml anymore. Such setting can be found in workers and test suite settings if necessary.
