### PR TITLE
Allow set vf count for sriov test and check guest health for irqbalance test

### DIFF
--- a/data/virt_autotest/virt_logs_collector.sh
+++ b/data/virt_autotest/virt_logs_collector.sh
@@ -105,7 +105,7 @@ while { \${retry_times} > 0 } {
          expect -re "~( |\\\])#"
          if { \${extra_logs} == {support_config} } {
             send "rm -f -r \${logs_folder}/*supportconfig*\r"
-            send "supportconfig -y -A -o AUDIT -t \${logs_folder} -B guest_\${guest_transformed}_supportconfig_\\\${time_stamp}\r"
+            send "supportconfig -y -A -x aFSLIST,AUDIT -t \${logs_folder} -B guest_\${guest_transformed}_supportconfig_\\\${time_stamp}\r"
          }
          if { \${extra_logs} == {sos_report} } {
             send "rm -f -r \${logs_folder}/*sosreport*\r"
@@ -199,8 +199,8 @@ function collect_system_log_and_diagnosis() {
 	   else	   
     	      local time_stamp=`date '+%Y%m%d%H%M%S'`
 	      ${sshpass_ssh_cmd} rm -f -r ${logs_folder}/*supportconfig*
-	      echo -e "${sshpass_ssh_cmd} supportconfig -y -A -o AUDIT -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}"
-	      ${sshpass_ssh_cmd} supportconfig -y -A -o AUDIT -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}
+	      echo -e "${sshpass_ssh_cmd} supportconfig -y -A -x aFSLIST,AUDIT -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}"
+	      ${sshpass_ssh_cmd} supportconfig -y -A -x aFSLIST,AUDIT -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}
 	   fi
 	   ret_result=$?
 	   if [[ ${ret_result} -eq 0 ]];then

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -13,7 +13,7 @@ use testapi;
 use utils 'script_retry';
 use version_utils qw(is_sle);
 use virt_autotest::common;
-use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute remove_vm save_original_guest_xmls restore_downloaded_guests restore_original_guests upload_virt_logs);
+use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute remove_vm save_original_guest_xmls restore_downloaded_guests restore_original_guests upload_virt_logs check_guest_health);
 
 our $vm_xml_save_dir = "/tmp/download_vm_xml";
 
@@ -92,6 +92,8 @@ sub run_test {
             }
         }
         record_info("NIC IRQs distribution on $nproc cpu cores", "@increased_irqs_on_cpu");
+
+        check_guest_health($guest);
     }
 
     restore_xml_changed_guests();
@@ -136,6 +138,7 @@ sub prepare_guest_for_irqbalance {
     }
 
     wait_guest_online($vm_name);
+    check_guest_health($vm_name);
     assert_script_run "ssh root\@$vm_name \"zypper in -y irqbalance\"" unless script_run("ssh root\@$vm_name \"rpm -q irqbalance\"") eq 0;
 
 }


### PR DESCRIPTION
- Allow to set the count of VFs to be plugged in to the guests to ease reproduce bugs
- Upload one more vf configration xml file which might be needed when opening a bug
- add more debug info for dns resolution failure on sriov test
- Add check guest health in irqbalance tests
- Exclude collecting "File system list" and "Audit" logs because supportconfig always hung at these two steps and failed to create supportconfig.tar.gz, fg. http://openqa.suse.de/tests/13021703#step/hotplugging_guest_preparation/108 & https://openqa.suse.de/tests/13047795#step/sriov_network_card_pci_passthrough/484.  Even sometime they finally passed, it took more than 1 hour, fg. https://openqa.suse.de/tests/13037049,  which is unacceptable.

Related ticket: https://progress.opensuse.org/issues/151133 & https://progress.opensuse.org/issues/151486
Verification run: 
[sriov test with PASSTHROUGH_VF_COUNT=2 to reproduce bug](https://openqa.suse.de/tests/13047795#)
[sriov test](https://openqa.suse.de/tests/13069567)
[sriov test](https://openqa.suse.de/tests/13058611)
[xen irqbalance test](https://openqa.suse.de/tests/13058622) 
[sriov test with a fake unresolved dns failure](https://openqa.suse.de/tests/13059450)
[sriov test with more debugging on dns failure](https://openqa.suse.de/tests/13069408)
