### PR TITLE
xfstests: add libcap package for overlayfs

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -354,10 +354,12 @@ sub install_dependencies_overlayfs {
     my @deps = qw(
       overlayfs-tools
       unionmount-testsuite
+      libcap-progs
     );
     script_run('zypper --gpg-auto-import-keys ref');
     if (is_transactional) {
-        trup_install(join(' ', @deps));
+        # Excluding libcap-progs since install issue
+        trup_install(join(' ', @deps[0 .. $#deps - 1]));
         reboot_on_changes;
     }
     else {


### PR DESCRIPTION
setcap is needed by overlay/064, so add libcap-progs for dependency

- Related ticket: N/A
- Needles: N/A
- Verification run: 
http://10.67.133.133/tests/487#step/generate_report/57 (SLE)
http://10.67.133.133/tests/493#step/overlay-064/2 (Micro)
