### PR TITLE
Improve test results of mr_test for saptune 3.1

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -84,6 +84,14 @@ sub setup {
         assert_script_run 'sed -i "/:\/proc\/sys\/net\/ipv4\/tcp_keepalive/s/^/#/" Pattern/SLE15/testpattern_*';
         assert_script_run 'sed -i "/:\/proc\/sys\/net\/ipv4\/tcp_keepalive/s/^/#/" Pattern/SLE12/testpattern_*';
     }
+
+    # Remove "sap.conf" file to fix 12SP5 Public Cloud images Errors (see bsc#1218083 for more info):
+    #   UserTasksMax                          [FAIL]  max == 12288
+    #   UserTasksMax (sapconf DropIn)         [FAIL]  regular == missing
+    if (is_sle("=12-sp5") && get_var('PUBLIC_CLOUD')) {
+        assert_script_run "rm -f /etc/systemd/logind.conf.d/sap.conf";
+    }
+
     $self->reboot_wait;
 }
 


### PR DESCRIPTION
Improve test results of mr_test for saptune 3.1 including Public Cloud and On-premise cases for pre-released 15sp6 and released 12sp5/15sp+ products.

TEAM-8662 - [saptune] mr_test in CSP for saptune 3.1

Improved test results according to https://confluence.suse.com/display/qasle/TEAM-8662+%5Bsaptune%5D+mr_test+in+CSP+for+saptune+3.1

- Related ticket: https://jira.suse.com/browse/TEAM-8662
- Needles: NA
- Verification run:  
  
sle-12-SP5 saptune_solutions PC:  
      _https://openqa.suse.de/tests/13076788   (failed), can be tracked by [Bug 1218083](https://bugzilla.suse.com/show_bug.cgi?id=1218083))
    (It shows 'failed' but not 'softfailed' as `parse_extra_log` can not parse `softfailed` ATM I think)_
      https://openqa.suse.de/tests/13095379 (passed, as added fix according to bsc#1218083)

sle-12-SP5 saptune_solutions On-Pre:  
      https://openqa.suse.de/tests/13072266  (passed)
sle-15-SP6 saptune_notes ppc64le On-Pre: 
      https://openqa.suse.de/tests/13072269  (failed, can be tracked by [bug 1218013](https://bugzilla.suse.com/show_bug.cgi?id=1218013))
sle-15-SP6 saptune_solutions ppc64le On-Pre:  
      https://openqa.suse.de/tests/13072272  (failed, can be tracked by [bug 1218013](https://bugzilla.suse.com/show_bug.cgi?id=1218013))
sle-15-SP6 saptune_solutions x86_64 On-Pre:  
      https://openqa.suse.de/tests/13072274  (passed)
sle-15-SP6 saptune_notes x86_64 On-Pre: 
      https://openqa.suse.de/tests/13072276  (passed)
sle-15-SP5 saptune_solutions x86_64 On-Pre: 
      https://openqa.suse.de/tests/13072288  (passed)
