### PR TITLE
Boot sl-micro 6.0 in VMWare

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -485,7 +485,7 @@ sub uefi_bootmenu_params {
         }
     }
     else {
-        if (is_microos && get_var('BOOT_HDD_IMAGE')) {
+        if ((is_sle_micro || is_microos) && get_var('BOOT_HDD_IMAGE')) {
             # skip healthchecker lines
             for (1 .. 5) { send_key "down"; }
         }
@@ -575,10 +575,10 @@ sub bootmenu_default_params {
     }
     else {
         # On JeOS and MicroOS we don't have YaST installer.
-        push @params, "Y2DEBUG=1" unless is_jeos || is_microos || is_selfinstall;
+        push @params, "Y2DEBUG=1" unless is_jeos || is_microos || is_selfinstall || (is_sle_micro && get_var('BOOT_HDD_IMAGE'));
 
         # gfxpayload variable replaced vga option in grub2
-        if (!is_jeos && !is_microos && !is_selfinstall && (is_i586 || is_x86_64)) {
+        if (!(is_sle_micro && get_var('BOOT_HDD_IMAGE')) && !is_jeos && !is_microos && !is_selfinstall && (is_i586 || is_x86_64)) {
             push @params, "vga=791";
             my $video = 'video=1024x768';
             $video .= '-16' if check_var('QEMUVGA', 'cirrus');
@@ -595,7 +595,7 @@ sub bootmenu_default_params {
         if (is_microos || is_selfinstall) {
             push @params, get_bootmenu_console_params $args{baud_rate};
         }
-        elsif (!is_jeos) {
+        elsif (!is_jeos && !(is_sle_micro && get_var('BOOT_HDD_IMAGE'))) {
             # make plymouth go graphical
             push @params, "plymouth.ignore-serial-consoles" unless $args{pxe};
             push @params, get_bootmenu_console_params $args{baud_rate};

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -53,14 +53,20 @@ sub load_boot_from_disk_tests {
         loadtest 'installation/bootloader_uefi';
     }
 
+    # read FIRST_BOOT_CONFIG in order to know how the image will be configured
+    # ignition|combustion|ignition+combustion is considered as default path
     if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
         loadtest 'jeos/firstrun';
     } elsif (check_var('FIRST_BOOT_CONFIG', 'cloud-init')) {
         loadtest 'boot/cloud_init';
-    } elsif (is_s390x()) {
-        loadtest 'boot/boot_to_desktop';
     } else {
-        loadtest 'microos/disk_boot';
+        if (is_s390x()) {
+            loadtest 'boot/boot_to_desktop';
+        } elsif (is_vmware) {
+            ;
+        } else {
+            loadtest 'microos/disk_boot';
+        }
     }
 
     loadtest 'installation/system_workarounds' if (is_aarch64 && is_microos);

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -43,7 +43,7 @@ use lockapi 'mutex_wait';
 use bootloader_setup;
 use registration;
 use utils;
-use version_utils qw(is_jeos is_microos is_opensuse is_sle is_selfinstall);
+use version_utils qw(is_jeos is_microos is_opensuse is_sle is_selfinstall is_sle_micro);
 use Utils::Backends qw(is_ipmi);
 
 # hint: press shift-f10 trice for highest debug level
@@ -135,7 +135,7 @@ sub run {
         if (get_var("PROMO") || get_var('LIVETEST') || get_var('LIVECD')) {
             send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 11, 3);
         }
-        elsif (!is_jeos && !is_microos('VMX')) {
+        elsif (!(is_jeos || is_sle_micro) && !is_microos('VMX')) {
             send_key_until_needlematch('inst-oninstallation', 'down', 11, 0.5);
         }
     }
@@ -161,7 +161,7 @@ sub run {
 
         # JeOS is never deployed with Linuxrc involved,
         # so 'regurl' does not apply there.
-        registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED) unless is_jeos || is_opensuse;
+        registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED) unless is_jeos || (is_sle_micro && get_var('BOOT_HDD_IMAGE')) || is_opensuse;
 
         # boot
         mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');


### PR DESCRIPTION
VMWare image can be configured either by ignition/combustion or using
jeos-firstboot as a fallback. Boot test modules should be the same as
used in Minimal-VM VMWare tests.

- ticket: https://progress.opensuse.org/issues/158344

#### Verification runs

* [VMware-x86_64-Build5.12-slem_docker](http://kepler.suse.cz/tests/23090#step/firstrun/7)
* [microos-Tumbleweed-DVD-x86_64-Build20240404-microos@uefi](http://kepler.suse.cz/tests/23089#)
* [microos-Tumbleweed-MicroOS-Image-x86_64-Build20240404-microos@64bit](http://kepler.suse.cz/tests/23088#)
* [microos-Tumbleweed-MicroOS-Image-x86_64-Build20240404-microos-wizard](http://kepler.suse.cz/tests/23087#)
