### PR TITLE
installation/configure_sdboot: Really make sure the inst overview loaded

### DIFF
--- a/tests/installation/configure_sdboot.pm
+++ b/tests/installation/configure_sdboot.pm
@@ -60,8 +60,10 @@ sub run {
     }
 
     send_key $cmd{ok};
-    # Adapting system setting needs longer time in case of installing/upgrading with multi-addons
+    # It doesn't immediately notice that the overview needs recalculation.
+    # Give it some time to make sure that it's fully loaded.
+    assert_screen 'installation-settings-overview-loaded', 220;
+    wait_still_screen 3;
     assert_screen 'installation-settings-overview-loaded', 220;
 }
-
 1;


### PR DESCRIPTION
Otherwise it tries to start the installation before it's been recalculated.

Failure: https://openqa.opensuse.org/tests/3662819#step/start_install/3

VRS:
https://openqa.opensuse.org/tests/3667342
https://openqa.opensuse.org/tests/3667343
https://openqa.opensuse.org/tests/3667344