### PR TITLE
Enable Horizontal Migration Test in QAM

### DIFF
--- a/schedule/sles4sap/qam/common/qam_install_sles4sap.yaml
+++ b/schedule/sles4sap/qam/common/qam_install_sles4sap.yaml
@@ -44,6 +44,10 @@ conditional_schedule:
       12-SP4:
         - installation/sles4sap_product_installation_mode
       12-SP5:
+        - '{{product_installation_mode}}'
+  product_installation_mode:
+    SLE_PRODUCT:
+      sles4sap:
         - installation/sles4sap_product_installation_mode
   update_test_repo:
     QAM_INCI:
@@ -57,6 +61,8 @@ conditional_schedule:
         - installation/system_role
       12-SP4:
         - installation/system_role
+      12-SP5:
+        - '{{qam_system_role}}'
       15:
         - installation/system_role
       15-SP1:
@@ -69,6 +75,10 @@ conditional_schedule:
         - installation/system_role
       15-SP5:
         - installation/system_role
+  qam_system_role:
+    HORIZONTAL_MIGRATION:
+      1:
+        - installation/system_role
   sles4sap_product_installation_mode:
     SYSTEM_ROLE:
       default:
@@ -80,6 +90,9 @@ conditional_schedule:
       12-SP3:
         - installation/user_settings
       12-SP4:
+        - installation/user_settings
+    HORIZONTAL_MIGRATION:
+      1:
         - installation/user_settings
   patch_and_reboot:
     FLAVOR:

--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -30,6 +30,7 @@ sub run {
         $product = 'sles_sap' if (is_sles4sap and is_sle('<15'));
         $product = 'sles' if (is_sles4sap and is_sle('>=15'));
         $product = 'sle_' . $product if is_rt or is_hpc;
+        $product = 'sles' if (is_sles4sap and check_var('SCC_REGCODE_SLES4SAP', 'invalid_key') and is_sle('=12-SP5'));
         $checker{NAME} = uc($product);
         $checker{NAME} = 'SLES' if ($product =~ /^sles/);
         $checker{VERSION_ID} =~ s/\-SP/./;


### PR DESCRIPTION
Enable Horizontal Migration Test in QAM Incidents job groups.
TEAM-9036 - Enable Horizontal Migration Test in QAM

Added 4 test cases for each product.

    create_hdd_gnome_qam_sap
    sap_sles4sap_failing_horizontal_migration_rollback
    sles4sap_horizontal_migration_sapconf
    sles4sap_horizontal_migration_saptune

  

- Related ticket: https://jira.suse.com/browse/TEAM-9036
- Needles: NA
- Verification run:

  15-SP5: https://openqa.suse.de/tests/13764966#dependencies (passed, no LTSS) 
  15-SP4: https://openqa.suse.de/tests/13779136#dependencies (passed, LTSS)
  15-SP3: https://openqa.suse.de/tests/13779304#dependencies (passed, LTSS)
  15-SP2: https://openqa.suse.de/tests/13779317#dependencies (passed, LTSS)
  15-SP1: End of LTSS.
  12-SP5: https://openqa.suse.de/tests/13778201#dependencies (passed, no LTSS)
  qam-create_hdd_sles4sap_gnome: 12-SP5: http://openqa.suse.de/tests/13778972 (passed, VRs for code changes not break other test cases)
