### PR TITLE
Verify lock_package test after migration

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -480,6 +480,7 @@ sub load_online_migration_tests {
     if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE'))) {
         loadtest "console/check_os_release";
         loadtest "console/check_system_info";
+        loadtest "console/verify_lock_package" if (get_var("LOCK_PACKAGE"));
     }
 }
 
@@ -1181,6 +1182,7 @@ else {
             if (is_sle && (get_var('FLAVOR') =~ /Migration/) && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE'))) {
                 loadtest "console/check_os_release";
                 loadtest "console/check_system_info";
+                loadtest "console/verify_lock_package" if (get_var("LOCK_PACKAGE"));
             }
         }
     }

--- a/tests/console/verify_lock_package.pm
+++ b/tests/console/verify_lock_package.pm
@@ -1,37 +1,31 @@
 # SUSE's openQA tests
 #
-# Copyright 2017 SUSE LLC
+# Copyright 2023 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: lock package test mainly used for migration testsuite - poo#17206
+# Summary: verify lock package works after migation test.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-package lock_package;
+package verify_lock_package;
 use base "consoletest";
 use strict;
 use warnings;
 use testapi;
 use utils;
 
-our $locked_pkg_info = [];
-
 sub run {
     select_console 'root-console';
 
     # Packages to be locked is comma-separated
     my @pkgs = split(/,/, get_var('LOCK_PACKAGE'));
+    my $old_version_str = get_var('LOCK_PACKAGE_VERSIONS');
     my $version_str = '';
-    zypper_install_available @pkgs;
     for my $pkg (@pkgs) {
         # Save each package's name, version and release info to variable
         my $fullname = script_output "rpm -q $pkg";
-        push @$locked_pkg_info, {name => $pkg, fullname => $fullname};
         $version_str = $version_str ? join(',', $version_str, $fullname) : $fullname;
-
-        # Add a lock for each package
-        zypper_call "al $pkg";
     }
-    set_var('LOCK_PACKAGE_VERSIONS', $version_str);
+    die "The packages hadn't been locked as expected, origin: $old_version_str new: $version_str" if ($version_str ne $old_version_str);
 }
 
 sub test_flags {


### PR DESCRIPTION
Enhance the lock_package test through ensure packages installed before test and verify lock_package test after migration.

- Related ticket: https://progress.opensuse.org/issues/133652
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/12861468#
      http://openqa.nue.suse.com/tests/12873535#details #online migration VR