### PR TITLE
Revert "Small rootless_podman_refactoring"

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -27,6 +27,7 @@ use Utils::Architectures;
 use Utils::Logging 'save_and_upload_log';
 
 my $bsc1200623 = 0;    # to prevent printing the soft-failure more than once
+my $podman_version;
 
 sub run {
     my ($self) = @_;
@@ -35,6 +36,7 @@ sub run {
 
     my $podman = $self->containers_factory('podman');
 
+    $podman_version = get_podman_version();
     # add testuser to systemd-journal group to allow non-root
     # user to access container logs via journald event driver
     # bsc#1207673, bsc#1218023
@@ -150,7 +152,6 @@ sub verify_userid_on_container {
     # Check for bsc#1182428
     # podman 2.1.1 with keep-id option list unexpected capabilities
     # podman of the same version can still show the nsenter original issue
-    my $podman_version = get_podman_version();
     my $buggy_podman = (package_version_cmp($podman_version, '2.1.1') == 0);
 
     if ($buggy_podman && (is_aarch64 || is_s390x)) {


### PR DESCRIPTION
This reverts commit d9466f529117cc0c2a07ff8f05f351ffb0f4a4c4.

Revert the commit that changed the place where we run `get_podman_version()`.

On s390x, the `$podman_version` variable contains this string: `2024-02-28T12:56:16.358246+01:00 susetest systemd[2772]: Failed to start podman-5639.scope.\n2.1.1`.  

- Related ticket: https://progress.opensuse.org/issues/156187
- Failing test: https://openqa.suse.de/tests/13625916
- Verification run: https://openqa.suse.de/tests/13628131
