### PR TITLE
Add functions to delete stale peerings

### DIFF
--- a/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
@@ -21,6 +21,7 @@ conditional_schedule:
       '1':
         - publiccloud/validate_repos
         - sles4sap/publiccloud/qesap_terraform
+        - sles4sap/publiccloud/clean_leftover_peerings
         - sles4sap/publiccloud/network_peering
         - sles4sap/publiccloud/add_server_to_hosts
         - sles4sap/publiccloud/cluster_add_repos

--- a/schedule/sles4sap/sles4sap_ibsm_embargo_check.yml
+++ b/schedule/sles4sap/sles4sap_ibsm_embargo_check.yml
@@ -14,6 +14,7 @@ vars:
 schedule:
   - boot/boot_to_desktop
   - sles4sap/publiccloud/qesap_terraform
+  - sles4sap/publiccloud/clean_leftover_peerings
   - sles4sap/publiccloud/network_peering
   - sles4sap/publiccloud/add_server_to_hosts
   - sles4sap/publiccloud/check_ibsm_embargoed

--- a/tests/sles4sap/publiccloud/clean_leftover_peerings.pm
+++ b/tests/sles4sap/publiccloud/clean_leftover_peerings.pm
@@ -1,0 +1,31 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Deployment steps for qe-sap-deployment
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use strict;
+use warnings;
+use base 'sles4sap_publiccloud_basetest';
+use testapi;
+use qesapdeployment;
+use publiccloud::utils qw(is_azure is_ec2);
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    if (is_azure) {
+        if (!get_var('IBSM_RG')) {
+            record_info('NO IBSM', 'No IBSM_RG variable found. Exiting');
+            return 0;
+        }
+        my $group = get_var('IBSM_RG');
+        my $vnet_name = qesap_az_get_vnet($group);
+        qesap_az_clean_old_peerings(rg => $group, vnet => $vnet_name);
+    }
+}
+
+1;


### PR DESCRIPTION
Sometimes, a job will terminate without calling proper peering cleanup. This may prevent future jobs running on the same worker from creating a peering, leading them to fail.

This pr adds a set of functions and a new module, which checks all open peerings, checks if their jobs have finished, and if the answer is positive, deletes those peerings.

- Related ticket: https://jira.suse.com/browse/TEAM-8671
- Verification run: https://openqa.suse.de/tests/12551639
https://openqa.suse.de/tests/12554006
