### PR TITLE
Add peering clean to peering jobs

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -33,6 +33,7 @@ sub run {
         }
         loadtest('sles4sap/publiccloud/qesap_terraform', name => 'deploy_qesap_terraform', run_args => $run_args, @_);
         if (check_var('IS_MAINTENANCE', 1)) {
+            loadtest('sles4sap/publiccloud/clean_leftover_peerings', name => 'clean_leftover_peerings', run_args => $run_args, @_);
             loadtest('sles4sap/publiccloud/network_peering', name => 'network_peering', run_args => $run_args, @_);
             loadtest('sles4sap/publiccloud/add_server_to_hosts', name => 'add_server_to_hosts', run_args => $run_args, @_);
             loadtest('sles4sap/publiccloud/cluster_add_repos', name => 'cluster_add_repos', run_args => $run_args, @_);


### PR DESCRIPTION
Adds the old peering cleanup module to the rest of the IBSM jobs on OSD.
- Related ticket: https://jira.suse.com/browse/TEAM-8671
- Verification run: 
https://openqa.suse.de/tests/12572929
https://openqa.suse.de/tests/12572949

(failures unrelated to new module)
