### PR TITLE
Update product name for SL Micro 6.0 and group commmon parameters

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <guest>
-    <guest_os_name>slem</guest_os_name>
+    <guest_os_name>slm</guest_os_name>
     <guest_version>6.0</guest_version>
     <guest_version_major>6</guest_version_major>
     <guest_version_minor>0</guest_version_minor>
@@ -15,19 +15,19 @@
     <guest_domain_name/>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>host-model</guest_cpumodel>
+    <guest_cpumodel>mode=host-passthrough,check=none,migratable=on</guest_cpumodel>
     <guest_metadata/>
-    <guest_boot_settings>hd</guest_boot_settings>
+    <guest_boot_settings>uefi,arch=x86_64,firmware.feature0.name=secure-boot,firmware.feature0.enabled=yes,firmware.feature0.name=enrolled-keys,firmware.feature0.enabled=yes</guest_boot_settings>
     <guest_xpath/>
-    <guest_installation_automation_method>ignition</guest_installation_automation_method>
-    <guest_installation_automation_platform>qemu</guest_installation_automation_platform>
-    <guest_installation_automation_file>ignition_config_non_encrypted_image.ign</guest_installation_automation_file>
+    <guest_installation_automation_method>ignition+combustion</guest_installation_automation_method>
+    <guest_installation_automation_platform>metal</guest_installation_automation_platform>
+    <guest_installation_automation_file>ignition_config_encrypted_image.ign#combustion_script</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
     <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SLE-Micro.x86_64-6.0-Default-qcow-Build12345.qcow2</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-encrypted-Build12345.raw</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>
@@ -46,13 +46,13 @@
     <guest_ipaddr/>
     <guest_ipaddr_static>false</guest_ipaddr_static>
     <guest_macaddr/>
-    <guest_graphics>vnc</guest_graphics>
+    <guest_graphics>spice</guest_graphics>
     <guest_controller/>
     <guest_input/>
-    <guest_serial>pty</guest_serial>
+    <guest_serial>pty,target.type=isa-serial</guest_serial>
     <guest_parallel/>
-    <guest_channel/>
-    <guest_console/>
+    <guest_channel>type=unix#spicevmc</guest_channel>
+    <guest_console>pty,target.type=serial</guest_console>
     <guest_hostdev/>
     <guest_filesystem/>
     <guest_sound/>
@@ -60,9 +60,9 @@
     <guest_video/>
     <guest_smartcard/>
     <guest_redirdev/>
-    <guest_memballoon/>
-    <guest_tpm/>
-    <guest_rng/>
+    <guest_memballoon>virtio</guest_memballoon>
+    <guest_tpm>model=tpm-tis,backend.type=emulator,backend.version=2.0</guest_tpm>
+    <guest_rng>virtio,backend.model=random</guest_rng>
     <guest_panic/>
     <guest_memdev/>
     <guest_vsock/>
@@ -74,7 +74,7 @@
     <guest_memtune/>
     <guest_blkiotune/>
     <guest_memorybacking/>
-    <guest_features/>
+    <guest_features>vmport.state=off,smm=on</guest_features>
     <guest_clock/>
     <guest_power_management/>
     <guest_events/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <guest>
-    <guest_os_name>slem</guest_os_name>
+    <guest_os_name>slm</guest_os_name>
     <guest_version>6.0</guest_version>
     <guest_version_major>6</guest_version_major>
     <guest_version_minor>0</guest_version_minor>
@@ -15,19 +15,19 @@
     <guest_domain_name/>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>host-model</guest_cpumodel>
+    <guest_cpumodel>mode=host-passthrough,check=none,migratable=on</guest_cpumodel>
     <guest_metadata/>
-    <guest_boot_settings>hd</guest_boot_settings>
+    <guest_boot_settings>uefi,arch=x86_64,firmware.feature0.name=secure-boot,firmware.feature0.enabled=yes,firmware.feature0.name=enrolled-keys,firmware.feature0.enabled=yes</guest_boot_settings>
     <guest_xpath/>
