### PR TITLE
Fix addon syntax in bug-872532_ix64ph1069.xml

### DIFF
--- a/data/yam/autoyast/bug-872532_ix64ph1069.xml
+++ b/data/yam/autoyast/bug-872532_ix64ph1069.xml
@@ -13,14 +13,12 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
-    </addons>
-    <addon t="map">
-        <arch>{{ARCH}}</arch>
+      <addon>
         <name>sle-module-python3</name>
-        <reg_code/>
-        <release_type>nil</release_type>
         <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
       </addon>
+    </addons>
   </suse_register>
   <bootloader>
     <global>


### PR DESCRIPTION
- Related ticket: [poo#159096](https://progress.opensuse.org/issues/159096)
- Verification run: [autoyast_bug-872532_ix64ph1069](https://openqa.suse.de/tests/14059883#live)
