### PR TITLE
only do explicit install on SLE_BCI repo for dists that have them

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -260,7 +260,8 @@ sub test_systemd_install {
     if ($image_id eq 'opensuse-tumbleweed' ||
         ($image_id eq 'opensuse-leap' && check_version('>=15.4', "$image_version.$image_sp", qr/\d{2}\.\d/)) ||
         ($image_id eq 'sles' && check_version('>=15-SP4', "$image_version-SP$image_sp", qr/\d{2}-sp\d/))) {
-        my $repo = $image_id eq 'sles' ? '-r SLE_BCI' : '';
+        # lock to SLE_BCI repo for SLES versions not under LTSS (LTSS has no BCI repo anymore)
+        my $repo = ($image_id eq 'sles' && check_version('>=15-SP5', "$image_version-SP$image_sp", qr/\d{2}-sp\d/)) ? '-r SLE_BCI' : '';
         assert_script_run("$runtime run $image /bin/bash -c 'zypper al udev && zypper -n in $repo systemd'", timeout => 300);
     }
 }


### PR DESCRIPTION
The sles-ltss containers are not providing a SLE_BCI repository anymore, so don't restrict to it.

- Related ticket: https://progress.opensuse.org/issues/152074