### PR TITLE
Support bare metal installation with ISO on USB

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/combustion/script
+++ b/data/virt_autotest/host_unattended_installation_files/combustion/script
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euxo pipefail
+
+grub2_config() {
+    file=/etc/default/grub
+    sed -i 's/^\s*GRUB_TIMEOUT=.*$/GRUB_TIMEOUT=15/g' $file
+    sed -i -r 's/^(\s|#)*GRUB_TERMINAL=.*$/GRUB_TERMINAL="gfxterm console"/g' $file
+    sed -i 's/console=tty0//g' $file
+    sed -i 's/console=tty[^ ]*/console=SERIALCONSOLE,115200/g' $file
+    echo "DEBUG: now $file is,"
+    cat $file
+    grub2-mkconfig -o /boot/grub2/grub.cfg
+}
+
+# Redirect output to the console
+exec > >(exec tee -a /dev/SERIALCONSOLE) 2>&1
+    grub2_config # Configure grub2 in the system
+

--- a/data/virt_autotest/host_unattended_installation_files/ignition/config.ign
+++ b/data/virt_autotest/host_unattended_installation_files/ignition/config.ign
@@ -1,0 +1,34 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "root",
+        "passwordHash": "$5$yWyONd1vdHjF/ZUp$HDJnaXL8B/zPAenwqBLUiPJfAw/L.emrVoSHX/LjkwA"
+      }
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/ssh/sshd_config.d/sshd_config.conf",
+        "mode": 420,
+        "overwrite": true,
+        "contents": {
+          "source": "data:text/plain;charset=utf-8;base64,UGVybWl0Um9vdExvZ2luIHllcwpQdWJrZXlBdXRoZW50aWNhdGlvbiB5ZXMKUGFzc3dvcmRBdXRoZW50aWNhdGlvbiB5ZXM="
+        }
+      },
+      {
+        "path": "/etc/selinux/config",
+        "mode": 420,
+        "overwrite": true,
+        "contents": {
+          "source": "data:text/plain;charset=utf-8;base64,U0VMSU5VWD1wZXJtaXNzaXZlClNFTElOVVhUWVBFPXRhcmdldGVk"
+        }
+      }
+    ]
+  }
+}
+

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -22,7 +22,7 @@ use Socket;
 use virt_autotest::utils qw(is_xen_host check_port_state);
 use Utils::Backends;
 
-our @EXPORT = qw(set_grub_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot ipmitool enable_sev_in_kernel add_kernel_options set_grub_terminal_and_timeout reconnect_when_ssh_console_broken set_ipxe_bootscript);
+our @EXPORT = qw(set_grub_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot ipmitool enable_sev_in_kernel add_kernel_options set_grub_terminal_and_timeout reconnect_when_ssh_console_broken set_ipxe_bootscript set_floppy_boot set_disk_boot);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
@@ -566,4 +566,25 @@ sub set_ipxe_bootscript {
       unless $response->{success};
 }
 
