### PR TITLE
Remove pattern sap-b1 from autoyast_sles4sap.xml

### DIFF
--- a/data/autoyast_sle15/autoyast_sles4sap.xml.ep
+++ b/data/autoyast_sle15/autoyast_sles4sap.xml.ep
@@ -160,7 +160,6 @@
       <pattern>sap_server</pattern>
       <pattern>sap-hana</pattern>
       <pattern>sap-nw</pattern>
-      <pattern>sap-b1</pattern>
     </patterns>
     <products config:type="list">
       <product>SLES_SAP</product>


### PR DESCRIPTION
Remove pattern "sap-b1" from autoyast_sles4sap.xml.ep for prerelease sap product 15-SP6 as it is not supported from 15-SP5

TEAM-9115 - [15-SP6] autoyast_sles4sap_hana failed on "installation": "Attempt to `start` service 'firewalld' failed" & "Error while setting pattern: sap-b1"

- Related ticket: https://jira.suse.com/browse/TEAM-9115
- Needles: NA
- Verification run:
  x86_64: http://openqa.suse.de/tests/13789913# (passed)
  ppc64le: https://openqa.suse.de/tests/13789911#step/installation/95 (failure can be tracked by Bug 1220851)

[Bug 1220851](https://bugzilla.suse.com/show_bug.cgi?id=1220851) - [Build 60.3] openQA test fails in "autoyast_sles4sap_hana" autoyast installation, it reports : Value '' is invalid. Use one of: ports, hostnames

NOTE: Checking steps of test code:
step1:
I checked openQA test code only "autoyast_sles4sap_hana.yaml" uses "autoyast_sles4sap.xml.ep"
```
# grep -r autoyast_sles4sap.xml.ep
schedule/sles4sap/installation/autoyast_sles4sap_hana.yaml:  AUTOYAST: autoyast_sle15/autoyast_sles4sap.xml.ep
# grep -r "autoyast_sles4sap_hana.yaml"
Got nothing.
```
Step2: Then check some gitlab job groups yaml files
```
# grep -r autoyast_sles4sap_hana.yaml 
openqa_ha_sap/openQA/yaml_job_groups/ow15/SLE15/sles4sap.yaml:          YAML_SCHEDULE: schedule/sles4sap/installation/autoyast_sles4sap_hana.yaml
openqa_ha_sap/openQA/yaml_job_groups/sap/prerelease_sap.yml:          YAML_SCHEDULE: schedule/sles4sap/installation/autoyast_sles4sap_hana.yaml
openqa_ha_sap/openQA/yaml_job_groups/sap/prerelease_sap.yml:          YAML_SCHEDULE: schedule/sles4sap/installation/autoyast_sles4sap_hana.yaml
# grep -r autoyast_sles4sap.xml.ep
Ｇot nothing
```
So from the outputs of "Step2". The code change only effect 15sp6 test cases in "prerelease_sap.yml" and 15sp5 test cases in "sles4sap.yaml"
There is still no 15sp5- test cases using "autoyast_sles4sap_hana.yaml" or/and "autoyast_sles4sap.xml.ep".
So I delete sap-b1 directly.
