### PR TITLE
slem_prepare: updated to handle multimodule

### DIFF
--- a/tests/publiccloud/slem_prepare.pm
+++ b/tests/publiccloud/slem_prepare.pm
@@ -29,7 +29,7 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {fatal => 1, publiccloud_multi_module => 1};
 }
 
 1;


### PR DESCRIPTION
All the tests `slem_containers[_selinux]` in groups _Public Cloud / SLEM 5.[5,4,3,2,1] on Public Cloud_, now after completed, behave correctly in `_cleanup()`, having set in the module the test_flag `publiccloud_multi_module`

- Related ticket: https://progress.opensuse.org/issues/153355
- Needles: none
- Verification run: see next messages