### PR TITLE
Add whitelist for bsc#1215377 on SLE Micro

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -473,5 +473,12 @@
             "microos":  ["Tumbleweed"]
         },
         "type": "bug"
+    },
+    "bsc#1215377": {
+        "description": "plugin /usr/sbin/sedispatch terminated unexpectedly",
+        "products": {
+            "sle-micro": ["5.4" , "5.5"]
+        },
+        "type": "bug"
     }
 }


### PR DESCRIPTION
We can soft-fail the jobs which hit the below bug,
https://bugzilla.suse.com/show_bug.cgi?id=1215377
Then add it the whitelist

[Progress tickets](https://progress.opensuse.org/issues/135875)
[VR](https://openqa.suse.de/tests/overview?build=rfan0918&distri=sle-micro&version=5.4)

Please ignore the new failure on aarch64 platform, it is caused by known issue [known bug](https://bugzilla.suse.com/show_bug.cgi?id=1215405)