### PR TITLE
console/sshd: test_cryptographic_policies: ensure known host keys don't get dropped

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -76,7 +76,7 @@ sub test_cryptographic_policies() {
     # TODO: This does not work for Tumbleweed because of nmap
     # See pull request #11930 for more details
     my @crypto_params = (["Ciphers", "cipher", "-c "], ["KexAlgorithms", "kex", "-o kexalgorithms="], ["MACS", "mac", "-m "]);
-    push(@crypto_params, ["HostKeyAlgorithms", "key", "-o HostKeyAlgorithms="]) unless (is_opensuse);
+    push(@crypto_params, ["HostKeyAlgorithms", "key", "-o UpdateHostKeys=no -o HostKeyAlgorithms="]) unless (is_opensuse);
     my @policies;
 
     # Create an array of the different cryptographic policies that will be tested


### PR DESCRIPTION
Since OpenSSH 8.5 [0], UpdateHostKeys is enabled by default on the ssh client configuration.

Calling the ssh client with -o HostKeyAlgorithms=<single_algorithm> would then drop the other, now "foreign" algorithms from ~/.ssh/known_hosts, making the subsequent HostKeyAlgorithms tests fail.

This commit fixes that by adding -o UpdateHostKeys=no on the test command, so that the ssh client will not try to change the known_hosts file anymore.

`UpdateHostKeys` is available since OpenSSH 6.8 [1] so every SLE-15 release should be covered, and SLE-12-SP5 as well.

[0] https://www.openssh.com/txt/release-8.5
[1] https://github.com/openssh/openssh-portable/commit/8d4f87258f31cb6def9b3b55b6a7321d84728ff2

- Related ticket: https://progress.opensuse.org/issues/156058
- Verification run: https://openqa.suse.de/tests/13604341
