### PR TITLE
Make ensa_supportserver run on the root-console

### DIFF
--- a/schedule/sles4sap/ensa/ensa_supportserver.yaml
+++ b/schedule/sles4sap/ensa/ensa_supportserver.yaml
@@ -1,7 +1,7 @@
 ---
 name: ensa_supportserver
 description: >
-  SupportServer definition for HA tests.
+  SupportServer definition for ENSA2 tests.
 
   Some settings are required in the job group or test suite for this schedule to work.
 
@@ -24,6 +24,7 @@ vars:
   SUPPORT_SERVER: '1'
   SUPPORT_SERVER_ROLES: dhcp,dns,ntp,ssh,iscsi
   VIDEOMODE: text
+  VIRTIO_CONSOLE: '0'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: openqa_support_server_sles12sp3.%ARCH%.qcow2
 schedule:


### PR DESCRIPTION
This adds the omitted VIRTIO_CONSOLE setting.

- Related ticket: https://jira.suse.com/browse/TEAM-8977
- Verification run: http://openqaworker15.qa.suse.cz/tests/280691#
