### PR TITLE
Install curl fo CC selinux tests

### DIFF
--- a/tests/security/cc/cc_selinux_setup.pm
+++ b/tests/security/cc/cc_selinux_setup.pm
@@ -17,6 +17,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
 
+    zypper_call("in curl");
     my $file = "$selinuxtest::dir" . "$selinuxtest::policyfile_tar" . '/data/selinux/selinux-policy-targeted-*.noarch.rpm';
     $self->download_policy_pkgs();
     assert_script_run("rpm -ivh --nosignature --nodeps --noplugins $file");


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/158781

- Verification run: https://openqa.suse.de/tests/13993161  (no more error about curl missing)
