### PR TITLE
lib/power_action_utils.pm: Use only ctrl-alt-del for shutdown

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -216,7 +216,6 @@ sub poweroff_x11 {
     }
 
     if (check_var("DESKTOP", "mate")) {
-        x11_start_program("mate-session-save --shutdown-dialog", valid => 0);
         send_key "ctrl-alt-delete";    # shutdown
         assert_and_click 'mate_shutdown_btn';
     }


### PR DESCRIPTION
Ctrl-alt-del opens the shutdown dialog already, no need to run an obscure command.

- Verification run: https://openqa.opensuse.org/tests/3875528
