### PR TITLE
Enable flatpak tests for 15+

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2027,7 +2027,7 @@ sub load_x11_other {
             loadtest "x11/seahorse";
             loadtest "x11/gnome_music";
         }
-        loadtest 'x11/flatpak' if (is_opensuse);
+        loadtest 'x11/flatpak' if (is_opensuse || is_sle('15+'));
     }
     # shotwell was replaced by gnome-photos in SLE15 & yast_virtualization isn't in SLE15
     if (is_sle('>=12-sp2') && is_sle('<15')) {


### PR DESCRIPTION
Enable flatpak for SLE 15+, see ECO https://jira.suse.com/browse/PED-7568
 
- VR https://openqa.suse.de/tests/overview?distri=sle&build=ECO-7568&groupid=414