-    <guest_installation_automation_method>ignition+combustion</guest_installation_automation_method>
-    <guest_installation_automation_platform>qemu</guest_installation_automation_platform>
-    <guest_installation_automation_file>ignition_config_non_encrypted_image.ign#combustion_script</guest_installation_automation_file>
+    <guest_installation_automation_method>ignition</guest_installation_automation_method>
+    <guest_installation_automation_platform>metal</guest_installation_automation_platform>
+    <guest_installation_automation_file>ignition_config_encrypted_image.ign</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
     <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SLE-Micro.x86_64-6.0-Default-qcow-Build12345.qcow2</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-encrypted-Build12345.raw</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>
@@ -46,13 +46,13 @@
     <guest_ipaddr/>
     <guest_ipaddr_static>false</guest_ipaddr_static>
     <guest_macaddr/>
-    <guest_graphics>vnc</guest_graphics>
+    <guest_graphics>spice</guest_graphics>
     <guest_controller/>
     <guest_input/>
-    <guest_serial>pty</guest_serial>
+    <guest_serial>pty,target.type=isa-serial</guest_serial>
     <guest_parallel/>
-    <guest_channel/>
-    <guest_console/>
+    <guest_channel>type=unix#spicevmc</guest_channel>
+    <guest_console>pty,target.type=serial</guest_console>
     <guest_hostdev/>
     <guest_filesystem/>
     <guest_sound/>
@@ -60,9 +60,9 @@
     <guest_video/>
     <guest_smartcard/>
     <guest_redirdev/>
-    <guest_memballoon/>
-    <guest_tpm/>
-    <guest_rng/>
+    <guest_memballoon>virtio</guest_memballoon>
+    <guest_tpm>model=tpm-tis,backend.type=emulator,backend.version=2.0</guest_tpm>
+    <guest_rng>virtio,backend.model=random</guest_rng>
     <guest_panic/>
     <guest_memdev/>
     <guest_vsock/>
@@ -74,7 +74,7 @@
     <guest_memtune/>
     <guest_blkiotune/>
     <guest_memorybacking/>
-    <guest_features/>
+    <guest_features>vmport.state=off,smm=on</guest_features>
     <guest_clock/>
     <guest_power_management/>
     <guest_events/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <guest>
-    <guest_os_name>slem</guest_os_name>
+    <guest_os_name>slm</guest_os_name>
     <guest_version>6.0</guest_version>
     <guest_version_major>6</guest_version_major>
     <guest_version_minor>0</guest_version_minor>
@@ -15,19 +15,19 @@
     <guest_domain_name/>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>mode=host-passthrough,check=none,migratable=on</guest_cpumodel>
+    <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata/>
-    <guest_boot_settings>uefi,arch=x86_64,firmware.feature0.name=secure-boot,firmware.feature0.enabled=yes,firmware.feature0.name=enrolled-keys,firmware.feature0.enabled=yes</guest_boot_settings>
+    <guest_boot_settings>hd</guest_boot_settings>
     <guest_xpath/>
     <guest_installation_automation_method>ignition+combustion</guest_installation_automation_method>
-    <guest_installation_automation_platform>metal</guest_installation_automation_platform>
-    <guest_installation_automation_file>ignition_config_encrypted_image.ign#combustion_script</guest_installation_automation_file>
+    <guest_installation_automation_platform>qemu</guest_installation_automation_platform>
+    <guest_installation_automation_file>ignition_config_non_encrypted_image.ign#combustion_script</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
     <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SLE-Micro.x86_64-6.0-Default-encrypted-Build12345.raw</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-qcow-Build12345.qcow2</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>
@@ -46,13 +46,13 @@
     <guest_ipaddr/>
     <guest_ipaddr_static>false</guest_ipaddr_static>
     <guest_macaddr/>
-    <guest_graphics>spice</guest_graphics>
+    <guest_graphics>vnc</guest_graphics>
     <guest_controller/>
     <guest_input/>
-    <guest_serial>pty,target.type=isa-serial</guest_serial>
+    <guest_serial>pty</guest_serial>
     <guest_parallel/>
-    <guest_channel>type=unix#spicevmc</guest_channel>
-    <guest_console>pty,target.type=serial</guest_console>
+    <guest_channel/>
+    <guest_console/>
     <guest_hostdev/>
     <guest_filesystem/>
     <guest_sound/>
@@ -60,9 +60,9 @@
     <guest_video/>
     <guest_smartcard/>
     <guest_redirdev/>
