### PR TITLE
Enable rasdaemon on all architectures on Tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2534,7 +2534,7 @@ sub load_extra_tests_syscontainer {
 sub load_extra_tests_kernel {
     loadtest "kernel/tuned";
     loadtest "kernel/fwupd" if is_sle('15+');
-    loadtest "hpc/rasdaemon" if ((is_sle('15+') || is_tumbleweed) && (!is_ppc64le));
+    loadtest "hpc/rasdaemon" if ((is_sle('15+') && (!is_ppc64le)) || is_tumbleweed);
 
     # keep it on the latest place as it taints kernel
     loadtest "kernel/module_build";


### PR DESCRIPTION
Fix poo#158161: rasdaemon was disabled on ppc64le architecture on Tumbleweed because of bsc#1219917. Bug was fixed and we can enable test again.

- Related ticket: https://progress.opensuse.org/issues/158161
- Needles: none
- Verification run: 
TW x86_64: https://openqa.opensuse.org/tests/4045380   (test is included)
TW ppc64le: https://openqa.opensuse.org/tests/4045378 (test is included, installation passed, but failed at later stage)
SLE x86_64: https://openqa.suse.de/tests/13892393 (test is included)
SLE ppc64le:  https://openqa.suse.de/tests/13892392  (test excluded)