### PR TITLE
microos/selfinstall: Call eject_cd earlier if a forced reboot happens

### DIFF
--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -35,11 +35,15 @@ sub run {
     # Before combustion 1.2, a reboot is necessary for firstboot configuration
     if (is_alp || is_leap_micro || is_sle_micro) {
         wait_serial('reboot: Restarting system', 240) or die "SelfInstall image has not rebooted as expected";
+        # Avoid booting into selfinstall again
+        eject_cd() unless $no_cd;
+        microos_login;
+    } else {
+        microos_login;
+        # The installed system is definitely up now, so the CD can be ejected
+        eject_cd() unless $no_cd;
     }
 
-    microos_login;
-    # The installed system is definitely up now, so the CD can be ejected
-    eject_cd() unless $no_cd;
 }
 
 sub test_flags {


### PR DESCRIPTION
Older selfinstall medium does a reboot after kexec. The install medium needs to be ejected at that point to avoid booting into it again.

- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17797#issuecomment-1727220353
- Verification run: http://10.168.4.192/tests/1338
