### PR TITLE
Add ENSA2 setup and testmodules

### DIFF
--- a/data/ha/ensa2_cluster_resources.template
+++ b/data/ha/ensa2_cluster_resources.template
@@ -1,0 +1,38 @@
+primitive rsc_fs_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS% Filesystem \
+  params device="%USR_SAP_DEVICE_ASCS%" directory="/usr/sap/%INSTANCE_SID%/ASCS%INSTANCE_ID_ASCS%" \
+         fstype=xfs \
+  op start timeout=60s interval=0 \
+  op stop timeout=60s interval=0 \
+  op monitor interval=20s timeout=40s
+primitive rsc_ip_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS% IPaddr2 \
+  params ip=%VIRTUAL_IP_ASCS% \
+  op monitor interval=10s timeout=20s
+primitive rsc_sap_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS% SAPInstance \
+  operations $id=rsc_sap_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS%-operations \
+  op monitor interval=11 timeout=60 on-fail=restart \
+  params InstanceName=%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS%_%VIRTUAL_HOSTNAME_ASCS% \
+     START_PROFILE="/usr/sap/%INSTANCE_SID%/SYS/profile/%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS%_%VIRTUAL_HOSTNAME_ASCS%" \
+     AUTOMATIC_RECOVER=false \
+  meta resource-stickiness=5000
+primitive rsc_fs_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS% Filesystem \
+  params device="%USR_SAP_DEVICE_ERS%" directory="/usr/sap/%INSTANCE_SID%/ERS%INSTANCE_ID_ERS%" fstype=xfs \
+  op start timeout=60s interval=0 \
+  op stop timeout=60s interval=0 \
+  op monitor interval=20s timeout=40s
+primitive rsc_ip_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS% IPaddr2 \
+  params ip=%VIRTUAL_IP_ERS% \
+  op monitor interval=10s timeout=20s
+primitive rsc_sap_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS% SAPInstance \
+  operations $id=rsc_sap_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS%-operations \
+  op monitor interval=11 timeout=60 on-fail=restart \
+  params InstanceName=%INSTANCE_SID%_ERS%INSTANCE_ID_ERS%_%VIRTUAL_HOSTNAME_ERS% \
+         START_PROFILE="/usr/sap/%INSTANCE_SID%/SYS/profile/%INSTANCE_SID%_ERS%INSTANCE_ID_ERS%_%VIRTUAL_HOSTNAME_ERS%" \
+         AUTOMATIC_RECOVER=false IS_ERS=true
+group grp_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS% \
+  rsc_ip_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS% rsc_fs_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS% rsc_sap_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS% \
+	meta resource-stickiness=3000
+group grp_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS% \
+  rsc_ip_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS% rsc_fs_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS% rsc_sap_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS%
+colocation col_sap_%INSTANCE_SID%_no_both -5000: grp_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS% grp_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS%
+order ord_sap_%INSTANCE_SID%_first_start_ascs Optional: rsc_sap_%INSTANCE_SID%_ASCS%INSTANCE_ID_ASCS%:start \
+      rsc_sap_%INSTANCE_SID%_ERS%INSTANCE_ID_ERS%:stop symmetrical=false

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -11,14 +11,14 @@ use base Exporter;
 use Exporter;
 use strict;
 use warnings;
-use version_utils 'is_sle';
-use Scalar::Util 'looks_like_number';
+use version_utils qw(is_sle);
+use Scalar::Util qw(looks_like_number);
 use utils;
 use testapi;
 use lockapi;
 use isotovideo;
-use x11utils 'ensure_unlocked_desktop';
-use Utils::Logging 'export_logs';
+use x11utils qw(ensure_unlocked_desktop);
+use Utils::Logging qw(export_logs);
 use Carp qw(croak);
 use Data::Dumper;
 
@@ -78,6 +78,8 @@ our @EXPORT = qw(
   collect_sbd_delay_parameters
   check_iscsi_failure
   cluster_status_matches_regex
+  crm_wait_for_maintenance
+  crm_check_resource_location
 );
 
 =head1 SYNOPSIS
@@ -1246,6 +1248,98 @@ sub cluster_status_matches_regex {
         record_info("Cluster errors: ", join("\n", @resource_list));
         return 1;
     }
+}
+
+=head3 crm_maintenance_status
+
+    crm_maintenance_status();
+
+Check maintenance mode status. Returns true (maintenance active) or false (maintenance inactive).
+Croaks if unknown status is received.
+
+=cut
+
+sub crm_maintenance_status {
+    my $cmd_output = script_output('crm configure show cib-bootstrap-options | grep maintenance-mode');
+    $cmd_output =~ s/\s//g;
+    my $status = (split('=', $cmd_output))[-1];
+    croak "CRM returned unrecognized status: '$status'" unless grep(/^$status$/, ('false', 'true'));
+    return $status;
+}
+
+=head3 crm_wait_for_maintenance
+
+    crm_wait_for_maintenance(target_state=>$target_state, [loop_sleep=>$loop_sleep, timeout=>$timeout]);
+
+Wait for maintenance to be turned on or off. Croaks on timeout.
+
+=over 3
+
+B<target_state> Target state of the maintenance mode (true/false)
+
+B<loop_sleep> Override default sleep value between checks
+
+B<timeout> Override default timeout value
+
+=back
+
+=cut
+
+sub crm_wait_for_maintenance {
+    my (%args) = @_;
+    my $timeout = $args{timeout} // bmwqemu::scale_timeout(30);
+    my $loop_sleep = $args{loop_sleep} // 5;
+
+    croak "Invalid argument value: \$target_state = '$args{'target_state'}'" unless grep(/^$args{'target_state'}$/, ('false', 'true'));
+
+    my $current_status = crm_maintenance_status();
+    my $start_time = time;
+    while ($current_status ne $args{'target_state'}) {
+        $current_status = crm_maintenance_status();
+        croak "Timeout while waiting for maintenance mode: '$args{'target_state'}'" if (time - $start_time > $timeout);
+        sleep $loop_sleep;
+    }
+    record_info("Maintenance", "Maintenance status: $current_status");
+    return $current_status;
+}
+
+=head3 crm_check_resource_location
+
+    crm_check_resource_location(resource=>$resource, [wait_for_target=>$wait_for_target, timeout=>$timeout]);
+
+Checks current resource location, returns physical hostname of the node. Can be used to wait for desired state Eg: after failover.
+Croaks upon timeout.
+
+=over 3
+
+B<wait_for_target> Target location of the resource specified - physical hostname
+
+B<resource> Resource to check
+
+B<timeout> Override default timeout value
+
+=back
+
+=cut
+
+sub crm_check_resource_location {
+    my (%args) = @_;
+    my $wait_for_target = $args{wait_for_target} // 0;
+    my $timeout = $args{timeout} // bmwqemu::scale_timeout(120);
+    my $cmd = join(' ', "crm resource status", $args{resource}, "| grep 'resource $args{resource} is'"); # Grep to avoid random kernel message appearing in script_output
+    my $out;
+    my $current_location;
+
+    my $start_time = time;
+    while (time < ($start_time + $timeout)) {
+        $out = script_output($cmd);
+        $current_location = (split(': ', $out))[-1];
+        return ($current_location) unless ($wait_for_target);
+        return ($current_location) if $wait_for_target eq $current_location;
+        sleep 5;
+    }
+
+    croak "Test timed out while waiting for resource '$args{resource}' to move to '$wait_for_target'";
 }
 
 1;

