### PR TITLE
Fix Tumbleweed virtualization test for modular libvirt

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use Utils::Architectures;
 use utils;
+use virt_autotest::utils qw(restart_libvirtd);
 
 sub run {
     x11_start_program('xterm');
@@ -49,17 +50,8 @@ sub run {
     x11_start_program('xterm');
     wait_screen_change { send_key 'alt-f10' };
     become_root;
-    systemctl 'start libvirtd', timeout => 60;
+    restart_libvirtd;
     wait_screen_change { send_key 'ret' };
-    systemctl 'status libvirtd', timeout => 60;
-    # manually start the 'default' network if it is not active
-    if (script_run("virsh net-info default |& grep '^Active.*no'") == 0) {
-        record_soft_failure 'bsc#1123699';
-        record_info("start default network", "libvirtd did not start the
-            network by default. See
-            https://bugzilla.opensuse.org/show_bug.cgi?id=1123699");
-        assert_script_run("virsh net-start default");
-    }
     send_key 'ret';
     # close the xterm
     send_key 'alt-f4';


### PR DESCRIPTION
**Fix test failures in yast_virtualization for modular libvirt**

- Description:
This Pull Request addresses the test failures in the yast_virtualization module for the modular libvirt setup. The main goal is to make the tests green again.

Reuse the modular libvirt in virt_autotest::utils.pm and restart the modular libvirt. Some daemons are started by default but some daemons are required to be started manually.

- Related ticket: https://progress.opensuse.org/issues/133862
- Verification run: 
https://openqa.opensuse.org/tests/3675096 
https://openqa.opensuse.org/tests/3677738
https://openqa.opensuse.org/tests/3677786


- Latest runs:
https://openqa.opensuse.org/tests/3678860#step/yast_virtualization/61
https://openqa.opensuse.org/tests/3678868
https://openqa.opensuse.org/tests/3679617#
