### PR TITLE
Revisit soft-failure bsc#1203004 for GMC

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -611,6 +611,10 @@ sub deal_with_dependency_issues {
     }
 }
 
+sub is_sles_in_gm_phase {
+    return !get_var('BETA');
+}
+
 sub save_remote_upload_y2logs {
     my ($self, %args) = @_;
 

--- a/tests/installation/licensing/verify_license_translations.pm
+++ b/tests/installation/licensing/verify_license_translations.pm
@@ -54,8 +54,9 @@ sub run {
         $license_agreement->select_language($found_lang);
         $license_agreement_info = $license_agreement->collect_current_license_agreement_info();
         if ($license_agreement_info->{text} !~ /$translation->{text}/) {
-            record_soft_failure("EULA content for the language: '$translation->{language}' didn't validate. See bsc#1203004 for details.\n");
-            diag("EULA validation failed:\nExpected:\n$translation->{text}\nActual:\n$license_agreement_info->{text}\n\n");
+            my $eula_err = "EULA content for the language: '$translation->{language}' didn't validate.";
+            die($eula_err) if $self->is_sles_in_gm_phase();
+            record_info('EULA', "EULAs usually not ready before GMC: $eula_err");
         }
     }
     # Set language back to default


### PR DESCRIPTION
- Description: Revisit soft-failure [bsc#1203004](https://bugzilla.suse.com/show_bug.cgi?id=1203004), must be fail only for **GMC builds**
- Related ticket: [poo#151837](https://progress.opensuse.org/issues/151837)
- Verification run: [overview](https://openqa.suse.de/tests/overview?build=issues-151837)
- Related [PR#18441](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18441)