--- a/schedule/sles4sap/ha_supportserver.yaml
+++ b/schedule/sles4sap/ha_supportserver.yaml
@@ -30,5 +30,11 @@ vars:
 schedule:
   - support_server/login
   - support_server/setup
+  - '{{setup_ensa_nfs}}'
   - ha/barrier_init
   - support_server/wait_children
+conditional_schedule:
+  setup_ensa_nfs:
+    ENSA_SETUP:
+      1:
+        - sles4sap/ensa_filesystems

--- a/schedule/sles4sap/netweaver/netweaver_ensa2.yaml
+++ b/schedule/sles4sap/netweaver/netweaver_ensa2.yaml
@@ -1,0 +1,72 @@
+---
+name: netweaver_cluster_node
+description: >
+  NetWeaver Cluster Test. Schedule for all nodes.
+
+  Some settings are required in the job group or test suite for this schedule to work.
+
+  The other settings required in the job group are.
+
+  CLUSTER_INFOS must be defined in the parent job to the name of the cluster, number
+  of nodes and number of LUNs. Example 'nw:2:3'
+  CLUSTER_NAME must be defined for all jobs as a string.
+  INSTANCE_ID, INSTANCE_IP_CIDR, INSTANCE_SID and INSTANCE_TYPE must be defined and set
+  according to NE needs.
+  HA_CLUSTER_INIT must be defined to yes on the job that initializes the cluster, and to
+  no in the rest of the cluster node jobs
+  HA_CLUSTER_JOIN must be defined for the rest of the jobs, and it must contain the
+  hostname of the job where HA_CLUSTER_INIT is defined to yes
+  NW must be defined pointing to the location of the NW installation masters
+  HOSTNAME must be defined to different hostnames for each node.
+  MAX_JOB_TIME is recommended to be defined as well to a high value (ex. 20000)
+  All jobs with the exception of the parent job must include a PARALLEL_WITH setting
+  referencing the parent job.
+  SLE_PRODUCT must be defined and set to sles4sap.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  BOOT_HDD_IMAGE: '1'
+  USE_SUPPORT_SERVER: '1'
+  HDD_SCC_REGISTERED: '1'
+  VIRTIO_CONSOLE: '0'
+  HA_CLUSTER: '1'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
+schedule:
+  - boot/boot_to_desktop
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/watchdog
+  - sles4sap/patterns
+  - '{{cluster_setup}}'
+  - sles4sap/netweaver_network
+  - '{{ensa_filesystems}}'
+  - sles4sap/netweaver_swpm_installation
+  - sles4sap/netweaver_ensa2_cluster
+  - '{{setup_cluster_connector}}'
+  - '{{test_ensa_web_methods}}'
+  - ha/check_logs
+conditional_schedule:
+  cluster_setup:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/ha_cluster_init
+      no:
+        - ha/ha_cluster_join
+  ensa_filesystems:
+    ENSA_SETUP:
+      1:
+        - sles4sap/ensa_filesystems
+  setup_cluster_connector:
+    ENSA_SETUP:
+      1:
+        - sles4sap/netweaver_ensa2_cluster_connector
+  test_ensa_web_methods:
+    ENSA_SETUP:
+      1:
+        - sles4sap/netweaver_ensa2_web_methods

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -18,8 +18,8 @@ subtest "Run 'setup_sbd_delay_publiccloud' with different values" => sub {
 
     my %passing_values_vs_expected = (
         '1' => '1',
-        'yes' => 'yes',
-        'no' => 'no',
+        yes => 'yes',
+        no => 'no',
         '0' => '0',
         '100' => '100',
         '100s' => '100');

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -9,7 +9,7 @@ use Test::Mock::Time;
 use List::Util qw(any none);
 use Data::Dumper;
 
-use testapi 'set_var';
+use testapi qw(set_var);
 use qesapdeployment;
 set_var('QESAP_CONFIG_FILE', 'MARLIN');
 
@@ -275,9 +275,9 @@ subtest '[qesap_az_clean_old_peerings]' => sub {
 
     $qesap->redefine(qesap_az_get_active_peerings => sub {
             return (
-                'peering1' => '100001',
-                'peering2' => '100002',
-                'peering3' => '100003'
+                peering1 => '100001',
+                peering2 => '100002',
+                peering3 => '100003'
             );
     });
 
@@ -346,7 +346,7 @@ subtest '[qesap_az_create_sas_token] with custom permissions' => sub {
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'BOAT' });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
-    my $ret = qesap_az_create_sas_token(container => 'NEMO', storage => 'DORY', keyname => 'MARLIN', 'permission' => 'SHELL');
+    my $ret = qesap_az_create_sas_token(container => 'NEMO', storage => 'DORY', keyname => 'MARLIN', permission => 'SHELL');
 
     ok((any { /.*--permission SHELL.*/ } @calls), 'Configured permission');
 };

