### PR TITLE
run_ltp: Save crashdump on test timeout

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -17,6 +17,7 @@ use Utils::Backends;
 use LTP::utils;
 use version_utils qw(is_jeos is_sle);
 use utils 'assert_secureboot_status';
+use kdump_utils;
 
 sub run {
     my ($self) = @_;
@@ -41,6 +42,11 @@ sub run {
     }
 
     select_serial_terminal;
+
+    if (check_var_array('LTP_DEBUG', 'crashdump')) {
+        configure_service(yast_interface => 'cli');
+        select_serial_terminal;
+    }
 
     # Debug code for poo#81142
     script_run('gzip -9 </dev/fb0 >framebuffer.dat.gz');

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -28,6 +28,7 @@ use rpi 'enable_tpm_slb9670';
 use bootloader_setup 'add_grub_xen_replace_cmdline_settings';
 use virt_autotest::utils 'is_xen_host';
 use Utils::Backends 'get_serial_console';
+use kdump_utils;
 
 sub add_we_repo_if_available {
     # opensuse doesn't have extensions
@@ -305,6 +306,11 @@ sub run {
     enable_tpm_slb9670 if ($is_ima && get_var('MACHINE') =~ /RPi/);
 
     select_serial_terminal;
+
+    if (get_var('LTP_COMMAND_FILE') && check_var_array('LTP_DEBUG', 'crashdump')) {
+        configure_service(yast_interface => 'cli');
+        select_serial_terminal;
+    }
 
     export_ltp_env;
 


### PR DESCRIPTION
Add support for optionally saving crashdump for debugging when LTP tests time out.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - install_ltp, crashdump disabled: https://openqa.suse.de/tests/13781728
  - install_ltp, crashdump enabled: https://openqa.suse.de/tests/13781727
  - boot_ltp, crashdump disabled: https://openqa.suse.de/tests/13781723
  - boot_ltp, crashdump enabled: https://openqa.suse.de/tests/13781722