### PR TITLE
PC: Enable SSH RSA SHA-1 alg as hotfix for SLE15-SP6 in img_proof

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -14,6 +14,7 @@ use Mojo::File 'path';
 use Mojo::JSON;
 use publiccloud::utils qw(is_ondemand is_hardened);
 use publiccloud::ssh_interactive 'select_host_console';
+use version_utils 'is_sle';
 
 sub run {
     my ($self, $args) = @_;
@@ -54,6 +55,12 @@ sub run {
         assert_script_run "cd img-proof";
         assert_script_run "python3 setup.py install";
         assert_script_run "cp -r usr/* /usr";
+    }
+
+    if (is_sle('=15-SP6')) {
+        record_soft_failure('poo#156763 - Rebuild the PC Tools image when python3.11-paramiko is available and drop the SSH-RSA SHA-1');
+        $instance->ssh_assert_script_run('echo PubkeyAcceptedKeyTypes=+ssh-rsa | sudo tee -a /etc/ssh/sshd_config');
+        $instance->ssh_assert_script_run('sudo systemctl restart sshd');
     }
 
     my $img_proof = $provider->img_proof(

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -150,7 +150,7 @@ sub run {
     # The python3-paramiko is too old (2.4 on 15-SP6)
     # The python311-paramiko is from SLE-Module-Python3-15-SP5-Updates which we have in PC tools image
     zypper_call("in python311-paramiko python311-scp");
-    $instance->run_ssh_command(cmd => 'sudo sshd -T');
+
     my $sut = ':user=' . $instance->username;
     $sut .= ':sudo=1';
     $sut .= ':key_file=$(realpath ' . $instance->provider->ssh_key . ')';


### PR DESCRIPTION
- Related ticket: [poo#156763](https://progress.opensuse.org/issues/156763)
- Verification run: [Azure 15-SP6 hardened img_proof](https://pdostal-server.suse.cz/tests/5963), [Azure 15-SP6 img_proof](https://pdostal-server.suse.cz/tests/5965), [Azure 15-SP5 img_proof](https://pdostal-server.suse.cz/tests/5964)
