### PR TITLE
Add support for host/guest upgrade scc customization

### DIFF
--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -52,6 +52,14 @@ sub get_script_run {
     if (get_var("SKIP_GUEST_INSTALL") && is_x86_64) {
         $pre_test_cmd .= " -k $vm_xml_dir";
     }
+
+    my $do_registration = check_var('GUEST_SCC_REGISTER', 'installation') ? "true" : "false";
+    my $registration_server = get_var('SCC_URL', 'https://scc.suse.com');
+    my $registration_code = get_var('SCC_REGCODE', 'INVALID_REGCODE');
+    $pre_test_cmd .= " -e $do_registration";
+    $pre_test_cmd .= " -s $registration_server";
+    $pre_test_cmd .= " -c $registration_code";
+
     return $pre_test_cmd;
 }
 

--- a/tests/virt_autotest/host_upgrade_generate_run_file.pm
+++ b/tests/virt_autotest/host_upgrade_generate_run_file.pm
@@ -28,6 +28,9 @@ sub get_script_run {
     #Prefer to use offline media for upgrade to avoid registration via autoyast
     $upgrade_repo =~ s/-Online-/-Full-/ if ($upgrade_repo =~ /15-sp[2-9]/i);
     my $guest_list = get_var("GUEST_LIST", "");
+    my $do_registration = (check_var('SCC_REGISTER', 'installation') || check_var('REGISTER', 'installation') || get_var('AUTOYAST', '')) ? "true" : "false";
+    my $registration_server = get_var('SCC_URL', 'https://scc.suse.com');
+    my $registration_code = get_var('SCC_REGCODE', 'INVALID_REGCODE');
 
     $pre_test_cmd = "/usr/share/qa/tools/_generate_vh-update_tests.sh";
     $pre_test_cmd .= " -m $mode";
@@ -36,6 +39,9 @@ sub get_script_run {
     $pre_test_cmd .= " -u $upgrade";
     $pre_test_cmd .= " -r $upgrade_repo";
     $pre_test_cmd .= " -i $guest_list";
+    $pre_test_cmd .= " -e $do_registration";
+    $pre_test_cmd .= " -s $registration_server";
+    $pre_test_cmd .= " -c $registration_code";
 
     return "$pre_test_cmd";
 }


### PR DESCRIPTION
* **This** aims to add support for host/guest upgrade test with non-default scc registration information. 
 
* **Take** host upgrade test as an example, registered SLE 12-SP5 host will also try to register upgraded 15-SP6 host which may need a different scc url instead of scc.suse.com and corresponding scc addons also need registration together.

* **Current** host upgrade is about to fail due to improper scc url, please refer to [failure1](https://openqa.suse.de/tests/12161735#step/reboot_and_wait_up_upgrade/1) and [2](https://openqa.suse.de/tests/12161736#step/reboot_and_wait_up_upgrade/1). Yast terminates before upgrade process starts.

* **Add** three parameters, including whether do registration, registration server and registration code, at all levels, including host_upgrade_generate_run_file.pm/guest_upgrade_run.pm, _generate_vh-update_tests.sh/test_virtualization-guest-upgrade-run, vh_update.sh/test_full_guest_upgrade.sh/guest_upgrade.sh and vh-update-lib.sh.

* **Add** code snippet responsible for inserting suse_register and associated addons section in autoyast file. 

* **Please** also see associated submits [pr#804](https://github.com/SUSE/qa-automation/pull/804) and [pr#1080](https://github.com/SUSE/qa-testsuites/pull/1080). These three pull requests should be merged together.

* **Verification runs:**
  * [host upgrade 12sp5 to 15sp6 kvm x86_64. Upgrade process successfully started.](https://openqa.suse.de/tests/12222978)
  * [host upgrade 12sp5 to 15sp6 xen x86_64. Upgrade process successfully started.](https://openqa.suse.de/tests/12224262)
  * [guest upgrade 12sp5 to 15sp6 kvm unregistered. Guest upgrade started.](https://openqa.suse.de/tests/12229606)
  * [guest upgrade 12sp5 to 15sp6 xen registered. Guest upgrade started.](https://openqa.suse.de/tests/12229643)
  * [host upgrade on aarch64. Host upgrade started.](http://openqa.qa2.suse.asia/tests/62607)
  * [host upgrade on aarch64. unregistered](https://openqa.suse.de/tests/12301326)
  * Also did verification manually regarding INVALID_REGCODE, official scc url and unregistered scenarios. autoyast file generated valid and does not cause error.