### PR TITLE
Convert get_var to explicit sub argument

### DIFF
--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -233,6 +233,7 @@ subtest "[setup_sbd_delay_publiccloud] with different values" => sub {
 subtest '[azure_fencing_agents_playbook_args] Check Mandatory args' => sub {
     # Create a list of mandatory arguments.
     my %mandatory_args = (
+        'fence_type' => 'LieutenantWilliamBligh,',
         'spn_application_id' => 'LongJohnSilver',
         'spn_application_password' => 'CaptainFlint');
     # Notice like they are mandatory only if fencing is SPN
@@ -250,15 +251,14 @@ subtest '[azure_fencing_agents_playbook_args] Check Mandatory args' => sub {
 };
 
 
-subtest '[azure_fencing_agents_playbook_args] Native fencing setup (default value)' => sub {
-    my $returned_value = azure_fencing_agents_playbook_args();
-    is $returned_value, '-e azure_identity_management=msi', "Default to MSI if called without arguments and AZURE_FENCE_AGENT_CONFIGURATION is not specified";
+subtest '[azure_fencing_agents_playbook_args] Invalid fencing type' => sub {
+    dies_ok { azure_fencing_agents_playbook_args(fence_type => 'Bounty') };
 };
 
 
 subtest '[azure_fencing_agents_playbook_args] MSI setup' => sub {
     set_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi');
-    my $returned_value = azure_fencing_agents_playbook_args();
+    my $returned_value = azure_fencing_agents_playbook_args(fence_type => 'msi');
     is $returned_value, '-e azure_identity_management=msi', "Default to MSI if called without arguments and AZURE_FENCE_AGENT_CONFIGURATION is 'msi'";
     set_var('AZURE_FENCE_AGENT_CONFIGURATION', undef);
 };
@@ -266,7 +266,9 @@ subtest '[azure_fencing_agents_playbook_args] MSI setup' => sub {
 
 subtest '[azure_fencing_agents_playbook_args] SPN setup' => sub {
     my %mandatory_args =
-      ('spn_application_id' => 'GolDRodger', 'spn_application_password' => 'JackSparrow');
+      ('fence_type' => 'spn',
+        'spn_application_id' => 'GoldRodger',
+        'spn_application_password' => 'JackSparrow');
 
     set_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn');
     my $returned_value = azure_fencing_agents_playbook_args(%mandatory_args);


### PR DESCRIPTION
Remove a get_var from azure_fencing_agents_playbook_args and convert to sub argument. Caller will read from the var. It keep the code simpler. Improve debug logs from stop_db sub, for the crash testcase.

- Related ticket: https://jira.suse.com/browse/TEAM-9215

# Verification run:

 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-04-09T04:03:11Z-hanasr_azure_test_spn@64bit -> http://openqaworker15.qa.suse.cz/tests/280299

 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-04-09T04:03:11Z-hanasr_azure_test_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/280300

