### PR TITLE
Avoid bsc#1180307 in 'ncurses' test

### DIFF
--- a/tests/console/ncurses.pm
+++ b/tests/console/ncurses.pm
@@ -23,6 +23,9 @@ sub run {
     zypper_call 'in dialog';
     select_console 'root-console';
 
+    # To avoid bsc#1180307
+    assert_script_run("/usr/lib/systemd/systemd-vconsole-setup");
+
     # Try to draw a bold red line
     script_run('echo "$(tput smacs;tput setaf 1;tput bold)lqqqqqqqqqqqqqqk$(tput rmacs;tput sgr0)"');
     # Try a simple yes/no dialog


### PR DESCRIPTION
https://progress.opensuse.org/issues/153081

VR: 
[sles15](https://openqa.suse.de/tests/13193606#step/ncurses/7)
[sles12](http://openqa.suse.de/tests/13193619#step/ncurses/9)
[tw](https://openqa.opensuse.org/tests/3846433#step/ncurses/21)
