### PR TITLE
HPC: Do not attempt to install slurm-node for old slurm versions

### DIFF
--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -25,10 +25,17 @@ sub run ($self) {
 
     $self->prepare_user_and_group();
 
-    # Install slurm
+    # If one wants to test unversioned slurm, one should not
+    # install slurm-node at all. Also slurm rpm does not
+    # provide mariadb as a dependency
+    if ($slurm_pkg eq 'slurm' and is_sle('=12-sp5')) {
+        zypper_call("in $slurm_pkg mariadb");
+    } else {
+        zypper_call("in $slurm_pkg $slurm_pkg-node");
+    }
+
     # $slurm_pkg-munge is installed explicitly since slurm_23_02
-    zypper_call("in $slurm_pkg $slurm_pkg-munge $slurm_pkg-slurmdbd");
-    zypper_call("in $slurm_pkg-node");
+    zypper_call("in $slurm_pkg-munge $slurm_pkg-slurmdbd");
 
     my $mariadb_service = "mariadb";
     $mariadb_service = "mysql" if is_sle('<12-sp4');

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -13,6 +13,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
+use version_utils 'is_sle';
 use hpc::utils 'get_slurm_version';
 
 sub run ($self) {
@@ -20,9 +21,16 @@ sub run ($self) {
     $self->prepare_user_and_group();
     my $slurm_pkg = get_slurm_version(get_var('SLURM_VERSION', ''));
 
-    # Install slurm
+    # If one wants to test unversioned slurm, one should not
+    # install slurm-node at all.
+    if ($slurm_pkg eq 'slurm' and is_sle('=12-sp5')) {
+        zypper_call("in $slurm_pkg");
+    } else {
+        zypper_call("in $slurm_pkg-node");
+    }
+
     # $slurm_pkg-munge is installed explicitly since slurm_23_02
-    zypper_call("in $slurm_pkg-node $slurm_pkg-munge");
+    zypper_call("in $slurm_pkg-munge");
 
     if (get_required_var('EXT_HPC_TESTS')) {
         zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);


### PR DESCRIPTION
For the older, base, slurm versions there is no slurm-node package. The tests attempt to install it which leads to conflicts. Also, the slurm base version, does not provide mariadb as a dependency, so that must be installed explicitly

- Related ticket: https://progress.opensuse.org/issues/156868
- Verification run: 

sle12sp5:
https://openqa.suse.de/tests/13740825
https://openqa.suse.de/tests/13740828
https://openqa.suse.de/tests/13740824
https://openqa.suse.de/tests/13740826
https://openqa.suse.de/tests/13740829

sle15sp2/slurm (20.02)
https://openqa.suse.de/tests/13742515
https://openqa.suse.de/tests/13742519
https://openqa.suse.de/tests/13742517
https://openqa.suse.de/tests/13742518
https://openqa.suse.de/tests/13742514
https://openqa.suse.de/tests/13742516

sle15sp2/slurm-node (22_05)
https://openqa.suse.de/tests/13742724
https://openqa.suse.de/tests/13742725
https://openqa.suse.de/tests/13742722
https://openqa.suse.de/tests/13742723
https://openqa.suse.de/tests/13742721
https://openqa.suse.de/tests/13742726

sle15sp5/ delta cluster:
https://openqa.suse.de/tests/13742731
https://openqa.suse.de/tests/13742735
https://openqa.suse.de/tests/13742733
https://openqa.suse.de/tests/13742734
https://openqa.suse.de/tests/13742732

sle15sp5/ gamma cluster
https://openqa.suse.de/tests/13742741
https://openqa.suse.de/tests/13742742
https://openqa.suse.de/tests/13742744
 https://openqa.suse.de/tests/13742745
 https://openqa.suse.de/tests/13742743
 https://openqa.suse.de/tests/13742740

sle15sp6:
https://openqa.suse.de/tests/13742756
https://openqa.suse.de/tests/13742758
https://openqa.suse.de/tests/13742755
https://openqa.suse.de/tests/13742759
https://openqa.suse.de/tests/13742760
https://openqa.suse.de/tests/13742757
