### PR TITLE
P.C. Azure L machine v3 allowed

### DIFF
--- a/tests/publiccloud/az_l8s_nvme.pm
+++ b/tests/publiccloud/az_l8s_nvme.pm
@@ -31,7 +31,7 @@ sub benchmark_device {
 sub run {
     select_serial_terminal;
 
-    die "This test only works on Azure L instances" unless (get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'L(8|16|32|48|64|80)s_v2');
+    die "This test only works on Azure L instances" unless (get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'L(8|16|32|48|64|80)s_v(2|3)');
 
     # Ensure the required disks are present
     record_info('lsbkl', script_output('lsblk'));


### PR DESCRIPTION
The Azure machines of L type had Lsv3 filtered out, now included together with Lsv2.

- Related ticket: poo [152961](https://progress.opensuse.org/issues/152961)

- Needles: none

- Verification run:  https://openqa.suse.de/tests/13165007