### PR TITLE
Add support for systemd-boot as bootloader on MicroOS

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -193,7 +193,7 @@ sub load_transactional_tests {
     loadtest 'microos/patterns' if is_sle_micro;
     loadtest 'transactional/transactional_update';
     loadtest 'transactional/rebootmgr';
-    loadtest 'transactional/health_check';
+    loadtest 'transactional/health_check' if is_bootloader_grub2;    # health-checker needs GRUB2 (poo#129748)
 }
 
 

--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -11,7 +11,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_microos is_selfinstall);
+use version_utils qw(is_microos is_selfinstall is_bootloader_grub2 is_bootloader_sdboot);
 use power_action_utils 'power_action';
 use Utils::Architectures qw(is_aarch64);
 use Utils::Backends qw(is_ipmi);
@@ -45,7 +45,8 @@ sub microos_reboot {
     select_console 'sol', await_console => 0 if is_ipmi();
     # No grub bootloader on xen-pv
     # grub2 needle is unreliable (stalls during timeout) - poo#28648
-    assert_screen 'grub2', 300;
+    assert_screen 'grub2', 300 if is_bootloader_grub2;
+    assert_screen 'systemd-boot', 300 if is_bootloader_sdboot;
     send_key('ret') unless get_var('KEEP_GRUB_TIMEOUT');
     microos_login;
 }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -884,7 +884,7 @@ sub wait_boot {
     # When no bounce back on power KVM, we need skip bootloader process and go ahead when 'displaymanager' matched.
     elsif (get_var('OFW') && (check_screen('displaymanager', 5))) {
     }
-    else {
+    elsif (is_bootloader_grub2) {
         assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600) if (uses_qa_net_hardware() || get_var("PXEBOOT"));
         $self->handle_grub(bootloader_time => $bootloader_time, in_grub => $in_grub);
         # part of soft failure bsc#1118456
@@ -896,6 +896,12 @@ sub wait_boot {
                 send_key 'ret';
             }
         }
+    } elsif (is_bootloader_sdboot) {
+        assert_screen 'systemd-boot', 300;
+        save_screenshot;    # Show what's selected for booting
+        send_key('ret');
+    } else {
+        die 'Unknown bootloader';
     }
     reconnect_xen if check_var('VIRSH_VMM_FAMILY', 'xen');
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -46,6 +46,8 @@ use constant {
           is_openstack
           is_leap_migration
           is_tunneled
+          is_bootloader_grub2
+          is_bootloader_sdboot
           requires_role_selection
           check_version
           get_os_release
@@ -770,6 +772,25 @@ Returns true if TUNNELED is set to 1
 sub is_tunneled {
     return get_var('TUNNELED', 0);
 }
+
+=head2 is_bootloader_grub2
+
+Returns true if the SUT uses GRUB2 as bootloader
+=cut
+
+sub is_bootloader_grub2 {
+    return get_var('BOOTLOADER', 'grub2') eq 'grub2';
+}
+
+=head2 is_bootloader_sdboot
+
+Returns true if the SUT uses systemd-boot as bootloader
+=cut
+
+sub is_bootloader_sdboot {
+    return get_var('BOOTLOADER', 'grub2') eq 'systemd-boot';
+}
+
 
 =head2 has_test_issues
 

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -14,22 +14,30 @@ use testapi;
 use transactional qw(process_reboot);
 use bootloader_setup qw(change_grub_config);
 use utils qw(ensure_ca_certificates_suse_installed zypper_call);
-use version_utils qw(is_alp);
+use version_utils qw(is_alp is_bootloader_grub2 is_bootloader_sdboot);
 
 sub run {
     select_console 'root-console';
 
-    # GRUB Configuration
-    my $keep_grub_timeout = get_var('KEEP_GRUB_TIMEOUT');
+    # Bootloader configuration
     my $extrabootparams = get_var('EXTRABOOTPARAMS');
-    change_grub_config('=\"[^\"]*', "& $extrabootparams", 'GRUB_CMDLINE_LINUX_DEFAULT') if $extrabootparams;
-    $keep_grub_timeout or change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT');
+    my $keep_grub_timeout = get_var('KEEP_GRUB_TIMEOUT');
 
-    if (!$keep_grub_timeout or $extrabootparams) {
-        record_info('GRUB', script_output('cat /etc/default/grub'));
-        assert_script_run('transactional-update grub.cfg');
-        ensure_ca_certificates_suse_installed if get_var('HOST_VERSION');
-        process_reboot(trigger => 1);
+    if (is_bootloader_grub2) {
+        change_grub_config('=\"[^\"]*', "& $extrabootparams", 'GRUB_CMDLINE_LINUX_DEFAULT') if $extrabootparams;
+        $keep_grub_timeout or change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT');
+
+        if (!$keep_grub_timeout or $extrabootparams) {
+            record_info('GRUB', script_output('cat /etc/default/grub'));
+            assert_script_run('transactional-update grub.cfg');
+            ensure_ca_certificates_suse_installed if get_var('HOST_VERSION');
+            process_reboot(trigger => 1);
+        }
+    } elsif (is_bootloader_sdboot) {
+        die 'EXTRABOOTPARAMS not implemented for this bootloader' if $extrabootparams;
+        assert_script_run('bootctl set-timeout menu-force') unless $keep_grub_timeout;
+    } else {
+        die 'Unknown bootloader';
     }
 
     if (is_alp) {

--- a/variables.md
+++ b/variables.md
@@ -33,6 +33,7 @@ BCI_TESTS_BRANCH | string | | Branch to be cloned from bci-tests. Used by `bci_p
 BCI_TIMEOUT | string | | Timeout given to the command to test each environment. Used by `bci_test.pm`.
 BCI_TARGET | string | ibs-cr | Container project to be tested. `ibs-cr` is the CR project, `ibs` is the released images project
 BCI_SKIP | boolean | false | Switch to disable BCI test runs. Necessary for fine-granular test disablement
+BOOTLOADER | string | grub2 | Which bootloader is used by the image (and in the future also: will be selected during installation)
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.
 CASEDIR | string | | Path to the directory which contains tests.


### PR DESCRIPTION
Add two helper functions to version_utils to determine which bootloader is used and make use of those in strategic places.

Implement the minimal amount of functionality needed to make a basic microos test pass.

Needs https://build.opensuse.org/request/show/1118337

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/801
- Verification run: http://10.168.4.192/tests/1375

VR using GRUB: https://openqa.opensuse.org/tests/3652123#live
