### PR TITLE
Netavark is default it sle-micro 6.0

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -102,7 +102,7 @@ sub load_host_tests_podman {
         loadtest 'containers/podman_bci_systemd';
         loadtest 'containers/podman_pods';
         # Default for ALP is Netavark
-        loadtest('containers/podman_network_cni') unless (is_alp);
+        loadtest('containers/podman_network_cni') unless (is_alp || is_sle_micro('6.0+'));
         # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
         loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -10,7 +10,7 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use version_utils qw(package_version_cmp is_transactional is_jeos is_alp);
+use version_utils qw(package_version_cmp is_transactional is_jeos is_alp is_sle_micro);
 use containers::utils qw(get_podman_version registry_url);
 use transactional qw(trup_call check_reboot_changes);
 use utils qw(zypper_call);
@@ -76,7 +76,7 @@ sub run {
         return 1;
     }
 
-    switch_to_netavark unless is_alp;
+    switch_to_netavark unless (is_alp || is_sle_micro('6.0+'));
     $podman->cleanup_system_host();
 
     ## TEST1


### PR DESCRIPTION
Do not install nor switch to netavark as it is the default setup in sle-micro 6.0

- Related ticket: https://progress.opensuse.org/issues/152581
- Verification run: http://kepler.suse.cz/tests/22339#
