### PR TITLE
filesystem: Add btrfs-progs tests to yaml scheduler

### DIFF
--- a/schedule/filesystem/btrfs-progs.yaml
+++ b/schedule/filesystem/btrfs-progs.yaml
@@ -1,0 +1,10 @@
+---
+name: 'btrfs-progs@sle_micro'
+description:    >
+  Maintainer: An Long <lan@suse.com>
+  btrfs-progs test suite for SLE-Micro
+schedule:
+    - microos/disk_boot
+    - btrfs-progs/install
+    - btrfs-progs/run
+    - btrfs-progs/generate_report


### PR DESCRIPTION
Recently btrfs-progs has frequently failed in boot_to_desktop.  Switch from boot_to_desktop to microos/disk_boot.pm should workaround this issue. But update boot_hdd_image subroutine  is not a graceful way to do it. Thus we add a yaml scheduler to deal this.

- Related ticket: https://progress.opensuse.org/issues/158988
- Needles: N/A
- Verification run: http://10.67.133.133/tests/592
