### PR TITLE
Fix refreshment issue for iscsi_client

### DIFF
--- a/lib/YaST/workarounds.pm
+++ b/lib/YaST/workarounds.pm
@@ -15,7 +15,6 @@ use Config::Tiny;
 our @EXPORT = qw(
   apply_workaround_poo124652
   apply_workaround_bsc1206132
-  workaround_poo124652_for_send_key_until
 );
 
 =head1 Workarounds for known issues
@@ -76,35 +75,6 @@ sub apply_workaround_bsc1206132 {
     my $str = $Config->write_string();
     assert_script_run("echo \"$str\" > $service_unit");
     systemctl('daemon-reload');
-}
-
-=head2 workaround_poo124652_for_send_key_until ():
-
-Workaround screen refresh issue for the send_key_until_needle_match
-
-Records a soft failure with a reference to bsc#1206132
-
-This is the wrapper for send_key_until_needle_match for applying
-apply_workaround_bsc1206132.
-
-=cut
-
-sub workaround_poo124652_for_send_key_until {
-    my ($tag, $key, $counter, $timeout) = @_;
-
-    $counter //= 20;
-    $timeout //= 1;
-
-    my $real_timeout = 0;
-    while (!check_screen($tag, $real_timeout)) {
-        wait_screen_change {
-            send_key $key;
-        };
-        if (--$counter <= 0) {
-            apply_workaround_bsc1206132 $tag;
-        }
-        $real_timeout = $timeout;
-    }
 }
 
 1;

--- a/lib/yast2_widget_utils.pm
+++ b/lib/yast2_widget_utils.pm
@@ -77,7 +77,7 @@ sub change_service_configuration_step {
 
     send_key $shortcut;
     send_key 'end';
-    workaround_poo124652_for_send_key_until $needle_selection, 'up', 6, 1;
+    send_key_until_needlematch $needle_selection, 'up', 6, 1;
     if (check_var_array('EXTRATEST', 'y2uitest_ncurses')) {
         send_key 'ret';
         apply_workaround_poo124652($needle_check) if (is_sle('>=15-SP4'));

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -35,6 +35,7 @@ use Utils::Logging 'save_and_upload_log';
 my $test_data = get_test_suite_data();
 
 sub initiator_service_tab {
+    apply_workaround_poo124652('iscsi-client-service') if (is_sle('>=15-SP4'));
     unless (is_sle('<15') || is_leap('<15.1')) {
         if (is_sle('=15')) {
             change_service_configuration(
@@ -70,6 +71,8 @@ sub initiator_discovered_targets_tab {
     # next and press connect button
     send_key "alt-n";
     assert_and_click 'iscsi-initiator-connect-button';
+    wait_still_screen(2);
+    apply_workaround_poo124652('iscsi-initiator-discovery-startup') if (is_sle('>=15-SP4'));
     send_key_until_needlematch 'iscsi-initiator-connect-automatic', 'down';
     send_key 'alt-o';
     assert_screen 'iscsi-initiator-discovery-enable-login-auth';


### PR DESCRIPTION
- Description:
   * Revert the [**PR_1828**](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1828) 
   * Use a simple workaround while not making it too complicated for code.

- Related ticket: https://progress.opensuse.org/issues/152821
- Needles: 
     -  iscsi_client_service-20240103
     -  iscsi-initiator-discovery-startup-20240104
- Verification run: 
   - 30 run for  [**mru-iscsi_client_normal_auth_backstore_lvm**](https://openqa.suse.de/tests/overview?build=hjluo%2Fos-autoinst-distri-opensuse%23redress_iscsi&version=15-SP4&distri=sle)