### PR TITLE
x11/remote_desktop: make test more robust by using a more specific tag

### DIFF
--- a/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
@@ -104,7 +104,7 @@ sub run {
     send_key_until_needlematch('vncviewer-minimize', 'tab');
     release_key 'alt';
     assert_screen 'gnome-terminal-launched';
-    assert_and_click 'system-indicator';
+    assert_and_click 'vnc-system-indicator';
     assert_and_click 'user-logout-sector';
     assert_and_click 'logout-system';
     assert_screen 'logout-dialogue';


### PR DESCRIPTION
Sometimes the test fails because it does not log out the persistent vnc session.  Because it chooses the host 'system-indicator' instead of 'system-indicator' in vnc session.

So add a more specific tag 'vnc-system-indicator'.

- Related ticket: https://progress.opensuse.org/issues/158077
- Needles: added
- Verification run: 
https://openqa.suse.de/tests/13885281#step/persistent_vncsession_xvnc/51
