### PR TITLE
Recover the function to write guest ip

### DIFF
--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -355,7 +355,7 @@
     </user>
   </users>
 <scripts>
-<init-scripts config:type="list">
+<post-scripts config:type="list">
 <script>
 <filename>PU1-cv-users.sh</filename>
 <source>
@@ -364,15 +364,16 @@
 mkdir -p -m 700 /root/.ssh
 echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_key
+cat > /etc/init.d/after.local<< EOF
+#!/bin/sh
+ip a | grep eth0 | grep -Po '(?<=inet )[\d.]+' > /root/$(hostname)
+logger "IP is written into file"
+curl -k -u root:{{PASS}} -T /root/$(hostname) sftp://{{SUT_IP}}/tmp/guests_ip/ --ftp-create-dirs
+exit 0
+EOF
+chmod u+x /etc/init.d/after.local
 ]]></source>
 </script>
-<script>
-<filename>PU0-cv-users.sh</filename>
-<source>
-<![CDATA[
-ip a | grep eth0 | grep -Po '(?<=inet )[\d.]+' > /root/$(hostname); logger "IP is written into file"; curl -k -u root:nots3cr3t -T /root/$(hostname) sftp://{{SUT_IP}}/tmp/guests_ip/ --ftp-create-dirs; exit 0;
-]]></source>
-</script>
-</init-scripts>
+</post-scripts>
 </scripts>
 </profile>


### PR DESCRIPTION
It doesn't work during MU kernel-default test, recover it.


- Related ticket: https://progress.opensuse.org/issues/158829
- Needles: N/A
- Verification run: http://openqa.qam.suse.cz/tests/71193#step/patch_guests/31