### PR TITLE
podman_netavark: conditionally rm containers.conf (contd.)

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -88,14 +88,17 @@ sub run {
 
     select_serial_terminal;
     my $podman = $self->containers_factory('podman');
-    my $podman_version = get_podman_version();
 
+    my $podman_version = get_podman_version();
     if (package_version_cmp($podman_version, '4.0.0') < 0) {
         record_info('No support', "Netavark backend is not supported in podman-$podman_version");
         return 1;
     }
 
-    switch_to_netavark if is_cni_default || is_cni_in_tw;
+    if ((is_cni_default || is_cni_in_tw) && package_version_cmp($podman_version, '4.8.0') < 0) {
+        switch_to_netavark;
+    }
+
     $podman->cleanup_system_host();
 
     # it is turned off in


### PR DESCRIPTION
The previous PR #18480 was mistakenly merged, this is a follow-up.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1218937
- Verification run: https://openqa.suse.de/tests/13289134
- Related to: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18480
