### PR TITLE
Align Micro 6.0 with MicroOS

### DIFF
--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -33,7 +33,7 @@ sub run {
     }
 
     # Before combustion 1.2, a reboot is necessary for firstboot configuration
-    if (is_leap_micro || is_sle_micro) {
+    if (is_leap_micro('<6.0') || is_sle_micro('<6.0')) {
         wait_serial('reboot: Restarting system', 240) or die "SelfInstall image has not rebooted as expected";
         # Avoid booting into selfinstall again
         eject_cd() unless $no_cd;


### PR DESCRIPTION
There is no reboot after `dd`-ing the raw image into drive. This behavior is the same as we can see in MicroOS.

##### Verification runs

* [slem 6.0](http://kepler.suse.cz/tests/22212#step/selfinstall/5)
* [slem 5.5](http://kepler.suse.cz/tests/22213#step/selfinstall/7)

