### PR TITLE
Remove virtproxyd from virt test as it has been removed from all system

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_one_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_one_disk.xml
@@ -120,7 +120,6 @@
 	<service>virtnetworkd</service>
 	<service>virtnodedevd</service>
 	<service>virtsecretd</service>
-	<service>virtproxyd</service>
 	<service>virtnwfilterd</service>
       </enable>
     </services>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_two_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_kvm_two_disk.xml
@@ -126,7 +126,6 @@
 	<service>virtnetworkd</service>
 	<service>virtnodedevd</service>
 	<service>virtsecretd</service>
-	<service>virtproxyd</service>
 	<service>virtnwfilterd</service>
       </enable>
     </services>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_one_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_one_disk.xml
@@ -121,7 +121,6 @@
 	<service>virtnetworkd</service>
 	<service>virtnodedevd</service>
 	<service>virtsecretd</service>
-	<service>virtproxyd</service>
 	<service>virtnwfilterd</service>
       </enable>
     </services>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_two_disk.xml
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast_opensuse_xen_two_disk.xml
@@ -127,7 +127,6 @@
 	<service>virtnetworkd</service>
 	<service>virtnodedevd</service>
 	<service>virtsecretd</service>
-	<service>virtproxyd</service>
 	<service>virtnwfilterd</service>
       </enable>
     </services>

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -54,9 +54,10 @@ sub check_modular_libvirt_daemons {
     my @daemons = @_;
 
     if (!@daemons) {
-        @daemons = qw(network nodedev nwfilter secret storage proxy lock);
+        @daemons = qw(network nodedev nwfilter secret storage lock);
         # For details, please refer to poo#137096
         (is_xen_host) ? push @daemons, 'xen' : push @daemons, ('qemu', 'log');
+        push @daemons, 'proxy' if is_sle;
     }
 
     foreach my $daemon (@daemons) {
@@ -79,9 +80,10 @@ sub restart_modular_libvirt_daemons {
     my @daemons = @_;
 
     if (!@daemons) {
-        @daemons = qw(network nodedev nwfilter secret storage proxy lock);
+        @daemons = qw(network nodedev nwfilter secret storage lock);
         # For details, please refer to poo#137096
         (is_xen_host) ? push @daemons, 'xen' : push @daemons, ('qemu', 'log');
+        push @daemons, 'proxy' if is_sle;
     }
 
     if (is_alp) {
@@ -211,9 +213,10 @@ sub check_libvirtd {
 # Developer asked to use different log file as log_output per daemon.
 sub turn_on_libvirt_debugging_log {
 
-    my @libvirt_daemons = is_monolithic_libvirtd ? "libvirtd" : qw(virtqemud virtstoraged virtnetworkd virtnodedevd virtsecretd virtproxyd virtnwfilterd virtlockd);
+    my @libvirt_daemons = is_monolithic_libvirtd ? "libvirtd" : qw(virtqemud virtstoraged virtnetworkd virtnodedevd virtsecretd virtnwfilterd virtlockd);
     # For details, please refer to poo#137096
     push @libvirt_daemons, 'virtlogd' if is_kvm_host;
+    push @libvirt_daemons, 'virtproxyd' if is_sle;
 
     #turn on debug and log filter for libvirt services
     #disable log_level = 1 'debug' as it generage large output

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -32,7 +32,6 @@ sub run {
     }
     send_key 'alt-k';    # KVM Server
     send_key 'alt-v';    # KVM tools
-    send_key 'alt-l';    # libvirt-lxc
 
     # launch the installation
     send_key 'alt-a';


### PR DESCRIPTION
- Remove proxyd from modulue libvirt daemons as it has been removed from all system
- Remove obsolete lxc from yast virtualuzation(https://openqa.opensuse.org/tests/3954883#step/yast_virtualization/12)


Related ticket: https://progress.opensuse.org/issues/152320
- Verification run: 
[TW virtualization@64bit](https://openqa.opensuse.org/tests/3954883)
[SLE15SP6 KVM](http://openqa.suse.de/tests/13571893)
