### PR TITLE
Die if SUSEConnect does not register

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -37,7 +37,8 @@ sub run {
 
     # There are sporadic failures due to the command timing out, so we increase the timeout
     # and make use of retries to overcome a possible sporadic network issue.
-    script_retry("$cmd", retry => $retries, delay => $delay, timeout => 180);
+    my $output = script_output_retry("$cmd", retry => $retries, delay => $delay, timeout => 180);
+    die($output) if ($output =~ m/error|timeout|problem retrieving/i);
     process_reboot(trigger => 1) if is_transactional;
     # Check available extenstions (only present in sle)
     my $extensions = script_output_retry("$reg_cmd --list-extensions", retry => $retries, delay => $delay);


### PR DESCRIPTION
Transactional-update returns 0 even if SUSEConnect failed. By doing a small check of the output, we can fail the test if there is a failure or timeout.

Current behavior:
registration fails but test continues: https://openqa.suse.de/tests/13756870#step/suseconnect_scc/21

Verification runs:
- https://openqa.suse.de/tests/13757405#step/suseconnect_scc/28
- https://openqa.suse.de/tests/13756405#step/suseconnect_scc/21