### PR TITLE
Add key setps for s390x qemu tests

### DIFF
--- a/schedule/functional/extra_tests_qemu.yaml
+++ b/schedule/functional/extra_tests_qemu.yaml
@@ -4,6 +4,10 @@ description:    >
     Extra qemu tests
 conditional_schedule:
     start:
+        ARCH:
+            's390x':
+                - installation/bootloader_start
+                - boot/boot_to_desktop
         BACKEND:
             'qemu':
                 - installation/bootloader_start


### PR DESCRIPTION
https://progress.opensuse.org/issues/155719

VR:

[s390x](http://openqa.suse.de/tests/13563725) **Please ignore the failed test module, it is a known issue**
[qemu-backend](http://openqa.suse.de/tests/13563735)