### PR TITLE
Disable Qt6 devel toolkit package tests on sles

### DIFF
--- a/tests/x11/toolkits/prepare.pm
+++ b/tests/x11/toolkits/prepare.pm
@@ -17,8 +17,11 @@ use registration qw(add_suseconnect_product register_product);
 sub run {
     select_console 'root-console';
 
+    my $qt5_devel = 'libQt5Core-devel libQt5Gui-devel libQt5Widgets-devel';
+    my $qt6_devel = 'qt6-core-devel qt6-gui-devel qt6-widgets-devel';    # devel packages for Qt6 are not L3 supported in SLES
+
     if (is_sle) {
-        # enable sdk
+        $qt6_devel = '';    # devel packages for Qt6 are not L3 supported in SLES - See https://bugzilla.suse.com/show_bug.cgi?id=1217337
         assert_script_run 'source /etc/os-release';
         if (get_var 'ADDONURL_SDK') {
             zypper_call('ar ' . get_var('ADDONURL_SDK') . ' sdk-repo');
@@ -34,10 +37,7 @@ sub run {
         }
     }
 
-    my $qt5_devel = 'libQt5Core-devel libQt5Gui-devel libQt5Widgets-devel';
-    my $qt6_devel = 'qt6-core-devel qt6-gui-devel qt6-widgets-devel';
-
-    zypper_call "in gcc gcc-c++ tcl tk xmessage fltk-devel motif-devel gtk2-devel gtk3-devel gtk4-devel java java-devel $qt5_devel $qt6_devel";
+    zypper_call "in gcc gcc-c++ tcl tk xmessage fltk-devel motif-devel gtk3-devel gtk3-devel gtk4-devel java java-devel $qt5_devel $qt6_devel";
 
     if (is_opensuse) {
         # make sure to use latest java (that matches the java compiler that was just installed)

--- a/tests/x11/toolkits/qt6.pm
+++ b/tests/x11/toolkits/qt6.pm
@@ -9,11 +9,17 @@
 use base 'x11test';
 use strict;
 use warnings;
+use version_utils 'is_sle';
 use testapi;
 
 sub run {
-    select_console 'x11';
 
+    if (is_sle) {
+        record_info 'Qt6', 'Qt6 is not available on SLE';
+        return;
+    }
+
+    select_console 'x11';
     x11_start_program('xterm');
     assert_script_run 'cd data/toolkits';
 


### PR DESCRIPTION
Since for qt6 there's no L3 support on SLE disable its testing except for openSUSE

- Don't install qt6 devel on sles packages as they are not supported
- Exit early if is SLE as per PED-7127

VR: https://openqa.suse.de/tests/13924395#live