### PR TITLE
Only call Ansible fully-patch-system if HANA

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -621,12 +621,15 @@ sub create_playbook_section_list {
     my ($ha_enabled) = @_;
     my @playbook_list;
 
-    # Add registration module as first element - "QESAP_SCC_NO_REGISTER" skips scc registration via ansible
-    push @playbook_list, 'registration.yaml -e reg_code=' . get_required_var('SCC_REGCODE_SLES4SAP') . " -e email_address=''"
-      unless (get_var('QESAP_SCC_NO_REGISTER'));
+    unless (get_var('QESAP_SCC_NO_REGISTER')) {
+        # Add registration module as first element - "QESAP_SCC_NO_REGISTER" skips scc registration via ansible
+        push @playbook_list, 'registration.yaml -e reg_code=' . get_required_var('SCC_REGCODE_SLES4SAP') . " -e email_address=''";
 
-    # Add "fully patch system" module after registration module and before test start/configuration moudles
-    push @playbook_list, 'fully-patch-system.yaml';
+        # Add "fully patch system" module after registration module and before test start/configuration moudles.
+        # Temporary moved inside ha_enabled condition to avoid test without Ansible to fails.
+        # To be properly addressed in the caller and fully-patch-system can be placed back out of the if.
+        push @playbook_list, 'fully-patch-system.yaml';
+    }
 
     # SLES4SAP/HA related playbooks
     if ($ha_enabled) {


### PR DESCRIPTION
Add playbook fully-patch-system scheduling only if HANA is enabled.

This PR is an hot fix for mr_test failure introduced by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17787

## Related ticket:
TEAM-8437 - [qesap-deployment] Fully patch system before test start

## Verification run: 

- sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-10-03T04:03:09Z-hanasr_azure_test_sapconf@64bit -> http://openqaworker15.qa.suse.cz/tests/240440

 - sle-15-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:30903:systemd-rpm-macros-sles4sap_gnome_saptune_notes@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/240441

