### PR TITLE
Optimization of patch_and_reboot and transfer_repos

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -297,6 +297,8 @@ sub prepare_ssh_tunnel {
 
 sub kill_packagekit {
     my ($instance) = @_;
+    # sle-micro do not have pkcon installed
+    return if (is_sle_micro);
     my $ret = $instance->ssh_script_run(cmd => "sudo pkcon quit", timeout => 120);
     if ($ret) {
         # Older versions of systemd don't support "disable --now"

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -16,7 +16,6 @@ use strict;
 
 use publiccloud::utils qw(kill_packagekit fully_update_system);
 use publiccloud::ssh_interactive qw(select_host_console);
-use version_utils qw(is_sle_micro);
 
 sub run {
     my ($self, $args) = @_;
@@ -25,7 +24,7 @@ sub run {
     my $cmd_time = time();
     my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;
     # pkcon not present on SLE-micro
-    kill_packagekit($args->{my_instance}) unless (is_sle_micro);
+    kill_packagekit($args->{my_instance});
     $args->{my_instance}->ssh_script_retry("sudo zypper -n --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
     record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');
     record_soft_failure('bsc#1195382 - Considerable decrease of zypper performance and increase of registration times') if ((time() - $cmd_time) > 240);

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -25,8 +25,7 @@ sub run {
     my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
     my @addons = split(/,/, get_var('SCC_ADDONS', ''));
     my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);
-    # /opt folder in Hardened images requires extra permissions so we will use /tmp instead
-    my $repodir = is_hardened() ? "/tmp/repos/" : "/opt/repos/";
+    my $repodir = "/opt/repos/";
     # Trigger to skip the download to speed up verification runs
     if ($skip_mu) {
         record_info('Skip download', 'Skipping maintenance update download (triggered by setting)');


### PR DESCRIPTION
Optimization of patch_and_reboot moving sle-micro check, repodir in transfer_repos set uncoditional

- Related ticket: https://progress.opensuse.org/issues/137168 
- Needles:none
- Verification run: https://openqa.suse.de/tests/13290723
