### PR TITLE
Improve error message for s390 param construction

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -3,6 +3,7 @@ use base 'distribution';
 use serial_terminal ();
 use strict;
 use warnings;
+use Sys::Hostname qw(hostname);
 use Utils::Architectures;
 use utils qw(
   disable_serial_getty
@@ -567,6 +568,7 @@ sub init_consoles {
             my ($s390_guest_hostname) = $s390_guest_fqdn =~ /(.*?)\..*$/;
             my $s390_guest_subnetmask = get_required_var("ZVM_GUEST_SUBNETMASK");
             my $packed_ip = gethostbyname($s390_guest_fqdn);
+            die "Failed to get host by name for '$s390_guest_fqdn' (on " . hostname . ")" unless $packed_ip;
             my $s390_guest_ip = inet_ntoa($packed_ip);
             $s390_params .= " HostIP=${s390_guest_ip}/${s390_guest_subnetmask}";
             $s390_params .= " Hostname=${s390_guest_hostname}";


### PR DESCRIPTION
This should help to prevent an error message we encountered like 'Bad
arg length for Socket::inet_ntoa, length is 0, should be 4'.

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18189 https://openqa.opensuse.org/tests/3751720
```

 - opensuse-Tumbleweed-DVD-s390x-Build20231115-autoyast_zvm@s390x-zVM-vswitch-l2 -> https://openqa.opensuse.org/tests/3751739

now saying

```
Failed to get host by name for 'o3zvm004.openqanet.opensuse.org' (on openqaworker23_container)
```

Related progress issue: https://progress.opensuse.org/issues/137408