### PR TITLE
OneDrive popup blocks tests

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -150,8 +150,9 @@ sub run {
         # assert_screen ['trust_nvidia_gpg_keys', 'wsl-installation-completed'], timeout => 240;
         # send_key 'alt-t' if (match_has_tag 'trust_nvidia_gpg_keys');
 
-        assert_screen 'wsl-installation-completed', 240;
+        assert_screen('wsl-installation-completed', 240);
         send_key 'alt-f';
+        click_lastmatch if (check_screen('wsl-onedrive-popup'));
         # Back to CLI
         assert_screen 'wsl-linux-prompt';
     } else {


### PR DESCRIPTION
A new popup for OneDrive appears and breaks the needles. New logic has been added to click and close it in case it appears

- Related ticket: https://progress.opensuse.org/issues/154693
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/wsl-onedrive-popup-20240202.png
- Verification runs:
  - https://openqa.suse.de/tests/13433421
  - https://openqa.opensuse.org/tests/3915798
  - https://openqa.opensuse.org/tests/3915799
