### PR TITLE
containers: Exit install_packages if packages are installed

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -66,7 +66,7 @@ sub _cleanup {
 
 sub install_packages {
     my @pkgs = @_;
-    return 0 unless @pkgs;
+    return if (script_run("rpm -q @pkgs >/dev/null") == 0);
 
     if (is_transactional) {
         trup_call("pkg install @pkgs");


### PR DESCRIPTION
Return earlier from install_packages if packages are installed.

- Related ticket: https://progress.opensuse.org/issues/155980
- Failing test: https://openqa.opensuse.org/tests/3960079#
- Verification run: https://openqa.opensuse.org/tests/3961088