### PR TITLE
wicked: cleanup ifreload-3.sh

### DIFF
--- a/data/wicked/ifreload-3.sh
+++ b/data/wicked/ifreload-3.sh
@@ -713,7 +713,7 @@ cleanup()
 	echo "-----------------------------------"
 	wicked ifstatus all
 	echo "-----------------------------------"
-	brctl show
+	show_bridges
 	echo "-----------------------------------"
 	ls -l /var/run/wicked/nanny/
 	echo "==================================="


### PR DESCRIPTION
`brctl` from `bridge-utils` isn't installed by default.