### PR TITLE
Update condition for ipxe installer

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -239,7 +239,7 @@ sub run {
             if (check_var('VIDEOMODE', 'text') and is_sle('<=15-SP5')) {
                 enter_cmd_slow('DISPLAY= yast.ssh');
             }
-            else {
+            elsif (check_var('VIDEOMODE', 'text') or check_var('VIDEOMODE', 'ssh-x')) {
                 enter_cmd_slow("yast.ssh");
             }
             save_screenshot;


### PR DESCRIPTION
Need update the condition for ipxe installer to make sure yast installation test won't run on ssh while should be on vnc.

Failed job: https://openqa.suse.de/tests/13712542#step/access_beta_distribution/2

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/13724169#details
