### PR TITLE
Fix wizard_hana_install missing master password

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -85,7 +85,11 @@ sub run {
     send_key 'alt-s';    # SAP SID
     send_key_until_needlematch 'sap-wizard-sid-empty', 'backspace' if check_var('DESKTOP', 'textmode');
     type_string $sid;
-    wait_screen_change { send_key 'alt-a' };    # SAP Password
+    if (is_sle('>=15-SP6')) {
+        wait_screen_change { send_key 'alt-p' };    # SAP Password
+    } else {
+        wait_screen_change { send_key 'alt-a' };    # SAP Password
+    }
     type_password $sles4sap::instance_password;
     wait_screen_change { send_key 'tab' };
     type_password $sles4sap::instance_password;


### PR DESCRIPTION
TEAM-9116 - [15-SP6] sles4sap_scc_textmode_hana_wizard failed on "wizard_hana_install": "You must provide a master password for your install"

TEAM-9115 - [15-SP6] autoyast_sles4sap_hana failed on "installation": "Attempt to `start` service 'firewalld' failed" & "Error while setting pattern: sap-b1"

- Related ticket: [TEAM-9115](https://jira.suse.com/browse/TEAM-9115)
- Needles: NA
- Verification run
sles4sap_scc_gnome_hana_wizard@ppc64le-sap:
-- https://openqa.suse.de/tests/13838764#step/wizard_hana_install/42 (The failed test step passed. It hangs on following steps,  I cancel it as it will be timed out after 4+ hours)
sles4sap_online_dvd_gnome_wizard@64bit-ipmi-nvdimm: 
-- https://openqa.suse.de/tests/13838742#step/wizard_hana_install/49 (The failed test step passed. It hangs on "Configuring Syestem according to auto-install settings" and then needle 'sap-wizard-profile-ready' not shows up)

