### PR TITLE
Containers: test privileged mode

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -85,6 +85,11 @@ sub load_image_tests_docker {
     }
 }
 
+sub load_container_engine_privileged_mode {
+    my ($run_args) = @_;
+    loadtest('containers/privileged_mode', run_args => $run_args, name => $run_args->{runtime} . "_privileged_mode");
+}
+
 sub load_host_tests_podman {
     my ($run_args) = @_;
     # podman package is only available as of 15-SP1
@@ -93,6 +98,7 @@ sub load_host_tests_podman {
         # In Public Cloud we don't have internal resources
         load_image_test($run_args) unless is_public_cloud || is_alp;
         load_3rd_party_image_test($run_args);
+        load_container_engine_privileged_mode($run_args);
         loadtest 'containers/podman_bci_systemd';
         loadtest 'containers/podman_pods';
         # Default for ALP is Netavark
@@ -116,6 +122,7 @@ sub load_host_tests_docker {
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud || is_alp;
     load_3rd_party_image_test($run_args);
+    load_container_engine_privileged_mode($run_args);
     # Firewall is not installed in Public Cloud, JeOS OpenStack and MicroOS but it is in SLE Micro
     loadtest 'containers/docker_firewall' unless (is_public_cloud || is_openstack || is_microos);
     unless (is_sle("<=15") && is_aarch64) {

--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -1,0 +1,54 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: podman
+# Summary: Test container runtime privileged mode
+# Maintainer: qa-c@suse.de
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils qw(validate_script_output_retry);
+use containers::utils qw(reset_container_network_if_needed);
+
+sub run {
+    my ($self, $args) = @_;
+    select_serial_terminal;
+
+    my $runtime = $args->{runtime};
+    my $engine = $self->containers_factory($runtime);
+    $self->{runtime} = $engine;
+    reset_container_network_if_needed($runtime);
+
+    my $image = "registry.suse.com/bci/bci-base:latest";
+
+    record_info('Test', 'Launch a container with privileged mode');
+    # /dev is only accessible in privileged mode
+    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus");
+
+    # Mounting tmpfs only works in privileged mode because the read-only protection in the default mode
+    assert_script_run("$runtime run --rm --privileged $image mount -t tmpfs none /mnt");
+
+    # Capabilities are only available in privileged mode
+    my $capbnd = script_output("cat /proc/1/status | grep CapBnd");
+    validate_script_output("$runtime run --rm --privileged $image cat /proc/1/status | grep CapBnd", sub { m/$capbnd/ });
+}
+
+sub cleanup {
+    my ($self) = @_;
+    $self->{runtime}->cleanup_system_host();
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    $self->cleanup();
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->cleanup();
+}
+
+1;


### PR DESCRIPTION
Test privileged mode in podman and docker. The command mount -t tmpfs none /mnt
only works in privileged mode because the read-only protection in the default mode

- Related ticket: https://progress.opensuse.org/issues/135518
- Verification run: 
- http://openqa.suse.de/tests/12335440 (15-SP4 podman)
- http://openqa.suse.de/tests/12335443 (15-SP4 docker)
- http://openqa.suse.de/tests/12335444 (12-SP5 docker)
