### PR TITLE
Check guest health before and after each virt feature test

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -29,7 +29,7 @@ use Carp;
 our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest guest_is_sle is_guest_ballooned is_xen_host is_kvm_host reset_log_cursor check_failures_in_journal check_host_health check_guest_health
   is_monolithic_libvirtd turn_on_libvirt_debugging_log
   print_cmd_output_to_file ssh_setup ssh_copy_id create_guest import_guest install_default_packages upload_y2logs ensure_default_net_is_active ensure_guest_started
-  ensure_online add_guest_to_hosts restart_libvirtd check_libvirtd remove_additional_disks remove_additional_nic collect_virt_system_logs shutdown_guests wait_guest_online start_guests restore_downloaded_guests save_original_guest_xmls restore_original_guests
+  ensure_online add_guest_to_hosts restart_libvirtd check_libvirtd remove_additional_disks remove_additional_nic collect_virt_system_logs shutdown_guests wait_guest_online start_guests restore_downloaded_guests save_original_guest_xmls restore_original_guests save_guests_xml_for_change restore_xml_changed_guests
   is_guest_online wait_guests_shutdown remove_vm setup_common_ssh_config add_alias_in_ssh_config parse_subnet_address_ipv4 backup_file manage_system_service setup_rsyslog_host
   check_port_state subscribe_extensions_and_modules download_script download_script_and_execute is_sev_es_guest upload_virt_logs recreate_guests download_vm_import_disks enable_nm_debug check_activate_network_interface set_host_bridge_interface_with_nm upload_nm_debug_log restart_modular_libvirt_daemons check_modular_libvirt_daemons);
 
@@ -281,7 +281,7 @@ sub check_failures_in_journal {
     $cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$machine " . "\"$cmd\"" if $machine ne 'localhost';
     if (script_run($cmd) != 0) {
         $failures = "Fail to get journal logs from $machine";
-        record_info("Warning", "$failures in checking its health", result => 'softfail');
+        record_info("Warning", "$failures when checking its health", result => 'softfail');
         return $failures;
     }
 
@@ -1034,13 +1034,39 @@ sub restore_original_guests {
         if (script_run("ls $save_dir/$guest.xml") == 0) {
             restore_downloaded_guests($guest, $save_dir);
             record_info "Guest $guest is restored.";
+            assert_script_run "virsh start $guest";
+            wait_guest_online($guest);
         }
         else {
             record_info("Fail to restore guest!", "$guest", result => 'softfail');
         }
     }
     script_run("virsh list --all");
-    save_screenshot;
+}
+
+
+#save the guest configuration files into a folder
+#create a dir for storing changed guest configuration files only
+sub save_guests_xml_for_change {
+    my ($save_dir, @guests) = @_;
+    $save_dir //= "/tmp/download_vm_xml";
+    save_original_guest_xmls($save_dir, @guests);
+    my $changed_xml_dir = "$save_dir/changed_xml";
+    script_run("[ -d $changed_xml_dir ] && rm -rf $changed_xml_dir/*");
+    script_run("mkdir -p $changed_xml_dir");
+}
+
+#restore guest which xml configuration files were changed in a test
+sub restore_xml_changed_guests {
+    my $changed_xml_dir = shift;
+    $changed_xml_dir //= "/tmp/download_vm_xml/changed_xml";
+    my @changed_guests = split('\n', script_output("ls -1 $changed_xml_dir | cut -d '.' -f1"));
+    foreach my $guest (@changed_guests) {
+        remove_vm($guest);
+        restore_downloaded_guests($guest, $changed_xml_dir);
+        assert_script_run "virsh start $guest";
+        wait_guest_online($guest);
+    }
 }
 
 sub upload_virt_logs {

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -252,30 +252,55 @@ sub reset_log_cursor {
     }
 }
 
