### PR TITLE
Record when Development repos are found in IBSM jobs and skip them

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -624,7 +624,6 @@ sub create_playbook_section_list {
     unless (get_var('QESAP_SCC_NO_REGISTER')) {
         # Add registration module as first element - "QESAP_SCC_NO_REGISTER" skips scc registration via ansible
         push @playbook_list, 'registration.yaml -e reg_code=' . get_required_var('SCC_REGCODE_SLES4SAP') . " -e email_address=''";
-
         # Add "fully patch system" module after registration module and before test start/configuration moudles.
         # Temporary moved inside ha_enabled condition to avoid test without Ansible to fails.
         # To be properly addressed in the caller and fully-patch-system can be placed back out of the if.

--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -23,6 +23,10 @@ sub run {
 
     while (defined(my $maintrepo = shift @repos)) {
         next if $maintrepo =~ /^\s*$/;
+        if ($maintrepo =~ /Development-Tools/) {
+            record_info("MISSING REPOS", "There are Development-Tools repos in this incident, that are not uploaded to IBSM. Later errors, if they occur, may be due to these.");
+            next;
+        }
         foreach my $instance (@{$self->{instances}}) {
             next if ($instance->{'instance_id'} !~ m/vmhana/);
             $instance->run_ssh_command(cmd => "sudo zypper --no-gpg-checks ar -f -n TEST_$count $maintrepo TEST_$count",


### PR DESCRIPTION
IBS Mirror does not clone `Development-Tools` repositories. This pr uses `record_info` to report if tests they contain `Development-Tools` repos, so that the reviewer is aware that a repo was left out.

- Related ticket: https://jira.suse.com/browse/TEAM-8608
- Verification run: https://openqa.suse.de/tests/12365737#step/cluster_add_repos/3
