### PR TITLE
Add schedule and condition for 15SP3 skip_registration

### DIFF
--- a/schedule/yast/skip_registration/skip_registration_15sp3.yaml
+++ b/schedule/yast/skip_registration/skip_registration_15sp3.yaml
@@ -1,0 +1,32 @@
+---
+name:           skip_registration
+description:    >
+  Skipping registration for SLE 15, as requires network connection.
+  This is default behavior for SLE 12.
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/licensing/accept_license
+  - installation/registration/skip_registration
+  - installation/addon_products_sle
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+  - installation/partitioning/accept_proposed_layout
+  - installation/clock_and_timezone/accept_timezone_configuration
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+  - installation/installation_settings/validate_default_target
+  - installation/bootloader_settings/disable_boot_menu_timeout
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+  - installation/logs_from_installation_system
+  - installation/performing_installation/confirm_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -170,7 +170,7 @@ sub run {
             $sr_number++ unless (is_sle('15+') && $sr_number == 1);
             # in full_installer the dialog to choose the installation media
             # does not appear, thus we have to skip it
-            unless ((check_var('FLAVOR', 'Full')) || check_var('FLAVOR', 'Full-QR') || ((is_sle('15-SP2+') && get_var('MEDIA_UPGRADE')))) {
+            unless ((check_var('FLAVOR', 'Full')) || check_var('FLAVOR', 'Full-QR') || (is_sle('15-SP3+') && (check_var('FLAVOR', 'Server-DVD-Updates'))) || ((is_sle('15-SP2+') && get_var('MEDIA_UPGRADE')))) {
                 assert_screen 'addon-menu-active';
                 wait_screen_change { send_key 'alt-d' };    # DVD
                 send_key $cmd{next};


### PR DESCRIPTION
The existing skip_registration schedule doesn't work for 15SP3. Adding a customized one.

- Related ticket: https://progress.opensuse.org/issues/154729
- Verification runs :  https://openqa.suse.de/tests/13450454
https://openqa.suse.de/tests/13450445

Merge before: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/72/diffs
