### PR TITLE
Cleanup cache after unloading /usr/sbin/nscd profile

### DIFF
--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -40,11 +40,11 @@ sub run {
     };
 
     # Check the test files exist, double check to avoid perfomance issue
-    my $ret = script_run "ls -1 $test_binfiles > tee /dev/$serialdev";
+    my $ret = script_run "ls -1 $test_binfiles | tee /dev/$serialdev";
     if ($ret) {
         # If failed try sync and then check again
         assert_script_run "sync";
-        assert_script_run "ls -1 $test_binfiles > tee /dev/$serialdev";
+        assert_script_run "ls -1 $test_binfiles | tee /dev/$serialdev";
     }
 
     script_run_interactive(
@@ -60,11 +60,11 @@ sub run {
 
     # Output generated profiles list to serial console
     # Check the new genrated test files exist, double check to avoid perfomance issue
-    $ret = script_run "ls -1 $aa_tmp_prof/*pam* > tee /dev/$serialdev";
+    $ret = script_run "ls -1 $aa_tmp_prof/*pam* | tee /dev/$serialdev";
     if ($ret) {
         # If failed then try sync and then check again
         assert_script_run "sync";
-        assert_script_run "ls -1 $aa_tmp_prof/*pam* > tee /dev/$serialdev";
+        assert_script_run "ls -1 $aa_tmp_prof/*pam* | tee /dev/$serialdev";
     }
 
     assert_script_run "aa-disable -d $aa_tmp_prof usr.sbin.nscd";

--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -69,6 +69,12 @@ sub run {
 
     assert_script_run "aa-disable -d $aa_tmp_prof usr.sbin.nscd";
     $self->aa_tmp_prof_clean("$aa_tmp_prof");
+
+    assert_script_run "aa-status | tee /dev/$serialdev";
+
+    # delete cache file of aa-autodep generated profile, so that the next reload creates a fresh cache of /etc/apparmor.d/usr.sbin.nscd
+    # (wouldn't happen without deleting the cache file because the cache timestamp is newer than the profile (+ used abstractions) timestamp)
+    assert_script_run "rm -v /var/cache/apparmor/*/usr.sbin.nscd";
 }
 
 1;

--- a/tests/security/apparmor/aa_logprof.pm
+++ b/tests/security/apparmor/aa_logprof.pm
@@ -54,13 +54,11 @@ sub run {
 
     validate_script_output "aa-complain -d $aa_tmp_prof usr.sbin.nscd", sub { m/Setting.*complain/ };
 
-    # For tumbleweed, unload /usr/sbin/nscd profile in case, clean up the audit.log
-    if (is_tumbleweed) {
-        script_run "echo '/usr/sbin/nscd {}' | apparmor_parser -R";
-    }
     assert_script_run "echo > $log_file";
 
     systemctl('start nscd');
+
+    assert_script_run "aa-status | tee /dev/$serialdev";
 
     # Upload audit.log for reference
     upload_logs "$log_file";


### PR DESCRIPTION
This is needed because the cache file has a newer timestamp than the
profile in /etc/apparmor.d/. Otherwise the next relaod (in
lib/apparmortest.pm pre_run_hook()) would load the cached /usr/sbin/nscd
profile as created by aa-autodep.

The shipped profile that gets loaded (and is expected to be used) in the
aa-logprof test is named 'nscd' (without the path), therefore it won't
replace the /usr/sbin/nscd profile when it gets loaded.

The final result was that nscd was running under the wrong profile
(/usr/sbin/nscd from the cache), and therefore didn't create any log
entries for the 'nscd' profile.

With this fixed, we can also remove the workaround that was added to
cover this test bug in Tumbleweed for the last two years.

Note: I intentionally left some aa-status calls in the tests. They make
it much easier to verify that the expected profiles are loaded, and that
all processes run under the expected profile.

Fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1215856

While on it, also do another minor fix:

aa-autodep tests: Make sure output gets displayed instead of redirecting it into a file named 'tee'

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1215856
- Needles: n/a
- Verification run: https://openqa.opensuse.org/tests/3662635