### PR TITLE
Increase timout for zypper ref

### DIFF
--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -498,6 +498,10 @@ subtest '[wait_for_zypper] zypper fails at first try with non 7 rc' => sub {
     my $self = sles4sap_publiccloud->new();
     my $pc_instance = Test::MockModule->new('publiccloud::instance');
     my $instance = publiccloud::instance->new();
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud');
+    $sles4sap_publiccloud->redefine(record_info => sub {
+            note(join(' ', 'RECORD_INFO -->', @_));
+    });
     $pc_instance->redefine(run_ssh_command => sub { return 1; });
 
     lives_ok { $self->wait_for_zypper(instance => $instance) } 'Zypper command failed with a non-locking issue and did not retry';


### PR DESCRIPTION
This increases the timeout for zypper in `wait_for_zypper`.

- Related ticket: https://jira.suse.com/browse/TEAM-9059
- Verification run: https://openqa.suse.de/tests/13626173 (sporadic problem did not happen)
