### PR TITLE
Skip ssh_public_key variable usage in openstack

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -618,7 +618,9 @@ sub terraform_destroy {
         assert_script_run('cd ' . TERRAFORM_DIR);
         # Add region variable also to `terraform destroy` (poo#63604) -- needed by AWS.
         $cmd .= "-var 'region=" . $self->provider_client->region . "' ";
-        $cmd .= "-var 'ssh_public_key=" . $self->ssh_key . ".pub' ";
+        unless (is_openstack) {
+            $cmd .= "-var 'ssh_public_key=" . $self->ssh_key . ".pub' ";
+        }
         # Add image_id, offer and sku on Azure runs, if defined.
         if (is_azure) {
             my $image = $self->get_image_id();


### PR DESCRIPTION
openstack cleanup is failing due to `ssh_public_key` variable. This leads to hanging instances that are later on blocking resources for upcoming test runs.

- ticket: https://progress.opensuse.org/issues/158044
- Verification run: http://kepler.suse.cz/tests/23228#
