### PR TITLE
Add bsc#1221504 (bluetooth errors in syslog) to known bugs

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -619,5 +619,13 @@
             "microos":  ["Tumbleweed"]
         },
         "type": "ignore"
+    },
+    "bsc#1221504": {
+        "description": "bluetoothd.*Failed to (reset Adv Monitors|clear UUIDs|add UUID): Failed",
+        "products": {
+            "opensuse": ["15.6"],
+            "sle": ["15-SP6"]
+        },
+        "type": "bug"
     }
 }


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1221504
Failes e.g. in https://openqa.suse.de/tests/13924015