### PR TITLE
Edit skip_registration schedule

### DIFF
--- a/schedule/yast/skip_registration/skip_registration_15sp3.yaml
+++ b/schedule/yast/skip_registration/skip_registration_15sp3.yaml
@@ -7,6 +7,8 @@ vars:
   ADDONS: 'all-packages'
   SCC_ADDONS: 'base,serverapp,desktop'
   SCC_REGISTER: 'none'
+  DESKTOP: 'gnome'
+  YUI_REST_API: '1'
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui


### PR DESCRIPTION
Apparently, the DESKTOP var is also overriden to automatic setting textmode, even though for the same test sp4 and sp5, it is automatically set to desktop. Setting up all vars in the schedule as well. Adding YUI_REST_API as it's the only necessary var remaining out of the schedule and it will be more readable for debugging if it's needed.
 Fixes failure: https://openqa.suse.de/tests/13542368
VR: https://openqa.suse.de/tests/13541289
