### PR TITLE
Add disk identifier of unreal2/3 to SLE autoyast profile template for virt test

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -112,7 +112,7 @@
     </dns>
   </networking>
   <partitioning config:type="list">
-  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x6f4ee0801165fe0029a9209ce8d20dfd'};
+  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'unreal2' => 'wwn-0x55cd2e415081e693', 'unreal3' => 'wwn-0x55cd2e4150817d43', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x6f4ee0801165fe0029a9209ce8d20dfd'};
   % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
   % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : '';
     <drive>
@@ -129,6 +129,7 @@
           <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
           <label>osroot<%= int(rand(99)) %></label>
+          <size>120G</size>
         </partition>
         <partition>
           <create config:type="boolean">true</create>
@@ -138,7 +139,6 @@
           <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
           <resize config:type="boolean">false</resize>
-          <size>120G</size>
         </partition>
       </partitions>
       <type config:type="symbol">CT_DISK</type>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -118,7 +118,7 @@
     <ntp_sync>systemd</ntp_sync>
   </ntp-client>
   <partitioning config:type="list">
-  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x6f4ee0801165fe0029a9209ce8d20dfd'};
+  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'unreal2' => 'wwn-0x55cd2e415081e693', 'unreal3' => 'wwn-0x55cd2e4150817d43', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x6f4ee0801165fe0029a9209ce8d20dfd'};
   % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
   % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : ''; 
     <drive>
@@ -135,6 +135,7 @@
           <mount>/</mount>
           <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
+          <size>120G</size>
         </partition>
         <partition>
           <create config:type="boolean">true</create>
@@ -144,7 +145,6 @@
           <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
           <resize config:type="boolean">false</resize>
-          <size>120G</size>
         </partition>
       </partitions>
       <type config:type="symbol">CT_DISK</type>


### PR DESCRIPTION
unreal2 and unreal3 are new SUTs on OSD. 

- Add their disk wwns to sle autoyast template.
- Change the OS partition instead of '/var/lib/libvirt/images' to default 120G as it was in non-autoyast installation.

- Verification run: 
[sle15sp6 kvm non-autoyast on unreal2](https://openqa.suse.de/tests/12415704)
[sle15sp6 xen non-autoyast on unreal3](https://openqa.suse.de/tests/12415810)   //please ignore debugging screenshots
[sle15sp6 kvm autoyast on unreal2](https://openqa.suse.de/tests/12416972)
[sle12sp5 kvm autoyast on unreal3](https://openqa.suse.de/tests/12416987)
