### PR TITLE
Verify cluster health at the end

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -88,7 +88,8 @@ sub run {
 
     # Cleanup the resource and check cluster
     $self->cleanup_resource();
-    $self->wait_for_cluster();
+    $self->wait_for_cluster(wait_time => 60, max_retries => 10);
+    $self->display_full_status();
 
     record_info("Done", "Test finished");
 }


### PR DESCRIPTION
Verify that the cluster is in S_IDLE and get the crm status at the end of each Takeover or Secondary HanaSR test step

- Related ticket: https://jira.suse.com/browse/TEAM-9253 https://jira.suse.com/browse/TEAM-9239


# Verification run:

##  sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-04-16T04:03:11Z-hanasr_azure_test_msi@64bit 

### http://openqaworker15.qa.suse.cz/tests/281281

http://openqaworker15.qa.suse.cz/tests/281281#step/Stop_site_a-primary/704  --> https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19122/files#diff-6b1b9620bf9f9d9ca1005e2e30986615be757ce405dc23e791815d048b5702ecR80  

http://openqaworker15.qa.suse.cz/tests/281281#step/Stop_site_a-primary/725  --> `crm resource cleanup`

http://openqaworker15.qa.suse.cz/tests/281281#step/Stop_site_a-primary/748  --> `crm resource status msl_SAPHana_HDB_HA000`


### http://openqaworker15.qa.suse.cz/tests/281284
:red_circle:  fails at Ansible reboot timeout, before to reach the PR code

###  http://openqaworker15.qa.suse.cz/tests/281287

##  sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-04-16T04:03:11Z-hanasr_azure_test_sbd@64bit 

### http://openqaworker15.qa.suse.cz/tests/281282

Fails during Ansible (and then fails for timeout as disabling the virtual environment, like an issue on the openQA worker), before to reach the PR code

### http://openqaworker15.qa.suse.cz/tests/281285

Fails in Ansible at reboot, before to reach the PR code

###  http://openqaworker15.qa.suse.cz/tests/281288

##  sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-04-16T04:03:11Z-hanasr_azure_test_spn@64bit 

### http://openqaworker15.qa.suse.cz/tests/281283


### http://openqaworker15.qa.suse.cz/tests/281286

https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19122/files   --> https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19122/

http://openqaworker15.qa.suse.cz/tests/281286#step/Stop_site_a-primary/677 --> `crm resource cleanup`

http://openqaworker15.qa.suse.cz/tests/281286#step/Stop_site_a-primary/699 and http://openqaworker15.qa.suse.cz/tests/281286#step/Stop_site_a-primary/721 --> `is_hana_resource_running`  calling  `crm resource status msl_SAPHana_HDB_HA000`

http://openqaworker15.qa.suse.cz/tests/281286#step/Stop_site_a-primary/789 and http://openqaworker15.qa.suse.cz/tests/281286#step/Stop_site_a-primary/858  --> `check_crm_output`

http://openqaworker15.qa.suse.cz/tests/281286#step/Stop_site_a-primary/949  --> cluster status summary
