### PR TITLE
xfstests: Update o3 xfstests test repo

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -36,6 +36,7 @@ sub install_xfstests_from_repo {
     elsif (is_tumbleweed) {
         zypper_ar('http://download.opensuse.org/tumbleweed/repo/oss/', name => 'repo-oss');
         zypper_ar('http://download.opensuse.org/tumbleweed/repo/non-oss/', name => 'repo-non-oss');
+        zypper_ar('http://download.opensuse.org/repositories/home:/yosun:/branches:/filesystems/openSUSE_Tumbleweed/', name => 'xfstests-repo', priority => 90, no_gpg_check => 1);
     }
     elsif (is_alp) {
         my $repo_url = get_var('XFSTESTS_REPO', 'http://download.suse.de/ibs/home:/yosun:/branches:/QA:/Head/ALP-Standard-Core-1.0-Build/');
@@ -66,10 +67,10 @@ sub install_xfstests_from_repo {
         zypper_call('in xfstests fio');
     }
     if (is_sle) {
-        script_run 'ln -s /var/lib/xfstests/ /opt/xfstests';
+        script_run 'ln -s /var/lib/xfstests /opt/xfstests';
     }
     elsif (is_tumbleweed || is_leap) {
-        script_run 'ln -s /usr/lib/xfstests/ /opt/xfstests';
+        script_run 'ln -s /usr/lib/xfstests /opt/xfstests';
     }
 }
 


### PR DESCRIPTION
  As now the xfstests version is quite old in testing Tumbleweed update the new ibs repo.
  
  - Verification run:
  
  - in Tumbleweed: 
      create_hdd_xfstests: https://openqa.opensuse.org/tests/3993393
      subtests based on new hdd: [xfstests_btrfs-btrfs-201-999](https://openqa.opensuse.org/tests/3993511)  [xfstests_btrfs-btrfs-101-200](https://openqa.opensuse.org/tests/3991158)
  - in SLES SP6: 
      create_hdd_xfstests: https://openqa.suse.de/tests/13734397
      subtests based on new hdd: [xfstests_btrfs-btrfs-101-200](https://openqa.suse.de/tests/13734402)
  - in Public cloud:
      grub2-publiccloud_xfs_000-100: https://openqa.suse.de/tests/13734399