### PR TITLE
Fix the issue when removing hanaonkvm test

### DIFF
--- a/tests/kernel_performance/full_run.pm
+++ b/tests/kernel_performance/full_run.pm
@@ -36,7 +36,8 @@ sub full_run {
     if (my $skip_cases = get_var('SKIP_M_CASES')) {
         foreach my $case (split(/,/, $skip_cases)) {
             record_info("Skip testing case $case in PROJECT_M");
-            script_run("sed -i '/$case/d' $list_path/list");
+            script_run("sed -i '/^workload.*$case/d' $list_path/list");
+            script_run("sed -i '/^_func:.*$case/d' $list_path/list");
         }
     }
 


### PR DESCRIPTION
When skipping case 'hanaonkvm' from the list file, we need to remove calling the function for creating VM.
Verification run: http://10.67.129.4/tests/68969
