### PR TITLE
Install cni-plugins for buildah

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -37,7 +37,7 @@ sub run {
         zypper_call('install skopeo');
 
         # temporarily necessary due to https://bugzilla.suse.com/show_bug.cgi?id=1220568
-        zypper_call('install cni-plugins') if (is_sle("=15-SP3"));
+        zypper_call('install cni-plugins') if (is_sle("15-SP3+"));
     }
     record_info('Version', script_output('buildah --version'));
 


### PR DESCRIPTION
SP6 and SP5 refreshed images dont have cni-plugins package and needs to be installed explicitly.

- ticket: https://progress.opensuse.org/issues/156556
- Verification run: http://kepler.suse.cz/tests/22709#
