### PR TITLE
Switch checks if incident is embargoed from OBS to smelt

### DIFF
--- a/lib/maintenance_smelt.pm
+++ b/lib/maintenance_smelt.pm
@@ -15,7 +15,7 @@ use base "Exporter";
 use Exporter;
 
 
-our @EXPORT = qw(query_smelt get_incident_packages get_packagebins_in_modules);
+our @EXPORT = qw(query_smelt get_incident_packages get_packagebins_in_modules is_embargo_update);
 
 sub query_smelt {
     my $graphql = $_[0];
@@ -62,6 +62,15 @@ sub get_packagebins_in_modules {
     # Return a hash of hashes, hashed by name. The values are hashes with the keys 'name', 'supportstatus' and
     # 'package'.
     return map { $_->{name} => $_ } @arr;
+}
+
+sub is_embargo_update {
+    my ($incident, $type) = @_;
+    return 0 if ($type =~ /PTF/);
+    my $url = "https://smelt.suse.de/api/v1/basic/incidents/$incident/";
+    my $res = Mojo::UserAgent->new->get($url)->result;
+    die "Request to $url failed, response code " . $res->code if $res->code > 299;
+    return defined($res->json->{embargo});
 }
 
 1;

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -21,6 +21,7 @@ use utils;
 use version_utils qw(is_sle is_public_cloud get_version_id is_transactional);
 use transactional qw(check_reboot_changes trup_call process_reboot);
 use registration;
+use maintenance_smelt qw(is_embargo_update);
 
 # Indicating if the openQA port has been already allowed via SELinux policies
 my $openqa_port_allowed = 0;
@@ -37,7 +38,6 @@ our @EXPORT = qw(
   is_gce
   is_container_host
   is_hardened
-  is_embargo_update
   registercloudguest
   register_addon
   register_openstack
@@ -188,14 +188,6 @@ sub is_container_host() {
 
 sub is_hardened() {
     return is_public_cloud && get_var('FLAVOR') =~ 'Hardened';
-}
-
-sub is_embargo_update {
-    my ($incident, $type) = @_;
-    return 0 if ($type =~ /PTF/);
-    script_retry("curl -sSf https://build.suse.de/attribs/SUSE:Maintenance:$incident -o /tmp/$incident.txt");
-    return 1 if (script_run("grep 'OBS:EmbargoDate' /tmp/$incident.txt") == 0);
-    return 0;
 }
 
 # Get credentials from the Public Cloud micro service, which requires user

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -15,7 +15,7 @@ use testapi;
 use strict;
 use utils;
 use publiccloud::ssh_interactive "select_host_console";
-use publiccloud::utils "is_embargo_update";
+use maintenance_smelt qw(is_embargo_update);
 
 sub run {
     my ($self, $args) = @_;


### PR DESCRIPTION
Current implementation of  `is_embargo_update`  in master will always return False because OBS currently requires authentication and will redirect you to Login page so you won't get actual incident  