### PR TITLE
Schedule existing dpdk test on SLE 15-sp5

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -79,6 +79,7 @@ conditional_schedule:
       15-SP5:
         - console/firewalld
         - console/lshw
+        - console/dpdk
       15-SP4:
         - console/firewalld
         - console/lshw

--- a/tests/console/dpdk.pm
+++ b/tests/console/dpdk.pm
@@ -83,7 +83,7 @@ sub test_ovs_dpdk {
 
     # check dpdk-hugepages
     # we have issue with missing python script dpdk-hugepages.py, see boo#1212113
-    assert_script_run 'which dpdk-hugepages.py -s' if (is_sle || is_tumbleweed || (is_leap('>=15.5') && !(check_var('FLAVOR', 'DVD-Updates'))));
+    assert_script_run 'which dpdk-hugepages.py' if (is_sle('>=15-sp5') || is_tumbleweed || (is_leap('>=15.5') && !(check_var('FLAVOR', 'DVD-Updates'))));
     assert_script_run 'grep -i  "dpdk enabled" /var/log/openvswitch/ovs-vswitchd.log';
 }
 


### PR DESCRIPTION
schedule existing dpdk test on SLE 15-sp5

- Related ticket: https://progress.opensuse.org/issues/153053
- Verification run: https://openqa.suse.de/tests/13257032