### PR TITLE
Add softfailure for bsc#1212825

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -66,7 +66,11 @@ sub basic_container_tests {
     validate_script_output("$runtime ps", qr/basic_test_container/);
     validate_script_output("$runtime container inspect --format='{{.State.Running}}' basic_test_container", qr/true/);
     assert_script_run("$runtime stop basic_test_container");
-    validate_script_output("$runtime ps", sub { $_ !~ m/basic_test_container/ });
+    if (script_output("$runtime ps") =~ m/basic_test_container/) {
+        record_soft_failure("bsc#1212825 race condition in docker/podman stop");
+        # We still expect the container to eventually stop
+        validate_script_output_retry("$runtime ps", sub { $_ !~ m/basic_test_container/ }, retry => 3, delay => 60);
+    }
     validate_script_output("$runtime container inspect --format='{{.State.Running}}' basic_test_container", qr/false/);
     assert_script_run("$runtime container start basic_test_container");
     validate_script_output("$runtime ps", qr/basic_test_container/);


### PR DESCRIPTION
Adds a conditional softfailure for bsc#1212825 where there is a race condition in docker/podman stop.

- Related failure: https://openqa.suse.de/tests/13886270#step/docker/133
- Verification run: [TW-podman](https://openqa.opensuse.org/tests/4045469) (unrelated failure) | [TW-docker](https://openqa.opensuse.org/tests/4045468)
