### PR TITLE
containers: Enable podman upstream tests in SLEM 5.4

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -42,8 +42,9 @@ sub run {
     }
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns bats catatonit jq make netavark netcat-openbsd openssl podman-remote python3-PyYAML socat skopeo sudo systemd-container);
+    my @pkgs = qw(aardvark-dns bats catatonit jq make netavark netcat-openbsd openssl podman-remote python3-PyYAML socat sudo systemd-container);
     push @pkgs, qw(apache2-utils buildah criu go gpg2) unless is_sle_micro;
+    push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');
     if (is_transactional) {
         trup_call "-c pkg install -y @pkgs";
         check_reboot_changes;


### PR DESCRIPTION
 Enable podman upstream tests in SLEM 5.4

- Related ticket: https://progress.opensuse.org/issues/153214
- Verification run: https://openqa.suse.de/tests/13447403