### PR TITLE
Change to use serial_terminal for scc_deregistration

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1266,7 +1266,7 @@ This is needed to prevent access conflicts to the RPM database.
 =cut
 
 sub quit_packagekit {
-    script_run("systemctl mask packagekit; systemctl stop packagekit; while pgrep packagekitd; do sleep 1; done");
+    script_run("systemctl mask packagekit; systemctl stop packagekit; while pgrep packagekitd; do sleep 1; done", timeout => 60);
 }
 
 =head2 wait_for_purge_kernels

--- a/tests/console/scc_deregistration.pm
+++ b/tests/console/scc_deregistration.pm
@@ -9,11 +9,12 @@ use warnings;
 use base "consoletest";
 use testapi;
 use registration "scc_deregistration";
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     return unless (get_var('SCC_REGISTER') || get_var('HDD_SCC_REGISTERED'));
 
-    select_console 'root-console';
+    select_serial_terminal;
     scc_deregistration;
 }
 


### PR DESCRIPTION
Change to use serial_terminal for scc_deregistration

- Related ticket: https://progress.opensuse.org/issues/137585
- Verification run: 
   ten times: http://openqa.suse.de/tests/12861496#next_previous
   aarch64: http://openqa.suse.de/t12861845
  s390x: http://openqa.suse.de/t12861886