### PR TITLE
Modify addons_with_license conditions

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -135,7 +135,7 @@ sub accept_addons_license {
     # license (see bsc#1089163) and so are not be shown twice
     push @addons_with_license, @SLE15_ADDONS_WITHOUT_LICENSE unless (is_sle('15+') || is_sle_micro);
     # HA and WE have licenses when calling yast2 scc
-    push @addons_with_license, @SLE15_ADDONS_WITH_LICENSE_NOINSTALL if (is_sle('15+') and get_var('IN_PATCH_SLE'));
+    push @addons_with_license, @SLE15_ADDONS_WITH_LICENSE_NOINSTALL if (is_sle('15+') and is_sle('<=15-sp4') and get_var('IN_PATCH_SLE'));
     # HA does not show EULA when doing migration to 12-SP5
     @addons_with_license = grep { $_ ne 'ha' } @addons_with_license if (is_sle('12-sp5+') && get_var('UPGRADE') && !get_var('IN_PATCH_SLE'));
 


### PR DESCRIPTION
ha module doesn't display eula when it has already been displayed before, but requires registration code. This PR fixes related failures.

Progress ticket: https://progress.opensuse.org/issues/136991
MR for support image: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/635
MR for migrations tests: https://gitlab.suse.de/coolgw/wegao-test/-/merge_requests/348
