### PR TITLE
Disable auto-install second stage for sles12 host installation

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -53,6 +53,12 @@
     <ask-list config:type="list"/>
     <mode>
       <confirm config:type="boolean">false</confirm>
+      <!-- Introduce WITHOUT_AUTOYAST_SECOND_STAGE to disable second stage to avoid configuration error of uninitialized interface -->
+      % if ($check_var->('WITHOUT_AUTOYAST_SECOND_STAGE', '1')) {
+      <second_stage config:type="boolean">false</second_stage>
+      % } else {
+      <second_stage config:type="boolean">true</second_stage>
+      % }
     </mode>
     <proposals config:type="list"/>
     <signature-handling>
@@ -91,6 +97,7 @@
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
     <managed config:type="boolean">false</managed>
+    <virt_bridge_proposal config:type="boolean">true</virt_bridge_proposal>
     <interfaces config:type="list">
       <interface>
         <device>br0</device>


### PR DESCRIPTION
* **Configuration** error: uninitialized interface can be seen during sles12sp5 host autoyast installation, please see [here](https://openqa.suse.de/tests/12561583#step/installation/6).

* **The** error has nothing to do with any inactive or down interfaces. On the contrary, error reported on available interface.

* **By** the way, although automation tells "Error detected during first stage of the installation", this is an error reported during second stage of autoyast installation actually.

* **Disable** auto-install second stage for sles12sp5 host installation to avoid configuration error of uninitialized interface can be seen during configuring lan in second stage.

* **Experiment** shows that disabling second stage will get rid of this error with gonzo machine, because all three consecutive verification runs passed autoyast installation without error which is a significant improvement compared with previous almost 100% reproducibility.

* **In** order to be compatible with various scenarios of autoyast installation, introducing parameter ```WITHOUT_AUTOYAST_SECOND_STAGE``` to determine whether second stage is needed. For those 12sp5 xen tests do not use second stage, setting ```XEN_DEFAULT_BOOT_IS_SET``` to 0.

* **Also** set ```virt_bridge_proposal``` to ```true```  to always have bridge interface setup on virtualization host.

* **Verification Runs:**
  * [12sp5 autoyast installation (without second stage) with gonzo](https://openqa.suse.de/tests/12589628)
  * [guest install on 12sp5 kvm with second stage](https://openqa.suse.de/tests/12614833)
  * [guest install on 12sp5 kvm without second stage](https://openqa.suse.de/tests/12659116)
  * [guest install on 12sp5 xen without second stage](https://openqa.suse.de/tests/12659117)
  * [uefi guest install on 12sp5 kvm without second stage](https://openqa.suse.de/tests/12659120)
  * [uefi guest install on 12sp5 xen without second stage](https://openqa.suse.de/tests/12659133)
  * [host upgrade 12sp5 to 15sp6 kvm without second stage](https://openqa.suse.de/tests/12659118)
  * [host upgrade 12sp5 to 15sp6 xen without second stage](https://openqa.suse.de/tests/12659119)
  * [guest upgrade on 12sp5 kvm host without second stage](https://openqa.suse.de/tests/12659531)
  * [guest upgrade on 12sp5 xen host without second stage](https://openqa.suse.de/tests/12659123)