### PR TITLE
LTP: Don't set TMPDIR

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -150,7 +150,7 @@ sub export_ltp_env {
 
 # Set up basic shell environment for running LTP tests
 sub prepare_ltp_env {
-    assert_script_run('export LTPROOT=' . get_ltproot() . '; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
+    assert_script_run('export LTPROOT=' . get_ltproot() . '; export LTP_COLORIZE_OUTPUT=n PATH=$LTPROOT/testcases/bin:$PATH');
 
     # setup for LTP networking tests
     assert_script_run("export PASSWD='$testapi::password'");


### PR DESCRIPTION
`TMPDIR=/tmp` was set long time ago in 741f15a65 in early implementation of openQA LTP runner. I don't think it was needed even back then.

But later, when prepare_ltp_env() was added in deae63bb6, it was called more times, thus it overwrite `TMPDIR` set for some testsuited via LTP_ENV openQA variable.

NOTE: `TMPDIR` setup is needed e.g. for ltp_fs on Tumbleweed (e.g. for isofs) or for ltp_syscalls (e.g. for fallocate06 https://openqa.opensuse.org/tests/3908370#step/fallocate06/6 due https://github.com/linux-test-project/ltp/commit/3626124a42adfe536af2abff63213fa1ccc63795).

- Verification run: http://quasar.suse.cz/tests/3141#step/isofs/8
@mdoucha @czerw @acerv FYI