### PR TITLE
Test for firewalld container in ALP product

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -63,7 +63,7 @@ sub configure_static_ip {
 
     if ($is_nm) {
         my $nm_id;
-        my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep '$device' | head -n1");
+        my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | grep '$device' | head -n1");
         ($device, $nm_id) = split(':', $nm_list);
 
         record_info('set_ip', "Device: $device\n NM ID: $nm_id\nIP: $ip\nMTU: $mtu");
@@ -110,7 +110,7 @@ sub configure_default_gateway {
     if ($is_nm) {
         my $nm_id;
         # When $device is not specified grep just does nothing and first connection is selected
-        my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep '$device' | head -n1");
+        my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | grep '$device' | head -n1");
         ($device, $nm_id) = split(':', $nm_list);
 
         assert_script_run "nmcli connection modify '$nm_id' ipv4.gateway 10.0.2.2";
@@ -128,7 +128,7 @@ sub configure_static_dns {
     my $servers = join(" ", @{$conf->{nameserver}});
 
     if ($is_nm) {
-        $nm_id = script_output('nmcli -t -f NAME c | head -n 1') unless ($nm_id);
+        $nm_id = script_output('nmcli -t -f NAME c | grep -v ^lo: | head -n 1') unless ($nm_id);
 
         assert_script_run "nmcli connection modify '$nm_id' ipv4.dns '$servers'";
     } else {

--- a/schedule/alp/firewalld_container.yaml
+++ b/schedule/alp/firewalld_container.yaml
@@ -1,0 +1,14 @@
+---
+name: Firewalld in a Container
+description: >
+    Install and test firewalld container
+conditional_schedule:
+    firewalld_container:
+        HOSTNAME:
+            'client':
+                - microos/workloads/firewalld-container/firewalld_client
+            'server':
+                - microos/workloads/firewalld-container/firewalld_server
+schedule:
+    - microos/disk_boot
+    - '{{firewalld_container}}'

--- a/tests/microos/workloads/firewalld-container/firewalld_client.pm
+++ b/tests/microos/workloads/firewalld-container/firewalld_client.pm
@@ -1,0 +1,46 @@
+# SUSE"s openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: podman firewalld-container
+# Summary: install and verify firewalld container.
+# Maintainer: QE Core <qe-core@suse.de>
+
+use base 'consoletest';
+use warnings;
+use strict;
+use testapi;
+use lockapi;
+use utils qw(set_hostname script_retry);
+use mm_network 'setup_static_mm_network';
+
+# MM network check: try to ping the gateway, and the server
+sub ensure_server_reachable {
+    assert_script_run('ping -c 1 10.0.2.2');
+    assert_script_run('ping -c 1 10.0.2.101');
+}
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+    set_hostname(get_var('HOSTNAME') // 'client');
+    # 101 = server, 102 = client
+    setup_static_mm_network('10.0.2.102/24');
+    mutex_wait 'barrier_setup_done';
+    barrier_wait 'FIREWALLD_CLIENT_READY';
+    barrier_wait 'FIREWALLD_SERVER_READY';
+    ensure_server_reachable();
+    barrier_wait 'FIREWALLD_SERVER_PORT_OPEN';
+    # ensure the port is open on the server
+    my $network_probe = 'curl http://10.0.2.101:8080/';
+    script_retry($network_probe, retry => 3, delay => 30);
+    # wait for port being closed by firewall
+    barrier_wait 'FIREWALLD_SERVER_PORT_CLOSED';
+    # the next command should fail because port 8080 is closed
+    die if (script_run($network_probe) == 0);
+    barrier_wait 'FIREWALLD_TEST_FINISHED';
+}
+
+1;
+

--- a/tests/microos/workloads/firewalld-container/firewalld_server.pm
+++ b/tests/microos/workloads/firewalld-container/firewalld_server.pm
@@ -1,0 +1,85 @@
+# SUSE"s openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: podman firewalld-container
+# Summary: install and verify firewalld container.
+# Maintainer: QE Core <qe-core@suse.de>
+
+use base 'consoletest';
+use warnings;
+use strict;
+use testapi;
+use lockapi;
+use mmapi;
+use utils qw(set_hostname);
+use transactional qw(trup_call check_reboot_changes);
+use mm_network 'setup_static_mm_network';
+use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
+
+
+sub remove_builtin_pkg_firewalld {
+    record_info("SERVER DEBUG", "removing firewalld and reboot if needed");
+    trup_call('pkg remove firewalld');
+    check_reboot_changes;
+}
+
+sub start_firewalld_container {
+    record_info("SERVER DEBUG", "installing firewalld container");
+    my $containerpath = 'registry.opensuse.org/suse/alp/workloads/tumbleweed_images/suse/alp/workloads/firewalld';
+    assert_script_run 'podman search firewalld';
+    assert_script_run "podman container runlabel install $containerpath";
+    assert_script_run "podman container runlabel run $containerpath";
+}
+
+sub firewall_port {
+    my $arg = shift;
+    record_info("SERVER DEBUG", "$arg firewall port");
+    my $podman_prefix = "podman exec firewalld firewall-cmd ";
+    my $options = '--zone=public --permanent ';
+    if ($arg eq 'open') { $options .= '--add-port=8080/tcp'; }
+    elsif ($arg eq 'close') { $options .= '--remove-port=8080/tcp'; }
+    else { die "invalid command for firewalld action"; }
+    assert_script_run $podman_prefix . $options;
+    assert_script_run $podman_prefix . '--reload';
+}
+
+# MM network check: try to ping the gateway, the client and the internet
+sub ensure_client_reachable {
+    assert_script_run('ping -c 1 10.0.2.2');
+    assert_script_run('ping -c 1 10.0.2.102');
+    assert_script_run('curl conncheck.opensuse.org');
+}
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+    disable_and_stop_service($self->firewall) if check_unit_file($self->firewall);
+    remove_builtin_pkg_firewalld();    # on ALP this needs a reboot
+    set_hostname(get_var('HOSTNAME') // 'server');
+    barrier_create($_, 2) for ('FIREWALLD_SERVER_READY', 'FIREWALLD_CLIENT_READY', 'FIREWALLD_SERVER_PORT_OPEN',
+        'FIREWALLD_SERVER_PORT_CLOSED', 'FIREWALLD_TEST_FINISHED');
+    mutex_create 'barrier_setup_done';
+    setup_static_mm_network('10.0.2.101/24');
+    barrier_wait 'FIREWALLD_CLIENT_READY';
+    ensure_client_reachable();
+    barrier_wait 'FIREWALLD_SERVER_READY';
+    start_firewalld_container();
+    # start a basic python http server
+    my $python_pid = background_script_run("python3 -m http.server 8080");
+    firewall_port('open');
+    barrier_wait 'FIREWALLD_SERVER_PORT_OPEN';
+    # tells the client server is ready so can probe the port
+    # client is checking the server port
+    firewall_port('close');
+    barrier_wait 'FIREWALLD_SERVER_PORT_CLOSED';
+    # here client is checking the port
+    barrier_wait 'FIREWALLD_TEST_FINISHED';
+    assert_script_run "kill $python_pid";
+    assert_script_run "podman stop firewalld";
+    wait_for_children();
+}
+
+1;
+


### PR DESCRIPTION
Introduce a new multi-machine test for checking containerized firewalld workload in ALP product

- Fixes also a bug on `mm_network.pm` that sporadically caused `lo` interface being selected

- Related ticket: https://progress.opensuse.org/issues/131189
- Needles: none
- Verification runs:
  - https://openqa.suse.de/tests/12908711
  - https://openqa.suse.de/tests/12908712
  - https://openqa.suse.de/tests/12908713
  - https://openqa.suse.de/tests/12908714
  - https://openqa.suse.de/tests/12908715
  - https://openqa.suse.de/tests/12908716
  - https://openqa.suse.de/tests/12908717
  - https://openqa.suse.de/tests/12908718
  - https://openqa.suse.de/tests/12908719
  - https://openqa.suse.de/tests/12908720
  - https://openqa.suse.de/tests/12908721
  - https://openqa.suse.de/tests/12908722
  - https://openqa.suse.de/tests/12908723
  - https://openqa.suse.de/tests/12908724
  - https://openqa.suse.de/tests/12908725
  - https://openqa.suse.de/tests/12908726
  - https://openqa.suse.de/tests/12908727
  - https://openqa.suse.de/tests/12908728
  - https://openqa.suse.de/tests/12908729
  - https://openqa.suse.de/tests/12908730
  - https://openqa.suse.de/tests/12908731
  - https://openqa.suse.de/tests/12908732
  - https://openqa.suse.de/tests/12908733
  - https://openqa.suse.de/tests/12908734
  - https://openqa.suse.de/tests/12908735
  - https://openqa.suse.de/tests/12908736
  - https://openqa.suse.de/tests/12908737
  - https://openqa.suse.de/tests/12908738
  - https://openqa.suse.de/tests/12908739
  - https://openqa.suse.de/tests/12908740
