### PR TITLE
Pubcloud image creation: precheck before pushing perf data to influxdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ docs/**/*.html
 /script/yaml_generator/env/
 __pycache__/
 .tidyall.d/
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/**/*.html
 /script/yaml_generator/env/
 __pycache__/
 .tidyall.d/
+.vscode/

--- a/lib/db_utils.pm
+++ b/lib/db_utils.pm
@@ -67,15 +67,20 @@ sub influxdb_push_data {
     my ($url, $db, $org, $token, $data, %args) = @_;
     $args{quiet} //= 1;
     $args{proceed_on_failure} //= 0;
+    $args{timeout} //= 90;
     $data = build_influx_query($data);
+    # connectivity pre-check
+    if (script_run('curl --silent --insecure --fail ' . $url . '>/dev/null', timeout => $args{timeout}, die_on_timeout => 0)) {    # curl error
+        record_info("Check", 'Cannot access DB on: ' . $url, result => 'fail');
+        return 0;
+    }
     my $cmd = sprintf("curl -iLk -X POST '$url/api/v2/write?org=$org&bucket=$db' --header 'Authorization: Token $token' --write-out 'RETURN_CODE:%%{response_code}' --data-binary '%s'", $data);
-
     # Hide the token in the info box
     my $out = $cmd;
     $out =~ s/$token/<redacted>/;
     record_info('curl POST', $out);
 
-    my $output = script_output($cmd, quiet => $args{quiet}, proceed_on_failure => $args{proceed_on_failure});
+    my $output = script_output($cmd, $args{timeout}, quiet => $args{quiet}, proceed_on_failure => $args{proceed_on_failure});
     my ($return_code) = $output =~ /RETURN_CODE:(\d+)/;
     unless ($return_code >= 200 && $return_code < 300) {
         my $msg = "Failed pushing data into Influx DB:\n$output\n";

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -631,15 +631,13 @@ To activate boottime push, shall be available results and
 =cut
 
 sub store_boottime_db() {
-    my ($self, $results) = @_;
+    my ($self, $results, $url) = @_;
     my $data_push = get_var('PUBLIC_CLOUD_PERF_PUSH_DATA', 1);
-    my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI', 'http://publiccloud-ng.qa.suse.de:8086');
     my $org = get_var('PUBLIC_CLOUD_PERF_DB_ORG', 'qec');
     my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf_2');
     my $token = get_var('_SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN');
-    my $db_timeout = 180;
 
-    return unless ($results && $data_push);
+    return unless ($results && $data_push && $url);
     unless ($token) {
         record_info("WARN", "_SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN is missing ", result => 'fail');
         return 0;
@@ -670,7 +668,7 @@ sub store_boottime_db() {
         tags => $tags,
         values => $results->{analyze}
     };
-    my $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1, timeout => $db_timeout);
+    my $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1);
     return unless ($res);
 
     record_info("STORE blame", $results->{type});
@@ -680,7 +678,7 @@ sub store_boottime_db() {
         tags => $tags,
         values => $results->{blame}
     };
-    $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1, timeout => $db_timeout);
+    $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1);
     return $res;
 }
 

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -637,6 +637,7 @@ sub store_boottime_db() {
     my $org = get_var('PUBLIC_CLOUD_PERF_DB_ORG', 'qec');
     my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf_2');
     my $token = get_var('_SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN');
+    my $db_timeout = 180;
 
     return unless ($results && $data_push);
     unless ($token) {
@@ -669,7 +670,7 @@ sub store_boottime_db() {
         tags => $tags,
         values => $results->{analyze}
     };
-    my $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1);
+    my $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1, timeout => $db_timeout);
     return unless ($res);
 
     record_info("STORE blame", $results->{type});
@@ -679,7 +680,7 @@ sub store_boottime_db() {
         tags => $tags,
         values => $results->{blame}
     };
-    $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1);
+    $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1, timeout => $db_timeout);
     return $res;
 }
 

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -75,7 +75,8 @@ sub run {
     my $disk_type = get_var('PUBLIC_CLOUD_HDD2_TYPE');
     my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI');
     my $use_nvme = is_azure() && get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'Standard_L(8|16|32|64)s_v(2|3)';
-
+    my $db_timeout = 180;
+    my $res;
     my @scenario = (
         {
             name => 'reference',
@@ -202,7 +203,9 @@ sub run {
             my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf_2');
             my $token = get_required_var('_SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN');
             my $org = get_var('PUBLIC_CLOUD_PERF_DB_ORG', 'qec');
-            influxdb_push_data($url, $db, $org, $token, $data) if (check_var('PUBLIC_CLOUD_PERF_PUSH_DATA', 1));
+            $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1, timeout => $db_timeout)
+              if (check_var('PUBLIC_CLOUD_PERF_PUSH_DATA', 1));
+            return unless ($res);
             my %influx_read_args = (
                 url => $url,
                 db => $db,

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -73,10 +73,8 @@ sub run {
     my $runtime = get_var('PUBLIC_CLOUD_FIO_RUNTIME', 300);
     my $disk_size = get_var('PUBLIC_CLOUD_HDD2_SIZE');
     my $disk_type = get_var('PUBLIC_CLOUD_HDD2_TYPE');
-    my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI');
+    my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI', 'http://publiccloud-ng.qa.suse.de:8086');
     my $use_nvme = is_azure() && get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ 'Standard_L(8|16|32|64)s_v(2|3)';
-    my $db_timeout = 180;
-    my $res;
     my @scenario = (
         {
             name => 'reference',
@@ -194,7 +192,7 @@ sub run {
         $values->{write_latency} = $json->{jobs}[0]->{write}->{lat_ns}->{mean} / 1000;
 
         # Store values in influx-db
-        if ($url) {
+        if (is_ok_url($url)) {
             my $data = {
                 table => 'storage_fio',
                 tags => $tags,
@@ -203,9 +201,8 @@ sub run {
             my $db = get_var('PUBLIC_CLOUD_PERF_DB', 'perf_2');
             my $token = get_required_var('_SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN');
             my $org = get_var('PUBLIC_CLOUD_PERF_DB_ORG', 'qec');
-            $res = influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1, timeout => $db_timeout)
+            influxdb_push_data($url, $db, $org, $token, $data, proceed_on_failure => 1)
               if (check_var('PUBLIC_CLOUD_PERF_PUSH_DATA', 1));
-            return unless ($res);
             my %influx_read_args = (
                 url => $url,
                 db => $db,


### PR DESCRIPTION
In public cloud, during image creation and statistics collection, pre-check added in `influxdb_push_data`, to verify that influx db url is working well, otherwise no data pushed, but test will normally continue. 

Also timeouts added to internal curl post commands.

- Related ticket: https://progress.opensuse.org/issues/155416 
- Needles: none
- Verification run: see body posts
