### PR TITLE
Remove intel_iommu=on from Xen Dom0 kernel command line - MU part

### DIFF
--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -12,7 +12,7 @@
       <terminal>serial</terminal>
       <timeout config:type="integer">10</timeout>
       <trusted_grub>false</trusted_grub>
-      <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200 <%= $check_var->('IPMI_HW', 'AMD') ? "amd_iommu=on" : "intel_iommu=on" %></xen_append>
+      <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200</xen_append>
       <xen_kernel_append>dom0_max_vcpus=4 dom0_mem=8192M,max:8192M loglvl=all guest_loglvl=all</xen_kernel_append>
     </global>
     <loader_type>grub2</loader_type>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -96,10 +96,10 @@
       <trusted_grub>false</trusted_grub>
       <terminal>console</terminal>
       % if ($check_var->('SYSTEM_ROLE', 'xen')) {
-      <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200 <%= $check_var->('IPMI_HW', 'AMD') ? "amd_iommu=on" : "intel_iommu=on" %></xen_append>
+      <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200</xen_append>
       <xen_kernel_append><%= $check_var->('IPMI_HW', 'AMD') ? "" : "dom0_max_vcpus=4 dom0_mem=8192M,max:8192M" %> vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
       % } else {
-      <append>splash=silent <%= $check_var->('IPMI_HW', 'AMD') ? "amd_iommu=on" : "intel_iommu=on" %></append>
+      <append>splash=silent</append>
       % }
     </global>
     <loader_type>grub2</loader_type>


### PR DESCRIPTION
Remove intel_iommu=on from xen dom0 kernel command line - MU part


- Related ticket: https://progress.opensuse.org/issues/157954
- Needles: N/A
- Verification run: 
     - [sles15sp5](http://openqa.qam.suse.cz/tests/overview?build=PR%3Atest%3A18954%3Awitch&distri=sle&version=15-SP5&groupid=168)
     - [sles12sp5](http://openqa.qam.suse.cz/tests/overview?build=PR%3Atest%3A18954%3Awizard&distri=sle&version=12-SP5&groupid=160)