### PR TITLE
gnome/nautilus: close custom permission dialog

### DIFF
--- a/tests/x11/gnomecase/nautilus_permission.pm
+++ b/tests/x11/gnomecase/nautilus_permission.pm
@@ -42,6 +42,7 @@ sub run {
     assert_and_click 'nautilus-read-write-permission';
     assert_and_click 'nautilus-default-other-access-permission';
     assert_and_click 'nautilus-read-write-permission';
+    send_key "esc";    #close the custom permissions dialog
     send_key "esc";    #close the dialog
                        #reopen the properties menu to check if the changes kept
     if (is_sle('15+') || is_leap('15.0+') || is_tumbleweed) {
@@ -55,6 +56,7 @@ sub run {
     assert_screen 'nautilus-properties';
     assert_and_click 'nautilus-access-permission';
     assert_screen 'nautilus-permissions-changed';
+    send_key "esc";    #close the custom permissions dialog
     send_key "esc";    #close the dialog
 
     #clean: remove the created new note


### PR DESCRIPTION
In recent GNOME versions, we need to press ESC once more to get
back to the file view. Pressing too many times ESC does not matter,
as we end up on the nautilus file list; this makes it easier for us
not having to worry about the GNOME version running.

- Related ticket: https://progress.opensuse.org/issues/136229
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3789921
