### PR TITLE
Remove x11 test modules for regression ppc64le

### DIFF
--- a/schedule/migration/offline_regression_upgrade@pvm.yaml
+++ b/schedule/migration/offline_regression_upgrade@pvm.yaml
@@ -54,9 +54,6 @@ conditional_schedule:
         - console/zypper_lifecycle
         - console/orphaned_packages_check
         - console/consoletest_finish
-        - x11/desktop_runner
-        - x11/setup
-        - x11/xterm
   rollback_after_migration:
     ROLLBACK_AFTER_MIGRATION:
       1:

--- a/schedule/migration/ppc64le_regression_test_offline_textmode.yaml
+++ b/schedule/migration/ppc64le_regression_test_offline_textmode.yaml
@@ -83,9 +83,6 @@ conditional_schedule:
         - console/zypper_lifecycle
         - console/orphaned_packages_check
         - console/consoletest_finish
-        - x11/desktop_runner
-        - x11/setup
-        - x11/xterm
   rollback_after_migration:
     ROLLBACK_AFTER_MIGRATION:
       1:


### PR DESCRIPTION
- Description: Remove x11 test modules for regression ppc64le
  + _ppc64le_regression_test_offline_textmode.yaml should not include desktop x11 test modules_
- Related ticket: [poo#158191](https://progress.opensuse.org/issues/158191)
- Verification run: [overview](https://openqa.suse.de/tests/overview?build=issues-158191)
- Related [PR#19173](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19173) from @lemon-suse 
  + also here X11 tests are removed for file `schedule/migration/ppc64le_regression_test_offline_textmode.yaml`
  + some merge conflict could happen
