### PR TITLE
run_ltp: Print tasktrace on test failure

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -41,12 +41,14 @@ sub run {
         $self->wait_boot(ready_time => 1800);
     }
 
-    select_serial_terminal;
-
     if (check_var_array('LTP_DEBUG', 'crashdump')) {
-        configure_service(yast_interface => 'cli');
         select_serial_terminal;
+        configure_service(yast_interface => 'cli');
     }
+
+    # Initialize VNC console now to avoid login attempts on frozen system
+    select_console('root-console') if get_var('LTP_DEBUG');
+    select_serial_terminal;
 
     # Debug code for poo#81142
     script_run('gzip -9 </dev/fb0 >framebuffer.dat.gz');

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -305,13 +305,14 @@ sub run {
 
     enable_tpm_slb9670 if ($is_ima && get_var('MACHINE') =~ /RPi/);
 
-    select_serial_terminal;
-
     if (get_var('LTP_COMMAND_FILE') && check_var_array('LTP_DEBUG', 'crashdump')) {
-        configure_service(yast_interface => 'cli');
         select_serial_terminal;
+        configure_service(yast_interface => 'cli');
     }
 
+    # Initialize VNC console now to avoid login attempts on frozen system
+    select_console('root-console') if get_var('LTP_DEBUG');
+    select_serial_terminal;
     export_ltp_env;
 
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -286,6 +286,17 @@ sub save_crashdump {
     upload_logs('/root/crashdump.tar.xz');
 }
 
+sub dump_tasktrace {
+    my $old_console = current_console();
+
+    select_console('root-console', await_console => 0);
+    send_key('alt-sysrq-t');
+    send_key('alt-sysrq-w');
+    wait_serial(qr/sysrq: .*Show Blocked State/, timeout => 300);
+    send_key('ret');
+    select_console($old_console, await_console => 0);
+}
+
 sub upload_tcpdump {
     my $self = shift;
     my $pid = $self->{tcpdump_pid};
@@ -385,6 +396,7 @@ sub run_post_fail {
     my ($self, $msg) = @_;
 
     $self->upload_tcpdump() if defined($self->{tcpdump_pid});
+    $self->dump_tasktrace() if check_var_array('LTP_DEBUG', 'tasktrace');
     $self->save_crashdump()
       if $self->{timed_out} && check_var_array('LTP_DEBUG', 'crashdump');
 
@@ -475,6 +487,7 @@ E.g.: key=value,key2="value with spaces",key3='another value with spaces'
 Comma separated list of debug features to enable during test run.
 C<tcpdump>: Capture all packets sent or received during each test.
 C<crashdump>: Save kernel crashdump on test timeout.
+C<tasktrace>: Print backtrace of all processes and show blocked tasks
 
 =cut
 

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -307,7 +307,11 @@ sub upload_tcpdump {
     if ($self->{timed_out}) {
         $old_console = current_console();
         select_console('root-console');
-        return unless defined(script_run("kill -s INT $pid && while [ -d /proc/$pid ]; do usleep 100000; done", die_on_timeout => 0));
+
+        unless (defined(script_run("kill -s INT $pid && while [ -d /proc/$pid ]; do usleep 100000; done", die_on_timeout => 0))) {
+            select_console($old_console, await_console => 0);
+            return;
+        }
     }
     else {
         assert_script_run("kill -s INT $pid && wait $pid");


### PR DESCRIPTION
Add support for optionally printing process backtraces and blocked tasks on test failure.

Also add minor fixes for corner cases in tcpdump and crashdump handling.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - debug disabled: https://openqa.suse.de/tests/13814385
  - tasktrace only: https://openqa.suse.de/tests/13814388
  - boot_ltp, all debug features: https://openqa.suse.de/tests/13814386
  - install_ltp, all debug features: https://openqa.suse.de/tests/13814387