### PR TITLE
xfstests: fix install issue

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -781,20 +781,22 @@ elsif (get_var('XFSTESTS')) {
         loadtest 'kernel/change_kernel';
     }
     prepare_target;
-    if (get_var('XFSTESTS_INSTALL', 0) || check_var('XFSTESTS', 'installation') || is_pvm || check_var('ARCH', 's390x')) {
+    if (check_var('XFSTESTS_INSTALL', 1) || check_var('XFSTESTS', 'installation') || is_pvm || check_var('ARCH', 's390x')) {
         loadtest 'xfstests/install';
-    }
-    else {
-        set_var('NO_KDUMP', '1') if !get_var('NO_KDUMP');
-    }
-    unless (check_var('NO_KDUMP', '1')) {
-        loadtest 'xfstests/enable_kdump';
-    }
-    if (get_var('XFSTEST_KLP')) {
-        loadtest 'kernel/install_klp_product';
-    }
-    if (check_var('XFSTESTS', 'installation')) {
-        loadtest 'shutdown/shutdown';
+        unless (check_var('NO_KDUMP', '1')) {
+            loadtest 'xfstests/enable_kdump';
+        }
+        if (get_var('XFSTEST_KLP')) {
+            loadtest 'kernel/install_klp_product';
+        }
+        if (check_var('XFSTESTS', 'installation')) {
+            loadtest 'shutdown/shutdown';
+        }
+        else {
+            loadtest 'xfstests/partition';
+            loadtest 'xfstests/run';
+            loadtest 'xfstests/generate_report';
+        }
     }
     else {
         loadtest 'xfstests/partition';

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -90,6 +90,8 @@ sub collect_version {
 
 sub run {
     select_serial_terminal;
+    # Return if xfstests installed
+    script_run("zypper se -i xfstests") != 0 || return;
 
     # Disable PackageKit
     quit_packagekit;

--- a/variables.md
+++ b/variables.md
@@ -423,7 +423,7 @@ Variable        | Type      | Default value | Details
 XFSTESTS_REPO | string | | repo to install xfstests package
 DEPENDENCY_REPO | string | | ibs/obs repo to install related test package to solve dependency issues. e.g. fio
 XFSTESTS_DEVICE | string | | manually set a test disk for both TEST_DEV and SCRATCH_DEV
-XFSTESTS_INSTALL | boolean | 0 | Install xfstests and dependency package.
+XFSTESTS_INSTALL | boolean | false | Install xfstests and dependency package.
 
 
 Filesystem specific setting:


### PR DESCRIPTION
1. Check whether xfstests is installed before installation.
2. call the klp and kdump module after installation.

- Related ticket: https://progress.opensuse.org/issues/158074
- Needles: N/A
- Verification run:
http://10.67.133.133/tests/547 (create_hdd)
http://10.67.133.133/tests/548 (create_hdd-klp)
http://10.67.133.133/tests/546 (create_hdd-klp, skip install)
http://10.67.133.133/tests/559 (xfstests, install klp)
http://10.67.133.133/tests/552 (xfstests)
http://10.67.133.133/tests/556 (xfstests, install xfstests, install klp)
http://10.67.133.133/tests/554 (xfstests, install xfstests, install kdump)
https://openqa.suse.de/tests/13885755 (public cloud)