### PR TITLE
Don't run rasdaemon on ppc64le

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2528,7 +2528,7 @@ sub load_extra_tests_syscontainer {
 sub load_extra_tests_kernel {
     loadtest "kernel/tuned";
     loadtest "kernel/fwupd" if is_sle('15+');
-    loadtest "hpc/rasdaemon" if (is_sle('15+') || is_tumbleweed);
+    loadtest "hpc/rasdaemon" if ((is_sle('15+') || is_tumbleweed) && (!is_ppc64le));
 
     # keep it on the latest place as it taints kernel
     loadtest "kernel/module_build";


### PR DESCRIPTION
Fix poo#155146: rasdaemon is not supported on ppc64le architecture.

- Related ticket: https://progress.opensuse.org/issues/155146
- Needles: 
- Verification runs

##### x86_64
- TW: http://openqa.opensuse.org/tests/3985281
- 15-sp6: https://openqa.suse.de/tests/13707791
- 15-sp5: https://openqa.suse.de/tests/13707792

##### ppc64le:
- TW: https://openqa.opensuse.org/tests/3985282
- 15-sp6: https://openqa.suse.de/tests/13707788
