### PR TITLE
Adapt kselftests module to use packages only

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   add_ltp_repo
   get_default_pkg
   install_from_repo
+  prepare_whitelist_environment
 );
 
 sub loadtest_kernel {
@@ -247,18 +248,7 @@ sub schedule_tests {
         format => 'result_array:v2',
         environment => {},
         results => []};
-    my $environment = {
-        product => get_var('DISTRI') . ':' . get_var('VERSION'),
-        revision => get_var('BUILD'),
-        flavor => get_var('FLAVOR'),
-        arch => get_var('ARCH'),
-        backend => get_var('BACKEND'),
-        kernel => '',
-        libc => '',
-        gcc => '',
-        harness => 'SUSE OpenQA',
-        ltp_version => ''
-    };
+    my $environment = prepare_whitelist_environment();
 
     my $ver_linux_out = script_output("cat /tmp/ver_linux_before.txt");
     if ($ver_linux_out =~ qr'^Linux C Library\s*>?\s*(.*?)\s*$'m) {
@@ -430,6 +420,23 @@ sub install_from_repo {
           q(/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > )
           . get_ltp_openposix_test_list_file($want_32bit);
     }
+}
+
+sub prepare_whitelist_environment {
+    my $environment = {
+        product => get_var('DISTRI') . ':' . get_var('VERSION'),
+        revision => get_var('BUILD'),
+        flavor => get_var('FLAVOR'),
+        arch => get_var('ARCH'),
+        backend => get_var('BACKEND'),
+        kernel => '',
+        libc => '',
+        gcc => '',
+        harness => 'SUSE OpenQA',
+        ltp_version => ''
+    };
+
+    return $environment;
 }
 
 1;

--- a/tests/kernel/kselftests.pm
+++ b/tests/kernel/kselftests.pm
@@ -7,73 +7,34 @@
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 use base 'opensusebasetest';
-use testapi qw(get_var get_required_var set_var);
-use utils;
+
 use strict;
-use testapi;
 use warnings;
+use testapi;
 use serial_terminal 'select_serial_terminal';
+use registration;
+use utils;
 use LTP::WhiteList;
-use version_utils qw(is_transactional);
-use transactional 'trup_install';
 use LTP::kirk;
+use LTP::utils;
 
-sub download_kernel_source
+sub run_tests
 {
-    my @kv = split /\./, script_output "uname -r";
-    my ($kv0, $kv1, $kv2) = ($kv[0], $kv[1], (split /-/, $kv[2])[0]);
-    my $url = "https://mirrors.kernel.org/pub/linux/kernel/v$kv0.x/linux-$kv0.$kv1";
+    my ($root) = @_;
 
-    $url .= $kv2 eq '0' ? ".tar.gz" : ".$kv2.tar.gz";
-
-    assert_script_run("mkdir /root/linux");
-    assert_script_run("curl " . $url . "| tar xz --strip-components=1 -C /root/linux", timeout => 600);
-}
-
-sub run
-{
-    my ($self) = @_;
-
-    select_serial_terminal;
-
-    # install build tools
-    zypper_call("ref");
-    is_transactional ? trup_install("gcc make") : zypper_call("in -t pattern devel_basis");
-
-    # download linux source code
-    download_kernel_source;
-
-    # compile tests
-    my $suite = get_required_var('KSELFTESTS_SUITE');
-    my $root = "/root/linux/tools/testing/selftests";
-
-    assert_script_run("make -C /root/linux headers", timeout => 1800);
-    assert_script_run("make -C $root/$suite", timeout => 1800);
-
-    # set tests to skip
-    my $environment = {
-        product => get_var('DISTRI') . ':' . get_var('VERSION'),
-        revision => get_var('BUILD'),
-        flavor => get_var('FLAVOR'),
-        arch => get_var('ARCH'),
-        backend => get_var('BACKEND'),
-        kernel => script_output('uname -r'),
-        libc => '',
-        gcc => '',
-        harness => 'SUSE OpenQA',
-        ltp_version => ''
-    };
+    my $env = prepare_whitelist_environment();
+    $env->{kernel} = script_output('uname -r');
 
     my $issues = get_var('KSELFTESTS_KNOWN_ISSUES', '');
     my $whitelist = LTP::WhiteList->new($issues);
-    my @skipped = $whitelist->list_skipped_tests($environment, 'kselftests');
-    my $test_exclude;
+    my @skipped = $whitelist->list_skipped_tests($env, 'kselftests');
+    my $skip_tests;
     if (@skipped) {
-        $test_exclude = join("|", @skipped);
+        $skip_tests = join("|", @skipped);
 
         record_info(
             "Exclude",
-            "Excluding tests: $test_exclude",
+            "Excluding tests: $skip_tests",
             result => 'softfail'
         );
     }
@@ -83,14 +44,30 @@ sub run
         {src => "/tmp", dst => "/tmp"}
     );
 
+    my $suite = get_var('KSELFTESTS_SUITE', '');
+
     LTP::kirk->run(
         framework => "kselftests:root=$root",
-        skip => $test_exclude,
+        skip => $skip_tests,
         suite => $suite,
         # when KIRK_INSTALL == 'container' we want to share
         # kselftests folder and kirk logs folder
         container_volumes => \@volumes,
     );
+}
+
+sub run
+{
+    select_serial_terminal;
+
+    my $repo = get_var('KSELFTESTS_REPO', '');
+    my $suite = get_var('KSELFTESTS_SUITE', '');
+
+    zypper_call("ar -f $repo kselftests");
+    zypper_call("--gpg-auto-import-keys ref");
+
+    zypper_call("install -y kselftests-$suite");
+    run_tests("/usr/share/kselftests");
 }
 
 1;


### PR DESCRIPTION
This patch removes all sources build dependences and it adds packages support for multiple kselftests testing suites.

- Related ticket: https://progress.opensuse.org/issues/131180
- Verification run: https://openqa.suse.de/tests/13706574 https://openqa.suse.de/tests/13706573
