### PR TITLE
Fix hardened tests on img_proof

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -274,7 +274,7 @@ sub prepare_ssh_tunnel {
     # Permit root passwordless login over SSH
     $instance->ssh_assert_script_run('sudo cat /etc/ssh/sshd_config');
     $instance->ssh_assert_script_run('sudo sed -i "s/PermitRootLogin no/PermitRootLogin prohibit-password/g" /etc/ssh/sshd_config');
-    $instance->ssh_assert_script_run('sudo sed -iE "/^AllowTcpForwarding/c\AllowTcpForwarding yes" /etc/ssh/sshd_config') if (is_hardened());
+    $instance->ssh_assert_script_run('sudo sed -i "/^AllowTcpForwarding/c\AllowTcpForwarding yes" /etc/ssh/sshd_config') if (is_hardened());
     $instance->ssh_assert_script_run('sudo systemctl reload sshd');
 
     # Copy SSH settings for remote root


### PR DESCRIPTION
This PR is a hotfix for the hardened_test on img_proof:
- Fix the permissions on /etc/ssh/sshd_config
- Disable pam_apparmor (which is not even configured and has been [problematic](https://confluence.suse.com/display/SAP/Testing+of+Public+Cloud+Hardened+Images) in the past.  It prevents sudo from running inside pytest which is run by img-proof.

TODO:
- Generate the SCAP report and upload it (another PR).

Bugs opened:
- [openssh-server upgrade changes permissions for sshd_config from 0600 to 0640](https://bugzilla.suse.com/show_bug.cgi?id=1219100)

--

- Related ticket: https://progress.opensuse.org/issues/153982
- Verification run: https://openqa.suse.de/tests/13318097