### PR TITLE
Fix incorrect function name

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -52,7 +52,7 @@ sub run {
 
     # SBD delay related setup for 'stop' to fix sporadic 'takeover failed to complete' issue on EC2
     if ($takeover_action eq 'stop' and check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
-        $self->setup_sbd_delay();
+        $self->setup_sbd_delay_publiccloud();
         $sbd_delay = $self->sbd_delay_formula();
     }
 


### PR DESCRIPTION
Function 'sbd_delay_setup' was renamed in PR17754 to 'sbd_delay_setup_publiccloud'. There is a missing instance which was not renamed properly, causing kto fail EC2 tests. This PR fixes the mistake. 

- Related ticket: PR17754
- Verification run: 
Failure: https://openqa.suse.de/tests/12204186#step/Stop_site_a-primary/12
Fixed: 
https://openqaworker15.qa.suse.cz/tests/231126#live
https://openqa.suse.de/tests/12210412
* VRs are failing because of other reasons and pass the problematic spot