### PR TITLE
Crash Dump Configuration file updated, need update code to validate new values

### DIFF
--- a/test_data/yast/yast2_ncurses/textmode.yaml
+++ b/test_data/yast/yast2_ncurses/textmode.yaml
@@ -8,6 +8,5 @@ config_files:
       KDUMP_DUMPLEVEL: 31
       KDUMP_DUMPFORMAT: compressed
       KDUMP_SAVEDIR: '(file://|)/var/crash'
-      KDUMP_KEEP_OLD_DUMPS: 5
-      KDUMP_IMMEDIATE_REBOOT: 'yes'
-      KDUMP_COPY_KERNEL: 'yes'
+      KDUMP_KEEP_OLD_DUMPS: 0
+      KDUMP_IMMEDIATE_REBOOT: 'true'


### PR DESCRIPTION
Crash Dump Configuration file updated, need update code to validate new values

- Related ticket: https://progress.opensuse.org/issues/137555
- Verification run: https://openqa.suse.de/tests/12440943#
   https://openqa.suse.de/tests/12440955#
   https://openqa.suse.de/tests/12440944#
- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1214383