-    <guest_memballoon>virtio</guest_memballoon>
-    <guest_tpm>model=tpm-tis,backend.type=emulator,backend.version=2.0</guest_tpm>
-    <guest_rng>virtio,backend.model=random</guest_rng>
+    <guest_memballoon/>
+    <guest_tpm/>
+    <guest_rng/>
     <guest_panic/>
     <guest_memdev/>
     <guest_vsock/>
@@ -74,7 +74,7 @@
     <guest_memtune/>
     <guest_blkiotune/>
     <guest_memorybacking/>
-    <guest_features>vmport.state=off,smm=on</guest_features>
+    <guest_features/>
     <guest_clock/>
     <guest_power_management/>
     <guest_events/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_qcow_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_qcow_ignition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <guest>
-    <guest_os_name>slem</guest_os_name>
+    <guest_os_name>slm</guest_os_name>
     <guest_version>6.0</guest_version>
     <guest_version_major>6</guest_version_major>
     <guest_version_minor>0</guest_version_minor>
@@ -15,19 +15,19 @@
     <guest_domain_name/>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>mode=host-passthrough,check=none,migratable=on</guest_cpumodel>
+    <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata/>
-    <guest_boot_settings>uefi,arch=x86_64,firmware.feature0.name=secure-boot,firmware.feature0.enabled=yes,firmware.feature0.name=enrolled-keys,firmware.feature0.enabled=yes</guest_boot_settings>
+    <guest_boot_settings>hd</guest_boot_settings>
     <guest_xpath/>
     <guest_installation_automation_method>ignition</guest_installation_automation_method>
-    <guest_installation_automation_platform>metal</guest_installation_automation_platform>
-    <guest_installation_automation_file>ignition_config_encrypted_image.ign</guest_installation_automation_file>
+    <guest_installation_automation_platform>qemu</guest_installation_automation_platform>
+    <guest_installation_automation_file>ignition_config_non_encrypted_image.ign</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
     <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SLE-Micro.x86_64-6.0-Default-encrypted-Build12345.raw</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-qcow-Build12345.qcow2</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>
@@ -46,13 +46,13 @@
     <guest_ipaddr/>
     <guest_ipaddr_static>false</guest_ipaddr_static>
     <guest_macaddr/>
-    <guest_graphics>spice</guest_graphics>
+    <guest_graphics>vnc</guest_graphics>
     <guest_controller/>
     <guest_input/>
-    <guest_serial>pty,target.type=isa-serial</guest_serial>
+    <guest_serial>pty</guest_serial>
     <guest_parallel/>
-    <guest_channel>type=unix#spicevmc</guest_channel>
-    <guest_console>pty,target.type=serial</guest_console>
+    <guest_channel/>
+    <guest_console/>
     <guest_hostdev/>
     <guest_filesystem/>
     <guest_sound/>
@@ -60,9 +60,9 @@
     <guest_video/>
     <guest_smartcard/>
     <guest_redirdev/>
-    <guest_memballoon>virtio</guest_memballoon>
-    <guest_tpm>model=tpm-tis,backend.type=emulator,backend.version=2.0</guest_tpm>
-    <guest_rng>virtio,backend.model=random</guest_rng>
+    <guest_memballoon/>
+    <guest_tpm/>
+    <guest_rng/>
     <guest_panic/>
     <guest_memdev/>
     <guest_vsock/>
@@ -74,7 +74,7 @@
     <guest_memtune/>
     <guest_blkiotune/>
     <guest_memorybacking/>
-    <guest_features>vmport.state=off,smm=on</guest_features>
+    <guest_features/>
     <guest_clock/>
     <guest_power_management/>
     <guest_events/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <guest>
-  <guest_os_name>slem</guest_os_name>
+  <guest_os_name>slm</guest_os_name>
   <guest_version>6.0</guest_version>
   <guest_version_major>6</guest_version_major>
   <guest_version_minor>0</guest_version_minor>
@@ -26,7 +26,7 @@
   <guest_installation_method_others/>
   <guest_installation_extra_args/>
   <guest_installation_wait/>
