### PR TITLE
HPC: Remove zypper in mariadb from slurmdb module

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -33,6 +33,11 @@ sub run ($self) {
     my $mariadb_service = "mariadb";
     $mariadb_service = "mysql" if is_sle('<12-sp4');
 
+    #for all slurm versions we have mariadb as a dependency apart from slurm18
+    #TODO: remove below line as soon as not needed
+    zypper_call("in mariadb") if $slurm_pkg =~ "slurm_18";
+    #specific if for sle15-sp1 with base slurm only which should be removed in early 2024
+    zypper_call("in mariadb") if (is_sle("=15-sp1") && $slurm_pkg eq "slurm");
     systemctl("start $mariadb_service");
     systemctl("is-active $mariadb_service");
 

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -28,7 +28,6 @@ sub run ($self) {
     # Install slurm
     # $slurm_pkg-munge is installed explicitly since slurm_23_02
     zypper_call("in $slurm_pkg $slurm_pkg-munge $slurm_pkg-slurmdbd");
-    # $slurm_pkg-munge is installed explicitly since slurm_23_02
     zypper_call("in $slurm_pkg-node");
 
     my $mariadb_service = "mariadb";

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -34,7 +34,6 @@ sub run ($self) {
     my $mariadb_service = "mariadb";
     $mariadb_service = "mysql" if is_sle('<12-sp4');
 
-    zypper_call("in mariadb");
     systemctl("start $mariadb_service");
     systemctl("is-active $mariadb_service");
 


### PR DESCRIPTION
This mariadb install seems redundant now since all needed dependencies including db should be installed with slurm/slurmdbd. Moreover this additional and somehow redundat zypper in mariadb resulted in a test failure for sle15sp1 since there are two mariadbs provided

Verification run:
**SLE12-SP5** 
**- slurm 18.08:**
**db node**: https://openqa.suse.de/tests/12442120
master node: https://openqa.suse.de/tests/12442123
slave nodes: https://openqa.suse.de/tests/12442121 
https://openqa.suse.de/tests/12442118
master backup node: https://openqa.suse.de/tests/12442119

**- slurm 20.02:**
**db node**: https://openqa.suse.de/tests/12442124
master node: https://openqa.suse.de/tests/12442126
slave nodes:  https://openqa.suse.de/tests/12442129
https://openqa.suse.de/tests/12442127
master backup node: https://openqa.suse.de/tests/12442125

**SLE15-SP1:**
**- slurm base (non-versioned)/18:**
**db node**: https://openqa.suse.de/tests/12442598
master node: https://openqa.suse.de/tests/12442595
slave nodes: https://openqa.suse.de/tests/12442599
https://openqa.suse.de/tests/12442596

**- slurm 20.02:**
**db node**: https://openqa.suse.de/tests/12442724
master node: https://openqa.suse.de/tests/12442719
slave nodes: https://openqa.suse.de/tests/12442720
https://openqa.suse.de/tests/12442721
master backup node: https://openqa.suse.de/tests/12442723

**SLE15-SP2:**
**- slurm base (non-versioned)/20:**
**db node**: https://openqa.suse.de/tests/12442740
master node: https://openqa.suse.de/tests/12442741
slave nodes: https://openqa.suse.de/tests/12442742
https://openqa.suse.de/tests/12442738

**- slurm 22.05:**
**db node**: https://openqa.suse.de/tests/12442750
master node: https://openqa.suse.de/tests/12442751
slave nodes: https://openqa.suse.de/tests/12442749
https://openqa.suse.de/tests/12442747
master backup node: https://openqa.suse.de/tests/12442748
