### PR TITLE
Remove validate_default_target module from multiple yast test schedules

### DIFF
--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp.yaml
@@ -11,8 +11,6 @@ schedule:
     - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/select_role_text_mode
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/consoletest_setup

--- a/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
+++ b/schedule/yast/addon_extensions_http_ftp/addon_extensions_http_ftp@s390x.yaml
@@ -11,8 +11,6 @@ schedule:
     - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/select_role_text_mode
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/consoletest_setup

--- a/schedule/yast/autologin@yast.yaml
+++ b/schedule/yast/autologin@yast.yaml
@@ -13,5 +13,3 @@ schedule:
     - installation/authentication/use_same_password_for_root
     - installation/authentication/enable_autologin
     - installation/authentication/default_user_simple_pwd
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target

--- a/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings@s390x.yaml
@@ -21,6 +21,4 @@ schedule:
     - installation/partitioning/warning/zipl_small
     - installation/partitioning/warning/rootfs_small
     - installation/partitioning/accept_proposed_layout
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation: []

--- a/schedule/yast/btrfs/btrfs+warnings_x86_64.yaml
+++ b/schedule/yast/btrfs/btrfs+warnings_x86_64.yaml
@@ -20,5 +20,3 @@ schedule:
     - installation/partitioning/warning/prep_small
     - installation/partitioning/warning/zipl_small
     - installation/partitioning/warning/rootfs_small
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target

--- a/schedule/yast/dud_development_tools.yaml
+++ b/schedule/yast/dud_development_tools.yaml
@@ -19,8 +19,6 @@ schedule:
     - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/hostname
     - console/system_prepare

--- a/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+force_recompute.yaml
@@ -21,8 +21,6 @@ schedule:
     - installation/partitioning/guided_setup/accept_default_hard_disks_selection
     - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
+++ b/schedule/yast/encryption/activate_encrypted_volume+import_users.yaml
@@ -19,5 +19,3 @@ schedule:
   local_user:
     - installation/authentication/import_users
     - installation/authentication/root_simple_pwd
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target

--- a/schedule/yast/encryption/crypt_no_lvm_x86_64.yaml
+++ b/schedule/yast/encryption/crypt_no_lvm_x86_64.yaml
@@ -20,8 +20,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/encrypt_simple_pwd
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm_iscsi.yaml
+++ b/schedule/yast/encryption/cryptlvm_iscsi.yaml
@@ -22,8 +22,6 @@ schedule:
     - installation/partitioning/guided_setup/select_disks
     - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/encryption/cryptlvm_sle_15_x86_64.yaml
+++ b/schedule/yast/encryption/cryptlvm_sle_15_x86_64.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/encryption/home_encrypted.yaml
+++ b/schedule/yast/encryption/home_encrypted.yaml
@@ -7,8 +7,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/edit_proposal_encrypt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot@s390x.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   suggested_partitioning:
     - installation/partitioning/new_partitioning_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   grub:
     - installation/boot_encrypt
     - installation/handle_reboot

--- a/schedule/yast/encryption/lvm_encrypt_separate_boot_x86_64.yaml
+++ b/schedule/yast/encryption/lvm_encrypt_separate_boot_x86_64.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   suggested_partitioning:
     - installation/partitioning/new_partitioning_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/encryption/lvm_full_encrypt.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt.yaml
@@ -12,8 +12,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/new_partitioning_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt@s390x.yaml
@@ -12,8 +12,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/new_partitioning_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   grub:
     - installation/boot_encrypt
     - installation/handle_reboot

--- a/schedule/yast/encryption/lvm_full_encrypt_x86_64.yaml
+++ b/schedule/yast/encryption/lvm_full_encrypt_x86_64.yaml
@@ -13,8 +13,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/new_partitioning_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/fstab_mount_by.yaml
+++ b/schedule/yast/fstab_mount_by.yaml
@@ -10,8 +10,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/new_partitioning_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_fstab
 test_data:

--- a/schedule/yast/gpt.yaml
+++ b/schedule/yast/gpt.yaml
@@ -11,8 +11,6 @@ schedule:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   software:
     - installation/change_desktop
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/hostname
     - console/validate_partition_table_via_blkid

--- a/schedule/yast/iscsi_ibft.yaml
+++ b/schedule/yast/iscsi_ibft.yaml
@@ -20,8 +20,6 @@ schedule:
     - installation/partitioning/guided_setup/select_disks
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/hostname

--- a/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_x86_64.yaml
+++ b/schedule/yast/lvm/lvm+cancel_existing_cryptlvm_x86_64.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   guided_partitioning:
     - installation/partitioning/lvm_ignore_existing
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/lvm/lvm+resize_lv.yaml
+++ b/schedule/yast/lvm/lvm+resize_lv.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/partitioning/guided_setup/do_not_propose_separate_home
     - installation/partitioning/resize_existing_lv
   suggested_partitioning: []
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/check_network

