### PR TITLE
Remove unsused absolutize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ testing" && exit 2)
 
 tools/tidy: os-autoinst/
 	@test -e tools/tidy || ln -s ../os-autoinst/tools/tidy tools/
-	@test -e tools/absolutize || ln -s ../os-autoinst/tools/absolutize tools/
 	@test -e .perltidyrc || ln -s os-autoinst/.perltidyrc ./
 
 tools/lib/: os-autoinst/


### PR DESCRIPTION
This is a follow up to os-autoinst/os-autoinst#2396

