### PR TITLE
Avoid redacted openQA-URLs in GitHub action logs

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -8,7 +8,7 @@ on:
   # branch. This is necessary to allow accessing the API credential secrets.
   workflow_dispatch:
 env:
-  OPENQA_HOST: ${{ secrets.OPENQA_URL }}
+  OPENQA_HOST: ${{ vars.OPENQA_URL }}
   OPENQA_API_KEY: ${{ secrets.OPENQA_API_KEY }}
   OPENQA_API_SECRET: ${{ secrets.OPENQA_API_SECRET }}
   GH_REPO: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
* Use normal variable for openQA host in GitHub action
* See https://progress.opensuse.org/issues/130934

---

I've already added the variable in our settings and will remove the secret from our settings when this PR is merged.

Note that we could alternatively

* also remove the line completely.
* change the GitHub action code in the scripts repo to use the default value (o3) also when `OPENQA_HOST` is set to an empty value.