### PR TITLE
Match pxe boot needle

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -125,11 +125,11 @@ sub login_to_console {
     }
 
     my @bootup_needles = is_ipxe_boot ? qw(grub2) : qw(grub2 grub1 prague-pxe-menu);
-    unless (is_tumbleweed or check_screen(@bootup_needles, get_var('AUTOYAST') && !get_var("NOT_DIRECT_REBOOT_AFTER_AUTOYAST") ? 1 : 180)) {
+    unless (is_tumbleweed or check_screen(\@bootup_needles, get_var('AUTOYAST') && !get_var("NOT_DIRECT_REBOOT_AFTER_AUTOYAST") ? 1 : 180)) {
         ipmitool("chassis power reset");
         reset_consoles;
         select_console 'sol', await_console => 0;
-        check_screen(@bootup_needles, 120);
+        check_screen(\@bootup_needles, 120);
     }
 
     # If a PXE menu will appear just select the default option (and save us the time)


### PR DESCRIPTION

PXE boot needle mismatch, fix it.

- Related ticket:  https://progress.opensuse.org/issues/158389
- Needles: NA
- Verification run: http://openqa.qam.suse.cz/tests/70845#step/login_console/1
