### PR TITLE
Remove PUBLIC_CLOUD_PROVIDER from qesap_get_nodes_*

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -511,10 +511,18 @@ sub qesap_get_inventory {
 =head3 qesap_get_nodes_number
 
 Get the number of cluster nodes from the inventory.yaml
+
+=over 1
+
+=item B<PROVIDER> - Cloud provider name using same format of PUBLIC_CLOUD_PROVIDER setting
+
+=back
 =cut
 
 sub qesap_get_nodes_number {
-    my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my (%args) = @_;
+    croak "Missing mandatory argument 'provider'" unless $args{provider};
+    my $inventory = qesap_get_inventory(provider => $args{provider});
     my $yp = YAML::PP->new();
 
     my $inventory_content = script_output("cat $inventory");
@@ -529,10 +537,18 @@ sub qesap_get_nodes_number {
 =head3 qesap_get_nodes_names
 
 Get the cluster nodes' names from the inventory.yaml
+
+=over 1
+
+=item B<PROVIDER> - Cloud provider name using same format of PUBLIC_CLOUD_PROVIDER setting
+
+=back
 =cut
 
 sub qesap_get_nodes_names {
-    my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my (%args) = @_;
+    croak "Missing mandatory argument 'provider'" unless $args{provider};
+    my $inventory = qesap_get_inventory(provider => $args{provider});
     my $yp = YAML::PP->new();
 
     my $inventory_content = script_output("cat $inventory");

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -1088,7 +1088,10 @@ sub cypress_configs {
       ' -f Premium' .
       ' -n %s' .
       ' --trento-version %s',
-      $machine_ip, get_trento_password(), qesap_get_nodes_number(), get_required_var('TRENTO_VERSION');
+      $machine_ip,
+      get_trento_password(),
+      qesap_get_nodes_number(provider => get_required_var('PUBLIC_CLOUD_PROVIDER')),
+      get_required_var('TRENTO_VERSION');
     if (get_var('TRENTO_AGENT_RPM')) {
         my $cypress_env_cmd .= ' -a ' . get_var('TRENTO_AGENT_RPM');
     }

--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -211,8 +211,10 @@ subtest '[cypress_configs]' => sub {
 
     my $ver = '9.8.7';
     set_var('TRENTO_VERSION' => $ver);
+    set_var('PUBLIC_CLOUD_PROVIDER' => 'CACIOTTA');
     cypress_configs('/FESTA/BANCONE/SPREMUTA');
     set_var('TRENTO_VERSION', undef);
+    set_var('PUBLIC_CLOUD_PROVIDER', undef);
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  L-->  " . join("\n  L-->  ", @logs));
     ok((any { /cypress\.env\.py -u .*43\.43\.43\.43 -p SPUMA_DI_TONNO -f Premium -n $nodes --trento-version $ver/ } @calls), '[cypress.env.py] cmd is ok');

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -411,8 +411,6 @@ subtest '[qesap_file_find_string] fail' => sub {
 subtest '[qesap_get_nodes_number]' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     my @calls;
-    my $cloud_provider = 'NEMO';
-    set_var('PUBLIC_CLOUD_PROVIDER', $cloud_provider);
     my $str = <<END;
 all:
   children:
@@ -436,9 +434,8 @@ END
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return $str; });
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
 
-    my $res = qesap_get_nodes_number();
+    my $res = qesap_get_nodes_number(provider => 'NEMO');
 
-    set_var('PUBLIC_CLOUD_PROVIDER', undef);
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     is $res, 3, 'Number of agents like expected';
     like $calls[0], qr/cat.*\/CRUSH/;
@@ -1017,11 +1014,9 @@ all:
 END
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return $str; });
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
-    set_var('PUBLIC_CLOUD_PROVIDER', 'NEMO');
 
-    my @hosts = qesap_get_nodes_names();
+    my @hosts = qesap_get_nodes_names(provider => 'NEMO');
 
-    set_var('PUBLIC_CLOUD_PROVIDER', undef);
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  H-->  " . join("\n  H-->  ", @hosts));
     ok((scalar @hosts == 3), 'Exactly 3 hosts in the example inventory');

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -12,14 +12,15 @@ use qesapdeployment;
 
 sub run {
     my ($self) = @_;
+    my $provider = get_required_var('PUBLIC_CLOUD_PROVIDER');
     my @ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => 1800);
     die "'qesap.py terraform' return: $ret[0]" if ($ret[0]);
-    my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
+    my $inventory = qesap_get_inventory(provider => $provider);
     upload_logs($inventory, failok => 1);
 
     # Set up azure native fencing
-    if (get_var('QESAPDEPLOY_FENCING') eq 'native' && get_var('PUBLIC_CLOUD_PROVIDER') eq 'AZURE') {
-        my @nodes = qesap_get_nodes_names();
+    if (get_var('QESAPDEPLOY_FENCING') eq 'native' && $provider eq 'AZURE') {
+        my @nodes = qesap_get_nodes_names(provider => $provider);
         foreach my $host_name (@nodes) {
             if ($host_name =~ /hana/) {
                 qesap_az_setup_native_fencing_permissions(


### PR DESCRIPTION
Remove usage of setting PUBLIC_CLOUD_PROVIDER from qesap_get_nodes_number and qesap_get_nodes_name methods. Convert them to arguments.


# Verification run: 
## qesap regression

### GCP
 http://openqaworker15.qa.suse.cz/tests/275224 :green_circle: fails but it is fine, same failure of the original job ( `Configure cluster IP [gcp]` )

### Azure

 - **sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ibsmirror_peering_test@64bit** http://openqaworker15.qa.suse.cz/tests/275227

 - **sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit** -> http://openqaworker15.qa.suse.cz/tests/275228

 - **sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test_msi@64bit** -> http://openqaworker15.qa.suse.cz/tests/275229
 - **sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test_spn@64bit** -> http://openqaworker15.qa.suse.cz/tests/275230

## hanasr

http://openqaworker15.qa.suse.cz/tests/275225 :red_circle: Terraform/Azure failure probably not related to this PR change
http://openqaworker15.qa.suse.cz/tests/275231

## mr_test

http://openqaworker15.qa.suse.cz/tests/275226 :green_circle: 