### PR TITLE
containers: Remove soft-failure for podman 4.7.0+

### DIFF
--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -61,7 +61,7 @@ sub run {
     # NOTE: When https://github.com/containers/podman/issues/19529 is solved we must add a version check here
     my $ret = script_run("$runtime run --rm --volumes-from $test_container $test_image ls /$test_dir/$test_file");
     if ($ret != 0) {
-        if ($runtime eq "podman") {
+        if ($runtime eq "podman" && (version->parse($podman_version) < version->parse('4.7.0'))) {
             record_soft_failure("gh#containers/podman#19529 - Unexpected error with --volumes-from") if ($ret != 0 && $runtime == "podman");
         } else {
             die("--volumes-from failed");


### PR DESCRIPTION
Remove soft-failure for https://github.com/containers/podman/issues/19529 as it was fixed on 4.7.0.

- Verification run: Not needed since the test is not soft-failing on latest podman: https://openqa.opensuse.org/tests/3612585