### PR TITLE
Edit skip_registration schedule

### DIFF
--- a/schedule/yast/skip_registration/skip_registration_15sp3.yaml
+++ b/schedule/yast/skip_registration/skip_registration_15sp3.yaml
@@ -3,6 +3,10 @@ name:           skip_registration
 description:    >
   Skipping registration for SLE 15, as requires network connection.
   This is default behavior for SLE 12.
+vars:
+  ADDONS: 'all-packages'
+  SCC_ADDONS: 'base,serverapp,desktop'
+  SCC_REGISTER: 'none'
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui


### PR DESCRIPTION
The skip_registration fails for 15SP3 because of main.pm sets ADDONS to null as the MAIN_TEST_REPO is empty as the ltss module is not include din SCC_ADDONS, as this is a skip registation test and ltss needs registation. So the only option is to  set the vars in the yaml schedule because it is parsed after the main.pm. +ADDONS doesn't work here. Setting ADDONS='all-packages' because when set to 'desktop' it fails as it matches with a non high lighted desktop needle that is used in another module but has the same tag.

VR: https://openqa.suse.de/tests/13535185#details