### PR TITLE
Force sort order for lsblk command

### DIFF
--- a/tests/console/lvm.pm
+++ b/tests/console/lvm.pm
@@ -66,7 +66,9 @@ sub run {
 
     # Create 3 partitions
     assert_script_run 'echo -e "g\nn\n\n\n+1G\nt\n8e\nn\n\n\n+1G\nt\n2\n8e\nn\n\n\n\nt\n\n8e\np\nw" | fdisk ' . $disk;
-    assert_script_run 'lsblk';
+    # The order of the mountpoints is not always the same, so there's need to
+    # force the sort order
+    assert_script_run 'lsblk --tree --sort=MOUNTPOINT';
 
     my $timeout = 180;
 


### PR DESCRIPTION
When listing the mountpoints with the 'lsblk' command, the MOUNTPOINT column order may differ, causing tests to fail sporadicly. I've added the options '--tree --sort=MOUNTPOINT' to force the order

- Related ticket: https://progress.opensuse.org/issues/152837
- Verification runs:
  - https://openqa.suse.de/tests/13130136
  - https://openqa.suse.de/tests/13130137
  - https://openqa.suse.de/tests/13130138
  - https://openqa.suse.de/tests/13130139