### PR TITLE
[HPC] Move cpuid in single job

### DIFF
--- a/schedule/hpc/multi_machine_test.yaml
+++ b/schedule/hpc/multi_machine_test.yaml
@@ -49,6 +49,7 @@ conditional_schedule:
         - hpc/pdsh_slave
       dolly_master:
         - hpc/dolly_master
+        - '{{cpuid}}'
       dolly_slave:
         - hpc/dolly_slave
       hpc_master:
@@ -64,5 +65,4 @@ schedule:
   - '{{bootmenu}}'
   - boot/boot_to_desktop
   - hpc/before_test
-  - '{{cpuid}}'
   - '{{hpctest}}'


### PR DESCRIPTION
Avoid running redundant tests of cpuid for each mpi test suite. The change will run it only for dolly test suite.

- Verification run: 
https://aquarius.suse.cz/tests/19317#details