### PR TITLE
Fix Azure broken cluster in qesap regression

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -27,7 +27,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HA0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fullypatch.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fullypatch.yaml
@@ -27,7 +27,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HA0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
@@ -28,7 +28,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HA0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -26,7 +26,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HA0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
@@ -26,7 +26,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HA0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -26,7 +26,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HA0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'


### PR DESCRIPTION
Fix Azure broken cluster in qesap regression via replace sap_hana_install_sid='HDB' with sap_hana_install_sid='HA0'

TEAM-8442 - Azure: broken cluster in qesap regression

- Related ticket: https://jira.suse.com/browse/TEAM-8442
- Needles: NA
- Verification run (all passed):
* qesap_azure_saptune_test (qesap_azure.yaml)  
    https://openqaworker15.qa.suse.cz/tests/243955 (passed)
* qesap_azure_fullypatch (qesap_azure_fullypatch.yaml)  
    http://openqaworker15.qa.suse.cz/t243956 (passed)
* qesap_azure_ansible_roles_test (qesap_azure_roles.yaml)  
    https://openqaworker15.qa.suse.cz/tests/243962   (passed)
* qesap_azure_ibsmirror_peering_test (qesap_azure.yaml)  
    http://openqaworker15.qa.suse.cz/t243958  (passed)
* qesap_azure_sapconf_test (qesap_azure_sapconf.yaml)  
    https://openqaworker15.qa.suse.cz/tests/243963   (passed)
* qesap_azure_uri (qesap_azure_uri.yaml)  
    https://openqaworker15.qa.suse.cz/tests/243961  (passed)
