### PR TITLE
Add setting to configure registration playbook

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -19,6 +19,7 @@ terraform:
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -35,7 +36,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' -e use_suseconnect=%SUSECONNECT%
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
@@ -22,6 +22,7 @@ terraform:
     drbd_cluster_fencing_mechanism: '%FENCING%'
     netweaver_cluster_fencing_mechanism: '%FENCING%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -38,7 +39,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -19,6 +19,7 @@ terraform:
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -35,7 +36,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=true

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -17,6 +17,7 @@ terraform:
     vnet_address_range: '%VNET_ADDRESS_RANGE%'
     subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -33,7 +34,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_reboottimeout=900

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -20,6 +20,7 @@ terraform:
     drbd_cluster_fencing_mechanism: '%FENCING%'
     netweaver_cluster_fencing_mechanism: '%FENCING%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -36,7 +37,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_reboottimeout=900

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -20,6 +20,7 @@ terraform:
     drbd_cluster_fencing_mechanism: '%FENCING%'
     netweaver_cluster_fencing_mechanism: '%FENCING%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -36,7 +37,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_reboottimeout=900

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -15,6 +15,7 @@ terraform:
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -31,7 +32,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=true -e use_reboottimeout=900

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -15,6 +15,7 @@ terraform:
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -31,7 +32,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' -e use_suseconnect=%SUSECONNECT%
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=%USE_SAPCONF%

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -21,6 +21,7 @@ terraform:
     hana_log_disk_type: '%HANA_LOG_DISK_TYPE%'
 
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -37,7 +38,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
@@ -23,6 +23,7 @@ terraform:
     drbd_cluster_fencing_mechanism: '%FENCING%'
     netweaver_cluster_fencing_mechanism: '%FENCING%'
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -39,7 +40,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -21,6 +21,7 @@ terraform:
     hana_log_disk_type: '%HANA_LOG_DISK_TYPE%'
 
 ansible:
+  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
@@ -37,7 +38,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
   create:
-    - registration.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml
     - pre-cluster.yaml
     - sap-hana-preconfigure.yaml -e use_sapconf=true

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -44,6 +44,9 @@ sub run {
     $variables{USE_SAPCONF} = get_var('QESAPDEPLOY_USE_SAPCONF', 'false');
     $variables{SSH_KEY_PRIV} = '/root/.ssh/id_rsa';
     $variables{SSH_KEY_PUB} = '/root/.ssh/id_rsa.pub';
+    $variables{REGISTRATION_PLAYBOOK} = get_var('QESAPDEPLOY_REGISTRATION_PLAYBOOK', 'registration');
+    $variables{REGISTRATION_PLAYBOOK} =~ s/\.yaml$//;
+    $variables{SUSECONNECT} = get_var('QESAPDEPLOY_USE_SUSECONNECT', 'false');
 
     # Only BYOS images needs it
     $variables{SCC_REGCODE_SLES4SAP} = get_var('SCC_REGCODE_SLES4SAP', '');


### PR DESCRIPTION
Add two setting for the qesap regression:
 - QESAPDEPLOY_REGISTRATION_PLAYBOOK allow to select the filename of the registration playbook, default is registration.
 - QESAPDEPLOY_USE_SUSECONNECT control value for use_suseconnect Ansible argument of the registration_role playbook.

*Related ticket:* TEAM-8932

# Verification run:

## qesap regression default settings
 - http://openqaworker15.qa.suse.cz/tests/273990 :green_circle: 
 - http://openqaworker15.qa.suse.cz/tests/274002

## QESAPDEPLOY_REGISTRATION_PLAYBOOK=donalduck
 - http://openqaworker15.qa.suse.cz/tests/273991 :green_circle: 
 qesap regression default settings trigger with not existing playbook filename `QESAPDEPLOY_REGISTRATION_PLAYBOOK=donalduck`
 ```
ERROR    Missing playbook: /root/qe-sap-deployment/ansible/playbooks/donalduck.yaml
4UPHd-1-
```
 
- http://openqaworker15.qa.suse.cz/tests/274003

## QESAPDEPLOY_REGISTRATION_PLAYBOOK=registration.yaml
`QESAPDEPLOY_REGISTRATION_PLAYBOOK` expect filename without extension. Intentionally try to use filename with extension to proof that the test code silently remove the `.yaml`
 - http://openqaworker15.qa.suse.cz/tests/274004
 
## QESAPDEPLOY_REGISTRATION_PLAYBOOK=registration_role
- qesap regression default settings http://openqaworker15.qa.suse.cz/tests/273993 :green_circle:  trigger with non default but existing registration playbook `QESAPDEPLOY_REGISTRATION_PLAYBOOK=registration_role`, not SUSEConnect
 - http://openqaworker15.qa.suse.cz/tests/274005

## QESAPDEPLOY_REGISTRATION_PLAYBOOK=registration_role and QESAPDEPLOY_USE_SUSECONNECT=true

 - qesap regression with settings to force SUSEConnect http://openqaworker15.qa.suse.cz/tests/273995 :green_circle:  `QESAPDEPLOY_REGISTRATION_PLAYBOOK=registration_role` and  `QESAPDEPLOY_USE_SUSECONNECT=true`
From the Ansible log:
1. SUSEConnect is properly selected as preferred reg tool
```
DEBUG    OUTPUT: TASK [sles_register : Print required action] ***********************************
DEBUG    OUTPUT: task path: /root/community.sles-for-sap/roles/sles_register/tasks/tasks.yml:6
DEBUG    OUTPUT: Monday 15 January 2024  06:23:05 -0500 (0:00:00.062)       0:00:13.566 ******** 
DEBUG    OUTPUT: ok: [vmhana01] => {
DEBUG    OUTPUT:     "msg": "Registration required, SUSEConnect will be used"
DEBUG    OUTPUT: }
```

2. Registration is ok `TASK [sles_register : Register with SUSEConnect]`
