### PR TITLE
Fix sudo test logic for NOPASSWD

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -22,6 +22,9 @@ use utils 'zypper_call';
 use version_utils qw(is_sle is_public_cloud);
 use publiccloud::utils qw(is_azure is_byos);
 
+my $test_password = 'Sud0_t3st';
+my $parm_user = '';
+
 sub sudo_with_pw {
     my ($command, %args) = @_;
     my ($grep, $env);
@@ -44,22 +47,16 @@ sub test_sudoers {
     sudo_with_pw 'sudo zypper -n in -f yast2', password => $sudo_password, timeout => 300;
 }
 
-sub run {
-    my $test_password = 'Sud0_t3st';
-    select_console 'root-console';
-    zypper_call 'in sudo expect';
-    select_console 'user-console';
-    # Defaults targetpw -> asks for root PW
-    my $exp_user = (is_azure && is_sle('>=15-SP4')) ? 'bernhard is not in the sudoers file' : 'root';
-    validate_script_output("expect -c 'spawn sudo id -un;expect password {send \"$testapi::password\\r\";interact}'", sub { qr/^$exp_user\$/ });
-    select_console 'root-console';
-    # Prepare a file with content '1' for later IO redirection test
-    assert_script_run 'echo 1 >/run/openqa_sudo_test';
-    # prepare sudoers and test user
-    assert_script_run 'echo "bernhard ALL = (root) NOPASSWD: /usr/bin/journalctl, /usr/bin/dd, /usr/bin/cat, PASSWD: /usr/bin/zypper, /usr/bin/su, /usr/bin/id, /bin/bash" >/etc/sudoers.d/test';
+sub prepare_sudoers {
+    my $root_no_pass = shift // 0;
+    $parm_user = ' (root)' if $root_no_pass;
+    assert_script_run "echo 'bernhard ALL =$parm_user NOPASSWD: /usr/bin/journalctl, /usr/bin/dd, /usr/bin/cat, PASSWD: /usr/bin/zypper, /usr/bin/su, /usr/bin/id, /bin/bash' >/etc/sudoers.d/test";
     # use script_run because yes is still writing to the pipe and then command is exiting with 141
     script_run "groupadd sudo_group && useradd -m -d /home/sudo_test -G sudo_group,\$(stat -c %G /dev/$serialdev) sudo_test && yes $test_password|passwd -q sudo_test";
-    assert_script_run 'echo "%sudo_group ALL = (root) NOPASSWD: /usr/bin/journalctl, PASSWD: /usr/bin/zypper" >/etc/sudoers.d/sudo_group';
+    assert_script_run "echo '%sudo_group ALL =$parm_user NOPASSWD: /usr/bin/journalctl, PASSWD: /usr/bin/zypper' >/etc/sudoers.d/sudo_group";
+}
+
+sub full_test {
     select_console 'user-console';
     # check if password is required
     assert_script_run 'sudo -K && ! timeout 5 sudo id -un';
@@ -101,6 +98,23 @@ sub run {
     sudo_with_pw 'bash -c "sudo su - sudo_test 2>check_err.log"', password => "$test_password";
     assert_script_run 'grep -i "not allowed" check_err.log';
     enter_cmd "exit", wait_still_screen => 3;
+}
+
+sub run {
+    select_console 'root-console';
+    zypper_call 'in sudo expect';
+    select_console 'user-console';
+    # Defaults targetpw -> asks for root PW
+    my $exp_user = (is_azure && is_sle('>=15-SP4')) ? 'bernhard is not in the sudoers file' : 'root';
+    validate_script_output("expect -c 'spawn sudo id -un;expect password {send \"$testapi::password\\r\";interact}'", sub { qr/^$exp_user\$/ });
+    foreach my $num (0, 1) {
+        record_info "iteration $num";
+        select_console 'root-console';
+        # Prepare a file with content '1' for later IO redirection test
+        assert_script_run 'echo 1 >/run/openqa_sudo_test';
+        prepare_sudoers("$num");
+        full_test;
+    }
 }
 
 sub post_run_hook {


### PR DESCRIPTION
https://progress.opensuse.org/issues/156928

- Verification run: 
[sle](http://openqa.suse.de/tests/overview?distri=sle&build=rfan0311)
[tw](https://openqa.opensuse.org/tests/4003715#step/sudo/98)

Please ignore the failed test module, it is known issue