### PR TITLE
Add support for s390x qemu

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -854,15 +854,15 @@ sub unregister_needle_tags {
 }
 
 sub load_bootloader_s390x {
-    return 0 unless is_s390x;
-
     if (is_backend_s390x) {
         loadtest "installation/bootloader_s390";
+        return 1;
     }
-    else {
+    if (is_s390x && is_svirt) {
         loadtest "installation/bootloader_zkvm";
+        return 1;
     }
-    return 1;
+    return 0;
 }
 
 sub boot_hdd_image {

--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -43,17 +43,15 @@ sub run {
         $self->boot_from_pxe::run();
         return;
     }
-    if (is_s390x()) {
-        if (check_var("BACKEND", "s390x")) {
-            record_info('bootloader_s390x');
-            $self->bootloader_s390::run();
-            return;
-        }
-        else {
-            record_info('bootloader_zkvm');
-            $self->bootloader_zkvm::run();
-            return;
-        }
+    if (is_s390x() && check_var("BACKEND", "s390x")) {
+        record_info('bootloader_s390x');
+        $self->bootloader_s390::run();
+        return;
+    }
+    if (is_s390x() && check_var("BACKEND", "svirt")) {
+        record_info('bootloader_zkvm');
+        $self->bootloader_zkvm::run();
+        return;
     }
     if (is_svirt && is_x86_64()) {
         set_bridged_networking();


### PR DESCRIPTION
For now our tests on s390x only expected z/VM or KVM on s390x using the
svirt backend.

This commit now adds support for the third case using the (default) qemu
backend where we actually do not need to do anything s390x specific.

Verification runs:

```
for i in  https://openqa.suse.de/tests/14068509 https://openqa.opensuse.org/tests/4054629 https://openqa.opensuse.org/tests/4054622 https://openqa.suse.de/tests/14005042 https://openqa.suse.de/tests/14096877 https://openqa.suse.de/tests/14092754; do openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19128 $i; done
```

 - sle-15-SP6-Online-s390x-Build79.1-okurz-poo158985-default-okurz-poo158985@s390x-kvm -> https://openqa.suse.de/tests/14103628 (so far expected to fail, native s390x qemu in development)
 - opensuse-Tumbleweed-DVD-s390x-Build20240329-autoyast_zvm@s390x-zVM-vswitch-l2 -> https://openqa.opensuse.org/tests/4097728 (schedule as expected, fails later due to other reason)
 - opensuse-Tumbleweed-DVD-s390x-Build20240329-textmode@s390x-zVM-vswitch-l2 -> https://openqa.opensuse.org/tests/4097729 (passed)
 - sle-15-SP6-Online-s390x-Build79.1-default@s390x-kvm -> https://openqa.suse.de/tests/14105090 (passed)
 - sle-15-SP6-Online-s390x-Build82.1-default@s390x-kvm -> https://openqa.suse.de/tests/14103626 (passed)
 - sle-15-SP6-Online-s390x-Build82.1-default@s390x-zVM -> https://openqa.suse.de/tests/14103627 (passed)

But multiple fail due to https://progress.opensuse.org/issues/158170 which we need to sort out first.

Related progress issue: https://progress.opensuse.org/issues/158985