### PR TITLE
console: apache: fix default configuration path in SP6

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -124,8 +124,9 @@ sub run {
         }
         else {
             # Create directory for the new instance and prepare config
+            my $apache2_default_configuration = is_sle('<15-SP6') ? "/usr/share/doc/packages/$apache2/httpd.conf.default" : "/usr/share/doc/packages/$apache2/conf/httpd.conf";
             assert_script_run 'mkdir -p /tmp/prefork';
-            assert_script_run "sed 's_\(/var/log/apache2\|/var/run\)_/tmp/prefork_; s/80/8080/' /usr/share/doc/packages/$apache2/httpd.conf.default > /tmp/prefork/httpd.conf";
+            assert_script_run "sed 's_\(/var/log/apache2\|/var/run\)_/tmp/prefork_; s/80/8080/' $apache2_default_configuration > /tmp/prefork/httpd.conf";
 
             # httpd.default.conf contains wrong service userid and groupid
             assert_script_run q{sed -ie 's/^User daemon$/User wwwrun/' /tmp/prefork/httpd.conf};


### PR DESCRIPTION
The apache2 package in SLE 15 SP6 moved the default configuration to /usr/share/doc/packages/apache2/conf/httpd.conf.

- Related ticket: https://progress.opensuse.org/issues/157879
- Verification run: https://openqa.suse.de/tests/13880135
