### PR TITLE
Explicit servername in ca-certificates test

### DIFF
--- a/tests/console/ca_certificates_mozilla.pm
+++ b/tests/console/ca_certificates_mozilla.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright 2018-2020 SUSE LLC
+# Copyright 2018-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: ca-certificates-mozilla openssl
 # Summary: Install ca-certificates-mozilla and test connection to a secure website
 # - install ca-certificates-mozilla and openssl
 # - connect to static.opensuse.org:443 using openssl and verify that the return code is 0
-# Maintainer: Orestis Nalmpantis <onalmpantis@suse.de>
+# Maintainer: QE Core <qe-core@suse.de>
 
 use base "consoletest";
 use strict;
@@ -19,7 +19,8 @@ use utils 'zypper_call';
 sub run {
     select_serial_terminal;
     zypper_call 'in ca-certificates-mozilla openssl';
-    assert_script_run('echo "x" | openssl s_client -connect static.opensuse.org:443 | grep "Verify return code: 0"');
+    my $server = "static.opensuse.org";    # due to infra setup, need to pass explicit servername for older openssl
+    assert_script_run(qq[echo "x" | openssl s_client -connect $server:443 -servername $server | grep "Verify return code: 0"]);
 }
 
 1;


### PR DESCRIPTION
With the latest infrastructure changes, the website `https://static.opensuse.org` requires explicit "servername" parameter when invoked from an older openSSL client. 

- Related ticket: https://progress.opensuse.org/issues/138998
- Needles: nope
- Verification runs: 
  - https://openqa.suse.de/tests/12753795
  - https://openqa.suse.de/tests/12753796
  - https://openqa.suse.de/tests/12753797
  - https://openqa.suse.de/tests/12753798
  - https://openqa.suse.de/tests/12753799
  - https://openqa.suse.de/tests/12753800
  - https://openqa.suse.de/tests/12753801
  - https://openqa.suse.de/tests/12753802
  - https://openqa.suse.de/tests/12753803
  - https://openqa.suse.de/tests/12753805
  - https://openqa.suse.de/tests/12753807
  - https://openqa.suse.de/tests/12753810


