### PR TITLE
Change hdbnsutil -sr_register command composition

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -372,12 +372,12 @@ sub check_takeover {
 =cut
 
 sub enable_replication {
-    my ($self) = @_;
+    my ($self, $topology) = @_;
     my $hostname = $self->{my_instance}->{instance_id};
     die("Database on the fenced node '$hostname' is not offline") if ($self->is_hana_database_online);
     die("System replication '$hostname' is not offline") if ($self->is_primary_node_online);
 
-    my $topology = $self->get_hana_topology();
+    #my $topology = $self->get_hana_topology();
     foreach (qw(vhost remoteHost srmode op_mode site)) {
         die "Missing '$_' field in topology output" unless defined(%$topology{$hostname}->{$_});
     }

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -378,10 +378,12 @@ sub enable_replication {
     die("System replication '$hostname' is not offline") if ($self->is_primary_node_online);
 
     my $topology = $self->get_hana_topology();
-    foreach (qw(vhost remoteHost srmode op_mode)) { die "Missing '$_' field in topology output" unless defined(%$topology{$hostname}->{$_}); }
+    foreach (qw(vhost remoteHost srmode op_mode site)) {
+        die "Missing '$_' field in topology output" unless defined(%$topology{$hostname}->{$_});
+    }
 
     my $cmd = join(' ', 'hdbnsutil -sr_register',
-        '--name=' . %$topology{$hostname}->{vhost},
+        '--name=' . %$topology{$hostname}->{site},
         '--remoteHost=' . %$topology{$hostname}->{remoteHost},
         '--remoteInstance=00',
         '--replicationMode=' . %$topology{$hostname}->{srmode},

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -441,12 +441,14 @@ subtest '[enable_replication]' => sub {
             remoteHost => 'vmhana02',
             srmode => 'PIPPO',
             op_mode => 'PAPERINO',
+            site => 'DONALDUCK',
         },
         vmhana02 => {
             vhost => 'vmhana02',
             remoteHost => 'vmhana01',
             srmode => 'PIPPO',
             op_mode => 'PAPERINO',
+            site => 'ROCKERDUCK',
         }
     );
     $sles4sap_publiccloud->redefine(get_hana_topology => sub { return \%test_topology; });
@@ -465,6 +467,8 @@ subtest '[enable_replication]' => sub {
 
     note("\n  C -->  " . join("\n  -->  ", @calls));
     ok((any { qr/hdbnsutil -sr_register/ } @calls), 'hdbnsutil cmd correctly called');
+    ok((any { qr/--name=DONALDUCK/ } @calls), 'hdbnsutil name');
+    ok((any { qr/--remoteHost=vmhana02/ } @calls), 'hdbnsutil vmhana02');
 };
 
 done_testing;

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -451,7 +451,7 @@ subtest '[enable_replication]' => sub {
             site => 'ROCKERDUCK',
         }
     );
-    $sles4sap_publiccloud->redefine(get_hana_topology => sub { return \%test_topology; });
+    #$sles4sap_publiccloud->redefine(get_hana_topology => sub { return \%test_topology; });
     my @calls;
     $sles4sap_publiccloud->redefine(run_cmd => sub {
             my ($self, %args) = @_;
@@ -461,7 +461,7 @@ subtest '[enable_replication]' => sub {
 
     set_var('SAP_SIDADM', 'YONDUR');
 
-    $self->enable_replication();
+    $self->enable_replication(\%test_topology);
 
     set_var('SAP_SIDADM', undef);
 

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -57,6 +57,9 @@ sub run {
         $sbd_delay = $self->sbd_delay_formula();
     }
 
+    # Check topology before to stop HANA
+    my $topology = $self->get_hana_topology();
+
     # Stop/kill/crash HANA DB and wait till SSH is again available with pacemaker running.
     $self->stop_hana(method => $takeover_action);
     $self->{my_instance}->wait_for_ssh(username => 'cloudadmin');
@@ -81,7 +84,7 @@ sub run {
     $self->check_takeover;
 
     record_info('Replication', join(' ', ('Enabling replication on', ucfirst($site_name), '(DEMOTED)')));
-    $self->enable_replication();
+    $self->enable_replication($topology);
 
     record_info(ucfirst($site_name) . ' start');
     $self->cleanup_resource();


### PR DESCRIPTION
Change string used as --name argument in hdbnsutil -sr_register to match site name used during the deployment. The site name is directly retrieved using SAPHanaSR-showAttr.

This solution has minimal set of change but it does not work.

 `site` field is not present in `SAPHanaSR-showAttr` outout:
-  calling `SAPHanaSR-showAttr` after the HANA stop http://openqaworker15.qa.suse.cz/tests/275465#step/Stop_site_a-primary/80
- but also calling it before http://openqaworker15.qa.suse.cz/tests/275480#step/Stop_site_a-primary/13

- Related ticket: https://jira.suse.com/browse/TEAM-9012

This PR does not work as it is, the issue for the moment has been fixed in a different way in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18680

# Verification run:

## 15sp5

### sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-02-06T05:03:11Z-hanasr_azure_test_sbd@64bit 
 
- http://openqaworker15.qa.suse.cz/tests/275465 result with COMMIT1

- http://openqaworker15.qa.suse.cz/tests/275480 result with COMMIT2

## 15sp4
- sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-02-06T05:03:11Z-hanasr_azure_test_sapconf_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/275466

## 15sp3
 - sle-15-SP3-HanaSr-Azure-Byos-x86_64-Build15-SP3_2024-02-06T05:03:11Z-hanasr_azure_test_spn@64bit -> http://openqaworker15.qa.suse.cz/tests/275467

