### PR TITLE
Containers: install_pkg report if already installed in netavark tests

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -75,6 +75,8 @@ sub install_packages {
         } else {
             zypper_call("in @pkgs");
         }
+    } else {
+        record_info("Install", "Installation skipped, package(s) present already: " . join ', ', @pkgs);
     }
 }
 


### PR DESCRIPTION
Containers: in podman netavark tests preparation, added report if pkgs already installed in installation skipped case. 
Also as non-functional change, it is useful for test control.

- Followup of PR [18728](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18728)
- Needles: N/A
- Verification run: 
  - sle-micro-6.0-Base-x86_64-Build14.2-slem_podman@64bit
    https://openqa.suse.de/tests/13603790#step/podman_netavark/58
