### PR TITLE
Fix network disconnection during post_fail_hook because br0 config overwritten and other minor improvement

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -432,8 +432,9 @@ sub toggle_package {
 }
 
 sub use_wicked {
+    # Config DHCP for all interfaces except br0 and bring them up
     script_run "cd /proc/sys/net/ipv4/conf";
-    script_run("for i in *[0-9]; do echo BOOTPROTO=dhcp > /etc/sysconfig/network/ifcfg-\$i; wicked --debug all ifup \$i; done", 600);
+    script_run("for i in *[0-9]; do [ \$i != 'br0' ] && echo BOOTPROTO=dhcp > /etc/sysconfig/network/ifcfg-\$i; wicked --debug all ifup \$i; done", 600);
     save_screenshot;
 }
 

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -106,7 +106,7 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
-    test_ayp_url unless get_var('VIRT_AUTOTEST') and is_tumbleweed;
+    test_ayp_url unless get_var('IPXE_STATIC');
     my $test_data = get_test_suite_data();
     my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot package-notification nvidia-validation-failed import-untrusted-gpg-key);
 
@@ -117,7 +117,7 @@ sub run {
         push(@needles, @expected_warnings);
     }
     my @processed_warnings;
-    if (get_var('EXTRABOOTPARAMS') =~ m/startshell=1/) {
+    if (get_var('EXTRABOOTPARAMS', '') =~ m/startshell=1/) {
         push @needles, 'linuxrc-start-shell-after-installation';
     }
     push @needles, 'autoyast-confirm' if get_var('AUTOYAST_CONFIRM');


### PR DESCRIPTION
- Fix network disconnection(fg. https://openqa.suse.de/tests/12409285#step/installation/17) during post_fail_hook because br0 config overwritten.  br0 is the network bridge created by default on a kvm/xen server. its enlave an master interface eth0/em1/eth1/....
- Avoid issueing warnings fg. `Use of uninitialized value in pattern match (m//) at sle/tests/autoyast/installation.pm line 120.` in https://openqa.suse.de/tests/12409280/logfile?filename=autoinst-log.txt
- Replace a setting

Related ticket: https://progress.opensuse.org/issues/137078
Verification run: 
[connection not broken in post_fail_hook](https://openqa.suse.de/tests/12423462)
[a normal sle test](https://openqa.suse.de/tests/12426655)
