### PR TITLE
Fix reboot issue in PublicCloud for xfstests

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -79,7 +79,7 @@ sub process_reboot {
 
     if (is_public_cloud) {
         my $instance = publiccloud::instances::get_instance();
-        $instance->softreboot();    # Handled re-establishing of the required ssh tunnel and consoles
+        $instance->softreboot();    # Re-establishes the required ssh tunnel and consoles
         return;
     }
 

--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -150,6 +150,9 @@ sub run {
     partition_disk($device, $mnt_xfs, $mnt_scratch);
     create_config($device, $mnt_xfs, $mnt_scratch);
     script_run("source $CONFIG_FILE");
+
+    # Dummy file, required in xfstests/run.pm
+    assert_script_run("fallocate -l 32M /opt/xfstests/test_dev");
 }
 
 1;

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -293,7 +293,7 @@ sub save_kdump {
     $args{kernel} ||= 0;
     $args{debug} ||= 0;
     my $name = test_name($test);
-    my $ret = script_run("mv /var/crash/* $dir/$name");
+    my $ret = script_run("mv /var/crash/* $dir/$name", timeout => 300);
     if ($args{debug}) {
         $ret += script_run("if [ -e /usr/lib/debug/boot ]; then tar zcvf $dir/$name/vmcore-debug.tar.gz --absolute-names /usr/lib/debug/boot; fi");
     }


### PR DESCRIPTION
Fix the reboot failure in publiccloud due to the helper VM being rebooted instead of the publiccloud VM. This test regression was introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18616

Also increase the timeout for the mv command due to https://openqa.suse.de/tests/13555099#step/run/39

- Related failure: https://openqa.suse.de/tests/13555242#step/run/30
- Verification run: https://duck-norris.qe.suse.de/tests/14304
