### PR TITLE
fix test fails in mutt - New screen "SSL Certificate Check"

### DIFF
--- a/tests/console/mutt.pm
+++ b/tests/console/mutt.pm
@@ -49,6 +49,9 @@ sub run {
 
     record_info 'receive mail', 'Run mutt as a user to read the mail';
     enter_cmd "mutt";
+    if (check_screen 'mutt-verify-certificate', 0) {
+        send_key 'q';
+    }
     send_key 'a';
     assert_screen 'mutt-message-list';
     send_key 'ret';


### PR DESCRIPTION
This commit fixes the new screen in the mutt test with a SSL certificate check. I have only tested this with the mutt in Tumbleweed. 

- Related ticket: https://progress.opensuse.org/issues/138194
- Verification run: https://openqa.opensuse.org/tests/3700669