--- a/t/17_sles4sap.t
+++ b/t/17_sles4sap.t
@@ -1,0 +1,377 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use testapi;
+use sles4sap;
+
+sub undef_vars {
+    set_var($_, undef) for qw(
+      INSTANCE_ALIAS
+      INSTANCE_TYPE
+      INSTANCE_IP_CIDR
+      HOSTS_SHARED_DIRECTORY
+      SAP_INSTANCES
+      INSTANCE_SID
+      _SECRET_SAP_MASTER_PASSWORD
+      ASCS_PRODUCT_ID
+      INSTANCE_ID);
+}
+
+subtest '[prepare_swpm]' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(assert_script_run => sub { return 0 });
+    $sles4sap->redefine(record_info => sub { return 0; });
+    $sles4sap->redefine(script_output => sub { return 1; });
+    my %input_vars = (sapcar_bin_path => '/sapinst/SAPCAR',
+        sar_archives_dir => '/sapinst/',
+        swpm_sar_filename => 'SWPM10SP36_4-20009701.SAR',
+        target_path => '/tmp/SWPM');
+
+    is $mockObject->prepare_swpm(%input_vars), '/tmp/SWPM/sapinst', 'Pass with returning correct username';
+
+    # Fail with missing arguments
+    foreach my $argument (keys %input_vars) {
+        my $original_value = $input_vars{$argument};
+        $input_vars{$argument} = undef;
+        dies_ok { $mockObject->prepare_swpm(%input_vars) } "Fail with missing argument: '$argument'";
+        $input_vars{$argument} = $original_value;
+    }
+
+    $sles4sap->redefine(assert_script_run => sub { die if grep /test/, @_; return 0; });
+    dies_ok { $mockObject->prepare_swpm(%input_vars) } "Fail with missing executable 'sapinst' in path";
+
+};
+
+subtest '[is_instance_type_supported]' => sub {
+    my $mockObject = sles4sap->new();
+    my @supported_values = qw(ASCS HDB ERS PAS AAS);
+    my @unsupported_values = ('ASC', 'HD', 'DB', '00', 'ASCS00', ' ', '');
+
+    foreach (@supported_values) { is $mockObject->is_instance_type_supported($_), $_,
+          "Return instance type with supported value '$_'."; }
+    foreach (@unsupported_values) { dies_ok { $mockObject->is_instance_type_supported($_) }
+        "Fail with missing argument or unsupported value:'$_'"; }
+    dies_ok { $mockObject->is_instance_type_supported() } 'Fail with undefined argument';
+};
+
+subtest '[get_nw_instance_name] Test expected failures.' => sub {
+    my $mockObject = sles4sap->new();
+    my $instance_id = '00';
+    my $sap_sid = 'EN2';
+    my %passing_values = (
+        ASCS => "ASCS$instance_id",
+        ERS => "ERS$instance_id",
+        PAS => "D$instance_id",
+        AAS => "D$instance_id"
+    );
+
+    foreach (keys %passing_values) {
+        is $mockObject->get_nw_instance_name(sap_sid => $sap_sid, instance_id => $instance_id, instance_type => $_),
+          $passing_values{$_}, "Pass with path for $_: $passing_values{$_}";
+    }
+};
+
+subtest '[netweaver_installation_data] Test passing values.' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(get_nw_instance_name => sub { return '/usr/sap/something' });
+    $sles4sap->redefine(get_sidadm => sub { return 'loladm' });
+    set_var('INSTANCE_SID', 'LOL');
+    set_var('_SECRET_SAP_MASTER_PASSWORD', 'CorrectHorseBatteryStaple');
+    set_var('INSTANCE_ALIAS', 'virtual_hostname');
+    my $product_id = 'SAP:PRODUCT.ID';
+    my @sap_instances = ('HDB', 'ASCS', 'ERS', 'PAS', 'AAS');
+    foreach (@sap_instances) { set_var($_ . '_PRODUCT_ID', $product_id); }
+
+    my %correct_values = (
+        'HDB,ASCS,ERS,PAS,AAS' => 'all supported instances defined',
+        'ASCS,ERS' => '2 supported instances defined',
+        ASCS => 'single instance defined'
+    );
+
+    foreach (keys(%correct_values)) {
+        set_var('SAP_INSTANCES', $_);
+        ok $mockObject->netweaver_installation_data(), "Pass with $correct_values{$_}";
+    }
+    undef_vars();
+};
+
+subtest '[netweaver_installation_data] Test expected failures.' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(get_sidadm => sub { return 'loladm' });
+    my $product_id = 'SAP:PRODUCT.ID';
+    my @sap_instances = ('HDB', 'ASCS', 'ERS', 'PAS', 'AAS');
+    foreach (@sap_instances) { set_var($_ . '_PRODUCT_ID', $product_id); }
+
+    set_var('SAP_INSTANCES', 'HDB;ASCS;ERS;PAS;AAS');
+    dies_ok { $mockObject->netweaver_installation_data() } "Expected failure with incorrect delimiter used ';'";
+    set_var('SAP_INSTANCES', '');
+    dies_ok { $mockObject->netweaver_installation_data() } "Expected failure with parameter 'SAP_INSTANCES' empty";
+    set_var('SAP_INSTANCES', undef);
+    dies_ok { $mockObject->netweaver_installation_data() } "Expected failure with parameter 'SAP_INSTANCES' undefined";
+    undef_vars();
+};
+
+subtest '[netweaver_installation_data] Test returned values - instance data' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(get_sidadm => sub { return 'loladm' });
+    my $sap_dir_placeholder = 'DIR00';
+    $sles4sap->redefine(get_nw_instance_name => sub { return $sap_dir_placeholder });
+
+    # Set required variables
+    my $sap_sid = 'LOL';
+    my $product_id = 'SAP:PRODUCT.ID';
+    my $instance_id = 0;
+    my @sap_instances = ('HDB', 'ASCS', 'ERS', 'PAS', 'AAS');
+    set_var('SAP_INSTANCES', join(',', @sap_instances));
+    set_var('INSTANCE_SID', $sap_sid);
+    set_var('_SECRET_SAP_MASTER_PASSWORD', 'CorrectHorseBatteryStaple');
+    foreach (@sap_instances) { set_var($_ . '_PRODUCT_ID', $product_id); }
+
+    my $nw_install_data = $mockObject->netweaver_installation_data();
+
+    foreach (@sap_instances) {
+        my $instance_data = $nw_install_data->{instances}{$_};
+        my $sap_dir = $_ eq 'HDB' ? undef : $sap_dir_placeholder;    # DB export does not have directory
+        is $instance_data->{instance_id}, sprintf("%02d", $instance_id), "Pass with correct 'instance_sid' for instance type '$_'";
+        is $instance_data->{product_id}, $product_id, "Pass with correct 'product_id' for instance type '$_'";
+        is $instance_data->{instance_dir_name}, $sap_dir, "Pass with correct 'instance_dir' for instance type '$_'";
+        $instance_id++;
+    }
+    undef_vars();
+};
+
+subtest '[netweaver_installation_data] Test returned values - common variables' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(get_nw_instance_name => sub { return 'DIR00' });
+    $sles4sap->redefine(get_sidadm => sub { return 'loladm' });
+    # Set required variables
+    my $sap_sid = 'LOL';
+    my $product_id = 'SAP:PRODUCT.ID';
+    my $sappassword = 'CorrectHorseBatteryStaple';
+    set_var('SAP_INSTANCES', ('ASCS'));
+    set_var('INSTANCE_SID', $sap_sid);
+    set_var('_SECRET_SAP_MASTER_PASSWORD', $sappassword);
+    set_var('ASCS_PRODUCT_ID', $product_id);
+
+    my $nw_install_data = $mockObject->netweaver_installation_data();
+
+    is $nw_install_data->{instance_sid}, $sap_sid, "Pass with correct 'instance_sid'";
+    is $nw_install_data->{sidadm}, lc $sap_sid . 'adm', "Pass with correct 'sidadm'";
+    is $nw_install_data->{sidadm_uid}, '1001', "Pass with correct 'sidadm_uid'";
+    is $nw_install_data->{sapsys_gid}, '1002', "Pass with correct 'sapsys_gid'";
+    is $nw_install_data->{sap_master_password}, $sappassword, "Pass with correct 'sap_master_password'";
+    is $nw_install_data->{sap_directory}, "/usr/sap/$sap_sid", "Pass with correct 'sap_directory'";
+    undef_vars();
+};
+
+subtest '[sapcontrol_process_check] Test expected failures.' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(record_info => sub { return; });
+    $sles4sap->redefine(sapcontrol => sub { return '3'; });
+    my %argument_values = (
+        sidadm => 'sidadm', instance_id => '00', expected_state => 'started');
+
+    $argument_values{expected_state} = undef;
+    dies_ok { $mockObject->sapcontrol_process_check(%argument_values) } "Expected failure with missing argument: 'expected_state'";
+    $argument_values{expected_state} = 'started';
+
+    foreach ('stoped', 'stated', 'sstopped', 'startedd', 'somethingweird', ' started ') {
+        my $orig_value = $argument_values{expected_state};
+        $argument_values{expected_state} = $_;
+        dies_ok { $mockObject->sapcontrol_process_check(%argument_values) } "Fail with unsupported 'expected_state' value: \'$_'";
+        $argument_values{expected_state} = $orig_value;
+    }
+
+    $sles4sap->redefine(sapcontrol => sub { return '3' });
+    $argument_values{expected_state} = 'stopped';
+    dies_ok { $mockObject->sapcontrol_process_check(%argument_values) } 'Fail with services not stopped.';
+    $sles4sap->redefine(sapcontrol => sub { return '4' });
+    $argument_values{expected_state} = 'started';
+    dies_ok { $mockObject->sapcontrol_process_check(%argument_values) } 'Fail with services not started.';
+};
+
+subtest '[sapcontrol_process_check] Function PASS.' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(record_info => sub { return; });
+    my %argument_values = (instance_id => '00', expected_state => 'started');
+
+    $sles4sap->redefine(sapcontrol => sub { return '4' });
+    $argument_values{expected_state} = 'stopped';
+    is $mockObject->sapcontrol_process_check(%argument_values), 'stopped', 'Pass with services being stopped (RC4)';
+    $sles4sap->redefine(sapcontrol => sub { return '3' });
+    $argument_values{expected_state} = 'started';
+    is $mockObject->sapcontrol_process_check(%argument_values), 'started', 'Pass with services being started (RC3)';
+};
+
+subtest '[share_hosts_entry] All args defined' => sub {
+    my $mockObject = sles4sap->new();
+    my @calls;
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(assert_script_run => sub { push @calls, @_; return 0 });
+    $sles4sap->redefine(script_run => sub { push @calls, @_; return 0 });
+    set_var('INSTANCE_TYPE', 'Astrid');
+    $mockObject->share_hosts_entry(virtual_hostname => 'Olivia', virtual_ip => '192.168.1.1', shared_directory_root => '/Peter/Walter');
+
+    is $calls[1], 'mkdir -p /Peter/Walter/hosts', "Test 'mkdir' command";
+    is $calls[2], "echo '192.168.1.1 Olivia' >> /Peter/Walter/hosts/Astrid", "Test 'hosts' file entry";
+
+    undef_vars();
+};
+
+subtest '[share_hosts_entry] Test default values' => sub {
+    my $mockObject = sles4sap->new();
+    my @calls;
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(assert_script_run => sub { push @calls, @_; return 0 });
+    $sles4sap->redefine(script_run => sub { push @calls, @_; return 0 });
+    set_var('INSTANCE_ALIAS', 'Olivia');
+    set_var('INSTANCE_TYPE', 'Astrid');
+    set_var('INSTANCE_IP_CIDR', '192.168.1.1/24');
+
+    $mockObject->share_hosts_entry();
+
+    is $calls[1], 'mkdir -p /sapmnt/hosts', "Test 'mkdir' command";
+    is $calls[2], "echo '192.168.1.1 Olivia' >> /sapmnt/hosts/Astrid", "Test 'hosts' file entry";
+    undef_vars();
+};
+
+subtest '[share_hosts_entry] Test default values' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(assert_script_run => sub { return 1; });
+    $sles4sap->redefine(assert_script_run => sub { return 1; });
+    set_var('INSTANCE_ALIAS', 'Olivia');
+    set_var('INSTANCE_TYPE', 'Astrid');
+    set_var('INSTANCE_IP_CIDR', '192.168.1.1/24');
+
+    dies_ok { $mockObject->share_hosts_entry(shared_directory_root => '/Peter/Walter') } 'Fail if directory is not mount point';
+    undef_vars();
+};
+
+subtest '[add_hosts_file_entries]' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    my @cat_commands;
+    $sles4sap->redefine(assert_script_run => sub { push @cat_commands, @_; });
+
+    $mockObject->add_hosts_file_entries();
+    is $cat_commands[0], 'cat /sapmnt/hosts/* >> /etc/hosts', 'Check correct command composition.';
+};
+
+subtest '[get_sidadm]' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+
+    dies_ok { $mockObject->get_sidadm() } "Fail with missing 'INSTANCE_SID' parameter";
+    set_var('INSTANCE_SID', 'BEL');
+
+    $sles4sap->redefine(script_run => sub { return 1; });
+    dies_ok { $mockObject->get_sidadm('must_exist' => 1) } 'Fail if sidadm does not exist [RC1]';
+
+    $sles4sap->redefine(script_run => sub { return 0; });
+    is $mockObject->get_sidadm('must_exist' => 1), 'beladm', 'Pass if sidadm does exist [RC0]';
+
+    is $mockObject->get_sidadm(), 'beladm', 'Generate correct username.';
+    undef_vars();
+};
+
+subtest '[sapcontrol] Test expected failures' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $sles4sap->redefine(get_sidadm => sub { return 'abcadm'; });
+    my %arguments = (instance_id => '00', webmethod => 'GoOverThere');
+
+    $sles4sap->redefine(script_output_retry_check => sub { return 'abcadm'; });
+    $sles4sap->redefine(script_run => sub { return '0'; });
+    $arguments{webmethod} = '';
+    dies_ok { $mockObject->sapcontrol(%arguments) } 'Fail without specifying webmethod';
+    $arguments{webmethod} = 'GoOverThere';
+
+    $arguments{instance_id} = '';
+    dies_ok { $mockObject->sapcontrol(%arguments) } 'Fail without specifying instance_id';
+    $arguments{instance_id} = '00';
+
+    $sles4sap->redefine(script_output_retry_check => sub { return 'ninasharp'; });
+    dies_ok { $mockObject->sapcontrol(%arguments) } 'Fail if running under incorrect user';
+    $sles4sap->redefine(script_output_retry_check => sub { return 'abcadm'; });
+
+    $arguments{remote_hostname} = 'charlie';
+    dies_ok { $mockObject->sapcontrol(%arguments) } 'Remote execution fail without sidadm password';
+};
+
+subtest '[sapcontrol] Test using correct values' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    my @calls;
+    $sles4sap->redefine(script_output => sub { return 'command output' });
+    $sles4sap->redefine(script_output_retry_check => sub { return 'abcadm'; });
+    $sles4sap->redefine(script_run => sub { push(@calls, @_); return '0'; });
+    $sles4sap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $sles4sap->redefine(get_sidadm => sub { return 'abcadm'; });
+
+    my %arguments = (instance_id => '00', webmethod => 'GoOverThere');
+
+    is $mockObject->sapcontrol(%arguments), '0', 'Return correct RC';
+    is $calls[0], 'sapcontrol -nr 00 -function GoOverThere', 'Execute correct command';
+    $arguments{additional_args} = 'And Return Back';
+    $mockObject->sapcontrol(%arguments);
+    is $calls[1], 'sapcontrol -nr 00 -function GoOverThere And Return Back', 'Execute correct command with additional args';
+    $arguments{additional_args} = '';
+
+    $arguments{return_output} = 1;
+    is $mockObject->sapcontrol(%arguments), 'command output', 'Return command output instead of RC';
+    $arguments{return_output} = 0;
+
+    $arguments{remote_hostname} = 'charlie';
+    $arguments{sidadm_password} = 'Fr@ncis';
+    $mockObject->sapcontrol(%arguments);
+    is $calls[2], 'sapcontrol -nr 00 -host charlie -user abcadm Fr@ncis -function GoOverThere',
+      'Execute correct command for remote execution';
+};
+
+subtest '[get_instance_profile_path]' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    set_var('INSTANCE_SID', 'EN2');
+    set_var('INSTANCE_TYPE', 'ASCS');
+
+    $sles4sap->redefine(get_sidadm => sub { return 'abcadm'; });
+    $sles4sap->redefine(script_run => sub { return '0'; });
+    $sles4sap->redefine(script_output => sub { return 'EN2_ASCS00_sapen2as'; });
+    $sles4sap->redefine(get_nw_instance_name => sub { return 'ASCS00'; });
+    is $mockObject->get_instance_profile_path(instance_id => '00', instance_type => 'ASCS'), '/sapmnt/EN2/profile/EN2_ASCS00_sapen2as', 'Return correct ASCS profile path.';
+    undef_vars();
+};
+
+subtest '[get_remote_instance_number]' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    $sles4sap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    set_var('INSTANCE_ID', '00');
+    my $sapcontrol_out = '
+30.11.2023 07:15:42
+GetSystemInstanceList
+OK
+hostname, instanceNr, httpPort, httpsPort, startPriority, features, dispstatus
+sapen2er, 1, 50113, 50114, 0.5, ENQREP, GREEN
+sapen2as, 0, 50013, 50014, 1, MESSAGESERVER|ENQUE, GREEN';
+    $sles4sap->redefine(sapcontrol => sub { return $sapcontrol_out });
+
+    is $mockObject->get_remote_instance_number(instance_type => 'ASCS'), '00', 'Return correct ASCS instance number.';
+    is $mockObject->get_remote_instance_number(instance_type => 'ERS'), '01', 'Return correct ERS instance number.';
+
+    undef_vars();
+};
+
+done_testing;

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -183,6 +183,38 @@ sub run {
             barrier_create("HANA_REPLICATE_STATE_${cluster_name}_NODE$_", $num_nodes);
         }
     }
