### PR TITLE
HDD autoyast partitioning updated for BCI tests

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -39,13 +39,8 @@
     </mode>
   </general>
   <bootloader>
-    % unless ($check_var->('ARCH', 's390x')) {
-    <device_map config:type="list">
-      <device_map_entry>
-        <firmware>hd0</firmware>
-        <linux>/dev/vda</linux>
-      </device_map_entry>
-    </device_map>
+    % if ($check_var->('ARCH', 'ppc64le') or $check_var->('ARCH', 's390x')) {
+    <loader_type>grub2</loader_type>
     % }
     <global>
       % if ($check_var->('ARCH', 's390x')) {
@@ -62,8 +57,13 @@
       % }
       <timeout config:type="integer">-1</timeout>
     </global>
-    % if ($check_var->('ARCH', 'ppc64le') or $check_var->('ARCH', 's390x')) {
-    <loader_type>grub2</loader_type>
+    % unless ($check_var->('ARCH', 's390x')) {
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/vda</linux>
+      </device_map_entry>
+    </device_map>
     % }
   </bootloader>
   <networking>
@@ -100,6 +100,90 @@
     </zones>
   </firewall>
   % }
+  % if ($check_var->('ARCH', 's390x')) {
+  <partitioning config:type="list">
+    <drive config:type="map">
+      <device>/dev/vda</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">ext2</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>acl,user_xattr</fstopt>
+          <mount>/boot/zipl</mount>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>300M</size>
+        </partition>
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/</mount>
+          <size>max</size>
+          <subvolumes config:type="list">
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/s390x-emu</path>
+            </subvolume>
+          </subvolumes>
+          <subvolumes_prefix>@</subvolumes_prefix>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  % }
+  % unless ($check_var->('ARCH', 's390x')) {
+  <partitioning config:type="list">
+    <drive config:type="map">
+      <device>/dev/vda</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <partitions config:type="list">
+        <partition config:type="map">
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/</mount>
+          <size>max</size>
+          <subvolumes config:type="list">
+          % if ($check_var->('ARCH', 'x86_64')) {
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/x86_64-efi</path>
+            </subvolume>
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/i386-pc</path>
+            </subvolume>
+          % } 
+          % if ($get_var->('ARCH') =~ /^ppc64/ ) {
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/powerpc-ieee1275</path>
+            </subvolume>
+          % }
+          % if ($get_var->('ARCH') =~ /^aarch64/) {
+            <subvolume config:type="map">
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/arm64-efi/</path>
+            </subvolume>
+          % }
+          </subvolumes>
+          <subvolumes_prefix>@</subvolumes_prefix>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  % }
   <software>
     <products config:type="list">
       <product>SLES</product>
@@ -119,7 +203,7 @@
       % }}
       % if ($get_var->('VERSION') =~ /15$|15-SP1|15-SP2/) {
       <package>podman-cni-config</package>
-      % }}
+      % }
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>


### PR DESCRIPTION
Autoyast file partitioning updated for BCI containers HDD image, refactoring and fixing of code in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18195, with particular attention to **s390x** case.

- Related ticket: https://progress.opensuse.org/issues/151510
- Needles: none
- Verification run: TBD
