### PR TITLE
SL Micro avoid false soft-fails for 1217231

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -590,7 +590,7 @@
         "type": "bug"
     },
     "bsc#1217231": {
-        "description": "systemd-cryptsetup.*Failed to deactivate|systemd.*Timed out waiting for device",
+        "description": "systemd-cryptsetup.*Failed to deactivate|systemd.*Timed out waiting for device /UUID.*",
         "products": {
             "sle-micro": ["6.0"]
         },


### PR DESCRIPTION
Some tests are soft-failing in the message:
`Timed out waiting for device /dev/disk/by-label/ignition. which should be ignored in the "no-config-drive" entry of this file.`
e.g. https://openqa.suse.de/tests/14021867#step/journal_check/22

VR: https://openqa.suse.de/tests/14154793#