### PR TITLE
xfstests: Add XFSTESTS_SKIP_INSTALL parameter

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -638,6 +638,12 @@ sub load_virt_feature_tests {
     }
 }
 
+sub load_xfstests_tests {
+    loadtest 'xfstests/partition';
+    loadtest 'xfstests/run';
+    loadtest 'xfstests/generate_report';
+}
+
 testapi::set_distribution(DistributionProvider->provide());
 
 # set failures
@@ -781,31 +787,23 @@ elsif (get_var('XFSTESTS')) {
         loadtest 'kernel/change_kernel';
     }
     prepare_target;
-    if (is_pvm || check_var('ARCH', 's390x')) {
+    if (get_var('XFSTESTS_SKIP_INSTALL', 0) || check_var('XFSTESTS', 'installation') || is_pvm || check_var('ARCH', 's390x')) {
         loadtest 'xfstests/install';
         unless (check_var('NO_KDUMP', '1')) {
             loadtest 'xfstests/enable_kdump';
         }
-        loadtest 'xfstests/partition';
-        loadtest 'xfstests/run';
-        loadtest 'xfstests/generate_report';
-    }
-    else {
+        if (get_var('XFSTEST_KLP')) {
+            loadtest 'kernel/install_klp_product';
+        }
         if (check_var('XFSTESTS', 'installation')) {
-            loadtest 'xfstests/install';
-            unless (check_var('NO_KDUMP', '1')) {
-                loadtest 'xfstests/enable_kdump';
-            }
-            if (get_var('XFSTEST_KLP')) {
-                loadtest 'kernel/install_klp_product';
-            }
             loadtest 'shutdown/shutdown';
         }
         else {
-            loadtest 'xfstests/partition';
-            loadtest 'xfstests/run';
-            loadtest 'xfstests/generate_report';
+            load_xfstests_tests();
         }
+    }
+    else {
+        load_xfstests_tests();
     }
 }
 elsif (get_var("BTRFS_PROGS")) {

--- a/variables.md
+++ b/variables.md
@@ -422,6 +422,7 @@ Variable        | Type      | Default value | Details
 XFSTESTS_REPO | string | | repo to install xfstests package
 DEPENDENCY_REPO | string | | ibs/obs repo to install related test package to solve dependency issues. e.g. fio
 XFSTESTS_DEVICE | string | | manually set a test disk for both TEST_DEV and SCRATCH_DEV
+XFSTESTS_SKIP_INSTALL | boolean | 0 | Skipping the install step including xfstests package and dependency package installation.
 
 
 Filesystem specific setting:


### PR DESCRIPTION
Typically, we running xfstests on the disk witch xfstests is installed. To save disk space, add XFSTESTS_SKIP_INSTALL parameter to running xfstests directly. This eliminates the need to generate qcow2 file with xfstests by PUBLISH_HDD.

- Related ticket: https://progress.opensuse.org/issues/157288
- Needles: N/A
- Verification run:
http://10.67.129.54/tests/904 (VIRTIO_CONSOLE=1 XFSTESTS_NO_HEARTBEAT=1)
http://10.67.129.54/tests/899 (VIRTIO_CONSOLE=0)
http://10.67.129.54/tests/906 (XFSTESTS_SKIP_INSTALL=0)
http://10.67.129.54/tests/908 (create_hdd_xfstests)
https://openqa.suse.de/tests/13818606 (public cloud)
