### PR TITLE
Manage sub arguments in sles4sap PC lib

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -81,7 +81,7 @@ sub run {
     $self->check_takeover;
 
     record_info('Replication', join(' ', ('Enabling replication on', ucfirst($site_name), '(DEMOTED)')));
-    $self->enable_replication($site_name);
+    $self->enable_replication(site_name => $site_name);
 
     record_info(ucfirst($site_name) . ' start');
     $self->cleanup_resource();

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -47,7 +47,7 @@ sub run {
 
             # Recreate instances data as the redeployment of terraform + ansible changes the instances
             my $provider_instance = $self->provider_factory();
-            my $instances = create_instance_data($provider_instance);
+            my $instances = create_instance_data(provider => $provider_instance);
             foreach my $instance (@$instances) {
                 record_info 'New Instance', join(' ', 'IP: ', $instance->public_ip, 'Name: ', $instance->instance_id);
                 if (get_var('FENCING_MECHANISM') eq 'native' && $provider eq 'AZURE') {

--- a/tests/sles4sap/publiccloud/qesap_reuse_infra.pm
+++ b/tests/sles4sap/publiccloud/qesap_reuse_infra.pm
@@ -38,7 +38,7 @@ sub run {
     qesap_import_instances($test_id);
 
     my $provider = $self->provider_factory();
-    my $instances = create_instance_data($provider);
+    my $instances = create_instance_data(provider => $provider);
     $self->{instances} = $run_args->{instances} = $instances;
 
     record_info('IMPORT OK', 'Instance data imported.');

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -159,7 +159,7 @@ sub run {
     die 'Terraform deployment FAILED. Check "qesap*" logs for details.' if ($ret[0]);
 
     $provider->terraform_applied(1);
-    my $instances = create_instance_data($provider);
+    my $instances = create_instance_data(provider => $provider);
     foreach my $instance (@$instances) {
         record_info 'Instance', join(' ', 'IP: ', $instance->public_ip, 'Name: ', $instance->instance_id);
         $self->{my_instance} = $instance;


### PR DESCRIPTION
Unify the way function arguments are managed across all function in this lib. Add more UT coverage.
Design principle for this change are:
- always use arguments as HASH
- avoid copy args to local variables if not needed
- croak for args validation as soon as possible, using always same message format, not using `(` and `)` if not needed
- document all args
- not export functions only used internally


# Verification run: 

##  sle-15-SP4-Azure-SAP-BYOS-Incidents-x86_64-Build:32996:sed-SAPHanaSR-ScaleUp-PerfOpt-msi@az_Standard_E8s_v3
- http://openqaworker15.qa.suse.cz/tests/279250

## sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-03-22T05:03:08Z-hanasr_azure_test_sapconf_sbd@64bit
 - http://openqaworker15.qa.suse.cz/tests/279179 :green_circle: 
 -  http://openqaworker15.qa.suse.cz/tests/279248  :green_circle:

## sle-15-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:32998:aaa_base-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3
- http://openqaworker15.qa.suse.cz/tests/279180 :green_circle: 

## sle-15-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:32998:aaa_base-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3
- http://openqaworker15.qa.suse.cz/tests/279181 :red_circle: fails for issue in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18933
- http://openqaworker15.qa.suse.cz/tests/279182 :red_circle: fails for issue in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18933
- http://openqaworker15.qa.suse.cz/tests/279249 :red_circle: fails for issue in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18933
- http://openqaworker15.qa.suse.cz/tests/279267


