### PR TITLE
Move the default python for qesap to 3.11

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -50,7 +50,7 @@ my @log_files = ();
 use constant QESAPDEPLOY_PREFIX => 'qesapdep';
 
 use constant QESAPDEPLOY_VENV => '/tmp/exec_venv';
-use constant QESAPDEPLOY_PY_DEFAULT_VER => '3.10';
+use constant QESAPDEPLOY_PY_DEFAULT_VER => '3.11';
 
 our @EXPORT = qw(
   qesap_upload_logs


### PR DESCRIPTION
- Related ticket: https://jira.suse.com/browse/TEAM-8981

# Verification run:

## qesap regression ow15
 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/278053 :green_circle: 

## HanaSR ow15
 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-03-06T05:03:10Z-hanasr_azure_test_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/278054 :green_circle: Python is ok, problem is later during the test Crash_site

## MU on ow15
 - sle-15-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:32633:saptune-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/278055

## MU OSD
 - sle-15-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:32865:ClusterTools2-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/278056