### PR TITLE
Fix sync issue in `mm_ping` scenario leading to sporadic failures

### DIFF
--- a/schedule/functional/mm_ping.yaml
+++ b/schedule/functional/mm_ping.yaml
@@ -8,3 +8,4 @@ schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
     - network/setup_multimachine
+    - network/conclude_multimachine

--- a/tests/network/conclude_multimachine.pm
+++ b/tests/network/conclude_multimachine.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Waits for parallel children to finish
+# Maintainer: Marius Kittler <mkittler@suse.de>
+
+use base 'basetest';
+use strict;
+use warnings;
+use testapi;
+use mmapi;
+
+sub run {
+    my $hostname = get_required_var('HOSTNAME');
+    wait_for_children if $hostname =~ m/server|master/;
+}
+
+1;


### PR DESCRIPTION
* Ensure the server outlives the client job as it is the owner of the barriers; otherwise the client might fail with `lock owner already finished`
* Note that this is in-line with the examples in our documentation on https://open.qa/docs/#_test_synchronization_and_locking_api
* See https://progress.opensuse.org/issues/156052#note-6 for details
* 2nd attempt after https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18757

---

openqa: Clone https://openqa.opensuse.org/tests/3964713