### PR TITLE
Add required package 'openssh' to autoyast config file

### DIFF
--- a/data/yam/autoyast/bug-872532_ix64ph1069.xml
+++ b/data/yam/autoyast/bug-872532_ix64ph1069.xml
@@ -672,6 +672,7 @@
       <package>libbtrfs0</package>
       <package>libdconf1</package>
       <package>libgirepository-1_0-1</package>
+      <package>openssh</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-intel</package>

--- a/data/yam/autoyast/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/yam/autoyast/bug-876411_btrfs_h5_autoinst.xml
@@ -705,6 +705,7 @@
       <package>libgirepository-1_0-1</package>
       <package>libvmtools0</package>
       <package>open-vm-tools</package>
+      <package>openssh</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-amd</package>


### PR DESCRIPTION
https://progress.opensuse.org/issues/138080

- Verification run: 

http://openqa.suse.de/tests/12561466
http://openqa.suse.de/tests/12561467

**Please** omit the new failure, it is caused by [bsc#1216283](https://bugzilla.suse.com/show_bug.cgi?id=1216283)