### PR TITLE
UEFI boot fails and does not press key

### DIFF
--- a/tests/wsl/install/ms_win_installation.pm
+++ b/tests/wsl/install/ms_win_installation.pm
@@ -30,10 +30,10 @@ sub run {
     my $self = shift;
 
     if (get_var('UEFI')) {
-        while (check_screen('windows-boot', timeout => 5)) {
-            send_key 'spc';
-            record_info('SPC', 'Space key pressed');
-        }    # boot from CD or DVD
+        # Boot from CD or DVD prompt...
+        assert_screen('windows-boot', timeout => 30);
+        send_key 'spc';
+        record_info('SPC', 'Space key pressed');
     }
 
     if (check_var('WIN_UNATTENDED', '0')) {


### PR DESCRIPTION
When starting UEFI machines, the 'Press any key to boot from CD or DVD...' prompt shows up and there's need to press a key. I'll replace the way it is being pressed, so that there's only a single press instead of continuous pressing until needlematch

- Verification run: *pending*
