### PR TITLE
journal_check: add bug refs for issues that were hidden before 21a82d6

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -452,5 +452,19 @@
             "microos":  ["Tumbleweed"]
         },
         "type": "bug"
+    },
+    "boo#1215367": {
+        "description": "pam_wtmpdb\\(login:session\\): Failed to execute statement: database is locked",
+        "products": {
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "bug"
+    },
+    "boo#1215368": {
+        "description": "systemctl: invalid option -- '\\.'",
+        "products": {
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "bug"
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17773

Some issues had been hidden in the tests due to a bug in some regex. This has been fixed and some (potentially older) issues now surface (and block stagings)

Accept them for now as 'known issues'

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1215367, https://bugzilla.opensuse.org/show_bug.cgi?id=1215368
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3578494
