### PR TITLE
Revert "Fix sporadic issues in yast2_instserver"

### DIFF
--- a/lib/y2_module_guitest.pm
+++ b/lib/y2_module_guitest.pm
@@ -10,8 +10,6 @@ use warnings;
 use utils;
 use testapi;
 use Exporter 'import';
-use version_utils 'is_sle';
-use YaST::workarounds;
 
 our @EXPORT = qw(launch_yast2_module_x11 %setup_nis_nfs_x11);
 our %setup_nis_nfs_x11 = (
@@ -62,7 +60,7 @@ sub launch_yast2_module_x11 {
     diag 'assuming root-auth-dialog, typing password';
     type_password;
     send_key 'ret';
-    apply_workaround_poo124652($args{target_match}, $args{match_timeout}) if (is_sle('>=15-SP4'));
+    assert_screen $args{target_match}, $args{match_timeout};
     # Uses hotkey for gnome, adjust if need for other desktop
     send_key 'alt-f10' if $args{maximize_window};
 }

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -54,7 +54,7 @@ sub test_nfs_instserver {
     assert_screen('yast2-instserver-nfs');
     # use default nfs config
     send_key_and_wait("alt-n", 2);
-    apply_workaround_poo124652('yast2-instserver-ui', 200) if (is_sle('>=15-SP4'));
+    assert_screen('yast2-instserver-ui', 200);
     # finish wizard
     send_key_and_wait("alt-f", 3);
     # check that the nfs instserver is working
@@ -83,7 +83,7 @@ sub test_ftp_instserver {
     type_string "test";
     wait_still_screen 2, 2;
     send_key_and_wait("alt-n", 3);
-    apply_workaround_poo124652('yast2-instserver-ui', 200) if (is_sle('>=15-SP4'));
+    assert_screen('yast2-instserver-ui');
     # finish wizard
     send_key_and_wait("alt-f", 3);
     # check that the ftp instserver is working
@@ -124,9 +124,10 @@ sub test_http_instserver {
     send_key_and_wait("alt-n", 2);
     send_key_and_wait("alt-o", 2);
     apply_workaround_poo124652([qw(yast2-instserver-ui yast2-instserver-change-media)], 300) if (is_sle('>=15-SP4'));
+    assert_screen([qw(yast2-instserver-ui yast2-instserver-change-media)], 300);
     # skip "insert next cd" on SLE 12.x
     send_key_and_wait("alt-s", 2) if is_sle("<=12-SP5") && match_has_tag('yast2-instserver-change-media');
-    apply_workaround_poo124652('yast2-instserver-ui', 200) if (is_sle('>=15-SP4'));
+    assert_screen('yast2-instserver-ui');
     # finish wizard
     send_key_and_wait("alt-f", 3);
     # check that the http instserver is working


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#18434

- needs to be reverted because of failures in YaST Maintenance Update group for SP1. 
- if we replace an `assert_screen` with `apply_workaround_poo12462` that is only called for `is_sle('>=15-SP4')` that means,  we don't do that `assert_screen` on other versions at all. This ends up in failures. 