### PR TITLE
WIP: Refactor kernel flavor switching and add test support for kernel-64kb

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -24,6 +24,16 @@ use Utils::Backends;
 use LTP::utils;
 use transactional;
 
+sub add_update_repos {
+    my @repos = split(",", shift);
+
+    while (my ($i, $val) = each(@repos)) {
+        zypper_call("ar $val kernel-update-$i");
+    }
+
+    zypper_call("ref");
+}
+
 sub check_kernel_package {
     my $kernel_name = shift;
 
@@ -47,13 +57,7 @@ sub first_azure_release {
 
     fully_patch_system;
     remove_kernel_packages();
-
-    my @repos = split(",", $repo);
-    while (my ($i, $val) = each(@repos)) {
-        zypper_call("ar $val kernel-update-$i");
-    }
-
-    zypper_call("ref");
+    add_update_repos($repo);
     zypper_call("in -l kernel-azure", exitcode => [0, 100, 101, 102, 103], timeout => 700);
     zypper_call('in kernel-devel');
 }
@@ -96,11 +100,7 @@ sub update_kernel {
         zypper_call('in kernel-devel');
     }
 
-    my @repos = split(",", $repo);
-    while (my ($i, $val) = each(@repos)) {
-        zypper_call("ar $val kernel-update-$i");
-    }
-    zypper_call("ref");
+    add_update_repos($repo);
 
     #Get patch list related to incident
     my $patches = '';

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -441,6 +441,11 @@ sub run {
         $self->change_kernel_flavor($repo, $incident_id, $kernel_package,
             ['kernel-default']);
     }
+    elsif (get_var('KERNEL_64KB')) {
+        $kernel_package = 'kernel-64kb';
+        $self->change_kernel_flavor($repo, $incident_id, $kernel_package,
+            ['kernel-default']);
+    }
     elsif (get_var('KOTD_REPO')) {
         install_kotd($repo);
     }
@@ -494,6 +499,12 @@ because there is never any kernel-azure package in the pool repository.
 When KERNEL_BASE variable evaluates to true, the job should test the
 alternative minimal kernel. Uninstall kernel-default and install
 kernel-default-base instead. Then update kernel as in the default case.
+
+=head2 KERNEL_64KB
+
+When KERNEL_64KB variable evaluates to true, the job should test the
+alternative kernel with 64KB pagesize. Uninstall kernel-default and install
+kernel-64kb instead. Then update kernel as in the default case.
 
 =head2 KOTD_REPO
 


### PR DESCRIPTION
Improve kernel flavor switching in maintenance tests and add support for `kernel-64kb` on aarch64.

- Related ticket: https://progress.opensuse.org/issues/151153
- Needles: N/A
- Verification run: Pending (no incidents for testing)
