### PR TITLE
Containers: Disable privileged mode

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -98,7 +98,6 @@ sub load_host_tests_podman {
         # In Public Cloud we don't have internal resources
         load_image_test($run_args) unless is_public_cloud || is_alp;
         load_3rd_party_image_test($run_args);
-        load_container_engine_privileged_mode($run_args);
         loadtest 'containers/podman_bci_systemd';
         loadtest 'containers/podman_pods';
         # Default for ALP is Netavark
@@ -122,7 +121,6 @@ sub load_host_tests_docker {
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud || is_alp;
     load_3rd_party_image_test($run_args);
-    load_container_engine_privileged_mode($run_args);
     # Firewall is not installed in Public Cloud, JeOS OpenStack and MicroOS but it is in SLE Micro
     loadtest 'containers/docker_firewall' unless (is_public_cloud || is_openstack || is_microos);
     unless (is_sle("<=15") && is_aarch64) {


### PR DESCRIPTION
Because fails in different VRs, is disabled until will be more stable

- Related ticket: https://progress.opensuse.org/issues/135518
- Verification run: 