### PR TITLE
Add resource cleanup to hana_sr_test_secondary

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -86,6 +86,9 @@ sub run {
     die("Site B '$site_b->{instance_id}' did NOT start in replication mode.")
       if $self->get_promoted_hostname() eq $site_b->{instance_id};
 
+    # Cleanup the resource
+    $self->cleanup_resource();
+
     record_info("Done", "Test finished");
 }
 


### PR DESCRIPTION
This pr adds resource cleanup at the end of `hana_sr_test_secondary.pm`, in the same manner it happens for `hana_sr_takeover.pm`. This removes the errors seen by crm output (example of old test, without cleanup, with errors: https://openqa.suse.de/tests/13503040#step/Crash_replica/3 - compare it to the VR)

- Related ticket: https://jira.suse.com/browse/TEAM-9057
- Verification run: https://openqa.suse.de/tests/13717129#step/Crash_replica/3
