### PR TITLE
Replace patch_and_reboot with general version for sap jobs

### DIFF
--- a/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
@@ -26,6 +26,6 @@ conditional_schedule:
         - sles4sap/publiccloud/cluster_add_repos
         - sles4sap/publiccloud/mr_test_setup_env
         - publiccloud/registration
-        - publiccloud/patch_and_reboot
+        - sles4sap/publiccloud/general_patch_and_reboot
         - publiccloud/ssh_interactive_start
         - publiccloud/instance_overview


### PR DESCRIPTION
`patch_and_reboot` is a `qe-c` module that does not provide proper resource and peering cleanup for our SAP jobs. This pr replaces instances of `patch_and_reboot` with `general_patch_and_reboot`, which is almost identical but a) is able to iterate and execute on multiple VMs, and b) inherists our own SAP basetest class instead of qe-c's basetest class, so offers proper cleanup.

- Related ticket: https://jira.suse.com/browse/TEAM-8605
- Verification run: https://openqa.suse.de/tests/12386242#step/general_patch_and_reboot/94
