### PR TITLE
Update clocksource whitelisted messages

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -336,7 +336,7 @@
         "type": "ignore"
     },
     "chrony": {
-        "description": "chronyd.*Received KoD RATE from|System clock wrong by.*, adjustment started|System clock was stepped by.*",
+        "description": "chronyd.*Received KoD RATE from|System clock wrong by.*|System clock was stepped by.*",
         "products": {
             "sle-micro": [ "5.0", "5.1" ],
             "opensuse": ["Tumbleweed", "15.2", "15.3"],
@@ -615,29 +615,8 @@
         },
         "type": "ignore"
     },
-    "tsc unstable": {
-        "description": "clocksource: timekeeping watchdog on CPU.*: Marking clocksource 'tsc' as unstable because the skew is too large",
-        "products": {
-            "sle": ["15-SP6"]
-        },
-        "type": "ignore"
-    },
-    "clocksource info": {
-        "description": "clocksource: .* .*now: .* .*last: .* mask: .*",
-        "products": {
-            "sle": ["15-SP6"]
-        },
-        "type": "ignore"
-    },
-    "clocksource skewed": {
-        "description": "clocksource: .* skewed .* over watchdog .*",
-        "products": {
-            "sle": ["15-SP6"]
-        },
-        "type": "ignore"
-    },
-    "clocksource switched": {
-        "description": "clocksource: .* is current clocksource",
+    "skip watchdog check": {
+        "description": "clocksource: Long readout interval, skipping watchdog check:.*$",
         "products": {
             "sle": ["15-SP6"]
         },


### PR DESCRIPTION
Recently the watchdog has received several updates hence we should update the list of acceptable messages

- https://bugzilla.suse.com/show_bug.cgi?id=1221307#c3
- Verification run: https://openqa.suse.de/tests/13780080#step/journal_check/8
