### PR TITLE
Deregister dropped module for maintenance migration

### DIFF
--- a/tests/console/scc_cleanup_reregister.pm
+++ b/tests/console/scc_cleanup_reregister.pm
@@ -16,6 +16,7 @@
 use strict;
 use warnings;
 use base "opensusebasetest";
+use migration 'deregister_dropped_modules';
 use testapi;
 use registration qw(cleanup_registration register_product register_addons_cmd);
 use scheduler 'get_test_suite_data';
@@ -26,6 +27,7 @@ sub run {
     register_product;
     my $addons = get_test_suite_data()->{addons};
     register_addons_cmd($addons);
+    deregister_dropped_modules;
 }
 
 1;


### PR DESCRIPTION
Need deregister dropped module (ltss) for maintenance migration from 15SP2 to 15SP3.

- Related ticket: https://progress.opensuse.org/issues/159219
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/162
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/14141248#  Installation
  https://openqa.suse.de/tests/14141249#  Migration from 15SP2 to 15SP3