### PR TITLE
Select correct GRUB entry in selfinstall

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -135,7 +135,7 @@ sub run {
         if (get_var("PROMO") || get_var('LIVETEST') || get_var('LIVECD')) {
             send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 11, 3);
         }
-        elsif (!(is_jeos || is_sle_micro) && !is_microos('VMX')) {
+        elsif (!(is_jeos || (is_sle_micro && !is_selfinstall)) && !is_microos('VMX')) {
             send_key_until_needlematch('inst-oninstallation', 'down', 11, 0.5);
         }
     }


### PR DESCRIPTION
follow up
for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19034

##### Verification runs:

* http://kepler.suse.cz/tests/23092#step/bootloader_uefi/4
* http://kepler.suse.cz/tests/23093#
