### PR TITLE
rsync_server: ensure /etc/rsyncd.secrets has mode 600

### DIFF
--- a/tests/console/rsync_server.pm
+++ b/tests/console/rsync_server.pm
@@ -29,6 +29,7 @@ sub run {
     #preparation of rsync config files
     assert_script_run('curl -v -o /etc/rsyncd.conf ' . data_url('console/rsyncd.conf'));
     assert_script_run 'echo "test42:424242" > /etc/rsyncd.secrets';
+    assert_script_run 'chmod 600 /etc/rsyncd.secrets';
 
     if (is_sle('<12-sp5')) {    #using xinetd on sle 12
         assert_script_run(q{sed -i 's/\(\s*disable\s*=\).*/\1 no/' /etc/xinetd.d/rsync});


### PR DESCRIPTION
In the past, the package installed an /etc/rsyncd.secrets file with mode 0600.
The test then added credentials there using echo user:pass > /etc/rsyncd.secrets
(preserving the mode of the file)

The package changed to install template config to /usr/etc. As the file now does
not exist in /etc, echo creates a new file with mode 644 - which in turn is
denied by rsync's default config (strict modes on)

- Related ticket: https://progress.opensuse.org/issues/152891
- Needles: N/A
- Verification run: NONE
