### PR TITLE
Add func to retrieve native fencing type

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -97,6 +97,7 @@ our @EXPORT = qw(
   qesap_az_get_active_peerings
   qesap_az_clean_old_peerings
   qesap_az_setup_native_fencing_permissions
+  qesap_az_get_native_fencing_type
   qesap_az_enable_system_assigned_identity
   qesap_az_assign_role
   qesap_az_get_tenant_id
@@ -1862,6 +1863,22 @@ sub qesap_az_clean_old_peerings {
             qesap_az_simple_peering_delete(rg => $args{rg}, vnet_name => $args{vnet}, peering_name => $key);
         }
     }
+}
+
+=head2 qesap_az_get_native_fencing_type
+
+    qesap_az_get_native_fencing_type();
+
+    Gets the native fencing type (spn/msi)
+
+=cut
+
+sub qesap_az_get_native_fencing_type {
+    my $type = get_var('AZURE_FENCE_AGENT_CONFIGURATION', get_var('QESAP_AZURE_FENCE_AGENT_CONFIGURATION', 'msi'));
+    unless ($type eq 'msi' || $type eq 'spn') {
+        die "Invalid type: $type. Must be 'msi' or 'spn'.";
+    }
+    return $type;
 }
 
 =head2 qesap_az_setup_native_fencing_permissions

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -966,4 +966,25 @@ subtest '[qesap_is_job_finished]' => sub {
     ok($results[2] == 0, "Consider 'running' if the openqa job status response is 'running'");
 };
 
+subtest '[qesap_az_get_native_fencing_type]' => sub {
+    my $res_empty = qesap_az_get_native_fencing_type();
+    ok($res_empty eq 'msi', "Return 'msi' if openqa var is empty");
+};
+
+subtest '[qesap_az_get_native_fencing_type] wrong value for openqa variable' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    $qesap->redefine(get_var => sub { return 'AEGEAN'; });
+    dies_ok { qesap_az_get_native_fencing_type(); } 'Expected die if value is unexpected';
+};
+
+subtest '[qesap_az_get_native_fencing_type] correct variable' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    $qesap->redefine(get_var => sub { return 'msi'; });
+    my $res_msi = qesap_az_get_native_fencing_type();
+    $qesap->redefine(get_var => sub { return 'spn'; });
+    my $res_spn = qesap_az_get_native_fencing_type();
+    ok($res_msi eq 'msi', "Return 'msi' if openqa var is 'msi'");
+    ok($res_spn eq 'spn', "Return 'spn' if openqa var is 'spn'");
+};
+
 done_testing;


### PR DESCRIPTION
Adds a function to retrieve the native fencing method (msi or spn) and relevant tests.

- Related ticket: https://jira.suse.com/browse/TEAM-8714
- Verification run: function not used anywhere yet
