### PR TITLE
Minor containers lib refactoring

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -20,7 +20,7 @@ use Mojo::JSON;
 
 our @EXPORT = qw(is_unreleased_sle install_podman_when_needed install_docker_when_needed install_containerd_when_needed
   test_container_runtime test_container_image scc_apply_docker_image_credentials scc_restore_docker_image_credentials
-  install_buildah_when_needed test_rpm_db_backend activate_containers_module check_containers_connectivity
+  install_buildah_when_needed activate_containers_module check_containers_connectivity
   switch_cgroup_version install_packages);
 
 sub is_unreleased_sle {
@@ -195,21 +195,6 @@ sub scc_apply_docker_image_credentials {
 
 sub scc_restore_docker_image_credentials {
     assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{.bak,}" if (is_sle() && get_var('SCC_DOCKER_IMAGE'));
-}
-
-sub test_rpm_db_backend {
-    my %args = @_;
-    my $image = $args{image};
-    my $runtime = $args{runtime};
-
-    die 'Argument $image not provided!' unless $image;
-    die 'Argument $runtime not provided!' unless $runtime;
-
-    my ($running_version, $sp, $host_distri) = get_os_release("$runtime run $image");
-    # TW and SLE 15-SP3+ uses rpm-ndb in the image
-    if ($host_distri eq 'opensuse-tumbleweed' || ($host_distri eq 'sles' && check_version('>=15-SP3', "$running_version-SP$sp", qr/\d{2}(?:-sp\d)?/))) {
-        validate_script_output "$runtime run $image rpm --eval %_db_backend", sub { m/ndb/ };
-    }
 }
 
 sub check_containers_connectivity {


### PR DESCRIPTION
This PR:
  - Moves `test_rpm_db_backend` from lib to test module calling it
  - Moves `test_search_registry` from lib to test module calling it

Related ticket: https://progress.opensuse.org/issues/155470
Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20240416-containers_host_docker@64bit -> https://openqa.opensuse.org/t4089621
  - opensuse-Tumbleweed-DVD-x86_64-Build20240416-containers_host_podman@64bit -> https://openqa.opensuse.org/t4089622
