### PR TITLE
Remove check_screen for nvidia in autoyast installation

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -284,12 +284,6 @@ sub run {
             @needles = grep { $_ ne 'autoyast-postpartscript' } @needles;
             $postpartscript = 1;
         }
-        elsif (check_screen('nvidia-validation-failed', 5) && check_var('BETA', '1')) {
-            # nvidia repo might be not ready in beta phase
-            record_soft_failure 'bsc#1144831';
-            wait_still_screen { send_key 'alt-o' };
-            send_key 'alt-n';
-        }
         elsif (match_has_tag('autoyast-error')) {
             die 'Error detected during first stage of the installation';
         }


### PR DESCRIPTION
This part is not needed and will cause timing issue for autoyast installation.

- Failed job: https://openqa.suse.de/tests/12568901#
- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.nue.suse.com/tests/12574240#step/svirt_upload_assets/8