-  <guest_installation_media>http://openqa.suse.de/assets/hdd/SLE-Micro.x86_64-6.0-Default-Build12345.raw.xz</guest_installation_media>
+  <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-Build12345.raw.xz</guest_installation_media>
   <guest_installation_fine_grained/>
   <guest_os_variant>opensusetumbleweed</guest_os_variant>
   <guest_storage_path/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_raw_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_0_64_kvm_hvm_x86_64_default_raw_ignition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <guest>
-  <guest_os_name>slem</guest_os_name>
+  <guest_os_name>slm</guest_os_name>
   <guest_version>6.0</guest_version>
   <guest_version_major>6</guest_version_major>
   <guest_version_minor>0</guest_version_minor>
@@ -26,7 +26,7 @@
   <guest_installation_method_others/>
   <guest_installation_extra_args/>
   <guest_installation_wait/>
-  <guest_installation_media>http://openqa.suse.de/assets/hdd/SLE-Micro.x86_64-6.0-Default-Build12345.raw.xz</guest_installation_media>
+  <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-Build12345.raw.xz</guest_installation_media>
   <guest_installation_fine_grained/>
   <guest_os_variant>opensusetumbleweed</guest_os_variant>
   <guest_storage_path/>

--- a/lib/guest_installation_and_configuration_metadata.pm
+++ b/lib/guest_installation_and_configuration_metadata.pm
@@ -235,24 +235,20 @@ our %guest_params = (
     'stop_run' => ''    # Guest creation finish time
 );
 
-# This is get_required_var('SUT_IP')
-our $host_ipaddr;
-# This is script_output('hostname')
-our $host_name;
-# This is script_output('dnsdomainname')
-our $host_domain_name;
-# Major version of host os release from /etc/os-release on host
-our $host_version_major;
-# Minor version of host os release from /etc/os-release on host
-our $host_version_minor;
-# Version ID of host os release from /etc/os-release on host
-our $host_version_id;
-# Public key used for ssh login to guest
-our $ssh_public_key;
-# Private key used for ssh login to guest
-our $ssh_private_key;
-# SSH command used for ssh login, for example, "ssh -vvv -i identity_file username"
-our $ssh_command;
+# Global data structure %host_params contains all parameters not pertinent to
+# any specific guest and only relating to operations on host. All parameters
+# in this structure are only initialized once in a single test run.
+our %host_params = (
+    'host_ipaddr' => '',    # This is get_required_var('SUT_IP')
+    'host_name' => '',    # This is script_output('hostname')
+    'host_domain_name' => '',    # This is script_output('dnsdomainname')
+    'host_version_major' => '',    # Major version of host os release from /etc/os-release on host
+    'host_version_minor' => '',    # Minor version of host os release from /etc/os-release on host
+    'host_version_id' => '',    # Version ID of host os release from /etc/os-release on host
+    'ssh_public_key' => '',    # Public key used for ssh login to guest
+    'ssh_private_key' => '',    # Private key used for ssh login to guest
+    'ssh_command' => ''    # SSH command used for ssh login, for example, "ssh -vvv -i identity_file username"
+);
 
 # Global data structure %guest_network_matrix to specify network devices to be
 # used for guest configuring and installing. Virtual networks, including nat,


### PR DESCRIPTION
* **SUSE** Linux Micro is the new product name for version 6.0 which needs to be updated in corresponding places. 

* **And** grouping common parameters that are pertinent to host in one global structure ```%host_params``` in ```guest_installation_and_configuration_metadata.pm``` ensures more clear and neat layout.

* **Verification Runs:**
  *  [**SL Micro 6.0 on SL Micro 6.0** link1](http://10.100.228.134/tests/2397) [link2](http://10.100.204.18/tests/2397) [link3](http://10.67.18.153/tests/2397) [link4](http://10.149.193.170/tests/2397)
  *  [**sles15sp5 on SL Micro 6.0** link1](http://10.100.228.134/tests/2396) [link2](http://10.100.204.18/tests/2396) [link3](http://10.67.18.153/tests/2396) [link4](http://10.149.193.170/tests/2396)
  * [15sp6 on 15sp6 xen](https://openqa.suse.de/tests/13972274)
  * [15sp6 on 12sp5 kvm](https://openqa.suse.de/tests/13972275)
  * [15sp6 on 15sp5 xen](https://openqa.suse.de/tests/13972276)
  * [12sp5 on 15sp6 kvm](https://openqa.suse.de/tests/13972277)
