### PR TITLE
Schedule ntpd tests in FIPS mode

### DIFF
--- a/lib/services/ntpd.pm
+++ b/lib/services/ntpd.pm
@@ -22,6 +22,10 @@ sub install_service {
     zypper_call('in ntp');
 }
 
+sub remove_service {
+    zypper_call('rm ntp');
+}
+
 # This will be used by QAM ntp test.
 sub check_config {
     my $server_count = script_output 'ntpq -p | tail -n +3 | wc -l';
@@ -47,6 +51,10 @@ sub config_service {
 
 sub enable_service {
     common_service_action($service_name, $service_type, 'enable');
+}
+
+sub disable_service {
+    common_service_action($service_name, $service_type, 'disable');
 }
 
 sub start_service {

--- a/schedule/security/fips_crypt_tool.yaml
+++ b/schedule/security/fips_crypt_tool.yaml
@@ -14,6 +14,7 @@ schedule:
     - console/git
     - console/clamav
     - console/openvswitch_ssl
+    - security/ntpd
     - console/ntp_client
     - console/cups
     - console/cryptsetup

--- a/tests/security/ntpd.pm
+++ b/tests/security/ntpd.pm
@@ -1,0 +1,45 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: ntp
+# Summary: Basics ntp test - add ntp servers, obtain time
+# Maintainer: : QE Security <none@suse.de>
+#
+# This test has been adapted from console/ntp.pm and changed to clean up after
+# itself, which is required if we want to run chrony test afterwards, since it
+# fails when ntpd is installed.
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use services::ntpd;
+use serial_terminal qw(select_serial_terminal);
+use Utils::Logging 'save_and_upload_log';
+
+sub run {
+    select_serial_terminal;
+    services::ntpd::install_service();
+    services::ntpd::enable_service();
+    services::ntpd::start_service();
+    services::ntpd::check_config();
+    services::ntpd::config_service();
+    services::ntpd::check_service();
+    services::ntpd::check_function();
+    services::ntpd::disable_service();
+    services::ntpd::stop_service();
+    services::ntpd::remove_service();
+}
+
+sub post_fail_hook {
+    assert_script_run 'cp /etc/ntp.conf.bkp /etc/ntp.conf' if (script_run('test -f /etc/ntp.conf.bkp') == 0);
+    upload_logs '/var/log/ntp';
+    save_and_upload_log('journalctl --no-pager -o short-precise', 'journalctl.txt');
+}
+
+sub post_run_hook {
+    assert_script_run 'cp /etc/ntp.conf.bkp /etc/ntp.conf' if (script_run('test -f /etc/ntp.conf.bkp') == 0);
+}
+
+1;


### PR DESCRIPTION
Extend ntpd library to allow service stop/disable and uninstall and schedule a new ntpd test in FIPS mode.

- Related ticket: https://progress.opensuse.org/issues/159285
- Verification runs:
    - https://openqa.suse.de/tests/14131988
    - https://openqa.suse.de/tests/14131998
    - https://openqa.suse.de/tests/14131918
    - https://openqa.suse.de/tests/14131922
