### PR TITLE
Reset console for sles15sp3 MU migration

### DIFF
--- a/schedule/migration/migration_autoyast.yaml
+++ b/schedule/migration/migration_autoyast.yaml
@@ -1,12 +1,12 @@
 ---
 schedule:
-  - autoyast/prepare_profile
-  - migration/version_switch_origin_system
   - boot/boot_to_desktop
+  - migration/version_switch_origin_system
   - migration/record_disk_info
   - console/scc_cleanup_reregister
   - migration/reboot_to_upgrade
   - migration/version_switch_upgrade_target
+  - autoyast/prepare_profile
   - installation/bootloader
   - autoyast/installation
   - autoyast/console


### PR DESCRIPTION
##
##### ${{\color{green}\Huge{\textsf{  Reset console for sles15sp3 MU migration \}}}}\$
- Related ticket: 
  * https://progress.opensuse.org/issues/159219
- Needles: 
  * N/A
- Verification run: 
  * [**15sp3_and_15sp4**](https://openqa.suse.de/tests/overview?build=hjluo%2F%2Fos-autoinst-distri-opensuse%23reset_console_12sp5&distri=sle&version=12-SP5)
##
