### PR TITLE
Improve lib arguments handling for Azure Native fencing

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1912,10 +1912,14 @@ sub qesap_az_enable_system_assigned_identity {
         croak "Missing argument: '$_'" unless defined($args{$_});
     }
 
-    my $az_cmd = "az vm identity assign";
-    my $az_args = "--only-show-errors -g '$args{resource_group}' -n '$args{vm_name}' --query 'systemAssignedIdentity' -o tsv";
-    my $identity_id = script_output(join(' ', $az_cmd, $az_args));
-    croak 'Returned output does not match ID pattern' if qesap_az_validate_uuid_pattern($identity_id) eq 0;
+    my $identity_id = script_output(join(' ',
+            'az vm identity assign',
+            '--only-show-errors',
+            "-g '$args{resource_group}'",
+            "-n '$args{vm_name}'",
+            "--query 'systemAssignedIdentity'",
+            '-o tsv'));
+    die 'Returned output does not match ID pattern' if qesap_az_validate_uuid_pattern($identity_id) eq 0;
     return $identity_id;
 }
 

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -745,29 +745,29 @@ sub create_playbook_section_list {
     );
 
     Collects data and creates string of arguments that can be supplied to playbook.
-    spn_application_id - application ID that allows API access for stonith device
+    spn_application_id - application ID that allows API access for STONITH device
     spn_application_password - password provided for application ID above
 
 =cut
 
 sub azure_fencing_agents_playbook_args {
     my (%args) = @_;
-    my $spn_application_id = $args{spn_application_id};
-    my $spn_application_password = $args{spn_application_password};
+
     my $fence_agent_openqa_var = get_var('AZURE_FENCE_AGENT_CONFIGURATION') // 'msi';
     croak "AZURE_FENCE_AGENT_CONFIGURATION contains dubious value: '$fence_agent_openqa_var'" unless
       !$fence_agent_openqa_var or $fence_agent_openqa_var =~ /msi|spn/;
     my $fence_agent_configuration = $fence_agent_openqa_var eq 'spn' ? $fence_agent_openqa_var : 'msi';
 
-    foreach ('spn_application_id', 'spn_application_password') {
-        next unless ($fence_agent_configuration eq 'spn');
-        croak "Missing '$_' argument" unless defined($args{$_});
+    if ($fence_agent_configuration eq 'spn') {
+        foreach ('spn_application_id', 'spn_application_password') {
+            croak "Missing '$_' argument" unless defined($args{$_});
+        }
     }
 
     my $playbook_opts = "-e azure_identity_management=$fence_agent_configuration";
     $playbook_opts = join(' ', $playbook_opts,
-        "-e spn_application_id=$spn_application_id",
-        "-e spn_application_password=$spn_application_password") if $fence_agent_configuration eq 'spn';
+        "-e spn_application_id=$args{spn_application_id}",
+        "-e spn_application_password=$args{spn_application_password}") if $fence_agent_configuration eq 'spn';
 
     return ($playbook_opts);
 }
@@ -864,6 +864,7 @@ sub get_hana_database_status {
 =over 2
 
 =item B<TIMEOUT> - default 900
+
 =item B<TOTAL_CONSECUTIVE_PASSES> - default 5
 
 =back


### PR DESCRIPTION
Improve as lib arguments are managed, do not create auxiliary variables when possible.
Split some unit tests.
No behavioral changes.

- Related ticket: TEAM-8714

## Verification run:

### sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2023-12-11T05:03:14Z-hanasr_azure_test_msi@64bit

 -> http://openqaworker15.qa.suse.cz/tests/272774 :red_circle: failed in Ansible task `SAP HSR - Register secondary node to HANA System Replication` due to `unable to contact primary site host vmhana01:40006. connection refused`
 ->  http://openqaworker15.qa.suse.cz/tests/272797 :green_circle: 

 ### sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2023-12-11T05:03:14Z-hanasr_azure_test_spn@64bit

-> http://openqaworker15.qa.suse.cz/tests/272775 :red_circle: fails in Ansible with `Timed out waiting for last boot time check (timeout=600)`
-> http://openqaworker15.qa.suse.cz/tests/272798 :green_circle: 
