### PR TITLE
Unify the variable about os image for qesap

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -18,7 +18,7 @@ terraform:
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image: '%QESAP_CLUSTER_OS_VER%'
+    os_image: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA
     hana_count: '%NODE_COUNT%'

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -16,7 +16,7 @@ terraform:
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image_uri: '%OS_URI%'
+    os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA
     hana_count: '%NODE_COUNT%'

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#   Settings are meant to be controlled via OpenQA variables and managed by test:
+#   tests/sles4sap/publiccloud/qesap_ansible.pm
 provider: 'aws'
 apiver: 3
 terraform:
@@ -15,10 +17,11 @@ terraform:
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     aws_credentials: '/root/amazon_credentials'
-    os_image: '%QESAP_CLUSTER_OS_VER%'
+    os_image: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA
-    hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'
     hana_instancetype: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2_product.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2_product.yaml
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#   Settings are meant to be controlled via OpenQA variables and managed by test:
+#   tests/sles4sap/publiccloud/qesap_ansible.pm
 provider: 'aws'
 apiver: 3
 terraform:
@@ -15,11 +17,12 @@ terraform:
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     aws_credentials: '/root/amazon_credentials'
-    os_image: '%SLE_IMAGE%'
+    os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     os_owner: 'self'
 
     # HANA
-    hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'
     hana_instancetype: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+

--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -4,21 +4,24 @@
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#   Settings are meant to be controlled via OpenQA variables and managed by test:
+#   tests/sles4sap/publiccloud/qesap_ansible.pm
 provider: 'gcp'
 apiver: 3
 terraform:
   variables:
+    # GENERAL VARIABLES #
     project: 'ei-sle-qa-sap-8469'
     region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    os_image: '%SLE_IMAGE%'
-    private_key: '~/.ssh/id_rsa'
     public_key: '~/.ssh/id_rsa.pub'
+    private_key: '~/.ssh/id_rsa'
+    os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     gcp_credentials_file: '/root/google_credentials.json'
 
     # HANA
-    hana_count: '1'
+    hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'
     hana_data_disk_type: '%HANA_DISK_TYPE%'
     hana_log_disk_type: '%HANA_DISK_TYPE%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -6,19 +6,18 @@
 # Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
 #   Settings are meant to be controlled via OpenQA variables and managed by test:
 #   tests/sles4sap/publiccloud/qesap_ansible.pm
-
 provider: 'aws'
 apiver: 3
 terraform:
   variables:
     # GENERAL VARIABLES #
     aws_region: '%PUBLIC_CLOUD_REGION%'
-    aws_credentials: '/root/amazon_credentials'
-    admin_user: 'cloudadmin'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
+    admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image: '%SLE_IMAGE%'
+    aws_credentials: '/root/amazon_credentials'
+    os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     os_owner: '%SLE_IMAGE_OWNER%'
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
 

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -6,18 +6,17 @@
 # Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
 #   Settings are meant to be controlled via OpenQA variables and managed by test:
 #   tests/sles4sap/publiccloud/qesap_ansible.pm
-
 provider: 'azure'
 apiver: 3
 terraform:
   variables:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
-    admin_user: 'cloudadmin'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
+    admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image: "%PUBLIC_CLOUD_IMAGE_ID%"
+    os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -6,7 +6,6 @@
 # Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
 #   Settings are meant to be controlled via OpenQA variables and managed by test:
 #   tests/sles4sap/publiccloud/qesap_ansible.pm
-
 provider: 'azure'
 apiver: 3
 terraform:
@@ -15,11 +14,11 @@ terraform:
     vnet_address_range: "%VNET_ADDRESS_RANGE%"
     subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
     az_region: '%PUBLIC_CLOUD_REGION%'
-    admin_user: 'cloudadmin'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
+    admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image: "%PUBLIC_CLOUD_OS_IMAGE%"
+    os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
@@ -29,11 +28,13 @@ terraform:
     hana_ha_enabled: '%HA_CLUSTER%'
     vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -13,11 +13,11 @@ terraform:
   variables:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'
-    admin_user: 'cloudadmin'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
+    admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
-    os_image_uri: '%OS_URI%'
+    os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
     hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
 
     # HANA
