### PR TITLE
Split WSL version from dashes

### DIFF
--- a/tests/wsl/install_wsl.pm
+++ b/tests/wsl/install_wsl.pm
@@ -74,7 +74,7 @@ sub run {
         record_info 'Port close', 'Closing serial port...';
         $self->run_in_powershell(cmd => '$port.close()', code => sub { });
         $self->run_in_powershell(cmd => 'exit', code => sub { });
-        $self->use_search_feature($WSL_version);
+        $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
         assert_and_click 'wsl-suse-startup-search';
     } elsif ($install_from eq 'msstore') {
         # Install required SUSE distro from the MS Store


### PR DESCRIPTION
The WSL version contains dashes instead of spaces which causes Leap tests to fail, as Windows cannot find the app in the search bar when written with dashes

- Verification runs:
  - https://openqa.suse.de/tests/12857353
  - https://openqa.opensuse.org/tests/3744855
  - https://openqa.opensuse.org/tests/3744854
