### PR TITLE
New screens added to the Windows installation process

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -120,7 +120,7 @@ sub reboot_or_shutdown {
 sub wait_boot_windows {
     # Reset the consoles: there is no user logged in anywhere
     reset_consoles;
-    assert_screen 'windows-screensaver', 600;
+    assert_screen 'windows-screensaver', 900;
     send_key_until_needlematch 'windows-login', 'esc';
     type_password;
     send_key 'ret';    # press shutdown button

--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -73,6 +73,7 @@ sub run {
         sleep 3;
         assert_and_click 'windows-next';
     }
+    assert_and_click 'windows-browsing-data' if (check_screen('windows-browsing-data'));
     my $count = 0;
     my @privacy_menu =
       split(',', get_required_var('WIN_INSTALL_PRIVACY_NEEDLES'));
@@ -86,8 +87,7 @@ sub run {
 
     if (check_screen('windows-custom-experience', timeout => 120)) {
         assert_and_click 'windows-custom-experience';
-        assert_screen 'windows-make-cortana-personal-assistant';
-        assert_and_click 'windows-accept';
+        assert_and_click 'windows-make-cortana-personal-assistant';
     }
 
     assert_screen(['windows-desktop', 'windows-edge-decline', 'networks-popup-be-discoverable'], timeout => 600);

--- a/tests/wsl/install/ms_win_installation.pm
+++ b/tests/wsl/install/ms_win_installation.pm
@@ -1,78 +1,23 @@
 # SUSE's openQA tests
-#
-# Copyright 2016-2018 SUSE LLC
+# Copyright 2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Windows 10 installation test module
-#    modiffied (only win10 drivers) iso from https://fedoraproject.org/wiki/Windows_Virtio_Drivers is needed
-#    Works only with CDMODEL=ide-cd and QEMUCPU=host or core2duo (maybe other but not qemu64)
-# Maintainer: Jozef Pupava <jpupava@suse.com>
+# Summary: Run an unattended Windows installation
+# Maintainer: qe-c
 
-use base "windowsbasetest";
+use base 'windowsbasetest';
 use strict;
 use warnings;
-
 use testapi;
 
-sub prepare_win11 {
-    # Change some regedit values to skip system requirements check
-    send_key 'shift-f10';
-    assert_screen 'windows-install-cmd';
-    type_string "reg add HKEY_LOCAL_MACHINE\\SYSTEM\\Setup /v LabConfig\n";
-    type_string "reg add HKEY_LOCAL_MACHINE\\SYSTEM\\Setup\\LabConfig /v BypassTPMCheck /t REG_DWORD /d 1\n";
-    type_string "reg add HKEY_LOCAL_MACHINE\\SYSTEM\\Setup\\LabConfig /v BypassRAMCheck /t REG_DWORD /d 1\n";
-    type_string "reg add HKEY_LOCAL_MACHINE\\SYSTEM\\Setup\\LabConfig /v BypassSecureBootCheck /t REG_DWORD /d 1\n";
-    type_string "exit\n";
-}
-
 sub run {
+    my ($self) = @_;
+
     if (get_var('UEFI')) {
         assert_screen 'windows-boot';
         send_key 'spc';    # boot from CD or DVD
     }
-    # This test works onlywith CDMODEL=ide-cd due to windows missing scsi drivers which are installed via scsi iso
-    assert_screen 'windows-setup', 300;
-    send_key 'alt-n';    # next
-    prepare_win11 if (check_var('WIN_VERSION', '11'));
-
-    save_screenshot;
-    send_key 'alt-i';    # install Now
-    save_screenshot;
-    send_key 'alt-n';    # next
-    assert_screen 'windows-activate';
-    if (my $key = get_var('_SECRET_WINDOWS_10_PRO_KEY')) {
-        type_password $key . "\n";
-        assert_screen([qw(windows-wrong-key windows-license-with-key)]);
-        die("The provided product key didn't work...") if (match_has_tag('windows-wrong-key'));
-    }
-    else {
-        assert_and_click 'windows-no-prod-key';
-        assert_screen 'windows-select-system';
-        send_key_until_needlematch('windows-10-pro', 'down');
-        send_key 'alt-n';    # select OS (Win 10 Pro)
-        assert_screen 'windows-license';
-    }
-    send_key 'alt-a';    # accept eula
-    send_key 'alt-n';    # next
-    assert_screen 'windows-installation-type';
-    send_key 'alt-c';    # custom
-    assert_screen 'windows-disk-partitioning';
-    send_key 'alt-l';    # load driver
-    assert_screen 'windows-load-driver';
-    send_key 'alt-b';    # browse button
-    send_key 'c';
-    save_screenshot;
-    send_key 'c';    # go to second CD drive with drivers
-    send_key 'right';    # ok
-    sleep 0.5;
-    send_key 'ret';
-    wait_still_screen stilltime => 3, timeout => 10;
-    send_key_until_needlematch 'windows-all-drivers-selected', 'shift-down';    # select all drivers
-    send_key 'alt-n';
-    assert_screen 'windows-partitions';
-    assert_and_click 'windows-next-install';
-    assert_screen 'windows-restart', 600;
-    send_key 'alt-r';
+    $self->wait_boot_windows;
 }
 
 1;


### PR DESCRIPTION
From time to time, new screens are added to the Windows installation process, which causes the needles to crash.

- Related ticket: *none*
- Needles:
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/win10_firstboot-windows-signin-with-ms-20230919.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-accept-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-account-setup-20230918.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-browsing-data-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-create-account-20230920.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-dont-get-tailored-experiences-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-dont-improve-inking&typing-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-dont-use-adID-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-dont-user-my-location-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-edge-decline-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-limited-exp-20230920.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-lock-screen-in-search-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-make-cortana-personal-assistant-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-next-20230919.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-offline-20230919.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-second-keyboard-20230907.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-security-question-20230920.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-security-question2-20230920.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-select-personal-use-20230919.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-send-full-diagnostic-data-20230921.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/windows-skip-second-keyboard-20230907.png
- Verification run: http://openqa.suse.de/tests/12224072
