### PR TITLE
Remove verify_os_version form zypper_migration module

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -14,7 +14,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use power_action_utils 'power_action';
-use version_utils qw(is_desktop_installed is_sles4sap is_leap_migration is_sle_micro verify_os_version);
+use version_utils qw(is_desktop_installed is_sles4sap is_leap_migration is_sle_micro);
 use Utils::Backends 'is_pvm';
 use Utils::Logging 'upload_solvertestcase_logs';
 use transactional;
@@ -22,9 +22,6 @@ use transactional;
 sub run {
     my $self = shift;
     select_console 'root-console';
-    # This multi-naming of the same var should be addressed in poo#157873
-    my $version_to_verify = is_sle_micro ? get_var("FROM_VERSION") : get_var(("HDDVERSION"), get_required_var("ORIGIN_SYSTEM_VERSION"));
-    verify_os_version($version_to_verify);
     # precompile regexes
     my $zypper_continue = qr/^Continue\? \[y/m;
     my $zypper_migration_target = qr/\[num\/q\]/m;
@@ -168,7 +165,6 @@ sub run {
         # sometimes reboot takes longer time after online migration, give more time
         $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 500, ready_time => 600, nologin => is_sles4sap);
     }
-    verify_os_version;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
After PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18936/files
Some tests break due to different var naming for before and after migration version. Removing the verify_os_version will fix the problem.
VRs:
SAP: https://openqa.suse.de/tests/13951421
Yast slem: 13946786https://openqa.suse.de/tests/13951422