### PR TITLE
wicked: Fix incomplete journal logs

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -655,7 +655,8 @@ sub upload_wicked_logs {
     record_info('Logs', "Collecting logs in $logs_dir");
     script_run("mkdir -p $logs_dir");
     script_run("date +'%Y-%m-%d %T.%6N' > $logs_dir/date");
-    script_run("journalctl -b -o short-precise|tail -n +2 > $logs_dir/journalctl.log");
+    script_run('journalctl --sync');
+    script_run("journalctl -b -o short-precise > $logs_dir/journalctl.log");
     script_run("wicked ifstatus --verbose all > $logs_dir/wicked_ifstatus.log 2>&1");
     script_run("wicked show-config > $logs_dir/wicked_config.log 2>&1");
     script_run("wicked show-xml > $logs_dir/wicked_xml.log 2>&1");

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -51,6 +51,12 @@ sub run {
         RateLimitBurst=0
 EOT
     record_info('journald.conf', script_output('systemd-analyze cat-config --no-pager systemd/journald.conf'));
+    # Prepare jounral to write to disk
+    assert_script_run('mkdir -p /var/log/journal');
+    assert_script_run('systemd-tmpfiles --create --prefix /var/log/journal');
+    assert_script_run('journalctl --flush');
+    assert_script_run('journalctl --sync');
+
     #preparing directories for holding config files
     assert_script_run('mkdir -p /data/{static_address,dynamic_address}');
 


### PR DESCRIPTION
I guess, because of the havy use of `reload-last-good-snapshot` feature, the journal somehow isn't consistent.
E.g. we are storing a `journalctl -b -o short-precise` in the pre_test_hook and one in the post_test_hook.
So with this, the journal of pre, should be a subset of post, but it wasn't


see:
```bash
 wget https://openqa.suse.de/tests/13547853/file/t16_bridge_ifreload_physical_post.tar.gz
 wget https://openqa.suse.de/tests/13547853/file/t16_bridge_ifreload_physical_pre.tar.gz
 ls -1 * | xargs -I F tar -zxvf F
 meld t16_bridge_ifreload_physical_pre/journalctl.log t16_bridge_ifreload_physical_post/journalctl.log
```
here ` t16_bridge_ifreload_physical_post/journalctl.log` should start with the same log as `t16_bridge_ifreload_physical_pre/journalctl.log`.


- Verification run: http://openqa.wicked.suse.de/tests/188335