### PR TITLE
Limit k3s service pods

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -35,7 +35,7 @@ sub check_k3s {
     assert_script_run('k3s kubectl config view --raw');
     validate_script_output_retry("k3s kubectl get nodes", qr/ Ready.*control-plane,master /, retry => 6, delay => 15, timeout => 90);
     validate_script_output_retry("k3s kubectl get namespaces", qr/default.*Active/, timeout => 120, delay => 60, retry => 3);
-    validate_script_output_retry('k3s kubectl get events -A', qr/Started container coredns/, retry => 6, delay => 30, timeout => 90);
+    validate_script_output_retry('k3s kubectl get events -A', qr/Started container local-path-provisioner/, retry => 6, delay => 30, timeout => 90);
 
     # the default service account should be ready by now
     assert_script_run("k3s kubectl get serviceaccount default -o name");
@@ -93,6 +93,8 @@ sub install_k3s {
     # github.com/k3s-io/k3s#5946 - The kubectl delete namespace helm-ns-413 command freezes and does nothing
     my $disables = '--disable=metrics-server';
     $disables .= ' --disable-helm-controller' unless (get_var('K3S_ENABLE_HELM_CONTROLLER'));
+    $disables .= ' --disable=traefik';
+    $disables .= ' --disable=coredns' unless get_var('K3S_ENABLE_COREDNS');
 
     while (my ($key, $value) = each %k3s_args) {
         if ($value) {


### PR DESCRIPTION
Some of the pods are failing due to multiple reasons and we dont require them for our testing purposes. Therefore we would like to reduce to sporadic issues when starting k3s in for our container tests.

- ticket: https://progress.opensuse.org/issues/152753
##### Verification runs: 

* http://kepler.suse.cz/tests/22543#step/podman_pods/216
* http://kepler.suse.cz/tests/22544#step/kubectl/168
* http://kepler.suse.cz/tests/22542#step/helm_K3S/88