### PR TITLE
Add ignore for truncation of dmi_memory_id

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -603,5 +603,12 @@
             "alp":  ["1.0"]
         },
         "type": "bug"
+    },
+    "Truncating stdout of dmi_memory_id": {
+        "description": "Truncating stdout of 'dmi_memory_id' up to .* byte",
+        "products": {
+            "sle": ["15-SP6"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
Ignore the output of truncating the dmi_memory_id.

- Related failure: e.g. https://openqa.suse.de/tests/13395352
- Verification run: https://duck-norris.qe.suse.de/tests/14281#step/journal_check/9 (unrelated failure)
