### PR TITLE
Add missing cleanup to containers modules

### DIFF
--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -70,6 +70,7 @@ sub run {
     assert_script_run("podman rm secret-test");
     $output = script_output("podman run --name secret-test secret-test-image:latest /bin/sh -c 'cat /run/secrets/secret1 & printenv TOP_SECRET2'", proceed_on_failure => 1);
     die("Secret committed") if ($output =~ m/T0p_S3cr3t1|T0p_S3cr3t2/);
+    assert_script_run("podman rm secret-test");
 
     # Remove secrets
     record_info("secret rm", "Remove all secrets created");


### PR DESCRIPTION
This PR:
  - Adds missing cleanup in podman_quadlet module.
  - Removes container in podman secret module.

Related ticket: https://progress.opensuse.org/issues/159405
Failing test: https://openqa.opensuse.org/tests/4098172#step/secret_podman/154

Verification runs: 
- opensuse-Tumbleweed-JeOS-for-AArch64-aarch64-Build20240418-jeos-container_host@aarch64-HD20G -> https://openqa.opensuse.org/t4099472