### PR TITLE
Ship libnfsmap1 in place of nfsidmap on sle15sp6

### DIFF
--- a/tests/network/autofs_client.pm
+++ b/tests/network/autofs_client.pm
@@ -39,7 +39,7 @@ use testapi;
 use lockapi;
 use autofs_utils qw(setup_autofs_server check_autofs_service);
 use utils qw(systemctl script_retry);
-use version_utils 'is_opensuse';
+use version_utils qw(is_leap is_sle);
 use strict;
 use warnings;
 
@@ -65,7 +65,7 @@ sub run {
     validate_script_output("systemctl --no-pager status autofs", sub { m/Active:\s*active/ }, 180);
 
     # nfsidmap
-    is_opensuse ? assert_script_run("rpm -q libnfsidmap1") : assert_script_run("rpm -q nfsidmap");
+    (is_leap('<15.6') || is_sle('<15-SP6')) ? assert_script_run("rpm -q nfsidmap") : assert_script_run("rpm -q libnfsidmap1");
     # Allow failing, it's to clear the keyring if one exists
     assert_script_run("nfsidmap -c || true");
     assert_script_run("mkdir -p $test_mount_dir_nfsidmap");

--- a/tests/network/autofs_server.pm
+++ b/tests/network/autofs_server.pm
@@ -33,7 +33,7 @@ use base 'consoletest';
 use testapi;
 use lockapi;
 use utils qw(systemctl zypper_call);
-use version_utils 'is_opensuse';
+use version_utils qw(is_leap is_sle);
 use strict;
 use warnings;
 
@@ -46,7 +46,7 @@ sub run {
     select_console "root-console";
     my $test_share_dir = "/tmp/nfs/server";
     my $nfsidmap_share_dir = "/home/tux";
-    if (is_opensuse) {
+    if (!is_sle) {
         zypper_call('modifyrepo -e 1');
         zypper_call('ref');
     }
@@ -61,7 +61,7 @@ sub run {
 
     # nfsidmap
     assert_script_run "echo N > /sys/module/nfsd/parameters/nfs4_disable_idmapping";
-    is_opensuse ? zypper_call('in libnfsidmap1') : zypper_call('in nfsidmap');
+    (is_leap('<15.6') || is_sle('<15-SP6')) ? zypper_call('in nfsidmap') : zypper_call('in libnfsidmap1');
     systemctl 'restart nfs-idmapd';
     assert_script_run "nfsidmap -c || true";
     assert_script_run "useradd -m tux";


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1222947

- Verification run: 
[sle15sp6](https://openqa.suse.de/tests/14112155#dependencies)
[sle15sp5](https://openqa.suse.de/tests/14112202#dependencies)
[tw](https://openqa.opensuse.org/tests/4098096#dependencies)