### PR TITLE
[WIP] Update bootloader tag id for installation via libyui

### DIFF
--- a/lib/YaST/Bootloader/BootloaderOptionsPage.pm
+++ b/lib/YaST/Bootloader/BootloaderOptionsPage.pm
@@ -11,11 +11,14 @@ package YaST::Bootloader::BootloaderOptionsPage;
 use parent 'Installation::Navigation::NavigationBase';
 use strict;
 use warnings;
+use testapi;
+use version_utils qw(is_sle);
 
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{txb_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::Grub2Widget::TimeoutWidget\""});
+    $self->{txb_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::TimeoutWidget\""}) if (is_sle);
+    $self->{txb_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::Grub2Widget::TimeoutWidget\""}) if (check_var('FLAVOR', 'Staging-DVD'));
     return $self;
 }
 


### PR DESCRIPTION
The bootloader tag id is defferrnt on Tumbleweed and SLES, need to make
it work on both. And on Tumbleweed, only the staging builds' bootloader
tag id is updated, the daily builds of Tumbleweed is the same with SLES
builds.

- Related ticket: n/a
- Needles: n/a
- Verification run: 
https://openqa.suse.de/tests/12326129# (sles15sp5 yast mu)
https://openqa.suse.de/tests/12326128# (sles15sp6 staging)
https://openqa.opensuse.org/tests/3602642#step/disable_boot_menu_timeout/2 (tumbleweed daily)
https://openqa.opensuse.org/tests/3602641#step/disable_boot_menu_timeout/2 (tumbleweed staging)