### PR TITLE
Use check_screen for expected_grub in process_reboot

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -111,8 +111,9 @@ sub process_reboot {
                 unlock_if_encrypted();
             }
             # Replace by wait_boot if possible
-            assert_screen 'grub2', 150;
-            wait_screen_change { send_key 'ret' };
+            if (check_screen 'grub2', 150) {
+                wait_screen_change { send_key 'ret' };
+            }
         }
         assert_screen 'linux-login', 200;
 


### PR DESCRIPTION
process_reboot cannot catch grub2 needle on MicroOS 6.0(autoboot in GRUB), thus grub2 check should not be mandatory.

- Related ticket: https://progress.opensuse.org/issues/154087
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/13355769 (on ALP)
https://openqa.suse.de/tests/13355691 (on Marble)
