### PR TITLE
Add openssh to autoyast package list on s390x

### DIFF
--- a/data/autoyast_sle15/mini_s390x.xml
+++ b/data/autoyast_sle15/mini_s390x.xml
@@ -37,6 +37,9 @@
         <products config:type="list">
             <product>SLES</product>
         </products>
+        <packages config:type="list">
+            <package>openssh</package>
+        </packages>
     </software>
     <users config:type="list">
         <user>


### PR DESCRIPTION
'openssh' is not installed by default on sle15sp6 with minimal role
during autoyast installation, so add it to make sure ssh can work on s390x platform which needs ssh access

- Verification run: [s390x-mimi-ay](https://openqa.suse.de/tests/12809351#details)