### PR TITLE
Add 'wait_for_idle' wrapper function

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -67,6 +67,7 @@ our @EXPORT = qw(
   get_hana_site_names
   wait_for_cluster
   wait_for_zypper
+  wait_for_idle
 );
 
 =head2 run_cmd
@@ -202,7 +203,7 @@ sub sles4sap_cleanup {
 
 sub get_hana_topology {
     my ($self) = @_;
-    $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5', timeout => 120);
+    $self->wait_for_idle(timeout => 240);
     my $cmd_out = $self->run_cmd(cmd => 'SAPHanaSR-showAttr --format=script', quiet => 1);
     return calculate_hana_topology(input => $cmd_out);
 }
@@ -1091,6 +1092,38 @@ sub wait_for_zypper {
     }
 
     die "Zypper is still locked after $max_retries retries, aborting (rc: 7)" if $retry >= $max_retries;
+}
+
+=head2 wait_for_idle
+
+    The function wraps the `cs_wait_for_idle` command, and restarts in case of timeout (once, this
+    time fatal) after displaying cluster information.
+
+=over 1
+
+=item B<$timeout> - The timeout (in seconds) for the command.
+
+=back
+=cut
+
+sub wait_for_idle {
+    my ($self, %args) = @_;
+    my $timeout = $args{timeout} // 240;
+
+    my $rc = $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5', timeout => $timeout, rc_only => 1, proceed_on_failure => 1);
+    if ($rc == 124) {
+        record_info("cs_wait_for_idle", "cs_wait_for_idle timed out after $timeout. Gathering info and retrying");
+        $self->run_cmd(cmd => 'cs_clusterstate', proceed_on_failure => 1);
+        $self->run_cmd(cmd => 'crm_mon -r -R -n -N -1', proceed_on_failure => 1);
+        $self->run_cmd(cmd => 'SAPHanaSR-showAttr', proceed_on_failure => 1);
+        # Run again, but allow to fail this time
+        $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5', timeout => $timeout);
+    } elsif ($rc != 0) {
+        die "Command 'cs_wait_for_idle --sleep 5' failed with return code $rc";
+    }
+    else {
+        record_info("cs_wait_for_idle", "cs_wait_for_idle completed successfully");
+    }
 }
 
 1;

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -37,7 +37,7 @@ sub run {
 
     # Check initial cluster status
     $self->run_cmd(cmd => 'zypper -n in ClusterTools2', timeout => 300);
-    $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5', timeout => 120);
+    $self->wait_for_idle(timeout => 240);
     my $cluster_status = $self->run_cmd(cmd => 'crm status');
     record_info('Cluster status', $cluster_status);
     die(uc($site_name) . " '$target_site->{instance_id}' is NOT in MASTER mode.") if


### PR DESCRIPTION
Adds a function wrapper for `cs_wait_for_idle`, which gathers info and retries in case of timeout. Replaces direct use of `cs_wait_for_idle` with the new function.

- Related ticket: https://jira.suse.com/browse/TEAM-9180
- Verification run: 
-- `cs_wait_for_idle` fails with rc 124: https://openqa.suse.de/tests/13881104#step/Crash_site_a-primary/641
-- cs_clusterstatus is executed: https://openqa.suse.de/tests/13881104#step/Crash_site_a-primary/663
-- crm mon is executed: https://openqa.suse.de/tests/13881104#step/Crash_site_a-primary/685
-- SAPHanaSR-showattr is executed: https://openqa.suse.de/tests/13881104#step/Crash_site_a-primary/707
finally, cs_wait_for_idle is re-run one more time (this time if it fails, it fails) and passes: https://openqa.suse.de/tests/13881104#step/Crash_site_a-primary/729

another VR: https://openqa.suse.de/tests/13881542
