### PR TITLE
Enable coredns for helm-rmt container image testing

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -243,6 +243,7 @@ sub load_container_tests {
     }
 
     if (get_var('HELM_CONFIG')) {
+        set_var('K3S_ENABLE_COREDNS', 1);
         loadtest 'containers/helm_rmt';
         return;
     }


### PR DESCRIPTION
In order to avoid connectivity issues, we need to enable coredns container in k3s server.

```
Defaulted container "rmt-app" out of: rmt-app, rmt-app-init (init)
error: unable to upgrade connection: container not found ("rmt-app")
```
- Verification run: http://kepler.suse.cz/tests/22600#