### PR TITLE
kdump: Change vmlinux location from /boot/ to /usr/lib on SLE Micro 6.0+

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -434,7 +434,7 @@ sub check_function {
         # check the core dump via the crash utility if possible
         my $crash_cmd;
         my $vmcore_glob = '/var/crash/*/vmcore';
-        my $vmlinux_glob = (is_sle("<16") || is_sle_micro || is_leap("<16.0"))
+        my $vmlinux_glob = (is_sle("<16") || is_sle_micro("<6.0") || is_leap("<16.0"))
           ? '/boot/vmlinux-$(uname -r)*'
           : '/usr/lib/modules/$(uname -r)/vmlinux*';
         if (!is_transactional) {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/151762
- Needles: none
- Verification run:

There are no jobs for SLE Micro <6.0  which we can clone.
SLE Micro 6.0: https://openqa.suse.de/tests/12932186
TW: https://openqa.opensuse.org/tests/3769751
15-SP5: https://openqa.suse.de/tests/12932188

