### PR TITLE
Create record_info with qesap Ansible error

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -2335,8 +2335,17 @@ sub qesap_terrafom_ansible_deploy_retry {
         record_info('ANSIBLE RETRY PASS');
     }
     else {
-        qesap_file_find_string(file => $args{error_log}, search_string => 'fatal:');
-        qesap_file_find_string(file => $args{error_log}, search_string => 'failed: [');
+        my $ansible_fatal = script_output("grep -A30 'fatal:' $args{error_log} | cut -c-200",
+            proceed_on_failure => 1);
+        my $ansible_failed = script_output("grep -A30 'failed: \\[' $args{error_log} | cut -c-200",
+            proceed_on_failure => 1);
+        record_info('ANSIBLE ISSUE',
+            join("\n",
+                'Ansible fatal:',
+                $ansible_fatal,
+                "\n---------",
+                "Ansible failed:",
+                $ansible_failed));
         qesap_cluster_logs();
         return 1;
     }

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -1085,4 +1085,21 @@ subtest '[qesap_add_server_to_hosts]' => sub {
     ok((any { qr/sed.*\/etc\/hosts/ } @calls), 'AWS Region matches');
 };
 
+subtest '[qesap_terrafom_ansible_deploy_retry] generic Ansible failures, no retry' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my @calls;
+
+    $qesap->redefine(qesap_file_find_string => sub {
+            my (%args) = @_;
+            push @calls, $args{cmd};
+            #return 1 if $args{search_string} eq 'Missing sudo password';
+            return 0; });
+    $qesap->redefine(script_output => sub { return 'ALGA' });
+    $qesap->redefine(qesap_cluster_logs => sub { return; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $ret = qesap_terrafom_ansible_deploy_retry(error_log => 'CORAL');
+    ok $ret == 1;
+};
+
 done_testing;


### PR DESCRIPTION
Change grep on the log to get more context.
Fix regexp in the grep
Add a record_info

# Verification run:

## HanaSR

 - sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2024-03-04T05:03:09Z-hanasr_aws_test_saptune@64bit ->
 
 http://openqaworker15.qa.suse.cz/tests/277914 here an example of the error message http://openqaworker15.qa.suse.cz/tests/277914#step/deploy_qesap_ansible/38

with `\\[` http://openqaworker15.qa.suse.cz/tests/277989

 - sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-03-04T05:03:09Z-hanasr_azure_test_sapconf_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/277915


## qesap regression
 - sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/277913 The new `record_info` block is only executed for Ansible and only if the error is not one of them used to trigger a retry http://openqaworker15.qa.suse.cz/tests/277913#step/deploy/47
 
- sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_ibsmirror_peering_test@64bit -> http://openqaworker15.qa.suse.cz/tests/277911

 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_sbd_test@64bit -> http://openqaworker15.qa.suse.cz/tests/277912 an example with a different error message http://openqaworker15.qa.suse.cz/tests/277912#step/deploy/63
