### PR TITLE
Port users of /etc/sudoers to /etc/sudoers.d/

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -269,7 +269,7 @@ sub test_pgsql {
     assert_script_run "sudo -u postgres psql -d openQAdb -c \"SELECT * FROM test\" | grep 'can php write this?'";
 
     # add sudo rights to switch postgresql version and run script to determine oldest and latest version
-    assert_script_run 'echo "postgres ALL=(root) NOPASSWD: ALL" >>/etc/sudoers';
+    assert_script_run 'echo "postgres ALL=(root) NOPASSWD: ALL" >/etc/sudoers.d/postgres';
     assert_script_run "gpasswd -a postgres \$(stat -c %G /dev/$serialdev)";
     assert_script_run 'sudo chsh postgres -s /bin/bash';
     enter_cmd "su - postgres", wait_still_screen => 1;

--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -119,7 +119,7 @@ sub run {
     #verify password changed in remote 389-ds.
     validate_script_output('ldapwhoami -x -H ldap://ldapserver -D uid=alice,ou=users,dc=sssdtest,dc=com -w n0vell88', sub { m/alice/ });
     #Sudo run a command as another user
-    assert_script_run("sed -i '/Defaults targetpw/s/^/#/' /etc/sudoers");
+    assert_script_run("echo 'Defaults !targetpw' >/etc/sudoers.d/notargetpw");
     enter_cmd('ssh -oStrictHostKeyChecking=no mary@localhost', wait_still_screen => 5);
     enter_cmd('open5use', wait_still_screen => 5);
     enter_cmd('echo open5use|sudo -S -l > /tmp/sudouser', wait_still_screen => 1);

--- a/tests/console/sssd_openldap_functional.pm
+++ b/tests/console/sssd_openldap_functional.pm
@@ -73,7 +73,7 @@ sub run {
     validate_script_output('sshpass -p n0vell88 ssh bob@localhost echo "login as new password!"', sub { m/new password/ });
     validate_script_output('ldapwhoami -x -H ldap://ldapserver -D uid=bob,ou=users,dc=sssdtest,dc=com -w n0vell88', sub { m/bob/ });
     #Sudo run a command as another user
-    assert_script_run("sed -i '/Defaults targetpw/s/^/#/' /etc/sudoers");
+    assert_script_run("echo 'Defaults !targetpw' >/etc/sudoers.d/notargetpw");
     validate_script_output('sshpass -p open5use ssh adam@localhost "echo open5use|sudo -S -l"', sub { m#/usr/bin/cat# });
     assert_script_run(qq(su -c 'echo "file read only by owner bob" > hello && chmod 600 hello' -l bob));
     validate_script_output('sshpass -p open5use ssh adam@localhost "echo open5use|sudo -S -u bob /usr/bin/cat /home/bob/hello"', sub { m/file read only by owner bob/ });


### PR DESCRIPTION
The former no longer exists in TW and sudoers.d should be used anyway.

- Verification runs:
  http://10.168.4.192/tests/1409 (php_postgresql)
  http://10.168.4.192/tests/1412 (sssd_389ds_functional)
