### PR TITLE
Press second ret key when enabling USE_SUPPORT_SERVER

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -659,15 +659,18 @@ sub grub_select {
     elsif (!get_var('S390_ZKVM')) {
         # confirm default choice
         send_key 'ret';
-        if (get_var('USE_SUPPORT_SERVER') && is_aarch64 && is_opensuse)
-        {
-            # On remote installations of openSUSE distris on aarch64, first key
-            # press doesn't always reach the SUT, so introducing the workaround
-            wait_still_screen;
-            if (check_screen('grub2')) {
-                record_info 'WARN', 'Return key did not reach the system, re-trying';
-                send_key 'ret';
-            }
+    }
+
+    if (((is_ppc64le && is_qemu) || (!get_var('S390_ZKVM') && is_aarch64 && is_opensuse)) && get_var('USE_SUPPORT_SERVER')) {
+        # First key press doesn't always reach the SUT on all the remote installations.
+        # It happens on some specific machine types:
+        # - on aarch64 using openSUSE distris
+        # - on ppc64le at second boot in short time
+        # so introducing the workaround
+        wait_still_screen;
+        if (check_screen('grub2')) {
+            record_info 'WARN', 'Return key did not reach the system, re-trying';
+            send_key 'ret';
         }
     }
 }


### PR DESCRIPTION
refer to https://jira.suse.com/browse/TEAM-8890?focusedId=1335959&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1335959, ppc64le vm booted twice when enabling **USE_SUPPORT_SERVER**, this PR is a workaround to press the second ret key to fix the issue.

- Related ticket: https://jira.suse.com/browse/TEAM-8890
- Needles: N/A
- Verification run:
    ppc64le:
        https://openqa.suse.de/tests/13845125#step/priority_fencing_delay/15
        https://openqa.suse.de/tests/13845142#step/boot_to_desktop#1/5
    aarch64:
        https://openqa.suse.de/tests/13845133#step/priority_fencing_delay/48
    x86_64:
        https://openqa.suse.de/tests/13845137#step/priority_fencing_delay/11

