### PR TITLE
Filter out useless noise in uuid variable

### DIFF
--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -93,6 +93,8 @@ sub run {
         my $get_uuid_cmd = 'for bd in $(grep ^DEVICE ' . $mdadm_conf . '); do [[ "$bd" == "DEVICE" ]] && continue; ';
         $get_uuid_cmd .= 'blkid -o export "$bd" | sed -n -e s/[\-:]//g -e /^UUID=/s/^UUID=//p; done | sort -u';
         my $uuid = script_output $get_uuid_cmd;
+        # filter out the noise in the output of openQA script_output API
+        $uuid =~ s/(^\[.*$)|(\n)//mg;
         $uuid = join(':', substr($uuid, 0, 8), substr($uuid, 8, 8), substr($uuid, 16, 8), substr($uuid, 24));
         die 'MD RAID devices have different UUIDs!' if ($uuid =~ /\n/);
         my $mdadm_uuid = script_output "sed -r -n -e '/ARRAY/s/.*UUID=([0-9a-z:]+).*/\\1/p' $mdadm_conf";


### PR DESCRIPTION
fix the issue from TEAM-9113 by filtering out useless return line characters and the lines beginning with square bracket, I checked all the failed openQA jobs, the failure was triggered by the useless lines beginning with square bracket, so the fix is valid so far.

- Related ticket: https://jira.suse.com/browse/TEAM-9113
- Needles: https://openqa.suse.de/tests/13712032#step/check_after_reboot/31
- Verification run:
        https://openqa.suse.de/tests/13770883#step/check_after_reboot/30, 
        https://openqa.suse.de/tests/13769676#step/check_after_reboot/30
