### PR TITLE
Remove leading comma

### DIFF
--- a/lib/ssh_crypto_policy.pm
+++ b/lib/ssh_crypto_policy.pm
@@ -64,11 +64,7 @@ sub add_to_sshd_config() {
 
     # Create the config line that allows all the available algorithms
     # An example config can be "Ciphers aes128-ctr,aes192-ctr,aes256-ctr"
-    my $config_line = $self->{name} . " ";
-
-    for my $algorithm (@{$self->{algorithm_array}}) {
-        $config_line .= $algorithm . ",";
-    }
+    my $config_line = $self->{name} . ' ' . join(",", @{$self->{algorithm_array}});
 
     assert_script_run("(echo '$config_line' && cat /etc/ssh/sshd_config) > /etc/ssh/sshd_config_");
     assert_script_run("mv /etc/ssh/sshd_config_ /etc/ssh/sshd_config");


### PR DESCRIPTION
Don't add a leading "," after each config line.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1218141#c16
- Verification run: [12-SP5 JeOS](https://openqa.suse.de/tests/13103407#step/sshd/456) | [15-SP5 JeOS](https://openqa.suse.de/tests/13103405#step/rpm/149) | [12-SP5 Server-DVD](https://openqa.suse.de/tests/13103406#step/sshd/456) | [15-SP5 Server-DVD](https://openqa.suse.de/tests/13103404#step/sshd/436)
