### PR TITLE
Update utils.pm

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1789,7 +1789,7 @@ sub reconnect_mgmt_console {
     elsif (is_x86_64) {
         if (is_ipmi) {
             select_console 'sol', await_console => 0;
-            assert_screen([qw(qa-net-selection prague-pxe-menu grub2)], 300);
+            assert_screen([qw(qa-net-selection prague-pxe-menu nue-ipxe-menu grub2)], 300);
             # boot to hard disk is default
             send_key 'ret';
         }


### PR DESCRIPTION
"nue-ipxe-menu" added to the "reconnect_mgmt_console"

Test with IPMI hosts fails continue after 'handle_reboot'

- Verification run: https://openqa.suse.de/tests/12536708#step/handle_reboot/2
