### PR TITLE
Add softfail for bsc#1215377 in ALP

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -497,7 +497,8 @@
         "description": "plugin /usr/sbin/sedispatch terminated unexpectedly",
         "products": {
             "sle-micro": ["5.4" , "5.5", "6.0"],
-            "leap-micro": [ "5.5" ]
+            "leap-micro": [ "5.5" ],
+	     "alp": ["1.0"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
Added a new entry for the ALP issue in the journal_check test (bsc#1215377)

Verifcation Run:
[alp-1.0-Dolomite-Default-x86_64](https://openqa.suse.de/tests/13262292#)
[Staging: ALP](http://openqa.suse.de/tests/13262298#)
