### PR TITLE
12-SP5: kube-client is in PCM module

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -149,7 +149,10 @@ sub install_kubectl {
     }
 
     # kubectl is in the container module
-    add_suseconnect_product(get_addon_fullname('contm')) if (is_sle);
+    if (is_sle) {
+        add_suseconnect_product(get_addon_fullname('contm'));
+        add_suseconnect_product(get_addon_fullname('pcm'), '12') if is_sle('=12-sp5');
+    }
     my $k8s_pkg = get_var('K8S_CLIENT', 'kubernetes-client-provider');
     if (!get_var('K8S_CLIENT') && (is_sle || is_sle_micro)) {
         die '"K8S_CLIENT" was not set in test suite definition';

--- a/tests/containers/kubectl.pm
+++ b/tests/containers/kubectl.pm
@@ -22,7 +22,8 @@ sub run {
 
     install_kubectl();
     # Record kubectl version and check if the tool itself is healthy
-    record_info("kubectl", script_output("kubectl version --client --output=json"));
+    record_info("kubectl", script_output(
+            sprintf('kubectl version --client %s', is_sle('=12-sp5') ? "" : "--output=json")));
 
     # Prepare the webserver testdata
     assert_script_run('mkdir -p /srv/www/kubectl');


### PR DESCRIPTION
Minor adjustments in order to test kube-client in 12-SP5. Please merge after https://bugzilla.suse.com/show_bug.cgi?id=1216540 is fixed

- Verification run: [buggy](http://kepler.suse.cz/tests/22050#step/kubectl/156)
