### PR TITLE
xfstests: Add steps to install KOTD kernel

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -780,6 +780,9 @@ elsif (get_var('XFSTESTS')) {
         get_var('ASSET_CHANGE_KERNEL_RPM')) {
         loadtest 'kernel/change_kernel';
     }
+    if (get_var('KOTD_REPO')) {
+        loadtest 'kernel/update_kernel';
+    }
     prepare_target;
     if (check_var('XFSTESTS_INSTALL', 1) || check_var('XFSTESTS', 'installation') || is_pvm || check_var('ARCH', 's390x')) {
         loadtest 'xfstests/install';


### PR DESCRIPTION
Enable xfstests in KOTD

- Related ticket: https://progress.opensuse.org/issues/154597
- Needles: N/A
- Verification run: http://10.67.133.133/tests/573
