### PR TITLE
Add FIPS option to 389ds_sssd.yaml

### DIFF
--- a/schedule/security/389ds_sssd.yaml
+++ b/schedule/security/389ds_sssd.yaml
@@ -5,8 +5,13 @@ schedule:
     - boot/boot_to_desktop
     - console/consoletest_setup
     - network/setup_multimachine
+    - '{{fips_setup}}'
     - '{{tls_389ds}}'
 conditional_schedule:
+    fips_setup:
+        FIPS_ENABLED:
+            1:
+                - fips/fips_setup
     tls_389ds:
         HOSTNAME:
             server:


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/137117
- Verification runs:
  - 15-SP5: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=20231003-1&groupid=431
  - 15-SP4: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=20231003-1&groupid=431