### PR TITLE
Workaround/fix to let usb boot works on old Supermicro machines

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -147,9 +147,13 @@ sub run {
     # However, serial console and AGAMA_AUTO settings are actually useful.
     # If agama provides support for installation via ssh connection or others,
     # we will then consider adding them back.
-    if (is_ipmi && is_selfinstall) {
-        # directly start installation
-        send_key "f10";
+    if (is_ipmi && is_uefi_boot && is_selfinstall) {
+        # Directly start installation
+        if (check_var("CTRL_X_TO_BOOT", "1")) {
+            send_key "ctrl-x";
+        } else {
+            send_key "f10";
+        }
         wait_still_screen;
         return;
     }

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -94,7 +94,7 @@ sub set_bootscript {
 
     # Support passing both EXTRA_PXE_CMDLINE to bootscripts
     $cmdline_extra .= get_var('EXTRA_PXE_CMDLINE') . ' ' if get_var('EXTRA_PXE_CMDLINE');
-    $cmdline_extra .= " root=/dev/ram0 initrd=initrd textmode=1" if (check_var('IPXE_UEFI', '1') and !is_usb_boot);
+    $cmdline_extra .= " root=/dev/ram0 initrd=initrd textmode=1" if (check_var('IPXE_UEFI', '1'));
 
     if ($autoyast ne '') {
         $cmdline_extra .= " autoyast=$autoyast sshd=1 sshpassword=$testapi::password ";


### PR DESCRIPTION
We are going to deploy the SL Micro 6 baremetal test on OSD kermit machine. This machine's behavior is different from earlier automation tested machine in BJ. So this PR is to workaround/fix 2 issues on it.
    - kermit does not support pressing F10 to start installation, but only ctrl+x
    - kermit needs to specify `initrd=initrd` on pxe boot kernel line

- Related ticket: https://progress.opensuse.org/issues/151498#  
- Verification run: 
      - sle micro uefi usb boot: 
          - http://10.67.129.77/tests/333, PASS on BJ HP machine vh015
          - http://openqa.suse.de/tests/13964355: OSD kermit machine, expected FAIL by bug 1222411, other verification parts are good, so fix/workaround for it works
    - legacy boot sles test:
        - https://openqa.suse.de/tests/13971351, PASS
    - uefi boot sles test: I tried to verify it as regression test, but they seem to need some uefi support code, which is irrelevant with sle micro usb boot code, so leave it to Julie, she is working on uefi switch task for  sles test