+    # Netweaver stack installation barriers
+    # Installation flow:
+    # ASCS: |--install progress-->
+    # ERS:  |___wait for ASCS____|--install progress-->
+    # DB:   |____________waits for ASCS (ERS)__________|--install progress-->
+    # PAS   |___________________waits for DB_________________________________|--install progress-->
+    # AAS   |___________________waits for PAS______________________________________________________|--install progress-->
+
+    if (get_var('SAP_INSTANCES')) {
+        my @instances = split(',', get_var('SAP_INSTANCES'));
+        my $no_of_instances = @instances;
+        record_info('Instances no', $no_of_instances);
+        my %wait_times = (
+            ASCS => $no_of_instances,    # everything waits for ASCS
+            ERS => $no_of_instances - 1,    # everything but ASCS waits for ERS
+            HDB => grep('ERS', @instances) == 1 ? $no_of_instances - 2 : $no_of_instances - 1,    # Everything but ASCS (optionally ERS) waits for HDB
+        );
+        $wait_times{PAS} = $wait_times{HDB} - 1;    # PAS waits for HDB = same time -1. Only AAS waits for PAS
+
+        for my $instance_type (@instances) {
+            next() if ($wait_times{$instance_type} <= 1);    # Do not raise barrier for single instance
+            barrier_create("SAPINST_$instance_type", $wait_times{$instance_type});
+        }
+        barrier_create('SAPINST_INSTALLATION_FINISHED', $no_of_instances);
+        barrier_create('SAPINST_SYNC_NODES', $no_of_instances);
+        barrier_create('ENSA_CLUSTER_SETUP', $no_of_instances);
+        barrier_create('ENSA_CLUSTER_CONNECTOR_SETUP_DONE', $no_of_instances);
+        barrier_create('ENSA_TEST_END', $no_of_instances);
+        barrier_create('ENSA_FAILOVER_DONE', '2');
+        barrier_create('ENSA_ORIGINAL_STATE', '2');
+        barrier_create('ISCSI_LUN_PREPARE', '2');    #only ASCS/ERS need that
+    }
 
     # Wait for all children to start
     # Children are server/test suites that use the PARALLEL_WITH variable

