### PR TITLE
HPC: Install specific mariadb version for sle15-sp1

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -34,7 +34,13 @@ sub run ($self) {
     my $mariadb_service = "mariadb";
     $mariadb_service = "mysql" if is_sle('<12-sp4');
 
-    zypper_call("in mariadb");
+    #TODO: clean up this part; there should be no mariadb_service which results in non mariadb etc.
+    #there is a product change where we have 2 different mariadb for sle15-sp1
+    if (is_sle("=15-sp1")) {
+        zypper_call("in mariadb104");
+    } else {
+        zypper_call("in mariadb");
+    }
     systemctl("start $mariadb_service");
     systemctl("is-active $mariadb_service");
 


### PR DESCRIPTION
This is a dirty and ugly approach to if a product version and explicitly install specific mariadb version. This patch is as is since there are some failures in the maintanance and those should be sorted

Verification run: 
affected sle15-sp1:
https://openqa.suse.de/tests/12440013
https://openqa.suse.de/tests/12440014
https://openqa.suse.de/tests/12440009
https://openqa.suse.de/tests/12440010

15-sp2: just to make sure all is good:
https://openqa.suse.de/tests/12440123
https://openqa.suse.de/tests/12440122
https://openqa.suse.de/tests/12440126
https://openqa.suse.de/tests/12440125
https://openqa.suse.de/tests/12440124


