### PR TITLE
Fix forgotten sles4sap status flags update

### DIFF
--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -23,12 +23,18 @@ our @EXPORT = qw(cleanup import_context);
 sub cleanup {
     my ($self, $args) = @_;
 
-    sles4sap_cleanup(
+    my $res = sles4sap_cleanup(
         $self,
         cleanup_called => $self->{cleanup_called},
         network_peering_present => $self->{network_peering_present},
         ansible_present => $self->{ansible_present}
     );
+
+    if ($res) {
+        $self->{cleanup_called} = 1;
+        $self->{network_peering_present} = 0;
+        $self->{ansible_present} = 0;
+    }
 
     $args->{my_provider}->terraform_applied(0)
       if ((defined $args)


### PR DESCRIPTION
Small fix for potential bug mentioned in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17942#discussion_r1352365135

- Related ticket: https://jira.suse.com/browse/TEAM-8605
- Verification run: https://openqa.suse.de/tests/12487292 (PASS case), https://openqa.suse.de/tests/12487420 (FAIL case)
