### PR TITLE
Xfstests: decouple installation steps

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -638,12 +638,6 @@ sub load_virt_feature_tests {
     }
 }
 
-sub load_xfstests_tests {
-    loadtest 'xfstests/partition';
-    loadtest 'xfstests/run';
-    loadtest 'xfstests/generate_report';
-}
-
 testapi::set_distribution(DistributionProvider->provide());
 
 # set failures
@@ -787,23 +781,25 @@ elsif (get_var('XFSTESTS')) {
         loadtest 'kernel/change_kernel';
     }
     prepare_target;
-    if (get_var('XFSTESTS_SKIP_INSTALL', 0) || check_var('XFSTESTS', 'installation') || is_pvm || check_var('ARCH', 's390x')) {
+    if (get_var('XFSTESTS_INSTALL', 0) || check_var('XFSTESTS', 'installation') || is_pvm || check_var('ARCH', 's390x')) {
         loadtest 'xfstests/install';
-        unless (check_var('NO_KDUMP', '1')) {
-            loadtest 'xfstests/enable_kdump';
-        }
-        if (get_var('XFSTEST_KLP')) {
-            loadtest 'kernel/install_klp_product';
-        }
-        if (check_var('XFSTESTS', 'installation')) {
-            loadtest 'shutdown/shutdown';
-        }
-        else {
-            load_xfstests_tests();
-        }
     }
     else {
-        load_xfstests_tests();
+        set_var('NO_KDUMP', '1') if !get_var('NO_KDUMP');
+    }
+    unless (check_var('NO_KDUMP', '1')) {
+        loadtest 'xfstests/enable_kdump';
+    }
+    if (get_var('XFSTEST_KLP')) {
+        loadtest 'kernel/install_klp_product';
+    }
+    if (check_var('XFSTESTS', 'installation')) {
+        loadtest 'shutdown/shutdown';
+    }
+    else {
+        loadtest 'xfstests/partition';
+        loadtest 'xfstests/run';
+        loadtest 'xfstests/generate_report';
     }
 }
 elsif (get_var("BTRFS_PROGS")) {

--- a/variables.md
+++ b/variables.md
@@ -423,7 +423,7 @@ Variable        | Type      | Default value | Details
 XFSTESTS_REPO | string | | repo to install xfstests package
 DEPENDENCY_REPO | string | | ibs/obs repo to install related test package to solve dependency issues. e.g. fio
 XFSTESTS_DEVICE | string | | manually set a test disk for both TEST_DEV and SCRATCH_DEV
-XFSTESTS_SKIP_INSTALL | boolean | 0 | Skipping the install step including xfstests package and dependency package installation.
+XFSTESTS_INSTALL | boolean | 0 | Install xfstests and dependency package.
 
 
 Filesystem specific setting:


### PR DESCRIPTION
In order to save disk and scalability, we intend to decouple installation steps. So that dedicated installation case is no longer necessary.

1. Rename XFSTESTS_SKIP_INSTALL to XFSTESTS_INSTALL to avoid confusion
2. All steps before testing can be run individually (install kdump etc.)

- Related ticket: https://progress.opensuse.org/issues/157756
- Needles: N/A
- Verification run: 
http://10.67.133.133/tests/529 (create_hdd_xfstests)
http://10.67.133.133/tests/530 (create_hdd_xfstests with klp)
http://10.67.133.133/tests/531 (xfstests with enable_kdump)
http://10.67.133.133/tests/533 (xfstests with klp)
http://10.67.133.133/tests/532 (xfstests with kdump and klp)
http://10.67.133.133/tests/534 (XFSTESTS_INSTALL=1)
https://openqa.suse.de/tests/13858199 (public cloud)
