### PR TITLE
Fix keyboard shortcuts in evolution tests

### DIFF
--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -47,8 +47,9 @@ sub run {
     }
 
     # Help
-    send_key "alt-h";
+    hold_key "alt-h";
     wait_still_screen(2);
+    release_key "alt-h";
     send_key "a";
     assert_screen "evolution_about";
     send_key "esc";

--- a/tests/x11/evolution/evolution_timezone_setup.pm
+++ b/tests/x11/evolution/evolution_timezone_setup.pm
@@ -35,9 +35,7 @@ sub run {
     $self->setup_pop($account);
     # Set up timezone via: Edit->Preference->calendor and task->uncheck "use
     # sYstem timezone", then select
-    send_key "alt-e";
-    send_key_until_needlematch "evolution-preference-highlight", "down";
-    send_key "ret";
+    send_key "ctrl-shift-s";
     assert_screen "evolution-preference";
     send_key_until_needlematch "evolution-calendorAtask", "down";
     send_key "alt-y";


### PR DESCRIPTION
For the "About" page, we need to "hold_key" instead of "send_key".

For the "Preference" page, we use shortcut "ctrl-alt-s" directly.

- Related ticket: https://progress.opensuse.org/issues/154870
- Needles: None
- Verification run:
15SP6: https://openqa.suse.de/tests/13762880#step/evolution_smoke/20
https://openqa.suse.de/tests/13762880#step/evolution_timezone_setup/31
15SP5: https://openqa.suse.de/tests/13762887

