### PR TITLE
Hotfix: Install jq

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -47,6 +47,7 @@ sub run {
             # Sometimes, the host doesn't get an IP automatically via dhcp, we need force it just in case
             assert_script_run("dhclient -v");
             script_retry("apt-get update -qq -y", timeout => $update_timeout);
+            script_retry("apt-get install -y jq");    # HOTFIX, should be removed ASAP.
         } elsif ($host_distri eq 'centos') {
             assert_script_run("dhclient -v");
             script_retry("yum update -q -y --nobest", timeout => $update_timeout);


### PR DESCRIPTION
Installs jq unconditionally. This is a hotfix and should be removed soon.

- Related failures:https://openqa.suse.de/tests/14148392#step/bci_version_check/23
- Verification run: https://openqa.suse.de/tests/14148626
