### PR TITLE
Using AND(&&) to replace semicolon in bash command

### DIFF
--- a/tests/ha/priority_fencing_delay.pm
+++ b/tests/ha/priority_fencing_delay.pm
@@ -23,7 +23,7 @@ sub stonith_iptables {
         if (is_node(1)) {
             # Wait for the stonith match, then flush the rules for the next test
             script_run "until grep -qi offline <($crm_mon_cmd) ; do sleep 1; done", 60;
-            assert_script_run "iptables -F; iptables -X";
+            assert_script_run "iptables -F && iptables -X";
         }
 
         # Node 2 should reboot


### PR DESCRIPTION
Two commands joined by a semicolon return two separated exit codes, so it doesn't match **assert_script_run**, it matches after using AND(&&) because only returning one exit code.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/13846021#step/priority_fencing_delay/35

PS: job#13846021 failed because of node02 job timeout, but **iptables** command worked well
