### PR TITLE
Prepare sudo for the testapi user in all cases

### DIFF
--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -55,10 +55,8 @@ sub run {
         $instance->ssh_assert_script_run(q(sudo sed -i "/Defaults targetpw/s/^#//" /etc/sudoers));
     }
 
-    # For maintenance test runs, the testapi user (typically 'bernhard') is expected to be allowed to run sudo commands
-    if (check_var('PUBLIC_CLOUD_QAM', '1')) {
-        $instance->ssh_assert_script_run("echo \"$testapi::username ALL=(ALL) ALL\" | sudo tee /etc/sudoers.d/010_openqa");
-    }
+    # We expect that the testapi user (typically 'bernhard') is allowed to run sudo commands
+    $instance->ssh_assert_script_run("echo \"$testapi::username ALL=(ALL) ALL\" | sudo tee /etc/sudoers.d/010_openqa");
 }
 
 sub test_flags {


### PR DESCRIPTION
Product-QA test runs also require the testapi user (bernhard) being able to run sudo commands. This commit allows bernhard to run sudo in all test runs.

- Related ticket: https://progress.opensuse.org/issues/156649
- Verification run: TBD
