### PR TITLE
Increase hana_cluster hdbsql timed out value to 900

### DIFF
--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -53,7 +53,7 @@ sub run {
             add_to_known_hosts($_);
         }
         assert_script_run "scp -qr /usr/sap/$sid/SYS/global/security/rsecssfs/* root\@$node2:/usr/sap/$sid/SYS/global/security/rsecssfs/";
-        assert_script_run qq(su - $sapadm -c "hdbsql -u system -p $sles4sap::instance_password -i $instance_id -d SYSTEMDB \\"BACKUP DATA FOR FULL SYSTEM USING FILE ('backup')\\""), 300;
+        assert_script_run qq(su - $sapadm -c "hdbsql -u system -p $sles4sap::instance_password -i $instance_id -d SYSTEMDB \\"BACKUP DATA FOR FULL SYSTEM USING FILE ('backup')\\""), 900;
         assert_script_run "su - $sapadm -c 'hdbnsutil -sr_enable --name=$node1'";
 
         # Synchronize the nodes


### PR DESCRIPTION
Increase test module "hana_cluster" command "hdbsql" timed out value to 900 

TEAM-9013 - [15sp6][SLES for SAP Applications] SAPHanaSR_ScaleUp_PerfOpt_WMP failed on hana_cluster: hdbsql timed out


- Related ticket: https://jira.suse.com/browse/TEAM-9013
- Needles: NA
- Verification run:
http://openqa.suse.de/tests/13906708#step/hana_cluster/43 (hdbsql succeeded, new failures are other issues)
  (0 rows affected (overall time 244.922078 sec; server time 244.921632 sec))
https://openqa.suse.de/tests/13906831#step/hana_cluster/43 (hdbsql succeeded, new failures are other issues)
  (0 rows affected (overall time 516.465933 sec; server time 516.465597 sec))