### PR TITLE
Fix no permission to access serial console on ppc64le

### DIFF
--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -19,6 +19,7 @@ use warnings;
 
 sub run {
     is_ipmi ? use_ssh_serial_console : select_console 'root-console';
+    ensure_serialdev_permissions;
 
     my $timeout = get_var('PREPARE_TEST_DATA_TIMEOUT', 300);
 


### PR DESCRIPTION
Quick PR to fix no permission access serial console on ppc64le.

- Failed job: https://openqa.suse.de/tests/12958494#step/prepare_test_data/12
- Needles: N/A
- Verification run: http://openqa.nue.suse.com/tests/12958637#