### PR TITLE
Adjust s390x passed rules number too

### DIFF
--- a/tests/security/oscap_stig/oscap_xccdf_eval.pm
+++ b/tests/security/oscap_stig/oscap_xccdf_eval.pm
@@ -30,7 +30,7 @@ sub run {
         'content_rule_aide_scan_notification');
 
     if (is_s390x) {
-        $n_passed_rules = 215;
+        $n_passed_rules = 214;
         $n_failed_rules = 5;
     }
     # Exclusion for ARM platform


### PR DESCRIPTION
In the earlier PR I forgot to adjust the number of passed cases for s390x.
