### PR TITLE
Fix "SAPHanaSR" random timed out on "wait_for_ssh"

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -300,6 +300,10 @@ sub stop_hana {
             # Try only extending ssh_opts
             ssh_opts => "-o ServerAliveInterval=2 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR",
             %args);
+        # It is better to wait till ssh disappear
+        record_info("Wait ssh disappear start");
+        my $out = $self->{my_instance}->wait_for_ssh(timeout => 60, wait_stop => 1);
+        record_info("Wait ssh disappear end", "$out") if (defined $out);
         sleep 10;
         $self->{my_instance}->wait_for_ssh();
         return ();


### PR DESCRIPTION
Fix "SAPHanaSR-ScaleUp-PerfOpt" sporadical timed out on "wait_for_ssh" after/during doing "stop_hana()"; fix HANA SR - PC Azure sporadic pacemaker service does not restart.
Set HA_SBD_START_DELAY default to 60. This is the core fix. See MR: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/597. 
Add wait_for_ssh(wait_stop => 1). It is better to add "Wait ssh disappear".

TEAM-8854 - [PC][15sp3][timebox] "SAPHanaSR-ScaleUp-PerfOpt" sporadically timed out on "wait_for_ssh" after/during doing "stop_hana()"
TEAM-8800) - [HANA SR - PC Azure][Sporadic] - pacemaker service does not restart

Experiments:
1. Tried to use `crash => "reboot &"` instead of `crash => "echo b > /proc/sysrq-trigger &"` to `crash` the os. This method works but it is not valid
2. Tried to set `HA_SBD_START_DELAY=90 or 60`. This method works too (I tired 20+ times and can not reproduce TEAM-8800 and TEAM-8854).
3. It also can fix another sporadic issue [TEAM-8800](https://jira.suse.com/browse/TEAM-8800)

- Related ticket: 
  https://jira.suse.com/browse/TEAM-8854  
  https://jira.suse.com/browse/TEAM-8800
- Needles: NA
- Verification run: 
I tried 20+ times, test case can pass, for example: https://openqa.suse.de/tests/13193580#next_previous (Build = "Lily-testing3-sbd-delay90")