### PR TITLE
Remove LUKS version and the key location check at encrypt module

### DIFF
--- a/test_data/yam/agama_full_disk_encryption.yaml
+++ b/test_data/yam/agama_full_disk_encryption.yaml
@@ -7,7 +7,5 @@ cryptsetup:
     properties:
       type: LUKS2
       cipher: aes-xts-plain64
-      key_location: keyring
       mode: read/write
 backup_file_info: 'LUKS encrypted file, ver 2, header size 16384, ID 3, algo sha256'
-backup_path: '/root/bkp_luks_header'


### PR DESCRIPTION
Remove LUKS version and the key location check at encrypt module

- Related ticket: https://progress.opensuse.org/issues/135194
- Verification run: https://openqa.opensuse.org/tests/3597558#step/validate_encrypt/19