### PR TITLE
Skip console font check in s390x

### DIFF
--- a/tests/console/console_reboot.pm
+++ b/tests/console/console_reboot.pm
@@ -27,7 +27,7 @@ sub run {
     }
     select_console 'root-console';
     ensure_serialdev_permissions;
-    check_console_font;
+    check_console_font unless is_s390x;
 }
 
 sub test_flags {


### PR DESCRIPTION
https://github.com/os-autoinst/xterm_console is responsible to set the console fonts correctly. However as we are using a ssh connection in s390x, the set up is more complex.
As of now and as this issue is not present anywhere else than s390x, we can skip this check for now only in s390x tests.

Failing test: https://openqa.suse.de/tests/14106323#step/console_reboot/34
