### PR TITLE
 Add ltss module to workaround bug 1216116

### DIFF
--- a/data/yam/autoyast/support_images/sles15sp3_install_gnome_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_gnome_all_patterns_aarch64.xml
@@ -104,7 +104,6 @@
       <pattern>base-32bit</pattern>
       <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
-      <pattern>common-criteria</pattern>
       <pattern>dhcp_dns_server</pattern>
       <pattern>directory_server</pattern>
       <pattern>documentation</pattern>
@@ -160,6 +159,14 @@
         <name>sle-module-server-applications</name>
         <release_type>nil</release_type>
         <version>15.3</version>
+      </addon>
+      <!-- workaround for bug 1216116 -->
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>15.3</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp3_install_gnome_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_gnome_all_patterns_s390x.xml
@@ -114,7 +114,6 @@
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
-      <pattern>common-criteria</pattern>
       <pattern>dhcp_dns_server</pattern>
       <pattern>directory_server</pattern>
       <pattern>documentation</pattern>
@@ -165,6 +164,14 @@
         <name>sle-module-desktop-applications</name>
         <release_type>nil</release_type>
         <version>15.3</version>
+      </addon>
+      <!-- workaround for bug 1216116 -->
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>15.3</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp3_install_gnome_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_gnome_all_patterns_x86_64.xml
@@ -98,7 +98,6 @@
       <pattern>base-32bit</pattern>
       <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
-      <pattern>common-criteria</pattern>
       <pattern>dhcp_dns_server</pattern>
       <pattern>directory_server</pattern>
       <pattern>documentation</pattern>
@@ -156,6 +155,14 @@
         <name>sle-module-desktop-applications</name>
         <release_type>nil</release_type>
         <version>15.3</version>
+      </addon>
+      <!-- workaround for bug 1216116 -->
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>15.3</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp3_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_textmode_all_patterns_aarch64.xml
@@ -103,7 +103,6 @@
       <pattern>base-32bit</pattern>
       <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
-      <pattern>common-criteria</pattern>
       <pattern>dhcp_dns_server</pattern>
       <pattern>directory_server</pattern>
       <pattern>documentation</pattern>
@@ -146,6 +145,14 @@
         <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <version>{{VERSION}}</version>
+      </addon>
+      <!-- workaround for bug 1216116 -->
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>15.3</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp3_install_textmode_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_textmode_all_patterns_s390x.xml
@@ -112,7 +112,6 @@
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
-      <pattern>common-criteria</pattern>
       <pattern>dhcp_dns_server</pattern>
       <pattern>directory_server</pattern>
       <pattern>documentation</pattern>
@@ -156,6 +155,14 @@
         <reg_code/>
         <release_type>nil</release_type>
         <version>15.3</version>
+      </addon>
+      <!-- workaround for bug 1216116 -->
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>15.3</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp3_install_textmode_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_textmode_all_patterns_x86_64.xml
@@ -96,7 +96,6 @@
       <pattern>base-32bit</pattern>
       <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
-      <pattern>common-criteria</pattern>
       <pattern>dhcp_dns_server</pattern>
       <pattern>directory_server</pattern>
       <pattern>documentation</pattern>
@@ -142,6 +141,14 @@
         <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <version>{{VERSION}}</version>
+      </addon>
+      <!-- workaround for bug 1216116 -->
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>15.3</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>


### PR DESCRIPTION
Add ltss module for sles15sp3 all patterns with default module. 
We add it to workaround [**_bug 1216116_**](https://bugzilla.suse.com/show_bug.cgi?id=1216116).

- Related ticket: [**132854**](https://progress.opensuse.org/issues/132854)
- Needles: N/A
- Verification run: 
  * [**sle_autoyast_support_image_gnome_15sp3_all_patterns**](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=sle_autoyast_support_image_gnome_15sp3_all_patterns_dev&modules=&module_re=&distri=sle&version=15-SP3&build=GM&groupid=220)
   * [**sle_autoyast_support_image_textmode_15sp3_all_patterns**](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=sle_autoyast_support_image_textmode_15sp3_all_patterns_dev&modules=&module_re=&distri=sle&version=15-SP3&build=GM&groupid=220)
   * VRs for modules combination{x86_64}:
      https://openqa.suse.de/tests/12549679
      https://openqa.suse.de/tests/12549713
      https://openqa.suse.de/tests/12549714
      https://openqa.suse.de/tests/12549715
