### PR TITLE
Support manual disk unlocking on MicroOS

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -11,6 +11,7 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
+use utils qw(need_unlock_after_bootloader unlock_if_encrypted);
 use version_utils qw(is_microos is_selfinstall is_bootloader_grub2 is_bootloader_sdboot);
 use power_action_utils 'power_action';
 use Utils::Architectures qw(is_aarch64);
@@ -48,6 +49,7 @@ sub microos_reboot {
     assert_screen 'grub2', 300 if is_bootloader_grub2;
     assert_screen 'systemd-boot', 300 if is_bootloader_sdboot;
     send_key('ret') unless get_var('KEEP_GRUB_TIMEOUT');
+    unlock_if_encrypted if need_unlock_after_bootloader;
     microos_login;
 }
 

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -906,7 +906,7 @@ sub wait_boot {
     reconnect_xen if check_var('VIRSH_VMM_FAMILY', 'xen');
 
     # on s390x svirt encryption is unlocked with unlock_bootloader before here
-    if (need_passphrase_again) {
+    if (need_unlock_after_bootloader) {
         unlock_if_encrypted unless get_var('S390_ZKVM');
     }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -11,7 +11,7 @@ use warnings;
 use testapi qw(is_serial_terminal :DEFAULT);
 use lockapi 'mutex_wait';
 use mm_network;
-use version_utils qw(is_alp is_sle_micro is_microos is_leap is_leap_micro is_public_cloud is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos package_version_cmp is_transactional);
+use version_utils qw(is_alp is_sle_micro is_microos is_leap is_leap_micro is_public_cloud is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos package_version_cmp is_transactional is_bootloader_sdboot);
 use Utils::Architectures;
 use Utils::Systemd qw(systemctl disable_and_stop_service);
 use Utils::Backends;
@@ -1065,6 +1065,8 @@ without LVM configuration (cr_swap,cr_home etc).
 sub need_unlock_after_bootloader {
     my $need_unlock_after_bootloader = is_leap('<15.6') || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || is_alp || (!get_var('LVM', '0') && !get_var('FULL_LVM_ENCRYPT', '0'));
     return 0 if is_boot_encrypted && !$need_unlock_after_bootloader;
+    # MicroOS with sdboot supports automatic TPM based unlocking.
+    return 0 if is_microos && is_bootloader_sdboot && get_var('QEMUTPM');
     return 1;
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -52,7 +52,7 @@ our @EXPORT = qw(
   set_zypper_lock_timeout
   unlock_bootloader
   is_boot_encrypted
-  need_passphrase_again
+  need_unlock_after_bootloader
   is_bridged_networking
   set_bridged_networking
   assert_screen_with_soft_timeout
@@ -1047,9 +1047,12 @@ sub is_boot_encrypted {
     return 1;
 }
 
-=head2 need_passphrase_again
+=head2 need_unlock_after_bootloader
 
- need_passphrase_again();
+ need_unlock_after_bootloader();
+
+Whether the disk encryption password(s) need to be entered during system boot
+(e.g. plymouth or systemd-cryptsetup text prompt).
 
 With newer grub2 (in TW and SLE15-SP6 currently), if root disk is encrypted and
 contains `/boot`, entering the passphrase in GRUB2 is enough. The key is passed
@@ -1059,9 +1062,9 @@ without LVM configuration (cr_swap,cr_home etc).
 
 =cut
 
-sub need_passphrase_again {
-    my $need_passphrase_again = is_leap('<15.6') || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || is_alp || (!get_var('LVM', '0') && !get_var('FULL_LVM_ENCRYPT', '0'));
-    return 0 if is_boot_encrypted && !$need_passphrase_again;
+sub need_unlock_after_bootloader {
+    my $need_unlock_after_bootloader = is_leap('<15.6') || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || is_alp || (!get_var('LVM', '0') && !get_var('FULL_LVM_ENCRYPT', '0'));
+    return 0 if is_boot_encrypted && !$need_unlock_after_bootloader;
     return 1;
 }
 

--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -14,7 +14,7 @@ use base "installbasetest";
 use utils;
 
 sub run {
-    unlock_if_encrypted(check_typed_password => 1) if need_passphrase_again;
+    unlock_if_encrypted(check_typed_password => 1) if need_unlock_after_bootloader;
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/152829
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/807
- Verification runs:
  * With TPM: http://10.168.4.192/tests/1443
  * Without TPM: http://10.168.4.192/tests/1442
  * ALP (turns out not to use microos/process_reboot but only transactional/process_reboot...): http://10.168.4.192/tests/1445
