### PR TITLE
HPC: Slurm-18 provides db as a dependency

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -33,9 +33,6 @@ sub run ($self) {
     my $mariadb_service = "mariadb";
     $mariadb_service = "mysql" if is_sle('<12-sp4');
 
-    #for all slurm versions we have mariadb as a dependency apart from slurm18
-    #TODO: remove below line as soon as not needed
-    zypper_call("in mariadb") if $slurm_pkg =~ "slurm_18";
     systemctl("start $mariadb_service");
     systemctl("is-active $mariadb_service");
 


### PR DESCRIPTION
In the logs one can see:
Problem: mariadb104-10.4.30-8.5.46.aarch64 conflicts with mariadb provided by
mariadb-10.2.44-3.53.1...
 Solution 1: Following actions will be done:
  deinstallation of mariadb104-10.4.30-8.5.46.aarch64
  deinstallation of mariadb104-errormessages-10.4.30-8.5.46.noarch
  deinstallation of mariadb104-client-10.4.30-8.5.46.aarch64
 Solution 2: do not install mariadb-10.2.44-3.53.1.aarch64

Which is a direct result of mariadb being already installed by slurm:
zypper -n in slurm_18_08 slurm_18_08-munge slurm_18_08-slurmdbd
...
(16/25) Installing: python3-mysqlclient-1.3.14-8.9.2.aarch64 [............done]
(17/25) Installing: mariadb104-10.4.30-8.5.46.aarch64 [............done]
(18/25) Installing: libhwloc5-2.0.0.1.11.5-4.2.aarch64 [.......done]
(19/25) Installing: libibmad5-2.1.0-1.30.aarch64 [......done]
(20/25) Installing: slurm_18_08-sql-18.08.9-3.20.1.aarch64 [...........done]

In essence there is a specific mariadb version for hpc product and it is
being installed as slurm dependency. Any attempt to install mariadb
using zypper (zypper in mariadb) after slurm is installed (now,
including slurm-18 as well) will result in a conflict