### PR TITLE
Container run --init verification updated

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -93,8 +93,8 @@ sub basic_container_tests {
     assert_script_run("$runtime container exec basic_test_container curl -sfI https://opensuse.org", fail_message => "cannot reach opensuse.org");
 
     ## Test `--init`, i.e. the container process won't be PID 1 (to avoid zombie processes)
-    # expected output: the `ps` command is not running as PID 1.
-    validate_script_output("$runtime run --rm --init $image ps --no-headers -xo 'pid args'", sub { $_ !~ m/ 1 .*ps.*/ });
+    # expected output: the `ps` command is not running as PID 1. The $runtime-init process shall be 1 instead.
+    validate_script_output("$runtime run --rm --init $image ps --no-headers -xo 'pid args'", sub { $_ =~ m/\s*1 .*${runtime}-init .*/ });
 
     ## Test prune
     assert_script_run("$runtime container commit basic_test_container example.com/prune-test");


### PR DESCRIPTION
Container run --init pid 1 check was failing for false positive, due to check expression used. Here used a new expression to state the process expected to be present and pid=1.

- Related ticket: https://progress.opensuse.org/issues/156895
- Needles: N/A
- Verification run: see PR body.
