### PR TITLE
Improve internal of check_crm_output

### DIFF
--- a/lib/saputils.pm
+++ b/lib/saputils.pm
@@ -169,14 +169,11 @@ sub check_hana_topology {
 sub check_crm_output {
     my (%args) = @_;
     croak("Argument <input> missing") unless $args{input};
-    my $resource_started = 1;
-    my $failed_actions = 0;
+    my $resource_starting = ($args{input} =~ /:\s*Starting/) ? 1 : 0;
+    my $failed_actions = ($args{input} =~ /Failed Resource Actions:/) ? 1 : 0;
 
-    $resource_started = !($args{input} =~ /:\s*Starting/);
-    $failed_actions = ($args{input} =~ /Failed Resource Actions:/);
-
-    record_info('check_crm_output', "resource_started: $resource_started failed_actions: $failed_actions");
-    return ($resource_started && !$failed_actions);
+    record_info('check_crm_output', "resource_starting:$resource_starting failed_actions:$failed_actions");
+    return (($resource_starting != 1) && ($failed_actions != 1) ? 1 : 0);
 }
 
 1;

--- a/t/18_saputils.t
+++ b/t/18_saputils.t
@@ -236,4 +236,24 @@ subtest '[check_hana_topology] invalid input' => sub {
     ok(($topology_ready == 0), 'invalid input leads to the return of 0');
 };
 
+subtest '[check_crm_output] input argument is mandatory' => sub {
+    dies_ok { check_crm_output() };
+};
+
+subtest '[check_crm_output] no starting no failed' => sub {
+    my $saputils = Test::MockModule->new('saputils', no_auto => 1);
+    $saputils->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $ret = check_crm_output(input => 'PUFFI');
+    ok $ret eq 1, "Ret:$ret has to be 1";
+};
+
+subtest '[check_crm_output] starting and failed' => sub {
+    my $saputils = Test::MockModule->new('saputils', no_auto => 1);
+    $saputils->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $ret = check_crm_output(input => '
+        :  Starting
+        Failed Resource Actions:');
+    ok $ret eq 0, "Ret:$ret has to be 0";
+};
+
 done_testing;


### PR DESCRIPTION
Improve internal implementation if check_crm_output by avoiding variables and managing bool condition in a more symmetric way. Add unit testing.

- Related ticket: https://progress.opensuse.org/issues/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
