### PR TITLE
kdump: Fix yaml schedule on s390x

### DIFF
--- a/schedule/kernel/kdump.yaml
+++ b/schedule/kernel/kdump.yaml
@@ -13,3 +13,6 @@ conditional_schedule:
         BACKEND:
             spvm:
                 - installation/bootloader
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm


### PR DESCRIPTION
Fix poo#159201: There was missing installation/bootloader_zkvm module on
s390x architecture. Existing boot condition was extended.

- Related ticket: https://progress.opensuse.org/issues/159201
- Needles: none
- Verification run: https://openqa.suse.de/tests/14057491
