### PR TITLE
Fix man page validation for docker, podman

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -252,18 +252,11 @@ sub basic_container_tests {
     assert_script_run "$runtime run --rm --init $tumbleweed ps --no-headers -xo 'pid args' | grep '1 .*init'";
 
     if (script_run('command -v man') == 0) {
-        my $output = script_output("man -P cat $runtime build", proceed_on_failure => 1);
-        if (!($output =~ "$runtime-build - Build")) {
-            # Check for bsc#1215465
-            if (is_tumbleweed || is microos) {
-                if (script_run("man -P cat $runtime build") != 0) {
-                    record_soft_failure("bsc#1215465 - man -P cat docker build fails");
-                } else {
-                    die("man -P cat output is not validating");
-                }
-            } else {
-                die("man -P cat output is not validating");
-            }
+        # Note: The output of man contains non-ASCII characters. Even a dash (`-`) imposes difficulties here, so it's best to stay with letters
+        if ($runtime eq 'podman') {
+            validate_script_output("man -P cat $runtime-build", sub { m/Build a container image using a Containerfile/ }, fail_message => "`man $runtime build` contents not validating");
+        } elsif ($runtime eq 'docker') {
+            validate_script_output("man -P cat $runtime-build", sub { m/Build an image from a Dockerfile/ }, fail_message => "`man $runtime build` contents not validating");
         }
     }
 


### PR DESCRIPTION
Fix the man page validation of docker and podman to account for non-ASCII characters being present now.

- Related ticket: https://progress.opensuse.org/issues/137456
- Related failure: https://openqa.opensuse.org/tests/3634257
- Verification runs: [TW docker](https://duck-norris.qe.suse.de/tests/14141) | [TW podman](https://duck-norris.qe.suse.de/tests/14140) | [15-SP5 docker](https://duck-norris.qe.suse.de/tests/14143) | [15-SP5 podman](https://duck-norris.qe.suse.de/tests/14145) | [15-SP4 docker](https://duck-norris.qe.suse.de/tests/14144) | [15-SP4 podman](https://duck-norris.qe.suse.de/tests/14146) | [15-SP3 docker](https://duck-norris.qe.suse.de/tests/14147) | [15-SP3 podman](https://duck-norris.qe.suse.de/tests/14148) | [15-SP2 docker](https://duck-norris.qe.suse.de/tests/14149) | [15-SP2 podman](https://duck-norris.qe.suse.de/tests/14150) | [15-SP1 docker](https://duck-norris.qe.suse.de/tests/14151) | [15-SP1 podman](https://duck-norris.qe.suse.de/tests/14152) | [12-SP5 docker](https://duck-norris.qe.suse.de/tests/14153)
