### PR TITLE
Install kirk from repositories

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -14,9 +14,11 @@ use Utils::Backends;
 use autotest;
 use LTP::WhiteList;
 use LTP::TestInfo 'testinfo';
-use version_utils qw(is_jeos is_openstack is_rt);
+use version_utils qw(is_jeos is_released is_sle is_leap is_tumbleweed is_rt is_transactional);
 use File::Basename 'basename';
 use Utils::Architectures;
+use repo_tools 'add_qa_head_repo';
+use utils;
 
 our @EXPORT = qw(
   get_ltproot
@@ -29,6 +31,9 @@ our @EXPORT = qw(
   schedule_tests
   shutdown_ltp
   want_ltp_32bit
+  add_ltp_repo
+  get_default_pkg
+  install_from_repo
 );
 
 sub loadtest_kernel {
@@ -349,6 +354,69 @@ sub parse_runfiles {
             parse_runtest_file($name, read_runfile(get_ltproot() . "/runtest/$name"),
                 $cmd_pattern, $cmd_exclude, $test_result_export, $suffix);
         }
+    }
+}
+
+sub add_ltp_repo {
+    my $repo = get_var('LTP_REPOSITORY');
+
+    if (!$repo) {
+        if (is_sle || is_transactional) {
+            add_qa_head_repo;
+            return;
+        }
+
+        # ltp for leap15.2 is available only x86_64
+        if (is_leap('15.4+')) {
+            $repo = get_var('VERSION');
+        } elsif ((is_leap('=15.2') && is_x86_64) || is_leap('15.3+')) {
+            $repo = sprintf("openSUSE_Leap_%s", get_var('VERSION'));
+        } elsif (is_tumbleweed) {
+            $repo = "openSUSE_Factory";
+            $repo = "openSUSE_Factory_ARM" if (is_aarch64() || is_arm());
+            $repo = "openSUSE_Factory_PowerPC" if is_ppc64le();
+            $repo = "openSUSE_Factory_zSystems" if is_s390x();
+        } else {
+            die sprintf("Unexpected combination of version (%s) and architecture (%s) used", get_var('VERSION'), get_var('ARCH'));
+        }
+        $repo = "https://download.opensuse.org/repositories/benchmark:/ltp:/devel/$repo/";
+    }
+
+    zypper_ar($repo, name => 'ltp_repo');
+}
+
+sub get_default_pkg {
+    my @packages;
+
+    if (is_sle && is_released) {
+        push @packages, 'ltp-stable';
+        push @packages, 'ltp-stable-32bit' if is_x86_64;
+    } else {
+        push @packages, 'ltp';
+        push @packages, 'ltp-32bit' if is_x86_64 && !is_jeos;
+    }
+
+    return join(' ', @packages);
+}
+
+sub install_from_repo {
+    my @pkgs = split(/\s* \s*/, get_var('LTP_PKG', get_default_pkg));
+
+    if (is_transactional) {
+        assert_script_run("transactional-update -n -c pkg install " . join(' ', @pkgs), 180);
+    } else {
+        zypper_call("in --recommends " . join(' ', @pkgs));
+    }
+
+    my $run_cmd = is_transactional ? 'transactional-update -c -d --quiet run' : '';
+    for my $pkg (@pkgs) {
+        my $want_32bit = want_ltp_32bit($pkg);
+
+        record_info("LTP pkg: $pkg", script_output("$run_cmd rpm -qi $pkg | tee "
+                  . get_ltp_version_file($want_32bit)));
+        assert_script_run "find " . get_ltproot($want_32bit) .
+          q(/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > )
+          . get_ltp_openposix_test_list_file($want_32bit);
     }
 }
 


### PR DESCRIPTION
Now it's possible to define KIRK_FROM variable that can define how we install kirk: from LTP repository or git.
This modification add support for transactional-update command.

- SLE-SP5 https://openqa.suse.de/tests/12466993#
- ALP with repo installation: https://openqa.suse.de/tests/12467943#
- ALP with git installation: https://openqa.suse.de/tests/12470996#

Ticket: https://progress.opensuse.org/issues/132680