### PR TITLE
Fix configuring static IP after 40b811b7c

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -58,10 +58,11 @@ sub configure_static_ip {
     my $ip = $args{ip};
     my $mtu = $args{mtu} // get_var('MM_MTU', 1380);
     my $is_nm = $args{is_nm} // is_networkmanager();
-    my $device = $args{device} // '\S';
+    my $device = $args{device};
 
     if ($is_nm) {
         my $nm_id;
+        $device = '\S' unless defined $device;
         my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v '^lo:' | grep -e '$device' | head -n1");
         ($device, $nm_id) = split(':', $nm_list);
 

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -62,7 +62,7 @@ sub configure_static_ip {
 
     if ($is_nm) {
         my $nm_id;
-        $device = '\S' unless defined $device;
+        $device //= '\S';
         my $nm_list = script_output("nmcli -t -f DEVICE,NAME c | grep -v '^lo:' | grep -e '$device' | head -n1");
         ($device, $nm_id) = split(':', $nm_list);
 
@@ -75,7 +75,7 @@ sub configure_static_ip {
         my $mac = $net_conf->{fixed}->{mac};
 
         # Get default network adapter name
-        $device = script_output("grep $mac /sys/class/net/*/address |cut -d / -f 5") unless ($device);
+        $device ||= script_output("grep $mac /sys/class/net/*/address |cut -d / -f 5");
         record_info('set_ip', "Device: $device\nIP: $ip\nMTU: $mtu");
 
         # check for duplicate IP


### PR DESCRIPTION
This change didn't take the code path for non-NM-based setups into account. There the default for the device parameter is determined differently and we must not assume `\S`.

See https://progress.opensuse.org/issues/156067