### PR TITLE
 Fix brokenness of FIPS setup on SLE >=15-SP4 in env mode

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -56,8 +56,16 @@ sub get_fips_pattern_name {
 
 sub install_fips {
     my $fips_pattern_name = get_fips_pattern_name();
-    zypper_call("in crypto-policies-scripts") if (is_sle('>=15-SP4') || is_jeos || is_tumbleweed);
+    if (get_var("FIPS_ENV_MODE")) {
+        zypper_call("in -t pattern $fips_pattern_name") if !is_alp;
+    }
+    # In kernel mode only, use the crypto-policies
+    else {
+        zypper_call("in crypto-policies-scripts") if (is_sle('>=15-SP4') || is_jeos || is_tumbleweed);
+    }
+    # In ALP, use the same for kernel and environment mode
     trup_call("pkg install -t pattern $fips_pattern_name") if is_alp || is_sle_micro;
+    # No crypto-policies in older SLE
     zypper_call("in -t pattern $fips_pattern_name") if is_sle('<=15-SP3');
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/152230
- Verification runs:
https://openqa.suse.de/tests/12999644 - env mode
https://openqa.suse.de/tests/12999660 - another env mode fips test
https://openqa.suse.de/tests/12999666 - a kernel mode test

