### PR TITLE
Extend timeout to get the expected needle

### DIFF
--- a/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
+++ b/lib/YaST/NetworkSettings/NetworkCardSetup/VLANAddressTab.pm
@@ -23,7 +23,7 @@ use constant {
 
 sub fill_in_vlan_id {
     my ($self, $vlan_id) = @_;
-    apply_workaround_poo124652(ADDRESS_TAB);
+    apply_workaround_poo124652(ADDRESS_TAB, timeout => 30);
     send_key 'alt-v';
     send_key 'tab';
     wait_screen_change { type_string($vlan_id) };


### PR DESCRIPTION
Extend timeout to get the expected needle

- Related ticket: https://progress.opensuse.org/issues/158158
- Verification run: Rerun eight times. All of them can pass https://openqa.suse.de/tests/13960378#next_previous
