### PR TITLE
Fix the export=CONTAINER_RUNTIME

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -98,7 +98,7 @@ sub run {
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     assert_script_run("cd /root/BCI-tests");
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
-    assert_script_run("export CONTAINER_RUNTIMES=$engine");
+    assert_script_run("export CONTAINER_RUNTIME=$engine");
     $version =~ s/-SP/./g;
     $version = lc($version);
     assert_script_run("export OS_VERSION=$version");


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/150980
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification runs: https://openqa.suse.de/tests/12835693, https://openqa.suse.de/tests/12835973, https://openqa.suse.de/tests/12835974, https://openqa.suse.de/tests/12836031, https://openqa.suse.de/tests/12836044
