### PR TITLE
Fix sles15sp4 teradata fake test

### DIFF
--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -40,7 +40,7 @@ sub run {
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));
     my $host_os_version = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
     foreach my $guest (@guests) {
-        if ($guest eq $host_os_version || $guest eq "${host_os_version}PV" || $guest eq "${host_os_version}HVM") {
+        if ($guest eq $host_os_version || $guest eq "${host_os_version}TD" || $guest eq "${host_os_version}PV" || $guest eq "${host_os_version}HVM") {
             if (check_var('PATCH_WITH_ZYPPER', '1')) {
                 assert_script_run("ssh root\@$guest dmesg --level=emerg,crit,alert,err -tx|sort -o /tmp/${guest}_dmesg_err_before.txt");
                 record_info("Patching $guest");


### PR DESCRIPTION
The testing process for Teradata on SLES15SP4 did not include the installation of packages, indicating an apparent lack of real testing



- Related ticket:  https://progress.opensuse.org/issues/136334
- Needles: None
- Verification run: [sles15sp4 teradata](https://openqa.suse.de/tests/12230065#step/patch_guests/34), [sles12sp5 no teradata](https://openqa.suse.de/tests/12230305)

