### PR TITLE
Fix and schedule openssl nodejs tests for SLE 15 SP4 and SP5

### DIFF
--- a/data/console/test_openssl_nodejs.sh
+++ b/data/console/test_openssl_nodejs.sh
@@ -85,6 +85,9 @@ main(){
   OS_VERSION="$1"
   echo "OS_VERSION: $OS_VERSION"
 
+  # set variable to fix https://progress.opensuse.org/issues/155083
+  export OPENSSL_SYSTEM_CIPHERS_OVERRIDE=xyz_nonexistent_file
+
   # Install dependencies to apply source patches and run tests
   zypper -n in quilt rpm-build  libopenssl1_1-hmac
 

--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -41,10 +41,12 @@ conditional_schedule:
   version_specific:
     VERSION:
       15-SP5:
+        - console/openssl_nodejs
         - console/golang
         - console/redis
         - '{{arch_specific}}'
       15-SP4:
+        - console/openssl_nodejs
         - console/golang
         - console/redis
         - '{{arch_specific}}'


### PR DESCRIPTION
Fix and schedule openssl nodejs tests for SLE 15 SP4 and SP5

- Related ticket: https://progress.opensuse.org/issues/155083

- Verification run:
15sp4 x86 https://openqa.suse.de/tests/13502006
15sp4 s390 https://openqa.suse.de/tests/13502015
15sp4 aarch https://openqa.suse.de/tests/13502016

15sp5 aarch https://openqa.suse.de/tests/13502017
15sp5 s390 https://openqa.suse.de/tests/13502018
15sp5 x86(full schedule) https://openqa.suse.de/tests/13502022
