### PR TITLE
Refactor NFS client ID code & Increase timeout in copy_media call in hana_install test module

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -366,6 +366,34 @@ sub prepare_profile {
     }
 }
 
+=head2 _do_mount
+
+ _do_mount( $proto, $path, $target);
+
+Performs a call to the mount command (used by both C<mount_media> and C<copy_media>) with
+appropiate options depending on the protocol. Function internal to the class.
+
+=cut
+
+sub _do_mount {
+    my ($proto, $path, $mnt_path) = @_;
+
+    # Set some NFS options in case we are using NFS
+    my $nfs_client_id = md5_hex(get_required_var('JOBTOKEN'));
+    my $options = 'ro';
+    if ($proto eq 'nfs') {
+        my $nfs_timeo = get_var('NFS_TIMEO');
+        $options = $nfs_timeo ? "timeo=$nfs_timeo,rsize=16384,wsize=16384,ro" : 'rsize=16384,wsize=16384,ro';
+        # Attempt to force a unique NFSv4 client id
+        assert_script_run "modprobe nfs nfs4_unique_id=$nfs_client_id";
+        # Check nfs4_unique_id parameter file exists
+        assert_script_run 'until ls /sys/module/nfs/parameters/nfs4_unique_id; do sleep 1; done';
+    }
+    assert_script_run "mount -t $proto -o $options $path $mnt_path", 90;
+    # Check NFS client ID
+    assert_script_run 'cat /sys/module/nfs/parameters/nfs4_unique_id' if ($proto eq 'nfs');
+}
+
 =head2 copy_media
 
  $self->copy_media( $proto, $path, $timeout, $target);
@@ -388,25 +416,13 @@ sub copy_media {
     my $mnt_path = '/mnt';
     my $media_path = "$mnt_path/" . get_required_var('ARCH');
 
-    # Set some NFS options in case we are using NFS
-    my $nfs_client_id = md5_hex(get_required_var('JOBTOKEN'));
-    my $options = 'ro';
-    if ($proto eq 'nfs') {
-        my $nfs_timeo = get_var('NFS_TIMEO');
-        $options = $nfs_timeo ? "timeo=$nfs_timeo,rsize=16384,wsize=16384,ro" : 'rsize=16384,wsize=16384,ro';
-        # Attempt to force a unique NFSv4 client id
-        assert_script_run "modprobe nfs nfs4_unique_id=$nfs_client_id";
-        # Check nfs4_unique_id parameter file exists
-        assert_script_run 'until ls /sys/module/nfs/parameters/nfs4_unique_id; do sleep 1; done';
-    }
-
     # First create $target and copy media there
     assert_script_run "mkdir $target";
-    assert_script_run "mount -t $proto -o $options $path $mnt_path", 90;
-    # Check NFS client ID
-    assert_script_run 'cat /sys/module/nfs/parameters/nfs4_unique_id';
+    _do_mount($proto, $path, $mnt_path);
     $media_path = $mnt_path if script_run "[[ -d $media_path ]]";    # Check if specific ARCH subdir exists
-    assert_script_run "rsync -azr --info=progress2 $media_path/ $target/", $nettout;
+    my $rsync = 'rsync -azr --info=progress2';
+    record_info 'rsync stats (dry-run)', script_output("$rsync --dry-run --stats $media_path/ $target/", proceed_on_failure => 1);
+    assert_script_run "$rsync $media_path/ $target/", $nettout;
 
     # Unmount the share, as we don't need it anymore
     assert_script_run "umount $mnt_path";
@@ -440,10 +456,9 @@ sub mount_media {
     my ($self, $proto, $path, $target) = @_;
     my $mnt_path = '/mnt';
     my $media_path = "$mnt_path/" . get_required_var('ARCH');
-    my $options = ($proto eq 'nfs') ? 'rsize=16384,wsize=16384,ro' : 'ro';
 
     assert_script_run "mkdir $target";
-    assert_script_run "mount -t $proto -o $options $path $mnt_path";
+    _do_mount($proto, $path, $mnt_path);
     $media_path = $mnt_path if script_run "[[ -d $media_path ]]";    # Check if specific ARCH subdir exists
 
     # Create a overlay to "allow" writes to the readonly filesystem

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -109,7 +109,7 @@ sub run {
     $self->prepare_profile('HANA');
 
     # Copy media
-    $self->copy_media($proto, $path, 1800, '/sapinst');
+    $self->copy_media($proto, $path, 2700, '/sapinst');
 
     # Mount points information: use the same paths and minimum sizes as the wizard (based on RAM size)
     my $full_size = ceil($RAM / 1024);    # Use the ceil value of RAM in GB


### PR DESCRIPTION
This PR includes 2 changes:

1. Refactor NFS client ID code so it is used by `copy_media` and `mount_media` methods.
2. Increase `copy_media` timeout from 30 minutes (1800 seconds) to 45 minutes (2700 seconds) in the `copy_media` call in the `sles4sap/hana_install` test module.

- Related ticket: https://progress.opensuse.org/issues/135923
- Needles: N/A
- Verification run: [HANA on 15-SP1](https://openqaworker15.qa.suse.cz/tests/236448), [NetWeaver on 12-SP5](http://openqaworker15.qa.suse.cz/tests/236449), [HANA on 15-SP5](http://openqaworker15.qa.suse.cz/tests/236450), [NetWeaver on 15-SP5](http://openqaworker15.qa.suse.cz/tests/236447), [HANA on 12-SP5](http://openqaworker15.qa.suse.cz/tests/236451)
