### PR TITLE
Make the installation of Windows unattended

### DIFF
--- a/data/wsl/Autounattend_BIOS.xml
+++ b/data/wsl/Autounattend_BIOS.xml
@@ -1,0 +1,363 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+	<settings pass="windowsPE">
+		<component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+			<SetupUILanguage>
+				<UILanguage>en-US</UILanguage>
+			</SetupUILanguage>
+			<InputLocale>0409:00000409</InputLocale>
+			<SystemLocale>en-US</SystemLocale>
+			<UILanguage>en-US</UILanguage>
+			<UILanguageFallback>en-US</UILanguageFallback>
+			<UserLocale>en-US</UserLocale>
+		</component>
+		<component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+                    <Path>E:\</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+		<component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DiskConfiguration>
+                <Disk wcm:action="add">
+                    <CreatePartitions>
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Type>Primary</Type>
+                            <Size>100</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+                            <Extend>true</Extend>
+                            <Order>2</Order>
+                            <Type>Primary</Type>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <ModifyPartition wcm:action="add">
+                            <Active>true</Active>
+                            <Format>NTFS</Format>
+                            <Label>System Reserved</Label>
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <TypeID>0x27</TypeID>
+                        </ModifyPartition>
+                        <ModifyPartition wcm:action="add">
+                            <Active>true</Active>
+                            <Format>NTFS</Format>
+                            <Label>OS</Label>
+                            <Letter>C</Letter>
+                            <Order>2</Order>
+                            <PartitionID>2</PartitionID>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                </Disk>
+            </DiskConfiguration>
+			<ImageInstall>
+				<OSImage>
+					<InstallTo>
+						<DiskID>0</DiskID>
+						<PartitionID>2</PartitionID>
+					</InstallTo>
+				</OSImage>
+			</ImageInstall>
+			<UserData>
+				<ProductKey>
+					<Key>VK7JG-NPHTM-C97JM-9MPGT-3V66T</Key>
+				</ProductKey>
+				<AcceptEula>true</AcceptEula>
+			</UserData>
+			<RunSynchronous>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>1</Order>
+					<Path>%windir%\System32\reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>2</Order>
+					<Path>%windir%\System32\reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>3</Order>
+					<Path>%windir%\System32\reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>4</Order>
+					<Path>%windir%\System32\reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+			</RunSynchronous>
+		</component>
+	</settings>
+	<settings pass="generalize"></settings>
+	<settings pass="specialize">
+		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+			<TimeZone>Central Europe Standard Time</TimeZone>
+		</component>
+		<component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+			<RunSynchronous>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>1</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'MicrosoftTeams' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>2</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Clipchamp.Clipchamp' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>3</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.BingWeather' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>4</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.MicrosoftOfficeHub' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>5</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.MicrosoftSolitaireCollection' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>6</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.MicrosoftStickyNotes' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>7</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.People' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>8</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.ScreenSketch' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>9</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Windows.Photos' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>10</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsAlarms' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>11</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsCalculator' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>12</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsCamera' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>13</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsFeedbackHub' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>14</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsMaps' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>15</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.XboxGameOverlay' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>16</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.XboxIdentityProvider' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>17</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.XboxSpeechToTextOverlay' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>18</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.YourPhone' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>19</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.BingNews' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>20</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Paint' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>21</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.PowerAutomateDesktop' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>22</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Todos' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>23</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsNotepad' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>24</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsTerminal' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>25</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'MicrosoftCorporationII.QuickAssist' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>26</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Microsoft3DViewer' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>27</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.MSPaint' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>28</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Office.OneNote' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>29</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Wallet' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>30</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.XboxApp' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>31</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Getstarted' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>32</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.GetHelp' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>33</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Sense &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>34</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>35</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WdBoot &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>36</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>37</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WdFilter &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>38</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>39</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WdNisDrv &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>40</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>41</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WdNisSvc &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>42</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>43</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WinDefend &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>44</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>45</Order>
+					<Path>%windir%\System32\regini.exe C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>46</Order>
+					<Path>%windir%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>47</Order>
+					<Path>%windir%\System32\cmd.exe /c DEL %windir%\System32\OneDriveSetup.exe</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>48</Order>
+					<Path>%windir%\System32\cmd.exe /c DEL %windir%\SysWOW64\OneDriveSetup.exe</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>49</Order>
+					<Path>%windir%\System32\reg.exe LOAD HKU\mount C:\Users\Default\NTUSER.DAT</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>50</Order>
+					<Path>%windir%\System32\reg.exe DELETE HKU\mount\Software\Microsoft\Windows\CurrentVersion\Run /v OneDriveSetup /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>51</Order>
+					<Path>%windir%\System32\reg.exe UNLOAD HKU\mount</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>52</Order>
+					<Path>%windir%\System32\reg.exe ADD HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU /v AUOptions /t REG_DWORD /d 4 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>53</Order>
+					<Path>%windir%\System32\reg.exe ADD HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU /v NoAutoRebootWithLoggedOnUsers /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>54</Order>
+					<Path>powershell.exe Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' -Name HiberbootEnabled -Value 0</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>55</Order>
+					<Path>powershell.exe powercfg /hibernate off</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>56</Order>
+					<Path>powershell.exe powercfg -change -monitor-timeout-ac 0</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>57</Order>
+					<Path>powershell.exe Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' -Name VisualFXSetting -Value 2</Path>
+				</RunSynchronousCommand>
+			</RunSynchronous>
+		</component>
+	</settings>
+	<settings pass="auditSystem"></settings>
+	<settings pass="auditUser"></settings>
+	<settings pass="oobeSystem">
+<component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                        <InputLocale>0409:00000409</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+			<UserAccounts>
+				<LocalAccounts>
+					<LocalAccount wcm:action="add">
+						<Name>Bernhard M. Wiedeman</Name>
+						<Group>Administrators</Group>
+						<Password>
+							<Value>nots3cr3t</Value>
+							<PlainText>true</PlainText>
+						</Password>
+					</LocalAccount>
+				</LocalAccounts>
+			</UserAccounts>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <ProtectYourPC>1</ProtectYourPC>
+                <UnattendEnableRetailDemo>false</UnattendEnableRetailDemo>
+            </OOBE>
+		</component>
+	</settings>
+</unattend>

