### PR TITLE
Fix libyui tests on IPXE workers

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -120,6 +120,8 @@ sub set_bootscript {
     $cmdline_extra .= " Y2DEBUG=1 linuxrc.log=/dev/$serial_dev linuxrc.core=/dev/$serial_dev linuxrc.debug=4,trace reboot_timeout=0 "
       if (get_var('VIRT_AUTOTEST') || get_var('HANA_PERF'));
 
+    $cmdline_extra .= get_var('EXTRABOOTPARAMS', '');
+
     my $bootscript = <<"END_BOOTSCRIPT";
 #!ipxe
 echo ++++++++++++++++++++++++++++++++++++++++++

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -104,21 +104,21 @@ sub set_bootscript {
     }
     $cmdline_extra .= " plymouth.enable=0 ";
 
-    # Extra options for virtualization tests with ipmi backend
-    if (get_var('VIRT_AUTOTEST') || get_var('HANA_PERF')) {
-        $cmdline_extra .= " video=1024x768 vt.color=0x07 " if check_var('VIDEOMODE', 'text');
-        # Support either IPXE_CONSOLE=ttyS1,115200 or SERIALDEV=ttyS1
-        my $serial_dev;
-        if (get_var('IPXE_CONSOLE')) {
-            get_var('IPXE_CONSOLE') =~ /^(\w+)/;
-            $serial_dev = $1;
-        }
-        else {
-            $serial_dev = get_var('SERIALDEV', 'ttyS1');
-            $cmdline_extra .= " console=$serial_dev,115200 ";
-        }
-        $cmdline_extra .= " Y2DEBUG=1 linuxrc.log=/dev/$serial_dev linuxrc.core=/dev/$serial_dev linuxrc.debug=4,trace reboot_timeout=0";
+    $cmdline_extra .= " video=1024x768 vt.color=0x07 " if check_var('VIDEOMODE', 'text');
+    # Support either IPXE_CONSOLE=ttyS1,115200 or SERIALDEV=ttyS1
+    my $serial_dev;
+    if (get_var('IPXE_CONSOLE')) {
+        get_var('IPXE_CONSOLE') =~ /^(\w+)/;
+        $serial_dev = $1;
     }
+    else {
+        $serial_dev = get_var('SERIALDEV', 'ttyS1');
+        $cmdline_extra .= " console=$serial_dev,115200 ";
+    }
+
+    # Extra options for virtualization tests with ipmi backend
+    $cmdline_extra .= " Y2DEBUG=1 linuxrc.log=/dev/$serial_dev linuxrc.core=/dev/$serial_dev linuxrc.debug=4,trace reboot_timeout=0 "
+      if (get_var('VIRT_AUTOTEST') || get_var('HANA_PERF'));
 
     my $bootscript = <<"END_BOOTSCRIPT";
 #!ipxe

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -15,7 +15,7 @@ use utils;
 use testapi;
 use bmwqemu;
 use ipmi_backend_utils;
-use version_utils qw(is_upgrade is_tumbleweed);
+use version_utils qw(is_upgrade is_tumbleweed is_sle is_leap);
 use bootloader_setup 'prepare_disks';
 use Utils::Architectures;
 use virt_autotest::utils qw(is_kvm_host is_xen_host);
@@ -117,9 +117,9 @@ sub set_bootscript {
     }
 
     # Extra options for virtualization tests with ipmi backend
-    $cmdline_extra .= " Y2DEBUG=1 linuxrc.log=/dev/$serial_dev linuxrc.core=/dev/$serial_dev linuxrc.debug=4,trace reboot_timeout=0 "
-      if (get_var('VIRT_AUTOTEST') || get_var('HANA_PERF'));
-
+    $cmdline_extra .= " Y2DEBUG=1 linuxrc.log=/dev/$serial_dev linuxrc.core=/dev/$serial_dev linuxrc.debug=4,trace ";
+    $cmdline_extra .= " reboot_timeout=" . get_var('REBOOT_TIMEOUT', 0) . ' '
+      unless (is_leap('<15.2') || is_sle('<15-SP2'));
     $cmdline_extra .= get_var('EXTRABOOTPARAMS', '');
 
     my $bootscript = <<"END_BOOTSCRIPT";


### PR DESCRIPTION
Adding `IPXE=1` to some IPMI workers had the side effect of breaking libyui tests because `ipxe_install` does not do the required setup normally done by `boot_from_pxe`. Unconditionally configure textmode console and add `EXTRABOOTPARAMS` to iPXE boot script to allow libyui tests to boot using `ipxe_install`.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/12205773
