### PR TITLE
Support open-vm-tools tests on sle-micro 6.0 vmdk image

### DIFF
--- a/schedule/virt_autotest/slem_open_vm_tools.yaml
+++ b/schedule/virt_autotest/slem_open_vm_tools.yaml
@@ -1,0 +1,15 @@
+name:           slem_open_vm_tools
+description:    >
+    Maintainer: nan.zhang@suse.com, qe-virt@suse.de
+    SLE-Micro vmdk image setups with integration services and open-vm-tools test modules
+schedule:
+    - installation/bootloader_svirt
+    - installation/bootloader_uefi
+    - jeos/firstrun
+    - transactional/host_config
+    - console/suseconnect_scc
+    - console/system_prepare
+    - console/check_network
+    - console/system_state
+    - console/integration_services
+    - virt_autotest/esxi_open_vm_tools


### PR DESCRIPTION
Created a yaml file (schedule/virt_autotest/slem_open_vm_tools.yaml) to run open-vm-tools tests based on guest installation with the vmdk image.

- Related ticket: https://progress.opensuse.org/issues/153754
- Verification run: 
