### PR TITLE
libgcrypt, nginx, mutt: Add verbose for debugging

### DIFF
--- a/lib/services/nginx.pm
+++ b/lib/services/nginx.pm
@@ -18,7 +18,7 @@ use utils qw(zypper_call common_service_action script_retry);
 my $service_type = 'Systemd';
 
 sub install_service {
-    zypper_call 'in nginx';
+    zypper_call '-v in nginx', timeout => 1000;
 }
 
 sub enable_service {

--- a/tests/console/libgcrypt.pm
+++ b/tests/console/libgcrypt.pm
@@ -24,7 +24,7 @@ sub run {
     select_console 'root-console';
     assert_script_run "rpm -q libgcrypt20";
     if (script_run("rpm -q libgcrypt-devel") == 1) {
-        zypper_call "in gcc libgcrypt-devel";
+        zypper_call "-v in gcc libgcrypt-devel", timeout => 1000;
     }
 
     select_console 'user-console';

--- a/tests/console/mutt.pm
+++ b/tests/console/mutt.pm
@@ -28,8 +28,7 @@ use utils;
 sub run {
     select_serial_terminal;
 
-    zypper_call("in mutt", exitcode => [0, 102, 103]);
-    zypper_call("in wget", exitcode => [0, 102, 103]);
+    zypper_call("-v in mutt wget", exitcode => [0, 102, 103], timeout => 1000);
 
     # Mutt is Mutt (bsc#1094717) and has build in support for IMAP and SMTP
     validate_script_output 'mutt -v', sub { m/\+USE_IMAP/ && m/\+USE_SMTP/ && not m/NeoMutt/ };

--- a/tests/console/valgrind.pm
+++ b/tests/console/valgrind.pm
@@ -141,7 +141,7 @@ sub prepare {
         add_suseconnect_product(get_addon_fullname('sdk'));
     }
 
-    zypper_call 'in gcc valgrind';
+    zypper_call '-v in gcc valgrind', timeout => 1000;
 
     # Compile the valgrind test program
     assert_script_run 'mkdir -p /var/tmp/valgrind';


### PR DESCRIPTION
Increase timeout, maintenance repos are super slow
```
Retrieving: repomd.xml [.done (253 B/s)]
Checking whether to refresh metadata for http-download.suse.de-6658790f Retrieving: repomd.xml [.done (253 B/s)]
Checking whether to refresh metadata for http-download.suse.de-6b71bc81 Retrieving: repomd.xml [.done (253 B/s)]
Checking whether to refresh metadata for http-download.suse.de-6e13c51a Retrieving: repomd.xml [.done (253 B/s)]
Checking whether to refresh metadata for http-download.suse.de-7155363c Retrieving: repomd.xml [.done (253 B/s)]
```

- Related ticket: https://openqa.suse.de/tests/12429884#next_previous
- Verification run: https://openqa.suse.de/tests/12442663