### PR TITLE
Fix podman_firewall test module for netavark network backend

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 SUSE LLC
+# Copyright 2015-2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package containers::common;
@@ -297,11 +297,6 @@ sub check_containers_connectivity {
     my $runtime = shift;
     record_info "connectivity", "Checking that containers can connect to the host, to each other and outside of the host";
     my $container_name = 'sut_container';
-
-    if (script_run('ping -6 -c 2 google.com') != 0 && is_sle_micro) {
-        record_info('Disable ipv6', 'https://sd.suse.com/servicedesk/customer/portal/1/SD-135489', result => 'softfail');
-        assert_script_run 'sysctl -w net.ipv6.conf.all.disable_ipv6=1';
-    }
 
     # Run container in the background (sleep for 30d because infinite is not supported by sleep in busybox)
     script_retry "$runtime pull " . registry_url('alpine'), retry => 3, delay => 120;

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2021-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: module loader of container tests
@@ -103,10 +103,10 @@ sub load_host_tests_podman {
         loadtest 'containers/podman_pods';
         # Default for ALP is Netavark
         loadtest('containers/podman_network_cni') unless (is_alp || is_sle_micro('6.0+'));
-        # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
-        loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
         # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
         loadtest 'containers/podman_firewall' unless (is_public_cloud || is_openstack || is_microos || is_alp);
+        # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
+        loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
         # Buildah is not available in SLE Micro, MicroOS and staging projects
         loadtest 'containers/buildah' unless (is_sle_micro || is_microos || is_leap_micro || is_alp || is_staging);
         loadtest 'containers/podman_quadlet' if is_tumbleweed;

--- a/tests/containers/podman_firewall.pm
+++ b/tests/containers/podman_firewall.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021-2023 SUSE LLC
+# Copyright 2021-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: podman firewalld
@@ -33,18 +33,10 @@ sub run {
         $stop_firewall = 1;
     }
 
-    # cni-podman0 interface is created when running the first container
-    assert_script_run "podman pull " . registry_url('alpine');
-    assert_script_run "podman run --rm " . registry_url('alpine');
-    validate_script_output('ip a s cni-podman0', sub { /,UP/ });
-
-    # Run container in the background
+    # network interface is created when running the first container
     assert_script_run "podman pull " . registry_url('alpine');
     assert_script_run "podman run -id --rm --name $container_name -p 1234:1234 " . registry_url('alpine') . " sleep 30d";
-
-    # Cheking rules of specific running container
-    validate_script_output("iptables -vn -t nat -L PREROUTING", sub { /CNI-HOSTPORT-DNAT/ });
-    validate_script_output("iptables -vn -t nat -L POSTROUTING", sub { /CNI-HOSTPORT-MASQ/ });
+    validate_script_output("ip a s", sub { m/podman.* state UP / }, fail_message => "podman network interface fails to start");
 
     # Kill the container running on background (this may take some time)
     assert_script_run "podman kill $container_name ";


### PR DESCRIPTION
- Follow up to: #18240
- New year's verification runs: [JeOS](https://openqa.opensuse.org/tests/3871457), [Tumbleweed](https://openqa.opensuse.org/tests/3871458), [SLEM 5.3 aarch64](https://openqa.suse.de/tests/13258742), [SLEM 5.1](https://openqa.suse.de/tests/13258743), [SLEM 5.4](https://openqa.suse.de/tests/13258744), [SLE 15-SP2](https://openqa.suse.de/tests/13258745), [SLE 15-SP1](https://openqa.suse.de/tests/13258746), [SLE 15-SP4](https://openqa.suse.de/tests/13258747), [SLE 15-SP5](https://openqa.suse.de/tests/13258749), [SLE 15-SP3](https://openqa.suse.de/tests/13258748).
- 22th verification runs: opensuse-Tumbleweed-JeOS-for-kvm-and-xen.x86_64 [jeos-container_host@64bit_virtio-2G](https://pdostal-server.suse.cz/tests/5544), sle-15-SP5-Server-DVD-Updates.x86_64 [podman_tests@64bit](https://pdostal-server.suse.cz/tests/5546), sle-15-SP3-Server-DVD-Updates.x86_64 [podman_cgroupv2_tests@64bit](https://pdostal-server.suse.cz/tests/5539), sle-15-SP4-Server-DVD-Updates.x86_64 [podman_cgroupv2_tests@64bit](https://pdostal-server.suse.cz/tests/5540), sle-15-SP2-Server-DVD-Updates.x86_64 [podman_tests@64bit](https://pdostal-server.suse.cz/tests/5542), sle-15-SP1-Server-DVD-Updates.x86_64 [podman_tests@64bit](https://pdostal-server.suse.cz/tests/5543), opensuse-Tumbleweed-DVD.x86_64 [containers_host_podman@64bit](https://pdostal-server.suse.cz/tests/5545), [#13136864](https://openqa.suse.de/tests/13136864#) sle-micro-5.2-MicroOS-Image-Updates-x86_64-BuildPDOSTAL-slem_containers@pdostal_os-autoinst-distri-opensuse_podman_firewall@64bit, [#13136866](https://openqa.suse.de/tests/13136866#) sle-micro-5.4-Default-Updates-x86_64-BuildPDOSTAL-slem_containers@pdostal_os-autoinst-distri-opensuse_podman_firewall@64bit, [#13136867](https://openqa.suse.de/tests/13136867#) sle-micro-5.1-MicroOS-Image-Updates-x86_64-BuildPDOSTAL-slem_containers@pdostal_os-autoinst-distri-opensuse_podman_firewall@64bit, [#13136868](https://openqa.suse.de/tests/13136868#) sle-micro-5.3-MicroOS-Image-Updates-aarch64-BuildPDOSTAL-slem_containers@pdostal_os-autoinst-distri-opensuse_podman_firewall@aarch64
- 20th verification runs: 
[SLEM5.3](https://openqa.suse.de/tests/13115332), [SLEM5.2](https://openqa.suse.de/tests/13115325#), [SLEM5.4](https://openqa.suse.de/tests/13115316), [SLEM5.1](https://openqa.suse.de/tests/13115320), [15-SP3](https://pdostal-server.suse.cz/tests/5526), [15-SP4](https://pdostal-server.suse.cz/tests/5527), [SP-SP5](https://pdostal-server.suse.cz/tests/5528), [15-SP2](https://pdostal-server.suse.cz/tests/5529), [15-SP1](https://pdostal-server.suse.cz/tests/5530), [tw](https://pdostal-server.suse.cz/tests/5525), [JeOS](https://pdostal-server.suse.cz/tests/5524), [SLEM6.0](https://pdostal-server.suse.cz/tests/5531)