### PR TITLE
Fix hanaSR crm_mon "no inactive resources" failure

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -657,7 +657,11 @@ sub check_cluster_state {
     my $cmd = (defined $args{proceed_on_failure} && $args{proceed_on_failure} == 1) ? \&script_run : \&assert_script_run;
 
     $cmd->("$crm_mon_cmd");
-    $cmd->("$crm_mon_cmd | grep -i 'no inactive resources'") if is_sle '12-sp3+';
+    if (is_sle '12-sp3+') {
+        # Add sleep as command 'crm_mon' outputs 'Inactive resources:' instead of 'no inactive resources' on 12-sp5
+        sleep 5;
+        $cmd->("$crm_mon_cmd | grep -i 'no inactive resources'");
+    }
     $cmd->('crm_mon -1 | grep \'partition with quorum\'');
     # In older versions, node names in crm node list output are followed by ": normal". In newer ones by ": member"
     $cmd->(q/crm_mon -s | grep "$(crm node list | grep -E -c ': member|: normal') nodes online"/);


### PR DESCRIPTION
Fix SAPHanaSR_ScaleUp_PerfOpt_node01 command "crm_mon" failure: "no inactive resources" failure

TEAM-8696 - [SAPHanaSR_ScaleUp_PerfOpt_node01] test module "sap_suse_cluster_connector" failed on: command 'crm_mon -R -r -n -N -1 | grep -i 'no inactive resources''

- Related ticket: https://jira.suse.com/browse/TEAM-8696
- Needles: NA
- Verification run (tried 2 times all passed):
https://openqa.suse.de/tests/12633869#step/sap_suse_cluster_connector/234 (passed)
https://openqa.suse.de/tests/12633872#step/sap_suse_cluster_connector/237 (passed)