### PR TITLE
Fixed powershell startup menu popup

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -72,6 +72,11 @@ sub open_powershell_as_admin {
         assert_and_click "windows-user-account-ctl-hidden" if match_has_tag("windows-user-account-ctl-hidden");
         assert_and_click "windows-user-acount-ctl-yes";
         wait_still_screen stilltime => 3, timeout => 12;
+        if (check_var('WIN_VERSION', '11')) {
+            # When opening Powershell, sometimes the startup menu window pops up.
+            assert_screen(['powershell-with-startup-menu', 'powershell-as-admin-window'], 240);
+            send_key 'esc' if match_has_tag('powershell-with-startup-menu');
+        }
         assert_screen 'powershell-as-admin-window', timeout => 240;
         assert_and_click 'window-max';
         wait_still_screen stilltime => 3, timeout => 12;


### PR DESCRIPTION
When powershell opens in win11, the Startup menu shows up breaking previous needle logic. Introduced code in windowsbasetest.pm to account for this.


- Related ticket: https://progress.opensuse.org/issues/137471
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/powershell-with-startup-menu-20231009.png
- Verification run: https://openqa.suse.de/tests/12551885#step/update_windows/5
