### PR TITLE
Remove cyclic dependency between `main_common.pm` and `main_ltp.pm`

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -72,7 +72,6 @@ our @EXPORT = qw(
   load_iso_in_external_tests
   load_jeos_tests
   load_kernel_baremetal_tests
-  load_kernel_tests
   load_nfs_tests
   load_nfv_master_tests
   load_nfv_trafficgen_tests
@@ -277,27 +276,6 @@ sub is_kernel_test {
 
 sub is_systemd_test {
     return get_var('SYSTEMD_TESTSUITE');
-}
-
-# Isolate the loading of LTP tests because they often rely on newer features
-# not present on all workers. If they are isolated then only the LTP tests
-# will fail to load when there is a version mismatch instead of all tests.
-{
-    local $@;
-
-    eval "use main_ltp 'load_kernel_tests'";
-    if ($@) {
-        bmwqemu::fctwarn("Failed to load main_ltp.pm:\n$@", 'main_common.pm');
-        eval q%{
-            sub load_kernel_tests {
-                if (is_kernel_test())
-                {
-                    die "Can not run kernel tests because evaluating main_ltp.pm failed";
-                }
-                return 0;
-            }
-        %;
-    }
 }
 
 sub replace_opensuse_repos_tests {

--- a/lib/main_ltp_loader.pm
+++ b/lib/main_ltp_loader.pm
@@ -1,0 +1,28 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package main_ltp_loader;
+use strict;
+use warnings;
+use base 'Exporter';
+use Exporter;
+
+our @EXPORT_OK = qw(load_kernel_tests);
+
+# Isolate the loading of LTP tests because they often rely on newer features
+# not present on all workers. If they are isolated then only the LTP tests
+# will fail to load when there is a version mismatch instead of all tests.
+local $@;
+eval "use main_ltp 'load_kernel_tests'";
+if ($@) {
+    bmwqemu::fctwarn("Failed to load main_ltp.pm:\n$@", 'main_ltp.pm');
+    eval q%{
+        sub load_kernel_tests {
+            die "Can not run kernel tests because evaluating main_ltp.pm failed"
+                if is_kernel_test;
+            return 0;
+        }
+    %;
+}
+
+1;

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -12,6 +12,7 @@ use warnings;
 use base 'Exporter';
 use Exporter;
 use main_common;
+use main_ltp_loader 'load_kernel_tests';
 use main_containers qw(load_container_tests is_container_test);
 use testapi qw(check_var get_required_var get_var set_var);
 use version_utils;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -22,6 +22,7 @@ BEGIN {
 use utils;
 use version_utils qw(is_jeos is_gnome_next is_krypton_argon is_leap is_tumbleweed is_rescuesystem is_desktop_installed is_opensuse is_sle is_staging);
 use main_common;
+use main_ltp_loader 'load_kernel_tests';
 use known_bugs;
 use YuiRestClient;
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -29,6 +29,7 @@ BEGIN {
 }
 use utils;
 use main_common;
+use main_ltp_loader 'load_kernel_tests';
 use main_pods;
 use known_bugs;
 use YuiRestClient;


### PR DESCRIPTION
Having a cyclic dependency is generally wrong. It now finally leads to problems when trying to use `repo_tools.pm` from `LTP/utils.pm` which on its own should be fine (see https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17965).

Instead of relying on `main_ltp.pm` being loaded implicitly via `main_common.pm` (which `main_ltp.pm` itself depends on) this change simply loads `main_ltp.pm` where it is needed.

This change preserves the error handling. To avoid duplication the error handling was moved in the separate module `main_ltp_loader.pm` which is used instead of using `main_ltp.pm` directly. It still works (tested by putting `use foo;` in `main_ltp.pm` and running the compile check).

I've also just ran an LTP test locally and it still worked. So I guess this change doesn't break everything.