### PR TITLE
Move all python related to tests to new test suite

### DIFF
--- a/schedule/functional/extra_tests_gnome.yaml
+++ b/schedule/functional/extra_tests_gnome.yaml
@@ -26,18 +26,6 @@ conditional_schedule:
                 - x11/steam
                 - x11/wine
                 - x11/chrome
-    python_liblouis:
-        DISTRI:
-            sle:
-                - '{{python_liblouis_sle}}'
-            opensuse:
-                - console/python_liblouis
-    python_liblouis_sle:
-        ARCH:
-            'x86_64':
-                - console/python_liblouis
-            'aarch64':
-                - console/python_liblouis
     opensuse_tests:
         DISTRI:
             opensuse:
@@ -67,6 +55,5 @@ schedule:
     - '{{keyboard_layout_gdm}}'
     - console/yast2_lan_device_settings
     - console/check_default_network_manager
-    - '{{python_liblouis}}'
     - console/coredump_collect
     - console/zypper_log_packages

--- a/schedule/functional/extra_tests_gnome_development.yaml
+++ b/schedule/functional/extra_tests_gnome_development.yaml
@@ -27,18 +27,6 @@ conditional_schedule:
                 - x11/wine
                 - x11/chrome
                 - qe-core/x11/openbroadcastersoftware.py
-    python_liblouis:
-        DISTRI:
-            sle:
-                - '{{python_liblouis_sle}}'
-            opensuse:
-                - console/python_liblouis
-    python_liblouis_sle:
-        ARCH:
-            'x86_64':
-                - console/python_liblouis
-            'aarch64':
-                - console/python_liblouis
     opensuse_tests:
         DISTRI:
             opensuse:
@@ -68,6 +56,5 @@ schedule:
     - '{{keyboard_layout_gdm}}'
     - console/yast2_lan_device_settings
     - console/check_default_network_manager
-    - '{{python_liblouis}}'
     - console/coredump_collect
     - console/zypper_log_packages

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -62,7 +62,6 @@ conditional_schedule:
                 - console/gcc
                 - console/wpa_supplicant
                 - appgeo/gdal
-                - console/rabbitmq
                 - console/openqa_review
                 - console/zbar
                 - console/a2ps
@@ -71,7 +70,6 @@ conditional_schedule:
                 - console/nano
                 - '{{steamcmd}}'
                 - console/libqca2
-                - console/python_scientific
                 - console/vmstat
                 - console/kdump_and_crash
                 - console/ansible
@@ -85,7 +83,6 @@ conditional_schedule:
                 - console/supportutils
                 - console/zziplib
                 - console/vsftpd
-                - console/python3_new_version_check
                 - console/year_2038_detection
     tumbleweed_tests:
         VERSION:
@@ -93,8 +90,6 @@ conditional_schedule:
                 - console/parsec
                 - console/systemd_rpm_macros
                 - console/vsftpd
-                - console/python_flake8
-                - console/python3_new_version_check
                 - console/year_2038_detection
 schedule:
     - installation/bootloader_start
@@ -120,7 +115,6 @@ schedule:
     - console/rpm
     - console/slp
     - console/pkcon
-    - console/python_pycairo
     - console/command_not_found
     - console/openssl_alpn
     - console/autoyast_removed

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -6,9 +6,6 @@ schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
     - console/add_phub_extension
-    - console/python_scientific
-    - console/python_flake8
-    - console/django
     - '{{wpa_supplicant}}'
     - console/vmstat
     - console/ansible

--- a/schedule/functional/stack_tests_python.yaml
+++ b/schedule/functional/stack_tests_python.yaml
@@ -1,0 +1,63 @@
+---
+name: stack_tests_python
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - '{{add_phub_extension}}'
+  - console/python_scientific
+  - '{{distri_version_specific}}'
+conditional_schedule:
+  distri_version_specific:
+    DISTRI:
+      sle:
+        - '{{version_specific}}'
+      opensuse:
+        - console/python_flake8
+        - console/python_pycairo
+        - console/django
+        - '{{python_liblouis}}'
+        - console/rabbitmq
+        - console/python3_new_version_check
+        - console/python3_setuptools
+        - console/python3_beautifulsoup4
+  version_specific:
+    VERSION:
+      15-SP5:
+        - console/python_flake8
+        - console/python_pycairo
+        - console/django
+        - '{{python_liblouis}}'
+        - console/rabbitmq
+        - console/python3_new_version_check
+        - console/python3_setuptools
+        - console/python3_beautifulsoup4
+      15-SP4:
+        - console/python_flake8
+        - console/python_pycairo
+        - console/django
+        - '{{python_liblouis}}'
+        - console/rabbitmq
+        - console/python3_new_version_check
+        - console/python3_setuptools
+        - console/python3_beautifulsoup4
+      15-SP3:
+        - console/python_flake8
+        - console/django
+        - console/python_liblouis
+      15-SP2:
+        - console/python_flake8
+        - console/django
+        - console/python_liblouis
+      15-SP1:
+        - console/python_flake8
+        - console/django
+  python_liblouis:
+    ARCH:
+      'x86_64':
+        - console/python_liblouis
+      'aarch64':
+        - console/python_liblouis
+  add_phub_extension:
+    DISTRI:
+      sle:
+        - console/add_phub_extension

--- a/schedule/qam/12-SP1/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP1/mau-extratests-phub.yaml
@@ -6,7 +6,6 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - console/vmstat
   - console/systemd_rpm_macros
   - console/coredump_collect

--- a/schedule/qam/12-SP2/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP2/mau-extratests-phub.yaml
@@ -6,7 +6,6 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - console/vmstat
   - console/systemd_rpm_macros
   - console/coredump_collect

