### PR TITLE
Enhance migration code in maintenance

### DIFF
--- a/schedule/migration/migration_autoyast.yaml
+++ b/schedule/migration/migration_autoyast.yaml
@@ -1,11 +1,10 @@
 ---
 schedule:
   - boot/boot_to_desktop
-  - migration/version_switch_origin_system
   - migration/record_disk_info
-  - console/scc_cleanup_reregister
-  - migration/reboot_to_upgrade
-  - migration/version_switch_upgrade_target
+  - yam/migration/setup_registration
+  - yam/migration/setup_upgrade
+  - yam/migration/reboot_to_boot_screen
   - autoyast/prepare_profile
   - installation/bootloader
   - autoyast/installation

--- a/tests/console/scc_cleanup_reregister.pm
+++ b/tests/console/scc_cleanup_reregister.pm
@@ -16,7 +16,6 @@
 use strict;
 use warnings;
 use base "opensusebasetest";
-use migration 'deregister_dropped_modules';
 use testapi;
 use registration qw(cleanup_registration register_product register_addons_cmd);
 use scheduler 'get_test_suite_data';
@@ -27,7 +26,6 @@ sub run {
     register_product;
     my $addons = get_test_suite_data()->{addons};
     register_addons_cmd($addons);
-    deregister_dropped_modules;
 }
 
 1;

--- a/tests/yam/migration/reboot_to_boot_screen.pm
+++ b/tests/yam/migration/reboot_to_boot_screen.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Reboot system and reach boot screen.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use power_action_utils 'power_action';
+
+sub run {
+    select_console 'root-console';
+    power_action('reboot', textmode => 1, keepconsole => 1);
+    assert_screen('inst-bootmenu', 300);
+}
+
+1;
+

--- a/tests/yam/migration/setup_registration.pm
+++ b/tests/yam/migration/setup_registration.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Setup registration before migration.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use registration 'register_addons_cmd';
+
+sub run {
+    my @addons = split(/,/, get_required_var('SCC_ADDONS'));
+    my @addons_drop = split(/,/, get_var('SCC_ADDONS_DROP'));
+    my %filter;
+    @filter{@addons_drop} = {};
+
+    select_console('root-console');
+    assert_script_run('SUSEConnect --debug --cleanup');
+    assert_script_run('SUSEConnect --debug --regcode ' . get_required_var('SCC_REGCODE'), 200);
+    my $addons_to_register = join(',', grep !exists $filter{$_}, @addons);
+    register_addons_cmd($addons_to_register);
+}
+
+1;

--- a/tests/yam/migration/setup_upgrade.pm
+++ b/tests/yam/migration/setup_upgrade.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Makes preprations for migration: version swap, update ttys and notify
+# to not boot from hard disk.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use migration 'reset_consoles_tty';
+
+sub run {
+    # Save the initial/origin version of the product in order to restore later if needed
+    set_var('VERSION_1', get_var('VERSION'));
+
+    # Change version to the secondary/target one
+    set_var('VERSION', get_var('VERSION_2'));
+    record_info('Version', 'VERSION=' . get_var('VERSION'));
+
+    # tty assignation might differ between product versions
+    reset_consoles_tty();
+
+    # Boot from Hard Disk will not be selected in boot screen
+    set_var('BOOT_HDD_IMAGE', 0);
+}
+
+1;


### PR DESCRIPTION
- Description: Enhance migration code in maintenance. How? Making as simple as possible to read for the existing migrations:
  - Using simple commands instead of library functions which have conditional logic.
  - Addons are set at the level of medium, so the most clear way to deal with this setting is with another setting to exclude certain addons which should not be registered before migration.
  - There is no need to unregister addons in these kind of scenario, we will not register them in the first place.
  - Actions to setup upgrade and reboot for now do not take into account other architectures or situations on purpose.

- Job group changes: [mr#171](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/171)

- Verification run: [current migrations in maintenance](https://openqa.suse.de/tests/overview?version=&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23refactor_reregister)
