### PR TITLE
Enable Azure native fencing mechanisms

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -27,6 +27,8 @@ terraform:
     hana_ha_enabled: '%HA_CLUSTER%'
     vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 
 ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -43,4 +43,73 @@ subtest "Run 'setup_sbd_delay_publiccloud' with different values" => sub {
 
 };
 
+subtest '[azure_fencing_agents_playbook_args] Check Mandatory args' => sub {
+    set_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn');
+    my %mandatory_args = (
+        'spn_application_id' => 'LongJohnSilver',
+        'spn_application_password' => 'CaptainFlint');
+
+    for my $key (keys %mandatory_args) {
+        my $original_value = $mandatory_args{$key};
+        delete $mandatory_args{$key};
+        dies_ok { azure_fencing_agents_playbook_args(%mandatory_args) } "Expected failure: missing mandatory arg - $key";
+        $mandatory_args{$key} = $original_value;
+    }
+    set_var('AZURE_FENCE_AGENT_CONFIGURATION', '');
+};
+
+subtest '[azure_fencing_agents_playbook_args] Native fencing setup (default value)' => sub {
+    set_var('FENCING_MECHANISM', 'native');
+    my $returned_value = azure_fencing_agents_playbook_args();
+    is $returned_value, '-e azure_identity_management=msi', "Test returned value: $returned_value";
+    set_var('AZURE_FENCE_AGENT_CONFIGURATION', '');
+};
+
+subtest '[azure_fencing_agents_playbook_args] MSI setup' => sub {
+    set_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi');
+    set_var('FENCING_MECHANISM', 'native');
+    my $returned_value = azure_fencing_agents_playbook_args();
+    is $returned_value, '-e azure_identity_management=msi', "Test returned value: $returned_value";
+    set_var('AZURE_FENCE_AGENT_CONFIGURATION', '');
+};
+
+subtest '[azure_fencing_agents_playbook_args] SPN setup' => sub {
+    set_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn');
+    set_var('FENCING_MECHANISM', 'native');
+    my %mandatory_args =
+      ('spn_application_id' => 'GolDRodger', 'spn_application_password' => 'JackSparrow');
+
+    my $expected_result = join(' ',
+        '-e azure_identity_management=spn',
+        "-e spn_application_id=$mandatory_args{spn_application_id}",
+        "-e spn_application_password=$mandatory_args{spn_application_password}",
+    );
+
+    my $returned_value = azure_fencing_agents_playbook_args(%mandatory_args);
+    is $returned_value, $expected_result, "Test returned value:\n$returned_value";
+
+    set_var('AZURE_FENCE_AGENT_CONFIGURATION', '');
+};
+
+subtest '[list_cluster_nodes]' => sub {
+    my $self = sles4sap_publiccloud->new();
+    my @instances = ('Captain_hook', 'CaptainHarlock');
+    $self->{instances} = \@instances;
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
+    $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $crm_node_server_out = "Captain_hook\nCaptainHarlock";
+    $sles4sap_publiccloud->redefine(run_cmd => sub {
+            my ($self, %args) = @_;
+            return 0 if $args{cmd} eq 'crm status';
+            return $crm_node_server_out; }
+    );
+
+    my $node_list = $self->list_cluster_nodes();
+    is ref($node_list), 'ARRAY', 'Func,tion returns array ref.';
+    is @$node_list, @instances, 'Test expected result.';
+
+    $sles4sap_publiccloud->redefine(run_cmd => sub { return 1; });
+    dies_ok { $self->list_cluster_nodes() } 'Expected failure: missing mandatory arg';
+};
+
 done_testing;

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -146,4 +146,84 @@ subtest '[qesap_az_vnet_peering_delete] delete failure' => sub {
     ok((any { /jsc#7487/ } @soft_failure), 'soft failure');
 };
 
+subtest '[qesap_az_setup_native_fencing_permissions]' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    $qesap->redefine(qesap_az_enable_system_assigned_identity => sub { return 'WalkThePlank!'; });
+    $qesap->redefine(qesap_az_assign_role => sub { return 'AyeAyeCaptain!'; });
+    my %mandatory_args = (
+        vm_name => 'CaptainUsop',
+        subscription_id => 'c0ffeeee-c0ff-eeee-1234-123456abcdef',
+        resource_group => 'StrawhatPirates'
+    );
+
+    foreach ('vm_name', 'subscription_id', 'resource_group') {
+        my $orig_value = $mandatory_args{$_};
+        $mandatory_args{$_} = undef;
+        dies_ok { qesap_az_setup_native_fencing_permissions(%mandatory_args) } "Expected failure: missing mandatory arg: $_";
+        $mandatory_args{$_} = $orig_value;
+    }
+
+    ok qesap_az_setup_native_fencing_permissions(%mandatory_args), 'PASS with all args defined';
+};
+
+subtest '[qesap_az_assign_role]' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    $qesap->redefine(assert_script_run => sub { return 1; });
+
+    my %mandatory_args = (
+        assignee => 'CaptainUsop',
+        subscription_id => 'c0ffeeee-c0ff-eeee-1234-123456abcdef',
+        resource_group => 'StrawhatPirates',
+        role => 'Liar'
+    );
+    # check mandatory args
+    foreach ('assignee', 'role', 'subscription_id', 'resource_group') {
+        my $orig_value = $mandatory_args{$_};
+        $mandatory_args{$_} = undef;
+        dies_ok { qesap_az_assign_role(%mandatory_args) } "Expected failure: missing mandatory arg: $_";
+        $mandatory_args{$_} = $orig_value;
+    }
+
+    ok qesap_az_assign_role(%mandatory_args), 'PASS with all args defined';
+};
+
+subtest '[qesap_az_validate_uuid_pattern]' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    $qesap->redefine(diag => sub { return; });
+    my $good_uuid = 'c0ffeeee-c0ff-eeee-1234-123456abcdef';
+    my @bad_uuid_list = ('OhCaptainMyCaptain',    # complete nonsense
+        'c0ffeee-c0ff-eeee-1234-123456abcdef',    # First 7 characters inttead of 8
+        'c0ffeeee-c0ff-eeee-xxxx-123456abcde',    # Using non hexadecimal values 'x'
+        'c0ffeeee_c0ff-eeee-1234-123456abcdef');    # Underscore instead of dash
+
+    is qesap_az_validate_uuid_pattern($good_uuid), $good_uuid, "Return UUID if valid: $good_uuid ";
+
+    foreach my $bad_uuid (@bad_uuid_list) {
+        is qesap_az_validate_uuid_pattern($bad_uuid), 0, "Return '0' with invalid UUID: $bad_uuid";
+    }
+};
+
+subtest '[qesap_az_enable_system_assigned_identity]' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $vm_name = 'CaptainHook';
+    my $resource_group = 'TheJollyRoger';
+    my $good_uuid = 'c0ffeeee-c0ff-eeee-1234-123456abcdef';
+
+    $qesap->redefine(script_output => sub { return $good_uuid; });
+    is qesap_az_enable_system_assigned_identity($vm_name, $resource_group), $good_uuid, 'PASS with valid UUID';
+    # Missing args
+    dies_ok { qesap_az_enable_system_assigned_identity($vm_name) } 'Fail with missing resource group';
+    dies_ok { qesap_az_enable_system_assigned_identity() } 'Fail with missing args';
+};
+
+subtest '[qesap_az_get_tenant_id]' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    dies_ok { qesap_az_get_tenant_id() } 'Expected failure: missing mandatory arg';
+
+    my $valid_uuid = 'c0ffeeee-c0ff-eeee-1234-123456abcdef';
+    $qesap->redefine(script_output => sub { return $valid_uuid; });
+    $qesap->redefine(qesap_az_validate_uuid_pattern => sub { return $valid_uuid; });
+    is qesap_az_get_tenant_id($valid_uuid), 'c0ffeeee-c0ff-eeee-1234-123456abcdef', 'Returned value is a valid UUID';
+};
+
 done_testing;

