### PR TITLE
Fix hana_cluster node2 register error

### DIFF
--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -75,6 +75,7 @@ sub run {
 
         assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StopSystem HDB'";
         assert_script_run "until su - $sapadm -c 'hdbnsutil -sr_state' | grep -q 'online: false' ; do sleep 1 ; done", 120;
+        sleep bmwqemu::scale_timeout(10);
         $self->do_hana_sr_register(node => $node1);
         sleep bmwqemu::scale_timeout(10);
         my $start_cmd = "su - $sapadm -c 'sapcontrol -nr $instance_id -function StartSystem HDB'";


### PR DESCRIPTION
Fix hana_cluster node2 register error by adding sleep 10

TEAM-9052 - Secondary node is not register with hana cluster and primary node due to new hana version

- Related ticket: https://jira.suse.com/browse/TEAM-9052
- Needles: NA
- Verification run:
Using SPS07rev73 to to VRs for maintenance jobs:
  * Maintenance: SAP/HA Incidents / Maintenance: SLE 15 SP3 SAP Incidents
  15sp3 x86 qam-SAPHanaSR_ScaleUp_PerfOpt_WMP_node01, cloned testid=13557819
  It failed on hana_cluster before (https://openqa.suse.de/tests/13563447#step/hana_cluster/13, or see TEAM-9052).
  https://openqa.suse.de/tests/13571786#dependencies ("sleep 180" passed)
  https://openqa.suse.de/tests/13571757#dependencies ("sleep 30" passed)
  https://openqa.suse.de/tests/13571895#dependencies ("sleep 30" passed)

  * Maintenance: QR / Maintenance - QR - SLE15SP5-SAP
  15sp5 ppc64le sles4sap_hana_node01, cloned testid=13311529
  It failed on wmp_check_process#2 before.
  http://openqa.suse.de/tests/13563630 (failed on monitoring_services without this code changes)
  http://openqa.suse.de/tests/13571840#dependencies (passed)
	
  * Maintenance: Aggregated updates / SAP/HA Maintenance Updates
    15sp3 x86 qam_sles4sap_wmp_hana_node, cloned testid=13568188
    http://openqa.suse.de/tests/13572007 (passed)