### PR TITLE
Apply the glitch workaround in yast2_security

### DIFF
--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -39,7 +39,7 @@ sub run {
     wait_screen_change { send_key "alt-o" };
 
     # Check previously set values + Login Settings
-    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120, apply_workaround => is_sle('>=15-SP4') ? 1 : 0);
     assert_and_click "yast2_security-pwd-settings";
     apply_workaround_poo124652('yast2_security-check-min-pwd-len-and-exp-days') if (is_sle('>=15-SP4'));
     assert_screen "yast2_security-check-min-pwd-len-and-exp-days";
@@ -62,7 +62,7 @@ sub run {
     wait_screen_change { send_key "alt-o" };
 
     # Check previously set values
-    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120);
+    y2_module_guitest::launch_yast2_module_x11("security", match_timeout => 120, apply_workaround => is_sle('>=15-SP4') ? 1 : 0);
     assert_and_click "yast2_security-misc-settings";
     apply_workaround_poo124652('yast2_security-file-perms-secure') if (is_sle('>=15-SP4'));
     assert_screen "yast2_security-file-perms-secure";


### PR DESCRIPTION
##
- Description:
   *  Apply the glitch workaround in yast2_securit
- Related ticket: 
  * https://progress.opensuse.org/issues/154690
- Needles: 
  * None
- Verification run: 
  * [**VR_10_times**](https://openqa.suse.de/tests/overview?build=hjluo%2Fos-autoinst-distri-opensuse%23y2_security_again&distri=sle&version=15-SP6)
  
  ##