--- a/tests/sles4sap/ensa_filesystems.pm
+++ b/tests/sles4sap/ensa_filesystems.pm
@@ -1,0 +1,87 @@
+# SUSE's SLES4SAP openQA tests
+
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Configure NetWeaver filesystems for ENSA2 based installation
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base 'sles4sap';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use utils qw(systemctl file_content_replace);
+use hacluster;
+use lockapi;
+
+sub run {
+    my ($self) = @_;
+    my $nfs_root = get_required_var('NFS_MOUNT');
+    my $nw_install_data = $self->netweaver_installation_data();
+    my $create_directories = join(',', 'sapmnt', 'SYS');
+    my $sap_sid = $nw_install_data->{instance_sid};
+    my $sap_dir = $nw_install_data->{sap_directory};
+
+    select_serial_terminal;
+
+    # Setup NFS directory structure on supportserver side
+    if (check_var('SUPPORT_SERVER', '1')) {
+        my $nfs_permissions = get_required_var("NFS_PERMISSIONS");
+        record_info('NFS prep', 'Preparing SAP related exports');
+
+        assert_script_run("mkdir -p $nfs_root/$sap_sid/{$create_directories}");
+        # assert_script_run("chmod -Rv 777 $nfs_root/$sap_sid");
+        # assert_script_run("chown -Rv $sidadm_uid:$sapsys_guid $nfs_root/$sap_sid/*");
+        assert_script_run("echo $nfs_root *\($nfs_permissions\) >> /etc/exports");
+        assert_script_run("exportfs -r");
+        systemctl("restart nfs-server");
+        systemctl("restart rpcbind");
+        systemctl("is-active nfs-server -a rpcbind");
+        return;
+    }
+
+    # Mount shared SAP  NFS filesystems
+    record_info('NFS mounts', 'Preparing shared NFS filesystems');
+    assert_script_run("mkdir -p /sapmnt $sap_dir/{$create_directories}");
+    assert_script_run("echo 'ns:$nfs_root/$sap_sid/sapmnt /sapmnt nfs defaults 0 0' >> /etc/fstab");
+    assert_script_run("echo 'ns:$nfs_root/$sap_sid/SYS $sap_dir/SYS nfs defaults 0 0' >> /etc/fstab");
+    assert_script_run('mount -a');
+    assert_script_run("chmod -Rv 777 /sapmnt/");
+    assert_script_run("chmod -Rv 777 $sap_dir/");
+
+    # Prepare and mount ISCSI devices
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my $instance_dir = $nw_install_data->{instances}{$instance_type}{instance_dir_name};
+    set_var('INSTANCE_ID', $nw_install_data->{instances}{$instance_type}{instance_id});
+
+    if ($instance_type eq 'ASCS') {
+        record_info('ISCSI mounts', 'Preparing shared NFS filesystems');
+        my $lun_path = get_lun(use_once => 0);    # ERS will use the same LUN.
+        set_var('USR_SAP_DEVICE_ASCS', "$lun_path-part1");    # save it in variable for other modules
+        set_var('USR_SAP_DEVICE_ERS', "$lun_path-part2");    # save it in variable for other modules
+        assert_script_run("mkdir -p $sap_dir/$instance_dir");
+        assert_script_run("parted -s $lun_path mklabel gpt");
+        assert_script_run("parted -s $lun_path mkpart primary 0% 50%");
+        assert_script_run("parted -s $lun_path mkpart primary 50% 100%");
+        assert_script_run("mkfs.xfs $lun_path-part1");
+        assert_script_run("mkfs.xfs $lun_path-part2");
+        assert_script_run("mount $lun_path-part1 $sap_dir/$instance_dir");
+        assert_script_run("chmod 777 $sap_dir/$instance_dir");
+    }
+
+    barrier_wait('ISCSI_LUN_PREPARE');    # ENSA needs to wait for partitioning being done
+    if ($instance_type eq 'ERS') {
+        my $lun_path = get_lun;    # ERS removes lun from the list.
+        assert_script_run("partprobe; fdisk -l $lun_path");
+        assert_script_run("mkdir -p $sap_dir/$instance_dir");
+        assert_script_run("mount $lun_path-part2 $sap_dir/$instance_dir");
+        assert_script_run("chmod 777 $sap_dir/$instance_dir");
+    }
+    record_info('Block devices', assert_script_run('lsblk'));
+    record_info('Mounts', assert_script_run("mount | grep $sap_sid"));
+    record_info('Usrsap dir', assert_script_run("ls -alitr $sap_dir"));
+}
+
+1;

