### PR TITLE
Add some timeout for krb5 test

### DIFF
--- a/tests/console/krb5.pm
+++ b/tests/console/krb5.pm
@@ -15,6 +15,7 @@
 
 use base 'consoletest';
 use utils qw(zypper_call systemctl);
+use Utils::Architectures 'is_aarch64';
 use strict;
 use serial_terminal;
 use warnings;
@@ -25,6 +26,11 @@ sub logout_and_verify_shell_availability {
     script_run 'logout', 0;
     # verify shell is ready with simple command
     wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
+    # re-connecct serial console on aarch64, see poo#157960
+    if (is_aarch64) {
+        sleep 3;
+        select_serial_terminal;
+    }
 }
 
 sub run {


### PR DESCRIPTION
https://progress.opensuse.org/issues/157960

- Verification run: [sle-aarch64](http://openqa.suse.de/tests/overview?build=rfan0328_krb5_timeout_fix&version=15-SP5&distri=sle)