### PR TITLE
containers: Use .txt for extension and do not tar /proc/self

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -238,7 +238,7 @@ sub test_container_image {
     my %args = @_;
     my $image = $args{image};
     my $runtime = $args{runtime};
-    my $logfile = "/var/tmp/container_logs";
+    my $logfile = "/var/tmp/container_logs.txt";
 
     die 'Argument $image not provided!' unless $image;
     die 'Argument $runtime not provided!' unless $runtime;

--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -97,8 +97,6 @@ sub post_fail_hook {
     cleanup();
     select_serial_terminal();
     save_and_upload_log('cat /etc/{subuid,subgid}', "/tmp/permissions.txt");
-    assert_script_run("tar -capf /tmp/proc_files.tar.xz /proc/self");
-    upload_logs("/tmp/proc_files.tar.xz");
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -206,8 +206,6 @@ sub post_run_hook {
 sub post_fail_hook {
     my $self = shift;
     save_and_upload_log('cat /etc/{subuid,subgid}', "/tmp/permissions.txt");
-    assert_script_run("tar -capf /tmp/proc_files.tar.xz /proc/self");
-    upload_logs("/tmp/proc_files.tar.xz");
     if (is_sle) {
         save_and_upload_log('ls -la /etc/zypp/credentials.d', "/tmp/credentials.d.perm.txt");
         assert_script_run "setfacl -x u:$testapi::username /etc/zypp/credentials.d/*";


### PR DESCRIPTION
- Use .txt for extension in log to be browser-friendly.
- It's impossible to use `tar` on `/proc/self`.  First it only grabs the self symlink and secondly tar doesn't work on pseudo-filesystems that advertize a zero size for "regular" files.

https://openqa.suse.de/tests/13364962/file/rootless_podman-proc_files.tar.xz