### PR TITLE
Fix qesap log grep

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -444,7 +444,8 @@ sub qesap_execute {
 sub qesap_file_find_string {
     my (%args) = @_;
     foreach (qw(file search_string)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-    return script_run("grep \"$args{search_string}\" $args{file}");
+    my $ret = script_run("grep \"$args{search_string}\" $args{file}");
+    return $ret == 0 ? 1 : 0;
 }
 
 =head3 qesap_get_inventory

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -378,10 +378,10 @@ subtest '[qesap_file_find_string] success' => sub {
     # internally the function is using grep to search for a specific
     # error string. Here the result of the grep.
     my $log = 'ERROR    OUTPUT:              "msg": "Timed out waiting for last boot time check (timeout=600)",';
-    # Create a mock to replace the script_output
+    # Create a mock to replace the script_run
     # The mock will return, within the function under test,
-    # the result of the grep.
-    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 1; });
+    # the result of the grep. grep return 0 in case of string match
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
 
     my $res = qesap_file_find_string(file => 'JACQUES', search_string => 'Timed out waiting for last boot time check');
 
@@ -398,7 +398,8 @@ subtest '[qesap_file_find_string] fail' => sub {
     # The mock will return, within the function under test,
     # the result of the grep.
     # Here simulate that the grep does not return any match
-    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    # grep return 1 in case of string NOT matching
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 1; });
 
     my $res = qesap_file_find_string(file => 'JACQUES', search_string => 'Timed out waiting for last boot time check');
 


### PR DESCRIPTION
Fix logic of qesap_file_find_string about grep exit code in case of match.

Related to bug in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17903

- Related ticket: [TEAM-8593](https://jira.suse.com/browse/TEAM-8593)

# Verification run:
All VR with a simulated failure use https://github.com/SUSE/qe-sap-deployment/pull/184

## No failure
http://openqaworker15.qa.suse.cz/tests/248633 No qesap.py failure [this code version](https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/65487c871b4991e98744a600198f05fcd21b47aa..e18e95e16aacf92edcb0c3ef9ae7550830f697d5)

## Simulate non zero rc with `timeout` error message
 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/248684
 Timeout error properly detected in the Ansible log http://openqaworker15.qa.suse.cz/tests/248684#step/deploy/47
 :green_circle: 
 
