### PR TITLE
ipxe_install: Make the set_bootscript_hdd() delay configurable

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -225,16 +225,7 @@ sub run {
     }
 
     # when we don't use autoyast, we need to also load the right test modules to perform the remote installation
-    if (get_var('AUTOYAST')) {
-        # VIRT_AUTOTEST need not sleep and set_bootscript_hdd
-        return if get_var('VIRT_AUTOTEST');
-        # HANA PERF uses DELL R840 and R740, their UEFI IPXE boot need not set_bootscript_hdd
-        return if (get_var('HANA_PERF') && get_var('IPXE_UEFI'));
-        # make sure to wait for a while befor changing the boot device again, in order to not change it too early
-        sleep get_var('PXE_BOOT_TIME', 120);
-        set_bootscript_hdd if get_var('IPXE_UEFI');
-    }
-    else {
+    unless (get_var('AUTOYAST')) {
         my $ssh_vnc_wait_time = 1500;
         #for virtualization test, 9 minutes is enough to load installation system, 75 minutes is too long
         $ssh_vnc_wait_time = 180 if get_var('VIRT_AUTOTEST');
@@ -251,7 +242,7 @@ sub run {
             die "Do not catch needle with tag $ssh_vnc_tag!" if is_usb_boot;
         }
 
-        set_bootscript_hdd if get_var('IPXE_UEFI');
+        set_bootscript_hdd if get_var('IPXE_SET_HDD_BOOTSCRIPT');
 
         unless (get_var('HOST_INSTALL_AUTOYAST')) {
             select_console 'installation';
@@ -267,6 +258,11 @@ sub run {
             save_screenshot;
             wait_still_screen;
         }
+    }
+    elsif (get_var('IPXE_SET_HDD_BOOTSCRIPT')) {
+        # make sure to wait for a while befor changing the boot device again, in order to not change it too early
+        sleep get_var('PXE_BOOT_TIME', 120);
+        set_bootscript_hdd;
     }
 }
 

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -231,7 +231,7 @@ sub run {
         # HANA PERF uses DELL R840 and R740, their UEFI IPXE boot need not set_bootscript_hdd
         return if (get_var('HANA_PERF') && get_var('IPXE_UEFI'));
         # make sure to wait for a while befor changing the boot device again, in order to not change it too early
-        sleep 120;
+        sleep get_var('PXE_BOOT_TIME', 120);
         set_bootscript_hdd if get_var('IPXE_UEFI');
     }
     else {
@@ -271,3 +271,13 @@ sub run {
 }
 
 1;
+
+=head1 Configuration
+
+=head2 PXE_BOOT_TIME
+
+The time in seconds that the worker takes from power-on to starting execution
+of the PXE script or menu. Default is 120s. Setting the variable too high is
+safer than too low.
+
+=cut

--- a/variables.md
+++ b/variables.md
@@ -101,6 +101,7 @@ INSTALLONLY | boolean | false | Indicates that test suite conducts only installa
 INSTLANG | string | en_US | Installation locale settings.
 IPERF_REPO | string | | Link to repository with iperf tool for network performance testing. Currently used in Public Cloud Azure test
 IPXE | boolean | false | Indicates ipxe boot.
+IPXE_SET_HDD_BOOTSCRIPT | boolean | false | Upload second IPXE boot script for booting from HDD after the installation boot script gets executed. This is a workaround for cases where the installer fails to switch default boot order to HDD boot. See also PXE_BOOT_TIME.
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
 IS_MM_CLIENT | boolean | | If set, run client-specific part of the multimachine job

--- a/variables.md
+++ b/variables.md
@@ -163,6 +163,7 @@ RMT_SERVER | string | Local server to be used in RMT registration.
 SALT_FORMULAS_PATH | string | | Used to point to a tarball with relative path to [/data/yast2](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data/yast2) which contains all the needed files (top.sls, form.yml, ...) to support provisioning with Salt masterless mode.
 PKGMGR_ACTION_AT_EXIT | string | "" | Set the default behavior of the package manager when package installation has finished. Possible actions are: close, restart, summary. If PKGMGR_ACTION_AT_EXIT is not set in openQA, test module will read the default value from /etc/sysconfig/yast2.
 PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
+PXE_BOOT_TIME | integer | 120 | Approximate time that IPMI worker needs to load and execute PXE boot payload. Should be set in the IPMI worker configuration.
 QA_TESTSUITE | string | | Comma or semicolon separated a list of the automation cases' name, and these cases will be installed and triggered if you call "start_testrun" function from qa_run.pm
 QAM_MINIMAL | string | "full" or "small" | Full is adding patterns x11, gnome-basic, base, apparmor in minimal/install_patterns test. Small is just base.
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.


### PR DESCRIPTION
Some workers need more than 2 minutes to reach PXE bootloader after power-on. Add a variable `PXE_BOOT_TIME` to control the bootscript switch delay for UEFI machines so that it can be configured on each worker.

This is the correct solution for #17769

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - without `PXE_BOOT_TIME`: https://openqa.suse.de/tests/12223015
  - with `PXE_BOOT_TIME`: https://openqa.suse.de/tests/12223016
  - without `AUTOYAST`: https://openqa.suse.de/tests/12223020