### PR TITLE
check if VM guest is locked by test

### DIFF
--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -362,4 +362,10 @@ sub post_fail_hook {
     }
 }
 
+sub post_run_hook () {
+    # The test is considered over, this step ensures virtual machine guest is unlocked by removing the 'lock_guest' file via SSH,
+    # it is called at the conclusion of a test run.
+    script_run("ssh root\@$_ rm lock_guest") foreach (keys %virt_autotest::common::guests);
+}
+
 1;

--- a/tests/virtualization/universal/open_vm_tools.pm
+++ b/tests/virtualization/universal/open_vm_tools.pm
@@ -36,4 +36,10 @@ sub run {
 
 }
 
+sub post_run_hook () {
+    # The test is considered over, this step ensures virtual machine guest is unlocked by removing the 'lock_guest' file via SSH,
+    # it is called at the conclusion of a test run.
+    script_run("ssh root\@$_ rm lock_guest") foreach (keys %virt_autotest::common::guests);
+}
+
 1;

--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -66,6 +66,20 @@ sub run {
     }
 }
 
+sub post_run_hook () {
+    # The test for HyperV is considered over, this step ensures virtual machine guest is unlocked by removing the 'lock_guest' file via SSH,
+    # it is called at the conclusion of a test run.
+    if (check_var('REGRESSION', 'hyperv')) {
+        script_run("ssh root\@$_ rm lock_guest") foreach (keys %virt_autotest::common::guests);
+    }
+}
+
+sub post_fail_hook () {
+    # The test is considered over, this step ensures virtual machine guest is unlocked by removing the 'lock_guest' file via SSH,
+    # it is called at the conclusion of a test run.
+    script_run("ssh root\@$_ rm lock_guest") foreach (keys %virt_autotest::common::guests);
+}
+
 sub test_flags {
     return {fatal => 1, milestone => 1};
 }

--- a/tests/virtualization/universal/upgrade_guests.pm
+++ b/tests/virtualization/universal/upgrade_guests.pm
@@ -22,6 +22,12 @@ sub run {
 
     script_run("mkdir /root/update_guests");
     foreach my $guest (keys %virt_autotest::common::guests) {
+        # Locks the guest machine to prevent parallel test runs. Uses an SSH command to create and check a 'lock_guest' file.
+        # Retries with a delay of 60 seconds and up to 40 attempts if the guest is currently busy.
+        # We must not forget to unlock the guest in the end of the test by removing the 'lock_guest' file.
+        assert_script_run("ssh root\@$guest touch lock_guest");
+        my $check_guest_lock = "grep -q locked lock_guest && exit 1 || echo locked > lock_guest; exit \$?";
+        script_retry("ssh root\@$guest \"flock lock_guest sh -c '$check_guest_lock'\"", delay => 60, retry => 40, fail_message => "Guest is currently busy");
         # Remove test repositories. Those will be added in patch_guests again, here we want to upgrade the guests to the latest released version.
         script_run("ssh root\@$guest rm -f '/etc/zypp/repos.d/SUSE_Maintenance*' '/etc/zypp/repos.d/TEST*' '/tmp/dup*' ");
         # Update all guests at once to save some time.
@@ -40,6 +46,8 @@ sub post_fail_hook {
     # Collect logs on failure
     script_run('tar -cf /root/update_logs.tar /root/update_guests');
     upload_logs('/root/update_logs.tar');
+    # Unlock guest
+    script_run("ssh root\@$_ rm lock_guest") foreach (keys %virt_autotest::common::guests);
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
I have manually checked that flock is working and waiting for the guest to be released to start new test.

- Related ticket: https://progress.opensuse.org/issues/127367
- Needles: N/A
- Verification run: 
[12-SP3](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP3&build=%3Atbaev%3A%3A12-SP3%3A%3Atest%3A&groupid=322)
[12-SP4](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP4&build=%3Atbaev%3A%3A12-SP4%3A%3Atest%3A&groupid=322)
[12-SP5](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=%3Atbaev%3A%3A12-SP5%3A%3Atest%3A&groupid=322)
[15-SP2](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP2&build=%3Atbaev%3A%3A15-SP2%3A%3Atest%3A&groupid=322)
[15-SP3](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=%3Atbaev%3A%3A15-SP3%3A%3Atest%3A&groupid=322)
[15-SP4](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=%3Atbaev%3A%3A15-SP4%3A%3Atest%3A&groupid=322)
[15-SP5](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=%3Atbaev%3A%3A15-SP5%3A%3Atest%3A&groupid=322)
