### PR TITLE
un-schedule access_beta_distribution for sle-micro

### DIFF
--- a/schedule/sle-micro/yam/slem_extensions_and_modules_aarch64.yaml
+++ b/schedule/sle-micro/yam/slem_extensions_and_modules_aarch64.yaml
@@ -3,8 +3,6 @@ description:    >
   Maintainer: QE Yam <qe-yam at suse de>
   SUSE Linux Enterprise Micro installation with phub and live addons.
 schedule:
-  access_beta_distribution:
-    - installation/access_beta_distribution
   addons:
     - installation/module_registration/register_extensions_and_modules
     - installation/module_registration/import_untrusted_gnpupg_key

--- a/schedule/sle-micro/yam/slem_extensions_and_modules_s390x.yaml
+++ b/schedule/sle-micro/yam/slem_extensions_and_modules_s390x.yaml
@@ -3,8 +3,6 @@ description:    >
   Maintainer: QE Yam <qe-yam at suse de>
   SUSE Linux Enterprise Micro installation with phub and live addons.
 schedule:
-  access_beta_distribution:
-    - installation/access_beta_distribution
   addons:
     - installation/module_registration/register_extensions_and_modules
   timeout:

--- a/schedule/sle-micro/yam/slem_extensions_and_modules_x86_64.yaml
+++ b/schedule/sle-micro/yam/slem_extensions_and_modules_x86_64.yaml
@@ -3,8 +3,6 @@ description:    >
   Maintainer: QE Yam <qe-yam at suse de>
   SUSE Linux Enterprise Micro installation with phub and live addons.
 schedule:
-  access_beta_distribution:
-    - installation/access_beta_distribution
   addons:
     - installation/module_registration/register_extensions_and_modules
   grub:

--- a/schedule/sle-micro/yam/slem_installation_default_s390x.yaml
+++ b/schedule/sle-micro/yam/slem_installation_default_s390x.yaml
@@ -3,8 +3,6 @@ description:    >
   Maintainer: QE Yam <qe-yam at suse de>
   SUSE Linux Enterprise Micro installation
 schedule:
-  access_beta_distribution:
-    - installation/access_beta_distribution
   addons:
     - installation/module_registration/skip_module_registration
   timeout:

--- a/schedule/sle-micro/yam/slem_installation_default_x86_64.yaml
+++ b/schedule/sle-micro/yam/slem_installation_default_x86_64.yaml
@@ -3,8 +3,6 @@ description:    >
   Maintainer: QE Yam <qe-yam at suse de>
   SUSE Linux Enterprise Micro installation
 schedule:
-  access_beta_distribution:
-    - installation/access_beta_distribution
   addons:
     - installation/module_registration/skip_module_registration
   grub:

--- a/schedule/sle-micro/yam/slem_installation_default_zvm.yaml
+++ b/schedule/sle-micro/yam/slem_installation_default_zvm.yaml
@@ -3,8 +3,6 @@ description:    >
   Maintainer: QE Yam <qe-yam at suse de>
   SUSE Linux Enterprise Micro installation
 schedule:
-  access_beta_distribution:
-    - installation/access_beta_distribution
   disk_activation:
     - installation/disk_activation/select_configure_dasd_disks
     - installation/disk_activation/configure_dasd

--- a/schedule/yast/sle/flows/default_slem.yaml
+++ b/schedule/yast/sle/flows/default_slem.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta_distribution: []
+# access_beta_distribution:
+#   - installation/access_beta_distribution
 license_agreement:
   - installation/licensing/accept_license
 disk_activation: []


### PR DESCRIPTION
Added commented schedule to default, so we just need to [un]comment the default file when needed.