### PR TITLE
Remove obsolete softfail from cloud-netconfig

### DIFF
--- a/tests/publiccloud/cloud_netconfig.pm
+++ b/tests/publiccloud/cloud_netconfig.pm
@@ -14,7 +14,6 @@
 use Mojo::Base 'publiccloud::basetest';
 use Test::Assert 'assert_equals';
 use testapi;
-use version_utils 'is_sle';
 use publiccloud::utils qw(is_azure is_ec2 is_gce);
 
 sub run {
@@ -37,22 +36,10 @@ sub run {
         die('cloud-netconfig.service status appears to be incorrect!');
     }
 
-    # Currently, cloud-netconfig.timer is not active for older SLES versions in
-    # GCE. C.f. bsc#1219428.
-    if (is_gce() && is_sle('<15-SP4')) {
-        if ($instance->ssh_script_run(
-                cmd => 'systemctl status cloud-netconfig.timer'
-        )) {
-            record_soft_failure('bsc#1219428');
-        } else {
-            record_info('Success', 'cloud-netconfig.timer is active.');
-        }
-    } else {
-        $instance->ssh_assert_script_run(
-            cmd => 'systemctl status cloud-netconfig.timer',
-            fail_message => 'cloud-netconfig.timer appears not to be started.'
-        );
-    }
+    $instance->ssh_assert_script_run(
+        cmd => 'systemctl status cloud-netconfig.timer',
+        fail_message => 'cloud-netconfig.timer appears not to be started.'
+    );
 
     # 75-persistent-net-generator.rules is usually a symlink to /dev/null in SLES 12+
     $instance->ssh_assert_script_run(


### PR DESCRIPTION
The softfail is obsolete, because corresponding tests were unscheduled for the time being.

- Related ticket: https://progress.opensuse.org/issues/154519
- Verification run: https://stratoscamper.qe.prg2.suse.org/tests/24
