### PR TITLE
Enable use_suseconnect argument for registration.yaml

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -728,7 +728,7 @@ sub create_playbook_section_list {
         if ($args{registration} eq 'suseconnect') {
             # For the moment, only role version of the registration playbook, using roles from community.sles-for-sap,
             # is supporting force suseconnec.
-            push @playbook_list, "registration_role.yaml $reg_code -e use_suseconnect=true";
+            push @playbook_list, "registration.yaml $reg_code -e use_suseconnect=true";
         }
         else {
             push @playbook_list, "registration.yaml $reg_code";

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -453,8 +453,7 @@ subtest '[create_playbook_section_list] registration => suseconnect' => sub {
     set_var('SCC_REGCODE_SLES4SAP', undef);
     set_var('USE_SAPCONF', undef);
     note("\n  -->  " . join("\n  -->  ", @$ansible_playbooks));
-    ok((any { /.*registration_role\.yaml.*/ } @$ansible_playbooks), 'registration_role playbook is called when registration => suseconnect');
-    ok((any { /.*use_suseconnect=true.*/ } @$ansible_playbooks), 'registration_role playbook is called with use_suseconnect=true when registration => suseconnect');
+    ok((any { /.*use_suseconnect=true.*/ } @$ansible_playbooks), 'registration playbook is called with use_suseconnect=true when registration => suseconnect');
 };
 
 done_testing;


### PR DESCRIPTION
Change the `registration` playbook to take an optional argument `use_suseconnect`, similar to the registration role.

- Related ticket: https://jira.suse.com/browse/TEAM-8980
- Verification run: 
https://openqa.suse.de/tests/13374416 
https://openqa.suse.de/tests/13375013 (EC2)

**NOTE**: Merge together with https://github.com/SUSE/qe-sap-deployment/pull/203