### PR TITLE
HPC: Move imb tests from mpi_master to specific pm test module

### DIFF
--- a/schedule/hpc/multi_machine_test.yaml
+++ b/schedule/hpc/multi_machine_test.yaml
@@ -15,6 +15,10 @@ conditional_schedule:
     ARCH:
       x86_64:
         - hpc/cpuid
+  scientific_libs:
+    IMB:
+      RUN:
+        - hpc/mpi_imb
   hpctest:
     HPC:
       slurm_master:
@@ -29,6 +33,7 @@ conditional_schedule:
         - hpc/slurm_master_backup_db
       mpi_master:
         - hpc/mpi_master
+        - '{{scientific_libs}}'
       mpi_slave:
         - hpc/mpi_slave
       ganglia_server:

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -61,7 +61,9 @@ sub run ($self) {
         barrier_create('MPI_SETUP_READY', $nodes);
         barrier_create('MPI_BINARIES_READY', $nodes);
         barrier_create('MPI_RUN_TEST', $nodes);
-        barrier_create('IMB_TEST_DONE', $nodes);
+        if (check_var('IMB', 'RUN')) {
+            barrier_create('IMB_TEST_DONE', $nodes);
+        }
     }
     elsif (check_var('HPC', 'ww4_controller')) {
         barrier_create('WWCTL_READY', $nodes);

--- a/tests/hpc/mpi_imb.pm
+++ b/tests/hpc/mpi_imb.pm
@@ -1,0 +1,95 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Basic MPI integration test using IMB.
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use Mojo::Base qw(hpcbase hpc::utils), -signatures;
+use testapi;
+use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
+use lockapi;
+use utils;
+use registration;
+use version_utils 'is_sle';
+use Utils::Logging 'export_logs';
+use isotovideo;
+
+use POSIX 'strftime';
+
+sub run ($self) {
+    select_serial_terminal();
+    my $mpi = get_required_var('MPI');
+    my $mpi2load = '';
+    my %exports_path = (
+        bin => '/home/bernhard/bin',
+        hpc_lib => '/usr/lib/hpc',
+    );
+    my $user_virtio_fixed = isotovideo::get_version() >= 35;
+    my $prompt = $user_virtio_fixed ? $testapi::username . '@' . get_required_var('HOSTNAME') . ':~> ' : undef;
+
+    script_run("sudo -u $testapi::username mkdir -p $exports_path{bin}");
+    zypper_call("in imb-gnu-$mpi-hpc");
+
+    type_string('pkill -u root', lf => 1) unless $user_virtio_fixed;
+    select_user_serial_terminal($prompt);
+    # module load for openmpi2,3 and4 uses 'openmpi' without its version
+    $mpi2load = ($mpi =~ /openmpi2|openmpi3|openmpi4/) ? 'openmpi' : $mpi;
+
+    $self->check_nodes_availability();
+
+    # And login as normal user to run the tests
+    # NOTE: This behaves weird. Need another solution apparently
+    type_string('pkill -u root') unless $user_virtio_fixed;
+    select_user_serial_terminal($prompt);
+    # load mpi after all the relogins
+    my @load_modules = $mpi2load;
+    assert_script_run("module load gnu @load_modules");
+    script_run("module av");
+
+    my $imb_version = script_output("rpm -q --queryformat '%{VERSION}' imb-gnu-$mpi-hpc");
+    record_info('testing IMB', 'Run all IMB-MPI1 components');
+    # Run IMB-MPI1 without args to run the whole set of testings. Mind the timeout if you do so
+    assert_script_run("mpirun -np 4 /usr/lib/hpc/gnu7/$mpi/imb/$imb_version/bin/IMB-MPI1 PingPong");
+    barrier_wait('IMB_TEST_DONE');
+}
+
+sub test_flags ($self) {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook ($self) {
+    $self->destroy_test_barriers();
+    export_logs();
+}
+
+1;
+
+=head1 Variables explanation
+
+=over
+=item $mpi
+Stores the MPI implementation. This is usually whatever MPI job variable is
+given
+
+=item %exports_path
+Holds the common paths which nodes locate libraries and source code.
+
+=item $user_virtio_fixed
+A boolean which determines whether isotovideo can set user console prompt or
+not
+
+=item $prompt
+Used by C<select_user_serial_terminal> to get a user terminal
+
+=item $mpi2load
+differentiates the openmpi name to be used in lmod loading. C<lmod> can load
+only one mpi. In case of openmpi2, openmpi3, openmpi4 which is stored in C<mpi>,
+it takes their place as all are found as I<openmpi>
+
+=item $imb_version
+Stores the version of the imb installed package. It is used to determine the
+path in the L<lib|/usr/lib/hpc/gnu7/$mpi/imb> which the bins are located.
+
+=cut

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -37,7 +37,7 @@ sub run ($self) {
     my $prompt = $user_virtio_fixed ? $testapi::username . '@' . get_required_var('HOSTNAME') . ':~> ' : undef;
 
     script_run("sudo -u $testapi::username mkdir -p $exports_path{bin}");
-    zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel imb-gnu-$mpi-hpc");
+    zypper_call("in $mpi-gnu-hpc $mpi-gnu-hpc-devel");
 
     my $need_restart = $self->setup_scientific_module();
     $self->relogin_root if $need_restart;
@@ -144,32 +144,6 @@ sub run ($self) {
     }
     barrier_wait('MPI_RUN_TEST');
     record_info 'MPI_RUN_TEST', strftime("\%H:\%M:\%S", localtime);
-
-    my $imb_version = script_output("rpm -q --queryformat '%{VERSION}' imb-gnu-$mpi-hpc");
-
-    if ($mpi eq 'mvapich2') {
-        my $return = script_run("set -o pipefail; mpirun -np 4 /usr/lib/hpc/gnu7/$mpi/imb/$imb_version/bin/IMB-MPI1 PingPong |& tee /tmp/mpi_bin.log", timeout => 120);
-        if ($return == 136) {
-            if (script_run('grep \'Caught error: Floating point exception (signal 8)\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1175679 Floating point exception should be fixed on mvapich2/2.3.4');
-            }
-        } elsif ($return == 1 || $return == 139 || $return == 255) {
-            if (script_run('grep \'Caught error: Segmentation fault (signal 11)\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1144000 MVAPICH2: segfault while executing without ib_uverbs loaded');
-            } elsif (script_run('grep \'failure occurred while posting a receive for message data\' /tmp/mpi_bin.log') == 0) {
-                record_soft_failure('bsc#1209130 MPI Benchmarks unable to run on 15SP1 with imb-gnu-mvapich2-hpc');
-            }
-        } else {
-            ##TODO: consider more robust handling of various errors
-            die("echo $return - not expected errorcode") unless $return == 0;
-        }
-    } else {
-        record_info 'testing IMB', 'Run all IMB-MPI1 components';
-        # Run IMB-MPI1 without args to run the whole set of testings. Mind the timeout if you do so
-        assert_script_run("mpirun -np 4 /usr/lib/hpc/gnu7/$mpi/imb/$imb_version/bin/IMB-MPI1 PingPong");
-    }
-    barrier_wait('IMB_TEST_DONE');
-    record_info 'IMB_TEST_DONE', strftime("\%H:\%M:\%S", localtime);
 }
 
 sub test_flags ($self) {

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -31,8 +31,9 @@ sub run ($self) {
     record_info 'MPI_BINARIES_READY', strftime("\%H:\%M:\%S", localtime);
     barrier_wait('MPI_RUN_TEST');
     record_info 'MPI_RUN_TEST', strftime("\%H:\%M:\%S", localtime);
-    barrier_wait('IMB_TEST_DONE');
-    record_info 'IMB_TEST_DONE', strftime("\%H:\%M:\%S", localtime);
+    if (check_var('IMB', 'RUN')) {
+        barrier_wait('IMB_TEST_DONE');
+    }
 }
 
 sub test_flags ($self) {


### PR DESCRIPTION
The idea is to use scheduler to load required test modules based on specific test variables. In such case the barriers for scientific libs should be conditional

- Related ticket: https://progress.opensuse.org/issues/126842
- Verification run:

SLE15sp6: openmpi, no IMB test:
https://openqa.suse.de/tests/13919390
https://openqa.suse.de/tests/13919391
https://openqa.suse.de/tests/13919389
https://openqa.suse.de/tests/13919392

sle15sp6: openmpi, with IMB test:
https://openqa.suse.de/tests/13919413
https://openqa.suse.de/tests/13919412
https://openqa.suse.de/tests/13919414
https://openqa.suse.de/tests/13919411

sle15sp6: mpich, no IMB test:
https://openqa.suse.de/tests/13919464
https://openqa.suse.de/tests/13919461
https://openqa.suse.de/tests/13919463
https://openqa.suse.de/tests/13919462

sle15sp6: mpich, with IMB test:
https://openqa.suse.de/tests/13919468
https://openqa.suse.de/tests/13919466
https://openqa.suse.de/tests/13919467
https://openqa.suse.de/tests/13919465

sle15sp6: mvapich2, no IMB test:
https://openqa.suse.de/tests/13919531
https://openqa.suse.de/tests/13919530
https://openqa.suse.de/tests/13919532
https://openqa.suse.de/tests/13919529

sle15sp6: mvapich2, with IMB test:
https://openqa.suse.de/tests/13919534
https://openqa.suse.de/tests/13919535
https://openqa.suse.de/tests/13919533
https://openqa.suse.de/tests/13919536
