### PR TITLE
Correct OS check for correct reboot call

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -89,7 +89,7 @@ sub process_reboot {
 
     handle_first_grub if ($args{automated_rollback});
 
-    if (! is_s390x && (is_microos || is_sle_micro('<6.0'))) {
+    if (!is_s390x && (is_microos || is_sle_micro('<6.0'))) {
         microos_reboot $args{trigger};
         record_kernel_audit_messages();
     } elsif (is_backend_s390x) {

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -89,7 +89,7 @@ sub process_reboot {
 
     handle_first_grub if ($args{automated_rollback});
 
-    if (is_microos || is_sle_micro && !is_s390x) {
+    if (! is_s390x && (is_microos || is_sle_micro('<6.0'))) {
         microos_reboot $args{trigger};
         record_kernel_audit_messages();
     } elsif (is_backend_s390x) {


### PR DESCRIPTION
Minor tweak was needed to correct sle-micro reboot processing in case the version is >= 6 and 
there is an encrypted disk.

- Related ticket: https://progress.opensuse.org/issues/152651
- Verification runs: 
   * Marble
   https://openqa.suse.de/tests/13077342

   * Dolomite
   https://openqa.suse.de/tests/13077391

