### PR TITLE
Fix sles4sap_cleanup about undefined arguments

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -162,17 +162,14 @@ sub get_promoted_hostname {
 
 sub sles4sap_cleanup {
     my ($self, %args) = @_;
-    $args{cleanup_called} //= 'undefined';
-    $args{network_peering_present} //= 'undefined';
-    $args{ansible_present} //= 'undefined';
     # If there's an open ssh connection to the VMs, return to host console first
     select_host_console(force => 1);
     record_info(
         'Cleanup',
         join(' ',
-            'cleanup_called:', $args{cleanup_called},
-            'network_peering_present:', $args{network_peering_present},
-            'ansible_present:', $args{ansible_present}));
+            'cleanup_called:', $args{cleanup_called} // 'undefined',
+            'network_peering_present:', $args{network_peering_present} // 'undefined',
+            'ansible_present:', $args{ansible_present} // 'undefined'));
 
     qesap_upload_logs();
     if ($args{network_peering_present}) {
@@ -183,7 +180,7 @@ sub sles4sap_cleanup {
     return 0 if ($args{cleanup_called});
     my @cmd_list;
 
-    # Only run the Ansible deregister if Ansible has been executed
+    # Only run the Ansible de-register if Ansible has been executed
     push(@cmd_list, 'ansible') if ($args{ansible_present});
 
     # Terraform destroy can be executed in any case


### PR DESCRIPTION
Remove regression introduced in previous commit that force undefined argument to get value the string 'undefined'.
Add unit testing.

- Related ticket: https://jira.suse.com/browse/TEAM-9232
- Fix regression introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18937

# Verification run:
- sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2024-04-09T04:03:11Z-hanasr_aws_test_saptune@64bit -> http://openqaworker15.qa.suse.cz/tests/280284 :green_apple:  `terraform destroy` called in case of failure http://openqaworker15.qa.suse.cz/tests/280284#step/deploy_qesap_ansible/406
 - sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-04-09T04:03:11Z-hanasr_azure_test_sapconf_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/280285