--- a/tests/sles4sap/netweaver_ensa2_cluster.pm
+++ b/tests/sles4sap/netweaver_ensa2_cluster.pm
@@ -1,0 +1,64 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: Configure cluster resources for ENSA2
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base 'sles4sap';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use utils qw(file_content_replace);
+use hacluster qw(wait_until_resources_started);
+use lockapi;
+
+sub run {
+    my ($self) = @_;
+    # Set maintenance to 'true'
+    assert_script_run("crm configure property maintenance-mode='true'");
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my $install_data = $self->netweaver_installation_data();
+
+    select_serial_terminal;
+
+    barrier_wait('ENSA_CLUSTER_SETUP') unless $instance_type eq 'ASCS';    # All nodes wait for cluster setup on ASCS
+    if ($instance_type eq 'ASCS') {
+        my $ascs = $install_data->{instances}{ASCS};
+        my $ers = $install_data->{instances}{ERS};
+
+        my $hosts_shared_dir = get_required_var('HOSTS_SHARED_DIRECTORY');
+        my ($ascs_ip, $ascs_hostname) = split(' ', script_output("cat $hosts_shared_dir/ASCS"));
+        my ($ers_ip, $ers_hostname) = split(' ', script_output("cat $hosts_shared_dir/ERS"));
+
+        my $template_file = 'ensa2_cluster_resources.template';
+        my $url = autoinst_url . "/data/ha/$template_file";
+        my $temp_dir = '/tmp/cluster';
+        my %template_variables = (
+            '%INSTANCE_SID%' => $install_data->{instance_sid},
+            '%INSTANCE_ID_ASCS%' => $ascs->{instance_id},
+            '%INSTANCE_ID_ERS%' => $ers->{instance_id},
+            '%VIRTUAL_IP_ASCS%' => $ascs_ip,
+            '%VIRTUAL_IP_ERS%' => $ers_ip,
+            '%VIRTUAL_HOSTNAME_ASCS%' => $ascs_hostname,
+            '%VIRTUAL_HOSTNAME_ERS%' => $ers_hostname,
+            '%USR_SAP_DEVICE_ASCS%' => get_required_var('USR_SAP_DEVICE_ASCS'),
+            '%USR_SAP_DEVICE_ERS%' => get_required_var('USR_SAP_DEVICE_ERS')
+        );
+
+        assert_script_run("mkdir -p $temp_dir");
+        assert_script_run "curl -f -v $url -o $temp_dir/$template_file";
+        file_content_replace("$temp_dir/$template_file", '--sed-modifier' => 'g', %template_variables);
+
+        upload_logs("$temp_dir/$template_file");
+        assert_script_run("crm configure load update $temp_dir/$template_file");
+        barrier_wait('ENSA_CLUSTER_SETUP');
+    }
+    assert_script_run("crm configure property maintenance-mode='false'");
+    wait_until_resources_started();
+    $self->sap_show_status_info(cluster => 1, netweaver => 1,
+        instance_id => $install_data->{instances}{$instance_type}{instance_id});
+}
+
+1;

