### PR TITLE
installation: avoid partitioning issue

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -15,7 +15,7 @@ use warnings;
 use testapi;
 use version_utils qw(is_leap is_storage_ng is_sle is_tumbleweed);
 use partition_setup qw(%partition_roles is_storage_ng_newui);
-
+use utils 'type_string_slow';
 sub run {
     if (check_var('SYSTEM_ROLE', 'Common_Criteria')) {
         assert_screen 'Common-Criteria-Evaluated-Configuration-RN-Next';
@@ -27,7 +27,7 @@ sub run {
         send_key 'alt-n';
         send_key 'down';
         send_key 'alt-f';
-        type_string 'ext4';
+        type_string_slow 'ext4';
         send_key 'alt-i';
         send_key 'b';
         assert_screen 'partitioning-ext4_root-btrfs_home';
@@ -38,7 +38,7 @@ sub run {
         send_key 'alt-n';
         send_key 'down';
         send_key 'alt-f';
-        type_string 'ext4';
+        type_string_slow 'ext4';
         send_key 'alt-i';
         send_key 'x';
         assert_screen 'partitioning-ext4_root-xfs_home';


### PR DESCRIPTION
We often got create partition issue since kernel 6.x. it's due to system menu cannot response in time. Thus use type_string_slow instead of type_string to avoid fails.


- Related ticket: https://progress.opensuse.org/issues/138737
- Needles: N/A
- Verification run: http://10.67.129.54/tests/864
