### PR TITLE
Turn bridge_stp off to unblock SLE 12-SP5 autoyast installation

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -109,8 +109,9 @@
         <bridge_ports><%= $get_var->('SUT_NETDEVICE') %></bridge_ports>
         % } else {
         <bridge_ports>eth0 eth1 em1 em2</bridge_ports>
-        % }
-        <bridge_stp>on</bridge_stp>
+	% }
+        <!-- Turn bridge_stp off to unblock autoyast installation. Please refer to bsc#1222105 -->
+        <bridge_stp>off</bridge_stp>
         <startmode>auto</startmode>
       </interface>
     </interfaces>


### PR DESCRIPTION
* **Turning** bridge_stp on may cause malfunctioning server after successful installation. System waits for wicked interface to be up for good and fails to boot up. Please refer to bsc#1222105.

* **Turning** bridge_stp off can help solve the problem.

* **Verification Runs:**
  * [15sp6 on 12sp5 kvm sapworker3:2](https://openqa.suse.de/tests/13897604)
  * [15sp6 on 12sp5 xen worker35:49](https://openqa.suse.de/tests/13897160)
  * [15sp6 on 12sp5 xen  imagetester:8](https://openqa.suse.de/tests/13897111)
  * [12sp5 to 15sp6 host upgrade xen imagetester:2](https://openqa.suse.de/tests/13897609)
  * [12sp5 to 15sp6 host ugprade kvm imagetester:8](https://openqa.suse.de/tests/13897112)
