### PR TITLE
helm: Fix cURL parameters (create-dirs, not create-dir)

### DIFF
--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -102,10 +102,10 @@ sub run {
 
     install_helm();
 
-    assert_script_run('curl --create-dir -vo ~/helm-test/Chart.yaml ' . data_url('containers/helm-test/') . 'Chart.yaml');
-    assert_script_run('curl --create-dir -vo ~/helm-test/values.yaml ' . data_url('containers/helm-test/') . 'values.yaml');
-    assert_script_run('curl --create-dir -vo ~/helm-test/templates/job.yaml ' . data_url('containers/helm-test/templates/') . 'job.yaml');
-    assert_script_run('curl --create-dir -vo ~/helm-test/templates/NOTES.txt ' . data_url('containers/helm-test/templates/') . 'NOTES.txt');
+    assert_script_run('curl --create-dirs -vo ~/helm-test/Chart.yaml ' . data_url('containers/helm-test/') . 'Chart.yaml');
+    assert_script_run('curl --create-dirs -vo ~/helm-test/values.yaml ' . data_url('containers/helm-test/') . 'values.yaml');
+    assert_script_run('curl --create-dirs -vo ~/helm-test/templates/job.yaml ' . data_url('containers/helm-test/templates/') . 'job.yaml');
+    assert_script_run('curl --create-dirs -vo ~/helm-test/templates/NOTES.txt ' . data_url('containers/helm-test/templates/') . 'NOTES.txt');
 
     assert_script_run("kubectl create namespace helm-ns-$job_id");
     assert_script_run("kubectl config set-context --current --namespace=helm-ns-$job_id");


### PR DESCRIPTION

- Related ticket: cURL 8.6.0 is stricter on cli parameters (https://openqa.opensuse.org/tests/3908674#step/helm_K3S/130)
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/3908751#live
