### PR TITLE
kernel: Add yaml schedule for gfx and usb product testing

### DIFF
--- a/schedule/kernel/gfx-usb-drivers.yaml
+++ b/schedule/kernel/gfx-usb-drivers.yaml
@@ -1,0 +1,20 @@
+---
+name: gfx-usb-drivers
+schedule:
+- autoyast/prepare_profile
+- installation/bootloader_start
+- autoyast/installation
+- console/yast2_vnc
+- console/force_scheduled_tasks
+- autoyast/autoyast_reboot
+- installation/handle_reboot
+- installation/first_boot
+- console/system_prepare
+- console/consoletest_setup
+- console/hostname
+- console/textinfo
+- console/consoletest_finish
+- x11/glxgears
+- kernel/usb_nic
+- kernel/usb_drive
+- shutdown/shutdown


### PR DESCRIPTION
Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18460

Schedule to validate i915 + usb in product testing. It is based  on existing qam schedule and little bit stripped down.

- Related ticket: https://progress.opensuse.org/issues/138122
- Related job group configuration: https://gitlab.suse.de/kernel-qa/kernelqa-openqa-yaml/-/merge_requests/489
- Needles: none
- Verification run:  https://openqa.suse.de/tests/14171867#

Test suite settings:

```
        testsuite: null
        settings:
          CASEDIR: https://github.com/czerw/os-autoinst-distri-opensuse#15-sp6-ay
          AUTOYAST: autoyast_qam/15_installation.xml.ep
          AUTOYAST_PREPARE_PROFILE: '1'
          DESKTOP: gnome
          MIRROR_HTTP: http://dist.suse.de/install/SLP/SLE-%VERSION%-Full-LATEST/%ARCH%/DVD1/
          NOAUTOLOGIN: '0'
          SCC_ADDONS: base,sdk,serverapp
          TIMEOUT_SCALE: '3'
          +NOVIDEO: ''
          YAML_SCHEDULE: schedule/kernel/gfx-usb-drivers.yaml    
```

