### PR TITLE
SAS URI token generation for Trento

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -268,8 +268,12 @@ sub cluster_config {
 
     $variables{HANA_ACCOUNT} = get_required_var("TRENTO_QESAPDEPLOY_HANA_ACCOUNT");
     $variables{HANA_CONTAINER} = get_required_var("TRENTO_QESAPDEPLOY_HANA_CONTAINER");
-    if (get_var("TRENTO_QESAPDEPLOY_HANA_TOKEN")) {
-        $variables{HANA_TOKEN} = get_required_var("TRENTO_QESAPDEPLOY_HANA_TOKEN");
+    if (get_var("TRENTO_QESAPDEPLOY_HANA_KEYNAME")) {
+        $variables{HANA_TOKEN} = qesap_az_create_sas_token(storage => get_required_var('TRENTO_QESAPDEPLOY_HANA_ACCOUNT'),
+            container => (split("/", get_required_var('TRENTO_QESAPDEPLOY_HANA_CONTAINER')))[0],
+            keyname => get_required_var('TRENTO_QESAPDEPLOY_HANA_KEYNAME'),
+            lifetime => 30);
+        record_info('TOKEN', $variables{HANA_TOKEN});
         # escape needed by 'sed'
         # but not implemented in file_content_replace() yet poo#120690
         $variables{HANA_TOKEN} =~ s/\&/\\\&/g;

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -7,7 +7,7 @@
 # https://github.com/SUSE/qe-sap-deployment
 
 # Available OpenQA parameters:
-# HA_CLUSTER - Enables HA/Hana cluser scenario
+# HA_CLUSTER - Enables HA/Hana cluster scenario
 # NODE_COUNT - number of nodes to deploy. Needs to be >1 for cluster usage.
 # PUBLIC_CLOUD_INSTANCE_TYPE - VM size, sets terraform 'vm_size' parameter
 # USE_SAPCONF - (true/false) set 'false' to use saptune
@@ -15,10 +15,13 @@
 # FENCING_MECHANISM - (sbd/native) choose fencing mechanism
 # QESAP_SCC_NO_REGISTER - define variable in openqa to skip SCC registration via ANSIBLE
 # HANA_MEDIA - Hana install media directory
+# HANA_ACCOUNT - Azure Storage name
+# HANA_CONTAINER - Azure Container name
+# HANA_KEYNAME - Azure key name in the Storage to generate SAS URI token used by hana_media in qe-sap-deployment
 # _HANA_MASTER_PW (mandatory) - Hana master PW (secret)
 # INSTANCE_SID - SAP Sid
 # INSTANCE_ID - SAP instance id
-# ANSIBLE_REMOTE_PYTHON - define python version to be used for qesap-deploymnet (default '/usr/bin/python3')
+# ANSIBLE_REMOTE_PYTHON - define python version to be used for qe-sap-deploymnet (default '/usr/bin/python3')
 # PUBLIC_CLOUD_IMAGE_LOCATION - needed by get_blob_uri
 
 use strict;
@@ -43,7 +46,7 @@ sub test_flags {
     Check if a requested openQA variable is defined and returns it's current value.
     If the variable is not defined, it will:
      - defines it
-     - assignes the default value provided
+     - assigns the default value provided
      - returns its value
     $variable - variable to check against OpenQA settings
     $default - default value to set in case the variable is missing.

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -53,7 +53,7 @@ sub run {
 
     $variables{HANA_ACCOUNT} = get_required_var('QESAPDEPLOY_HANA_ACCOUNT');
     $variables{HANA_CONTAINER} = get_required_var('QESAPDEPLOY_HANA_CONTAINER');
-    if (get_var('QESAPDEPLOY_HANA_TOKEN')) {
+    if (get_var('QESAPDEPLOY_HANA_KEYNAME')) {
         $variables{HANA_TOKEN} = qesap_az_create_sas_token(storage => get_required_var('QESAPDEPLOY_HANA_ACCOUNT'),
             container => (split("/", get_required_var('QESAPDEPLOY_HANA_CONTAINER')))[0],
             keyname => get_required_var('QESAPDEPLOY_HANA_KEYNAME'),

--- a/variables.md
+++ b/variables.md
@@ -256,7 +256,7 @@ TRENTO_WEB_PASSWORD | string | | Trento web password for the admin user. If not 
 TRENTO_QESAPDEPLOY_CLUSTER_OS_VER | string | | OS for nodes in SAP cluster.
 TRENTO_QESAPDEPLOY_HANA_ACCOUNT | string | | Azure blob server account for the SAP installers for the qe-sap-deployment hana_media.yaml.
 TRENTO_QESAPDEPLOY_HANA_CONTAINER | string | | Azure blob server container for the qe-sap-deployment hana_media.yaml.
-TRENTO_QESAPDEPLOY_HANA_TOKEN | string | | Azure blob server token for the qe-sap-deployment hana_media.yaml.
+TRENTO_QESAPDEPLOY_HANA_KEYNAME | string | | Azure blob server key name used to generate the SAS URI token for the qe-sap-deployment hana_media.yaml.
 TRENTO_QESAPDEPLOY_SAPCAR | string | | SAPCAR file name for the qe-sap-deployment hana_media.yaml.
 TRENTO_QESAPDEPLOY_IMDB_SERVER | string | | IMDB_SERVER file name for the qe-sap-deployment hana_media.yaml.
 TRENTO_QESAPDEPLOY_IMDB_CLIENT | string | | IMDB_CLIENT file name for the qe-sap-deployment hana_media.yaml.


### PR DESCRIPTION
Add token generation in Trento too.
Fix qesap regression token generation condition.
Remove all TOKEN settings.
Fix some setting documentation.

Related ticket: [TEAM-8713](https://jira.suse.com/browse/TEAM-8713)


## Verification run:

### qesap regression

 - sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/258104  :green_apple: Ansible download media is ok

 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit -> http://openqaworker15.qa.suse.cz/tests/258108  :green_apple: Ansible download media is ok


### HanaSR

 - sle-15-SP3-HanaSr-Azure-Byos-x86_64-Build15-SP3_2023-10-30T12:54:21Z-hanasr_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/258109

 - sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2023-10-30T12:54:21Z-hanasr_aws_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/258110
 - 
### Trento

 - sle-15-SP4-Trento-PremiumRolling-x86_64-BuildRolling2.1.0-build65.1-trento_test@64bit -> http://openqaworker15.qa.suse.cz/tests/258117
