### PR TITLE
Remove qesap setting HANA_OS_MAJOR_VERSION

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -19,7 +19,6 @@ terraform:
     aws_credentials: '/root/amazon_credentials'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     os_owner: '%SLE_IMAGE_OWNER%'
-    hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
 
     # HANA
     hana_count: '%NODE_COUNT%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -17,7 +17,6 @@ terraform:
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
-    hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -19,7 +19,6 @@ terraform:
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
-    hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -18,7 +18,6 @@ terraform:
     public_key: '~/.ssh/id_rsa.pub'
     private_key: '~/.ssh/id_rsa'
     os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
-    hana_os_major_version: '%HANA_OS_MAJOR_VERSION%'
 
     # HANA
     hana_count: '%NODE_COUNT%'

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -11,7 +11,6 @@
 # NODE_COUNT - number of nodes to deploy. Needs to be >1 for cluster usage.
 # PUBLIC_CLOUD_INSTANCE_TYPE - VM size, sets terraform 'vm_size' parameter
 # USE_SAPCONF - (true/false) set 'false' to use saptune
-# HANA_OS_MAJOR_VERSION - sets 'hana_os_major_version' terraform parameter - default is taken from 'VERSION'
 # FENCING_MECHANISM - (sbd/native) choose fencing mechanism
 # QESAP_SCC_NO_REGISTER - define variable in openqa to skip SCC registration via ANSIBLE
 # HANA_MEDIA - Hana install media directory


### PR DESCRIPTION
Remove Terraform variable that does no more exist in qe-sap-deployment.

Removed in qe-sap-deployment in https://github.com/SUSE/qe-sap-deployment/pull/128

- Related ticket:  TEAM-6956

# Verification run:

## sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5-hanasr_azure_test_sbd@64bit

http://openqaworker15.qa.suse.cz/tests/269375
http://openqaworker15.qa.suse.cz/tests/269374 :red_circle: generic Terraform error

