### PR TITLE
Properly mask typed hypervisor passwords

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -70,10 +70,10 @@ sub handle_password_prompt {
         assert_screen("password-prompt", 60);
     }
     if ($console eq 'hyperv-intermediary') {
-        type_string get_required_var('VIRSH_GUEST_PASSWORD');
+        type_password get_required_var('VIRSH_GUEST_PASSWORD');
     }
     elsif ($console eq 'svirt') {
-        type_string(get_required_var(check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'HYPERV_PASSWORD' : 'VIRSH_PASSWORD'));
+        type_password get_required_var(check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'HYPERV_PASSWORD' : 'VIRSH_PASSWORD');
     }
     else {
         type_password;


### PR DESCRIPTION

Verification runs:
`openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19046 https://openqa.suse.de/tests/13913331`
* default@s390x-kvm: https://openqa.suse.de/tests/13965557


Related progress issue: https://progress.opensuse.org/issues/157537