### PR TITLE
SLEMicro pc updates: fixes for img_proof issues

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -821,7 +821,6 @@ the second run will update the system.
 
 sub ssh_fully_patch_system {
     my $remote = shift;
-
     my $cmd_time = time();
     # first run, possible update of packager -- exit code 103
     my $ret = script_run("ssh $remote 'sudo zypper -n patch --with-interactive -l'", 1500);

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -15,13 +15,11 @@ use testapi;
 use strict;
 use utils;
 use publiccloud::ssh_interactive "select_host_console";
-use publiccloud::utils qw(is_hardened);
 use maintenance_smelt qw(is_embargo_update);
 
 sub run {
     my ($self, $args) = @_;
     select_host_console();    # select console on the host, not the PC instance
-
     my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
     my @addons = split(/,/, get_var('SCC_ADDONS', ''));
     my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);


### PR DESCRIPTION
Followup to PR 18454, SLEMicro pc updates fixes for img_proof issues.

The img_proof pubcloud test had some unpredictable and irregular impact from the new routine structure of named PR. In particular in some VR tests the test_sles_hardened.py remained blocked for an internl error, but also internal img_proof tests reboots losted the instance reference.  
This new structure better marks differences of new added code for `sle_micro` management, `else` using the original code, improving tests resilience.

- Related ticket: https://progress.opensuse.org/issues/137168
- Needles: none
- Verification run: https://openqa.suse.de/tests/13314994
  - More VR to follow
