### PR TITLE
Reboot system before relabeling it

### DIFF
--- a/tests/security/selinux/enforcing_mode_setup.pm
+++ b/tests/security/selinux/enforcing_mode_setup.pm
@@ -22,6 +22,11 @@ sub run {
     # make sure SELinux in "permissive" mode
     validate_script_output("sestatus", sub { m/.*Current\ mode:\ .*permissive.*/sx });
 
+    power_action("reboot", textmode => 1);
+    reconnect_mgmt_console if is_pvm;
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
+    select_serial_terminal;
+
     # label system
     assert_script_run("semanage boolean --modify --on selinuxuser_execmod");
     script_run("restorecon -R /", timeout => 1800, die_on_timeout => 0);


### PR DESCRIPTION
If we don't do this then there are strange AVCs with no target class in the AVC log.  This can't be reproduced locally and is something specific to openQA. It makes no sense that this works, but it does

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1215303
- Verification run: https://openqa.suse.de/tests/12925602
