### PR TITLE
hpc: Add rasdaemon test to kernel extra testsuite

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2528,6 +2528,7 @@ sub load_extra_tests_syscontainer {
 sub load_extra_tests_kernel {
     loadtest "kernel/tuned";
     loadtest "kernel/fwupd" if is_sle('15+');
+    loadtest "hpc/rasdaemon" if (is_sle('15+') || is_tumbleweed);
 
     # keep it on the latest place as it taints kernel
     loadtest "kernel/module_build";


### PR DESCRIPTION
Fix poo#155146: rasdaemon is part of Server applications module since SLE 15.  We need to test it daily updates on SLE 15+ and also Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/155146
- Needles: none
- Verification run:
TW: https://openqa.opensuse.org/tests/3923359
SLE 15-SP1: https://openqa.suse.de/tests/13467405
SLE 15-SP2: https://openqa.suse.de/tests/13467431
SLE 15-SP3: https://openqa.suse.de/tests/13467403
SLE 15-Sp4: https://openqa.suse.de/tests/13467430
SLE 15-SP5: https://openqa.suse.de/tests/13467413
SLE 15-SP6: https://openqa.suse.de/tests/13467423

