### PR TITLE
xfstests: Fix a minor issue in generate_report

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -31,7 +31,7 @@ my $JUNIT_FILE = '/opt/output.xml';
 
 sub log_end {
     my $file = shift;
-    my $cmd = "echo '\nTest run complete' >> $file";
+    my $cmd = "echo 'Test run complete' >> $file";
     send_key 'ret';
     script_run($cmd, proceed_on_failure => 1);
 }


### PR DESCRIPTION
The generate_report part has a minor issue could see in web result https://openqa.suse.de/tests/13918278#step/generate_report/13

- Related ticket: https://progress.opensuse.org/issues/158083
- Verification run: 
- SLE https://openqa.suse.de/tests/13919118
- Public cloud https://openqa.suse.de/tests/13919167