### PR TITLE
Zypper patch system before test start on PC

### DIFF
--- a/data/sles4sap/qe_sap_deployment/hanasr_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/hanasr_azure.yaml
@@ -27,6 +27,7 @@ ansible:
     - https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/%PUBLIC_CLOUD_RESOURCE_NAME%/installer_sar/hana/%HANA_CLIENT_SAR%
   create:
     - registration.yaml -e reg_code=%SCC_REGCODE_SLES4SAP% -e email_address=""
+    - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=${SAPCONF}
     - cluster_sbd_prep.yaml

--- a/data/sles4sap/qe_sap_deployment/hanasr_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/hanasr_ec2.yaml
@@ -24,6 +24,7 @@ ansible:
     - "s3://%PUBLIC_CLOUD_RESOURCE_NAME%/inst_sar/hana/%HANA_CLIENT_SAR%"
   create:
     - registration.yaml -e reg_code=%SCC_REGCODE_SLES4SAP% -e email_address=""
+    - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=${SAPCONF}
     - cluster_sbd_prep.yaml

--- a/data/sles4sap/qe_sap_deployment/hanasr_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/hanasr_gcp.yaml
@@ -40,6 +40,7 @@ ansible:
     - "gs://%PUBLIC_CLOUD_RESOURCE_NAME%/inst_sar/hana/%HANA_CLIENT_SAR%"
   create:
     - registration.yaml -e reg_code=%SCC_REGCODE_SLES4SAP% -e email_address=""
+    - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=${SAPCONF}
     - cluster_sbd_prep.yaml

--- a/data/sles4sap/qe_sap_deployment/trento_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/trento_azure.yaml
@@ -32,6 +32,7 @@ ansible:
     secondary_site: 'miky'
   create:
     - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=true
     - cluster_sbd_prep.yaml

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -625,6 +625,9 @@ sub create_playbook_section_list {
     push @playbook_list, 'registration.yaml -e reg_code=' . get_required_var('SCC_REGCODE_SLES4SAP') . " -e email_address=''"
       unless (get_var('QESAP_SCC_NO_REGISTER'));
 
+    # Add "fully patch system" module after registration module and before test start/configuration moudles
+    push @playbook_list, 'fully-patch-system.yaml';
+
     # SLES4SAP/HA related playbooks
     if ($ha_enabled) {
         push @playbook_list, 'pre-cluster.yaml', 'sap-hana-preconfigure.yaml -e use_sapconf=' . get_required_var('USE_SAPCONF');

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -36,7 +36,7 @@ sub run {
     $self->{my_instance} = $target_site;
 
     # Check initial cluster status
-    $self->run_cmd(cmd => 'zypper -n in ClusterTools2');
+    $self->run_cmd(cmd => 'zypper -n in ClusterTools2', timeout => 300);
     $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5');
     my $cluster_status = $self->run_cmd(cmd => 'crm status');
     record_info('Cluster status', $cluster_status);

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -54,11 +54,6 @@ sub run {
         # Check ssh connection for all hosts
         $instance->wait_for_ssh;
 
-        # Update sudo package as a temporary fix for bsc#1205325
-        if (is_sle('=15-sp2')) {
-            $instance->run_ssh_command(cmd => 'sudo zypper up -y sudo');
-            record_soft_failure('bsc#1205325 - update sudo pkg');
-        }
         # Skip instances without HANA db or setup without cluster
         next if ($instance_id !~ m/vmhana/) or !$ha_enabled;
         $self->wait_for_sync();


### PR DESCRIPTION
Fully patch system before test start on public cloud qesap-deployment test cases
TEAM-8437 - [qesap-deployment] Fully patch system before test start

1. Fully patch system before test start via ansible playbook
2. Fix the timed out issue introduce in this "fully patch"
3. Remove previous workaround on "zypper up sudo" 

- Related ticket: https://jira.suse.com/browse/TEAM-8437
- Needles: NA
- Verification run:
 1. sle-15-SP2-HanaSr-Azure-Byos: hanasr_azure_test
  https://openqaworker15.qa.suse.cz/tests/229811   (passed, (02:02 hours))
 2. sle-15-SP4-HanaSr-Aws-Byos: hanasr_aws_test_saptune
  http://openqaworker15.qa.suse.cz/t229807 (Command "sudo SAPHanaSR-showAttr" passed)
  (The "Fenced database 'vmhana01' is not offline" failure is a known issue)  
 3. sle-15-SP4-Azure-SAP-BYOS: SAPHanaSR-ScaleUp-PerfOpt
  https://openqaworker15.qa.suse.cz/tests/229815   (passed)
4. sle-15-SP5-Qesap-Azure-Byos: qesap_azure_sapconf_test
  https://openqaworker15.qa.suse.cz/tests/231114 (passed, VR for code changes in "config.yaml" files)