### PR TITLE
No need install openldap for regression 15sp3 jobs

### DIFF
--- a/tests/migration/openldap_configuration.pm
+++ b/tests/migration/openldap_configuration.pm
@@ -11,6 +11,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use strict;
 use warnings;
+use Utils::Architectures;
 use utils;
 use Utils::Systemd qw(systemctl disable_and_stop_service check_unit_file);
 use version_utils qw(is_tumbleweed is_sle);
@@ -19,6 +20,10 @@ use Utils::Logging 'tar_and_upload_log';
 sub run {
     my ($self) = @_;
     select_serial_terminal;
+
+    # Install openldap since we need use slaptest tools
+    my $install_openldap = !((get_var('FLAVOR') =~ /Regression/) && check_var('HDDVERSION', '15-SP3') && is_x86_64);
+    zypper_call("in sssd sssd-tools sssd-ldap openldap2 openldap2-client") if $install_openldap;
 
     # Disable and stop the nscd daemon because it conflicts with sssd
     disable_and_stop_service('nscd') if check_unit_file('nscd');


### PR DESCRIPTION
No need install openldap for regression 15sp3 jobs

- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18607
- VR: https://openqa.opensuse.org/tests/3923570
