### PR TITLE
Consider Slowroll as Tumbleweed

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -315,7 +315,7 @@ Returns true if called on tumbleweed
 sub is_tumbleweed {
     # Tumbleweed and its stagings
     return 0 unless check_var('DISTRI', 'opensuse');
-    return 1 if get_var('VERSION') =~ /Tumbleweed/;
+    return 1 if get_var('VERSION') =~ /Tumbleweed|Slowroll/;
     return 1 if is_gnome_next;
     return get_var('VERSION') =~ /^Staging:/;
 }


### PR DESCRIPTION
Consider Slowroll as Tumbleweed
because it inherits all its packages and is at most some weeks behind.

This should help with
https://openqa.opensuse.org/tests/3994128#step/glibc_locale/32
where `glibc-lang` was missing, because `is_tumbleweed` returned false.