--- a/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
+++ b/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
@@ -1,0 +1,90 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Test module for azure stonith based fencing agent
+# Settings:
+#   FENCING_MECHANISM - needs to be set  to 'native'
+#   PUBLIC_CLOUD_PROVIDER - needs to be set to 'AZURE'
+#   AZURE_FENCE_AGENT_CONFIGURATION - set to 'msi' or 'spn' (default value: msi)
+#   SPN related settings:
+#       _SECRET_AZURE_SPN_APPLICATION_ID - application ID for fencing agent
+#       _SECRET_AZURE_SPN_APP_PASSWORD - application password used by fencing agent
+
+use strict;
+use warnings FATAL => 'all';
+
+use base 'sles4sap_publiccloud_basetest';
+use serial_terminal 'select_serial_terminal';
+use testapi;
+use sles4sap_publiccloud;
+use qesapdeployment;
+use Data::Dumper;
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    my $instances = $self->{instances} = $run_args->{instances};
+    my $provider_client = $run_args->{instances}[0]{provider}{provider_client};
+    my $fence_agent_configuration = get_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi');
+    my $resource_group = qesap_az_get_resource_group();
+    my $subscription_id = $provider_client->{subscription};
+    my $tenant_id = check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn') ? qesap_az_get_tenant_id($subscription_id) : '';
+    my $spn_application_id = get_var('_SECRET_AZURE_SPN_APPLICATION_ID');
+    my $spn_application_password = get_var('_SECRET_AZURE_SPN_APP_PASSWORD');
+    my @cluster_nodes = @{$self->list_cluster_nodes()};
+
+    die 'Resoruce group not found' unless $resource_group;
+    die 'Tenant ID is required in case of Azure SPN fencing' if check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn') and !$tenant_id;
+    # Setting up credentials as variables so they do not show up in openQA outputs in plaintext
+    my $bashrc_vars = "export SUBSCRIPTION_ID=$subscription_id
+        export TENANT_ID=$tenant_id
+        export SPN_APPLICATION_ID=$spn_application_id
+        export SPN_APP_PASSWORD=$spn_application_password";
+
+    my $fence_agent_cmd = join(' ',
+        'fence_azure_arm',
+        "-C \'\'",
+        '--action=list',
+        "--resourceGroup=$resource_group",
+        '--subscriptionId=$SUBSCRIPTION_ID');
+
+    $fence_agent_cmd = join(' ', $fence_agent_cmd, "--$fence_agent_configuration",) if $fence_agent_configuration eq 'msi';
+    $fence_agent_cmd = join(' ', $fence_agent_cmd,
+        '--username=$SPN_APPLICATION_ID',
+        '--password=$SPN_APP_PASSWORD',
+        '--tenantId=$TENANT_ID') if $fence_agent_configuration eq 'spn';
+
+    select_serial_terminal;
+    # prepare bashrc file - this way credentials ar enot presented in outputs
+    save_tmp_file('bashrc', $bashrc_vars);
+    assert_script_run('curl ' . autoinst_url . '/files/bashrc -o /tmp/bashrc');
+
+    foreach my $instance (@$instances) {
+        $self->{my_instance} = $instance;
+        # do not probe VMs that are nto a part of cluster
+        next unless grep(/^$instance->{instance_id}$/, @cluster_nodes);
+        my $scp_cmd = join('', 'scp /tmp/bashrc ',
+            $instance->{username},
+            '@', $instance->{public_ip},
+            ':/home/',
+            $instance->{username},
+            '/.bashrc');
+        assert_script_run($scp_cmd);
+
+        record_info('Test start', "Running test from $instance->{instance_id}.");
+        my @nodes_ready = split(/[\n\s]/, $self->run_cmd(cmd => $fence_agent_cmd));
+
+        foreach (@cluster_nodes) {
+            die "VM '$_' " . uc($fence_agent_configuration) . ' is not configured correctly.'
+              unless grep /^$_$/, @nodes_ready;
+        }
+        $self->display_full_status();
+    }
+}
+
+1;

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -40,6 +40,12 @@ sub run {
         }
         loadtest('sles4sap/publiccloud/qesap_ansible', name => 'deploy_qesap_ansible', run_args => $run_args, @_);
     }
+    if (check_var('FENCING_MECHANISM', 'native') and check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+        # MSI is preferred method not requiring additional password so it is set to default.
+        my $fence_agent_setup_type = uc(get_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi'));
+        my $test_name = "Verify_azure_fence_agent_($fence_agent_setup_type)";
+        loadtest('sles4sap/publiccloud/azure_fence_agents_test', name => $test_name, run_args => $run_args, @_);
+    }
 }
 
 1;


### PR DESCRIPTION
This PR adds libraries, test and configuration files that enable Azure native fencing on HANAsr test. 

- Related ticket:
https://jira.suse.com/browse/TEAM-8631
https://jira.suse.com/browse/TEAM-8632

- Needles: N/A
- Verification run:
SBD: https://openqaworker15.qa.suse.cz/tests/250569#step/Stop_site_a-primary/7
Native SPN: https://openqaworker15.qa.suse.cz/tests/250572#step/Verify_azure_fence_agent_(SPN)/48
Native MSI: https://openqaworker15.qa.suse.cz/tests/251370#step/Verify_azure_fence_agent_(MSI)/40