### PR TITLE
Added socket units needle

### DIFF
--- a/tests/qemu/qemu.pm
+++ b/tests/qemu/qemu.pm
@@ -62,7 +62,7 @@ sub run {
         is_qemu_preinstalled or install_qemu('qemu-s390x');
         # use kernel from host system for booting
         enter_cmd "qemu-system-s390x -nographic -kernel /boot/image -initrd /boot/initrd";
-        assert_screen ['qemu-reached-target-basic-system', 'qemu-s390x-exec-0x7f4-not-impl', 'qemu-linux-req-more-recent-proc-hw'], 400;
+        assert_screen ['qemu-reached-target-basic-system', 'qemu-s390x-exec-0x7f4-not-impl', 'qemu-linux-req-more-recent-proc-hw', 'qemu-reached-target-socket-units'], 400;
         if (match_has_tag 'qemu-s390x-exec-0x7f4-not-impl') {
             record_soft_failure 'bsc#1124595 - qemu on s390x fails when called WITHOUT kvm: EXECUTE on instruction prefix 0x7f4 not implemented';
             return;


### PR DESCRIPTION
Terminal output now shows "socket units" instead of "basic system."

Created an appropriate needle to account for this.

- Related ticket: https://progress.opensuse.org/issues/152977
- Needles:    https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/qemu-reached-target-socket-units-20231229.png
- Verification run: https://openqa.suse.de/tests/13168934#
