### PR TITLE
Minor fixes for netavark test in PC

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -189,10 +189,10 @@ sub run {
         systemctl('enable --now netavark-dhcp-proxy.socket');
         systemctl('status netavark-dhcp-proxy.socket');
 
-        my $dev = script_output(q(ip -br link show | awk '/UP / {print $1}'));
+        my $dev = script_output(q(ip -br link show | awk '/UP / {print $1}'| head -n 1));
         my $extra = '';
         if (is_public_cloud) {
-            my $sn = script_output(qq(ip -o -f inet addr show $dev | awk '/scope global/ {print \$4}')) =~ s/\.\d+\//\.0\//r;
+            my $sn = script_output(qq(ip -o -f inet addr show $dev | awk '/scope global/ {print \$4}' | head -n 1)) =~ s/\.\d+\//\.0\//r;
             $extra .= "--subnet $sn ";
             my $gw = $sn =~ s/0\/\d+$/1/r;
             $extra .= "--gateway $gw ";


### PR DESCRIPTION
Some PC instances can have multiple IPs or multiple active interfaces.
In order to proceed with netavark sub tests, we just need to pick one of
them.

- Related ticket: https://progress.opensuse.org/issues/xyz

#### Verification runs:

- [sle-15-SP6-Azure-BYOS-aarch64-Build0454-publiccloud_containers@64bit](https://openqa.suse.de/tests/13187899#step/podman_netavark/211)
- [sle-15-SP6-GCE-BYOS-x86_64-Build0425-publiccloud_containers@gce_n1_standard_2](https://openqa.suse.de/tests/13187904#step/podman_netavark/211)