### PR TITLE
LTP Whitelist: Add keep_fail attribute to whitelist JSON

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -126,10 +126,16 @@ sub override_known_failures {
         }
     }
 
-    my $msg = "Failure in LTP:$suite:$testname is known, overriding to softfail";
-    bmwqemu::diag($msg);
-    $testmod->{result} = 'softfail';
-    $testmod->record_soft_failure_result(join("\n", $msg, ($entry->{message} // ())));
+    if ($entry->{keep_fail}) {
+        $testmod->record_resultfile('Known', $entry->{message}, result => 'fail');
+    }
+    else {
+        my $msg = "Failure in LTP:$suite:$testname is known, overriding to softfail";
+        bmwqemu::diag($msg);
+        $testmod->{result} = 'softfail';
+        $testmod->record_soft_failure_result(join("\n", $msg, ($entry->{message} // ())));
+    }
+
     return 1;
 }
 


### PR DESCRIPTION
A non-zero keep_fail attribute in a whitelist entry will prevent matching failures from being whitelisted. Only a fail info box will be created with the message provided by the whitelist entry to give test reviewers reliable info about the failure, in particular a bugref and symptoms so that different failures don't get mixed together. This will be used for failures which need to be closely tracked and cannot be whitelisted.

- Related ticket: https://progress.opensuse.org/issues/137873
- Needles: N/A
- Verification run: Pending
