### PR TITLE
Allow all users to read log files of interest

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -620,7 +620,7 @@ sub measure_boottime() {
     $Data::Dumper::Sortkeys = 1;
     record_info("RESULTS", Dumper($ret));
     my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
-    $instance->run_ssh_command(cmd => 'sudo chmod o+r ' . join(' ', map { "/var/log/$_" } @logs));
+    $instance->run_ssh_command(cmd => 'sudo chmod a+r ' . join(' ', map { "/var/log/$_" } @logs));
     $instance->upload_log("/var/log/" . $_, log_name => 'measure_boottime_' . $_ . '.txt', failok => 1) foreach (@logs);
     return $ret;
 }


### PR DESCRIPTION
Instead of allowing others to read the log files and therefore potentially locking out the group, we should allow all users to read the log files of interest.

- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19175
- Verification run: https://openqa.suse.de/tests/14128382
