### PR TITLE
Registered BYOS images before any patching is run

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -37,7 +37,6 @@ sub run {
             loadtest('sles4sap/publiccloud/network_peering', name => 'network_peering', run_args => $run_args, @_);
             loadtest('sles4sap/publiccloud/add_server_to_hosts', name => 'add_server_to_hosts', run_args => $run_args, @_);
             loadtest('sles4sap/publiccloud/cluster_add_repos', name => 'cluster_add_repos', run_args => $run_args, @_);
-            loadtest('sles4sap/publiccloud/general_patch_and_reboot', name => 'general_patch_and_reboot', run_args => $run_args, @_);
         }
         loadtest('sles4sap/publiccloud/qesap_ansible', name => 'deploy_qesap_ansible', run_args => $run_args, @_);
     }


### PR DESCRIPTION
Remove test module `general_patch_and_reboot`.
Test module `general_patch_and_reboot` is duplicated as test module `deploy_qesap_ansible` also does the `patch` and `reboot` stuff.


TEAM-8741 - [BYOS]BYOS images are registered before any patching is run
- Related ticket: https://jira.suse.com/browse/TEAM-8741
- Needles: NA
- Verification run: https://openqa.suse.de/tests/12815589# (passed)
