### PR TITLE
Remove the PUBLIC_CLOUD_EC2_BOOT_MODE variable and --boot-mode parameter

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -134,7 +134,6 @@ sub upload_img {
     my $sec_group = get_var('PUBLIC_CLOUD_EC2_UPLOAD_SECGROUP');
     my $vpc_subnet = get_var('PUBLIC_CLOUD_EC2_UPLOAD_VPCSUBNET');
     my $instance_type = get_var('PUBLIC_CLOUD_EC2_UPLOAD_INSTANCE_TYPE', get_default_instance_type());
-    my $boot_mode = get_var('PUBLIC_CLOUD_EC2_BOOT_MODE', 'uefi-preferred');
 
     # ec2uploadimg will fail without this file, but we can have it empty
     # because we passing all needed info via params anyway
@@ -157,7 +156,6 @@ sub upload_img {
           . "--ec2-ami '" . $helper_ami_id . "' "
           . "--type '" . $instance_type . "' "
           . "--user '" . $self->provider_client->username . "' "
-          . "--boot-mode '" . $boot_mode . "' "
           . ($sec_group ? "--security-group-ids '" . $sec_group . "' " : '')
           . ($vpc_subnet ? "--vpc-subnet-id '" . $vpc_subnet . "' " : '')
           . "'$file'",

--- a/variables.md
+++ b/variables.md
@@ -298,7 +298,7 @@ PUBLIC_CLOUD_TOOLS_CLI | boolean | false | If set, it schedules `publiccloud_too
 PUBLIC_CLOUD_EC2_UPLOAD_AMI | string | "" | Needed to decide which image will be used for helper VM for upload some image. When not specified some predefined value will be used. Overwrite the value for `ec2uploadimg --ec2-ami`.
 PUBLIC_CLOUD_EC2_UPLOAD_SECGROUP | string | "" | Allow to instruct ec2uploadimg script to use some existing security group instead of creating new one. If given, the parameter `--security-group-ids` is passed to `ec2uploadimg`.
 PUBLIC_CLOUD_EC2_UPLOAD_VPCSUBNET | string | "" | Allow to instruct ec2uploadimg script to use some existing VPC instead of creating new one.
-PUBLIC_CLOUD_EC2_BOOT_MODE | string | "uefi-preferred" | The `--boot-mode` parameter for `ec2uploadimg` script. Available values: `legacy-bios`, `uefi`, `uefi-preferred`
+PUBLIC_CLOUD_EC2_BOOT_MODE | string | "uefi-preferred" | The `--boot-mode` parameter for `ec2uploadimg` script. Available values: `legacy-bios`, `uefi`, `uefi-preferred` Currently unused variable. Use `git blame` to get context.
 PUBLIC_CLOUD_FIO | boolean | false | If set, storage_perf test module is added to the job.
 PUBLIC_CLOUD_FIO_RUNTIME | integer | 300 | Set the execution time for each FIO tests.
 PUBLIC_CLOUD_FIO_SSD_SIZE | string | "100G" | Set the additional disk size for the FIO tests.


### PR DESCRIPTION
- Related ticket: [poo#128459](https://progress.opensuse.org/issues/128459)
- Related pull request: #17743, #17976
- Verification run: [first upload](https://pdostal-server.suse.cz/tests/5349), [second upload](https://pdostal-server.suse.cz/tests/5355) - Check the dependencies to see that the children are booting.