### PR TITLE
Drop test_basic_strongswan, lacking network setup

### DIFF
--- a/tests/security/cc/trustedprograms.pm
+++ b/tests/security/cc/trustedprograms.pm
@@ -44,9 +44,6 @@ sub run {
 
     run_testcase('trustedprograms', (make => 1, timeout => 1200));
 
-    # Add a reminder that https://progress.opensuse.org/issues/96438 is not yet fixed.
-    record_soft_failure("poo#96438 - basic_strongswan FAILS");
-
     # Compare current test results with baseline
     my $result = compare_run_log('trustedprograms');
 


### PR DESCRIPTION
This bash script has been failing since ever it was created for sle 12  and besides it needs updated the ciphers for sle 15, it will never work due to lack of proper network setup in openQA, therefor we can drop it, as this might be too tricky in 
openQA.

- Related ticket's note: [poo#115919#note-20](https://progress.opensuse.org/issues/96438?issue_count=19&issue_position=18&next_issue_id=72037&prev_issue_id=115919#note-20)
- Related MR: [mr#62](https://gitlab.suse.de/security/audit-test-sle15/-/merge_requests/62)
- Verification run: [cc_audit-test-part2](https://openqa.suse.de/tests/12163312)
