### PR TITLE
Rename CONTAINER_RUNTIME to CONTAINER_RUNTIMES

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -308,7 +308,7 @@ sub reset_container_network_if_needed {
     # This workaround is only needed from SLE 15-SP3 (and Leap 15.3) onwards.
     # See https://bugzilla.suse.com/show_bug.cgi?id=1213811
     if ($version eq "15" && $sp >= 3) {
-        my $runtime = get_required_var('CONTAINER_RUNTIME');
+        my $runtime = get_required_var('CONTAINER_RUNTIMES');
         if ($host_distri =~ /sles|opensuse/ && $runtime =~ /docker/) {
             if ($current_engine eq 'podman') {
                 # Only stop docker, if docker is active. This is also a free check if docker is present

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -594,7 +594,7 @@ sub load_jeos_openstack_tests {
     unless (get_var('CI_VERIFICATION')) {
         loadtest "console/suseconnect_scc";
     }
-    unless (get_var('CONTAINER_RUNTIME')) {
+    unless (get_var('CONTAINER_RUNTIMES')) {
         loadtest "console/journal_check";
         loadtest "microos/libzypp_config";
     }
@@ -631,7 +631,7 @@ sub load_jeos_tests {
         loadtest "jeos/build_key";
         loadtest "console/prjconf_excluded_rpms";
     }
-    unless (get_var('CONTAINER_RUNTIME')) {
+    unless (get_var('CONTAINER_RUNTIMES')) {
         loadtest "console/journal_check";
         loadtest "microos/libzypp_config";
     }
@@ -644,7 +644,7 @@ sub load_jeos_tests {
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/verify_efi_mok' if get_var 'CHECK_MOK_IMPORT';
     # zypper_ref needs to run on jeos-containers. the is_sle is required otherwise is scheduled twice on o3
-    loadtest "console/zypper_ref" if (get_var('CONTAINER_RUNTIME') && is_sle);
+    loadtest "console/zypper_ref" if (get_var('CONTAINER_RUNTIMES') && is_sle);
 }
 
 sub installzdupstep_is_applicable {

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -28,7 +28,7 @@ our @EXPORT = qw(
 );
 
 sub is_container_test {
-    return get_var('CONTAINER_RUNTIME', 0);
+    return get_var('CONTAINER_RUNTIMES', 0);
 }
 
 sub is_container_image_test {
@@ -204,7 +204,7 @@ sub update_host_and_publish_hdd {
         # we only need to shutdown the VM before publishing the HDD
         loadtest 'boot/boot_to_desktop';
         loadtest 'containers/update_host';
-        loadtest 'containers/openshift_setup' if check_var('CONTAINER_RUNTIME', 'openshift');
+        loadtest 'containers/openshift_setup' if check_var('CONTAINER_RUNTIMES', 'openshift');
     }
     loadtest 'shutdown/cleanup_before_shutdown' if is_s390x;
     loadtest 'shutdown/shutdown';
@@ -212,7 +212,7 @@ sub update_host_and_publish_hdd {
 }
 
 sub load_container_tests {
-    my $runtime = get_required_var('CONTAINER_RUNTIME');
+    my $runtime = get_required_var('CONTAINER_RUNTIMES');
 
     if (get_var('CONTAINER_UPDATE_HOST')) {
         update_host_and_publish_hdd();

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -83,8 +83,8 @@ sub run {
 
     my ($version, $sp, $host_distri) = get_os_release;
 
-    # CONTAINER_RUNTIME can be "docker", "podman" or both "podman,docker"
-    my $engines = get_required_var('CONTAINER_RUNTIME');
+    # CONTAINER_RUNTIMES can be "docker", "podman" or both "podman,docker"
+    my $engines = get_required_var('CONTAINER_RUNTIMES');
     my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
     my $bci_tests_branch = get_var('BCI_TESTS_BRANCH');
 

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -60,7 +60,7 @@ sub run_tox_cmd {
     # e.g. junit_python.xml -> junit_python_podman.xml
     # We use script_run because the file might not exist if tox timed out or other
     # unexpected error.
-    script_run('mv junit_' . $env . '.xml junit_' . $env . '_${CONTAINER_RUNTIME}.xml');
+    script_run('mv junit_' . $env . '.xml junit_' . $env . '_${CONTAINER_RUNTIMES}.xml');
 }
 
 sub run {
@@ -98,7 +98,7 @@ sub run {
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     assert_script_run("cd /root/BCI-tests");
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
-    assert_script_run("export CONTAINER_RUNTIME=$engine");
+    assert_script_run("export CONTAINER_RUNTIMES=$engine");
     $version =~ s/-SP/./g;
     $version = lc($version);
     assert_script_run("export OS_VERSION=$version");

--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -27,15 +27,15 @@ sub run {
     my $build = get_required_var('CONTAINER_IMAGE_BUILD');
     record_info('IMAGE', $image);
 
-    # If multiple engines are defined (e.g. CONTAINER_RUNTIME=podman,docker), we use just one. podman is preferred.
-    my $engines = get_required_var('CONTAINER_RUNTIME');
+    # If multiple engines are defined (e.g. CONTAINER_RUNTIMES=podman,docker), we use just one. podman is preferred.
+    my $engines = get_required_var('CONTAINER_RUNTIMES');
     my $engine;
     if ($engines =~ /podman/) {
         $engine = 'podman';
     } elsif ($engines =~ /docker/) {
         $engine = 'docker';
     } else {
-        die('No valid container engines defined in CONTAINER_RUNTIME variable!');
+        die('No valid container engines defined in CONTAINER_RUNTIMES variable!');
     }
 
     script_retry("$engine pull -q $image", timeout => 300, delay => 60, retry => 3);

--- a/tests/containers/helm_rmt.pm
+++ b/tests/containers/helm_rmt.pm
@@ -27,7 +27,7 @@ sub run {
 
     my ($version, $sp, $host_distri) = get_os_release;
     # Skip HELM tests on SLES <15-SP3 and on PPC, where k3s is not available
-    return if (!($host_distri == "sles" && $version == 15 && $sp >= 3) || is_ppc64le || check_var('CONTAINER_RUNTIME', 'k8s'));
+    return if (!($host_distri == "sles" && $version == 15 && $sp >= 3) || is_ppc64le || check_var('CONTAINER_RUNTIMES', 'k8s'));
 
     systemctl 'stop firewalld';
     ensure_ca_certificates_suse_installed();

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -22,7 +22,7 @@ sub run {
     my $interface;
     my $update_timeout = 2400;    # aarch64 takes sometimes 20-30 minutes for completion
     my ($version, $sp, $host_distri) = get_os_release;
-    my $engine = get_required_var('CONTAINER_RUNTIME');
+    my $engine = get_required_var('CONTAINER_RUNTIMES');
 
     # Update the system to get the latest released state of the hosts.
     # Check routing table is well configured

--- a/tests/containers/suma_containers.pm
+++ b/tests/containers/suma_containers.pm
@@ -34,7 +34,7 @@ sub run {
     my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
 
     if (check_var('CONTAINER_SUMA', 'image')) {
-        my $runtimes = get_required_var('CONTAINER_RUNTIME');
+        my $runtimes = get_required_var('CONTAINER_RUNTIMES');
         my @runtimes = split /,/, $runtimes;
         for my $runtime (@runtimes) {
             script_retry("$runtime pull $image", timeout => 300, delay => 60, retry => 3);

--- a/tests/publiccloud/slem_prepare.pm
+++ b/tests/publiccloud/slem_prepare.pm
@@ -21,7 +21,7 @@ sub run {
     select_serial_terminal;
 
     if (get_var("PUBLIC_CLOUD_CONTAINERS")) {
-        my $runtime = get_required_var('CONTAINER_RUNTIME');
+        my $runtime = get_required_var('CONTAINER_RUNTIMES');
         # Install packages for container test runs
         trup_call("pkg install $runtime toolbox");
         $instance->softreboot();

--- a/variables.md
+++ b/variables.md
@@ -41,7 +41,7 @@ CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test mo
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
 CLUSTER_TYPES | string | false | Set the type of cluster that have to be analyzed (example: "drbd hana"). This variable belongs to PUBLIC_CLOUD_.
-CONTAINER_RUNTIME | string | | Container runtime to be used, e.g.  `docker`, `podman`, or both `podman,docker`. In addition, it is also used for other container tests, like  `kubectl`, `helm`, etc.
+CONTAINER_RUNTIMES | string | | Container runtime to be used, e.g.  `docker`, `podman`, or both `podman,docker`. In addition, it is also used for other container tests, like  `kubectl`, `helm`, etc.
 CONTAINERS_K3S_VERSION | string |  | If defined, install the provided version of k3s
 CONTAINERS_NO_SUSE_OS | boolean | false | Used by main_containers to see if the host is different than SLE or openSUSE.
 CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.


### PR DESCRIPTION
We should rename the openQA setting CONTAINER_RUNTIME to CONTAINER_RUNTIMES to indicate, that it might contain multiple runtimes, e.g. docker,podman

- Related ticket: https://progress.opensuse.org/issues/134354
- Needles: *not_needed*
- Verification run: https://openqa.suse.de/tests/12824128

Paired with: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1395
