### PR TITLE
Filter Desktop-Applications out of the repos to be added to ibsm

### DIFF
--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -24,8 +24,8 @@ sub run {
 
     while (defined(my $maintrepo = shift @repos)) {
         next if $maintrepo =~ /^\s*$/;
-        if ($maintrepo =~ /Development-Tools/) {
-            record_info("MISSING REPOS", "There are Development-Tools repos in this incident, that are not uploaded to IBSM. Later errors, if they occur, may be due to these.");
+        if ($maintrepo =~ /Development-Tools/ or $maintrepo =~ /Desktop-Applications/) {
+            record_info("MISSING REPOS", "There are repos in this incident, that are not uploaded to IBSM. ($maintrepo). Later errors, if they occur, may be due to these.");
             next;
         }
         foreach my $instance (@{$self->{instances}}) {


### PR DESCRIPTION
The rpms that are included in these modules are not currently tested and including them breaks the scenarios because they are not currently synced to IBSM


- Related ticket: TEAM-9246
- Verification run: http://openqaworker15.qa.suse.cz/tests/280754#step/cluster_add_repos/14