### PR TITLE
Add new qam-gfxdrivers schedule for baremetal

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -160,6 +160,8 @@ sub poweroff_x11 {
             # we need to kill all open ssh connections before the system shuts down
             prepare_system_shutdown;
             send_key "ret";
+            # Switch to sol console to observe system shutdown on IPMI backend
+            select_console 'sol', await_console => 0 if is_ipmi;
         }
     }
 
@@ -435,7 +437,7 @@ Example:
 
 sub assert_shutdown_with_soft_timeout {
     my ($args) = @_;
-    $args->{timeout} //= is_s390x ? 600 : get_var('DEBUG_SHUTDOWN') ? 180 : 60;
+    $args->{timeout} //= (is_s390x || is_ipmi) ? 600 : get_var('DEBUG_SHUTDOWN') ? 180 : 60;
     $args->{soft_timeout} //= 0;
     $args->{bugref} //= "No bugref specified";
     if ($args->{soft_timeout}) {

--- a/schedule/qam/15/qam-gfxdrivers.yaml
+++ b/schedule/qam/15/qam-gfxdrivers.yaml
@@ -1,0 +1,29 @@
+---
+name: qam-gfxdrivers
+schedule:
+- autoyast/prepare_profile
+- installation/bootloader_start
+- autoyast/installation
+- autoyast/console
+- autoyast/login
+- autoyast/wicked
+- autoyast/repos
+- autoyast/clone
+- autoyast/logs
+- console/yast2_vnc
+- console/force_scheduled_tasks
+- autoyast/autoyast_reboot
+- kernel/update_kernel
+- console/system_prepare
+- console/check_network
+- console/system_state
+- console/prepare_test_data
+- console/consoletest_setup
+- locale/keymap_or_locale
+- console/textinfo
+- console/hostname
+- console/consoletest_finish
+- locale/keymap_or_locale_x11
+- x11/glxgears
+- shutdown/cleanup_before_shutdown
+- shutdown/shutdown

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2018 SUSE LLC
+# Copyright 2016-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: vncmanager xorg-x11
@@ -15,12 +15,12 @@ use testapi;
 use utils;
 use registration 'add_suseconnect_product';
 use yast2_shortcuts qw($is_older_product %remote_admin %firewall_settings %firewall_details $confirm);
-use Utils::Backends 'is_pvm';
+use Utils::Backends qw(is_pvm is_ipmi);
 
 sub configure_remote_admin {
     # Force ncurses mode on powerVM setup to skip ssh forwarding x11 console
     my %params = (yast2_module => 'remote');
-    $params{yast2_opts} = '--ncurses' if (get_var("FIPS_ENABLED") && is_pvm);
+    $params{yast2_opts} = '--ncurses' if ((get_var("FIPS_ENABLED") && is_pvm) || is_ipmi);
     my $module_name = y2_module_consoletest::yast2_console_exec(%params);
     # Remote Administration Settings
     assert_screen 'yast2_vnc_remote_administration';


### PR DESCRIPTION
Enhancement poo#130219: We need to test gnome based installation on
baremetal to do basic verification of kernel graphical stack. Module
yast2_vnc was extended with condition to run in ncurses mode on IPMI
backend. Improve shutdown handling on IPMI backend, increase timeout
for shutdown and switch to sol console after shutdown.

- Related ticket: https://progress.opensuse.org/issues/130219
- Needles: none
- Verification run: 
 
qam-gfxdrivers 15-sp5: https://openqa.suse.de/tests/12850693#
qam-gnome 15-sp5: https://openqa.suse.de/tests/12849770