### PR TITLE
Add function to wait for zypper if needed

### DIFF
--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -7,6 +7,7 @@
 use strict;
 use warnings;
 use base 'sles4sap_publiccloud_basetest';
+use sles4sap_publiccloud;
 use testapi;
 
 sub test_flags {
@@ -29,6 +30,7 @@ sub run {
         }
         foreach my $instance (@{$self->{instances}}) {
             next if ($instance->{'instance_id'} !~ m/vmhana/);
+            $self->wait_for_zypper(instance => $instance);
             $instance->run_ssh_command(cmd => "sudo zypper --no-gpg-checks ar -f -n TEST_$count $maintrepo TEST_$count",
                 username => 'cloudadmin');
         }
@@ -36,6 +38,7 @@ sub run {
     }
     foreach my $instance (@{$self->{instances}}) {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
+        $self->wait_for_zypper(instance => $instance);
         $instance->run_ssh_command(cmd => 'sudo zypper -n ref', username => 'cloudadmin', timeout => 1500);
     }
 }


### PR DESCRIPTION
Sometimes zypper is locked, so this pr adds a function to wait until it is released or for a specified amount of time.

- Related ticket: https://jira.suse.com/browse/TEAM-9059
- Verification runs: 
https://openqa.suse.de/tests/13580534 (zypper wasn't locked)
https://openqa.suse.de/tests/13564155 (zypper wasn't locked)
https://openqa.suse.de/tests/13565334 (zypper wasn't locked)
https://openqa.suse.de/tests/13566890 (zypper wasn't locked)