### PR TITLE
Fix sporadic issues in yast2_instserver

### DIFF
--- a/lib/y2_module_guitest.pm
+++ b/lib/y2_module_guitest.pm
@@ -10,6 +10,8 @@ use warnings;
 use utils;
 use testapi;
 use Exporter 'import';
+use version_utils 'is_sle';
+use YaST::workarounds;
 
 our @EXPORT = qw(launch_yast2_module_x11 %setup_nis_nfs_x11);
 our %setup_nis_nfs_x11 = (
@@ -60,7 +62,7 @@ sub launch_yast2_module_x11 {
     diag 'assuming root-auth-dialog, typing password';
     type_password;
     send_key 'ret';
-    assert_screen $args{target_match}, $args{match_timeout};
+    apply_workaround_poo124652($args{target_match}, $args{match_timeout}) if (is_sle('>=15-SP4'));
     # Uses hotkey for gnome, adjust if need for other desktop
     send_key 'alt-f10' if $args{maximize_window};
 }

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -54,7 +54,7 @@ sub test_nfs_instserver {
     assert_screen('yast2-instserver-nfs');
     # use default nfs config
     send_key_and_wait("alt-n", 2);
-    assert_screen('yast2-instserver-ui', 200);
+    apply_workaround_poo124652('yast2-instserver-ui', 200) if (is_sle('>=15-SP4'));
     # finish wizard
     send_key_and_wait("alt-f", 3);
     # check that the nfs instserver is working
@@ -83,7 +83,7 @@ sub test_ftp_instserver {
     type_string "test";
     wait_still_screen 2, 2;
     send_key_and_wait("alt-n", 3);
-    assert_screen('yast2-instserver-ui');
+    apply_workaround_poo124652('yast2-instserver-ui', 200) if (is_sle('>=15-SP4'));
     # finish wizard
     send_key_and_wait("alt-f", 3);
     # check that the ftp instserver is working
@@ -124,10 +124,9 @@ sub test_http_instserver {
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
     apply_workaround_poo124652([qw(yast2-instserver-ui yast2-instserver-change-media)], 300) if (is_sle('>=15-SP4'));
-    assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 300);
     # skip "insert next cd" on SLE 12.x
     send_key_and_wait("alt-s", 2) if is_sle("<=12-SP5") && match_has_tag('yast2-instserver-change-media');
-    assert_screen('yast2-instserver-ui');
+    apply_workaround_poo124652('yast2-instserver-ui', 200) if (is_sle('>=15-SP4'));
     # finish wizard
     send_key_and_wait("alt-f", 3);
     # check that the http instserver is working


### PR DESCRIPTION
- Description:
    -   Fix sporadic issues in yast2_instserver

- Related ticket: [**153379**](https://progress.opensuse.org/issues/153379)

- Related MR:  [**700**](https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/700)
- Needles: N/A
- Verification run: 
   - [**VR**](https://openqa.suse.de/tests/overview?build=hjluo%2Fos-autoinst-distri-opensuse%23extratests-yast2u&version=15-SP4&distri=sle) **_20/20 PASSED_**
   -  Fixed
        -  https://openqa.suse.de/tests/13239241#step/yast2_instserver/10
        -  https://openqa.suse.de/tests/13239238#step/yast2_instserver/40
        - https://openqa.suse.de/tests/13239257#step/yast2_instserver/10