### PR TITLE
Revert py for qesap to 3.10

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -50,8 +50,8 @@ my @log_files = ();
 use constant QESAPDEPLOY_PREFIX => 'qesapdep';
 
 use constant QESAPDEPLOY_VENV => '/tmp/exec_venv';
-use constant QESAPDEPLOY_PY => 'python3.11';
-use constant QESAPDEPLOY_PIP => 'pip3.11';
+use constant QESAPDEPLOY_PY => 'python3.10';
+use constant QESAPDEPLOY_PIP => 'pip3.10';
 
 our @EXPORT = qw(
   qesap_upload_logs


### PR DESCRIPTION
Revert part of the PC commit to update the tool image. Job using qe-sap-deployment are configured to use a fixed HDD for the pc_tool image. At the moment it is 51.

Partial revert of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18400

Related ticket: ???

# Verification run:

 - HANASR sle-15-SP4-Azure-SAP-BYOS-Incidents-x86_64-******-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/274480 :green_circle: 
 - MR_TEST sle-15-SP4-Azure-SAP-BYOS-Incidents-saptune-x86_64-*******-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/274481  :green_circle: 
 -  QESAP REGRESSION sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit -> http://openqaworker15.qa.suse.cz/tests/274482  :green_circle: 


