### PR TITLE
Quick fix for missing pattern installation on aarch64

### DIFF
--- a/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_aarch64.yaml
+++ b/schedule/yast/select_modules_and_patterns/select_modules_and_patterns_aarch64.yaml
@@ -15,6 +15,7 @@ schedule:
     - installation/partitioning/guided_setup/accept_default_part_scheme
     - installation/partitioning/guided_setup/do_not_propose_separate_home
   software:
+    - installation/select_visible_patterns_from_bottom
     - installation/installation_settings/validate_default_target
   system_preparation:
     - console/system_prepare


### PR DESCRIPTION
Fixes this:

https://openqa.suse.de/tests/13565314#step/validate_installed_patterns/5

by adding `select_visibile_patterns_from_bottom` test module to the YAML schedule.

[Verification run](https://openqa.suse.de/tests/13574263)
