### PR TITLE
containers: only run man if the actual command is present

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -251,7 +251,7 @@ sub basic_container_tests {
     # Using an init process as PID 1
     assert_script_run "$runtime run --rm --init $tumbleweed ps --no-headers -xo 'pid args' | grep '1 .*init'";
 
-    if (script_run('command -v man') == 0) {
+    if (script_run('test -x /usr/bin/man') == 0) {
         # Note: The output of man contains non-ASCII characters. Even a dash (`-`) imposes difficulties here, so it's best to stay with letters
         if ($runtime eq 'podman') {
             validate_script_output("man -P cat $runtime-build", sub { m/Build a container image using a Containerfile/ }, fail_message => "`man $runtime build` contents not validating");


### PR DESCRIPTION
Newer versions of microos-tools install an alias man=man-online.
The 'command -v man' check in the interactive shell follows the alias
and reports it as known command. Subsequently, the test calls
bash -eox pipefail script.sh though, in which case script.sh does not
have access to the aliased commands. As a consequence, at this point,
'man' fails to be executed.

- Related ticket: Identified by openQA when testing SR of new microos-tools package
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3864126
