### PR TITLE
Use specified network interface in autoyast profile

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -97,7 +97,12 @@
         <bootproto>dhcp</bootproto>
         <bridge>yes</bridge>
         <bridge_forwarddelay>0</bridge_forwarddelay>
+        <!-- Use specified interface instead of a list to avoid ip lease inconsistency. Please refer to poo#135641. -->
+        % if ($check_var->('SUT_NETDEVICE', 'eth1') or $check_var->('SUT_NETDEVICE', 'em1')) {
+        <bridge_ports><%= $get_var->('SUT_NETDEVICE') %></bridge_ports>
+        % } else {
         <bridge_ports>eth0 eth1 em1 em2</bridge_ports>
+        % }
         <bridge_stp>off</bridge_stp>
         <startmode>auto</startmode>
       </interface>


### PR DESCRIPTION
* **Some** SUT machines do not use default network interface, for example, eth0. 

* **In** order to have virtualization bridge interface correctly configured, it is better to use specified interface in bridge_ports instead of just using a list of ports that can be available, which may lead to ip lease inconsistency.

* **The** [failure](https://10.145.10.207/tests/12549852#step/login_console/7) looks like this. After modifying config for br0 by only keeping ```eth1``` in bridge_ports, the machine can get correct ip and hostname.

* **Verification runs:**
  * Manual verification passed
  * [Passed on machine uses default interface](https://openqa.suse.de/tests/12561537)
  * [Passed on machine uses eth1 interface](https://openqa.suse.de/tests/12561720)
