### PR TITLE
wicked: handle coredump of unknown source

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -1109,7 +1109,16 @@ sub prepare_coredump {
         assert_script_run("echo '$core_pattern' > /etc/sysctl.d/50-coredump.conf");
     }
 
-    assert_script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend)" ]');
+
+    my $core_dump = script_output('coredumpctl -q --no-pager --no-legend', proceed_on_failure => 1);
+    if (length($core_dump) != 0) {
+        if ($core_dump =~ m/wicked/) {
+            record_info("CORE DUMP", $core_dump, result => 'fail');
+            die("Wicked coredump found in before_test, cleanup your installation first!");
+        } else {
+            record_info("CORE DUMP", $core_dump, result => 'warn');
+        }
+    }
     for my $pkg (qw(wicked-debuginfo wicked-debugsource)) {
         if (script_run("zypper search $pkg") == 0) {
             zypper_call("in --force -y --force-resolution $pkg");


### PR DESCRIPTION
If there are coredumps, but not related to wicked, we should not fail in before_test module.

- Failed job: https://openqa.opensuse.org/tests/3705475#step/before_test/44
- Verification run: https://openqa.opensuse.org/tests/3705628
