### PR TITLE
containers: Fix call to cleanup_system_host in secret module

### DIFF
--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -20,7 +20,7 @@ sub run {
     my ($self, $args) = @_;
     my $output = '';
 
-    $self->containers_factory('podman');
+    my $engine = $self->containers_factory('podman');
 
     my $podman_version = get_podman_version();
     # Skip this module on podman < 3.1.0
@@ -77,7 +77,7 @@ sub run {
     die("Secrets have not been deleted")
       if (script_output("podman secret ls --quiet"));
 
-    $self->cleanup_system_host();
+    $engine->cleanup_system_host();
 }
 
 1;


### PR DESCRIPTION
Verification runs:
- microos-Staging:I-Staging-DVD-x86_64-BuildI.549.1-container-host-microos@64bit-2G-HD40G -> https://openqa.opensuse.org/t3937961 (failing test: https://openqa.opensuse.org/tests/3937885#step/secret_podman/119)
- sle-micro-5.2-MicroOS-Image-Updates-s390x-Build20240213-1-slem_containers_selinux@s390x-kvm -> https://openqa.suse.de/t13519557 (failing test: https://openqa.suse.de/tests/13517592#step/secret_podman/109)