### PR TITLE
Install qa_lib_virtauto on upgraded host explicitly

### DIFF
--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -29,7 +29,7 @@ sub run {
     my $self = shift;
 
     #Install qa test repo
-    if ((is_x86_64 || is_aarch64) && is_sle('=12-SP5', get_var('VERSION_TO_INSTALL')) && is_sle('>=15-SP2', get_var('TARGET_DEVELOPING_VERSION'))) {
+    if ((is_x86_64 || is_aarch64) && is_sle('>=15-SP2', get_var('TARGET_DEVELOPING_VERSION'))) {
         my ($upgrade_release) = lc(get_required_var('UPGRADE_PRODUCT')) =~ /sles-([0-9]+-sp[0-9]+)/;
         my $qa_test_repo = 'http://dist.nue.suse.com/ibs/QA:/Head/SLE-' . uc($upgrade_release);
         script_run("zypper rm -n -y qa_lib_virtauto", 300);


### PR DESCRIPTION
* **After** upgrade, dependency packages might be changed, so the package relying on them might not be preserved.

* **Package** qa_lib_virtauto is not official suse product to be involved in dependency resolving during upgrade. It needs to be installed explicitly on upgraded host to prevent missing script or library file, otherwise test run may fail like [this](https://openqa.suse.de/tests/12550171#step/host_upgrade_step3_run/39).

* **Verification runs:**
  * [15sp5 to 15sp6 kvm](https://openqa.suse.de/tests/12568284)
  * [15sp5 to 15sp6 xen](https://openqa.suse.de/tests/12568285)
  * [12sp5 to 15sp6 xen](https://openqa.suse.de/tests/12568283)
  * [12sp5 to 15sp6 kvm](https://openqa.suse.de/tests/12614941)
  * Verification with the latest Build26.14 can not be done due to [bsc#1216349](https://bugzilla.suse.com/show_bug.cgi?id=1216349)