### PR TITLE
Fix uploading guest assets in virt guest installation tests

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -365,7 +365,7 @@ sub download_script {
 
     my $cmd = "curl -o ~/$script_name $script_url";
     $cmd = "ssh root\@$machine " . "\"$cmd\"" if ($machine ne 'localhost');
-    unless (script_retry($cmd, timeout => 300, retry => 2, die => 0) == 0) {
+    unless (script_retry($cmd, timeout => 900, retry => 2, die => 0) == 0) {
         # Add debug codes as the url only exists in a dynamic openqa URL
         record_info("URL is not accessible", "$script_url", result => 'fail') unless head($script_url);
         unless ($machine eq 'localhost') {

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -224,11 +224,11 @@ sub add_junit_log {
 sub upload_guest_assets {
     my $self = shift;
 
-    if (get_var('CASEDIR')) {
-        record_info('Skip uploading guest assets', 'Guest assets will only be uploaded with test codes in git master branch.');
+    if (get_var('CASEDIR') =~ /os-autoinst-distri-opensuse/) {
+        record_info('Skip uploading guest assets', 'Guest assets is not allowed to be uploaded with test codes in git.');
         return;
     }
-    record_info('Uploading guest assets', 'as UPLOAD_GUEST_ASSETS flag is set');
+    record_info('Uploading guest assets as UPLOAD_GUEST_ASSETS flag is set');
     record_info('Skip upload guest asset.', 'No successful guest, skip upload assets.') unless @{$self->{success_guest_list}};
 
     foreach my $guest (@{$self->{success_guest_list}}) {


### PR DESCRIPTION
- Upload guest assets for normal job and clone job only, and not allow jobs with PR or personal branch upload guest assets.
- Have to increase the download time from 5 min to 15 min again because it sets the timeout of shell command rather than the openqa api. Fg. it exceeded 5 min in this test, http://10.67.129.27/tests/111#, and the test failed.

To distinguish those jobs by `CASEDIR`:

for jobs or without PR:
`CASEDIR='sle|opensuse|...'`

for jobs with PR or personal branch:
```
CASEDIR=/var/lib/openqa/pool/7/os-autoinst-distri-opensuse
CASEDIR=https://github.com/Julie-CAO/os-autoinst-distri-opensuse#julie/upload_guest_disk
```

- Related ticket: https://progress.opensuse.org/issues/137726
- Verification run: 
http://10.67.129.27/tests/111   //a normal job(upload guest assets)
http://10.67.129.27/tests/112   //a clone job without PR
https://openqa.suse.de/tests/12463703   //a clone job with personal branch(No upload)
https://openqa.suse.de/tests/12464229   //a clone job with PR(No upload)
