### PR TITLE
Add needle check for successful iPXE start before changing boot device

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -231,7 +231,13 @@ sub run {
         # HANA PERF uses DELL R840 and R740, their UEFI IPXE boot need not set_bootscript_hdd
         return if (get_var('HANA_PERF') && get_var('IPXE_UEFI'));
         # make sure to wait for a while befor changing the boot device again, in order to not change it too early
-        sleep 120;
+        my $sleep = get_var('IPXE_FIXED_SLEEP_DURATION');
+        if ($sleep) {
+            sleep $sleep;
+        } else {
+            # give the needle a longer timeout in order to accomodate even the slowest server machines
+            assert_screen('IPXE_LOAD_KERNEL', 600);
+        }
         set_bootscript_hdd if get_var('IPXE_UEFI');
     }
     else {


### PR DESCRIPTION
When we boot slow systems, a hard-coded timeout is either too long or too short, depending on the hardware used.
Instead of guessing, we should add a needle check to see when iPXE has successfully started to load a kernel image, then we can safely change UEFI boot device again.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
