### PR TITLE
pc: Use .txt extension for img-proof logs

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -95,7 +95,7 @@ sub run {
         patch_json $img_proof->{results};
     }
 
-    upload_logs($img_proof->{logfile});
+    upload_logs($img_proof->{logfile}, log_name => basename($img_proof->{logfile}) . ".txt");
     parse_extra_log(IPA => $img_proof->{results});
     assert_script_run('rm -rf img_proof_results');
 
@@ -112,7 +112,7 @@ sub run {
             my $file = path(bmwqemu::result_dir(), $filename);
             my $json = Mojo::JSON::decode_json($file->slurp);
             next if ($json->{result} ne 'fail');
-            $instance->upload_log('/var/log/cloudregister', log_name => 'cloudregister.log');
+            $instance->upload_log('/var/log/cloudregister', log_name => 'cloudregister.txt');
             last;
         }
         $instance->run_ssh_command(cmd => 'rpm -qa > /tmp/rpm_qa.txt', no_quote => 1);


### PR DESCRIPTION
Use .txt extension for img-proof logs to make them browser friendly and avoid downloading them.