### PR TITLE
[virtualization][Leap] Fix TW virtman_view - libvirtd is not installed before launch virt-manager

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -170,6 +170,7 @@ sub is_kvm_host {
 sub is_monolithic_libvirtd {
     record_info('WARNING', 'Libvirt package is not installed', result => 'fail') if (script_run('rpm -q libvirt-libs'));
     unless (is_alp) {
+        # why not check "is-active" for libvirtd.socket or libvirtd.service because, If either of them is active the system is using the monolithic daemon.
         return 1 if script_run('systemctl is-enabled libvirtd.service') == 0;
     }
     return 0;


### PR DESCRIPTION
### Description
This addresses an issue in the virtualization test scenario for openSUSE Leap not Tumbleweed, earlier the ticket was miscommunicated to work on TW. The problem arises in the virtman_view step, where libvirtd appears not to be installed before launching virt-manager. The issue has been observed consistently, and the root cause seems to be related to recent changes in the code, particularly in the is_monolithic_libvirtd subroutine.

Changes Made:

Install Libvirt client and daemon as it is not available for modular libvirt on Leap, the restart_modular_libvirt is not enough
Start the service

Observations and Analysis:

- The recent failure in the virtman_view step seems to be related to the detection of libvirt installation, and this PR aims to address that.
- The test failure might be influenced by changes in how libvirtd is checked, especially with the use of modular libvirt daemons.
- We think that libvirt is missing and not installed by default.

- Related ticket: https://progress.opensuse.org/issues/150842
- Verification run: https://openqa.opensuse.org/tests/3782515#