--- a/tests/sles4sap/netweaver_ensa2_cluster_connector.pm
+++ b/tests/sles4sap/netweaver_ensa2_cluster_connector.pm
@@ -1,0 +1,72 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: Configure cluster connector for ENSA2.
+# Test module is expected to be run after Netweaver installation process finished and
+# at least simple cluster being set up. (Test handles maintenance mode via crm shell)
+# Execute this only on ASCS or ERS instance.
+#
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use strict;
+use warnings;
+use base 'sles4sap';
+use testapi;
+use hacluster;
+use serial_terminal qw(select_serial_terminal);
+use utils qw(file_content_replace);
+use lockapi;
+
+sub run {
+    my ($self) = @_;
+    my $sap_sid = get_required_var('INSTANCE_SID');
+    my $physical_hostname = get_required_var('HOSTNAME');
+    my $nw_install_data = $self->netweaver_installation_data();
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my $instance_id = $nw_install_data->{instances}{$instance_type}{instance_id};
+    my $sidadm = $self->get_sidadm(must_exist => 1);
+
+    select_serial_terminal;
+    assert_script_run("usermod -a -G haclient $sidadm");
+
+    if ($instance_type eq 'ASCS') {
+        my $profile_path_ascs = $self->get_instance_profile_path(instance_id => $instance_id, instance_type => 'ASCS');
+        my $instance_id_ers = $self->get_remote_instance_number(instance_type => 'ERS');
+        my $profile_path_ers = $self->get_instance_profile_path(instance_type => 'ERS', instance_id => $instance_id_ers);
+
+        record_info('SAP params', 'Changing SAP instance parameters required for cluster connector');
+        assert_script_run("crm configure property maintenance-mode='true'");
+        crm_wait_for_maintenance(target_state => 'true');
+
+        foreach ($profile_path_ascs, $profile_path_ers) {
+            assert_script_run("echo 'service/halib = \$(DIR_EXECUTABLE)/saphascriptco.so' >> $_");
+            assert_script_run("echo 'service/halib_cluster_connector = /usr/bin/sap_suse_cluster_connector' >> $_");
+            # Disable autostart
+            file_content_replace($_, 'Autostart = 1', 'Autostart = 0');
+        }
+
+        # Disable service restart
+        file_content_replace($profile_path_ascs, 'Restart_Program_01 = local $(_ENQ)', 'Start_Program_01 = local $(_ENQ)');
+        file_content_replace($profile_path_ers, 'Restart_Program_00 = local $(_ER)', 'Start_Program_00 = local $(_ER)');
+    }
+
+    barrier_wait('ENSA_CLUSTER_CONNECTOR_SETUP_DONE');
+
+    # Restart instances to apply parameter values
+    record_info('SAP restart', 'Restarting ASCS and ERS to apply parameters');
+    $self->sapcontrol(webmethod => 'StopService', instance_id => $instance_id);
+    $self->sapcontrol_process_check(expected_state => 'failed', wait_for_state => 1);    # After stop service sapcontrol returns RC1 (NIECONN_REFUSED)
+    $self->sapcontrol(webmethod => 'StartService', additional_args => $sap_sid, instance_id => $instance_id);
+    $self->sapcontrol_process_check(expected_state => 'started', wait_for_state => 1);
+
+    assert_script_run("crm configure property maintenance-mode='false'");
+    crm_wait_for_maintenance(target_state => 'false');
+
+    # Ensure resource groups are started in correct place (physical hostname)
+    crm_check_resource_location(resource => "grp_$sap_sid\_$instance_type$instance_id", wait_for_target => $physical_hostname);
+    $self->sap_show_status_info(cluster => 1, netweaver => 1,
+        instance_id => $instance_id);
+}
+
+1;

