### PR TITLE
New grub on 15SP6 don't need to type LUKS passphrase

### DIFF
--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -16,10 +16,11 @@ use testapi qw(check_var get_var record_info);
 use version_utils qw(is_leap is_sle is_leap_micro is_sle_micro is_alp);
 
 sub run {
-    # With newer grub2 (in TW only currently), entering the passphrase in GRUB2
+    # With newer grub2 (in TW and SLE 15SP6 currently), entering the passphrase in GRUB2
     # is enough. The key is passed on during boot, so it's not asked for
     # a second time.
-    return if is_boot_encrypted && !is_leap && !is_sle && !is_leap_micro && !is_sle_micro && !is_alp;
+    my $need_to_enter_passphrase = is_leap || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || is_alp;
+    return if is_boot_encrypted && !$need_to_enter_passphrase;
 
     unlock_if_encrypted(check_typed_password => 1);
 }


### PR DESCRIPTION
A quick fix to address 15SP6 grub update; for readability reasons, introduce a boolean variable that explicit the condition when we can skip the passphrase input

- Related ticket: https://progress.opensuse.org/issues/151393
- Needles: nope
- Verification runs: 
  - SLE 15sp6: https://openqa.suse.de/tests/12908857
  - SLE 15sp5: https://openqa.suse.de/tests/12909185
  - Tumbleweed: https://openqa.opensuse.org/tests/3761967
  - Leap 15sp6: https://openqa.opensuse.org/tests/3761964
  - Leap 15sp4: https://openqa.opensuse.org/tests/3761960


