### PR TITLE
Replace addon_others with addon_products in create_hdd_maintenance.xml.ep

### DIFF
--- a/data/yam/autoyast/support_images/create_hdd_maintenance.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_maintenance.xml.ep
@@ -31,16 +31,13 @@
         %}
     </suse_register>
     <add-on>
-        <add_on_others config:type="list">
-            % for my $repo (@$repos) {
-            % my ($repo_id, $addon) = $repo =~ (/(\d+)\/(.*)\//);
-        <listentry>
-        <media_url><%= $repo %></media_url>
-            <name><%= $addon . "_" . $repo_id %></name>
-            <alias><%= $addon . "_" . $repo_id %></alias>
-        </listentry>
-        %}
-        </add_on_others>
+       <add_on_products config:type="list">
+         % for my $repo (@$repos) {
+         <listentry>
+           <media_url><%= $repo %></media_url>
+         </listentry>
+         % }
+       </add_on_products>
     </add-on>
     <bootloader>
         <global>


### PR DESCRIPTION
Currently, th ecreate_hdd_gnome tests run with addon_others and the mu repos are not visible after installation. This can be fixed by using addon_products
- Related ticket: https://progress.opensuse.org/issues/155827
- Verification run: https://openqa.suse.de/tests/14016028#step/repos/9
