### PR TITLE
Let slurm-node installation on SLE12

### DIFF
--- a/tests/hpc/hpc_support.pm
+++ b/tests/hpc/hpc_support.pm
@@ -13,7 +13,6 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
-use version_utils 'is_sle';
 
 sub prepare_db {
     my $hostname = get_required_var("HOSTNAME");
@@ -35,9 +34,7 @@ sub run {
         barrier_wait("HPC_PRE_MIGRATION");
     }
 
-    zypper_call("in slurm-munge slurm-slurmdbd mariadb ganglia-gmond");
-    # install slurm-node if sle15, not available yet for sle12
-    zypper_call('in slurm-node') if is_sle '15+';
+    zypper_call("in slurm-node slurm-munge slurm-slurmdbd mariadb ganglia-gmond");
 
     systemctl("start mariadb");
     systemctl("is-active mariadb");

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -28,9 +28,8 @@ sub run ($self) {
     # Install slurm
     # $slurm_pkg-munge is installed explicitly since slurm_23_02
     zypper_call("in $slurm_pkg $slurm_pkg-munge $slurm_pkg-slurmdbd");
-    # install slurm-node if sle15, not available yet for sle12
     # $slurm_pkg-munge is installed explicitly since slurm_23_02
-    zypper_call("in $slurm_pkg-node") if is_sle '15+';
+    zypper_call("in $slurm_pkg-node");
 
     my $mariadb_service = "mariadb";
     $mariadb_service = "mysql" if is_sle('<12-sp4');

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -14,7 +14,6 @@ use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
 use hpc::utils 'get_slurm_version';
-use version_utils 'is_sle';
 
 sub run ($self) {
     select_serial_terminal();
@@ -23,9 +22,7 @@ sub run ($self) {
 
     # Install slurm
     # $slurm_pkg-munge is installed explicitly since slurm_23_02
-    zypper_call("in $slurm_pkg-munge");
-    # install slurm-node if sle15, not available yet for sle12
-    zypper_call("in $slurm_pkg-node") if is_sle '15+';
+    zypper_call("in $slurm_pkg-node $slurm_pkg-munge");
 
     if (get_required_var('EXT_HPC_TESTS')) {
         zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);


### PR DESCRIPTION
slurm-node is released and can be install. No need to block it anymore.

- Related ticket: none
- Verification run: https://aquarius.suse.cz/tests/19220#details