### PR TITLE
Make s390x kvm setup information more visable

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -66,7 +66,6 @@ sub set_svirt_domain_elements {
 sub run {
     my $svirt = select_console('svirt', await_console => 0);
 
-    record_info('SUT hostname', $svirt->get_cmd_output('hostname'));
     record_info('free -h', $svirt->get_cmd_output('free -h'));
     record_info('virsh freecell --all', $svirt->get_cmd_output('virsh freecell --all'));
     record_info('virsh domstats', $svirt->get_cmd_output('virsh domstats'));
@@ -76,6 +75,9 @@ sub run {
     zkvm_add_interface $svirt;
 
     $svirt->define_and_start;
+    record_info('SUT hostname', get_var('VIRSH_HOSTNAME'));
+    record_info('VM instance', get_var('VIRSH_INSTANCE'));
+    record_info('Guest ip', get_var('VIRSH_GUEST'));
 
     if (!get_var("BOOT_HDD_IMAGE") or (get_var('PATCHED_SYSTEM') and !get_var('ZDUP'))) {
         if (check_var("VIDEOMODE", "text")) {


### PR DESCRIPTION
- Verification run: 
  [SUT hostname](https://openqa.suse.de/tests/13373142#step/bootloader_zkvm/32)
  [VM instance](https://openqa.suse.de/tests/13373142#step/bootloader_zkvm/33)
  [Guest ip](https://openqa.suse.de/tests/13373142#step/bootloader_zkvm/34)
