### PR TITLE
Revert "Improve maximize window poo#138248"

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -52,8 +52,7 @@ sub open_powershell_as_admin {
     if (get_var('QAM_WINDOWS_SERVER')) {
         send_key_until_needlematch 'windows-quick-features-menu', 'super-x';
         wait_screen_change { send_key('shift-a') };
-        # Maximize window
-        wait_screen_change { send_key('super-up') };
+        wait_screen_change { assert_and_click('window-max') };
         assert_screen 'windows_server_powershell_opened', 30;
     } else {
         if (check_var('WIN_VERSION', '10')) {
@@ -79,8 +78,7 @@ sub open_powershell_as_admin {
             send_key 'esc' if match_has_tag('powershell-with-startup-menu');
         }
         assert_screen 'powershell-as-admin-window', timeout => 240;
-        # Maximize window
-        send_key 'super-up';
+        assert_and_click 'window-max';
         wait_still_screen stilltime => 3, timeout => 12;
         _setup_serial_device unless (exists $args{no_serial});
     }

--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -119,12 +119,11 @@ sub run {
     assert_screen [qw(yast2-wsl-firstboot-welcome wsl-installing-prompt)], 480;
 
     if (match_has_tag 'yast2-wsl-firstboot-welcome') {
-
         # The new process of installing, appears in an already maximized window,
         # but sometimes it loses focus. So I created another needle to check if
         # the window is already maximized and click somewhere else to bring it to focus.
         assert_screen(['window-max', 'window-minimize']);
-        send_key 'super-up' if match_has_tag 'window-max';
+        assert_and_click 'window-max' if match_has_tag 'window-max';
         assert_and_click 'window-minimize' if match_has_tag 'window-minimize';
         wait_still_screen stilltime => 3, timeout => 10;
         is_fake_scc_url_needed && set_fake_scc_url();
@@ -156,8 +155,8 @@ sub run {
         # Back to CLI
         assert_screen 'wsl-linux-prompt';
     } else {
-        #1) Make sure to maximize the window and skip registration, we cannot register against proxy SCC
-        send_key 'super-up';
+        #1) skip registration, we cannot register against proxy SCC
+        assert_and_click 'window-max';
         assert_screen 'wsl-registration-prompt', 300;
         send_key 'ret';
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#18135

Seeing that the improvement did make thins worth (and the benefit was doubted pre-merge), revert seems to be the most sensible thing.