### PR TITLE
Revisit launch_yast2_module_x11 to use parameter to apply workaround

### DIFF
--- a/lib/y2_module_guitest.pm
+++ b/lib/y2_module_guitest.pm
@@ -35,7 +35,8 @@ Launch a yast configuration module C<$module> or the yast control center if C<$m
 
 Calls C<assert_screen> on C<$target_match>, defaults to C<yast2-$module-ui>.
 
-Optional C<$match_timeout> can be specified as a timeout on the C<assert_screen> call on C<$target_match>. 
+Optional C<$match_timeout> can be specified as a timeout on the C<assert_screen> call on C<$target_match>.
+Optional C<$apply_workaround> can be specified as all apply_workaround_poo124652 on the C<assert_screen> call on C<$target_match>.
 C<$maximize_window> option allows to maximize application window using shortcut.
 
 =cut
@@ -44,6 +45,7 @@ sub launch_yast2_module_x11 {
     my ($module, %args) = @_;
     $module //= '';
     $args{target_match} //= $module ? "yast2-$module-ui" : 'yast2-ui';
+    $args{apply_workaround} //= 0;
     my @tags = ['root-auth-dialog', ref $args{target_match} eq 'ARRAY' ? @{$args{target_match}} : $args{target_match}];
     # Terminate yast processes which may still run
     if (get_var('YAST2_GUI_TERMINATE_PREVIOUS_INSTANCES')) {
@@ -62,8 +64,12 @@ sub launch_yast2_module_x11 {
     diag 'assuming root-auth-dialog, typing password';
     type_password;
     send_key 'ret';
-    wait_still_screen 2, 2;
-    is_sle('>=15-SP4') ? apply_workaround_poo124652($args{target_match}, $args{match_timeout}) : assert_screen $args{target_match}, $args{match_timeout};
+    if ($args{apply_workaround}) {
+        apply_workaround_poo124652($args{target_match}, $args{match_timeout});
+    }
+    else {
+        assert_screen $args{target_match}, $args{match_timeout};
+    }
     # Uses hotkey for gnome, adjust if need for other desktop
     send_key 'alt-f10' if $args{maximize_window};
 }

--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -143,7 +143,7 @@ sub test_http_instserver {
 }
 
 sub start_yast2_instserver {
-    y2_module_guitest::launch_yast2_module_x11("instserver", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("instserver", match_timeout => 120, apply_workaround => is_sle('>=15-SP4') ? 1 : 0);
     wait_still_screen;
 }
 


### PR DESCRIPTION
- Description:
    -   Revisit launch_yast2_module_x11 to use parameter to apply workaround
- Related ticket:
    -  https://progress.opensuse.org/issues/153379
- Needles: N/A
- Verification run: 
     - [**15sp5**](https://openqa.suse.de/tests/overview?distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23gui_refresh_2nd&version=15-SP5)
     - [**15sp4**](https://openqa.suse.de/tests/overview?distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23gui_refresh_2nd&version=15-SP4)
     - [**15sp3**](https://openqa.suse.de/tests/overview?distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23gui_refresh_2nd&version=15-SP3)
