### PR TITLE
Add workaround for bug#1158557 in disable_grub_timeout

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -50,6 +50,10 @@ sub run {
             return;
         }
     }
+
+    # Workaround for bug#1158557
+    send_key 'ret' if (check_screen('inst-bootloader-unknown-udev-device'));
+
     assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
     # Depending on an optional button "release notes" we need to press "tab"
     # to go to the first tab


### PR DESCRIPTION
Add workaround for bug#1158557 as it causes failure when migrating Leap 15.5 to 15.6

- Related ticket: https://progress.opensuse.org/issues/133211
- Verification run: http://falafel.suse.cz/tests/1398
