### PR TITLE
Recover condition not to install alp_elemental_client in SLM6.0

### DIFF
--- a/tests/microos/patterns.pm
+++ b/tests/microos/patterns.pm
@@ -23,8 +23,11 @@ sub run {
     my @available_patterns = split(/\n/, script_output "zypper -q se -t pattern -u");
     my @patterns = map { m/\|\s+(.*?)\s+\|.*pattern$/ } @available_patterns;
 
-    # install new patterns
+    # on slem6.0,no need to install 'alp_elemental_client', see bsc#1219200
     my @inst_patterns = @patterns;
+    @inst_patterns = grep (!/alp_elemental_client/, @patterns) if is_sle_micro('>=6.0');
+
+    # install new patterns
     trup_call('pkg install -t pattern ' . join(" ", @inst_patterns), timeout => 720);
     process_reboot(trigger => 1);
 


### PR DESCRIPTION
This ammends the removal of this condition in https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/c0ca4b7e6e0d3d062ad75fd0e9e7efd830021fa3

VR: http://openqa.suse.de/tests/13944528