### PR TITLE
svirt: Assert text-logged-in-root after password

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -897,6 +897,7 @@ sub activate_console {
     elsif ($console eq 'svirt' || $console eq 'hyperv-intermediary') {
         my $os_type = (check_var('VIRSH_VMM_FAMILY', 'hyperv') && $console eq 'svirt') ? 'windows' : 'linux';
         handle_password_prompt($console);
+        assert_screen('text-logged-in-root', 60);
         $self->set_standard_prompt('root', os_type => $os_type, skip_set_standard_prompt => $args{skip_set_standard_prompt});
         save_svirt_pty;
     }


### PR DESCRIPTION
- Related ticket: https://openqa.suse.de/tests/12626798#step/bootloader_svirt/4
- Verification run: https://openqa.suse.de/tests/12627204