### PR TITLE
Crop the ssh termination suffix

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -200,7 +200,10 @@ sub ssh_script_output {
     delete($args{cmd});
     delete($args{ssh_opts});
     delete($args{username});
-    return script_output($ssh_cmd, %args);
+    my $output = script_output($ssh_cmd, %args);
+    # Filter the output ending from "Connection to ($HOST) closed."
+    $output =~ s/Connection to .* closed\.$//;
+    return $output;
 }
 
 =head2 ssh_script_retry


### PR DESCRIPTION
Trim the `Connection to *** closed.` suffix from ssh_script_output.

- Related issue: https://openqa.suse.de/tests/12223247#step/slem_basic/247
- Verification runs: [slem-basic](https://duck-norris.qe.suse.de/tests/13945#step/slem_basic/243) | [15-SP5 Azure](https://duck-norris.qe.suse.de/tests/13946#step/check_registercloudguest/80) | [15-SP5 GCE](https://duck-norris.qe.suse.de/tests/13947#step/check_registercloudguest/70)

`ssh_script_output` is mostly used in the consoletests, e.g. in `check_registercloudguest`.