### PR TITLE
Add cluster checks in hana_sr_takeover

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -11,6 +11,7 @@ use base 'sles4sap_publiccloud_basetest';
 use testapi;
 use sles4sap_publiccloud;
 use publiccloud::utils;
+use hacluster qw($crm_mon_cmd);
 use serial_terminal 'select_serial_terminal';
 
 sub test_flags {
@@ -86,6 +87,8 @@ sub run {
     record_info(ucfirst($site_name) . ' start');
     $self->cleanup_resource();
 
+    die "Required hana resource is NOT running on $self->{my_instance}, aborting" unless $self->is_hana_resource_running();
+    $self->run_cmd(cmd => $crm_mon_cmd, timeout => 300);
     record_info('Done', 'Test finished');
 }
 


### PR DESCRIPTION
This pr adds a quiet optional argument for `is_hana_ready`, changes the `record_info` output to something more meaningful, and runs `crm mon` in the end of hana_sr_takeover`, to allow the reviewer to troubleshoot in case of failure.

- Related ticket: https://jira.suse.com/browse/TEAM-9239
- Verification run: https://openqa.suse.de/tests/14057479
https://openqa.suse.de/tests/14040271
new, revised output: https://openqa.suse.de/tests/14040271#step/Crash_site_b-primary/670
crm output at the end of the module: https://openqa.suse.de/tests/14040271#step/Crash_site_b-primary/684