### PR TITLE
Make sure pressing alt-i at the right time when starting installation

### DIFF
--- a/tests/installation/disable_kdump.pm
+++ b/tests/installation/disable_kdump.pm
@@ -42,6 +42,9 @@ sub run {
     save_screenshot;
     send_key $cmd{ok};
 
+    # avoid matching "installation-settings-overview-loaded" tag in advance
+    wait_still_screen(3);
+
     # Adapting system setting needs longer time in case of installing/upgrading with multi-addons
     assert_screen 'installation-settings-overview-loaded', 220;
 }


### PR DESCRIPTION
installation conformation dialog didn't pop up after pressing alt-i, this resulted in matching needle timeout, this PR fixed this issue or at least reduce the frequency of this issue

- Related ticket: https://jira.suse.com/browse/TEAM-9210
- Needles: N/A
- Verification run:
    https://openqa.suse.de/tests/13907188
    https://openqa.suse.de/tests/13907189
