### PR TITLE
Support UEFI iPXE autoyast host installation for virt test

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -47,7 +47,7 @@
       <append>loglevel=5 gfxpayload=1024x768 <%= $check_var->('AMD', '1') ? "amd_iommu=on" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
       % }
     </global>
-    <loader_type>grub2</loader_type>
+    <loader_type>default</loader_type>
   </bootloader>
   <general>
     <ask-list config:type="list"/>
@@ -116,7 +116,7 @@
     </interfaces>
   </networking>
   <partitioning config:type="list">
-  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'unreal2' => 'wwn-0x55cd2e415081e693', 'unreal3' => 'wwn-0x55cd2e4150817d43', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x6f4ee0801165fe0029a9209ce8d20dfd'};
+  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'unreal2' => 'wwn-0x55cd2e415081e693', 'unreal3' => 'wwn-0x55cd2e4150817d43', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x5002538e117150d5'};
   % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
   % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : '';
     <drive>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -59,7 +59,7 @@
       <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 <%= $check_var->('AMD', '1') ? "amd_iommu=on" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
       % }
     </global>
-    <loader_type>grub2</loader_type>
+    <loader_type>default</loader_type>
   </bootloader>
   <general>
     <ask-list config:type="list"/>
@@ -110,7 +110,7 @@
     <ntp_sync>systemd</ntp_sync>
   </ntp-client>
   <partitioning config:type="list">
-  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'unreal2' => 'wwn-0x55cd2e415081e693', 'unreal3' => 'wwn-0x55cd2e4150817d43', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x6f4ee0801165fe0029a9209ce8d20dfd'};
+  % my $wwn = {'quinn' => 'wwn-0x5000c50099db2117', 'kermit-1' => 'wwn-0x500a075119406ab6', 'gonzo-1' => 'wwn-0x500a075119406aa6', 'fozzie-1' => 'wwn-0x55cd2e414f1f16f1', 'scooter-1' => 'wwn-0x55cd2e414f1760e2', 'amd-zen3-gpu-sut1-1' => 'wwn-0x500a075133755d4b', 'ix64ph1075' => 'wwn-0x5000c5004f25d745', 'openqaipmi5' => 'wwn-0x5000c5008711f2fc', 'unreal2' => 'wwn-0x55cd2e415081e693', 'unreal3' => 'wwn-0x55cd2e4150817d43', 'ph052' => 'wwn-0x5000c500e28a91bb', 'ph053' => 'wwn-0x5000c500e28a68d7', 'vh001' => 'wwn-0x50014ee0042a24ed', 'vh012' => 'wwn-0x5000c500b905e133', 'vh013' => 'wwn-0x6d0946606f4e7f0026b540d30c0d64a7', 'vh014' => 'wwn-0x6d0946606f4e620026b62d9505faa64b', 'vh015' => 'wwn-0x50000f0a47804240', 'vh016' => 'wwn-0x50000f0a47803ea0', 'vh017' => 'wwn-0x50014ee0af3af7ce', 'vh080' => 'wwn-0x6f4ee08011680e002ae552c4140dfb15', 'vh081' => 'wwn-0x6f4ee0801168bc0029aa28da5a049c94', 'vh082' => 'wwn-0x5002538e117150d5'};
   % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
   % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : ''; 
     <drive>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_one_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_one_disk.xml
@@ -39,7 +39,7 @@
     </yesno_messages>
   </report>
   <bootloader>
-    <loader_type>grub2</loader_type>
+    <loader_type>default</loader_type>
     <global>
       <activate>true</activate>
       <boot_mbr>true</boot_mbr>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_two_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_two_disk.xml
@@ -39,7 +39,7 @@
     </yesno_messages>
   </report>
   <bootloader>
-    <loader_type>grub2</loader_type>
+    <loader_type>default</loader_type>
     <global>
       <activate>true</activate>
       <boot_mbr>true</boot_mbr>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_one_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_one_disk.xml
@@ -39,7 +39,7 @@
     </yesno_messages>
   </report>
   <bootloader>
-    <loader_type>grub2</loader_type>
+    <loader_type>default</loader_type>
     <global>
       <activate>true</activate>
       <boot_mbr>true</boot_mbr>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_two_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_two_disk.xml
@@ -39,7 +39,7 @@
     </yesno_messages>
   </report>
   <bootloader>
-    <loader_type>grub2</loader_type>
+    <loader_type>default</loader_type>
     <global>
       <activate>true</activate>
       <boot_mbr>true</boot_mbr>


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/138317
- Verification run: 
[vh082_autoyast_full_feature_tests](http://10.67.129.27/tests/208)
[vh082_autoyast_ltss_tests](http://10.67.129.27/tests/202)
[vh082_non_autoyast_host_installation](http://10.67.129.27/tests/200)
[vh081_autoyast_full_feature_tests](http://10.67.129.27/tests/215)
[vh081_non_autoyast_host_installation](http://10.67.129.27/tests/213)
[sle12sp5_on_non_UEFI_machines](http://openqa.suse.de/t13276160)   
