### PR TITLE
Add ltss Dockerfile

### DIFF
--- a/data/containers/Dockerfile.ltss
+++ b/data/containers/Dockerfile.ltss
@@ -1,0 +1,13 @@
+# Containerfile for LTSS Base images (15-SP1, 15-SP2)
+# This requires a different Containerfile, as packages required for the regulart testing are not available
+
+# baseimage_var is a placeholder of your base image, e.g. registry.suse.com/suse/sle15:15.2
+# use base variable when you call test_containered_app
+FROM baseimage_var
+
+RUN zypper ref && rm -rf /var/cache
+
+# Set experimental variable
+ENV WORLD_VAR Arda
+
+ENTRYPOINT true

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -193,7 +193,9 @@ sub test_opensuse_based_image {
         # If we are in not-released SLE host, we can't use zypper commands inside containers
         # that are not the same version as the host, so we skip this test.
         test_zypper_on_container($runtime, $image);
-        build_and_run_image(base => $image, runtime => $runtime);
+        # Older SLES containers require a different Containerfile
+        my $dockerfile = ($image =~ 'sle15:15\.1$|sle15:15\.2$' ? "Dockerfile.ltss" : "Dockerfile");
+        build_and_run_image(base => $image, runtime => $runtime, dockerfile => $dockerfile);
         if (is_sle && $runtime->runtime eq 'docker') {
             build_with_zypper_docker(image => $image, runtime => $runtime, version => $version);
         }


### PR DESCRIPTION
Adds separate Dockerfile to ltss base container images because apache2 is not available there anymore.

- Related ticket: https://progress.opensuse.org/issues/151672
- Verification run: TBD
