### PR TITLE
pc: Add read permissions to SCAP report to download it

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -71,6 +71,7 @@ sub run {
     parse_extra_log(IPA => $img_proof->{results});
     assert_script_run('rm -rf img_proof_results');
 
+    $instance->run_ssh_command(cmd => 'sudo chmod a+r /var/tmp/report.html', no_quote => 1);
     $instance->upload_log('/var/tmp/report.html', failok => 1);
 
     # fail, if at least one test failed


### PR DESCRIPTION
Finally a shiny SCAP report in:
https://openqa.suse.de/tests/13323447/file/img_proof-report.html

Related PR:
https://github.com/SUSE-Enceladus/img-proof/pull/372
