### PR TITLE
Fix expired key when uning zypper

### DIFF
--- a/tests/virtualization/external/prepare.pm
+++ b/tests/virtualization/external/prepare.pm
@@ -19,7 +19,7 @@ sub run {
     script_run("SUSEConnect -r " . get_var('SCC_REGCODE'), timeout => 420);
     assert_script_run "rm /etc/zypp/repos.d/SUSE_Maintenance* || true";
     assert_script_run "rm /etc/zypp/repos.d/TEST* || true";
-    zypper_call '-t in nmap iputils bind-utils', exitcode => [0, 102, 103, 106];
+    zypper_call '-t --gpg-auto-import-keys in nmap iputils bind-utils', exitcode => [0, 102, 103, 106];
 
     # Fill the current pairs of hostname & address into /etc/hosts file
     if (get_var("REGRESSION", '') =~ /vmware/) {


### PR DESCRIPTION
The root cause of the issue is that the key for the problematic repository has expired. 
Solution:
use the command sudo zypper -n --gpg-auto-import-keys to automatically import and trust the repository key, then proceed with package installation.



- Related ticket:  https://progress.opensuse.org/issues/137579
- Needles: NONE
- Verification run: [Vmware test](https://openqa.suse.de/tests/12423233)， [Hyper-V test](http://openqa.suse.de/tests/12423272)
