### PR TITLE
Reduce failure probability by switching to serial terminal

### DIFF
--- a/tests/console/check_network.pm
+++ b/tests/console/check_network.pm
@@ -18,7 +18,7 @@ use warnings;
 sub run {
     # let's see how it looks at the beginning
     save_screenshot;
-    is_ipmi ? use_ssh_serial_console : select_console 'root-console';
+    is_ipmi ? use_ssh_serial_console : select_serial_terminal;
 
     # https://fate.suse.com/320347 https://bugzilla.suse.com/show_bug.cgi?id=988157
     if (check_var('NETWORK_INIT_PARAM', 'ifcfg=eth0=dhcp')) {

--- a/tests/console/check_network.pm
+++ b/tests/console/check_network.pm
@@ -10,10 +10,11 @@
 # Maintainer: Zaoliang Luo <zluo@suse.de>
 
 use base "consoletest";
-use testapi;
-use Utils::Backends;
 use strict;
 use warnings;
+use testapi;
+use Utils::Backends;
+use serial_terminal;
 
 sub run {
     # let's see how it looks at the beginning

--- a/tests/console/installation_snapshots.pm
+++ b/tests/console/installation_snapshots.pm
@@ -15,10 +15,11 @@ use base 'consoletest';
 use strict;
 use warnings;
 use testapi;
+use serial_terminal;
 use version_utils qw(is_jeos is_sle);
 
 sub run {
-    select_console 'root-console';
+    select_serial_terminal;
 
     # Check if the corresponding snapshot is there
     my ($snapshot_desc, $snapshot_type);


### PR DESCRIPTION
- Avoid poo#43889 by switching to serial console
- Switch imports around


VR: [passed with flying colors](https://openqa.suse.de/tests/overview?version=15-SP6&distri=sle&build=os-autoinst%2Fos-autoinst-distri-opensuse%2318141)