### PR TITLE
gdb: disable debuginfod url during test

### DIFF
--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -49,6 +49,8 @@ sub run {
     # as systemd's dependency with *sysvinit-tools* was dropped
     $test_deps .= ' sysvinit-tools' if (is_sle('>15-sp2') || is_leap('>15.2'));
     zypper_call("in $test_deps");
+    # disable debuginfod
+    assert_script_run('unset DEBUGINFOD_URLS');
 
     #Test Case 1
     assert_script_run("curl -O " . data_url('gdb/test1.c'));


### PR DESCRIPTION
The installation of debuginfod-profile is triggered automatically,
which in turn sets DEBUGINFOD_URL. As we test against unpublished
snapshots, our debuginfo packages are not available yet.

- Related ticket: https://progress.opensuse.org/issues/133268
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3786356
