### PR TITLE
Fix dashboard broken issue in new version of grafana

### DIFF
--- a/tests/sles4sap/grafana_dashboards.pm
+++ b/tests/sles4sap/grafana_dashboards.pm
@@ -57,6 +57,15 @@ sub run {
     send_key 'tab';
     send_key 'ret';
     assert_and_click "grafana-home", timeout => $timeout;
+
+    # dashboards don't show in home webpage in new version
+    # of grafana, but in the left sidebar of grafana
+    wait_still_screen;
+    if (!check_screen('select_suse-dashboard')) {
+        assert_and_click "select_grafana_left_sidebar", timeout => $timeout;
+        assert_and_click "select_dashboard_in_left_sidebar", timeout => $timeout;
+    }
+
     assert_and_click "select_suse-dashboard", timeout => $timeout;
     assert_screen "check_suse-dashboard", $timeout;
 


### PR DESCRIPTION
the layout of dashboard has some changes on 15-SP6, this results in the case sles4sap_grafana_dashboards failed, this PR fixed the issue.

- Related ticket: https://jira.suse.com/browse/TEAM-8806
- Needles:
    https://openqa.suse.de/tests/13890881#step/grafana_dashboards/41
    https://openqa.suse.de/tests/13890881#step/grafana_dashboards/42
    https://openqa.suse.de/tests/13890881#step/grafana_dashboards/43
    https://openqa.suse.de/tests/13890881#step/grafana_dashboards/44
- Verification run: 
    https://openqa.suse.de/tests/13896909
    https://openqa.suse.de/tests/13896920
    https://openqa.suse.de/tests/13896925
