### PR TITLE
Remove 'space_cache' option for btrfs

### DIFF
--- a/data/yam/autoyast/btrfs.xml
+++ b/data/yam/autoyast/btrfs.xml
@@ -76,7 +76,7 @@
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">btrfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>rw,relatime,space_cache</fstopt>
+          <fstopt>rw,relatime</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <mount>/</mount>
           <mountby config:type="symbol">uuid</mountby>

--- a/test_data/yast/autoyast/profiles/btrfs.yaml
+++ b/test_data/yast/autoyast/profiles/btrfs.yaml
@@ -8,7 +8,7 @@ profile:
             - mount: swap
             - mount: /
               subvolumes_prefix: ''
-              fstopt: rw,relatime,space_cache
+              fstopt: rw,relatime
               subvolumes:
                 subvolume:
                   - path: usr/local

--- a/tests/autoyast/verify_btrfs.pm
+++ b/tests/autoyast/verify_btrfs.pm
@@ -16,7 +16,7 @@ sub run {
 
     ### Verify mounted drives ###
     # Common part of regexp
-    my $common_opts = qr/rw|relatime|space_cache|subvolid=\d+/;
+    my $common_opts = qr/rw|relatime|discard=async|space_cache=v2|subvolid=\d+/;
 
     # Get verify mount options for root
     validate_script_output "findmnt / -no OPTIONS", sub {


### PR DESCRIPTION
Based on https://bugzilla.suse.com/show_bug.cgi?id=1217053, We don't need this option anymore.

- Verification run: http://openqa.suse.de/tests/12931189
