### PR TITLE
Fix broken selfinstall for ALP

### DIFF
--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -33,7 +33,7 @@ sub run {
     }
 
     # Before combustion 1.2, a reboot is necessary for firstboot configuration
-    if (is_alp || is_leap_micro || is_sle_micro) {
+    if (is_leap_micro || is_sle_micro) {
         wait_serial('reboot: Restarting system', 240) or die "SelfInstall image has not rebooted as expected";
         # Avoid booting into selfinstall again
         eject_cd() unless $no_cd;


### PR DESCRIPTION
ALP's combustion version is recent enough to not require a reboot for firstboot.

- Related failures: https://openqa.suse.de/tests/12484607#
- Verification run: https://duck-norris.qe.suse.de/tests/14253#step/selfinstall/1
