### PR TITLE
Start Modular libvirt Log from sles15SP6

### DIFF
--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -291,14 +291,54 @@
   </users>
   <scripts>
     <post-scripts config:type="list">
+      % if ($check_var->('SYSTEM_ROLE', 'xen') && $get_var->('VERSION') gt '15-SP5') {
       <script>
-        <filename>debug_libvirtd.sh</filename>
+        <filename>configure_xen_modular_libvirt_log.sh</filename>
         <source><![CDATA[
-cat >> /etc/libvirt/libvirtd.conf<< EOF
+for drv in xen network nodedev nwfilter secret storage proxy lock
+do
+cat >> "/etc/libvirt/virt${drv}d.conf" << EOF
+log_level = 1
+log_filters="1:qemu 1:libxl 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci"
+log_outputs="1:file:/var/log/libvirt/virt${drv}d.log"
+EOF
+done
+]]>
+        </source>
+      </script>
+      % }
+      % if ($check_var->('SYSTEM_ROLE', 'kvm') && $get_var->('VERSION') gt '15-SP5') {
+      <script>
+        <filename>configure_kvm_modular_libvirt_log.sh</filename>
+        <source><![CDATA[
+for drv in qemu log network nodedev nwfilter secret storage proxy lock 
+do
+cat >> "/etc/libvirt/virt${drv}d.conf" << EOF
+log_level = 1
+log_filters="1:qemu 1:libxl 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci"
+log_outputs="1:file:/var/log/libvirt/virt${drv}d.log"
+EOF
+done
+]]>
+        </source>
+      </script>
+      % }
+      % if ($get_var->('VERSION') lt '15-SP6') {
+      <script>
+        <filename>configure_monolithic_libvirt_log.sh</filename>
+        <source><![CDATA[
+cat >> "/etc/libvirt/libvirtd.conf" << EOF
 log_level = 1
 log_filters="1:qemu 1:libxl 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci"
 log_outputs="1:file:/var/log/libvirt/libvirtd.log"
 EOF
+]]>
+        </source>
+      </script>
+      % }
+      <script>
+        <filename>config_setup.sh</filename>
+        <source><![CDATA[
 cp /usr/lib/systemd/network/99-default.link  /etc/systemd/network/99-default.link
 sed -i s/MACAddressPolicy=persistent/MACAddressPolicy=none/ /etc/systemd/network/99-default.link
 


### PR DESCRIPTION
Progress ticket: https://progress.opensuse.org/issues/130766

Start debug log for modular libvirt from sles15SP6


- Related ticket: https://progress.opensuse.org/issues/130766
- Related jira ticket: https://jira.suse.com/browse/PED-4804
- Related document: https://confluence.suse.com/pages/viewpage.action?pageId=1241481218#Modularlibvirt:introduction&howto-Debuglogformodularlibvirt
- Needles: N/A
- Verification run:
- [x] [sles15sp6 with modular when using xen ](http://10.100.103.207/tests/281)
- [x] [sles15sp6 with modular when using kvm](http://10.100.103.207/tests/282) 
- [x] [sles15sp5 with Monolithic when using xen](http://10.100.103.207/tests/278) 
- [x] [sles15sp5 with Monolithic when using kvm](http://10.100.103.207/tests/277)

