### PR TITLE
Remove useless static nameserver in sle15 autoyast template

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -96,14 +96,6 @@
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
     <backend>wicked</backend>
-    <dns>
-      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
-      <nameservers config:type="list">
-        <nameserver>10.162.0.1</nameserver>
-<!--gonzo and a another machine can not get nameserver from local dns server after autoyast installation. Put a static nameserver option above. If nameserver is retrived from dhcp they will be merged. Otherwise use the static -->
-      </nameservers>
-      <resolv_conf_policy>auto</resolv_conf_policy>
-    </dns>
     <virt_bridge_proposal config:type="boolean">true</virt_bridge_proposal>
   </networking>
   <ntp-client>

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -158,7 +158,7 @@ sub prepare_host {
     #install required packages on host
     zypper_call '-t in pciutils nmap';    #to run 'lspci' and 'nmap' command
 
-    #check VT-d is supported in Intel x86_64 machines
+    #check IOMMU based on VT-d is supported in Intel x86_64 machines
     if (script_run("grep Intel /proc/cpuinfo") == 0) {
         assert_script_run "dmesg | grep -E \"DMAR:.*IOMMU enabled\"";
     }
@@ -400,7 +400,7 @@ sub save_network_device_status_logs {
 
     #logging device information in guest
     my $debug_script = "sriov_network_guest_logging.sh";
-    download_script($debug_script, machine => $vm) if (${test_step} eq "1-initial");
+    download_script($debug_script, machine => $vm, proceed_on_failure => 1) if (${test_step} eq "1-initial");
     script_run("ssh root\@$vm \"~/$debug_script\" >> $log_file 2>&1", die_on_timeout => 0);
 
     script_run "mv $log_file $log_dir/${vm}_${test_step}_network_device_status.txt";

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -195,7 +195,7 @@ sub post_fail_hook {
     foreach my $guest (keys %virt_autotest::common::guests) {
         my $log_file = $log_dir . "/$guest" . "_irqbalance_debug";
         my $debug_script = "xen_irqbalance_guest_logging.sh";
-        download_script_and_execute($debug_script, machine => $guest, output_file => $log_file);
+        download_script_and_execute($debug_script, machine => $guest, output_file => $log_file, proceed_on_failure => 1);
     }
     upload_virt_logs($log_dir, "irqbalance_debug");
     $self->SUPER::post_fail_hook;


### PR DESCRIPTION
- Continue test even if logging script fail to be downloaded, take this case as example, https://openqa.suse.de/tests/12803055#step/sriov_network_card_pci_passthrough/147. Not sure the root of the dns problem, but test should continue even if no logs are uploaded. The failure could not be reproduced, it might be fixed by the other commit in this PR, or the dns resolution failure could occurred sporatically.
- Remove useless static nameserver in sle15. The nameserver was removed from sle12 host via https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18055

- Related ticket: https://progress.opensuse.org/issues/150848

Verification run:
https://openqa.suse.de/tests/12822812#step/sriov_network_card_pci_passthrough/149   //a simulated dns failure
https://openqa.suse.de/tests/12815611
https://openqa.suse.de/tests/12815613
https://openqa.suse.de/tests/12816981
https://openqa.suse.de/tests/12822714
https://openqa.suse.de/tests/12815601
