### PR TITLE
Install zypper-docker only up to 15-SP5

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -210,8 +210,10 @@
       <package>acl</package>
       % if ($check_var->('INSTALL_RUNTIMES', '1')) {
       <package>docker</package>
-      % unless ($check_var->('ARCH', 'aarch64') and $get_var->('VERSION') =~ /12-SP3|12-SP4|12-SP5|15$/) {
+      % if (!$check_var->('ARCH', 'aarch64') and $get_var->('VERSION') =~ /15-SP[1-5]$/) {
       <package>zypper-docker</package>
+      % }
+      % unless ($check_var->('ARCH', 'aarch64') and $get_var->('VERSION') =~ /12-SP3|12-SP4|12-SP5|15$/) {
       <package>container-diff</package>
       % }
       % unless ($get_var->('VERSION') =~ /12-SP3|12-SP4|12-SP5|15$/) {


### PR DESCRIPTION
zypper-docker has become deprecated from 15-SP6 onwards. Install zypper-docker only on older SLES versions, when matching.

- Related ticket: https://progress.opensuse.org/issues/159387
- Verification run: [15-SP6 x86_64](https://openqa.suse.de/tests/14113781) | [15-SP6 aarch64](https://openqa.suse.de/tests/14113782) | [15-SP5 x86_64](https://openqa.suse.de/tests/14113783) | [15-SP5 aarch64](https://openqa.suse.de/tests/14113784) | [12-SP4 x86_64](https://openqa.suse.de/tests/14113785) | [15-SP3 s390x](https://openqa.suse.de/tests/14113786)
