### PR TITLE
New logic to type LUKS passphrase in grub phase

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -34,7 +34,7 @@ sub grub_test {
 
     reconnect_mgmt_console if is_pvm;
     handle_installer_medium_bootup();
-    workaround_type_encrypted_passphrase;
+    unlock_bootloader;
     # 60 due to rare slowness e.g. multipath poo#11908
     # 90 as a workaround due to the qemu backend fallout
     assert_screen('grub2', $timeout);

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -11,7 +11,7 @@ use warnings;
 use testapi qw(is_serial_terminal :DEFAULT);
 use lockapi 'mutex_wait';
 use mm_network;
-use version_utils qw(is_sle_micro is_microos is_leap is_public_cloud is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos package_version_cmp is_transactional);
+use version_utils qw(is_alp is_sle_micro is_microos is_leap is_leap_micro is_public_cloud is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos package_version_cmp is_transactional);
 use Utils::Architectures;
 use Utils::Systemd qw(systemctl disable_and_stop_service);
 use Utils::Backends;
@@ -50,8 +50,9 @@ our @EXPORT = qw(
   zypper_patches
   zypper_install_available
   set_zypper_lock_timeout
-  workaround_type_encrypted_passphrase
+  unlock_bootloader
   is_boot_encrypted
+  need_passphrase_again
   is_bridged_networking
   set_bridged_networking
   assert_screen_with_soft_timeout
@@ -1005,28 +1006,16 @@ sub set_zypper_lock_timeout {
     script_run("export ZYPP_LOCK_TIMEOUT='$timeout'");
 }
 
-=head2 workaround_type_encrypted_passphrase
+=head2 unlock_bootloader
 
- workaround_type_encrypted_passphrase();
+ unlock_bootloader();
 
-Record soft-failure for unresolved feature fsc#320901 which we think is
-important and then unlock encrypted boot partitions if we expect it to be
-encrypted. This condition is met on 'storage-ng' which by default puts the
-boot partition within the encrypted LVM same as in test scenarios where we
-explicitly create an LVM including boot (C<FULL_LVM_ENCRYPT>). C<ppc64le> was
-already doing the same by default also in the case of pre-storage-ng but not
-anymore for storage-ng.
+Unlock bootloader if boot partition is encrypted.
 
 =cut
 
-sub workaround_type_encrypted_passphrase {
-    # nothing to do if the boot partition is not encrypted in FULL_LVM_ENCRYPT
-    return unless is_boot_encrypted();
-    record_info(
-        "LUKS pass", "Workaround for 'Provide kernel interface to pass LUKS password from bootloader'.\n" .
-          'For further info, please, see https://fate.suse.com/320901, https://jira.suse.com/browse/SLE-2941, ' .
-          'https://jira.suse.com/browse/SLE-3976') if is_sle('12-SP4+');
-    unlock_if_encrypted;
+sub unlock_bootloader {
+    unlock_if_encrypted if is_boot_encrypted();
 }
 
 =head2 is_boot_encrypted
@@ -1054,6 +1043,24 @@ sub is_boot_encrypted {
     # installer would propose an encrypted installation again
     return 0 if get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE');
 
+    return 1;
+}
+
+=head2 need_passphrase_again
+
+ need_passphrase_again();
+
+With newer grub2 (in TW and SLE15-SP6 currently), if root disk is encrypted and
+contains `/boot`, entering the passphrase in GRUB2 is enough. The key is passed
+on during boot, so it's not asked for a second time.
+We need to enter the passphrase again if there are separate partitions encrypted
+without LVM configuration (cr_swap,cr_home etc).
+
+=cut
+
+sub need_passphrase_again {
+    my $need_passphrase_again = is_leap('<15.6') || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || is_alp || (!get_var('LVM', '0') && !get_var('FULL_LVM_ENCRYPT', '0'));
+    return 0 if is_boot_encrypted && !$need_passphrase_again;
     return 1;
 }
 

--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -12,7 +12,7 @@ use warnings;
 use base 'opensusebasetest';
 use testapi;
 use power_action_utils 'power_action';
-use utils qw(workaround_type_encrypted_passphrase reconnect_mgmt_console);
+use utils qw(unlock_bootloader reconnect_mgmt_console);
 use bootloader_setup qw(stop_grub_timeout boot_into_snapshot change_grub_config);
 use Utils::Backends 'is_pvm';
 use Utils::Architectures qw(is_aarch64);

--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -12,16 +12,9 @@ use strict;
 use warnings;
 use base "installbasetest";
 use utils;
-use testapi qw(check_var get_var record_info);
-use version_utils qw(is_leap is_sle is_leap_micro is_sle_micro is_alp);
 
 sub run {
-    # With newer grub2 (in TW only currently), entering the passphrase in GRUB2
-    # is enough. The key is passed on during boot, so it's not asked for
-    # a second time.
-    return if is_boot_encrypted && !is_leap && !is_sle && !is_leap_micro && !is_sle_micro && !is_alp;
-
-    unlock_if_encrypted(check_typed_password => 1);
+    unlock_if_encrypted(check_typed_password => 1) if need_passphrase_again;
 }
 
 1;

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -12,7 +12,7 @@ use warnings;
 
 use testapi;
 use Utils::Architectures;
-use utils 'workaround_type_encrypted_passphrase';
+use utils 'unlock_bootloader';
 use power_action_utils 'power_action';
 use version_utils 'is_sle12_hdd_in_upgrade';
 
@@ -22,7 +22,7 @@ use registration;
 sub run {
     # reboot from previously booted hdd to do pre check or change e.g. before upgrade
     power_action('reboot');
-    workaround_type_encrypted_passphrase;
+    unlock_bootloader;
 
     # If the target has a different version, make sure the matching needles are used
     # for the bootmenu below already.


### PR DESCRIPTION
https://progress.opensuse.org/issues/151393

VRs:
[tw crypt_no_lvm](https://openqa.opensuse.org/tests/3787186#)
[sle crypt_no_lvm](https://openqa.suse.de/tests/12988792#)
[Staging](https://openqa.suse.de/tests/overview?build=rfan1206_stage&version=15-SP6&distri=sle)
[yast failed cases](https://openqa.suse.de/tests/overview?build=rfan1206&version=15-SP6&distri=sle)
[yast passed cases](http://openqa.suse.de/tests/overview?build=rfan1207_yast&version=15-SP6&distri=sle)

New VRs:
[boot_to_desktop](http://openqa.suse.de/tests/12999431#)
[staging](http://openqa.suse.de/tests/overview?version=15-SP6&distri=sle&build=rfan1208_stage)
[yast sainty](https://openqa.suse.de/tests/overview?version=15-SP6&build=rfan1208_yast&distri=sle)
[kernel_encrypt_create_hdd](http://openqa.suse.de/tests/12999490#)