### PR TITLE
Add qesap_execute retry function

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -63,6 +63,7 @@ our @EXPORT = qw(
   qesap_get_ansible_roles_dir
   qesap_prepare_env
   qesap_execute
+  qesap_execute_conditional_retry
   qesap_ansible_cmd
   qesap_ansible_script_output_file
   qesap_ansible_script_output
@@ -484,6 +485,73 @@ sub qesap_execute {
     qesap_upload_logs();
     my @results = ($exec_rc, $exec_log);
     return @results;
+}
+
+=head3 qesap_execute_conditional_retry
+
+    qesap_execute(cmd => $qesap_script_cmd [, verbose => 1, cmd_options => $cmd_options] );
+    cmd_options - allows to append additional qesap.py commands arguments
+    like "qesap.py terraform -d"
+        Example:
+        qesap_execute(cmd => 'terraform', cmd_options => '-d') will result in:
+        qesap.py terraform -d
+
+    Execute qesap glue script commands. Check project documentation for available options:
+    https://github.com/SUSE/qe-sap-deployment
+    Test only returns execution result, failure has to be handled by calling method.
+
+=over 7
+
+=item B<CMD> - qesap.py subcommand to run
+
+=item B<CMD_OPTIONS> - set of arguments for the qesap.py subcommand
+
+=item B<VERBOSE> - activate verbosity in qesap.py
+
+=item B<TIMEOUT> - max expected execution time
+
+=item B<LOGNAME> - filename of the log file. This argument is optional,
+                   if not specified the log filename is internally calculated
+                   using content from CMD and CMD_OPTIONS.
+
+=item B<RETRIES> - number of retries in case of expected error
+
+=item B<ERROR_STRING> - error string to look for
+
+=back
+=cut
+
+sub qesap_execute_conditional_retry {
+    my (%args) = @_;
+    croak 'Missing mandatory cmd argument' unless $args{cmd};
+    croak 'Missing mandatory error string' unless $args{error_string};
+    my $verbose = $args{verbose} ? "--verbose" : "";
+    $args{cmd_options} ||= '';
+    $args{timeout} //= bmwqemu::scale_timeout(90);
+    $args{logname} //= '';
+    $args{retries} //= 1;
+
+    my @ret = qesap_execute(cmd => $args{cmd}, verbose => $args{verbose}, timeout => $args{timeout}, logname => $args{logname});
+
+    if ($ret[0]) {
+        if (qesap_file_find_string(file => $ret[1], search_string => $args{error_string})) {
+            record_info('DETECTED '. uc($args{cmd}) . ' ERROR', $args{error_string});
+            @ret = qesap_execute(cmd => $args{cmd},
+                logname => 'qesap_' . $args{cmd} . '_retry.log.txt',
+                timeout => $args{timeout});
+            if ($ret[0])
+            {
+                qesap_cluster_logs();
+                die "'qesap.py $args{cmd}' return: $ret[0]";
+            }
+            record_info('QESAP_EXECUTE RETRY PASS');
+            return @ret;
+        }
+        else {
+            die "'qesap.py $args{cmd}' return: $ret[0]";
+        }
+    }
+    return @ret;
 }
 
 =head3 qesap_file_find_string

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -13,7 +13,7 @@ use qesapdeployment;
 sub run {
     my ($self) = @_;
     my $provider = get_required_var('PUBLIC_CLOUD_PROVIDER');
-    qesap_execute_conditional_retry(cmd => 'terraform', verbose => 1, timeout => 1800, retries => 1, search_string => 'An internal execution error occurred. Please retry later');
+    my @ret = qesap_execute_conditional_retry(cmd => 'terraform', verbose => 1, timeout => 1800, retries => 1, error_string => 'An internal execution error occurred. Please retry later');
 
     my $inventory = qesap_get_inventory(provider => $provider);
     upload_logs($inventory, failok => 1);

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -13,25 +13,8 @@ use qesapdeployment;
 sub run {
     my ($self) = @_;
     my $provider = get_required_var('PUBLIC_CLOUD_PROVIDER');
-    my @ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => 1800);
+    qesap_execute_conditional_retry(cmd => 'terraform', verbose => 1, timeout => 1800, retries => 1, search_string => 'An internal execution error occurred. Please retry later');
 
-    if ($ret[0]) {
-        if (qesap_file_find_string(file => $ret[1], search_string => 'An internal execution error occurred. Please retry later')) {
-            record_info('DETECTED TERRAFORM ERROR', 'INTERNAL ERROR');
-            @ret = qesap_execute(cmd => 'terraform',
-                logname => 'qesap_terraform_retry.log.txt',
-                timeout => 1800);
-            if ($ret[0])
-            {
-                qesap_cluster_logs();
-                die "'qesap.py terraform' return: $ret[0]";
-            }
-            record_info('TERRAFORM RETRY PASS');
-        }
-        else {
-            die "'qesap.py terraform' return: $ret[0]";
-        }
-    }
     my $inventory = qesap_get_inventory(provider => $provider);
     upload_logs($inventory, failok => 1);
 


### PR DESCRIPTION
**IMPORTANT**: Revert https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18605 before merging this

Add function to retry `qesap_execute` is a certain error string is detected in the returned logs.

- Related ticket: https://jira.suse.com/browse/TEAM-9027
- Verification runs:

**sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_sapconf_test@64bit**:
http://openqaworker15.qa.suse.cz/tests/276071

passed without error

**sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_saptune_test@64bit**:
http://openqaworker15.qa.suse.cz/tests/276072

passed without error

**FORCED ERROR (invalid QESAPDEPLOY_CLUSTER_OS_VER) BUT NOT THE ERROR WE'RE SEARCHING FOR**:
http://openqaworker15.qa.suse.cz/tests/276073#step/deploy/16

We can see the grep, but since the string we want is not found, it fails without retry
