### PR TITLE
Add softfailure for bsc1215380

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -521,5 +521,13 @@
             "microos":  ["Tumbleweed"]
         },
         "type": "bug"
+    },
+    "bsc#1215380" : {
+        "description": "Failed to start Entropy Daemon based on the HAVEGE algorithm.",
+        "products": {
+            "sle-micro": ["5.3"],
+            "leap-micro": ["5.3"]
+        },
+        "type": "bug"
     }
 }


### PR DESCRIPTION
Manually marking those failures as softfailures becomes cumbersome.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1215380
- Related failure: https://openqa.suse.de/tests/12358146#step/journal_check/22
- Verification run: https://openqa.suse.de/tests/12358338
