### PR TITLE
Fix is_rt for those matching Virt in flavor

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -432,7 +432,7 @@ Returns true if called on a real time system
 =cut
 
 sub is_rt {
-    return (check_var('SLE_PRODUCT', 'rt') || get_var('FLAVOR') =~ /rt/i);
+    return (check_var('SLE_PRODUCT', 'rt') || get_var('FLAVOR') =~ /-rt/i);
 }
 
 =head2 is_hpc


### PR DESCRIPTION
The virtualization incident flavors of sle micro 5.5 is named DVD/Default-Virt-Incidents. The current is_rt check will return true when checking this flavor, so accidentally load rt related tests and skip virt tests. This PR fixes this by correcting is_rt check.

- Related ticket: https://progress.opensuse.org/issues/154969
- Verification run: 
    - https://openqa.suse.de/tests/13755649#
    - for RT flavor historical jobs, I do not find any recent job that has existing incident repo, so can't trigger such validation job. But local simple check for existing RT flavors are good. So should be fine.