### PR TITLE
Fix hyperv svirt needle issue

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -897,7 +897,6 @@ sub activate_console {
     elsif ($console eq 'svirt' || $console eq 'hyperv-intermediary') {
         my $os_type = (check_var('VIRSH_VMM_FAMILY', 'hyperv') && $console eq 'svirt') ? 'windows' : 'linux';
         handle_password_prompt($console);
-        assert_screen('text-logged-in-root', 60);
         $self->set_standard_prompt('root', os_type => $os_type, skip_set_standard_prompt => $args{skip_set_standard_prompt});
         save_svirt_pty;
     }


### PR DESCRIPTION
Progress ticket: https://progress.opensuse.org/issues/138554
bootloader_hyperv svirt login has needle mismatch issue.



- Related ticket: https://progress.opensuse.org/issues/138554
- Needles: none
- Verification run: [Hyper-v VR test](http://openqa.suse.de/tests/12676846)
