### PR TITLE
wicked: fix use of uninitialized value

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -529,8 +529,8 @@ sub unique_macaddr {
     $prefix =~ s/:/_/;
     $prefix = hex($prefix);
 
-    $self->{unique_macaddr_cnt} = $self->{unique_macaddr_cnt} ? 0 : $self->{unique_macaddr_cnt} + 1;
-    $prefix += $self->{unique_macaddr_cnt};
+    $self->{unique_macaddr_cnt} //= 0;
+    $prefix += $self->{unique_macaddr_cnt}++;
 
     my $w_id = get_required_var('WORKER_ID');
     die("WORKER_ID too big!") if ($w_id > 0xffffffff);


### PR DESCRIPTION
Fix use of unitialized value in wickedbase::unique_macaddr(). 

See: https://openqa.suse.de/tests/13492603/logfile?filename=autoinst-log.txt
```
Use of uninitialized value in addition (+) at sle/lib/wickedbase.pm line 532.
	wickedbase::unique_macaddr(t11_bridge_interface_legacy=HASH(0x55bfa4ead8a0)) called at sle/lib/wickedbase.pm line 561
	wickedbase::setup_bridge(t11_bridge_interface_legacy=HASH(0x55bfa4ead8a0), "/etc/sysconfig/network/ifcfg-br0", "/etc/sysconfig/network/ifcfg-dummy0", "ifup") called at sle/tests/wicked/advanced/sut/t11_bridge_interface_legacy.pm line 26
	t11_bridge_interface_legacy::run(t11_bridge_interface_legacy=HASH(0x55bfa4ead8a0), wicked::TestContext=HASH(0x55bfa4bcd5b0)) called at /usr/lib/os-autoinst/basetest.pm line 348
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 346
	basetest::runtest(t11_bridge_interface_legacy=HASH(0x55bfa4ead8a0)) called at /usr/lib/os-autoinst/autotest.pm line 415
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 415
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 272
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 272
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 323
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x55bfa6725600)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 329
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 329
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x55bfa6725600), CODE(0x55bfa55828d0)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 492
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x55bfa6725600)) called at /usr/lib/os-autoinst/autotest.pm line 325
	autotest::start_process() called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Runner.pm line 94
	OpenQA::Isotovideo::Runner::start_autotest(OpenQA::Isotovideo::Runner=HASH(0x55bf9fbb8e70)) called at /usr/bin/isotovideo line 192
	eval {...} called at /usr/bin/isotovideo line 181
```




- Verification run: https://openqa.suse.de/tests/13517914