### PR TITLE
Add support for SL Micro to add_custom_grub_entries

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -123,8 +123,11 @@ sub add_custom_grub_entries {
     elsif (is_alp()) {
         $distro = "ALP";
     }
-    elsif (is_sle_micro()) {
+    elsif (is_sle_micro('<6.0')) {
         $distro = "SLE Micro";
+    }
+    elsif (is_sle_micro()) {
+        $distro = "SL Micro";
     }
     elsif (check_var('SLE_PRODUCT', 'slert')) {
         $distro = "SLE_RT" . ' \\?' . get_required_var('VERSION');


### PR DESCRIPTION
Fix poo#158203: SLE Micro 6.0 was renamed to SL Micro. We need to make difference for is_sle_micro by version.

- Related ticket: https://progress.opensuse.org/issues/158203
- Needles: none
- Verification run: 

SL Micro: https://openqa.suse.de/tests/13897597
SLE Micro 5.5: https://openqa.suse.de/tests/13897610#