--- a/schedule/yast/lvm/lvm_sle.yaml
+++ b/schedule/yast/lvm/lvm_sle.yaml
@@ -13,8 +13,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/enable_lvm
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
   system_validation:

--- a/schedule/yast/lvm/lvm_sle_x86_64.yaml
+++ b/schedule/yast/lvm/lvm_sle_x86_64.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/enable_lvm
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
   system_validation:

--- a/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning@s390x.yaml
@@ -14,8 +14,6 @@ schedule:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
   suggested_partitioning:
     - installation/partitioning/new_partitioning_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/hostname

--- a/schedule/yast/lvm/lvm_thin_provisioning_x86_64.yaml
+++ b/schedule/yast/lvm/lvm_thin_provisioning_x86_64.yaml
@@ -15,8 +15,6 @@ schedule:
   expert_partitioning:
     - installation/partitioning/new_partitioning_gpt
   suggested_partitioning: []
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/hostname

--- a/schedule/yast/lvm_multipath_encrypted_x86_64.yaml
+++ b/schedule/yast/lvm_multipath_encrypted_x86_64.yaml
@@ -17,8 +17,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/encrypt_lvm_simple_pwd
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   first_login:
     - installation/boot_encrypt
     - installation/first_boot

--- a/schedule/yast/lvm_multipath_x86_64.yaml
+++ b/schedule/yast/lvm_multipath_x86_64.yaml
@@ -16,8 +16,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/enable_lvm
     - installation/partitioning/guided_setup/do_not_propose_separate_home
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -8,8 +8,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/setup_raid1_lvm
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_lvm_raid1
 test_data:

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -8,8 +8,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/setup_raid1_lvm
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_lvm_raid1
 test_data:

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_x86_64.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_x86_64.yaml
@@ -11,8 +11,6 @@ schedule:
   expert_partitioning:
     - installation/partitioning/setup_raid1_lvm
   suggested_partitioning: []
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_lvm_raid1
 test_data:

--- a/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition@s390x.yaml
@@ -8,8 +8,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/modify_existing_partition
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation: []
   system_validation:
     - console/validate_modify_existing_partition

--- a/schedule/yast/modify_existing_partition/modify_existing_partition_x86_64.yaml
+++ b/schedule/yast/modify_existing_partition/modify_existing_partition_x86_64.yaml
@@ -9,8 +9,6 @@ schedule:
   expert_partitioning:
     - installation/partitioning/modify_existing_partition
   suggested_partitioning: []
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_modify_existing_partition
 test_data:

--- a/schedule/yast/msdos/msdos@s390x.yaml
+++ b/schedule/yast/msdos/msdos@s390x.yaml
@@ -7,8 +7,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/msdos_partition_table
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation: []
   system_validation:
     - console/validate_partition_table_via_parted

--- a/schedule/yast/msdos/msdos@svirt-xen-hvm.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-hvm.yaml
@@ -7,8 +7,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/msdos_partition_table
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_parted
     - console/validate_blockdevices

--- a/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
+++ b/schedule/yast/msdos/msdos@svirt-xen-pv.yaml
@@ -7,8 +7,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/msdos_partition_table
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_parted
     - console/validate_blockdevices

--- a/schedule/yast/msdos/msdos_aarch64.yaml
+++ b/schedule/yast/msdos/msdos_aarch64.yaml
@@ -8,8 +8,6 @@ schedule:
   expert_partitioning:
     - installation/partitioning/msdos_partition_table
   suggested_partitioning: []
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_parted
     - console/validate_blockdevices

--- a/schedule/yast/msdos/msdos_x86_64.yaml
+++ b/schedule/yast/msdos/msdos_x86_64.yaml
@@ -8,8 +8,6 @@ schedule:
   expert_partitioning:
     - installation/partitioning/msdos_partition_table
   suggested_partitioning: []
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_parted
     - console/validate_blockdevices

--- a/schedule/yast/multipath.yaml
+++ b/schedule/yast/multipath.yaml
@@ -13,8 +13,6 @@ schedule:
     - installation/multipath
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/force_scheduled_tasks

--- a/schedule/yast/nvme.yaml
+++ b/schedule/yast/nvme.yaml
@@ -11,8 +11,6 @@ schedule:
     - installation/module_registration/register_module_desktop
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
   system_validation:

--- a/schedule/yast/raid/raid0_sle_gpt.yaml
+++ b/schedule/yast/raid/raid0_sle_gpt.yaml
@@ -9,8 +9,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/raid_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   installation_logs:
     - installation/logs_from_installation_system
     - console/upload_y2logs_as_asset

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -9,8 +9,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/raid_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -9,8 +9,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/raid_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -9,8 +9,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/raid_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -9,8 +9,6 @@ vars:
 schedule:
   suggested_partitioning:
     - installation/partitioning/raid_gpt
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/schedule/yast/repo_inst.yaml
+++ b/schedule/yast/repo_inst.yaml
@@ -18,7 +18,5 @@ schedule:
     - installation/module_registration/register_module_desktop
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_mirror_repos

--- a/schedule/yast/select_disk/select_disk_x86_64.yaml
+++ b/schedule/yast/select_disk/select_disk_x86_64.yaml
@@ -12,8 +12,6 @@ schedule:
     - installation/partitioning/guided_setup/select_disks
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_first_disk_selection
 test_data:

--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_x86_64.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_x86_64.yaml
@@ -16,8 +16,6 @@ schedule:
     - installation/partitioning/guided_setup/do_not_propose_separate_home
   software:
     - installation/select_visible_patterns_from_bottom
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/consoletest_setup

--- a/schedule/yast/skip_registration/skip_registration_x86_64.yaml
+++ b/schedule/yast/skip_registration/skip_registration_x86_64.yaml
@@ -14,8 +14,6 @@ schedule:
     - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/schedule/yast/sle/guided_btrfs/guided_btrfs.yaml
+++ b/schedule/yast/sle/guided_btrfs/guided_btrfs.yaml
@@ -7,8 +7,6 @@ vars:
   HDDSIZEGB: 40
   YUI_REST_API: 1
 schedule:
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   extension_module_selection:
     - installation/module_registration/register_module_desktop
   system_role:

--- a/schedule/yast/sle/guided_btrfs/guided_btrfs@s390x_kvm.yaml
+++ b/schedule/yast/sle/guided_btrfs/guided_btrfs@s390x_kvm.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/force_scheduled_tasks

--- a/schedule/yast/sle/guided_btrfs/guided_btrfs_aarch64.yaml
+++ b/schedule/yast/sle/guided_btrfs/guided_btrfs_aarch64.yaml
@@ -7,8 +7,6 @@ vars:
   HDDSIZEGB: 40
   YUI_REST_API: 1
 schedule:
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   extension_module_selection:
     - installation/module_registration/register_module_desktop
   system_role:

--- a/schedule/yast/sle/guided_btrfs/guided_btrfs_s390x_zvm.yaml
+++ b/schedule/yast/sle/guided_btrfs/guided_btrfs_s390x_zvm.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/force_scheduled_tasks

--- a/schedule/yast/sle/guided_btrfs/guided_btrfs_x86_64.yaml
+++ b/schedule/yast/sle/guided_btrfs/guided_btrfs_x86_64.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare
     - console/force_scheduled_tasks

--- a/schedule/yast/sle/guided_ext4/guided_ext4.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4.yaml
@@ -8,8 +8,6 @@ vars:
 schedule:
   guided_filesystem:
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_ext4/guided_ext4_s390x_kvm.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4_s390x_kvm.yaml
@@ -10,8 +10,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   extension_module_selection:
     - installation/module_registration/register_module_desktop
   system_role:

--- a/schedule/yast/sle/guided_ext4/guided_ext4_s390x_zvm.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4_s390x_zvm.yaml
@@ -10,8 +10,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_parted
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_ext4/guided_ext4_svirt_pv.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4_svirt_pv.yaml
@@ -13,8 +13,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_ext4/guided_ext4_svirt_xen.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4_svirt_xen.yaml
@@ -13,8 +13,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   stop_timeout_system_reboot: []
   system_validation:
     - console/validate_partition_table_via_blkid

