### PR TITLE
Restrict get_blob_uri call to Azure qesap regression

### DIFF
--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -24,9 +24,13 @@ sub run {
     if (get_var('QESAPDEPLOY_CLUSTER_OS_VER')) {
         $variables{OS_VER} = get_var('QESAPDEPLOY_CLUSTER_OS_VER');
     }
-    else {
+    elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
         $variables{STORAGE_ACCOUNT_NAME} = get_required_var('STORAGE_ACCOUNT_NAME');
         $variables{OS_URI} = $provider->get_blob_uri(get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
+    }
+    else
+    {
+        $variables{OS_VER} = $provider->get_image_id();
     }
     $variables{OS_OWNER} = get_var('QESAPDEPLOY_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 


### PR DESCRIPTION
get_blob_uri is used to populate the terraform.tfvars for Azure images not from the Azure catalog, uploaded by `publiccloud_upload_img` test module.
Avoid the the test is attempting to use the same mechanism when used in AWS/GCP testing.


- Related ticket: TEAM-8627

- Verification run: http://openqaworker15.qa.suse.cz/tests/246993
