### PR TITLE
pc: Move hardened test to smoke tests

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -59,6 +59,7 @@ sub load_maintenance_publiccloud_tests {
             loadtest "publiccloud/sev" if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
             loadtest "publiccloud/xen" if (get_var('PUBLIC_CLOUD_XEN'));
             loadtest "publiccloud/az_l8s_nvme" if (get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'Standard_L(8|16|32|64)s_v2');
+            loadtest "publiccloud/hardened" if is_hardened;
         } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
             loadtest("publiccloud/azure_nfs", run_args => $args);
         } elsif (check_var('PUBLIC_CLOUD_NVIDIA', 1)) {

--- a/tests/publiccloud/hardened.pm
+++ b/tests/publiccloud/hardened.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test public cloud hardened images
+#
+# Maintainer: <qa-c@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+
+sub run {
+    select_serial_terminal;
+
+    # Basic tests required by https://github.com/SUSE-Enceladus/img-proof/issues/358
+    assert_script_run('grep "Authorized uses only. All activity may be monitored and reported." /etc/motd');
+    assert_script_run('sudo grep always,exit /etc/audit/rules.d/access.rules /etc/audit/rules.d/delete.rules');
+    # Check that at least one account has password age
+    assert_script_run("sudo awk -F: '\$5 ~ /[0-9]/ { print \$1, \$5; }' /etc/shadow  | grep '[0-9]'");
+    # NOTE: Cannot run full evaluation with --fetch-remote-resources because of https://github.com/OpenSCAP/openscap/issues/1796
+    assert_script_run("mkdir oscap");
+    assert_script_run("curl -o- https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml.gz | gunzip -c > oscap/suse.linux.enterprise.15.xml", timeout => 180);
+    my $ret = script_run("sudo oscap xccdf eval --report report.html --local-files oscap/ --profile pcs-hardening /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml", timeout => 300);
+    upload_logs("report.html");
+    record_soft_failure("bsc#1216088 - Public Cloud Hardened image fail SCAP test") if ($ret);
+}
+
+1;


### PR DESCRIPTION
Move hardened test to smoke tests

- Related ticket: https://progress.opensuse.org/issues/133628
- Verification run: https://openqa.suse.de/tests/12442448

Found a bug in hardened images:
https://bugzilla.suse.com/show_bug.cgi?id=1216088
