### PR TITLE
Add temporary s390x condition for suseconnect

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -316,7 +316,7 @@ sub register_addons_cmd {
             }
             elsif (grep(/$name/, keys %ADDONS_REGCODE)) {
                 my $opt = "";
-                if (is_sle("=15-SP4")) {
+                if (is_sle("=15-SP4") && !(is_s390x)) {
                     $opt = " --auto-agree-with-licenses";
                 }
                 add_suseconnect_product($name, undef, undef, "-r " . $ADDONS_REGCODE{$name} . $opt, 300, $retry);


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/154120
- Verification runs:   https://openqa.suse.de/tests/overview?distri=sle&build=sofiasyria%2Fos-autoinst-distri-opensuse%23temp_s390&version=15-SP6
