### PR TITLE
Remove softfailure of bsc#950763

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2434,7 +2434,6 @@ sub install_patterns {
                 $cf_selected = 1;
             }
             elsif ($cf_selected == 1) {
-                record_soft_failure 'bsc#950763 CFEngine pattern is listed twice in installer';
                 next;
             }
         }


### PR DESCRIPTION
After discussion with Klaus for https://bugzilla.suse.com/show_bug.cgi?id=1217694, he just think to make the bug 'Won't fix' for it is just a cosmetic issue and doesn't affect functionality. So we don't need the soft failure any more.

- Related ticket: https://progress.opensuse.org/issues/151882
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/13410780#