### PR TITLE
Remove docker-compose for 12sp3

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -140,7 +140,7 @@ sub load_host_tests_docker {
         # to maintenance jobs or new products after Beta release
         # PackageHub is not available in SLE Micro | MicroOS
         loadtest 'containers/registry' if (is_x86_64 || is_sle('>=15-sp4'));
-        loadtest 'containers/docker_compose' unless is_public_cloud;
+        loadtest 'containers/docker_compose' unless (is_public_cloud || is_sle('=12-sp3'));
     }
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro) {


### PR DESCRIPTION
The version of docker-compose is very outdated in 12sp3 which causes the test to fail

- Related ticket: https://progress.opensuse.org/issues/153385
- Verification runs:
  - [12-SP3](https://openqa.suse.de/tests/13230813)
  - [12-SP5](https://openqa.suse.de/tests/13230814)
