### PR TITLE
Fix failing test run on empty AVC

### DIFF
--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -30,12 +30,12 @@ sub check_avc {
 
     my $instance = $self->{my_instance};
     # Read the Access Vector Cache to check for SELinux denials
-    my $avc = $instance->ssh_script_output(cmd => 'sudo ausearch -ts boot -m avc --format raw | grep type=AVC');
+    my $avc = $instance->ssh_script_output(cmd => 'sudo ausearch -ts boot -m avc --format raw | ( grep type=AVC || true )');
     record_info("AVC at boot", $avc);
     return if ($avc =~ "no matches");
 
     ## Gain better formatted logs and upload them for further investigation
-    $instance->ssh_assert_script_run(cmd => 'sudo ausearch -ts boot -m avc > ausearch.txt');
+    $instance->ssh_assert_script_run(cmd => 'sudo ausearch -ts boot -m avc > ausearch.txt || true');    # ausearch fails if there are no matches
     assert_script_run("scp " . $instance->username() . "@" . $instance->public_ip . ":ausearch.txt ausearch.txt");
     upload_logs("ausearch.txt");
 


### PR DESCRIPTION
If the AVC is empty, the `grep` does not match any items and therefore fails. This commit updates the grep command to not fail on empty input.

- Related ticket: https://progress.opensuse.org/issues/136046
- Related failure: https://openqa.suse.de/tests/12229826#step/slem_basic/240
- Verification run: https://duck-norris.qe.suse.de/tests/13951#
