### PR TITLE
Run HANA nodes on QEMU with VIRTIO_CONSOLE=1 on QAM/Aggregates

### DIFF
--- a/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node1.yaml
@@ -19,7 +19,6 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
   WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node2.yaml
+++ b/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node2.yaml
@@ -19,7 +19,6 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
   WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node1.yaml
@@ -19,7 +19,6 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
   WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node2.yaml
+++ b/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node2.yaml
@@ -19,7 +19,6 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
   WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP4/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP4/qam-sles4sap_wmp_hana_node1.yaml
@@ -19,7 +19,6 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
   WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP4/qam-sles4sap_wmp_hana_node2.yaml
+++ b/schedule/qam/15-SP4/qam-sles4sap_wmp_hana_node2.yaml
@@ -19,7 +19,6 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
   WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP5/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP5/qam-sles4sap_wmp_hana_node1.yaml
@@ -19,7 +19,6 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
   WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP5/qam-sles4sap_wmp_hana_node2.yaml
+++ b/schedule/qam/15-SP5/qam-sles4sap_wmp_hana_node2.yaml
@@ -19,7 +19,6 @@ vars:
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
   WMP_TEST_REPO: 'https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz'
 schedule:
   - boot/boot_to_desktop


### PR DESCRIPTION
Commit 98e884f337a553dd8c36d07eb238ed6b44341a2d forces HANA nodes to run on the serial terminal by removing the VIRTIO_CONSOLE=0 setting from the schedules, but the aggregates schedules are located in a different directory so they were not updated as part of that commit. This commit fixes this.

- Related ticket: https://jira.suse.com/browse/TEAM-8684 & https://progress.opensuse.org/issues/138113
- Needles: N/A
- Verification run: N/A
