### PR TITLE
Fix podman_firewall test module for netavark network backend

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -298,11 +298,6 @@ sub check_containers_connectivity {
     record_info "connectivity", "Checking that containers can connect to the host, to each other and outside of the host";
     my $container_name = 'sut_container';
 
-    if (script_run('ping -6 -c 2 google.com') != 0 && is_sle_micro) {
-        record_info('Disable ipv6', 'https://sd.suse.com/servicedesk/customer/portal/1/SD-135489', result => 'softfail');
-        assert_script_run 'sysctl -w net.ipv6.conf.all.disable_ipv6=1';
-    }
-
     # Run container in the background (sleep for 30d because infinite is not supported by sleep in busybox)
     script_retry "$runtime pull " . registry_url('alpine'), retry => 3, delay => 120;
     assert_script_run "$runtime run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -103,10 +103,10 @@ sub load_host_tests_podman {
         loadtest 'containers/podman_pods';
         # Default for ALP is Netavark
         loadtest('containers/podman_network_cni') unless (is_alp || is_sle_micro('6.0+'));
-        # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
-        loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
         loadtest 'containers/podman_firewall' unless (is_public_cloud || is_openstack || is_microos || is_alp);
+        # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
+        loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
         # Buildah is not available in SLE Micro, MicroOS and staging projects
         loadtest 'containers/buildah' unless (is_sle_micro || is_microos || is_leap_micro || is_alp || is_staging);
         loadtest 'containers/podman_quadlet' if is_tumbleweed;


### PR DESCRIPTION
- Verification runs: 
[SLEM5.3](https://openqa.suse.de/tests/13115332), [SLEM5.2](https://openqa.suse.de/tests/13115325#), [SLEM5.4](https://openqa.suse.de/tests/13115316), [SLEM5.1](https://openqa.suse.de/tests/13115320), [15-SP3](https://pdostal-server.suse.cz/tests/5526), [15-SP4](https://pdostal-server.suse.cz/tests/5527), [SP-SP5](https://pdostal-server.suse.cz/tests/5528), [15-SP2](https://pdostal-server.suse.cz/tests/5529), [15-SP1](https://pdostal-server.suse.cz/tests/5530), [tw](https://pdostal-server.suse.cz/tests/5525), [JeOS](https://pdostal-server.suse.cz/tests/5524), [SLEM6.0](https://pdostal-server.suse.cz/tests/5531)