### PR TITLE
Fix teradata incorrect guest VM values

### DIFF
--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -206,7 +206,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     } else {
         %guests = ();
     }
-    %guests = %guests{"sles${guest_version}PV", "sles${guest_version}HVM"} unless (check_var('TERADATA', ''));
+    %guests = get_var('TERADATA') ? %guests{"sles${guest_version}PV", "sles${guest_version}HVM"} : %guests;
 
 } elsif (get_var("REGRESSION", '') =~ /kvm|qemu/) {
     %guests = (
@@ -333,7 +333,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     } else {
         %guests = ();
     }
-    %guests = %guests{"sles$guest_version"} unless (check_var('TERADATA', ''));
+    %guests = get_var('TERADATA') ? %guests{"sles$guest_version"} : %guests;
 
 } elsif (get_var("REGRESSION", '') =~ /vmware/) {
     %guests = (


### PR DESCRIPTION
lib/common.pm has an issue causing incorrect Teradata guest VM values based on the host's SLES version and the teradata variable.


- Related ticket: https://progress.opensuse.org/issues/136985
- Needles: None
- Verification run: 
[15-SP4:no_teradata:kvm](http://openqa.qam.suse.cz/tests/61086#step/prepare_guests/40),
[15-SP3:no_teradata:xen](http://openqa.qam.suse.cz/tests/61197#),
[15-SP4:TERADATA:kvm](http://openqa.qam.suse.cz/tests/61088#step/prepare_guests/28),
[15-SP4:TERADATA:xen](http://openqa.qam.suse.cz/tests/61092#step/prepare_guests/34)
