### PR TITLE
Adapt qemu test for SLE Micro 6.0

### DIFF
--- a/tests/qemu/qemu.pm
+++ b/tests/qemu/qemu.pm
@@ -18,8 +18,12 @@ use version_utils qw(is_sle_micro is_leap_micro is_transactional);
 
 # 'patterns-microos-kvm_host' is required for SUMA client use case
 sub is_qemu_preinstalled {
-    if (is_sle_micro || is_leap_micro) {
+    if (is_sle_micro('<6.0') || is_leap_micro) {
         assert_script_run('rpm -q patterns-microos-kvm_host');
+        return 1;
+    }
+    elsif (is_sle_micro('>=6.0')) {
+        assert_script_run('rpm -q patterns-alp-kvm_host');
         return 1;
     }
     return 0;


### PR DESCRIPTION
* **Starting** from SLE Micro 6.0, which uses ALP code base, there are some packages changes, for exmaple, patterns-microos-kvm_host is changed to patterns-alp-kvm_host.

* **Verification Runs:**
  * [x86_64](https://openqa.suse.de/tests/13058518)
  * [aarch64](https://openqa.suse.de/tests/13058517)