### PR TITLE
Add soft_failure of known bsc#1217773 for slem migration cases

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -589,7 +589,7 @@
     "bsc#1217773": {
         "description": "Unable to send container stderr message to parent Broken pipe",
         "products": {
-            "sle-micro": ["5.4"]
+            "sle-micro": ["5.4", "5.5", "6.0"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
Add soft_failure for bsc#1219209 for slem migration cases. , the bug
report was already reported for slem 5.4, bsc#1217773, so add slem 5.5
and 6.0 to skip the error of "Unable to send container stderr message to
parent Broken pipe"

- Related ticket: https://progress.opensuse.org/issues/154681
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/13684902#step/journal_check/10
