### PR TITLE
Update UTT repo for Leap Micro

### DIFF
--- a/data/microos/utt-leap.repo
+++ b/data/microos/utt-leap.repo
@@ -1,7 +1,7 @@
-[openSUSE_Maintenance_17456]
-name=openSUSE:Maintenance:17456 (openSUSE_Leap_15.3_Update)
+[openSUSE_Maintenance_17952]
+name=openSUSE:Maintenance:17952 (openSUSE_Leap_15.5_Update)
 type=rpm-md
-baseurl=https://download.opensuse.org/repositories/openSUSE:/Maintenance:/17456/openSUSE_Leap_15.3_Update/
+baseurl=https://download.opensuse.org/repositories/openSUSE:/Maintenance:/17952/openSUSE_Leap_15.5_Update/
 gpgcheck=1
-gpgkey=https://download.opensuse.org/repositories/openSUSE:/Maintenance:/17456/openSUSE_Leap_15.3_Update/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/openSUSE:/Maintenance:/17952/openSUSE_Leap_15.5_Update/repodata/repomd.xml.key
 enabled=1


### PR DESCRIPTION
The package provided by the repository has lower version than the installed localy from the data directory. This makes the command transactional-update cleanup to fail with nothing to update. There is a new utt repo with higher version.

https://progress.opensuse.org/issues/136298

VR: https://openqa.opensuse.org/tests/3594587