### PR TITLE
Use proxy server from s390x's network

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -15,6 +15,7 @@ use containers::utils qw(get_podman_version registry_url);
 use transactional qw(trup_call check_reboot_changes);
 use utils qw(zypper_call);
 use Utils::Systemd qw(systemctl);
+use Utils::Architectures qw(is_s390x);
 
 sub is_cni_in_tw {
     return (script_output("podman info -f '{{.Host.NetworkBackend}}'") =~ "cni") && is_microos && get_var('TDUP');
@@ -205,7 +206,7 @@ sub run {
 
         my $dev = script_output(q(ip -br link show | awk '/UP / {print $1}'| head -n 1));
         my $extra = '';
-        if (is_public_cloud) {
+        if (is_public_cloud || is_s390x) {
             my $sn = script_output(qq(ip -o -f inet addr show $dev | awk '/scope global/ {print \$4}' | head -n 1)) =~ s/\.\d+\//\.0\//r;
             $extra .= "--subnet $sn ";
             my $gw = $sn =~ s/0\/\d+$/1/r;


### PR DESCRIPTION
Same situation as for PC, netavark dhcp proxy could not receive a lease.
Therefore when starting a container tests need to be careful what IPs
are being used.

- ticket: [Investigate failure of podman_netavark on
  s390x](https://progress.opensuse.org/issues/152194)
- VR: https://openqa.suse.de/tests/13374393#step/podman_netavark/258