### PR TITLE
Temporarily disable privileged container test runs

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -98,7 +98,10 @@ sub load_host_tests_podman {
         # In Public Cloud we don't have internal resources
         load_image_test($run_args) unless is_public_cloud || is_alp;
         load_3rd_party_image_test($run_args);
-        load_container_engine_privileged_mode($run_args);
+
+        ## Temporarily disabled, see poo#135518
+        #load_container_engine_privileged_mode($run_args);
+
         loadtest 'containers/podman_bci_systemd';
         loadtest 'containers/podman_pods';
         # Default for ALP is Netavark
@@ -122,7 +125,10 @@ sub load_host_tests_docker {
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud || is_alp;
     load_3rd_party_image_test($run_args);
-    load_container_engine_privileged_mode($run_args);
+
+    ## Temporarily disabled, see poo#135518
+    #load_container_engine_privileged_mode($run_args);
+
     # Firewall is not installed in Public Cloud, JeOS OpenStack and MicroOS but it is in SLE Micro
     loadtest 'containers/docker_firewall' unless (is_public_cloud || is_openstack || is_microos);
     unless (is_sle("<=15") && is_aarch64) {


### PR DESCRIPTION
Disable privileged container test runs because of unintended failures on non-mainstream architectures and images.

- Related ticket: https://progress.opensuse.org/issues/135518
- Verification run: https://openqa.suse.de/tests/12374466 (not present in schedule anymore)
