### PR TITLE
Don't install mariadb after rmt-server

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -263,7 +263,6 @@ sub rmt_wizard {
         record_soft_failure 'bsc#1195759';
         zypper_call 'in rmt-server';
     }
-    zypper_call 'in mariadb';
 
     enter_cmd "yast2 rmt;echo yast2-rmt-wizard-\$? > /dev/$serialdev";
     assert_screen 'yast2_rmt_registration';

--- a/tests/console/rmt/rmt_feature.pm
+++ b/tests/console/rmt/rmt_feature.pm
@@ -15,11 +15,13 @@ use warnings;
 use testapi;
 use repo_tools;
 use utils;
+use serial_terminal qw(select_serial_terminal);
 
 sub run {
     select_console 'root-console';
     record_info('RMT server setup', 'Start to setup a rmt server');
     rmt_wizard();
+    select_serial_terminal;
     # sync from SCC
     rmt_sync;
     # enable all modules of products at one arch


### PR DESCRIPTION
rmt does install mariadb104, installing then mariadb (10.2) will result in collision which will by default fail
Enable serial console after yast setup

- Related ticket: https://progress.opensuse.org/issues/135506
- Verification run: https://openqa.suse.de/tests/12325317