### PR TITLE
Fixed ms_win_installation test

### DIFF
--- a/tests/wsl/install/ms_win_firstboot.pm
+++ b/tests/wsl/install/ms_win_firstboot.pm
@@ -73,6 +73,8 @@ sub run {
         sleep 3;
         assert_and_click 'windows-next';
     }
+    assert_and_click('windows-access-to-browsing-data')
+      if (check_var('WIN_VERSION', '10'));
     my $count = 0;
     my @privacy_menu =
       split(',', get_required_var('WIN_INSTALL_PRIVACY_NEEDLES'));
@@ -111,6 +113,12 @@ sub run {
     assert_and_click 'windows-lock-screen-background';
     assert_and_click 'windows-select-picture';
 
+    # close window lock screen window
+    send_key "alt-f4";
+
+    # open powershell
+    $self->open_powershell_as_admin;
+
     # turn off hibernation and fast startup
     $self->power_configuration;
 
@@ -146,7 +154,7 @@ sub run {
 
     # poweroff
     $self->reboot_or_shutdown(1);
-    $self->wait_boot_windows(is_firstboot => 1);
+    $self->wait_boot_windows;
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/153391
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/ms_win_firstboot-windows-access-to-browsing-data-20240109.png
- Verification runs: 
- https://openqa.suse.de/tests/13245634
- https://openqa.suse.de/tests/13245639


Created a new needle for Windows 10 installation.
Fixed installation sequence by closing a window and opening Powershell.
Removed firstboot flag from the end of the test. 