### PR TITLE
Install openldap2 packages in SLES15SP3 migration regression cases

### DIFF
--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -10,6 +10,7 @@
 use base "consoletest";
 use strict;
 use warnings;
+use Utils::Architectures;
 use testapi;
 use utils;
 use power_action_utils 'power_action';
@@ -30,6 +31,10 @@ sub run {
     # update patches we'd better to select_console to make test robust.
     select_console 'root-console';
     install_patterns() if (get_var('PATTERNS'));
+    # Install openldap package as required
+    if ((get_var('FLAVOR') =~ /Regression/) && check_var('HDDVERSION', '15-SP3') && is_x86_64) {
+        zypper_call("in sssd sssd-tools sssd-ldap openldap2 openldap2-client");
+    }
     deregister_dropped_modules;
     # disable multiversion for kernel-default based on bsc#1097111, for migration continuous cases only
     if (get_var('FLAVOR', '') =~ /Continuous-Migration/) {

--- a/tests/migration/openldap_configuration.pm
+++ b/tests/migration/openldap_configuration.pm
@@ -20,9 +20,6 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    # Install openldap since we need use slaptest tools
-    zypper_call("in sssd sssd-tools sssd-ldap openldap2 openldap2-client");
-
     # Disable and stop the nscd daemon because it conflicts with sssd
     disable_and_stop_service('nscd') if check_unit_file('nscd');
 

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -87,6 +87,11 @@ sub patching_sle {
     # Install salt packages as required
     install_salt_packages() if (check_var_array('SCC_ADDONS', 'asmm'));
 
+    # Install openldap package as required
+    if ((get_var('FLAVOR') =~ /Regression/) && check_var('HDDVERSION', '15-SP3') && is_x86_64) {
+        zypper_call("in sssd sssd-tools sssd-ldap openldap2 openldap2-client");
+    }
+
     # create btrfs subvolume for aarch64
     create_btrfs_subvolume() if (is_aarch64);
 


### PR DESCRIPTION
Install openldap2 packages in SLES15SP3 migration regression cases

- Related ticket: https://progress.opensuse.org/issues/154912
- Verification run: https://openqa.suse.de/tests/13449058#
   https://openqa.suse.de/tests/13449059
