### PR TITLE
New test for container secret subcommand

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -22,6 +22,7 @@ our @EXPORT = qw(
   is_container_test
   load_container_tests
   load_host_tests_podman
+  load_secret_test
   load_image_test
   load_3rd_party_image_test
   load_container_engine_test
@@ -75,6 +76,11 @@ sub load_volume_tests {
     loadtest('containers/volumes', run_args => $run_args, name => 'volumes_' . $run_args->{runtime});
 }
 
+sub load_secret_test {
+    my ($run_args) = @_;
+    loadtest('containers/secret', run_args => $run_args, name => 'secret_' . $run_args->{runtime});
+}
+
 sub load_image_tests_docker {
     my ($run_args) = @_;
     load_image_test($run_args);
@@ -116,6 +122,7 @@ sub load_host_tests_podman {
             loadtest 'containers/rootless_podman';
             loadtest 'containers/podman_remote' if is_sle '>15-sp2';
         }
+        load_secret_test($run_args);
         load_volume_tests($run_args);
     }
 }
@@ -146,11 +153,12 @@ sub load_host_tests_docker {
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro) {
         loadtest 'containers/validate_btrfs';
     }
-    load_volume_tests($run_args);
     if (is_tumbleweed || is_microos) {
         loadtest 'containers/buildx';
         loadtest 'containers/rootless_docker';
     }
