### PR TITLE
Add network ping check with different packet sizes

### DIFF
--- a/tests/kernel/multipath_iscsi.pm
+++ b/tests/kernel/multipath_iscsi.pm
@@ -23,6 +23,9 @@ sub run {
 
     select_serial_terminal;
 
+    # Check connectivity to target inside multimachine network (supportserver)
+    ping_size_check($target);
+
     # Install iscsi
     zypper_call("in open-iscsi");
 


### PR DESCRIPTION
Enhancement poo#135818: Adds new function ping_size_check, which
will ping defined target with different and increasing size with
disabled packet fragmentation. If is specified size, it will do single ping
check with one size. Main use of this function is in multi machine
jobs for network verification (MTU in GRE tunnel).

- Related ticket: https://progress.opensuse.org/issues/135818
- Needles: none
- Verification run:  
https://openqa.suse.de/tests/12221263  (contains controlled single size demo failure for size 1431)
https://openqa.suse.de/tests/12221377 (standard run)
