### PR TITLE
Add whitelist for bsc#1215405 and bsc#1215378 on SLE Micro

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -480,5 +480,19 @@
             "sle-micro": ["5.4" , "5.5"]
         },
         "type": "bug"
+    },
+    "bsc#1215378": {
+        "description": "libvirtd.*: error from service: GDBus.Error:org.freedesktop.login1.OperationInProgress: The operation inhibition has been requested for is already running",
+        "products": {
+            "sle-micro": ["5.4" , "5.5"]
+        },
+        "type": "bug"
+    },
+    "bsc#1215405": {
+        "description": "setroubleshoot.*SELinux is preventing (.*rebootmgrd|.*NetworkManager|sshd).* from.* access.*|setroubleshoot.*: failed to retrieve rpm info for path.*",
+        "products": {
+            "sle-micro": ["5.4" , "5.5"]
+        },
+        "type": "bug"
     }
 }


### PR DESCRIPTION
We can soft-fail the jobs cased by bugs below by
adding a new whitelist:
https://bugzilla.suse.com/show_bug.cgi?id=1215405
https://bugzilla.suse.com/show_bug.cgi?id=1215378


- Related ticket: https://progress.opensuse.org/issues/135926

- Verification run: 
[Yam](https://openqa.suse.de/tests/overview?version=5.5&distri=sle-micro&build=rfan0919)
[Core](https://openqa.suse.de/tests/overview?version=5.5&distri=sle-micro&build=rfan0919_fnc)

**s390x** seems we don't have available resources to run the tests now, but I think it is fine to merge since no issues with x86_64 and aarch64:)