### PR TITLE
[RFC] Implement module for Slowroll testing

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2820,6 +2820,7 @@ sub load_system_update_tests {
         }
         else {
             loadtest "update/zypper_clear_repos";
+            loadtest "update/slowroll_repos" if check_var('VERSION', 'Slowroll');
             set_var('CLEAR_REPOS', 1);
         }
     }

--- a/tests/update/slowroll_repos.pm
+++ b/tests/update/slowroll_repos.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Add slowroll repos in the system
+# Maintainer: Yiannis Bonatakis <ybonatakis@suse.com>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+    assert_script_run "rm /etc/zypp/repos.d/*";
+    assert_script_run "zypper -n --gpg-auto-import-keys ar --refresh http://cdn.opensuse.org/slowroll/repo/oss/ base-oss";
+    assert_script_run "zypper -n --gpg-auto-import-keys ar --refresh http://cdn.opensuse.org/slowroll/repo/non-oss/ base-non-oss";
+    assert_script_run "zypper -n --gpg-auto-import-keys ar --refresh -p 80 http://cdn.opensuse.org/update/slowroll/repo/oss/ update";
+
+    assert_script_run "zypper -n --gpg-auto-import-keys dup";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Slowroll is Beta. Repos are provided in download.o.o for testing. This commit introduce a new module which adds those repos in the system. it should be used after the main installation. The update and staging repos are the most interesting to test.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/135731
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
