### PR TITLE
Adopt SR-IOV PCI passthrough test to maintenance test

### DIFF
--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -209,6 +209,7 @@
   <software>
     <packages config:type="list">
       <package>dhcp-client</package>
+      <package>xmlstarlet</package>
     </packages>
     <products config:type="list">
       <product><%= uc $get_var->('SLE_PRODUCT') %></product>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -88,19 +88,18 @@
   <bootloader>
     <global>
       <activate>true</activate>
-      <boot_mbr>true</boot_mbr>
       <gfxmode>auto</gfxmode>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <serial>serial --speed=115200 --unit=<%= $get_var->('SERIALDEV') =~ s/ttyS//r %> --word=8 --parity=no --stop=1</serial>
       <timeout config:type="integer">10</timeout>
       <trusted_grub>false</trusted_grub>
-      <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200</xen_append>
       <terminal>console</terminal>
-      % if ($check_var->('VERSION', '15')) {
-      <xen_kernel_append>dom0_max_vcpus=4 dom0_mem=8192M,max:8192M vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
+      % if ($check_var->('SYSTEM_ROLE', 'xen')) {
+      <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200 <%= $check_var->('IPMI_HW', 'AMD') ? "amd_iommu=on" : "intel_iommu=on" %></xen_append>
+      <xen_kernel_append><%= $check_var->('IPMI_HW', 'AMD') ? "" : "dom0_max_vcpus=4 dom0_mem=8192M,max:8192M" %> vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
       % } else {
-      <xen_kernel_append>vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
+      <append>splash=silent <%= $check_var->('IPMI_HW', 'AMD') ? "amd_iommu=on" : "intel_iommu=on" %></append>
       % }
     </global>
     <loader_type>grub2</loader_type>
@@ -109,7 +108,7 @@
     <ask-list config:type="list"/>
     <mode>
       <confirm config:type="boolean">false</confirm>
-      % if ($get_var->('VERSION') gt '15-SP3') {
+      % if ($get_var->('VERSION') gt '15-SP2') {
       <final_reboot config:type="boolean">true</final_reboot>
       % }
     </mode>

--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -206,7 +206,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     } else {
         %guests = ();
     }
-    %guests = %guests{"sles${guest_version}PV", "sles${guest_version}HVM"} unless (check_var('TERADATA', ''));
+    %guests = %guests{"sles${guest_version}PV", "sles${guest_version}HVM"} if (get_var('TERADATA'));
 
 } elsif (get_var("REGRESSION", '') =~ /kvm|qemu/) {
     %guests = (
@@ -333,7 +333,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     } else {
         %guests = ();
     }
-    %guests = %guests{"sles$guest_version"} unless (check_var('TERADATA', ''));
+    %guests = %guests{"sles$guest_version"} if (get_var('TERADATA'));
 
 } elsif (get_var("REGRESSION", '') =~ /vmware/) {
     %guests = (

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -123,14 +123,14 @@ sub is_hyperv_virtualization {
 #feel free to extend to support more cases
 sub is_fv_guest {
     my $guest = shift;
-    return $guest =~ /\bfv\b/ || $guest =~ /\bhvm\b/;
+    return $guest =~ /\bfv\b/ || $guest =~ /hvm/i;
 }
 
 #return 1 if it is a pv guest judging by name
 #feel free to extend to support more cases
 sub is_pv_guest {
     my $guest = shift;
-    return $guest =~ /\bpv\b/;
+    return $guest =~ /pv/i;
 }
 
 #Check if guest is SLE with optional filter for:

--- a/schedule/qam/common/virt/qam_virt_tests.yaml
+++ b/schedule/qam/common/virt/qam_virt_tests.yaml
@@ -53,3 +53,5 @@ conditional_schedule:
         - virtualization/universal/virtmanager_offon
         - virtualization/universal/virtmanager_add_devices
         - virtualization/universal/virtmanager_rm_devices
+      'sriov_network_card_pci_passthrough':
+        - virt_autotest/sriov_network_card_pci_passthrough


### PR DESCRIPTION
Adopt SR-IOV PCI passthrough test from product automation test to maintenance test

- Related ticket: https://progress.opensuse.org/issues/89098
- Needles: no
- Verification run: 
- sle15sp2 xen and kvm: http://10.67.183.130/tests/overview?version=15-SP2&groupid=2&build=sriov%3Avr&distri=sle
- sle15sp4 kvm: http://10.67.183.130/tests/overview?distri=sle&version=15-SP4&groupid=2&build=sriov%3Avr
- sle15sp5 xen: http://openqa.qam.suse.cz/tests/overview?groupid=168&build=%3AS%3AM%3A31417%3A312541%3Axen%3A%3Asriov&version=15-SP5&distri=sle
- gi-guest_developing-on-host_sles15sp5-xen: https://openqa.suse.de/tests/12857627