### PR TITLE
Remove desktop module from textmode ay profiles

### DIFF
--- a/data/yam/autoyast/create_hdd_textmode_aarch64.xml
+++ b/data/yam/autoyast/create_hdd_textmode_aarch64.xml
@@ -328,13 +328,6 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <reg_code/>
-        <release_type>nil</release_type>
-        <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/yam/autoyast/create_hdd_textmode_s390x.xml
+++ b/data/yam/autoyast/create_hdd_textmode_s390x.xml
@@ -337,7 +337,6 @@
       <package>wicked</package>
       <package>snapper</package>
       <package>sle-module-server-applications-release</package>
-      <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
       <package>openssh</package>
       <package>kexec-tools</package>
@@ -371,13 +370,6 @@
   </ssh_import>
   <suse_register t="map">
     <addons t="list">
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <reg_code/>
-        <release_type>nil</release_type>
-        <version>{{VERSION}}</version>
-      </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_aarch64.xml
@@ -97,12 +97,7 @@ exit 0
     </products>
   </software>
   <suse_register t="map">
-      <addons t="list">
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <version>{{VERSION}}</version>
-      </addon>
+    <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>SLES-LTSS</name>

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_s390x.xml
@@ -113,12 +113,7 @@ exit 0
     </products>
   </software>
   <suse_register t="map">
-        <addons t="list">
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <version>{{VERSION}}</version>
-      </addon>
+    <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>SLES-LTSS</name>

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_x86_64.xml
@@ -94,12 +94,7 @@ exit 0
     </products>
   </software>
   <suse_register t="map">
-      <addons t="list">
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <version>{{VERSION}}</version>
-      </addon>
+    <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>SLES-LTSS</name>

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_default_patterns_s390x.xml
@@ -166,11 +166,6 @@ exit 0
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-	<version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
         <name>SLES-LTSS</name>
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>

--- a/data/yam/autoyast/support_images/sles15sp5_install_minimal_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_minimal_default_patterns_s390x.xml
@@ -135,11 +135,6 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-	<version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
         <version>{{VERSION}}</version>
       </addon>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_aarch64.xml
@@ -100,11 +100,6 @@ exit 0
       <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
         <version>{{VERSION}}</version>
       </addon>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_s390x.xml
@@ -113,12 +113,7 @@ exit 0
     </products>
   </software>
   <suse_register t="map">
-        <addons t="list">
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <version>{{VERSION}}</version>
-      </addon>
+    <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_x86_64.xml
@@ -97,11 +97,6 @@ exit 0
       <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
         <version>{{VERSION}}</version>
       </addon>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_default_patterns_s390x.xml
@@ -166,11 +166,6 @@ exit 0
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-	<version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
         <version>{{VERSION}}</version>
       </addon>


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/153043
Related MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/693
VRs: 
SP6: https://openqa.suse.de/tests/overview?build=sofiasyria%2Fos-autoinst-distri-opensuse%23rm_desktop&version=15-SP6&distri=sle 
SP5: https://openqa.suse.de/tests/overview?distri=sle&build=sofiasyria%2Fos-autoinst-distri-opensuse%23rm_desktop&version=15-SP5 
SP4: https://openqa.suse.de/tests/overview?version=15-SP4&build=sofiasyria%2Fos-autoinst-distri-opensuse%23rm_desktop&distri=sle