### PR TITLE
Netavark clean up is broken

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -49,7 +49,7 @@ sub _cleanup {
     my $podman = shift->containers_factory('podman');
     select_console 'log-console';
     remove_subtest_setup;
-
+    script_run('rm -rf /etc/containers/containers.conf');
     $podman->cleanup_system_host();
 
     # podman >=4.8.0 defaults to netavark,
@@ -57,7 +57,6 @@ sub _cleanup {
     # to cni which leads to failing tests
     my $podman_version = get_podman_version();
     if (package_version_cmp($podman_version, '4.8.0') < 0) {
-        script_run('rm -rf /etc/containers/containers.conf');
         validate_script_output('podman info --format {{.Host.NetworkBackend}}', sub { /cni/ });
     } else {
         validate_script_output('podman info --format {{.Host.NetworkBackend}}', sub { /netavark/ });


### PR DESCRIPTION
If CNI is default, it does not restore the backend configuration after config file removal.

#### Verification runs

* [sle15sp6](http://kepler.suse.cz/tests/22563#)
* [sle15sp5]()
* [sle15sp4](http://kepler.suse.cz/tests/22561#step/podman_netavark/281)
* [sle15sp3](http://kepler.suse.cz/tests/22570#step/podman_netavark/1)
* [sle-micro 6.0](http://kepler.suse.cz/tests/22569#step/podman_netavark/1)
* [sle-micro 5.4](http://kepler.suse.cz/tests/22564#step/podman_netavark/1)
* [Tumbleweed-JeOS](http://kepler.suse.cz/tests/22566#step/podman_netavark/1)
* [microos]()
* [container-host-old2microosnext@64bit]()