### PR TITLE
Libvirt in modular mode on 15-SP5

### DIFF
--- a/tests/security/cc/audit_remote_libvirt.pm
+++ b/tests/security/cc/audit_remote_libvirt.pm
@@ -14,7 +14,7 @@ use testapi;
 use utils;
 use audit_test qw(run_testcase compare_run_log);
 use version_utils 'is_sle';
-use virt_autotest::utils 'check_modular_libvirt_daemons';
+use virt_autotest::utils qw(check_modular_libvirt_daemons restart_modular_libvirt_daemons);
 
 sub run {
     my ($self) = shift;
@@ -26,13 +26,17 @@ sub run {
     zypper_call('in libvirt virt-manager');
 
     # Start libvirtd daemon and start the default libvirt network
-    assert_script_run('systemctl start libvirtd');
+    if (is_sle('15-sp5+')) {
+        assert_script_run('systemctl daemon-reload');
+        restart_modular_libvirt_daemons;
+    } else {
+        assert_script_run('systemctl start libvirtd');
+    }
     assert_script_run('virsh net-define /etc/libvirt/qemu/networks/default.xml');
     assert_script_run('virsh net-start default');
-    is_sle('15-sp6+') ?
+    is_sle('15-sp5+') ?
       check_modular_libvirt_daemons('qemu') :    # when system uses modular libvirt daemons
       assert_script_run('systemctl is-active libvirtd');    # when system uses monolithic libvirt daemons
-    assert_script_run('virsh net-list | grep default | grep active');
 
     # Download the pre-installed guest images and sample xml files
     my $vm_name = 'nested-L2-vm';


### PR DESCRIPTION
Modular mode libvirt check has been done by @jknphy in #18110. This simply changes the check to cover 15-SP5 as well.

- Related ticket: https://progress.opensuse.org/issues/156658
- Verification run: https://openqa.suse.de/tests/13924430

The VR has failed, but due to a different issue. It is passing the point which is fixed by this PR when compared to the old run: https://openqa.suse.de/tests/13817297#step/audit_remote_libvirt/10
