### PR TITLE
ipxe_install: Verify that PXE boot override is enabled

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -48,7 +48,7 @@ sub poweron_host {
 sub set_pxe_boot {
     while (1) {
         my $stdout = ipmitool('chassis bootparam get 5');
-        last if $stdout =~ m/Force PXE/;
+        last if $stdout =~ m/Boot Flag Valid.*Force PXE/s;
         diag "setting boot device to pxe";
         my $options = get_var('IPXE_UEFI') ? 'options=efiboot' : '';
         ipmitool("chassis bootdev pxe ${options}");


### PR DESCRIPTION
Boot flag validity check was dropped in 080200a67017 which now causes ipxe_install to accept stale IPMI flags and not set PXE boot override when needed. Add the IPMI boot flag validity check back.

Fixes: 080200a67017 ("Support ipxe installation for ipmi backend tests(virt, perf and hana tests)")

- Related ticket: https://progress.opensuse.org/issues/130219
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/12167973