### PR TITLE
containers: Skip compose test on Staging

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -93,8 +93,9 @@ sub load_container_engine_privileged_mode {
 
 sub load_compose_tests {
     my ($run_args) = @_;
+    return if (is_staging);
     return unless (is_tumbleweed || is_microos);
-    # compose is not available on these arches:
+    # compose is only available on these arches:
     # https://github.com/containers/podman/issues/21757
     return unless (is_aarch64 || is_x86_64);
     loadtest('containers/compose', run_args => $run_args, name => $run_args->{runtime} . "_compose");


### PR DESCRIPTION
Failing test: https://openqa.opensuse.org/tests/3949608#step/podman_compose/43
