### PR TITLE
Wait in a loop until ipconfig is removed

### DIFF
--- a/tests/sles4sap/cloud_netconfig/configure.pm
+++ b/tests/sles4sap/cloud_netconfig/configure.pm
@@ -128,7 +128,7 @@ sub run {
         '--admin-username cloudadmin',
         '--authentication-type ssh',
         '--generate-ssh-keys');
-    assert_script_run($az_cmd);
+    assert_script_run($az_cmd, timeout => 600);
 }
 
 sub test_flags {

--- a/tests/sles4sap/cloud_netconfig/sanity.pm
+++ b/tests/sles4sap/cloud_netconfig/sanity.pm
@@ -64,6 +64,7 @@ sub run {
     record_info('TEST STEP', 'is-system-running OK');
 
     # Check that cloud-netconfig is installed
+    assert_script_run("$ssh_cmd sudo zypper ref");    # Needed in the PAYG images
     assert_script_run("$ssh_cmd zypper se -s -i cloud-netconfig");
     assert_script_run("$ssh_cmd cat /etc/default/cloud-netconfig");
     assert_script_run("$ssh_cmd sudo journalctl |grep -E 'cloud-netconfig\\['");


### PR DESCRIPTION
Change the test to not only check the ip configuration once, but check
multiple times till change is applied.
Add `zypper ref`
Swap order on some az commands to reduce amount of time they are
executed.

- Related ticket: TEAM-8721

# Verification run:

## BYOS
-  http://mango.qe.nue2.suse.org/tests/5679

## PAYG 
- http://mango.qe.nue2.suse.org/tests/5680
- http://openqaworker15.qa.suse.cz/tests/277360
