### PR TITLE
Prevent Windows password expiration

### DIFF
--- a/data/wsl/Autounattend_BIOS.xml
+++ b/data/wsl/Autounattend_BIOS.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
 	<settings pass="windowsPE">
 		<component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -323,6 +323,10 @@
 				<RunSynchronousCommand wcm:action="add">
 					<Order>57</Order>
 					<Path>powershell.exe Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' -Name VisualFXSetting -Value 2</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>58</Order>
+					<Path>powershell.exe Set-LocalUser -Name "Bernhard M. Wiedeman" -PasswordNeverExpires 1</Path>
 				</RunSynchronousCommand>
 			</RunSynchronous>
 		</component>

--- a/data/wsl/Autounattend_UEFI.xml
+++ b/data/wsl/Autounattend_UEFI.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
 	<settings pass="windowsPE">
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -341,6 +341,10 @@
 				<RunSynchronousCommand wcm:action="add">
 					<Order>57</Order>
 					<Path>powershell.exe Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' -Name VisualFXSetting -Value 2</Path>
+				</RunSynchronousCommand>
+				<RunSynchronousCommand wcm:action="add">
+					<Order>58</Order>
+					<Path>powershell.exe Set-LocalUser -Name "Bernhard M. Wiedeman" -PasswordNeverExpires 1</Path>
 				</RunSynchronousCommand>
 			</RunSynchronous>
 		</component>

--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -144,6 +144,11 @@ sub run {
         cmd => 'reg add HKEY_CURRENT_USER\Policies\Microsoft\Windows\Explorer /v DisableSearchBoxSuggestions /t REG_DWORD /d 1'
     );
 
+    # prevent password from expiring
+    $self->run_in_powershell(
+        cmd => 'Set-LocalUser -Name "Bernhard M. Wiedeman" -PasswordNeverExpires 1'
+    );
+
     # poweroff
     $self->reboot_or_shutdown(1);
     $self->wait_boot_windows(is_firstboot => 1);


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/153211
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x

Changed Autounnatend.xml files to include Powershell command which should prevent password expiration.
Added the same Powershell command during Windows attended installation.

As this is supposed to prevent Windows password from expiring, we won't know for certain that it works until it actually ignores the expiration date. 

New qcows were uploaded so WSL tests pass without encountering an expired password.