### PR TITLE
Workaround for rmt scc cred timeout bsc#1218084

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -264,6 +264,8 @@ sub rmt_wizard {
         zypper_call 'in rmt-server';
     }
 
+    my $count = 1;
+  WORKAROUND:
     enter_cmd "yast2 rmt;echo yast2-rmt-wizard-\$? > /dev/$serialdev";
     assert_screen 'yast2_rmt_registration';
     send_key 'alt-u';
@@ -275,8 +277,16 @@ sub rmt_wizard {
     type_string(get_required_var('SMT_ORG_PASSWORD'));
     wait_still_screen(2, 5);
     send_key 'alt-n';
-    assert_screen 'yast2_rmt_config_written_successfully', 200;
-    send_key 'alt-o';
+    assert_screen [qw(yast2_rmt_config_written_successfully yast2_rmt_timeout)], 200;
+    if (match_has_tag 'yast2_rmt_timeout') {
+        die 'Credentials timed out 10 times' if $count == 10;
+        # soft_fail is on needle
+        send_key 'ret';
+        wait_still_screen(1, 2);
+        record_info 'Retry', "Retry No. " . $count++;
+        goto WORKAROUND;
+    }
+    send_key 'alt-o' if match_has_tag 'yast2_rmt_config_written_successfully';
     assert_screen 'yast2_rmt_db_password';
     send_key 'alt-p';
     type_string "rmt";


### PR DESCRIPTION
Behavior of this failure is random, first run all tests passed without retry, now I restarted two jobs they had to retry both.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1218084
- Verification run: https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=qam_rmt&modules=&module_re=&group_glob=&not_group_glob=&distri=sle&build=20240102-1&groupid=414
