### PR TITLE
Remove references to post-sap-hana-cluster.yaml

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -45,6 +45,5 @@ ansible:
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
     - sap-hana-cluster.yaml
-    - post-sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -47,6 +47,5 @@ ansible:
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
     - sap-hana-cluster.yaml -e azure_identity_management=%AZURE_NATIVE_FENCING_AIM%
-    - post-sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -47,6 +47,5 @@ ansible:
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
     - sap-hana-cluster.yaml -e azure_identity_management=%AZURE_NATIVE_FENCING_AIM% -e spn_application_id=%AZURE_NATIVE_FENCING_APP_ID% -e spn_application_password=%AZURE_NATIVE_FENCING_APP_PASSWORD%
-    - post-sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
@@ -45,6 +45,5 @@ ansible:
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
     - sap-hana-cluster.yaml
-    - post-sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -43,6 +43,5 @@ ansible:
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
     - sap-hana-cluster.yaml
-    - post-sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
@@ -41,6 +41,5 @@ ansible:
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
     - sap-hana-cluster.yaml
-    - post-sap-hana-cluster.yaml
   destroy:
 

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -43,6 +43,5 @@ ansible:
     - sap-hana-system-replication.yaml
     - sap-hana-system-replication-hooks.yaml
     - sap-hana-cluster.yaml
-    - post-sap-hana-cluster.yaml
   destroy:
     - deregister.yaml

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -335,8 +335,8 @@ sub stop_hana {
         my $out = $self->{my_instance}->wait_for_ssh(timeout => 60, wait_stop => 1);
         record_info("Wait ssh disappear end", "out:" . ($out // 'undefined'));
         sleep 10;
-        $self->{my_instance}->wait_for_ssh(timeout => 900);
-        return;
+        $out = $self->{my_instance}->wait_for_ssh(timeout => 900);
+        record_info("Wait ssh is back again", "out:" . ($out // 'undefined'));
     }
     else {
         my $sapadmin = lc(get_required_var('INSTANCE_SID')) . 'adm';
@@ -841,7 +841,6 @@ sub create_playbook_section_list {
           sap-hana-system-replication-hooks.yaml
         );
         push @playbook_list, $hana_cluster_playbook;
-        push @playbook_list, 'post-sap-hana-cluster.yaml';
     }
     return (\@playbook_list);
 }


### PR DESCRIPTION
Remove any reference to qe-sap-deployment Ansible playbook post-sap-hana-cluster.yaml as it has been merged to sap-hana-cluster.yaml in a latest qesap version.

Related to https://github.com/SUSE/qe-sap-deployment/pull/216

- Related ticket: https://jira.suse.com/browse/TEAM-9093

# Verification run: 

## HanaSR

###  sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-04-16T04:03:11Z-hanasr_azure_test_sapconf_msi@64bit 
-> http://openqaworker15.qa.suse.cz/tests/280768


 ### sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-04-16T04:03:11Z-hanasr_azure_test_sapconf_sbd@64bit 
 - -> http://openqaworker15.qa.suse.cz/tests/280769
 
## qesap regression

### sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test@64bit 
- http://openqaworker15.qa.suse.cz/tests/280765

### sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit 
- http://openqaworker15.qa.suse.cz/tests/280766
