### PR TITLE
Add <kdump> section in autoyast_sle-micro_updates.xml.ep

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
@@ -41,6 +41,14 @@
       <pattern>microos-selinux</pattern>
     </patterns>
   </software>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>191M</crash_kernel>
+    <general>
+      <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>1</KDUMP_DUMPLEVEL>
+    </general>
+  </kdump>
   <users config:type="list">
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>


### PR DESCRIPTION
- Description: adding `<kdump>` to fix soft-failure [bsc#1195060](https://bugzilla.suse.com/show_bug.cgi?id=1195060)
- Related ticket: [poo#](https://progress.opensuse.org/issues/153619)
- Verification run: [overview](https://openqa.suse.de/tests/overview?build=issues-153619)
