### PR TITLE
security: use we tests only on supported releases

### DIFF
--- a/schedule/security/fips_crypt_x11.yaml
+++ b/schedule/security/fips_crypt_x11.yaml
@@ -22,9 +22,13 @@ conditional_schedule:
     tests_for_64bit:
         ARCH:
             x86_64:
-                - x11/seahorse_sshkey
-                - x11/hexchat_ssl
+                - '{{we_supported_versions}}'
     xca:
         ARCH:
             x86_64:
                 - fips/xca
+    we_supported_versions:
+        VERSION:
+            15-SP5:
+                - x11/seahorse_sshkey
+                - x11/hexchat_ssl


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/153041
- Verification runs:
15-SP4: https://openqa.suse.de/tests/13186345 (tests not included anymore)
15-SP5: https://openqa.suse.de/tests/13186353 (tests still included)