### PR TITLE
Replace SCC_URL with HOST_SCC_URL for virt test host installation

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -60,7 +60,7 @@ sub set_bootscript {
     my $host = get_required_var('SUT_IP');
     my $arch = get_required_var('ARCH');
     my $autoyast = get_var('AUTOYAST', '');
-    my $regurl = get_var('SCC_URL', '');
+    my $regurl = get_var('VIRT_AUTOTEST') ? get_var('HOST_SCC_URL', '') : get_var('SCC_URL', '');
     my $console = get_var('IPXE_CONSOLE', '');
     my $mirror_http = get_required_var('MIRROR_HTTP');
 


### PR DESCRIPTION
Incorrect SCC server is used for virt tests on non-developing host. Replace SCC_URL with HOST_SCC_URL to fix it.

- Verification run: 
[sle12sp5 host](https://openqa.suse.de/tests/13208156)
[sle15sp6 host](https://openqa.suse.de/tests/13208164)   //fail at proxy scc registration as expected
