### PR TITLE
virt_autotest: enhancement s390x guest_installation_run

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -69,8 +69,11 @@ sub post_execute_script_assertion {
 sub run {
     my $self = shift;
 
-    select_console 'sol', await_console => 0;
-    use_ssh_serial_console;
+    # Only for x86_64
+    if (is_x86_64) {
+        select_console 'sol', await_console => 0;
+        use_ssh_serial_console;
+    }
 
     # Add option to keep guest after successful installation
     # Only for x86_64 now


### PR DESCRIPTION
Enhancement for s390x guest installation

- Related ticket: https://progress.opensuse.org/issues/157495
- Verification run: 
s390x
[gi-guest_developing-on-host_sles15sp5-kvm](https://openqa.suse.de/tests/13952406#) PASS
x86_64
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/13952584#) PASS
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/13952585#) PASS
