### PR TITLE
Introduce CONTAINERS_CGROUP_VERSION variable

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -334,6 +334,8 @@ sub switch_cgroup_version {
 
     my $setting = ($version == 1) ? 0 : 1;
 
+    return if (script_output("cat /proc/cmdline") =~ "systemd\.unified_cgroup_hierarchy=$setting");
+
     record_info "cgroup v$version", "Switching to cgroup v$version";
     if (is_transactional) {
         add_grub_cmdline_settings("systemd.unified_cgroup_hierarchy=$setting", update_grub => 0);

--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -40,6 +40,10 @@ sub run {
 
     my $dir = "/root/DockerTest";
 
+    if (get_var('CONTAINERS_CGROUP_VERSION')) {
+        switch_cgroup_version($self, get_var('CONTAINERS_CGROUP_VERSION'));
+    }
+
     my $engine = $self->containers_factory($self->{runtime});
     test_seccomp() if ($self->{runtime} eq 'docker');
 

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -55,7 +55,7 @@ sub run {
     }
 
     # Prepare for Podman 3.4.4 and CGroups v2
-    if (is_sle('15-SP3+') || is_leap('15.3+')) {
+    if ((is_sle('15-SP3+') || is_leap('15.3+')) && !check_var('CONTAINERS_CGROUP_VERSION', '1')) {
         assert_script_run "usermod -a -G systemd-journal $testapi::username";
         switch_cgroup_version($self, 2);
         select_serial_terminal;

--- a/variables.md
+++ b/variables.md
@@ -44,6 +44,7 @@ CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for
 CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium fails to visualize error in the test module and not just put this information in the autoinst log file.
 CLUSTER_TYPES | string | false | Set the type of cluster that have to be analyzed (example: "drbd hana"). This variable belongs to PUBLIC_CLOUD_.
 CONTAINER_RUNTIMES | string | | Container runtime to be used, e.g.  `docker`, `podman`, or both `podman,docker`. In addition, it is also used for other container tests, like  `kubectl`, `helm`, etc.
+CONTAINERS_CGROUP_VERSION | string | | If defined, cgroups version to switch to
 CONTAINERS_K3S_VERSION | string |  | If defined, install the provided version of k3s
 CONTAINERS_NO_SUSE_OS | boolean | false | Used by main_containers to see if the host is different than SLE or openSUSE.
 CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.


### PR DESCRIPTION
Introduce CONTAINERS_CGROUP_VERSION variable to switch cgroups version.

- Related ticket: https://progress.opensuse.org/issues/137198
- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20231126-containers_host_docker@64bit -> https://openqa.opensuse.org/tests/3765302#step/docker/21
 
Bug opened for podman:
https://bugzilla.opensuse.org/show_bug.cgi?id=1217590

TODO:
- Add scheduling for TW on opensuse-jobgroups
- Add scheduling for SLE 15-SP3+ on qac-openqa-yaml