### PR TITLE
flash_sd.sh: Remove deprecated --direct option

### DIFF
--- a/data/generalhw_scripts/flash_sd.sh
+++ b/data/generalhw_scripts/flash_sd.sh
@@ -43,7 +43,7 @@ IFS=: read -r flasher_ip destination_folder <<< "$destination"
 
 echo "* Switch SD card to flasher"
 if [ "$tool" = "usbsdmux" ]; then
-  ssh root@$flasher_ip usbsdmux --direct /dev/usb-sd-mux/id-$device_serial host
+  ssh root@$flasher_ip usbsdmux /dev/usb-sd-mux/id-$device_serial host
 elif [ "$tool" = "sd-mux-ctrl" ]; then
   ssh root@$flasher_ip sd-mux-ctrl --device-serial=$device_serial --ts
 else
@@ -94,7 +94,7 @@ fi
 
 echo "* Switch SD card to SUT"
 if [ "$tool" = "usbsdmux" ]; then
-  ssh root@$flasher_ip usbsdmux --direct /dev/usb-sd-mux/id-$device_serial dut
+  ssh root@$flasher_ip usbsdmux /dev/usb-sd-mux/id-$device_serial dut
 elif [ "$tool" = "sd-mux-ctrl" ]; then
   ssh root@$flasher_ip sd-mux-ctrl --device-serial=$device_serial --dut
 else


### PR DESCRIPTION
Running jeos-ltp-syscalls@RPi4 on siodtw01 worker showed:

ssh root@localhost usbsdmux --direct /dev/usb-sd-mux/id-000000001223 host usbsdmux: usage of -s/-c/-d arguments is deprecated as the service/client split is no longer required. Please upgrade your scripts to not supply either of these arguments

This warning was added to usbsdmux in 04/2021
https://github.com/linux-automation/usbsdmux/commit/656e3d5ca46f6e7a707925707dc9504dcd18fb33 released in 0.2.0. Now there is 0.3.0.

data/generalhw_scripts/flash_sd.sh was written in 03/2020.  Other script data/generalhw_scripts/flash_sd_rootless.sh, which was added in 60e74b12a44379144924a7494ae173232b74f2a1 (2O22) did not use --direct option from the start. Test was verified to work without --direct, thus removed.

- Verification run: https://openqa.opensuse.org/tests/3856425
