### PR TITLE
Replace reboot process for slem rollback

### DIFF
--- a/tests/microos/rollback.pm
+++ b/tests/microos/rollback.pm
@@ -12,23 +12,16 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use power_action_utils 'power_action';
-use Utils::Backends 'is_remote_backend';
 use version_utils 'verify_os_version';
+use transactional 'process_reboot';
 
-sub reboot {
-    my ($self) = @_;
-    power_action('reboot', textmode => 1, keepconsole => 1);
-    reconnect_mgmt_console if is_remote_backend;
-    $self->wait_boot(ready_time => 300, bootloader_time => 300);
-}
 sub run {
     my ($self) = @_;
-    $self->reboot;
+    process_reboot(trigger => 1);
     select_console 'root-console';
     verify_os_version;
     script_run("transactional-update rollback last");
-    $self->reboot;
+    process_reboot(trigger => 1);
     select_console 'root-console';
     my $rollback_version = get_var("FROM_VERSION");
     verify_os_version($rollback_version);


### PR DESCRIPTION
failure of reboot in the beginning of rollback module : https://openqa.suse.de/tests/overview?result=failed&arch=&flavor=&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=&distri=sle-micro&version=6.0&build=9.1&groupid=510#

- Related ticket: https://progress.opensuse.org/issues/157096
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle-micro&build=sofiasyria%2Fos-autoinst-distri-opensuse%23slem_vnc&version=6.0  
