### PR TITLE
Enable sle-module-python3 installation on 15-SP6

### DIFF
--- a/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_aarch64.xml.ep
@@ -38,10 +38,10 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
-      % unless ($check_var->('VERSION', '15') || $check_var->('VERSION', '15-SP6')) {
+      % unless ($check_var->('VERSION', '15')) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
-        % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
+        % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5') || $check_var->('VERSION', '15-SP6')) {
         <name>sle-module-python2</name>
         % } else {
         <name>sle-module-python3</name>
@@ -424,8 +424,8 @@
       <package>sle-module-development-tools-release</package>
       <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
-      % unless ($check_var->('VERSION', '15') || $check_var->('VERSION', '15-SP6')) {
-      % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5')) {
+      % unless ($check_var->('VERSION', '15')) {
+      % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5') || $check_var->('VERSION', '15-SP6')) {
       <package>sle-module-python2-release</package>
       % } else {
       <package>sle-module-python3-release</package>

--- a/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
+++ b/data/autoyast_sle15/hpc/create_hdd_textmode_x86_64.xml.ep
@@ -38,10 +38,10 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
-      % unless ($check_var->('VERSION', '15') || $check_var->('VERSION', '15-SP6')) {
+      % unless ($check_var->('VERSION', '15')) {
       <addon config:type="map">
         <arch>{{ARCH}}</arch>
-        % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION','15-SP5')) {
+        % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION','15-SP5') || $check_var->('VERSION', '15-SP6')) {
         <name>sle-module-python2</name>
         % } else {
         <name>sle-module-python3</name>
@@ -464,7 +464,7 @@
       <package>sle-module-development-tools-release</package>
       <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
-      % unless ($check_var->('VERSION', '15') || $check_var->('VERSION', '15-SP6')) {
+      % unless ($check_var->('VERSION', '15')) {
       % unless ($check_var->('VERSION', '15-SP4') || $check_var->('VERSION', '15-SP5') || $check_var->('VERSION', '15-SP6')) {
       <package>sle-module-python2-release</package>
       % } else {


### PR DESCRIPTION
Modify profile and enable sle-module-python3 in the Autoyast profile
to perform installation of the module on 15-SP6.

- Related ticket: https://progress.opensuse.org/issues/134195
- Verification run: 
https://openqa.suse.de/tests/overview?version=12-SP5&distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2318116

https://openqa.suse.de/tests/overview?distri=sle&build=b10n1k%2Fos-autoinst-distri-opensuse%2318116&version=15-SP6
https://openqa.suse.de/tests/overview?build=b10n1k%2Fos-autoinst-distri-opensuse%2318116&distri=sle&version=15-SP2
