### PR TITLE
Add apostrophe when adding parameters into conf file

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -41,7 +41,7 @@ sub extract_settings_qaset_config {
     my @fields = split(/;/, $values);
     if (scalar @fields > 0) {
         foreach my $a_value (@fields) {
-            assert_script_run("echo ${a_value} >> /root/qaset/config");
+            assert_script_run("echo '${a_value}' >> /root/qaset/config");
         }
     }
 }


### PR DESCRIPTION
When we add some parameters into SLEPerf configuration file, we need to use apostrophe. Otherwise the command will fail if there is speical string in parameters, such double quotas.


