### PR TITLE
Centralize SAPHanaSR-showAttr parsing

### DIFF
--- a/lib/saputils.pm
+++ b/lib/saputils.pm
@@ -1,0 +1,84 @@
+# SUSE's openQA tests
+#
+# Copyright 2017-2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Functions for SAP tests
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+## no critic (RequireFilenameMatchesPackage);
+package saputils;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use testapi;
+use List::MoreUtils qw(uniq);
+use Carp qw(croak);
+
+our @EXPORT = qw(
+  calculate_hana_topology
+);
+
+=head1 SYNOPSIS
+
+Package with utility functionality for tests on SLES for
+SAP Applications.
+
+This package is a stateless library.
+To keep this library as generic as possible avoid as much as possible any other dependency usage,
+like other baseclass or testapi. Avoid using get_var/set_var at this level.
+
+=cut
+
+
+=head2 calculate_hana_topology
+    calculate_hana_topology([input => $saphanasr_showAttr_format_script_output]);
+
+    Expect `SAPHanaSR-showAttr --format=script` as input.
+    Parses this input, returns a hash of hashes containing values for each host.
+
+    Output like:
+            Hosts/vmhana01/remoteHost="vmhana02"
+            Hosts/vmhana01/sync_state="PRIM"
+            Hosts/vmhana01/vhost="vmhana01"
+            Hosts/vmhana02/remoteHost="vmhana01"
+            Hosts/vmhana02/sync_state="SOK"
+            Hosts/vmhana02/vhost="vmhana02"
+    result in
+    {
+        vmhana01 => {
+            remoteHost => 'vmhana02',
+            sync_state => 'PRIM',
+            vhost => 'vmhana01',
+        },
+        vmhana02 => {
+            remoteHost => 'vmhana01',
+            sync_state => 'SOK',
+            vhost => 'vmhana02',
+        },
+    }
+=cut
+
+
+sub calculate_hana_topology {
+    my (%args) = @_;
+    croak "Missing mandatory 'input' argument" unless $args{input};
+    record_info("cmd_out", $args{input});
+    my %topology;
+    my @all_parameters = map { if (/^Hosts/) { s,Hosts/,,; s,",,g; $_ } else { () } } split("\n", $args{input});
+    my @all_hosts = uniq map { (split("/", $_))[0] } @all_parameters;
+
+    for my $host (@all_hosts) {
+        # Only takes parameter and value for lines about one specific host at time
+        my %host_parameters = map {
+            my ($node, $parameter, $value) = split(/[\/=]/, $_);
+            if ($host eq $node) { ($parameter, $value) } else { () }
+        } @all_parameters;
+        $topology{$host} = \%host_parameters;
+    }
+
+    return \%topology;
+}
+
+1;

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2017-2020 SUSE LLC
+# Copyright 2017-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Functions for SAP tests
@@ -27,7 +27,6 @@ use utils qw(zypper_call);
 use Digest::MD5 qw(md5_hex);
 use Utils::Systemd qw(systemctl);
 use Utils::Logging qw(save_and_upload_log);
-use List::MoreUtils qw(uniq);
 use Carp qw(croak);
 
 our @EXPORT = qw(

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -7,7 +7,6 @@ use Test::MockModule;
 use Test::Mock::Time;
 
 use List::Util qw(any none);
-use Data::Dumper;
 
 use testapi 'set_var';
 use qesapdeployment;

--- a/t/14_qesap_ansible.t
+++ b/t/14_qesap_ansible.t
@@ -7,7 +7,6 @@ use Test::MockModule;
 use Test::Mock::Time;
 
 use List::Util qw(any none);
-use Data::Dumper;
 
 use testapi 'set_var';
 use qesapdeployment;

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -7,7 +7,6 @@ use Test::MockModule;
 use Test::Mock::Time;
 
 use List::Util qw(any none);
-use Data::Dumper;
 
 use testapi qw(set_var);
 use qesapdeployment;

--- a/t/17_sles4sap.t
+++ b/t/17_sles4sap.t
@@ -24,7 +24,7 @@ subtest '[prepare_swpm]' => sub {
     my $mockObject = sles4sap->new();
     my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
     $sles4sap->redefine(assert_script_run => sub { return 0 });
-    $sles4sap->redefine(record_info => sub { return 0; });
+    $sles4sap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $sles4sap->redefine(script_output => sub { return 1; });
     my %input_vars = (sapcar_bin_path => '/sapinst/SAPCAR',
         sar_archives_dir => '/sapinst/',
@@ -175,7 +175,7 @@ subtest '[netweaver_installation_data] Test returned values - common variables' 
 subtest '[sapcontrol_process_check] Test expected failures.' => sub {
     my $mockObject = sles4sap->new();
     my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
-    $sles4sap->redefine(record_info => sub { return; });
+    $sles4sap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $sles4sap->redefine(sapcontrol => sub { return '3'; });
     my %argument_values = (
         sidadm => 'sidadm', instance_id => '00', expected_state => 'started');
@@ -202,7 +202,7 @@ subtest '[sapcontrol_process_check] Test expected failures.' => sub {
 subtest '[sapcontrol_process_check] Function PASS.' => sub {
     my $mockObject = sles4sap->new();
     my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
-    $sles4sap->redefine(record_info => sub { return; });
+    $sles4sap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my %argument_values = (instance_id => '00', expected_state => 'started');
 
     $sles4sap->redefine(sapcontrol => sub { return '4' });

--- a/t/18_saputils.t
+++ b/t/18_saputils.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use Data::Dumper;
+use List::Util qw(any);
+use testapi;
+use saputils;
+
+
+subtest '[calculate_hana_topology] invalid output' => sub {
+    my $saputils = Test::MockModule->new('saputils', no_auto => 1);
+    $saputils->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $topology = calculate_hana_topology(input => 'PUFFI');
+    ok keys %$topology == 0, 'No entry in topology if SAPHanaSR-showAttr has nothing';
+};
+
+subtest '[calculate_hana_topology] minimal 2 nodes' => sub {
+    my $saputils = Test::MockModule->new('saputils', no_auto => 1);
+    $saputils->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $topology = calculate_hana_topology(input => 'Global/global/cib-time="Thu Feb  1 18:33:56 2024"
+Global/global/maintenance="false"
+Sites/site_b/b="SOK"
+Hosts/vmhana01/vhost="AAAAAAA"
+Hosts/vmhana02/vhost="BBBBBBB"');
+    ok keys %$topology == 2, 'Output is about exactly 2 hosts';
+    ok((any { qr/vmhana01/ } keys %$topology), 'External hash has key vmhana01');
+    ok((any { qr/vmhana02/ } keys %$topology), 'External hash has key vmhana02');
+};
+
+subtest '[calculate_hana_topology] internal keys' => sub {
+    my $saputils = Test::MockModule->new('saputils', no_auto => 1);
+    $saputils->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $topology = calculate_hana_topology(input => 'Global/global/cib-time="Thu Feb  1 18:33:56 2024"
+Global/global/maintenance="false"
+Sites/site_b/b="SOK"
+Hosts/vmhana01/remoteHost="vmhana02"
+Hosts/vmhana01/sync_state="PRIM"
+Hosts/vmhana01/vhost="vmhana01"
+Hosts/vmhana02/remoteHost="vmhana01"
+Hosts/vmhana02/sync_state="SOK"
+Hosts/vmhana02/vhost="vmhana02"');
+
+    note("Parsed input looks like " . Dumper($topology));
+    ok((keys %$topology eq 2), "Parsed input has two hosts, so two outer keys.");
+
+    while (my ($key, $value) = each %$topology) {
+        ok((keys %$value eq 3), "Parsed input has 3 values for each host, so 3 inner keys.");
+
+        # how to access one value of an inner hash
+        like(%$value{remoteHost}, qr/vmhana0/, 'remoteHost is like vmhana0');
+    }
+    # how to access one inner value in one shot
+    ok((%$topology{vmhana01}->{sync_state} eq 'PRIM'), 'sync_state of vmhana01 is exactly PRIM');
+};
+
+done_testing;


### PR DESCRIPTION
Rework get_hana_topology and function used by it to move the pure string parsing part of the `SAPHanaSR-showAttr --format=script` output to a separate and centralized place.
Change get_hana_topology return data format frm list of hash to hash of hash, remove the hosthame argument.

- Related ticket: TEAM-9022

# Verification run:

## HanaSR

### 15sp5

#### sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-02-05T05:03:09Z-hanasr_azure_test_sbd@64bit 
- http://openqaworker15.qa.suse.cz/tests/275404 :green_circle: overall test is pass, changed code looks ok, most nested `enable_replication` composed cmd http://openqaworker15.qa.suse.cz/tests/275404#step/Stop_site_a-primary/87

- http://openqaworker15.qa.suse.cz/tests/275463

 #### sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-02-05T05:03:09Z-hanasr_azure_test_msi@64bit

- http://openqaworker15.qa.suse.cz/tests/275405 :green_circle: code in the PR behaves properly. Overall result is FAIL, seems vmhana01 node is not healthy http://openqaworker15.qa.suse.cz/tests/275405#step/Crash_site_a-primary/97 


### 15sp4

#### sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-02-05T05:03:09Z-hanasr_azure_test_sapconf_msi@64bit 

- http://openqaworker15.qa.suse.cz/tests/275400 :red_circle: job FAILS before to reach the changed code. It fails for timeout in `az vm identity assign`.
- http://openqaworker15.qa.suse.cz/tests/275464

#### sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-02-05T05:03:09Z-hanasr_azure_test_sapconf_sbd@64bit 

- http://openqaworker15.qa.suse.cz/tests/275401 :green_circle: 

 #### sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-02-05T05:03:09Z-hanasr_azure_test_sapconf_spn@64bit 

- http://openqaworker15.qa.suse.cz/tests/275402 :green_circle: it has Ansible reboot timeout but then self recovery http://openqaworker15.qa.suse.cz/tests/275402#step/deploy_qesap_ansible/22

 #### sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-02-05T05:03:09Z-hanasr_azure_test_saptune_msi@64bit 

- http://openqaworker15.qa.suse.cz/tests/275403



### 15sp6

### 12sp5

#### sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2024-02-05T05:03:09Z-hanasr_azure_test_sbd@64bit

- http://openqaworker15.qa.suse.cz/tests/275406 :green_circle: 
