### PR TITLE
Test changes for kubevirt v1.1.0

### DIFF
--- a/data/virt_autotest/kubevirt_tests/config.toml.tmpl
+++ b/data/virt_autotest/kubevirt_tests/config.toml.tmpl
@@ -1,0 +1,107 @@
+[plugins.opt]
+  path = "{{ .NodeConfig.Containerd.Opt }}"
+[plugins.cri]
+  stream_server_address = "127.0.0.1"
+  stream_server_port = "10010"
+  enable_selinux = {{ .NodeConfig.SELinux }}
+  enable_unprivileged_ports = {{ .EnableUnprivileged }}
+  enable_unprivileged_icmp = {{ .EnableUnprivileged }}
+  device_ownership_from_security_context = true
+{{- if .DisableCgroup}}
+  disable_cgroup = true
+{{end}}
+{{- if .IsRunningInUserNS }}
+  disable_apparmor = true
+  restrict_oom_score_adj = true
+{{end}}
+{{- if .NodeConfig.AgentConfig.PauseImage }}
+  sandbox_image = "{{ .NodeConfig.AgentConfig.PauseImage }}"
+{{end}}
+{{- if .NodeConfig.AgentConfig.Snapshotter }}
+[plugins.cri.containerd]
+  snapshotter = "{{ .NodeConfig.AgentConfig.Snapshotter }}"
+  disable_snapshot_annotations = {{ if eq .NodeConfig.AgentConfig.Snapshotter "stargz" }}false{{else}}true{{end}}
+{{ if eq .NodeConfig.AgentConfig.Snapshotter "stargz" }}
+{{ if .NodeConfig.AgentConfig.ImageServiceSocket }}
+[plugins.stargz]
+cri_keychain_image_service_path = "{{ .NodeConfig.AgentConfig.ImageServiceSocket }}"
+[plugins.stargz.cri_keychain]
+enable_keychain = true
+{{end}}
+{{ if .PrivateRegistryConfig }}
+{{ if .PrivateRegistryConfig.Mirrors }}
+[plugins.stargz.registry.mirrors]{{end}}
+{{range $k, $v := .PrivateRegistryConfig.Mirrors }}
+[plugins.stargz.registry.mirrors."{{$k}}"]
+  endpoint = [{{range $i, $j := $v.Endpoints}}{{if $i}}, {{end}}{{printf "%q" .}}{{end}}]
+{{if $v.Rewrites}}
+  [plugins.stargz.registry.mirrors."{{$k}}".rewrite]
+{{range $pattern, $replace := $v.Rewrites}}
+    "{{$pattern}}" = "{{$replace}}"
+{{end}}
+{{end}}
+{{end}}
+{{range $k, $v := .PrivateRegistryConfig.Configs }}
+{{ if $v.Auth }}
+[plugins.stargz.registry.configs."{{$k}}".auth]
+  {{ if $v.Auth.Username }}username = {{ printf "%q" $v.Auth.Username }}{{end}}
+  {{ if $v.Auth.Password }}password = {{ printf "%q" $v.Auth.Password }}{{end}}
+  {{ if $v.Auth.Auth }}auth = {{ printf "%q" $v.Auth.Auth }}{{end}}
+  {{ if $v.Auth.IdentityToken }}identitytoken = {{ printf "%q" $v.Auth.IdentityToken }}{{end}}
+{{end}}
+{{ if $v.TLS }}
+[plugins.stargz.registry.configs."{{$k}}".tls]
+  {{ if $v.TLS.CAFile }}ca_file = "{{ $v.TLS.CAFile }}"{{end}}
+  {{ if $v.TLS.CertFile }}cert_file = "{{ $v.TLS.CertFile }}"{{end}}
+  {{ if $v.TLS.KeyFile }}key_file = "{{ $v.TLS.KeyFile }}"{{end}}
+  {{ if $v.TLS.InsecureSkipVerify }}insecure_skip_verify = true{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{- if not .NodeConfig.NoFlannel }}
+[plugins.cri.cni]
+  bin_dir = "{{ .NodeConfig.AgentConfig.CNIBinDir }}"
+  conf_dir = "{{ .NodeConfig.AgentConfig.CNIConfDir }}"
+{{end}}
+[plugins.cri.containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+[plugins.cri.containerd.runtimes.runc.options]
+	SystemdCgroup = {{ .SystemdCgroup }}
+{{ if .PrivateRegistryConfig }}
+{{ if .PrivateRegistryConfig.Mirrors }}
+[plugins.cri.registry.mirrors]{{end}}
+{{range $k, $v := .PrivateRegistryConfig.Mirrors }}
+[plugins.cri.registry.mirrors."{{$k}}"]
+  endpoint = [{{range $i, $j := $v.Endpoints}}{{if $i}}, {{end}}{{printf "%q" .}}{{end}}]
+{{if $v.Rewrites}}
+  [plugins.cri.registry.mirrors."{{$k}}".rewrite]
+{{range $pattern, $replace := $v.Rewrites}}
+    "{{$pattern}}" = "{{$replace}}"
+{{end}}
+{{end}}
+{{end}}
+{{range $k, $v := .PrivateRegistryConfig.Configs }}
+{{ if $v.Auth }}
+[plugins.cri.registry.configs."{{$k}}".auth]
+  {{ if $v.Auth.Username }}username = {{ printf "%q" $v.Auth.Username }}{{end}}
+  {{ if $v.Auth.Password }}password = {{ printf "%q" $v.Auth.Password }}{{end}}
+  {{ if $v.Auth.Auth }}auth = {{ printf "%q" $v.Auth.Auth }}{{end}}
+  {{ if $v.Auth.IdentityToken }}identitytoken = {{ printf "%q" $v.Auth.IdentityToken }}{{end}}
+{{end}}
+{{ if $v.TLS }}
+[plugins.cri.registry.configs."{{$k}}".tls]
+  {{ if $v.TLS.CAFile }}ca_file = "{{ $v.TLS.CAFile }}"{{end}}
+  {{ if $v.TLS.CertFile }}cert_file = "{{ $v.TLS.CertFile }}"{{end}}
+  {{ if $v.TLS.KeyFile }}key_file = "{{ $v.TLS.KeyFile }}"{{end}}
+  {{ if $v.TLS.InsecureSkipVerify }}insecure_skip_verify = true{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{range $k, $v := .ExtraRuntimes}}
+[plugins.cri.containerd.runtimes."{{$k}}"]
+  runtime_type = "{{$v.RuntimeType}}"
+[plugins.cri.containerd.runtimes."{{$k}}".options]
+  BinaryName = "{{$v.BinaryName}}"
+{{end}}

--- a/data/virt_autotest/kubevirt_tests/full-tests.conf
+++ b/data/virt_autotest/kubevirt_tests/full-tests.conf
@@ -18,6 +18,7 @@ GINKGO_FOCUS=vmipreset_test.go
 
 [vmi_configuration_test]
 GINKGO_FOCUS=vmi_configuration_test.go
+GINKGO_SKIP=hugepages-2Mi with passt enabled
 SOFT_FAIL=test_id:1681
 
 [vmi_headless_test]
@@ -35,7 +36,7 @@ GINKGO_FOCUS=container_disk_test.go
 
 [datavolume_test]
 GINKGO_FOCUS=datavolume.go
-GINKGO_SKIP=test_id:3189|test_id:6686|test_id:5252|should resolve DataVolume sourceRef|test_id:8571
+GINKGO_SKIP=test_id:3189|test_id:6686|test_id:5252|should resolve DataVolume sourceRef|test_id:8571|virtiofs VirtIO-FS with multiple PVCs should be successfully started and accessible with passt enabled|test_id:5253|test_id:5254
 
 [hotplug_test]
 GINKGO_FOCUS=hotplug.go

--- a/data/virt_autotest/kubevirt_tests/node-helper.yaml
+++ b/data/virt_autotest/kubevirt_tests/node-helper.yaml
@@ -53,7 +53,7 @@ spec:
         - name: TAG1
           value: "quay.io/kubevirt/fedora-with-test-tooling-container-disk:latest"
         - name: IMAGE2
-          value: "quay.io/kubevirt/alpine-ext-kernel-boot-demo:v0.49.0"
+          value: "quay.io/kubevirt/alpine-ext-kernel-boot-demo:v${KUBEVIRT_VERSION}"
         - name: TAG2
           value: "registry:5000/kubevirt/alpine-ext-kernel-boot-demo:devel"
         volumeMounts:


### PR DESCRIPTION
1. bsc#1217658 - add config file to enable `device_ownership_from_security_context` CRI option
2. bsc#1217660 - skip test case "hugepages-2Mi with passt enabled" & "virtiofs VirtIO-FS with multiple PVCs should be successfully started and accessible with passt enabled"
3. Create a tmpfs mount point '/var/provision/kubevirt.io/tests' for kubevirt agent test module

- Related ticket: https://progress.opensuse.org/issues/133598
- Verification run: http://10.67.129.96/tests/2696