### PR TITLE
toolbox zypper-up output on console

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -110,7 +110,7 @@ sub run {
     my $toolbox_has_repos = toolbox_has_repos();
     if ($toolbox_has_repos) {
         assert_script_run 'toolbox -r -- zypper -n ref', timeout => 300;
-        if (script_run('toolbox -- zypper -n up 2>&1 > /var/tmp/toolbox_zypper_up.txt', timeout => 300) != 0) {
+        if (script_run('toolbox -- zypper -n up 2>&1 | tee /var/tmp/toolbox_zypper_up.txt', timeout => 300) != 0) {
             upload_logs('/var/tmp/toolbox_zypper_up.txt');
             die "zypper up failed within toolbox";
         }


### PR DESCRIPTION
The `toolbox.pm` test code provided a zypper update log `toolbox_zypper_up.txt` (L#114) only when failed, otherwise none, so that when test pass we had NO information of what happened, unable to verify if installation was really ok or a false-positive occurred, like nothing done, instead. 
This simple change allows to see that output. 

- Related ticket: https://progress.opensuse.org/issues/156925#note-7
- Verification run: Passed test show in a console image needle the `toolbox -- zypper up output`, that before was only redirected to a file and not visible
https://openqa.suse.de/tests/13765724#step/toolbox/65
https://openqa.suse.de/tests/13765554#step/toolbox/65
