### PR TITLE
Move bci_prepare to "Create bootable host HDDs" for non-sle hosts

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -238,6 +238,7 @@ sub update_host_and_publish_hdd {
         loadtest 'boot/boot_to_desktop';
         loadtest 'containers/update_host';
         loadtest 'containers/openshift_setup' if check_var('CONTAINER_RUNTIMES', 'openshift');
+        loadtest 'containers/bci_prepare';
     }
     loadtest 'shutdown/cleanup_before_shutdown' if is_s390x;
     loadtest 'shutdown/shutdown';


### PR DESCRIPTION
This time for non-sle hosts. 

- Related to:
  - https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19172
  - https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1607
- Verification run: https://openqa.suse.de/tests/14132220
