### PR TITLE
LTP: Move exporting LTP_ENV to a separate function

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -21,6 +21,7 @@ use repo_tools 'add_qa_head_repo';
 use utils;
 
 our @EXPORT = qw(
+  export_ltp_env
   get_ltproot
   get_ltp_openposix_test_list_file
   get_ltp_version_file
@@ -137,11 +138,17 @@ sub log_versions {
     script_run('aa-enabled; aa-status');
 }
 
+sub export_ltp_env {
+    my $ltp_env = get_var('LTP_ENV');
+
+    if ($ltp_env) {
+        $ltp_env =~ s/,/ /g;
+        script_run("export $ltp_env");
+    }
+}
 
 # Set up basic shell environment for running LTP tests
 sub prepare_ltp_env {
-    my $ltp_env = get_var('LTP_ENV');
-
     assert_script_run('export LTPROOT=' . get_ltproot() . '; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 
     # setup for LTP networking tests
@@ -150,11 +157,6 @@ sub prepare_ltp_env {
     my $block_dev = get_var('LTP_BIG_DEV');
     if ($block_dev && get_var('NUMDISKS') > 1) {
         assert_script_run("lsblk -la; export LTP_BIG_DEV=$block_dev");
-    }
-
-    if ($ltp_env) {
-        $ltp_env =~ s/,/ /g;
-        script_run("export $ltp_env");
     }
 
     assert_script_run('cd $LTPROOT/testcases/bin');

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -42,6 +42,8 @@ sub run {
 
     select_serial_terminal;
 
+    export_ltp_env;
+
     # Debug code for poo#81142
     script_run('gzip -9 </dev/fb0 >framebuffer.dat.gz');
     upload_logs('framebuffer.dat.gz', failok => 1);

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -303,6 +303,8 @@ sub run {
 
     select_serial_terminal;
 
+    export_ltp_env;
+
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
         script_run('echo 1 > /sys/module/printk/parameters/time');
         $grub_param .= ' printk.time=1';


### PR DESCRIPTION
Move LTP_ENV from prepare_ltp_env() to newly created export_ltp_env(). This function is called in both boot_ltp.pm (which previously used this code) and install_ltp.pm (new now).

The only effect should be that passing variables can be used also in install_ltp.pm. One can therefore now pass compiler flags (e.g. CFLAGS).

Also, using "env" is a bit confusing as it can mean "setup environment" (i.e. in prepare_ltp_env()) or "environment variable" export_ltp_env(). Maybe we should rename the functions.

Verification run:
- http://quasar.suse.cz/tests/3055 (note various info boxes, e.g. http://quasar.suse.cz/tests/3055#step/install_ltp/124, vs. the original code, which does not have info boxes: http://quasar.suse.cz/tests/3054). Tested on broken LTP - before fix https://github.com/linux-test-project/ltp/commit/063825edb78158da4a2d1ab981f6f792b84ca712)
