### PR TITLE
Get NETDEV from the SUT in certain s390x scenarios

### DIFF
--- a/tests/security/cc/ipsec/ipsec_client.pm
+++ b/tests/security/cc/ipsec/ipsec_client.pm
@@ -16,6 +16,7 @@ use audit_test;
 use atsec_test;
 use Utils::Architectures;
 use lockapi;
+use network_utils 'iface';
 
 sub run {
     my ($self) = @_;
@@ -23,7 +24,7 @@ sub run {
 
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV.
-    my $netdev = get_var('NETDEV', 'eth0');
+    my $netdev = iface;
     assert_script_run("ip addr add $atsec_test::client_ip/24 dev $netdev") if (is_s390x);
 
     assert_script_run("cd $audit_test::test_dir/ipsec_configuration/toe");

--- a/tests/security/cc/ipsec/ipsec_server.pm
+++ b/tests/security/cc/ipsec/ipsec_server.pm
@@ -17,6 +17,7 @@ use atsec_test;
 use Utils::Architectures;
 use lockapi;
 use mmapi 'get_children';
+use network_utils 'iface';
 
 sub run {
     my ($self) = @_;
@@ -24,7 +25,7 @@ sub run {
 
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV.
-    my $netdev = get_var('NETDEV', 'eth0');
+    my $netdev = iface;
     assert_script_run("ip addr add $atsec_test::server_ip/24 dev $netdev") if (is_s390x);
 
     assert_script_run("cd $audit_test::test_dir/ipsec_configuration/server");

--- a/tests/security/mariadb/mariadb_ssl_client.pm
+++ b/tests/security/mariadb/mariadb_ssl_client.pm
@@ -14,6 +14,7 @@ use testapi;
 use utils;
 use Utils::Architectures;
 use lockapi;
+use network_utils 'iface';
 
 sub run {
     my ($self) = @_;
@@ -28,7 +29,7 @@ sub run {
 
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV.
-    my $netdev = get_var('NETDEV', 'eth0');
+    my $netdev = iface;
     assert_script_run("ip addr add $client_ip/24 dev $netdev") if (is_s390x);
 
     zypper_call('in mariadb');

--- a/tests/security/mariadb/mariadb_ssl_server.pm
+++ b/tests/security/mariadb/mariadb_ssl_server.pm
@@ -15,6 +15,7 @@ use utils;
 use Utils::Architectures;
 use lockapi;
 use mmapi 'wait_for_children';
+use network_utils 'iface';
 
 sub run {
     my ($self) = @_;
@@ -27,7 +28,7 @@ sub run {
 
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV.
-    my $netdev = get_var('NETDEV', 'eth0');
+    my $netdev = iface;
     assert_script_run("ip addr add $server_ip/24 dev $netdev") if (is_s390x);
     systemctl("stop firewalld") if (is_s390x);
 

--- a/tests/security/postgresql_ssl/postgresql_ssl_client.pm
+++ b/tests/security/postgresql_ssl/postgresql_ssl_client.pm
@@ -14,6 +14,7 @@ use testapi;
 use utils;
 use Utils::Architectures;
 use lockapi;
+use network_utils 'iface';
 
 sub run {
     my ($self) = @_;
@@ -27,7 +28,7 @@ sub run {
 
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV
-    my $netdev = get_var('NETDEV', 'eth0');
+    my $netdev = iface;
     assert_script_run("ip addr add $client_ip/24 dev $netdev") if (is_s390x);
     systemctl("stop firewalld");
 

--- a/tests/security/postgresql_ssl/postgresql_ssl_server.pm
+++ b/tests/security/postgresql_ssl/postgresql_ssl_server.pm
@@ -15,6 +15,7 @@ use utils;
 use Utils::Architectures;
 use lockapi;
 use mmapi 'wait_for_children';
+use network_utils 'iface';
 
 sub run {
     my ($self) = @_;
@@ -28,7 +29,7 @@ sub run {
 
     # We don't run setup_multimachine in s390x, but we need to know the server and client's
     # ip address, so we add a known ip to NETDEV
-    my $netdev = get_var('NETDEV', 'eth0');
+    my $netdev = iface;
     assert_script_run("ip addr add $server_ip/24 dev $netdev") if (is_s390x);
     systemctl("stop firewalld");
 


### PR DESCRIPTION
NETDEV is referring to the if name on the hypervisor (which is vlan2114 in this case) it would
be best for the test to grab it from the SUT directly.

- Related ticket: [poo#137711](https://progress.opensuse.org/issues/137711)
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=jknphy%2Fos-autoinst-distri-opensuse%23netdev
