### PR TITLE
LTP Whitelist: Add support for new livepatch downgrade variant

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -72,7 +72,7 @@ sub find_whitelist_entry {
         @issues = @{$suite};
     }
     else {
-        $test =~ s/_postun$//g if check_var('KGRAFT', 1) && check_var('UNINSTALL_INCIDENT', 1);
+        $test =~ s/_postun$//g if check_var('KGRAFT', 1) && (check_var('UNINSTALL_INCIDENT', 1) || check_var('KGRAFT_DOWNGRADE', 1));
         return undef unless exists $suite->{$test};
         @issues = @{$suite->{$test}};
     }


### PR DESCRIPTION
Secureboot tests now use two different implementations of downgrading livepatches, one custom by disabling update repo and running update, another through a standard KLP management tool. Both implementations need post-uninstall tests but the latter is not handled correctly by LTP whitelist because it's controlled by a new variable: `KGRAFT_DOWNGRADE`. Fix condition for removing livepatch post-uninstall suffix from LTP test names when the new uninstall method is used.

- Related ticket: https://progress.opensuse.org/issues/109476
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/13433436