### PR TITLE
Fix some is_leap calls

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -807,7 +807,7 @@ Returns true if the SUT uses Plasma 6.
 sub is_plasma6 {
     return 0 unless check_var('DESKTOP', 'kde');
     return 1 if is_krypton_argon;
-    return 0 if is_leap("<16");
+    return 0 if is_leap("<16.0");
     return 1;
 }
 

--- a/tests/console/journald_fss.pm
+++ b/tests/console/journald_fss.pm
@@ -27,10 +27,10 @@ sub run {
     select_serial_terminal;
 
     # Enable FSS (Forward Secure Sealing)
-    my $path = (is_sle('>=15-SP6') || is_leap('>=15-SP6') || is_tumbleweed) ? "/etc/systemd/journald.conf.d" : "/etc/systemd";
+    my $path = (is_sle('>=15-SP6') || is_leap('>=15.6') || is_tumbleweed) ? "/etc/systemd/journald.conf.d" : "/etc/systemd";
     my $journald_conf = "$path/journald.conf";
 
-    assert_script_run("sed -i -e 's/^Storage/#Storage/g' -e 's/^Seal/#Seal/g' $journald_conf") if is_sle('<=15-SP5') || is_leap('<=15-SP5');
+    assert_script_run("sed -i -e 's/^Storage/#Storage/g' -e 's/^Seal/#Seal/g' $journald_conf") if is_sle('<=15-SP5') || is_leap('<=15.5');
     assert_script_run("echo -e \"Storage=persistent\nSeal=yes\" >> $journald_conf");
     assert_script_run("mkdir -p /var/log/journal");
     systemctl 'restart systemd-journald.service';

--- a/tests/fips/openjdk/openjdk_fips.pm
+++ b/tests/fips/openjdk/openjdk_fips.pm
@@ -22,9 +22,9 @@ sub run {
     my $self = @_;
 
     my @java_versions = (17);
-    if (is_sle('<=15-SP5') || is_leap('<=15-SP5')) {
+    if (is_sle('<=15-SP5') || is_leap('<=15.5')) {
         push @java_versions, 11;
-    } elsif (is_sle('>=15-SP6') || is_leap('<=15-SP6') || is_tumbleweed) {
+    } elsif (is_sle('>=15-SP6') || is_leap('<=15.6') || is_tumbleweed) {
         push @java_versions, 21;
     } else {
         die "Unsupported SLE/openSUSE version for this test.";


### PR DESCRIPTION
It needs to be maj.min, no other syntax allowed.

One case found by @rfan1: https://openqa.opensuse.org/tests/4011502#step/opensuse_welcome/6

Other cases found by `git grep -E 'is_leap\([^.]*\)`

