### PR TITLE
Schedule libgit2 test

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -91,6 +91,12 @@ conditional_schedule:
                 - console/systemd_rpm_macros
                 - console/vsftpd
                 - console/year_2038_detection
+    libgit2:
+        ARCH:
+            x86_64:
+                - console/libgit2
+            aarch64:
+                - console/libgit2
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
@@ -167,5 +173,5 @@ schedule:
     - console/coredump_collect
     - console/valgrind
     - console/sssd_389ds_functional
-    - console/libgit2
+    - '{{libgit2}}'
     - console/zypper_log_packages


### PR DESCRIPTION
https://progress.opensuse.org/issues/157963
Run libgit2 test on x86_64 and aarch64

**There are some issues on s390x and ppc64le, see https://github.com/libgit2/libgit2/issues/6784**

- Verification run:
[s390x](http://openqa.suse.de/tests/13896881#)
[ppc64kle](http://openqa.suse.de/tests/13896883#)
[aarch64](http://openqa.suse.de/tests/13896995#)
[x86_64](http://openqa.suse.de/tests/13896998#)