### PR TITLE
Add network setting rom_bar=off for 15-SP6 guest on 12-SP5 KVM host

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -37,7 +37,7 @@
     <guest_storage_others></guest_storage_others>
     <guest_network_type>bridge</guest_network_type>
     <guest_network_device>br123</guest_network_device>
-    <guest_network_others></guest_network_others>
+    <guest_network_others>rom_bar=off</guest_network_others>
     <guest_netaddr>192.168.123.0/24</guest_netaddr>
     <guest_ipaddr></guest_ipaddr>
     <guest_ipaddr_static>false</guest_ipaddr_static>

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -874,7 +874,12 @@ sub config_guest_network_selection {
         $self->{guest_netaddr_attached} = [$self->{guest_netaddr}];
     }
 
-    $self->{guest_network_selection_options} .= ",$self->{guest_network_others}" if ($self->{guest_network_others} ne '');
+    if ($self->{guest_network_others} ne '') {
+        $self->{guest_network_selection_options} .= ",$self->{guest_network_others}";
+        if ($self->{guest_version} eq '15-sp6' and check_var('VERSION_TO_INSTALL', '12-SP5') and $self->{guest_network_others} =~ /rom_bar=off/) {
+            record_soft_failure("bsc#1217359 - [SLES][12-SP5][x86_64][kvm][uefi] Failed to install 15-SP6 uefi guest on 12-SP5 KVM host due to efi exception");
+        }
+    }
 
     return $self;
 }


### PR DESCRIPTION
* **Regression** issue found in bsc#1217359 has workaround to let guest installation pass, which requires additional network settings for SLES 15-SP6 guest on 12-SP5 KVM host. 
 
* **Network** settings need extra rom_bar=off to workaround the issue, for example, ```--network bridge=br123,mac=52:54:00:b3:21:25,rom_bar=off```.

* **This** can be easily achieved by setting ```guest_network_others``` to ```rom_bar=off``` in guest profile ```sles_15_sp6_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml ```

* **Verification Runs:**
  * [15sp6 on 12sp5 kvm](https://openqa.suse.de/tests/13755928)
  * [15sp6 on 12sp5 xen](https://openqa.suse.de/tests/13755636)
  * [15sp6 on 15sp6 kvm](https://openqa.suse.de/tests/13755726)
  * [12sp5 on 15sp6 xen](https://openqa.suse.de/tests/13755727)