### PR TITLE
Switch CC installation test from autoyast to libyui

### DIFF
--- a/lib/Distribution/Sle/15_current.pm
+++ b/lib/Distribution/Sle/15_current.pm
@@ -31,6 +31,7 @@ use Installation::ModuleRegistration::SeparateRegCodesController;
 use YaST::DNSServer::Sle::DNSServerController;
 use YaST::DNSServer::Sle::DNSServerSetupController;
 use Installation::NTPConfiguration::NTPConfigurationPage;
+use Installation::CommonCriteriaConfiguration::CommonCriteriaConfigurationController;
 
 =head2 get_license_agreement
 
@@ -101,6 +102,10 @@ sub get_dns_server_setup {
 
 sub get_ntp_configuration {
     return Installation::NTPConfiguration::NTPConfigurationPage->new();
+}
+
+sub get_common_criteria_configuration {
+    return Installation::CommonCriteriaConfiguration::CommonCriteriaConfigurationController->new();
 }
 
 1;

--- a/lib/Installation/CommonCriteriaConfiguration/CommonCriteriaConfigurationController.pm
+++ b/lib/Installation/CommonCriteriaConfiguration/CommonCriteriaConfigurationController.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This class introduces business actions for Common Criteria page
+#          using YuiRestClient.
+#
+# Maintainer: QE Security <none@suse.de>
+
+package Installation::CommonCriteriaConfiguration::CommonCriteriaConfigurationController;
+use strict;
+use warnings;
+use Installation::CommonCriteriaConfiguration::CommonCriteriaConfigurationPage;
+use Installation::Popups::YesNoPopup;
+use YuiRestClient;
+
+=head1 PARTITIONING_SCHEME
+
+=head2 SYNOPSIS
+
+The class introduces business actions for Common Criteria screen using REST API.
+
+=cut
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {}, $class;
+    return $self->init($args);
+}
+
+sub init {
+    my ($self, $args) = @_;
+    $self->{CommonCriteriaConfigurationPage} = Installation::CommonCriteriaConfiguration::CommonCriteriaConfigurationPage->new({app => YuiRestClient::get_app()});
+    $self->{WeakPasswordPopup} = Installation::Popups::YesNoPopup->new({app => YuiRestClient::get_app()});
+    return $self;
+}
+
+sub get_common_criteria_configuration_page {
+    my ($self) = @_;
+    die "Common Criteria configuration page is not displayed" unless $self->{CommonCriteriaConfigurationPage}->is_shown();
+    return $self->{CommonCriteriaConfigurationPage};
+}
+
+sub get_weak_password_warning {
+    my ($self) = @_;
+    die "Popup for too simple password is not displayed" unless $self->{WeakPasswordPopup}->is_shown();
+    return $self->{WeakPasswordPopup};
+}
+
+sub configure_encryption {
+    my ($self, $password) = @_;
+    $self->get_common_criteria_configuration_page()->enter_password($password);
+    $self->get_common_criteria_configuration_page()->enter_confirm_password($password);
+}
+
+sub go_forward {
+    my ($self, $args) = @_;
+    $self->get_common_criteria_configuration_page()->press_next();
+}
+
+1;

--- a/lib/Installation/CommonCriteriaConfiguration/CommonCriteriaConfigurationPage.pm
+++ b/lib/Installation/CommonCriteriaConfiguration/CommonCriteriaConfigurationPage.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: This class introduces methods to handle Common Criteria setup page.
+#
+# Maintainer: QE Security <none@suse.de>
+
+package Installation::CommonCriteriaConfiguration::CommonCriteriaConfigurationPage;
+use parent 'Installation::Navigation::NavigationBase';
+use strict;
+use warnings;
+
+sub init {
+    my $self = shift;
+    $self->SUPER::init();
+    $self->{txb_password} = $self->{app}->textbox({id => 'passphrase'});
+    $self->{txb_repeat_password} = $self->{app}->textbox({id => 'repeat_passphrase'});
+    return $self;
+}
+
+sub enter_password {
+    my ($self, $password) = @_;
+    return $self->{txb_password}->set($password);
+}
+
+sub enter_confirm_password {
+    my ($self, $password) = @_;
+    return $self->{txb_repeat_password}->set($password);
+}
+
+sub is_shown {
+    my ($self) = @_;
+    return $self->{txb_password}->exist();
+}
+
+1;

