### PR TITLE
containers: Add debug info to post_fail_hook in docker_firewall

### DIFF
--- a/tests/containers/firewall.pm
+++ b/tests/containers/firewall.pm
@@ -60,6 +60,12 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
 
+    if ($runtime eq "docker") {
+        systemctl('status docker.service', ignore_failure => 1);
+        script_run('journalctl -xeu docker.service');
+        systemctl('restart docker', ignore_failure => 1);
+    }
+
     # Stop the firewall if it was started by this test module
     if ($stop_firewall == 1) {
         systemctl('stop ' . $self->firewall());


### PR DESCRIPTION
This PR adds debug information in post_fail_hook

- Related ticket: https://progress.opensuse.org/issues/157330
- Failing test: https://openqa.opensuse.org/tests/4015303#step/docker_firewall/137
- Verification run: https://openqa.opensuse.org/tests/4015866 (failing because of https://bugzilla.opensuse.org/show_bug.cgi?id=1221458)