### PR TITLE
console: Add upstream ZFS tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1832,6 +1832,8 @@ sub load_extra_tests_himmelblau {
 }
 
 sub load_extra_tests_filesystem {
+    loadtest "console/zfs";
+    return;
     loadtest "console/lsof";
     loadtest "console/autofs";
     loadtest 'console/lvm';

--- a/tests/console/zfs.pm
+++ b/tests/console/zfs.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2023 SUSE LLC
+# Copyright 2023-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: zfs util-linux
@@ -13,14 +13,15 @@
 # - Test .zfs/snapshot for correct snapshots
 # - Test snapshot transfer (tank->dozer)
 # - Test if the module and filesystems survive a reboot
-# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+# - Run upstream ZFS tests
+# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de> & Ricardo Branco <rbranco@suse.de>
 
 use Mojo::Base 'consoletest';
 use testapi;
 use utils;
 use version_utils;
 use power_action_utils 'power_action';
-use serial_terminal 'select_serial_terminal';
+use serial_terminal;
 
 my $disksize = "100M";    # Size of the test disks
 
@@ -126,6 +127,29 @@ sub reboot {
     power_action('reboot', textmode => 1);
     $self->wait_boot(bootloader_time => 300);
     select_serial_terminal();
+}
+
+sub upstream_tests {
+    my @patterns = qw(devel_C_C++ devel_rpm_build);
+    my @pkgs = qw(kernel-devel ksh libattr-devel libffi-devel libudev-devel ncompress openssl-3-devel python3-cffi python3-devel zfs-devel);
+
+    zypper_call "install -t pattern " . join(" ", @patterns);
+    zypper_call "install . " . join(" ", @pkgs);
+
+    my $version = script_output "rpm -q --queryformat '%{VERSION}' zfs";
+    script_retry("curl -sL https://github.com/openzfs/zfs/releases/download/zfs-$version/zfs-$version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
+    assert_script_run "cd zfs-$version";
+    assert_script_run "./configure", timeout => 300;
+    assert_script_run "make pkg-utils", timeout => 300;
+    zypper_call "install zfs-test-*.rpm";
+
+    my $user = $testapi::username;
+    assert_script_run "echo '$user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/50-$user";
+
+    select_user_serial_terminal;
+
+    script_run "/usr/share/zfs/zfs-tests.sh -v | tee /var/tmp/zfs-test.txt", timeout => 12000;
+    upload_logs "/var/tmp/zfs-test.txt";
 }
 
 sub run {
@@ -301,6 +325,8 @@ sub run {
     assert_script_run('! stat /tank/Big_Buck_Bunny_8_seconds_bird_clip.ogv');
     # Celebrate successful test run :-)
     script_run("echo -e 'Congarts! zfs test completed sucessfully\n.~~~~.\ni====i_\n|cccc|_)\n|cccc|   hjw\n -==-'");
+
+    $self->upstream_tests;
 }
 
 sub post_fail_hook {

--- a/tests/console/zfs.pm
+++ b/tests/console/zfs.pm
@@ -156,16 +156,6 @@ sub run {
     my $self = shift;
     select_serial_terminal();
 
-    if (!is_sle()) {
-        record_info 'grub2 zfs', 'ensure that zfs in grub2 is not available on SLE but on openSUSE';
-        my @bootloader_rpms = split(/\n/, script_output("zypper se 'grub2-' | grep 'Bootloader with support' | grep '^i' | awk '{print \$3}'"));
-        for my $rpm (@bootloader_rpms) {
-            assert_script_run("rpm -ql $rpm | grep zfs ; test \"\$?\" == \"1\"");
-            zypper_call "in $rpm-extras";
-            assert_script_run("rpm -ql $rpm-extras | grep zfs");
-        }
-    }
-
     return unless (install_zfs());    # Possible softfailure if module is not yet available (e.g. new Leap version)
     my $additional = "";
     $additional = "--allow-unsupported" if (is_sle);


### PR DESCRIPTION
Add upstream ZFS tests

NOTE: This needs QEMURAM to be set to 8G.

TODO:
- Use -s option to specify smaller (vdev): `	-s SIZE     Use vdevs of SIZE (default: 4G)`
