### PR TITLE
Remove ansible retry function for MU tests

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -38,6 +38,9 @@ sub run {
     unless (get_var('QESAP_DEPLOYMENT_IMPORT')) {
         my @ret = qesap_execute(cmd => 'ansible', timeout => 3600, verbose => 1);
         if ($ret[0]) {
+            if (check_var('IS_MAINTENANCE', '1')) {
+                die("TEAM-9068 Ansible failed. Retry not supported for IBSM updates\n ret[0]: $ret[0]");
+            }
             # Retry to deploy terraform + ansible
             if (qesap_terrafom_ansible_deploy_retry(error_log => $ret[1])) {
                 die "Retry failed, original ansible return: $ret[0]";


### PR DESCRIPTION
To mitigate TEAM-9068 we need to disable the retries for ansible untill we can make it idempotent.

- Related ticket: TEAM-9068
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=no_ansible_retry
https://openqa.suse.de/tests/13544223 The restart is blocked
https://openqa.suse.de/tests/13544224 Unrelated failure
The rest are green
