### PR TITLE
Remove at-spi* packages from profile

### DIFF
--- a/data/yam/autoyast/bug-887126_autoinst.xml
+++ b/data/yam/autoyast/bug-887126_autoinst.xml
@@ -394,8 +394,6 @@
   <software>
     <instsource/>
     <packages config:type="list">
-      <package>at-spi2-atk-common</package>
-      <package>at-spi2-atk-gtk2</package>
       <package>dconf</package>
       <package>grub2-snapper-plugin</package>
       <package>gsettings-backend-dconf</package>


### PR DESCRIPTION
Due to the fix https://build.suse.de/request/show/326197 of bsc#1221841, we should remove the at-spi* packages from corresponding profile.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/14048502#