--- a/schedule/qam/12-SP3/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP3/mau-extratests-phub.yaml
@@ -6,7 +6,6 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - console/vmstat
   - console/systemd_rpm_macros
   - console/coredump_collect

--- a/schedule/qam/12-SP4/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP4/mau-extratests-phub.yaml
@@ -6,7 +6,6 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - console/vmstat
   - console/systemd_rpm_macros
   - console/coredump_collect

--- a/schedule/qam/12-SP5/mau-extratests-phub.yaml
+++ b/schedule/qam/12-SP5/mau-extratests-phub.yaml
@@ -6,7 +6,6 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - console/vmstat
   - console/systemd_rpm_macros
   - console/coredump_collect

--- a/schedule/qam/15-SP1/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP1/mau-extratests-phub.yaml
@@ -6,9 +6,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - '{{sle15_x86_64}}'
-  - console/python_flake8
   - console/vmstat
   - console/systemd_rpm_macros
   - console/coredump_collect

--- a/schedule/qam/15-SP2/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP2/mau-extratests-phub.yaml
@@ -6,9 +6,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - '{{sle15_x86_64}}'
-  - console/python_flake8
   - console/vmstat
   - console/systemd_rpm_macros
   - console/coredump_collect

--- a/schedule/qam/15-SP2/qam-gnome.yaml
+++ b/schedule/qam/15-SP2/qam-gnome.yaml
@@ -65,9 +65,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/glibc_sanity
-        - console/python_liblouis
-      aarch64:
-        - console/python_liblouis
   salt:
     SLE_PRODUCT:
       sles:

--- a/schedule/qam/15-SP3/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP3/mau-extratests-phub.yaml
@@ -6,9 +6,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - '{{sle15_x86_64}}'
-  - console/python_flake8
   - console/vmstat
   - console/ansible
   - console/systemd_rpm_macros

--- a/schedule/qam/15-SP3/qam-gnome.yaml
+++ b/schedule/qam/15-SP3/qam-gnome.yaml
@@ -64,9 +64,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/glibc_sanity
-        - console/python_liblouis
-      aarch64:
-        - console/python_liblouis
   salt:
     SLE_PRODUCT:
       sles:

--- a/schedule/qam/15-SP4/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP4/mau-extratests-phub.yaml
@@ -6,9 +6,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - '{{sle15_x86_64}}'
-  - console/python_flake8
   - console/vmstat
   - '{{arch_specific15_sp4}}'
   - console/systemd_rpm_macros

--- a/schedule/qam/15-SP4/qam-gnome.yaml
+++ b/schedule/qam/15-SP4/qam-gnome.yaml
@@ -64,9 +64,6 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/glibc_sanity
-        - console/python_liblouis
-      aarch64:
-        - console/python_liblouis
   salt:
     SLE_PRODUCT:
       sles:

--- a/schedule/qam/15-SP5/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP5/mau-extratests-phub.yaml
@@ -6,7 +6,6 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - '{{sle15_x86_64}}'
   # - console/python_flake8 Removed due to bsc#1209609
   - console/vmstat

--- a/schedule/qam/15-SP5/qam-gnome.yaml
+++ b/schedule/qam/15-SP5/qam-gnome.yaml
@@ -59,14 +59,12 @@ schedule:
 - x11/reboot_gnome
 - shutdown/cleanup_before_shutdown
 - shutdown/shutdown
+- '{{svirt_upload_assets}}'
 conditional_schedule:
   console_tests:
     ARCH:
       x86_64:
         - console/glibc_sanity
-        - console/python_liblouis
-      aarch64:
-        - console/python_liblouis
   salt:
     SLE_PRODUCT:
       sles:

--- a/schedule/qam/15/mau-extratests-phub.yaml
+++ b/schedule/qam/15/mau-extratests-phub.yaml
@@ -6,9 +6,7 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/add_phub_extension
-  - console/python_scientific
   - '{{sle15_x86_64}}'
-  - console/python_flake8
   - console/vmstat
   - console/systemd_rpm_macros
   - console/coredump_collect

--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -43,16 +43,10 @@ conditional_schedule:
       15-SP5:
         - console/golang
         - console/redis
-        - console/python3_new_version_check
-        - console/python3_setuptools
-        - console/python3_beautifulsoup4
         - '{{arch_specific}}'
       15-SP4:
         - console/golang
         - console/redis
-        - console/python3_new_version_check
-        - console/python3_setuptools
-        - console/python3_beautifulsoup4
         - '{{arch_specific}}'
       15-SP3:
         - console/openssl_nodejs


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/138401
- Needles: NO
- Verification run: 
 Tumbleweed: [x86_64](https://openqa.opensuse.org/tests/3782553)
  LEAP: [x86_64](https://openqa.opensuse.org/tests/3782554) | [aarch64](https://openqa.opensuse.org/tests/3782512)  |[ppc64le](https://openqa.opensuse.org/tests/3782567)
15-SP5: [x86_64](https://openqa.suse.de/tests/13062414) | [ s390x](https://openqa.suse.de/tests/13062412) | [aarch64](https://openqa.suse.de/tests/13062416)
15-SP4: [x86_64](https://openqa.suse.de/tests/13062431) | [ s390x](https://openqa.suse.de/tests/13062429) | [aarch64](https://openqa.suse.de/tests/13062433)

MR to schedule in 15-SP4/15-SP5:  https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/678 
PR for LEAP and Tumbleweed: https://github.com/os-autoinst/opensuse-jobgroups/pull/402