### PR TITLE
Make firefox_print function more robust.

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1076,6 +1076,8 @@ sub firefox_print {
     # Specify the path and name of output file
     send_key "ctrl-a";
     type_string("/home/$username/ffprint/$file-output.pdf");
+    wait_still_screen 2;
+    save_screenshot;
 
     # Click save button on the save to destination page
     assert_and_click("firefox-print-output-save");


### PR DESCRIPTION
firefox_printing_pdf and firefox_printing_frames fail frequently。
Update firefox_print function to make it more robust.

- Related ticket: https://progress.opensuse.org/issues/138455
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/13715840#
