### PR TITLE
Remove outdated softfailure for bsc#1004573

### DIFF
--- a/tests/x11/firefox/firefox_urlsprotocols.pm
+++ b/tests/x11/firefox/firefox_urlsprotocols.pm
@@ -10,7 +10,6 @@
 # firefox
 # - On firefox, access a http url
 # - On firefox, access a https url
-# - On firefox, access a ftp url
 # - On firefox, access a local url
 # - Close firefox
 # Maintainer: wnereiz <wnereiz@github>
@@ -32,8 +31,6 @@ sub run {
         local => "file:///usr/share/w3m/w3mhelp.html"
     );
 
-    # smb not supported
-    record_soft_failure 'bsc#1004573';
     for my $proto (sort keys %sites_url) {
         $self->firefox_open_url($sites_url{$proto}, assert_loaded_url => 'firefox-urls_protocols-' . $proto);
     }


### PR DESCRIPTION
bsc#1004573 has been marked as WONTFIX
So, we need to remove the corresponding softfailure

- Related ticket: https://progress.opensuse.org/issues/156715
- Needles: N/A
- Verification run: 

> - X11: https://openqa.suse.de/tests/13724296#
> - Wayland: https://openqa.suse.de/tests/13724283#