### PR TITLE
PC check_registercloudguest improvements

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -53,7 +53,7 @@ sub run {
             $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean", fail_message => 'Failed to deregister the previously registered BYOS system');
             $instance->ssh_script_run(cmd => 'sudo rm /etc/zypp/repos.d/*.repo');
         } else {
-            if ($instance->ssh_script_output(cmd => 'sudo zypper lr', proceed_on_failure => 1) !~ /No repositories defined/gm) {
+            if ($instance->ssh_script_output(cmd => 'zypper lr', proceed_on_failure => 1) !~ /No repositories defined/gm) {
                 die 'The BYOS instance should be unregistered and report "Warning: No repositories defined.".';
             }
 
@@ -76,8 +76,8 @@ sub run {
             $instance->ssh_assert_script_run(cmd => '! sudo SUSEConnect -d', fail_message => 'SUSEConnect succeeds but it is not supported should fail on BYOS');
         }
     } else {
-        if ($instance->ssh_script_output(cmd => 'sudo zypper -x lr | grep "<repo" | wc -l', timeout => 360) < 3) {
-            record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
+        if ($instance->ssh_script_output(cmd => 'zypper -x lr | grep "<repo" | wc -l', timeout => 300) < 3) {
+            record_info('zypper lr', $instance->ssh_script_output(cmd => 'zypper lr'));
             die 'The list of zypper repositories is too short.';
         }
 
@@ -97,11 +97,11 @@ sub run {
     $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
     # It might take a bit for the system to remove the repositories
     foreach my $i (1 .. 4) {
-        last if ($instance->ssh_script_output(cmd => 'sudo zypper -x lr | grep "<repo" | wc -l', timeout => 600) == 0);
+        last if ($instance->ssh_script_output(cmd => 'zypper -x lr | grep "<repo" | wc -l', timeout => 300) == 0);
         sleep 15;
     }
-    if ($instance->ssh_script_output(cmd => 'sudo zypper lr | grep "<repo" | wc -l', timeout => 600) > 0) {
-        record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
+    if ($instance->ssh_script_output(cmd => 'zypper lr | grep "<repo" | wc -l', timeout => 300) > 0) {
+        record_info('zypper lr', $instance->ssh_script_output(cmd => 'zypper lr'));
         die('The list of zypper repositories is not empty.');
     }
     if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') != 0) {
@@ -117,8 +117,8 @@ sub run {
 
     $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest $regcode_param", timeout => 300, retry => 3, delay => 120);
 
-    if ($instance->ssh_script_output(cmd => 'sudo zypper -x lr | grep "<repo" | wc -l', timeout => 600) == 0) {
-        record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
+    if ($instance->ssh_script_output(cmd => 'zypper -x lr | grep "<repo" | wc -l', timeout => 300) == 0) {
+        record_info('zypper lr', $instance->ssh_script_output(cmd => 'zypper lr'));
         die('The list of zypper repositories is empty.');
     }
     if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') == 0) {
@@ -126,8 +126,8 @@ sub run {
     }
 
     $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest $regcode_param --force-new", timeout => 300, retry => 3, delay => 120);
-    if ($instance->ssh_script_output(cmd => 'sudo zypper -x lr | grep "<repo" | wc -l', timeout => 600) == 0) {
-        record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
+    if ($instance->ssh_script_output(cmd => 'zypper -x lr | grep "<repo" | wc -l', timeout => 300) == 0) {
+        record_info('zypper lr', $instance->ssh_script_output(cmd => 'zypper lr'));
         die('The list of zypper repositories is empty.');
     }
     if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') == 0) {

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -76,7 +76,7 @@ sub run {
             $instance->ssh_assert_script_run(cmd => '! sudo SUSEConnect -d', fail_message => 'SUSEConnect succeeds but it is not supported should fail on BYOS');
         }
     } else {
-        if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 360) < 5) {
+        if ($instance->ssh_script_output(cmd => 'sudo zypper -x lr | grep "<repo" | wc -l', timeout => 360) < 3) {
             record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
             die 'The list of zypper repositories is too short.';
         }
@@ -95,7 +95,13 @@ sub run {
     }
 
     $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
-    if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) > 2) {
+    # It might take a bit for the system to remove the repositories
+    foreach my $i (1 .. 4) {
+        last if ($instance->ssh_script_output(cmd => 'sudo zypper -x lr | grep "<repo" | wc -l', timeout => 600) == 0);
+        sleep 15;
+    }
+    if ($instance->ssh_script_output(cmd => 'sudo zypper lr | grep "<repo" | wc -l', timeout => 600) > 0) {
+        record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
         die('The list of zypper repositories is not empty.');
     }
     if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') != 0) {
@@ -111,7 +117,8 @@ sub run {
 
     $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest $regcode_param", timeout => 300, retry => 3, delay => 120);
 
-    if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
+    if ($instance->ssh_script_output(cmd => 'sudo zypper -x lr | grep "<repo" | wc -l', timeout => 600) == 0) {
+        record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
         die('The list of zypper repositories is empty.');
     }
     if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') == 0) {
@@ -119,7 +126,8 @@ sub run {
     }
 
     $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest $regcode_param --force-new", timeout => 300, retry => 3, delay => 120);
-    if ($instance->ssh_script_output(cmd => 'sudo zypper lr | wc -l', timeout => 600) == 0) {
+    if ($instance->ssh_script_output(cmd => 'sudo zypper -x lr | grep "<repo" | wc -l', timeout => 600) == 0) {
+        record_info('zypper lr', $instance->ssh_script_output(cmd => 'sudo zypper lr'));
         die('The list of zypper repositories is empty.');
     }
     if ($instance->ssh_script_output(cmd => 'sudo ls /etc/zypp/credentials.d/ | wc -l') == 0) {


### PR DESCRIPTION
* Retry after deregistering the system before checking the present repositories
* Count the number of present repositories from the XML output
   * We cannot check the `/etc/zypp/repos.d/` folder as it does not contain all the repositories (because of zypper services)
   * The `zypper lr` contains additional lines and those are not easy to filter out.

- Related ticket: [poo#155776](https://progress.opensuse.org/issues/155776)
- Verification run: [EC2](https://pdostal-server.suse.cz/tests/5982), [Azure](https://pdostal-server.suse.cz/tests/5983), [GCE](https://pdostal-server.suse.cz/tests/5984)