@@ -25,11 +25,13 @@ terraform:
     hana_ha_enabled: '%HA_CLUSTER%'
     vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 
 ansible:
-  az_storage_account_name: "%HANA_ACCOUNT%"
-  az_container_name:  "%HANA_CONTAINER%"
-  az_sas_token: "%HANA_TOKEN%"
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -117,15 +117,17 @@ sub run {
     }
 
     my $subscription_id = $provider->{provider_client}{subscription};
+    my $os_image_name;
 
-    # This section is only needed by tests using images uploaded
-    # with publiccloud_upload_img so using conf.yaml templates
-    # with OS_URI or SLE_IMAGE
     if (is_azure() && get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) {
-        set_var('OS_URI', $provider->get_blob_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION')));
+        # This section is only needed by Azure tests using images uploaded
+        # with publiccloud_upload_img. This is because qe-sap-deployment
+        # is still not able to use images from Azure Gallery
+        $os_image_name = $provider->get_blob_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
     } else {
-        set_var('SLE_IMAGE', $provider->get_image_id());
+        $os_image_name = $provider->get_image_id();
     }
+    set_var('SLES4SAP_OS_IMAGE_NAME', $os_image_name);
 
     set_var_output('USE_SAPCONF', 'true');
     my $ansible_playbooks = create_playbook_section_list($ha_enabled);


### PR DESCRIPTION
Unify the variable used in all the  qesap conf.yaml template for HanaSr and mr_tests.

- Related ticket: TEAM-8180

# Verification run:

## OSD Maintenance: SLE 15 SP5 SAP Incidents 

### sles4sap_azure_generic_maintenance.yaml

 sle-15-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:31486:saptune-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3 

For this test is is crucial to select the right combination of settings:

#### http://openqaworker15.qa.suse.cz/tests/269108 ( http://openqaworker15.qa.suse.cz/tests/269107 with more logs)  
Cloned from https://openqa.suse.de/tests/12825885 and manually adding:
 - `PUBLIC_CLOUD_AZURE_OFFER=""`  that is like removing it
 - `PUBLIC_CLOUD_IMAGE_ID="suse:sles-sap-15-SP5-byos:gen2:latest"`

#### ( http://openqaworker15.qa.suse.cz/tests/269106 with more logs)  :green_circle: 
Cloned from https://openqa.suse.de/tests/12825885 and manually adding:
 - `PUBLIC_CLOUD_IMAGE_LOCATION=""`   that is like removing it
 - `PUBLIC_CLOUD_AZURE_OFFER=""`  that is like removing it
 - `PUBLIC_CLOUD_IMAGE_ID="suse:sles-sap-15-SP5-byos:gen2:latest"`

#### http://openqaworker15.qa.suse.cz/tests/268520 ( http://openqaworker15.qa.suse.cz/tests/268759 with more logs)  :red_circle:
Cloned from https://openqa.suse.de/tests/12825885 without any setting changes

Result is  `os_image` in the generated `config.yaml` and `terraform.tfvars` is empty

Checking the settings tab:
- `PUBLIC_CLOUD_AZURE_OFFER` is not empty 
- there's no `PUBLIC_CLOUD_IMAGE_*`  settings. In particular `PUBLIC_CLOUD_IMAGE_LOCATION` is missing.
 
The empty string probably come from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17677 combination.

####  http://openqaworker15.qa.suse.cz/tests/268524  ( http://openqaworker15.qa.suse.cz/tests/268760 with more logs)  :red_circle:
Cloned from https://openqa.suse.de/tests/12825885 and manually adding `PUBLIC_CLOUD_IMAGE_ID="suse:sles-sap-15-SP5-byos:gen2:latest"`  

Result is  `os_image` in the generated `config.yaml` and `terraform.tfvars` is empty

Checking the settings tab:
- `PUBLIC_CLOUD_AZURE_OFFER` is not empty 
- the only `PUBLIC_CLOUD_IMAGE_*`  configured setting is `PUBLIC_CLOUD_IMAGE_ID`. It means that `PUBLIC_CLOUD_IMAGE_LOCATION` is missing.

The empty string probably come from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17677 combination.

#### http://openqaworker15.qa.suse.cz/tests/268752 :red_circle: 
Cloned from https://openqa.suse.de/tests/12825885 and manually adding:
 - `PUBLIC_CLOUD_AZURE_OFFER=""`  that is like removing it
 - `PUBLIC_CLOUD_IMAGE_LOCATION="gnoccobalocco"` dummy value
 - `PUBLIC_CLOUD_IMAGE_ID="suse:sles-sap-15-SP5-byos:gen2:latest"`

Result is  `os_image = "https://******/gnoccobalocco" 

#### http://openqaworker15.qa.suse.cz/tests/268756  ( http://openqaworker15.qa.suse.cz/tests/268761 with more logs)  :red_circle:
Cloned from https://openqa.suse.de/tests/12825885 and manually adding `PUBLIC_CLOUD_IMAGE_LOCATION="suse:sles-sap-15-SP5-byos:gen2:latest"`

Result is  `os_image = "https://*******/suse:sles-sap-15-SP5-byos:gen2:latest"`

#### http://openqaworker15.qa.suse.cz/tests/268757 :red_circle: 
Cloned from https://openqa.suse.de/tests/12825885 and manually adding:
 - `PUBLIC_CLOUD_IMAGE_LOCATION="suse:sles-sap-15-SP5-byos:gen2:latest"`
 - `PUBLIC_CLOUD_IMAGE_ID="suse:sles-sap-15-SP5-byos:gen2:latest"`

Result is `os_image = "https://****/suse:sles-sap-15-SP5-byos:gen2:latest"`

### mr_test_ec2.yaml

 - sle-15-SP5-EC2-SAP-BYOS-Incidents-saptune-x86_64-Build:31486:saptune-sles4sap_gnome_saptune_delete_rename@ec2_r5b.metal -> http://openqaworker15.qa.suse.cz/tests/268521 :green_circle: 


## OSD mr_test Latest - HA + SAP 

### mr_test_gcp.yaml

 - sle-15-SP5-GCE-SAP-x86_64-Build0377-sles4sap_gnome_saptune_delete_rename@gce_n1_highmem_8 -> http://openqaworker15.qa.suse.cz/tests/268506 :green_circle: 

### sles4sap_azure_generic_uri.yaml

 - sle-15-SP5-Azure-SAP-BYOS-x86_64-Build0378-azure_sap_byos_hanasr_sapconf@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/268522 :green_circle: 


### mr_test_ec2.yaml 

 - sle-15-SP5-EC2-SAP-BYOS-Incidents-saptune-x86_64-Build:31486:saptune-sles4sap_gnome_saptune_overrides@ec2_r5.8xlarge -> http://openqaworker15.qa.suse.cz/tests/268523


## ow15 HanaSR regression

### sles4sap_aws_generic.yaml
-  sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2023-11-16T05:03:11Z-hanasr_aws_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/268500 :green_circle: 

### sles4sap_azure_generic.yaml
 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2023-11-16T05:03:11Z-hanasr_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/268502 Terraform fails but the terraform.tfvars properly get a valid os_image value
```
os_image = "SUSE:sles-sap-15-sp5-byos:gen2:2023.06.20"
```
 http://openqaworker15.qa.suse.cz/tests/268516 :green_circle: 

The same but with more debug logs http://openqaworker15.qa.suse.cz/tests/269085 :green_circle: 
 
 - sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-11-16T05:03:11Z-hanasr_azure_test_sapconf@64bit -> http://openqaworker15.qa.suse.cz/tests/268501  :green_circle: fails in Ansible but Terraform is fine, that means Terraform properly get the variable about the os_image
 - sle-15-SP3-HanaSr-Azure-Byos-x86_64-Build15-SP3_2023-11-16T05:03:11Z-hanasr_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/268503  :green_circle: 
 - sle-15-SP2-HanaSr-Azure-Byos-x86_64-Build15-SP2_2023-11-16T05:03:11Z-hanasr_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/268504  :green_circle:
 - sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2023-11-16T05:03:11Z-hanasr_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/268505  :green_circle: