### PR TITLE
Add scenario where TPM2 will fail key unsealing

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -20,7 +20,7 @@ use Carp;
 use microos 'microos_reboot';
 use power_action_utils qw(power_action prepare_system_shutdown);
 use version_utils;
-use utils 'reconnect_mgmt_console';
+use utils qw(reconnect_mgmt_console unlock_if_encrypted);
 use Utils::Backends;
 use Utils::Architectures;
 use publiccloud::instances;
@@ -75,6 +75,7 @@ sub process_reboot {
     $args{trigger} //= 0;
     $args{automated_rollback} //= 0;
     $args{expected_grub} //= 1;
+    $args{expected_passphrase} //= 0;
 
     if (is_public_cloud) {
         my $instance = publiccloud::instances::get_instance();
@@ -105,6 +106,9 @@ sub process_reboot {
             if (is_aarch64 && check_screen('tianocore-mainmenu', 30)) {
                 # Use firmware boot manager of aarch64 to boot HDD, when needed
                 opensusebasetest::handle_uefi_boot_disk_workaround();
+            }
+            if ($args{expected_passphrase}) {
+                unlock_if_encrypted();
             }
             # Replace by wait_boot if possible
             assert_screen 'grub2', 150;

--- a/schedule/security/alp/check_tpm2.yaml
+++ b/schedule/security/alp/check_tpm2.yaml
@@ -6,3 +6,4 @@ schedule:
     - transactional/host_config
     - transactional/enable_selinux
     - security/tpm2/tpm2_measured_boot
+    - security/tpm2/tpm2_fail_key_unsealing

--- a/tests/security/tpm2/tpm2_fail_key_unsealing.pm
+++ b/tests/security/tpm2/tpm2_fail_key_unsealing.pm
@@ -1,0 +1,35 @@
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: TPM2 scenario where boot components are updated, failing LUKS key unsealing.
+# Calculate the new PCRs and updates the signature in the sealed key with command
+# `fdectl tpm-authorize`.
+#
+# Maintainer: QE Security <none@suse.de>
+# Tags: poo#134984
+
+use strict;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+use transactional 'process_reboot';
+
+sub run {
+    select_console('root-console');
+
+    # Modify boot component
+    assert_script_run(
+        'sed -i \'s/set btrfs_relative_path="yes"/set  btrfs_relative_path="yes"/\' '
+          . '/boot/efi/EFI/*/grub.cfg');
+
+    # Expect after reboot passphrase prompt due to unsealing of the LUKS key should fail
+    process_reboot(trigger => 1, expected_passphrase => 1);
+
+    # Compute/install new policy after changes using authorized policies
+    assert_script_run('fdectl tpm-authorize');
+
+    # processing of reboot should end up in grub menu with TPM2 unsealing the key back again
+    process_reboot(trigger => 1);
+}
+
+1;


### PR DESCRIPTION
Add TPM2 scenario where boot components are updated, failing LUKS key unsealing. In order to pass key unsealing back, calculate the new PCRs and updates the signature in the sealed key with command `fdectl tpm-authorize`.

Add parameter in process_reboot to process passphrase prompt, due it is needed when failing the key unsealing and apparently is the only library method that ensure proper console handling.

- Related ticket: [poo#134984](https://progress.opensuse.org/issues/134984)
- Related MR: [mr#168](https://gitlab.suse.de/qe-security/osd-sle15-security/-/merge_requests/168)
- Verification run: [check_tpm2](https://openqa.suse.de/tests/12304295#details)
