### PR TITLE
Simplify database access check

### DIFF
--- a/tests/jeos/image_info.pm
+++ b/tests/jeos/image_info.pm
@@ -47,8 +47,6 @@ sub run {
         $hdd = get_required_var('HDD_1');
     }
 
-    record_info('HDD', $hdd);
-
     if ($hdd =~ /\.xz/) {
         # We want to monitor the size of uncompressed images.
         my $cmd = "nice ionice unxz -k $hdd -c > hdd_uncompressed";
@@ -61,6 +59,7 @@ sub run {
         $image = $hdd;
         $image_size = -s $hdd;
     }
+    record_info('HDD', "Image:   $hdd\nSize:    $image_size Bytes");
 
     # DB availability check
     unless (check_postgres_db) {


### PR DESCRIPTION
Simplify the access check for the PostGREST database and introduce POSTGRES_DB variable for defining the target database for the image stats.

- Related ticket: https://progress.opensuse.org/issues/138371
- Verification run: https://openqa.opensuse.org/tests/3938739#step/image_info/8 and http://k2.qe.suse.de/d/rga27zLVz/image-size?orgId=2
- Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/426