### PR TITLE
Change the 't=' to 'config:type=' for sle12sp5 autoyast profile

### DIFF
--- a/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_s390x.xml
@@ -147,84 +147,84 @@
   <ntp-client>
     <ntp_policy>auto</ntp_policy>
   </ntp-client>
-  <partitioning t="list">
-    <drive t="map">
+  <partitioning config:type="list">
+    <drive config:type="map">
       <device>/dev/disk/by-path/ccw-0.0.0000</device>
       <disklabel>gpt</disklabel>
-      <enable_snapshots t="boolean">true</enable_snapshots>
-      <partitions t="list">
-        <partition t="map">
-          <create t="boolean">true</create>
-          <filesystem t="symbol">ext2</filesystem>
-          <format t="boolean">true</format>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">ext2</filesystem>
+          <format config:type="boolean">true</format>
           <mount>/boot/zipl</mount>
-          <mountby t="symbol">path</mountby>
-          <partition_id t="integer">131</partition_id>
-          <partition_nr t="integer">1</partition_nr>
-          <resize t="boolean">false</resize>
+          <mountby config:type="symbol">path</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
           <size>314572800</size>
         </partition>
-        <partition t="map">
-          <create t="boolean">true</create>
-          <create_subvolumes t="boolean">true</create_subvolumes>
-          <filesystem t="symbol">btrfs</filesystem>
-          <format t="boolean">true</format>
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
           <mount>/</mount>
-          <mountby t="symbol">path</mountby>
-          <partition_id t="integer">131</partition_id>
-          <partition_nr t="integer">2</partition_nr>
-          <quotas t="boolean">true</quotas>
-          <resize t="boolean">false</resize>
+          <mountby config:type="symbol">path</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <quotas config:type="boolean">true</quotas>
+          <resize config:type="boolean">false</resize>
           <size>max</size>
-          <subvolumes t="list">
-            <subvolume t="map">
-              <copy_on_write t="boolean">false</copy_on_write>
+          <subvolumes config:type="list">
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">false</copy_on_write>
               <path>var</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>usr/local</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>tmp</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>srv</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>root</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>opt</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>home</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>boot/grub2/s390x-emu</path>
             </subvolume>
           </subvolumes>
           <subvolumes_prefix>@</subvolumes_prefix>
         </partition>
-        <partition t="map">
-          <create t="boolean">true</create>
-          <filesystem t="symbol">swap</filesystem>
-          <format t="boolean">true</format>
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
           <mount>swap</mount>
-          <mountby t="symbol">path</mountby>
-          <partition_id t="integer">130</partition_id>
-          <partition_nr t="integer">3</partition_nr>
-          <resize t="boolean">false</resize>
+          <mountby config:type="symbol">path</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <resize config:type="boolean">false</resize>
           <size>2148515328</size>
         </partition>
       </partitions>
-      <type t="symbol">CT_DISK</type>
+      <type config:type="symbol">CT_DISK</type>
       <use>all</use>
     </drive>
   </partitioning>

--- a/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_ppc64le.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_ppc64le.xml
@@ -95,77 +95,77 @@
       <pattern>x11</pattern>
     </patterns>
   </software>
-  <partitioning t="list">
-    <drive t="map">
+  <partitioning config:type="list">
+    <drive config:type="map">
       <device>/dev/vda</device>
       <disklabel>gpt</disklabel>
-      <enable_snapshots t="boolean">true</enable_snapshots>
-      <partitions t="list">
-        <partition t="map">
-          <create t="boolean">true</create>
-          <format t="boolean">false</format>
-          <partition_id t="integer">65</partition_id>
-          <partition_nr t="integer">1</partition_nr>
-          <resize t="boolean">false</resize>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">false</format>
+          <partition_id config:type="integer">65</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
           <size>8388608</size>
         </partition>
-        <partition t="map">
-          <create t="boolean">true</create>
-          <create_subvolumes t="boolean">true</create_subvolumes>
-          <filesystem t="symbol">btrfs</filesystem>
-          <format t="boolean">true</format>
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
           <mount>/</mount>
-          <mountby t="symbol">uuid</mountby>
-          <partition_id t="integer">131</partition_id>
-          <partition_nr t="integer">2</partition_nr>
-          <quotas t="boolean">true</quotas>
-          <resize t="boolean">false</resize>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <quotas config:type="boolean">true</quotas>
+          <resize config:type="boolean">false</resize>
           <size>max</size>
