### PR TITLE
install_ltp: Install TPM DTS only on LTP IMA tests

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -290,6 +290,7 @@ sub run {
     my $inst_ltp = get_var 'INSTALL_LTP';
     my $cmd_file = get_var('LTP_COMMAND_FILE');
     my $grub_param = 'ignore_loglevel';
+    my $is_ima = $cmd_file =~ m/^ima$/i;
 
     if ($inst_ltp !~ /(repo|git)/i) {
         die 'INSTALL_LTP must contain "git" or "repo"';
@@ -299,7 +300,7 @@ sub run {
         $self->wait_boot;
     }
 
-    enable_tpm_slb9670 if (get_var('MACHINE') =~ /RPi/);
+    enable_tpm_slb9670 if ($is_ima && get_var('MACHINE') =~ /RPi/);
 
     select_serial_terminal;
 


### PR DESCRIPTION
Reboot scheduled on JeOS RPI by enable_tpm_slb9670() after slb9670 DTS installation fails on some reason. Avoid it for other tests (JeOS on RPI runs various LTP runtests) so that they don't fail.

Even the issue is fixed, it's still better to run it only on IMA (reboot is unnecessary slowdown for other tests).

Verification run: https://openqa.opensuse.org/tests/3830657
