### PR TITLE
Make coredumps more visible

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -249,7 +249,7 @@ sub problem_detection {
     clear_console;
 
     # Segmentation faults
-    save_and_upload_log("coredumpctl list", "segmentation-faults-list.txt", {screenshot => 1, noupload => 1});
+    record_info('COREDUMP detection: ', script_output('coredumpctl list', proceed_on_failure => 1));
     save_and_upload_log("coredumpctl info", "segmentation-faults-info.txt", {screenshot => 1, noupload => 1});
     # Save core dumps
     enter_cmd "mkdir -p coredumps";


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/112547

- Verification run: https://openqa.suse.de/tests/12941265#step/python_flake8/174 [coredump files can be listed if any]