### PR TITLE
kernel baremetal: Schedule partitioning_firstdisk if NUMDISKS is > 1

### DIFF
--- a/schedule/kernel/prepare_baremetal.yaml
+++ b/schedule/kernel/prepare_baremetal.yaml
@@ -14,7 +14,7 @@ schedule:
     - installation/system_role
     - installation/partitioning
     - '{{no_enlarge_swap}}'
-    - installation/partitioning_firstdisk
+    - '{{partitioning_firstdisk}}'
     - installation/partitioning_finish
     - installation/installer_timezone
     - installation/user_settings
@@ -48,3 +48,9 @@ conditional_schedule:
         SYSTEM_ROLE:
             textmode:
                 - installation/partitioning/no_enlarge_swap
+    partitioning_firstdisk:
+        NUMDISKS:
+            2:
+                - installation/partitioning_firstdisk
+            3:
+                - installation/partitioning_firstdisk


### PR DESCRIPTION
Fix poo#156847: We need to schedule partitioning_firstdisk only if NUMDISKS is higher than 1. We have machines with 2 and 3 disks only.

- Related ticket: https://progress.opensuse.org/issues/156847
- Needles: none
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP6&distri=sle&build=czerw%2Fos-autoinst-distri-opensuse%2319071