### PR TITLE
Ignore clocksource messages

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -610,5 +610,33 @@
             "sle": ["15-SP6"]
         },
         "type": "ignore"
+    },
+    "tsc unstable": {
+        "description": "clocksource: timekeeping watchdog on CPU.*: Marking clocksource 'tsc' as unstable because the skew is too large",
+        "products": {
+            "sle": ["15-SP6"]
+        },
+        "type": "ignore"
+    },
+    "clocksource info": {
+        "description": "clocksource: .* .*now: .* .*last: .* mask: .*",
+        "products": {
+            "sle": ["15-SP6"]
+        },
+        "type": "ignore"
+    },
+    "clocksource skewed": {
+        "description": "clocksource: .* skewed .* over watchdog .*",
+        "products": {
+            "sle": ["15-SP6"]
+        },
+        "type": "ignore"
+    },
+    "clocksource switched": {
+        "description": "clocksource: .* is current clocksource",
+        "products": {
+            "sle": ["15-SP6"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
Ignore kernel warnings about clocksource skewing

- Related failure: https://openqa.suse.de/tests/13449279#step/journal_check/9
- Discussion: https://suse.slack.com/archives/C02DQJKULE4/p1707302944678129
- Verification run: https://duck-norris.qe.suse.de/tests/14287#step/journal_check/1 and https://duck-norris.qe.suse.de/tests/14288#step/journal_check/1
