### PR TITLE
btrfs-progs: workaround grub2 issue for installation

### DIFF
--- a/tests/btrfs-progs/install.pm
+++ b/tests/btrfs-progs/install.pm
@@ -11,8 +11,9 @@ use base 'opensusebasetest';
 use utils;
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use version_utils 'is_transactional';
+use version_utils qw(is_transactional is_sle_micro);
 use transactional;
+use Utils::Architectures 'is_aarch64';
 
 use constant STATUS_LOG => '/opt/status.log';
 
@@ -51,7 +52,7 @@ sub run {
         zypper_ar($dep_url, name => 'dependency-repo', priority => 90);
         if (is_transactional) {
             trup_call("pkg install $btrfs_package_name");
-            reboot_on_changes;
+            (is_sle_micro(">=6.0") && is_aarch64) ? process_reboot(trigger => 1, expected_grub => 0) : reboot_on_changes;
         }
         else {
             zypper_call 'rm btrfsprogs' unless get_var('KEEP_DEFAULT_BTRFS_BINARY');


### PR DESCRIPTION
grub2 autoboot on Micro 6.0 on aarch64. Thus use expected_grub=0 to workaround this.


- Related ticket: https://progress.opensuse.org/issues/154087
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/13442038 (Marble)
https://openqa.suse.de/tests/13442039 (ALP)
