### PR TITLE
Combustion test adjustments in SLE

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -355,12 +355,13 @@
         "type": "ignore"
     },
     "no-config-drive": {
-        "description": "Timed out waiting for device (/dev/disk/by-label/ignition|/dev/combustion/config)",
+        "description": "Timed out waiting for device (/dev/disk/by-label/ignition|/dev/combustion/config)|dev-combustion-config.device: Job dev-combustion-config.device/start timed out.",
         "products": {
             "leap-micro": ["5.3"],
             "sle-micro": ["5.3", "5.4" , "5.5"],
             "microos":  ["Tumbleweed"],
-            "opensuse":  ["Tumbleweed"]
+            "opensuse":  ["Tumbleweed"],
+            "sle": ["15-SP6"]
         },
         "type": "ignore"
     },

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -19,6 +19,10 @@ conditional_schedule:
                 - installation/bootloader_uefi
             's390x-kvm':
                 - installation/bootloader_start
+            'uefi-virtio-vga':
+                - installation/bootloader_uefi
+            '64bit-virtio-vga':
+                - installation/bootloader_uefi
     efi:
         UEFI:
             '1':


### PR DESCRIPTION
Whenever the combustion device is missing, ignore the systemd time out
message

- http://kepler.suse.cz/tests/21996#
