### PR TITLE
Don't run /dev/bus on JeOS

### DIFF
--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -13,7 +13,7 @@ use serial_terminal 'select_serial_terminal';
 use utils qw(validate_script_output_retry);
 use containers::utils qw(reset_container_network_if_needed);
 use Utils::Architectures;
-use version_utils qw(is_public_cloud);
+use version_utils qw(is_public_cloud is_jeos);
 
 sub run {
     my ($self, $args) = @_;
@@ -29,7 +29,7 @@ sub run {
     record_info('Test', 'Launch a container with privileged mode');
 
     # /dev is only accessible in privileged mode
-    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus") unless (is_s390x || is_public_cloud);
+    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus") unless (is_s390x || is_public_cloud || is_jeos);
 
     # Mounting tmpfs only works in privileged mode because the read-only protection in the default mode
     assert_script_run("$runtime run --rm --privileged $image mount -t tmpfs none /mnt");


### PR DESCRIPTION
The test `ls /dev/bus` will not work on JeOS.


- Related failure: https://openqa.suse.de/tests/12358111#step/docker_privileged_mode/40
- Verification run: https://openqa.suse.de/tests/12359894
