### PR TITLE
Add back name in `agama_installation.yaml`

### DIFF
--- a/schedule/yam/agama/agama_installation.yaml
+++ b/schedule/yam/agama/agama_installation.yaml
@@ -1,4 +1,5 @@
 ---
+name: agama_installation
 description: >
   Playwright test on agama
 schedule:


### PR DESCRIPTION
The name was removed by 97c613a132377909d480bbc18187569b39206bc6 without further explanation. It is likely a mistake because it causes the YAML validation to fail (technically it still succeeds despite the error but that is another problem):

```
$ make test-yaml-valid
tools/check_yaml
not ok 1694 - schedule/yam/agama/agama_installation.yaml has invalid schema
#   Failed test 'schedule/yam/agama/agama_installation.yaml has invalid schema'
#   at tools/test_yaml_valid line 42.
# Error: /name: Missing property.
1..2833
# Looks like you failed 1 test of 2833.
check_yaml SUCCESS
```