### PR TITLE
Update autoyast_hpc profile to include LTSS addon

### DIFF
--- a/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
@@ -50,6 +50,15 @@
         <arch>{{ARCH}}</arch>
       </addon>
       % }
+      % if ($is_ltss) {
+      <addon config:type="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLE_HPC-LTSS</name>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      % }
     </addons>
   </suse_register>
   <bootloader>

--- a/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
@@ -50,6 +50,15 @@
         <arch>{{ARCH}}</arch>
       </addon>
       % }
+      % if ($is_ltss) {
+      <addon config:type="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLE_HPC-LTSS</name>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      % }
     </addons>
   </suse_register>
   <bootloader>


### PR DESCRIPTION
The autoyast_hpc_%ARCH%.xml.ep are missing the ltss addons.

- Related ticket: https://progress.opensuse.org/issues/137348
- Verification run: tbd
