### PR TITLE
Fix missing .* in the soft-failure for bsc1215405

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -497,7 +497,7 @@
         "type": "bug"
     },
     "bsc#1215405": {
-        "description": "setroubleshoot.*SELinux is preventing (.*rebootmgrd|.*NetworkManager|sshd).* from.* access.*|setroubleshoot.*: failed to retrieve rpm info for path.*",
+        "description": "setroubleshoot.*SELinux is preventing .*(rebootmgrd|NetworkManager|sshd).* from.* access.*|setroubleshoot.*: failed to retrieve rpm info for path.*",
         "products": {
             "sle-micro": ["5.4" , "5.5"],
             "leap-micro": [ "5.5" ]


### PR DESCRIPTION
Just to avoid this: https://openqa.suse.de/tests/12325898#step/journal_check/10
VR: https://openqa.suse.de/tests/12342071