### PR TITLE
pc: Use ssh_script_run in case report path doesn't exist

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -71,7 +71,7 @@ sub run {
     parse_extra_log(IPA => $img_proof->{results});
     assert_script_run('rm -rf img_proof_results');
 
-    $instance->run_ssh_command(cmd => 'sudo chmod a+r /var/tmp/report.html', no_quote => 1);
+    $instance->ssh_script_run(cmd => 'sudo chmod a+r /var/tmp/report.html', no_quote => 1);
     $instance->upload_log('/var/tmp/report.html', failok => 1);
 
     # fail, if at least one test failed


### PR DESCRIPTION
Fix for failing test: https://openqa.suse.de/tests/13317903#step/img_proof/53