### PR TITLE
Do not grep for "kcryptd workqueues" in changelog

### DIFF
--- a/tests/security/check_kernel_config/dm_crypt.pm
+++ b/tests/security/check_kernel_config/dm_crypt.pm
@@ -25,11 +25,6 @@ sub run {
     # Install runtime dependencies
     zypper_call("in sudo");
 
-    # Make sure the code changes are there
-    if (is_sle) {
-        assert_script_run("rpm -q kernel-default --changelog | grep 'dm crypt' | grep 'kcryptd workqueues'");
-    }
-
     # Simulate a ram device
     assert_script_run("modprobe brd rd_nr=1 rd_size=512000");
 


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/155266

Verification runs:
- SP6 x86_64: https://openqa.suse.de/tests/13522739
- SP6 aarch64: https://openqa.suse.de/tests/13525711
- SP6 s390x: https://openqa.suse.de/tests/13525712
- SP5 x86_64: https://openqa.suse.de/tests/13525710
- SP4 x86_64: https://openqa.suse.de/tests/13525718