### PR TITLE
installation/isosize.pm: Use basetest as base class

### DIFF
--- a/tests/installation/isosize.pm
+++ b/tests/installation/isosize.pm
@@ -8,7 +8,7 @@
 # - Check if iso size is smaller than max defined size
 # Maintainer: Alberto Planas <aplanas@suse.com>
 
-use base "opensusebasetest";
+use base "basetest";
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION
This test runs before anything is set up, so avoid doing any extra stuff such as post_fail_hook.

Failure: https://openqa.opensuse.org/tests/4077118 (not sure yet why it breaks this badly)
VR: https://openqa.opensuse.org/tests/4078760#live