### PR TITLE
containers: Skip podman secret test on podman < 3.1.0

### DIFF
--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -20,6 +20,10 @@ sub run {
     my ($self, $args) = @_;
     my $output = '';
 
+    my $podman_version = get_podman_version();
+    # Skip this module on podman < 3.1.0
+    return if (version->parse($podman_version) < version->parse('3.1.0'));
+
     select_serial_terminal();
 
     # Create a secret1 from file and inspect it
@@ -37,7 +41,6 @@ sub run {
 
     # "podman secret exists" was added to podman 4.5.0 according to
     # https://github.com/containers/podman/blob/main/RELEASE_NOTES.md#450
-    my $podman_version = get_podman_version();
     if (version->parse($podman_version) >= version->parse('4.5.0')) {
         # Check if secret exists
         record_info("secret exists", "In Podman, check that each created secret exists");


### PR DESCRIPTION
The secret subcommands were added in podman 3.1.0 according to:
https://github.com/containers/podman/blob/main/RELEASE_NOTES.md#310

- Failing test: https://openqa.suse.de/tests/13508482#step/podman/67
- Verification run: https://openqa.suse.de/tests/13509671