### PR TITLE
wicked: configure journald via drop-in

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -43,11 +43,14 @@ sub run {
     }
     record_info('INFO', 'Setting debug level for wicked logs');
     file_content_replace('/etc/sysconfig/network/config', '--sed-modifier' => 'g', '^WICKED_DEBUG=.*' => 'WICKED_DEBUG="all"', '^WICKED_LOG_LEVEL=.*' => 'WICKED_LOG_LEVEL="debug2"');
-    file_content_replace('/etc/systemd/journald.conf', '--debug' => 1,
+    $self->write_cfg('/usr/lib/systemd/journald.conf.d/99-openqa-wicked-tests.conf', <<EOT);
+        [Journal]
         # see: https://github.com/systemd/systemd/commit/f0367da7d1a61ad698a55d17b5c28ddce0dc265a
-        '^#?RateLimitInterval=.*' => 'RateLimitInterval=0',
-        '^#?RateLimitIntervalSec=.*' => 'RateLimitIntervalSec=0',
-        '^#?RateLimitBurst=.*' => 'RateLimitBurst=0');
+        RateLimitInterval=0
+        RateLimitIntervalSec=0
+        RateLimitBurst=0
+EOT
+    record_info('journald.conf', script_output('systemd-analyze cat-config --no-pager systemd/journald.conf'));
     #preparing directories for holding config files
     assert_script_run('mkdir -p /data/{static_address,dynamic_address}');
 


### PR DESCRIPTION
The `/etc/systemd/journald.conf` doesn't exists on latest Tumbleweed. As it is moved to `/usr/...`.
Use drop-in mechanism to write our journal configuration.


Error's: 
- http://openqa.wicked.suse.de/tests/170674#step/before_test/20
- https://openqa.opensuse.org/tests/3696259#step/before_test/20

fixed: 
- http://openqa.wicked.suse.de/tests/170885#step/before_test/20