### PR TITLE
Adapt yast2 modules tests of configuring firewall for Tumbleweed

### DIFF
--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -201,9 +201,12 @@ sub run {
         type_string_slow($vsftpd_directives->{dsa_cert_file});
     }
 
-    assert_screen 'yast2_ftp_port_closed';
-    send_key 'alt-p';    # open port in firewall
-    assert_screen 'yast2_ftp_port_opened';
+    # skip open firewall ports in Tumbleweed bsc#1207390
+    if (is_sle || is_leap) {
+        assert_screen 'yast2_ftp_port_closed';
+        send_key 'alt-p';    # open port in firewall
+        assert_screen 'yast2_ftp_port_opened';
+    }
     send_key 'alt-f';    # done and close the configuration page now
 
     # yast might take a while on sle12 due to suseconfig
@@ -212,9 +215,9 @@ sub run {
     # check /etc/vsftpd.conf whether it has been updated accordingly
     $self->vsftd_setup_checker($vsftpd_directives);
 
-    # check presence of vsftpd service in firewalld
+    # check presence of vsftpd service in firewalld excluding Tumbleweed (bsc#1207390)
     if ($self->firewall eq 'firewalld') {
-        vsftpd_firewall_checker;
+        vsftpd_firewall_checker unless is_tumbleweed;
     }
 
     # let's try to run it

--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -59,9 +59,9 @@ sub run {
     assert_screen 'yast2_tftp-server_configuration_newdir_typed';
 
     # open port in firewall, if needed
-    assert_screen([qw(yast2_tftp_open_port yast2_tftp_closed_port)]);
+    assert_screen([qw(yast2_tftp_open_port yast2_tftp_closed_port yast2_tftp_no_network_interfaces)]);
 
-    #we only need to open the port if closed:
+    # we only need to open the port if closed:
     if (match_has_tag('yast2_tftp_closed_port')) {
         send_key 'alt-f';    # open tftp port in firewall
         assert_screen 'yast2_tftp_open_port';
@@ -69,6 +69,10 @@ sub run {
         assert_screen 'yast2_tftp_firewall_details';
         send_key 'alt-o';    # close the window
         assert_screen 'yast2_tftp_open_port';    # assert that window is closed
+    }
+    # bsc#1207390, skip open firewall ports for tumbleweed
+    elsif (match_has_tag('yast2_tftp_no_network_interfaces') && is_tumbleweed) {
+        assert_screen 'yast2_tftp_no_network_interfaces';
     }
 
     # view log

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -16,6 +16,7 @@ use utils;
 use registration 'add_suseconnect_product';
 use yast2_shortcuts qw($is_older_product %remote_admin %firewall_settings %firewall_details $confirm);
 use Utils::Backends qw(is_pvm is_ipmi);
+use version_utils;
 
 sub configure_remote_admin {
     # Force ncurses mode on powerVM setup to skip ssh forwarding x11 console
@@ -27,17 +28,18 @@ sub configure_remote_admin {
     send_key $remote_admin{allow_remote_admin_with_session};
     assert_screen 'yast2_vnc_allow_remote_admin_with_session';
     # Firewall Settings
-    if (check_screen 'yast2_vnc_firewall_port_closed') {
-        send_key $firewall_settings{open_port};
+    assert_screen([qw(yast2_vnc_no_network_interface yast2_vnc_firewall_port_closed yast2_vnc_firewall_port_open)]);
+    if (is_tumbleweed && (match_has_tag('yast2_vnc_no_network_interface'))) {
+        send_key $cmd{next};
     }
-    # Firewall Details
-    assert_screen 'yast2_vnc_firewall_port_open';
-    send_key $firewall_settings{details};
-    assert_screen 'yast2_vnc_firewall_port_details';
-    send_key $firewall_details{network_interfaces};
-    assert_screen 'yast2_vnc_firewall_details_interface_selected';
-    send_key $cmd{ok};
-    assert_screen 'yast2_vnc_firewall_details_selected';
+    if (match_has_tag('yast2_vnc_firewall_port_closed')) {
+        send_key $firewall_settings{open_port};
+        check_firewall_port_details();
+    }
+    if (match_has_tag('yast2_vnc_firewall_port_open')) {
+        check_firewall_port_details();
+    }
+
     # Confirm configuration
     send_key $confirm;
     assert_screen 'yast2_vnc_warning_text';
@@ -45,6 +47,16 @@ sub configure_remote_admin {
     wait_serial("$module_name-0", 60) || die "'yast2 remote' didn't finish";
     # Restart display-manager service to make the changes take effect for powerVM x11 access in FIPs test
     systemctl('restart display-manager') if (get_var("FIPS_ENABLED") && is_pvm);
+}
+
+sub check_firewall_port_details {
+    assert_screen 'yast2_vnc_firewall_port_open';
+    send_key $firewall_settings{details};
+    assert_screen 'yast2_vnc_firewall_port_details';
+    send_key $firewall_details{network_interfaces};
+    assert_screen 'yast2_vnc_firewall_details_interface_selected';
+    send_key $cmd{ok};
+    assert_screen 'yast2_vnc_firewall_details_selected';
 }
 
 sub check_service_listening {


### PR DESCRIPTION
Tumbleweed is using NetworkManager, YaST cannot configure the firewall when the system uses NetworkManager, so adapt yast2 modules tests of configuring firewall for Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/134078
- Needles: n/a
- Verification run: 
https://openqa.opensuse.org/tests/3846404#  (tumbleweed)
https://openqa.suse.de/tests/13193568# (sles)

