### PR TITLE
Scope package installation in container

### DIFF
--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -13,7 +13,7 @@ use serial_terminal 'select_serial_terminal';
 use utils qw(validate_script_output_retry);
 use containers::utils qw(reset_container_network_if_needed);
 use Utils::Architectures;
-use Utils::Backends qw(is_xen_pv);
+use Utils::Backends qw(is_xen_pv is_hyperv);
 use version_utils qw(is_public_cloud is_sle);
 use utils qw(script_retry);
 
@@ -35,7 +35,7 @@ sub run {
     # xen-pv does not define USB passthrough in the xml as of now
     # this feature has to be added -> https://progress.opensuse.org/issues/138410
     assert_script_run("$runtime run --rm $image bash -c '! test -d /dev/bus'");
-    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus") unless (is_s390x || is_public_cloud || is_xen_pv);
+    assert_script_run("$runtime run --rm --privileged $image ls /dev/bus") unless (is_s390x || is_public_cloud || is_xen_pv || is_hyperv);
 
     # Mounting tmpfs only works in privileged mode because the read-only protection in the default mode
     assert_script_run("$runtime run --rm --privileged $image mount -t tmpfs none /mnt");
@@ -46,7 +46,7 @@ sub run {
 
     # Podman inside the container
     assert_script_run("$runtime run -d --privileged --name outer-container $image sleep 100000");
-    assert_script_run("$runtime exec outer-container zypper in -y podman");
+    assert_script_run("$runtime exec outer-container zypper in -r SLE_BCI -y podman");
     # overlayfs can be used starting with kernel 4.18 by unprivileged users in an user namespace
     assert_script_run("$runtime exec outer-container podman run -it $image ls") unless is_sle('=15-SP1');
 }


### PR DESCRIPTION
If proxy scc is used and the container is based on different version of
SLE the repo URLs inside of container are invalid.

HyperV does not has `/dev/bus` as xen pv.

#### Verification runs

* [15-SP4](http://kepler.suse.cz/tests/22102#step/docker_privileged_mode/92)
* [15-SP6](http://kepler.suse.cz/tests/22101#step/podman_privileged_mode/65)
* [TW](http://kepler.suse.cz/tests/22103#)