### PR TITLE
xfstests: Add softfail control feature

### DIFF
--- a/lib/filesystem_utils.pm
+++ b/lib/filesystem_utils.pm
@@ -34,7 +34,8 @@ our @EXPORT = qw(
   lsblk_command
   validate_lsblk
   get_partition_table_via_blkid
-  is_lsblk_able_to_display_mountpoints);
+  is_lsblk_able_to_display_mountpoints
+  generate_xfstests_list);
 
 =head2 str_to_mb
 
@@ -507,6 +508,35 @@ sub validate_lsblk {
         }
     }
     return $errors;
+}
+
+=head2
+
+Generate xfstests subtests list
+This function translate test range to single tests, with xfstests test name format.
+Input an parameter with list of subtest name, Return a hash of test list.
+e.g. generate "xfs/001-003,xfs/005" into "{xfs/001 => 1, xfs/002 => 1, xfs/003 => 1, xfs/005 => 1}"
+
+=cut
+
+sub generate_xfstests_list {
+    my $raw_list = shift;
+    my @split_list = split(/,/, $raw_list);
+    my @test_list;
+    foreach my $test_item (@split_list) {
+        $test_item =~ m"\w+/";
+        my ($test_category, $test_num) = ($&, $');
+        if ($test_num =~ /^(\d{3})-(\d{3})$/) {
+            push(@test_list, map { $_ = "$test_category$_" } ($1 .. $2));
+        }
+        elsif ($test_num =~ /^\d{3}$/) {
+            push(@test_list, "$test_category$test_num");
+        }
+        else {
+            die "Invalid test list: $test_item";
+        }
+    }
+    return map { $_ => 1 } @test_list;
 }
 
 1;

--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -22,6 +22,7 @@ use File::Basename;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use upload_system_log;
+use filesystem_utils 'generate_xfstests_list';
 
 my $STATUS_LOG = '/opt/status.log';
 my $LOG_DIR = '/opt/log';
@@ -55,48 +56,54 @@ sub analyze_result {
     my $skip_num = 0;
     my $total_time = 0;
     my $test_range = '';
+    my %softfail_list = generate_xfstests_list(get_var('XFSTESTS_SOFTFAIL'));
     foreach (split("\n", $text)) {
+        my ($test_name, $test_status, $test_time);
         if ($_ =~ /(\S+)\s+\.{3}\s+\.{3}\s+(PASSED|FAILED|SKIPPED)\s+\((\S+)\)/g) {
-            my $test_name = $1;
-            my $test_status = $2;
-            my $test_time = $3;
-            (my $test_path = $test_name) =~ s/-/\//;
-            $test_num += 1;
-            $test_range = $test_range . $test_path . " ... ... " . $test_status . " ($test_time seconds)" . "\n";
-            $test_path = '/opt/log/' . $test_path;
-            bmwqemu::fctinfo("$test_name");
-            if ($test_status =~ /FAILED|SKIPPED/) {
-                my $test_out_content = script_output("if [ -f $test_path ]; then tail -n 200 $test_path | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo 'No log in test path, find log in serial0.txt'; fi", 600);
-                my $test_out_bad = '';
-                my $test_full_log = '';
-                my $test_dmesg = '';
-                if ($test_status =~ /FAILED/) {
-                    $test_out_bad = script_output("if [ -f $test_path.out.bad ]; then tail -n 200 $test_path.out.bad | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo '$test_path.out.bad not exist';fi", 600);
-                    $test_full_log = script_output("if [ -f $test_path.full ]; then tail -n 200 $test_path.full | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo '$test_path.full not exist'; fi", 600);
-                    $test_dmesg = script_output("if [ -f $test_path.dmesg ]; then tail -n 200 $test_path.dmesg | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; fi", 600);
-                    $fail_num += 1;
-                }
-                else {
-                    $skip_num += 1;
-                }
-                # show fail message
-                my $targs = OpenQA::Test::RunArgs->new();
-                $targs->{name} = $test_name;
-                $targs->{time} = $test_time;
-                $targs->{status} = $test_status;
-                $targs->{output} = $test_out_content;
-                if ($test_status =~ /FAILED/) {
-                    $targs->{outbad} = $test_out_bad;
-                    $targs->{fullog} = $test_full_log;
-                    $targs->{dmesg} = $test_dmesg;
-                }
-                autotest::loadtest("tests/xfstests/xfstests_failed.pm", name => $test_name, run_args => $targs);
+            $test_name = $1;
+            $test_status = $2;
+            $test_time = $3;
+        }
+        else {
+            next;
+        }
+        (my $generate_name = $test_name) =~ s/-/\//;
+        $test_num += 1;
+        $test_range = $test_range . $generate_name . " ... ... " . $test_status . " ($test_time seconds)" . "\n";
+        my $test_path = '/opt/log/' . $generate_name;
+        bmwqemu::fctinfo("$generate_name");
+        if ($test_status =~ /FAILED|SKIPPED/) {
+            my $test_out_content = script_output("if [ -f $test_path ]; then tail -n 200 $test_path | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo 'No log in test path, find log in serial0.txt'; fi", 600);
+            my $test_out_bad = '';
+            my $test_full_log = '';
+            my $test_dmesg = '';
+            if ($test_status =~ /FAILED/) {
+                $test_out_bad = script_output("if [ -f $test_path.out.bad ]; then tail -n 200 $test_path.out.bad | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo '$test_path.out.bad not exist';fi", 600);
+                $test_full_log = script_output("if [ -f $test_path.full ]; then tail -n 200 $test_path.full | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo '$test_path.full not exist'; fi", 600);
+                $test_dmesg = script_output("if [ -f $test_path.dmesg ]; then tail -n 200 $test_path.dmesg | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; fi", 600);
+                $fail_num += 1;
+                $test_status = 'SOFTFAILED' if exists($softfail_list{$generate_name});
             }
             else {
-                $pass_num += 1;
+                $skip_num += 1;
             }
-            $total_time += $test_time;
+            # show fail message
+            my $targs = OpenQA::Test::RunArgs->new();
+            $targs->{name} = $test_name;
+            $targs->{time} = $test_time;
+            $targs->{status} = $test_status;
+            $targs->{output} = $test_out_content;
+            if ($test_status =~ /FAILED|SOFTFAILED/) {
+                $targs->{outbad} = $test_out_bad;
+                $targs->{fullog} = $test_full_log;
+                $targs->{dmesg} = $test_dmesg;
+            }
+            autotest::loadtest("tests/xfstests/xfstests_failed.pm", name => $test_name, run_args => $targs);
         }
+        else {
+            $pass_num += 1;
+        }
+        $total_time += $test_time;
     }
     record_info('Summary', "Test number: $test_num\nPass: $pass_num\nSkip: $skip_num\nFail: $fail_num\nTotal time: $total_time seconds\n");
     record_info('Test Ranges', "$test_range");

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -198,6 +198,8 @@ sub exclude_grouplist {
         $group_name = substr($group_name, 1);
         my $cmd = "awk '/$group_name/' $INST_DIR/tests/$test_folder/group.list | awk '{printf \"$test_folder/\"}{printf \$1}{printf \",\"}' > tmp.group";
         script_run($cmd);
+        $cmd = "awk '/$group_name/' $INST_DIR/tests/$FSTYPE/group.list | awk '{printf \"$FSTYPE/\"}{printf \$1}{printf \",\"}' >> tmp.group";
+        script_run($cmd) if ($test_folder eq "generic" and $TEST_RANGES =~ /$FSTYPE/);
         $cmd = "cat tmp.group";
         my %tmp_list = map { $_ => 1 } split(/,/, substr(script_output($cmd), 0, -1));
         %tests_list = (%tests_list, %tmp_list);
@@ -217,6 +219,8 @@ sub include_grouplist {
         next if ($group_name =~ /^\!/);
         my $cmd = "awk '/$group_name/' $INST_DIR/tests/$test_folder/group.list | awk '{printf \"$test_folder/\"}{printf \$1}{printf \",\"}' > tmp.group";
         script_run($cmd);
+        $cmd = "awk '/$group_name/' $INST_DIR/tests/$FSTYPE/group.list | awk '{printf \"$FSTYPE/\"}{printf \$1}{printf \",\"}' >> tmp.group";
+        script_run($cmd) if ($test_folder eq "generic" and $TEST_RANGES =~ /$FSTYPE/);
         $cmd = "cat tmp.group";
         my $tests = substr(script_output($cmd), 0, -1);
         foreach my $single_test (split(/,/, $tests)) {

--- a/tests/xfstests/xfstests_failed.pm
+++ b/tests/xfstests/xfstests_failed.pm
@@ -12,10 +12,15 @@ use testapi;
 
 sub run {
     my ($self, $args) = @_;
-    my $test_status = $args->{status};
-    record_info('INFO', "name: $args->{name}\ntest result: $test_status\ntime: $args->{time}\n");
+    record_info('INFO', "name: $args->{name}\ntest result: $args->{status}\ntime: $args->{time}\n");
     record_info('output', "$args->{output}");
-    if ($test_status =~ /FAILED/) {
+    if ($args->{status} =~ /SOFTFAILED/) {
+        $self->{result} = 'softfail';
+        record_info('out.bad', "$args->{outbad}");
+        record_info('full', "$args->{fullog}");
+        record_info('dmesg', "$args->{dmesg}");
+    }
+    elsif ($args->{status} =~ /^FAILED/) {
         $self->{result} = 'fail';
         record_info('out.bad', "$args->{outbad}");
         record_info('full', "$args->{fullog}");


### PR DESCRIPTION
During review QAM and o3 results may need to set test fail to softfail. Add a new parameter XFSTESTS_SOFTFAIL to do so. When any tests fail, first check whether it is in this softfail list, if so change the result from fail to softfail.
Also, I did some refactoring work to avoid the CI checking error "Code structure is deeply nested".

- Related ticket: https://progress.opensuse.org/issues/137732
- Verification run: http://10.67.133.133/tests/356
- VR description: I set XFSTESTS_SOFTFAIL=generic/686 in this verify run. Previous tests are failing in this generic/686 test. The verify run should mark softfail in generic/686. Because the code change involve include/exclude group feature I test it in following test and works fine http://10.67.133.133/tests/361 (xfs/270 is in 'mount' group and it's successful excluded by set exclude all 'mount' group)
