### PR TITLE
Containers: zypper install skipped for LTSS latest

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -251,17 +251,24 @@ sub test_systemd_install {
     my %args = @_;
     my $image = $args{image};
     my $runtime = $args{runtime};
-
     die 'Argument $image not provided!' unless $image;
     die 'Argument $runtime not provided!' unless $runtime;
-
+    # reference values:
+    my $leap_vmin = '15.4';
+    my $sle_vmin = '15-SP4';
+    my $bci_vmin = '15-SP5';
+    my $flavor_skip = "Online";
+    # release
     my ($image_version, $image_sp, $image_id) = get_os_release("$runtime run --entrypoint '' $image");
     # TW and starting with SLE 15-SP4/Leap15.4 systemd's dependency with udev has been dropped
     if ($image_id eq 'opensuse-tumbleweed' ||
-        ($image_id eq 'opensuse-leap' && check_version('>=15.4', "$image_version.$image_sp", qr/\d{2}\.\d/)) ||
-        ($image_id eq 'sles' && check_version('>=15-SP4', "$image_version-SP$image_sp", qr/\d{2}-sp\d/))) {
+        ($image_id eq 'opensuse-leap' && check_version('>=' . $leap_vmin, "$image_version.$image_sp", qr/\d{2}\.\d/)) ||
+        ($image_id eq 'sles' && check_version('>=' . $sle_vmin, "$image_version-SP$image_sp", qr/\d{2}-sp\d/))) {
+        # Skip run case:
+        return 0 if (get_var('FLAVOR') =~ /$flavor_skip/ &&
+            $image_id eq 'sles' && check_version('<' . $bci_vmin, "$image_version-SP$image_sp", qr/\d{2}-sp\d/));
         # lock to SLE_BCI repo for SLES versions not under LTSS (LTSS has no BCI repo anymore)
-        my $repo = ($image_id eq 'sles' && check_version('>=15-SP5', "$image_version-SP$image_sp", qr/\d{2}-sp\d/)) ? '-r SLE_BCI' : '';
+        my $repo = ($image_id eq 'sles' && check_version('>=' . $bci_vmin, "$image_version-SP$image_sp", qr/\d{2}-sp\d/)) ? '-r SLE_BCI' : '';
         assert_script_run("$runtime run $image /bin/bash -c 'zypper al udev && zypper -n in $repo systemd'", timeout => 300);
     }
 }


### PR DESCRIPTION
Containers: zypper install using SLE_BCI from 15-SP4 shall be skipped for LTSS in Latest.

See other info in https://progress.opensuse.org/issues/154159#note-2.

- Related ticket: https://progress.opensuse.org/issues/154159
- Needles:N/A
- Verification run: see body posts