### PR TITLE
Fix cmd composition for terraform destroy

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -606,15 +606,13 @@ sub terraform_destroy {
 
     select_host_console(force => 1);
 
-    my $cmd;
+    my $cmd = 'terraform destroy -no-color -auto-approve ';
     record_info('INFO', 'Removing terraform plan...');
     if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
         assert_script_run('cd ' . TERRAFORM_DIR . '/' . $self->conv_openqa_tf_name);
-        $cmd = 'terraform destroy -no-color -auto-approve';
     }
     else {
         assert_script_run('cd ' . TERRAFORM_DIR);
-        $cmd = 'terraform destroy -no-color -auto-approve ';
         # Add region variable also to `terraform destroy` (poo#63604) -- needed by AWS.
         $cmd .= "-var 'region=" . $self->provider_client->region . "' ";
         $cmd .= "-var 'ssh_public_key=" . $self->ssh_key . ".pub' ";


### PR DESCRIPTION
Fix missing space between arguments in code under PUBLIC_CLOUD_SLES4SAP

- Related ticket: poo#6074

- Verification run:  sle-15-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:32998:aaa_base-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/279251

