### PR TITLE
Fix hana_cluster failure on hana node register

### DIFF
--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -75,7 +75,7 @@ sub run {
 
         assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StopSystem HDB'";
         assert_script_run "until su - $sapadm -c 'hdbnsutil -sr_state' | grep -q 'online: false' ; do sleep 1 ; done", 120;
-        sleep bmwqemu::scale_timeout(10);
+        sleep bmwqemu::scale_timeout(30);
         $self->do_hana_sr_register(node => $node1);
         sleep bmwqemu::scale_timeout(10);
         my $start_cmd = "su - $sapadm -c 'sapcontrol -nr $instance_id -function StartSystem HDB'";


### PR DESCRIPTION
TEAM-9052 - Secondary node is not register with hana cluster and primary node due to new hana version

In pr https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18716 I added `sleep bmwqemu::scale_timeout(10);` but it is not enough for ppc64le test case SAPHanaSR_ScaleUp_PerfOpt_WMP_node. So add more time.

- Related ticket: https://jira.suse.com/browse/TEAM-9052
- Needles: NA
- Verification run: 
-15sp6 ppc64le, sles4sap_scc_textmode_hana_cli, version SPS07rev73_IMDB76
  http://openqa.suse.de/tests/13580613 (passed)
- 5sp6 ppc64le, SAPHanaSR_ScaleUp_PerfOpt_WMP_node, version SPS07rev73_IMDB76
   http://openqa.suse.de/tests/13580713#step/check_logs/51 (failed on check log but it is a known issue: bsc#1219359)