### PR TITLE
pc: Basic test for Hardened images

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2018-2019 SUSE LLC
+# Copyright 2018-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: python3-img-proof
@@ -12,8 +12,20 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use Mojo::File 'path';
 use Mojo::JSON;
-use publiccloud::utils 'is_ondemand';
+use publiccloud::utils qw(is_ondemand is_hardened);
 use publiccloud::ssh_interactive 'select_host_console';
+
+sub test_hardened {
+    my $instance = shift;
+
+    # Basic tests required by /motd https://github.com/SUSE-Enceladus/img-proof/issues/358
+    $instance->ssh_assert_script_run(cmd => 'grep \"Authorized uses only. All activity may be monitored and reported.\" /etc/motd');
+    $instance->ssh_assert_script_run(cmd => 'sudo grep always,exit /etc/audit/rules.d/access.rules /etc/audit/rules.d/delete.rules');
+    # Check that at least one account has password age
+    $instance->ssh_assert_script_run(cmd => 'sudo awk -F: "\$5 ~ /[0-9]/ { print \$1, \$5; }\" /etc/shadow  | grep \"[0-9]\"');
+    # NOTE: Cannot run full evaluation with --fetch-remote-resources because of https://github.com/OpenSCAP/openscap/issues/1796
+    $instance->ssh_assert_script_run(cmd => "sudo oscap xccdf eval --profile pcs-hardening /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml", timeout => 300);
+}
 
 sub run {
     my ($self, $args) = @_;
@@ -71,6 +83,8 @@ sub run {
         $instance->run_ssh_command(cmd => 'sudo journalctl -b > /tmp/journalctl_b.txt', no_quote => 1);
         upload_logs('/tmp/journalctl_b.txt');
     }
+
+    test_hardened($instance) if is_hardened;
 }
 
 sub cleanup {


### PR DESCRIPTION
Basic test for Hardened images:
- Run OpenSCAP.
- Check /etc/motd as per https://github.com/SUSE-Enceladus/img-proof/issues/358
- Check /etc/audit/rules.d/{access,delete}.rules as per the above ticket.
- Check account age as per the above ticket.

Related ticket: https://progress.opensuse.org/issues/133628

Verification runs:
- sle-15-SP4-Azure-BYOS-Hardened-Incidents-x86_64-Build:30903:systemd-rpm-macros-publiccloud_img_proof@az_Standard_B2s -> https://openqa.suse.de/tests/12417292
