### PR TITLE
containers: Restrict compose test to x86_64 & aarch64

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -94,7 +94,9 @@ sub load_container_engine_privileged_mode {
 sub load_compose_tests {
     my ($run_args) = @_;
     return unless (is_tumbleweed || is_microos);
-    return if (is_ppc64le || is_staging);
+    # compose is not available on these arches:
+    # https://github.com/containers/podman/issues/21757
+    return unless (is_aarch64 || is_x86_64);
     loadtest('containers/compose', run_args => $run_args, name => $run_args->{runtime} . "_compose");
 }
 


### PR DESCRIPTION
Restrict compose test to x86_64 & aarch64

https://github.com/containers/podman/issues/21757