### PR TITLE
Bring back apparmor testing in JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2336,6 +2336,7 @@ sub load_security_tests {
     my @security_tests = qw(
       fips_setup
       crypt_core
+      apparmor
     );
 
     # Check SECURITY_TEST and call the load functions iteratively.
@@ -2940,6 +2941,23 @@ sub load_nfs_tests {
 
 sub load_upstream_systemd_tests {
     loadtest 'systemd_testsuite/prepare_systemd_and_testsuite';
+}
+
+sub load_security_tests_apparmor {
+    load_security_console_prepare;
+
+    if (check_var('TEST', 'mau-apparmor') || is_jeos) {
+        loadtest "security/apparmor/aa_prepare";
+    }
+    loadtest "security/apparmor/aa_status";
+    loadtest "security/apparmor/aa_enforce";
+    loadtest "security/apparmor/aa_complain";
+    loadtest "security/apparmor/aa_genprof";
+    loadtest "security/apparmor/aa_autodep";
+    loadtest "security/apparmor/aa_logprof";
+    loadtest "security/apparmor/aa_easyprof";
+    loadtest "security/apparmor/aa_notify";
+    loadtest "security/apparmor/aa_disable";
 }
 
 1;


### PR DESCRIPTION
Apparmor test cases were moved to yaml in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16534. Resulting in false positive testing in all JeOS job groups (osd and o3).

- ticket: [security/apparmor jobs are gone - fix schedule](https://progress.opensuse.org/issues/135752)

#### VRs

* [sle-15-SP5-JeOS-for-kvm-and-xen-QR.x86_64](http://kepler.suse.cz/tests/21945#)
* [opensuse-Tumbleweed-JeOS-for-kvm-and-xen.x86_64](http://kepler.suse.cz/tests/21944)
