### PR TITLE
Revert 8c93916 partially for k8s

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -40,12 +40,12 @@ sub provider_factory {
 
         if ($args{service} eq 'ECR') {
             $provider = publiccloud::ecr->new(
-                region => get_required_var('PUBLIC_CLOUD_REGION')
+                region => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1')
             );
         }
         elsif ($args{service} eq 'EKS') {
             $provider = publiccloud::eks->new(
-                region => get_required_var('PUBLIC_CLOUD_REGION')
+                region => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1')
             );
         }
         elsif ($args{service} eq 'EC2') {
@@ -60,7 +60,7 @@ sub provider_factory {
         $args{service} //= 'AVM';
         if ($args{service} eq 'ACR') {
             $provider = publiccloud::acr->new(
-                region => get_required_var('PUBLIC_CLOUD_REGION'),
+                region => get_var('PUBLIC_CLOUD_REGION', 'westeurope'),
                 subscription => get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID'),
                 username => get_var('PUBLIC_CLOUD_USER', 'azureuser')
             );


### PR DESCRIPTION


It appears that in case of k8s tests we can not do region required
because in this case we running all 3 providers within same job so
region need to hold 3 different value at the same time
