### PR TITLE
Add installation and smoke test for SAP ASE

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   SAPINIT_RE
   SYSTEMD_RE
   SYSTEMCTL_UNITS_RE
+  ASE_RESPONSE_FILE
   ensure_serialdev_permissions_for_sap
   fix_path
   set_ps_cmd
@@ -70,6 +71,8 @@ our @EXPORT = qw(
   sapcontrol
   get_instance_profile_path
   get_remote_instance_number
+  load_ase_env
+  upload_ase_logs
 );
 
 =head1 SYNOPSIS
@@ -117,6 +120,17 @@ whether the SAP workload was started via systemd units.
 =cut
 
 has SYSTEMCTL_UNITS_RE => undef;
+
+=head2 ASE_RESPONSE_FILE
+
+    $self->ASE_RESPONSE_FILE($filename);
+
+Let the class methods know the name of the ASE response file currently in use. It is set to
+undef by default. Test modules testing for SAP ASE should set this property before anything else.
+
+=cut
+
+has ASE_RESPONSE_FILE => undef;
 
 =head2 ensure_serialdev_permissions_for_sap
 
@@ -297,13 +311,14 @@ Croaks on failure.
 
 sub prepare_profile {
     my ($self, $profile) = @_;
-    return unless ($profile eq 'HANA' or $profile eq 'NETWEAVER');
+    my @valid_profiles = qw(HANA NETWEAVER SAP-ASE);
+    return unless (grep /^$profile$/, @valid_profiles);
 
     # Will prepare system with saptune only if it's available.
     my $has_saptune = $self->is_saptune_installed();
 
     if ($has_saptune) {
-        assert_script_run "saptune daemon start";
+        assert_script_run 'saptune service takeover';
         assert_script_run "saptune solution apply $profile";
     }
     elsif (is_sle('15+')) {
@@ -341,7 +356,7 @@ sub prepare_profile {
         $prev_console = undef;
 
         # If running in DESKTOP=gnome, systemd-logind restart may cause the graphical console to
-        # reset and appear in SUD, so need to select 'root-console' again
+        # reset and appear in SUT, so need to select 'root-console' again
         assert_screen(
             [
                 qw(root-console displaymanager displaymanager-password-prompt generic-desktop
@@ -351,28 +366,28 @@ sub prepare_profile {
     }
     else {
         # If running in DESKTOP=gnome, systemd-logind restart may cause the graphical
-        # console to reset and appear in SUD, so need to select 'root-console' again
+        # console to reset and appear in SUT, so need to select 'root-console' again
         # 'root-console' can be re-selected safely even if DESKTOP=textmode
         select_serial_terminal;
     }
 
     if ($has_saptune) {
-        assert_script_run "saptune daemon start";
+        assert_script_run 'saptune service takeover';
         my $ret = script_run("saptune solution verify $profile", die_on_timeout => 0);
         if (!defined $ret) {
-            # Command timed out. 'saptune daemon start' could have caused the SUT to
+            # Command timed out. 'saptune service takeover' could have caused the SUT to
             # move out of root-console, so select root-console and try again
             select_serial_terminal;
             $ret = script_run "saptune solution verify $profile";
         }
         record_soft_failure("poo#57464: 'saptune solution verify' returned warnings or errors! Please check!") if ($ret && !is_qemu());
 
-        my $output = script_output "saptune daemon status", proceed_on_failure => 1;
+        my $output = script_output 'saptune service status', proceed_on_failure => 1;
         if (!defined $output) {
             # Command timed out or failed. 'saptune solution verify' could have caused
             # the SUT to move out of root-console, so select root-console and try again
             select_serial_terminal;
-            $output = script_output "saptune daemon status";
+            $output = script_output 'saptune service status';
         }
         record_info("saptune status", $output);
     }
@@ -996,13 +1011,16 @@ sub startup_type {
     swpm_sar_filename=>$swpm_sar_filename,
     target_path=>$target_path);
 
-B<sapcar_bin_path> Filename with full path to SAPCAR binary
-B<sar_archives_dir> Directory which contains all required SAR archives (SWPM, SAP kernel, Patches, etc...)
-B<swpm_sar_filename> SWPM SAR archive filename
-B<target_path> Target path for archives to be unpacked into
-
 Unpacks and prepares swpm package from specified source dir into target directory using SAPCAR tool.
 After extraction it checks for 'sapinst' executable being present in target path. Croaks if executable is missing.
+
+B<sapcar_bin_path> Filename with full path to SAPCAR binary
+
+B<sar_archives_dir> Directory which contains all required SAR archives (SWPM, SAP kernel, Patches, etc...)
+
+B<swpm_sar_filename> SWPM SAR archive filename
+
+B<target_path> Target path for archives to be unpacked into
 
 =cut
 
@@ -1039,7 +1057,9 @@ sub prepare_swpm {
 Copies sapinst profile template from NFS to target dir and fills in required variables.
 
 B<profile_target_file> Full filename and path for sapinst install profile to be created
+
 B<profile_template_file> Template file location from which will the profile be sceated
+
 B<sar_location_directory> Location of SAR files -  this is filled into template
 
 =cut
@@ -1073,10 +1093,15 @@ sub prepare_sapinst_profile {
 
 Prepares data for installation of all SAP components using openqa parameter "SAP_INSTANCES".
 parameter example: SAP_INSTANCES = "ASCS,ERS,PAS,AAS".
+
 B<HDB> = Hana database export - netweaver component, not database
+
 B<ASCS> = Central services
+
 B<ERS> = Enqueue replication
+
 B<PAS> = Primary application server
+
 B<AAS> = Additional application server
 
 =cut
@@ -1132,6 +1157,7 @@ sub netweaver_installation_data {
 Returns standard sap instance directory name constructed from instance id and instance type.
 
 B<instance_type> Instance type (ASCS, ERS, PAS, AAS)
+
 B<instance_id> Instance ID - two digit number
 
 =cut
@@ -1175,17 +1201,22 @@ sub is_instance_type_supported {
 
 =head2 share_hosts_entry
 
- $self->share_hosts_entry(virtual_hostname=>$virtual_hostname,
-    virtual_ip=>$virtual_ip,
-    shared_directory_root=>shared_directory_root);
+  $self->share_hosts_entry(virtual_hostname=>$virtual_hostname,
+                           virtual_ip=>$virtual_ip,
+                           shared_directory_root=>shared_directory_root);
 
- Creates file with virtual IP and hostname entry for /etc/hosts file on mounted shared device (Default: /sapmnt).
- This is to help creating /etc/hosts file which would include entries for all nodes.
- File name: <INSTANCE_TYPE>
- File content: <virtual IP> <virtual_hostname>
+Creates file with virtual IP and hostname entry for C</etc/hosts> file on mounted shared
+device (Default: C</sapmnt>). This is to help creating C</etc/hosts> file which would include
+entries for all nodes.
+
+File name: <INSTANCE_TYPE>
+
+File content: <virtual IP> <virtual_hostname>
 
 B<virtual_hostname> Virtual hostname (alias) which is tied to instance and will be moved with HA IP addr resource
+
 B<virtual_ip> Virtual IP addr tied to an instance and HA resource
+
 B<shared_directory_root> Shared directory available for all instances. Separate directory 'hosts' will be created
 
 =cut
@@ -1249,6 +1280,7 @@ Prints output for standard set of commands to show info about system in various 
 It is possible to activate or deactivate various output sections by named args:
 
 B<cluster> - Shows cluster related outputs
+
 B<netweaver> - Shows netweaver related outputs
 
 =cut
@@ -1289,17 +1321,23 @@ Executes sapcontrol webmethod for instance specified in arguments and returns ex
 Allows remote execution of webmethods between instances, however not all webmethods are possible to execute in that manner.
 
 Sapcontrol return codes:
-RC 0 = webmethod call was successfull
-RC 1 = webmethod call failed
-RC 2 = last webmethod call in progress (processes are starting/stopping)
-RC 3 = all processes GREEN
-RC 4 = all processes GREY (stopped)
+
+    RC 0 = webmethod call was successfull
+    RC 1 = webmethod call failed
+    RC 2 = last webmethod call in progress (processes are starting/stopping)
+    RC 3 = all processes GREEN
+    RC 4 = all processes GREY (stopped)
 
 B<instance_id> 2 digit instance number
+
 B<webmethod> webmethod name to be executed (Ex: Stop, GetProcessList, ...)
+
 B<additional_args> additional arguments to be appended at the end of command
+
 B<return_output> returns output instead of RC
+
 B<remote_hostname> hostname of the target instance for remote execution. Local execution does not need this.
+
 B<sidadm_password> Password for sidadm user. Only required for remote execution.
 
 =cut
@@ -1348,16 +1386,25 @@ sub sapcontrol {
 
 Runs "sapcontrol -nr <INST_NO> -function GetProcessList" via SIDadm and compares RC against expected state.
 Croaks if state is not correct.
-RC 0 = webmethod call was successfull
-RC 1 = webmethod call failed (This includes NIECONN_REFUSED status)
-RC 2 = last webmethod call in progress (processes are starting/stopping)
-RC 3 = all processes GREEN
-RC 4 = all processes GREY (stopped)
+
+Expected return codes are:
+
+    RC 0 = webmethod call was successfull
+    RC 1 = webmethod call failed (This includes NIECONN_REFUSED status)
+    RC 2 = last webmethod call in progress (processes are starting/stopping)
+    RC 3 = all processes GREEN
+    RC 4 = all processes GREY (stopped)
+
+Method arguments:
 
 B<expected_state> State that is expected (failed, started, stopped)
+
 B<instance_id> Instance number - two digit number
+
 B<loop_sleep> sleep time between checks - only used if 'wait_for_state' is true
+
 B<timeout> timeout for waiting for target state, after which function croaks
+
 B<wait_for_state> If set to true, function will wait for expected state until success or timeout
 
 =cut
@@ -1440,6 +1487,7 @@ sub get_remote_instance_number () {
 Returns full instance profile path for specified instance type
 
 B<instance_type> Instance type (ASCS, ERS, PAS, AAS)
+
 B<instance_id> Instance number - two digit number
 
 =cut
@@ -1461,6 +1509,45 @@ sub get_instance_profile_path () {
     croak "Profile '$profile_path' does not exist" if script_run("test -e $profile_path");
 
     return ($profile_path);
+}
+
+=head2 load_ase_env
+
+  $self->load_ase_env
+
+Loads environment variables from ASE installation into the current shell session.
+
+=cut
+
+sub load_ase_env {
+    my ($self) = @_;
+    return unless $self->ASE_RESPONSE_FILE;
+
+    # SAP ASE installation leaves a SYBASE.sh file with environment variables definitions in
+    # the directory where it was installed. The command below will extract the value of the
+    # install directory from the response file and prepend it to SYBASE.sh to load those
+    # variables
+    # Command will look like this:
+    # source $(awk -F= '/^USER_INSTALL_DIR/ {print $2}' $HOME/ASE_RESPONSE_FILE.txt)/SYBASE.sh
+    assert_script_run q|source $(awk -F= '/^USER_INSTALL_DIR/ {print $2}' $HOME/| . $self->ASE_RESPONSE_FILE . ')/SYBASE.sh';
+    assert_script_run 'export LANG=' . get_var('INSTLANG', 'en_US.UTF-8');
+}
+
+=head2 upload_ase_logs
+
+  $self->upload_ase_logs
+
+Save and upload to openQA the SAP ASE installation logs. These are typically located in
+C</opt/sap/log> and C</opt/sap/$SYBASE_ASE/install> but depend on the response file used
+during installation.
+
+=cut
+
+sub upload_ase_logs {
+    my ($self) = @_;
+    return unless $self->ASE_RESPONSE_FILE;
+    $self->load_ase_env;
+    save_and_upload_log('tar -zcf ase_logs.tar.gz $SYBASE/log $SYBASE/$SYBASE_ASE/install/*.log', 'ase_logs.tar.gz');
 }
 
 sub post_run_hook {
@@ -1488,6 +1575,9 @@ sub post_fail_hook {
 
     # NW installation logs, if needed
     $self->upload_nw_install_log if get_var('NW');
+
+    # ASE installation logs, if needed
+    $self->upload_ase_logs;
 
     # HA cluster logs, if needed
     ha_export_logs if get_var('HA_CLUSTER');

--- a/schedule/sles4sap/ase/test_ase.yaml
+++ b/schedule/sles4sap/ase/test_ase.yaml
@@ -1,0 +1,20 @@
+---
+name: test_ase
+description: >
+  SAP ASE smoke test for SLES for SAP.
+  This will install SAP ASE in SUT, and then perform some small tests to confirm
+  ASE is running after installation.
+  It does not test for automatic startup after a boot, nor covers SAP ASE HA scenarios.
+  Requires installation media and response file as openQA assets.
+vars:
+  BOOTFROM: c
+  BOOT_HDD_IMAGE: '1'
+  HDD_SCC_REGISTERED: '1'
+  # Below have to be entered in the OpenQA UI because it doesn't read this YAML
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-%DESKTOP%.qcow2
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/ase_install
+  - sles4sap/ase_test

--- a/tests/sles4sap/ase_install.pm
+++ b/tests/sles4sap/ase_install.pm
@@ -1,0 +1,105 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Install SAP ASE via command line using a response file. Both
+# the installation media and the response file are supplied as openQA
+# assets. Verify installation with sles4sap/ase_test.
+#
+# This test module expects the tarball with the installation files for SAP ASE
+# in ASSET_0 and the gzipped response file in ASSET_1
+#
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base 'sles4sap';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use utils qw(file_content_replace);
+use Utils::Logging qw(save_and_upload_log);
+use version_utils qw(is_sle);
+
+=head2 prepare_system_for_ase
+
+  $self->prepare_system_for_ase
+
+Run some preparation commands in the system before SAP ASE's installation.
+This includes setting kernel.randomize_va_space to the recommended value,
+adding the hostname to /etc/hosts, creating a target directory where to
+download the ASE installer and applying the SAP-ASE profile to the
+system via saptune.
+
+=cut
+
+sub prepare_system_for_ase {
+    my ($self, %args) = @_;
+    $args{target} //= '/sapinst';
+    # Add host's IP to /etc/hosts
+    $self->add_hostname_to_hosts;
+    $self->prepare_profile('SAP-ASE');
+    # We need to ensure that the kernel parameter kernel.randomize_va_space is set to 0 SLES 11+
+    assert_script_run 'sysctl kernel.randomize_va_space=0';
+    record_info 'kernel.randomize_va_space', script_output('sysctl kernel.randomize_va_space', proceed_on_failure => 1);
+    assert_script_run "mkdir -p $args{target}";
+}
+
+=head2 download_ase_assets
+
+  my $installation_dir = $self->download_ase_assets()
+
+Download SAP ASE installation tarball (.TGZ format) from ASSET_0 setting, and dowload
+the response file require for installation (.GZ text format) from ASSET_1 setting.
+Returns the directory that contains the unpacked installation files.
+
+=cut
+
+sub download_ase_assets {
+    my ($self, %args) = @_;
+    $args{target} //= '/sapinst';
+    $args{timeout} //= 600;
+    assert_script_run "pushd $args{target}";
+    # Verify ASSET_0 and ASSET_1 are set
+    get_required_var("ASSET_$_") for (0 .. 1);
+    # Download assets into SUT
+    record_info 'SAP ASE Installer', get_var('ASSET_0');
+    my $ase_location = data_url('ASSET_0');
+    assert_script_run "wget -O - $ase_location | tar -zxf -", timeout => $args{timeout};
+    # SAP ASE installer extracts its contents in a directory that begins with 'ebf'
+    # The following lines will attempt to find the directory name the files were extracted on
+    my $instdir = script_output 'echo ":$(ls -d ebf* | tail -1):"';
+    die "Could not determine the installer's path. Current contents of [$args{target}] are:\n" . script_output 'ls'
+      unless ($instdir =~ /:([^:]+):/);
+    $instdir = "$args{target}/$1";
+    record_info 'Installer Directory', $instdir;
+    assert_script_run 'popd';
+    my $response_file_location = data_url('ASSET_1');
+    assert_script_run "wget -O - $response_file_location | gunzip -c > " . $self->ASE_RESPONSE_FILE, timeout => $args{timeout};
+    return $instdir;
+}
+
+sub run {
+    my ($self) = @_;
+    my $response_file = get_required_var('ASSET_1');    # Response file comes gzipped in ASSET_1
+    $response_file =~ s/.gz$//;
+    $self->ASE_RESPONSE_FILE($response_file);    # Set the response file name in the object instance
+
+    select_serial_terminal;
+    enter_cmd 'cd';    # Let's start in $HOME
+    $self->prepare_system_for_ase;
+    my $instdir = $self->download_ase_assets;
+    file_content_replace($self->ASE_RESPONSE_FILE, '%PASSWORD%', $testapi::password);
+    upload_logs $self->ASE_RESPONSE_FILE;
+    assert_script_run "pushd $instdir";
+    # In manual tests, it took ca. 35 minutes to install ASE, so expecting 1 hour to be enough
+    assert_script_run './setup.bin -i silent -f $HOME/' . $self->ASE_RESPONSE_FILE, timeout => 3600;
+    assert_script_run 'popd';
+    $self->upload_ase_logs;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/sles4sap/ase_test.pm
+++ b/tests/sles4sap/ase_test.pm
@@ -1,0 +1,99 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: SAP ASE smoke test. Run some commands and queries to verify SAP ASE is running
+# Requires: sles4sap/ase_install
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+use base "sles4sap";
+use strict;
+use warnings;
+use Carp qw(croak);
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+
+sub run_ase_query {
+    my %args = @_;
+    croak "Got no query!" unless $args{query};
+    $args{timeout} //= 30;
+    assert_script_run "echo '$args{query}' > query.file; echo go >> query.file";
+    assert_script_run 'cat query.file';
+    script_output "isql -Usa -P$testapi::password -SSYBASE -i query.file", $args{timeout};
+}
+
+sub is_ase_up {
+    my ($t) = @_;
+
+    # showserver will produce an output like this:
+    #
+    # F S UID        PID  PPID  C PRI  NI ADDR SZ WCHAN  STIME TTY          TIME CMD
+# 4 S root     25985 25984 10  80   0 - 286666 futex_ 17:47 ?       00:00:57 /opt/sap/ASE-16_0/bin/dataserver -sSYBASE -d/opt/sap/data/master.dat -e/opt/sap/ASE-16_0/install/SYBASE.log -c/opt/sap/ASE-16_0/SYBASE.cfg -M/opt/sap/ASE-16_0 -N/opt/sap/ASE-16_0/sysam/SYBASE.properties -i/opt/sap
+# 0 S root     26194 26193  0  80   0 -  5072 do_sys 17:48 ?        00:00:00 /opt/sap/ASE-16_0/bin/backupserver -e/opt/sap/ASE-16_0/install/SYBASE_BS.log -N25 -C20 -I/opt/sap/interfaces -M/opt/sap/ASE-16_0/bin/sybmultbuf -SSYBASE_BS
+    #
+    # To confirm ASE is up, we need to look at the line with dataserv. The 4 conditions below
+    # were identified as belonging to the database server and not to the other servers, so we are
+    # using all 4 conditions to determine ASE is up
+    return ($t =~ /dataserver / && $t =~ /SYBASE\.properties/ && $t =~ /SYBASE\.cfg/ && $t =~ /\-sSYBASE[^_]/);
+}
+
+sub run {
+    my ($self) = @_;
+    my $response_file = get_required_var('ASSET_1');
+    $response_file =~ s/.gz$//;
+    $self->ASE_RESPONSE_FILE($response_file);    # This module verifies SAP-ASE. We need to supply it with the response file name
+
+    # Define some variables with the scripts and files to be used while testing
+    my $showserver = '$SYBASE/$SYBASE_ASE/install/showserver';
+    my $cockpit_script = '$SYBASE/COCKPIT-4/bin/cockpit.sh';
+    my $second_log = '$HOME/second_ase_start.log';
+
+    select_serial_terminal;
+    enter_cmd 'cd';    # Let's start in $HOME
+    $self->load_ase_env;
+
+    # Is ASE running?
+    my $out = script_output $showserver;
+    die 'SAP ASE is not running' unless is_ase_up($out);
+    record_info 'showserver', $out;
+
+    # Can we connect to ASE?
+    $out = run_ase_query(query => 'select @@version');
+    die "Failed to run query. Error: [$out]" unless ($out =~ /row affected/);
+    record_info 'ASE Version', $out;
+
+    # Can ASE be stopped and started?
+    $out = run_ase_query(query => 'shutdown', timeout => 300);
+    die 'Problems detected while attempting a shutdown of ASE' unless ($out =~ /Server SHUTDOWN by request/ && $out =~ /ASE is terminating this process/);
+    $out = script_output $showserver;
+    die 'SAP ASE is still running' if is_ase_up($out);
+    # Start SAP ASE and send the output to a log file to upload to the test results
+    enter_cmd '$SYBASE/$SYBASE_ASE/install/RUN_SYBASE > ' . $second_log . ' 2>&1 &';    # Sadly, ASE start script is not daemonized, so run it with &
+                                                                                        # Wait until ASE finishes starting
+    send_key 'ret';    # Type enter to get a shell prompt
+    assert_script_run "until (grep -q 'This software contains confidential and trade secret information of SAP AG' $second_log); do sleep 5; done", timeout => 300;
+    $out = script_output $showserver;
+    die 'SAP ASE is not running' unless is_ase_up($out);
+    upload_logs $second_log;
+
+    # Check ASE cockpit
+    $out = script_output "$cockpit_script -status";
+    die 'Cockpit server is not running' unless ($out =~ /Cockpit server is running/);
+    record_info 'Cockpit Server', script_output "$cockpit_script --info";
+    assert_script_run "$cockpit_script -stop";
+    $out = script_output "$cockpit_script -status";
+    die 'Cockpit server is not stopped' unless ($out =~ /Cockpit server is stopped/);
+    # Now to start the cockpit server, it's not possible to do so and detach from the script
+    # without killing the cockpit server, so we start this in a different terminal to avoid
+    # blocking the serial terminal
+    select_console 'root-console';
+    $self->load_ase_env;
+    enter_cmd "$cockpit_script -start";
+    assert_screen 'sap-ase-cockpit', 300;
+    select_serial_terminal;
+    $out = script_output "$cockpit_script -status";
+    die 'Cockpit server is not running' unless ($out =~ /Cockpit server is running.+:4992$/);
+}
+
+1;


### PR DESCRIPTION
Add test modules to install SAP ASE and to perform some smoke tests on the installed software: check that the server is running, query it to get the installed SAP ASE version, stop and start the database server, query the cockpit service status and stop and start the cockpit.

Included with the test modules is a YAML schedule loading the new modules, and also the changes required for SAP ASE in `lib/sles4sap.pm`.

Also included in the PR is the change from the deprecated `saptune daemon` commands to the new `saptune service` commands, and minor typo fixes and formatting to the POD documentation in `lib/sles4sap.pm`.

- Related ticket: https://jira.suse.com/browse/TEAM-8934
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1656
- Verification runs:

12-SP5: http://mango.qe.nue2.suse.org/tests/5662
15-SP2: http://mango.qe.nue2.suse.org/tests/5651
15-SP3: http://mango.qe.nue2.suse.org/tests/5652
15-SP4: http://mango.qe.nue2.suse.org/tests/5654
15-SP5: http://mango.qe.nue2.suse.org/tests/5663
15-SP6: http://mango.qe.nue2.suse.org/tests/5596 (Failure unrelated to this PR. SAP ASE is currently not installable in 15-SP6 due to [bsc#1218200](https://bugzilla.suse.com/show_bug.cgi?id=1218200))

- Regression tests:

NetWeaver: http://mango.qe.nue2.suse.org/tests/5660
HANA: http://mango.qe.nue2.suse.org/tests/5661

