### PR TITLE
Public Cloud: Support different regions in Azure upload_img

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -419,10 +419,11 @@ sub create_image_version {
     my $version = generate_img_version();
     my $os_vhd_uri = $self->get_blob_uri($file);
     my $tags = generate_tags();
+    my $target_regions = ($self->provider_client->region !~ $self->storage_region) ? $self->provider_client->region . ' ' . $self->storage_region : $self->provider_client->region;
     # Note: Repetitive calls do not fail
     assert_script_run("az sig image-version create --debug --resource-group '$resource_group' --gallery-name '$gallery' " .
           "--gallery-image-definition '$definition' --gallery-image-version '$version' --os-vhd-storage-account '$sa_url' " .
-          "--os-vhd-uri $os_vhd_uri --target-regions '" . $self->provider_client->region . "' --location " . $self->storage_region, timeout => 60 * 30);
+          "--os-vhd-uri $os_vhd_uri --target-regions $target_regions --location " . $self->storage_region, timeout => 60 * 30);
 }
 
 =head2 upload_img


### PR DESCRIPTION
As our image blob container is located in `westeurope` also our image versions needs to be located over there.
This fixes the case where we want to upload specific image version also to different region

- Related ticket: [poo#154243](https://progress.opensuse.org/issues/154243)
- Verification run: [southeastasia](https://pdostal-server.suse.cz/tests/5653#step/upload_image/193), [westeurope](https://pdostal-server.suse.cz/tests/5654#live)