### PR TITLE
Add fix for poo156295

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -49,7 +49,7 @@ sub run {
         my $cont_storage = '/etc/containers/storage.conf';
         if ($unresolved_config =~ m|$cont_storage|) {
             assert_script_run(sprintf('mv  %s.rpmnew %s', $cont_storage, $cont_storage));
-            assert_script_run('rm -rf /var/lib/containers/storage') if is_aarch64;
+            assert_script_run('rm -rf /var/lib/containers/storage');
             assert_script_run('podman system reset -f');
         }
     }


### PR DESCRIPTION
Unconditional cleanup prevents [bsc#1217683](https://bugzilla.opensuse.org/show_bug.cgi?id=1217683) from happening when updating from a podman with `btrfs` as default storage backend.

- Related ticket: https://progress.opensuse.org/issues/156295
- Verification run: https://duck-norris.qe.suse.de/tests/14455
