### PR TITLE
virt_autotest: enhancement compress single qcow2 disk via qemu-img

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -331,7 +331,7 @@ sub get_guest_disk_name_from_guest_xml {
 sub compress_single_qcow2_disk {
     my ($orig_disk, $compressed_disk) = @_;
     my $timeout = '720';
-    my $cmd = "time nice ionice qemu-img convert --force-share -c -p -O qcow2 $orig_disk $compressed_disk";
+    my $cmd = "time nice ionice qemu-img convert --force-share -c -m 1 -p -O qcow2 $orig_disk $compressed_disk";
 
     if ($orig_disk =~ /qcow2/) {
         die("Disk compression failed from $orig_disk to $compressed_disk.") if (script_run($cmd, timeout => $timeout, die => 0, retry => 2) ne 0);


### PR DESCRIPTION
Enhancement compress single qcow2 disk via qemu-img

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1216796
- Verification run: 
[gi-guest_developing-on-host_developing-kvm](http://openqa.suse.de/tests/12869104#) fail by [bsc#1217139](https://bugzilla.suse.com/show_bug.cgi?id=1217139)
[gi-guest_sles12sp5-on-host_developing-kvm](http://openqa.suse.de/tests/12869105#) fail by [bsc#1217139](https://bugzilla.suse.com/show_bug.cgi?id=1217139)
[gi-guest_sles15sp5-on-host_developing-kvm](http://openqa.suse.de/tests/12869106#) fail by [bsc#1217139](https://bugzilla.suse.com/show_bug.cgi?id=1217139)