### PR TITLE
Skip version check for PRs in Tumbleweed

### DIFF
--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -61,6 +61,12 @@ sub run {
         $checker{ID} = "opensuse-tumbleweed";
         $checker{CPE_NAME} = "cpe:/o:opensuse:tumbleweed:$checker{VERSION}";
         $checker{PRETTY_NAME} = $checker{NAME};
+
+        # Return early if BUILD is os-autoinst/os-autoinst-distri-opensuse
+        if (get_var('BUILD') =~ m/os-autoinst-distri-opensuse/) {
+            record_info "PR/Verification run", "os-autoinst/os-autoinst-distri-opensuse detected, skipping check";
+            return;
+        }
     }
 
     my $release = script_output "cat /etc/os-release";


### PR DESCRIPTION
Noticed on #19023 that for TW the module would fail, due to the build rewritten by the openqa-clone-custom-gitref-spec script, exit early in such case

[![VR](https://openqa.opensuse.org/tests/latest/badge?arch=x86_64&distri=opensuse&flavor=JeOS-for-kvm-and-xen&machine=64bit_virtio-2G&test=jeos-extra%40foursixnine%2Fos-autoinst-distri-opensuse%23dontlookatme&version=Tumbleweed)](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=JeOS-for-kvm-and-xen&machine=64bit_virtio-2G&test=jeos-extra%40foursixnine%2Fos-autoinst-distri-opensuse%23dontlookatme&version=Tumbleweed)