### PR TITLE
Missing URLs for testing images in SLE Micro

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -211,6 +211,16 @@ our %images_list = (
             totest => sub { },
             available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
         },
+        '15-SP4' => {
+            released => sub { 'registry.suse.com/suse/sle15:15.4' },
+            totest => sub { },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
+        '15-SP5' => {
+            released => sub { 'registry.suse.com/suse/sle15:15.5' },
+            totest => sub { },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+        },
         '5.0' => {
             released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
             totest => sub { },


### PR DESCRIPTION
The BCI URLs for testing 15-SP4 and 15-SP5 in SLE Micro were missing

- Related ticket: https://progress.opensuse.org/issues/151699
- Verification run: https://openqa.suse.de/tests/12931527