+    load_secret_test($run_args);
+    load_volume_tests($run_args);
 }
 
 sub load_host_tests_containerd_crictl {

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -30,19 +30,19 @@ sub run {
     }
 
     # Create a secret1 from file and inspect it
-    record_info("secret create file");
+    record_info("secret create file", "Create new secret from a file");
     script_run("printf T0p_S3cr3t1 > secret1.txt");
     assert_script_run("$runtime secret create secret1 secret1.txt", fail_message => "Error creating secret from file", timeout => 60);
     record_info("secret inspect file", script_output("$runtime secret inspect secret1"));
 
     # Create a secret2 from CLI and inspect it
-    record_info("secret create CLI");
+    record_info("secret create CLI", "Create a new secret directly from CLI");
     assert_script_run("printf T0p_S3cr3t2 | $runtime secret create secret2 -", fail_message => "Error creating secret from CLI", timeout => 60);
     record_info("secret inspect CLI", script_output("$runtime secret inspect secret2"));
 
     # Check if secret exists (only in podman)
     if ($runtime =~ 'podman') {
-        record_info("secret exists");
+        record_info("secret exists", "In Podman, check that each created secret exists");
         assert_script_run("podman secret exists secret1", fail_message => "Error checking if secret exists");
         assert_script_run("podman secret exists secret2", fail_message => "Error checking if secret exists");
         # This secret3 does not exist and thus `secret exists` must return 1
@@ -50,40 +50,41 @@ sub run {
     }
 
     # List all secrets
-    record_info("secret ls");
+    record_info("secret ls", script_output("$runtime secret ls"));
     assert_script_run("$runtime secret ls");
 
     # Run two containers passing secret1 as an env variable and secret2 as default
     my $runtime_command = ($runtime =~ 'docker') ? 'service create' : 'run';
     record_info("Access secrets");
-    script_run("$runtime pull registry.opensuse.org/opensuse/bci/bci-busybox:latest", timeout => 120);
+    script_retry("$runtime pull registry.opensuse.org/opensuse/bci/bci-busybox:latest",
+        retry => 3, delay => 10, timeout => 120);
 
     # secret1 testing (default secret)
     validate_script_output("$runtime $runtime_command --name secret1-test --secret secret1 bci-busybox:latest cat /run/secrets/secret1", sub { m/T0p_S3cr3t1/ });
     # Commit the container and check that the secrets are not in it
-    record_info("Commit container secret1-test");
+    record_info("Commit cont", "Commit container secret1-test");
     assert_script_run("$runtime commit secret1-test secret1-test-image");
     my $output = script_output("$runtime $runtime_command --name secret1-test-commit secret1-test-image:latest cat /run/secrets/secret1", proceed_on_failure => 1);
-    die("Secret commited") if ($output =~ !m/T0p_S3cr3t1/);
+    die("Secret commited") if ($output !~ m/T0p_S3cr3t1/);
 
     # Accessing secrets as env variables is not available in Docker
     if ($runtime =~ 'podman') {
         # secret2 testing (env secret)
         validate_script_output("podman run --name secret2-test --secret secret2,type=env,target=TOP_SECRET2 bci-busybox:latest printenv TOP_SECRET2", sub { m/T0p_S3cr3t2/ });
         # Commit the container and check that the secrets are not in it
-        record_info("Commit container secret2-test");
+        record_info("Commit cont", "Commit container secret2-test");
         assert_script_run("podman commit secret2-test secret2-test-image");
         $output = script_output("podman run --name secret2-test-commit secret2-test-image:latest printenv TOP_SECRET2", proceed_on_failure => 1);
-        die("Secret commited") if ($output =~ !m/T0p_S3cr3t2/);
+        die("Secret commited") if ($output !~ m/T0p_S3cr3t2/);
     }
 
     # Remove secrets
-    record_info("secret rm");
+    record_info("secret rm", "Remove all secrets created");
     assert_script_run("$runtime secret rm secret1 secret2");
     validate_script_output("$runtime secret ls --quiet", sub { m// }, fail_message => "Secrets have not been deleted");
 
     # Stop the swarm in Docker
-    assert_script_run("docker swarm leave --force") if ($runtime == 'docker');
+    assert_script_run("docker swarm leave --force") if ($runtime =~ 'docker');
 }
 
 1;

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -64,7 +64,7 @@ sub run {
     # Commit the container and check that the secrets are not in it
     record_info("Commit cont", "Commit container secret1-test");
     assert_script_run("$runtime commit secret1-test secret1-test-image");
-    my $output = script_output("$runtime $runtime_command --name secret1-test-commit secret1-test-image:latest cat /run/secrets/secret1", proceed_on_failure => 1);
+    $output = script_output("$runtime $runtime_command --name secret1-test-commit secret1-test-image:latest cat /run/secrets/secret1", proceed_on_failure => 1);
     die("Secret commited") if ($output =~ m/T0p_S3cr3t1/);
 
     # Accessing secrets as env variables is not available in Docker

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -81,7 +81,7 @@ sub run {
     # Remove secrets
     record_info("secret rm", "Remove all secrets created");
     assert_script_run("$runtime secret rm secret1 secret2");
-    $output = script_output("$runtime secret ls --quiet"); 
+    $output = script_output("$runtime secret ls --quiet");
     die("Secrets have not been deleted") if ($output);
 
     # Stop the swarm in Docker

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -81,7 +81,8 @@ sub run {
     # Remove secrets
     record_info("secret rm", "Remove all secrets created");
     assert_script_run("$runtime secret rm secret1 secret2");
-    validate_script_output("$runtime secret ls --quiet", sub { m// }, fail_message => "Secrets have not been deleted");
+    $output = script_output("$runtime secret ls --quiet"); 
+    die("Secrets have not been deleted") if ($output);
 
     # Stop the swarm in Docker
     assert_script_run("docker swarm leave --force") if ($runtime =~ 'docker');

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -56,14 +56,15 @@ sub run {
     # Run two containers passing secret1 as an env variable and secret2 as default
     my $runtime_command = ($runtime =~ 'docker') ? 'service create' : 'run';
     record_info("Access secrets");
-    script_run("$runtime pull registry.opensuse.org/opensuse/bci/bci-busybox:latest");
+    script_run("$runtime pull registry.opensuse.org/opensuse/bci/bci-busybox:latest", timeout => 120);
 
     # secret1 testing (default secret)
     validate_script_output("$runtime $runtime_command --name secret1-test --secret secret1 bci-busybox:latest cat /run/secrets/secret1", sub { m/T0p_S3cr3t1/ });
     # Commit the container and check that the secrets are not in it
     record_info("Commit container secret1-test");
     assert_script_run("$runtime commit secret1-test secret1-test-image");
-    validate_script_output("$runtime $runtime_command --name secret1-test-commit secret1-test-image:latest cat /run/secrets/secret1", sub { !m/T0p_S3cr3t1/ });
+    my $output = script_output("$runtime $runtime_command --name secret1-test-commit secret1-test-image:latest cat /run/secrets/secret1", proceed_on_failure => 1);
+    die("Secret commited") if ($output =~ !m/T0p_S3cr3t1/);
 
     # Accessing secrets as env variables is not available in Docker
     if ($runtime =~ 'podman') {
@@ -72,13 +73,14 @@ sub run {
         # Commit the container and check that the secrets are not in it
         record_info("Commit container secret2-test");
         assert_script_run("podman commit secret2-test secret2-test-image");
-        validate_script_output("podman run --name secret1-test-commit secret-test-image:latest printenv TOP_SECRET2", sub { !m/T0p_S3cr3t2/ });
+        $output = script_output("podman run --name secret2-test-commit secret2-test-image:latest printenv TOP_SECRET2", proceed_on_failure => 1);
+        die("Secret commited") if ($output =~ !m/T0p_S3cr3t2/);
     }
 
     # Remove secrets
     record_info("secret rm");
     assert_script_run("$runtime secret rm secret1 secret2");
-    assert_script_run("! $runtime secret ls --quiet", fail_message => "Secrets have not been deleted");
+    validate_script_output("$runtime secret ls --quiet", sub { m// }, fail_message => "Secrets have not been deleted");
 
     # Stop the swarm in Docker
     assert_script_run("docker swarm leave --force") if ($runtime == 'docker');

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -1,0 +1,77 @@
+# SUSE's openQA tests
+#
+# Copyright 2023-2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: podman, docker
+# Summary: Test the `secret` subcommand for Docker and Podman
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use containers::common;
+use containers::container_images;
+
+sub run {
+    my ($self, $args) = @_;
+    my $runtime = $args->{runtime};
+    my $output = '';
+
+    select_serial_terminal();
+
+    # In Docker, secrets can only be used in a swarm
+    if ($runtime =~ 'docker') {
+        my $ip_addr = script_output(qq(ip -6 address show dev eth0 |
+        awk '/inet6/{split(\$2, a, "/"); print a[1]; exit;}'));
+        record_info("docker swarm init", "Initializing docker swarm in IP $ip_addr");
+        assert_script_run("docker swarm init --advertise-addr $ip_addr");
+    }
+
+    # Create a secret1 from CLI and inspect it
+    record_info("secret create CLI");
+    assert_script_run("printf T0p_S3cr3t1 | $runtime secret create secret1 -", fail_message => "Error creating secret from CLI", timeout => 60);
+    record_info("secret inspect CLI", script_output("$runtime secret inspect secret1"));
+
+    # Create a secret2 from file and inspect it
+    record_info("secret create file");
+    script_run("printf T0p_S3cr3t2 > secret2.txt");
+    assert_script_run("$runtime secret create secret2 secret2.txt", fail_message => "Error creating secret from file", timeout => 60);
+    record_info("secret inspect file", script_output("$runtime secret inspect secret2"));
+
+    # Check if secret exists (only in podman)
+    if ($runtime =~ 'podman') {
+        record_info("secret exists");
+        assert_script_run("podman secret exists secret1", fail_message => "Error checking if secret exists");
+        assert_script_run("podman secret exists secret2", fail_message => "Error checking if secret exists");
+        # This secret3 does not exist and thus `secret exists` must return 1
+        assert_script_run("! podman secret exists secret3", fail_message => "Error checking if secret exists");
+    }
+
+    # List all secrets
+    record_info("secret ls");
+    assert_script_run("$runtime secret ls");
+
+    # Run a container passing secret1 as an env variable and secret2 as default
+    my $runtime_command = ($runtime =~ 'docker') ? 'service' : 'run';
+    record_info("Access secrets");
+    script_run("$runtime pull registry.opensuse.org/opensuse/bci/bci-busybox:latest");
+    validate_script_output("$runtime $runtime_command --rm --name secret-test --secret secret1,type=env,target=TOP_SECRET1 --secret secret2 bci-busybox:latest printenv TOP_SECRET1", sub { m/T0p_S3cr3t1/ });
+    validate_script_output("$runtime $runtime_command --name secret-test --secret secret1,type=env,target=TOP_SECRET1 --secret secret2 bci-busybox:latest cat /run/secrets/secret2", sub { m/T0p_S3cr3t2/ });
+    # Commit the container and check that the secrets are not in it
+    record_info("Commit container");
+    assert_script_run("$runtime commit secret-test secret-test-image");
+    validate_script_output("$runtime $runtime_command --rm --name new-secret-test secret-test-image:latest printenv TOP_SECRET1", sub { !m/T0p_S3cr3t1/ });
+    validate_script_output("$runtime $runtime_command --name new-secret-test secret-test-image:latest cat /run/secrets/secret2", sub { !m/T0p_S3cr3t2/ });
+
+    # Remove secrets
+    record_info("secret rm");
+    assert_script_run("$runtime secret rm secret1 secret2");
+    assert_script_run("! $runtime secret ls --quiet", fail_message => "Secrets have not been deleted");
+
+    # Stop the swarm in Docker
+    assert_script_run("docker swarm leave --force") if ($runtime == 'docker');
+}
+
+1;

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -65,7 +65,7 @@ sub run {
     record_info("Commit cont", "Commit container secret1-test");
     assert_script_run("$runtime commit secret1-test secret1-test-image");
     my $output = script_output("$runtime $runtime_command --name secret1-test-commit secret1-test-image:latest cat /run/secrets/secret1", proceed_on_failure => 1);
-    die("Secret commited") if ($output !~ m/T0p_S3cr3t1/);
+    die("Secret commited") if ($output =~ m/T0p_S3cr3t1/);
 
     # Accessing secrets as env variables is not available in Docker
     if ($runtime =~ 'podman') {
@@ -75,7 +75,7 @@ sub run {
         record_info("Commit cont", "Commit container secret2-test");
         assert_script_run("podman commit secret2-test secret2-test-image");
         $output = script_output("podman run --name secret2-test-commit secret2-test-image:latest printenv TOP_SECRET2", proceed_on_failure => 1);
-        die("Secret commited") if ($output !~ m/T0p_S3cr3t2/);
+        die("Secret commited") if ($output =~ m/T0p_S3cr3t2/);
     }
 
     # Remove secrets


### PR DESCRIPTION
New testsuite for the secret subcommand in Podman and Docker

- Related ticket: https://progress.opensuse.org/issues/150857
- Verification runs:
  - [Podman](https://openqa.suse.de/tests/13450474)    :green_circle:
  - [Docker](https://openqa.suse.de/tests/13450495)    :red_circle:
- Continues in: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18620
