### PR TITLE
Handle multiple ALP dolomite repos

### DIFF
--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -43,7 +43,21 @@ sub run {
     if (is_alp) {
         # Add additional ALP repositories
         my $repo = get_required_var('REPO_SLE_ALP');
-        zypper_call("ar http://openqa.suse.de/assets/repo/$repo 'ALP Build Repository'");
+        my $hash = eval($repo);
+        my @repos;
+        if (ref $hash eq ref {}) {
+            foreach (keys %$hash) {
+                push @repos, $_;
+                push @repos, $hash->{$_} if defined($hash->{$_});
+            }
+        } else {
+            push @repos, $repo;
+        }
+
+        for (my $i = 0; $i <= $#repos; $i++) {
+            zypper_call("ar http://openqa.suse.de/assets/repo/$repos[$i] ALP_$i");
+        }
+
         my $source_repo = get_var('REPO_ALP_SOURCE_BUILD');
         zypper_call("ar $source_repo 'ALP Source Build Repository'") if $source_repo;
         zypper_call("--gpg-auto-import-keys ref");


### PR DESCRIPTION
If the ALP repo is populated with multiple repositories, add them all.

`REPO_SLE_ALP={"ALP-Dolomite-1.0-x86_64-Build10.13-Media1","ALP-Dolomite-Unsupported-1.0-x86_64-Build10.13-Media1"}`

- ticket: [[Dolomite] test fails in host_config - fix multiple repo handler](https://progress.opensuse.org/issues/153382)

#### Verification runs

* http://kepler.suse.cz/tests/22441#step/host_config/31
* http://kepler.suse.cz/tests/22440#step/host_config/29
