### PR TITLE
Add bsc#1205589 workaround for SLE16SP6

### DIFF
--- a/tests/x11/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11/gnomecase/nautilus_open_ftp.pm
@@ -21,7 +21,7 @@ sub run {
     wait_screen_change { send_key 'ctrl-l' };
     enter_cmd "ftp://ftp.suse.com";
     assert_screen 'nautilus-ftp-login';
-    if (is_tumbleweed) {
+    if (is_tumbleweed || is_sle('15-SP6+')) {
         record_soft_failure("bsc#1205589 Enter key doesn't work on nautilus-ftp-login screen");
         assert_and_click "nautilus-ftp-connect";
     }


### PR DESCRIPTION
The Enter key doesn't work on nautilus-ftp-login screen since from GNOME45 (bsc#1205589)
In recent SLE15SP6 builds, the GNOME was updated to 45, so we need to add workaround for bsc#1205589

- Related ticket: https://progress.opensuse.org/issues/154198
- Needles: already added when debugging on o.s.d
- Verification run: 

> - Wayland: https://openqa.suse.de/tests/13467020#
> - X11: https://openqa.suse.de/tests/13466991#

No verification runs needed for Tumbleweed since the workaround has already enabled for it.
No verification runs needed for Leap since the test suite is not enabled for it.