### PR TITLE
Don't delete the Tumbleweed image

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -88,7 +88,6 @@ sub run {
     record_info('Test', "Cleanup");
     assert_script_run("buildah rm $container");
     assert_script_run("buildah rmi newimage");
-    assert_script_run("buildah rmi $image");
 }
 
 1;


### PR DESCRIPTION
The Tumbleweed image is used across multiple test runs and should not be removed.

- Related ticket: https://progress.opensuse.org/issues/156127
- Verification run: https://duck-norris.qe.suse.de/tests/14315
