### PR TITLE
Remove useless dns setting in autoyast

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -107,14 +107,6 @@
         <startmode>auto</startmode>
       </interface>
     </interfaces>
-    <dns>
-      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
-      <nameservers config:type="list">
-        <nameserver>10.162.0.1</nameserver>
-<!--gonzo and a another machine can not get nameserver from local dns server after autoyast installation. Put a static nameserver option above. If nameserver is retrived from dhcp they will be merged. Otherwise use the static -->
-      </nameservers>
-      <resolv_conf_policy>auto</resolv_conf_policy>
-    </dns>
   </networking>
   <partitioning config:type="list">
   % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'unreal2' => 'wwn-0x55cd2e415081e693', 'unreal3' => 'wwn-0x55cd2e4150817d43', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x6f4ee0801165fe0029a9209ce8d20dfd'};


### PR DESCRIPTION
* **Remove** useless dns setting in autoyast profile for sles12, because incorrect ip address of bridge issue is fixed by pr#18011 and the dns becomes unavailable after machine relocation.

* **Verification Runs:**
  * [12sp5 kvm host](https://openqa.suse.de/tests/12633068)
  * [12sp5 xen host](https://openqa.suse.de/tests/12633093)