### PR TITLE
Add 'zypper search' with strict Python3 package

### DIFF
--- a/lib/python_version_utils.pm
+++ b/lib/python_version_utils.pm
@@ -38,7 +38,7 @@ returns an array of strings with all the available python versions in the reposi
 =cut
 
 sub get_available_python_versions() {
-    my @python3_versions = split(/\n/, script_output(qq[zypper se 'python3[0-9]*' | awk -F '|' '/python3[0-9]/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]));
+    my @python3_versions = split(/\n/, script_output(qq[zypper se '/^python3[0-9]{1,2}\$/' | awk -F '|' '/python3[0-9]/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]));
     record_info("Available versions", "All available new python3 versions are: @python3_versions");
     return @python3_versions;
 }

--- a/tests/console/python3_new_version_check.pm
+++ b/tests/console/python3_new_version_check.pm
@@ -18,16 +18,18 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use version_utils;
 use utils "zypper_call";
+use python_version_utils;
 use registration "add_suseconnect_product";
 
 sub run {
     select_serial_terminal;
     # Test system python3 version
-    my @system_python_version = script_output(qq[zypper se --installed-only --provides '/usr/bin/python3' | awk -F '|' '/python3[0-9]*/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]);
-    die "There are many python3 versions installed " if (scalar(@system_python_version) > 1);
-    record_info("System python version", "$system_python_version[0]");
+    my $system_python_version = get_system_python_version();
+    record_info("System python version", "$system_python_version");
     assert_script_run("[ -f man_or_boy.py ] || curl -O " . data_url("console/man_or_boy.py") . " || true");
-    my $python3_spec_release = get_python3_specific_release($system_python_version[0]);
+
+    my $python3_spec_release = script_output("rpm -q $system_python_version | awk -F \'-\' \'{print \$2}\'");
+    record_info("python_verison", $python3_spec_release);
     if (is_sle('>=15-SP4')) {
         if ((package_version_cmp($python3_spec_release, "3.6") < 0) ||
             (package_version_cmp($python3_spec_release, "3.7") >= 0)) {
@@ -36,46 +38,25 @@ sub run {
         }
     }
     record_info("Testing system python version $python3_spec_release", "python $python3_spec_release is tested now");
-    my $man_or_boy = script_output("/usr/bin/python3 man_or_boy.py");
-    if ($man_or_boy != -67) {
-        die("Execution of 'man_or_boy.py' with $system_python_version[0] is not correct\n");
-    }
+    run_python_test("/usr/bin/python3");
+
     # Test all avaiable new python3 versions if any
-    my $ret = zypper_call('se "python3[0-9]*"', exitcode => [0, 104]);
-    die('No new python3 packages available') if ($ret == 104);
-    my @python3_versions = split(/\n/, script_output(qq[zypper se 'python3[0-9]*' | awk -F '|' '/python3[0-9]/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]));
-    record_info("Available versions", "All available new python3 versions are: @python3_versions");
+    my @python3_versions = get_available_python_versions();
     foreach my $python3_spec_release (@python3_versions) {
         record_info("Testing $python3_spec_release", "$python3_spec_release is tested now");
-        my $python3_version = get_python3_specific_release($python3_spec_release);
-        zypper_call("install $python3_spec_release");
+        my $python3_version = get_python3_binary($python3_spec_release);
+        zypper_call("install $python3_spec_release-base");
         # Running classic testing algorithm 'man_or_boy'. More info at:
         # https://rosettacode.org/wiki/Man_or_boy_test
-        my $man_or_boy = script_output("$python3_version man_or_boy.py");
-        if ($man_or_boy != -67) {
-            die("Execution of 'man_or_boy.py' with $python3_version is not correct\n");
-        }
+        run_python_test($python3_version);
     }
 }
 
-sub get_python3_specific_release {
-    my ($python3_version) = @_;
-    if ($python3_version eq "python3") {
-        return script_output("rpm -q python3 | awk -F \'-\' \'{print \$2}\'");
-    }
-    my $sub_version = substr($python3_version, 7);
-    return "python3.$sub_version";
-}
-
-sub remove_installed_pythons {
-    my $default_python = script_output("python3 --version | awk -F ' ' '{print \$2}\'");
-    my @python3_versions = split(/\n/, script_output(qq[zypper se 'python3[0-9]*' | awk -F '|' '/python3[0-9]/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]));
-    record_info("Available versions", "All available new python3 versions are: @python3_versions");
-    foreach my $python3_spec_release (@python3_versions) {
-        my $python_versions = script_output("rpm -q $python3_spec_release | awk -F \'-\' \'{print \$2}\'");
-        record_info("Python version", "$python_versions:$default_python");
-        next if ($python_versions == $default_python);
-        assert_script_run("zypper remove -y  $python3_spec_release-base");
+sub run_python_test () {
+    my ($python_package) = @_;
+    my $man_or_boy = script_output("$python_package man_or_boy.py");
+    if ($man_or_boy != -67) {
+        die("Execution of 'man_or_boy.py' with $python_package is not correct\n");
     }
 
 }

--- a/tests/console/python3_setuptools.pm
+++ b/tests/console/python3_setuptools.pm
@@ -17,28 +17,26 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use version_utils;
+use python_version_utils;
 use utils "zypper_call";
 
 sub run {
     select_serial_terminal;
     # Verify the system's python3 version
-    my @system_python_version = script_output(qq[zypper se --installed-only --provides '/usr/bin/python3' | awk -F '|' '/python3[0-9]*/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]);
-    die "There are many python3 versions installed " if (scalar(@system_python_version) > 1);
+    my $system_python_version = get_system_python_version();
+    record_info("System python version", "$system_python_version");
 
     # Import the project directory for creating a source distribution package.
     # The directory should contain setup.py and a Python module named test_module.py
     assert_script_run('curl -L -s ' . data_url('python/python3-setuptools') . ' | cpio --make-directories --extract && cd data');
 
     # Creating and installing the source distribution package
-    build_install_package($system_python_version[0]);
-    cleanup_package($system_python_version[0]);
+    build_install_package($system_python_version);
+    cleanup_package($system_python_version);
 
     # Test all avaiable new python3 versions in SLEs if any
     if (is_sle) {
-        my $ret = zypper_call('se "python3[0-9]*"', exitcode => [0, 104]);
-        die('No new python3 packages available') if ($ret == 104);
-        my @python3_versions = split(/\n/, script_output(qq[zypper se 'python3[0-9]*' | awk -F '|' '/python3[0-9]/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]));
-        record_info("Available versions", "All available new python3 versions are: @python3_versions");
+        my @python3_versions = get_available_python_versions();
         foreach my $python3_spec_release (@python3_versions) {
             zypper_call("install $python3_spec_release");
             build_install_package($python3_spec_release);
@@ -47,15 +45,6 @@ sub run {
     }
 }
 
-sub get_python3_specific_release {
-    my ($python3_version) = @_;
-    if ($python3_version eq "python3") {
-        record_info("System python version is:", script_output("rpm -q python3 | awk -F \'-\' \'{print \$2}\'"));
-        return 3;
-    }
-    my $sub_version = substr($python3_version, 7);
-    return "3.$sub_version";
-}
 
 # Creating the source package with the name 'dist/user_package_setuptools-1.0.tar.gz' in the dist folder.
 # Installing the package and verifying it using the sample Python module 'test_module.py'.
@@ -63,42 +52,31 @@ sub build_install_package {
     my ($python3_release_version) = @_;
     record_info("pip3 version:", script_output("rpm -q $python3_release_version-pip"));
     record_info("python3-setuptools:", script_output("rpm -q $python3_release_version-setuptools"));
-    my $python_version = get_python3_specific_release($python3_release_version);
-    assert_script_run("python$python_version -m venv myenv");
+    my $python_version = get_python3_binary($python3_release_version);
+    my @python_spec_release = split("python", $python_version);
+    assert_script_run("$python_version -m venv myenv");
     assert_script_run("source myenv/bin/activate");
-    assert_script_run("python$python_version setup.py sdist ");
+    assert_script_run("$python_version setup.py sdist ");
     validate_script_output("ls", sub { m/dist/ });
-    validate_script_output("pip$python_version install dist/user_package_setuptools-1.0.tar.gz", sub { m/Successfully installed/ });
-    my @package_loc = split(/:/, script_output("pip$python_version show user_package_setuptools | grep Location"));
+    validate_script_output("pip$python_spec_release[1] install dist/user_package_setuptools-1.0.tar.gz", sub { m/Successfully installed/ });
+    my @package_loc = split(/:/, script_output("pip$python_spec_release[1] show user_package_setuptools | grep Location"));
     validate_script_output("ls $package_loc[1]", sub { m/user_package_setuptools/ });
-    assert_script_run("python$python_version sample_test_module/test_module.py");
+    assert_script_run("python$python_spec_release[1] sample_test_module/test_module.py");
 }
 
 # Uninstall the installed user_package_setuptools and verify it.
 sub cleanup_package {
     my ($python3_release_version) = @_;
-    my $python_version = get_python3_specific_release($python3_release_version);
-    assert_script_run("pip$python_version uninstall user_package_setuptools -y");
-    my $out = script_output "python$python_version sample_test_module/test_module.py", proceed_on_failure => 1;
+    my $python_version = get_python3_binary($python3_release_version);
+    my @python_spec_release = split("python", $python_version);
+    assert_script_run("pip$python_spec_release[1] uninstall user_package_setuptools -y");
+    my $out = script_output "$python_version sample_test_module/test_module.py", proceed_on_failure => 1;
     die("pip uninstall failed for the package") if (index($out, "ModuleNotFoundError") == -1);
     # Deletion of user_package_setuptools.egg-info and dist folder
     assert_script_run("rm -r user_package_setuptools.egg-info");
     assert_script_run("rm -r dist");
     assert_script_run("deactivate");
 
-}
-
-# Remove the installed availble python versions.
-sub remove_installed_pythons {
-    my $default_python = script_output("python3 --version | awk -F ' ' '{print \$2}\'");
-    my @python3_versions = split(/\n/, script_output(qq[zypper se -i 'python3[0-9]*' | awk -F '|' '/python3[0-9]/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]));
-    record_info("Available versions", "All available new python3 versions are: @python3_versions");
-    foreach my $python3_spec_release (@python3_versions) {
-        my $python_versions = script_output("rpm -q $python3_spec_release | awk -F \'-\' \'{print \$2}\'");
-        record_info("Python version", "$python_versions:$default_python");
-        next if ($python_versions == $default_python);
-        zypper_call("remove $python3_spec_release-base");
-    }
 }
 
 sub post_run_hook {


### PR DESCRIPTION
 and also refactor common functions used in the python3 tests.

- Related ticket: https://progress.opensuse.org/issues/152629
                             https://progress.opensuse.org/issues/138401
- Needles: No
- Verification run:  
  Tumbleweed: [x86_64](https://openqa.opensuse.org/tests/3863171#)
   SLE15-SP5: [x86_64](https://openqa.suse.de/tests/13230852) | [aarch64](https://openqa.suse.de/tests/13230850) | [s390x](https://openqa.suse.de/tests/13230851)
   SLE15-SP4: [x86_64](https://openqa.suse.de/tests/13230855) | [aarch64](https://openqa.suse.de/tests/13230858) | [s390x](https://openqa.suse.de/tests/13230854)
