### PR TITLE
Wait for bootloader on SLiMy BETA images

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -20,10 +20,10 @@ sub run {
     # default timeout in grub2 is set to 10s
     # osd's arm machines tend to stall when trying to match grub2
     # this leads to test failures because openQA does not assert grub2 properly
-    # SLEM updated GM images from https://openqa.suse.de/group_overview/377
+    # SLEM updated GM and BETA images from https://openqa.suse.de/group_overview/377
     # already have disabled grub timeout in order to install updates and reboot
     # therefore *aarch64* images would hang in GRUB2
-    if ((get_var('HDD_1') !~ /GM-Updated/ && (is_sle_micro || is_leap_micro)) && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
+    if ((get_var('HDD_1') !~ /GM-Updated/ && get_var('HDD_1') !~ /Beta-Updated/ && (is_sle_micro || is_leap_micro)) && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
         shift->wait_boot_past_bootloader(textmode => 1);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
Add SLiMy BETA images to the selected images that need to wait past the bootloader.

- Related ticket: https://progress.opensuse.org/issues/157141
- Related failure: https://openqa.suse.de/tests/14004347#step/disk_boot/4
- Verification runs: [aarch64](https://openqa.suse.de/tests/14004371) | [x86_64](https://openqa.suse.de/tests/14004399)
