### PR TITLE
Fix sudo workflow for testapi user

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -104,9 +104,11 @@ sub run {
     select_console 'root-console';
     zypper_call 'in sudo expect';
     select_console 'user-console';
-    # Defaults targetpw -> asks for root PW
-    my $exp_user = (is_azure && is_sle('>=15-SP4')) ? 'bernhard is not in the sudoers file' : 'root';
-    validate_script_output("expect -c 'spawn sudo id -un;expect password {send \"$testapi::password\\r\";interact}'", sub { qr/^$exp_user\$/ });
+    # Check if sudo asks for the root password.
+    # On Azure from SLE15 onwards, 'Defaults targetpw' is disabled. There sudo is expected to ask for the user password
+    my $exp_user = (is_azure && is_sle(">=15")) ? "$testapi::username" : "root";
+    validate_script_output("expect -c 'spawn sudo id -un;expect \"password for $exp_user\" {send \"$testapi::password\\r\";interact}'", sub { $_ =~ m/^root$/m });
+
     foreach my $num (0, 1) {
         record_info "iteration $num";
         select_console 'root-console';

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -54,6 +54,11 @@ sub run {
     if (is_sle('<15') && is_azure) {
         $instance->ssh_assert_script_run(q(sudo sed -i "/Defaults targetpw/s/^#//" /etc/sudoers));
     }
+
+    # For maintenance test runs, the testapi user (typically 'bernhard') is expected to be allowed to run sudo commands
+    if (check_var('PUBLIC_CLOUD_QAM', '1')) {
+        $instance->ssh_assert_script_run("echo \"$testapi::username ALL=(ALL) ALL\" | sudo tee /etc/sudoers.d/010_openqa");
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Fix the workflow for the testapi user (bernhard) on publiccloud by allowing the testapi user to run sudo commands.

Also check in the sudo test runs for the expected user for the password input.

The rationale for those changes can be found as summary in https://progress.opensuse.org/issues/156649#note-20.

- Related ticket: https://progress.opensuse.org/issues/156649

Verification runs:

- [Tumbleweed](https://openqa.opensuse.org/tests/4048726#step/sudo/9) (unrelated failure in `check_os_release`)
- [15-SP5 Azure-Basic](https://duck-norris.qe.suse.de/tests/14565#step/sudo/9)
- [15-SP5 EC2](https://duck-norris.qe.suse.de/tests/14566#step/sudo/9)
- [15-SP4 Azure-BYOS](https://duck-norris.qe.suse.de/tests/14567#step/sudo/9)
- [15-SP3 GCE-BYOS](https://duck-norris.qe.suse.de/tests/14564#step/sudo/9)
- [15-SP3 Azure-BYOS](https://duck-norris.qe.suse.de/tests/14568#step/sudo/9) (unrelated `gpg` failure)
- [12-SP5 Azure-Basic](https://duck-norris.qe.suse.de/tests/14563#step/sudo/9) - `root` is expected, this is 12-SP5!
- [15-SP5 Server-DVD](https://duck-norris.qe.suse.de/tests/14569#step/sudo/9) (unrelated failure in samba)
- [15-SP4 Server-DVD](https://duck-norris.qe.suse.de/tests/14570#step/sudo/9) (unrelated failure in samba)
- [15-SP3 Server-DVD](https://duck-norris.qe.suse.de/tests/14574#step/sudo/9) (unrelated failure in samba)
- [15-SP2 Server-DVD](https://duck-norris.qe.suse.de/tests/14572#step/sudo/9) (unrelated failure in samba)
- [12-SP5 Server-DVD](https://duck-norris.qe.suse.de/tests/14573#step/sudo/9) (unrelated failure in samba)