### PR TITLE
Oscap: adjust allowed failed rules

### DIFF
--- a/tests/security/oscap_stig/oscap_xccdf_eval.pm
+++ b/tests/security/oscap_stig/oscap_xccdf_eval.pm
@@ -20,27 +20,33 @@ sub run {
     # Get ds file and profile ID
     my $f_ssg_ds = is_sle ? $oscap_tests::f_ssg_sle_ds : $oscap_tests::f_ssg_tw_ds;
     my $profile_ID = is_sle ? $oscap_tests::profile_ID_sle_stig : $oscap_tests::profile_ID_tw;
-    my $n_passed_rules = 215;
-    my $n_failed_rules = 5;
+    my $n_passed_rules = 212;
+    my $n_failed_rules = 8;
     my @eval_match = (
+        'content_rule_grub2_uefi_password',
         'content_rule_is_fips_mode_enabled',
-        'content_rule_partition_for_var_log_audit',
-        'content_rule_grub2_password',
+        'content_rule_smartcard_configure_cert_checking',
+        'content_rule_install_smartcard_packages',
         'content_rule_no_files_unowned_by_user',
-        'content_rule_aide_scan_notification');
+        'content_rule_partition_for_var_log_audit',
+        'content_rule_aide_scan_notification',
+        'content_rule_smartcard_configure_ca');
 
     if (is_s390x) {
-        $n_passed_rules = 214;
-        $n_failed_rules = 5;
+        $n_passed_rules = 211;
+        $n_failed_rules = 8;
     }
     # Exclusion for ARM platform
     if (is_aarch64 or is_arm) {
         @eval_match = (
-            'content_rule_is_fips_mode_enabled',
-            'content_rule_partition_for_var_log_audit',
-            'content_rule_grub2_uefi_password',
-            'content_rule_no_files_unowned_by_user',
-            'content_rule_aide_scan_notification');
+        'content_rule_grub2_uefi_password',
+        'content_rule_is_fips_mode_enabled',
+        'content_rule_smartcard_configure_cert_checking',
+        'content_rule_install_smartcard_packages',
+        'content_rule_no_files_unowned_by_user',
+        'content_rule_partition_for_var_log_audit',
+        'content_rule_aide_scan_notification',
+        'content_rule_smartcard_configure_ca');
     }
 
     $self->oscap_evaluate($f_ssg_ds, $profile_ID, $n_passed_rules, $n_failed_rules, \@eval_match);

--- a/tests/security/oscap_stig/oscap_xccdf_eval.pm
+++ b/tests/security/oscap_stig/oscap_xccdf_eval.pm
@@ -39,14 +39,14 @@ sub run {
     # Exclusion for ARM platform
     if (is_aarch64 or is_arm) {
         @eval_match = (
-        'content_rule_grub2_uefi_password',
-        'content_rule_is_fips_mode_enabled',
-        'content_rule_smartcard_configure_cert_checking',
-        'content_rule_install_smartcard_packages',
-        'content_rule_no_files_unowned_by_user',
-        'content_rule_partition_for_var_log_audit',
-        'content_rule_aide_scan_notification',
-        'content_rule_smartcard_configure_ca');
+            'content_rule_grub2_uefi_password',
+            'content_rule_is_fips_mode_enabled',
+            'content_rule_smartcard_configure_cert_checking',
+            'content_rule_install_smartcard_packages',
+            'content_rule_no_files_unowned_by_user',
+            'content_rule_partition_for_var_log_audit',
+            'content_rule_aide_scan_notification',
+            'content_rule_smartcard_configure_ca');
     }
 
     $self->oscap_evaluate($f_ssg_ds, $profile_ID, $n_passed_rules, $n_failed_rules, \@eval_match);


### PR DESCRIPTION
The number of allowed failed rules need adjustment again. 

- Related ticket: https://progress.opensuse.org/issues/154084
- Verification run: <todo>
