### PR TITLE
libgcrypt2-hmac is deprecated in sle15sp6

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -183,6 +183,8 @@ sub run {
         libgcrypt20 => '1.9.0',
         'libgcrypt20-hmac' => '1.9.0'
     };
+    delete $pkg_list->{'libgcrypt20-hmac'} if is_sle('15-SP6+');
+
     if (is_public_cloud() && check_var('BETA', '1')) {
         if (zypper_call("in " . join(' ', keys %$pkg_list), exitcode => [0, 4]) == '4') {
             record_info("Aborting", "The repositories are behind Public Cloud image. See bsc#1199312");


### PR DESCRIPTION
More details in https://bugzilla.suse.com/show_bug.cgi?id=1216347#c1 -ticket: https://progress.opensuse.org/issues/138677

#### Verification runs: 

* [microos](http://kepler.suse.cz/tests/22119#step/gpg/9)
* [15sp5](http://kepler.suse.cz/tests/22118#step/gpg/10)
* [15sp6](http://kepler.suse.cz/tests/22117#step/gpg/7)
