### PR TITLE
WIP: Add partitioning list to prevent by-path mounting

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -129,7 +129,6 @@
 
   <partitioning config:type="list">
     <drive>
-      <device>/dev/vda</device>
       <disklabel>gpt</disklabel>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">

--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -126,6 +126,33 @@
       % }
     </patterns>
   </software>
+
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <disklabel>gpt</disklabel>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">vfat</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>utf8</fstopt>
+          <mount>/boot/efi</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <resize config:type="boolean">false</resize>
+          <size>134217728</size>
+        </partition>
+        <partition config:type="map">
+          <mountby config:type="symbol">uuid</mountby>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+        </partition>
+      </partitions>
+      <use>all</use>
+    </drive>
+  </partitioning>
+
   <services-manager>
     <default_target>multi-user</default_target>
     <services>


### PR DESCRIPTION
Mounting by-path doesn't work on s390x so we need to mount the created filesystems by uuid.


- Related failure: https://openqa.suse.de/tests/12542535#live
- Related ticket: https://progress.opensuse.org/issues/137807
- Verification run: TBD
