### PR TITLE
Change the qesap SAS token lifetime

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -109,7 +109,9 @@ sub run {
         my $escaped_token = qesap_az_create_sas_token(storage => get_required_var('HANA_ACCOUNT'),
             container => (split("/", get_required_var('HANA_CONTAINER')))[0],
             keyname => get_required_var('HANA_KEYNAME'),
-            lifetime => 30);
+            # lifetime has to be enough to reach the point of the test that
+            # executes qe-sap-deployment Ansible playbook 'sap-hana-download-media.yaml'
+            lifetime => 90);
         # escape needed by 'sed'
         # but not implemented in file_content_replace() yet poo#120690
         $escaped_token =~ s/\&/\\\&/g;

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -57,7 +57,10 @@ sub run {
         $variables{HANA_TOKEN} = qesap_az_create_sas_token(storage => get_required_var('QESAPDEPLOY_HANA_ACCOUNT'),
             container => (split("/", get_required_var('QESAPDEPLOY_HANA_CONTAINER')))[0],
             keyname => get_required_var('QESAPDEPLOY_HANA_KEYNAME'),
-            lifetime => 30);
+            # lifetime has to be enough to reach the point of the test that
+            # executes qe-sap-deployment Ansible playbook 'sap-hana-download-media.yaml'
+            # and eventually any Ansible retry.
+            lifetime => 120);
         record_info('TOKEN', $variables{HANA_TOKEN});
         # escape needed by 'sed'
         # but not implemented in file_content_replace() yet poo#120690


### PR DESCRIPTION
Change the token lifetime accommodating it with the test duration.

- Related ticket: [TEAM-8713](https://jira.suse.com/browse/TEAM-8713)

- Verification run:

- *qesap regression* sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test@64bit** -> http://openqaworker15.qa.suse.cz/tests/269109 :green_circle:  fails in destroy but that not relevant as destroy is not using the token
- *HanaSR* sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-11-20T12:40:41Z-hanasr_azure_test_saptune_spn@64bit -> http://openqaworker15.qa.suse.cz/tests/269110 :green_circle:  fails after the end of the deployment
