### PR TITLE
console/year_2038_detection.pm: Only treat as softfail on SLE <= 15 and make syncing more reliable

### DIFF
--- a/tests/console/year_2038_detection.pm
+++ b/tests/console/year_2038_detection.pm
@@ -83,7 +83,8 @@ sub run {
     # wait for chronyd service to check the system clock change;
     # add some timeout after 'chronyc makestep'
     script_retry('journalctl -u chronyd | grep -e "System clock wrong" -e "Received KoD RATE"', delay => 60, retry => 3, die => 0);
-    record_soft_failure('poo#127343, Time sync with NTP server failed') if script_run('chronyc makestep && sleep 2 && (date +"%Y-%m-%d" | grep -v 2038)') != 0;
+    assert_script_run('chronyc makestep');
+    record_soft_failure('poo#127343, Time sync with NTP server failed') unless script_retry('date +"%Y-%m-%d" | grep -v 2038', delay => 5, retry => 5, die => 0) == 0;
 }
 
 # Rollback the system because of poo#127343, to restore the chronyd.service state,

--- a/tests/console/year_2038_detection.pm
+++ b/tests/console/year_2038_detection.pm
@@ -86,8 +86,9 @@ sub run {
     record_soft_failure('poo#127343, Time sync with NTP server failed') if script_run('chronyc makestep && sleep 2 && (date +"%Y-%m-%d" | grep -v 2038)') != 0;
 }
 
-# We need to force the sytem to rollback to snapshot because of poo#127343
-# so that we can get the right system clock
+# Rollback the system because of poo#127343, to restore the chronyd.service state,
+# to avoid polluting the journal with time travel (very confusing to read) and other
+# side effects of time warps.
 sub test_flags {
     return {always_rollback => 1};
 }


### PR DESCRIPTION
On TW/ALP/etc. this is a proper failure.

Verification runs:
https://openqa.opensuse.org/tests/3677459 (TW MicroOS)

Apparently it's not scheduled for Leap? Feel free to do VRs for SLE.

Depends on #18084 