### PR TITLE
Import repo keys

### DIFF
--- a/data/containers/Dockerfile
+++ b/data/containers/Dockerfile
@@ -2,6 +2,7 @@
 # use base variable when you call test_containered_app
 FROM baseimage_var
 
+RUN zypper --gpg-auto-import-keys ref
 RUN zypper -n in apache2 && zypper clean -a
 RUN echo 'ServerName AppacheInContainer' >> /etc/apache2/httpd.conf
 


### PR DESCRIPTION
Root cause of why zypper was returning 106 in 12-SP5 container tests.

```
Retrieving repository 'SLE-12-SP5-GA-Desktop-nVidia-Driver' metadata [..

New repository or package signing key received:

  Repository:       SLE-12-SP5-GA-Desktop-nVidia-Driver
  Key Name:         NVIDIA Corporation <linux-bugs@nvidia.com>
  Key Fingerprint:  9B763D49 D8A5C892 FC178BAC F5113243 C66B6EAE
  Key Created:      Thu Jun 15 16:13:18 2006
  Key Expires:      (does not expire)
  Subkey:           F016EEAA03224CDD 2006-06-15 [does not expire]
  Rpm Name:         gpg-pubkey-c66b6eae-4491871e

Do you want to reject the key, trust temporarily, or trust always?
[r/t/a/? shows all options] (r): r
error]
Repository 'SLE-12-SP5-GA-Desktop-nVidia-Driver' is invalid.
[container-suseconnect-zypp:SLE-12-SP5-GA-Desktop-nVidia-Driver|https://download.nvidia.com/suse/sle12sp5/]
Valid metadata not found at specified URL
```

- Verification runs
  * [12-SP5](http://kepler.suse.cz/tests/22652#step/image_docker/177)
  * [15-SP5](http://kepler.suse.cz/tests/22651#step/image_podman/154)