### PR TITLE
podman: network backend control/switch added

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -116,7 +116,7 @@ sub load_host_tests_podman {
     loadtest 'containers/podman_bci_systemd';
     loadtest 'containers/podman_pods';
     # Default for ALP is Netavark
-    loadtest('containers/podman_network_cni') unless (is_alp || is_sle_micro('6.0+'));
+    loadtest('containers/podman_network_cni') unless (is_alp || is_sle_micro('6.0+') || (is_sle_micro('=5.5') && is_public_cloud));
     # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
     load_firewall_test($run_args) unless (is_public_cloud || is_openstack || is_microos || is_alp);
     # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -65,7 +65,9 @@ sub _cleanup {
 }
 
 sub install_packages {
-    my @pkgs = qw(netavark aardvark-dns);
+    my @pkgs = @_;
+    return 0 unless @pkgs;
+
     if (is_transactional) {
         trup_call("pkg install @pkgs");
         check_reboot_changes;
@@ -75,7 +77,7 @@ sub install_packages {
 }
 
 sub switch_to_netavark {
-    install_packages();
+    install_packages('netavark', 'aardvark-dns');
     # change network backend to *netavark*
     assert_script_run(q(echo -e '[Network]\nnetwork_backend="netavark"' >> /etc/containers/containers.conf));
     # reset the storage back to the initial state
@@ -99,7 +101,7 @@ sub run {
         switch_to_netavark;
     } else {
         record_info('default', 'netavark should be the default network backend');
-        zypper_call('in aardvark-dns') if is_sle;
+        install_packages('aardvark-dns');
     }
 
     $podman->cleanup_system_host();


### PR DESCRIPTION
Last update for SLEM PC aggregates: added netavark as default also for SLEM5.5 in pcloud, and skipped cni tests.

- Related ticket: https://progress.opensuse.org/issues/137168
- Verification run: See PR body.
