### PR TITLE
Fix the issue of the wrong interface being selected in KEA DHCP test

### DIFF
--- a/tests/microos/workloads/kea-container/dhcp4_client.pm
+++ b/tests/microos/workloads/kea-container/dhcp4_client.pm
@@ -26,7 +26,7 @@ sub run {
     disable_and_stop_service($self->firewall) if check_unit_file($self->firewall);
 
     assert_script_run('nmcli conn');
-    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | head -n1");
     my ($device, $nm_id) = split(':', $nm_list);
     assert_script_run "nmcli connection modify '$nm_id' ipv4.method auto";
     assert_script_run("nmcli conn up '$nm_id'");
@@ -35,7 +35,7 @@ sub run {
     record_info("ip a", script_output("ip a"));
     assert_script_run('ping -c 1 10.0.2.101');
 
-    $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | head -n1");
     ($device, $nm_id) = split(':', $nm_list);
     validate_script_output("ip -4 addr show dev $device | sed -rne '/inet/s/[[:blank:]]*inet ([0-9\\.]*).*/\\1/p'", sub { m/10.0.2.12[0-5]/ });
     #validate_script_output("$addr",  sub {m/10.0.2.12[0-5]/});

--- a/tests/microos/workloads/kea-container/dhcp6_client.pm
+++ b/tests/microos/workloads/kea-container/dhcp6_client.pm
@@ -26,7 +26,7 @@ sub run {
     disable_and_stop_service($self->firewall) if check_unit_file($self->firewall);
 
     assert_script_run('nmcli conn');
-    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | head -n1");
     my ($device, $nm_id) = split(':', $nm_list);
     assert_script_run "nmcli connection modify '$nm_id' ipv6.method dhcp";
     assert_script_run("nmcli conn up '$nm_id'");
@@ -35,6 +35,8 @@ sub run {
     record_info("ip a", script_output("ip a"));
     record_info("ip -6 route", script_output("ip -6 route"));
 
+    $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | head -n1");
+    ($device, $nm_id) = split(':', $nm_list);
     assert_script_run("ip -6 route add  fe12:3456:789a::1/48 dev $device");
     assert_script_run('ping -c 1 fe12:3456:789a::2');
     validate_script_output("ip -6 addr show dev $device || sed -nE 's/^.*inet6 ([^/]+)\/.*$/\1/p'", sub { m/fe12:3456:789a::[4-9]/ });

--- a/tests/microos/workloads/kea-container/setup_dhcp4_server.pm
+++ b/tests/microos/workloads/kea-container/setup_dhcp4_server.pm
@@ -56,7 +56,7 @@ sub install_dhcp_container {
     assert_script_run("podman container runlabel install $image");
 
     # Copy the configured kea-dhcp4 config file to the container host and add the network interface name to listen on DHCP4 server
-    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | head -n1");
     my ($device, $nm_id) = split(':', $nm_list);
     assert_script_run('curl -v -o /etc/kea/kea-dhcp4.conf  ' . data_url('kea-dhcp/kea-dhcp4.conf'));
     assert_script_run("cat  /etc/kea/kea-dhcp4.conf");

--- a/tests/microos/workloads/kea-container/setup_dhcp6_server.pm
+++ b/tests/microos/workloads/kea-container/setup_dhcp6_server.pm
@@ -58,7 +58,7 @@ sub install_dhcp_container {
     assert_script_run("podman container runlabel install $image");
 
     # Copy the configured kea-dhcp6 config file to the container host and add the network interface name to listen on DHCP4 server
-    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | head -n1");
     ($device, $nm_id) = split(':', $nm_list);
     assert_script_run('curl -v -o /etc/kea/kea-dhcp6.conf  ' . data_url('kea-dhcp/kea-dhcp6.conf'));
     assert_script_run("cat  /etc/kea/kea-dhcp6.conf");
@@ -74,7 +74,7 @@ sub install_dhcp_container {
 
 sub setup_static_mm_network_ipv6 {
     my $ip = shift;
-    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | head -n1");
+    my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v ^lo: | head -n1");
     ($device, $nm_id) = split(':', $nm_list);
     record_info('set_ip', "Device: $device\n NM ID: $nm_id\nIP: $ip");
     assert_script_run "nmcli connection modify '$nm_id' ifname '$device' ip6 $ip ipv6.method manual";


### PR DESCRIPTION
Fixed the issue of selecting the 'lo' interface in Kea DHCP tests. Now, both the KEA DHCP tests on IPv4 and IPv6 have successfully passed.

- Needles: No
- Verification run: 
[Kea_dhcp4_server](https://openqa.suse.de/tests/12970246#) | [Kea_dhcp4_client](https://openqa.suse.de/tests/12970248#)
[Kea_dhcp6_server](https://openqa.suse.de/tests/12970244#)  | [Kea_dhcp6_client](https://openqa.suse.de/tests/12970247#)