### PR TITLE
HPC: Add second slurm partition

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -79,6 +79,9 @@ sub run_basic_tests() {
     my %test08 = t08_basic();
     push(@all_results, \%test08);
 
+    my %test09 = t09_basic();
+    push(@all_results, \%test09);
+
     return @all_results;
 }
 
@@ -206,6 +209,17 @@ sub t08_basic() {
             last;
         }
     }
+
+    my %results = generate_results($name, $description, $result);
+    return %results;
+}
+
+sub t09_basic() {
+    my $name = 'Second slurm partition';
+    my $description = 'Run srun jobs against non-default partition';
+    my $cluster_nodes = get_required_var('CLUSTER_NODES');
+
+    my $result = script_run("srun --partition=minor -N $cluster_nodes date");
 
     my %results = generate_results($name, $description, $result);
     return %results;


### PR DESCRIPTION
The config.pm change allow the second slurm partition to be configured, so that the tests could get more complex and slurm jobs could be run against any of the existing partition. At the same time there is the default partition so there is no need to change any of the existing tests; those should run the same way

- Related ticket: https://progress.opensuse.org/issues/135248
- Verification run:
beta cluster/x86_64
**https://openqa.suse.de/tests/13718253**
https://openqa.suse.de/tests/13718254
https://openqa.suse.de/tests/13718252
https://openqa.suse.de/tests/13718251

delta cluster/x86_64
**https://openqa.suse.de/tests/13718270**
https://openqa.suse.de/tests/13718271
https://openqa.suse.de/tests/13718268
https://openqa.suse.de/tests/13718269

delta cluster/arm
**https://openqa.suse.de/tests/13718276**
https://openqa.suse.de/tests/13718273
https://openqa.suse.de/tests/13718275
https://openqa.suse.de/tests/13718277

sle15sp2: 
https://openqa.suse.de/tests/13734226
and also a run with old slurm version:
https://openqa.suse.de/tests/13734233

sle12sp5:
https://openqa.suse.de/tests/13734318#