### PR TITLE
Container cleanup fixes

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -353,6 +353,9 @@ sub cleanup_system_host {
             $self->_engine_script_run("pod rm --force --all", 120);
         }
         $self->_engine_assert_script_run("rm --force --all", 120);
+        # podman system prune -f --external was added to podman 4.0.0
+        # and it allows to prune external containers created by buildah
+        $self->_engine_script_run("system prune -f --external", 300);
     }
     $self->_engine_assert_script_run("volume prune -f", 300);
     $self->_engine_assert_script_run("system prune -a -f", 300);

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -141,15 +141,15 @@ sub load_host_tests_docker {
         loadtest 'containers/registry' if (is_x86_64 || is_sle('>=15-sp4'));
         loadtest 'containers/docker_compose' unless (is_public_cloud || is_sle('=12-sp3'));
     }
-    # Expected to work anywhere except of real HW backends, PC and Micro
-    unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro) {
-        loadtest 'containers/validate_btrfs';
-    }
     if (is_tumbleweed || is_microos) {
         loadtest 'containers/buildx';
         loadtest 'containers/rootless_docker';
     }
     load_volume_tests($run_args);
+    # Expected to work anywhere except of real HW backends, PC and Micro
+    unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro) {
+        loadtest 'containers/validate_btrfs';
+    }
 }
 
 sub load_host_tests_containerd_crictl {

--- a/tests/containers/docker_firewall.pm
+++ b/tests/containers/docker_firewall.pm
@@ -70,6 +70,8 @@ sub run {
         systemctl('stop ' . $self->firewall());
         systemctl('restart docker');
     }
+
+    $engine->cleanup_system_host();
 }
 
 sub post_fail_hook {

--- a/tests/containers/podman_firewall.pm
+++ b/tests/containers/podman_firewall.pm
@@ -47,6 +47,8 @@ sub run {
 
     # Stop the firewall if it was started by this test module
     systemctl('stop ' . $self->firewall()) if $stop_firewall;
+
+    $podman->cleanup_system_host();
 }
 
 sub post_fail_hook {

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -20,6 +20,8 @@ sub run {
     my ($self, $args) = @_;
     my $output = '';
 
+    $self->containers_factory('podman');
+
     my $podman_version = get_podman_version();
     # Skip this module on podman < 3.1.0
     return if (version->parse($podman_version) < version->parse('3.1.0'));
@@ -74,6 +76,8 @@ sub run {
     assert_script_run("podman secret rm secret1 secret2");
     die("Secrets have not been deleted")
       if (script_output("podman secret ls --quiet"));
+
+    $self->cleanup_system_host();
 }
 
 1;

--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -19,6 +19,8 @@ sub run {
     my ($self, $args) = @_;
     my $runtime = $args->{runtime};
 
+    my $engine = $self->containers_factory($runtime);
+
     select_serial_terminal();
 
     my $docker_version = "";
@@ -144,6 +146,8 @@ sub run {
     assert_script_run("$runtime volume prune $all -f | grep -Fx $test_volume");
     assert_script_run("! $runtime volume inspect $test_volume");
     assert_script_run("[ \$($runtime volume ls --quiet --filter dangling=true | wc -l\) -eq 0 ]");
+
+    $engine->cleanup_system_host();
 }
 
 1;


### PR DESCRIPTION
This PR:
- Removes external containers on cleanup_system_host() because `podman prune` only removes stuff created by podman but not external tools like buildah, et al.
- Adds missing calls to cleanup_system_host() on the podman_firewall & docker_firewall modules.
- Adds missing container_factory calls to the volumes & secret modules.
- Runs the validate_btrfs module last, as it changes the storage driver, fills the disk, etc.

---

- Related ticket: https://progress.opensuse.org/issues/155419#note-1
- Verification runs:
  - sle-15-SP1-JeOS-for-kvm-and-xen-Updates-x86_64-Build20240212-1-jeos-containers-podman@uefi-virtio-vga -> https://openqa.suse.de/t13513600 (failed test: https://openqa.suse.de/tests/13505861)
  - opensuse-Tumbleweed-DVD-x86_64-Build20240212-ricardobranco777_revert_factory@64bit -> https://openqa.opensuse.org/t3936327