### PR TITLE
Whitelist sshd kex_exchange_identification error for SLE Micro 6.0

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -355,7 +355,7 @@
     "ssh-connection-close-by-remote": {
         "description": "error: kex_exchange_identification: Connection closed by remote host",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4" , "5.5" ],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "6.0" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3", "15.4", "15.5"],
             "microos":  ["Tumbleweed"],
             "sle": ["15-SP2", "15-SP3", "15-SP4", "15-SP5", "15-SP6"]


### PR DESCRIPTION
* **An** old issue ```Feb 19 02:31:21.618612 s390kvm090 sshd[2186]: error: kex_exchange_identification: Connection closed by remote host``` started occurring to SLE Micro 6.0 test. Please refer to [example](https://openqa.suse.de/tests/13542740#step/journal_check/12).

* **This** issue can be whitelisted safely.

* **Verification Runs:**
  * [sshd error is gone](https://openqa.suse.de/tests/13542811)