### PR TITLE
java: revert limiting to OSS repo but rather make the package names more explicit

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -49,8 +49,7 @@ sub run {
     # java-11-openjdk                   -> Basesystem
     # java-10-openjdk & java-1_8_0-ibm  -> Legacy
     my $cmd = 'install --auto-agree-with-licenses ';
-    $cmd .= '-r OSS ' if is_opensuse;    # Avoid -debug{info,source} packages
-    $cmd .= (is_sle('15+') || is_sle('=12-SP5') || is_leap) ? 'java-11-openjdk{,-demo,-devel} java-1_*' : 'java-*';
+    $cmd .= (is_sle('15+') || is_sle('=12-SP5') || is_leap) ? 'java-11-openjdk{,-demo,-devel} java-1_*' : 'java-*-devel';
 
     if (is_transactional) {
         select_console 'root-console';


### PR DESCRIPTION

Instead of installing java-* (which includes debuginfo), be more specific and install java-*-devel.

- Related ticket: https://progress.opensuse.org/issues/152206
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3809161

Limiting to `-r OSS` causes issues as the name is not stable across all tests (works in regular ToTest based QA runs, but not on image tests)