### PR TITLE
Fix ISCSI partitioning

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -359,8 +359,9 @@ sub setup_iscsi_server {
     my $size = 0;
     for (my $num_lun = 1; $num_lun <= $num_luns; $num_lun++) {
         $start = $size + 1;
-        $size = $num_lun * $lun_size * 1024;
-        script_run "parted --script $hdd_lun mkpart primary ${start}MiB ${size}MiB";
+        # Last partition size in percentage to ensure it is not larger that device size.
+        $size = $num_lun eq $num_luns ? '100%' : $num_lun * $lun_size * 1024 . 'MiB';
+        script_run "parted --script $hdd_lun mkpart primary ${start}MiB ${size}";
     }
 
     # The easiest way (really!?) to configure LIO is with YaST


### PR DESCRIPTION
ISCSI partition sizes are not calculated correctly in some cases in module 
supportserver/setup.pm. Sometimes the last partition size ends being outside of 
device size causing 'parted' command to fail. This PR changes last partition end 
size to percentage (100%) so the size is calculated by 'parted'.

- Related ticket: https://jira.suse.com/browse/TEAM-8766
- Needles: N/A
- Verification run:

#number of LUNs was changed to '4'  
Failure: http://openqaworker15.qa.suse.cz/tests/268488#step/setup/43
VR: https://openqaworker15.qa.suse.cz/tests/268497#step/setup/43
