### PR TITLE
Fix for not installing efivar in SL Micro 6.0

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -352,11 +352,7 @@ sub run {
 
     log_versions 1;
 
-    if (is_transactional) {
-        assert_script_run("transactional-update -n -c pkg install efivar", 90);
-    } else {
-        zypper_call('in efivar') if is_sle('12+') || is_opensuse;
-    }
+    zypper_call('in efivar') if is_sle('12+') || is_opensuse;
 
     $grub_param .= ' console=hvc0' if (get_var('ARCH') eq 'ppc64le');
     $grub_param .= ' console=ttysclp0' if (get_var('ARCH') eq 's390x');


### PR DESCRIPTION
https://openqa.suse.de/tests/13945402