### PR TITLE
Install also HANA client as it's required by monitoring_services

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -255,9 +255,9 @@ sub run {
     # Install hana
     my @hdblcm_args = qw(--autostart=n --shell=/bin/sh --workergroup=default --system_usage=custom --batch
       --hostname=$(hostname) --db_mode=multiple_containers --db_isolation=low --restrict_max_mem=n
-      --userid=1001 --groupid=79 --use_master_password=n --skip_hostagent_calls=n --system_usage=production
-      --components=server);
+      --userid=1001 --groupid=79 --use_master_password=n --skip_hostagent_calls=n --system_usage=production);
     push @hdblcm_args,
+      "--components=server,client",
       "--sid=$sid",
       "--number=$instid",
       "--home=$mountpts{usr_sap}->{mountpt}",


### PR DESCRIPTION
`sles4sap/monitoring_services` test module determines the version of python to use depending on the python versions associated to the HANA client, so we must make sure that `sles4sap/hana_install` also installs this component.

- Related ticket: N/A
- Needles: N/A
- Failing Test: https://openqa.suse.de/tests/13086538#step/monitoring_services/1
- Verification run: https://openqaworker15.qa.suse.cz/tests/273224 & https://openqaworker15.qa.suse.cz/tests/273222