### PR TITLE
multipath: Add post fail hook to upload coredump

### DIFF
--- a/tests/kernel/multipath_iscsi.pm
+++ b/tests/kernel/multipath_iscsi.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2023 SUSE LLC
+# Copyright 2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Smoke test for multipath over iscsi
@@ -43,6 +43,12 @@ sub run {
     assert_script_run("multipathd -k\"show multipaths status\"");
     # Connection cleanup
     iscsi_logout $iqn, $target;
+}
+
+sub post_fail_hook {
+    my $self = shift;
+    $self->SUPER::post_fail_hook;
+    $self->upload_coredumps;
 }
 
 1;


### PR DESCRIPTION
Enhancement poo#155197: We need to upload coredump file get more information
in case of failure.

- Related ticket: https://progress.opensuse.org/issues/155197
- Needles: 
- Verification run:  https://openqa.suse.de/tests/13470122