### PR TITLE
Rename deployment test module for cloud-netconfig

### DIFF
--- a/schedule/sles4sap/cloud-components/cloud_netconfig.yml
+++ b/schedule/sles4sap/cloud-components/cloud_netconfig.yml
@@ -6,7 +6,7 @@ vars:
     TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
     - boot/boot_to_desktop
-    - sles4sap/cloud_netconfig/configure
+    - sles4sap/cloud_netconfig/deploy
     - sles4sap/cloud_netconfig/sanity
     - sles4sap/cloud_netconfig/test
     - sles4sap/cloud_netconfig/destroy

--- a/tests/sles4sap/cloud_netconfig/destroy.pm
+++ b/tests/sles4sap/cloud_netconfig/destroy.pm
@@ -11,14 +11,17 @@ use testapi;
 use mmapi 'get_current_job_id';
 use serial_terminal 'select_serial_terminal';
 
+use constant DEPLOY_PREFIX => 'clne';
+
 sub run {
     my ($self) = @_;
 
-    die 'Azure is the only CSP supported for the moment' unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    die('Azure is the only CSP supported for the moment')
+      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
 
     select_serial_terminal;
 
-    my $rg = 'clne' . get_current_job_id();
+    my $rg = DEPLOY_PREFIX . get_current_job_id();
     assert_script_run("az group delete --name $rg -y", timeout => 600);
 }
 

--- a/tests/sles4sap/cloud_netconfig/sanity.pm
+++ b/tests/sles4sap/cloud_netconfig/sanity.pm
@@ -50,39 +50,18 @@ sub run {
     my $vm_ip;
     my $ssh_cmd;
     my $ret;
-    # check that the VM is reachable using both public IP addresses
-    foreach (1 .. 2) {
-        $az_cmd = join(' ',
-            'az network public-ip show',
-            "--resource-group $rg",
-            '--name', DEPLOY_PREFIX . "-pub_ip-$_",
-            '--query "ipAddress"',
-            '-o tsv');
-        $vm_ip = script_output($az_cmd);
-        $ssh_cmd = 'ssh ' . $vm_user . '@' . $vm_ip;
-
-        my $start_time = time();
-        # Looping until SSH port 22 is reachable or timeout.
-        while ((time() - $start_time) < 300) {
-            $ret = script_run("nc -vz -w 1 $vm_ip 22", quiet => 1);
-            last if defined($ret) and $ret == 0;
-            sleep 10;
-        }
-        assert_script_run("ssh-keyscan $vm_ip | tee -a ~/.ssh/known_hosts");
-    }
-    record_info('TEST STEP', 'VM reachable with SSH');
-
-    # Looping until is-system-running or timeout.
-    my $start_time = time();
-    while ((time() - $start_time) < 300) {
-        $ret = script_run("$ssh_cmd sudo systemctl is-system-running");
-        last unless $ret;
-        sleep 10;
-    }
+    $az_cmd = join(' ',
+        'az network public-ip show',
+        "--resource-group $rg",
+        '--name', DEPLOY_PREFIX . "-pub_ip-1",
+        '--query "ipAddress"',
+        '-o tsv');
+    $vm_ip = script_output($az_cmd);
+    $ssh_cmd = 'ssh ' . $vm_user . '@' . $vm_ip;
 
     # print (no check for the moment) the OS release description
     assert_script_run("$ssh_cmd cat /etc/os-release");
-    record_info('TEST STEP', 'is-system-running OK');
+    record_info('TEST STEP', 'machine is ssh reachable OK');
 
     # Check that cloud-netconfig is installed
     assert_script_run("$ssh_cmd sudo zypper ref");    # Needed in the PAYG images

--- a/tests/sles4sap/cloud_netconfig/test.pm
+++ b/tests/sles4sap/cloud_netconfig/test.pm
@@ -43,7 +43,7 @@ sub run {
     my $ssh_cmd = 'ssh ' . $vm_user . '@' . $vm_ip;
 
     # Delete an ip-config
-    my $az_cmd = join(' ', 'az network nic ip-config delete',
+    $az_cmd = join(' ', 'az network nic ip-config delete',
         '--resource-group', $rg,
         '--name ipconfig2',
         '--nic-name', DEPLOY_PREFIX . '-nic');

--- a/tests/sles4sap/cloud_netconfig/test.pm
+++ b/tests/sles4sap/cloud_netconfig/test.pm
@@ -13,24 +13,40 @@ use testapi;
 use mmapi 'get_current_job_id';
 use serial_terminal 'select_serial_terminal';
 
+use constant DEPLOY_PREFIX => 'clne';
+
 sub run {
     my ($self) = @_;
 
-    die 'Azure is the only CSP supported for the moment' unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    die('Azure is the only CSP supported for the moment')
+      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
 
     select_serial_terminal;
 
-    my $rg = 'clne' . get_current_job_id();
+    my $rg = DEPLOY_PREFIX . get_current_job_id();
+    my $az_cmd;
 
-    my $vm_user = script_output("az vm list --resource-group $rg --query '[0].osProfile.adminUsername' -o tsv");
-    my $vm_ip = script_output("az network public-ip show --resource-group $rg --name clne-pub_ip-1 --query 'ipAddress' -o tsv");
+    $az_cmd = join(' ',
+        'az vm list',
+        "--resource-group $rg",
+        '--query "[0].osProfile.adminUsername"',
+        '-o tsv');
+    my $vm_user = script_output($az_cmd);
+
+    $az_cmd = join(' ',
+        'az network public-ip show',
+        "--resource-group $rg",
+        '--name', DEPLOY_PREFIX . '-pub_ip-1',
+        '--query "ipAddress"',
+        '-o tsv');
+    my $vm_ip = script_output($az_cmd);
     my $ssh_cmd = 'ssh ' . $vm_user . '@' . $vm_ip;
 
     # Delete an ip-config
     my $az_cmd = join(' ', 'az network nic ip-config delete',
         '--resource-group', $rg,
         '--name ipconfig2',
-        '--nic-name clne-nic');
+        '--nic-name', DEPLOY_PREFIX . '-nic');
     assert_script_run($az_cmd);
 
     # Intermediate optional test, check on the cloud side
@@ -64,7 +80,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    my $rg = 'clne' . get_current_job_id();
+    my $rg = DEPLOY_PREFIX . get_current_job_id();
     script_run("az group delete --name $rg -y", timeout => 600);
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Rename test module from configure to deploy
Use die always with `()`
Use constant for cloud resources name prefix
Add optional SLE registration

- Related ticket: https://jira.suse.com/browse/TEAM-8721

Verification run:

- sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-cloud_netconfig_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/279191
- sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-cloud_netconfig_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/279190