### PR TITLE
xfstests: install fsverity-utils in SLES

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -3,11 +3,11 @@
 # Copyright 2018-2020 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
-# Package: zypper xfstests fio
+# Package: zypper xfstests fio fsverity-utils
 # Summary: Install xfstests
 # - Stop packagekit service
 # - Add qa-head repository
-# - Install qa_test_xfstests fio
+# - Install qa_test_xfstests fio fsverity-utils
 # - If XFSTESTS_REPO is set, install xfstests, filesystems
 # - Otherwise, run "/usr/share/qa/qa_test_xfstests/install.sh"
 # Maintainer: Yong Sun <yosun@suse.com>
@@ -56,7 +56,7 @@ sub install_xfstests_from_repo {
         reboot_on_changes;
     }
     else {
-        zypper_call('in xfstests fio');
+        zypper_call('in xfstests fio fsverity-utils');
     }
     if (is_sle) {
         script_run 'ln -s /var/lib/xfstests /opt/xfstests';


### PR DESCRIPTION
fsverity-utils is needed by xfstests verity group. But we only install it in SLES, because SLE Micro with a readonly FS and fsverity-utils just influnce a few tests.

- Related ticket: https://progress.opensuse.org/issues/159483
- Needles: N/A
- Verification run:
http://10.67.133.133/tests/593 (install in SLES)
http://10.67.133.133/tests/594 (run generic/572 in btrfs)
http://10.67.133.133/tests/600 (run generic/572 in ext4)
http://10.67.133.133/tests/597 (install in Micro, no influence)
https://openqa.opensuse.org/tests/4109758 (install in Tumbleweed)
