### PR TITLE
Adding dynamic variables to identify server.

### DIFF
--- a/tests/virtualization/external/prepare.pm
+++ b/tests/virtualization/external/prepare.pm
@@ -23,15 +23,17 @@ sub run {
 
     # Fill the current pairs of hostname & address into /etc/hosts file
     if (get_var("REGRESSION", '') =~ /vmware/) {
+        my $vmware_server = get_required_var('VMWARE_SERVER');
         foreach my $guest (keys %virt_autotest::common::guests) {
-            my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no root\@esxi7.qa.suse.cz "vim-cmd vmsvc/get.guest \\`vim-cmd vmsvc/getallvms | grep -w $guest|cut -d ' ' -f1\\`|grep -A 1 hostName|grep ipAddress|cut -d '\\"' -f2"));
+            my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$vmware_server "vim-cmd vmsvc/get.guest \\`vim-cmd vmsvc/getallvms | grep -w $guest|cut -d ' ' -f1\\`|grep -A 1 hostName|grep ipAddress|cut -d '\\"' -f2"));
             record_info("$guest: $ip");
             assert_script_run(qq(echo "$ip $guest" >> /etc/hosts));
         }
     } else {
+        my $hyperv_server = get_required_var('HYPERV_SERVER');
         foreach my $guest (keys %virt_autotest::common::guests) {
             my $vm_name = $virt_autotest::common::guests{$guest}->{vm_name};
-            my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no Administrator\@win2k19.qa.suse.cz 'powershell "get-vm -Name $vm_name | select -ExpandProperty networkadapters | select ipaddresses"' | grep -oE '[0-9]+.[0-9]+.[0-9]+.[0-9]+'));
+            my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no Administrator\@$hyperv_server 'powershell "get-vm -Name $vm_name | select -ExpandProperty networkadapters | select ipaddresses"' | grep -oE '[0-9]+.[0-9]+.[0-9]+.[0-9]+'));
             record_info("$guest: $ip");
             assert_script_run(qq(echo "$ip $guest" >> /etc/hosts));
         }


### PR DESCRIPTION
In this change we add test parameters to the "Maintenance: Virtualization - VMware + Hyper-V" Test Job so that the server details of hyperv and vmware are dynamically passed.

Related ticket: https://progress.opensuse.org/issues/133466
Needles: No corresponding needles.
Verification run:
Passing runs : 
vmware : https://openqa.suse.de/tests/12447151#
hyperv : https://openqa.suse.de/tests/12447152#
Failing runs : (Testing the code by not giving desired parameters.)
https://openqa.suse.de/tests/overview?build=%3AS%3AM%3A30957%3A309785%3A&distri=sle&version=15-SP5&groupid=322
Both failed with appropriate error messages.

