### PR TITLE
Add ansible-galaxy install to qesap regression

### DIFF
--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -41,33 +41,6 @@ subtest '[qesap_get_inventory] lower case' => sub {
     is $inventory_path, '/BRUCE/nemo/inventory.yaml', "inventory_path:$inventory_path is the expected one";
 };
 
-subtest '[qesap_create_folder_tree/qesap_get_file_paths] default' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
-    my @calls;
-    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
-    $qesap->redefine(data_url => sub { return; });    # needed by qesap_get_file_paths
-
-    qesap_create_folder_tree();
-
-    note("\n  -->  " . join("\n  -->  ", @calls));
-    is $calls[0], 'mkdir -p /root/qe-sap-deployment', "Default deploy location is /root/qe-sap-deployment";
-};
-
-subtest '[qesap_create_folder_tree/qesap_get_file_paths] user specified deployment_dir' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
-    my @calls;
-    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
-    $qesap->redefine(data_url => sub { return; });    # needed by qesap_get_file_paths
-    my $custom_dir = '/DORY';
-    set_var('QESAP_DEPLOYMENT_DIR', $custom_dir);
-
-    qesap_create_folder_tree();
-
-    note("\n  -->  " . join("\n  -->  ", @calls));
-    set_var('QESAP_DEPLOYMENT_DIR', undef);
-    is $calls[0], "mkdir -p $custom_dir", "Custom deploy location is $custom_dir";
-};
-
 subtest '[qesap_get_deployment_code] from default github' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     my @calls;
