### PR TITLE
Add 'openssh' package to autoyast profile in spvm

### DIFF
--- a/data/yam/autoyast/mini_remote.xml
+++ b/data/yam/autoyast/mini_remote.xml
@@ -40,6 +40,9 @@
         </services>
     </services-manager>
     <software>
+        <packages config:type="list">
+            <package>openssh</package>
+        </packages>
         <products config:type="list">
             <product>SLES</product>
         </products>


### PR DESCRIPTION
- Description: Add `openssh` package to autoyast profile in spvm
- Related ticket: [poo#158269](https://progress.opensuse.org/issues/158269)
- Verification run: [overview](https://openqa.suse.de/tests/overview?build=issues-158269)
  + `tests/autoyast/installation.pm` **passed**
  + the next error on `tests/autoyast/console.pm` is due to the [bsc#1221005](https://bugzilla.suse.com/show_bug.cgi?id=1221005)
