### PR TITLE
transactional: Add comment with link to poo#159039

### DIFF
--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -85,6 +85,8 @@ sub run {
         check_reboot_changes;
         check_package(stage => 'up');
 
+        # NOTE: This has a very small chance of failing
+        # See https://progress.opensuse.org/issues/159039
         record_info 'Update #2', 'System should be up to date - no changes expected';
         trup_call 'cleanup up';
         check_reboot_changes 0;


### PR DESCRIPTION
Add comment with link to poo#159039 about the very small chance of `t-u cleanup up` failing is an update suddenly appears.

- Related ticket: https://progress.opensuse.org/issues/159036