### PR TITLE
smartcard: Do not check version of obsoleted pkcs11-helper package

### DIFF
--- a/tests/security/smartcard/version_check.pm
+++ b/tests/security/smartcard/version_check.pm
@@ -29,7 +29,6 @@ sub run {
         'pcsc-lite' => '1.9.4',
         'libp11-3' => '0.4.11',
         'pcsc-tools' => '1.5.8',
-        'pkcs11-helper' => '1.25.1'
     };
     zypper_call("in " . join(' ', keys %$pkg_list));
     package_upgrade_check($pkg_list);


### PR DESCRIPTION
The package has been deprecated as it does not have any real content.

- Related ticket: https://progress.opensuse.org/issues/155560
- Needles: N/A
- Verification run: N/A
