### PR TITLE
SLEM pubcloud aggregated: basic tests updated

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -276,21 +276,14 @@ sub load_slem_on_pc_tests {
     if (get_var('PUBLIC_CLOUD_DOWNLOAD_TESTREPO')) {
         load_publiccloud_download_repos();
     } else {
+        # SLEM basic test
         loadtest("boot/boot_to_desktop");
         loadtest("publiccloud/prepare_instance", run_args => $args);
         loadtest("publiccloud/registration", run_args => $args);
         # 2 next modules of pubcloud needed for sle-micro incidents/repos verification
         loadtest("publiccloud/transfer_repos", run_args => $args);
         loadtest("publiccloud/patch_and_reboot", run_args => $args);
-
-        loadtest("publiccloud/ssh_interactive_start", run_args => $args);
-        loadtest("publiccloud/instance_overview", run_args => $args);
-        loadtest("publiccloud/slem_prepare", run_args => $args);
-        loadtest("transactional/enable_selinux") if (get_var('ENABLE_SELINUX'));
-        if (get_var("PUBLIC_CLOUD_CONTAINERS")) {
-            load_container_tests() if is_container_test;
-        }
-        loadtest("publiccloud/ssh_interactive_end", run_args => $args);
+        loadtest("publiccloud/slem_basic", run_args => $args);
     }
 }
 

--- a/schedule/sle-micro/publiccloud/basic.yml
+++ b/schedule/sle-micro/publiccloud/basic.yml
@@ -5,4 +5,8 @@ description: >
   Maintainer: <qa-c@suse.de>
 schedule:
   - boot/boot_to_desktop
+  - publiccloud/prepare_instance
+  - publiccloud/registration
+  - publiccloud/transfer_repos
+  - publiccloud/patch_and_reboot
   - publiccloud/slem_basic


### PR DESCRIPTION
SLEM Pub.Cloud aggregates for test group [532](https://openqa.suse.de/tests/overview?distri=sle-micro&version=5.5&groupid=532), modified tests: 
- slem_basic updated, triggered by code: basic.yaml in YAML_SCEDULE setting no more used;  
- slem_containers_selinux removed.

See also MR#[1552](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1552) 

- Related ticket: https://progress.opensuse.org/issues/137168
- Verification run: TBD