@@ -647,6 +620,188 @@ subtest '[qesap_calculate_deployment_name] with postfix' => sub {
 
 subtest '[qesap_prepare_env] die for missing argument' => sub {
     dies_ok { qesap_prepare_env(); } "Expected die if called without provider arguments";
+};
+
+sub create_qesap_prepare_env_mocks_noret {
+    my $called_functions = shift;
+    my $mock_func = shift;
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+
+    # First mock functions returning nothing
+    foreach (@{$mock_func}) {
+        my $fn = $_;
+        $called_functions->{$fn} = 0;
+        $qesap->redefine($fn => sub { $called_functions->{$fn} = 1; return; });
+    }
+    return $qesap;
+}
+
+sub create_qesap_prepare_env_mocks_with_calls {
+    my $called_functions = shift;
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+
+    # then mock functions with some more complex return value
+    $called_functions->{qesap_get_file_paths} = 0;
+    $qesap->redefine(qesap_get_file_paths => sub {
+            $called_functions->{qesap_get_file_paths} = 1;
+            my %paths;
+            $paths{qesap_conf_src} = '/REEF';
+            $paths{qesap_conf_trgt} = '/SYDNEY.YAML';
+            $paths{terraform_dir} = '/SPLASH';
+            $paths{deployment_dir} = '/WAVE';
+            $paths{roles_dir} = '/BRUCE';
+            return (%paths);
+    });
+    $called_functions->{qesap_get_terraform_dir} = 0;
+    $qesap->redefine(qesap_get_terraform_dir => sub { $called_functions->{qesap_get_terraform_dir} = 1; return '/SHELL'; });
+    $called_functions->{qesap_execute} = 0;
+    $qesap->redefine(qesap_execute => sub { $called_functions->{qesap_execute} = 1; return (0, "ALL GOOD"); });
+
+    return $qesap;
+}
+
+subtest '[qesap_prepare_env]' => sub {
+    my %called_functions;
+    my @mock_func = qw(qesap_get_variables
+      qesap_yaml_replace
+      qesap_create_folder_tree
+      qesap_get_deployment_code
+      qesap_get_roles_code
+      qesap_pip_install
+      qesap_galaxy_install);
+    my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
+    $qesap = create_qesap_prepare_env_mocks_with_calls(\%called_functions);
+    my @calls;
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(qesap_upload_logs => sub { return; });
+
+    qesap_prepare_env(provider => 'DONALDUCK');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    foreach (qw(qesap_get_file_paths qesap_get_terraform_dir qesap_execute)) {
+        my $fn = $_;
+        ok $called_functions{$fn} eq 1, "$fn called by qesap_prepare_env";
+    }
+    foreach (@mock_func) {
+        my $fn = $_;
+        ok $called_functions{$fn} eq 1, "$fn called by qesap_prepare_env";
+    }
+};
+
+subtest '[qesap_prepare_env] openqa_variables' => sub {
+    my %called_functions;
+    my @mock_func = qw(qesap_get_variables
+      qesap_yaml_replace
+      qesap_create_folder_tree
+      qesap_get_deployment_code
+      qesap_get_roles_code
+      qesap_pip_install
+      qesap_galaxy_install);
+    my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
+    $qesap = create_qesap_prepare_env_mocks_with_calls(\%called_functions);
+    my @calls;
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(qesap_upload_logs => sub { return; });
+
+    my %variables;
+    qesap_prepare_env(openqa_variables => \%variables, provider => 'DONALDUCK');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok $called_functions{qesap_get_variables} eq 0, "qesap_get_variables not called by qesap_prepare_env when using openqa_variables";
+};
+
+subtest '[qesap_prepare_env] only_configure' => sub {
+    my %called_functions;
+    my @mock_func = qw(qesap_get_variables
+      qesap_yaml_replace
+      qesap_create_folder_tree
+      qesap_get_deployment_code
+      qesap_get_roles_code
+      qesap_pip_install
+      qesap_galaxy_install);
+    my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
+    $qesap = create_qesap_prepare_env_mocks_with_calls(\%called_functions);
+    my @calls;
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(qesap_upload_logs => sub { return; });
+
+    qesap_prepare_env(provider => 'DONALDUCK', only_configure => 1);
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    # Check that a specific subset of function is not executed in only_configure mode
+    foreach (qw(qesap_create_folder_tree qesap_get_deployment_code qesap_get_roles_code qesap_pip_install qesap_galaxy_install)) {
+        my $fn = $_;
+        ok $called_functions{$fn} eq 0, "$fn not called by qesap_prepare_env in only_configure mode";
+    }
+};
+
+subtest '[qesap_prepare_env/qesap_yaml_replace]' => sub {
+    my %called_functions;
+    my @mock_func = qw(qesap_get_variables);
+    my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
+    $qesap = create_qesap_prepare_env_mocks_with_calls(\%called_functions);
+    my @calls;
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; });
+    $called_functions{file_content_replace} = 0;
+    $qesap->redefine(file_content_replace => sub { $called_functions{file_content_replace} = 1; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(qesap_upload_logs => sub { return; });
+
+    qesap_prepare_env(provider => 'DONALDUCK', only_configure => 1);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok $called_functions{file_content_replace} eq 1, "file_content_replace called by qesap_yaml_replace";
+};
+
+subtest '[qesap_prepare_env/qesap_create_folder_tree/qesap_get_file_paths] default' => sub {
+    my %called_functions;
+    my @mock_func = qw(qesap_get_variables
+      qesap_yaml_replace
+      qesap_get_deployment_code
+      qesap_get_roles_code
+      qesap_pip_install
+      qesap_galaxy_install);
+    my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
+    my @calls;
+    $qesap->redefine(data_url => sub { return '/TORNADO'; });
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(qesap_upload_logs => sub { return; });
+
+    qesap_prepare_env(provider => 'DONALDUCK');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    is $calls[0], 'mkdir -p /root/qe-sap-deployment', "Default deployment_dir is /root/qe-sap-deployment";
+    ok((any { qr/curl.*\/TORNADO -o \/root\/qe-sap-deployment\/scripts\/qesap\/MARLIN/ } @calls), 'Default location for the openQA conf.yaml templates');
+};
+
+subtest '[qesap_prepare_env/qesap_create_folder_tree/qesap_get_file_paths] user specified deployment_dir' => sub {
+    my %called_functions;
+    my @mock_func = qw(qesap_get_variables
+      qesap_yaml_replace
+      qesap_get_deployment_code
+      qesap_get_roles_code
+      qesap_pip_install
+      qesap_galaxy_install);
+    my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
+    my @calls;
+    $qesap->redefine(data_url => sub { return '/TORNADO'; });
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(qesap_upload_logs => sub { return; });
+
+    set_var('QESAP_DEPLOYMENT_DIR', '/SUN');
+    qesap_prepare_env(provider => 'DONALDUCK');
+    set_var('QESAP_DEPLOYMENT_DIR', undef);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    is $calls[0], "mkdir -p /SUN", "Custom deploy location is /SUN";
 };
 
 sub create_qesap_prepare_env_mocks() {


### PR DESCRIPTION
Optionally add call to ansible-galaxy if requirements.yml is present, so if new qe-sap-deployment version is used.

This PR can be merged at any time without any change in the qe-sap-deplyoment, but it is a preparation for https://github.com/SUSE/qe-sap-deployment/pull/189


# Verification run:

## qesap regression

http://openqaworker15.qa.suse.cz/tests/266525 :green_circle: 

## HanaSR

http://openqaworker15.qa.suse.cz/tests/266522 :green_circle: 