### PR TITLE
Fix sporadic failures on nmcli invocation

### DIFF
--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -15,6 +15,7 @@ use mm_network 'setup_static_mm_network';
 use utils qw(zypper_call permit_root_ssh set_hostname ping_size_check);
 use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
 use version_utils qw(is_sle is_opensuse);
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = @_;
@@ -28,8 +29,7 @@ sub run {
     }
     mutex_wait 'barrier_setup_mm_done';
 
-    select_console 'root-console';
-
+    select_serial_terminal;
     # Do not use external DNS for our internal hostnames
     assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');
     assert_script_run('echo "10.0.2.102 client minion" >> /etc/hosts');


### PR DESCRIPTION
The serial console somehow looks like it messes up with the interpolation
of `mn_id`. Using serial terminal produces more stable results and problem
seems to go away.
In additional there are changes to prevent the uninitialized value warnings in autoinst-log on this jobs.

https://progress.opensuse.org/issues/155170

- Verification run: https://openqa.opensuse.org/tests/overview?distri=opensuse&build=b10n1k%2Fos-autoinst-distri-opensuse%2318713&version=Tumbleweed (x100)
