### PR TITLE
Remove subscription_id from az related qesap API

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -49,7 +49,6 @@ sub run {
                 if (get_var('FENCING_MECHANISM') eq 'native' && get_var('PUBLIC_CLOUD_PROVIDER') eq 'AZURE') {
                     qesap_az_setup_native_fencing_permissions(
                         vm_name => $instance->instance_id,
-                        subscription_id => $provider->{provider_client}{subscription},
                         resource_group => qesap_az_get_resource_group());
                 }
             }

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -159,9 +159,7 @@ sub run {
         if (get_var('FENCING_MECHANISM') eq 'native' && get_var('PUBLIC_CLOUD_PROVIDER') eq 'AZURE') {
             qesap_az_setup_native_fencing_permissions(
                 vm_name => $instance->instance_id,
-                subscription_id => $subscription_id,
-                resource_group => qesap_az_get_resource_group()
-            );
+                resource_group => qesap_az_get_resource_group());
         }
     }
 


### PR DESCRIPTION
Remove subscription id from qesap_az_setup_native_fencing_permissions and qesap_az_assign_role and calculate it on the fly using az cli.
Manage arguments for qesap_az_enable_system_assigned_identity with a different Perl pattern.
Reorganize few UT to split tests about missing arguments from test from proper behavior.

- Related ticket: TEAM-8714

## Verification run:

- SBD fencing - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2023-12-07T05:03:10Z-hanasr_azure_test_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/272524 :green_circle:  deployment phase is ok

- Native MSI  - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2023-12-07T05:03:10Z-hanasr_azure_test_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/272525  :green_circle:  deployment phase is ok. Failure is later in [Kill_site_b-primary](http://openqaworker15.qa.suse.cz/tests/272525/modules/Kill_site_b-primary/steps/1/src)

- Native SPN - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2023-12-07T05:03:10Z-hanasr_azure_test_spn@64bit -> http://openqaworker15.qa.suse.cz/tests/272526 :green_circle:  deployment phase is ok
