### PR TITLE
Enhance and fix logging in virt automation tests

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -216,14 +216,14 @@ sub turn_on_libvirt_debugging_log {
     push @libvirt_daemons, 'virtlogd' if is_kvm_host;
 
     #turn on debug and log filter for libvirt services
-    #set log_level = 1 'debug'
+    #disable log_level = 1 'debug' as it generage large output
     #the size of libvirtd with debug level and without any filter on sles15sp3 xen is over 100G,
     #which consumes all the disk space. Now get comfirmation from virt developers,
     #log filter is set to store component logs with different levels.
     foreach my $daemon (@libvirt_daemons) {
         my $conf_file = "/etc/libvirt/$daemon.conf";
         if (script_run("ls $conf_file") == 0) {
-            script_run "sed -i '/^[# ]*log_level *=/{h;s/^[# ]*log_level *= *[0-9].*\$/log_level = 1/};\${x;/^\$/{s//log_level = 1/;H};x}' $conf_file";
+            script_run "sed -i 's/^[ ]*log_level *=/#&/' $conf_file";
             script_run "sed -i '/^[# ]*log_outputs *=/{h;s%^[# ]*log_outputs *=.*[0-9].*\$%log_outputs = \"1:file:/var/log/libvirt/$daemon.log\"%};\${x;/^\$/{s%%log_outputs = \"1:file:/var/log/libvirt/$daemon.log\"%;H};x}' $conf_file";
             script_run "sed -i '/^[# ]*log_filters *=/{h;s%^[# ]*log_filters *=.*[0-9].*\$%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%};\${x;/^\$/{s%%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%;H};x}' $conf_file";
         }

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -111,6 +111,7 @@ sub test_network_interface {
     my $routed = $args{routed} // 0;
     my $target = $args{target} // script_output("dig +short google.com");
 
+    record_info("Network test", "testing $mac");
     check_guest_ip("$guest", net => $net) if ((is_sle('>15') || is_alp) && ($isolated == 1) && get_var('VIRT_AUTOTEST'));
 
     save_guest_ip("$guest", name => $net);

--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -184,7 +184,7 @@ sub post_fail_hook {
     # virt logs are included in next step "virt_utils::collect_host_and_guest_logs"
     collect_virt_system_logs() unless get_var("VIRT_AUTOTEST");
 
-    virt_utils::collect_host_and_guest_logs;
+    virt_utils::collect_host_and_guest_logs('', '', '', "_" . caller 0);
     upload_logs("/var/log/clean_up_virt_logs.log");
     save_screenshot;
     upload_logs("/var/log/guest_console_monitor.log");

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -38,6 +38,9 @@ sub run_test {
     #clean up test logs
     script_run "[ -d $log_dir ] && rm -rf $log_dir; mkdir -p $log_dir";
 
+    #save original guest configuration file in case of restore in post_fail_hook()
+    save_original_guest_xmls();
+
     #get the SR-IOV device BDF and interface
     my @host_pfs;
     @host_pfs = find_sriov_ethernet_devices();
@@ -48,9 +51,6 @@ sub run_test {
     # enable 8 vfs for the SR-IOV device on host
     my @host_vfs = enable_vf(@host_pfs);
     record_info("VFs enabled", "@host_vfs");
-
-    #save original guest configuration file in case of restore in post_fail_hook()
-    save_original_guest_xmls();
 
     foreach my $guest (keys %virt_autotest::common::guests) {
         if (virt_autotest::utils::is_sev_es_guest($guest) ne 'notsev') {

--- a/tests/virt_autotest/validate_system_health.pm
+++ b/tests/virt_autotest/validate_system_health.pm
@@ -49,10 +49,10 @@ sub run_test {
     # Upload logs on x86_64
     if (get_var('FORCE_UPLOAD_LOGS') || @unhealthy_list != 0) {
         if (get_var('FORCE_UPLOAD_LOGS')) {
-            collect_host_and_guest_logs(join(' ', grep { $_ ne 'host' } keys %health_status));
+            collect_host_and_guest_logs(join(' ', grep { $_ ne 'host' } keys %health_status), '', '', '_validate_system_health');
         }
         else {
-            collect_host_and_guest_logs(join(' ', grep { $_ ne 'host' } @unhealthy_list));
+            collect_host_and_guest_logs(join(' ', grep { $_ ne 'host' } @unhealthy_list), '', '', '_validate_system_health');
         }
         $self->upload_coredumps;
         save_screenshot;


### PR DESCRIPTION
- Disable log_level=1 in libvirt as there is log_filter defined. also refer to https://bugzilla.suse.com/show_bug.cgi?id=1217965#c8
- Save guest configuration file ealier for restorartion in post_fail_hook. Tests could fail at any time and guest configuration files could be required at that time. see failure: http://10.67.129.27/tests/204#step/sriov_network_card_pci_passthrough/222
- Fix uploading virt logs in post_fail_hook. logs are not uploaded in post_fail_hook currently, as they are overritten by logs in its following test modules. fg. https://openqa.suse.de/tests/13269602#downloads

Verification run: 
[a failed test with logs uploaded](https://openqa.suse.de/tests/13284640#downloads)