--- a/lib/Installation/SystemRole/Sle/SystemRoleController.pm
+++ b/lib/Installation/SystemRole/Sle/SystemRoleController.pm
@@ -21,7 +21,8 @@ sub init {
         text_mode => 'Text Mode',
         minimal => 'Minimal',
         transactional_server => 'Transactional Server',
-        HA_node => 'HA node'
+        HA_node => 'HA node',
+        common_criteria => 'Common Criteria evaluated configuration'
     };
     return $self;
 }

--- a/lib/Installation/SystemRole/SystemRoleController.pm
+++ b/lib/Installation/SystemRole/SystemRoleController.pm
@@ -29,7 +29,8 @@ sub init {
         desktop_with_Xfce => 'Desktop with Xfce',
         generic_desktop => 'Generic Desktop',
         server => 'Server',
-        transactional_server => 'Transactional Server'
+        transactional_server => 'Transactional Server',
+        common_criteria => 'Common Criteria evaluated configuration'
     };
     return $self;
 }

--- a/schedule/security/create_hdd_cc_libyui/cc.yaml
+++ b/schedule/security/create_hdd_cc_libyui/cc.yaml
@@ -1,0 +1,21 @@
+name: create_hdd_common_criteria
+description: >
+  Installation using the Common Criteria role and full disk
+  encryption on beta SLES.
+schedule:
+  system_role:
+    - installation/system_role/select_common_criteria_role
+    - installation/common_criteria_configuration/common_criteria_encryption_pwd
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - security/cc/ensure_crypto_checks_enabled
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/security/create_hdd_cc_libyui/cc_qr.yaml
+++ b/schedule/security/create_hdd_cc_libyui/cc_qr.yaml
@@ -1,0 +1,25 @@
+---
+name: create_hdd_common_criteria
+description: >
+  Installation using the Common Criteria role and full disk
+  encryption on QR SLES.
+schedule:
+  access_beta: []
+  product_selection:
+    - installation/product_selection/install_SLES
+  system_role:
+    - installation/system_role/select_common_criteria_role
+    - installation/common_criteria_configuration/common_criteria_encryption_pwd
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - security/cc/ensure_crypto_checks_enabled
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/security/create_hdd_cc_libyui/cc_qr_aarch64.yaml
+++ b/schedule/security/create_hdd_cc_libyui/cc_qr_aarch64.yaml
@@ -1,0 +1,25 @@
+---
+name: create_hdd_common_criteria
+description: >
+  Installation using the Common Criteria role and full disk
+  encryption on QR SLES.
+schedule:
+  access_beta: []
+  product_selection:
+    - installation/product_selection/install_SLES
+  system_role:
+    - installation/system_role/select_common_criteria_role
+    - installation/common_criteria_configuration/common_criteria_encryption_pwd
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  first_login:
+    - security/boot_encrypt_no_video_present
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - security/cc/ensure_crypto_checks_enabled
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/security/create_hdd_cc_libyui/cc_qr_s390x.yaml
+++ b/schedule/security/create_hdd_cc_libyui/cc_qr_s390x.yaml
@@ -1,0 +1,24 @@
+---
+name: create_hdd_common_criteria
+description: >
+  Installation using the Common Criteria role and full disk
+  encryption on QR SLES.
+schedule:
+  access_beta: []
+  system_role:
+    - installation/system_role/select_common_criteria_role
+    - installation/common_criteria_configuration/common_criteria_encryption_pwd
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  grub:
+    - installation/boot_encrypt
+    - installation/handle_reboot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - security/cc/ensure_crypto_checks_enabled
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown
+    - shutdown/svirt_upload_assets

