### PR TITLE
pc: Increase timeout for SCAP profile download

### DIFF
--- a/tests/publiccloud/hardened.pm
+++ b/tests/publiccloud/hardened.pm
@@ -27,7 +27,7 @@ sub run {
     my $xml_path = "pub/projects/security/oval/suse.linux.enterprise.15.xml";
     # Downloaded file should have slashes replaced by hyphens
     my $xml_file = $xml_path =~ s/\//-/gr;
-    assert_script_run("curl -o- https://ftp.suse.com/$xml_path.gz | gunzip -c > oscap/$xml_file", timeout => 180);
+    assert_script_run("curl -o- https://ftp.suse.com/$xml_path.gz | gunzip -c > oscap/$xml_file", timeout => 300);
     my $ret = script_run("sudo oscap xccdf eval --report report.html --local-files oscap/ --profile pcs-hardening /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml", timeout => 300);
     upload_logs("report.html");
     record_soft_failure("bsc#1216088 - Public Cloud Hardened image fail SCAP test") if ($ret);


### PR DESCRIPTION
Increase timeout for SCAP profile download

- Failing job: https://openqa.suse.de/tests/12539965/logfile?filename=autoinst-log.txt
- Verification run: https://openqa.suse.de/t12552741