### PR TITLE
Fixed return value verification

### DIFF
--- a/tests/wsl/update_windows.pm
+++ b/tests/wsl/update_windows.pm
@@ -19,7 +19,7 @@ sub run {
         cmd => 'cd \\; $port.WriteLine($(cscript .\\UpdateInstall.vbs /Automate))',
         code => sub {
             die("Update script finished unespectedly or timed out...")
-              unless wait_serial("The update process finished with value 1", timeout => 3600);
+              unless wait_serial('The update process finished with value \d+\S+', timeout => 3600);
         }
     );
     save_screenshot;


### PR DESCRIPTION
The return code of the vbs script could be a 0 or 1, but in the answer there's only 1 checked. Added some regexp to check any of them

- Verification run: https://openqa.opensuse.org/tests/3667154
