### PR TITLE
virt_autotest: fix up compressing guest disk file timeout

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2012-2020 SUSE LLC
+# Copyright 2012-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 package virt_utils;
@@ -330,13 +330,11 @@ sub get_guest_disk_name_from_guest_xml {
 # Please refer to https://qemu.readthedocs.io/en/latest/tools/qemu-img.html to ease your mind on working with --force-share and convert and many others.
 sub compress_single_qcow2_disk {
     my ($orig_disk, $compressed_disk) = @_;
+    my $timeout = '720';
+    my $cmd = "time nice ionice qemu-img convert --force-share -c -p -O qcow2 $orig_disk $compressed_disk";
 
     if ($orig_disk =~ /qcow2/) {
-        my $cmd = "nice ionice qemu-img convert -c -p -O qcow2 $orig_disk $compressed_disk";
-        if (script_run($cmd, 360) ne 0) {
-            $cmd = "nice ionice qemu-img convert --force-share -c -p -O qcow2 $orig_disk $compressed_disk";
-            die("Disk compression failed from $orig_disk to $compressed_disk.") if (script_run($cmd, 360) ne 0);
-        }
+        die("Disk compression failed from $orig_disk to $compressed_disk.") if (script_run($cmd, timeout => $timeout, die => 0, retry => 2) ne 0);
         save_screenshot;
         record_info('Disk compression', "Disk compression done from $orig_disk to $compressed_disk.");
     }


### PR DESCRIPTION
Refer to the following Error info during :
```
command 'nice ionice qemu-img convert -c -p -O qcow2 /var/lib/libvirt/images/sles-15-sp5-64-fv-def-net.qcow2 guest_sles-15-sp5-64-fv-def-net_on-host_sle-15-SP6_build28.1_xen_x86_64.disk' timed out at /usr/lib/os-autoinst/testapi.pm line 985.
    testapi::script_run("nice ionice qemu-img convert -c -p -O qcow2 /var/lib/libvirt/"..., 360) called at sle/tests/virt_autotest/virt_utils.pm line 336

```
Timeout to compressing both 12sp5 and 15sp5 guest disk file on 15sp6 xen domain0. So, setup TIMEOUT both KVM and XEN to fix up compressing guest disk file timeout problem.  

- Related ticket: https://progress.opensuse.org/issues/138575
- Verification run: 
[gi-guest_sles12sp5-on-host_developing-xen](https://openqa.suse.de/tests/12744879#)
[gi-guest_sles15sp5-on-host_developing-kvm](https://openqa.suse.de/tests/12744883#)
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/12744884#)
[gi-guest_developing-on-host_sles15sp5-kvm](https://openqa.suse.de/tests/12744900#)