### PR TITLE
Add cluster log collection in sles4sap_pc tests

### DIFF
--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -63,6 +63,7 @@ sub post_fail_hook {
         diag('Skip post fail', "Variable 'QESAP_NO_CLEANUP_ON_FAILURE' defined.");
         return;
     }
+    qesap_cluster_logs();
     $self->cleanup();
 }
 


### PR DESCRIPTION
Add call to qesap_cluster_logs in post_fail_hook of sles4sap_publiccloud basetest.


- Related ticket: TEAM-8800


# Verification run:

- sle-15-SP3-Azure-SAP-PAYG-Incidents-x86_64-Build:31531:SAPHanaSR-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3
 
--> http://openqaworker15.qa.suse.cz/tests/272839 :green_circle:  it fails with error similar to TEAM-8800 and now we have error logs :partying_face: 

- sle-15-SP2-Azure-SAP-BYOS-Incidents-x86_64-Build:31531:SAPHanaSR-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3 

--> http://openqaworker15.qa.suse.cz/tests/272835 this one is fine, test fails and logs are properly collected (check the log tab) :green_circle: 

--> http://openqaworker15.qa.suse.cz/tests/272836 in this one there's a test module failure, the post_fail_hooks properly call the function `qesap_cluster_logs()` to collect logs, but then there's a timeout failure from this one as looking for the Ansible inventory on the JumpHost http://openqaworker15.qa.suse.cz/tests/272836/logfile?filename=autoinst-log.txt

```
[2023-12-12T16:23:09.886114+01:00] [debug] [pid:52758] post_fail_hook failed: command 'test -e /root/qe-sap-deployment/terraform//azure/inventory.yaml' timed out at /usr/lib/os-autoinst/testapi.pm line 985.
  	testapi::script_run("test -e /root/qe-sap-deployment/terraform//azure/inventory.yaml") called at /var/lib/openqa/pool/74/os-autoinst-distri-opensuse/lib/qesapdeployment.pm line 1078
  	qesapdeployment::qesap_cluster_logs() called at /var/lib/openqa/pool/74/os-autoinst-distri-opensuse/lib/sles4sap_publiccloud_basetest.pm line 66
  	sles4sap_publiccloud_basetest::post_fail_hook(hana_sr_takeover=HASH(0x56473c2ffaa8)) called at /usr/lib/os-autoinst/basetest.pm line 315
```

:red_circle:  Problem here is that the cluster resource cleanup, part of the post_fail_hook, are not called due to the failure.

--> http://openqaworker15.qa.suse.cz/tests/272837 :green_circle:  it fails and we have log collected

--> http://openqaworker15.qa.suse.cz/tests/272838 test does not fails so post_fail_hook is not called. This VR is not as relevant as the others.