### PR TITLE
MD5 sum check added on downloaded SAP HANA archives 

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -44,7 +44,7 @@ sub download_hana_assets_from_server {
     my $hana_location = data_url('ASSET_0');
     # Each HANA asset is about 16GB. A ten minute timeout assumes a generous
     # 27.3MB/s download speed. Adjust according to expected server conditions.
-    assert_script_run "wgeti -O -- - $hana_location | tar -xf -- -", timeout => $nettout;
+    assert_script_run "wget -O -- - $hana_location | tar -xf -- -", timeout => $nettout;
     # Skip checksum check if DISABLE_CHECKSUM is set, or if checksum file is not
     # part of the archive
     my $sap_chksum_file = 'MD5FILE.DAT';

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -57,7 +57,7 @@ sub download_hana_assets_from_server {
     # If SAP provided MD5 sum file is present convert it to the md5sum format
     assert_script_run "[[ -f $sap_chksum_file ]] && awk '{print \$2\" \"\$1}' $target/$sap_chksum_file > $target/$chksum_file";
     assert_script_run "md5sum -c --quiet $chksum_file", $nettout;
-    assert_script_run "cd";
+    assert_script_run "popd";
 }
 
 

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -55,7 +55,7 @@ sub download_hana_assets_from_server {
     # Switch to $target to verify copied contents are OK
     assert_script_run "pushd $target";
     # If SAP provided MD5 sum file is present convert it to the md5sum format
-    assert_script_run "[[ -f $sap_chksum_file ]] && awk '{print $2\" \"$1}' $target/$sap_chksum_file > $target/$chksum_file";
+    assert_script_run "[[ -f $sap_chksum_file ]] && awk '{print \$2\" \"\$1}' $target/$sap_chksum_file > $target/$chksum_file";
     assert_script_run "md5sum -c --quiet $chksum_file", $nettout;
     assert_script_run "cd";
 }

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -44,7 +44,7 @@ sub download_hana_assets_from_server {
     my $hana_location = data_url('ASSET_0');
     # Each HANA asset is about 16GB. A ten minute timeout assumes a generous
     # 27.3MB/s download speed. Adjust according to expected server conditions.
-    assert_script_run "wget -O -- - $hana_location | tar -xf -- -", timeout => $nettout;
+    assert_script_run "wget -O - $hana_location | tar -xf -", timeout => $nettout;
     # Skip checksum check if DISABLE_CHECKSUM is set, or if checksum file is not
     # part of the archive
     my $sap_chksum_file = 'MD5FILE.DAT';
@@ -56,7 +56,7 @@ sub download_hana_assets_from_server {
     assert_script_run "pushd $target";
     # If SAP provided MD5 sum file is present convert it to the md5sum format
     assert_script_run "[[ -f $sap_chksum_file ]] && awk '{print $2\" \"$1}' $target/$sap_chksum_file > $target/$chksum_file";
-    assert_script_run "md5sum -c --quiet -- $chksum_file", $nettout;
+    assert_script_run "md5sum -c --quiet $chksum_file", $nettout;
     assert_script_run "cd";
 }
 


### PR DESCRIPTION
MD5 sum check is now done up the "untared" archives piped directly from the `wget` command

- Verification run:  https://openqa.suse.de/tests/13435596#step/hana_install/39
