### PR TITLE
sles4sap tests get sshkeys files from PC libs

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -16,7 +16,7 @@ terraform:
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -14,7 +14,7 @@ terraform:
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -14,7 +14,7 @@ terraform:
     aws_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     aws_credentials: '/root/amazon_credentials'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
 

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2_product.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2_product.yaml
@@ -14,7 +14,7 @@ terraform:
     aws_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     aws_credentials: '/root/amazon_credentials'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     os_owner: 'self'

--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -15,8 +15,7 @@ terraform:
     region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
-    private_key: '~/.ssh/id_rsa'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     gcp_credentials_file: '/root/google_credentials.json'
 

--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -14,7 +14,7 @@ terraform:
     aws_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     aws_credentials: '/root/amazon_credentials'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     os_owner: '%SLE_IMAGE_OWNER%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -14,7 +14,7 @@ terraform:
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -16,7 +16,7 @@ terraform:
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -15,7 +15,7 @@ terraform:
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
-    public_key: '~/.ssh/id_rsa.pub'
+    public_key: '%SLES4SAP_SSHKEY%.pub'
     os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
 
     # HANA

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -256,7 +256,7 @@ sub gcloud_install {
 }
 
 sub get_ssh_private_key_path {
-    return (is_azure() || get_var('PUBLIC_CLOUD_SLES4SAP')) ? '~/.ssh/id_rsa' : '~/.ssh/id_ed25519';
+    return (is_azure()) ? '~/.ssh/id_rsa' : '~/.ssh/id_ed25519';
 }
 
 sub prepare_ssh_tunnel {

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -637,7 +637,7 @@ sub create_instance_data {
                 public_ip => $type_data->{$vm_label}->{ansible_host},
                 instance_id => $vm_label,
                 username => get_required_var('PUBLIC_CLOUD_USER'),
-                ssh_key => '~/.ssh/id_rsa',
+                ssh_key => get_ssh_private_key_path(),
                 provider => $provider,
                 region => $provider->provider_client->region,
                 type => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -30,7 +30,7 @@ use testapi;
 use publiccloud::ssh_interactive 'select_host_console';
 use publiccloud::instance;
 use publiccloud::instances;
-use publiccloud::utils qw(is_azure is_gce);
+use publiccloud::utils qw(is_azure is_gce get_ssh_private_key_path);
 use sles4sap_publiccloud;
 use qesapdeployment;
 use serial_terminal 'select_serial_terminal';
@@ -98,6 +98,8 @@ sub run {
     record_info 'Resource Group', "Resource Group used for deployment: $deployment_name";
 
     my $provider = $self->provider_factory();
+    set_var('SLES4SAP_SSHKEY', get_ssh_private_key_path());
+
     # Needed to create the SAS URI token
     if (!is_azure()) {
         my $azure_client = publiccloud::azure_client->new();

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -8,6 +8,7 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use publiccloud::azure_client;
+use publiccloud::utils qw(get_ssh_private_key_path);
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use qesapdeployment;
@@ -42,8 +43,8 @@ sub run {
     $variables{OS_OWNER} = get_var('QESAPDEPLOY_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 
     $variables{USE_SAPCONF} = get_var('QESAPDEPLOY_USE_SAPCONF', 'false');
-    $variables{SSH_KEY_PRIV} = $provider->ssh_key;
-    $variables{SSH_KEY_PUB} = $self->ssh_key . '.pub';
+    $variables{SSH_KEY_PRIV} = get_ssh_private_key_path();
+    $variables{SSH_KEY_PUB} = get_ssh_private_key_path() . '.pub';
     $variables{REGISTRATION_PLAYBOOK} = get_var('QESAPDEPLOY_REGISTRATION_PLAYBOOK', 'registration');
     $variables{REGISTRATION_PLAYBOOK} =~ s/\.yaml$//;
     $variables{SUSECONNECT} = get_var('QESAPDEPLOY_USE_SUSECONNECT', 'false');


### PR DESCRIPTION
sles4sap tests using qe-sap-deployment no more use hardcoded sshkey file path but get it from PC using get_ssh_private_key_path()

Related ticket: [poo#155554](https://progress.opensuse.org/issues/155554)

# Verification

## HanaSR

### sles4sap_azure_generic.yaml 
 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-03-04T05:03:09Z-hanasr_azure_test_sbd@64bit
 
http://openqaworker15.qa.suse.cz/tests/277916 :green_circle: 

### sles4sap_azure_generic_maintenance.yaml

- sle-15-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:32633:saptune-SAPHanaSR-ScaleUp-PerfOpt-msi@az_Standard_E8s_v3 

http://openqaworker15.qa.suse.cz/tests/277917  :green_circle: Failure is later after the end of the deployment

### sles4sap_aws_generic.yaml

 - sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2024-03-04T05:03:09Z-hanasr_aws_test_saptune@64bit 
 
http://openqaworker15.qa.suse.cz/tests/277925
## mr_test

### mr_test_azure.yaml

 - sle-15-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:32633:saptune-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3 

http://openqaworker15.qa.suse.cz/tests/277922 :green_circle: 

### mr_test_ec2.yaml

 - sle-15-SP5-EC2-SAP-BYOS-Incidents-saptune-x86_64-Build:32633:saptune-sles4sap_gnome_saptune_delete_rename@ec2_r5b.metal 
 
http://openqaworker15.qa.suse.cz/tests/277923 :green_circle:  http://openqaworker15.qa.suse.cz/tests/277923/file/qesap_terraform-terraform.tfvars is using `public_key: '~/.ssh/id_ed25519.pub'`
  
The key is successfully used in any further communication with the deployed server
```
# timeout  300 ssh -t  -i '~/.ssh/id_ed25519' "cloudadmin@3.254.93.200" -- $'sudo zypper -n --gpg-auto-import-keys ref'; echo ibPyc-$?-
Repository 'SLE-Module-Basesystem15-SP5-Pool' is up to date.
Repository 'SLE-Module-Basesystem15-SP5-Updates' is up to date.
```

## qesap regression

### qesap_azure.yaml

- sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_saptune_test@64bit ->

http://openqaworker15.qa.suse.cz/tests/277918
http://openqaworker15.qa.suse.cz/tests/277919 with `PUBLIC_CLOUD: '1'` :green_circle: 

### qesap_aws_fencing.yaml

 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_sbd_test@64bit 
 
http://openqaworker15.qa.suse.cz/tests/277921 :red_circle: Error in th efirst Ansible command `ansible -vvvv -i /root/qe-sap-deployment/terraform/aws/inventory.yaml all -a true --ssh-extra-args="-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new"`

http://openqaworker15.qa.suse.cz/tests/277924 :green_circle: fails later in the deployment, in the same place the one cloned from
  
### qesap_gcp_sapconf.yaml

 - sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test@64bit 

 http://openqaworker15.qa.suse.cz/tests/277920 :green_circle: Failure is in Ansible `Configure cluster IP [gcp]` but it is the same as in the job that this VR has been cloned from