### PR TITLE
Remove private_key from qe-sap-deployment

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -17,7 +17,6 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -15,7 +15,6 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
     os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -15,7 +15,6 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
     aws_credentials: '/root/amazon_credentials'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
 

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2_product.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2_product.yaml
@@ -15,7 +15,6 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
     aws_credentials: '/root/amazon_credentials'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     os_owner: 'self'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -12,7 +12,6 @@ terraform:
     deployment_name: '%DEPLOYMENTNAME%'
     os_image: '%OS_VER%'
     os_owner: '%OS_OWNER%'
-    private_key: '%SSH_KEY_PRIV%'
     public_key: '%SSH_KEY_PUB%'
     aws_credentials: '/root/amazon_credentials'
     hana_instancetype: '%HANA_INSTANCE_TYPE%'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
@@ -12,7 +12,6 @@ terraform:
     deployment_name: '%DEPLOYMENTNAME%'
     os_image: '%OS_VER%'
     os_owner: '%OS_OWNER%'
-    private_key: '%SSH_KEY_PRIV%'
     public_key: '%SSH_KEY_PUB%'
     aws_credentials: '/root/amazon_credentials'
     hana_instancetype: '%HANA_INSTANCE_TYPE%'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -12,7 +12,6 @@ terraform:
     deployment_name: '%DEPLOYMENTNAME%'
     os_image: '%OS_VER%'
     os_owner: '%OS_OWNER%'
-    private_key: '%SSH_KEY_PRIV%'
     public_key: '%SSH_KEY_PUB%'
     aws_credentials: '/root/amazon_credentials'
     hana_instancetype: '%HANA_INSTANCE_TYPE%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -15,7 +15,6 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
     aws_credentials: '/root/amazon_credentials'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     os_owner: '%SLE_IMAGE_OWNER%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -15,7 +15,6 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -17,7 +17,6 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -16,7 +16,6 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
     os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA


### PR DESCRIPTION
Remove the private_key from all Azure and Aws conf.yaml for the qe-sap-deployment tests.

Related to https://github.com/SUSE/qe-sap-deployment/pull/127


# Verification run

## qesap regression

### AWS

#### qesap_aws.yaml

 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/274111  :green_circle: Test fails in Ansible `TASK [Configure cluster IP [aws]]` like the one this vr is cloned from. On the other side the Terraform warning is gone

```
DEBUG    OUTPUT: The root module does not declare a variable named "private_key" but a value
DEBUG    OUTPUT: was found in file "terraform.tfvars". If you meant to use this value, add a
DEBUG    OUTPUT: "variable" block to the configuration.
```
#### qesap_aws_fencing.yaml

- sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/274113 :green_circle: 

#### qesap_aws_sapconf.yaml

 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/274114   :green_circle: Test fails in Ansible `TASK [Configure cluster IP [aws]]` like the one this vr is cloned from. On the other side the Terraform warning is gone
 
## HanaSR

#### sles4sap_azure_generic_maintenance.yaml

#### sles4sap_azure_generic_uri.yaml

 - sle-15-SP6-Azure-SAP-BYOS-x86_64-Build0404-azure_sap_byos_hanasr_sapconf@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/274118

#### sles4sap_azure_generic.yaml

 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-01-16T05:03:09Z-hanasr_azure_test_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/274117


###  AWS

#### sles4sap_aws_generic.yaml

## mr_test

### Azure

#### mr_test_azure.yaml

#### mr_test_azure_uri.yaml

### AWS

#### mr_test_ec2.yaml

#### mr_test_ec2_product.yaml