### PR TITLE
Public Cloud: Use ed25519 in GCP and AWS

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -84,6 +84,10 @@ variable "subnet_id" {
   default = ""
 }
 
+variable "ssh_public_key" {
+  default = "/root/.ssh/id_ed25519.pub"
+}
+
 resource "random_id" "service" {
   count = var.instance_count
   keepers = {
@@ -162,7 +166,7 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
 
   admin_ssh_key {
     username   = "azureuser"
-    public_key = file("/root/.ssh/id_rsa.pub")
+    public_key = file("${var.ssh_public_key}")
   }
 
   os_disk {

--- a/data/publiccloud/terraform/azure_nfstest.tf
+++ b/data/publiccloud/terraform/azure_nfstest.tf
@@ -61,6 +61,11 @@ variable "subnet_id" {
   default = ""
 }
 
+variable "ssh_public_key" {
+  default = "/root/.ssh/id_ed25519.pub"
+}
+
+
 ## ---- data ---------------------------------------------------------------- ##
 
 // IP address of the client
@@ -185,7 +190,7 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
 
   admin_ssh_key {
     username   = "azureuser"
-    public_key = file("~/.ssh/id_rsa.pub")
+    public_key = file("${var.ssh_public_key}")
   }
 
   os_disk {

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -76,6 +76,10 @@ variable "ipv6_address_count" {
   default = 0
 }
 
+variable "ssh_public_key" {
+  default = "/root/.ssh/id_ed25519.pub"
+}
+
 resource "random_id" "service" {
   count = var.instance_count
   keepers = {
@@ -86,7 +90,7 @@ resource "random_id" "service" {
 
 resource "aws_key_pair" "openqa-keypair" {
   key_name   = "openqa-${element(random_id.service.*.hex, 0)}"
-  public_key = file("/root/.ssh/id_rsa.pub")
+  public_key = file("${var.ssh_public_key}")
 }
 
 resource "aws_instance" "openqa" {

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -88,6 +88,11 @@ variable "vm_create_timeout" {
   default = "20m"
 }
 
+variable "ssh_public_key" {
+  default = "/root/.ssh/id_ed25519.pub"
+}
+
+
 resource "random_id" "service" {
   count = var.instance_count
   keepers = {
@@ -124,7 +129,7 @@ resource "google_compute_instance" "openqa" {
   }
 
   metadata = merge({
-    sshKeys             = "susetest:${file("/root/.ssh/id_rsa.pub")}"
+    sshKeys             = "susetest:${file("${var.ssh_public_key}")}"
     openqa_created_by   = var.name
     openqa_created_date = timestamp()
     openqa_created_id   = element(random_id.service.*.hex, count.index)

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -24,6 +24,8 @@ has container => 'sle-images';
 has image_gallery => 'test_image_gallery';
 has lease_id => undef;
 has storage_region => 'westeurope';
+# The ssh_key already exists in parrent class
+has ssh_key => '/root/.ssh/id_rsa';
 
 my $default_sku = 'gen2';
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -30,7 +30,7 @@ has terraform_applied => 0;
 has resource_name => sub { get_var('PUBLIC_CLOUD_RESOURCE_NAME', 'openqa-vm') };
 has provider_client => undef;
 
-has ssh_key => '/root/.ssh/id_rsa';
+has ssh_key => '/root/.ssh/id_ed25519';
 
 =head1 METHODS
 
@@ -154,11 +154,13 @@ Creates an ssh keypair in a given file path by $args{ssh_private_key_file}
 =cut
 
 sub create_ssh_key {
-    my ($self, %args) = @_;
-    $args{ssh_private_key_file} //= '/root/.ssh/id_rsa';
-    if (script_run('test -f ' . $args{ssh_private_key_file}) != 0) {
-        assert_script_run('SSH_DIR=`dirname ' . $args{ssh_private_key_file} . '`; mkdir -p $SSH_DIR');
-        assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -C "" -m pem -f ' . $args{ssh_private_key_file});
+    my ($self) = @_;
+    my $alg = $self->ssh_key;
+    $alg =~ s@[a-z0-9/-_~.]*id_@@;
+    record_info($alg, "The $alg key will be generated.");
+    if (script_run('test -f ' . $self->ssh_key) != 0) {
+        assert_script_run('SSH_DIR=`dirname ' . $self->ssh_key . '`; mkdir -p $SSH_DIR');
+        assert_script_run('ssh-keygen -t ' . $alg . ' -q -N "" -C "" -m pem -f ' . $self->ssh_key);
     }
 }
 
@@ -510,6 +512,7 @@ sub terraform_apply {
     if (get_var('PUBLIC_CLOUD_NVIDIA')) {
         $cmd .= "-var gpu=true ";
     }
+    $cmd .= "-var 'ssh_public_key=" . $self->ssh_key . ".pub' ";
     $cmd .= "-out myplan";
     record_info('TFM cmd', $cmd);
 

--- a/tests/publiccloud/aws_cli.pm
+++ b/tests/publiccloud/aws_cli.pm
@@ -38,7 +38,7 @@ sub run {
     record_info("EC2 AMI", "EC2 AMI query: " . $image_id);
 
     my $ssh_key = "openqa-cli-test-key-$job_id";
-    assert_script_run("aws ec2 import-key-pair --key-name '$ssh_key' --public-key-material fileb://~/.ssh/id_rsa.pub");
+    assert_script_run("aws ec2 import-key-pair --key-name '$ssh_key' --public-key-material fileb://" . $provider->ssh_key . ".pub");
 
     my $machine_name = "openqa-cli-test-vm-$job_id";
     my $security_group_name = "openqa-cli-test-sg-$job_id";


### PR DESCRIPTION
Switching to ed25519 in Google and Amazon. Azure still supports only RSA.

- Related ticket: [poo#155554](https://progress.opensuse.org/issues/155554)
- Verification run: [cli](https://pdostal-server.suse.cz/t5697), [sle-15-SP2-Azure-BYOS-Updates.x86_64](https://pdostal-server.suse.cz/tests/5691), [sle-15-SP2-EC2-BYOS-Updates.aarch64](https://pdostal-server.suse.cz/tests/5687), [sle-12-SP5-Azure-BYOS-Updates.x86_64](https://pdostal-server.suse.cz/tests/5692), [sle-15-SP2-GCE-BYOS-Updates.x86_64](https://pdostal-server.suse.cz/tests/5689), [sle-12-SP5-EC2-BYOS-Updates.x86_64](https://pdostal-server.suse.cz/tests/5688), [sle-12-SP5-GCE-BYOS-Updates.x86_64](https://pdostal-server.suse.cz/tests/5690), [SAP-Ansible](https://pdostal-server.suse.cz/tests/5701)