### PR TITLE
Add python3 to avoid dependency popup

### DIFF
--- a/tests/installation/module_selection/select_nonconflicting_modules.pm
+++ b/tests/installation/module_selection/select_nonconflicting_modules.pm
@@ -21,7 +21,7 @@ use warnings;
 
 sub run {
     $testapi::distri->get_module_selection()->select_modules(
-        [qw(containers desktop development legacy web)]);
+        [qw(containers desktop development legacy web python)]);
 }
 
 1;


### PR DESCRIPTION
Quick fix for [unexpected popup dialog](https://openqa.suse.de/tests/13351512#step/addon_products_via_SCC_yast2/21) to satisfy dependency for `lifecycle-data-sle-module-python3` package.

[Verification run](https://openqa.suse.de/tests/13357532#) 