### PR TITLE
Allow to clone and monitor a job when creating a PR

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -13,6 +13,7 @@ env:
   OPENQA_API_SECRET: ${{ secrets.OPENQA_API_SECRET }}
   GH_REPO: ${{ github.event.pull_request.head.repo.full_name }}
   GH_REF: ${{ github.event.pull_request.head.ref }}
+  GH_PR_BODY: ${{ github.event.pull_request.body }}
 
 jobs:
   trigger_and_monitor_openqa:
@@ -41,3 +42,10 @@ jobs:
           UEFI_PFLASH_VARS=opensuse-Tumbleweed-x86_64-${{ steps.latest_build.outputs.build }}-textmode@64bit-uefi-vars.qcow2
           BUILD="$GH_REPO.git#$GH_REF" _GROUP_ID="${OPENQA_SCHEDULE_GROUP_ID:-118}"
           CASEDIR="$GITHUB_SERVER_URL/$GH_REPO.git#$GH_REF"
+  clone_mentioned_job:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.opensuse.org/devel/openqa/containers/tumbleweed:client
+    steps:
+      - name: Clone and monitor job mentioned in PR description
+        uses: os-autoinst/scripts/actions/clone-job@master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ if (match_has_tag('yast2_missing_package')) {
 * Whenever possible, [provide a verification run][1] of a job that runs the code.
   This can also be done by mentioning the job to be cloned via
   `openqa: Clone https://openqa.opensuse.org/tests/<JOB_ID>` in the PR description.
-  This only works for jobs on https://openqa.opensuse.org. For other job you can
+  This only works for jobs on https://openqa.opensuse.org. For other jobs you can
   use the [openqa-clone-custom-git-refspec][2] script.
 
 Also see the [DoD/DoR][3] as a helpful (but not mandatory) guideline for new contributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,11 @@ if (match_has_tag('yast2_missing_package')) {
 * Every pull request is tested by our CI system for different perl versions,
   if something fails, run `make test` (don't forget to `make prepare` if your setup is new)
   but the CI results are available too, in case they need to be investigated further
-* Whenever possible, [provide a verification run][1] of a job that runs the code [provided in the pull request][2]
+* Whenever possible, [provide a verification run][1] of a job that runs the code.
+  This can also be done by mentioning the job to be cloned via
+  `openqa: Clone https://openqa.opensuse.org/tests/<JOB_ID>` in the PR description.
+  This only works for jobs on https://openqa.opensuse.org. For other job you can
+  use the [openqa-clone-custom-git-refspec][2] script.
 
 Also see the [DoD/DoR][3] as a helpful (but not mandatory) guideline for new contributions.
 


### PR DESCRIPTION
This change allows to clone a job when creating a PR by mentioning it in the PR description via `@openqa: Clone https://openqa.opensuse.org/…`.

This requires the split-out monitor-subcommand provided by openQA PR https://github.com/os-autoinst/openQA/pull/5482.

I tested this locally, e.g.:

```
cat .github/workflows/openqa.yml | yq -r '.jobs.clone_mentioned_job.steps[0].run' | env GH_REPO=foo GH_REF=bar OPENQA_HOST=http://127.0.0.1:9526 OPENQA_API_KEY=… OPENQA_API_SECRET=… GH_PR_BODY="Merge my changes\n\n @openqa: Clone http://127.0.0.1:9526/tests/4240  \nfootnote" DRY_RUN_JOB_IDS='{"4240" : 4246, "4239" : 4245}' bash
Cloned 'http://127.0.0.1:9526/tests/4240' into:
http://127.0.0.1:9526/tests/4246
http://127.0.0.1:9526/tests/4245
script/openqa-cli monitor … 4246 4245
{"blocked_by_id":null,"id":4246,"result":"none","state":"scheduled"}
Job state of job ID 4246: scheduled, waiting …
^C
```

It also works without `DRY_RUN_JOB_IDS`; then it actually clones the job and parses the output of `openqa-clone-job`.

---

Related ticket: https://progress.opensuse.org/issues/130934