### PR TITLE
containers: cni issue in volumes_podman tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/**/*.html
 /script/yaml_generator/env/
 __pycache__/
 .tidyall.d/
+.vscode/

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -54,6 +54,7 @@ our @EXPORT = qw(
   is_updates_test_repo
   is_updates_tests
   is_migration_tests
+  is_sh_ok
   kdestep_is_applicable
   kdump_is_applicable
   load_autoyast_clone_tests
@@ -332,6 +333,27 @@ sub is_desktop_module_selected {
       || (!is_sle('15+') && get_var('SCC_ADDONS', '') =~ /desktop|we|productivity|ha/)
       || (is_sle('15+') && get_var('SCC_ADDONS', '') =~ /desktop|we/)
       || is_sles4sap;
+}
+
+=head2 is_sh_ok
+
+    is_sh_ok($exit_code);
+
+For perl checks, to convert in positive-logic true or 1 value the exit_code 0 of an ok shell script.
+Can be used i.e. with script_run() in perl code.
+
+Return:
+the perl check passed status for a shell ok exit code, 
+that is true(1) and ok when input value is defined and zero: C<$x eq 0>
+otherwise false(undef or non-0).
+
+=cut
+
+sub is_sh_ok {
+    my $x = shift;
+    # convert to number
+    if (defined($x) and $x =~ /^[+-]?\d+$/) { $x += 0 } else { undef $x }
+    return (defined($x) and $x eq 0);
 }
 
 sub default_desktop {

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -11,7 +11,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
 use version_utils qw(package_version_cmp is_transactional is_jeos is_leap is_sle_micro is_leap_micro is_sle is_microos is_public_cloud);
-use containers::utils qw(get_podman_version registry_url);
+use containers::utils qw(get_podman_version registry_url check_podman);
 use transactional qw(trup_call check_reboot_changes);
 use utils qw(zypper_call);
 use Utils::Systemd qw(systemctl);
@@ -62,6 +62,8 @@ sub _cleanup {
     }
 
     validate_script_output('podman network ls', sub { /podman\s+bridge/ });
+
+    check_podman(reset => 1);
 }
 
 sub switch_to_netavark {

--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -30,7 +30,6 @@ sub run {
     } else {
         return;
     }
-
     # From https://docs.docker.com/storage/bind-mounts/
     # The --mount flag does not support z or Z options for modifying selinux labels.
     my $Z = $runtime eq "podman" ? ",Z" : "";

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -53,6 +53,8 @@ sub run {
         }
         # VM repos.dir support preparation
         $args->{my_instance}->ssh_assert_script_run("sudo mkdir $repodir;sudo chmod 777 $repodir");
+        # List repos IDs prepared for transfer to vm:
+        script_run("cat /tmp/transfer_repos.txt; ls -l ~/repos/*/*/*/*");
         # Mitigate occasional CSP network problems (especially one CSP is prone to those issues!)
         # Delay of 2 minutes between the tries to give their network some time to recover after a failure
         # For rsync the ~/repos/./ means that the --relative will take efect after.


### PR DESCRIPTION
A container network issue impacted `volumes_podman` in `slem_containers_selinux` tests of group [532](https://openqa.suse.de/group_overview/532), after **cni** and **neavark** modules run. Some check have been added, to introduce resilience.

Also present a repo listing in transfer_repos, to help checking expected repos when issues of `repository-not-found` may occurr.

Finally, proposed a test-function using positive-logic in perl code test in place of the shell inverted-logic checks, to replace shell exit code `script == 0` checks with more radable `is_sh_ok(script)`.

- Related ticket: https://progress.opensuse.org/issues/137168
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/13473070
