### PR TITLE
pc: Change permissions of log files so we can copy them

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -620,6 +620,7 @@ sub measure_boottime() {
     $Data::Dumper::Sortkeys = 1;
     record_info("RESULTS", Dumper($ret));
     my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
+    $instance->run_ssh_command(cmd => 'sudo chmod o+r ' . join(' ', map { "/var/log/$_" } @logs));
     $instance->upload_log("/var/log/" . $_, log_name => 'measure_boottime_' . $_ . '.txt', failok => 1) foreach (@logs);
     return $ret;
 }


### PR DESCRIPTION
Hardened images have strict permissions on log files and we're experiencing errors when trying to upload them:

`scp: /var/log/cloud-init.log: Permission denied
`

- Related ticket: https://progress.opensuse.org/issues/158871
- Failing test: https://openqa.suse.de/tests/14017587/logfile?filename=serial_terminal.txt
- Verification run: https://openqa.suse.de/tests/14124382/logfile?filename=serial_terminal.txt (failing because of another issue).  Error must not be present in serial log.
