### PR TITLE
Add installation module for custom kernel flavor with kernel-64kb support

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -19,6 +19,7 @@ use File::Basename 'basename';
 use Utils::Architectures;
 use repo_tools 'add_qa_head_repo';
 use utils;
+use kernel 'get_kernel_flavor';
 
 our @EXPORT = qw(
   export_ltp_env
@@ -91,7 +92,7 @@ sub get_ltp_version_file {
 sub log_versions {
     my $report_missing_config = shift;
     my $kernel_pkg = is_jeos || get_var('KERNEL_BASE') ? 'kernel-default-base' :
-      (is_rt ? 'kernel-rt' : 'kernel-default');
+      (is_rt ? 'kernel-rt' : get_kernel_flavor);
     my $kernel_pkg_log = '/tmp/kernel-pkg.txt';
     my $ver_linux_log = '/tmp/ver_linux_before.txt';
     my $kernel_config = script_output('for f in "/boot/config-$(uname -r)" "/usr/lib/modules/$(uname -r)/config" /proc/config.gz; do if [ -f "$f" ]; then echo "$f"; break; fi; done');

--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -403,6 +403,10 @@ sub get_default_pkg {
 }
 
 sub install_from_repo {
+    # Workaround for kernel-64kb, until we add multibuild support to LTP package
+    # Lock kernel-default to don't pull it as LTP dependency
+    zypper_call 'al kernel-default' if get_kernel_flavor eq 'kernel-64kb';
+
     my @pkgs = split(/\s* \s*/, get_var('LTP_PKG', get_default_pkg));
 
     if (is_transactional) {

--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -30,6 +30,9 @@ sub remove_kernel_packages {
     if (check_var('SLE_PRODUCT', 'slert')) {
         @packages = qw(kernel-rt kernel-rt-devel kernel-source-rt);
     }
+    elsif (get_kernel_flavor eq 'kernel-64kb') {
+        @packages = qw(kernel-64kb*);
+    }
     else {
         @packages = qw(kernel-default kernel-default-devel kernel-macros kernel-source);
     }

--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -17,7 +17,12 @@ use warnings;
 
 our @EXPORT = qw(
   remove_kernel_packages
+  get_kernel_flavor
 );
+
+sub get_kernel_flavor {
+    return get_var('KERNEL_FLAVOR', 'kernel-default');
+}
 
 sub remove_kernel_packages {
     my @packages;

--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -1,14 +1,21 @@
 # SUSE's openQA tests
 #
-# Copyright 2018-2019 SUSE LLC
+# Copyright 2018-2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
-use 5.018;
+
+# Summary: Kernel helper functions
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package kernel;
+
+use base Exporter;
 use testapi;
+use strict;
 use utils;
 use version_utils 'is_sle';
 use warnings;
 
-our @EXPORT_OK = qw(
+our @EXPORT = qw(
   remove_kernel_packages
 );
 
@@ -34,3 +41,4 @@ sub remove_kernel_packages {
     return @packages;
 }
 
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2351,6 +2351,7 @@ sub load_system_prepare_tests {
     }
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest 'console/hostname' unless is_bridged_networking;
+    loadtest 'kernel/install_kernel_flavor' if get_var('KERNEL_FLAVOR');
     loadtest 'console/install_rt_kernel' if check_var('SLE_PRODUCT', 'SLERT');
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
     loadtest 'console/check_selinux_fails' if get_var('SELINUX');

--- a/schedule/kernel/prepare_baremetal.yaml
+++ b/schedule/kernel/prepare_baremetal.yaml
@@ -29,6 +29,7 @@ schedule:
     - installation/reboot_after_installation
     - installation/handle_reboot
     - installation/first_boot
+    - kernel/install_kernel_flavor
     - console/hostname
     - console/system_prepare
     - console/force_scheduled_tasks

--- a/tests/kernel/install_kernel_flavor.pm
+++ b/tests/kernel/install_kernel_flavor.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Install custom kernel and remove kernel-default (if it is requested)
+# Maintainer: QE Kernel <kernel-qa@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils qw(zypper_call);
+use kernel 'get_kernel_flavor';
+
+sub run {
+    select_serial_terminal;
+
+    my $kernel_flavor = get_kernel_flavor;
+    if (get_kernel_flavor ne 'kernel-default') {
+        zypper_call("in +${kernel_flavor} -kernel-default -kernel-default-devel -kernel-macros -kernel-source", exitcode => [0, 104]);
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -16,7 +16,7 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils qw(is_sle is_transactional package_version_cmp);
 use qam;
-use kernel 'remove_kernel_packages';
+use kernel;
 use klp;
 use power_action_utils 'power_action';
 use repo_tools 'add_qa_head_repo';
@@ -384,7 +384,8 @@ sub install_kotd {
     fully_patch_system;
     remove_kernel_packages;
     zypper_ar($repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
-    zypper_call("in -l kernel-default kernel-devel");
+    my $kernel_flavor = get_kernel_flavor;
+    zypper_call("in -l ${kernel_flavor} kernel-devel");
 }
 
 sub boot_to_console {
@@ -411,7 +412,7 @@ sub run {
 
     my $repo = get_var('KOTD_REPO');
     my $incident_id = undef;
-    my $kernel_package = 'kernel-default';
+    my $kernel_package = get_kernel_flavor;
 
     unless ($repo) {
         $repo = get_required_var('INCIDENT_REPO');

--- a/variables.md
+++ b/variables.md
@@ -101,6 +101,7 @@ IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine 
 K3S_SYMLINK | string | | Can be 'skip' or 'force'. Skips the installation of k3s symlinks to tools like kubectl or forces the creation of symlinks
 K3S_BIN_DIR | string | | If defined, install k3s to this provided directory instead of `/usr/local/bin/`
 K3S_CHANNEL | string | | Set the release channel to pick the k3s version from. Options include "stable", "latest" and "testing"
+KERNEL_FLAVOR | string | kernel-default | Set specific kernel flavor for test scenarios
 KUBECTL_CLUSTER | string | | Defines the cluster used to test `kubectl`. Currently only `k3s` is supported.
 KUBECTL_VERSION | string | v1.22.12 | Defines the kubectl version.
 KEEP_DISKS | boolean | false | Prevents disks wiping for remote backends without snaphots support, e.g. ipmi, powerVM, zVM


### PR DESCRIPTION
Enhancement poo#151153: We should to be able to install any kernel
flavor. New variable KERNEL_FLAVOR was introduced. 

First  use case is for kernel-64kb on aarch64 baremetal.

- Related ticket: https://progress.opensuse.org/issues/151153
- Needles:  NONE

####  Verification run: 
##### KERNEL_FLAVOR=kernel-64kb
15-SP5 installation: https://openqa.suse.de/tests/12879693
15-SP5 install_ltp with update_ltp for KOTD: https://openqa.suse.de/tests/12879694 
15-SP5 cve: https://openqa.suse.de/tests/12881277
15-SP5 syscalls: https://openqa.suse.de/tests/12881278

##### Without KERNEL_FLAVOR
15-SP5 installation: https://openqa.suse.de/tests/12881505
15-SP5 install_ltp with update_ltp for KOTD: https://openqa.suse.de/tests/12881506
15-SP5 cve: https://openqa.suse.de/tests/12881507
15-SP5 syscalls: https://openqa.suse.de/tests/12881508
