### PR TITLE
15-SP6 install openvswitch

### DIFF
--- a/tests/console/openvswitch.pm
+++ b/tests/console/openvswitch.pm
@@ -28,7 +28,7 @@ sub run {
     select_serial_terminal;
 
     # openvswitch is moved to legacy module, we need to test newer version on sle15sp5+
-    my $pkg_name = (is_sle('>=15-sp5') or is_leap('>=15.5')) ? 'openvswitch3' : 'openvswitch';
+    my $pkg_name = (is_sle('=15-sp5') or is_leap('=15.5')) ? 'openvswitch3' : 'openvswitch';
     # package openvswitch-switch still exist for sle12-sp2
     $pkg_name = 'openvswitch-switch' if is_sle('=12-sp2');
 


### PR DESCRIPTION
The package name has been modified from openvswitch3 to openvswitch

```
---+----------------------+-----------------------------------------------------------+--------
i  | libopenvswitch-3_1-0 | Open vSwitch core libraries
| package
i+ | openvswitch          | A multilayer virtual network switch
| package
   | openvswitch-devel    | Development files for Open vSwitch
| package
   | openvswitch-ipsec    | Open vSwitch IPsec tunneling support
| package
   | openvswitch-pki      | Open vSwitch public key infrastructure
dependency package | package
   | openvswitch-test     | Open vSwitch test package
| package
   | openvswitch-vtep     | Open vSwitch VTEP emulator
| package
```

- Verification runs: 
  * http://kepler.suse.cz/tests/22690#step/openvswitch/1
  * http://kepler.suse.cz/tests/22689#step/openvswitch/1
  * http://kepler.suse.cz/tests/22691#step/openvswitch/1
