### PR TITLE
xfstests: Getting faster test speed

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -412,6 +412,7 @@ XFSTESTS_HEARTBEAT_TIMEOUT | integer | 200 | The timeout (seconds) of not receiv
 XFSTESTS_SUBTEST_MAXTIME | integer | 2400 | Define the max test time (seconds) for a single subtest. The test logic will take the time out as a hang, to reset SUT and continue the rest of the tests. Considering xfstests contain some fuzzing tests which take quite a long time to finish, I suggest this max time don't set too small
 XFSTESTS_NO_HEARTBEAT | boolean | 0 | set XFSTESTS_NO_HEARTBEAT=1 to enable non-heartbeat mode. The heartbeat mode is default, you could also unset this parameter
 XFSTESTS_TIMEOUT | integer | 2000 | set de timeout (seconds) for each subtest. It is only used in non-heartbeat mode. And it's the only time control strategy in that mode
+XFSTESTS_HIGHSPEED | boolean | 0 | set XFSTESTS_HIGHSPEED=1 to reduce the typing and waiting time. Suggest to set also VIRTIO_CONSOLE=1 and XFSTESTS_NO_HEARTBEAT=1 to getting highest performance. But beware system may hang in a crash because send_key 'alt-sysrq-b' not working in virtio console.
 
 
 Installation related: some optional setting to solve testsuite installation dependency issue


### PR DESCRIPTION
1. Modify some code to higher test speed
2. Add an XFSTESTS_HIGHSPEED switch to get better performance but less stability, which could accurately be configured in stable tests
3. When VIRTIO_CONSOLE is enabled, use another API than send_key because send_key is not supported in virtio console.

- Related ticket: https://progress.opensuse.org/issues/154975
- Verification run: 
- Enable XFSTESTS_HIGHSPEED(also disable Heartbeat): https://openqa.suse.de/tests/13539724
The test time getting much faster, and could compare to the one without this PR: https://openqa.suse.de/tests/13365224
Test time 31:15 minutes->06:32 minutes
- a test without enabling XFSTESTS_HIGHSPEED(to prove it not affect tests without this setting): https://openqa.suse.de/tests/13539723