### PR TITLE
Improve maximize window poo#138248

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -52,7 +52,8 @@ sub open_powershell_as_admin {
     if (get_var('QAM_WINDOWS_SERVER')) {
         send_key_until_needlematch 'windows-quick-features-menu', 'super-x';
         wait_screen_change { send_key('shift-a') };
-        wait_screen_change { assert_and_click('window-max') };
+        # Maximize window
+        wait_screen_change { send_key('super-up') };
         assert_screen 'windows_server_powershell_opened', 30;
     } else {
         if (check_var('WIN_VERSION', '10')) {
@@ -78,7 +79,8 @@ sub open_powershell_as_admin {
             send_key 'esc' if match_has_tag('powershell-with-startup-menu');
         }
         assert_screen 'powershell-as-admin-window', timeout => 240;
-        assert_and_click 'window-max';
+        # Maximize window
+        send_key 'super-up';
         wait_still_screen stilltime => 3, timeout => 12;
         _setup_serial_device unless (exists $args{no_serial});
     }

--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -119,11 +119,12 @@ sub run {
     assert_screen [qw(yast2-wsl-firstboot-welcome wsl-installing-prompt)], 480;
 
     if (match_has_tag 'yast2-wsl-firstboot-welcome') {
+
         # The new process of installing, appears in an already maximized window,
         # but sometimes it loses focus. So I created another needle to check if
         # the window is already maximized and click somewhere else to bring it to focus.
         assert_screen(['window-max', 'window-minimize']);
-        assert_and_click 'window-max' if match_has_tag 'window-max';
+        send_key 'super-up' if match_has_tag 'window-max';
         assert_and_click 'window-minimize' if match_has_tag 'window-minimize';
         wait_still_screen stilltime => 3, timeout => 10;
         is_fake_scc_url_needed && set_fake_scc_url();
@@ -155,8 +156,8 @@ sub run {
         # Back to CLI
         assert_screen 'wsl-linux-prompt';
     } else {
-        #1) skip registration, we cannot register against proxy SCC
-        assert_and_click 'window-max';
+        #1) Make sure to maximize the window and skip registration, we cannot register against proxy SCC
+        send_key 'super-up';
         assert_screen 'wsl-registration-prompt', 300;
         send_key 'ret';
 


### PR DESCRIPTION
in order to maximize a window, swaps a needle verification for a keyboard input (super+up).

- Related ticket: https://progress.opensuse.org/issues/138248

- Verification run (updated): https://openqa.suse.de/tests/13070688#


