### PR TITLE
Specify registry url for busybox

### DIFF
--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -43,7 +43,7 @@ sub run {
     assert_script_run("mkdir -p $test_dir");
 
     # Create Dockerfile with VOLUME defined
-    assert_script_run("echo -e 'FROM busybox\\nVOLUME /$test_dir' > $test_dir/Dockerfile");
+    assert_script_run("echo -e 'FROM registry.opensuse.org/opensuse/bci/bci-busybox:latest\\nVOLUME /$test_dir' > $test_dir/Dockerfile");
 
     # Build image
     assert_script_run("$runtime build -t $test_image -f $test_dir/Dockerfile $test_dir/");


### PR DESCRIPTION
Dockerfile in volumes.pm was missing full path to busybox container used for the test. To avoid the ambiguity of source, always use container from registy.opensuse.org.

```
STEP 1/2: FROM busybox
Please select an image:
    registry.opensuse.org/busybox:latest
    registry.suse.com/busybox:latest
    docker.io/library/busybox:latest
```

- ticket: https://progress.opensuse.org/issues/150806
- Verification run: http://kepler.suse.cz/tests/22207#step/volumes_podman/17