--- a/schedule/security/create_hdd_cc_libyui/cc_qr_x86_64.yaml
+++ b/schedule/security/create_hdd_cc_libyui/cc_qr_x86_64.yaml
@@ -1,0 +1,25 @@
+---
+name: create_hdd_common_criteria
+description: >
+  Installation using the Common Criteria role and full disk
+  encryption on QR SLES.
+schedule:
+  access_beta: []
+  product_selection:
+    - installation/product_selection/install_SLES
+  system_role:
+    - installation/system_role/select_common_criteria_role
+    - installation/common_criteria_configuration/common_criteria_encryption_pwd
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  first_login:
+    - installation/boot_encrypt
+    - installation/first_boot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - security/cc/ensure_crypto_checks_enabled
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/security/create_hdd_cc_libyui/cc_s390x.yaml
+++ b/schedule/security/create_hdd_cc_libyui/cc_s390x.yaml
@@ -1,0 +1,23 @@
+---
+name: create_hdd_common_criteria
+description: >
+  Installation using the Common Criteria role and full disk
+  encryption on beta SLES.
+schedule:
+  system_role:
+    - installation/system_role/select_common_criteria_role
+    - installation/common_criteria_configuration/common_criteria_encryption_pwd
+  suggested_partitioning:
+    - installation/partitioning/new_partitioning_gpt
+  grub:
+    - installation/boot_encrypt
+    - installation/handle_reboot
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - security/cc/ensure_crypto_checks_enabled
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown
+    - shutdown/svirt_upload_assets

--- a/tests/installation/common_criteria_configuration/common_criteria_encryption_pwd.pm
+++ b/tests/installation/common_criteria_configuration/common_criteria_encryption_pwd.pm
@@ -1,0 +1,19 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: The test module configure the disk encryption password
+# when using the Common Criteria role.
+# Maintainer: QE Security <none@suse.de>
+
+use parent 'y2_installbase';
+use strict;
+use warnings;
+
+sub run {
+    my $common_criteria_configuration = $testapi::distri->get_common_criteria_configuration();
+    $common_criteria_configuration->configure_encryption($testapi::password);
+    $common_criteria_configuration->go_forward();
+    $common_criteria_configuration->get_weak_password_warning->press_yes();
+}
+
+1;

--- a/tests/installation/system_role/select_common_criteria_role.pm
+++ b/tests/installation/system_role/select_common_criteria_role.pm
@@ -1,0 +1,17 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Select System Role 'Common Criteria' and navigate to next
+# screen in SLES.
+#
+# Maintainer: QE Security <none@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+
+sub run {
+    $testapi::distri->get_system_role()->select_system_role('common_criteria');
+}
+
+1;

--- a/tests/security/atsec/setup_atsec_env.pm
+++ b/tests/security/atsec/setup_atsec_env.pm
@@ -19,7 +19,7 @@ sub run {
 
     select_console 'root-console';
 
-    zypper_call('in wget gcc make');
+    zypper_call('in wget gcc make curl');
 
     my $code_path = get_required_var('CODE_PATH');
     my ($file_name) = $code_path =~ m|/([^/]+)\.tar$|;

--- a/tests/security/boot_encrypt_no_video_present.pm
+++ b/tests/security/boot_encrypt_no_video_present.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+
+# Summary: Unlock encrypted partitions during bootup after the bootloader
+#   passed, e.g. from plymouth.
+# Maintainer: QE Security <none@suse.de>
+
+use strict;
+use warnings;
+use base "installbasetest";
+use utils;
+use testapi;
+
+sub run {
+    # used by aarch64 on 15-SP5 QR (https://progress.opensuse.org/issues/156655)
+    assert_screen 'encrypted-disk-no-video';
+    wait_serial("Please enter passphrase for disk.*");
+    type_string_slow("$testapi::password");
+    send_key 'ret';
+    wait_still_screen 15;
+}
+
+1;


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/156655
VRs:
- 15-SP6: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=77.1&groupid=431
- 15-SP5-QR: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=137.7&groupid=431

Please note that s390x is green only because I've applied a workaround to the current known ssh bug. Installation tests will be red on that platform until that bug is fixed.