### PR TITLE
Wait longer for network interface attached to public facing network

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -147,7 +147,8 @@ sub test_network_interface {
 
     # Show the IP address of secondary (tested) interface
     assert_script_run("ssh root\@$guest ip -o -4 addr list $nic | awk \"{print \\\$4}\" | cut -d/ -f1 | head -n1");
-    my $addr = script_output "ssh root\@$guest ip -o -4 addr list $nic | awk \"{print \\\$4}\" | cut -d/ -f1 | head -n1";
+    my $test_timeout = ($net eq 'vnet_host_bridge') ? 360 : 90;
+    my $addr = script_output("ssh root\@$guest ip -o -4 addr list $nic | awk \"{print \\\$4}\" | cut -d/ -f1 | head -n1", timeout => $test_timeout);
     if ($addr eq "") {
         assert_script_run "ssh root\@$guest 'ip a'";
         die "No IP found for $nic in $guest";


### PR DESCRIPTION
* **Network** interface attached to public facing network requires more time to get ip address assigned, for example, virtual machine employs host bridge network may fail to get ip address assigned very quickly. Please refer to [this failure](https://openqa.suse.de/tests/13084938#step/libvirt_host_bridge_virtual_network/93).

* **This** might be related to the huge number of devices in the network and subsequent conflicts detecting when a new device joins. It requires additional time to finish. 

* **Extend** timeout value to wait longer may help solve the problem.

* **Verification Runs:**
  * [verification run 01](https://openqa.suse.de/tests/13542933)
  * [verification run 02](https://openqa.suse.de/tests/13542934)
  * [verification run 03](https://openqa.suse.de/tests/13564605)
  * [verification run 04](https://openqa.suse.de/tests/13564607)
  * [verification run 05](https://openqa.suse.de/tests/13564608)
  * [verification run 06](https://openqa.suse.de/tests/13573795)
  * [verification run 07](https://openqa.suse.de/tests/13573798)
  * [verification run 08](https://openqa.suse.de/tests/13573804)
  * [verification run 09](https://openqa.suse.de/tests/13573801)
  * [verification run 10](https://openqa.suse.de/tests/13573805)