### PR TITLE
containers: Temporarily disable docker-compose top

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -93,7 +93,7 @@ sub load_container_engine_privileged_mode {
 
 sub load_compose_tests {
     my ($run_args) = @_;
-    return unless (is_tumbleweed || is_microos);
+    return unless (is_tumbleweed);
     loadtest('containers/compose', run_args => $run_args, name => $run_args->{runtime} . "_compose");
 }
 


### PR DESCRIPTION
Temporary fix for `Error response from daemon: top can only be used on running containers`.

I suspect there's a race condition here but needs proper investigation.

- Failing test: https://openqa.opensuse.org/tests/3943962#step/podman_compose/105
