### PR TITLE
Add ltss to SLES15SP3 textmode default patterns ay installation

### DIFF
--- a/data/yam/autoyast/support_images/sles15sp3_install_textmode_default_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_textmode_default_patterns_aarch64.xml
@@ -104,6 +104,7 @@ exit 0
     <packages t="list">
       <package>sle-module-server-applications-release</package>
       <package>sle-module-basesystem-release</package>
+      <package>sles-ltss-release</package>
       <package>shim</package>
       <package>openssh</package>
       <package>mokutil</package>
@@ -140,6 +141,13 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp3_install_textmode_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_textmode_default_patterns_s390x.xml
@@ -104,6 +104,7 @@ exit 0
     <packages t="list">
       <package>sle-module-server-applications-release</package>
       <package>sle-module-basesystem-release</package>
+      <package>sles-ltss-release</package>
       <package>openssh</package>
       <package>kexec-tools</package>
       <package>grub2</package>
@@ -128,16 +129,23 @@ exit 0
     </products>
   </software>
   <suse_register config:type="map">
-    <addons t="list">
-      <addon t="map">
+    <addons config:type="list">
+      <addon config:type="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <version>{{VERSION}}</version>
       </addon>
-      <addon t="map">
+      <addon config:type="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
+      </addon>
+      <addon config:type="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration config:type="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp3_install_textmode_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp3_install_textmode_default_patterns_x86_64.xml
@@ -104,6 +104,7 @@ exit 0
     <packages t="list">
       <package>sle-module-server-applications-release</package>
       <package>sle-module-basesystem-release</package>
+      <package>sles-ltss-release</package>
       <package>openssh</package>
       <package>kexec-tools</package>
       <package>grub2</package>
@@ -138,6 +139,13 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>


### PR DESCRIPTION
Add ltss to sles15sp3 textmode default patterns autoyast installation.

- Related ticket: https://progress.opensuse.org/issues/152185
- Verification run: [autoyast installation and images verify](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=20231212-2&groupid=251) 
- Related mr: [support images testsuite update](https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/677); [migration testsuites update](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/11)
