### PR TITLE
virt_autotest: enhancement for modular libvirt daemons

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -170,7 +170,7 @@ sub is_kvm_host {
 sub is_monolithic_libvirtd {
     record_info('WARNING', 'Libvirt package is not installed', result => 'fail') if (script_run('rpm -q libvirt-libs'));
     unless (is_alp) {
-        return 1 if script_run('rpm -q libvirt-libs | grep -e "libs-9\.0" -e "libs-[1-8]\."') == 0;
+        return 1 if script_run('systemctl is-enabled libvirtd.service') == 0;
     }
     return 0;
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/137876
- Verification run:
[gi-guest_developing-on-host_developing-kvm](http://openqa.suse.de/tests/12785888#) PASS
[gi-guest_developing-on-host_sles15sp5-kvm](http://openqa.suse.de/tests/12785889#) PASS
[gi-guest_developing-on-host_sles12sp5-kvm](http://openqa.suse.de/tests/12785893#) FAIL by bsc#1205880
[gi-guest_developing-on-host_developing-xen](http://openqa.suse.de/tests/12785891#) FAIL by bsc#1216587
