### PR TITLE
Add sap cleanup to PC basetest

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -152,6 +152,17 @@ sub _cleanup {
 
 sub post_fail_hook {
     my ($self) = @_;
+    if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
+        # This is called explicitly to avoid cyclical imports
+        sles4sap_publiccloud::sles4sap_cleanup(
+            $self,
+            cleanup_called => $self->{cleanup_called} // undef,
+            network_peering_present => 1,
+            ansible_present => 0
+        );
+        return;
+    }
+
     $self->_cleanup() unless $self->{cleanup_called};
 }
 


### PR DESCRIPTION
PC Modules that we use in sles4sap tests, and sap modules that inherit the PC basetest class instead of the sles4sap basetest class, do not correctly run cleanup for sap and do not destroy the peering. 

In order to tackle this in the least invasive and breaking way, this pr adds a simple conditional sap resource+peering cleanup to the PC basetest class `post_fail_hook`.

- Related ticket: https://jira.suse.com/browse/TEAM-8605
- Verification runs:
--Without failure: https://openqa.suse.de/tests/12441883
--With failure in module that inherits sles4sap basetest class: https://openqa.suse.de/tests/12443208
--With failure in module that inherits PC baseclass, outside of ssh_interactive_start/end block: https://openqa.suse.de/tests/12443384
--With failure in module that inherits PC baseclass, inside of ssh_interactive_start/end block: https://openqa.suse.de/tests/12443401
