### PR TITLE
Remove 'zypper refresh' in xfstests installation

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -43,7 +43,6 @@ sub install_xfstests_from_repo {
         zypper_ar($repo_url, name => 'xfstests-repo');
         zypper_ar($dep_url, name => 'dependency-repo');
     }
-    zypper_call('--gpg-auto-import-keys ref');
     record_info('repo info', script_output('zypper lr -U'));
     if (is_transactional) {
         script_run('id fsgqa &> /dev/null || useradd -d /home/fsgqa -k /etc/skel -ms /bin/bash -U fsgqa');


### PR DESCRIPTION
'zypper refresh' is not a necessary step to install xfstests. So remove it for stability.

- Related ticket: https://progress.opensuse.org/issues/159018
- Needles: N/A
- Verification run: 
http://10.67.133.133/tests/580 (SLES)
https://openqa.suse.de/tests/14038560 (SLE Micro)
