### PR TITLE
Xen PV VMs are without usb

### DIFF
--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -13,6 +13,7 @@ use serial_terminal 'select_serial_terminal';
 use utils qw(validate_script_output_retry);
 use containers::utils qw(reset_container_network_if_needed);
 use Utils::Architectures;
+use Utils::Backends qw(is_xen_pv);
 use version_utils qw(is_public_cloud is_sle);
 use utils qw(script_retry);
 
@@ -31,8 +32,10 @@ sub run {
     record_info('Test', 'Launch a container with privileged mode');
 
     # /dev is only accessible in privileged mode
+    # xen-pv does not define USB passthrough in the xml as of now
+    # this feature has to be added -> https://progress.opensuse.org/issues/138410
     assert_script_run("$runtime run --rm $image bash -c '! test -d /dev/bus'");
-    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus") unless (is_s390x || is_public_cloud);
+    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus") unless (is_s390x || is_public_cloud || is_xen_pv);
 
     # Mounting tmpfs only works in privileged mode because the read-only protection in the default mode
     assert_script_run("$runtime run --rm --privileged $image mount -t tmpfs none /mnt");


### PR DESCRIPTION
`/dev/bus/` is missing in Xen PV VMs as we do not create VMs with usb passthrough.

- ticket: https://progress.opensuse.org/issues/135518
- Verification run: http://kepler.suse.cz/tests/22040#step/docker_privileged_mode/41
