### PR TITLE
Remove libpod local files in upgrade test scenario

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -52,6 +52,7 @@ sub run {
         my $cont_storage = '/etc/containers/storage.conf';
         if ($unresolved_config =~ m|$cont_storage|) {
             assert_script_run(sprintf('mv  %s.rpmnew %s', $cont_storage, $cont_storage));
+            assert_script_run('rm -rf /var/lib/containers/storage') if is_aarch64;
             assert_script_run('podman system reset -f');
         }
     }


### PR DESCRIPTION
Podman-reset yields an error after changing storage driver in [TUP test scenario](https://openqa.opensuse.org/tests/3583311#step/rootless_podman/51).

- ticket: https://progress.opensuse.org/issues/135017
- Verification run: https://openqa.opensuse.org/tests/3614543#live
