### PR TITLE
Switch vmware tests to UEFI boot as default

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -359,14 +359,14 @@ sub power_action {
         # instead of handling the still logged in system.
         handle_livecd_reboot_failure if get_var('LIVECD') && $action eq 'reboot';
         # Look aside before we are sure 'sut' console on VMware is ready, see poo#47150
-        select_console('svirt') if is_vmware && $action eq 'reboot';
+        select_console('svirt') if is_vmware && $action eq 'reboot' && !get_var('UEFI');
         reset_consoles;
         if ((check_var('VIRSH_VMM_FAMILY', 'xen') || get_var('S390_ZKVM')) && $action ne 'poweroff') {
             console('svirt')->start_serial_grab;
         }
         # When 'sut' is ready, select it
         # GRUB's serial terminal configuration relies on installation/add_serial_console.pm
-        if (is_vmware && $action eq 'reboot') {
+        if (is_vmware && $action eq 'reboot' && !get_var('UEFI')) {
             die 'GRUB not found on serial console' unless (is_jeos || wait_serial('GNU GRUB', 180));
             select_console('sut');
         }

--- a/schedule/virt_autotest/default_install_svirt.yaml
+++ b/schedule/virt_autotest/default_install_svirt.yaml
@@ -1,7 +1,7 @@
-name:           textmode_svirt
+name:           default_install_svirt
 description:    >
     Maintainer: nan.zhang@suse.com, qe-virt@suse.de
-    Textmode installation with integration services and open-vm-tools test modules
+    Default GUI installation test
 schedule:
     - installation/isosize
     - '{{bootloader}}'
@@ -19,16 +19,11 @@ schedule:
     - installation/disable_grub_timeout
     - installation/start_install
     - installation/await_install
-    - installation/add_serial_console
+    - '{{serial_console}}'
     - installation/logs_from_installation_system
     - installation/reboot_after_installation
     - installation/grub_test
     - installation/first_boot
-    - console/system_prepare
-    - console/check_network
-    - console/system_state
-    - console/integration_services
-    - '{{open_vm_tools}}'
 conditional_schedule:
     bootloader:
         VIRSH_VMM_FAMILY:
@@ -44,7 +39,7 @@ conditional_schedule:
                 - installation/bootloader_uefi
             0:
                 - installation/bootloader
-    open_vm_tools:
-        VIRSH_VMM_FAMILY:
-            vmware:
-                - virt_autotest/esxi_open_vm_tools
+    serial_console:
+        UEFI:
+            0:
+                - installation/add_serial_console

--- a/schedule/virt_autotest/online_upgrade_sles_vmware.yaml
+++ b/schedule/virt_autotest/online_upgrade_sles_vmware.yaml
@@ -1,0 +1,23 @@
+name:           online_upgrade_sles_vmware
+description:    >
+    Maintainer: nan.zhang@suse.com, qe-virt@suse.de
+    Online migration test against SLES base image
+schedule:
+    - migration/version_switch_origin_system
+    - installation/isosize
+    - '{{bootloader}}'
+    - installation/bootloader
+    - migration/online_migration/online_migration_setup
+    - migration/online_migration/register_system
+    - migration/online_migration/zypper_patch
+    - migration/version_switch_upgrade_target
+    - migration/online_migration/pre_migration
+    - migration/online_migration/zypper_migration
+    - migration/online_migration/post_migration
+conditional_schedule:
+    bootloader:
+        VIRSH_VMM_FAMILY:
+            vmware:
+                - installation/bootloader_svirt
+            hyperv:
+                - installation/bootloader_hyperv

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -345,7 +345,7 @@ sub run {
 
     # connects to a guest VNC session
     select_console('sut', await_console => 0);
-    vmware_set_permanent_boot_device($boot_device);
+    vmware_set_permanent_boot_device($boot_device) unless (check_var('UEFI', '1'));
 }
 
 


### PR DESCRIPTION
1. Create schedule/virt_autotest/default_install_svirt.yaml
2. Create schedule/virt_autotest/online_upgrade_sles_vmware.yaml
3. Set parameter UEFI=1 on openqa MACHINES 'svirt-vmware70'
4. Update tests/installation/bootloader_svirt.pm to skip bios boot order setup while UEFI booting

- Related ticket: https://progress.opensuse.org/issues/152917
- Related PR: https://github.com/os-autoinst/os-autoinst/pull/2424
- Verification run:
  default_install_svirt - https://openqa.suse.de/tests/13403750
  online_upgrade_sles15sp5_vmware - https://openqa.suse.de/tests/13409542
  textmode_svirt - https://openqa.suse.de/tests/13403752
