### PR TITLE
Set default xen boot for virt sle12 xen tests with autoyast installation

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -282,7 +282,7 @@
     </user>
   </users>
   <scripts>
-    <post-scripts config:type="list">
+    <init-scripts config:type="list">
       % if ($check_var->('SYSTEM_ROLE', 'xen') && $check_var->('XEN_DEFAULT_BOOT_IS_SET', 1)) {
       <script>
         <filename>default_xen_boot.sh</filename>
@@ -294,6 +294,6 @@ grub2-set-default 2
       </script>
       % }
       <script/>
-    </post-scripts>
+    </init-scripts>
   </scripts>
 </profile>


### PR DESCRIPTION
SLE 12-SP5 autoyast host installation does not use second stage due to product bug bsc#1216859. XEN_DEFAULT_BOOT_IS_SET=1 does not take effect, for example, [failure 1](https://openqa.suse.de/tests/13919059#step/login_console/29), [2](https://openqa.suse.de/tests/13913446#step/login_console/29) and [3](https://openqa.suse.de/tests/13919109#step/login_console/29).

- Related ticket: https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/178
Verification run: 
[sle12sp5 xen on my indevidual openqa](http://10.67.129.27/tests/336)
[on OSD](http://openqa.suse.de/tests/13924074)
