### PR TITLE
Proper fix of regression caused by 8c93916

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -39,14 +39,10 @@ sub provider_factory {
         $args{service} //= 'EC2';
 
         if ($args{service} eq 'ECR') {
-            $provider = publiccloud::ecr->new(
-                region => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1')
-            );
+            $provider = publiccloud::ecr->new();
         }
         elsif ($args{service} eq 'EKS') {
-            $provider = publiccloud::eks->new(
-                region => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1')
-            );
+            $provider = publiccloud::eks->new();
         }
         elsif ($args{service} eq 'EC2') {
             $provider = publiccloud::ec2->new();
@@ -60,7 +56,6 @@ sub provider_factory {
         $args{service} //= 'AVM';
         if ($args{service} eq 'ACR') {
             $provider = publiccloud::acr->new(
-                region => get_var('PUBLIC_CLOUD_REGION', 'westeurope'),
                 subscription => get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID'),
                 username => get_var('PUBLIC_CLOUD_USER', 'azureuser')
             );

--- a/lib/publiccloud/k8sbasetest.pm
+++ b/lib/publiccloud/k8sbasetest.pm
@@ -66,15 +66,29 @@ Returns the name for the container registry based on the public provider
 sub get_container_registry_service_name {
     my ($self, $provider) = @_;
 
-    $provider //= get_required_var('PUBLIC_CLOUD_PROVIDER');
-
     if ($provider eq 'EC2') {
+        # publiccloud::aws_client needs to demand PUBLIC_CLOUD_REGION due to other places where
+        # we don't want to have defaults and want tests to fail when region is not defined
+        # so this is workaround to keep variable required for publiccloud::aws_client
+        # but not for cases where we using publiccloud::ecr which also must to init publiccloud::aws_client
+        # and in this case we CAN NOT define it on job level because publiccloud::aws_client
+        # will be initialized together with publiccloud::azure_client so same variable will need
+        # to have two different values
+        set_var('PUBLIC_CLOUD_REGION', 'eu-central-1') unless get_var('PUBLIC_CLOUD_REGION');
         return "ECR";
     }
     elsif ($provider eq 'GCE') {
         return "GCR";
     }
     elsif ($provider eq 'AZURE') {
+        # publiccloud::azure_client needs to demand PUBLIC_CLOUD_REGION due to other places where
+        # we don't want to have defaults and want tests to fail when region is not defined
+        # so this is workaround to keep variable required for publiccloud::azure_client
+        # but not for cases where we using publiccloud::acr which also must to init publiccloud::azure_client
+        # and in this case we CAN NOT define it on job level because publiccloud::aws_client
+        # will be initialized together with publiccloud::azure_client so same variable will need
+        # to have two different values
+        set_var('PUBLIC_CLOUD_REGION', 'westeurope') unless get_var('PUBLIC_CLOUD_REGION');
         return "ACR";
     }
     else {

--- a/tests/containers/push_container_image_to_pc.pm
+++ b/tests/containers/push_container_image_to_pc.pm
@@ -16,18 +16,15 @@ sub run {
     my ($self, $run_args) = @_;
     my $provider = undef;
     my $container_registry_service = undef;
+    my $public_cloud_provider = shift(@{$run_args->{provider}});
+
+    die "Test called without \$run_args->{provider} denied" unless defined($public_cloud_provider);
+
 
     select_serial_terminal;
 
-    if (defined $run_args->{provider}) {
-        my $public_cloud_provider = shift(@{$run_args->{provider}});
-        $container_registry_service = $self->get_container_registry_service_name($public_cloud_provider);
-        $provider = $self->provider_factory(provider => $public_cloud_provider, service => $container_registry_service);
-    }
-    else {
-        $container_registry_service = $self->get_container_registry_service_name();
-        $provider = $self->provider_factory(service => $container_registry_service);
-    }
+    $container_registry_service = $self->get_container_registry_service_name($public_cloud_provider);
+    $provider = $self->provider_factory(provider => $public_cloud_provider, service => $container_registry_service);
 
     my $image = get_image_uri();
     my $tag = $provider->get_default_tag();


### PR DESCRIPTION


publiccloud::aws_client/azure_client needs to demand PUBLIC_CLOUD_REGION
due to other places where we do not want to have defaults and want tests
to fail when region is not defined so this is workaround to keep variable
required for publiccloud::aws_client/azure_client but not for cases where
we using publiccloud::eks/ecr/acr which also must to init
publiccloud::aws_client/azure_client and in this case we CAN NOT define it
on job level because publiccloud::aws_client will be initialized
together with publiccloud::azure_client so same variable will need to have two different values
