### PR TITLE
Fix export/import deployment functions

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1680,7 +1680,7 @@ sub qesap_import_instances {
     die("OpenQA test ID must be a number. Parameter 'QESAP_DEPLOYMENT_IMPORT' must contain ID of previously exported test")
       unless looks_like_number($test_id);
 
-    my $inventory_file = qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my $inventory_file = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
     my %files = ('id_rsa' => '/root/.ssh/',
         'id_rsa.pub' => '/root/.ssh/',
         basename($inventory_file) => dirname($inventory_file) . '/');
@@ -1706,7 +1706,7 @@ sub qesap_import_instances {
 
 sub qesap_export_instances {
     my @upload_files = (
-        qesap_get_inventory(get_required_var('PUBLIC_CLOUD_PROVIDER')),
+        qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER')),
         '/root/.ssh/id_rsa',
         '/root/.ssh/id_rsa.pub');
 


### PR DESCRIPTION
After change in 'qesap_get_inventory', two subroutines were not adjusted and stopped working. 
This PR fixes argument input accordingly.

- Verification run: 
Export: https://openqaworker15.qa.suse.cz/tests/241749#step/deploy_qesap_ansible/26
Import: https://openqaworker15.qa.suse.cz/tests/241753#step/verify_infrastructure/90

 * export test failed because of unrelated reason - keys exported correctly and VMs were not cleaned up