### PR TITLE
Use gpt as disklabel rather than old msdos for root disk

### DIFF
--- a/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_x86_64.xml
@@ -80,7 +80,7 @@
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>
-      <disklabel>msdos</disklabel>
+      <disklabel>gpt</disklabel>
       <enable_snapshots config:type="boolean">true</enable_snapshots>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">


### PR DESCRIPTION

- Verification run: [openqa.mypersonalinstance.de/tests/xyz#step/module/x](https://openqa.suse.de/tests/12220201#step/version_switch_origin_system#1/5)
