### PR TITLE
kdump: Increase timeout for aarch64 and hyperv

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -399,7 +399,7 @@ sub configure_service {
 sub check_function {
     my %args = @_;
     $args{test_type} //= '';
-    my $boot_timeout = is_aarch64 || is_hyperv ? 240 : undef;
+    my $boot_timeout = is_aarch64 || is_hyperv ? 300 : undef;
 
     my $self = y2_module_consoletest->new();
 


### PR DESCRIPTION
aarch64  baremetal  servers are slow and they need even higher timeout.

- Related ticket: https://progress.opensuse.org/issues/156781
- Needles: none
- Verification run: https://openqa.suse.de/tests/14048641#step/kdump/52 (needle matched correctly)