--- a/data/wsl/Autounattend_UEFI.xml
+++ b/data/wsl/Autounattend_UEFI.xml
@@ -1,0 +1,381 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+	<settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>0409:00000409</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+		<component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+                    <Path>E:\</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+		<component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DiskConfiguration>
+                <Disk wcm:action="add">
+                    <CreatePartitions>
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Type>Primary</Type>
+                            <Size>450</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+                            <Order>2</Order>
+                            <Type>EFI</Type>
+							<Size>100</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+                            <Order>3</Order>
+                            <Type>MSR</Type>
+							<Size>16</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+                            <Extend>true</Extend>
+                            <Order>4</Order>
+                            <Type>Primary</Type>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <ModifyPartition wcm:action="add">
+                            <Format>NTFS</Format>
+                            <Label>WinRE</Label>
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <TypeID>DE94BBA4-06D1-4D40-A16A-BFD50179D6AC</TypeID>
+                        </ModifyPartition>
+                        <ModifyPartition wcm:action="add">
+                            <Format>FAT32</Format>
+                            <Label>System</Label>
+                            <Order>2</Order>
+                            <PartitionID>2</PartitionID>
+                        </ModifyPartition>
+                        <ModifyPartition wcm:action="add">
+                            <Order>3</Order>
+                            <PartitionID>3</PartitionID>
+                        </ModifyPartition>
+						<ModifyPartition wcm:action="add">
+                            <Format>NTFS</Format>
+                            <Label>Windows</Label>
+                            <Letter>C</Letter>
+                            <Order>4</Order>
+                            <PartitionID>4</PartitionID>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                </Disk>
+            </DiskConfiguration>
+			<ImageInstall>
+				<OSImage>
+					<InstallTo>
+						<DiskID>0</DiskID>
+						<PartitionID>4</PartitionID>
+					</InstallTo>
+				</OSImage>
+			</ImageInstall>
+			<UserData>
+				<ProductKey>
+					<Key>VK7JG-NPHTM-C97JM-9MPGT-3V66T</Key>
+				</ProductKey>
+				<AcceptEula>true</AcceptEula>
+			</UserData>
+			<RunSynchronous>				
+				<RunSynchronousCommand wcm:action="add">
+					<Order>1</Order>
+					<Path>%windir%\System32\reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>2</Order>
+					<Path>%windir%\System32\reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>3</Order>
+					<Path>%windir%\System32\reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>4</Order>
+					<Path>%windir%\System32\reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+			</RunSynchronous>
+		</component>
+	</settings>
+	<settings pass="generalize"></settings>
+	<settings pass="specialize">
+		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+			<TimeZone>Central Europe Standard Time</TimeZone>
+		</component>
+		<component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+			<RunSynchronous>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>1</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'MicrosoftTeams' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>2</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Clipchamp.Clipchamp' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>3</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.BingWeather' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>4</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.MicrosoftOfficeHub' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>5</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.MicrosoftSolitaireCollection' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>6</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.MicrosoftStickyNotes' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>7</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.People' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>8</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.ScreenSketch' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>9</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Windows.Photos' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>10</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsAlarms' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>11</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsCalculator' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>12</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsCamera' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>13</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsFeedbackHub' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>14</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsMaps' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>15</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.XboxGameOverlay' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>16</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.XboxIdentityProvider' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>17</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.XboxSpeechToTextOverlay' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>18</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.YourPhone' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>19</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.BingNews' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>20</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Paint' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>21</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.PowerAutomateDesktop' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>22</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Todos' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>23</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsNotepad' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>24</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.WindowsTerminal' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>25</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'MicrosoftCorporationII.QuickAssist' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>26</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Microsoft3DViewer' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>27</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.MSPaint' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>28</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Office.OneNote' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>29</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Wallet' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>30</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.XboxApp' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>31</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.Getstarted' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>32</Order>
+					<Path>powershell.exe -NoProfile -Command "Get-AppxProvisionedPackage -Online | where 'DisplayName' -EQ 'Microsoft.GetHelp' | Remove-AppxProvisionedPackage -Online *&gt;&amp;1 &gt;&gt; $env:TEMP\package.log;"</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>33</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Sense &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>34</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>35</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WdBoot &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>36</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>37</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WdFilter &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>38</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>39</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WdNisDrv &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>40</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>41</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WdNisSvc &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>42</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>43</Order>
+					<Path>%windir%\System32\cmd.exe /c echo HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WinDefend &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>44</Order>
+					<Path>%windir%\System32\cmd.exe /c echo     "Start" = REG_DWORD 4 &gt;&gt; C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>45</Order>
+					<Path>%windir%\System32\regini.exe C:\Windows\Temp\regini.txt</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>46</Order>
+					<Path>%windir%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>47</Order>
+					<Path>%windir%\System32\cmd.exe /c DEL %windir%\System32\OneDriveSetup.exe</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>48</Order>
+					<Path>%windir%\System32\cmd.exe /c DEL %windir%\SysWOW64\OneDriveSetup.exe</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>49</Order>
+					<Path>%windir%\System32\reg.exe LOAD HKU\mount C:\Users\Default\NTUSER.DAT</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>50</Order>
+					<Path>%windir%\System32\reg.exe DELETE HKU\mount\Software\Microsoft\Windows\CurrentVersion\Run /v OneDriveSetup /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>51</Order>
+					<Path>%windir%\System32\reg.exe UNLOAD HKU\mount</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>52</Order>
+					<Path>%windir%\System32\reg.exe ADD HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU /v AUOptions /t REG_DWORD /d 4 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>53</Order>
+					<Path>%windir%\System32\reg.exe ADD HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU /v NoAutoRebootWithLoggedOnUsers /t REG_DWORD /d 1 /f</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>54</Order>
+					<Path>powershell.exe Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' -Name HiberbootEnabled -Value 0</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>55</Order>
+					<Path>powershell.exe powercfg /hibernate off</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>56</Order>
+					<Path>powershell.exe powercfg -change -monitor-timeout-ac 0</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>57</Order>
+					<Path>powershell.exe Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' -Name VisualFXSetting -Value 2</Path>
+				</RunSynchronousCommand>
+			</RunSynchronous>
+		</component>
+	</settings>
+	<settings pass="auditSystem"></settings>
+	<settings pass="auditUser"></settings>
+	<settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <InputLocale>0409:00000409</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+			<UserAccounts>
+				<LocalAccounts>
+					<LocalAccount wcm:action="add">
+						<Name>Bernhard M. Wiedeman</Name>
+						<Group>Administrators</Group>
+						<Password>
+							<Value>nots3cr3t</Value>
+							<PlainText>true</PlainText>
+						</Password>
+					</LocalAccount>
+				</LocalAccounts>
+			</UserAccounts>
+			<OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <ProtectYourPC>1</ProtectYourPC>
+                <UnattendEnableRetailDemo>false</UnattendEnableRetailDemo>
+            </OOBE>
+		</component>
+	</settings>
+</unattend>