+sub set_floppy_boot {
+    while (1) {
+        diag "setting boot device to floppy/primary removable media";
+        my $options = get_var('IPXE_UEFI') ? 'options=efiboot' : '';
+        ipmitool("chassis bootdev floppy ${options}");
+        sleep(3);
+        my $stdout = ipmitool('chassis bootparam get 5');
+        last if $stdout =~ m/Force Boot from Floppy/s;
+    }
+}
+
+sub set_disk_boot {
+    while (1) {
+        diag "setting boot device to default Hard-Drive";
+        my $options = get_var('IPXE_UEFI') ? 'options=efiboot' : '';
+        ipmitool("chassis bootdev disk ${options}");
+        sleep(3);
+        my $stdout = ipmitool('chassis bootparam get 5');
+        last if $stdout =~ m/Force Boot from default Hard-Drive/s;
+    }
+}
 1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -116,6 +116,7 @@ our @EXPORT = qw(
   ping_size_check
   is_ipxe_boot
   is_uefi_boot
+  is_usb_boot
 );
 
 our @EXPORT_OK = qw(
@@ -2954,6 +2955,20 @@ sub is_uefi_boot {
     if (check_var('UEFI', '1') or check_var('IPXE_UEFI', '1')) {
         return 1;
     }
+    return 0;
+}
+
+=head2 is_usb_boot
+
+ is_usb_boot();
+
+This will return C<1> if the env variables suggest
+that it boots from USB.
+
+=cut
+
+sub is_usb_boot {
+    return 1 if get_var('USB_BOOT', '');
     return 0;
 }
 

--- a/schedule/virt_autotest/slem6_baremetal_usb_install.yaml
+++ b/schedule/virt_autotest/slem6_baremetal_usb_install.yaml
@@ -1,0 +1,10 @@
+name: slem6_baremetal_usb_install.yaml
+description:    >
+    Maintainer: xlai@suse.com, qe-virt@suse.de
+    SLE Micro 6.0 bare metal machine installation with Self-Install iso schedule
+schedule:
+    - installation/ipxe_install
+    - installation/usb_install
+    - installation/bootloader_uefi
+    - microos/selfinstall
+    # system is now ready: ssh password login is ok, grub2 menu can show in sol

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -47,12 +47,12 @@ sub poweron_host {
 
 sub set_pxe_boot {
     while (1) {
-        my $stdout = ipmitool('chassis bootparam get 5');
-        last if $stdout =~ m/Boot Flag Valid.*Force PXE/s;
         diag "setting boot device to pxe";
         my $options = get_var('IPXE_UEFI') ? 'options=efiboot' : '';
         ipmitool("chassis bootdev pxe ${options}");
         sleep(3);
+        my $stdout = ipmitool('chassis bootparam get 5');
+        last if $stdout =~ m/Force PXE/s;
     }
 }
 
@@ -89,12 +89,12 @@ sub set_bootscript {
     }
 
     my $cmdline_extra;
-    $cmdline_extra .= " regurl=$regurl " if $regurl;
+    $cmdline_extra .= " regurl=$regurl " if ($regurl and !is_usb_boot);
     $cmdline_extra .= " console=$console " if $console;
 
     # Support passing both EXTRA_PXE_CMDLINE to bootscripts
     $cmdline_extra .= get_var('EXTRA_PXE_CMDLINE') . ' ' if get_var('EXTRA_PXE_CMDLINE');
-    $cmdline_extra .= " root=/dev/ram0 initrd=initrd textmode=1" if check_var('IPXE_UEFI', '1');
+    $cmdline_extra .= " root=/dev/ram0 initrd=initrd textmode=1" if (check_var('IPXE_UEFI', '1') and !is_usb_boot);
 
     if ($autoyast ne '') {
         $cmdline_extra .= " autoyast=$autoyast sshd=1 sshpassword=$testapi::password ";
@@ -174,7 +174,25 @@ sub run {
 
     poweroff_host;
 
-    #virtualization tests use a static ipxe configuration file in O3
+    # Note:
+    # SLE Micro 6.0 Self-Install image does not directly support pxe boot.
+    # To install it on bare metal machine, firstly bring up a minimum system via ipxe
+    # with this function(eg sle15sp5 gm). But we do not need to finish installation,
+    # booting to sshd-server-started is enough, at which we will have a ssh console
+    # to do latter steps.
+    # Then dd the Self-Install iso to a USB device.
+    # And then boot from the USB, and finish installation with the Self-Install iso.
+    # For more details, refer to poo#151498.
+    # To achieve the first step, in testsuite settings,
+    # - set `IPXE_UEFI`: SLE Micro 6.0+ only officially support uefi boot
+    # - set `USB_BOOT`: a flag to indicate this USB installation method,
+    #                   which stops further installation
+    # - set `MIRROR_HTTP`: the repository to bring up a minimum system(eg sle15sp5 gm)
+    # - do NOT set `AUTOYAST`
+
+    die "Can't set AUTOYAST for usb boot!" if (get_var('AUTOYAST', '') && is_usb_boot);
+
+    # virtualization tests use a static ipxe configuration file in O3
     set_bootscript unless get_var('IPXE_STATIC');
 
     set_pxe_boot;
@@ -187,7 +205,7 @@ sub run {
     if (get_var('VIRT_AUTOTEST')) {
         #it is static menu and choose the TW entry to start installation
         enter_o3_ipxe_boot_entry if get_var('IPXE_STATIC');
-        assert_screen([qw(load-linux-kernel load-initrd)], 240);
+        check_screen([qw(load-linux-kernel load-initrd)], 240);
         # Loading initrd spend much time(fg. 10-15 minutes to Beijing SUT)
         # Downloading from O3 became much more quick, some needles may not be caught.
         check_screen([qw(start-tw-install start-sle-install network-config-created)], 60);
@@ -225,9 +243,13 @@ sub run {
         if (check_screen(\@tags, $ssh_vnc_wait_time)) {
             save_screenshot;
             sleep 2;
+            return if is_usb_boot;
             prepare_disks if (!is_upgrade && !get_var('KEEP_DISKS'));
         }
-        save_screenshot;
+        else {
+            save_screenshot;
+            die "Do not catch needle with tag $ssh_vnc_tag!" if is_usb_boot;
+        }
 
         set_bootscript_hdd if get_var('IPXE_UEFI');
 

--- a/tests/installation/usb_install.pm
+++ b/tests/installation/usb_install.pm
@@ -1,0 +1,126 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: prepare USB for baremetal installation via ISO.
+# On a minimum system that is launched by ipxe and stops
+# at sshd-server-started, dd installation iso to one usb,
+# write ignition and combustion config to the other usb,
+# and launch the installation with the iso usb.
+# Maintainer: Xiaoli Ai(Alice) <xlai@suse.com>, qe-virt@suse.de
+
+package usb_install;
+use base 'y2_installbase';
+use strict;
+use warnings;
+
+use utils;
+use testapi;
+use bmwqemu;
+use ipmi_backend_utils;
+use Utils::Architectures;
+use LWP::Simple 'head';
+use Utils::Backends 'use_ssh_serial_console';
+
+sub run {
+    assert_screen('sshd-server-started', 5);
+    use_ssh_serial_console;
+    assert_script_run("set -o pipefail");
+
+    # Specify the two usb drives to use
+    my @usb = split('\n', script_output("ls /dev/disk/by-id/ -l | grep -i usb | grep -i -v -E \"generic|part\" | sed 's#^.*\\\/##'"));
+    record_info("Disk info on the machine:", script_output("ls /dev/disk/by-id/ -l; fdisk -l"));
+    die "No proper usb devices!" unless (scalar(@usb) == 2);
+    my $medium_usb = "/dev/$usb[0]";
+    my $provision_usb = "/dev/$usb[1]";
+    record_info("Pick usb drive $medium_usb to store ISO and $provision_usb to store ignition and combustion config.");
+
+    # Write ignition config to one usb
+    assert_script_run("echo y | mkfs.ext4 $provision_usb", 60);
+    assert_script_run("e2label $provision_usb ignition");
+    assert_script_run("mkdir  -p /mnt");
+    assert_script_run("mount $provision_usb /mnt");
+    assert_script_run("mkdir -p /mnt/ignition");
+    my $cmd = "curl -L "
+      . data_url("virt_autotest/host_unattended_installation_files/ignition/config.ign")
+      . " -o /mnt/ignition/config.ign";
+    script_retry($cmd, retry => 2, delay => 5, timeout => 60, die => 1);
+    save_screenshot;
+    assert_script_run("ls /mnt/ignition/config.ign");
+    save_screenshot;
+
+    # Write combustion script to the same usb with ignition
+    assert_script_run("mkdir -p /mnt/combustion");
+    $cmd = "curl -L "
+      . data_url("virt_autotest/host_unattended_installation_files/combustion/script")
+      . " -o /mnt/combustion/script";
+    script_retry($cmd, retry => 2, delay => 5, timeout => 60, die => 1);
+    save_screenshot;
+    my $SERIALCONSOLE = get_required_var('SERIALCONSOLE');
+    assert_script_run("sed -i 's/SERIALCONSOLE/$SERIALCONSOLE/g' /mnt/combustion/script");
+    assert_script_run("chmod a+x /mnt/combustion/script");
+    assert_script_run("ls -l /mnt/combustion/script");
+    save_screenshot;
+    record_info('Ignition and combustion content:', script_output('cat /mnt/ignition/config.ign /mnt/combustion/script'));
+
+    # Flush to usb stick
+    assert_script_run("sync");
+    assert_script_run("umount -l /mnt");
+    record_info("Ignition and combustion files are successfully downloaded and written to usb $provision_usb.");
+
+    # Download and dd the iso to the other usb
+    my $download_url = "http://" . get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME')) . "/assets/iso/" . get_required_var('ISO');
+    die "ISO URL is not accessible: $download_url." unless head($download_url);
+    $cmd = "curl -L $download_url | dd of=$medium_usb bs=1M";
+    script_retry($cmd, retry => 2, delay => 10, timeout => 600, die => 1);
+    save_screenshot;
+
+    # Flush
+    assert_script_run("sync");
+    record_info("ISO is saved successfully to usb $medium_usb.");
+
+    # Set next boot to usb
+    if (is_uefi_boot) {
+        # Some machines do not support setting floppy boot via ipmitool in uefi boot mode,
+        # so we use efibootmgr instead
+        record_info('efibootmgr output after dd iso to usb:', script_output('efibootmgr -v'));
+        save_screenshot;
+        my $UEFI_USB_BOOT_LABEL = "OpenQA-added-UEFI-USB-BOOT";
+
+        # Delete the sle micro usb boot entry if it exists already
+        # (old boot entry survives new installation)
+        my $output = '';
+        my $usb_boot_num = '';
+        my $cmd = "efibootmgr | grep $UEFI_USB_BOOT_LABEL";
+        if (script_run("$cmd") == 0) {
+            $output = script_output("$cmd");
+            save_screenshot;
+            $output =~ /Boot([0-9A-F]+)\*/m;
+            $usb_boot_num = $1;
+            assert_script_run("efibootmgr -B -b $usb_boot_num");
+            record_info("Existing UEFI boot for $UEFI_USB_BOOT_LABEL is deleted.", script_output('efibootmgr -v'));
+        }
+
+        # Add new sle micro usb boot entry
+        $cmd = "efibootmgr -c -d $medium_usb -p 2 -L $UEFI_USB_BOOT_LABEL -l /EFI/BOOT/grub.efi";
+        assert_script_run("$cmd");
+        save_screenshot;
+        $cmd = "efibootmgr | grep $UEFI_USB_BOOT_LABEL";
+        $output = script_output("$cmd");
+        $output =~ /Boot([0-9A-F]+)\*/m;
+        $usb_boot_num = $1;
+        assert_script_run("efibootmgr -n $usb_boot_num");
+        save_screenshot;
+        record_info("UEFI boot for $UEFI_USB_BOOT_LABEL is added", script_output('efibootmgr -v'));
+    } else {
+        set_floppy_boot;
+    }
+
+    # Power reset
+    ipmitool("chassis power reset");
+    reset_consoles;
+    select_console 'sol', await_console => 0;
+}
+
+1;

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -11,9 +11,11 @@ use testapi;
 use microos "microos_login";
 use Utils::Architectures qw(is_aarch64);
 use version_utils qw(is_leap_micro is_sle_micro);
+use utils;
 
 sub run {
     my ($self) = @_;
+
     assert_screen 'selfinstall-screen', 180;
     send_key 'down' unless check_screen 'selfinstall-select-drive';
     assert_screen 'selfinstall-select-drive';
@@ -39,7 +41,7 @@ sub run {
     } else {
         microos_login;
         # The installed system is definitely up now, so the CD can be ejected
-        eject_cd() unless $no_cd;
+        eject_cd() unless ($no_cd || is_usb_boot);
     }
 
 }


### PR DESCRIPTION
This PR mainly provides a way of baremetal machine installation via USB for sle micro 6, which does not have DVD image any more.

Related ticket: https://progress.opensuse.org/issues/151498
Needles: [MR link](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1653)
Verification run: 
- SLE MICRO 6 VT test:
  - USB INSTALL , sle micro 6: http://10.67.129.77/tests/318#, PASS
  - Default-qcow, vt test: http://openqa.suse.de/tests/13831550, PASS
- kernel test
  - AUTOYAST=1,  IPXE_UEFI=1, worker class 64bit-i915: http://openqa.suse.de/tests/13831512: PASS
- VT test:
  - AUTOYAST=1, IPXE=1, http://openqa.suse.de/tests/13831529: PASS for host installation
  - AUTOYAST=0, IPXE=1, http://openqa.suse.de/tests/13838285: PASS for host installation
- SLE MICRO 6 Container test
    - Default-SelfInstall, uefi: http://openqa.suse.de/tests/13831538, PASS for installation