### PR TITLE
kernel/bpftrace: mv runqlat to unreliable list

### DIFF
--- a/tests/kernel/bpftrace.pm
+++ b/tests/kernel/bpftrace.pm
@@ -40,7 +40,6 @@ sub run {
       naptime.bt
       oomkill.bt
       pidpersec.bt
-      runqlat.bt
       runqlen.bt
       setuids.bt
       ssllatency.bt
@@ -64,6 +63,7 @@ sub run {
       biostacks.bt
       mdflush.bt
       opensnoop.bt
+      runqlat.bt
       statsnoop.bt
       xfsdist.bt
       vfsstat.bt


### PR DESCRIPTION
Fails on TW Aarch64 due to missing symbols in the headers

- Related ticket: https://progress.opensuse.org/issues/137681
- Verification run: https://openqa.opensuse.org/tests/3650964 (failed for unrelated reason, waiting for new one)

@czerw 
