### PR TITLE
Set MTU also in `setup_static_network` helper of wicked tests

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -59,7 +59,6 @@ sub configure_static_ip {
     my $mtu = $args{mtu} // 1458;
     my $is_nm = $args{is_nm} // is_networkmanager();
     my $device = $args{device};
-    $mtu //= 1458;
 
     if ($is_nm) {
         my $nm_id;

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -36,16 +36,16 @@ sub setup_static_network {
     my (%args) = @_;
     my $ip = $args{ip} // '10.0.2.15';
     my $mtu = $args{mtu} // 1458;
-    # Set default values
-    $args{silent} //= 0;
-    configure_static_dns(get_host_resolv_conf(), silent => $args{silent});
-    assert_script_run('echo default ' . $args{gw} . ' - - > /etc/sysconfig/network/routes');
+    my $gw = $args{gw} // testapi::host_ip();
+
+    configure_static_dns(get_host_resolv_conf(), silent => $args{silent} // 0);
+    assert_script_run("echo default $gw - - > /etc/sysconfig/network/routes");
     my $iface = iface();
     assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'\\nMTU='$mtu'">/etc/sysconfig/network/ifcfg-$iface);
     assert_script_run 'rcnetwork restart';
     assert_script_run 'ip addr';
-    assert_script_run 'ping -c 1 ' . $args{gw} . '|| journalctl -b --no-pager -o short-precise > /dev/' . $serialdev;
-    assert_script_run('ip -6 addr add ' . $args{ipv6} . ' dev ' . $iface) if (exists($args{ipv6}));
+    assert_script_run "ping -c 1 $gw || journalctl -b --no-pager -o short-precise > /dev/$serialdev";
+    assert_script_run "ip -6 addr add $args{ipv6} dev $iface" if exists $args{ipv6};
 }
 
 =head2 iface

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -34,14 +34,14 @@ Set DNS server defined via required variable C<STATIC_DNS_SERVER>
 
 sub setup_static_network {
     my (%args) = @_;
+    my $ip = $args{ip} // '10.0.2.15';
+    my $mtu = $args{mtu} // 1458;
     # Set default values
-    $args{ip} //= '10.0.2.15';
-    $args{gw} //= testapi::host_ip();
     $args{silent} //= 0;
     configure_static_dns(get_host_resolv_conf(), silent => $args{silent});
     assert_script_run('echo default ' . $args{gw} . ' - - > /etc/sysconfig/network/routes');
     my $iface = iface();
-    assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$args{ip}'">/etc/sysconfig/network/ifcfg-$iface);
+    assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'\\nMTU='$mtu'">/etc/sysconfig/network/ifcfg-$iface);
     assert_script_run 'rcnetwork restart';
     assert_script_run 'ip addr';
     assert_script_run 'ping -c 1 ' . $args{gw} . '|| journalctl -b --no-pager -o short-precise > /dev/' . $serialdev;


### PR DESCRIPTION
We already set the MTU to 1458 various other MM scenarios, e.g. this makes
this helper consistent with what the similar helper `configure_static_ip`
already does.

This should fix the connection problems with scc.suse.com in 
`qam-wicked_basic_ref` and similar tests.

Related ticket: https://progress.opensuse.org/issues/151612