-#check kernels by grep keywords from journals
-#support x86_64 only
-#welcome everybody to extend this function
+# Grep keywords from journals and report warnings, support x86_64 only
+# Usage: check_failures_in_journal([machine], [no_cursor => 0]);
+# [machine]: an IP or QUDN of ssh accesible machine. "localhost" ie. the SUT itself, by default.
+# [no_cursor => 0]: value '0' means grep keywords from incremenal journal output only,
+# ie. Start searching from the place you previously searched.
+# value '1' means searching in the entire journal output(also including previous boots)
+# keywords: only "Coredump" and "Call trace" have been included so far
+# Work flow:
+# - save journal output to a tmp file
+# - get cursor from the saved file unless you'd like to search in the entire journals
+# - grep each keywords in the saved file
+# - if keywords are found, give warnings and upload the saved log
 sub check_failures_in_journal {
     return unless is_x86_64 and (is_sle or is_opensuse);
-    my $machine = shift;
+    my ($machine, %args) = @_;
     $machine //= 'localhost';
+    $args{no_cursor} //= 0;
 
+    # Save journal log to a tmp file
+    my $logfile = "/tmp/journalctl-$machine.log";
+    my $failures = "";
+    reset_log_cursor if $args{no_cursor} == 1;
     my $cursor = $log_cursors{$machine};
     my $cmd = "journalctl --show-cursor ";
-    $cmd .= defined($cursor) ? "--cursor='$cursor'" : "-b";
+    $cmd .= "--cursor='$cursor'" if defined($cursor);
+    $cmd .= " > $logfile";
     $cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$machine " . "\"$cmd\"" if $machine ne 'localhost';
-
-    my $log = script_output($cmd, type_command => 1, proceed_on_failure => 1);
-    my $failures = "";
-    my @warnings = ('Started Process Core Dump', 'Call Trace');
-
-    $log_cursors{$machine} = $1 if $log =~ m/-- cursor:\s*(\S+)\s*$/i;
-
-    foreach my $warn (@warnings) {
-        my $cmd = "journalctl | grep '$warn'";
-        $cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$machine " . "\"$cmd\"" if $machine ne 'localhost';
-        $failures .= "\"$warn\" in journals on $machine \n" if script_run("timeout --kill-after=3 --signal=9 120 $cmd") == 0;
+    if (script_run($cmd) != 0) {
+        $failures = "Fail to get journal logs from $machine";
+        record_info("Warning", "$failures in checking its health", result => 'softfail');
+        return $failures;
     }
+
+    # Get the cursor of the journal log file
+    unless ($args{no_cursor}) {
+        $cmd = "grep -oe \'-- cursor: *[^ ]*\' $logfile | cut -d ' ' -f3";
+        $cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$machine " . "\"$cmd\"" if $machine ne 'localhost';
+        $log_cursors{$machine} = script_output("$cmd", type_command => 1);
+    }
+
+    # Search warnings from the journal log file
+    my @warnings = ('Started Process Core Dump', 'Call Trace');
+    foreach (@warnings) {
+        $cmd = "grep '$_' $logfile";
+        $cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$machine " . "\"$cmd\"" if $machine ne 'localhost';
+        $failures .= "\"$_\" in journals on $machine \n" if script_run("$cmd") == 0;
+    }
+
+    # In case of failures, print message and upload journal log
     if ($failures) {
         if (get_var('KNOWN_BUGS_FOUND_IN_JOURNAL')) {
             record_soft_failure("Found failures: \n" . $failures . "There are known kernel bugs " . get_var('KNOWN_BUGS_FOUND_IN_JOURNAL') . ". Please look into journal files to determine if it is a known bug. If it is a new issue, please take action as described in poo#151361.");
@@ -283,11 +308,7 @@ sub check_failures_in_journal {
         else {
             record_soft_failure("Found new failures: " . $failures . " please take actions as described in poo#151361.\n");
         }
-
-        my $logfile = "/tmp/journalctl-$machine.log";
-
-        script_run("rm -f $logfile");
-        print_cmd_output_to_file('journalctl -b', $logfile, $machine);
+        script_run("rsync root\@$machine:$logfile $logfile", die_on_timeout => 0) if $machine ne 'localhost';
         upload_logs($logfile);
     }
     return $failures;
@@ -299,7 +320,8 @@ sub check_failures_in_journal {
 # Welcome everybody to extend this function
 sub check_host_health {
     return unless is_x86_64 and (is_sle or is_opensuse);
-    my $failures = check_failures_in_journal;
+
+    my $failures = caller 0 eq 'validate_system_health' ? check_failures_in_journal('localhost', no_cursor => 1) : check_failures_in_journal();
     unless ($failures) {
         record_info("Healthy host!");
         return 'pass';
@@ -322,17 +344,17 @@ sub check_guest_health {
     if (script_run("virsh list --all | grep \"$vm \"") == 0) {
         $vmstate = "ok" if (script_run("virsh domstate $vm | grep running") == 0);
     }
-    if (is_xen_host and script_run("xl list $vm") == 0) {
+    elsif (is_xen_host and script_run("xl list $vm") == 0) {
         script_retry("xl list $vm | grep \"\\-b\\-\\-\\-\\-\"", delay => 10, retry => 1, die => 0) for (0 .. 3);
         $vmstate = "ok" if script_run("xl list $vm | grep \"\\-b\\-\\-\\-\\-\"");
     }
     if ($vmstate eq "ok") {
-        $failures = check_failures_in_journal($vm);
+        $failures = caller 0 eq 'validate_system_health' ? check_failures_in_journal($vm, no_cursor => 1) : check_failures_in_journal($vm);
         return 'fail' if $failures;
         record_info("Healthy guest!", "$vm looks good so far!");
     }
     else {
-        record_info("Skip check_failures_in_journal for $vm", "$vm is not in desired state judged by either virsh or xl tool stack");
+        record_info("Skip check_failures_in_journal for $vm", "$vm is not in desired state judged by either virsh or xl tool stack", result => 'softfail');
     }
     return 'pass';
 }

--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -11,6 +11,8 @@ use strict;
 use warnings;
 use testapi;
 use Utils::Architectures;
+use Utils::Backends 'use_ssh_serial_console';
+use ipmi_backend_utils;
 use virt_utils;
 
 sub get_script_run {
@@ -66,6 +68,9 @@ sub post_execute_script_assertion {
 
 sub run {
     my $self = shift;
+
+    select_console 'sol', await_console => 0;
+    use_ssh_serial_console;
 
     # Add option to keep guest after successful installation
     # Only for x86_64 now

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -73,7 +73,6 @@ sub run_test {
         validate_guest_status($guest);
         save_guest_ip($guest, name => "br123");
         virt_autotest::utils::ssh_copy_id($guest);
-        check_guest_health($guest);
 
         # ALP guest uses networkmanager to control network, no /etc/sysconfig/network/ifcfg*
         next if ($guest =~ /alp/i);

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -173,7 +173,7 @@ sub find_sriov_ethernet_devices {
             # Any VFs can be passed through to guests
             # But only those VFs whose pv has physical network connection can get an IP from DHCP server
             my $nic = script_output "ls -l /sys/class/net |grep $_ | awk '{print \$9}'";
-            if (script_output("ip link show $nic up") =~ /$nic/) {
+            if (script_output("ip link show $nic up") =~ /$nic.* state UP/) {
                 push @sriov_devices, $_;
                 record_info("Find SR-IOV devices", "$_    $nic");
             }
@@ -182,6 +182,9 @@ sub find_sriov_ethernet_devices {
                 if (script_output("cat /sys/class/net/$nic/carrier") eq '1') {
                     push @sriov_devices, $_;
                     record_info("Find SR-IOV devices", "$_    $nic");
+                }
+                else {
+                    script_run("ip link set $nic down");
                 }
             }
         }

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -29,6 +29,8 @@ use virt_autotest::utils;
 use virt_autotest::virtual_network_utils qw(save_guest_ip test_network_interface);
 
 our $log_dir = "/tmp/sriov_pcipassthru";
+our $vm_xml_save_dir = "/tmp/download_vm_xml";
+
 sub run_test {
     my $self = shift;
 
@@ -39,7 +41,7 @@ sub run_test {
     script_run "[ -d $log_dir ] && rm -rf $log_dir; mkdir -p $log_dir";
 
     #save original guest configuration file in case of restore in post_fail_hook()
-    save_original_guest_xmls();
+    save_guests_xml_for_change($vm_xml_save_dir);
 
     #get the SR-IOV device BDF and interface
     my @host_pfs;
@@ -138,7 +140,7 @@ sub run_test {
     virt_autotest::utils::upload_virt_logs($log_dir, "logs");
 
     #redefine guest from their original configuration files
-    restore_original_guests();
+    restore_xml_changed_guests("$vm_xml_save_dir/changed_xml");
 }
 
 
@@ -215,40 +217,45 @@ sub prepare_guest_for_sriov_passthrough {
     unless (is_kvm_host || is_sle('=12-SP5') && is_fv_guest($vm) && !is_guest_ballooned($vm)) {
 
         #don't not use 'virsh edit' to change domain.xml because 'virsh define' does some error checking
-        assert_script_run "virsh dumpxml --inactive $vm > $vm.xml";
+        my $changed_xml_dir = "$vm_xml_save_dir/changed_xml";
+        assert_script_run "virsh dumpxml --inactive $vm > $changed_xml_dir/$vm.xml";
         script_run "virsh destroy $vm";
 
         #disable memory ballooning for fv guest as it is not supported
         if (is_fv_guest($vm) && is_guest_ballooned($vm)) {
-            assert_script_run "sed -i '/<currentMemory/d' $vm.xml";
+            assert_script_run "sed -i '/<currentMemory/d' $changed_xml_dir/$vm.xml";
             record_info "Disable guest ballooning", "$vm";
         }
         #enable pci-passthrough on sles15sp2+
         #set e820_host for pv guest
         #refer to bug #1167217 and but #1185081 for the reason
         unless (is_fv_guest($vm) && is_sle('<15-SP2')) {
-            unless (script_run("xmlstarlet sel -t -c /domain/features $vm.xml") == 0) {
-                assert_script_run "xmlstarlet edit -L -s /domain -t elem -n features -v '' $vm.xml";
+            unless (script_run("xmlstarlet sel -t -c /domain/features $changed_xml_dir/$vm.xml") == 0) {
+                assert_script_run "xmlstarlet edit -L -s /domain -t elem -n features -v '' $changed_xml_dir/$vm.xml";
             }
-            unless (script_run("xmlstarlet sel -t -c /domain/features/xen $vm.xml") == 0) {
-                assert_script_run "xmlstarlet edit -L -s /domain/features -t elem -n xen -v '' $vm.xml";
+            unless (script_run("xmlstarlet sel -t -c /domain/features/xen $changed_xml_dir/$vm.xml") == 0) {
+                assert_script_run "xmlstarlet edit -L -s /domain/features -t elem -n xen -v '' $changed_xml_dir/$vm.xml";
             }
-            assert_script_run "xmlstarlet edit -L \\
+            if (is_sle('>=15-SP2') && script_run("xmlstarlet sel -t -c /domain/features/xen/passthrough $changed_xml_dir/$vm.xml") != 0) {
+                assert_script_run "xmlstarlet edit -L \\
                                    -s /domain/features/xen -t elem -n passthrough -v '' \\
                                    -s ////passthrough -t attr -n state -v on \\
-                                   $vm.xml" unless is_sle('<15-SP2');
-            assert_script_run "xmlstarlet edit -L \\
+                                   $changed_xml_dir/$vm.xml";
+            }
+            if (is_pv_guest($vm) and script_run("xmlstarlet sel -t -c /domain/features/xen/e820_host $changed_xml_dir/$vm.xml") != 0) {
+                assert_script_run "xmlstarlet edit -L \\
                                    -s /domain/features/xen -t elem -n e820_host -v '' \\
                                    -s ////e820_host -t attr -n state -v on \\
-                                   $vm.xml" if is_pv_guest($vm);
+                                   $changed_xml_dir/$vm.xml";
+            }
         }
 
         #try undefine with --keep-nvram if undefine fails on uefi guest
         script_run "virsh undefine $vm || virsh undefine $vm --keep-nvram";
         assert_script_run(" ! virsh list --all | grep $vm");
-        assert_script_run "virsh define $vm.xml";
+        assert_script_run "virsh define $changed_xml_dir/$vm.xml";
         assert_script_run "virsh start $vm";
-        sleep 60;
+        wait_guest_online($vm);
     }
 
     #passwordless access to guest
@@ -404,10 +411,11 @@ sub post_fail_hook {
     foreach (keys %virt_autotest::common::guests) {
         save_network_device_status_logs($_, "post_fail_hook");
         script_run("ssh root\@$_ 'dmesg' >> $log_dir/dmesg_$_ 2>&1", die_on_timeout => 0);
+        check_guest_health($_);
     }
     virt_autotest::utils::upload_virt_logs($log_dir, "network_device_status");
     $self->SUPER::post_fail_hook;
-    restore_original_guests();
+    restore_original_guests($vm_xml_save_dir);
 
 }
 

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -95,7 +95,6 @@ sub run_test {
         #check the networking of the plugged interface
         #use br123 as ssh connection
         test_network_interface($guest, gate => $gateway, mac => $vfs[0]->{vm_mac}, net => 'br123');
-        check_guest_health($guest);
 
         #unplug the first vf from vm
         unplug_vf_from_vm($guest, $vfs[0]);
@@ -110,16 +109,12 @@ sub run_test {
             test_network_interface($guest, gate => $gateway, mac => $vfs[$i]->{vm_mac}, net => 'br123') if $i == 1;
             save_network_device_status_logs($guest, $i + 3 . "-after_hotplug_$vfs[$i]->{host_id}");
         }
-        check_guest_health($guest);
 
         #reboot the guest
         record_info("VM reboot", "$guest");
         script_run "ssh root\@$guest 'reboot'";    #don't use assert_script_run, or may fail on xen guests
         wait_guest_online($guest, 30);
         save_network_device_status_logs($guest, $passthru_vf_count + 3 . '-after_guest_reboot');
-
-        #check host and guest to make sure they work well
-        check_guest_health($guest);
 
         #check the remaining vf(s) inside vm
         for (my $i = 1; $i < $passthru_vf_count; $i++) {
@@ -136,9 +131,6 @@ sub run_test {
         }
         script_run "lspci | grep Ethernet";
         save_screenshot;
-
-        #check host and guest to make sure they work well
-        check_guest_health($guest);
 
     }
 
@@ -274,8 +266,6 @@ sub prepare_guest_for_sriov_passthrough {
         script_run "ssh root\@$vm \"sed -i '/^[# ]*Storage *=/{h;s/^[# ]*Storage *=.*\\\$/Storage=persistent/};\\\${x;/^\\\$/{s//Storage=persistent/;H};x}' $journald_conf_file\"";
         script_run "ssh root\@$vm 'systemctl restart systemd-journald'";
     }
-
-    check_guest_health($vm);
 
 }
 

--- a/tests/virt_autotest/validate_system_health.pm
+++ b/tests/virt_autotest/validate_system_health.pm
@@ -6,7 +6,7 @@
 # Summary: Do a basic examination to the host and guests after tests run
 # Maintainer: Julie CAO <JCao@suse.com>, qe-virt@suse.de
 
-use base "virt_feature_test_base";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;
@@ -19,15 +19,7 @@ use virt_utils qw(collect_host_and_guest_logs);
 use alp_workloads::kvm_workload_utils;
 use version_utils qw(is_alp);
 
-sub prepare_run_test {
-    unless (defined(script_run("rm -f /root/{commands_history,commands_failure}", die_on_timeout => 0))) {
-        reconnect_when_ssh_console_broken;
-        alp_workloads::kvm_workload_utils::enter_kvm_container_sh if is_alp;
-    }
-    script_run("history -c");
-}
-
-sub run_test {
+sub run {
     return unless is_x86_64 || is_alp;
 
     my $self = shift;
@@ -63,7 +55,6 @@ sub run_test {
 sub post_fail_hook {
     my $self = shift;
     diag("Module validate_system_health post fail hook starts.");
-    $self->junit_log_provision((caller(0))[3]);
     unless (defined(script_run("rm -f /root/{commands_history,commands_failure}", die_on_timeout => 0))) {
         reconnect_when_ssh_console_broken;
         alp_workloads::kvm_workload_utils::enter_kvm_container_sh if is_alp;

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -93,7 +93,6 @@ sub run_test {
         }
         record_info("NIC IRQs distribution on $nproc cpu cores", "@increased_irqs_on_cpu");
 
-        check_guest_health($guest);
     }
 
     restore_xml_changed_guests();
@@ -117,6 +116,7 @@ sub restore_xml_changed_guests {
         remove_vm($guest);
         restore_downloaded_guests($guest, $changed_xml_dir);
         assert_script_run "virsh start $guest";
+        wait_guest_online($guest);
     }
 }
 
@@ -138,7 +138,6 @@ sub prepare_guest_for_irqbalance {
     }
 
     wait_guest_online($vm_name);
-    check_guest_health($vm_name);
     assert_script_run "ssh root\@$vm_name \"zypper in -y irqbalance\"" unless script_run("ssh root\@$vm_name \"rpm -q irqbalance\"") eq 0;
 
 }

--- a/tests/virt_autotest/xen_guest_irqbalance.pm
+++ b/tests/virt_autotest/xen_guest_irqbalance.pm
@@ -13,7 +13,7 @@ use testapi;
 use utils 'script_retry';
 use version_utils qw(is_sle);
 use virt_autotest::common;
-use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute remove_vm save_original_guest_xmls restore_downloaded_guests restore_original_guests upload_virt_logs check_guest_health);
+use virt_autotest::utils qw(is_kvm_host guest_is_sle wait_guest_online download_script_and_execute remove_vm save_guests_xml_for_change restore_original_guests restore_xml_changed_guests upload_virt_logs);
 
 our $vm_xml_save_dir = "/tmp/download_vm_xml";
 
@@ -22,7 +22,7 @@ sub run_test {
 
     return if is_kvm_host;
 
-    save_original_guests();
+    save_guests_xml_for_change($vm_xml_save_dir);
 
     foreach my $guest (keys %virt_autotest::common::guests) {
 
@@ -95,29 +95,8 @@ sub run_test {
 
     }
 
-    restore_xml_changed_guests();
+    restore_xml_changed_guests("$vm_xml_save_dir/changed_xml");
 
-}
-
-#save the guest configuration files into a folder
-sub save_original_guests {
-    my $vm_xml_save_dir = "/tmp/download_vm_xml";
-    save_original_guest_xmls($vm_xml_save_dir);
-    my $changed_xml_dir = "$vm_xml_save_dir/changed_xml";
-    script_run("[ -d $changed_xml_dir ] && rm -rf $changed_xml_dir/*");
-    script_run("mkdir -p $changed_xml_dir");
-}
-
-#restore guest which xml configuration files were changed in prepare_guest_for_irqbalance()
-sub restore_xml_changed_guests {
-    my $changed_xml_dir = "$vm_xml_save_dir/changed_xml";
-    my @changed_guests = split('\n', script_output("ls -1 $changed_xml_dir | cut -d '.' -f1"));
-    foreach my $guest (@changed_guests) {
-        remove_vm($guest);
-        restore_downloaded_guests($guest, $changed_xml_dir);
-        assert_script_run "virsh start $guest";
-        wait_guest_online($guest);
-    }
 }
 
 #set up guest test environment to run irqbalance test
@@ -198,11 +177,11 @@ sub post_fail_hook {
         my $log_file = $log_dir . "/$guest" . "_irqbalance_debug";
         my $debug_script = "xen_irqbalance_guest_logging.sh";
         download_script_and_execute($debug_script, machine => $guest, output_file => $log_file, proceed_on_failure => 1);
+        check_guest_health($guest);
     }
     upload_virt_logs($log_dir, "irqbalance_debug");
     $self->SUPER::post_fail_hook;
-    restore_original_guests();
-
+    restore_original_guests($vm_xml_save_dir);
 }
 
 sub test_flags {


### PR DESCRIPTION
To fix the following problems:

- It is difficult to determine which tests is the culprit of errors or warnings in journals.

- In addition, current uploaded log by "journalctl -b" does not include the log of previous boot which reports the errors. fg. https://openqa.suse.de/tests/13564742#downloads => libvirt_virtual_network_init-journalctl-sles-15-sp6-64-fv-uefi-xen.log

- Related ticket: https://progress.opensuse.org/issues/155728
- Verification run: 
[gi-guest_sles15sp5-on-host_developing-xen](https://openqa.suse.de/tests/13763065)
[gi-host_sles12sp5-xen](http://10.67.129.27/tests/291)
[uefi-gi-guest_developing-on-host_sles12sp5-xen](https://openqa.suse.de/tests/13763082)
[gi-guest_sles12sp5-on-host_developing-xen](https://openqa.suse.de/tests/13763066)
[a failed uefi-gi-guest_developing-on-host_developing-xen](http://openqa.suse.de/tests/13722945)
[a failed sriov test on uefi guest](http://10.67.129.27/tests/318)
[continue feature tests on on-host_developing-xen above](http://10.67.129.27/tests/326)
