### PR TITLE
Deprecating openldap2 test in favor of `389ds` functional tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1746,7 +1746,7 @@ sub load_extra_tests_console {
     loadtest 'console/vhostmd' unless get_var('PUBLIC_CLOUD');
     loadtest 'console/rpcbind' unless is_jeos;
     # sysauth test scenarios run in the console
-    loadtest "sysauth/sssd" if (get_var('SYSAUTHTEST') || is_sle('12-SP5+'));
+    loadtest "sysauth/sssd" if (get_var('SYSAUTHTEST') || (is_sle('12-SP5+') && is_sle('<=15-SP3')));
     loadtest 'console/timezone';
     loadtest 'console/ntp' if is_sle('<15');
     loadtest 'console/procps';


### PR DESCRIPTION
`openldap2` was deprecated as of SLE-15-SP4, `389ds` is the supported alternative.

Limiting the test execution to run only until SLE-SP3.

- Deprecation Announced in SP2 [0].
- Announced Removal in SP4 [1].

For the still valid products, this will support #16176 to run properly.

`389ds` functional tests are equivalent enough to the test that will be disabled in >=SP4.

Addresses poo#120028 [2].

[0]: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP2/index.html#jsc-SLE-16552
[1]: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP4/index.html
[2]: https://progress.opensuse.org/issues/120028

- Related ticket: https://progress.opensuse.org/issues/120028
- Verification run:  TBD ~openqa.mypersonalinstance.de/tests/xyz#step/module/x~