-          <subvolumes t="list">
-            <subvolume t="map">
-              <copy_on_write t="boolean">false</copy_on_write>
+          <subvolumes config:type="list">
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">false</copy_on_write>
               <path>var</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>usr/local</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>tmp</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>srv</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>root</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>opt</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>boot/grub2/powerpc-ieee1275</path>
             </subvolume>
           </subvolumes>
           <subvolumes_prefix>@</subvolumes_prefix>
         </partition>
-        <partition t="map">
-          <create t="boolean">true</create>
-          <filesystem t="symbol">swap</filesystem>
-          <format t="boolean">true</format>
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
           <mount>swap</mount>
-          <mountby t="symbol">uuid</mountby>
-          <partition_id t="integer">130</partition_id>
-          <partition_nr t="integer">3</partition_nr>
-          <resize t="boolean">false</resize>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <resize config:type="boolean">false</resize>
           <size>2148515328</size>
         </partition>
       </partitions>
-      <type t="symbol">CT_DISK</type>
+      <type config:type="symbol">CT_DISK</type>
       <use>all</use>
     </drive>
   </partitioning>

--- a/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_x86_64.xml
@@ -22,81 +22,81 @@
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
   </general>
-  <partitioning t="list">
-    <drive t="map">
+  <partitioning config:type="list">
+    <drive config:type="map">
       <device>/dev/vda</device>
       <disklabel>gpt</disklabel>
-      <enable_snapshots t="boolean">true</enable_snapshots>
-      <partitions t="list">
-        <partition t="map">
-          <create t="boolean">true</create>
-          <format t="boolean">false</format>
-          <partition_id t="integer">263</partition_id>
-          <partition_nr t="integer">1</partition_nr>
-          <resize t="boolean">false</resize>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">false</format>
+          <partition_id config:type="integer">263</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
           <size>8388608</size>
         </partition>
-        <partition t="map">
-          <create t="boolean">true</create>
-          <create_subvolumes t="boolean">true</create_subvolumes>
-          <filesystem t="symbol">btrfs</filesystem>
-          <format t="boolean">true</format>
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
           <mount>/</mount>
-          <mountby t="symbol">uuid</mountby>
-          <partition_id t="integer">131</partition_id>
-          <partition_nr t="integer">2</partition_nr>
-          <quotas t="boolean">true</quotas>
-          <resize t="boolean">false</resize>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <quotas config:type="boolean">true</quotas>
+          <resize config:type="boolean">false</resize>
           <size>max</size>
-          <subvolumes t="list">
-            <subvolume t="map">
-              <copy_on_write t="boolean">false</copy_on_write>
+          <subvolumes config:type="list">
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">false</copy_on_write>
               <path>var</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>usr/local</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>tmp</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>srv</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>root</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>opt</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>boot/grub2/x86_64-efi</path>
             </subvolume>
-            <subvolume t="map">
-              <copy_on_write t="boolean">true</copy_on_write>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>boot/grub2/i386-pc</path>
             </subvolume>
           </subvolumes>
           <subvolumes_prefix>@</subvolumes_prefix>
         </partition>
-        <partition t="map">
-          <create t="boolean">true</create>
-          <filesystem t="symbol">swap</filesystem>
-          <format t="boolean">true</format>
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
           <mount>swap</mount>
-          <mountby t="symbol">uuid</mountby>
-          <partition_id t="integer">130</partition_id>
-          <partition_nr t="integer">3</partition_nr>
-          <resize t="boolean">false</resize>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <resize config:type="boolean">false</resize>
           <size>2148515328</size>
         </partition>
       </partitions>
-      <type t="symbol">CT_DISK</type>
+      <type config:type="symbol">CT_DISK</type>
       <use>all</use>
     </drive>
   </partitioning>


### PR DESCRIPTION
- Description:
  * In SLE12SP5 we have to use 'config:type' not the 't=' in the autoyast profile, the t shortcut was introduced in SLE-15-SP3.

- Related ticket: Quick PR
- More info:
   - [**slack_discussion**](https://suse.slack.com/archives/C02D1T4S58S/p1701089829017879)
- Needles: N/A
- Verification run: 
   - https://openqa.suse.de/tests/12915680#step/hostname/8
   - https://openqa.suse.de/tests/12915745#step/hostname/8
   - https://openqa.suse.de/tests/12915747#step/hostname/8
   
 - Without the fix it still has /home
   *   https://openqa.suse.de/tests/12915743#step/hostname/10
