### PR TITLE
Revert "containers: Use python instead of jq"

### DIFF
--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -45,8 +45,7 @@ sub run {
     record_info('Inspect', script_output("$engine inspect $image"));
 
     if ($build && $build ne 'UNKNOWN') {
-        # Note: Python command is equivalent to: jq -r '.[0].Config.Labels."org.opensuse.reference"'
-        my $reference = script_output(qq($engine inspect --type image $image | python -c 'import json, sys; print(json.load(sys.stdin)[0]["Config"]["Labels"]["org.opensuse.reference"])'));
+        my $reference = script_output(qq($engine inspect --type image $image | jq -r '.[0].Config.Labels."org.opensuse.reference"'));
         # Note: Both lines are aligned, thus the additional space
         record_info('builds', "CONTAINER_IMAGE_BUILD:  $build\norg.opensuse.reference: $reference");
         die('Missmatch in image build number. The image build number is different than the one triggered by the container bot!') if ($reference !~ /$buildrelease$/);


### PR DESCRIPTION
This reverts commit fb15959a3f84fb310a2a9c527f02ff77793d35c6.
https://suse.slack.com/archives/C02CGKBCGT1/p1714119913196329?thread_ts=1714061846.557459&cid=C02CGKBCGT1