### PR TITLE
Bump timeout for oscap fetching remote in s390x

### DIFF
--- a/lib/oscap_tests.pm
+++ b/lib/oscap_tests.pm
@@ -314,7 +314,7 @@ sub oscap_evaluate_remote {
     # Verify detection mode with remote
     my $ret = script_run(
         "oscap xccdf eval --profile $profile_ID --oval-results --fetch-remote-resources --report $f_report $f_ssg_ds > $f_stdout 2> $f_stderr",
-        timeout => 3000
+        timeout => 3600
     );
     record_info("Return=$ret",
         "# oscap xccdf eval --fetch-remote-resources --profile $profile_ID\" returns: $ret"


### PR DESCRIPTION
Except in rare occasions, probably linked to specific worker, we are able to run this expensive command in 16 minutes but most of the time it takes aroun 40-50 minutes, so we are reaching the boundary and bumping it a bit should help.

16': https://openqa.suse.de/tests/12450777#step/oscap_xccdf_eval_remote/61
51': https://openqa.suse.de/tests/12437781#step/oscap_xccdf_eval_remote/61

Note: No verification due to at the moment s390x infra is very unstable.

