### PR TITLE
Fix firewalld check_rules() to check for correct nft chain

### DIFF
--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -63,11 +63,7 @@ sub check_rules {
     } else {
         assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 25");
         assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 110");
-        if (is_leap("<16.0") || is_sle("<16")) {
-            assert_script_run("nft list chain inet firewalld filter_FWDI_public | grep icmp");
-        } else {
-            assert_script_run("nft list chain inet firewalld filter_FWD_public | grep icmp");
-        }
+        assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep icmp");
         assert_script_run("nft list chain inet firewalld filter_IN_public_allow | grep 2000-3000");
     }
 }


### PR DESCRIPTION
Firewalld adds the icmp protocol rule in the filter_IN_public_allow nftables chain, but the testcase is checking for this rule in the filter_FWD_public chain which it is not able to find and thus failing.

- Related ticket: https://progress.opensuse.org/issues/131411
- Needles: Not Needed
- Verification run: Tested locally. Issue is resolved. Test results in **softfailed** with "bsc#1206383 - iptables uses legacy backend instead of nftables"
