### PR TITLE
Configuring Dynamic IOMMU Settings for KVM Boot Parameters

### DIFF
--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -99,7 +99,7 @@
       <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200</xen_append>
       <xen_kernel_append><%= $check_var->('IPMI_HW', 'AMD') ? "" : "dom0_max_vcpus=4 dom0_mem=8192M,max:8192M" %> vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
       % } else {
-      <append>splash=silent</append>
+      <append>splash=silent <%= $check_var->('IPMI_HW', 'AMD') ? "" : "intel_iommu=on" %></append>
       % }
     </global>
     <loader_type>grub2</loader_type>


### PR DESCRIPTION
Progress ticket: https://progress.opensuse.org/issues/157954

1. IOMMU Enabled by Default: The iommu=on setting is activated by default, negating the need for manual kernel parameter adjustments for IOMMU support.

2. Specific Requirement for Intel Machines: For KVM virtualization on systems, only intel_iommu=on is explicitly required to enable IOMMU functionality for Intel-based systems. This adjustment reflects a focus on Intel hardware, with amd_iommu=on no longer needed in this context on AMD CPU system. The requirement to explicitly set IOMMU functionality does not apply to Xen environments.

3. SR-IOV Testing Considerations: The parameter iommu=on is removed from SLE12SP5 due to the absence of SR-IOV testing. In contrast, for SLE15, where SR-IOV tests are performed, the parameter intel_iommu=on is essential and should not be removed for KVM configurations, ensuring compatibility and optimal performance.


- Related ticket: https://progress.opensuse.org/issues/157954
- Needles: N/A
- Verification run: [KVM on sles15(INTEL CPU)](http://openqa.qam.suse.cz/tests/overview?distri=sle&version=15-SP4&build=sriov:verify:iommu:kvm), [XEN on sles15(INTEL CPU)](http://openqa.qam.suse.cz/tests/overview?distri=sle&version=15-SP3&build=sriov:verify:iommu:xen),[KVM on sles15(AMD CPU)](http://openqa.qam.suse.cz/tests/70848)
