### PR TITLE
Add target to check documentation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ test-compile-changed: os-autoinst/
 test_pod_whitespace_rule:
 	tools/check_pod_whitespace_rule
 
+.PHONY: test_pod_errors
+test_pod_errors:
+	tools/check_pod_errors
+
 .PHONY: test-yaml-valid
 test-yaml-valid:
 	tools/check_yaml
@@ -103,7 +107,7 @@ test-spec:
 	tools/update_spec --check
 
 .PHONY: test-static
-test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax test-code-style test-metadata test_pod_whitespace_rule
+test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax test-code-style test-metadata test_pod_whitespace_rule test_pod_errors
 
 .PHONY: test
 ifeq ($(TESTS),compile)

--- a/lib/YuiRestClient/Widget/Tree.pm
+++ b/lib/YuiRestClient/Widget/Tree.pm
@@ -136,5 +136,6 @@ Args has 2 named parameters:
 
 The path parameter is used for recursion in this function. 
 
+=back
 =cut
 

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1205,6 +1205,7 @@ sub check_iscsi_failure {
 =head3 cluster_status_matches_regex
 
 Check crm status output against a hardcode regular expression in order to check the cluster health 
+
 =over 1
 
 =item B<SHOW_CLUSTER_STATUS> - Output from 'crm status' command

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -403,6 +403,7 @@ sub qesap_yaml_replace {
 =item B<LOGNAME> - filename of the log file. This argument is optional,
                    if not specified the log filename is internally calculated
                    using content from CMD and CMD_OPTIONS.
+
 =back
 =cut
 
@@ -454,6 +455,7 @@ sub qesap_execute {
 =item B<FILE> - Path to the Ansible log file. (Required)
 
 =item B<SEARCH_STRING> - String to search for in the log file. (Required)
+
 =back
 =cut
 
@@ -966,6 +968,7 @@ sub qesap_wait_for_ssh {
 =item B<PROVIDER> - Cloud provider name, used to find the inventory
 
 =item B<FAILOK> - if not set, Ansible failure result in die
+
 =back
 =cut
 
@@ -1067,6 +1070,7 @@ sub qesap_cluster_logs {
 =head3 qesap_az_get_vnet
 
 Return the output of az network vnet list
+
 =over 1
 
 =item B<RESOURCE_GROUP> - resource group name to query

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -105,7 +105,7 @@ constant values for Trento tests
 =head2 Methods
 =cut
 
-=hean3 clone_trento_deployment
+=head3 clone_trento_deployment
 
 Clone gitlab.suse.de/qa-css/trento
 
@@ -237,6 +237,7 @@ sub get_resource_group {
 =head3 cluster_config
 
 Create a variable map and prepare the qe-sap-deployment using it
+
 =over 3
 
 =item B<PROVIDER> - CloudProvider name
@@ -859,6 +860,7 @@ sub cluster_wait_status {
 =head3 cluster_wait_status_by_regex
 
 Remotely run 'SAPHanaSR-showAttr' in a loop on $host, wait output that matches regular expression
+
 =over 3
 
 =item B<HOST> - Ansible name or filter for the remote host where to run 'SAPHanaSR-showAttr'

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -157,7 +157,7 @@ sub is_rescuesystem {
 
 =head2 is_virtualization_server
 
-Returns true if called on a virutalization server
+Returns true if called on a virtualization server
 =cut
 
 sub is_virtualization_server {
@@ -177,7 +177,7 @@ sub is_livecd {
 
 Usage: check_version('>15.0', get_var('VERSION'), '\d{2}')
 Query format: [= > < >= <=] version [+] (Example: <=12-sp3 =12-sp1 <4.0 >=15 3.0+)
-Check agains: product version to check against - probably get_var('VERSION')
+Check against: product version to check against - probably get_var('VERSION')
 Regex format: checks query version format (Example: /\d{2}\.\d/)#
 =cut
 
@@ -685,7 +685,7 @@ It parses the info from /etc/os-release file, which can reside in any physical h
 The file can also be placed anywhere as long as it can be reached somehow by its absolute file path,
 which should be passed in as the second argument os_release_file, for example, "/etc/os-release"
 At the same time, connection method to the entity in which the file reside should be passed in as the
-firt argument go_to_target, for example, "ssh root at name or ip address" or "way to download the file"
+first argument go_to_target, for example, "ssh root at name or ip address" or "way to download the file"
 For use only on locahost, no argument needs to be specified
 =cut
 
@@ -705,25 +705,19 @@ sub get_os_release {
 
 Identify running os without any dependencies parsing the I</etc/os-release>.
 
-=item C<distri_name>
+=over 4
 
-The expected distribution name to compare.
+=item C<distri_name> - The expected distribution name to compare.
 
-=item C<line>
+=item C<line> - The line we'll be parsing and checking.
 
-The line we'll be parsing and checking.
+=item C<go_to_target> - Command connecting to the SUT
 
-=item C<go_to_target>
-
-Command connecting to the SUT
-
-=item C<os_release_file>
-
-The full path to the Operating system identification file.
-Default to I</etc/os-release>.
+=item C<os_release_file> - The full path to the Operating system identification file. Default to I</etc/os-release>.
 
 Returns 1 (true) if the ID_LIKE variable contains C<distri_name>.
 
+=back
 =cut
 
 sub check_os_release {
@@ -857,7 +851,7 @@ sub package_version_cmp {
 
 =head2 is_quarterly_iso
 
-Returns true if called in quaterly iso testing
+Returns true if called in quarterly iso testing
 =cut
 
 sub is_quarterly_iso {

--- a/tools/check_pod_errors
+++ b/tools/check_pod_errors
@@ -1,0 +1,39 @@
+#!/bin/bash
+<< 'heredoc_pod_error_rule'
+The script checks that no POD error are present in any changed file.
+heredoc_pod_error_rule
+
+libs_files=$(git ls-files lib/ | grep '.pm$' | xargs echo)
+tmpfile=$(mktemp)
+tmperrorfile=$(mktemp)
+
+success=1
+if test -n "$libs_files"; then
+    for libfile in $libs_files; do
+        perldoc -T -D "${libfile}" 2>/dev/null 1>"$tmpfile"
+        grep -q "POD ERRORS" "$tmpfile" || continue
+
+        success=0
+        # search if the perdoc output is reporting any error
+        error_line=$(grep -n "POD ERRORS" "$tmpfile" | sed -n '$s/:.*//p')
+        # extract the error message from perldoc output
+        sed -n "$error_line,\$"p "$tmpfile" > "$tmperrorfile"
+        if [[ -n "${GITHUB_ACTIONS}" ]]; then
+            echo "::error file=${libfile}::perldoc ERRORS"
+            # add a notification for each error in the file
+            awk '/Around line/ {          # search for lines containing "Around line"
+                   match($0, /[0-9]+/);   # extract the line number of the error
+                   getline nextline;      # read the error description from the next line
+                   gsub(/^[ \t]+/, "", nextline);  # remove leading whitespace from the error message
+                   print "::error file='"${libfile}"',line="substr($0, RSTART, RLENGTH)"::"nextline;  # print in a github action compliant way
+                }' "$tmperrorfile"
+        else
+            echo "ERROR in file ${libfile}"
+            cat "$tmperrorfile"
+        fi
+    done
+else
+    echo "No lib files.";
+fi
+[ $success = 1 ] && echo "POD ERROR CHECK SUCCESS" && exit 0
+exit 1


### PR DESCRIPTION
Run perldoc and check for error in the documentation format. 
Add a make target about it.
Fix some documentation error.

Related ticket: https://progress.opensuse.org/issues/138521

This check is about spotting error otherwise visible in the official documentation: have a look at the end of https://os-autoinst.github.io/os-autoinst-distri-opensuse/qesapdeployment.html

Time for the target execution (on my laptop)

```
% time make test_pod_errors

tools/check_pod_errors
POD ERROR CHECK SUCCESS
make test_pod_errors  26.29s user 6.74s system 99% cpu 33.079 total
```


The overall script works like:
1. get a list of `.pm` files in the `lib/` folder using `git ls-files lib/` 
2. for each file run `perldoc -T -D "${libfile}"`
In case of no issue it print out the documentation on the stdout
```  qesap_az_get_tenant_id
        qesap_az_get_tenant_id( subscription_id=>$subscription_id )

        Returns tenant ID related to the specified subscription ID.
        subscription_id - valid azure subscription

  qesap_az_validate_uuid_pattern
        qesap_az_validate_uuid_pattern( uuid_string=>$uuid_string )

        Function checks input string against uuid pattern which is commonly used as an identifier for azure resources.
        returns uuid (true) on match, 0 (false) on mismatch.
```
exit code is 0

In case of problems, it keeps printing on the stdout all the documentation, but it ass the error report at the end
```
qesap_az_validate_uuid_pattern
        qesap_az_validate_uuid_pattern( uuid_string=>$uuid_string )

        Function checks input string against uuid pattern which is commonly used as an identifier for azure resources.
        returns uuid (true) on match, 0 (false) on mismatch.

    *

POD ERRORS
    Hey! The above document had some coding errors, which are explained
    below:

    Around line 1941:
        '=item' outside of any '=over'

        =over without closing =back
```
Exit code is always 0 also in case of error

3. the script look for `POD ERRORS` 
4. if it finds that, it mark the file as problematic and get the line of it in the stdout where the error report start
5. the script extracts and prints the error report
6. if there's at least one file with an error report, the script return a not zero value

- Verification run: tool executed by this PR github pipeline

The script create a different output format if executed within a github action

```
% export GITHUB_ACTIONS=1 
 
% ./tools/check_pod_errors

480:POD ERRORS
::error file=lib/qesapdeployment.pm::POD ERRORS
::error file=lib/qesapdeployment.pm,line=1941:        '=item' outside of any '=over'
```