### PR TITLE
Ignore 'System clock wrong by X seconds' message

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -503,5 +503,15 @@
             "leap-micro": [ "5.5" ]
         },
         "type": "bug"
+    },
+    "system-clock-wrong": {
+        "description": "System clock wrong by .*",
+        "products": {
+            "microos":  ["Tumbleweed"],
+            "sle": ["12-SP5", "15", "15-SP1", "15-SP2", "15-SP3", "15-SP4", "15-SP5"],
+            "sle-micro": ["5.1", "5.2", "5.3", "5.4" , "5.5"],
+            "leap-micro": ["5.1", "5.2", "5.3", "5.4" , "5.5"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
This message comes from chrony if the system clock is off and should be ignored.

- Related failure: https://openqa.suse.de/tests/12230814#step/journal_check/11
- Verification run: https://duck-norris.qe.suse.de/tests/13953