### PR TITLE
Implemented feature to support different expected results on service packs

### DIFF
--- a/lib/oscap_tests.pm
+++ b/lib/oscap_tests.pm
@@ -777,6 +777,8 @@ sub get_test_expected_results {
     if (is_aarch64 or is_arm) { $arch = "aarch64"; }
     if (is_ppc64le) { $arch = "ppc"; }
     if (is_x86_64) { $arch = "x86_64"; }
+    my $version = get_var('VERSION');
+    my $sles_sp = (split('-', $version))[1];
 
     my $exp_fail_list_name = $sle_version . "-exp_fail_list";
     my $expected_results_file_name = "openqa_tests_expected_results.yaml";
@@ -789,13 +791,16 @@ sub get_test_expected_results {
 
     # Phrase the expected results
     my $expected_results = YAML::PP::Load($data);
-    record_info("Looking expected results", "Looking expected results for \nprofile_ID: $profile_ID\ntype: $type\narch: $arch");
+    record_info("Looking expected results", "Looking expected results for \nprofile_ID: $profile_ID\ntype: $type\narch: $arch\nname: $exp_fail_list_name\nService Pack: $sles_sp");
 
-    $eval_match = $expected_results->{$profile_ID}->{$type}->{$arch}->{$exp_fail_list_name};
+    $eval_match = $expected_results->{$profile_ID}->{$type}->{$arch}->{$exp_fail_list_name}->{$sles_sp};
     if (defined $eval_match) {
         @eval_match = @$eval_match;
+        record_info("Got expected results", "Got expected results for \nprofile_ID: $profile_ID\ntype: $type\narch: $arch\nname: $exp_fail_list_name\nService Pack: $sles_sp\nList of expected to fail rules:\n" . (join "\n", @eval_match));
     }
-    record_info("Got expected results", "Got expected results for \nprofile_ID: $profile_ID\ntype: $type\narch: $arch\nList of expected to fail rules:\n" . (join "\n", @eval_match));
+    else {
+        record_info("No expected results", "Expected results are not defined.");
+    }
 
     $_[0] = \@eval_match;
     return 1;
@@ -823,6 +828,8 @@ sub get_test_exclusions {
         if (is_aarch64 or is_arm) { $arch = "aarch64"; }
         if (is_ppc64le) { $arch = "ppc"; }
         if (is_x86_64) { $arch = "x86_64"; }
+        my $version = get_var('VERSION');
+        my $sles_sp = (split('-', $version))[1];
 
         my $exclusions_list_name = $sle_version . "-exclusions_list";
         my $exclusions_file_name = "openqa_tests_exclusions.yaml";
@@ -835,15 +842,18 @@ sub get_test_exclusions {
 
         # Phrase the expected results
         my $exclusions_data = YAML::PP::Load($data);
-        record_info("Looking exclusions", "Looking exclusions for \nprofile_ID: $profile_ID\ntype: $type\narch: $arch");
+        record_info("Looking exclusions", "Looking exclusions for \nprofile_ID: $profile_ID\ntype: $type\narch: $arch\nname: $exclusions_list_name\nService Pack: $sles_sp");
 
-        $exclusions = $exclusions_data->{$profile_ID}->{$type}->{$arch}->{$exclusions_list_name};
+        $exclusions = $exclusions_data->{$profile_ID}->{$type}->{$arch}->{$exclusions_list_name}->{$sles_sp};
         # If results defined
         if (defined $exclusions) {
             @exclusions = @$exclusions;
             $found = 1;
+            record_info("Got exclusions", "Got exclusions for \nprofile_ID: $profile_ID\ntype: $type\narch: $arch\nname: $exclusions_list_name\nService Pack: $sles_sp\nList of excluded rules:\n" . (join "\n", @exclusions));
         }
-        record_info("Got exclusions", "Got exclusions for \nprofile_ID: $profile_ID\ntype: $type\narch: $arch\nList of excluded rules:\n" . (join "\n", @exclusions));
+        else {
+            record_info("No exclusions", "Exclusions are not defined.");
+        }
 
         $_[0] = \@exclusions;
         return $found;


### PR DESCRIPTION
Implemented feature to support different expected results on service packs. Now tests on SP6 will pass 

- Related ticket: https://progress.opensuse.org/issues/154696
- Verification run: https://openqa.suse.de/tests/13411774
