### PR TITLE
Improve error message when autoyast related check fails

### DIFF
--- a/t/06_autoyast.t
+++ b/t/06_autoyast.t
@@ -84,7 +84,7 @@ subtest 'validate_autoyast_profile' => sub {
     $autoyast_mock->redefine("record_info", sub { my ($title, $output) = @_; print("$title\n$output"); });
     # Test that profile validates
     eval { autoyast::validate_autoyast_profile($yaml) };
-    ok !$@;
+    is $@, '', 'autoyast validation succeeded';
 };
 
 done_testing;


### PR DESCRIPTION
This hopefully helps debugging the CI failure

```
    #   Failed test at t/06_autoyast.t line 87.
    # Looks like you failed 1 test of 1.

#   Failed test 'validate_autoyast_profile'
#   at t/06_autoyast.t line 88.
# Looks like you failed 1 test of 10.
```

we're currently seeing in some PRs.