### PR TITLE
New qesap lib to create SAS Token

### DIFF
--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -7,6 +7,7 @@
 use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
+use publiccloud::azure_client;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use qesapdeployment;
@@ -17,6 +18,12 @@ sub run {
 
     # Init al the PC gears (ssh keys)
     my $provider = $self->provider_factory();
+
+    # Needed to create the SAS URI token
+    if (!check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+        my $azure_client = publiccloud::azure_client->new();
+        $azure_client->init();
+    }
 
     my %variables;
     $variables{REGION} = $provider->provider_client->region;
@@ -47,7 +54,11 @@ sub run {
     $variables{HANA_ACCOUNT} = get_required_var('QESAPDEPLOY_HANA_ACCOUNT');
     $variables{HANA_CONTAINER} = get_required_var('QESAPDEPLOY_HANA_CONTAINER');
     if (get_var('QESAPDEPLOY_HANA_TOKEN')) {
-        $variables{HANA_TOKEN} = get_required_var('QESAPDEPLOY_HANA_TOKEN');
+        $variables{HANA_TOKEN} = qesap_az_create_sas_token(storage => get_required_var('QESAPDEPLOY_HANA_ACCOUNT'),
+            container => (split("/", get_required_var('QESAPDEPLOY_HANA_CONTAINER')))[0],
+            keyname => get_required_var('QESAPDEPLOY_HANA_KEYNAME'),
+            lifetime => 30);
+        record_info('TOKEN', $variables{HANA_TOKEN});
         # escape needed by 'sed'
         # but not implemented in file_content_replace() yet poo#120690
         $variables{HANA_TOKEN} =~ s/\&/\\\&/g;


### PR DESCRIPTION
Create new lib function to create token for storage container. Allow to set permission and duration.

No more secrets to be transmitted using job settings

It does not take care about double % issue yet

- Related ticket: [TEAM-8713](https://jira.suse.com/browse/TEAM-8713)

## Verification run:


### qesap regression

 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit -> http://openqaworker15.qa.suse.cz/tests/257072 :green_circle:  failure is a known issue far after the Hana installation 

- sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_fullypatch@64bit -> http://openqaworker15.qa.suse.cz/tests/257074 :green_circle:


### hanasr

 - sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-10-27T04:03:08Z-hanasr_azure_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/257100  :green_circle: 


- sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2023-10-27T04:03:08Z-hanasr_aws_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/257101 fails in ansible but failure seems not related to the PR changes and token seems properly generated as HANA properly downloaded and installed
 http://openqaworker15.qa.suse.cz/tests/257108
