### PR TITLE
Disable verification of storage_perf test

### DIFF
--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -19,66 +19,6 @@ use publiccloud::utils qw(is_byos registercloudguest);
 use constant NUMJOBS => 4;
 use constant IODEPTH => 4;
 
-=head2  get_mean_from_db
-
-    Calculates the mean value for given C<load_type> , C<scenario> , C<os_flavor> , C<os_version>.
-    C<limit> suppose to define the scope ( e.g. "limit 5" or "limit 5 offset 5")
-    In case getting empty response from InfluxDB will return C<undef> or mean value calculated by InfluxDB otherwise.
-
-=cut
-sub get_mean_from_db {
-    my ($args, $limit) = @_;
-
-    my $query = sprintf("SELECT MEAN(*) FROM (SELECT %s FROM storage WHERE scenario='%s' and os_flavor='%s' and os_version='%s' %s)", $args->{load_type}, $args->{scenario}, $args->{os_flavor}, $args->{os_version}, $limit);
-
-    my $json_res = influxdb_read_data($args->{url}, $args->{db}, $args->{org}, $args->{token}, $query);
-    # when there is no results , "series" section is not returned :
-    # { 'results' =>
-    #      [{
-    #        'statement_id' => 0
-    #      }]
-    #  };
-    unless (defined($json_res->{results}->[0]->{series})) {
-        record_info('NO RESULTS', sprintf("No results for load_type=%s, scenario=%s, Flavor=%s, Version=%s\n", $args->{load_type}, $args->{scenario}, $args->{os_flavor}, $args->{os_version}));
-        return undef;
-    }
-
-    # example of response when this is some data :
-    #{ 'results' =>
-    #    [{
-    #      'statement_id' => 0,
-    #      'series' => [{
-    #        'values' => [[ '1970-01-01T00:00:00Z', 0 ]],
-    #        'name' => 'storage',
-    #        'columns' => ['time','mean_write_throughput']
-    #                  }]
-    #     }]
-    #};
-    # we want to return **value** of "mean_write_throughput" (from example above)
-    my $series = $json_res->{results}->[0]->{series};
-    my @values = @{$series}[0]->{values};
-    return $values[0][0][1];
-}
-
-=head2 db_has_data
-
-  Using same as in get_mean_from_db  where clause ( C<scenario>, C<os_flavor>, C<os_version>) we just verify that
-  there is enough data for analysis by doing count() of all available rows
-
-=cut
-sub db_has_data {
-    my (%args) = @_;
-
-    my $query = sprintf("SELECT count(*) FROM storage WHERE scenario='%s' and os_flavor='%s' and os_version='%s'", $args{scenario}, $args{os_flavor}, $args{os_version});
-
-    my $json_res = influxdb_read_data($args{url}, $args{db}, $args{org}, $args{token}, $query);
-    return 0 unless (defined($json_res->{results}->[0]->{series}));
-
-    my $series = $json_res->{results}->[0]->{series};
-    my @values = @{$series}[0]->{values};
-    # explanation of data structures in get_mean_from_db
-    return $values[0][0][1] > 10;
-}
 
 =head2 analyze_previous_series
 
@@ -238,20 +178,6 @@ sub run {
                 os_flavor => $tags->{os_flavor},
                 os_version => $tags->{os_version}
             );
-            # we will try to do analysis on when there is enough input data
-            # currently test logic expect 10 test results ( so 9 + current one)
-            if (db_has_data(%influx_read_args)) {
-                # we will do anaysis for same load types which we just pushed to db
-                my @load_types = keys %$values;
-                # Change the test module result to 'fail' if deviation in analyze_previous_series() occures
-                if (analyze_previous_series(\%influx_read_args, \@load_types) == 1) {
-                    record_info("Possible performance deviation", "The test module detected a possible performance deviation", result => 'fail');
-                    $self->{result} = 'fail';
-                }
-            }
-            else {
-                record_info('NO DATA', "We need at least 10 test results to analyze " . $href->{name} . "\n");
-            }
         }
     }
 }


### PR DESCRIPTION


Current verification proved to be error prone
so currently we want to run test for some time
to collect data which will allow us to decide
which approach can be better.
