### PR TITLE
Tests will not continue when Errors pop-up occurs in virt test host autoyast installation

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -149,7 +149,7 @@
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">10</timeout>
+      <timeout config:type="integer">0</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -155,7 +155,7 @@
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">10</timeout>
+      <timeout config:type="integer">0</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_one_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_one_disk.xml
@@ -19,7 +19,7 @@
   <report>
     <errors>
       <show t="boolean">true</show>
-      <timeout t="integer">20</timeout>
+      <timeout t="integer">0</timeout>
       <log t="boolean">true</log>
     </errors>
     <messages>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_two_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_two_disk.xml
@@ -19,7 +19,7 @@
   <report>
     <errors>
       <show t="boolean">true</show>
-      <timeout t="integer">20</timeout>
+      <timeout t="integer">0</timeout>
       <log t="boolean">true</log>
     </errors>
     <messages>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_one_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_one_disk.xml
@@ -19,7 +19,7 @@
   <report>
     <errors>
       <show t="boolean">true</show>
-      <timeout t="integer">20</timeout>
+      <timeout t="integer">0</timeout>
       <log t="boolean">true</log>
     </errors>
     <messages>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_two_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_two_disk.xml
@@ -19,7 +19,7 @@
   <report>
     <errors>
       <show t="boolean">true</show>
-      <timeout t="integer">20</timeout>
+      <timeout t="integer">0</timeout>
       <log t="boolean">true</log>
     </errors>
     <messages>


### PR DESCRIPTION
Because of different screen resolution, not all "Error" pop-up can be detected by autoyast/installation.pm, so abort the test when errors happen.

- Related ticket: https://progress.opensuse.org/issues/138017
- Verification run: 
[sle15sp6 kvm](https://openqa.suse.de/tests/12535861#step/installation/5)  //installation stop when error pop-up occurs
[sle15sp6 kvm](https://openqa.suse.de/tests/12535846)  //installation stop when error pop-up occurs
[sle12sp5 host](https://openqa.suse.de/tests/12535887)   //test pass without errors
[TW](http://10.67.129.27/tests/120)    //installation stop when error pop-up occurs
