### PR TITLE
containers: Use python instead of jq

### DIFF
--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -45,7 +45,8 @@ sub run {
     record_info('Inspect', script_output("$engine inspect $image"));
 
     if ($build && $build ne 'UNKNOWN') {
-        my $reference = script_output(qq($engine inspect --type image $image | jq -r '.[0].Config.Labels."org.opensuse.reference"'));
+        # Note: Python command is equivalent to: jq -r '.[0].Config.Labels."org.opensuse.reference"'
+        my $reference = script_output(qq($engine inspect --type image $image | python -c 'import json, sys; print(json.load(sys.stdin)[0]["Config"]["Labels"]["org.opensuse.reference"])'));
         # Note: Both lines are aligned, thus the additional space
         record_info('builds', "CONTAINER_IMAGE_BUILD:  $build\norg.opensuse.reference: $reference");
         die('Missmatch in image build number. The image build number is different than the one triggered by the container bot!') if ($reference !~ /$buildrelease$/);


### PR DESCRIPTION
Use python instead of jq

- Failing test: https://openqa.suse.de/tests/14149034
- Verification run: https://openqa.suse.de/t14149768