### PR TITLE
Fix system-role issue on aarch64 on TW

### DIFF
--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -15,6 +15,7 @@ use warnings;
 use testapi;
 use Utils::Architectures;
 use version_utils qw(is_sle is_opensuse is_microos is_sle_micro);
+use YaST::workarounds;
 
 my %role_hotkey = (
     gnome => 's',
@@ -35,6 +36,11 @@ sub change_system_role {
         }
         else {
             assert_and_click "system-role-$system_role";
+            if (is_aarch64) {
+                if (!check_screen("system-role-$system_role-selected")) {
+                    apply_workaround_poo124652("system-role-$system_role-selected", 100);
+                }
+            }
             assert_and_click "system-role-$system_role-selected";
         }
     }


### PR DESCRIPTION
There are focus issue on aarch64 on TW, which cause we can't click the gnome role to select it. So send tab and hot keys to recover the focus to fix this issue.

- Related ticket: https://progress.opensuse.org/issues/138041
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3693563#step/system_role/8
   avoid regression on x86_64: https://openqa.opensuse.org/tests/3678463#step/system_role/4