--- a/schedule/yast/sle/guided_ext4/guided_ext4_x86_64.yaml
+++ b/schedule/yast/sle/guided_ext4/guided_ext4_x86_64.yaml
@@ -14,8 +14,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_xfs/guided_xfs.yaml
+++ b/schedule/yast/sle/guided_xfs/guided_xfs.yaml
@@ -7,8 +7,6 @@ vars:
 schedule:
   guided_filesystem:
     - installation/partitioning/guided_setup/select_filesystem_option_xfs
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_xfs/guided_xfs@s390x_kvm.yaml
+++ b/schedule/yast/sle/guided_xfs/guided_xfs@s390x_kvm.yaml
@@ -13,8 +13,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_xfs
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_xfs/guided_xfs_s390x_zvm.yaml
+++ b/schedule/yast/sle/guided_xfs/guided_xfs_s390x_zvm.yaml
@@ -13,8 +13,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_xfs
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_parted
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_xfs/guided_xfs_svirt_xen_hvm.yaml
+++ b/schedule/yast/sle/guided_xfs/guided_xfs_svirt_xen_hvm.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/partitioning/guided_setup/select_filesystem_option_xfs
   booting:
     - installation/bootloader_settings/disable_boot_menu_timeout
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_xfs/guided_xfs_svirt_xen_pv.yaml
+++ b/schedule/yast/sle/guided_xfs/guided_xfs_svirt_xen_pv.yaml
@@ -13,8 +13,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_xfs
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/sle/guided_xfs/guided_xfs_x86_64.yaml
+++ b/schedule/yast/sle/guided_xfs/guided_xfs_x86_64.yaml
@@ -13,8 +13,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/select_filesystem_option_xfs
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/ssh-x/ssh-x@s390x_zvm.yaml
+++ b/schedule/yast/ssh-x/ssh-x@s390x_zvm.yaml
@@ -14,8 +14,6 @@ schedule:
     - installation/partitioning/select_guided_setup
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/accept_default_fs_options
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   stop_timeout_system_reboot: []
   system_validation:
     - installation/validation/validate_sshd_reachable

--- a/schedule/yast/ssh_keys/do_not_import_ssh_keys.yaml
+++ b/schedule/yast/ssh_keys/do_not_import_ssh_keys.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/module_registration/register_module_desktop
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   security:
     - installation/ssh_host_key_settings/do_not_import_ssh_host_keys
   system_validation:

--- a/schedule/yast/ssh_keys/import_ssh_keys.yaml
+++ b/schedule/yast/ssh_keys/import_ssh_keys.yaml
@@ -15,8 +15,6 @@ schedule:
     - installation/module_registration/register_module_desktop
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   installation_settings:
     - installation/ssh_host_key_settings/import_ssh_host_keys
     - installation/launch_installation

--- a/schedule/yast/textmode/ha_textmode_minimal_base.yaml
+++ b/schedule/yast/textmode/ha_textmode_minimal_base.yaml
@@ -9,5 +9,3 @@ schedule:
     - installation/module_registration/register_extensions_and_modules
   system_role:
     - installation/system_role/select_role_minimal
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/ha_textmode_skip_registration.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration.yaml
@@ -12,5 +12,3 @@ schedule:
     - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/select_role_text_mode
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base.yaml
@@ -12,5 +12,3 @@ schedule:
     - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/select_role_minimal
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target

--- a/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_minimal_base_s390x.yaml
@@ -12,8 +12,6 @@ schedule:
     - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/select_role_minimal
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   installation_settings: []
   stop_timeout_system_reboot: []
   system_preparation: []

--- a/schedule/yast/textmode/ha_textmode_skip_registration_s390x.yaml
+++ b/schedule/yast/textmode/ha_textmode_skip_registration_s390x.yaml
@@ -12,8 +12,6 @@ schedule:
     - installation/add_on_product_installation/accept_add_on_installation
   system_role:
     - installation/system_role/select_role_text_mode
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   installation_settings: []
   stop_timeout_system_reboot: []
   system_preparation: []

--- a/schedule/yast/tumbleweed/guided_ext4.yaml
+++ b/schedule/yast/tumbleweed/guided_ext4.yaml
@@ -7,8 +7,6 @@ vars:
 schedule:
   guided_filesystem:
     - installation/partitioning/guided_setup/select_filesystem_option_ext4
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_partition_table_via_blkid
     - console/validate_blockdevices

--- a/schedule/yast/yast_no_self_update/yast_no_self_update@s390x_kvm.yaml
+++ b/schedule/yast/yast_no_self_update/yast_no_self_update@s390x_kvm.yaml
@@ -11,5 +11,3 @@ vars:
 schedule:
   product_selection:
     - installation/validate_no_self_update
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target

--- a/schedule/yast/yast_self_update/yast_self_update@s390x_kvm.yaml
+++ b/schedule/yast/yast_self_update/yast_self_update@s390x_kvm.yaml
@@ -11,5 +11,3 @@ vars:
 schedule:
   product_selection:
     - installation/validate_self_update
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target

--- a/schedule/yast/zfcp.yaml
+++ b/schedule/yast/zfcp.yaml
@@ -17,8 +17,6 @@ schedule:
     - installation/module_registration/register_module_desktop
   system_role:
     - installation/system_role/accept_selected_role_SLES_with_GNOME
-  default_systemd_target:
-    - installation/installation_settings/validate_default_target
   system_validation:
     - console/validate_zfcp
     - console/validate_zfcp_multipath


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/138383

- Verification run: https://openqa.suse.de/tests/12918071

