### PR TITLE
Fix the issue for spectre_v2 on skylake machine

### DIFF
--- a/tests/cpu_bugs/mitigations.pm
+++ b/tests/cpu_bugs/mitigations.pm
@@ -134,9 +134,10 @@ sub run {
                 if ($item eq 'spectre_v2') {
                     $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Retpolines,.*IBPB: conditional, IBRS_FW*";
                 }
-                if (get_var('MICRO_ARCHITECTURE') =~ /Skylake/) {
+                if ($item eq 'spectre_v2' && get_var('MICRO_ARCHITECTURE') =~ /Skylake/) {
                     $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: IBRS, IBPB: conditional, RSB filling.*";
                 }
+
             }
             if (is_qemu) {
                 #spectre_v2


### PR DESCRIPTION
Fix the issue for spectre_v2 on skylake machine

- Related ticket: https://progress.opensuse.org/issues/136091
- Verification run:http://10.67.129.4/tests/62267 (sle15sp5 maintain update)