### PR TITLE
Remove zypper-docker from newer SLES projects

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -151,8 +151,8 @@ sub load_host_tests_docker {
     load_firewall_test($run_args) unless (is_public_cloud || is_openstack || is_microos);
     unless (is_sle("<=15") && is_aarch64) {
         # these 2 packages are not avaiable for <=15 (aarch64 only)
-        # zypper-docker is not available in factory and in SLE Micro/MicroOS
-        loadtest 'containers/zypper_docker' unless (is_tumbleweed || is_sle_micro || is_microos || is_leap_micro);
+        # zypper-docker is only available on SLES < 15-SP6
+        loadtest 'containers/zypper_docker' if (is_sle("<15-SP6"));
         loadtest 'containers/docker_runc';
     }
     unless (check_var('BETA', 1) || is_sle_micro || is_microos || is_leap_micro || is_staging) {


### PR DESCRIPTION
zypper_docker is only available on SLES >12 and < 15-SP6 so limit the test runs to those platforms.

- Related failure: https://progress.opensuse.org/issues/156310
- Verification run: [15-SP6](https://openqa.suse.de/tests/13644314) (not present) | [15-SP5](https://openqa.suse.de/tests/13644316) (present)
