### PR TITLE
Workaround for bsc#1222411

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/combustion/script
+++ b/data/virt_autotest/host_unattended_installation_files/combustion/script
@@ -10,6 +10,9 @@ grub2_config() {
     echo "DEBUG: now $file is,"
     cat $file
     grub2-mkconfig -o /boot/grub2/grub.cfg
+    # Set boot to sl-secureboot entry -- newly installed SL Micro
+    bootnum=$(efibootmgr | grep sl-secureboot | grep -o "^Boot[^\s]*" | sed -e 's/Boot//' -e 's/\*//')
+    efibootmgr -o $bootnum
 }
 
 # Redirect output to the console

--- a/data/virt_autotest/host_unattended_installation_files/combustion/script
+++ b/data/virt_autotest/host_unattended_installation_files/combustion/script
@@ -13,6 +13,7 @@ grub2_config() {
 }
 
 # Redirect output to the console
-exec > >(exec tee -a /dev/SERIALCONSOLE) 2>&1
+# Comment off to workaround https://bugzilla.suse.com/show_bug.cgi?id=1222411#c9
+# exec > >(exec tee -a /dev/SERIALCONSOLE) 2>&1
     grub2_config # Configure grub2 in the system
 

--- a/data/virt_autotest/host_unattended_installation_files/ignition/config.ign
+++ b/data/virt_autotest/host_unattended_installation_files/ignition/config.ign
@@ -19,14 +19,6 @@
         "contents": {
           "source": "data:text/plain;charset=utf-8;base64,UGVybWl0Um9vdExvZ2luIHllcwpQdWJrZXlBdXRoZW50aWNhdGlvbiB5ZXMKUGFzc3dvcmRBdXRoZW50aWNhdGlvbiB5ZXM="
         }
-      },
-      {
-        "path": "/etc/selinux/config",
-        "mode": 420,
-        "overwrite": true,
-        "contents": {
-          "source": "data:text/plain;charset=utf-8;base64,U0VMSU5VWD1wZXJtaXNzaXZlClNFTElOVVhUWVBFPXRhcmdldGVk"
-        }
       }
     ]
   }

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -391,7 +391,7 @@ sub uefi_bootmenu_params {
     if (is_ipmi && is_selfinstall && is_usb_boot) {
         my $counter = 0;
         my $max_tries = 5;
-        while (!check_screen('no-tty0-but-term-linux', 2) && $counter++ < $max_tries) {
+        while (!check_screen('pass-bootparam-to-firstboot', 2) && $counter++ < $max_tries) {
             # Re-enter grub edit by discarding changes for 2+ round
             if ($counter > 1) {
                 send_key_until_needlematch('bootloader-grub2', 'esc', 3, 2);
@@ -453,7 +453,11 @@ sub uefi_bootmenu_params {
 
             # Add term setting
             type_string_very_slow(" rd.kiwi.term=linux ");
-            if (!check_screen("no-tty0-but-term-linux", 2)) {
+            next if (!check_screen("no-tty0-but-term-linux", 2));
+
+            # Pass bootparam to firstboot
+            type_string_very_slow(" rd.kiwi.install.pass.bootparam ");
+            if (!check_screen('pass-bootparam-to-firstboot', 2)) {
                 next;
             } else {
                 record_info('Successfully finished grub2 editing.');

--- a/tests/installation/usb_install.pm
+++ b/tests/installation/usb_install.pm
@@ -29,7 +29,9 @@ sub run {
     assert_script_run("set -o pipefail");
 
     # Specify the two usb drives to use
-    my @usb = split('\n', script_output("ls /dev/disk/by-id/ -l | grep -i usb | grep -i -v -E \"generic|part\" | sed 's#^.*\\\/##'"));
+    my $cmd = "ls /dev/disk/by-id/ -l | grep -i usb | "
+      . "grep -i -v -E \"generic|part|Virtual\" | sed 's#^.*\\\/##'";
+    my @usb = split('\n', script_output($cmd));
     record_info("Disk info on the machine:", script_output("ls /dev/disk/by-id/ -l; fdisk -l"));
     die "No proper usb devices!" unless (scalar(@usb) == 2);
     my $medium_usb = "/dev/$usb[0]";
@@ -42,7 +44,7 @@ sub run {
     assert_script_run("mkdir  -p /mnt");
     assert_script_run("mount $provision_usb /mnt");
     assert_script_run("mkdir -p /mnt/ignition");
-    my $cmd = "curl -L "
+    $cmd = "curl -L "
       . data_url("virt_autotest/host_unattended_installation_files/ignition/config.ign")
       . " -o /mnt/ignition/config.ign";
     script_retry($cmd, retry => 2, delay => 5, timeout => 60, die => 1);


### PR DESCRIPTION
- This PR mainly does below. Now with these, in OSD, kermit can finish SL Micro 6 bare metal installation successfully.
   - usb selection on vh082: exclude usb with key word `Virtual_NetFile`
   - installed os persistent boot setting for kermit: kermit can't set the newly installed `sl-secureboot` as first boot, so do it in combustion
   - add code to pass bootparam to firstboot
   - recover default selinux config by removing customized config file
   - workaround https://bugzilla.suse.com/show_bug.cgi?id=1222411#c9

The 2 OSD machines selected, kermit and scooter , have been fully enabled and updated in openqa worker settings to do SL Micro 6 test. See https://gitlab.suse.de/openqa/salt-pillars-openqa/-/merge_requests/775. But for general sles15sp6 test, please wait for Julie to finish uefi sles verifications in poo#153037.  After https://gitlab.suse.de/openqa/salt-pillars-openqa/-/merge_requests/775 is merged, kermit can serve official SL Micro 6 test directly. Scooter needs to wait until Julie's ticket work is done. 

- Related ticket: https://progress.opensuse.org/issues/151498
- Verification run: https://openqa.suse.de/tests/14014368 : PASS