### PR TITLE
slert: Replace product checks by variable with is_rt function

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -15,7 +15,7 @@ use Time::HiRes 'sleep';
 use testapi;
 use Utils::Architectures;
 use utils;
-use version_utils qw(is_opensuse is_microos is_sle_micro is_jeos is_leap is_sle is_selfinstall is_transactional);
+use version_utils qw(is_opensuse is_microos is_sle_micro is_jeos is_leap is_sle is_selfinstall is_transactional is_rt);
 use mm_network;
 use Utils::Backends;
 
@@ -126,7 +126,7 @@ sub add_custom_grub_entries {
     elsif (is_sle_micro()) {
         $distro = "SL Micro";
     }
-    elsif (check_var('SLE_PRODUCT', 'slert')) {
+    elsif (is_rt) {
         $distro = "SLE_RT" . ' \\?' . get_required_var('VERSION');
     }
     elsif (is_sle()) {

--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -12,7 +12,7 @@ use base Exporter;
 use testapi;
 use strict;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_rt);
 use warnings;
 
 our @EXPORT = qw(
@@ -27,7 +27,7 @@ sub get_kernel_flavor {
 sub remove_kernel_packages {
     my @packages;
 
-    if (check_var('SLE_PRODUCT', 'slert')) {
+    if (is_rt) {
         @packages = qw(kernel-rt kernel-rt-devel kernel-source-rt);
     }
     elsif (get_kernel_flavor eq 'kernel-64kb') {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -433,7 +433,7 @@ Returns true if called on a real time system
 =cut
 
 sub is_rt {
-    return (check_var('SLE_PRODUCT', 'rt') || get_var('FLAVOR') =~ /-rt/i);
+    return (check_var('SLE_PRODUCT', 'rt') || check_var('SLE_PRODUCT', 'slert') || get_var('FLAVOR') =~ /-rt/i);
 }
 
 =head2 is_hpc

--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -16,7 +16,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use registration;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_rt);
 
 sub run {
     if (get_var('AZURE')) {
@@ -25,7 +25,7 @@ sub run {
     }
 
     if (script_run('[ -d /lib/modules/$(uname -r)/build ]') != 0) {
-        if (check_var('SLE_PRODUCT', 'slert')) {
+        if (is_rt) {
             zypper_call('in -l kernel-devel-rt');
         }
         else {

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -14,7 +14,7 @@ use base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_sle is_sle_micro is_transactional package_version_cmp);
+use version_utils qw(is_sle is_sle_micro is_transactional package_version_cmp is_rt);
 use qam;
 use kernel;
 use klp;
@@ -86,7 +86,7 @@ sub update_kernel {
 
     fully_patch_system;
 
-    if (check_var('SLE_PRODUCT', 'slert')) {
+    if (is_rt) {
         install_package('kernel-devel-rt', skip_trup => 'There is no kernel-devel-rt available on transactional system.');
     }
     elsif (is_sle('12+')) {
@@ -220,7 +220,7 @@ sub install_lock_kernel {
         'kernel-source-rt' => $src_version
     );
 
-    if (check_var('SLE_PRODUCT', 'slert')) {
+    if (is_rt) {
         push @packages, "kernel-devel-rt";
     }
     else {
@@ -406,7 +406,7 @@ sub run {
     }
 
     # SLE Micro RT 5.1 image contains both kernel flavors, we need to remove kernel-default
-    if (is_sle_micro('=5.1') && check_var('SLE_PRODUCT', 'slert')) {
+    if (is_sle_micro('=5.1') && is_rt) {
         trup_call('pkg rm kernel-default');
         # kernel-rt will be removed with kernel-default, we can't lock it before, we need to install it after
         trup_call('-c pkg in kernel-rt');
@@ -425,7 +425,7 @@ sub run {
     }
 
     $kernel_package = 'kernel-default-base' if is_sle('<12');
-    $kernel_package = 'kernel-rt' if check_var('SLE_PRODUCT', 'slert');
+    $kernel_package = 'kernel-rt' if is_rt;
 
     if (get_var('KGRAFT')) {
         my $incident_klp_pkg = prepare_kgraft($repo, $incident_id);


### PR DESCRIPTION
Enhancement poo#132542: There is already existing function is_rt which should be used to detect SLE-RT. We shouldn't use check_var to detect correct SLE product..

- Related ticket: https://progress.opensuse.org/issues/132542
- Needles: none
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
