### PR TITLE
Test bonding two network interfaces on ALP

### DIFF
--- a/schedule/alp/bonding.yaml
+++ b/schedule/alp/bonding.yaml
@@ -1,0 +1,6 @@
+---
+description: 'Network bonding test suite for ALP'
+name: 'alp_bonding@x86_64'
+schedule:
+    - microos/disk_boot
+    - microos/network_bonding

--- a/tests/microos/network_bonding.pm
+++ b/tests/microos/network_bonding.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright 2016-2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test network bonding capability and connectivity
+# Maintainer: QE Core <qe-core@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use power_action_utils "power_action";
+
+sub test_failover {
+    my $device = shift;
+    # disable one child eth, other should keep bond0 alive
+    assert_script_run "ip link set dev $device down";
+    script_run 'ip a';
+    # networking should be still good
+    assert_script_run 'ping -c1 -I bond0 conncheck.opensuse.org';
+    # bring back up device
+    assert_script_run "ip link set dev $device up";
+}
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+    # remove existing NM-managed connections (except loopback)
+    my @interfaces = grep { !/^lo/ } split('\n', script_output 'nmcli -t -f NAME con');
+    assert_script_run "nmcli con delete '$_'" for @interfaces;
+    # create a new bonding interface and connect the two ethernet
+    assert_script_run "nmcli con add type bond ifname bond0 con-name bond0";
+    assert_script_run "nmcli con add type ethernet ifname $_ master bond0" for qw{eth0 eth1};
+    # bring up bond interface
+    assert_script_run "nmcli con up bond0";
+    # reboot to ensure connection properly comes up at start
+    power_action('reboot', textmode => 1);
+    $self->wait_boot;
+    select_console 'root-console';
+    # first connectivity check
+    assert_script_run 'ping -c1 -I bond0 conncheck.opensuse.org';
+    # check device failover
+    test_failover $_ for qw{eth0 eth1};
+}
+
+1;
+


### PR DESCRIPTION
Introduce a new test for ALP that create a network bond and check interface failover

- Related ticket: https://progress.opensuse.org/issues/151273
- Needles: no
- Verification run: https://openqa.suse.de/tests/12961079
