### PR TITLE
xfstests: Fix uninitialized value

### DIFF
--- a/lib/filesystem_utils.pm
+++ b/lib/filesystem_utils.pm
@@ -521,6 +521,7 @@ e.g. generate "xfs/001-003,xfs/005" into "{xfs/001 => 1, xfs/002 => 1, xfs/003 =
 
 sub generate_xfstests_list {
     my $raw_list = shift;
+    return unless $raw_list;
     my @split_list = split(/,/, $raw_list);
     my @test_list;
     foreach my $test_item (@split_list) {

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -191,6 +191,7 @@ sub tests_from_category {
 # If TEST_RANGES contain generic tests, then exclude tests from generic folder, else will exclude tests from filesystem type folder
 sub exclude_grouplist {
     my %tests_list = ();
+    return unless get_var('XFSTESTS_GROUPLIST');
     my $test_folder = $TEST_RANGES =~ /generic/ ? "generic" : $FSTYPE;
     my @group_list = split(/,/, get_var('XFSTESTS_GROUPLIST'));
     foreach my $group_name (@group_list) {
@@ -213,6 +214,7 @@ sub exclude_grouplist {
 # If TEST_RANGES contain generic tests, then include tests from generic folder, else will include tests from filesystem type folder
 sub include_grouplist {
     my @tests_list;
+    return unless get_var('XFSTESTS_GROUPLIST');
     my $test_folder = $TEST_RANGES =~ /generic/ ? "generic" : $FSTYPE;
     my @group_list = split(/,/, get_var('XFSTESTS_GROUPLIST'));
     foreach my $group_name (@group_list) {


### PR DESCRIPTION
Sometimes the blacklist and exclude group are all empty, and the $raw_list would be empty. Then the split will fails by uninitialized value.

- Verification run: 
- http://10.67.133.133/tests/437 (test without blacklist and grouplist works)
- http://10.67.133.133/tests/438 (test with grouplist works, changes not affect grouplist related tests)