### PR TITLE
Fix ENSA2 installation step time out on root-console/SLE12

### DIFF
--- a/tests/sles4sap/ensa/netweaver_swpm_installation.pm
+++ b/tests/sles4sap/ensa/netweaver_swpm_installation.pm
@@ -90,7 +90,7 @@ sub run {
         '-noguiserver');
 
     record_info('SAPINST EXEC', "Executing sapinst command:\n$swpm_command");
-    assert_script_run($swpm_command);
+    assert_script_run($swpm_command, timeout => 300);
 
     $self->sapcontrol_process_check(sidadm => $nw_install_data->{sidadm},
         instance_id => $instance_data->{instance_id},


### PR DESCRIPTION
ENSA2 wasn't originally tested on root-console/12sp5 where the installation takes more time than expected

- Related ticket: https://jira.suse.com/browse/TEAM-9259
- Verification run: 
[12SP5](http://openqaworker15.qa.suse.cz/tests/overview?build=%3A33441%3Aqemu&distri=sle&version=12-SP5) [12SP5](http://openqaworker15.qa.suse.cz/tests/overview?build=%3A33433%3Awireshark&distri=sle&version=12-SP5)
[15SP2 15SP4 15SP5](http://openqaworker15.qa.suse.cz/tests/overview?build=ensa2_more_time)
[15SP3](http://openqaworker15.qa.suse.cz/tests/overview?build=%3A32617%3Ashim&distri=sle&version=15-SP3)


