### PR TITLE
Skip zypper systemd install

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -257,7 +257,6 @@ sub test_systemd_install {
     my $leap_vmin = '15.4';
     my $sle_vmin = '15-SP4';
     my $bci_vmin = '15-SP5';
-    my $flavor_skip = "Online";
     # release
     my ($image_version, $image_sp, $image_id) = get_os_release("$runtime run --entrypoint '' $image");
     # TW and starting with SLE 15-SP4/Leap15.4 systemd's dependency with udev has been dropped
@@ -265,8 +264,7 @@ sub test_systemd_install {
         ($image_id eq 'opensuse-leap' && check_version('>=' . $leap_vmin, "$image_version.$image_sp", qr/\d{2}\.\d/)) ||
         ($image_id eq 'sles' && check_version('>=' . $sle_vmin, "$image_version-SP$image_sp", qr/\d{2}-sp\d/))) {
         # Skip run case:
-        return 0 if (get_var('FLAVOR') =~ /$flavor_skip/ &&
-            $image_id eq 'sles' && check_version('<' . $bci_vmin, "$image_version-SP$image_sp", qr/\d{2}-sp\d/));
+        return 0 if ($image_id eq 'sles' && check_version('<' . $bci_vmin, "$image_version-SP$image_sp", qr/\d{2}-sp\d/));
         # lock to SLE_BCI repo for SLES versions not under LTSS (LTSS has no BCI repo anymore)
         my $repo = ($image_id eq 'sles' && check_version('>=' . $bci_vmin, "$image_version-SP$image_sp", qr/\d{2}-sp\d/)) ? '-r SLE_BCI' : '';
         assert_script_run("$runtime run $image /bin/bash -c 'zypper al udev && zypper -n in $repo systemd'", timeout => 300);


### PR DESCRIPTION
Fix skip zypper systemd install on LTSS

- Related ticket: https://progress.opensuse.org/issues/154825
- Verification run: [sles15-ltss-on-Leap-15.4](https://openqa.suse.de/tests/13412878), [sles15-ltss-on-Leap-15.5](https://openqa.suse.de/tests/13412879),  [sles15-ltss-on-centos](https://openqa.suse.de/tests/13412880), [sles15-ltss-on-liberty9](https://openqa.suse.de/tests/13412881), [sles15-ltss-on-rhel8](https://openqa.suse.de/tests/13412883), [sles15-ltss-on-ubuntu](https://openqa.suse.de/tests/13412927), [ sle-15-SP6-Online-x86_64](https://openqa.suse.de/tests/13412917), [ sle-15-SP5](https://openqa.suse.de/tests/13412924)
