### PR TITLE
Update all outdated references to SUSE internal DNS server

### DIFF
--- a/data/autoyast_qam/12-common_base_installation.xml.ep
+++ b/data/autoyast_qam/12-common_base_installation.xml.ep
@@ -160,7 +160,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/data/autoyast_qam/12_installation.xml.ep
+++ b/data/autoyast_qam/12_installation.xml.ep
@@ -126,7 +126,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/data/autoyast_qam/15-common_base_installation.xml.ep
+++ b/data/autoyast_qam/15-common_base_installation.xml.ep
@@ -163,7 +163,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -129,7 +129,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/data/autoyast_sle12/autoyast_sles12sp3+alladdons_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+alladdons_allpatterns_reg_full_s390x.xml
@@ -318,7 +318,7 @@
       <domain>suse</domain>
       <hostname>linux-gspv</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>

--- a/data/autoyast_sle12/autoyast_sles12sp3+alladdons_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+alladdons_default_reg_full_s390x.xml
@@ -275,7 +275,7 @@
       <domain>suse</domain>
       <hostname>linux-gspv</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>

--- a/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_allpatterns_reg_full_s390x.xml
@@ -233,7 +233,7 @@
       <domain>suse</domain>
       <hostname>linux-gspv</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>

--- a/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_default_reg_full_s390x.xml
@@ -197,7 +197,7 @@
       <domain>suse</domain>
       <hostname>linux-gspv</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>

--- a/data/autoyast_sle12/autoyast_sles12sp3_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3_allpatterns_reg_full_s390x.xml
@@ -177,7 +177,7 @@
       <domain>suse</domain>
       <hostname>linux-gspv</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>

--- a/data/autoyast_sle12/autoyast_sles12sp3_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3_default_reg_full_s390x.xml
@@ -145,7 +145,7 @@
       <domain>suse</domain>
       <hostname>linux-gspv</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>

--- a/data/autoyast_sle12/ay.xml
+++ b/data/autoyast_sle12/ay.xml
@@ -318,7 +318,7 @@
       <domain>suse</domain>
       <hostname>linux-gspv</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP2-s390x-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP2-s390x-gnome
