### PR TITLE
JeOS: Test combustion image setup

### DIFF
--- a/data/microos/butane/script
+++ b/data/microos/butane/script
@@ -1,28 +1,73 @@
 #!/bin/bash
 # combustion: network
+# 
+# Simple openQA combustion script used for sle-micro or Minimal-VM start from 15-SP6 and their opensuse counterparts
+# due to known bug boo#1157133, the script is intended to be used only on x86_64
+# 
+# Test Objects:
+#   1) set localization and timezone
+#   2) create new fs in the test drive
+#   3) set root password
+#   4) create test users
+#   5) set systemd mount for test partition
+#   6) create test oneshot systemd service that creates a file
+#   7) enable sshd
+#   8) set test hostname 
+#   9) test networking
+#
 # Redirect output to the console
 exec > >(exec tee -a /dev/console) 2>&1
 set -eux
 
-#
-### drives and filesystems
-#
-DRIVE='/dev/vdc'
-PART='/dev/vdc1'
+create_fs() {
+    DRIVE='/dev/vdc'
+    PART='/dev/vdc1'
 
-# create partition and filesystem on additional drive
-echo "label: gpt" | sfdisk "$DRIVE"
-echo "name=testing_part" | sfdisk /dev/vdc -N1
+    # create partition and filesystem on additional drive
+    echo "label: gpt" | sfdisk "$DRIVE"
+    echo "name=testing_part" | sfdisk "$DRIVE" -N1
 
-# label new partition for testing and create labeled ext4
-mkfs.ext4 -L home "$PART"
+    # label new partition for testing and create labeled ext4
+    mkfs.ext4 -L home "$PART"
 
-# mount new partition
-mount -t ext4 "$PART" /home
+    # mount new partition
+    mount -t ext4 "$PART" /home
 
-# DEBUG
-blkid
-lsblk
+    # DEBUG
+    blkid
+    lsblk
+}
+
+systemd_mount() {
+
+cat << EOF > /etc/systemd/system/home.mount
+[Unit]
+Before=local-fs.target
+Requires=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
+After=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
+
+[Mount]
+Where=/home
+What=/dev/disk/by-partlabel/testing_part
+Type=ext4
+
+[Install]
+RequiredBy=local-fs.target
+EOF
+
+}
+
+### set locale, keyboard and timezone
+# exception: sle-micro comes with symlink /etc/localtime, thus systemd-firstboot fails
+# bsc#1215618 - systemd-firstboot --force fails to replace an existing /etc/localtime symlink
+rm -f /etc/localtime
+systemd-firstboot --force --timezone=UTC --locale=en_US.UTF-8 --keymap=us
+echo 'FONT=eurlatgr.psfu' >> /etc/vconsole.conf
+
+if ! grep -q tumbleweed /etc/os-release; then
+    create_fs
+    systemd_mount
+fi
 
 #
 ### users and groups
@@ -57,21 +102,6 @@ RemainAfterExit=no
 ExecStart=/usr/bin/touch /var/log/flagfile
 [Install]
 WantedBy=multi-user.target
-EOF
-
-cat << EOF > /etc/systemd/system/home.mount
-[Unit]
-Before=local-fs.target
-Requires=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
-After=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
-
-[Mount]
-Where=/home
-What=/dev/disk/by-partlabel/testing_part
-Type=ext4
-
-[Install]
-RequiredBy=local-fs.target
 EOF
 
 systemctl enable sshd.service

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -635,7 +635,12 @@ sub load_jeos_tests {
     }
 
     load_boot_tests();
-    loadtest "jeos/firstrun";
+    if (check_var('FIRST_BOOT_CONFIG', 'combustion')) {
+        loadtest 'microos/verify_setup';
+        loadtest 'microos/image_checks';
+    } else {
+        loadtest "jeos/firstrun";
+    }
     if (get_var('POSTGRES_IP')) {
         loadtest "jeos/image_info";
     }

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -38,6 +38,9 @@ conditional_schedule:
             'cloud-init':
                 - installation/first_boot
                 - console/system_prepare
+            'combustion':
+                - microos/verify_setup
+                - microos/image_checks
 schedule:
     - '{{bootloader}}'
     - '{{wizard}}'

--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -10,7 +10,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_microos is_sle_micro);
+use version_utils qw(is_microos is_sle_micro is_jeos);
 use Utils::Architectures qw(is_aarch64);
 
 sub run {
@@ -35,7 +35,7 @@ sub run {
     my $varsize = script_output "findmnt -rnboSIZE -T/var";
     die "/var did not grow, got $varsize B" unless $varsize > (5 * 1024 * 1024 * 1024);
 
-    if (get_var("FIRST_BOOT_CONFIG", "combustion+ignition") =~ /combustion/) {
+    if (get_var("FIRST_BOOT_CONFIG", is_jeos ? "wizard" : "combustion+ignition") =~ /combustion/) {
         # Verify that combustion ran
         validate_script_output('cat /usr/share/combustion-welcome', qr/Combustion was here/);
     }

--- a/tests/microos/verify_setup.pm
+++ b/tests/microos/verify_setup.pm
@@ -15,6 +15,7 @@ use serial_terminal 'select_serial_terminal';
 use utils qw(systemctl);
 use YAML::PP;
 use File::Basename qw(basename);
+use version_utils qw(is_tumbleweed is_microos);
 
 my $data;
 my $fail = 0;
@@ -75,6 +76,8 @@ sub systemd_tests {
 }
 
 sub disk_tests {
+    # tumbleweed nor microos does not come with mkfs.ext4
+    return if is_tumbleweed || is_microos;
     my $disks = get_test_object('storage', 'disks');
     my $filesystems = get_test_object('storage', 'filesystems');
     my $partitions = ();


### PR DESCRIPTION
[PED-6318](https://jira.suse.com/browse/PED-6318) introduces another option to configure images with combustion.
Re-use already existing test cases in order to test combustion on JeOS/Minimal-vm

- ticket: [Add combustion test for Minimal VM](https://progress.opensuse.org/issues/135371)

#### Verification runs: 

* [tw-jeos](http://kepler.suse.cz/tests/21924)
* [slem 5.4](http://kepler.suse.cz/tests/21923)
* [slem 5.3](http://kepler.suse.cz/tests/21927#)
* [slem 5.2](http://kepler.suse.cz/tests/21926#)
* [slem 5.1](http://kepler.suse.cz/tests/21928#)

