### PR TITLE
Make s390x zKVM SUT hostname more visible

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -66,6 +66,7 @@ sub set_svirt_domain_elements {
 sub run {
     my $svirt = select_console('svirt', await_console => 0);
 
+    record_info('SUT hostname', $svirt->get_cmd_output('hostname'));
     record_info('free -h', $svirt->get_cmd_output('free -h'));
     record_info('virsh freecell --all', $svirt->get_cmd_output('virsh freecell --all'));
     record_info('virsh domstats', $svirt->get_cmd_output('virsh domstats'));


### PR DESCRIPTION
https://progress.opensuse.org/issues/152619

- Verification run: https://openqa.suse.de/tests/13070132#step/bootloader_start/8