### PR TITLE
Update pacemaker_cts_cluster_exerciser to pacemaker-cts-2.1.7

### DIFF
--- a/tests/ha/pacemaker_cts_cluster_exerciser.pm
+++ b/tests/ha/pacemaker_cts_cluster_exerciser.pm
@@ -18,7 +18,7 @@ use utils qw(systemctl zypper_call exec_and_insert_password);
 use hacluster;
 
 sub run {
-    my $cts_bin = '/usr/share/pacemaker/tests/cts/CTSlab.py';
+    my $cts_bin = '/usr/share/pacemaker/tests/cts-lab';    #'/usr/share/pacemaker/tests/cts/CTSlab.py';
     my $log = '/tmp/cts_cluster_exerciser.log';
     my $cluster_name = get_cluster_name;
     my $results_file = '/tmp/cts_cluster_exerciser.results';
@@ -45,7 +45,8 @@ sub run {
 
         # Don't do stonith test since this one reboots a node randomly
         # and it's very difficult to handle in MM scenario.
-        assert_script_run "sed -i '/AllTestClasses.append(StonithdTest)/ s/^/#/' \$(rpm -ql pacemaker-cts|grep CTStests.py)";
+        #assert_script_run "sed -i '/AllTestClasses.append(StonithdTest)/ s/^/#/' \$(rpm -ql pacemaker-cts|grep CTStests.py)";
+        assert_script_run "sed -i '/StonithdTest,/ s/^/#/' \$(rpm -ql pacemaker-cts|grep tests/__init__.py)";
 
         # Start pacemaker cts cluster exerciser
         my $cts_start_time = time;


### PR DESCRIPTION
The new version of pacemaker Cluster Test Suite (pacemaker-cts) has different paths on several files, which have are causing failures on tests using the module `tests/ha/pacemaker_cts_cluster_exerciser.pm`.

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
