### PR TITLE
Add some basic usb tests for ethernet and mass storage

### DIFF
--- a/schedule/qam/15/qam-gfxdrivers.yaml
+++ b/schedule/qam/15/qam-gfxdrivers.yaml
@@ -27,5 +27,4 @@ schedule:
 - x11/glxgears
 - kernel/usb_nic
 - kernel/usb_drive
-- shutdown/cleanup_before_shutdown
 - shutdown/shutdown

--- a/schedule/qam/15/qam-gfxdrivers.yaml
+++ b/schedule/qam/15/qam-gfxdrivers.yaml
@@ -25,5 +25,7 @@ schedule:
 - console/consoletest_finish
 - locale/keymap_or_locale_x11
 - x11/glxgears
+- kernel/usb_nic
+- kernel/usb_drive
 - shutdown/cleanup_before_shutdown
 - shutdown/shutdown

--- a/tests/kernel/usb_drive.pm
+++ b/tests/kernel/usb_drive.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Package: usb_nic
-# Summary: Simple smoke test for testing USB NIC connected to system
+# Summary: Simple smoke test for testing USB drive connected to system
 # Maintainer: LSG QE Kernel <kernel-qa@suse.de>
 
 use base 'opensusebasetest';
@@ -13,7 +13,6 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use Utils::Logging 'export_logs_basic';
 
 sub run {
     my ($self) = @_;
@@ -37,7 +36,7 @@ sub run {
 
     assert_script_run "mount -t btrfs $device $mountpoint";
     assert_script_run "dd if=/dev/urandom of=$file bs=1M count=16";
-    assert_script_run "md5sum $file  > $md5";
+    assert_script_run "md5sum $file > $md5";
     assert_script_run "cp $file $file_copy";
 
     # unmount and flush slab and page cache

--- a/tests/kernel/usb_drive.pm
+++ b/tests/kernel/usb_drive.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: usb_nic
+# Summary: Simple smoke test for testing USB NIC connected to system
+# Maintainer: LSG QE Kernel <kernel-qa@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use Utils::Logging 'export_logs_basic';
+
+sub run {
+    my ($self) = @_;
+
+    select_serial_terminal;
+
+    my $lun = script_output 'lsscsi -t -v | awk -F" " \'/usb/ {split($2,a,/[\/]/); print a[6]}\'';
+    die "no usb storage device connected" if $lun eq "";
+
+    my $device = "/dev/" . script_output "lsscsi -v | awk -F\"/\" \'/$lun/ {print \$3; exit}\'";
+
+    # create filesystem, mountpoint and temporary file
+    my $tmp = script_output 'mktemp -d';
+    my $file = "$tmp/file";
+    my $md5 = "$tmp/md5";
+    my $mountpoint = "$tmp/mount";
+    my $file_copy = "$mountpoint/file";
+
+    assert_script_run "mkdir $mountpoint";
+    assert_script_run "mkfs.btrfs -f $device";
+
+    assert_script_run "mount -t btrfs $device $mountpoint";
+    assert_script_run "dd if=/dev/urandom of=$file bs=1M count=16";
+    assert_script_run "md5sum $file  > $md5";
+    assert_script_run "cp $file $file_copy";
+
+    # unmount and flush slab and page cache
+    assert_script_run "umount $mountpoint";
+    assert_script_run "echo 3 > /proc/sys/vm/drop_caches";
+
+    # remount and check md5sum
+    assert_script_run "mount -t btrfs $device $mountpoint";
+    assert_script_run "cd $mountpoint; md5sum -c $md5; cd /";
+
+    # cleanup
+    assert_script_run("umount $mountpoint");
+    assert_script_run("rm -r $tmp");
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/kernel/usb_nic.pm
+++ b/tests/kernel/usb_nic.pm
@@ -5,7 +5,7 @@
 
 # Package: usb_nic
 # Summary: Simple smoke test for testing USB NIC connected to system
-# Maintainer: LSG QE Kernel <kerneli-qa@suse.de>
+# Maintainer: LSG QE Kernel <kernel-qa@suse.de>
 
 use base 'opensusebasetest';
 use strict;
@@ -13,14 +13,11 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use Utils::Logging 'export_logs_basic';
 
 sub run {
     my ($self) = @_;
 
     select_serial_terminal;
-
-    zypper_call('in -t package ethtool');
 
     my $interface = script_output 'basename $(readlink /sys/class/net/* | grep usb )';
 

--- a/tests/kernel/usb_nic.pm
+++ b/tests/kernel/usb_nic.pm
@@ -1,0 +1,45 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: usb_nic
+# Summary: Simple smoke test for testing USB NIC connected to system
+# Maintainer: LSG QE Kernel <kerneli-qa@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use Utils::Logging 'export_logs_basic';
+
+sub run {
+    my ($self) = @_;
+
+    select_serial_terminal;
+
+    zypper_call('in -t package ethtool');
+
+    my $interface = script_output 'basename $(readlink /sys/class/net/* | grep usb )';
+
+    assert_script_run "echo \"BOOTPROTO='dhcp'\" > /etc/sysconfig/network/ifcfg-$interface";
+    assert_script_run "echo \"STARTMODE='auto'\" >> /etc/sysconfig/network/ifcfg-$interface";
+
+    assert_script_run "ifup $interface";
+
+    # wait until interface is up
+    my $timeout = 20;
+    ($timeout-- && sleep 5) while (script_run "ip -4 addr show $interface | grep inet" && $timeout);
+
+    my $ping_peer = script_output "ip route show dev $interface | cut -d ' ' -f 7";
+    assert_script_run "ping -I $interface -c 4 $ping_peer";
+    assert_script_run "ifdown $interface";
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/kernel/usb_nic.pm
+++ b/tests/kernel/usb_nic.pm
@@ -19,16 +19,31 @@ sub run {
 
     select_serial_terminal;
 
-    my $interface = script_output 'basename $(readlink /sys/class/net/* | grep usb )';
+    my $usb_net_devs = script_output('readlink /sys/class/net/* | grep usb', proceed_on_failure => 1);
+    die "no USB network interfaces found" unless $usb_net_devs ne "";
+
+    my $interface = script_output "basename $usb_net_devs | head -n1";
 
     assert_script_run "echo \"BOOTPROTO='dhcp'\" > /etc/sysconfig/network/ifcfg-$interface";
     assert_script_run "echo \"STARTMODE='auto'\" >> /etc/sysconfig/network/ifcfg-$interface";
 
     assert_script_run("ifup $interface -o debug", 60);
 
-    my $route = script_output "ip route show default";
-    my @ping_peer = $route =~ /default via (\S+)/;
-    assert_script_run "ping -I $interface -c 4 @ping_peer";
+    sleep 30;
+    my $inet = script_output("ip addr show dev $interface |  awk \'/inet / {split(\$0,a); print a[2]}\'", proceed_on_failure => 1);
+    die "no IP address configured" unless $inet ne "";
+
+    record_info("IP address(es)", "$inet");
+
+    my $neigh = script_output("ip neigh show dev $interface");
+    my $peer_count = 0;
+
+    while ($neigh =~ m/^(\S+)/mg) {
+        return unless script_run "ping -I $interface -c 4 $1";
+        $peer_count++;
+    }
+
+    record_info("Ping failed", "None of $peer_count peers responded to ping", result => 'fail');
 }
 
 sub test_flags {


### PR DESCRIPTION
We have some USB devices physically plugged into a baremetal machine. This adds some basic smoke tests for both mass storage and Ethernet connected via USB. 

- Related ticket: https://progress.opensuse.org/issues/138122
- Needles: -
- Verification run: https://openqa.suse.de/tests/14004960#next_previous