### PR TITLE
pc: Add swap unconditionally to hardened tests

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -63,6 +63,24 @@ sub run {
         $instance->ssh_assert_script_run('sudo systemctl restart sshd');
     }
 
+    if (is_hardened) {
+        # Workaround for https://github.com/OpenSCAP/openscap/issues/1796
+        my $swap_file = "/swapfile";
+        my $fstype = $instance->ssh_script_output(cmd => 'findmnt -no fstype /');
+        # Follow steps in https://btrfs.readthedocs.io/en/latest/Swapfile.html
+        my @cmds;
+        push(@cmds, "btrfs subvolume create $swap_file") if ($fstype eq "btrfs");
+        push(@cmds, "truncate -s 0 $swap_file");
+        push(@cmds, "chattr +C $swap_file") if ($fstype eq "btrfs");
+        push(@cmds, "fallocate -l 4G $swap_file");
+        push(@cmds, "chmod 600 $swap_file");
+        push(@cmds, "mkswap $swap_file");
+        push(@cmds, "swapon -v $swap_file");
+        foreach my $cmd (@cmds) {
+            $instance->ssh_assert_script_run("sudo $cmd");
+        }
+    }
+
     my $img_proof = $provider->img_proof(
         instance => $instance,
         tests => $tests,


### PR DESCRIPTION
Add swap unconditionally to hardened tests.

- Related ticket: https://progress.opensuse.org/issues/158062
- Verification runs:
  - EC2: https://openqa.suse.de/tests/13880041
  - Azure: https://openqa.suse.de/tests/13878442

NOTE: VR's fail due to https://bugzilla.suse.com/show_bug.cgi?id=1220269.  What matters is that the report.html is generated.