### PR TITLE
Add test for klp downgrade command

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -285,7 +285,11 @@ sub schedule_tests {
 
     parse_runfiles($cmd_file, $test_result_export, $suffix);
 
-    if (check_var('KGRAFT', 1) && check_var('UNINSTALL_INCIDENT', 1)) {
+    if (check_var('KGRAFT', 1) && check_var('KGRAFT_DOWNGRADE', 1)) {
+        loadtest_kernel 'klp_downgrade';
+        parse_runfiles($cmd_file, $test_result_export, $suffix . '_postun');
+    }
+    elsif (check_var('KGRAFT', 1) && check_var('UNINSTALL_INCIDENT', 1)) {
         loadtest_kernel 'uninstall_incident';
         parse_runfiles($cmd_file, $test_result_export, $suffix . '_postun');
     }

--- a/tests/kernel/klp_downgrade.pm
+++ b/tests/kernel/klp_downgrade.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright 2023 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Rollback to the previous kernel livepatch.
+# Maintainer: Martin Doucha <mdoucha@suse.cz>
+
+use 5.018;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    my $patches = script_output('klp patches');
+
+    assert_script_run('klp -n downgrade');
+    die 'Kernel reports the same livepatches as before downgrade'
+      if $patches eq script_output('klp patches');
+}
+
+sub test_flags {
+    return {
+        fatal => 1,
+        milestone => 1,
+    };
+}
+
+=head1 Configuration
+
+This test module is activated when KGRAFT=1 and KGRAFT_DOWNGRADE=1.
+
+=cut
+
+1;


### PR DESCRIPTION
Kernel livepatch downgrade was tested by uninstalling the livepatch incident up until now. The `klp` command line utility recently got a feature for downgrading livepatches and should be used instead on SLE-15SP3+.

Older SLE does not support the feature or the `klp` is not available. Those versions will continue using the current incident uninstall approach.

- Related ticket: https://progress.opensuse.org/issues/109476
- Needles: N/A
- Verification runs:
  - SLE-12SP5: https://openqa.suse.de/tests/13072161#step/uninstall_incident/5 (using old incident uninstall method)
  - SLE-15SP3: https://openqa.suse.de/tests/13052105#step/klp_downgrade/10
  - SLE-15SP4: https://openqa.suse.de/tests/13052106#step/klp_downgrade/10
  - SLE-15SP5: https://openqa.suse.de/tests/13052107#step/klp_downgrade/10
