### PR TITLE
Increase prepare_wsl timeout.

### DIFF
--- a/tests/wsl/prepare_wsl.pm
+++ b/tests/wsl/prepare_wsl.pm
@@ -33,7 +33,7 @@ sub run {
             cmd => "wsl --install --no-distribution",
             code => sub {
                 unless (is_aarch64) {
-                    assert_screen(["windows-user-account-ctl-hidden", "windows-user-acount-ctl-allow-make-changes"], 240);
+                    assert_screen(["windows-user-account-ctl-hidden", "windows-user-acount-ctl-allow-make-changes"], 900);
                     assert_and_click "windows-user-account-ctl-hidden" if match_has_tag("windows-user-account-ctl-hidden");
                     assert_and_click "windows-user-acount-ctl-yes";
                 }


### PR DESCRIPTION
Increase the timeout value for an assert_screen of WSL installation, which is taking longer than usual.



- Related ticket: https://progress.opensuse.org/issues/152927

- Verification run: 
- https://openqa.suse.de/tests/13164962#
- https://openqa.suse.de/tests/13164967#
- https://openqa.suse.de/tests/13164968#
- https://openqa.suse.de/tests/13164995#
- https://openqa.suse.de/tests/13164996#
- https://openqa.suse.de/tests/13165001#
