### PR TITLE
microos: Remove soft-failure for resolved bsc#1210587

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -95,15 +95,10 @@ sub run {
     record_info 'Test', "Update toolbox";
     assert_script_run('set -o pipefail');
     assert_script_run('toolbox -- zypper -n ref', timeout => 300);
+    # Test for bsc#1210587
     if (script_run('toolbox -- zypper -n up 2>&1 > /var/tmp/toolbox_zypper_up.txt', timeout => 300) != 0) {
         upload_logs('/var/tmp/toolbox_zypper_up.txt');
-        # Test for bsc#1210587
-        my $output = script_output('cat /var/tmp/toolbox_zypper_up.txt');
-        if ($output =~ m/Installation of timezone-.* failed/ && is_sle_micro) {
-            record_soft_failure("bsc#1210587 installation of timezone failed");
-        } else {
-            die "zypper up failed within toolbox";
-        }
+        die "zypper up failed within toolbox";
     }
 
     clean_container_host(runtime => 'podman');


### PR DESCRIPTION
Remove soft-failure for resolved [bsc#1210587](https://bugzilla.suse.com/show_bug.cgi?id=1210587)

Not soft-failing anymore:
- sle-micro-5.2-GCE-BYOS-x86_64-Build0517-slem_containers_selinux@64bit -> https://openqa.suse.de/tests/12345825
- sle-micro-5.3-GCE-BYOS-aarch64-Build0549-slem_containers@64bit -> https://openqa.suse.de/tests/12343039
- sle-micro-5.4-EC2-BYOS-aarch64-Build0287-slem_containers_selinux@64bit -> https://openqa.suse.de/tests/12343012

- Verification run: Not needed.
