### PR TITLE
Update SLES12SP5 autoyast profile's partition part

### DIFF
--- a/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_x86_64.xml
@@ -24,79 +24,8 @@
   </general>
   <partitioning config:type="list">
     <drive config:type="map">
-      <device>/dev/vda</device>
       <disklabel>gpt</disklabel>
       <enable_snapshots config:type="boolean">true</enable_snapshots>
-      <partitions config:type="list">
-        <partition config:type="map">
-          <create config:type="boolean">true</create>
-          <format config:type="boolean">false</format>
-          <partition_id config:type="integer">263</partition_id>
-          <partition_nr config:type="integer">1</partition_nr>
-          <resize config:type="boolean">false</resize>
-          <size>8388608</size>
-        </partition>
-        <partition config:type="map">
-          <create config:type="boolean">true</create>
-          <create_subvolumes config:type="boolean">true</create_subvolumes>
-          <filesystem config:type="symbol">btrfs</filesystem>
-          <format config:type="boolean">true</format>
-          <mount>/</mount>
-          <mountby config:type="symbol">uuid</mountby>
-          <partition_id config:type="integer">131</partition_id>
-          <partition_nr config:type="integer">2</partition_nr>
-          <quotas config:type="boolean">true</quotas>
-          <resize config:type="boolean">false</resize>
-          <size>max</size>
-          <subvolumes config:type="list">
-            <subvolume config:type="map">
-              <copy_on_write config:type="boolean">false</copy_on_write>
-              <path>var</path>
-            </subvolume>
-            <subvolume config:type="map">
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>usr/local</path>
-            </subvolume>
-            <subvolume config:type="map">
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>tmp</path>
-            </subvolume>
-            <subvolume config:type="map">
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>srv</path>
-            </subvolume>
-            <subvolume config:type="map">
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>root</path>
-            </subvolume>
-            <subvolume config:type="map">
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>opt</path>
-            </subvolume>
-            <subvolume config:type="map">
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>boot/grub2/x86_64-efi</path>
-            </subvolume>
-            <subvolume config:type="map">
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>boot/grub2/i386-pc</path>
-            </subvolume>
-          </subvolumes>
-          <subvolumes_prefix>@</subvolumes_prefix>
-        </partition>
-        <partition config:type="map">
-          <create config:type="boolean">true</create>
-          <filesystem config:type="symbol">swap</filesystem>
-          <format config:type="boolean">true</format>
-          <mount>swap</mount>
-          <mountby config:type="symbol">uuid</mountby>
-          <partition_id config:type="integer">130</partition_id>
-          <partition_nr config:type="integer">3</partition_nr>
-          <resize config:type="boolean">false</resize>
-          <size>2148515328</size>
-        </partition>
-      </partitions>
-      <type config:type="symbol">CT_DISK</type>
       <use>all</use>
     </drive>
   </partitioning>


### PR DESCRIPTION
As https://bugzilla.suse.com/show_bug.cgi?id=1219173#c18 say, the SLES12SP5 autoyast profile sets /var/ as a separate subvolume which  will exclude everything in /var/ attend the pre update snapshot, including the /var/lib/X11/X required by /usr/bin/X and display-manager. This cause the failure of booting to snapshot. So I update the SLES12SP5 autoyast profile of support images.

- Related issue: https://bugzilla.suse.com/show_bug.cgi?id=1219173#c18
- Needles: n/a
- Verification run:  
https://openqa.suse.de/tests/13602129#  (autoyast installation job to create image)
https://openqa.suse.de/tests/13602160#step/snapper_rollback/1 (migration job to verify the image)

