### PR TITLE
BCI tests failed-steps status changed from softfail to fail.

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -36,15 +36,16 @@ sub run_tox_cmd {
     $cmd .= " -k \"$bci_marker\"" if $bci_marker;
     $cmd .= " --reruns $bci_reruns --reruns-delay $bci_reruns_delay";
     $cmd .= "| tee $tox_out";
-    record_info("tox", "Running command: $cmd");
+    my $env_info = (split(/[ _:-]/, $env))[0];    # first word on many separators,to shorten long $env
+    record_info("tox " . $env_info, "Running command: $cmd");
     script_run("set -o pipefail");    # required because we don't want to rely on consoletest_setup for BCI tests.
     my $ret = script_run("timeout $bci_timeout $cmd", timeout => ($bci_timeout + 3));
     if ($ret == 124) {
         # man timeout: If  the command times out, and --preserve-status is not set, then exit with status 124.
-        record_info('Softfail', "The command <tox -e $env> timed out.", result => 'softfail');
+        record_info('TIMEOUT', "The command <tox -e $env> timed out.", result => 'fail');
         $error_count += 1;
     } elsif ($ret != 0) {
-        record_info('Softfail', "The command <tox -e $env> failed.", result => 'softfail');
+        record_info('FAILED', "The command <tox -e $env> failed.", result => 'fail');
         $error_count += 1;
     } else {
         record_info('PASSED');


### PR DESCRIPTION
BCI test run 2 or more steps of tox runs that, when fail, report in the webgui `no fail` and only in a final collecting phase all failed steps as enumerated in a single one only failure box. So on the web report it is not easy to identify the previous failed step.

Scope of this PR is to change from _softfailed_ to **failed** the report box of a **tox failed step**, more evident and helpful in debugging analysis.

- Verification runs of code updated:
  - http://mdati-openqa.qe.suse.de/tests/665
  - clone of https://openqa.suse.de/tests/12570974

  - failed step VR
  - 
    - http://mdati-openqa.qe.suse.de/tests/665#step/bci_test_docker/33
    - http://mdati-openqa.qe.suse.de/tests/665#step/bci_test_docker/40
  - failed step cloned
    - https://openqa.suse.de/tests/12570974#step/bci_test_docker/33
    - https://openqa.suse.de/tests/12570974#step/bci_test_docker/40

  - passed step VR
    - http://mdati-openqa.qe.suse.de/tests/665#step/bci_test_podman/47
    - http://mdati-openqa.qe.suse.de/tests/665#step/bci_test_podman/54

  - passed step cloned
    - https://openqa.suse.de/tests/12570974#step/bci_test_docker/47
    - https://openqa.suse.de/tests/12570974#step/bci_test_docker/54

  - final fail VR
    - http://mdati-openqa.qe.suse.de/tests/665#step/bci_test_podman/62
  - final fail cloned
    - https://openqa.suse.de/tests/12570974#step/bci_test_docker/62

- other VRs:
  - http://mdati-openqa.qe.suse.de/tests/666
    - clone of http://openqa.suse.de/tests/12579333   
  - http://mdati-openqa.qe.suse.de/tests/668
    - clone of http://openqa.suse.de/tests/12579025


