### PR TITLE
15SP6: register python3 module for GCE helm

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -247,6 +247,7 @@ sub gcloud_install {
     my $py_version = get_var('PYTHON_VERSION', '3.11');
     my $py_pkg_version = $py_version =~ s/\.//gr;
     push @pkgs, 'python' . $py_pkg_version;
+    add_suseconnect_product(get_addon_fullname('python3')) if is_sle('15-SP6+');
 
     zypper_call("in @pkgs", $timeout);
 


### PR DESCRIPTION
Install latest python3 from python3 module in GCE testing.

- ticket: https://progress.opensuse.org/issues/151260
- Verification run: http://kepler.suse.cz/tests/22233#step/helm_GCE/53
