### PR TITLE
lib/utils: Leap 15.6 has SDDM 0.20, the session is not tty7 anymore

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1489,7 +1489,7 @@ the session.
 =cut
 
 sub get_x11_console_tty {
-    my $new_sddm = !is_sle('<16') && !is_leap('<16.0');
+    my $new_sddm = !is_sle('<16') && !is_leap('<15.6');
     if (check_var('DESKTOP', 'kde') || check_var('DESKTOP', 'lxqt')) {
         return $new_sddm ? 2 : 7;
     }


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/3976118#step/shutdown/5 , https://openqa.opensuse.org/tests/3976803#step/updates_packagekit_kde/19 and https://openqa.opensuse.org/tests/3975923#step/consoletest_finish/19