### PR TITLE
pc: Upload SCAP profile used by img-proof

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -99,6 +99,13 @@ sub run {
         $instance->run_ssh_command(cmd => 'sudo journalctl -b > /tmp/journalctl_b.txt', no_quote => 1);
         upload_logs('/tmp/journalctl_b.txt');
     }
+
+    if (is_hardened) {
+        # Upload SCAP profile used by img-proof
+        my $url = "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml.gz";
+        assert_script_run("curl --fail -LO $url");
+        upload_logs("suse.linux.enterprise.15.xml.gz");
+    }
 }
 
 sub cleanup {


### PR DESCRIPTION
Upload SCAP profile used by img-proof.

It will help in the future with bugs like https://bugzilla.suse.com/show_bug.cgi?id=1220269 to compare what changed.