### PR TITLE
Add fullypatch qesap config variants for AWS/GCP

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fullypatch.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fullypatch.yaml
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'aws'
+apiver: 3
+terraform:
+  variables:
+    aws_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    os_owner: '%OS_OWNER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    aws_credentials: '/root/amazon_credentials'
+    hana_instancetype: '%HANA_INSTANCE_TYPE%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+ansible:
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HDB'
+    sap_hana_install_instance_number: '00'
+    sap_domain: 'qe-test.example.com'
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+  create:
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address=testing@suse.com
+    - fully-patch-system.yaml
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml -e use_sbd=false
+  destroy:
+    - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fullypatch.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fullypatch.yaml
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'gcp'
+apiver: 3
+terraform:
+  variables:
+    project: 'ei-sle-qa-sap-8469'
+    region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    gcp_credentials_file: '/root/google_credentials.json'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    hana_data_disk_type: '%HANA_DATA_DISK_TYPE%'
+    hana_log_disk_type: '%HANA_LOG_DISK_TYPE%'
+
+ansible:
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HDB'
+    sap_hana_install_instance_number: '00'
+    sap_domain: 'qe-test.example.com'
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+  create:
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - fully-patch-system.yaml
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml -e use_sbd=false
+  destroy:
+    - deregister.yaml


### PR DESCRIPTION
The two files are derived from qesap_aws.yaml and qesap_gcp.yaml and just add the new playbook added in  https://github.com/SUSE/qe-sap-deployment/pull/175


- Related ticket: TEAM-8437 TEAM-8629

## Verification run: 

### AWS

 - sle-12-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE12_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/247768 :green_circle: 

- sle-15-SP5-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE15_5_PAYG-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/247757 :green_circle: 

 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/247758  :green_circle: 

 - sle-15-SP4-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_4_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/247759  :green_circle: 


### GCP

 - sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/247777

 - sle-15-SP3-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_3_BYOS-qesap_gcp_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/247776

- sle-12-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE12_5_BYOS-qesap_gcp_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/247774

