### PR TITLE
Replace SCC_URL with HOST_SCC_URL and fix some failures

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -149,7 +149,7 @@
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">10</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -3,7 +3,7 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
-    <reg_server>{{SCC_URL}}</reg_server>
+    <reg_server><%= defined $bmwqemu::vars{"HOST_SCC_URL"} ? $bmwqemu::vars{"HOST_SCC_URL"} : "" %></reg_server>
     <reg_code>{{SCC_REGCODE}}</reg_code>
     <install_updates config:type="boolean">true</install_updates>
     % if (keys %$addons) {
@@ -155,7 +155,7 @@
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">10</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -69,7 +69,7 @@ sub expand_patterns {
             my @sle12;
             push @sle12, qw(Minimal apparmor base documentation) if check_var('DESKTOP', 'textmode');
             push @sle12, qw(Minimal apparmor base x11 documentation gnome-basic) if check_var('DESKTOP', 'gnome');
-            push @sle12, qw(desktop-base desktop-gnome) if get_var('SCC_ADDONS') =~ m/we/;
+            push @sle12, qw(desktop-base desktop-gnome) if get_var('SCC_ADDONS', '') =~ m/we/;
             push @sle12, qw(yast2) if is_sle('>=12-sp3');
             push @sle12, qw(32bit) if !is_aarch64 && get_var('DESKTOP') =~ /gnome|textmode/;
             return [@sle12];

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -326,12 +326,12 @@ sub download_script {
 
     my $cmd = "curl -o ~/$script_name $script_url";
     $cmd = "ssh root\@$machine " . "\"$cmd\"" if ($machine ne 'localhost');
-    unless (script_retry($cmd, retry => 2, die => 0) == 0) {
+    unless (script_retry($cmd, timeout => 300, retry => 2, die => 0) == 0) {
         # Add debug codes as the url only exists in a dynamic openqa URL
         record_info("URL is not accessible", "$script_url", result => 'fail') unless head($script_url);
         unless ($machine eq 'localhost') {
             record_info("machine is not ssh accessible", "$machine", result => 'fail') unless script_run("ssh root\@$machine 'hostname'") == 0;
-            record_info("OSD is unaccessible from $machine", "that means the machine is having problem to access SUSE network", result => 'fail') unless script_run("ssh root\@$machine 'ping openqa.suse.de'") == 0;
+            record_info("OSD is unaccessible from $machine", "that means the machine is having problem to access SUSE network", result => 'fail') unless script_run("ssh root\@$machine 'ping -c3 openqa.suse.de'") == 0;
         }
         die "Failed to download $script_url!";
     }

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -11,7 +11,6 @@
 
 use base "virt_feature_test_base";
 use virt_utils;
-use set_config_as_glue;
 use virt_autotest::virtual_network_utils;
 use virt_autotest::utils;
 use strict;

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -12,7 +12,6 @@ use warnings;
 use testapi;
 use utils 'script_retry';
 use version_utils qw(is_sle);
-use set_config_as_glue;
 use virt_autotest::common;
 use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute remove_vm save_original_guest_xmls restore_downloaded_guests restore_original_guests upload_virt_logs);
 


### PR DESCRIPTION
- Replace SCC_URL with HOST_SCC_URL as we need them both
- Fix failures when downloading large size files, fg. http://10.67.129.27/tests/101#step/vgpu/169
- Increase timeout of error pop-up during host installation to save screenshots, fg. https://openqa.suse.de/tests/12180564#step/installation/6
- Avoid issueing warnings in auto-inst.txt, fg. https://openqa.suse.de/tests/12180564/logfile?filename=autoinst-log.txt


Related ticket: https://progress.opensuse.org/issues/135932
Related MR on job group settings: https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/153
Verification run: 
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/12245544)
[prj4_guest_upgrade_sles15sp5_on_sles15sp5-xen](https://openqa.suse.de/tests/12245975)
[prj2_host_upgrade_sles12sp5_to_developing_kvm](https://openqa.suse.de/tests/12245975)
[uefi-gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/12245976)
