### PR TITLE
Fix python3-setuptools

### DIFF
--- a/tests/console/python3_setuptools.pm
+++ b/tests/console/python3_setuptools.pm
@@ -90,7 +90,7 @@ sub uninstall_package ($version_number) {
 
 sub cleanup {
     # Deletion of work folders
-    assert_script_run("rm -r dist user_package_setuptools.egg-info repo_webroot");
+    assert_script_run("rm -rf dist user_package_setuptools.egg-info repo_webroot");
     assert_script_run("deactivate");    # leave the virtual env
 }
 

--- a/tests/console/python3_setuptools.pm
+++ b/tests/console/python3_setuptools.pm
@@ -46,7 +46,6 @@ sub run_tests ($python3_spec_release) {
     build_package($python_binary);
     http_install_test($version_number);
     local_install_test($version_number);
-    cleanup();
 }
 
 # Creating the source package with the name 'dist/user_package_setuptools-1.0.tar.gz' in the dist folder.


### PR DESCRIPTION
Cleanup already runs on post, remove call on test function
Force deletion during cleanup, would not consider failure if some dirs are leftover or were not present while cleaning up

- Related ticket: https://progress.opensuse.org/issues/154588
- Verification run: https://openqa.suse.de/tests/13391757