### PR TITLE
Remove desktop addon from create_hdd_textmode

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_textmode_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_textmode_aarch64.xml
@@ -335,13 +335,6 @@
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
-        <reg_code/>
-        <release_type>nil</release_type>
-        <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
         <reg_code/>
         <release_type>nil</release_type>

--- a/data/autoyast_sle15/create_hdd/create_hdd_textmode_s390x.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_textmode_s390x.xml
@@ -337,7 +337,6 @@
       <package>wicked</package>
       <package>snapper</package>
       <package>sle-module-server-applications-release</package>
-      <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
       <package>openssh</package>
       <package>kexec-tools</package>
@@ -374,13 +373,6 @@
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
-        <reg_code/>
-        <release_type>nil</release_type>
-        <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>sle-module-desktop-applications</name>
         <reg_code/>
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/159093
- VR: https://openqa.suse.de/tests/overview?build=os-autoinst%2Fos-autoinst-distri-opensuse%2319130

Remove desktop addon and package from create_hdd_textmode autoyast profiles.