### PR TITLE
Add 'sle-module-python3' to autoyast config file

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_aarch64.xml
@@ -335,6 +335,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_allpatterns_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_allpatterns_aarch64.xml
@@ -77,6 +77,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_disabled_firewall.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_disabled_firewall.xml
@@ -105,6 +105,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_ppc64le.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_ppc64le.xml
@@ -367,6 +367,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_s390x.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_s390x.xml
@@ -380,6 +380,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_sdk_allpatterns_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_sdk_allpatterns_aarch64.xml
@@ -81,6 +81,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-development-tools</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_sdk_allpatterns_s390x.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_sdk_allpatterns_s390x.xml
@@ -358,6 +358,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-development-tools</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_we_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_we_x86_64.xml
@@ -339,6 +339,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_x86_64.xml
@@ -333,6 +333,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_x86_64_uefi.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_x86_64_uefi.xml
@@ -336,6 +336,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_minimal_base_sdk_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_minimal_base_sdk_aarch64.xml
@@ -337,6 +337,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-development-tools</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_minimal_base_sdk_ppc64le.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_minimal_base_sdk_ppc64le.xml
@@ -366,6 +366,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-development-tools</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_minimal_base_sdk_s390x.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_minimal_base_sdk_s390x.xml
@@ -377,6 +377,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-development-tools</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_minimal_base_sdk_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_minimal_base_sdk_x86_64.xml
@@ -328,6 +328,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-development-tools</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_encrypt_textmode_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_encrypt_textmode_aarch64.xml
@@ -330,6 +330,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_encrypt_textmode_ppc64le.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_encrypt_textmode_ppc64le.xml
@@ -386,6 +386,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_encrypt_textmode_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_encrypt_textmode_x86_64.xml
@@ -352,6 +352,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_textmode_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_textmode_aarch64.xml
@@ -326,6 +326,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_textmode_ppc64le.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_textmode_ppc64le.xml
@@ -372,6 +372,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_textmode_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_lvm_textmode_x86_64.xml
@@ -338,6 +338,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_textmode_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_textmode_aarch64.xml
@@ -5,6 +5,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_textmode_ppc64le.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_textmode_ppc64le.xml
@@ -5,6 +5,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_multipath_textmode_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_multipath_textmode_x86_64.xml
@@ -5,6 +5,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_aarch64.xml
@@ -329,6 +329,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-public-cloud</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_ppc64le.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_ppc64le.xml
@@ -360,6 +360,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-public-cloud</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_s390x.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_s390x.xml
@@ -371,6 +371,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-public-cloud</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_x86_64.xml
@@ -320,6 +320,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_textmode_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_textmode_aarch64.xml
@@ -328,6 +328,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_textmode_ppc64le.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_textmode_ppc64le.xml
@@ -359,6 +359,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_textmode_s390x.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_textmode_s390x.xml
@@ -373,6 +373,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_textmode_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_textmode_x86_64.xml
@@ -318,6 +318,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_textmode_x86_64_uefi.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_textmode_x86_64_uefi.xml
@@ -332,6 +332,13 @@
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>


### PR DESCRIPTION
https://progress.opensuse.org/issues/157843

- Verification run: http://openqa.suse.de/tests/13856391

Addons:
```
<addons t="list">
<addon t="map">
<arch>x86_64</arch>
<name>sle-module-python3</name>
<reg_code/>
<release_type>nil</release_type>
<version>15.6</version>
</addon>
<addon t="map">
<arch>x86_64</arch>
<name>sle-module-server-applications</name>
<reg_code/>
<release_type>nil</release_type>
<version>15.6</version>
</addon>
<addon t="map">
<arch>x86_64</arch>
<name>sle-module-basesystem</name>
<reg_code/>
<release_type>nil</release_type>
<version>15.6</version>
</addon>
</addons>
```