### PR TITLE
ALP: Don't add default repos manually, use SCC instead

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -40,7 +40,7 @@ sub load_config_tests {
     loadtest 'transactional/host_config' unless is_dvd;
     loadtest 'rt/rt_is_realtime' if is_rt;
     loadtest 'transactional/enable_selinux' if (get_var('ENABLE_SELINUX') && is_image);
-    loadtest 'console/suseconnect_scc' if (is_sle_micro && get_var('SCC_REGISTER') && !is_dvd);
+    loadtest 'console/suseconnect_scc' if (get_var('SCC_REGISTER') && !is_dvd);
     loadtest 'transactional/install_updates' if (is_sle_micro && is_released);
 }
 

--- a/schedule/security/selinux.yaml
+++ b/schedule/security/selinux.yaml
@@ -47,6 +47,8 @@ conditional_schedule:
         DISTRI:
             sle-micro:
                 - console/suseconnect_scc
+            alp:
+                - console/suseconnect_scc
     sle_os_tests:
         DISTRI:
             sle:

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -40,25 +40,7 @@ sub run {
         die 'Unknown bootloader';
     }
 
-    if (is_alp) {
-        # Add additional ALP repositories
-        my $repo = get_required_var('REPO_SLE_ALP');
-        my $hash = eval($repo);
-        my @repos;
-        if (ref $hash eq ref {}) {
-            foreach (keys %$hash) {
-                push @repos, $_;
-                push @repos, $hash->{$_} if defined($hash->{$_});
-            }
-        } else {
-            push @repos, $repo;
-        }
-
-        for (my $i = 0; $i <= $#repos; $i++) {
-            zypper_call("ar http://openqa.suse.de/assets/repo/$repos[$i] ALP_$i");
-        }
-
-        my $source_repo = get_var('REPO_ALP_SOURCE_BUILD');
+    if (my $source_repo = get_var('REPO_ALP_SOURCE_BUILD')) {
         zypper_call("ar $source_repo 'ALP Source Build Repository'") if $source_repo;
         zypper_call("--gpg-auto-import-keys ref");
     }


### PR DESCRIPTION
ALP products are available in SCC and the repos should be fetched from SCC or proxySCC accordingly, not added manually from a variable.
[Staging default image](https://openqa.suse.de/tests/13258751#)
[Staging encrypted image](https://openqa.suse.de/tests/13259004)
[Dolomite](https://openqa.suse.de/tests/13259005#)
[SLE Micro 6.0](https://openqa.suse.de/tests/13259009#)

