### PR TITLE
Correct serial device configuration in grub2 on KVM and XEN host

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -42,7 +42,7 @@
       <terminal>console</terminal>
       % if ($check_var->('SYSTEM_ROLE', 'xen')) {
       <xen_append>loglevel=5 vt.color=0x07 splash=silent console=hvc0 <%= $check_var->('AMD', '1') ? "amd_iommu=on" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
-      <xen_kernel_append>com2=115200,8n1 console=com2,vga loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
+      <xen_kernel_append><%= defined $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} ? $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} : "com2=115200,8n1 console=com2" %>,vga loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
       % } else {
       <append>loglevel=5 gfxpayload=1024x768 <%= $check_var->('AMD', '1') ? "amd_iommu=on" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
       % }

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -54,7 +54,9 @@
       <terminal>console</terminal>
       % if ($check_var->('SYSTEM_ROLE', 'xen')) {
       <xen_append>splash=silent quiet console=tty loglevel=5 <%= $check_var->('AMD', '1') ? "amd_iommu=on" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
-      <xen_kernel_append>console=com2,115200 vga=gfx-1024x768x16 loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
+      <!-- For some special beremetal machines, such as unreal2/3, their serial console:
+      SERIALDEV='ttyS2', XEN_SERIAL_CONSOLE="com1=115200,8n1,0x3e8,5 console=com1" -->
+      <xen_kernel_append><%= defined $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} ? $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} : "console=com2,115200" %> vga=gfx-1024x768x16 loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
       % } else {
       <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 <%= $check_var->('AMD', '1') ? "amd_iommu=on" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
       % }

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -80,15 +80,9 @@ sub setup_console_in_grub {
             $bootmethod = "module";
             $search_pattern = "vmlinuz";
 
-            # autoballoning is disabled since sles15sp1 beta2. we use default dom0_ram which is '10% of total ram + 1G'
-            # while for older release, bsc#1107572 "This dom0 memory amount works well with hosts having 4 to 8 Gigs of RAM"
-            # considering of one SUT in OSD with 4G ram only, we set dom0_mem=2G
             my $dom0_options = "";
-            if (is_sle('<=12-SP4') || is_sle('=15')) {
-                $dom0_options = "dom0_mem=2048M,max:2048M";
-            }
             if (get_var("ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH")) {
-                $dom0_options .= " iommu=on";
+                $dom0_options = "iommu=on";
             }
             $cmd
               = "sed -ri '/multiboot/ "

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -140,15 +140,6 @@ sub setup_console_in_grub {
         save_screenshot;
         upload_logs($grub_default_file);
     }
-    elsif ($grub_ver eq "grub1") {
-        $grub_cfg_file = "${root_dir}/boot/grub/menu.lst";
-        $cmd
-          = "cp $grub_cfg_file ${grub_cfg_file}.org \&\&  sed -i 's/timeout=-{0,1}[0-9]{1,}/timeout=30/g; /module \\\/boot\\\/vmlinuz/{s/console=.*,115200/console=$ipmi_console,115200/g;}; /kernel .*xen/{s/\$/ dom0_mem=2048M,max:2048M/;}' $grub_cfg_file";
-        assert_script_run($cmd);
-        save_screenshot;
-        $cmd = "sed -rn '/module \\\/boot\\\/vmlinuz/p' $grub_cfg_file";
-        assert_script_run($cmd);
-    }
     else {
         die "Not supported grub version!";
     }

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -76,7 +76,9 @@ sub setup_console_in_grub {
         #grub2
         $grub_cfg_file = "${root_dir}/boot/grub2/grub.cfg";
         if (${virt_type} eq "xen") {
-            $com_settings = get_var('IPMI_CONSOLE') ? "com2=" . get_var('IPMI_CONSOLE') : "";
+            # On some special beremetal machines, such as unreal2/3, their serial console:
+            # SERIALDEV='ttyS2', XEN_SERIAL_CONSOLE="com1=115200,8n1,0x3e8,5 console=com1"
+            $com_settings = get_var("XEN_SERIAL_CONSOLE", "console=com2,115200");
             $bootmethod = "module";
             $search_pattern = "vmlinuz";
 
@@ -87,7 +89,7 @@ sub setup_console_in_grub {
             $cmd
               = "sed -ri '/multiboot/ "
               . "{s/(console|loglevel|loglvl|guest_loglvl)=[^ ]*//g; "
-              . "/multiboot/ s/\$/ $dom0_options console=com2,115200 loglvl=all guest_loglvl=all sync_console $com_settings/;}; "
+              . "/multiboot/ s/\$/ $dom0_options $com_settings loglvl=all guest_loglvl=all sync_console/;}; "
               . "' $grub_cfg_file";
             assert_script_run($cmd);
             save_screenshot;

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -49,11 +49,11 @@ my $grub_ver = "grub2";
 
 sub get_dom0_serialdev {
     my $dom0_serialdev;
-    if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+    if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen") || check_var("SYSTEM_ROLE", "xen")) {
         $dom0_serialdev = "hvc0";
     }
     else {
-        $dom0_serialdev = get_var("LINUX_CONSOLE_OVERRIDE", "ttyS1");
+        $dom0_serialdev = get_var('LINUX_CONSOLE_OVERRIDE', get_var("SERIALCONSOLE", "ttyS1"));
     }
     enter_cmd("echo \"Debug info: hypervisor serial dev should be $dom0_serialdev.\"");
     return $dom0_serialdev;


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/156904
- Verification run: 

//GUI installation
[sle12sp5 kvm host on unreal3](https://openqa.suse.de/tests/13763062)
[sle12sp5 kvm host on unreal2](https://openqa.suse.de/tests/13764002)
[sle12sp5 kvm host on other machines](https://openqa.suse.de/t13778179)
[sle15sp5 kvm host on other machines](https://openqa.suse.de/t13778190)
[sle12sp5 xen host on unreal3](https://openqa.suse.de/tests/13778186)
[sle15sp6 xen host on unreal2](https://openqa.suse.de/tests/13778189)
[sle15sp5 xen host on other machines](http://openqa.suse.de/tests/13778205)

//Autoyast installation
[sle15sp6 kvm host on unreal2](https://openqa.suse.de/tests/13778226)
[sle15sp5 xen host on unreal3](http://openqa.suse.de/tests/13778233)
[sle15sp6 xen host on other machines](http://openqa.suse.de/t13778219)
