### PR TITLE
Remove DISPLAY from ipxe install for non-autoyast installation

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -234,11 +234,13 @@ sub run {
         unless (get_var('HOST_INSTALL_AUTOYAST')) {
             select_console 'installation';
             save_screenshot;
-            if (check_var('VIDEOMODE', 'ssh-x') or is_tumbleweed) {
-                enter_cmd_slow("yast.ssh");
-            }
-            elsif (check_var('VIDEOMODE', 'text')) {
+            #It was 'enter_cmd_slow('DISPLAY= yast.ssh') for SLE;'
+            #Removing 'DIAPLAY= ' for SLE15SP6 because it resulted in SCC registration failure(bsc#1218798).
+            if (check_var('VIDEOMODE', 'text') and is_sle('<=15-SP5')) {
                 enter_cmd_slow('DISPLAY= yast.ssh');
+            }
+            else {
+                enter_cmd_slow("yast.ssh");
             }
             save_screenshot;
             wait_still_screen;


### PR DESCRIPTION
- Remove DISPLAY per bsc#1218798
- don't include prj2 as it has been implemented in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18671

Verification run: http://10.67.129.27/tests/244

@alice-suse @waynechen55 @guoxuguang @nanzhg @RoyCai7 
