### PR TITLE
Re-introduce PID 1 test

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -95,6 +95,8 @@ sub basic_container_tests {
     ## Test `--init` option, i.e. the container process won't be PID 1 (to avoid zombie processes)
     # Ensure PID 1 has either the $runtime-init (e.g. podman-init) OR /init (e.g. `/dev/init) suffix
     validate_script_output("$runtime run --rm --init $image ps --no-headers -xo 'pid args'", sub { $_ =~ m/\s*1 .*(${runtime}-|\/)init .*/ });
+    # Ensure the `ps` command is not running as PID 1. either
+    validate_script_output("$runtime run --rm --init $image ps --no-headers -xo 'pid args'", sub { $_ =~ m/[02-9][0-9]* .*ps.*/ });
 
     ## Test prune
     assert_script_run("$runtime container commit basic_test_container example.com/prune-test");


### PR DESCRIPTION
Re-introduce the check for `ps` not running as PID 1.

- Related ticket: https://progress.opensuse.org/issues/155404
- Verification runs: [TW podman](https://duck-norris.qe.suse.de/tests/14445) | [TW docker](https://duck-norris.qe.suse.de/tests/14439) | [15-SP2 podman](https://duck-norris.qe.suse.de/tests/14440) | [15-SP2 docker](https://duck-norris.qe.suse.de/tests/14441) | [15-SP5 podman](https://duck-norris.qe.suse.de/tests/14442) | [15-SP5 docker](https://duck-norris.qe.suse.de/tests/14443) | [12-SP5 docker](https://duck-norris.qe.suse.de/tests/14444)
