### PR TITLE
containers: Fix silent error in podman secret

### DIFF
--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -68,8 +68,8 @@ sub run {
     record_info("Commit cont", "Commit container secret-test");
     assert_script_run("podman commit secret-test secret-test-image");
     assert_script_run("podman rm secret-test");
-    $output = script_output("podman run --name secret-test secret-test-image:latest 'cat /run/secrets/secret1 & printenv TOP_SECRET2'", proceed_on_failure => 1);
-    die("Secret commited") if ($output =~ m/T0p_S3cr3t1|T0p_S3cr3t2/);
+    $output = script_output("podman run --name secret-test secret-test-image:latest /bin/sh -c 'cat /run/secrets/secret1 & printenv TOP_SECRET2'", proceed_on_failure => 1);
+    die("Secret committed") if ($output =~ m/T0p_S3cr3t1|T0p_S3cr3t2/);
 
     # Remove secrets
     record_info("secret rm", "Remove all secrets created");


### PR DESCRIPTION
We have a silent error on `podman secret` as you can see [here](https://openqa.opensuse.org/tests/4096739/logfile?filename=serial_terminal.txt)

`Error: crun: executable file 'cat /run/secrets/secret1 & printenv TOP_SECRET2' not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found
`

- Verification run: https://openqa.opensuse.org/tests/4098603/logfile?filename=serial_terminal.txt