### PR TITLE
More refactoring and cleanup

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -19,7 +19,7 @@ use power_action_utils 'power_action';
 use Mojo::JSON;
 
 our @EXPORT = qw(is_unreleased_sle install_podman_when_needed install_docker_when_needed install_containerd_when_needed
-  test_container_runtime test_container_image scc_apply_docker_image_credentials scc_restore_docker_image_credentials
+  test_container_runtime test_container_image
   install_buildah_when_needed activate_containers_module check_containers_connectivity
   switch_cgroup_version install_packages);
 
@@ -185,16 +185,6 @@ sub test_container_image {
         die "Heartbeat test failed for $image";
     }
     assert_script_run "rm -f $logfile";
-}
-
-sub scc_apply_docker_image_credentials {
-    my $regcode = get_var 'SCC_DOCKER_IMAGE';
-    assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{,.bak}";
-    assert_script_run "echo -ne \"$regcode\" > /etc/zypp/credentials.d/SCCcredentials";
-}
-
-sub scc_restore_docker_image_credentials {
-    assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{.bak,}" if (is_sle() && get_var('SCC_DOCKER_IMAGE'));
 }
 
 sub check_containers_connectivity {

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -11,7 +11,7 @@ use testapi;
 use registration;
 use version_utils;
 use utils qw(zypper_call systemctl file_content_replace script_retry script_output_retry);
-use containers::utils qw(can_build_sle_base registry_url container_ip container_route);
+use containers::utils qw(registry_url container_ip container_route);
 use transactional qw(trup_call check_reboot_changes process_reboot);
 use bootloader_setup 'add_grub_cmdline_settings';
 use serial_terminal 'select_serial_terminal';

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020-2021 SUSE LLC
+# Copyright 2020-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Functionality concerning the testing of container images
@@ -21,9 +21,7 @@ use Utils::Architectures;
 use containers::utils;
 use containers::common qw(test_container_image is_unreleased_sle);
 
-our @EXPORT = qw(
-  test_opensuse_based_image ensure_container_rpm_updates build_and_run_image
-  test_zypper_on_container test_3rd_party_image upload_3rd_party_images_logs);
+our @EXPORT = qw(test_opensuse_based_image ensure_container_rpm_updates build_and_run_image test_zypper_on_container);
 
 =head2 build_and_run_image
 
@@ -221,25 +219,6 @@ sub test_zypper_on_container {
     assert_script_run("$runtime commit refreshed refreshed-image", timeout => 120);
     assert_script_run("$runtime rm -f refreshed");
     script_retry("$runtime run -i --rm --entrypoint '' refreshed-image zypper -nv ref", timeout => 300, retry => 3, delay => 60);
-}
-
-sub test_3rd_party_image {
-    my ($runtime, $image) = @_;
-    my $runtime_name = $runtime->runtime;
-    record_info('IMAGE', "Testing $image with $runtime_name");
-    test_container_image(image => $image, runtime => $runtime);
-    script_run("echo 'OK: $runtime_name - $image:latest' >> /var/tmp/${runtime_name}-3rd_party_images_log.txt");
-}
-
-sub upload_3rd_party_images_logs {
-    my $runtime = shift;
-    # Rename for better visibility in Uploaded Logs
-    if (script_run("mv /var/tmp/$runtime-3rd_party_images_log.txt /tmp/$runtime-3rd_party_images_log.txt") != 0) {
-        record_info("No logs", "No logs found");
-    } else {
-        upload_logs("/tmp/$runtime-3rd_party_images_log.txt");
-        script_run("rm /tmp/$runtime-3rd_party_images_log.txt");
-    }
 }
 
 1;

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -21,7 +21,7 @@ use Utils::Architectures;
 use containers::utils;
 use containers::common qw(test_container_image is_unreleased_sle);
 
-our @EXPORT = qw(build_with_zypper_docker build_with_sle2docker
+our @EXPORT = qw(
   test_opensuse_based_image ensure_container_rpm_updates build_and_run_image
   test_zypper_on_container test_3rd_party_image upload_3rd_party_images_logs);
 

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -21,7 +21,7 @@ use version_utils;
 use Mojo::Util 'trim';
 
 our @EXPORT = qw(runtime_smoke_tests get_vars
-  can_build_sle_base get_docker_version get_podman_version
+  get_docker_version get_podman_version
   check_min_runtime_version container_ip container_route registry_url reset_container_network_if_needed
 );
 
@@ -153,22 +153,6 @@ sub runtime_smoke_tests {
 
     # Remove the image we pulled
     assert_script_run("$runtime rmi $image");
-}
-
-=head2 can_build_sle_base
-
-C<can_build_sle_base> should be used to identify if sle base image runs against a
-system that it does not support registration and SUSEConnect.
-In this case the build of the base image is not going to work as it lacks the repositories
-
-The call should return false if the test is run on a non-sle host.
-
-=cut
-
-sub can_build_sle_base {
-    # script_run returns 0 if true, but true is 1 on perl
-    my $has_sle_registration = !script_run("test -e /etc/zypp/credentials.d/SCCcredentials");
-    return check_os_release('sles', 'ID') && $has_sle_registration;
 }
 
 sub reset_container_network_if_needed {

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -17,7 +17,7 @@ use containers::container_images;
 use containers::urls qw(get_image_uri);
 use db_utils qw(push_image_data_to_db);
 use containers::utils qw(reset_container_network_if_needed);
-use version_utils qw(check_version get_os_release);
+use version_utils qw(check_version get_os_release is_sle);
 
 sub scc_apply_docker_image_credentials {
     my $regcode = get_var 'SCC_DOCKER_IMAGE';

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -19,6 +19,16 @@ use db_utils qw(push_image_data_to_db);
 use containers::utils qw(reset_container_network_if_needed);
 use version_utils qw(check_version get_os_release);
 
+sub scc_apply_docker_image_credentials {
+    my $regcode = get_var 'SCC_DOCKER_IMAGE';
+    assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{,.bak}";
+    assert_script_run "echo -ne \"$regcode\" > /etc/zypp/credentials.d/SCCcredentials";
+}
+
+sub scc_restore_docker_image_credentials {
+    assert_script_run "cp /etc/zypp/credentials.d/SCCcredentials{.bak,}" if (is_sle() && get_var('SCC_DOCKER_IMAGE'));
+}
+
 sub test_rpm_db_backend {
     my ($self, %args) = @_;
     my $image = $args{image};


### PR DESCRIPTION
This PR:
- Moves scc_(apply|restore)_docker_image_credentials from lib to calling test module
- Removes unused exports in containers::common
- Moves 3rd_party_image methods from lib to calling test module
- Removes unused can_build_sle_base

Related ticket: https://progress.opensuse.org/issues/155470

Verification runs:
- opensuse-Tumbleweed-DVD-x86_64-Build20240417-containers_host_docker@64bit -> https://openqa.opensuse.org/t4094857
- opensuse-Tumbleweed-DVD-x86_64-Build20240417-containers_host_podman@64bit -> https://openqa.opensuse.org/t4094858
