### PR TITLE
Relax max load average threshold to cope with flakyness

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -22,8 +22,8 @@ use utils 'assert_screen_with_soft_timeout';
 use version_utils 'is_jeos';
 
 sub settle_load {
-    my $loop = 'read load dummy < /proc/loadavg  ; top -n1 -b| head -n30 ; test "${load/./}" -lt $limit && break ; sleep 5';
-    script_run "limit=10; for c in `seq 1 200`; do $loop; done; echo TOP-DONE > /dev/$serialdev", 0;
+    my $loop = 'read load dummy < /proc/loadavg  ; top -n1 -b| head -n30 ; test "${load/./}" -le $limit && break ; sleep 5';
+    script_run "limit=11; for c in `seq 1 200`; do $loop; done; echo TOP-DONE > /dev/$serialdev", 0;
     my $before = time;
     wait_serial('TOP-DONE', 1120) || die 'load not settled';
     # JeOS is different to SLE general as it extends the appliance's disk on first boot,


### PR DESCRIPTION
Tentative to make the test more reliable by relaxing the `force_scheduled_tasks` constraint check for loadavg <= 0.11 ; this PR addresses the first part of the ticket proposal.

- Related ticket: https://progress.opensuse.org/issues/137246
- Needles: NO
- SLE Verification runs: 
  - https://openqa.suse.de/tests/12374159
  - https://openqa.suse.de/tests/12374160
  - https://openqa.suse.de/tests/12374161
  - https://openqa.suse.de/tests/12374162
  - https://openqa.suse.de/tests/12374163
  - https://openqa.suse.de/tests/12374164
  - https://openqa.suse.de/tests/12374165
  - https://openqa.suse.de/tests/12374166
  - https://openqa.suse.de/tests/12374167
  - https://openqa.suse.de/tests/12374168
  - https://openqa.suse.de/tests/12374169
- Leap 15.4:
  - https://openqa.opensuse.org/tests/3626435              
  - https://openqa.opensuse.org/tests/3626436              
  - https://openqa.opensuse.org/tests/3626440              
- Leap 15.5:
  - https://openqa.opensuse.org/tests/3626553
  - https://openqa.opensuse.org/tests/3626554
- Tumbleweed: 
  - https://openqa.opensuse.org/tests/3626437              
  - https://openqa.opensuse.org/tests/3626439              
  - https://openqa.opensuse.org/tests/3626441              
  - https://openqa.opensuse.org/tests/3626442              
  - https://openqa.opensuse.org/tests/3626444              


