### PR TITLE
Better fix for changed widget IDs

### DIFF
--- a/lib/YaST/Bootloader/BootloaderOptionsPage.pm
+++ b/lib/YaST/Bootloader/BootloaderOptionsPage.pm
@@ -11,15 +11,12 @@ package YaST::Bootloader::BootloaderOptionsPage;
 use parent 'Installation::Navigation::NavigationBase';
 use strict;
 use warnings;
-use testapi;
-use version_utils qw(is_sle);
 
 
 sub init {
     my $self = shift;
     $self->SUPER::init();
-    $self->{txb_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::TimeoutWidget\""}) if (is_sle);
-    $self->{txb_grub_timeout} = $self->{app}->textbox({id => "\"Bootloader::Grub2Widget::TimeoutWidget\""}) if (check_var('FLAVOR', 'Staging-DVD'));
+    $self->{txb_grub_timeout} = $self->{app}->textbox({id => qr /"Bootloader::.*TimeoutWidget"/});
     return $self;
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/135512
- Needles: -
- Verification runs:
  - SLE: https://openqa.suse.de/tests/12332532
  - openSUSE staging: https://openqa.opensuse.org/tests/3604569
  
- Applied a regex to select the correct widget, that helps us to keep libyui code clean and without further version checks.
