### PR TITLE
rasdaemon: Skip functional tests on ppc64le and Tumbleweed

### DIFF
--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -60,6 +60,10 @@ sub run {
     my $rt = zypper_call('in rasdaemon');
     test_case('Installation', 'rasdaemon', $rt);
 
+    # Skip functional tests on ppc64le and Tumbleweed. It is not fully supported,
+    # we are interested in installation only
+    return if (is_ppc64le && is_tumbleweed);
+
     $rt = assert_script_run('! ras-mc-ctl --status');
     test_case('Check rasdaemon --status', 'drivers are not loaded', $rt);
 


### PR DESCRIPTION
Fix poo#158161: We should do only installation test on ppc64le architecture on Tumbleweed. rasdaemon is not supported on ppc64le and is included in Tumbleweed for people who are interested in it only.

- Related ticket: https://progress.opensuse.org/issues/158161
- Needles: none
- Verification run: 

SLE: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=czerw%2Fos-autoinst-distri-opensuse%2319095

TW: https://openqa.opensuse.org/tests/overview?distri=opensuse&build=czerw%2Fos-autoinst-distri-opensuse%2319095&version=Tumbleweed

ppc64le TW: https://openqa.opensuse.org/tests/4080610#step/HPC_rasdaemon_tests/1