### PR TITLE
Unschedule firefox_downloading for desktop

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2059,7 +2059,6 @@ sub load_x11_other {
 sub load_x11_webbrowser {
     loadtest "x11/firefox/firefox_smoke";
     loadtest "x11/firefox/firefox_urlsprotocols";
-    loadtest "x11/firefox/firefox_downloading";
     loadtest "x11/firefox/firefox_changesaving";
     loadtest "x11/firefox/firefox_fullscreen";
     loadtest "x11/firefox/firefox_localfiles";


### PR DESCRIPTION
firefox_downloading fails all the time
Unschedule it before it's fixed

- Related ticket: https://progress.opensuse.org/issues/135458
- Needles: N/A
- Verification run: 

> Wayland: https://openqa.suse.de/tests/13724114
> X11: https://openqa.suse.de/tests/13724132