### PR TITLE
Add back private_key in mr_test terraform config

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -16,6 +16,7 @@ terraform:
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '%SLES4SAP_SSHKEY%.pub'
+    private_key: '%SLES4SAP_SSHKEY%'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
     gcp_credentials_file: '/root/google_credentials.json'
 


### PR DESCRIPTION
Fix regression introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18791


- Related ticket: [poo#155554](https://progress.opensuse.org/issues/155554)

# Verification run: 

- sle-15-SP6-GCE-SAP-BYOS-x86_64-Build0467-sles4sap_gnome_saptune_delete_rename@gce_n1_highmem_8 -> http://openqaworker15.qa.suse.cz/tests/277988