### PR TITLE
Fix QESAP_CLUSTER_OS_VER error for mr_test

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -12,7 +12,7 @@ terraform:
     region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    os_image: '%QESAP_CLUSTER_OS_VER%'
+    os_image: '%SLE_IMAGE%'
     private_key: '~/.ssh/id_rsa'
     public_key: '~/.ssh/id_rsa.pub'
     gcp_credentials_file: '/root/google_credentials.json'


### PR DESCRIPTION
TEAM-8664 - [GCP][Latest - HA + SAP] all "mr_test" cases failed on qesap_terraform: Could not retrieve required variable QESAP_CLUSTER_OS_VER

The setting "SLE_IMAGE" comes from tests/sles4sap/publiccloud/qesap_terraform.pm

- Related ticket: https://jira.suse.com/browse/TEAM-8664
- Needles: NA
- Verification run: 
15SP5 production: https://openqa.suse.de/tests/12480370 (passed)
15SP5 maintenance: https://openqa.suse.de/tests/12481241 (passed)