### PR TITLE
Make gnu_compilers_hpc module to work with default package

### DIFF
--- a/tests/hpc/gnu_compilers_hpc.pm
+++ b/tests/hpc/gnu_compilers_hpc.pm
@@ -16,19 +16,21 @@ use Utils::Logging qw(export_logs);
 
 sub run ($self) {
     select_serial_terminal();
-    my $version = get_required_var('GNU_COMPILERS_HPC_VERSION');
+    my $version = get_var('GNU_COMPILERS_HPC_VERSION', '');
+    my $expected_version = $version ? $version : '7';
+
     zypper_call("in gnu$version-compilers-hpc");
     type_string('pkill -u root', lf => 1);
     $self->{serial_term_prompt} = '# ';
     serial_terminal::login('root', $self->{serial_term_prompt});
 
-    assert_script_run qq{module av | grep gnu/$version};
+    assert_script_run qq{module av | grep gnu/$expected_version};
     assert_script_run 'module load gnu';
-    assert_script_run qq{env |grep "MODULEPATH=/usr/share/lmod/moduledeps/gnu-$version"};
+    assert_script_run qq{env |grep "MODULEPATH=/usr/share/lmod/moduledeps/gnu-$expected_version"};
     zypper_call("in gnu$version-compilers-hpc-devel");
     assert_script_run 'module load gnu';
-    assert_script_run qq{env |grep "PATH=/usr/lib/hpc/compiler/gnu/$version/bin"};
-    assert_script_run qq{gcc --version | grep $version};
+    assert_script_run qq{env |grep "PATH=/usr/lib/hpc/compiler/gnu/$expected_version/bin"};
+    assert_script_run qq{gcc --version | grep $expected_version};
 }
 
 sub post_fail_hook ($self) {

--- a/tests/hpc/gnu_compilers_hpc.pm
+++ b/tests/hpc/gnu_compilers_hpc.pm
@@ -12,12 +12,17 @@ use Mojo::Base qw(hpcbase), -signatures;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils;
 use Utils::Logging qw(export_logs);
 
 sub run ($self) {
     select_serial_terminal();
     my $version = get_var('GNU_COMPILERS_HPC_VERSION', '');
-    my $expected_version = $version ? $version : '7';
+    # When non-versioned gnu_compilers_hpc is installed
+    # The default gcc version for SLE12 is 4.8
+    # Since SLE15 the default is gcc7
+    my $default_version = check_version('>=15-SP0', get_var('VERSION'), qr/\d{2}(?:-sp\d)?/) ? '7' : '4.8';
+    my $expected_version = $version ? $version : $default_version;
 
     zypper_call("in gnu$version-compilers-hpc");
     type_string('pkill -u root', lf => 1);
@@ -30,7 +35,7 @@ sub run ($self) {
     zypper_call("in gnu$version-compilers-hpc-devel");
     assert_script_run 'module load gnu';
     assert_script_run qq{env |grep "PATH=/usr/lib/hpc/compiler/gnu/$expected_version/bin"};
-    assert_script_run qq{gcc --version | grep $expected_version};
+    assert_script_run qq{gcc --version | grep -E "^gcc \\(SUSE Linux\\) $expected_version\\.[0-9]*"};
 }
 
 sub post_fail_hook ($self) {


### PR DESCRIPTION
At least for all the SLE15 the default gnu_compilers_hpc should use gcc7. The
tests for non-verioned package should work without the
GNU_COMPILERS_HPC_VERSION by default.

- Related ticket: https://progress.opensuse.org/issues/138002
- Verification run: 
https://aquarius.suse.cz/tests/19434

12sp5 https://openqa.suse.de/tests/overview?version=12-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2317993
15sp1 https://openqa.suse.de/tests/overview?version=15-SP1&build=b10n1k%2Fos-autoinst-distri-opensuse%2317993&distri=sle
15SP2 https://openqa.suse.de/tests/overview?version=15-SP2&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2317993
15sp3 https://openqa.suse.de/tests/overview?version=15-SP3&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2317993
15sp4 https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2317993&version=15-SP4
15sp5 https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2317993&version=15-SP5