### PR TITLE
Add new test for 64kb page size

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1083,7 +1083,7 @@ sub load_inst_tests {
         loadtest "installation/secure_boot";
     }
     if (installyaststep_is_applicable()) {
-        loadtest "installation/resolve_dependency_issues" unless get_var("DEPENDENCY_RESOLVER_FLAG");
+        loadtest "installation/resolve_dependency_issues" unless (get_var("DEPENDENCY_RESOLVER_FLAG") || get_var('KERNEL_64KB_PAGE_SIZE'));
         loadtest "installation/installation_overview";
         # On Xen PV we don't have GRUB on VNC
         # SELinux relabel reboots, so grub needs to timeout

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -166,10 +166,19 @@ Performs steps needed to go from the "pattern selection" screen to
 
 sub go_to_search_packages {
     my ($self) = @_;
-    send_key 'alt-d';    # details button
-    assert_screen 'packages-manager-detail';
-    assert_and_click 'packages-search-tab';
-    assert_and_click 'packages-search-field-selected';
+    if (check_var('VIDEOMODE', 'text')) {
+        assert_screen 'patterns-list-selected';
+        wait_screen_change { send_key 'alt-f' };
+        for (1 .. 4) { send_key 'down'; }
+        send_key 'ret';
+        assert_screen 'pattern_selector';
+    }
+    else {
+        send_key 'alt-d';    # details button
+        assert_screen 'packages-manager-detail';
+        assert_and_click 'packages-search-tab';
+        assert_and_click 'packages-search-field-selected';
+    }
 }
 
 =head2 move_down
@@ -228,10 +237,17 @@ C<$package_name>
 sub search_package {
     my ($self, $package_name) = @_;
     assert_and_click 'packages-search-field-selected';
-    wait_screen_change { send_key 'ctrl-a' };
-    wait_screen_change { send_key 'delete' };
-    type_string_slow "$package_name";
-    send_key 'alt-s';    # search button
+    if (check_var('VIDEOMODE', 'text')) {
+        wait_screen_change { send_key 'alt-p' };
+        type_string_slow "$package_name";
+        send_key 'ret';    # search
+    }
+    else {
+        wait_screen_change { send_key 'ctrl-a' };
+        wait_screen_change { send_key 'delete' };
+        type_string_slow "$package_name";
+        send_key 'alt-s';    # search button
+    }
 }
 
 =head2 select_all_patterns_by_menu


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/126110
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1652
- Other related MR: https://github.com/SUSE/qa-automation/pull/807 and https://github.com/SUSE/qa-testsuites/pull/1085
- Verification run: 
- [x] [select_patterns from sle-micro-5.5](http://openqa.suse.de/tests/12909721) The failure is not related to the current code changes.
- [x] [select_packages from sle-15-SP6-Online-ppc64le](http://openqa.suse.de/tests/12909722)
- [x] [select_packages with 64 page size from aarch64](http://10.67.129.176/tests/140)
- [x] [select_packages without 64 page size from aarch64](http://openqa.qa2.suse.asia/tests/65517)

Aim:
- To install a guest operating system with a 64KB page size on a hypervisor that also operates with a 64KB page size.

Implementation Strategy:
- For Baremetal Setup:
Introduce a new module named select_packages which is optimized for text mode. This module will facilitate the configuration and management of systems with a 64KB page size setting in a baremetal environment.
- For Virtual Machine (VM) Setup:
Create a new scenario that involves installing a kernel-64kb package using AutoYaST. This scenario will be based on the detection of a 64KB page size setting in the baremetal environment. The goal is to ensure that the VM's kernel is aligned with the 64KB page size used by the hypervisor.
- For BJ OSD:
Add a new testsuit gi-guest_64kpg_developing-on-host_64kpg_developing-kvm with 2 new parameters, one is KERNEL_64KB_PAGE_SIZE=1, another is PACKAGES=kernel-64kb.







