### PR TITLE
Install explicitly apparmor for older versions of sle

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -105,13 +105,14 @@ sub install_k3s {
         script_retry("curl -sfL https://get.k3s.io  -o install_k3s.sh", timeout => 180, delay => 60, retry => 3);
         assert_script_run("sh install_k3s.sh $disables", timeout => 300);
         script_run("rm -f install_k3s.sh");
+        zypper_call('in apparmor-parser') if is_sle('<15-SP4');
         setup_and_check_k3s;
         return;
     }
 
     # k3s-install script is already packaged for several products
     my @pkgs = qw(k3s-install);
-    push @pkgs, 'apparmor-parser' if is_sle('>=15-SP1');
+    push @pkgs, 'apparmor-parser' if is_sle('<15-SP4');
 
     if (script_run(sprintf('rpm -q %s', join(" ", @pkgs))) != 0) {
         if (is_transactional) {


### PR DESCRIPTION
k3s-config check reports missing apparmor-parser package on pre-installed systems.

- failure: https://openqa.suse.de/tests/12369980#step/kubectl/116

#### Verification runs:

* [15-SP1](http://kepler.suse.cz/tests/21973#step/kubectl/130)
* [15-SP3@s390x](https://openqa.suse.de/tests/12372094)
* [15-SP3@aarch64](https://openqa.suse.de/tests/12372095#details)
