### PR TITLE
Fix expected login message for SL Micro

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -121,7 +121,7 @@ wait_serial(get_login_message(), 300);
 sub get_login_message {
     my $arch = get_required_var("ARCH");
     return is_sle() ? qr/Welcome to SUSE Linux Enterprise .*\($arch\)/
-      : is_sle_micro() ? qr/Welcome to SUSE Linux Enterprise Micro .*\($arch\)/
+      : is_sle_micro() ? qr/Welcome to SUSE Linux.* Micro .*\($arch\)/
       : is_leap() ? qr/Welcome to openSUSE Leap.*/
       : qr/Welcome to openSUSE Tumbleweed 20.*/;
 }


### PR DESCRIPTION
After the product rename from SLE Micro to SL Micro, some tests using svirt backend started to fail because the "Enterprise" is gone from the prompt and the name.

VRs:
6.0: https://openqa.suse.de/tests/13892579#step/boot_to_desktop/10
5.5: https://openqa.suse.de/tests/13892582#step/boot_to_desktop/10
(tests are stopped after this change takes effect and passing)

