### PR TITLE
Add 2 new wwn for mutil-disk server

### DIFF
--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -165,7 +165,7 @@
   </ntp-client>
   <partitioning config:type="list">
     <drive>
-  % my $wwn = {lipa => 'wwn-0x5002538c4002f8bd', briza => 'wwn-0x5000c5004f0e566d'};
+  % my $wwn = {lipa => 'wwn-0x5002538c4002f8bd', briza => 'wwn-0x5000c5004f0e566d', pegasus => 'wwn-0x5002538c4002f8be', galactica => 'wwn-0x5002538c4002f8cd'};
   % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
   % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : '';
       <device><%= $device_id %></device>


### PR DESCRIPTION

After installing a new disk, both pegasus and galactica will have two disks. To ensure installation on the specified disk, World Wide Name (WWN) settings have been added.



- Related ticket:  https://progress.opensuse.org/issues/134447?issue_count=21&issue_position=15&next_issue_id=152789&prev_issue_id=153238#note-53
- Needles: n/a
- Verification run: [galactica](http://10.100.103.119/tests/611), [pegasus](http://10.100.103.119/tests/610)
