### PR TITLE
Support kubevirt tests on sle-micro 6.0

### DIFF
--- a/data/virt_autotest/kubevirt_tests/core-tests.conf
+++ b/data/virt_autotest/kubevirt_tests/core-tests.conf
@@ -29,3 +29,6 @@ GINKGO_FOCUS=test_id:1532
 
 [replicaset_test]
 GINKGO_FOCUS=test_id:4121
+
+[migration_test]
+GINKGO_FOCUS=should allow live migration with attached hotplug volumes

--- a/data/virt_autotest/kubevirt_tests/full-tests.conf
+++ b/data/virt_autotest/kubevirt_tests/full-tests.conf
@@ -11,7 +11,6 @@ GINKGO_FOCUS=vmi_lifecycle_test.go
 
 [vm_test]
 GINKGO_FOCUS=vm_test.go
-GINKGO_SKIP=test_id:3312
 
 [vmipreset_test]
 GINKGO_FOCUS=vmipreset_test.go
@@ -36,7 +35,7 @@ GINKGO_FOCUS=container_disk_test.go
 
 [datavolume_test]
 GINKGO_FOCUS=datavolume.go
-GINKGO_SKIP=test_id:3189|test_id:6686|test_id:5252|should resolve DataVolume sourceRef|test_id:8571|virtiofs VirtIO-FS with multiple PVCs should be successfully started and accessible with passt enabled|test_id:5253|test_id:5254
+GINKGO_SKIP=virtiofs VirtIO-FS with multiple PVCs should be successfully started and accessible with passt enabled
 
 [hotplug_test]
 GINKGO_FOCUS=hotplug.go
@@ -60,7 +59,6 @@ EXTRA_OPT=-skip-shasums-check
 
 [vmi_networking_test]
 GINKGO_FOCUS=vmi_networking.go
-GINKGO_SKIP=test_id:1780
 
 [networkpolicy_test]
 GINKGO_FOCUS=networkpolicy.go
@@ -92,17 +90,15 @@ GINKGO_FOCUS=services.go
 GINKGO_FOCUS=vmi_kernel_boot_test.go
 
 [infra_test]
-GINKGO_FOCUS=infra_test.go
-GINKGO_SKIP=test_id:4099|test_id:4137|test_id:4139|test_id:6535
+GINKGO_FOCUS=infrastructure.go
 
 [operator_test]
-GINKGO_FOCUS=operator_test.go
-GINKGO_SKIP=test_id:3153
+GINKGO_FOCUS=operator.go
 EXTRA_OPT=-skip-shasums-check
 
 [migration_test]
-GINKGO_FOCUS=migration_test.go
-GINKGO_SKIP=test_id:6979|test_id:6982|test_id:3190|test_id:4746
+GINKGO_FOCUS=migration.go
+GINKGO_SKIP=test_id:4746
 
 [subresource_api_test]
 GINKGO_FOCUS=subresource_api_test.go

--- a/lib/virt_autotest/kubevirt_utils.pm
+++ b/lib/virt_autotest/kubevirt_utils.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright 2021 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Utilities for setup kubevirt plugins and commands execution
+# Maintainer: Nan Zhang <nan.zhang@suse.com> qe-virt@suse.de
+
+package virt_autotest::kubevirt_utils;
+
+use base Exporter;
+use Exporter;
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+our @EXPORT = qw(
+  install_cni_plugins
+);
+
+sub install_cni_plugins {
+    # Setup cnv-bridge containernetworking plugin: one of the tests requires
+    # a newer version of the Linux bridge CNI:
+    #   https://github.com/kubevirt/kubevirt/commit/3fa7e2b67f9095d664e83eb1e13b587ab76b4950
+    assert_script_run("curl -LO https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz");
+    assert_script_run("curl -LO https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz.sha256");
+    assert_script_run("sha256sum --check cni-plugins-linux-amd64-v1.1.1.tgz.sha256");
+    assert_script_run("mkdir -p /opt/cni/bin");
+    assert_script_run("tar -xOf cni-plugins-linux-amd64-v1.1.1.tgz ./bridge > /opt/cni/bin/cnv-bridge");
+    assert_script_run("chmod +x /opt/cni/bin/cnv-bridge");
+}
+
+1;

--- a/schedule/virt_autotest/kubevirt-tests.yaml
+++ b/schedule/virt_autotest/kubevirt-tests.yaml
@@ -13,8 +13,8 @@ conditional_schedule:
             rke2-server:
                 - virt_autotest/kubevirt_barriers
     bootup_and_install:
-        WITH_HOST_INSTALL:
-            1:
+        RUN_TEST_ONLY:
+            0:
                 - '{{bootup}}'
                 - installation/welcome
                 - installation/scc_registration

--- a/schedule/virt_autotest/slem-kubevirt-tests.yaml
+++ b/schedule/virt_autotest/slem-kubevirt-tests.yaml
@@ -1,0 +1,29 @@
+name:           slem-kubevirt-tests
+description:    >
+    Maintainer: Nan Zhang <nan.zhang@suse.com> qe-virt@suse.de
+    Kubevirt server & agent node installation and test modules
+vars: {}
+schedule:
+    - '{{barrier_setup}}'
+    - '{{bootup_and_install}}'
+    - '{{kubevirt_tests}}'
+conditional_schedule:
+    bootup_and_install:
+        RUN_TEST_ONLY:
+            0:
+                - installation/ipxe_install
+                - installation/usb_install
+                - installation/bootloader_uefi
+                - microos/selfinstall
+                - transactional/host_config
+                - console/suseconnect_scc
+    barrier_setup:
+        SERVICE:
+            rke2-server:
+                - virt_autotest/kubevirt_barriers
+    kubevirt_tests:
+        SERVICE:
+            rke2-server:
+                - virt_autotest/kubevirt_tests_server
+            rke2-agent:
+                - virt_autotest/kubevirt_tests_agent


### PR DESCRIPTION
1. Add slem-kubevirt-tests.yaml
2. Add live migration into core tests
3. Enable NTP service
4. Setup cnv-bridge containernetworking plugin
5. Set the value of default storage class with true
6. Optimize Whereabouts plugin downloading

- Related ticket: https://progress.opensuse.org/issues/138638
- Verification run:
  sle-micro 6.0 - http://10.67.129.96/tests/3186
  sles15 sp6 - http://10.67.129.96/tests/3191
