### PR TITLE
Replace expected user with bernhard

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -105,8 +105,9 @@ sub run {
     zypper_call 'in sudo expect';
     select_console 'user-console';
     # Defaults targetpw -> asks for root PW
-    my $exp_user = (is_azure && is_sle('>=15-SP4')) ? 'bernhard is not in the sudoers file' : 'root';
-    validate_script_output("expect -c 'spawn sudo id -un;expect password {send \"$testapi::password\\r\";interact}'", sub { qr/^$exp_user\$/ });
+    my $exp_user = (is_azure && is_sle('>=15-SP4')) ? 'bernhard' : 'root';
+    assert_script_run("expect -c 'spawn sudo id -un;expect password {send \"$testapi::password\\r\";interact}'", fail_message => "sudo password input failed");
+    validate_script_output("expect -c 'spawn sudo id -un;expect password {send \"$testapi::password\\r\";interact}'", sub { qr/^$exp_user\$/ }, fail_message => "sudo doesn't return uid=0");
     foreach my $num (0, 1) {
         record_info "iteration $num";
         select_console 'root-console';


### PR DESCRIPTION
The expected user should be bernhard and not a error message about bernhard not being allowed to sudo. In addition run the sudo check once as `assert_script_run` to improve the error message in case of failures.

- Related ticket: https://progress.opensuse.org/issues/156649
- Verification runs: [15-SP5 Azure](https://duck-norris.qe.suse.de/tests/14467) | [15-SP5 Azure Basic](https://duck-norris.qe.suse.de/tests/14473) | [15-SP5 Azure BYOS](https://duck-norris.qe.suse.de/tests/14475) | [15-SP5 GCE](https://duck-norris.qe.suse.de/tests/14468) | [15-SP4 Azure BYOS](https://duck-norris.qe.suse.de/tests/14470)