### PR TITLE
Fix sync issue in `setup_multimachine` leading to sporadic failures

### DIFF
--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -40,11 +40,7 @@ sub run {
     disable_and_stop_service('apparmor', ignore_failure => 1);
 
     # Configure the internal network an  try it
-    if ($is_server) {
-        setup_static_mm_network('10.0.2.101/24');
-    } else {
-        setup_static_mm_network('10.0.2.102/24');
-    }
+    setup_static_mm_network($is_server ? '10.0.2.101/24' : '10.0.2.102/24');
 
     # Set the hostname to identify both minions
     set_hostname $hostname;
@@ -55,9 +51,7 @@ sub run {
     permit_root_ssh();
 
     barrier_wait 'MM_SETUP_DONE';
-    if (!$is_server) {
-        ping_size_check('server');
-    }
+    ping_size_check('server') unless $is_server;
     barrier_wait 'MM_SETUP_PING_CHECK_DONE';
     wait_for_children if $is_server;
 }

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use testapi;
 use lockapi;
+use mmapi;
 use mm_network 'setup_static_mm_network';
 use utils qw(zypper_call permit_root_ssh set_hostname ping_size_check);
 use Utils::Systemd qw(disable_and_stop_service systemctl check_unit_file);
@@ -58,6 +59,7 @@ sub run {
         ping_size_check('server');
     }
     barrier_wait 'MM_SETUP_PING_CHECK_DONE';
+    wait_for_children if $is_server;
 }
 
 1;


### PR DESCRIPTION
* Ensure the server outlives the client job as it is the owner of the
  barriers; otherwise the client might fail with `lock owner already
  finished`
* Note that this is in-line with the examples in our documentation on
  https://open.qa/docs/#_test_synchronization_and_locking_api
* See https://progress.opensuse.org/issues/156052#note-6 for details

---

openqa: Clone https://openqa.opensuse.org/tests/3964713