### PR TITLE
Register desktop appliaction after media migration from 12SP5 on ppc64le

### DIFF
--- a/schedule/migration/ppc64le_regression_test_offline_textmode.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline_textmode.yaml
@@ -78,7 +78,6 @@ conditional_schedule:
         - console/hostname
         - console/zypper_lr
         - console/zypper_ref
-        - console/check_system_info
         - console/firewall_enabled
         - console/zypper_lifecycle
         - console/orphaned_packages_check

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -24,6 +24,7 @@ use services::registered_addons 'full_registered_check';
 use List::MoreUtils 'uniq';
 use migration 'modify_kernel_multiversion';
 use strict;
+use Utils::Architectures 'is_ppc64le';
 use warnings;
 
 sub run {
@@ -47,6 +48,7 @@ sub run {
         if (is_sle('15+') && check_var('SLE_PRODUCT', 'sles')) {
             add_suseconnect_product(get_addon_fullname('base'), undef, undef, undef, 300, 1);
             add_suseconnect_product(get_addon_fullname('serverapp'), undef, undef, undef, 300, 1);
+            add_suseconnect_product(get_addon_fullname('desktop'), undef, undef, undef, 300, 1) if is_sle('=12-sp5', get_var('ORIGIN_SYSTEM_VERSION')) && is_ppc64le;
         }
         if (is_sle('15+') && check_var('SLE_PRODUCT', 'sled')) {
             add_suseconnect_product(get_addon_fullname('base'), undef, undef, undef, 300, 1);


### PR DESCRIPTION
We changed the 12SP5 migration test on ppc64le from gnome to textmode (multi-user), after media migration need register desktop application for later regression test.

- Related ticket: https://progress.opensuse.org/issues/157720
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/14211997#
