### PR TITLE
Ignore test message from combustion

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -609,5 +609,15 @@
             "sle": ["15-SP6"]
         },
         "type": "ignore"
+    },
+    "combustion_test_prepare": {
+        "description": "combustion: test_prepare function ran OK",
+        "products": {
+            "sle": ["15-SP5","15-SP6"],
+            "sle-micro": ["5.4","5.5", "6.0"],
+            "opensuse": ["Tumbleweed"],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
In order to verify that combustion prepare ran, the test writes a mock message in the logs.

- VR: http://kepler.suse.cz/tests/23057#step/journal_check/1

