### PR TITLE
HPC: Remove suboptimal get_mpi sub

### DIFF
--- a/lib/hpc/formatter.pm
+++ b/lib/hpc/formatter.pm
@@ -13,7 +13,7 @@ use version_utils qw(is_sle);
 
 has mpirun => sub {
     my ($self) = shift;
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     $self->mpirun("mpirun");
     my @mpirun_args;
     ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'

--- a/lib/hpc/utils.pm
+++ b/lib/hpc/utils.pm
@@ -18,20 +18,6 @@ use Exporter 'import';
 
 our @EXPORT = qw(get_slurm_version);
 
-sub get_mpi() {
-    my $mpi = get_required_var('MPI');
-
-    if ($mpi eq 'openmpi3') {
-        if (is_sle('<15')) {
-            $mpi = 'openmpi';
-        } elsif (is_sle('<15-SP2')) {
-            $mpi = 'openmpi2';
-        }
-    }
-
-    return $mpi;
-}
-
 =head2 get_slurm_version
 
  get_slurm_version();

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -23,7 +23,7 @@ use POSIX 'strftime';
 
 sub run ($self) {
     select_serial_terminal();
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
     my $mpi_bin = 'mpi_bin';
     my $mpi2load = '';
@@ -188,8 +188,7 @@ sub post_fail_hook ($self) {
 =over
 =item $mpi
 Stores the MPI implementation. This is usually whatever MPI job variable is
-given. It is changed when openmpi is used to get the corresponding version
-for products despite the MPI value. C<get_mpi> function needs to get improved
+given
 
 =item $mpi_compiler
 This is determined based on the source code which is used and comes together

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -16,7 +16,7 @@ use POSIX 'strftime';
 
 sub run ($self) {
     select_serial_terminal();
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     my %exports_path = (
         bin => '/home/bernhard/bin'
     );

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -24,7 +24,7 @@ my $compile_rt = undef;
 my $rt = undef;
 
 sub run ($self) {
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     my ($mpi_compiler, $mpi_c) = $self->get_mpi_src();
     my $mpi_bin = 'mpi_bin';
     my @cluster_nodes = $self->cluster_names();

--- a/tests/hpc/spack_slave.pm
+++ b/tests/hpc/spack_slave.pm
@@ -13,7 +13,7 @@ use utils;
 use Utils::Logging 'tar_and_upload_log';
 
 sub run ($self) {
-    my $mpi = $self->get_mpi();
+    my $mpi = get_required_var('MPI');
     my %exports_path = (bin => '/home/bernhard/bin');
 
     $self->mount_nfs_exports(\%exports_path);


### PR DESCRIPTION
This function is changing the test setting which is somehow confusing as there should be test var MPI and it should simply indicate which MPI version is being used

- Related ticket: https://progress.opensuse.org/issues/137138
- Verification run:
