### PR TITLE
Gather cluster logs on success

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -566,7 +566,6 @@ sub qesap_execute_conditional_retry {
     }
 
     if ($ret[0]) {
-        qesap_cluster_logs();
         die "'qesap.py (after retry) $args{cmd}' return: $ret[0]";
     }
 
@@ -1165,7 +1164,13 @@ sub qesap_upload_crm_report {
     $args{failok} //= 0;
 
     my $log_filename = "$args{host}-crm_report";
+
+    if ($log_filename =~ /hana\[(\d+)\]/) {
+        my $number = $1 + 1;
+        $log_filename = "vmhana0${number}-crm_report";
+    }
     $log_filename =~ s/[\[\]"]//g;
+
     my $crm_log = "/var/log/$log_filename";
     my $report_opt = !is_sle('12-sp4+') ? '-f0' : '';
     qesap_ansible_cmd(cmd => "crm report $report_opt -E /var/log/ha-cluster-bootstrap.log $crm_log",
@@ -2367,7 +2372,6 @@ sub qesap_terrafom_ansible_deploy_retry {
             timeout => 3600);
         if ($ret[0])
         {
-            qesap_cluster_logs();
             die "'qesap.py ansible' return: $ret[0]";
         }
         record_info('ANSIBLE RETRY PASS');
@@ -2399,7 +2403,6 @@ sub qesap_terrafom_ansible_deploy_retry {
             timeout => 3600
         );
         if ($ret[0]) {
-            qesap_cluster_logs();
             die "'qesap.py ansible' return: $ret[0]";
         }
         record_info('ANSIBLE RETRY PASS');
@@ -2416,7 +2419,6 @@ sub qesap_terrafom_ansible_deploy_retry {
                 "\n---------",
                 "Ansible failed:",
                 $ansible_failed));
-        qesap_cluster_logs();
         return 1;
     }
     return 0;

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -667,8 +667,8 @@ subtest '[qesap_upload_crm_report] ansible host query' => sub {
 
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  FETCH_FILENAME-->  " . join("\n  FETCH_FILENAME-->  ", @fetch_filename));
-    ok((any { /.*\/var\/log\/hana0\-crm_report/ } @calls), 'crm report file has the node name in it');
-    ok((any { /hana0\-crm_report\.tar\.gz/ } @fetch_filename), 'crm report fetch file is properly formatted');
+    ok((any { /.*\/var\/log\/vmhana01\-crm_report/ } @calls), 'crm report file has the node name in it');
+    ok((any { /vmhana01\-crm_report\.tar\.gz/ } @fetch_filename), 'crm report fetch file is properly formatted');
 };
 
 subtest '[qesap_calculate_deployment_name]' => sub {

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -38,7 +38,6 @@ sub run {
         my @ret = qesap_execute(cmd => 'ansible', timeout => 3600, verbose => 1);
         if ($ret[0]) {
             if (check_var('IS_MAINTENANCE', '1')) {
-                qesap_cluster_logs();
                 die("TEAM-9068 Ansible failed. Retry not supported for IBSM updates\n ret[0]: $ret[0]");
             }
             # Retry to deploy terraform + ansible
@@ -76,6 +75,12 @@ sub run {
     get_var('QESAP_DEPLOYMENT_IMPORT')
       ? record_info('IMPORT OK', 'Importing infrastructure successfully.')
       : record_info('DEPLOY OK', 'Ansible deployment process finished successfully.');
+}
+
+sub post_run_hook {
+    my ($self) = shift;
+    qesap_cluster_logs();
+    $self->SUPER::post_run_hook;
 }
 
 1;

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -50,11 +50,18 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    qesap_cluster_logs();
     qesap_upload_logs();
     my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
     qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300) unless (script_run("test -e $inventory"));
     qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
     $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = shift;
+    qesap_cluster_logs();
+    $self->SUPER::post_run_hook;
 }
 
 1;


### PR DESCRIPTION
This pr removes `qesap_cluster_logs` from individual functions, and adds it in the `post_fail` and `post_run` hooks of `sles4sap_publiccloud_basetest` and `deploy.pm`.

Also, the naming of the files is more representative of the host names.

- Related ticket: https://jira.suse.com/browse/TEAM-9076
- Verification run: https://openqa.suse.de/tests/13837393
