### PR TITLE
Remove bsc#1212351 softfail 

### DIFF
--- a/tests/hpc/gnu_compilers_hpc.pm
+++ b/tests/hpc/gnu_compilers_hpc.pm
@@ -25,6 +25,10 @@ sub run ($self) {
     assert_script_run qq{module av | grep gnu/$version};
     assert_script_run 'module load gnu';
     assert_script_run qq{env |grep "MODULEPATH=/usr/share/lmod/moduledeps/gnu-$version"};
+    zypper_call("in gnu$version-compilers-hpc-devel");
+    assert_script_run 'module load gnu';
+    assert_script_run qq{env |grep "PATH=/usr/lib/hpc/compiler/gnu/$version/bin"};
+    assert_script_run qq{gcc --version | grep $version};
 }
 
 sub post_fail_hook ($self) {

--- a/tests/hpc/gnu_compilers_hpc.pm
+++ b/tests/hpc/gnu_compilers_hpc.pm
@@ -25,13 +25,6 @@ sub run ($self) {
     assert_script_run qq{module av | grep gnu/$version};
     assert_script_run 'module load gnu';
     assert_script_run qq{env |grep "MODULEPATH=/usr/share/lmod/moduledeps/gnu-$version"};
-    if (zypper_call("in gnu$version-compilers-hpc-devel", exitcode => [107]) == 107) {
-        record_soft_failure 'bsc#1212351 Type in posttrans script for the non-base Compiler Version cause Script to fail';
-    }
-    assert_script_run 'module load gnu';
-    assert_script_run qq{env |grep "PATH=/usr/lib/hpc/compiler/gnu/$version/bin"};
-    assert_script_run qq{gcc --version | grep $version};
-
 }
 
 sub post_fail_hook ($self) {


### PR DESCRIPTION
Testing installation of gnu-compilers-hpc-devel doesnt include the expected exit code when the process is success. So far we were catching the error code to softfail.

- Related ticket: https://progress.opensuse.org/issues/137432
- Verification run: 
https://aquarius.suse.cz/tests/19271

updated VR: https://aquarius.suse.cz/tests/19273#
updated VR_2:
first commit: https://aquarius.suse.cz/tests/19286
with second commit: https://aquarius.suse.cz/tests/19287