### PR TITLE
 fix cluster_status_matches_regex to match case insensitive strings

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1219,7 +1219,7 @@ sub cluster_status_matches_regex {
     my $previous_line = '';
 
     for my $line (split("\n", $show_cluster_status)) {
-	if (lc($line) =~ /\s?(stopped|failed|pending|blocked|starting|promoting):?/) {
+        if ($line =~ /\s?(stopped|failed|pending|blocked|starting|promoting):?/i) {
             push @resource_list, $previous_line;
             push @resource_list, $line;
         }

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1219,7 +1219,7 @@ sub cluster_status_matches_regex {
     my $previous_line = '';
 
     for my $line (split("\n", $show_cluster_status)) {
-        if ($line =~ /(Stopped:| Stopped|Failed:| Failed|Pending:| Pending|Blocked:| Blocked)/) {
+	if (lc($line) =~ /\s?(stopped|failed|pending|blocked|starting|promoting):?/) {
             push @resource_list, $previous_line;
             push @resource_list, $line;
         }


### PR DESCRIPTION
This PR is about the match case insensitive string in the cluster_status_matches_regex function (lib/hacluster.pm)

- Related ticket: [TEAM-8594](https://jira.suse.com/browse/TEAM-8594)
- Verification run: Azure @ http://openqaworker15.qa.suse.cz/tests/244007#step/test_cluster/456
                                            http://openqaworker15.qa.suse.cz/tests/244006#step/test_cluster/456
                               AWS :http://openqaworker15.qa.suse.cz/tests/244009#
                               GCP :http://openqaworker15.qa.suse.cz/tests/244008# 
Latest VR : http://openqaworker15.qa.suse.cz/tests/245027#step/test_cluster/456
                    http://openqaworker15.qa.suse.cz/tests/245028#step/test_cluster/456
                    http://openqaworker15.qa.suse.cz/tests/245029
