### PR TITLE
Fix for ansible GUI remediation

### DIFF
--- a/lib/oscap_tests.pm
+++ b/lib/oscap_tests.pm
@@ -1032,8 +1032,6 @@ sub oscap_security_guide_setup {
 sub oscap_remediate {
     my ($self) = @_;
     my $out_ansible_playbook;
-    select_console 'root-console';
-
     # Verify mitigation mode
     if ($remediated == 0) {
         push(@test_run_report, "[tests_results]");
@@ -1071,6 +1069,11 @@ sub oscap_remediate {
         }
         $ret
           = script_run($script_cmd, timeout => 3200);
+        # In case if STIG rules switches console to GUI need to switch it back
+        if ($profile_ID =~ /stig/) {
+            select_console 'root-console';
+        }
+
         record_info("Return=$ret", "$script_cmd  returned: $ret");
         if ($ret != 0 and $ret != 2 and $ret != 4) {
             record_info("Returened $ret", 'remediation should be succeeded', result => 'fail');

--- a/tests/security/oscap_profile_tests/oscap_xccdf_remediate.pm
+++ b/tests/security/oscap_profile_tests/oscap_xccdf_remediate.pm
@@ -12,6 +12,7 @@ use utils;
 
 sub run {
     my ($self) = @_;
+    select_console 'root-console';
 
     $self->oscap_remediate();
 }


### PR DESCRIPTION
Fix for ansible GUI remediation - some ansible remediation rules switches from root-console to GUI and remediation fails.
After ansible remediation for STIG profile switching back to the root console.

- Related ticket: https://progress.opensuse.org/issues/154618
- Verification run: https://openqa.suse.de/tests/13433637
