### PR TITLE
Add default schedule for s390x kvm on textmode

### DIFF
--- a/schedule/yast/sle/flows/default_s390x_kvm_textmode.yaml
+++ b/schedule/yast/sle/flows/default_s390x_kvm_textmode.yaml
@@ -1,0 +1,54 @@
+---
+# Default ordered sequence of steps to be optionally overwritten for s390x kvm on textmode
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+access_beta:
+  - installation/access_beta_distribution
+license_agreement:
+  - installation/licensing/accept_license
+registration:
+  - installation/registration/register_via_scc
+extension_module_selection:
+  - installation/module_registration/skip_module_registration
+add_on_product:
+  - installation/add_on_product/skip_install_addons
+system_role:
+  - installation/system_role/accept_selected_role_text_mode
+guided_partitioning: []
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+security: []
+default_systemd_target: []
+installation_settings:
+  - installation/installation_settings/validate_ssh_service_enabled
+  - installation/installation_settings/open_ssh_port
+installation:
+  - installation/launch_installation
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+stop_timeout_system_reboot: []
+installation_logs:
+  - installation/logs_from_installation_system
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+reconnect_svirt:
+  - installation/performing_installation/reconnect_after_reboot
+grub:
+  - installation/handle_reboot
+first_login:
+  - installation/first_boot
+system_preparation:
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+system_validation: []


### PR DESCRIPTION
Do not use 'stop_timeout_system_reboot_now' in default schedule for s390x kvm on textmode.

- Related ticket: https://progress.opensuse.org/issues/157936
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/131
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/13906725#step/system_prepare/3 (now failed for bsc#1221005)
