### PR TITLE
Apply the glitch workaround in yast2_security

### DIFF
--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -28,7 +28,7 @@ sub run {
     select_console "x11";
 
     # Password Settings
-    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120, apply_workaround => is_sle('>=15-SP4') ? 1 : 0);
     assert_and_click "yast2_security-pwd-settings";
     send_key "alt-m";
     wait_still_screen 1;
@@ -51,7 +51,7 @@ sub run {
     wait_still_screen 3;
 
     # Check previously set values + Miscellaneous Settings
-    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120, apply_workaround => is_sle('>=15-SP4') ? 1 : 0);
     apply_workaround_poo124652('yast2_security-login-settings') if (is_sle('>=15-SP4'));
     assert_and_click "yast2_security-login-settings";
     apply_workaround_poo124652("yast2_security-login-attempts") if (is_sle('>=15-SP4'));


### PR DESCRIPTION
### Apply the glitch workaround in yast2_security
- Description:
     * The module fails due to the yast2 window not being properly refreshed and showing the content. 
       We can apply the existing workaround to avoid future failures
- Related ticket: 
     * [**154690**](https://progress.opensuse.org/issues/154690)
- Needles: 
     * N/A
- Verification run: 
     * [**_yast2_security_**](https://openqa.suse.de/tests/overview?distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23yast2_security&version=15-SP6)
