### PR TITLE
No need to reboot VM if no package update for sle-micro

### DIFF
--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -52,8 +52,10 @@ sub run {
         record_info('TEST', 'Installing Cockpit\'s Modules...');
         # In ALP, we need to refresh the metadata. poo#122029
         assert_script_run('zypper ref') if is_alp;
-        trup_call("pkg install @pkgs", timeout => 480);
-        check_reboot_changes;
+
+        my $results = script_output("transactional-update -n pkg install @pkgs", timeout => 480);
+        # No reboot needed if no package update
+        check_reboot_changes if ($results !~ /zypper: nothing to update/);
     }
 
     record_info('Cockpit', script_output('rpm -qi cockpit'));


### PR DESCRIPTION
https://progress.opensuse.org/issues/152877

- Verification run: [cockpit_service](https://openqa.suse.de/tests/13185922#step/cockpit_service/2)
   Please ignore the failed test module, it is a known one.
