### PR TITLE
Removed softfailure message for hotplugged nic of guest hosted on xen

### DIFF
--- a/tests/virtualization/universal/hotplugging_network_interfaces.pm
+++ b/tests/virtualization/universal/hotplugging_network_interfaces.pm
@@ -31,10 +31,6 @@ sub add_virtual_network_interface {
     unless ($guest =~ m/hvm/i && is_sle('<=12-SP2') && is_xen_host) {
         my $persistent_config_option = '';
         my $interface_model_option = '';
-        if (get_var('VIRT_AUTOTEST') && is_xen_host) {
-            record_soft_failure 'bsc#1168124 Bridge network interface hotplugging has to be performed at the beginning.';
-            $self->{test_results}->{$guest}->{"bsc#1168124 Bridge network interface hotplugging has to be performed at the beginning"}->{status} = 'SOFTFAILED';
-        }
         if (get_var('VIRT_AUTOTEST') && is_kvm_host) {
             $interface_model_option = '--model virtio';
         }


### PR DESCRIPTION
A soft-failure warning message was issued when a network interface is hotpluged on a guest vm which is hosted on xen host.

The corresponding bug https://bugzilla.suse.com/show_bug.cgi?id=1168124 is now resolved.

- Related ticket : https://progress.opensuse.org/issues/138443
- Needles: No corresponding needles.
- Verification run: http://openqa.qam.suse.cz/tests/62719#