### PR TITLE
Use more compact coding style in `setup_multimachine` module

### DIFF
--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -39,11 +39,7 @@ sub run {
     disable_and_stop_service('apparmor', ignore_failure => 1);
 
     # Configure the internal network an  try it
-    if ($is_server) {
-        setup_static_mm_network('10.0.2.101/24');
-    } else {
-        setup_static_mm_network('10.0.2.102/24');
-    }
+    setup_static_mm_network($is_server ? '10.0.2.101/24' : '10.0.2.102/24');
 
     # Set the hostname to identify both minions
     set_hostname $hostname;
@@ -54,9 +50,7 @@ sub run {
     permit_root_ssh();
 
     barrier_wait 'MM_SETUP_DONE';
-    if (!$is_server) {
-        ping_size_check('server');
-    }
+    ping_size_check('server') unless $is_server;
     barrier_wait 'MM_SETUP_PING_CHECK_DONE';
 }
 


### PR DESCRIPTION
This brings back only the coding style changes as they were reverted as part of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18757.