### PR TITLE
xfstests: add disk usage info for debug

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -52,6 +52,10 @@ sub install_xfstests_from_repo {
     zypper_call('--gpg-auto-import-keys ref');
     record_info('repo info', script_output('zypper lr -U'));
     if (is_transactional) {
+        script_run('id fsgqa &> /dev/null || useradd -d /home/fsgqa -k /etc/skel -ms /bin/bash -U fsgqa');
+        script_run('id fsgqa2 &> /dev/null || useradd -d /home/fsgqa2 -k /etc/skel -ms /bin/bash -U fsgqa2');
+        script_run('getent group sys >/dev/null || groupadd -r sys');
+        script_run('id daemon &> /dev/null || useradd daemon -g sys');
         trup_call('pkg install xfstests');
         unless (is_alp || $IS_MARBLE) {
             trup_call('--continue pkg install fio');

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -179,7 +179,7 @@ sub create_loop_device_by_rootsize {
         @loop_dev_size = (($size1 . 'M') x 2, ($size2 . 'M') x 4);
     }
     else {
-        $size > (20480 * ($amount + 1)) ? ($size = 20480) : ($size = $size / ($amount + 1));
+        $size > (20480 * ($amount + 1)) ? ($size = 20480) : ($size = int($size / ($amount + 1)));
         foreach (0 .. $amount) { push(@loop_dev_size, $size . 'M'); }
     }
     @filename = ('test_dev');
@@ -256,6 +256,7 @@ sub post_env_info {
     }
     $size_info = $size_info . "PAGE_SIZE     " . script_output("getconf PAGE_SIZE") . "\n";
     $size_info = $size_info . "QEMURAM       " . get_var("QEMURAM") . "\n";
+    $size_info = $size_info . "\n" . script_output("df -h");
     record_info('Size', $size_info);
 }
 


### PR DESCRIPTION
1. Add disk usage info by 'df -h'
2. round the value of loop device size to avoid long float number

- Related ticket: https://progress.opensuse.org/issues/152975
- https://progress.opensuse.org/issues/152613
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/13168712#step/partition/60 (long float number of disk size)
http://10.67.133.133/tests/421#step/partition/59 (rounded disk size)

https://openqa.suse.de/tests/13187951 (create hdd xfstests)
https://openqa.suse.de/tests/13187978 (generic/128 passed)
