### PR TITLE
Expand cloud-netconfig test coverage to GCE and EC2

### DIFF
--- a/tests/publiccloud/cloud_netconfig.pm
+++ b/tests/publiccloud/cloud_netconfig.pm
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: cloud-netconfig-{azure, gc2, gce}
+# Package: cloud-netconfig-{azure, ec2, gce}
 # Summary: This test ensures the consistency of cloud-netconfig's
 # functionality. The test shall be conducted on a VM in the cloud
 # infrastructure of a supported CSP.
@@ -15,12 +15,17 @@ use Mojo::Base 'publiccloud::basetest';
 use Test::Assert 'assert_equals';
 use testapi;
 use version_utils 'is_sle';
+use publiccloud::utils qw(is_azure is_ec2 is_gce);
 
 sub run {
     my ($self, $args) = @_;
     my $instance = $args->{my_instance};
     my $os_version = get_var('VERSION');
     my $pers_net_rules = '/etc/udev/rules.d/75-persistent-net-generator.rules';
+
+    # Cloud metadata service API is reachable at local destination
+    # 169.254.169.254 in case of all public cloud providers.
+    my $pc_meta_api_ip = '169.254.169.254';
 
     my $cloud_netconfig_svc_status = $instance->ssh_script_run(
         cmd => 'systemctl status cloud-netconfig.service');
@@ -50,10 +55,26 @@ sub run {
       $instance->ssh_script_output(cmd => $grep_cloudvm_ipv4_cmd);
     chomp($local_eth0_ip);
 
-    my $query_meta_ipv4_cmd =
-      'curl -H Metadata:true '
-      . '"http://169.254.169.254/metadata/instance/network/interface/0/ipv4/'
-      . 'ipAddress/0/privateIpAddress?api-version=2023-07-01&format=text"';
+    my $query_meta_ipv4_cmd = "";
+    if (is_azure()) {
+        $query_meta_ipv4_cmd =
+          'curl -H Metadata:true '
+          . "\"http://$pc_meta_api_ip/metadata/instance/network/interface/0/"
+          . 'ipv4/ipAddress/0/privateIpAddress?api-version=2023-07-01'
+          . '&format=text"';
+    }
+    elsif (is_ec2()) {
+        $query_meta_ipv4_cmd =
+          "curl \"http://$pc_meta_api_ip/latest/meta-data/local-ipv4\"";
+    }
+    elsif (is_gce()) {
+        $query_meta_ipv4_cmd =
+          'curl -H "Metadata-Flavor: Google" '
+          . "\"http://$pc_meta_api_ip/computeMetadata/v1/instance/"
+          . 'network-interfaces/0/ip"';
+    } else {
+        die("Unsupported public cloud provider.");
+    }
     my $metadata_eth0_ip =
       $instance->ssh_script_output(cmd => $query_meta_ipv4_cmd);
     assert_equals($metadata_eth0_ip, $local_eth0_ip,


### PR DESCRIPTION
This PR does expand existing minimal cloud-netconfig test coverage to include GCE and EC2 alongside Azure.

- Related ticket: https://progress.opensuse.org/issues/136235
- Verification runs:
Azure: https://openqa.suse.de/tests/13356451
GCE: https://openqa.suse.de/tests/13356712
EC2: https://openqa.suse.de/tests/13356711