### PR TITLE
Remove the check of verifying podman0 interface

### DIFF
--- a/data/kea-dhcp/kea-dhcp4.conf
+++ b/data/kea-dhcp/kea-dhcp4.conf
@@ -20,7 +20,7 @@
         {
             "name": "domain-name-servers",
             "data": "10.0.2.1, 10.0.2.2"
-        },
+        }
 
     ],
 
@@ -49,7 +49,7 @@
         "output_options": [
           {
                 "output": "stdout"
-          },
+          }
         ],
         "severity": "INFO",
         "debuglevel": 0

--- a/tests/microos/workloads/kea-container/setup_dhcp4_server.pm
+++ b/tests/microos/workloads/kea-container/setup_dhcp4_server.pm
@@ -65,8 +65,6 @@ sub install_dhcp_container {
     # Start the dhcp4 container in the background
     assert_script_run("podman run -itd --replace --name kea-dhcp4 --privileged --network=host -v /etc/kea:/etc/kea $image  kea-dhcp4 -c /etc/kea/kea-dhcp4.conf");
     validate_script_output('podman ps ', sub { m/kea-dhcp4/ });
-    # cni-podman0 interface is created when running the first container
-    validate_script_output('ip a s cni-podman0', sub { /,UP/ });
     validate_script_output('ss -lnp', sub { /10.0.2.101:67/ });
 }
 

--- a/tests/microos/workloads/kea-container/setup_dhcp6_server.pm
+++ b/tests/microos/workloads/kea-container/setup_dhcp6_server.pm
@@ -70,8 +70,6 @@ sub install_dhcp_container {
     # Start the dhcp6 container in the background
     assert_script_run("podman run -itd --replace --name kea-dhcp6 --privileged --network=host -v /etc/kea:/etc/kea $image  kea-dhcp6 -c /etc/kea/kea-dhcp6.conf");
     validate_script_output('podman ps ', sub { m/kea-dhcp6/ });
-    # cni-podman0 interface is created when running the first container
-    validate_script_output('ip a s cni-podman0', sub { /,UP/ });
 }
 
 sub setup_static_mm_network_ipv6 {


### PR DESCRIPTION
Removing the verification of the cni-podman0 interface after creating the DHCPv4 container workload in the background. The plan is to schedule the DHCP container test in the ALP Functional job group.

- Verification run:  [dhcp4_server](https://openqa.suse.de/tests/12892993) | [dhcp_client](https://openqa.suse.de/tests/12892994)
  [dhcp6_server](https://openqa.suse.de/tests/12892991) | [dhcp6_client](https://openqa.suse.de/tests/12892992#)
