### PR TITLE
Fix man page validation

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -252,11 +252,18 @@ sub basic_container_tests {
     assert_script_run "$runtime run --rm --init $tumbleweed ps --no-headers -xo 'pid args' | grep '1 .*init'";
 
     if (script_run('command -v man') == 0) {
-        $ret = script_run("man -P cat $runtime build | grep '$runtime-build - Build'");
-        if ($ret != 0) {
-            record_soft_failure("bsc#1215465 - man -P cat docker build fails") if (is_tumbleweed || is microos);
-        } else {
-            die("man -P cat docker build fails");
+        my $output = script_output("man -P cat $runtime build", proceed_on_failure => 1);
+        if (!($output =~ "$runtime-build - Build")) {
+            # Check for bsc#1215465
+            if (is_tumbleweed || is microos) {
+                if (script_run("man -P cat $runtime build") != 0) {
+                    record_soft_failure("bsc#1215465 - man -P cat docker build fails");
+                } else {
+                    die("man -P cat output is not validating");
+                }
+            } else {
+                die("man -P cat output is not validating");
+            }
         }
     }
 


### PR DESCRIPTION
Fix the broken man page validation on non-Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/137456
- Verification run: [15-SP5](https://duck-norris.qe.suse.de/tests/14125#step/docker/239) | [MicroOS](https://duck-norris.qe.suse.de/tests/14126)
