### PR TITLE
Increase timeout for booting

### DIFF
--- a/tests/qemu/qemu.pm
+++ b/tests/qemu/qemu.pm
@@ -58,7 +58,7 @@ sub run {
         is_qemu_preinstalled or install_qemu('qemu-s390x');
         # use kernel from host system for booting
         enter_cmd "qemu-system-s390x -nographic -kernel /boot/image -initrd /boot/initrd";
-        assert_screen ['qemu-reached-target-basic-system', 'qemu-s390x-exec-0x7f4-not-impl', 'qemu-linux-req-more-recent-proc-hw'], 180;
+        assert_screen ['qemu-reached-target-basic-system', 'qemu-s390x-exec-0x7f4-not-impl', 'qemu-linux-req-more-recent-proc-hw'], 300;
         if (match_has_tag 'qemu-s390x-exec-0x7f4-not-impl') {
             record_soft_failure 'bsc#1124595 - qemu on s390x fails when called WITHOUT kvm: EXECUTE on instruction prefix 0x7f4 not implemented';
             return;


### PR DESCRIPTION
Booting on s390x sometimes takes longer than the current timeout allows. This commit increases the timeout from 3 to 5 minutes.

- Related failure:
- Verification run: https://openqa.suse.de/tests/12365748
