### PR TITLE
Reorganize create_playbook_section_list to use sub arguments

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -3,7 +3,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
-# Summary: Library used for SLES4SAP publicccloud deployment and tests
+# Summary: Library used for SLES4SAP publiccloud deployment and tests
 #
 # Note: Subroutines executing commands on remote host (using "run_cmd" or "run_ssh_command") require
 # to have $self->{my_instance} defined.
@@ -696,29 +696,41 @@ sub delete_network_peering {
 
 =head2 create_ansible_playbook_list
 
-    Detects HANA/HA scenario from openQA variables and returns a list of ansible playbooks to include
+    Detects HANA/HA scenario from function arguments and returns a list of ansible playbooks to include
     in the "ansible: create:" section of config.yaml file.
 
+=over 3
+
+=item B<HA_ENABLED> - Enable the installation of HANA and the cluster configuration
+
+=item B<NO_REGISTER> - "QESAP_SCC_NO_REGISTER" skips scc registration via ansible
+
+=item B<FENCING> - select fencing mechanism
+
+=back
 =cut
 
 sub create_playbook_section_list {
-    my ($ha_enabled) = @_;
+    my (%args) = @_;
+    $args{ha_enabled} //= 1;
+    $args{no_register} //= 0;
+    $args{fencing} //= 'sbd';
+
     my @playbook_list;
 
-    unless (get_var('QESAP_SCC_NO_REGISTER')) {
-        # Add registration module as first element - "QESAP_SCC_NO_REGISTER" skips scc registration via ansible
+    unless ($args{no_register}) {
+        # Add registration module as first element
         push @playbook_list, 'registration.yaml -e reg_code=' . get_required_var('SCC_REGCODE_SLES4SAP') . " -e email_address=''";
-        # Add "fully patch system" module after registration module and before test start/configuration moudles.
-        # Temporary moved inside ha_enabled condition to avoid test without Ansible to fails.
+        # Add "fully patch system" module after registration module and before test start/configuration modules.
+        # Temporary moved inside no_register condition to avoid test without Ansible to fails.
         # To be properly addressed in the caller and fully-patch-system can be placed back out of the if.
         push @playbook_list, 'fully-patch-system.yaml';
     }
 
-    # Prepares Azure native fencing related arguments for 'sap-hana-cluster.yaml' playbook
     my $hana_cluster_playbook = 'sap-hana-cluster.yaml';
-    my $azure_native_fencing_args;
-    if (get_var('FENCING_MECHANISM') eq 'native') {
-        $azure_native_fencing_args = azure_fencing_agents_playbook_args(
+    if ($args{fencing} eq 'native' and is_azure) {
+        # Prepares Azure native fencing related arguments for 'sap-hana-cluster.yaml' playbook
+        my $azure_native_fencing_args = azure_fencing_agents_playbook_args(
             spn_application_id => get_var('_SECRET_AZURE_SPN_APPLICATION_ID'),
             spn_application_password => get_var('_SECRET_AZURE_SPN_APP_PASSWORD')
         );
@@ -726,9 +738,9 @@ sub create_playbook_section_list {
     }
 
     # SLES4SAP/HA related playbooks
-    if ($ha_enabled) {
+    if ($args{ha_enabled}) {
         push @playbook_list, 'pre-cluster.yaml', 'sap-hana-preconfigure.yaml -e use_sapconf=' . get_required_var('USE_SAPCONF');
-        push @playbook_list, 'cluster_sbd_prep.yaml' if (check_var('FENCING_MECHANISM', 'sbd'));
+        push @playbook_list, 'cluster_sbd_prep.yaml' if ($args{fencing} eq 'sbd');
         push @playbook_list, qw(
           sap-hana-storage.yaml
           sap-hana-download-media.yaml

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -131,7 +131,7 @@ sub run {
     set_var('SLES4SAP_OS_IMAGE_NAME', $os_image_name);
 
     set_var_output('USE_SAPCONF', 'true');
-    my $ansible_playbooks = create_playbook_section_list($ha_enabled);
+    my $ansible_playbooks = create_playbook_section_list(ha_enabled => $ha_enabled, no_register => get_var('QESAP_SCC_NO_REGISTER'), fencing => get_var('FENCING_MECHANISM'));
     my $ansible_hana_vars = create_hana_vars_section($ha_enabled);
 
     # Prepare QESAP deployment


### PR DESCRIPTION
Change the code to expose 3 arguments to select different behaviors. It was internally implicitly done with settings before. Now setting has been moved to the test module level. It will allow the function to be used in more context, maybe driven by different settings. Not all the settings has been removed from within the function, just them that influence the composition of the playbook list. No significant behavioral changes. Only Native fencing feature has been restricted to Azure.

- Related ticket: [TEAM-8903](https://jira.suse.com/browse/TEAM-8903)

h2. Verification run: 

h2. HanaSR Azure native fencing
 sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-01-11T05:03:13Z-hanasr_azure_test_sapconf_spn@64bit 

 - http://openqaworker15.qa.suse.cz/tests/273752 FAILED after the deployment
 - http://openqaworker15.qa.suse.cz/tests/273755 FAILED during the Ansible part of the deployment for Timeout at reboot
 -  http://openqaworker15.qa.suse.cz/tests/273756

HanaSR Azure sbd  - sle-15-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:32055:dtb-armv7l-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/273754

mr_test - sle-15-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:31967:systemd-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/273753
