### PR TITLE
Fix disk partitions error for sle12sp5 all patterns

### DIFF
--- a/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_x86_64.xml
@@ -80,22 +80,10 @@
   <partitioning config:type="list">
     <drive>
       <device>/dev/vda</device>
-      <disklabel>gpt</disklabel>
+      <disklabel>msdos</disklabel>
       <enable_snapshots config:type="boolean">true</enable_snapshots>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
-        <partition>
-          <create config:type="boolean">true</create>
-          <crypt_fs config:type="boolean">false</crypt_fs>
-          <format config:type="boolean">false</format>
-          <loop_fs config:type="boolean">false</loop_fs>
-          <mountby config:type="symbol">device</mountby>
-          <partition_id config:type="integer">65</partition_id>
-          <partition_nr config:type="integer">1</partition_nr>
-          <partition_type>primary</partition_type>
-          <resize config:type="boolean">false</resize>
-          <size>8225280</size>
-        </partition>
         <partition>
           <create config:type="boolean">true</create>
           <crypt_fs config:type="boolean">false</crypt_fs>
@@ -106,7 +94,7 @@
           <mount>swap</mount>
           <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">130</partition_id>
-          <partition_nr config:type="integer">2</partition_nr>
+          <partition_nr config:type="integer">1</partition_nr>
           <partition_type>primary</partition_type>
           <resize config:type="boolean">false</resize>
           <size>2146598400</size>
@@ -121,18 +109,22 @@
           <mount>/</mount>
           <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">3</partition_nr>
+          <partition_nr config:type="integer">2</partition_nr>
           <partition_type>primary</partition_type>
           <resize config:type="boolean">false</resize>
           <size>max</size>
           <subvolumes config:type="list">
             <listentry>
               <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>boot/grub2/powerpc-ieee1275</path>
+              <path>home</path>
             </listentry>
             <listentry>
               <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>home</path>
+              <path>boot/grub2/i386-pc</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/x86_64-efi</path>
             </listentry>
             <listentry>
               <copy_on_write config:type="boolean">true</copy_on_write>
@@ -205,6 +197,7 @@
           </subvolumes>
         </partition>
       </partitions>
+      <pesize/>
       <type config:type="symbol">CT_DISK</type>
       <use>all</use>
     </drive>


### PR DESCRIPTION
https://progress.opensuse.org/issues/132707


VR:
[create_hdd](https://openqa.suse.de/tests/12223680)
[Test with published qcow2](https://openqa.suse.de/tests/12224337)

The wrong configuration is mentioned at https://bugzilla.suse.com/show_bug.cgi?id=1215557