### PR TITLE
Remove ltss from addons in check_system_info after migration

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -113,6 +113,7 @@ sub run {
 
         # For hpc, system doesn't include legacy module
         $myaddons =~ s/lgm,?//g if (get_var("SCC_ADDONS", "") =~ /hpcm/);
+        $myaddons =~ s/ltss,?//g;
         check_addons($myaddons);
         check_product("after");
         check_buildid;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/157831
- Verification runs : https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=80.1&groupid=527