### PR TITLE
Skip zypper-migration-plugin for sles15sp3

### DIFF
--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -23,9 +23,9 @@ sub check_or_install_packages {
     if (get_var("FULL_UPDATE") || get_var("MINIMAL_UPDATE")) {
         # if system is fully updated or even minimal patch applied,
         # all necessary packages for online migration should be installed
-        # and zypper-migration-plugin was obsoleted since 15sp4.
+        # and zypper-migration-plugin was obsoleted since 15sp3.
         my @pkgs = qw(yast2-migration rollback-helper);
-        push @pkgs, "zypper-migration-plugin" if is_sle('<15-SP4', get_var('ORIGIN_SYSTEM_VERSION'));
+        push @pkgs, "zypper-migration-plugin" if is_sle('<15-SP3', get_var('ORIGIN_SYSTEM_VERSION'));
         assert_script_run("rpm -q $_") foreach @pkgs;
     } else {
         # install necessary packages for online migration if system is not updated


### PR DESCRIPTION
for sles15sp3 zypper migration, we don't need to make sure zypper-migration-plugin was install anymore.

- Related ticket: [**138461**](https://progress.opensuse.org/issues/138461)
- Needles: N/A
- Verification run: 
  * https://openqa.suse.de/tests/12849119
  * https://openqa.suse.de/tests/12849120
  * https://openqa.suse.de/tests/12849144 (zypper)
  * https://openqa.suse.de/tests/12849158 (yast)