--- a/tests/sles4sap/netweaver_ensa2_web_methods.pm
+++ b/tests/sles4sap/netweaver_ensa2_web_methods.pm
@@ -1,0 +1,80 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Executes failover using sapcontrol web methods on ensa2 cluster.
+# Requires: sles4sap/netweaver_install, ENV variables INSTANCE_SID, INSTANCE_TYPE and INSTANCE_ID
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use strict;
+use warnings;
+use base 'sles4sap';
+use testapi;
+use hacluster;
+use lockapi;
+use serial_terminal qw(select_serial_terminal);
+
+
+sub webmethod_checks {
+    my ($self, $instance_id) = @_;
+    # General status will help with troubleshooting
+    $self->sap_show_status_info(cluster => 1, netweaver => 1, instance_id => $instance_id);
+    record_info('ENSA check', "Executing 'HACheckConfig' and 'HACheckFailoverConfig'");
+    $self->sapcontrol(webmethod => 'HACheckConfig', instance_id => $instance_id);
+    $self->sapcontrol(webmethod => 'HACheckFailoverConfig', instance_id => $instance_id);
+}
+
+sub run {
+    my ($self) = @_;
+    my $sap_sid = get_required_var('INSTANCE_SID');
+    my $instance_id_original = get_required_var('INSTANCE_ID');
+    my $instance_type_original = get_required_var('INSTANCE_TYPE');
+    my $instance_type_remote = $instance_type_original eq 'ASCS' ? 'ERS' : 'ASCS';
+    my $physical_hostname = get_required_var('HOSTNAME');
+    my $instance_id_remote = $self->get_remote_instance_number(instance_type => $instance_type_remote);
+
+    select_serial_terminal;
+
+    my $instance_type = $instance_type_original;
+    my $instance_id = $instance_id_original;
+
+    # Ensure resource groups are started in correct place (physical hostname)
+    die "Resource 'grp_$sap_sid\_$instance_type$instance_id' is not located on $physical_hostname" unless
+      crm_check_resource_location(resource => "grp_$sap_sid\_$instance_type$instance_id") eq $physical_hostname;
+
+    $self->webmethod_checks($instance_id);
+    # Execute failover from ASCS instance
+    if ($instance_type eq 'ASCS') {
+        record_info('Failover', "Executing 'HAFailoverToNode'. Failover from $physical_hostname to remote site");
+        $self->sapcontrol(webmethod => 'HAFailoverToNode', instance_id => $instance_id, additional_args => "\"\"");
+    }
+
+    # After failover, instance type, ID etc is switched.
+    $instance_type = $instance_type_remote;
+    $instance_id = $instance_id_remote;
+    # Wait for failover to finish and check resource locations
+    record_info('Fail wait', 'Waiting for failover to complete');
+    crm_check_resource_location(resource => "grp_$sap_sid\_$instance_type$instance_id", wait_for_target => $physical_hostname);
+    barrier_wait('ENSA_FAILOVER_DONE');    # sync nodes
+
+    $self->webmethod_checks($instance_id);
+    # Execute failover from ASCS instance - this will return resources to original host
+    if ($instance_type eq 'ASCS') {
+        record_info('Failover', "Executing 'HAFailoverToNode'. Failover from $physical_hostname to remote site");
+        $self->sapcontrol(webmethod => 'HAFailoverToNode', instance_id => $instance_id, additional_args => "\"\"");
+    }
+
+    # After failover, instance type, ID etc is switched.
+    $instance_type = $instance_type_original;
+    $instance_id = $instance_id_original;
+
+    # Wait for failover to finish and check resource locations
+    record_info('Fail wait', 'Waiting for failover to complete');
+    crm_check_resource_location(resource => "grp_$sap_sid\_$instance_type$instance_id", wait_for_target => $physical_hostname);
+    barrier_wait('ENSA_ORIGINAL_STATE');    # sync nodes
+                                            # Final checks
+    $self->webmethod_checks($instance_id);
+}
+
+1;

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -68,7 +68,9 @@ sub run {
     # Create sapinst group
     assert_script_run "groupadd sapinst";
     assert_script_run "chgrp -R sapinst /sapinst/unattended";
-    assert_script_run "chmod 0775 /sapinst/unattended";
+
+    # setting permissions as per sapnote 2589600
+    assert_script_run "chmod -Rv 0775 /sapinst/unattended";
 
     # Start the installation
     enter_cmd "cd /sapinst/unattended";

--- a/tests/sles4sap/netweaver_network.pm
+++ b/tests/sles4sap/netweaver_network.pm
@@ -19,7 +19,7 @@ sub run {
     my $instance_type = get_required_var('INSTANCE_TYPE');
     my ($ip, $netmask) = split '/', get_required_var('INSTANCE_IP_CIDR');
     my $sid = get_required_var('INSTANCE_SID');
-    my $alias = lc("sap$sid" . substr($instance_type, 0, 2));
+    my $alias = get_var('INSTANCE_ALIAS', lc("sap$sid" . substr($instance_type, 0, 2)));
 
     # Export needed variables
     set_var('INSTANCE_ALIAS', "$alias");
@@ -30,8 +30,8 @@ sub run {
     my $eth = script_output "ip -o route | sed -rn '/^default/s/.+dev ([a-z]+[0-9]).+/\\1/p'";
     assert_script_run "ip a a dev $eth $ip/$netmask";
 
-    # Add IP addresses in /etc/hosts
-    assert_script_run "echo '$ip $alias' >> /etc/hosts";
+    # Add IP addresses in /etc/hosts. Skip for ENSA2 setup which is done via shared device later.
+    assert_script_run "echo '$ip $alias' >> /etc/hosts" unless (get_var('SAP_INSTANCES'));
 
     # Synchronize nodes
     barrier_wait "NW_CLUSTER_HOSTS_$cluster_name";

--- a/tests/sles4sap/netweaver_swpm_installation.pm
+++ b/tests/sles4sap/netweaver_swpm_installation.pm
@@ -1,0 +1,107 @@
+# SUSE's SLES4SAP openQA tests
+
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Configure NetWeaver filesystems for ENSA2 based installation
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base "sles4sap";
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use lockapi;
+use hacluster;
+use strict;
+use warnings;
+
+sub raise_barriers {
+    my (%args) = @_;
+    my @instances = $args{instances};
+    my $instance_type = $args{instance_type};
+    # ASCS needs to be installed before ERS, PAS, AAS. Hana DB can be installed in parallel.
+    foreach (@instances) { barrier_wait('SAPINST_ASCS') if $instance_type ne 'ASCS'; }
+    foreach (@instances) { barrier_wait('SAPINST_ERS') if grep(/$instance_type/, ('PAS', 'HDB', 'AAS'))
+          and grep('ERS', @instances); };    # Only if ERS is being installed with APP servers
+    foreach (@instances) { barrier_wait('SAPINST_HDB') if grep(/$instance_type/, ('PAS', 'AAS')); };    # PAS and AAS waits for HDB export
+    barrier_wait('SAPINST_PAS') if $instance_type eq 'AAS';    # Only AAS waits for PAS
+}
+
+sub release_barrier {
+    my (%args) = @_;
+    my @instances = $args{instances};
+    my $instance_type = $args{instance_type};
+    barrier_wait('SAPINST_ASCS') if $instance_type eq 'ASCS';    # release ASCS barrier
+    barrier_wait('SAPINST_ERS') if $instance_type eq 'ERS' and grep(/PAS/, @instances);    # release ERS barrier if PAS was part of setup
+    barrier_wait('SAPINST_HDB') if $instance_type eq 'HDB' and grep(/PAS/, @instances);    # release HDB barrier if PAS was part of setup
+    barrier_wait('SAPINST_PAS') if $instance_type eq 'PAS' and grep(/AAS/, @instances);    # release PAS barrier if AAS was part of setup
+}
+
+sub run {
+    my ($self) = @_;
+    my ($proto, $path) = $self->fix_path(get_required_var('NW'));
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my $nw_install_data = $self->netweaver_installation_data();
+    my $instance_data = $nw_install_data->{instances}{$instance_type};
+    my $hostname = get_var('INSTANCE_ALIAS', '$(hostname)');
+    my $media_mount_point = '/sapinst';
+
+    my $sar_archives_dir = $media_mount_point . '/' . get_var('SAR_SOURCES', 'SAR_SOURCES'); # relative path from NFS root to the DIR with KERNEL, SWPM... SAR archives
+    my $sapcar_bin = $media_mount_point . '/' . get_var('SAPCAR_BIN', 'SAPCAR');    # relative path from NFS root to SAPCAR binary
+    my $swpm_sar_filename = get_required_var('SWPM_SAR_FILENAME');
+    my $sapinst_unpack_path = '/tmp/SWPM';
+    my $sap_install_profile = "$sapinst_unpack_path/inifile.params";
+
+    my $product_id = $instance_data->{product_id};
+    my $sap_install_profile_template = join('/', $media_mount_point, get_var('SAP_PROFILE_DIR', 'sap_install_profiles'),
+        $instance_type . '_inifile.params');
+
+    select_serial_terminal;
+    record_info('Media mount', 'Mounting installation media');
+    $self->mount_media($proto, $path, $media_mount_point);
+    my $swpm_binary = $self->prepare_swpm(sapcar_bin_path => $sapcar_bin,
+        sar_archives_dir => $sar_archives_dir,
+        swpm_sar_filename => $swpm_sar_filename,
+        target_path => $sapinst_unpack_path
+    );
+
+    record_info('Profiles', 'Preparing installation profiles for SAP software provisioning manager');
+    $self->prepare_sapinst_profile(
+        profile_target_file => $sap_install_profile,
+        profile_template_file => $sap_install_profile_template,
+        sar_location_directory => $sapinst_unpack_path,
+        instance_type => $instance_type
+    );
+
+    $self->share_hosts_entry();
+    barrier_wait('SAPINST_SYNC_NODES');    # Sync all nodes before installation start
+    $self->add_hosts_file_entries();    # Each node creates a file with ow host entry on NFS
+
+    my @instances = keys %{$nw_install_data->{instances}};
+    # Raises instance specific barrier to prevent dependencies from running
+    raise_barriers(instance_type => $instance_type, instances => @instances);
+
+    my $swpm_command = join(' ', $swpm_binary,
+        "SAPINST_INPUT_PARAMETERS_URL=$sap_install_profile",
+        "SAPINST_USE_HOSTNAME=$hostname",
+        'SAPINST_SKIP_DIALOGS=true',
+        "SAPINST_EXECUTE_PRODUCT_ID=$product_id",
+        '-nogui',
+        '-noguiserver');
+
+    record_info('SAPINST EXEC', "Executing sapinst command:\n$swpm_command");
+    assert_script_run($swpm_command);
+
+    $self->sapcontrol_process_check(sidadm => $nw_install_data->{sidadm},
+        instance_id => $instance_data->{instance_id},
+        expected_state => 'started');
+
+    # releases instance specific barrier to signal installation being done and let dependencies continue
+    release_barrier(instance_type => $instance_type, instances => @instances);
+    # sync all nodes after installation done and show status info on SAP instances
+    barrier_wait('SAPINST_INSTALLATION_FINISHED');
+    $self->sap_show_status_info(netweaver => 1, instance_id => $instance_data->{instance_id})
+      if grep($instance_type, ('ERS', 'ASCS', 'PAS', 'AAS'));
+}
+
+1;


### PR DESCRIPTION
This PR creates new test coverage for SAP ENSA2 scenario. Modules include disk 
setup, swpm installation and simple failover scenario using sapcontrol 
webmethods. 

- Related ticket: 
- https://jira.suse.com/browse/TEAM-8766
- https://jira.suse.com/browse/TEAM-8630
- https://jira.suse.com/browse/TEAM-8767

- Needles: n/a
- Verification run: 
15SP3: https://openqaworker15.qa.suse.cz/tests/272531#
15SP5: https://openqaworker15.qa.suse.cz/tests/272590#

- Regression VR:
http://openqaworker15.qa.suse.cz/tests/272603#dependencies