### PR TITLE
LTP: Fix uninitialized value $pkg

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -62,7 +62,7 @@ sub shutdown_ltp {
 }
 
 sub want_ltp_32bit {
-    my $pkg = shift // get_var('LTP_PKG');
+    my $pkg = shift // get_var('LTP_PKG', '');
 
     # TEST is for running 32bit tests (e.g. ltp_syscalls_m32), checking
     # LTP_PKG is for install_ltp.pm which also uses prepare_ltp_env()


### PR DESCRIPTION
Fix error when LTP_PKG is not set:

    Use of uninitialized value $pkg in pattern match (m//) at lib/LTP/utils.pm line 69.
    LTP::utils::want_ltp_32bit() called at lib/LTP/utils.pm line 75
    LTP::utils::get_ltproot() called at tests/kernel/install_ltp.pm line 227
    install_ltp::install_from_git() called at tests/kernel/install_ltp.pm line 330
