### PR TITLE
Remove after.local usage form MU virt test

### DIFF
--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -355,7 +355,7 @@
     </user>
   </users>
 <scripts>
-<post-scripts config:type="list">
+<init-scripts config:type="list">
 <script>
 <filename>PU1-cv-users.sh</filename>
 <source>
@@ -364,16 +364,15 @@
 mkdir -p -m 700 /root/.ssh
 echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_key
-cat > /etc/init.d/after.local<< EOF
-#!/bin/sh
-ip a | grep eth0 | grep -Po '(?<=inet )[\d.]+' > /root/$(hostname)
-logger "IP is written into file"
-curl -k -u root:{{PASS}} -T /root/$(hostname) sftp://{{SUT_IP}}/tmp/guests_ip/ --ftp-create-dirs
-exit 0
-EOF
-chmod u+x /etc/init.d/after.local
 ]]></source>
 </script>
-</post-scripts>
+<script>
+<filename>initial_boot_notify.sh</filename>
+<source>
+<![CDATA[
+ip a | grep eth0 | grep -Po '(?<=inet )[\d.]+' > /root/$(hostname); logger "IP is written into file"; curl -k -u root:<%= $testapi::password %> -T /root/$(hostname) sftp://{{SUT_IP}}/tmp/guests_ip/ --ftp-create-dirs; exit 0;
+]]></source>
+</script>
+</init-scripts>
 </scripts>
 </profile>

--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -22,11 +22,10 @@ sub reboot_guest {
     my $guest = shift;
     record_info("Rebooting $guest");
     if (get_var("KVM") || get_var("XEN")) {
-        script_run("rm /tmp/guests_ip/$guest");
         script_run("virsh shutdown $guest");
         script_retry("virsh domstate $guest|grep 'shut off'", retry => 5);
         script_run("virsh start $guest");
-        script_retry("test -f /tmp/guests_ip/$guest", retry => 5, delay => 60);
+        script_retry("nmap $guest -PN -p ssh | grep open", retry => 5, delay => 60);
     } else {
         script_run("ssh root\@$guest reboot || true", timeout => 10);
         wait_guest_online($guest);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/153916 and https://progress.opensuse.org/issues/158829
- Needles: N/A
- Verification run: 
[15-SP5-KVM](http://openqa.qam.suse.cz/tests/71808#dependencies)
[15-SP5-XEN](http://openqa.qam.suse.cz/tests/71810#dependencies)
[15-SP6-KVM](http://openqa.qam.suse.cz/tests/71806#dependencies)
[15-SP6-XEN](http://openqa.qam.suse.cz/tests/71804#dependencies)