### PR TITLE
Add sles15sp4 ay profile for default module pattern install

### DIFF
--- a/data/yam/autoyast/support_images/sles15sp4_install_gnome_default_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_gnome_default_patterns_aarch64.xml
@@ -1,0 +1,1 @@
+sles15sp5_install_gnome_default_patterns_aarch64.xml

--- a/data/yam/autoyast/support_images/sles15sp4_install_gnome_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_gnome_default_patterns_s390x.xml
@@ -1,0 +1,1 @@
+sles15sp5_install_gnome_default_patterns_s390x.xml

--- a/data/yam/autoyast/support_images/sles15sp4_install_gnome_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_gnome_default_patterns_x86_64.xml
@@ -1,0 +1,1 @@
+sles15sp5_install_gnome_default_patterns_x86_64.xml

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_default_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_default_patterns_aarch64.xml
@@ -1,0 +1,1 @@
+sles15sp5_install_textmode_default_patterns_aarch64.xml

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_default_patterns_s390x.xml
@@ -1,0 +1,1 @@
+sles15sp5_install_textmode_default_patterns_s390x.xml

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_default_patterns_x86_64.xml
@@ -1,0 +1,1 @@
+sles15sp5_install_textmode_default_patterns_x86_64.xml


### PR DESCRIPTION
Add sles15sp4 ay profile for default module pattern install. Because the sles15sp4's installation ay profiles is the same with sles15sp5, so I add softlink to sles15sp5's ay profiles.

- Related ticket: https://progress.opensuse.org/issues/135992
- Needles: n/a
- Verification run: 
  [Create support images](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=20231011-2&groupid=251); [Verify created images](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=26.1&groupid=251)
- Related mr: [mr_link](https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/641)
