### PR TITLE
php_version: Don't check or add script module on maintenance tests

### DIFF
--- a/tests/console/php_version.pm
+++ b/tests/console/php_version.pm
@@ -23,7 +23,7 @@ sub run {
     select_serial_terminal;
 
 
-    if (is_sle) {
+    if (is_sle && !main_common::is_updates_tests) {
         # Check if BSC#1204824 is present
         if (script_run("suseconnect -l | grep 'Web and Scripting Module'| grep '(Activated)'") == 0) {
             die 'bsc#1204824 - Module activated already';


### PR DESCRIPTION
Maintenance tests have all modules pre-added

- Related ticket: #18168
- Verification run:
https://openqa.suse.de/tests/12904231
https://openqa.suse.de/tests/12904234
https://openqa.suse.de/tests/12904235
https://openqa.suse.de/tests/12904236
https://openqa.suse.de/tests/12904237
https://openqa.suse.de/tests/12904239
https://openqa.suse.de/tests/12904240
https://openqa.suse.de/tests/12904241
https://openqa.suse.de/tests/12904242
