### PR TITLE
Enhance sriov test a little bit and print more detailed logs

### DIFF
--- a/data/virt_autotest/sriov_network_guest_logging.sh
+++ b/data/virt_autotest/sriov_network_guest_logging.sh
@@ -10,6 +10,10 @@ lspci
 echo ""
 ip a
 echo ""
+ls -l /etc/sysconfig/network/
+echo ""
+for FILE in /etc/sysconfig/network/ifcfg-*; do echo $FILE; cat $FILE; done
+echo ""
 lsmod | grep -e vf -e virt -e kvm -e xen -e pci
 echo ""
-journalctl -n 3000 | grep -e 'kernel:' -e wickedd-dhcp4 -e systemd-udevd
+journalctl --cursor-file /tmp/cursor.txt | grep -e 'kernel:' -e wickedd-dhcp4 -e systemd-udevd

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -121,6 +121,7 @@ sub test_network_interface {
     $is_sriov_test = "true" if caller 0 eq 'sriov_network_card_pci_passthrough';
     script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 180);
     my $nic = script_output "ssh root\@$guest \"grep '$mac' /sys/class/net/*/address | cut -d'/' -f5 | head -n1\"";
+    die "$mac not found in guest $guest" unless $nic;
     if (check_var('TEST', 'qam-xen-networking') || check_var('TEST', 'qam-kvm-networking') || $is_sriov_test eq "true") {
         assert_script_run("ssh root\@$guest \"echo BOOTPROTO=\\'dhcp\\' > /etc/sysconfig/network/ifcfg-$nic\"");
 

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -124,7 +124,7 @@ sub run_test {
         check_guest_health($guest);
 
         #check the remaining vf(s) inside vm
-        for (my $i = 2; $i < $passthru_vf_count; $i++) {
+        for (my $i = 1; $i < $passthru_vf_count; $i++) {
             test_network_interface($guest, gate => $gateway, mac => $vfs[$i]->{vm_mac}, net => 'br123');
         }
 
@@ -399,6 +399,7 @@ sub save_network_device_status_logs {
     print_cmd_output_to_file("virsh domiflist $vm", $log_file);
 
     #logging device information in guest
+    script_run "echo '***** Status & logs inside $vm *****' >> $log_file";
     my $debug_script = "sriov_network_guest_logging.sh";
     download_script($debug_script, machine => $vm, proceed_on_failure => 1) if (${test_step} eq "1-initial");
     script_run("ssh root\@$vm \"~/$debug_script\" >> $log_file 2>&1", die_on_timeout => 0);


### PR DESCRIPTION
- check 3 VFs' network status. Originally it is 2 for sake of saving test time and IPs, but failures might be hidden.
- print more logs
- stop tests at the point the failure happens.

Related ticket: https://progress.opensuse.org/issues/151133

Verification run: 
always fail to reprodue failure.
https://openqa.suse.de/tests/12860822

