### PR TITLE
registration: Wait after confirming update repos

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -589,6 +589,7 @@ sub process_scc_register_addons {
         }
     }
     else {
+        wait_still_screen(2, 4);
         send_key $cmd{next};
         if (check_var('HDDVERSION', '12')) {
             assert_screen 'yast-scc-emptypkg';


### PR DESCRIPTION
Pressing next directly after repo confirmation can miss the key, installation is then stuck on unexpected modules list

This is from passed test where the modules list is not even visible in video, registration registered the next key press and it worked, but often it will not be so lucky and fail.
![reg_ntp4](https://github.com/os-autoinst/os-autoinst-distri-opensuse/assets/9447312/08cb446b-bd60-4e2a-85d6-a03c89bb1a95)

- Related ticket: https://openqa.suse.de/tests/12546751#step/ntp_config_settings/2
- Verification run: https://openqa.suse.de/tests/12552748
