### PR TITLE
Remove remnants in higher java versions

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -74,7 +74,7 @@ sub run {
         }
         else {
             remove_suseconnect_product('sle-module-legacy');
-            (script_run 'rpm -qa | grep java-1_') || zypper_call('rm java-1_*');
+            (script_run 'rpm -qa | grep java-*') || zypper_call('rm java-*');
         }
     }
 }


### PR DESCRIPTION
Remove java full from the system to avoid orphaned packages in SLES15-SP6.

- Related ticket: https://progress.opensuse.org/issues/155005
- Verification run: https://duck-norris.qe.suse.de/tests/14279
