### PR TITLE
welcome: Increase timeout on ppc64le

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -117,7 +117,7 @@ sub run {
     while ($iterations++ < scalar(@welcome_tags)) {
         # See poo#19832, sometimes manage to match same tag twice and test fails due to broken sequence
         wait_still_screen 5;
-        my $timeout = is_aarch64 ? '1000' : '500';
+        my $timeout = is_aarch64 || is_ppc64le ? '1000' : '500';
         assert_screen(\@welcome_tags, $timeout);
         # Normal exit condition
         if (match_has_tag 'local-registration-server') {


### PR DESCRIPTION
self update can need more time, IMO due to slow network

- Related ticket: 
```
 13438390 | qam-minimal-full                   | sle    | 15-SP2  | failed | :32469:openssl-1_0_0
 13438209 | qam-minimal-full                   | sle    | 15-SP2  | failed | :32466:openssl-1_1
 13438182 | qam-minimal-full                   | sle    | 15-SP2  | failed | :32466:openssl-1_1
 13437921 | qam-minimal-full                   | sle    | 15-SP2  | failed | :32469:openssl-1_0_0
 13437920 | qam-minimal                        | sle    | 15-SP2  | failed | :32469:openssl-1_0_0
 13437916 | qam-minimal                        | sle    | 15-SP2  | failed | :32466:openssl-1_1
 13437915 | qam-minimal-full                   | sle    | 15-SP2  | failed | :32466:openssl-1_1
 13436706 | qam-minimal-full                   | sle    | 15-SP2  | failed | :32469:openssl-1_0_0
 13436705 | qam-minimal                        | sle    | 15-SP2  | failed | :32469:openssl-1_0_0
 13436704 | qam-minimal-full                   | sle    | 15-SP2  | failed | :32466:openssl-1_1
 13436703 | qam-minimal                        | sle    | 15-SP2  | failed | :32466:openssl-1_1
 13376706 | qam-minimal-full                   | sle    | 15-SP2  | failed | :32283:cpio
 13376705 | qam-minimal                        | sle    | 15-SP2  | failed | :32283:cpio
```
- Verification run:
https://openqa.suse.de/tests/13441045