### PR TITLE
Add force SUSEconnect registration option

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -28,6 +28,7 @@ terraform:
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1276,7 +1276,7 @@ sub qesap_az_vnet_peering {
 
     Delete a single peering one way
 
-=over 3
+=over 4
 
 =item B<RG> - Name of the resource group
 

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -604,7 +604,7 @@ subtest '[qesap_upload_crm_report]' => sub {
     ok((any { /.*\/var\/log\/SALT\-crm_report/ } @calls), 'crm report file has the node name in it');
 };
 
-subtest '[qesap_upload_crm_report] ansyble host query' => sub {
+subtest '[qesap_upload_crm_report] ansible host query' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     my @calls;
     my @fetch_filename;

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -131,7 +131,19 @@ sub run {
     set_var('SLES4SAP_OS_IMAGE_NAME', $os_image_name);
 
     set_var_output('USE_SAPCONF', 'true');
-    my $ansible_playbooks = create_playbook_section_list(ha_enabled => $ha_enabled, no_register => get_var('QESAP_SCC_NO_REGISTER'), fencing => get_var('FENCING_MECHANISM'));
+    # This is the path where community.sles-for-sap repo
+    # has been cloned.
+    # Not all the conf.yaml used by this file needs it but
+    # it is just easyer to define it here for all.
+    set_var("ANSIBLE_ROLES", qesap_get_ansible_roles_dir());
+    my $reg_mode = 'registercloudguest';    # Use registercloudguest by default
+    if (get_var('QESAP_SCC_NO_REGISTER')) {
+        $reg_mode = 'noreg';
+    }
+    elsif (get_var('QESAP_FORCE_SUSECONNECT')) {
+        $reg_mode = 'suseconnect';
+    }
+    my $ansible_playbooks = create_playbook_section_list(ha_enabled => $ha_enabled, registration => $reg_mode, fencing => get_var('FENCING_MECHANISM'));
     my $ansible_hana_vars = create_hana_vars_section($ha_enabled);
 
     # Prepare QESAP deployment


### PR DESCRIPTION
Add option to force SUSEConnect usage in place of registercloudguest during registration for qe-sap-deployment.
It also needs to use role base registration playbook. This is needed to tests images uploaded in the cloud from IBS that are not known yet by the cloud reg service.

- Related ticket: [TEAM-8903](https://jira.suse.com/browse/TEAM-8903)

# Verification run:

## HanaSR

### Azure using catalogue OS image, native fencing and default registration
http://openqaworker15.qa.suse.cz/tests/273813 :green_circle: 

### Azure using OS image from IBS, native fencing and default registration
http://openqaworker15.qa.suse.cz/tests/273818 :green_circle:  (needs manual fix like HANA_KEYNAME) in http://openqaworker15.qa.suse.cz/tests/273818/file/deploy_qesap_terraform-sles4sap_azure_generic_uri.yaml it has `registration.yaml`. It fails but it is expected.  It calls `registercloudguest` like :

```
ERROR    OUTPUT:          fatal: [vmhana02]: FAILED! => {
ERROR    OUTPUT:              "attempts": 10,
ERROR    OUTPUT:              "changed": true,
ERROR    OUTPUT:              "cmd": [
ERROR    OUTPUT:                  "registercloudguest",
ERROR    OUTPUT:                  "--force-new",
ERROR    OUTPUT:                  "-r",
ERROR    OUTPUT:                  "******",
ERROR    OUTPUT:                  "-e",
ERROR    OUTPUT:                  ""
ERROR    OUTPUT:              ],
```
and as expected to fails for this image.

http://openqaworker15.qa.suse.cz/tests/273821 :green_circle: 

### Azure using OS image from IBS, native fencing and  with SUSEConnect registration
` QESAP_FORCE_SUSECONNECT=1` 

http://openqaworker15.qa.suse.cz/tests/273819 :green_circle: 

 It has `- registration_role.yaml    ...    -e use_suseconnect=true` as expected. Ansible part of the deployment correctly has
 
 ```
DEBUG    >    TASK [sles_register : Register with SUSEConnect] *******************************
```


then it fails like 

```
ERROR    OUTPUT:          fatal: [vmhana01]: FAILED! => {
ERROR    OUTPUT:              "changed": false,
ERROR    OUTPUT:              "elapsed": 617,
ERROR    OUTPUT:              "msg": "Timed out waiting for last boot time check (timeout=600)",
ERROR    OUTPUT:              "rebooted": true
ERROR    OUTPUT:          }
```

But quite like is not related to registration

http://openqaworker15.qa.suse.cz/tests/273820 :green_circle: 
