### PR TITLE
Add buildah tests in Docker

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -76,6 +76,11 @@ sub load_secret_tests {
     loadtest('containers/secret', run_args => $run_args, name => 'secret_' . $run_args->{runtime});
 }
 
+sub load_buildah_tests {
+    my ($run_args) = @_;
+    loadtest('containers/buildah', run_args => $run_args, name => 'buildah_' . $run_args->{runtime});
+}
+
 sub load_image_tests_docker {
     my ($run_args) = @_;
     load_image_test($run_args);
@@ -122,7 +127,7 @@ sub load_host_tests_podman {
     # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
     loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
     # Buildah is not available in SLE Micro, MicroOS and staging projects
-    loadtest 'containers/buildah' unless (is_sle_micro || is_microos || is_leap_micro || is_alp || is_staging);
+    load_buildah_tests($run_args) unless (is_sle_micro || is_microos || is_leap_micro || is_alp || is_staging);
     loadtest 'containers/podman_quadlet' if is_tumbleweed;
     # https://github.com/containers/podman/issues/5732#issuecomment-610222293
     # exclude rootless podman on public cloud because of cgroups2 special settings
@@ -156,6 +161,7 @@ sub load_host_tests_docker {
         # PackageHub is not available in SLE Micro | MicroOS
         loadtest 'containers/registry' if (is_x86_64 || is_sle('>=15-sp4'));
     }
+    load_buildah_tests($run_args) unless (is_sle_micro || is_microos || is_leap_micro || is_alp || is_staging);
     if (is_tumbleweed || is_microos) {
         loadtest 'containers/buildx';
         loadtest 'containers/rootless_docker';


### PR DESCRIPTION
The `buildah` test was being run only for podman. This way we are expanding it to Docker too, as requested in [bsc#1219563](https://bugzilla.suse.com/show_bug.cgi?id=1219563)

- Related ticket: https://progress.opensuse.org/issues/154930
- Verification run:
  - https://openqa.suse.de/tests/13605615
  - https://openqa.suse.de/tests/13605614
  - https://openqa.opensuse.org/tests/3964004
  - https://openqa.opensuse.org/tests/3964001
