### PR TITLE
[WIP] Update kvm package name for SL Micro 6.0

### DIFF
--- a/tests/qemu/qemu.pm
+++ b/tests/qemu/qemu.pm
@@ -23,7 +23,7 @@ sub is_qemu_preinstalled {
         return 1;
     }
     elsif (is_sle_micro('>=6.0')) {
-        assert_script_run('rpm -q kvm_host');
+        assert_script_run('rpm -q patterns-base-kvm_host');
         return 1;
     }
     return 0;


### PR DESCRIPTION
KVM package name is changed from patterns-alp-kvm_host to patterns-base-kvm_host, which needs to correct in automation test to ensure normal test run.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