--- a/schedule/wsl/install/create_windows_image.yaml
+++ b/schedule/wsl/install/create_windows_image.yaml
@@ -4,7 +4,14 @@ description:  >
       Basic Windows system deployment job.
       Exports qcow2 with clean Windows installation.
       Scheduled on bios boot and uefi workers.
+
+conditional_schedule:
+  unattended_install:
+    WIN_UNATTENDED:
+      '0':
+      - wsl/install/ms_win_firstboot
+
 schedule:
   - wsl/install/ms_win_installation
-  - wsl/install/ms_win_firstboot
+  - '{{unattended_install}}'
   - wsl/update_windows

--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -158,7 +158,7 @@ sub run {
 
     # poweroff
     $self->reboot_or_shutdown(1);
-    $self->wait_boot_windows;
+    $self->wait_boot_windows(is_firstboot => 1);
 }
 
 1;

--- a/tests/wsl/install/ms_win_installation.pm
+++ b/tests/wsl/install/ms_win_installation.pm
@@ -26,53 +26,63 @@ sub prepare_win11 {
 }
 
 sub run {
-    if (get_var('UEFI')) {
-        assert_screen 'windows-boot';
-        send_key 'spc';    # boot from CD or DVD
-    }
-    # This test works onlywith CDMODEL=ide-cd due to windows missing scsi drivers which are installed via scsi iso
-    assert_screen 'windows-setup', 300;
-    send_key 'alt-n';    # next
-    prepare_win11 if (check_var('WIN_VERSION', '11'));
 
-    save_screenshot;
-    send_key 'alt-i';    # install Now
-    save_screenshot;
-    send_key 'alt-n';    # next
-    assert_screen 'windows-activate';
-    if (my $key = get_var('_SECRET_WINDOWS_10_PRO_KEY')) {
-        type_password $key . "\n";
-        assert_screen([qw(windows-wrong-key windows-license-with-key)]);
-        die("The provided product key didn't work...") if (match_has_tag('windows-wrong-key'));
+    my $self = shift;
+
+    if (get_var('UEFI')) {
+        while (check_screen('windows-boot', timeout => 5)) {
+            send_key 'spc';
+            record_info('SPC', 'Space key pressed');
+        }    # boot from CD or DVD
     }
-    else {
-        assert_and_click 'windows-no-prod-key';
-        assert_screen 'windows-select-system';
-        send_key_until_needlematch('windows-10-pro', 'down');
-        send_key 'alt-n';    # select OS (Win 10 Pro)
-        assert_screen 'windows-license';
+
+    if (check_var('WIN_UNATTENDED', '0')) {
+        # This test works onlywith CDMODEL=ide-cd due to windows missing scsi drivers which are installed via scsi iso
+        assert_screen 'windows-setup', 300;
+        send_key 'alt-n';    # next
+        prepare_win11 if (check_var('WIN_VERSION', '11'));
+
+        save_screenshot;
+        send_key 'alt-i';    # install Now
+        save_screenshot;
+        send_key 'alt-n';    # next
+        assert_screen 'windows-activate';
+        if (my $key = get_var('_SECRET_WINDOWS_10_PRO_KEY')) {
+            type_password $key . "\n";
+            assert_screen([qw(windows-wrong-key windows-license-with-key)]);
+            die("The provided product key didn't work...") if (match_has_tag('windows-wrong-key'));
+        }
+        else {
+            assert_and_click 'windows-no-prod-key';
+            assert_screen 'windows-select-system';
+            send_key_until_needlematch('windows-10-pro', 'down');
+            send_key 'alt-n';    # select OS (Win 10 Pro)
+            assert_screen 'windows-license';
+        }
+        send_key 'alt-a';    # accept eula
+        send_key 'alt-n';    # next
+        assert_screen 'windows-installation-type';
+        send_key 'alt-c';    # custom
+        assert_screen 'windows-disk-partitioning';
+        send_key 'alt-l';    # load driver
+        assert_screen 'windows-load-driver';
+        send_key 'alt-b';    # browse button
+        send_key 'c';
+        save_screenshot;
+        send_key 'c';    # go to second CD drive with drivers
+        send_key 'right';    # ok
+        sleep 0.5;
+        send_key 'ret';
+        wait_still_screen stilltime => 3, timeout => 10;
+        send_key_until_needlematch 'windows-all-drivers-selected', 'shift-down';    # select all drivers
+        send_key 'alt-n';
+        assert_screen 'windows-partitions';
+        assert_and_click 'windows-next-install';
+        assert_screen 'windows-restart', 600;
+        send_key 'alt-r';
+    } else {
+        $self->wait_boot_windows(is_firstboot => 1);
     }
-    send_key 'alt-a';    # accept eula
-    send_key 'alt-n';    # next
-    assert_screen 'windows-installation-type';
-    send_key 'alt-c';    # custom
-    assert_screen 'windows-disk-partitioning';
-    send_key 'alt-l';    # load driver
-    assert_screen 'windows-load-driver';
-    send_key 'alt-b';    # browse button
-    send_key 'c';
-    save_screenshot;
-    send_key 'c';    # go to second CD drive with drivers
-    send_key 'right';    # ok
-    sleep 0.5;
-    send_key 'ret';
-    wait_still_screen stilltime => 3, timeout => 10;
-    send_key_until_needlematch 'windows-all-drivers-selected', 'shift-down';    # select all drivers
-    send_key 'alt-n';
-    assert_screen 'windows-partitions';
-    assert_and_click 'windows-next-install';
-    assert_screen 'windows-restart', 600;
-    send_key 'alt-r';
 }
 
 1;

--- a/tests/wsl/update_windows.pm
+++ b/tests/wsl/update_windows.pm
@@ -14,15 +14,6 @@ sub run {
 
     my $vbs_url = data_url("wsl/UpdateInstall.vbs");
     $self->open_powershell_as_admin;
-    # Create a registry value in win11 to prevent random reboots
-    if (get_var("WIN_VERSION") == '11') {
-        $self->run_in_powershell(cmd => "reg add HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows /v WindowsUpdate");
-        $self->run_in_powershell(cmd => "reg add HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate /v AU");
-        $self->run_in_powershell(cmd => "reg add HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU /v NoAutoRebootWithLoggedOnUsers /t REG_DWORD /d 1");
-        $self->reboot_or_shutdown(1);
-        $self->wait_boot_windows;
-        $self->open_powershell_as_admin;
-    }
     $self->run_in_powershell(cmd => "Invoke-WebRequest -Uri \"$vbs_url\" -OutFile \"C:\\UpdateInstall.vbs\"");
     $self->run_in_powershell(
         cmd => 'cd \\; $port.WriteLine($(cscript .\\UpdateInstall.vbs /Automate))',


### PR DESCRIPTION
By adding an `Autounattend.xml` file to the ISO root folder with all the options defined, the installation of Windows runs unattended without need of any clicks or screens.

- Related ticket: https://progress.opensuse.org/issues/121033
- Needles:
- Verification runs:
  - [Windows 10 BIOS](https://openqa.suse.de/tests/12373524)
  - [Windows 10 UEFI](https://openqa.suse.de/tests/12373672)
  - [Windows 11 UEFI](https://openqa.suse.de/tests/12374123)

  - [Job running on a PUBLISH_HDD_1](https://openqa.suse.de/tests/12374209)
  - [Win10 job group after changes](https://openqa.suse.de/tests/overview?distri=windows&version=10&build=22H2&groupid=287)
  - [Win11 job group after changes](https://openqa.suse.de/tests/overview?distri=windows&version=11&build=22H2&groupid=287)

*NOTE: the keys used in the XML files are the default ones provided by Microsoft for installing without activation*
