### PR TITLE
Remove '3' from ovn/openvswitch on 15.6

### DIFF
--- a/tests/console/openvswitch.pm
+++ b/tests/console/openvswitch.pm
@@ -27,8 +27,7 @@ use version_utils qw(is_sle is_leap);
 sub run {
     select_serial_terminal;
 
-    # openvswitch is moved to legacy module, we need to test newer version on sle15sp5+
-    my $pkg_name = (is_sle('>=15-sp5') or is_leap('>=15.5')) ? 'openvswitch3' : 'openvswitch';
+    my $pkg_name = (is_sle('=15-sp5') or is_leap('=15.5')) ? 'openvswitch3' : 'openvswitch';
     # package openvswitch-switch still exist for sle12-sp2
     $pkg_name = 'openvswitch-switch' if is_sle('=12-sp2');
 

--- a/tests/console/openvswitch_ssl.pm
+++ b/tests/console/openvswitch_ssl.pm
@@ -22,8 +22,7 @@ sub run {
     # Install runtime dependencies
     zypper_call("in wget");
 
-    # openvswitch is moved to legacy module, we need to test newer version on sle15sp5+
-    my $ovs_pkg = is_sle('>=15-sp5') ? 'openvswitch3' : 'openvswitch';
+    my $ovs_pkg = is_sle('=15-sp5') ? 'openvswitch3' : 'openvswitch';
     if (is_sle("<=12-SP5")) {
         zypper_call("in python python-base $ovs_pkg");
     } else {

--- a/tests/console/ovn.pm
+++ b/tests/console/ovn.pm
@@ -28,8 +28,7 @@ use version_utils qw(is_sle is_leap is_tumbleweed);
 
 sub run {
     select_serial_terminal;
-    # 'ovn' packages are moved to legacy module, we need to test newer version on sle15sp5+
-    my $ovn_ver = (is_sle('>=15-sp5') or is_leap('>=15.5')) ? 'ovn3' : 'ovn';
+    my $ovn_ver = (is_sle('=15-sp5') or is_leap('=15.5')) ? 'ovn3' : 'ovn';
     zypper_call("in $ovn_ver $ovn_ver-central $ovn_ver-devel $ovn_ver-docker $ovn_ver-host $ovn_ver-vtep", timeout => 300);
 
     # Start the openvswitch and OVN daemons

--- a/tests/console/ovs_client.pm
+++ b/tests/console/ovs_client.pm
@@ -49,7 +49,7 @@ sub run {
 
     # Install the needed packages
     # At moment we have opnvswitch3* packages on sles 15 sp5 only
-    if (is_sle('>=15-SP5')) {
+    if (is_sle('=15-SP5')) {
         zypper_call('in openvswitch3-ipsec tcpdump openvswitch3-pki openvswitch3-vtep', timeout => 300);
     }
     else {

--- a/tests/console/ovs_server.pm
+++ b/tests/console/ovs_server.pm
@@ -64,7 +64,7 @@ sub run {
 
     # Install the needed packages
     # At moment we have opnvswitch3* packages on sles 15 sp5 only
-    if (is_sle('>=15-SP5')) {
+    if (is_sle('=15-SP5')) {
         zypper_call('in openvswitch3-ipsec tcpdump openvswitch3-pki openvswitch3-vtep', timeout => 300);
     }
     else {


### PR DESCRIPTION
According to https://jira.suse.com/browse/PED-5766 the '3' in the name shall be used only on 15.5


- Related ticket: https://progress.opensuse.org/issues/156271
- Needles: 
- Verification run: 
- https://openqa.suse.de/tests/13662013
- https://openqa.suse.de/tests/13662017
- https://openqa.suse.de/tests/13662028
- https://openqa.suse.de/tests/13662031
- https://openqa.suse.de/tests/13662044