### PR TITLE
Quick fix for installer_extended on aarch64

### DIFF
--- a/schedule/yast/installer_extended/installer_extended_aarch64.yaml
+++ b/schedule/yast/installer_extended/installer_extended_aarch64.yaml
@@ -20,7 +20,6 @@ schedule:
     - installation/bootloader_start
   product_selection:
     - installation/language_keyboard/switch_keyboard_layout
-    - installation/product_selection/install_SLES
   license_agreement:
     - installation/licensing/verify_license_translations
     - installation/licensing/verify_license_has_to_be_accepted


### PR DESCRIPTION
Test still failed because the install_SLES test was hardcoded into the tests YAML_SCHEDULE.
- [Verification run](https://openqa.suse.de/tests/13580349)
