### PR TITLE
Complete SL Micro 6.0 test flow to include host installation part

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -250,7 +250,10 @@ sub prepare_common_environment {
         virt_autotest::utils::setup_common_ssh_config('/root/.ssh/config');
         script_run("[ -f /etc/ssh/ssh_config ] && sed -i -r -n \'s/^.*IdentityFile.*\$/#&/\' /etc/ssh/ssh_config");
         enable_debug_logging;
-        $guest_installation_and_configuration_metadata::host_params{host_ipaddr} = get_required_var('SUT_IP');
+        $guest_installation_and_configuration_metadata::host_params{host_sutip} = get_required_var('SUT_IP');
+        my $_default_route = script_output("ip route show default | grep -i dhcp | grep -vE br[[:digit:]]+", proceed_on_failure => 1);
+        my $_default_device = (!$_default_route) ? 'br0' : (split(' ', script_output("ip route show default | grep -i dhcp | grep -vE br[[:digit:]]+ | head -1")))[4];
+        $guest_installation_and_configuration_metadata::host_params{host_ipaddr} = (split('/', (split(' ', script_output("ip addr show dev $_default_device | grep \"inet \"")))[1]))[0];
         $guest_installation_and_configuration_metadata::host_params{host_name} = script_output("hostname");
         # For SUTs with multiple interfaces, `dnsdomainname` sometimes does not work
         $guest_installation_and_configuration_metadata::host_params{host_domain_name} = script_output("dnsdomainname", proceed_on_failure => 1);

--- a/lib/guest_installation_and_configuration_metadata.pm
+++ b/lib/guest_installation_and_configuration_metadata.pm
@@ -239,7 +239,8 @@ our %guest_params = (
 # any specific guest and only relating to operations on host. All parameters
 # in this structure are only initialized once in a single test run.
 our %host_params = (
-    'host_ipaddr' => '',    # This is get_required_var('SUT_IP')
+    'host_sutip' => '',    # This is get_required_var('SUT_IP')
+    'host_ipaddr' => '',    # This is ip addr of default host network device
     'host_name' => '',    # This is script_output('hostname')
     'host_domain_name' => '',    # This is script_output('dnsdomainname')
     'host_version_major' => '',    # Major version of host os release from /etc/os-release on host

--- a/schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml
+++ b/schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml
@@ -5,6 +5,9 @@ description: |
   Virtualization Guest Installation on SLE Micro KVM Host
 
 vars:
+  IPXE: 1
+  IPXE_UEFI: 1
+  USB_BOOT: 1
   VIRT_AUTOTEST: 1
   VIRT_PRJ1_GUEST_INSTALL: 1
   VIRT_UNIFIED_GUEST_INSTALL: 1
@@ -16,7 +19,7 @@ vars:
   PATTERNS: default,kvm
   MAX_JOB_TIME: 10800
 schedule:
-  # - "{{bootup_and_install}}"
+  - "{{bootup_and_install}}"
   - virt_autotest/login_console
   - virt_autotest/prepare_transactional_server
   - "{{install_guest}}"
@@ -25,26 +28,21 @@ conditional_schedule:
     DO_NOT_INSTALL_HOST:
       0:
         - "{{bootup}}"
-        - installation/welcome
-        - installation/scc_registration
-        - installation/ntp_config_settings
-        - installation/user_settings_root
-        - installation/resolve_dependency_issues
-        - installation/select_patterns
-        - installation/installation_overview
-        - installation/disable_grub_graphics
-        - installation/start_install
-        - installation/await_install
-        - installation/logs_from_installation_system
-        - installation/reboot_after_installation
-  install_guest:
-    SKIP_GUEST_INSTALL:
-      0:
-        - virt_autotest/unified_guest_installation
+        - "{{install}}"
   bootup:
     IPXE:
       1:
         - installation/ipxe_install
       0:
         - boot/boot_from_pxe
+  install:
+    USB_BOOT:
+      1:
+        - installation/usb_install
+        - installation/bootloader_uefi
+        - microos/selfinstall
+  install_guest:
+    SKIP_GUEST_INSTALL:
+      0:
+        - virt_autotest/unified_guest_installation
 ...

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -12,6 +12,8 @@ use microos "microos_login";
 use Utils::Architectures qw(is_aarch64);
 use version_utils qw(is_leap_micro is_sle_micro);
 use utils;
+use Utils::Backends qw(is_ipmi);
+use ipmi_backend_utils qw(ipmitool);
 
 sub run {
     my ($self) = @_;
@@ -44,6 +46,12 @@ sub run {
         eject_cd() unless ($no_cd || is_usb_boot);
     }
 
+    # Remove usb boot entry and empty usb disks to ensure installed system boots from hard disk
+    if (is_ipmi and is_uefi_boot and is_usb_boot) {
+        remove_efiboot_entry(boot_entry => 'OpenQA-added-UEFI-USB-BOOT');
+        empty_usb_disks;
+        ipmitool("chassis bootdev disk options=persistent,efiboot") for (0 .. 2);
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
* **Include** SL Micro 6.0 host installation part before doing guest installation. And also update corresponding settings needed in this test, including yaml ```schedule/virt_autotest/install_guest_on_slem_kvm_host.yaml```.

* **Introduce** new subroutine ```remove_efiboot_entry``` in ```lib/utils.pm``` to be called in ```selfinstall.pm``` to ensure temporarily added usb boot entry will deleted and installed system will boot from hard disk subsequently.

* **Introduce** new subroutine ```empty_usb_disks``` in ```lib/utils.pm``` to be called in ```selfinstall.pm``` to ensure system always boots from installed SL Micro on reboot.

* **Use** ```set_ssh_console_timeout_before_use``` in ```tests/virt_autotest/login_console.pm``` to prevent connection from being torn down for SL Micro as well. Sometime downloading all disk images cost too much time.

* **Update** ```set_ssh_console_timeout_before_use``` in ```tests/virt_autotest/login_console.pm```  to have passed in arguments to allow using different sshd configuration files. For example, SL Micro 6.0 which does not have default ```sshd_config``` in ```/etc/ssh``` folder.

* **Update** ```set_ssh_console_timeout``` in ```lib/Utils/Backend.pm``` to ensure keep alive settings are added in sshd configuration file, especially a customized configuration file is being used.

* **Introduce** ```host_sutip``` and ```host_ipaddr``` in ```lib/guest_installation_and_configuration_metadata.pm``` to record complete address info about host.

*  **By** the way, the host installation part, especially ```booloader_uefi```  failure rate of which is pretty high when network speed running slow.

* **Verification Run:**
  * [12sp5 kvm host](https://openqa.suse.de/tests/14212212)
  * [15sp6 kvm host](https://openqa.suse.de/tests/14212175)
  * [15sp6 xen host](https://openqa.suse.de/tests/14212176)
  * [uefi 15sp5 kvm host](https://openqa.suse.de/tests/14212179)
  * [uefi 12sp5 xen host](https://openqa.suse.de/tests/14212178)
  * [sle-micro-6.0-Base-SelfInstall-x86_64-Build10.11-slem_installation_default qemu backend](https://openqa.suse.de/tests/14212830)
  * [ sle-micro-6.0-Base-SelfInstall-x86_64-Build10.11-slem_podman qemu backend](https://openqa.suse.de/tests/14212835)
  * [SL Micro 6.0 ful test run with SL Micro 6.0 guest kermit](https://openqa.suse.de/tests/14211967)
  * [SL Micro 6.0 full test run with 15sp5 guest kermit](https://openqa.suse.de/tests/14212174)
  * [SL Micro 6.0 full test run with SL Micro 6.0 guest link1](http://10.100.228.134/tests/2622) [link2](http://10.100.204.18/tests/2622) [link3](http://10.67.18.153/tests/2622) [link4](http://10.149.193.170/tests/2622)
  * [SL Micro 6.0 full test run with sles 15sp5 guest link1](http://10.100.228.134/tests/2634) [link2](http://10.100.204.18/tests/2634) [link3](http://10.67.18.153/tests/2634) [link4](http://10.149.193.170/tests/2634)