### PR TITLE
Upload agama logs using agama cli

### DIFF
--- a/lib/Yam/agama/agama_base.pm
+++ b/lib/Yam/agama/agama_base.pm
@@ -19,11 +19,9 @@ sub pre_run_hook {
 }
 
 sub post_fail_hook {
-    my ($self) = @_;
     select_console 'root-console';
-    y2_base::save_upload_y2logs($self, skip_logs_investigation => 1);
-    save_and_upload_log('journalctl -u agama-auto', "/tmp/agama-auto-log.txt");
-    save_and_upload_log('journalctl -u agama', "/tmp/agama-journal-log.txt");
+    # "agama logs store" gathers output from dmesg, journalctl and y2logs.
+    save_and_upload_log('agama logs store', "/tmp/agama_logs.tar.bz2");
     upload_traces();
 }
 


### PR DESCRIPTION
The command "agama logs store" gathers output from dmesg, journalctl and y2logs, so pretty much everything we need, it obsoletes save_y2logs.

VR https://openqa.opensuse.org/tests/3627417#live