### PR TITLE
Disable ipv6 only on SLE Micro

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -295,7 +295,7 @@ sub check_containers_connectivity {
     record_info "connectivity", "Checking that containers can connect to the host, to each other and outside of the host";
     my $container_name = 'sut_container';
 
-    if (script_run('ping -6 -c 2 google.com') != 0) {
+    if (script_run('ping -6 -c 2 google.com') != 0 && is_sle_micro) {
         record_info('Disable ipv6', 'https://sd.suse.com/servicedesk/customer/portal/1/SD-135489', result => 'softfail');
         assert_script_run 'sysctl -w net.ipv6.conf.all.disable_ipv6=1';
     }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/138260 https://progress.opensuse.org/issues/138296
- Verification run: 
https://openqa.suse.de/tests/12597969 EC2 x86_64
https://openqa.suse.de/tests/12597973 EC2 aarch64
https://openqa.suse.de/tests/12597972 SLE micro