### PR TITLE
Un-schedule boot_encrypt module if only /boot is encrypted

### DIFF
--- a/schedule/security/autoyast_btrfs_luks1_separate_boot_tw.yaml
+++ b/schedule/security/autoyast_btrfs_luks1_separate_boot_tw.yaml
@@ -10,7 +10,6 @@ schedule:
   - installation/bootloader_start
   - autoyast/installation
   - installation/handle_reboot
-  - installation/boot_encrypt
   - installation/first_boot
   - autoyast/console
   - console/system_prepare


### PR DESCRIPTION
https://progress.opensuse.org/issues/152621

- Verification run: https://openqa.opensuse.org/tests/3812388
