### PR TITLE
[WIP]xfstests: The latest SLE using latest test repo

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -31,6 +31,7 @@ my $IS_MARBLE = is_sle_micro && check_var('VERSION', '6.0');
 
 sub install_xfstests_from_repo {
     if (is_sle) {
+        zypper_ar('http://download.suse.de/ibs/home:/lansuse:/branches:/QA:/Head/SLE-15-SP6/', name => 'xfstests-repo', priority => 90, no_gpg_check => 1) if is_sle('15-SP6+');
         add_qa_head_repo(priority => 100);
     }
     elsif (is_tumbleweed) {
@@ -65,10 +66,11 @@ sub install_xfstests_from_repo {
     else {
         zypper_call('in xfstests fio');
     }
-    if (is_sle) {
+    # Link all possible xfstests dir to /opt/xfstests, following tests could all find xfstests in /opt
+    if (-d '/var/lib/xfstests/') {
         script_run 'ln -s /var/lib/xfstests/ /opt/xfstests';
     }
-    elsif (is_tumbleweed || is_leap) {
+    elsif (-d '/usr/lib/xfstests/') {
         script_run 'ln -s /usr/lib/xfstests/ /opt/xfstests';
     }
 }


### PR DESCRIPTION
I found the latest QA_HEAD repo changed in osd backend, which has no record. Filesystem team developers prefer to assume the testsuite using the latest repo, but the QA:Head repo is usually not the latest one. Just enable the new repo in the latest SP6.
And test dir change could decoupling with the product and focus on existing dir.

- Verification run: 
- SLESSP6 https://openqa.suse.de/tests/13618788
- public cloud https://openqa.suse.de/tests/13654979