### PR TITLE
Unify two qesap functions for the log inspection

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -94,8 +94,8 @@ our @EXPORT = qw(
   qesap_calculate_deployment_name
   qesap_export_instances
   qesap_import_instances
-  qesap_ansible_log_find_timeout
-  qesap_ansible_log_find_missing_sudo_password
+  qesap_file_find_string
+
 );
 
 =head1 DESCRIPTION
@@ -426,30 +426,23 @@ sub qesap_execute {
     return @results;
 }
 
-=head3 qesap_ansible_log_find_timeout
+=head3 qesap_file_find_string
 
-    Return the Timeout error found in the Ansible log or not
+    Search for a string in the Ansible log file.
+    Returns 1 if the string is found in the log file, 0 otherwise.
+
+=over 2
+
+=item B<FILE> - Path to the Ansible log file. (Required)
+
+=item B<SEARCH_STRING> - String to search for in the log file. (Required)
+=back
 =cut
 
-sub qesap_ansible_log_find_timeout
-{
-    my ($file) = @_;
-    my $search_string = 'Timed out waiting for last boot time check';
-    my $timeout_match = script_output("grep \"$search_string\" $file || exit 0");
-    return $timeout_match ? 1 : 0;
-}
-
-=head3 qesap_ansible_log_find_missing_sudo_password
-
-    Return the '"msg": "Missing sudo password"' error found in the Ansible log or not
-=cut
-
-sub qesap_ansible_log_find_missing_sudo_password
-{
-    my ($file) = @_;
-    my $search_string = 'Missing sudo password';
-    my $missing_sudo_pwd_match = script_output("grep \"$search_string\" $file || exit 0");
-    return $missing_sudo_pwd_match ? 1 : 0;
+sub qesap_file_find_string {
+    my (%args) = @_;
+    foreach (qw(file search_string)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+    return script_run("grep \"$args{search_string}\" $args{file}");
 }
 
 =head3 qesap_get_inventory

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -372,7 +372,7 @@ subtest '[qesap_execute] check_logs' => sub {
     ok $res[1] =~ /\/.*.log.txt/, 'File pattern is okay';
 };
 
-subtest '[qesap_ansible_log_find_timeout] success' => sub {
+subtest '[qesap_file_find_string] success' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     my @calls;
     # internally the function is using grep to search for a specific
@@ -381,16 +381,16 @@ subtest '[qesap_ansible_log_find_timeout] success' => sub {
     # Create a mock to replace the script_output
     # The mock will return, within the function under test,
     # the result of the grep.
-    $qesap->redefine(script_output => sub { push @calls, $_[0]; return $log });
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 1; });
 
-    my $res = qesap_ansible_log_find_timeout('JACQUES');
+    my $res = qesap_file_find_string(file => 'JACQUES', search_string => 'Timed out waiting for last boot time check');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok $res == 1, 'Return is 1 when string is detected';
     ok((any { /grep.*JACQUES/ } @calls), 'Function calling grep against the log file');
 };
 
-subtest '[qesap_ansible_log_find_timeout] fail' => sub {
+subtest '[qesap_file_find_string] fail' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     my @calls;
 
@@ -398,9 +398,9 @@ subtest '[qesap_ansible_log_find_timeout] fail' => sub {
     # The mock will return, within the function under test,
     # the result of the grep.
     # Here simulate that the grep does not return any match
-    $qesap->redefine(script_output => sub { push @calls, $_[0]; return '' });
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
 
-    my $res = qesap_ansible_log_find_timeout('JACQUES');
+    my $res = qesap_file_find_string(file => 'JACQUES', search_string => 'Timed out waiting for last boot time check');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok $res == 0, 'Return is 0 when string is not detected';

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -24,7 +24,7 @@ sub run {
     @ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
     if ($ret[0])
     {
-        if (qesap_ansible_log_find_missing_sudo_password($ret[1])) {
+        if (qesap_file_find_string(file => $ret[1], search_string => 'Missing sudo password')) {
             record_info('DETECTED ANSIBLE MISSING SUDO PASSWORD ERROR');
             @ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
             if ($ret[0])
@@ -34,7 +34,7 @@ sub run {
             }
             record_info('ANSIBLE RETRY PASS');
         }
-        elsif (qesap_ansible_log_find_timeout($ret[1])) {
+        elsif (qesap_file_find_string(file => $ret[1], search_string => 'Timed out waiting for last boot time check')) {
             record_info('DETECTED ANSIBLE TIMEOUT ERROR');
             $self->clean_up();
             @ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => 1800);


### PR DESCRIPTION
Unify qesap_ansible_log_find_timeout and qesap_ansible_log_find_missing_sudo_password.

- Related ticket: [TEAM-8593](https://jira.suse.com/browse/TEAM-8593)

- Verification run:

 - sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test@64bit -> 
http://openqaworker15.qa.suse.cz/tests/241754

With simulated Ansible failure
```
% openqa-clone-job --parental-inheritance --skip-chained-deps --within-instance ${REF_JOB}  BUILD=mpagot_VR _GROUP="mpagot_dev" _GROUP_ID=0 _OBSOLETE=1 CASEDIR='https://github.com/mpagot/os-autoinst-distri-opensuse.git#'$(git rev-parse --abbrev-ref HEAD) QESAP_INSTALL_GITHUB_REPO='github.com/mpagot/qe-sap-deployment' QESAP_INSTALL_GITHUB_BRANCH='ansible_failure'
```

 - sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/241756#step/deploy/47  Then Ansible deregister but it is as we are using customized qesap.py to artificially produce an error. So everything is fine.

With passing Ansible
```
% openqa-clone-job --parental-inheritance --skip-chained-deps --within-instance ${REF_JOB}  BUILD=mpagot_VR _GROUP="mpagot_dev" _GROUP_ID=0 _OBSOLETE=1 CASEDIR='https://github.com/mpagot/os-autoinst-distri-opensuse.git#'$(git rev-parse --abbrev-ref HEAD)
 ```

http://openqaworker15.qa.suse.cz/tests/241758