### PR TITLE
Unschedule libgcrypt for unreleased SLE versions

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -87,7 +87,7 @@ sub load_publiccloud_consoletests {
     loadtest 'console/journalctl';
     loadtest 'console/procps';
     loadtest 'console/suse_module_tools';
-    loadtest 'console/libgcrypt' unless is_sle '=12-SP4';
+    loadtest 'console/libgcrypt' unless check_var('BETA', '1') && !get_var('PUBLIC_CLOUD_QAM');
 }
 
 my $should_use_runargs = sub {


### PR DESCRIPTION


Any scenarios which trying to install something are problematic for
unreleased version of SLE because we often has image with newer
than one which exists in SCC. And there is no way around that
