### PR TITLE
Uninstall package libopenssl-1_1-devel before migration

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -30,6 +30,7 @@ our @EXPORT = qw(
   set_scc_proxy_url
   set_zypp_single_rpmtrans
   remove_dropped_modules_packages
+  workaround_bsc_1220091
 );
 
 sub setup_sle {
@@ -249,6 +250,19 @@ sub set_zypp_single_rpmtrans {
 
     assert_script_run 'export ZYPP_SINGLE_RPMTRANS=1 ' if get_var('ZYPP_SINGLE_RPMTRANS');
 
+}
+
+=head2 workaround_bsc_1220091
+    workaround_bsc_1220091()
+
+This function is used for removing libopenssl-1_1-devel for bsc#1220091
+We need to remove package libopenssl-1_1-devel before migration.
+
+=cut
+
+sub workaround_bsc_1220091 {
+    my $pkg = 'libopenssl-1_1-devel';
+    zypper_call("rm $pkg") unless script_run("rpm -q $pkg");
 }
 
 1;

--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -40,7 +40,7 @@ sub run {
     if (get_var('FLAVOR', '') =~ /Continuous-Migration/) {
         modify_kernel_multiversion("disable");
     }
-
+    workaround_bsc_1220091;
     cleanup_disk_space if get_var('REMOVE_SNAPSHOTS');
     power_action('reboot', keepconsole => 1, textmode => 1);
     reconnect_mgmt_console if is_pvm;

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -127,6 +127,7 @@ sub patching_sle {
         modify_kernel_multiversion("disable");
     }
 
+    workaround_bsc_1220091;
     # Record the installed rpm list
     assert_script_run 'rpm -qa > /tmp/rpm-qa.txt';
     upload_logs '/tmp/rpm-qa.txt';


### PR DESCRIPTION
##
- Description:
   * Uninstall package libopenssl-1_1-devel if it is installed before migration
 
- Related ticket: 
  * https://progress.opensuse.org/issues/156184
- Needles: 
  * N/A
- Verification run: 
   * https://openqa.suse.de/t13643736
   * https://openqa.suse.de/t13643737
   * https://openqa.suse.de/t13643948
##   