### PR TITLE
pc: Fix name for downloaded SCAP XML

### DIFF
--- a/tests/publiccloud/hardened.pm
+++ b/tests/publiccloud/hardened.pm
@@ -24,7 +24,10 @@ sub run {
     assert_script_run("sudo awk -F: '\$5 ~ /[0-9]/ { print \$1, \$5; }' /etc/shadow  | grep '[0-9]'");
     # NOTE: Cannot run full evaluation with --fetch-remote-resources because of https://github.com/OpenSCAP/openscap/issues/1796
     assert_script_run("mkdir oscap");
-    assert_script_run("curl -o- https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml.gz | gunzip -c > oscap/suse.linux.enterprise.15.xml", timeout => 180);
+    my $xml_path = "pub/projects/security/oval/suse.linux.enterprise.15.xml";
+    # Downloaded file should have slashes replaced by hyphens
+    my $xml_file = $xml_path =~ s/\//-/gr;
+    assert_script_run("curl -o- https://ftp.suse.com/$xml_path.gz | gunzip -c > oscap/$xml_file", timeout => 180);
     my $ret = script_run("sudo oscap xccdf eval --report report.html --local-files oscap/ --profile pcs-hardening /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml", timeout => 300);
     upload_logs("report.html");
     record_soft_failure("bsc#1216088 - Public Cloud Hardened image fail SCAP test") if ($ret);


### PR DESCRIPTION
Avoid the warning message:

```
WARNING: Data stream component 'scap_org.open-scap_cref_pub-projects-security-oval-suse.linux.enterprise.15.xml' points out to the remote 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml'. The option --local-files 'oscap/' has been provided, but the file 'oscap/pub-projects-security-oval-suse.linux.enterprise.15.xml' can't be used locally: No such file or directory.
WARNING: Skipping ./pub-projects-security-oval-suse.linux.enterprise.15.xml file which is referenced from XCCDF content
```

- Related ticket: https://progress.opensuse.org/issues/133628
- Failing test: https://openqa.suse.de/tests/12441894/logfile?filename=serial_terminal.txt
- Verification run: https://openqa.suse.de/tests/12447030