### PR TITLE
Add support for the JeOS-for-RISCV flavor

### DIFF
--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -27,6 +27,7 @@ use constant {
           is_arm
           is_ppc64le
           is_ppc64
+          is_riscv
           is_orthos_machine
           is_supported_suse_domain
           is_zvm
@@ -154,6 +155,18 @@ sub is_ppc64le {
 
 sub is_ppc64 {
     return check_var('ARCH', 'ppc64');
+}
+
+=head2 is_riscv
+
+ is_riscv();
+
+ Returns whether ARCH is a riscv (currently only riscv64).
+
+=cut
+
+sub is_riscv {
+    return check_var('ARCH', 'riscv64');
 }
 
 =head2 is_orthos_machine

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -16,7 +16,7 @@ use autotest;
 use utils;
 use wicked::TestContext;
 use Utils::Architectures;
-use version_utils qw(:VERSION :BACKEND :SCENARIO);
+use version_utils qw(:VERSION :BACKEND :SCENARIO is_community_jeos);
 use Utils::Backends;
 use data_integrity_utils 'verify_checksum';
 use bmwqemu ();
@@ -606,7 +606,7 @@ sub load_jeos_openstack_tests {
 }
 
 sub load_jeos_tests {
-    if ((is_arm || is_aarch64) && is_opensuse()) {
+    if (is_community_jeos()) {
         # Enable jeos-firstboot, due to boo#1020019
         load_boot_tests();
         loadtest "jeos/prepare_firstboot";

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -925,6 +925,6 @@ Returns true for tests using the images built by the "JeOS" package on OBS
 =cut
 
 sub is_community_jeos {
-    return (get_var('FLAVOR', '') =~ /JeOS-for-(AArch64|RPi)/);
+    return (get_var('FLAVOR', '') =~ /JeOS-for-(AArch64|RISCV|RPi)/);
 }
 

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -64,7 +64,7 @@ sub verify_mounts {
 }
 
 sub verify_hypervisor {
-    my $virt = script_output('systemd-detect-virt');
+    my $virt = script_output('systemd-detect-virt', proceed_on_failure => 1);
 
     return 0 if (
         is_qemu && $virt =~ /(qemu|kvm)/ ||
@@ -72,6 +72,11 @@ sub verify_hypervisor {
         is_hyperv && $virt =~ /microsoft/ ||
         is_vmware && $virt =~ /vmware/ ||
         check_var("VIRSH_VMM_FAMILY", "xen") && $virt =~ /xen/);
+
+    if (is_qemu && is_riscv && $virt =~ /none/) {
+        record_soft_failure('boo#1218309');
+        return 0;
+    }
 
     die("Unknown hypervisor: $virt");
 }


### PR DESCRIPTION
It's JeOS like the others.

- Verification run: https://openqa.opensuse.org/tests/3829935#live