### PR TITLE
Correct bridge config in sles12 autoyast

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -103,14 +103,14 @@
         <device>br0</device>
         <bootproto>dhcp</bootproto>
         <bridge>yes</bridge>
-        <bridge_forwarddelay>0</bridge_forwarddelay>
+        <bridge_forwarddelay>15</bridge_forwarddelay>
         <!-- Use specified interface instead of a list to avoid ip lease inconsistency. Please refer to poo#135641. -->
         % if ($check_var->('SUT_NETDEVICE', 'eth1') or $check_var->('SUT_NETDEVICE', 'em1')) {
         <bridge_ports><%= $get_var->('SUT_NETDEVICE') %></bridge_ports>
         % } else {
         <bridge_ports>eth0 eth1 em1 em2</bridge_ports>
         % }
-        <bridge_stp>off</bridge_stp>
+        <bridge_stp>on</bridge_stp>
         <startmode>auto</startmode>
       </interface>
     </interfaces>


### PR DESCRIPTION
* **Parameter** ```bridge_forwarddelay``` can not be zero. Set it to 15 which is the most common value being used for bridge settings.

* **Parameter** ```bridge_stp``` is better given "on" for bridge settings.

* **Verification Runs:**
  * [sles12sp5 installation with second stage passed](https://openqa.suse.de/tests/12788993)
  * [sles12sp5 installation with second stage failed]()
  * [sles12sp5 installation without second stage](https://openqa.suse.de/tests/12788992)