### PR TITLE
xfstests: Add support for overlayfs testing

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -191,7 +191,15 @@ sub create_loop_device_by_rootsize {
         assert_script_run("losetup -fP $INST_DIR/$_", 300);
     }
     script_run("losetup -a");
-    format_with_options("$INST_DIR/test_dev", $para{fstype});
+    if ($para{fstype} =~ /overlay/) {
+        my $ovl_base_fs = get_var('XFSTESTS_OVERLAY_BASE_FS', 'xfs');
+        format_with_options("$INST_DIR/test_dev", $ovl_base_fs);
+        format_with_options("$INST_DIR/scratch_dev1", $ovl_base_fs);
+        script_run("echo 'export FSTYP=$ovl_base_fs' >> $CONFIG_FILE");
+    }
+    else {
+        format_with_options("$INST_DIR/test_dev", $para{fstype});
+    }
     # Create mount points
     script_run("mkdir $TEST_FOLDER $SCRATCH_FOLDER");
     # Setup configure file xfstests/local.config

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -271,7 +271,12 @@ sub test_run {
     my $test = shift;
     my ($category, $num) = split(/\//, $test);
     my $run_options = '';
-    $run_options = '-nfs' if check_var('XFSTESTS', 'nfs');
+    if (check_var('XFSTESTS', 'nfs')) {
+        $run_options = '-nfs';
+    }
+    elsif (check_var('XFSTESTS', 'overlay')) {
+        $run_options = '-overlay';
+    }
     my $inject_code = get_var('INJECT_INFO', '');
     my $cmd = "\n$TEST_WRAPPER '$test' $run_options $inject_code | tee $LOG_DIR/$category/$num; ";
     $cmd .= "echo \${PIPESTATUS[0]} > $HB_DONE_FILE\n";
@@ -428,7 +433,12 @@ sub test_run_without_heartbeat {
     my ($category, $num) = split(/\//, $test);
     my $run_options = '';
     my $status_num = 1;
-    $run_options = '-nfs' if check_var('XFSTESTS', 'nfs');
+    if (check_var('XFSTESTS', 'nfs')) {
+        $run_options = '-nfs';
+    }
+    elsif (check_var('XFSTESTS', 'overlay')) {
+        $run_options = '-overlay';
+    }
     my $inject_code = get_var('INJECT_INFO', '');
     eval {
         $test_start = time();

--- a/variables.md
+++ b/variables.md
@@ -219,6 +219,7 @@ XDMUSED | boolean | false | Indicates availability of xdm.
 XFS_MKFS_OPTIONS | string | | Define additional mkfs parameters. Used only in publiccloud test runs.
 XFS_TEST_DEVICE | string | | Define the device used for xfs tests. Used only in publiccloud test runs.
 XFS_TESTS_REFLINK | boolean | false | If set to true, the mkfsoption for using reflink will be added. Used only in publiccloud test runs.
+XFSTESTS_OVERLAY_BASE_FS | string | xfs | Define the base filesystem type of overlayfs
 YAML_SCHEDULE_DEFAULT | string | | Defines default yaml file to be overriden by test suite schedule.
 YAML_SCHEDULE_FLOWS | string | | Defines a comma-separated values representing additional flows which overrides steps on the schedule specified in YAML_SCHEDULE_DEFAULT.
 YAML_SCHEDULE | string | | Defines yaml file containing test suite schedule.


### PR DESCRIPTION
Add support for overlayfs testing

- Related ticket: https://progress.opensuse.org/issues/151283
- Needles: N/A
- Verification run: http://10.67.133.133/tests/435
