### PR TITLE
Add logname argument to qesap_execut

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -384,7 +384,7 @@ sub qesap_yaml_replace {
     https://github.com/SUSE/qe-sap-deployment
     Test only returns execution result, failure has to be handled by calling method.
 
-=over 4
+=over 5
 
 =item B<CMD> - qesap.py subcommand to run
 
@@ -393,6 +393,10 @@ sub qesap_yaml_replace {
 =item B<VERBOSE> - activate verbosity in qesap.py
 
 =item B<TIMEOUT> - max expected execution time
+
+=item B<LOGNAME> - filename of the log file. This argument is optional,
+                   if not specified the log filename is internally calculated
+                   using content from CMD and CMD_OPTIONS.
 =back
 =cut
 
@@ -403,10 +407,16 @@ sub qesap_execute {
     $args{cmd_options} ||= '';
 
     my %paths = qesap_get_file_paths();
-    my $exec_log = "/tmp/qesap_exec_$args{cmd}";
-    $exec_log .= "_$args{cmd_options}" if ($args{cmd_options});
-    $exec_log .= '.log.txt';
-    $exec_log =~ s/[-\s]+/_/g;
+    my $exec_log = '/tmp/';
+    if ($args{logname})
+    {
+        $exec_log .= $args{logname};
+    } else {
+        $exec_log .= "qesap_exec_$args{cmd}";
+        $exec_log .= "_$args{cmd_options}" if ($args{cmd_options});
+        $exec_log .= '.log.txt';
+        $exec_log =~ s/[-\s]+/_/g;
+    }
 
     my $qesap_cmd = join(' ', QESAPDEPLOY_PY, $paths{deployment_dir} . '/scripts/qesap/qesap.py',
         $verbose,

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -26,7 +26,9 @@ sub run {
     {
         if (qesap_file_find_string(file => $ret[1], search_string => 'Missing sudo password')) {
             record_info('DETECTED ANSIBLE MISSING SUDO PASSWORD ERROR');
-            @ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
+            @ret = qesap_execute(cmd => 'ansible',
+                logname => 'qesap_ansible_retry.log.txt',
+                timeout => 3600);
             if ($ret[0])
             {
                 qesap_cluster_logs();
@@ -37,9 +39,15 @@ sub run {
         elsif (qesap_file_find_string(file => $ret[1], search_string => 'Timed out waiting for last boot time check')) {
             record_info('DETECTED ANSIBLE TIMEOUT ERROR');
             $self->clean_up();
-            @ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => 1800);
+            @ret = qesap_execute(cmd => 'terraform',
+                verbose => 1,
+                logname => 'qesap_terraform_retry.log.txt',
+                timeout => 1800);
             die "'qesap.py terraform' return: $ret[0]" if ($ret[0]);
-            @ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
+            @ret = qesap_execute(cmd => 'ansible',
+                verbose => 1,
+                logname => 'qesap_ansible_retry.log.txt',
+                timeout => 3600);
             if ($ret[0])
             {
                 qesap_cluster_logs();


### PR DESCRIPTION
Add argument to allow the user to specify a specific filename for the log.
Use this new argument in qesap regression deployment retry.

- Related ticket:  https://jira.suse.com/browse/TEAM-8479 and https://jira.suse.com/browse/TEAM-8006

# Verification run: 

## no failure no retry

 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit -> http://openqaworker15.qa.suse.cz/tests/249491
