### PR TITLE
JeOS: Community images do not have pre-installed salt

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -26,6 +26,7 @@ use constant {
           is_selfinstall
           is_gnome_next
           is_jeos
+          is_community_jeos
           is_krypton_argon
           is_leap
           is_opensuse
@@ -890,5 +891,14 @@ sub php_version {
         $php_ver = '8';
     }
     ($php, $php_pkg, $php_ver);
+}
+
+=head2 is_community_jeos
+
+Returns true for tests using the images built by the "JeOS" package on OBS
+=cut
+
+sub is_community_jeos {
+    return (get_var('FLAVOR', '') =~ /JeOS-for-(AArch64|RPi)/);
 }
 

--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -24,7 +24,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils qw(zypper_call quit_packagekit systemctl);
-use version_utils qw(is_jeos is_opensuse is_sle is_leap);
+use version_utils qw(is_jeos is_opensuse is_sle is_leap is_community_jeos);
 use registration 'add_suseconnect_product';
 
 sub run {
@@ -42,7 +42,8 @@ sub run {
 
     quit_packagekit;
     my @packages = qw(salt-master);
-    push @packages, 'salt-minion' unless is_jeos && (is_sle || is_leap);
+    # On SLE/Leap based Minimal-VM/Minimal-Image, salt-minion has to be preinstalled
+    push @packages, 'salt-minion' unless is_jeos && (is_sle || is_leap) && !is_community_jeos;
     zypper_call("in @packages");
     my $cmd = <<'EOF';
 systemctl start salt-master


### PR DESCRIPTION
As it is in TW, community images are missing salt-minion.

##### Verification runs:

 - opensuse-15.5-JeOS-for-AArch64-aarch64-Build10.179-jeos@USBboot_aarch64 -> https://openqa.opensuse.org/tests/3609105
 - sle-15-SP4-JeOS-for-kvm-and-xen-Updates-x86_64-Build20230929-1-jeos-extratest@64bit-virtio-vga -> https://openqa.suse.de/tests/12345593
 - opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20230927-jeos@64bit_virtio -> https://openqa.opensuse.org/tests/3609106
 - opensuse-Tumbleweed-JeOS-for-AArch64-aarch64-Build20230922-jeos@aarch64-HD20G -> https://openqa.opensuse.org/tests/3609107
 - opensuse-Tumbleweed-JeOS-for-RPi-aarch64-Build20230922-jeos@RPi4 -> https://openqa.opensuse.org/tests/3609109
 - opensuse-15.5-JeOS-for-RPi-aarch64-Build10.179-jeos@RPi3 -> https://openqa.opensuse.org/tests/3609283