### PR TITLE
Fix leap kde test switch x11 console issue

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1492,7 +1492,7 @@ the session.
 =cut
 
 sub get_x11_console_tty {
-    my $new_sddm = (!is_sle('<16') && !is_leap('<15.6')) || is_krypton_argon;
+    my $new_sddm = (!is_sle('<15-SP6') && !is_leap('<15.6')) || is_krypton_argon;
     if (check_var('DESKTOP', 'kde') || check_var('DESKTOP', 'lxqt')) {
         return $new_sddm ? 2 : 7;
     }


### PR DESCRIPTION
The wrong condition caused the wrong x11 tty for leap kde migration test.

- Failed job: https://openqa.suse.de/tests/13922392#step/post_migration/16
- Related ticket: N/A
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/13932297#step/post_migration/14
