### PR TITLE
Fix sudo on 15-SP4

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -50,8 +50,8 @@ sub run {
     zypper_call 'in sudo expect';
     select_console 'user-console';
     # Defaults targetpw -> asks for root PW
-    my $exp_user = (is_azure && is_sle('>=15-SP4')) ? 'bernhard' : 'root';
-    assert_script_run("expect -c 'spawn sudo id -un;expect \"password for $exp_user\" {send \"$testapi::password\\r\";interact} default {exit 1}' | grep ^$exp_user");
+    my $exp_user = (is_azure && is_sle('>15-SP4')) ? 'bernhard' : 'root';
+    validate_script_output("expect -c 'spawn sudo id -un;expect \"password for $exp_user\" {send \"$testapi::password\\r\";interact} default {exit 1}'", sub { $_ !~ "^$exp_user\$" });
     select_console 'root-console';
     # Prepare a file with content '1' for later IO redirection test
     assert_script_run 'echo 1 >/run/openqa_sudo_test';


### PR DESCRIPTION
Fix for sudo on Azure for SLE 15-SP4 (non-BYOS), where the expected user is root.

- Related ticket: https://progress.opensuse.org/issues/152845
- Related to: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18339
- Verification run: [15-SP4 Server](https://openqa.suse.de/tests/13136556) | [15-SP4 Azure-Basic](https://openqa.suse.de/tests/13136557) | [15-SP4 Azure-BYOS](https://openqa.suse.de/tests/13136558) | [15-SP4 Azure-Basic aarch64](https://openqa.suse.de/tests/13136559) | [15-SP4 Azure-Standard](https://openqa.suse.de/tests/13136560) | [15-SP4 EC2-BYOS](https://openqa.suse.de/tests/13136561) | [15-SP5 Azure-BYOS](https://openqa.suse.de/tests/13136562) | [15-SP5 Azure-Basic](https://openqa.suse.de/tests/13136563) | [15-SP3 Azure-BYOS](https://openqa.suse.de/tests/13136564) | [15-SP3 GCE](https://openqa.suse.de/tests/13136565)