### PR TITLE
 Fix workaround to refresh some yast screen undefined issue

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/AddressTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/AddressTab.pm
@@ -11,6 +11,7 @@ package YaST::NetworkSettings::NetworkCardSetup::AddressTab;
 use strict;
 use warnings;
 use testapi;
+use YaST::workarounds;
 use parent 'YaST::NetworkSettings::NetworkCardSetup::NetworkCardSetupWizard';
 
 use constant {
@@ -18,12 +19,12 @@ use constant {
 };
 
 sub select_dynamic_address {
-    assert_screen(ADDRESS_TAB);
+    apply_workaround_poo124652(ADDRESS_TAB);
     send_key('alt-y');
 }
 
 sub select_no_link_and_ip_setup {
-    assert_screen(ADDRESS_TAB);
+    apply_workaround_poo124652(ADDRESS_TAB);
     send_key('alt-k');
 }
 

--- a/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
@@ -13,6 +13,7 @@ package YaST::NetworkSettings::NetworkCardSetup::VLANAddressTab;
 use strict;
 use warnings;
 use testapi;
+use YaST::workarounds;
 use parent 'YaST::NetworkSettings::NetworkCardSetup::AddressTab';
 
 use constant {


### PR DESCRIPTION
After adding apply_workaround_poo124652 to refresh the yast screen, the test 
run complains with 'Undefined subroutine'
- Related ticket: https://progress.opensuse.org/issues/151663
- Needles: N/A
- Verification run: 
   - https://openqa.suse.de/tests/12931258 yasts_gui
   - https://openqa.suse.de/tests/12931314 nis server
