### PR TITLE
Fix test_podman_privileged for s390x

### DIFF
--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -12,6 +12,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils qw(validate_script_output_retry);
 use containers::utils qw(reset_container_network_if_needed);
+use Utils::Architectures;
 
 sub run {
     my ($self, $args) = @_;
@@ -25,8 +26,9 @@ sub run {
     my $image = "registry.suse.com/bci/bci-base:latest";
 
     record_info('Test', 'Launch a container with privileged mode');
+
     # /dev is only accessible in privileged mode
-    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus");
+    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus") unless is_s390x;
 
     # Mounting tmpfs only works in privileged mode because the read-only protection in the default mode
     assert_script_run("$runtime run --rm --privileged $image mount -t tmpfs none /mnt");


### PR DESCRIPTION
In s390x the /dev/bus test cannot be done because doesn't exists

cannot access '/dev/bus': No such file or directory

- Related ticket: https://progress.opensuse.org/issues/135518
- Verification run: http://openqa.suse.de/tests/12341927
