### PR TITLE
Increase wait time for cs_wait_for_idle in CSP

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -37,7 +37,7 @@ sub run {
 
     # Check initial cluster status
     $self->run_cmd(cmd => 'zypper -n in ClusterTools2', timeout => 300);
-    $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5');
+    $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5', timeout => 120);
     my $cluster_status = $self->run_cmd(cmd => 'crm status');
     record_info('Cluster status', $cluster_status);
     die(uc($site_name) . " '$target_site->{instance_id}' is NOT in MASTER mode.") if


### PR DESCRIPTION
On prem tests wait by default for `cs_wait_for_idle` to finish in 120 seconds, which can be scaled using the `TIMEOUT_SCALE` setting. Similar tests in cloud service providers wait by default for 60 seconds, and we have observed some tests failing in this step. This commit increases the timeout to 120 seconds.

- Related ticket: https://jira.suse.com/browse/TEAM-9056
- Needles: N/A
- Verification run: None as it's only increasing a timeout.
