### PR TITLE
bind: Add auto-agree-with-licenses due to new feature

### DIFF
--- a/data/qam/handle_bind_source_dependencies.sh
+++ b/data/qam/handle_bind_source_dependencies.sh
@@ -56,7 +56,7 @@ else
         touch /tmp/REMOVE_PC
     fi
     if ! grep $SDK $SUSECONNECT; then
-        SUSEConnect -p $SDK/$VERSION_ID/$ARCH
+        SUSEConnect -p $SDK/$VERSION_ID/$ARCH --auto-agree-with-licenses
         touch /tmp/REMOVE_SDK
     fi
     if is_sle12; then


### PR DESCRIPTION
The script could be replaced with simpler way of just adding modules, but it was made like this in the past due to reasons which are not reauired anymore, but it works

https://bugzilla.suse.com/show_bug.cgi?id=1170267#c17

- Related ticket: https://openqa.suse.de/tests/13076187#step/bind/7
- Verification run: https://dzedro.suse.cz/tests/428