### PR TITLE
fix install_wsl race condition

### DIFF
--- a/tests/wsl/install_wsl.pm
+++ b/tests/wsl/install_wsl.pm
@@ -74,6 +74,8 @@ sub run {
         record_info 'Port close', 'Closing serial port...';
         $self->run_in_powershell(cmd => '$port.close()', code => sub { });
         $self->run_in_powershell(cmd => 'exit', code => sub { });
+        # powershell window take a while to close. Check that the screen is showing the desktop before the next command.
+        assert_screen 'windows_desktop', timeout => 15;
         $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
         assert_and_click 'wsl-suse-startup-search';
     } elsif ($install_from eq 'msstore') {


### PR DESCRIPTION
The install_wsl test would attempt to use the search function before exiting powershell. I added a line to check for windows desktop before proceeding with searching for WSL installation.

- Related ticket: https://progress.opensuse.org/issues/151624

- Verification run: https://openqa.opensuse.org/tests/3810149#step/install_wsl/1

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-search-bar-20231211.png