### PR TITLE
Add system_prepare for textmode uefi and x86_64

### DIFF
--- a/schedule/yast/textmode/textmode_x86_64.yaml
+++ b/schedule/yast/textmode/textmode_x86_64.yaml
@@ -6,6 +6,7 @@ vars:
   YUI_REST_API: 1
 schedule:
   system_preparation:
+    - console/system_prepare
     - console/consoletest_setup
     - console/force_scheduled_tasks
   system_validation:


### PR DESCRIPTION
- Description:
   * We need to add system_prepare for textmode uefi and x86_64
-  Ticket: Quick PR

- Needles: N/A

- VR:
   * https://openqa.suse.de/tests/12202202
   * https://openqa.suse.de/tests/12202203
- Reference: [**bug_1214452**](https://bugzilla.suse.com/show_bug.cgi?id=1214452)