### PR TITLE
Increase timeout to unpack HANA installer

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -45,7 +45,8 @@ sub download_hana_assets_from_server {
     # Each HANA asset is about 16GB. A ten minute timeout assumes a generous
     # 27.3MB/s download speed. Adjust according to expected server conditions.
     assert_script_run "wget $hana_location", timeout => $nettout;
-    assert_script_run "tar -xf $filename";
+    # 5 minutes should be more than enough to unpack the installer
+    assert_script_run "tar -xf $filename", timeout => 300;
     assert_script_run "cd";
 }
 


### PR DESCRIPTION
`sles4sap/hana_install` test module sporadically times out when unpacking the installer. See: https://openqa.suse.de/tests/13037858#step/hana_install/44

The serial terminal does not show errors:

```
2023-12-12 23:31:40 (29.6 MB/s) - ‘SPS05rev57_x86_64.tar’ saved [16489840640/16489840640]

DqIvc-0-
# tar -xf SPS05rev57_x86_64.tar; echo abWGm-$?-
abWGm-0-
# 
```

So more than likely, command is working but it's taking longer than the default time to finish.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
