### PR TITLE
Remove use_sbd configuration from the playbook commandline

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -43,6 +43,6 @@ ansible:
     - sap-hana-install.yaml
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml -e use_sbd=false
+    - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -43,6 +43,6 @@ ansible:
     - sap-hana-install.yaml
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml -e use_sbd=false
+    - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -45,6 +45,6 @@ ansible:
     - sap-hana-install.yaml
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml -e use_sbd=false
+    - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -45,6 +45,6 @@ ansible:
     - sap-hana-install.yaml
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml -e use_sbd=false
+    - sap-hana-cluster.yaml
   destroy:
     - deregister.yaml


### PR DESCRIPTION
The `use_sbd`  configured in the inventory

This PR is for qesap regression only
This PR depend on https://github.com/SUSE/qe-sap-deployment/pull/181 and maybe some jobs needs the first `qe-sap-deployment` release with it (will be 0.17.0)

## Related ticket
 [TEAM-8672](https://jira.suse.com/browse/TEAM-8672)

## Verification

### Before https://github.com/SUSE/qe-sap-deployment/pull/180
 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit -> http://openqaworker15.qa.suse.cz/tests/246959
 - sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/246960
 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/246961


### Including https://github.com/SUSE/qe-sap-deployment/pull/180
 - `qesap_aws.yaml` Native fencing :  sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/248635 :red_circle: 

The [inventory.yaml](http://openqaworker15.qa.suse.cz/tests/248635/file/deploy-inventory.yaml) has

```
all:
  vars:
    use_sbd: false
```

But Ansible fails in `TASK [Configure cluster IP [aws]]` as:

```
ERROR    OUTPUT:                      "_raw_params": "crm configure primitive rsc_ip_HDB_HDB00 ocf:suse:aws-vpc-move-ip params ip=192.168.1.10 routing_table=rtb-0d83f8ddb1dd9d482 interface=eth0 profile=default op start interval=0 timeout=180 op stop interval=0 timeout=180 op monitor interval=60 timeout=60",
...
ERROR    OUTPUT:              "rc": 1,
...
ERROR    OUTPUT:              "stderr": "\u001b[33mWARNING\u001b[0m: (cluster_status) \twarning: Fencing and resource management disabled due to lack of quorum\n\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: Resource start-up disabled since no STONITH resources have been defined\n\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: Either configure some or disable STONITH with the stonith-enabled option\n\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: NOTE: Clusters with shared data need STONITH to ensure data integrity\n\u001b[31mERROR\u001b[0m: crm_verify: Errors found during check: config not valid",
```

 - `qesap_aws_sapconf.yaml` Native fencing : - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/248636  :red_circle:  same as error as the other AWS test

 - `qesap_gcp.yaml` Native fencing :
 - `qesap_gcp_sapconf.yaml` Native fencing :
