### PR TITLE
Fix booting of bpftool, io_uring amd kdump on spvm backend

### DIFF
--- a/schedule/kernel/bpftools.yaml
+++ b/schedule/kernel/bpftools.yaml
@@ -2,7 +2,14 @@ name:          bpftools
 description:    >
     Compile and attach eBPF probes with bpftrace and BCC tools
 schedule:
+    - '{{boot}}'
     - boot/boot_to_desktop
     - kernel/bpftrace
     - kernel/bcc
     - shutdown/shutdown
+
+conditional_schedule:
+    boot:
+        BACKEND:
+            spvm:
+                - installation/bootloader

--- a/schedule/kernel/io_uring.yaml
+++ b/schedule/kernel/io_uring.yaml
@@ -2,6 +2,13 @@ name:          io_uring
 description:    >
     Test module to run liburing testing suite.
 schedule:
+    - '{{boot}}'
     - boot/boot_to_desktop
     - kernel/io_uring
     - shutdown/shutdown
+
+conditional_schedule:
+    boot:
+        BACKEND:
+            spvm:
+                - installation/bootloader

--- a/schedule/kernel/kdump.yaml
+++ b/schedule/kernel/kdump.yaml
@@ -3,6 +3,13 @@ description:    >
     Kdump kernel testing for various architectures with possibility to change crash
     memory using CRASH_MEMORY variable.
 schedule:
+    - '{{boot}}'
     - boot/boot_to_desktop
     - kernel/kdump
     - shutdown/shutdown
+
+conditional_schedule:
+    boot:
+        BACKEND:
+            spvm:
+                - installation/bootloader


### PR DESCRIPTION
Fix poo#158796: There was missing bootloader module, which is needed to properly boot on spvm backend.

- Related ticket: https://progress.opensuse.org/issues/158796
- Needles: none
- Verification run: 
https://openqa.suse.de/tests/overview?build=czerw%2Fos-autoinst-distri-opensuse%2319069&distri=sle&version=15-SP6

kdump: https://openqa.suse.de/tests/13994446

Failures in above VR are not related, we just want to validate system boot.