### PR TITLE
Apply workaround_poo124652 for send_key_until

### DIFF
--- a/lib/YaST/workarounds.pm
+++ b/lib/YaST/workarounds.pm
@@ -15,6 +15,7 @@ use Config::Tiny;
 our @EXPORT = qw(
   apply_workaround_poo124652
   apply_workaround_bsc1206132
+  workaround_poo124652_for_send_key_until
 );
 
 =head1 Workarounds for known issues
@@ -75,6 +76,35 @@ sub apply_workaround_bsc1206132 {
     my $str = $Config->write_string();
     assert_script_run("echo \"$str\" > $service_unit");
     systemctl('daemon-reload');
+}
+
+=head2 workaround_poo124652_for_send_key_until ():
+
+Workaround screen refresh issue for the send_key_until_needle_match
+
+Records a soft failure with a reference to bsc#1206132
+
+This is the wrapper for send_key_until_needle_match for applying
+apply_workaround_bsc1206132.
+
+=cut
+
+sub workaround_poo124652_for_send_key_until {
+    my ($tag, $key, $counter, $timeout) = @_;
+
+    $counter //= 20;
+    $timeout //= 1;
+
+    my $real_timeout = 0;
+    while (!check_screen($tag, $real_timeout)) {
+        wait_screen_change {
+            send_key $key;
+        };
+        if (--$counter <= 0) {
+            apply_workaround_bsc1206132 $tag;
+        }
+        $real_timeout = $timeout;
+    }
 }
 
 1;

--- a/lib/yast2_widget_utils.pm
+++ b/lib/yast2_widget_utils.pm
@@ -77,7 +77,7 @@ sub change_service_configuration_step {
 
     send_key $shortcut;
     send_key 'end';
-    send_key_until_needlematch $needle_selection, 'up', 6, 1;
+    workaround_poo124652_for_send_key_until $needle_selection, 'up', 6, 1;
     if (check_var_array('EXTRATEST', 'y2uitest_ncurses')) {
         send_key 'ret';
         apply_workaround_poo124652($needle_check) if (is_sle('>=15-SP4'));


### PR DESCRIPTION
We need to apply workaround_poo124652 for send key until needle match.


- Related ticket: https://progress.opensuse.org/issues/152065
  * Fix for this kind of error:
      * https://openqa.suse.de/tests/13010426#step/iscsi_client/55
- Needles: N/A
- Verification run: 
   * https://openqa.suse.de/t13022227
   * https://openqa.suse.de/t13022232