### PR TITLE
btrfs-progs: init btrfs-progs in main_micro_alp

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -321,6 +321,14 @@ sub load_tests {
         return 1;
     }
 
+    if (get_var('BTRFS_PROGS')) {
+        boot_hdd_image;
+        loadtest 'btrfs-progs/install';
+        loadtest 'btrfs-progs/run';
+        loadtest 'btrfs-progs/generate_report';
+        return 1;
+    }
+
     if (get_var('REMOTE_TARGET')) {
         load_remote_target_tests;
         return 1;


### PR DESCRIPTION
Enable btrfs-progs for alp dolomite in openqa

- Related ticket: https://progress.opensuse.org/issues/150872
- Needles: N/A
- Verification run: 
- http://10.67.129.54/tests/884 (SLES)
- http://10.67.133.133/tests/387 (ALP)

