### PR TITLE
Fix monitoring_services curl failed on connect

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -748,8 +748,8 @@ B<systemReplicationStatus.py> return codes are:
 sub check_replication_state {
     my ($self) = @_;
     my $sapadm = $self->set_sap_info(get_required_var('INSTANCE_SID'), get_required_var('INSTANCE_ID'));
-    # Wait by default for 5 minutes
-    my $time_to_wait = 300;
+    # Wait by default for 10 minutes
+    my $time_to_wait = 600;
     my $cmd = "su - $sapadm -c 'python exe/python_support/systemReplicationStatus.py'";
 
     # Replication check can only be done on PRIMARY node

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -81,7 +81,7 @@ sub run {
         my $start_cmd = "su - $sapadm -c 'sapcontrol -nr $instance_id -function StartSystem HDB'";
         assert_script_run $start_cmd;
         my $looptime = 90;
-        while (script_run "su - $sapadm -c 'hdbnsutil -sr_state' | grep -q 'online: true'") {
+        while (script_run "su - $sapadm -c 'hdbnsutil -sr_state' | grep -q 'online: true'", timeout => 120) {
             sleep bmwqemu::scale_timeout(1);
             --$looptime;
             last if ($looptime <= 0);


### PR DESCRIPTION
Fix monitoring_services `curl` sporadically `Failed to connect to localhost port 9668`: hanadb_exporter

-  add `retry` (line 103 ~ line 120 in file `monitoring_services.pm`)

Fix `script_run "su - $sapadm -c 'hdbnsutil -sr_state' ` sporadically timed out

- increase timeout value (in `lib/sles4sap.pm`)

Fix `check_replication_state` failed

- wait more time (in `hana_cluster.pm`)

NOTE: other changes are fixing tidy issue introduced. 

TEAM-9221 - [15-SP6][ppc64le][sporadic] "SAPHanaSR_ScaleUp_PerfOpt_WMP" failed on "monitoring_services": curl: (7) Failed to connect to localhost port 9668 after 7 ms: Couldn't connect to server

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://jira.suse.com/browse/TEAM-9221
- Needles: NA
- Verification run:
15-SP6: https://openqa.suse.de/tests/14014296#step/monitoring_services/114 (retry works and test case passed)
15-SP5: https://openqa.suse.de/tests/14014308#step/monitoring_services/114 (retry works and test case passed)
