### PR TITLE
HPC: Add basic HDF5 test

### DIFF
--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -13,7 +13,7 @@ use version_utils qw(is_sle);
 
 has mpirun => sub {
     my ($self) = shift;
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     $self->mpirun("mpirun");
     my @mpirun_args;
     ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'

--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -18,20 +18,6 @@ use Exporter 'import';
 
 our @EXPORT = qw(get_slurm_version);
 
-sub get_mpi() {
-    my $mpi = get_required_var('MPI');
-
-    if ($mpi eq 'openmpi3') {
-        if (is_sle('<15')) {
-            $mpi = 'openmpi';
-        } elsif (is_sle('<15-SP2')) {
-            $mpi = 'openmpi2';
-        }
-    }
-
-    return $mpi;
-}
-
 =head2 get_slurm_version
 
  get_slurm_version();

--- a/schedule/hpc/multi_machine_test.yaml
+++ b/schedule/hpc/multi_machine_test.yaml
@@ -15,6 +15,10 @@ conditional_schedule:
     ARCH:
       x86_64:
         - hpc/cpuid
+  scientific_libs:
+    HDF5:
+      RUN:
+        - hpc/mpi_hdf5
   hpctest:
     HPC:
       slurm_master:
@@ -29,6 +33,7 @@ conditional_schedule:
         - hpc/slurm_master_backup_db
       mpi_master:
         - hpc/mpi_master
+        - '{{scientific_libs}}'
       mpi_slave:
         - hpc/mpi_slave
       ganglia_server:

--- a/tests/hpc/mpi_hdf5.pm
+++ b/tests/hpc/mpi_hdf5.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Name: Basic MPI HDF5 test
+# Description: The test module does basic HDF5 testing by installing required
+# packages and then running basic HDF5 hello world example
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base qw(hpcbase hpc::utils), -signatures;
+use testapi;
+use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
+use lockapi;
+use utils;
+use registration;
+use Utils::Logging 'export_logs';
+use hpc::formatter;
+
+sub run ($self) {
+    record_info('TODO', 'Write simple test');
+    zypper_call("in hdf5-gnu-hpc hdf5-gnu-hpc-devel");
+    $self->relogin_root;
+    assert_script_run("module load gnu openmpi hdf5");
+    my $version = script_output("module whatis hdf5 | grep Version");
+    $version = (split(/: /, $version))[2];
+    #assert_script_run("$mpi_compiler -o $exports_path{'bin'}/$mpi_bin $exports_path{'bin'}/$mpi_c -Iexports_path{'hpc'}/gnu7/hdf5/$version/include -Iexports_path{'hpc'}/gnu7/hdf5/$version/lib64 -lhdf5");
+
+}
+
+sub test_flags ($self) {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
+    export_logs();
+}
+
+1;

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Basic MPI integration test. Checking for installability and
-#     usability of MPI implementations, or HPC libraries. Using mpirun locally and across
+#     usability of MPI implementations only. Using mpirun locally and across
 #     available nodes. Test meant to be run in VMs, so thus using ethernet
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
@@ -23,7 +23,7 @@ use POSIX 'strftime';
 
 sub run ($self) {
     select_serial_terminal();
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
     my $mpi_bin = 'mpi_bin';
     my $mpi2load = '';
@@ -188,8 +188,7 @@ sub post_fail_hook ($self) {
 =over
 =item $mpi
 Stores the MPI implementation. This is usually whatever MPI job variable is
-given. It is changed when openmpi is used to get the corresponding version
-for products despite the MPI value. C<get_mpi> function needs to get improved
+given
 
 =item $mpi_compiler
 This is determined based on the source code which is used and comes together

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -16,7 +16,7 @@ use POSIX 'strftime';
 
 sub run ($self) {
     select_serial_terminal();
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     my %exports_path = (
         bin => '/home/bernhard/bin'
     );

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -24,7 +24,7 @@ my $compile_rt = undef;
 my $rt = undef;
 
 sub run ($self) {
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
     my $mpi_bin = 'mpi_bin';
     my @cluster_nodes = $self->cluster_names();

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -13,7 +13,7 @@ use utils;
 use Utils::Logging 'tar_and_upload_log';
 
 sub run ($self) {
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     my %exports_path = (bin => '/home/bernhard/bin');
 
     $self->mount_nfs_exports(\%exports_path);


### PR DESCRIPTION
The openmpi got renamed to openmpi1

- Related ticket: https://progress.opensuse.org/issues/137138
- Verification run: 
