### PR TITLE
Extend AY profile for container hosts

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -31,6 +31,14 @@
         % }
         <arch>{{ARCH}}</arch>
       </addon>
+      % if ($get_var->('VERSION') =~ /15-SP[1-3]/) {
+      <addon>
+        <name>SLES-LTSS</name>
+        <arch>{{ARCH}}</arch>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
+      % }
     </addons>
   </suse_register>
   <general>


### PR DESCRIPTION
The AY profile is missing LTSS registration for eligible LTSS hosts.

- Related ticket: [Missing LTSS extension in 12-SP5, 15-SP1, 15-SP2 and 15-SP3 host images](https://progress.opensuse.org/issues/154174)
- Verification run: http://kepler.suse.cz/tests/22643#
