### PR TITLE
Fix openvpn tests for older systems

### DIFF
--- a/tests/network/openvpn_client.pm
+++ b/tests/network/openvpn_client.pm
@@ -18,6 +18,7 @@ use lockapi;
 use y2_module_guitest;
 use mm_network;
 use utils qw(systemctl zypper_call exec_and_insert_password script_retry);
+use version_utils 'is_sle';
 use strict;
 use warnings;
 
@@ -37,7 +38,10 @@ sub run {
     mutex_wait 'OPENVPN_STATIC_KEY';
 
     # Download the client config
-    assert_script_run("curl -o static.conf " . data_url("openvpn/static_client.conf"));
+    assert_script_run('curl -o static.conf ' . data_url('openvpn/static_client.conf'));
+
+    # Remove unsupported configuration options on older SLE versions
+    assert_script_run('sed -i "/^cipher/d; /^data-ciphers/d" static.conf') if (is_sle('<15-sp4'));
 
     # Download key from the server
     exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/static.key /etc/openvpn/static.key");
@@ -66,7 +70,10 @@ sub run {
     mutex_wait 'OPENVPN_CA_KEYS';
 
     # Write the client config
-    assert_script_run("curl -o ca.conf " . data_url("openvpn/ca_client.conf"));
+    assert_script_run('curl -o ca.conf ' . data_url('openvpn/ca_client.conf'));
+
+    # Remove unsupported configuration options on older SLE versions
+    assert_script_run('sed -i "/^cipher/d; /^data-ciphers/d" ca.conf') if (is_sle('<15-sp4'));
 
     # Download key from the server
     exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/pki/ca.crt /etc/openvpn/ca.crt");

--- a/tests/network/openvpn_server.pm
+++ b/tests/network/openvpn_server.pm
@@ -19,7 +19,7 @@ use y2_module_guitest;
 use mm_network;
 use mmapi 'wait_for_children';
 use utils qw(systemctl zypper_call exec_and_insert_password script_retry);
-use version_utils 'is_opensuse';
+use version_utils qw(is_sle is_opensuse);
 use repo_tools 'add_qa_head_repo';
 use strict;
 use warnings;
@@ -42,11 +42,14 @@ sub run {
     zypper_call('in openvpn easy-rsa');
     zypper_call("install openssl") if (script_run("which openssl") != 0);
     assert_script_run('cd /etc/openvpn');
-    assert_script_run('openvpn --genkey secret static.key');
+    assert_script_run('openvpn --genkey --secret static.key');
     mutex_create 'OPENVPN_STATIC_KEY';
 
     # Download the server config
-    assert_script_run("curl -o static.conf " . data_url("openvpn/static_server.conf"));
+    assert_script_run('curl -o static.conf ' . data_url('openvpn/static_server.conf'));
+
+    # Remove unsupported configuration options on older SLE versions
+    assert_script_run('sed -i "/^cipher/d; /^data-ciphers/d" static.conf') if (is_sle('<15-sp4'));
 
     # Start the server
     systemctl('start openvpn@static');
@@ -78,7 +81,10 @@ sub run {
     mutex_create 'OPENVPN_CA_KEYS';
 
     # Download the server config
-    assert_script_run("curl -o ca.conf " . data_url("openvpn/ca_server.conf"));
+    assert_script_run('curl -o ca.conf ' . data_url('openvpn/ca_server.conf'));
+
+    # Remove unsupported configuration options on older SLE versions
+    assert_script_run('sed -i "/^cipher/d; /^data-ciphers/d" ca.conf') if (is_sle('<15-sp4'));
 
     # Create the client config directory and the file for client
     assert_script_run("mkdir ccd");


### PR DESCRIPTION
Revert #18828 for compatibility with old platforms.
Related ticket: https://progress.opensuse.org/issues/156898

### Verification runs

- 12-SP3: https://openqa.suse.de/tests/13763448
- 12-SP5: https://openqa.suse.de/tests/13763179 
- 15-SP2: https://openqa.suse.de/tests/13763192
- 15-SP3: https://openqa.suse.de/tests/13763187
- 15-SP4: https://openqa.suse.de/tests/13763701
- 15-SP5: https://openqa.suse.de/tests/13763184