### PR TITLE
virt_autotest: enhancement reboot_and_wait_up_normal for s390x

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -864,8 +864,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/update_package";
         # Skip reset_partition for s390x due to there just be 42Gib disk space for each s390x LPAR
         loadtest "virt_autotest/reset_partition" if (!is_s390x);
-        # Skip reboot_and_wait_up_normal for s390x due to new changes from svirt backend for power_action_utils::power_action (see poo#151786)
-        loadtest "virt_autotest/reboot_and_wait_up_normal" if (!get_var('AUTOYAST') && get_var('REPO_0_TO_INSTALL') && (!is_s390x));
+        loadtest "virt_autotest/reboot_and_wait_up_normal" if (!get_var('AUTOYAST') && get_var('REPO_0_TO_INSTALL'));
         loadtest "virt_autotest/download_guest_assets" if get_var("SKIP_GUEST_INSTALL") && is_x86_64;
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -12,7 +12,6 @@ use warnings;
 use testapi;
 use ipmi_backend_utils;
 use base "proxymode";
-use power_action_utils 'power_action';
 use Utils::Architectures;
 use virt_autotest::utils;
 
@@ -23,7 +22,7 @@ sub reboot_and_wait_up {
     if (is_s390x) {
         record_info('INFO', 'Reboot LPAR');
         #Reboot s390x lpar
-        power_action('reboot', observe => 1, keepconsole => 1);
+        enter_cmd "reboot";
         my $svirt = select_console('svirt', await_console => 0);
         return;
     }


### PR DESCRIPTION
Enhancement reboot_and_wait_up_normal for s390x

- Related ticket: https://progress.opensuse.org/issues/151786
- Verification run:
[gi-guest_developing-on-host_sles15sp5-kvm@virt-s390x-kvm-sle15sp5](http://10.67.129.117/tests/414) PASS
[prj4_guest_upgrade_sles15sp5_on_sles15sp5-kvm@virt-s390x-kvm-sle15sp5](http://10.67.129.117/tests/413) PASS
[gi-guest_developing-on-host_sles12sp5-kvm@virt-s390x-kvm-sle12sp5](http://10.67.129.117/tests/426) PASS