### PR TITLE
Avoid loading perl_bootloader test module for sdboot based tests

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -193,7 +193,7 @@ sub load_common_tests {
     loadtest 'microos/services_enabled';
     # MicroOS -old images use wicked, but cockpit-wicked is no longer supported in TW
     loadtest 'microos/cockpit_service' unless (is_microos('Tumbleweed') && is_staging) || (is_microos('Tumbleweed') && get_var('HDD_1', '') =~ /-old/) || !get_var('SCC_REGISTER');
-    loadtest 'console/perl_bootloader';
+    loadtest 'console/perl_bootloader' unless (is_bootloader_sdboot);
     # Staging has no access to repos and the MicroOS-DVD does not contain ansible
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
     loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro);


### PR DESCRIPTION
perl_bootloader test module causes a failure for sdboot based tests: https://openqa.opensuse.org/tests/4080567#step/perl_bootloader/112

Related ticket: https://progress.opensuse.org/issues/158919