### PR TITLE
Lower MM MTU from 1458 to 1380

### DIFF
--- a/data/wicked/dhcp/dhcpd.conf
+++ b/data/wicked/dhcp/dhcpd.conf
@@ -16,7 +16,7 @@ subnet 10.0.2.0 netmask 255.255.255.0 {
   range  10.0.2.15  10.0.2.100;
   default-lease-time 14400;
   max-lease-time 172800;
-  option interface-mtu 1458;
+  option interface-mtu 1380;
   option domain-name "openqa.test";
   option domain-name-servers  10.0.2.2,  10.0.2.2;
   option routers 10.0.2.2;

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -56,7 +56,7 @@ sub is_networkmanager {
 sub configure_static_ip {
     my (%args) = @_;
     my $ip = $args{ip};
-    my $mtu = $args{mtu} // 1458;
+    my $mtu = $args{mtu} // 1380;
     my $is_nm = $args{is_nm} // is_networkmanager();
     my $device = $args{device};
 

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -35,7 +35,7 @@ Set DNS server defined via required variable C<STATIC_DNS_SERVER>
 sub setup_static_network {
     my (%args) = @_;
     my $ip = $args{ip} // '10.0.2.15';
-    my $mtu = $args{mtu} // 1458;
+    my $mtu = $args{mtu} // 1380;
     my $gw = $args{gw} // testapi::host_ip();
 
     configure_static_dns(get_host_resolv_conf(), silent => $args{silent} // 0);

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2897,8 +2897,8 @@ sub ping_size_check {
     my $target = shift;
     my $size = shift;
     # Check connectivity with different packet size to target
-    # Fragmentation is disabled, maximum size is 1430 to fit in 1458 MTU in GRE tunel
-    my @sizes = $size ? $size : (100, 1000, 1350, 1400, 1430);
+    # Fragmentation is disabled, maximum size is 1352 to fit in 1380 MTU in GRE tunel
+    my @sizes = $size ? $size : (100, 1000, 1252, 1350, 1352);
     for my $size (@sizes) {
         assert_script_run("ping -M do -s $size -c 1 $target", fail_message => "ping with packet size $size failed, problems with MTU size are expected. If it is multi-machine job, it can be GRE tunnel setup issue.");
     }

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -113,7 +113,7 @@ sub setup_networks {
         $setup_script .= "NETMASK=$net_conf->{$network}->{subnet_mask}\n";
         $setup_script .= "STARTMODE='auto'\n";
         # TCP cannot pass GRE tunnel with default MTU value 1500 in combination of DF flag set in L3 for ovs bridge
-        $setup_script .= "MTU='1458'\n";
+        $setup_script .= "MTU='1380'\n";
         $setup_script .= "EOT\n";
     }
     $setup_script .= "systemctl restart network\n";
@@ -205,8 +205,8 @@ sub dhcpd_conf_generation {
         $setup_script .= "  range  " . ip_in_subnet($net_conf->{$network}, 15) . "  " . ip_in_subnet($net_conf->{$network}, 100) . ";\n";
         $setup_script .= "  default-lease-time 14400;\n";
         $setup_script .= "  max-lease-time 172800;\n";
-        # dhcp clients have to use MTU 1458 to be able pass GRE Tunnel
-        $setup_script .= "  option interface-mtu 1458;\n";
+        # dhcp clients have to use MTU 1380 to be able pass GRE Tunnel
+        $setup_script .= "  option interface-mtu 1380;\n";
         $setup_script .= "  option domain-name \"openqa.test\";\n";
         if ($dns) {
             $setup_script .= "  option domain-name-servers  $server_ip,  $server_ip;\n";


### PR DESCRIPTION
We were using an MTU of 1458 for our GRE tunnels for MM tests:
```
1500 (default eth MTU)
- 20 Bytes IPv4 header
-  4 Bytes GRE header
- 14 Bytes Ethernet header whithin GRE tunnel
-  4 Bytes Ethernet VLAN TAG header whithin GRE tunnel
=> 1458 Bytes
```

With some MM workers in PRG2 and NUE2 we need to take
the path MTU between our locations into account,
which is 1422 (78 Bytes overhead).

So we have a usable MTU of 1380 left.

Ticket: https://progress.opensuse.org/issues/152389