### PR TITLE
Add rmt-server-pubcloud conflict

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -63,6 +63,7 @@ my @conflicting_packages = (
     # can't be installed in parallel, Conflicts: otherproviders(waagent-config) see python-azure-agent.spec
     'python-azure-agent-config-server', 'python-azure-agent-config-micro',
     'python-azure-agent-config-hpc', 'python-azure-agent-config-default',
+    'rmt-server-pubcloud',
     'kernel-default-base', 'kernel-default-extra'
 );
 


### PR DESCRIPTION
%package pubcloud
Summary:        RMT pubcloud extensions
Group:          Productivity/Networking/Web/Proxy
Requires:       rmt-server = %version
Provides:       rmt-server-configuration
Conflicts:      rmt-server-configuration

- Related ticket: https://progress.opensuse.org/issues/159528
- Verification run: https://openqa.suse.de/tests/14130618