### PR TITLE
Skip setting DISPLAY before opening yast.ssh for host upgrade

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -168,7 +168,19 @@ sub login_to_console {
             use_ssh_serial_console;
             save_screenshot;
             #start upgrade
-            enter_cmd("DISPLAY= yast.ssh");
+            if (check_var('VIDEOMODE', 'text')) {
+                if (lc(get_var('VERSION_TO_INSTALL', '')) eq '12-sp5' and lc(get_var('UPGRADE_PRODUCT', '')) eq 'sles-15-sp6') {
+                    #DIAPLAY= might be culprit that prevents host upgrade from proceeding at SCC registration. Please refer to bsc#1218798.
+                    record_soft_failure("bsc#1218798 - [SLES][15-SP6][x86_64][Build46.40] Unable to create repository due to valid metadata not found");
+                    enter_cmd("yast.ssh");
+                }
+                else {
+                    enter_cmd("DISPLAY= yast.ssh");
+                }
+            }
+            else {
+                enter_cmd("yast.ssh");
+            }
             save_screenshot;
             #wait upgrade finish
             assert_screen('rebootnow', 2700);


### PR DESCRIPTION
* **Recently** host upgrade keeps failing due to [bsc#1218798](https://bugzilla.suse.com/show_bug.cgi?id=1218798).

* **Skipping** setting DISPLAY before opening yast.ssh can help solve the issue.

* **Verification Runs:**
  * [xen offline upgrade starts](https://openqa.suse.de/tests/13743349)
  * [kvm offline upgrade starts](https://openqa.suse.de/tests/13743163)


