### PR TITLE
Fix subroutine redefined errors for sle-micro product

### DIFF
--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -14,8 +14,6 @@ use DistributionProvider;
 
 init_main();
 
-my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
-require $distri;
 testapi::set_distribution(susedistribution->new());
 
 $needle::cleanuphandler = sub {


### PR DESCRIPTION
* **There** are many "subroutine redefined" errors for sle-micro product in autoinst-log.txt. Please refer to [this example](https://openqa.suse.de/tests/13096276/logfile?filename=autoinst-log.txt).

* **And** these errors are caused by the "require" directive on lib/susedistribution.pm which is not used anywhere in products/sle-micro/main.pm. Removing references to this file fixes these errors.

* **This** change will not affect SLE Micro test run.

* **Verification Runs:**
  * [x86_64 runs well](https://openqa.suse.de/tests/13187369)
  * [aarch64 runs well](http://openqa.suse.de/tests/13187370)
  * [s390x runs well](http://openqa.suse.de/tests/13187371)