### PR TITLE
Do not install mariadb after smt pattern

### DIFF
--- a/tests/smt/smt_server_install.pm
+++ b/tests/smt/smt_server_install.pm
@@ -28,7 +28,6 @@ sub run {
     barrier_create('smt_finished', 2);
 
     zypper_call 'in -t pattern smt';
-    zypper_call 'in mariadb';
 
     select_console 'root-console';
 


### PR DESCRIPTION
Maybe before were broken dependencies on some version, but now smt pattern does install mariadb and following try to install mariadb again does just mess with mariadb versions

- Related ticket: https://openqa.suse.de/tests/13136367#step/smt_server_install/33
- Verification run: https://openqa.suse.de/tests/13136510
