### PR TITLE
Whitelist 1219229 - chronyd Could not add source

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -345,6 +345,13 @@
         },
         "type": "ignore"
     },
+    "bsc#1219229": {
+        "description": "chronyd.*Could not add source.*",
+        "products": {
+            "sle-micro": [ "6.0" ]
+        },
+        "type": "ignore"
+    },
     "ssh-connection-close-by-remote": {
         "description": "error: kex_exchange_identification: Connection closed by remote host",
         "products": {


### PR DESCRIPTION
As already investigated in the bug report, it is not a product issue, but a potential configuration issue on the DHCP server side. In any case, it is harmless, so it's ok to ignore it.

VR: http://openqa.suse.de/tests/13525356
