### PR TITLE
Fix publiccloud::azure::cleanup() for SLES4SAP

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -604,7 +604,7 @@ sub cleanup {
     my ($self, $args) = @_;
     select_host_console(force => 1);
 
-    $self->get_image_version();
+    $self->get_image_version() if (get_var('PUBLIC_CLOUD_BUILD'));
 
     if (defined($args->{my_instance}->{instance_id})) {
         my $id = $args->{my_instance}->{instance_id};


### PR DESCRIPTION
Fixing #18529

From @a-kpappas:
> This broke saptune tests https://openqa.suse.de/tests/13375715#step/ssh_interactive_end/29 (reposting here to trigger notifications)