### PR TITLE
Remove workaround for bsc1194917

### DIFF
--- a/lib/services/hpcpackage_remain.pm
+++ b/lib/services/hpcpackage_remain.pm
@@ -37,8 +37,7 @@ sub list_pkg {
 sub install_pkg {
     my $version = get_var('HDDVERSION');
     # Install all 'library wrappers' (packages matching -hpc, not having a version number with '_' after their name)
-    record_soft_failure("bsc#1194917 - openQA test fails : nothing provides 'gcc9' needed by the to be installed gnu9-compilers-hpc-devel-1.4-3.14.3.noarch");
-    my $module_list_p = script_output q[zypper search -r SLE-Module-HPC] . $version . q[-Pool -r SLE-Module-HPC] . $version . q[-Updates | cut -d '|' -f 2 | sed -e 's/ *//g' | grep -E '.*-hpc.*' | grep -vE 'system|module|suse' | grep -vE 'gnu9|gnu10|gnu11' | grep -vE '.*_[[:digit:]]+_[[:digit:]]+.*gnu|.*_[[:digit:]]+_[[:digit:]]+.*-hpc' | grep -vE '.*-static$' | grep -vE '.*hpc-macros.*'], proceed_on_failure => 1, timeout => 180;
+    my $module_list_p = script_output q[zypper search -r SLE-Module-HPC] . $version . q[-Pool -r SLE-Module-HPC] . $version . q[-Updates | cut -d '|' -f 2 | sed -e 's/ *//g' | grep -E '.*-hpc.*' | grep -vE 'system|module|suse' | grep -vE '.*_[[:digit:]]+_[[:digit:]]+.*gnu|.*_[[:digit:]]+_[[:digit:]]+.*-hpc' | grep -vE '.*-static$' | grep -vE '.*hpc-macros.*'], proceed_on_failure => 1, timeout => 180;
     my @pkginstall = split('\n', $module_list_p);
     # on x86 zypper will print out the Shell debug information, we need exclude it.
     @pkginstall = grep { !/LMOD_SH_DBG_ON/ } @pkginstall;


### PR DESCRIPTION
See https://progress.opensuse.org/issues/150935:
bsc#1194917 is 'VERIFIED INVALID' and https://bugzilla.suse.com/show_bug.cgi?id=1194917#c15 comments that 'After updating the openqa test case, the conflict reported in this bug is gone'.

[VRs](https://openqa.suse.de/tests/overview?version=15-SP6&build=JRivrain%2Fos-autoinst-distri-opensuse%2318151&distri=sle)

