### PR TITLE
Add workaround to refresh some yast screen

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
@@ -22,7 +22,7 @@ use constant {
 
 sub fill_in_vlan_id {
     my ($self, $vlan_id) = @_;
-    assert_screen(ADDRESS_TAB);
+    apply_workaround_poo124652(ADDRESS_TAB);
     send_key 'alt-v';
     send_key 'tab';
     wait_screen_change { type_string($vlan_id) };

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -90,7 +90,7 @@ sub nfs_server_configuration {
     send_key 'alt-n';    # next / OK
 
     # Setup Directories to Export
-    assert_screen 'nfs-server-export';
+    apply_workaround_poo124652('nfs-server-export');
     send_key 'alt-d';
     assert_screen 'nfs-server-export-popup';
     type_string $setup_nis_nfs_x11{nfs_dir};

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -33,7 +33,7 @@ sub run {
     #	kernel parameters and use graphical console
     wait_still_screen 3;
     assert_and_click 'yast2-bootloader_kernel-parameters';
-    assert_screen 'yast2-bootloader_kernel-parameters-switched';
+    apply_workaround_poo124652('yast2-bootloader_kernel-parameters-switched');
     send_key 'alt-p';
     send_key 'end';
     assert_screen 'yast2-bootloader_use-graphical-console';


### PR DESCRIPTION
We need to add workaround_poo124652 for some yast2 screen refresh with SHIFT+F3.

- Related ticket: https://progress.opensuse.org/issues/151663
- Needles: N/A
- Verification run: 
  - nis_server
    * https://openqa.suse.de/t12930810
    * https://openqa.suse.de/t12930811
  - yast2_gui
    * https://openqa.suse.de/t12930850
  
