### PR TITLE
Add native fencing in qesap regression

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'azure'
+apiver: 3
+terraform:
+  variables:
+    az_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    public_key: '%SSH_KEY_PUB%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    vnet_address_range: '%VNET_ADDRESS_RANGE%'
+    subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
+    hana_cluster_fencing_mechanism: '%FENCING%'
+    drbd_cluster_fencing_mechanism: '%FENCING%'
+    netweaver_cluster_fencing_mechanism: '%FENCING%'
+ansible:
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HA0'
+    sap_hana_install_instance_number: '00'
+    sap_domain: 'qe-test.example.com'
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+  create:
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - fully-patch-system.yaml
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml -e azure_identity_management=%AZURE_NATIVE_FENCING_AIM%
+  destroy:
+    - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'azure'
+apiver: 3
+terraform:
+  variables:
+    az_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    public_key: '%SSH_KEY_PUB%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    vnet_address_range: '%VNET_ADDRESS_RANGE%'
+    subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
+    hana_cluster_fencing_mechanism: '%FENCING%'
+    drbd_cluster_fencing_mechanism: '%FENCING%'
+    netweaver_cluster_fencing_mechanism: '%FENCING%'
+ansible:
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_sas_token: '%HANA_TOKEN%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  hana_vars:
+    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HA0'
+    sap_hana_install_instance_number: '00'
+    sap_domain: 'qe-test.example.com'
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+  create:
+    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - fully-patch-system.yaml
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml -e azure_identity_management=%AZURE_NATIVE_FENCING_AIM% -e spn_application_id=%AZURE_NATIVE_FENCING_APP_ID% -e spn_application_password=%AZURE_NATIVE_FENCING_APP_PASSWORD%
+  destroy:
+    - deregister.yaml

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -70,7 +70,7 @@ sub run {
     $variables{HANA_CLIENT_SAR} = get_required_var('QESAPDEPLOY_IMDB_CLIENT');
     $variables{HANA_SAPCAR} = get_required_var('QESAPDEPLOY_IMDB_SERVER');
     $variables{ANSIBLE_REMOTE_PYTHON} = get_var('QESAPDEPLOY_ANSIBLE_REMOTE_PYTHON', '/usr/bin/python3');
-    $variables{FENCING} = get_var('QESAPDEPLOY_FENCING', '');
+    $variables{FENCING} = get_var('QESAPDEPLOY_FENCING', 'sbd');
     if (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE')) {
         $variables{HANA_DATA_DISK_TYPE} = get_var('QESAPDEPLOY_HANA_DISK_TYPE', 'pd-ssd');
         $variables{HANA_LOG_DISK_TYPE} = get_var('QESAPDEPLOY_HANA_DISK_TYPE', 'pd-ssd');
@@ -80,6 +80,13 @@ sub run {
         my %peering_settings = qesap_az_calculate_address_range(slot => get_required_var('WORKER_ID'));
         $variables{VNET_ADDRESS_RANGE} = $peering_settings{vnet_address_range};
         $variables{SUBNET_ADDRESS_RANGE} = $peering_settings{subnet_address_range};
+        if ($variables{FENCING} eq 'native') {
+            $variables{AZURE_NATIVE_FENCING_AIM} = qesap_az_get_native_fencing_type();
+            if ($variables{AZURE_NATIVE_FENCING_AIM} eq 'spn') {
+                $variables{AZURE_NATIVE_FENCING_APP_ID} = get_required_var('_SECRET_AZURE_SPN_APPLICATION_ID');
+                $variables{AZURE_NATIVE_FENCING_APP_PASSWORD} = get_required_var('_SECRET_AZURE_SPN_APP_PASSWORD');
+            }
+        }
     }
 
     $variables{ANSIBLE_ROLES} = qesap_get_ansible_roles_dir();


### PR DESCRIPTION
This pr adds support for native fencing in qesap regression.

- Related ticket: https://jira.suse.com/browse/TEAM-8714
- Verification runs: 

### **spn** (cloned job with settings: AZURE_FENCE_AGENT_CONFIGURATION="spn" QESAP_CONFIG_FILE="qesap_azure_fencing_spn.yaml" QESAPDEPLOY_FENCING="native"):
- 15sp5: http://openqaworker15.qa.suse.cz/tests/273026
- 15sp4: http://openqaworker15.qa.suse.cz/tests/273027
- 15sp3: http://openqaworker15.qa.suse.cz/tests/273030
- 12sp5: http://openqaworker15.qa.suse.cz/tests/273031

### **msi** (cloned job with settings: QESAP_CONFIG_FILE="qesap_azure_fencing_spn.yaml" QESAPDEPLOY_FENCING="native" - msi is default when fencing is native, so no need to specify it):
- 15sp5: https://openqaworker15.qa.suse.cz/tests/273025
- 15sp4: http://openqaworker15.qa.suse.cz/tests/273028
- 15sp3: http://openqaworker15.qa.suse.cz/tests/273029
- 12sp5: http://openqaworker15.qa.suse.cz/tests/273032