### PR TITLE
Remove zypper-migration-plugin check

### DIFF
--- a/tests/migration/online_migration/pre_migration.pm
+++ b/tests/migration/online_migration/pre_migration.pm
@@ -22,10 +22,8 @@ sub check_or_install_packages {
     assert_script_run('modprobe nvram') if is_pvm_hmc;
     if (get_var("FULL_UPDATE") || get_var("MINIMAL_UPDATE")) {
         # if system is fully updated or even minimal patch applied,
-        # all necessary packages for online migration should be installed
-        # and zypper-migration-plugin was obsoleted since 15sp3.
+        # all necessary packages for online migration should be installed.
         my @pkgs = qw(yast2-migration rollback-helper);
-        push @pkgs, "zypper-migration-plugin" if is_sle('<15-SP3', get_var('ORIGIN_SYSTEM_VERSION'));
         assert_script_run("rpm -q $_") foreach @pkgs;
     } else {
         # install necessary packages for online migration if system is not updated


### PR DESCRIPTION
Now for sles15sp2/3 don't need package zypper-migration-plugin to make
yast2 migration work, we can safely remove it to make sles15sp2/sp3 
migration tests to pass.

- Related ticket: Quick PR original [**138461**](https://progress.opensuse.org/issue/138461)
- Needles: N/A
- Verification run: 
  * https://openqa.suse.de/tests/12861494
  * https://openqa.suse.de/tests/12861495
