### PR TITLE
Fix ha_cluster_join type_password failure

### DIFF
--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -54,7 +54,7 @@ sub run {
     my $redirection = is_serial_terminal() ? '' : "> /dev/$serialdev";
     enter_cmd "ha-cluster-join -yc $node_to_join ; echo ha-cluster-join-finished-\$? $redirection";
     wait_for_password_prompt(needle => 'ha-cluster-join-password', timeout => $join_timeout);
-    type_password;
+    type_password($testapi::password, max_interval => 30);
     send_key 'ret';
     if (check_var('TWO_NODES', 'no') && wait_for_password_prompt(needle => 'ha-cluster-join-3nodes-password', timeout => 150, failok => 1)) {
         type_password;


### PR DESCRIPTION
Fix ha_cluster_join type_password failure: lower the max_interval slower the typing
TEAM-9222 - [15-SP6][HA][x86+ppc64le][sporadic] ha_delta_node* failed on "ha_cluster_join": 'systemctl start pacemaker' timed out

- Related ticket: https://jira.suse.com/browse/TEAM-9222
- Needles: NA
- Verification run:
Tried 5 times all passed:
passed:   http://openqa.suse.de/tests/13960769#dependencies
passed:  http://openqa.suse.de/tests/13960804#dependencies
passed:  http://openqa.suse.de/tests/13960810#dependencies
passed:  http://openqa.suse.de/tests/13960815#dependencies
passed:  http://openqa.suse.de/tests/13960820#dependencies