### PR TITLE
Remove deprecated comment

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -726,8 +726,6 @@ sub create_playbook_section_list {
         # Add registration module as first element
         my $reg_code = '-e reg_code=' . get_required_var('SCC_REGCODE_SLES4SAP') . " -e email_address=''";
         if ($args{registration} eq 'suseconnect') {
-            # For the moment, only role version of the registration playbook, using roles from community.sles-for-sap,
-            # is supporting force suseconnec.
             push @playbook_list, "registration.yaml $reg_code -e use_suseconnect=true";
         }
         else {


### PR DESCRIPTION
This pr removes a now false comment, after https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18544 was merged.
- Related ticket: https://jira.suse.com/browse/TEAM-8980
- Verification run: it's just a comment
