### PR TITLE
[WIP]Workaround: skip needle checking to continue SLEM virt test for RC1 candidate temporarily

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -185,7 +185,8 @@ sub run {
     if (get_var('VIRT_AUTOTEST') || get_var('HANA_PERF')) {
         #it is static menu and choose the TW entry to start installation
         enter_o3_ipxe_boot_entry if get_var('IPXE_STATIC');
-        assert_screen([qw(load-linux-kernel load-initrd)], 240);
+        #for (1 .. 120) { save_screenshot; sleep 5; }  #julie debug
+        #assert_screen([qw(load-linux-kernel load-initrd)], 240);
         # Loading initrd spend much time(fg. 10-15 minutes to Beijing SUT)
         # Downloading from O3 became much more quick, some needles may not be caught.
         check_screen([qw(start-tw-install start-sle-install network-config-created)], 60);


### PR DESCRIPTION
We met missing needles problem in SLEM  tests. All ipxe_install-* needles were not loaded in tests, https://openqa.suse.de/tests/12133833#step/ipxe_install/21

It will take some time to locate the root cause and fix it, but the RC1 candidate tests need the results in short time. Let's make a PR to get it around to make test continue.

It is just a temporary change, please don't merge it.

@alice-suse @waynechen55 @nanzhg I'll have a try first, please wait for a moment. If the PR is ok, please trigger your test with it.


