### PR TITLE
HPC: get_mpi refactor

### DIFF
--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -21,11 +21,13 @@ our @EXPORT = qw(get_slurm_version);
 sub get_mpi() {
     my $mpi = get_required_var('MPI');
 
-    if ($mpi eq 'openmpi3') {
+    if ($mpi eq 'openmpi') {
         if (is_sle('<15')) {
-            $mpi = 'openmpi';
+            $mpi = 'openmpi1';
         } elsif (is_sle('<15-SP2')) {
             $mpi = 'openmpi2';
+        } else {
+            $mpi = 'openmpi3';
         }
     }
 

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -61,7 +61,6 @@ sub run ($self) {
         barrier_create('MPI_SETUP_READY', $nodes);
         barrier_create('MPI_BINARIES_READY', $nodes);
         barrier_create('MPI_RUN_TEST', $nodes);
-        barrier_create('IMB_TEST_DONE', $nodes);
     }
     elsif (check_var('HPC', 'ww4_controller')) {
         barrier_create('WWCTL_READY', $nodes);

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2017-2021 SUSE LLC
+# Copyright 2017-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Basic MPI integration test. Checking for installability and
@@ -25,16 +25,16 @@ sub run ($self) {
     select_serial_terminal();
     my $mpi = $self->get_mpi();
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
-    my $mpi_bin = 'mpi_bin';
-    my $mpi2load = '';
+    my $mpi_bin = "mpi_bin";
+    my $mpi2load = "";
     my @cluster_nodes = $self->cluster_names();
-    my $cluster_nodes = join(',', @cluster_nodes);
+    my $cluster_nodes = join(",", @cluster_nodes);
     my %exports_path = (
-        bin => '/home/bernhard/bin',
-        hpc_lib => '/usr/lib/hpc',
+        bin => "/home/bernhard/bin",
+        hpc_lib => "/usr/lib/hpc",
     );
     my $user_virtio_fixed = isotovideo::get_version() >= 35;
-    my $prompt = $user_virtio_fixed ? $testapi::username . '@' . get_required_var('HOSTNAME') . ':~> ' : undef;
+    my $prompt = $user_virtio_fixed ? $testapi::username . "@" . get_required_var("HOSTNAME") . ":~> " : undef;
 
     script_run("sudo -u $testapi::username mkdir -p $exports_path{bin}");
     zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel imb-gnu-$mpi-hpc");
@@ -44,47 +44,47 @@ sub run ($self) {
     $self->setup_nfs_server(\%exports_path);
 
     #TODO: Add comment for the below line
-    type_string('pkill -u root', lf => 1) unless $user_virtio_fixed;
+    type_string("pkill -u root", lf => 1) unless $user_virtio_fixed;
     select_user_serial_terminal($prompt);
     # for <15-SP2 the openmpi2 module is named simply openmpi
-    $mpi2load = ($mpi =~ /openmpi2|openmpi3|openmpi4/) ? 'openmpi' : $mpi;
+    $mpi2load = ($mpi =~ /openmpi2|openmpi3|openmpi4/) ? "openmpi" : $mpi;
 
-    barrier_wait('CLUSTER_PROVISIONED');
-    record_info 'CLUSTER_PROVISIONED', strftime("\%H:\%M:\%S", localtime);
+    barrier_wait("CLUSTER_PROVISIONED");
+    record_info("CLUSTER_PROVISIONED", strftime("\%H:\%M:\%S", localtime));
     ## all nodes should be able to ssh to each other, as MPIs requires so
     $self->generate_and_distribute_ssh($testapi::username);
     $self->check_nodes_availability();
 
-    record_info('INFO', script_output('cat /proc/cpuinfo'));
-    my $hostname = get_var('HOSTNAME', 'susetest');
-    record_info "hostname", "$hostname";
-    assert_script_run "hostnamectl status | grep $hostname";
+    record_info("INFO", script_output("cat /proc/cpuinfo"));
+    my $hostname = get_var("HOSTNAME", "susetest");
+    record_info("hostname", "$hostname");
+    assert_script_run("hostnamectl status | grep $hostname");
     assert_script_run("wget --quiet " . data_url("hpc/$mpi_c") . " -O $exports_path{'bin'}/$mpi_c");
 
     # I need to restart the nfs-server for some reason otherwise the compute nodes
     # cannot mount directories
-    record_info 'NFS', 'setup NFS';
-    select_console('root-console');
-    systemctl 'restart nfs-server';
+    record_info("NFS", "setup NFS");
+    select_console("root-console");
+    systemctl("restart nfs-server");
     # And login as normal user to run the tests
     # NOTE: This behaves weird. Need another solution apparently
-    type_string('pkill -u root') unless $user_virtio_fixed;
+    type_string("pkill -u root") unless $user_virtio_fixed;
     select_user_serial_terminal($prompt);
     # load mpi after all the relogins
     my @load_modules = $mpi2load;
-    push @load_modules, 'python3-scipy' if check_var('HPC_LIB', 'scipy');
-    push @load_modules, 'papi' if check_var('HPC_LIB', 'papi');
-    push @load_modules, 'openblas' if check_var('HPC_LIB', 'openblas');
-    assert_script_run "module load gnu @load_modules";
-    script_run "module av";
+    push @load_modules, "python3-scipy" if check_var("HPC_LIB", "scipy");
+    push @load_modules, "papi" if check_var("HPC_LIB", "papi");
+    push @load_modules, "openblas" if check_var("HPC_LIB", "openblas");
+    assert_script_run("module load gnu @load_modules");
+    script_run("module av");
 
-    barrier_wait('MPI_SETUP_READY');
-    record_info 'MPI_SETUP_READY', strftime("\%H:\%M:\%S", localtime);
-    if (get_var('HPC_LIB') eq 'papi') {
+    barrier_wait("MPI_SETUP_READY");
+    record_info "MPI_SETUP_READY", strftime("\%H:\%M:\%S", localtime);
+    if (get_var("HPC_LIB") eq "papi") {
         my $papi_version = script_output("module whatis papi | grep Version");
         $papi_version = (split(/: /, $papi_version))[2];
         assert_script_run("$mpi_compiler $exports_path{'bin'}/$mpi_c -o $exports_path{'bin'}/$mpi_bin -I/usr/lib/hpc/papi/$papi_version/include/ -L/usr/lib/hpc/papi/$papi_version/lib64/ -lpapi") if $mpi_compiler;
-    } elsif (get_var('HPC_LIB') eq 'openblas') {
+    } elsif (get_var("HPC_LIB") eq "openblas") {
         my $version = script_output("module whatis openblas | grep Version");
         $version = (split(/: /, $version))[2];
         assert_script_run("$mpi_compiler -o $exports_path{'bin'}/$mpi_bin $exports_path{'bin'}/$mpi_c -Iexports_path{'hpc'}/gnu7/openblas/$version/include -Iexports_path{'hpc'}/gnu7/openblas/$version/lib64 -lopenblas");
@@ -99,21 +99,21 @@ sub run ($self) {
     record_info 'MPI_BINARIES_READY', strftime("\%H:\%M:\%S", localtime);
     my $mpirun_s = hpc::formatter->new();
 
-    unless ($mpi_c eq 'sample_cplusplus.cpp') {    # because calls expects minimum 2 nodes
-        record_info('INFO', 'Run MPI over single machine');
-        if ($mpi eq 'mvapich2') {
+    unless ($mpi_c eq "sample_cplusplus.cpp") {    # because calls expects minimum 2 nodes
+        record_info("INFO", "Run MPI over single machine");
+        if ($mpi eq "mvapich2") {
             # mvapich2/2.2 known issue
             my $return = script_run("set -o pipefail;" . $mpirun_s->single_node("$exports_path{'bin'}/$mpi_bin |& tee /tmp/mpi_bin.log"), timeout => 120);
             if (script_run('grep \'invalid error code ffffffff\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1199811 known problem on single core on mvapich2/2.2');
+                record_soft_failure("bsc#1199811 known problem on single core on mvapich2/2.2");
             }
         } else {
             assert_script_run($mpirun_s->single_node("$exports_path{'bin'}/$mpi_bin"), timeout => 120);
         }
     }
 
-    record_info('INFO', 'Run MPI over several nodes');
-    if ($mpi eq 'mvapich2') {
+    record_info("INFO", "Run MPI over several nodes");
+    if ($mpi eq "mvapich2") {
         # we do not support ethernet with mvapich2
         my $return = script_run("set -o pipefail;" . $mpirun_s->all_nodes("$exports_path{'bin'}/$mpi_bin |& tee /tmp/mpi_bin.log"), timeout => 120);
         if ($return == 143) {
@@ -121,56 +121,56 @@ sub run ($self) {
         } elsif ($return == 139 || $return == 255) {
             # process running (on master return 139, on slave return 255)
             if (script_run('grep \'Caught error: Segmentation fault (signal 11)\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1144000 MVAPICH2: segfault while executing without ib_uverbs loaded');
+                record_soft_failure("bsc#1144000 MVAPICH2: segfault while executing without ib_uverbs loaded");
             }
         } elsif ($return == 136) {
             if (script_run('grep \'Caught error: Floating point exception (signal 8)\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1175679 Floating point exception should be fixed on mvapich2/2.3.4');
+                record_soft_failure("bsc#1175679 Floating point exception should be fixed on mvapich2/2.3.4");
             }
         } else {
             ##TODO: consider more robust handling of various errors
             die("echo $return - not expected errorcode");
         }
     } else {
-        if ($mpi_c eq 'sample_cplusplus.cpp') {
+        if ($mpi_c eq "sample_cplusplus.cpp") {
             assert_script_run($mpirun_s->slave_nodes("$exports_path{'bin'}/$mpi_bin"), timeout => 120);
             assert_script_run($mpirun_s->n_nodes("$exports_path{'bin'}/$mpi_bin", 2), timeout => 120);
         } else {
             # Skipping papi test on compute nodes as for some reason
             # module is not getting loaded for the c test execution
-            unless (get_var('HPC_LIB') eq 'papi') {
+            unless (get_var("HPC_LIB") eq "papi") {
                 assert_script_run($mpirun_s->all_nodes("$exports_path{'bin'}/$mpi_bin"), timeout => 120);
             }
         }
     }
-    barrier_wait('MPI_RUN_TEST');
-    record_info 'MPI_RUN_TEST', strftime("\%H:\%M:\%S", localtime);
+    barrier_wait("MPI_RUN_TEST");
+    record_info("MPI_RUN_TEST", strftime("\%H:\%M:\%S", localtime));
 
     my $imb_version = script_output("rpm -q --queryformat '%{VERSION}' imb-gnu-$mpi-hpc");
 
-    if ($mpi eq 'mvapich2') {
+    if ($mpi eq "mvapich2") {
         my $return = script_run("set -o pipefail; mpirun -np 4 /usr/lib/hpc/gnu7/$mpi/imb/$imb_version/bin/IMB-MPI1 PingPong |& tee /tmp/mpi_bin.log", timeout => 120);
         if ($return == 136) {
             if (script_run('grep \'Caught error: Floating point exception (signal 8)\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1175679 Floating point exception should be fixed on mvapich2/2.3.4');
+                record_soft_failure("bsc#1175679 Floating point exception should be fixed on mvapich2/2.3.4");
             }
         } elsif ($return == 1 || $return == 139 || $return == 255) {
             if (script_run('grep \'Caught error: Segmentation fault (signal 11)\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1144000 MVAPICH2: segfault while executing without ib_uverbs loaded');
+                record_soft_failure("bsc#1144000 MVAPICH2: segfault while executing without ib_uverbs loaded");
             } elsif (script_run('grep \'failure occurred while posting a receive for message data\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1209130 MPI Benchmarks unable to run on 15SP1 with imb-gnu-mvapich2-hpc');
+                record_soft_failure("bsc#1209130 MPI Benchmarks unable to run on 15SP1 with imb-gnu-mvapich2-hpc");
             }
         } else {
             ##TODO: consider more robust handling of various errors
             die("echo $return - not expected errorcode") unless $return == 0;
         }
     } else {
-        record_info 'testing IMB', 'Run all IMB-MPI1 components';
+        record_info("testing IMB", "Run all IMB-MPI1 components");
         # Run IMB-MPI1 without args to run the whole set of testings. Mind the timeout if you do so
         assert_script_run("mpirun -np 4 /usr/lib/hpc/gnu7/$mpi/imb/$imb_version/bin/IMB-MPI1 PingPong");
     }
-    barrier_wait('IMB_TEST_DONE');
-    record_info 'IMB_TEST_DONE', strftime("\%H:\%M:\%S", localtime);
+    barrier_wait("IMB_TEST_DONE");
+    record_info("IMB_TEST_DONE", strftime("\%H:\%M:\%S", localtime));
 }
 
 sub test_flags ($self) {

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -145,23 +145,6 @@ sub run ($self) {
     }
     barrier_wait("MPI_RUN_TEST");
     record_info("MPI_RUN_TEST", strftime("\%H:\%M:\%S", localtime));
-
-    if ($mpi eq "mvapich2") {
-        if ($return == 136) {
-            if (script_run('grep \'Caught error: Floating point exception (signal 8)\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure("bsc#1175679 Floating point exception should be fixed on mvapich2/2.3.4");
-            }
-        } elsif ($return == 1 || $return == 139 || $return == 255) {
-            if (script_run('grep \'Caught error: Segmentation fault (signal 11)\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure("bsc#1144000 MVAPICH2: segfault while executing without ib_uverbs loaded");
-            } elsif (script_run('grep \'failure occurred while posting a receive for message data\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure("bsc#1209130 MPI Benchmarks unable to run on 15SP1 with imb-gnu-mvapich2-hpc");
-            }
-        } else {
-            ##TODO: consider more robust handling of various errors
-            die("echo $return - not expected errorcode") unless $return == 0;
-        }
-    }
 }
 
 sub test_flags ($self) {

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -43,6 +43,7 @@ sub run ($self) {
     $self->relogin_root if $need_restart;
     $self->setup_nfs_server(\%exports_path);
 
+    #TODO: Add comment for the below line
     type_string('pkill -u root', lf => 1) unless $user_virtio_fixed;
     select_user_serial_terminal($prompt);
     # for <15-SP2 the openmpi2 module is named simply openmpi

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -1,9 +1,9 @@
 # SUSE's openQA tests
 #
-# Copyright 2017-2019 SUSE LLC
+# Copyright 2017-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: openmpi mpirun check
+# Summary: MPI slave node
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 use Mojo::Base qw(hpcbase hpc::utils), -signatures;

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -31,8 +31,6 @@ sub run ($self) {
     record_info("MPI_BINARIES_READY", strftime("\%H:\%M:\%S", localtime));
     barrier_wait("MPI_RUN_TEST");
     record_info("MPI_RUN_TEST", strftime("\%H:\%M:\%S", localtime));
-    barrier_wait("IMB_TEST_DONE");
-    record_info("IMB_TEST_DONE", strftime("\%H:\%M:\%S", localtime));
 }
 
 sub test_flags ($self) {

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -21,18 +21,18 @@ sub run ($self) {
         bin => '/home/bernhard/bin'
     );
     zypper_call("in $mpi-gnu-hpc");
-    barrier_wait('CLUSTER_PROVISIONED');
-    record_info 'CLUSTER_PROVISIONED', strftime("\%H:\%M:\%S", localtime);
-    barrier_wait('MPI_SETUP_READY');
-    record_info 'MPI_SETUP_READY', strftime("\%H:\%M:\%S", localtime);
+    barrier_wait("CLUSTER_PROVISIONED");
+    record_info("CLUSTER_PROVISIONED", strftime("\%H:\%M:\%S", localtime));
+    barrier_wait("MPI_SETUP_READY");
+    record_info("MPI_SETUP_READY", strftime("\%H:\%M:\%S", localtime));
     $self->mount_nfs_exports(\%exports_path);
     $self->setup_scientific_module();
-    barrier_wait('MPI_BINARIES_READY');
-    record_info 'MPI_BINARIES_READY', strftime("\%H:\%M:\%S", localtime);
-    barrier_wait('MPI_RUN_TEST');
-    record_info 'MPI_RUN_TEST', strftime("\%H:\%M:\%S", localtime);
-    barrier_wait('IMB_TEST_DONE');
-    record_info 'IMB_TEST_DONE', strftime("\%H:\%M:\%S", localtime);
+    barrier_wait("MPI_BINARIES_READY");
+    record_info("MPI_BINARIES_READY", strftime("\%H:\%M:\%S", localtime));
+    barrier_wait("MPI_RUN_TEST");
+    record_info("MPI_RUN_TEST", strftime("\%H:\%M:\%S", localtime));
+    barrier_wait("IMB_TEST_DONE");
+    record_info("IMB_TEST_DONE", strftime("\%H:\%M:\%S", localtime));
 }
 
 sub test_flags ($self) {


### PR DESCRIPTION
As of now the get_mpi() is having somehow twisted logic where everything is initially set to openmpi3. The patch is assuming the base openmpi test setting is set to openmpi and then adjust version depending of the sle hpc version. For sle12 it is openmpi1, for sle15-sp1 it is openmpi2 and for sle15-sp2+ it is openmpi3

Intermediate run after the git commit:  f9bd7f4423c3c2a26195150abe41d62547acc118
https://openqa.suse.de/tests/12563889
https://openqa.suse.de/tests/12563891
https://openqa.suse.de/tests/12563890

Final verification runs:
**12-SP5**

**15-SP1**

**15-SP2**

**15-SP3**

**15-SP4**

**15-SP5**