@@ -210,7 +210,7 @@
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
 [8CNameserver: 10.160.2.88[30C [ OK ]
-[8CNameserver: 10.160.0.1[31C [ OK ]
+[8CNameserver: 10.144.53.53[31C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]
 [2C- Checking default gateway[33C [ DONE ]
 [2C- Getting listening ports (TCP/UDP)[24C [ DONE ]

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP2-s390x-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP2-s390x-textmode
@@ -213,7 +213,7 @@
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
 [8CNameserver: 10.160.2.88[30C [ OK ]
-[8CNameserver: 10.160.0.1[31C [ OK ]
+[8CNameserver: 10.144.53.53[31C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]
 [2C- Checking default gateway[33C [ DONE ]
 [2C- Getting listening ports (TCP/UDP)[24C [ DONE ]

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP3-s390x-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP3-s390x-gnome
@@ -207,7 +207,7 @@
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
 [8CNameserver: 10.160.2.88[30C [ OK ]
-[8CNameserver: 10.160.0.1[31C [ OK ]
+[8CNameserver: 10.144.53.53[31C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]
 [2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
 [6C* Found 35 ports[39C

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP3-s390x-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP3-s390x-textmode
@@ -207,7 +207,7 @@
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
 [8CNameserver: 10.160.2.88[30C [ OK ]
-[8CNameserver: 10.160.0.1[31C [ OK ]
+[8CNameserver: 10.144.53.53[31C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]
 [2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
 [6C* Found 10 ports[39C

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-s390x-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP4-s390x-textmode
@@ -265,7 +265,7 @@
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
 [8CNameserver: 10.160.2.88[30C [ OK ]
-[8CNameserver: 10.160.0.1[31C [ OK ]
+[8CNameserver: 10.144.53.53[31C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]
 [2C- Checking default gateway[33C [ DONE ]
 [2C- Getting listening ports (TCP/UDP)[24C [ DONE ]

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP5-aarch64-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP5-aarch64-gnome
@@ -282,7 +282,7 @@
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
 [8CNameserver: 2620:113:80c0:8080:10:160:2:88[11C [ OK ]
-[8CNameserver: 2620:113:80c0:8080:10:160:0:1[12C [ OK ]
+[8CNameserver: 2a07:de40:b205:7:10:144:53:53[12C [ OK ]
 [8CNameserver: 2620:113:80c0:8000:10:161:0:98[11C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]
 [2C- Checking default gateway[33C [ DONE ]

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP5-aarch64-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP5-aarch64-textmode
@@ -279,7 +279,7 @@
 [6CIPv6 only[46C [ NO ]
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
-[8CNameserver: 10.160.0.1[31C [ OK ]
+[8CNameserver: 10.144.53.53[31C [ OK ]
 [8CNameserver: 149.44.160.1[29C [ NO RESPONSE ]
 [8CNameserver: 2620:113:80c0:8080:10:160:2:88[11C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP5-ppc64le-gnome
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP5-ppc64le-gnome
@@ -260,7 +260,7 @@
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
 [8CNameserver: 2620:113:80c0:8080:10:160:2:88[11C [ OK ]
-[8CNameserver: 2620:113:80c0:8080:10:160:0:1[12C [ OK ]
+[8CNameserver: 2a07:de40:b205:7:10:144:53:53[12C [ OK ]
 [8CNameserver: 2620:113:80c0:8000:10:161:0:98[11C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]
 [2C- Checking default gateway[33C [ DONE ]

--- a/data/lynis/baseline-lynis-audit-system-nocolors-15-SP5-ppc64le-textmode
+++ b/data/lynis/baseline-lynis-audit-system-nocolors-15-SP5-ppc64le-textmode
@@ -263,7 +263,7 @@
 [2C- Checking configured nameservers[26C
 [4C- Testing nameservers[36C
 [8CNameserver: 2620:113:80c0:8080:10:160:2:88[11C [ OK ]
-[8CNameserver: 2620:113:80c0:8080:10:160:0:1[12C [ OK ]
+[8CNameserver: 2a07:de40:b205:7:10:144:53:53[12C [ OK ]
 [8CNameserver: 2620:113:80c0:8000:10:161:0:98[11C [ OK ]
 [4C- Minimal of 2 responsive nameservers[20C [ OK ]
 [2C- Checking default gateway[33C [ DONE ]

--- a/data/qam/dracut/12-SP2_custom_lvm.xml.ep
+++ b/data/qam/dracut/12-SP2_custom_lvm.xml.ep
@@ -251,7 +251,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/data/qam/dracut/12-SP2_custom_usr.xml.ep
+++ b/data/qam/dracut/12-SP2_custom_usr.xml.ep
@@ -177,7 +177,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/data/qam/dracut/12_custom_lvm.xml.ep
+++ b/data/qam/dracut/12_custom_lvm.xml.ep
@@ -251,7 +251,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/data/yam/autoyast/sles_zvm.xml
+++ b/data/yam/autoyast/sles_zvm.xml
@@ -154,7 +154,7 @@
     <dns t="map">
       <dhcp_hostname t="boolean">true</dhcp_hostname>
       <nameservers t="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist t="list">

--- a/data/yam/autoyast/support_images/create_hdd_ha_sles.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_ha_sles.xml.ep
@@ -119,7 +119,7 @@
         <dhcp_hostname config:type="boolean">true</dhcp_hostname>
         <hostname>susetest</hostname>
         <nameservers config:type="list">
-          <nameserver>10.160.0.1</nameserver>
+          <nameserver>10.144.53.53</nameserver>
         </nameservers>
         <resolv_conf_policy>auto</resolv_conf_policy>
         <searchlist config:type="list">

--- a/data/yam/autoyast/support_images/create_hdd_sles_regression_aarch64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_sles_regression_aarch64.xml.ep
@@ -119,7 +119,7 @@
         <dhcp_hostname config:type="boolean">true</dhcp_hostname>
         <hostname>susetest</hostname>
         <nameservers config:type="list">
-          <nameserver>10.160.0.1</nameserver>
+          <nameserver>10.144.53.53</nameserver>
         </nameservers>
         <resolv_conf_policy>auto</resolv_conf_policy>
         <searchlist config:type="list">

--- a/data/yam/autoyast/support_images/create_hdd_sles_regression_s390x.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_sles_regression_s390x.xml.ep
@@ -67,7 +67,7 @@
         <dhcp_hostname config:type="boolean">true</dhcp_hostname>
         <hostname>susetest</hostname>
         <nameservers config:type="list">
-          <nameserver>10.160.0.1</nameserver>
+          <nameserver>10.144.53.53</nameserver>
         </nameservers>
         <resolv_conf_policy>auto</resolv_conf_policy>
         <searchlist config:type="list">

--- a/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_s390x.xml
@@ -51,7 +51,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_s390x.xml
@@ -44,7 +44,7 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <hostname>susetest</hostname>
       <nameservers config:type="list">
-        <nameserver>10.160.0.1</nameserver>
+        <nameserver>10.144.53.53</nameserver>
       </nameservers>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">

--- a/products/sle/templates
+++ b/products/sle/templates
@@ -289,7 +289,7 @@
                       backend => "s390x",
                       name => "zVM-vswitch-l2",
                       settings => [
-                        { key => "S390_NETWORK_PARAMS", value => "HostIP=10.161.155.@S390_HOST@/20 Hostname=s390vsl@S390_HOST@.suse.de Gateway=10.161.159.254 Nameserver=10.160.0.1 Domain=suse.de PortNo=0 Layer2=1 Portname=VSWNL2 ReadChannel=0.0.0800 WriteChannel=0.0.0801 DataChannel=0.0.0802" },
+                        { key => "S390_NETWORK_PARAMS", value => "HostIP=10.161.155.@S390_HOST@/20 Hostname=s390vsl@S390_HOST@.suse.de Gateway=10.161.159.254 Nameserver=10.144.53.53 Domain=suse.de PortNo=0 Layer2=1 Portname=VSWNL2 ReadChannel=0.0.0800 WriteChannel=0.0.0801 DataChannel=0.0.0802" },
                         { key => "WORKER_CLASS", value => "s390x-zVM-vswitch-l2" },
                       ],
                     },


### PR DESCRIPTION
10.160.0.1 was in the SUSE NUE datacenter which is now decommissioned
and replaced by 10.144.53.53.

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18287 https://openqa.suse.de/tests/13045251
```

sle-15-SP4-Server-DVD-Updates-s390x-Build20231211-1-mru-install-minimal-with-addons@s390x-kvm -> https://openqa.suse.de/tests/13049868

Related progress issue: https://progress.opensuse.org/issues/152461