### PR TITLE
Reduce execution time of the sles4sap pc UT

### DIFF
--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -3,11 +3,12 @@ use warnings;
 use Test::MockModule;
 use Test::Exception;
 use Test::More;
+use Test::Mock::Time;
 use testapi;
 
 use sles4sap_publiccloud;
 
-subtest "Run 'setup_sbd_delay_publiccloud' with different values" => sub {
+subtest "[setup_sbd_delay_publiccloud] with different values" => sub {
     my $self = sles4sap_publiccloud->new();
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { return; });
@@ -114,7 +115,7 @@ subtest '[list_cluster_nodes]' => sub {
     dies_ok { $self->list_cluster_nodes() } 'Expected failure: missing mandatory arg';
 };
 
-subtest '[is_hana_database_offline]' => sub {
+subtest '[is_hana_database_online]' => sub {
     my $self = sles4sap_publiccloud->new();
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(get_hana_database_status => sub { return 0; });
@@ -130,7 +131,7 @@ subtest '[is_hana_database_offline]' => sub {
     is $res, 0, "Hana database is offline";
 };
 
-subtest '[is_hana_database_offine with status online]' => sub {
+subtest '[is_hana_database_online] with status online' => sub {
     my $self = sles4sap_publiccloud->new();
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(get_hana_database_status => sub { return 1; });
@@ -146,7 +147,7 @@ subtest '[is_hana_database_offine with status online]' => sub {
     is $res, 1, "Hana database is online";
 };
 
-subtest '[is_primary_node_offline]' => sub {
+subtest '[is_primary_node_online]' => sub {
     my $self = sles4sap_publiccloud->new();
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     my $res = "";


### PR DESCRIPTION
Import a test library to mock the all time functions. The result is that all sleeps has mostly zero execution time. Test about waiting timeout failure are executed in shorter time.

Here execution time of the test with and without the fix

```
% time PERL5OPT=-MCarp::Always  prove --verbose -l -Ios-autoinst/ t/12_sles4sap_publicccloud.t

PERL5OPT=-MCarp::Always prove --verbose -l -Ios-autoinst/   0.88s user 0.25s system 0% cpu 7:31.37 total

PERL5OPT=-MCarp::Always prove --verbose -l -Ios-autoinst/   1.06s user 0.21s system 90% cpu 1.403 total
```
Or you can compare PR pipeline execution time of this PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/7193214082/job/19591195904?pr=18297#step:6:127 with one from a previous PR like https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/7182011242/job/19557579043?pr=18291#step:6:127  (this PR improve from 471secs to 21secs)



- Related ticket: https://jira.suse.com/browse/TEAM-8139

- Verification run: 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/7193214082/job/19591195904?pr=18297