### PR TITLE
Don't need 'handle_uefi_boot_disk_workaround' in slem self-install

### DIFF
--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -20,8 +20,6 @@ sub run {
     send_key 'ret';
     assert_screen 'slem-selfinstall-overwrite-drive';
     send_key 'ret';
-    # Use firmware boot manager of aarch64 to boot HDD
-    $self->handle_uefi_boot_disk_workaround if is_aarch64;
 
     my $no_cd;
     # workaround failed *kexec* execution on UEFI with SecureBoot


### PR DESCRIPTION
https://progress.opensuse.org/issues/153457

VR: https://openqa.suse.de/tests/13239372#step/selfinstall/19

**Please ignore the failed test module, it is a known issue**
