### PR TITLE
Need to wait more for qemu ppc64le wait boot

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -503,7 +503,7 @@ sub wait_grub_to_boot_on_local_disk {
 
     # We need to wait more for aarch64's tianocore-mainmenu and for qemu ppc64le
     if ((is_aarch64) || (is_ppc64le && is_qemu)) {
-        assert_screen(\@tags, 30);
+        assert_screen(\@tags, 90);
     } else {
         assert_screen(\@tags, 15);
     }

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -510,7 +510,8 @@ sub process_scc_register_addons {
                 send_key_until_needlematch "scc-module-$addon-selected", "down", ADDONS_COUNT;
             }
         }
-        wait_screen_change { send_key $cmd{next} };    # all addons selected
+        wait_still_screen 5;
+        wait_screen_change(sub { send_key $cmd{next} }, 30, similarity_level => 35);    # all addons selected
         wait_still_screen 2;
         # Process addons licenses
         accept_addons_license @scc_addons;
@@ -789,7 +790,7 @@ sub yast_scc_registration {
     # For Aarch64 if the worker run with heavy loads, it will
     # timeout in nearly 120 seconds. So we set it to 150. Same
     # for s390 since timeout happen.
-    assert_screen('scc-registration', timeout => (is_aarch64 || is_s390x) ? 150 : 90,);
+    assert_screen('scc-registration', timeout => (is_aarch64 || is_s390x) ? 150 : 120,);
     fill_in_registration_data;
     wait_serial("$module_name-0", 150) || die "yast scc failed";
     # To check repos validity after registration, call 'validate_repos' as needed

--- a/tests/migration/record_disk_info.pm
+++ b/tests/migration/record_disk_info.pm
@@ -11,9 +11,10 @@ use strict;
 use warnings;
 use testapi;
 use migration 'record_disk_info';
+use serial_terminal qw(select_serial_terminal);
 
 sub run {
-    select_console 'root-console';
+    select_serial_terminal();
 
     # The disk space usage info would be helpful to debug upgrade failure
     # with disk exhausted error


### PR DESCRIPTION
Need to wait more for qemu ppc64le "wait boot", "wait screen", etc

Due to ppc64le worker perfomance issues fix these `high frequency` issues as following:
  Wait more for qemu ppc64le in test module patch_sle
  Use select_serial_terminal instead of select_console in test module record_disk_info
  Set wait_screen_change similarity=35 instead of default 50

TEAM-8987 - [15SP6][HA Migration] migration_offline_scc_sle12sp5_ha_alpha_node02 failed on patch_sle: needle 'scc-addon-license-ha' mismatched


- Related ticket: https://jira.suse.com/browse/TEAM-8987
- Needles: NA
- Verification run:
https://openqa.suse.de/tests/14038553 (passed on migration)
https://openqa.suse.de/tests/14038549 (passed on migration)
https://openqa.suse.de/tests/14038542 (passed on migration)
https://openqa.suse.de/tests/14047665 (passed on migration)
https://openqa.suse.de/tests/14047669 (passed on migration)