### PR TITLE
pynfs: Use cdmackay's git tree

### DIFF
--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -46,7 +46,7 @@ sub install_dependencies_cthon04 {
 sub install_testsuite {
     my $testsuite = shift;
     if (get_var("PYNFS")) {
-        my $url = get_var('PYNFS_GIT_URL', 'git://git.linux-nfs.org/projects/bfields/pynfs.git');
+        my $url = get_var('PYNFS_GIT_URL', 'git://git.linux-nfs.org/projects/cdmackay/pynfs.git');
         my $rel = get_var('PYNFS_RELEASE');
 
         $rel = "-b $rel" if ($rel);


### PR DESCRIPTION
cdmackay's git tree not only contains fix for bsc#1217128, but it's newer (contains 6 more fixes from Jeff Layton).

Link: https://bugzilla.suse.com/show_bug.cgi?id=1217128#c3

Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1217128#c3
Verification run:
- https://openqa.suse.de/tests/overview?build=pynfs/use-cdmackay-git (sle 15-SP6)
- https://openqa.opensuse.org/tests/overview?build=pynfs/use-cdmackay-git (Tumbleweed)
