### PR TITLE
Added new check for LTSS regcode

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -7,7 +7,11 @@
     <install_updates config:type="boolean">true</install_updates>
     % }
     <email/>
+    % if ($get_var->('SCC_REGCODE_LTSS')) {
+    <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+    % } else {
     <reg_code>{{SCC_REGCODE}}</reg_code>
+    % }
     <reg_server>{{SCC_URL}}</reg_server>
     <addons config:type="list">
       % if ($get_var->('VERSION') =~ /^15/) {


### PR DESCRIPTION
If the variable `SCC_REGCODE_LTSS` exists, the test will prefer to use it instead of `SCC_REGCODE`

- Related ticket: https://progress.opensuse.org/issues/157069
- Verification run: *in_progress*
