### PR TITLE
Split io_uring and bpftrace tests from kernel extra tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2526,12 +2526,6 @@ sub load_extra_tests_syscontainer {
 }
 
 sub load_extra_tests_kernel {
-    if (is_tumbleweed || is_sle('>=15-sp5')) {
-        loadtest "kernel/bpftrace";
-        loadtest "kernel/bcc";
-        loadtest "kernel/io_uring";
-    }
-
     loadtest "kernel/tuned";
     loadtest "kernel/fwupd" if is_sle('15+');
 

--- a/schedule/kernel/bpftools.yaml
+++ b/schedule/kernel/bpftools.yaml
@@ -1,0 +1,8 @@
+name:          bpftools
+description:    >
+    Compile and attach eBPF probes with bpftrace and BCC tools
+schedule:
+    - boot/boot_to_desktop
+    - kernel/bpftrace
+    - kernel/bcc
+    - shutdown/shutdown

--- a/schedule/kernel/io_uring.yaml
+++ b/schedule/kernel/io_uring.yaml
@@ -1,0 +1,7 @@
+name:          io_uring
+description:    >
+    Test module to run liburing testing suite.
+schedule:
+    - boot/boot_to_desktop
+    - kernel/io_uring
+    - shutdown/shutdown


### PR DESCRIPTION
These tests modules are so far scheduled as kernal extra tests (on OSD via the test suites `extra_tests_kernel` and `extra_tests_kernel_spvm`). This change moves them to YAML schedule files so the can be scheduled via their own test suites (`io_uring` and `bpftrace` on OSD).

Related ticket: https://progress.opensuse.org/issues/138407