### PR TITLE
Always get site_name from settings

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -62,6 +62,7 @@ our @EXPORT = qw(
   is_hana_database_online
   get_hana_database_status
   is_primary_node_online
+  get_hana_site_names
 );
 
 =head2 run_cmd
@@ -372,7 +373,7 @@ sub check_takeover {
 =cut
 
 sub enable_replication {
-    my ($self) = @_;
+    my ($self, $site_name) = @_;
     my $hostname = $self->{my_instance}->{instance_id};
     die("Database on the fenced node '$hostname' is not offline") if ($self->is_hana_database_online);
     die("System replication '$hostname' is not offline") if ($self->is_primary_node_online);
@@ -381,7 +382,7 @@ sub enable_replication {
     foreach (qw(vhost remoteHost srmode op_mode)) { die "Missing '$_' field in topology output" unless defined(%$topology{$hostname}->{$_}); }
 
     my $cmd = join(' ', 'hdbnsutil -sr_register',
-        '--name=' . %$topology{$hostname}->{vhost},
+        '--name=' . $site_name,
         '--remoteHost=' . %$topology{$hostname}->{remoteHost},
         '--remoteInstance=00',
         '--replicationMode=' . %$topology{$hostname}->{srmode},
@@ -783,6 +784,21 @@ sub azure_fencing_agents_playbook_args {
     return ($playbook_opts);
 }
 
+=head2 get_hana_site_names
+
+    Get primary and secondary site name.
+    This information is both needed to configure the qe-sap-deployment
+    and later in the test when calling `hdbnsutil -sr_register`.
+    This function mostly read the information from job settings
+    HANA_PRIMARY_SITE and HANA_SECONDARY_SITE, so main reason to have
+    it behind a function is to have coherent defaults.
+
+=cut
+
+sub get_hana_site_names {
+    return (get_var('HANA_PRIMARY_SITE', 'site_a'), get_var('HANA_SECONDARY_SITE', 'site_b'));
+}
+
 =head2 create_hana_vars_section
 
     Detects HANA/HA scenario from openQA variables and creates "terraform: variables:" section in config.yaml file.
@@ -794,13 +810,14 @@ sub create_hana_vars_section {
     # Cluster related setup
     my %hana_vars;
     if ($ha_enabled == 1) {
+        my @hana_sites = get_hana_site_names();
         $hana_vars{sap_hana_install_software_directory} = get_required_var('HANA_MEDIA');
         $hana_vars{sap_hana_install_master_password} = get_required_var('_HANA_MASTER_PW');
         $hana_vars{sap_hana_install_sid} = get_required_var('INSTANCE_SID');
         $hana_vars{sap_hana_install_instance_number} = get_required_var('INSTANCE_ID');
         $hana_vars{sap_domain} = get_var('SAP_DOMAIN', 'qesap.example.com');
-        $hana_vars{primary_site} = get_var('HANA_PRIMARY_SITE', 'site_a');
-        $hana_vars{secondary_site} = get_var('HANA_SECONDARY_SITE', 'site_b');
+        $hana_vars{primary_site} = $hana_sites[0];
+        $hana_vars{secondary_site} = $hana_sites[1];
         set_var('SAP_SIDADM', lc(get_var('INSTANCE_SID') . 'adm'));
     }
     return (\%hana_vars);

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -439,14 +439,14 @@ subtest '[enable_replication]' => sub {
         vmhana01 => {
             vhost => 'vmhana01',
             remoteHost => 'vmhana02',
-            srmode => 'PIPPO',
-            op_mode => 'PAPERINO',
+            srmode => 'LeeAdama',
+            op_mode => 'ZakAdama',
         },
         vmhana02 => {
             vhost => 'vmhana02',
             remoteHost => 'vmhana01',
-            srmode => 'PIPPO',
-            op_mode => 'PAPERINO',
+            srmode => 'LeeAdama',
+            op_mode => 'ZakAdama',
         }
     );
     $sles4sap_publiccloud->redefine(get_hana_topology => sub { return \%test_topology; });
@@ -459,12 +459,29 @@ subtest '[enable_replication]' => sub {
 
     set_var('SAP_SIDADM', 'YONDUR');
 
-    $self->enable_replication();
+    $self->enable_replication('WilliamAdama');
 
     set_var('SAP_SIDADM', undef);
 
     note("\n  C -->  " . join("\n  -->  ", @calls));
     ok((any { qr/hdbnsutil -sr_register/ } @calls), 'hdbnsutil cmd correctly called');
+    ok((any { qr/-name WilliamAdama/ } @calls), 'hdbnsutil cmd has right site name');
+};
+
+subtest '[get_hana_site_names] default values' => sub {
+    my @res = get_hana_site_names();
+    ok(($res[0] eq 'site_a'), "Default value for the primary site is site_a");
+    ok(($res[1] eq 'site_b'), "Default value for the secondary site is site_b");
+};
+
+subtest '[get_hana_site_names] values from settings' => sub {
+    set_var('HANA_PRIMARY_SITE', 'MarcoPolo');
+    set_var('HANA_SECONDARY_SITE', 'ZhengHe');
+    my @res = get_hana_site_names();
+    set_var('HANA_PRIMARY_SITE', undef);
+    set_var('HANA_SECONDARY_SITE', undef);
+    ok(($res[0] eq 'MarcoPolo'), "Value for the primary site is from setting");
+    ok(($res[1] eq 'ZhengHe'), "Value for the secondary site is from setting");
 };
 
 done_testing;

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_primary_tests.pm
@@ -13,6 +13,7 @@ package hana_sr_schedule_primary_tests;
 use strict;
 use warnings FATAL => 'all';
 use base 'sles4sap_publiccloud_basetest';
+use sles4sap_publiccloud;
 use testapi;
 use main_common 'loadtest';
 
@@ -27,10 +28,11 @@ sub run {
     $self->import_context($run_args);
 
     record_info("Schedule", "Executing tests on master Hana DB");
+    my @hana_sites = get_hana_site_names();
     # 'HANASR_PRIMARY_ACTIONS' - define to override test flow
     my @database_actions = split(",", get_var("HANASR_PRIMARY_ACTIONS", 'stop,kill,crash'));
     for my $action (@database_actions) {
-        for my $site ('site_a', 'site_b') {
+        for my $site (@hana_sites) {
             my $test_name = join('_', ucfirst($action), "$site-primary");
             $run_args->{hana_test_definitions}{$test_name}{action} = $action;
             $run_args->{hana_test_definitions}{$test_name}{site_name} = $site;

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -28,9 +28,9 @@ sub run {
     my $takeover_action = $run_args->{hana_test_definitions}{$test_name}{action};
     my $site_name = $run_args->{hana_test_definitions}{$test_name}{site_name};
     my $target_site = $run_args->{$site_name};
-    my $sbd_delay;
     die("Target site '$site_name' data is missing. This might indicate deployment issue.")
       unless $target_site;
+    my $sbd_delay;
 
     # Switch to control to target site (currently PROMOTED)
     $self->{my_instance} = $target_site;
@@ -81,7 +81,7 @@ sub run {
     $self->check_takeover;
 
     record_info('Replication', join(' ', ('Enabling replication on', ucfirst($site_name), '(DEMOTED)')));
-    $self->enable_replication();
+    $self->enable_replication($site_name);
 
     record_info(ucfirst($site_name) . ' start');
     $self->cleanup_resource();

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -26,11 +26,13 @@ sub run {
 
     # Needed to have peering and ansible state propagated in post_fail_hook
     $self->import_context($run_args);
-    croak('site_b is missing or undefined in run_args') if (!$run_args->{site_b});
+
+    my @hana_sites = get_hana_site_names();
+    croak("$hana_sites[1] is missing or undefined in run_args") if (!$run_args->{$hana_sites[1]});
 
     my $hana_start_timeout = bmwqemu::scale_timeout(600);
     # $site_b = $instance of secondary instance located in $run_args->{$instances}
-    my $site_b = $run_args->{site_b};
+    my $site_b = $run_args->{$hana_sites[1]};
     my $sbd_delay;
     select_serial_terminal;
 

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -70,6 +70,7 @@ sub run {
     }
 
     # Check connectivity to all instances and status of the cluster in case of HA deployment
+    my @hana_sites = get_hana_site_names();
     foreach my $instance (@{$self->{instances}}) {
         $self->{my_instance} = $instance;
         my $instance_id = $instance->{'instance_id'};
@@ -85,8 +86,13 @@ sub run {
         my $resource_output = $self->run_cmd(cmd => "crm status full", quiet => 1);
         record_info("crm out", $resource_output);
         my $master_node = $self->get_promoted_hostname();
-        $run_args->{site_a} = $instance if ($instance_id eq $master_node);
-        $run_args->{site_b} = $instance if ($instance_id ne $master_node);
+
+        if ($instance_id eq $master_node) {
+            $run_args->{$hana_sites[0]} = $instance;
+        }
+        else {
+            $run_args->{$hana_sites[1]} = $instance;
+        }
     }
 
     get_var('QESAP_DEPLOYMENT_IMPORT')
@@ -97,8 +103,8 @@ sub run {
 
     record_info(
         'Instances:', "Detected HANA instances:
-    Site A (PRIMARY): $run_args->{site_a}{instance_id}
-    Site B: $run_args->{site_b}{instance_id}"
+    Site A (PRIMARY): $run_args->{$hana_sites[0]}{instance_id}
+    Site B: $run_args->{$hana_sites[1]}{instance_id}"
     );
     return 1;
 }


### PR DESCRIPTION
- Related ticket: https://jira.suse.com/browse/TEAM-9012


# Verification

## hanasr_azure_test_sbd
sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-02-19T05:03:10Z-hanasr_azure_test_sbd@64bit 

- http://openqaworker15.qa.suse.cz/tests/276313 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/276331 :green_circle: 

## hanasr_azure_test_msi
sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-02-19T05:03:10Z-hanasr_azure_test_msi@64bit 

- http://openqaworker15.qa.suse.cz/tests/276314 :green_circle: 

The deployment is using `site_a` 

```
DEBUG    OUTPUT: TASK [../roles/sap_ha_install_hana_hsr : SAP HSR - Register secondary node to HANA System Replication] ***


...

DEBUG    OUTPUT:     "cmd": "source /usr/sap/HA0/home/.sapenv.sh && /usr/sap/HA0/HDB00/exe/hdbnsutil -sr_register --name=site_b --remoteHost=vmhana01 --remoteInstance=00 --replicationMode=sync --operationMode=logreplay --online\n",
```
and

```
DEBUG    >        "cmd": "source /usr/sap/HA0/home/.sapenv.sh && /usr/sap/HA0/HDB00/exe/hdbnsutil -sr_register --name=site_b --remoteHost=vmhana01 --remoteInstance=00 --replicationMode=sync --operationMode=logreplay --online\n",
```

And with the new code, now also the test sequence is using right `site_a` in http://openqaworker15.qa.suse.cz/tests/276314#step/Stop_site_a-primary/82

- http://openqaworker15.qa.suse.cz/tests/276332 :red_circle: Ansible reboot timeout error
- http://openqaworker15.qa.suse.cz/tests/276336

## hanasr_azure_test_spn

 sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-02-19T05:03:10Z-hanasr_azure_test_spn@64bit 

 -  http://openqaworker15.qa.suse.cz/tests/276315 :green_circle: 
 - http://openqaworker15.qa.suse.cz/tests/276334

## hanasr_azure_test_spn with custom site names

 sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-02-19T05:03:10Z-hanasr_azure_test_spn@64bit with more funny site names `HANA_PRIMARY_SITE='Pippo'` and `HANA_SECONDARY_SITE='Topolino'`
 
-  http://openqaworker15.qa.suse.cz/tests/276333
-  http://openqaworker15.qa.suse.cz/tests/276337

