### PR TITLE
xfstests: Fix public cloud test fail after PR_18616

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -494,7 +494,7 @@ sub test_run_without_heartbeat {
 
 sub run {
     my $self = shift;
-    select_serial_terminal();
+    get_var('PUBLIC_CLOUD') ? select_console('root-console') : select_serial_terminal();
     return if get_var('XFSTESTS_NFS_SERVER');
     my $enable_heartbeat = 1;
     $enable_heartbeat = 0 if (check_var 'XFSTESTS_NO_HEARTBEAT', '1');


### PR DESCRIPTION
The previous PR made public cloud tests fail to boot in run steps. Change select_serial_terminal() back to select_console('root-console') when find this is a public cloud test.

- Related ticket: https://progress.opensuse.org/issues/155779
- Verification run: https://openqa.suse.de/tests/13602134