### PR TITLE
Kill all gpg parts before modifying configuration files

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -151,7 +151,7 @@ EOF
     assert_script_run("gpg2 -u $email --verify --verbose $tfile_asc");
 
     # cleanup
-    assert_script_run("rm -f ~/.gnupg/gpg-agent.conf ; gpg-connect-agent reloadagent /bye") if $gpg_ver ge 2.1;
+    assert_script_run("gpgconf --kill all") if $gpg_ver ge 2.1;
     # Restore
     assert_script_run("rm -rf $tfile.* $egg_file");
     assert_script_run("rm -rf .gnupg && gpg -K");    # Regenerate default ~/.gnupg


### PR DESCRIPTION
Ask gpgconf to kill all parts before cleaning up and regenerating, instead of just killing parts of it.

Fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1211456 and https://bugzilla.suse.com/show_bug.cgi?id=1211444. 

Fixing these paves the way for fixing https://bugzilla.opensuse.org/show_bug.cgi?id=1215890
