### PR TITLE
containers: Skip docker-compose test on Staging

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -94,7 +94,7 @@ sub load_container_engine_privileged_mode {
 sub load_compose_tests {
     my ($run_args) = @_;
     return unless (is_tumbleweed || is_microos);
-    return if (is_ppc64le);
+    return if (is_ppc64le || is_staging);
     loadtest('containers/compose', run_args => $run_args, name => $run_args->{runtime} . "_compose");
 }
 


### PR DESCRIPTION

Skip docker-compose test on Staging

Failing test: https://openqa.opensuse.org/tests/3947585#step/podman_compose/42