### PR TITLE
Regard non-detected location as de for virt machines location

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -1073,7 +1073,8 @@ sub upload_virt_logs {
     my ($log_dir, $compressed_log_name) = @_;
 
     my $full_compressed_log_name = "/tmp/$compressed_log_name.tar.gz";
-    script_run("tar -czf $full_compressed_log_name $log_dir; rm $log_dir -r", 60);
+    script_run("tar -czf $full_compressed_log_name $log_dir", 60);
+    script_run("for log in $log_dir; do if [ -d \$log ]; then cd \$log && rm -r *; else rm -r \$log; fi; done");
     save_screenshot;
     upload_logs "$full_compressed_log_name";
     save_screenshot;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -75,8 +75,13 @@ sub get_version_for_daily_build_guest {
 sub locate_sourcefile {
     my $location = '';
     if (!is_s390x) {
-        $location = script_output("perl /usr/share/qa/tools/location_detect_impl.pl", 60);
-        $location =~ s/[\r\n]+$//;
+        $location = script_output("perl /usr/share/qa/tools/location_detect_impl.pl", 60, proceed_on_failure => 1);
+        if ($location) {
+            $location =~ s/[\r\n]+$//;
+        }
+        else {
+            $location = 'de';
+        }
     }
     else {
         #S390x LPAR just be only located at DE now.


### PR DESCRIPTION
- quinn and fozzie moved to PRG rather than DE office
- Keep the uplevel directory when cleaning up the logs. `/var/log/libvirt/` was removed when uploading logs, it made module libvirt failing to restart.

- Related ticket: https://progress.opensuse.org/issues/153682#note-23
- Related PR: https://github.com/SUSE/qa-automation/pull/820
- Verification run: 
[gi-guest_sles12sp5-on-host_developing-kvm on quinn](https://openqa.suse.de/tests/13825699)
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm on fozzie](https://openqa.suse.de/tests/13828009)
