### PR TITLE
containers: Add --gpg-auto-import-keys to zypper ref in container

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -216,7 +216,7 @@ sub test_zypper_on_container {
     }
     validate_script_output_retry("$runtime run -i --entrypoint '' $image zypper lr -s", sub { m/.*Alias.*Name.*Enabled.*GPG.*Refresh.*Service/ }, timeout => 180);
     assert_script_run("$runtime run -t -d --name 'refreshed' --entrypoint '' $image bash", timeout => 300);
-    script_retry("$runtime exec refreshed zypper -nv ref", timeout => 600, retry => 3, delay => 60);
+    script_retry("$runtime exec refreshed zypper -nv --gpg-auto-import-keys ref", timeout => 600, retry => 3, delay => 60);
     assert_script_run("$runtime commit refreshed refreshed-image", timeout => 120);
     assert_script_run("$runtime rm -f refreshed");
     script_retry("$runtime run -i --rm --entrypoint '' refreshed-image zypper -nv ref", timeout => 300, retry => 3, delay => 60);


### PR DESCRIPTION
Add --gpg-auto-import-keys to zypper ref in container

- Related ticket: https://progress.opensuse.org/issues/155149
- Failing test: https://openqa.suse.de/tests/13440585/modules/image_docker/steps/169
- Verification run: https://openqa.suse.de/t13511122