### PR TITLE
qemu kvm: Enable aarch64 test for bare metal only

### DIFF
--- a/schedule/functional/extra_tests_qemu.yaml
+++ b/schedule/functional/extra_tests_qemu.yaml
@@ -3,9 +3,23 @@ description:    >
     Maintainer: dheidler.
     Extra qemu tests
 conditional_schedule:
+    start:
+        BACKEND:
+            'qemu':
+                - installation/bootloader_start
+                - boot/boot_to_desktop
+            'generalhw':
+                - jeos/prepare_firstboot
+                - jeos/firstrun
+                - update/zypper_clear_repos
+                - console/zypper_ar
+                - console/zypper_ref
+                - console/zypper_lr
     kvm:
         ARCH:
-            # nested kvm is not yet implemented on ARM and kvm not supported on ppc64le
+            # nested kvm is not yet available on ARM (but runnable on bare metal) and kvm not supported on ppc64le
+            'aarch64':
+                - qemu/kvm
             'x86_64':
                 - qemu/kvm
             's390x':
@@ -15,8 +29,7 @@ conditional_schedule:
             'opensuse':
                 - qemu/user
 schedule:
-    - installation/bootloader_start
-    - boot/boot_to_desktop
+    - '{{start}}'
     - qemu/info
     - qemu/qemu
     - '{{kvm}}'

--- a/tests/qemu/kvm.pm
+++ b/tests/qemu/kvm.pm
@@ -17,6 +17,11 @@ use utils;
 sub run {
     select_console 'root-console';
 
+    if (is_aarch64 && get_var('BACKEND') eq 'qemu') {
+        record_info 'Skip', 'No nested virt available on aarch64 yet';
+        return;
+    }
+
     if (is_x86_64) {
         enter_cmd "qemu-system-x86_64 -nographic -enable-kvm";
         assert_screen 'qemu-no-bootable-device', 60;


### PR DESCRIPTION
- Verification run: 
  * x86_64: https://openqa.opensuse.org/tests/3936149
  * aarch64 on RPi4: https://openqa.opensuse.org/tests/3934887 (expected fail on KVM due to a bug in spec file of qemu which disabled KVM)