### PR TITLE
Combine download of tarball and unpacking

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -44,9 +44,7 @@ sub download_hana_assets_from_server {
     my $hana_location = data_url('ASSET_0');
     # Each HANA asset is about 16GB. A ten minute timeout assumes a generous
     # 27.3MB/s download speed. Adjust according to expected server conditions.
-    assert_script_run "wget $hana_location", timeout => $nettout;
-    # 5 minutes should be more than enough to unpack the installer
-    assert_script_run "tar -xf $filename", timeout => 300;
+    assert_script_run "wget -O - $hana_location | tar -xf -", timeout => $nettout;
     assert_script_run "cd";
 }
 


### PR DESCRIPTION
Due to load in osd workers, the `sles4sap/hana_install` test module is sporadically taking longer than 15 minutes unpacking the HANA installation files tarball. This commit combines the download of the tarball asset with its unpacking in a single pipeline with the 2700 seconds timeout which seems to be enough to download the file; since tarball is not compressed, this solution should accomplish getting the tarball unpacked into the SUT and avoid the later timeout when trying to unpack a downloaded tarball.

- Related ticket: https://jira.suse.com/browse/TEAM-8871
- Needles: N/A
- Verification run: http://openqaworker15.qa.suse.cz/tests/273041
