### PR TITLE
Remove soft-failure of bsc#1142559 for yast2_keyboard test module

### DIFF
--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -78,7 +78,6 @@ sub run {
     x11_start_program("xterm");
     enter_cmd "/sbin/yast2 keyboard";
     if (check_screen("yast2-keyboard-ui", 10)) {
-        record_soft_failure "bsc#1142559, yast2 keyboard should not start as non root user";
         send_key "alt-c";
         wait_still_screen 2;
     }


### PR DESCRIPTION
The bsc#1142559 is closed as WONTFIX, so remove the soft-failure of bsc#1142559: Input command '/sbin/yast2 keyboard' on a non root user, the keyboard is started, but can not save any changes, so cancel the changes.

- Related ticket: https://progress.opensuse.org/issues/151900
- Needles: n/a
- Verification run: [15SP5](https://openqa.suse.de/tests/13442053#step/yast2_keyboard/26);  [15SP4](https://openqa.suse.de/tests/13442051#step/yast2_keyboard/26); [15SP3](https://openqa.suse.de/tests/13442124); [15SP2](https://openqa.suse.de/tests/13442108); [15SP1](https://openqa.suse.de/tests/13442132); [12-SP5](https://openqa.suse.de/tests/13442134)
