### PR TITLE
x11/remote_desktop: make sure to get IP address

### DIFF
--- a/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
@@ -47,6 +47,11 @@ sub run {
     mutex_unlock 'dhcp';
     mutex_lock 'xvnc';
 
+    # Make sure the client gets the IP address
+    x11_start_program('xterm');
+    assert_script_run('nmcli connection up eth0');
+    send_key 'alt-f4';
+
     # First time login and configure the visibility
     $self->start_vncviewer;
     handle_login;


### PR DESCRIPTION
The parallel support server takes a long time to setup DHCP server, so the NetworkManager may time out when getting IP address.

So we will make NetworkManager to connect again after DHCP server is ready.

- Related ticket: https://progress.opensuse.org/issues/135977
- Needles: None
- Verification run: https://openqa.suse.de/tests/13825711#step/persistent_vncsession_xvnc/8
