### PR TITLE
Fix container-selinux schedule for s390x

### DIFF
--- a/schedule/security/slmicro/selinux.yaml
+++ b/schedule/security/slmicro/selinux.yaml
@@ -1,6 +1,6 @@
-name: container_selinux
+name: selinux
 description: >
-    This is for container-selinux test on SLE Micro.
+    This is for SElinux test
 schedule:
     - '{{boot_s390}}'
     - '{{boot_non_s390}}'
@@ -8,8 +8,20 @@ schedule:
     - console/suseconnect_scc
     - security/selinux/selinux_setup
     - security/selinux/sestatus
-    - security/selinux/container_selinux
+    - security/selinux/semanage_fcontext
+    - security/selinux/semanage_boolean
+    - security/selinux/fixfiles
+    - security/selinux/print_se_context
+    - security/selinux/audit2allow
+    - security/selinux/semodule
+    - security/selinux/setsebool
+    - security/selinux/restorecon
+    - security/selinux/chcon
+    - security/selinux/chcat
+    - security/selinux/set_get_enforce
+    - security/selinux/selinuxexeccon
     - console/journal_check
+    - shutdown/shutdown
 conditional_schedule:
     boot_s390:
         ARCH:


### PR DESCRIPTION
https://progress.opensuse.org/issues/157138

VR: https://openqa.suse.de/tests/14039356
but with this, we need to add `EXCLUDE_MODULES=disk_boot` to s390x jobs..


VRs:
[container_selinux s390x](https://openqa.suse.de/tests/14173934#)
[container_selinux x86_64](https://openqa.suse.de/tests/14173937#)
[selinux s390x](https://openqa.suse.de/tests/14173935#)
[selinux x86_64](https://openqa.suse.de/tests/14173936#)