### PR TITLE
swtpm_env_setup: Don't run enable_tpm_slb9670() twice

### DIFF
--- a/tests/security/swtpm/swtpm_env_setup.pm
+++ b/tests/security/swtpm/swtpm_env_setup.pm
@@ -18,16 +18,13 @@ use Utils::Architectures;
 use rpi 'enable_tpm_slb9670';
 
 sub run {
+    # Enable TPM on Raspberry Pi 4
+    # Refer: https://en.opensuse.org/HCL:Raspberry_Pi3_TPM
     if (get_var('MACHINE') =~ /RPi4/) {
         enable_tpm_slb9670;
     } else {
         select_serial_terminal;
     }
-
-
-    # Enable TPM on Raspberry Pi 4
-    # Refer: https://en.opensuse.org/HCL:Raspberry_Pi3_TPM
-    enable_tpm_slb9670 if (get_var('MACHINE') =~ /RPi4/);
 
     # Install the required packages for libvirt environment setup
     zypper_call("in qemu libvirt swtpm virt-install virt-manager wget");


### PR DESCRIPTION
Fixes: cfa8f1472 ("lib: Add helper for Raspberry Pi")

Verification run:
- https://openqa.suse.de/tests/13121082 https://openqa.suse.de/tests/13121083
- https://openqa.opensuse.org/tests/3826802 https://openqa.opensuse.org/tests/3826803

@lilyeyes @rfan1 Is this enough for testing? Or post what else I should run.
@ggardet FYI
