### PR TITLE
Add qesap regression fencing controllable config.

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
@@ -1,0 +1,52 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'aws'
+apiver: 3
+terraform:
+  variables:
+    aws_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    os_owner: '%OS_OWNER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    aws_credentials: '/root/amazon_credentials'
+    hana_instancetype: '%HANA_INSTANCE_TYPE%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    hana_cluster_fencing_mechanism: '%FENCING%'
+    drbd_cluster_fencing_mechanism: '%FENCING%'
+    netweaver_cluster_fencing_mechanism: '%FENCING%'
+ansible:
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HDB'
+    sap_hana_install_instance_number: '00'
+    sap_domain: 'qe-test.example.com'
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+  create:
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address=testing@suse.com
+    - fully-patch-system.yaml
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml
+  destroy:
+    - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'gcp'
+apiver: 3
+terraform:
+  variables:
+    project: 'ei-sle-qa-sap-8469'
+    region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    private_key: '%SSH_KEY_PRIV%'
+    public_key: '%SSH_KEY_PUB%'
+    gcp_credentials_file: '/root/google_credentials.json'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    hana_data_disk_type: '%HANA_DATA_DISK_TYPE%'
+    hana_log_disk_type: '%HANA_LOG_DISK_TYPE%'
+    hana_cluster_fencing_mechanism: '%FENCING%'
+    drbd_cluster_fencing_mechanism: '%FENCING%'
+    netweaver_cluster_fencing_mechanism: '%FENCING%'
+ansible:
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HDB'
+    sap_hana_install_instance_number: '00'
+    sap_domain: 'qe-test.example.com'
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+  create:
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - fully-patch-system.yaml
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml
+  destroy:
+    - deregister.yaml

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -46,19 +46,20 @@ sub run {
 
     $variables{HANA_ACCOUNT} = get_required_var('QESAPDEPLOY_HANA_ACCOUNT');
     $variables{HANA_CONTAINER} = get_required_var('QESAPDEPLOY_HANA_CONTAINER');
-    if (get_var("QESAPDEPLOY_HANA_TOKEN")) {
+    if (get_var('QESAPDEPLOY_HANA_TOKEN')) {
         $variables{HANA_TOKEN} = get_required_var('QESAPDEPLOY_HANA_TOKEN');
         # escape needed by 'sed'
         # but not implemented in file_content_replace() yet poo#120690
         $variables{HANA_TOKEN} =~ s/\&/\\\&/g;
     }
-    $variables{HANA_SAR} = get_required_var("QESAPDEPLOY_SAPCAR");
-    $variables{HANA_CLIENT_SAR} = get_required_var("QESAPDEPLOY_IMDB_CLIENT");
-    $variables{HANA_SAPCAR} = get_required_var("QESAPDEPLOY_IMDB_SERVER");
-    $variables{ANSIBLE_REMOTE_PYTHON} = get_var("QESAPDEPLOY_ANSIBLE_REMOTE_PYTHON", "/usr/bin/python3");
+    $variables{HANA_SAR} = get_required_var('QESAPDEPLOY_SAPCAR');
+    $variables{HANA_CLIENT_SAR} = get_required_var('QESAPDEPLOY_IMDB_CLIENT');
+    $variables{HANA_SAPCAR} = get_required_var('QESAPDEPLOY_IMDB_SERVER');
+    $variables{ANSIBLE_REMOTE_PYTHON} = get_var('QESAPDEPLOY_ANSIBLE_REMOTE_PYTHON', '/usr/bin/python3');
+    $variables{FENCING} = get_var('QESAPDEPLOY_FENCING', '');
     if (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE')) {
-        $variables{HANA_DATA_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DISK_TYPE", "pd-ssd");
-        $variables{HANA_LOG_DISK_TYPE} = get_var("QESAPDEPLOY_HANA_DISK_TYPE", "pd-ssd");
+        $variables{HANA_DATA_DISK_TYPE} = get_var('QESAPDEPLOY_HANA_DISK_TYPE', 'pd-ssd');
+        $variables{HANA_LOG_DISK_TYPE} = get_var('QESAPDEPLOY_HANA_DISK_TYPE', 'pd-ssd');
     }
 
     if (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {


### PR DESCRIPTION
Add AWS and CGP config.yaml with terraform vars to control fencing and not using `-e use_sbd=false`.
Add QESAPDEPLOY_FENCING setting to control the config.yaml content.

# Verification run

## Azure
 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/250528 :green_circle: job failure is the same of cloned job, generated conf.yaml is fine.

this VR does not use any new .yaml file from this PR. It is mostly to check that change in `tests/sles4sap/qesapdeploy/configure.pm` does not interfere with existing jobs

## AWS

### Native
Triggered with:
- `QESAP_CONFIG_FILE=qesap_aws_fencing.yaml` the new conf.yaml file
- `QESAPDEPLOY_FENCING='native'` the new setting

 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/250529

### Sbd
Triggered with:
- `QESAP_CONFIG_FILE=qesap_aws_fencing.yaml` the new conf.yaml file
- `QESAPDEPLOY_FENCING='sbd'` the new setting

 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/250530

Generated [conf.yaml](http://openqaworker15.qa.suse.cz/tests/250530/file/configure-qesap_aws_fencing.yaml) has

```
    hana_cluster_fencing_mechanism: 'sbd'
    drbd_cluster_fencing_mechanism: 'sbd'
    netweaver_cluster_fencing_mechanism: 'sbd'
```
Generated [terraform.tfvars](http://openqaworker15.qa.suse.cz/tests/250530/file/configure-terraform.tfvars) has the same

Terraform runs without error

Generated [inventory.yaml](http://openqaworker15.qa.suse.cz/tests/250530/file/deploy-inventory.yaml) has
```
all:
  vars:
    use_sbd: true
```

Ansible runs without errors

`crm status` at the end is

```
tatus of pacemakerd: 'Pacemaker is running' (last updated 2023-10-19 12:55:15Z)
Cluster Summary:
  * Stack: corosync
  * Current DC: vmhana01 (version 2.1.5+20221208.a3f44794f-150500.6.5.8-2.1.5+20221208.a3f44794f) - partition with quorum
  * Last updated: Thu Oct 19 12:55:16 2023
  * Last change:  Thu Oct 19 12:54:44 2023 by root via crm_attribute on vmhana02
  * 2 nodes configured
  * 6 resource instances configured

Node List:
  * Online: [ vmhana01 vmhana02 ]

Full List of Resources:
  * rsc_iscsi_sbd	(stonith:external/sbd):	 Stopped
  * rsc_ip_HDB_HDB00	(ocf::suse:aws-vpc-move-ip):	 Started vmhana01
  * Clone Set: cln_SAPHanaTopology_HDB_HDB00 [rsc_SAPHanaTopology_HDB_HDB00]:
    * Started: [ vmhana01 vmhana02 ]
  * Clone Set: msl_SAPHana_HDB_HDB00 [rsc_SAPHana_HDB_HDB00] (promotable):
    * rsc_SAPHana_HDB_HDB00	(ocf::suse:SAPHana):	 Starting vmhana02
    * Slaves: [ vmhana01 ]

Failed Resource Actions:
  * rsc_iscsi_sbd_start_0 on vmhana02 'error' (1): call=10, status='complete', last-rc-change='Thu Oct 19 12:48:52 2023', queued=0ms, exec=3084ms
  * rsc_iscsi_sbd_start_0 on vmhana01 'error' (1): call=9, status='complete', last-rc-change='Thu Oct 19 12:48:47 2023', queued=0ms, exec=3139ms
[32mINFO[0m: SSH key for hacluster does not exist, hence generate it now
```

## GCP

### Native
sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/250531  :green_circle: 
  
Triggered with:
- `QESAP_CONFIG_FILE=qesap_gcp_fencing.yaml` the new conf.yaml file
- `QESAPDEPLOY_FENCING='native'` the new setting

content of generated [qesap_gcp_fencing.yaml](http://openqaworker15.qa.suse.cz/tests/250531/file/configure-qesap_gcp_fencing.yaml) is fine

```
    hana_cluster_fencing_mechanism: 'native'
    drbd_cluster_fencing_mechanism: 'native'
    netweaver_cluster_fencing_mechanism: 'native'
```

They are properly propagated to the generated [terraform.tfvars](http://openqaworker15.qa.suse.cz/tests/250531/file/configure-terraform.tfvars)

Terraform execution is ok http://openqaworker15.qa.suse.cz/tests/250531/file/configure-terraform.tfvars 
iscsi VM is not deployed

Ansible fails http://openqaworker15.qa.suse.cz/tests/250531/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt during the execution of `sap-hana-cluster.yaml` playbook. Failure is in `TASK [Configure cluster IP [gcp]]`. It is a known issue  and this PR is to have a test to monitor it   

### Sbd
 sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/250532


Triggered with:
- `QESAP_CONFIG_FILE=qesap_gcp_fencing.yaml` the new conf.yaml file
- `QESAPDEPLOY_FENCING='sbd'` the new setting

[conf.yaml](http://openqaworker15.qa.suse.cz/tests/250532/file/configure-qesap_gcp_fencing.yaml) is properly generated with 

```
    hana_cluster_fencing_mechanism: 'sbd'
    drbd_cluster_fencing_mechanism: 'sbd'
    netweaver_cluster_fencing_mechanism: 'sbd'
```

[terraform.tfvars](http://openqaworker15.qa.suse.cz/tests/250532/file/configure-terraform.tfvars) has them too

Terraform execution is [ok](http://openqaworker15.qa.suse.cz/tests/250532/logfile?filename=deploy-qesap_exec_terraform.log.txt)

Generated [inventory.yaml](http://openqaworker15.qa.suse.cz/tests/250532/file/deploy-inventory.yaml) has

```
all:
  vars:
    use_sbd: true
```

Ansible [fails](http://openqaworker15.qa.suse.cz/tests/250532/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt) failf in task `TASK [../roles/qe_sap_storage : SAP Storage Preparation - Prepare Volume Groups and Logical Volumes]` like 

```
ERROR    OUTPUT:          fatal: [qesapval250532-vmhana01]: FAILED! => {
ERROR    OUTPUT:              "msg": "{'hanadata': {'name': 'hanadata', 'directory': '/hana/data', 'vg': 'hanadatavg', 'lv': 'hanadatalv', 'pv': ['/dev/disk/by-id/google-{{ prefix }}-hana-data'], 'numluns': '1', 'stripesize': ''}, 'hanalog': {'name': 'hanalog', 'directory': '/hana/log', 'vg': 'hanalogvg', 'lv': 'hanaloglv', 'pv': ['/dev/disk/by-id/google-{{ prefix }}-hana-log'], 'numluns': '1', 'stripesize': ''}, 'hanashared': {'name': 'hanashared', 'directory': '/hana/shared', 'vg': 'hanasharedvg', 'lv': 'hanasharedlv', 'pv': ['/dev/disk/by-id/google-{{ prefix }}-hana-shared'], 'numluns': '1', 'stripesize': ''}, 'usrsap': {'name': 'usrsap', 'directory': '/usr/sap', 'vg': 'usrsapvg', 'lv': 'usrsaplv', 'pv': ['/dev/disk/by-id/google-{{ prefix }}-usr-sap'], 'numluns': '1', 'stripesize': ''}, 'backup': {'name': 'backup', 'directory': '/backup', 'vg': 'backupvg', 'lv': 'backuplv', 'pv': ['/dev/disk/by-id/google-{{ prefix }}-hana-backup'], 'numluns': '1', 'stripesize': ''}, 'install': {'name': 'install', 'directory': '/hana/install', 'vg': 'installvg', 'lv': 'installlv', 'pv': ['/dev/disk/by-id/google-{{ prefix }}-hana-software'], 'numluns': '1', 'stripesize': ''}}: 'prefix' is undefined"
```

Probably a `qe-sap-deployment` bug around https://github.com/SUSE/qe-sap-deployment/blob/main/ansible/playbooks/vars/gcp_hana_storage_profile.yaml or https://github.com/SUSE/qe-sap-deployment/pull/133 as the inventory has `prefix` here

```
all:
  children:
    iscsi:
      vars:
        prefix: qesapval250532
```

but not here
```
all:
  children:
    hana:
```

