### PR TITLE
containers: fix docker_firewall by allowing frequent docker restarts

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -106,6 +106,11 @@ sub install_docker_when_needed {
         }
     }
 
+    # Disable docker's own rate-limit in the service file (3 restarts in 60s)
+    # Our tests might restart the docker service more frequently than that
+    assert_script_run 'mkdir -p /etc/systemd/system/docker.service.d';
+    assert_script_run 'echo -e "[Service]\nStartLimitInterval=0s\n" > /etc/systemd/system/docker.service.d/limits.conf';
+
     # docker daemon can be started
     systemctl('enable docker');
     systemctl('is-enabled docker');

--- a/tests/containers/firewall.pm
+++ b/tests/containers/firewall.pm
@@ -60,16 +60,10 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
 
-    if ($runtime eq "docker") {
-        systemctl('status docker.service', ignore_failure => 1);
-        script_run('journalctl -xeu docker.service');
-        systemctl('restart docker', ignore_failure => 1);
-    }
-
     # Stop the firewall if it was started by this test module
     if ($stop_firewall == 1) {
         systemctl('stop ' . $self->firewall());
-        systemctl('restart docker') if ($runtime eq "docker");
+        systemctl('restart docker', ignore_failure => 1) if ($runtime eq "docker");
     }
 
     $self->SUPER::post_fail_hook;


### PR DESCRIPTION
- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1221458 and https://progress.opensuse.org/issues/157330
- Needles: N/A
- Verification Runs: [Working post_fail_hook](https://openqa.opensuse.org/tests/4017525), [docker_firewall fixed](https://openqa.opensuse.org/tests/4018048)
