### PR TITLE
Enable variable to softfail only some specific subtests

### DIFF
--- a/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
+++ b/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
@@ -4,7 +4,14 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Prepare systemd and testsuite.
-# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>, Thomas Blume <tblume@suse.com>
+#
+# This module works as a 'loader' for the actual systemd-testsuite testcases.
+# - install package systemd-testsuite, that contains a patched version of https://github.com/systemd/systemd
+# - for each test in the upstream testsuite, filter out those mentioned in the variable SYSTEMD_EXCLUDE
+# - for all other, schedule a new openQA testmodule: i.e. loadtest(runner.pm) passing a different name every time
+# - when this module ends, the single tests of the systemd testsuite are being executed by openQA as independent test modules.
+#
+# Maintainer: qe-core@suse.com, Thomas Blume <tblume@suse.com>
 
 use Mojo::Base qw(systemd_testsuite_test);
 use testapi;

--- a/tests/systemd_testsuite/runner.pm
+++ b/tests/systemd_testsuite/runner.pm
@@ -10,6 +10,7 @@ use Mojo::Base qw(systemd_testsuite_test);
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Logging 'save_and_upload_log';
+use version_utils 'is_sle';
 
 my $test_hash;
 my $logs_path_mask = '/var/tmp/systemd-tests/systemd-test';
@@ -29,6 +30,17 @@ sub build_cmd {
     return sprintf('%s make -C %s%s %s', join(" ", @opts), $dir, $test, $target);
 }
 
+# give a chance to softfail some specific subtests, known to not work on current SLE systemd
+sub decide_result {
+    my $name = shift;
+    my $ok_to_softfail = get_var('SYSTEMD_SOFTFAIL');
+    if (is_sle() && $name =~ m/$ok_to_softfail/) {
+        record_soft_failure("poo#151738");
+        return 'softfail';
+    }
+    return 'fail';
+}
+
 sub run {
     my ($self, $args) = @_;
     my $timeout = 900;
@@ -38,8 +50,12 @@ sub run {
     select_serial_terminal();
 
     assert_script_run(build_cmd('clean', $args), timeout => 180);
-    my $out = script_output(build_cmd('setup', $args), 240);
-
+    my $rc = script_run(build_cmd('setup', $args) . "> /tmp/out.txt", timeout => 240);
+    if ($rc != 0) {
+        $self->{result} = decide_result($args->{test});
+        return;
+    }
+    my $out = script_output('cat /tmp/out.txt');
     if ($out =~ $logs) {
         $test_hash = $1;
         record_info("$test_hash", sprintf('Test logs: %s.%s', $logs_path_mask, $test_hash));
@@ -48,16 +64,20 @@ sub run {
     }
 
     my $texec = sprintf('(%s;echo "%s [$?]")', build_cmd('run', $args), $marker);
-    my $test_log = script_output("$texec", $timeout);
-
+    $rc = script_run $texec . "> /tmp/out.txt", timeout => $timeout;
+    if ($rc != 0) {
+        $self->{result} = decide_result($args->{test});
+        return;
+    }
+    my $test_log = script_output 'cat /tmp/out.txt';
     if (defined($test_log) && $test_log =~ qr/$marker\s+\[(\d+)\]$/) {
         if ($1 != 0) {
             bmwqemu::diag "$args->{test} has failed with RC => $1!";
-            $self->{result} = 'fail';
+            $self->{result} = decide_result($args->{test});
         }
     } else {
         bmwqemu::diag "$args->{test} has timed out!";
-        $self->{result} = 'fail';
+        $self->{result} = decide_result($args->{test});
     }
 }
 

--- a/tests/systemd_testsuite/runner.pm
+++ b/tests/systemd_testsuite/runner.pm
@@ -4,7 +4,14 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Run systemd upstream test cases
-# Maintainer: Martin Loviska <mloviska@suse.com>
+#
+# This module is an helper to run a single systemd test case under openQA.
+# It is invoked from prepare_systemd_and_testsuite.pm with autotest::loadtest() and run_args parameter.
+#
+# Since the full upstream systemd testsuite it not yet compatible on SLE, when the test fails
+# or timeouts, if the test name is contained in the SYSTEMD_SOFTFAIL variable, mark it as softfailed.
+#
+# Maintainer: qe-core@suse.com, Martin Loviska <mloviska@suse.com>
 
 use Mojo::Base qw(systemd_testsuite_test);
 use testapi;
@@ -50,6 +57,7 @@ sub run {
     select_serial_terminal();
 
     assert_script_run(build_cmd('clean', $args), timeout => 180);
+    # redirect stdout as a workaround to run the command and keep both the return code and the output
     my $rc = script_run(build_cmd('setup', $args) . "> /tmp/out.txt", timeout => 240);
     if ($rc != 0) {
         $self->{result} = decide_result($args->{test});


### PR DESCRIPTION
As the systemd shipped on SLE cannot yet run the complete upstream systemd testsuite, we enable the feature to softfail only some specific sub-tests.

- Related ticket: https://progress.opensuse.org/issues/151738
- Needles: n/a
- Verification run:  https://openqa.suse.de/tests/13269669

(edit: added the ticket number to soft fail message)
