### PR TITLE
firefox: Drop unused code

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -626,7 +626,7 @@ sub restart_firefox {
     wait_still_screen 2;
     $self->exit_firefox_common;
     assert_script_run('time wait $(pidof firefox)');
-    enter_cmd "$cmd";
+    enter_cmd "$cmd" if defined $cmd;
     enter_cmd "firefox $url >>firefox.log 2>&1 &";
     $self->firefox_check_default;
     assert_screen 'firefox-url-loaded';

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -580,8 +580,6 @@ sub start_clean_firefox {
     $self->firefox_open_url('opensuse.org');
     my $count = 10;
     while ($count--) {
-        # workaround for bsc#1046005
-        assert_and_click 'firefox_titlebar' if check_screen('firefox_titlebar', 2);
         if (check_screen 'firefox_trackinfo', 3) {
             record_info 'Tracking protection', 'Track info did show up';
             assert_and_click 'firefox_trackinfo';
@@ -613,8 +611,6 @@ sub start_clean_firefox {
         wait_still_screen(3);
         assert_and_click 'firefox_readerview_window';
     }
-    # workaround for bsc#1046005
-    assert_and_click 'firefox_titlebar' if check_screen('firefox_titlebar', 2);
 
     # Help
     send_key "alt-h";
@@ -696,15 +692,6 @@ sub firefox_check_popups {
         elsif (match_has_tag('firefox_readerview_window')) {
             wait_screen_change { assert_and_click 'firefox_readerview_window'; };
         }
-
-        if (match_has_tag('firefox_trackinfo') or match_has_tag('firefox_readerview_window')) {
-            # bsc#1046005 does not seem to affect KDE and as the workaround sometimes results in
-            # accidentially moving the firefox window around, skip it.
-            if (!check_var("DESKTOP", "kde")) {
-                # workaround for bsc#1046005
-                assert_and_click 'firefox_titlebar' if check_screen('firefox_titlebar', 2);
-            }
-        }
     }
 }
 
@@ -712,9 +699,6 @@ sub firefox_open_url {
     my ($self, $url, %args) = @_;
     my $counter = 1;
     while (1) {
-        # make sure firefox window is focused
-        assert_and_click 'firefox_titlebar' if check_screen('firefox_titlebar', 2);
-        wait_still_screen 1, 2;
         send_key 'alt-d';
         send_key 'delete';
         send_key 'alt-d';

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -578,39 +578,10 @@ sub start_clean_firefox {
     assert_screen 'firefox-url-loaded', 90;
     # to avoid stuck trackinfo pop-up, refresh the browser
     $self->firefox_open_url('opensuse.org');
-    my $count = 10;
-    while ($count--) {
-        if (check_screen 'firefox_trackinfo', 3) {
-            record_info 'Tracking protection', 'Track info did show up';
-            assert_and_click 'firefox_trackinfo';
-            last;
-        }
-        # the needle match area has to be where trackinfo does pop-up
-        elsif (check_screen 'firefox-developertool-opensuse') {
-            record_info 'Tracking protection', 'Track info pop-up did NOT show up';
-            last;
-        }
-        elsif ($count eq 1) {
-            die 'trackinfo pop-up did not match';
-        }
-        else {
-            send_key 'f5';
-        }
-    }
-
-    # get rid of "Firefox Privacy Notice" page
-    wait_still_screen(3);
-    if (check_screen 'firefox_privacy_notice') {
-        assert_and_click 'firefox_privacy_notice';
-    }
 
     # get rid of the reader & tracking pop-up once, first test should have milestone flag
     $self->firefox_open_url('eu.httpbin.org/html', assert_loaded_url => 'firefox-urls_protocols-http');
     wait_still_screen(3);
-    if (check_screen 'firefox_readerview_window') {
-        wait_still_screen(3);
-        assert_and_click 'firefox_readerview_window';
-    }
 
     # Help
     send_key "alt-h";
@@ -645,7 +616,6 @@ sub start_firefox {
     # Using match_typed parameter on KDE as typing in desktop runner may fail
     x11_start_program('firefox https://html5test.opensuse.org', valid => 0, match_typed => ((check_var('DESKTOP', 'kde')) ? "firefox_url_typed" : ''));
     $self->firefox_check_default;
-    $self->firefox_check_popups;
     assert_screen 'firefox-html-test';
 }
 
@@ -672,26 +642,6 @@ sub firefox_check_default {
         wait_screen_change {
             assert_and_click 'firefox_default_browser_yes';
         };
-    }
-}
-
-# Check whether there are any pop up windows and handle them one by one
-sub firefox_check_popups {
-    # assert loaded webpage
-    assert_screen 'firefox-url-loaded', 300;
-    for (1 .. 3) {
-        # slow down loop and give firefox time to show pop-up
-        sleep 5;
-        # check pop-ups
-        assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox-launch)];
-        # handle the tracking protection pop up
-        if (match_has_tag('firefox_trackinfo')) {
-            wait_screen_change { assert_and_click 'firefox_trackinfo'; };
-        }
-        # handle the reader view pop up
-        elsif (match_has_tag('firefox_readerview_window')) {
-            wait_screen_change { assert_and_click 'firefox_readerview_window'; };
-        }
     }
 }
 

--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -27,6 +27,7 @@ sub run {
     enter_cmd('python3 -m http.server 48080 &');
     # curl provides an adequate time window for the server to run
     assert_script_run 'curl --connect-timeout 5 --max-time 10 --retry-connrefused 5 --retry-delay 1 --retry-max-time 40 http://localhost:48080/';
+    send_key 'alt-tab';    #Switch to firefox
     $self->firefox_open_url('http://localhost:48080/html5_video', assert_loaded_url => 'firefox-testvideo');
     $self->exit_firefox;
     enter_cmd('exit');

--- a/tests/x11/plasma_browser_integration.pm
+++ b/tests/x11/plasma_browser_integration.pm
@@ -24,10 +24,6 @@ sub run {
 
     # Start without parameters, otherwise the reminder does not trigger. Add a space to avoid autocomplete.
     x11_start_program(' firefox', valid => 0);
-    # Unfortunately that would result in a 100s delay waiting for a still screen here as
-    # the default start page is animated, so skip handling the dialog. It's not expected here anyway.
-    # $self->firefox_check_default();
-    $self->firefox_check_popups();
 
     # Click on the reminder, it might take a while to appear
     assert_and_click('plasma-browser-integration-reminder');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/98949
- Verification run: https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=qam-regression-firefox-SLES&modules=&module_re=&distri=sle&build=20231016-1
https://dzedro.suse.cz/tests/1954
https://dzedro.suse.cz/tests/1955
