### PR TITLE
wicked: use scapy container from different project

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -1160,7 +1160,7 @@ sub prepare_containers {
 sub get_containers {
     my $self = shift;
     if (!defined($self->{containers})) {
-        my $default_container = 'scapy=registry.opensuse.org/home/cfconrad/branches/opensuse/templates/images/tumbleweed/containers/scapy:latest';
+        my $default_container = 'scapy=registry.opensuse.org/home/cfconrad/openqa/containers/scapy:latest';
         my @containers = split(/\s*,\s*/, get_var("WICKED_CONTAINERS", $default_container));
         @containers = grep { /\w+=.+/ } @containers;
         $self->{containers} = {map { split(/=/, $_, 2) } @containers};


### PR DESCRIPTION
This project is configured to build the container for different architectures. 

- https://build.opensuse.org/project/show/home:cfconrad:openqa
- https://progress.opensuse.org/issues/137852
- https://registry.opensuse.org/cgi-bin/cooverview?srch_term=container%3Dhome%2Fcfconrad%2Fopenqa%2Fcontainers%2Fscapy+

