### PR TITLE
ed25519 is not supported in openstack

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -639,6 +639,7 @@ sub store_boottime_db() {
     my $token = get_var('_SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN');
 
     return unless ($results && $data_push && $url);
+    return if is_openstack;
     unless ($token) {
         record_info("WARN", "_SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN is missing ", result => 'fail');
         return 0;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -21,6 +21,7 @@ use Mojo::JSON qw(decode_json encode_json);
 use utils qw(file_content_replace script_retry);
 use mmapi;
 use db_utils qw(is_ok_url);
+use version_utils qw(is_openstack);
 
 use constant TERRAFORM_DIR => get_var('PUBLIC_CLOUD_TERRAFORM_DIR', '/root/terraform');
 use constant TERRAFORM_TIMEOUT => 30 * 60;
@@ -522,7 +523,9 @@ sub terraform_apply {
     if (get_var('PUBLIC_CLOUD_NVIDIA')) {
         $cmd .= "-var gpu=true ";
     }
-    $cmd .= "-var 'ssh_public_key=" . $self->ssh_key . ".pub' ";
+    unless (is_openstack) {
+        $cmd .= "-var 'ssh_public_key=" . $self->ssh_key . ".pub' ";
+    }
     $cmd .= "-out myplan";
     record_info('TFM cmd', $cmd);
 

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_public_cloud get_version_id is_transactional);
+use version_utils qw(is_sle is_public_cloud get_version_id is_transactional is_openstack);
 use transactional qw(check_reboot_changes trup_call process_reboot);
 use registration;
 use maintenance_smelt qw(is_embargo_update);
@@ -256,7 +256,8 @@ sub gcloud_install {
 }
 
 sub get_ssh_private_key_path {
-    return (is_azure()) ? '~/.ssh/id_rsa' : '~/.ssh/id_ed25519';
+    my $root_path = is_openstack ? '/root/' : '~/';
+    return (is_azure() || is_openstack) ? "${root_path}.ssh/id_rsa" : '~/.ssh/id_ed25519';
 }
 
 sub prepare_ssh_tunnel {


### PR DESCRIPTION
Used openstack version doesn't support ed25519 keys. We need to make an exception in public cloud libs.

```

BadRequestException: 400: Client Error for url:
https://engcloud.prv.suse.net:8774/v2.1/aec806fcad544e73bf8c24d6f010afda/os-keypairs,
Keypair data is invalid: failed to generate fingerprint
```

- Related ticket: https://progress.opensuse.org/issues/156634
- Verification run: http://kepler.suse.cz/tests/22699
