### PR TITLE
New test suite which enables FIPS and runs container hosts tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -120,7 +120,6 @@ sub load_firewall_test {
 
 sub load_host_tests_podman {
     my ($run_args) = @_;
-    loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
     load_container_engine_test($run_args);
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud;
@@ -152,7 +151,6 @@ sub load_host_tests_podman {
 
 sub load_host_tests_docker {
     my ($run_args) = @_;
-    loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
     load_container_engine_test($run_args);
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud;
@@ -294,6 +292,17 @@ sub load_container_tests {
 
     if (get_var('PODMAN_BATS_SKIP')) {
         loadtest 'containers/podman_integration';
+        return;
+    }
+
+    if (get_var('FIPS_ENABLED')) {
+        loadtest "fips/fips_setup";
+        foreach (split(',\s*', $runtime)) {
+            my $run_args = OpenQA::Test::RunArgs->new();
+            $run_args->{runtime} = $_;
+            load_container_engine_test($run_args);
+            load_image_test($run_args);
+        }
         return;
     }
 

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -120,6 +120,7 @@ sub load_firewall_test {
 
 sub load_host_tests_podman {
     my ($run_args) = @_;
+    loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
     load_container_engine_test($run_args);
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud;
@@ -151,6 +152,7 @@ sub load_host_tests_podman {
 
 sub load_host_tests_docker {
     my ($run_args) = @_;
+    loadtest "fips/fips_setup" if (get_var("FIPS_ENABLED"));
     load_container_engine_test($run_args);
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/138428
- Verification run:
  - [Podman test in SLE 15-SP6 JeOS with FIPS](https://openqa.suse.de/tests/14004999)
  - [Docker test in SLE 15-SP6 JeOS with FIPS](https://openqa.suse.de/tests/14004998)
  - [Podman test in SL Micro 6.0 with FIPS](https://openqa.suse.de/tests/14004997)
  - [Docker test in SL Micro 6.0 with FIPS](https://openqa.suse.de/tests/14004996)
  - [Container host test in Leap 15.6 JeOS with FIPS](https://openqa.opensuse.org/tests/4078458)
  - [Container host test in Tumbleweed JeOS with FIPS](https://openqa.opensuse.org/tests/4078459)
  - [Container host test in MicroOS with FIPS](https://openqa.opensuse.org/tests/4078461)
  - [Docker test in Tumbleweed with FIPS](https://openqa.opensuse.org/tests/4078463)
  - [Podman test in Tumbleweed with FIPS](https://openqa.opensuse.org/tests/4078462)
- Related PRs/MRs:
  - https://github.com/os-autoinst/opensuse-jobgroups/pull/444
  - https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1595
