### PR TITLE
Specify the serial unit to avoid Page Fault issue in grub 2.12

### DIFF
--- a/tests/installation/add_serial_console.pm
+++ b/tests/installation/add_serial_console.pm
@@ -39,7 +39,12 @@ sub run {
         assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub');
     }
     assert_script_run('echo GRUB_TERMINAL_OUTPUT=\"serial gfxterm\" >> /etc/default/grub');
-    assert_script_run('echo GRUB_SERIAL_COMMAND=\"serial\" >> /etc/default/grub');
+    # Specify the serial unit to workaround bsc#1219463
+    if (get_var('GRUB_SERIAL_UNIT')) {
+        assert_script_run('echo GRUB_SERIAL_COMMAND=\"serial --unit=' . get_var('GRUB_SERIAL_UNIT') . '\" >> /etc/default/grub');
+    } else {
+        assert_script_run('echo GRUB_SERIAL_COMMAND=\"serial\" >> /etc/default/grub');
+    }
     # Set expected resolution for GRUB and kernel
     assert_script_run('sed -ie \'s/GRUB_GFXMODE.*/GRUB_GFXMODE=\"1024x768x32\"/\' /etc/default/grub');
     assert_script_run('echo GRUB_GFXPAYLOAD_LINUX=\"1024x768x32\" >> /etc/default/grub');


### PR DESCRIPTION
To resolve [bsc#1219463](https://bugzilla.suse.com/show_bug.cgi?id=1219463), it requires to change the serial command parameter for workaround during installation.

```
From
> GRUB_SERIAL_COMMAND="serial"
To
> GRUB_SERIAL_COMMAND="serial --unit=0"
```

- Related ticket: https://progress.opensuse.org/issues/157714
- Verification run: [default_install_svirt@svirt-vmware70](https://openqa.suse.de/tests/13899471), [textmode_svirt@svirt-vmware70](https://openqa.suse.de/tests/13899479)
