### PR TITLE
Add installation/configure_sdboot module to select systemd-boot

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -101,7 +101,8 @@ sub load_installation_tests {
     } else {
         loadtest 'installation/installation_overview';
     }
-    loadtest 'installation/disable_grub_timeout';
+    loadtest 'installation/disable_grub_timeout' if is_bootloader_grub2;
+    loadtest 'installation/configure_sdboot' if is_bootloader_sdboot;
     loadtest 'installation/enable_selinux' if get_var('ENABLE_SELINUX');
     loadtest 'installation/start_install';
     loadtest 'installation/await_install';

--- a/tests/installation/configure_sdboot.pm
+++ b/tests/installation/configure_sdboot.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Select systemd-boot in the installer
+# Maintainer: Fabian Vogt <fvogt@suse.com>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = shift;
+
+    # Verify Installation Settings overview is displayed as starting point
+    assert_screen "installation-settings-overview-loaded", 90;
+
+    if (check_var('VIDEOMODE', 'text')) {
+        # Select section booting on Installation Settings overview on text mode
+        send_key $cmd{change};
+        assert_screen 'inst-overview-options';
+        send_key 'alt-b';
+    }
+    else {
+        # Select section booting on Installation Settings overview (video mode)
+        send_key_until_needlematch 'booting-section-selected', 'tab', 26, 1;
+        send_key 'ret';
+    }
+
+    assert_screen 'inst-bootloader-settings';
+
+    # Select systemd-boot as bootloader
+    send_key 'alt-b', wait_screen_change => 1;
+    send_key 'spc', wait_screen_change => 1;
+    send_key_until_needlematch 'inst-bootloader-systemd-boot-selected', 'down';
+    send_key 'ret', wait_screen_change => 1;    # Select the option
+    send_key 'ret', wait_screen_change => 1;    # Acknowledge the warning that this is WIP
+
+    unless (get_var('KEEP_GRUB_TIMEOUT')) {
+        assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
+        # Depending on an optional button "release notes" we need to press "tab"
+        # to go to the first tab
+        send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
+
+        send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right', 20, 2;
+        assert_screen 'installation-bootloader-options';
+        # Select Timeout dropdown box and disable
+        send_key 'alt-t';
+        # "-1" does not work and "menu-force" is not accepted, so use something else for the time being as workaround
+        record_soft_failure "boo#1216366: Disabling the timeout is not possible";
+        type_string "42";
+
+        wait_still_screen(1);
+        save_screenshot;
+        # ncurses uses blocking modal dialog, so press return is needed
+        send_key 'ret' if check_var('VIDEOMODE', 'text');
+    }
+
+    send_key $cmd{ok};
+    # Adapting system setting needs longer time in case of installing/upgrading with multi-addons
+    assert_screen 'installation-settings-overview-loaded', 220;
+}
+
+1;


### PR DESCRIPTION
If BOOTLOADER is set to systemd-boot, this module is scheduled and selects
systemd-boot instead of GRUB2 during installation with YaST.

The module code was based on installation/disable_grub_timeout.

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/802
- Verification runs: http://10.168.4.192/tests/1383 (textmode) http://10.168.4.192/tests/1381 (graphical)

They fail because of dep issues (hopefully) fixed by https://build.opensuse.org/request/show/1118843
