### PR TITLE
Remove the workaround for bsc1195133

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -289,11 +289,7 @@ sub run {
       "--logpath=$mountpts{hanalog}->{mountpt}/$sid",
       "--sapmnt=$mountpts{hanashared}->{mountpt}";
     push @hdblcm_args, "--pmempath=$pmempath", "--use_pmem" if get_var('NVDIMM');
-    # NOTE: Remove when SAP releases HANA with a fix for bsc#1195133
-    if (get_var('NVDIMM')) {
-        push @hdblcm_args, "--ignore=check_signature_file";
-        record_soft_failure("Workaround for bsc#1195133");
-    }
+
     my $cmd = join(' ', $hdblcm, @hdblcm_args);
     record_info 'hdblcm command', $cmd;
     assert_script_run $cmd, $tout;


### PR DESCRIPTION
bsc#1195133 is fixed, so we could remove this workaround.

Verification run:
https://openqa.suse.de/tests/13919147#
https://openqa.suse.de/tests/13919146#
https://openqa.suse.de/tests/13919145#
https://openqa.suse.de/tests/13919143#

