### PR TITLE
Add the conflict message to display on the openQA page 

### DIFF
--- a/tests/installation/select_patterns.pm
+++ b/tests/installation/select_patterns.pm
@@ -29,4 +29,13 @@ sub run {
     $self->accept_changes();
 }
 
+sub post_fail_hook {
+    my $self = shift;
+
+    select_console 'log-console';
+    my $ret = script_output("grep -E -m 1 \"nothing provides\" /var/log/YaST2/y2log", proceed_on_failure => 1);
+    record_info("Conflict:", $ret, result => 'fail') if ($ret);
+    $self->SUPER::post_fail_hook();
+}
+
 1;


### PR DESCRIPTION
Display the conflict message on the OpenQA web page whenever a conflict occurs during the installation.

- Related ticket: https://progress.opensuse.org/issues/138680
- Needles: No
- Verification run: 
  https://openqa.suse.de/tests/12855037#step/select_patterns/22
  https://openqa.suse.de/tests/12855039#step/select_patterns/1

Latest VRs:
https://openqa.suse.de/tests/12861755
https://openqa.suse.de/tests/12861756