### PR TITLE
containers: Skip RMT test on k8s as it uses helm

### DIFF
--- a/tests/containers/helm_rmt.pm
+++ b/tests/containers/helm_rmt.pm
@@ -27,7 +27,7 @@ sub run {
 
     my ($version, $sp, $host_distri) = get_os_release;
     # Skip HELM tests on SLES <15-SP3 and on PPC, where k3s is not available
-    return if (get_var('HELM_CONFIG') && (!($host_distri == "sles" && $version == 15 && $sp >= 3) || is_ppc64le));
+    return if (!($host_distri == "sles" && $version == 15 && $sp >= 3) || is_ppc64le || check_var('CONTAINER_RUNTIME', 'k8s'));
 
     systemctl 'stop firewalld';
     ensure_ca_certificates_suse_installed();


### PR DESCRIPTION
Skip RMT test on k8s as it uses helm

- Related ticket: https://progress.opensuse.org/issues/124385
- Failing test: https://openqa.suse.de/tests/12162189
- Verification run: sle-15-SP5-BCI-Updates-x86_64-Build9.48_rmt-server-image-rmt_on_k8s@64bit -> https://openqa.suse.de/t12163867
