### PR TITLE
Cleanup poo158982

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -22,7 +22,7 @@ use containers::utils;
 use containers::common qw(test_container_image is_unreleased_sle);
 
 our @EXPORT = qw(build_with_zypper_docker build_with_sle2docker
-  test_opensuse_based_image exec_on_container ensure_container_rpm_updates build_and_run_image
+  test_opensuse_based_image ensure_container_rpm_updates build_and_run_image
   test_zypper_on_container test_3rd_party_image upload_3rd_party_images_logs test_systemd_install);
 
 =head2 build_and_run_image
@@ -221,12 +221,6 @@ sub test_zypper_on_container {
     assert_script_run("$runtime commit refreshed refreshed-image", timeout => 120);
     assert_script_run("$runtime rm -f refreshed");
     script_retry("$runtime run -i --rm --entrypoint '' refreshed-image zypper -nv ref", timeout => 300, retry => 3, delay => 60);
-}
-
-sub exec_on_container {
-    my ($image, $runtime, $command, $timeout) = @_;
-    $timeout //= 120;
-    $runtime->run_container($image, cmd => $command, daemon => 1, timeout => $timeout);
 }
 
 sub test_3rd_party_image {

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -9,7 +9,7 @@
 package containers::docker;
 use Mojo::Base 'containers::engine';
 use testapi;
-use containers::utils qw(registry_url get_docker_version check_runtime_version);
+use containers::utils qw(registry_url get_docker_version);
 use containers::common qw(install_docker_when_needed);
 use utils qw(systemctl file_content_replace);
 use version_utils qw(get_os_release);

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -220,19 +220,6 @@ sub enum_containers {
     return \@containers;
 }
 
-=head2 get_images_by_repo_name
-
-Returns an array ref with the names of the images.
-
-=cut
-
-sub get_images_by_repo_name {
-    my ($self) = @_;
-    my $repo_images = $self->_engine_script_output("images --format '{{.Repository}}'", timeout => 120);
-    my @images = split /[\n\t ]/, $repo_images;
-    return \@images;
-}
-
 =head2 info
 
 Assert a C<property> against given expected C<value> if C<value> is given.

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -281,17 +281,6 @@ sub get_container_logs {
     $self->_engine_assert_script_run("container logs $container | tee $filename");
 }
 
-=head2 remove_image($image_name)
-
-Remove a image from the pool.
-
-=cut
-
-sub remove_image {
-    my ($self, $image_name) = @_;
-    $self->_engine_assert_script_run("rmi -f $image_name");
-}
-
 =head2 remove_container($container_name, [assert])
 
 Remove a container from the pool.

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -181,17 +181,6 @@ sub pull {
     return $self->_engine_script_retry("pull $image_name", timeout => $args{timeout} // 300, retry => 3, delay => 30, die => $die);
 }
 
-=head2 commit
-
-Save a existing container as a new image in the local registry
-
-=cut
-
-sub commit {
-    my ($self, $mycontainer, $new_image_name, %args) = @_;
-    $self->_engine_assert_script_run("commit $mycontainer $new_image_name", timeout => $args{timeout});
-}
-
 =head2 enum_images
 
 Return an array ref of the images

--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -21,7 +21,7 @@ use version_utils qw(is_sle is_microos is_public_cloud is_transactional is_sle_m
 use registration qw(add_suseconnect_product get_addon_fullname);
 use transactional qw(trup_call check_reboot_changes);
 
-our @EXPORT = qw(install_k3s uninstall_k3s install_kubectl install_helm install_oc apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log);
+our @EXPORT = qw(install_k3s uninstall_k3s install_kubectl install_helm apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log);
 
 sub check_k3s {
     record_info('k3s', "k3s version " . script_output("k3s --version") . " installed");
@@ -167,19 +167,6 @@ Installs helm from our repositories
 sub install_helm {
     zypper_call("in helm");
     record_info('helm', script_output("helm version"));
-}
-
-=head2 install_oc
-Installs oc
-=cut
-
-sub install_oc {
-    my $url = get_required_var('CONTAINER_OC_BINARY_URL');
-    assert_script_run("wget --no-check-certificate $url");
-    $url =~ m|([^/]+)/?$|;
-    assert_script_run("tar zxvf $1");
-    assert_script_run('mv oc /usr/local/bin');
-    assert_script_run('oc');
 }
 
 =head2 apply_manifest

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -21,7 +21,7 @@ use version_utils;
 use Mojo::Util 'trim';
 
 our @EXPORT = qw(runtime_smoke_tests get_vars
-  can_build_sle_base get_docker_version get_podman_version check_runtime_version
+  can_build_sle_base get_docker_version get_podman_version
   check_min_runtime_version container_ip container_route registry_url reset_container_network_if_needed
 );
 
@@ -36,11 +36,6 @@ sub get_docker_version {
 
 sub get_podman_version {
     return script_output "podman version | awk '/^Version:/ { print \$2 }'";
-}
-
-sub check_runtime_version {
-    my ($current, $other) = @_;
-    return check_version($other, $current, qr/\d{2}(?:\.\d+)/);
 }
 
 sub check_min_runtime_version {

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -18,7 +18,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use containers::common;
 use btrfs_test qw(set_playground_disk);
-use containers::utils qw(get_docker_version check_runtime_version);
+use containers::utils qw(get_docker_version);
 use version_utils;
 use Utils::Systemd qw(systemctl);
 


### PR DESCRIPTION
This PR removes unused functions: exec_on_container, commit, get_images_by_repo_name, remove_image, install_oc, check_runtime_version.

- Related ticket: https://progress.opensuse.org/issues/158982
- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20240417-containers_host_podman@64bit -> https://openqa.opensuse.org/t4091870
  - opensuse-Tumbleweed-DVD-x86_64-Build20240417-containers_host_docker@64bit -> https://openqa.opensuse.org/t4091871
