### PR TITLE
virt_autotest: enhancement for 15sp6 s390x guest installation tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -863,8 +863,10 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/login_console";
         loadtest "virt_autotest/install_package";
         loadtest "virt_autotest/update_package";
-        loadtest "virt_autotest/reset_partition";
-        loadtest "virt_autotest/reboot_and_wait_up_normal" if (!get_var('AUTOYAST') && get_var('REPO_0_TO_INSTALL'));
+        # Skip reset_partition for s390x due to there just be 42Gib disk space for each s390x LPAR
+        loadtest "virt_autotest/reset_partition" if (!is_s390x);
+        # Skip reboot_and_wait_up_normal for s390x due to new changes from svirt backend for power_action_utils::power_action (see poo#151786)
+        loadtest "virt_autotest/reboot_and_wait_up_normal" if (!get_var('AUTOYAST') && get_var('REPO_0_TO_INSTALL') && (!is_s390x));
         loadtest "virt_autotest/download_guest_assets" if get_var("SKIP_GUEST_INSTALL") && is_x86_64;
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016 SUSE LLC
+# Copyright 2016-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 package update_package;
@@ -49,12 +49,12 @@ sub run {
     my $self = shift;
     #workaroud: skip update package for registered aarch64 tests and because there are conflicts on sles15sp2 XEN
     $self->update_package() unless (!!get_var('AUTOYAST') || is_registered_sles && is_aarch64);
-    unless (!!get_var('AUTOYAST') || (is_registered_sles && is_aarch64) || is_s390x) {
-        set_grub_on_vh('', '', 'xen') if is_xen_host;
-        set_grub_on_vh('', '', 'kvm') if is_kvm_host;
-    } else {
+    if (!!get_var('AUTOYAST') || (is_registered_sles && is_aarch64)) {
         my @files_to_upload = ("/boot/grub2/grub.cfg", "/etc/default/grub");
         upload_logs($_, failok => 1) foreach (@files_to_upload);
+    } elsif (!is_s390x) {
+        set_grub_on_vh('', '', 'xen') if is_xen_host;
+        set_grub_on_vh('', '', 'kvm') if is_kvm_host;
     }
     update_guest_configurations_with_daily_build();
 
@@ -64,16 +64,15 @@ sub run {
     #workaround of bsc#1177790
     #disable DNSSEC validation as it is turned on by default but the forwarders donnot support it, refer to bsc#1177790
     if (is_sle('>=12-sp5')) {
-        #ues die_on_timeout=> 0 as workaround for s390x test during call script_run, refer to poo#106765
-        my %args = ();
         if (is_s390x) {
-            $args{die_on_timeout} = 0;
+            lpar_cmd("sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf");
+            lpar_cmd("grep 'dnssec-validation' /etc/named.conf");
+            lpar_cmd("systemctl restart named");
         } else {
-            $args{die_on_timeout} = 1;
+            script_run "sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf";
+            script_run "grep 'dnssec-validation' /etc/named.conf";
+            script_run "systemctl restart named";
         }
-        script_run "sed -i 's/#dnssec-validation auto;/dnssec-validation no;/g' /etc/named.conf", %args;
-        script_run "grep 'dnssec-validation' /etc/named.conf", %args;
-        script_run "systemctl restart named", %args;
         save_screenshot;
     }
 


### PR DESCRIPTION
- Description:

SKIP reset_partition test module, current s390x LPAR have 42GIb disk pace. we have to skip reset_partition during OSD s390x test run now.  

SKIP reboot_and_wait_up_normal test module, 
- [ ]  Situation 1, get new test failure from s390x reboot_and_wait_up_normal, refer to basic investigation, there is new changed from svirt backend now.  Next, need further investigate and create new PR to fix up this problem, create [poo#151786](https://progress.opensuse.org/issues/151786) to trace this problem

- [ ]  Situation 2, regarding new SLE12SP5 s390x test environment, we set up VLAN2114 for our OSD test run. but, there is a new product problem, added VLAN network do not work after reboot 12SP5 s390x system, filed as new product bug [bsc#1217953](https://bugzilla.suse.com/show_bug.cgi?id=1217953) - [12SP5][s390][VLAN] VLAN network does not work after reboot s390x system

- Related ticket: https://progress.opensuse.org/issues/135425

- Verification run: 
s390x
[gi-guest_developing-on-host_developing-kvm](http://10.67.129.59/tests/398) PASS
[gi-guest_sles12sp5-on-host_developing-kvm](http://10.67.129.59/tests/399) PASS
[gi-guest_sles15sp5-on-host_developing-kvm](http://10.67.129.59/tests/400) PASS
[gi-guest_developing-on-host_sles12sp5-kvm](http://10.67.129.59/tests/401) PASS
[gi-guest_developing-on-host_sles15sp5-kvm](http://10.67.129.59/tests/396) PASS
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](http://10.67.129.59/tests/382) PASS
[prj4_guest_upgrade_sles15sp5_on_sles15sp5-kvm](http://10.67.129.59/tests/380) PASS
x86_64
[gi-guest_developing-on-host_developing-xen](http://openqa.suse.de/tests/13224256#) PASS
[prj2_host_upgrade_sles12sp5_to_developing_kvm](http://openqa.suse.de/tests/13232880#) PASS
[prj2_host_upgrade_sles15sp5_to_developing_xen](http://openqa.suse.de/tests/13232883#) PASS
[prj4_guest_upgrade_sles15sp5_on_developing-kvm](http://openqa.suse.de/tests/13234355#) PASS
[prj4_guest_upgrade_sles15sp5_on_sles15sp5-kvm](http://openqa.suse.de/tests/13234357#) PASS
[prj4_guest_upgrade_sles15sp5_on_developing-xen](https://openqa.suse.de/tests/13234356) PASS
aarch64
[gi-guest_developing-on-host_developing-kvm](http://10.67.129.176/tests/248) PASS
