### PR TITLE
Make SL Micro 6 usb install work on vh081/82

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/combustion/script
+++ b/data/virt_autotest/host_unattended_installation_files/combustion/script
@@ -10,13 +10,10 @@ grub2_config() {
     echo "DEBUG: now $file is,"
     cat $file
     grub2-mkconfig -o /boot/grub2/grub.cfg
-    # Set boot to sl-secureboot entry -- newly installed SL Micro
-    bootnum=$(efibootmgr | grep sl-secureboot | grep -o "^Boot[^\s]*" | sed -e 's/Boot//' -e 's/\*//')
-    efibootmgr -o $bootnum
 }
 
 # Redirect output to the console
 # Comment off to workaround https://bugzilla.suse.com/show_bug.cgi?id=1222411#c9
-# exec > >(exec tee -a /dev/SERIALCONSOLE) 2>&1
+ exec > >(exec tee -a /dev/SERIALCONSOLE) 2>&1
     grub2_config # Configure grub2 in the system
 

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -391,6 +391,7 @@ sub uefi_bootmenu_params {
     if (is_ipmi && is_selfinstall && is_usb_boot) {
         my $counter = 0;
         my $max_tries = 5;
+        my $delete_key = get_var('DELETE_KEY', '') ? get_var('DELETE_KEY') : 'delete';
         while (!check_screen('pass-bootparam-to-firstboot', 2) && $counter++ < $max_tries) {
             # Re-enter grub edit by discarding changes for 2+ round
             if ($counter > 1) {
@@ -421,11 +422,11 @@ sub uefi_bootmenu_params {
             next if (!check_screen('on-linux-console-ttyS0', 2));
 
             # Delete `ttyS0`
-            send_key('delete', wait_screen_change => 1) for (1 .. 5);
+            send_key($delete_key, wait_screen_change => 1) for (1 .. 5);
             $_counter = 0;
             $_max = 3;
             while (!check_screen('deleted-ttyS0', 2) && $_counter++ < $_max) {
-                send_key('delete', wait_screen_change => 1);
+                send_key($delete_key, wait_screen_change => 1);
             }
             next if (!check_screen('deleted-ttyS0', 2));
 
@@ -443,11 +444,11 @@ sub uefi_bootmenu_params {
             next if (!check_screen('on-linux-console=tty0', 2));
 
             # Delete `console=tty0`
-            send_key('delete', wait_screen_change => 1) for (1 .. 12);
+            send_key($delete_key, wait_screen_change => 1) for (1 .. 12);
             $_counter = 0;
             $_max = 5;
             while (!check_screen('deleted-console=tty0', 2) && $_counter++ < $_max) {
-                send_key('delete', wait_screen_change => 1);
+                send_key($delete_key, wait_screen_change => 1);
             }
             next if (!check_screen('deleted-console=tty0', 2));
 

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -53,7 +53,8 @@ sub run {
     # Press key 't' to let grub2 boot menu show up in serial console
     if (is_ipmi && current_console eq 'sol' && is_selfinstall && get_var('IPXE_UEFI')) {
         assert_screen('press-t-for-boot-menu', 180);
-        send_key('t');
+        sleep 5;
+        send_key('t', wait_screen_change => 1);
     }
 
     # Enabled boot menu for x86_64 uefi. In migration cases we set cdrom as boot index=0


### PR DESCRIPTION
This PR mainly:
- makes usb install for sl micro 6 works on vh081(vh082 shall be the same)
- remove the code lines that sometimes make combustion script fail and then sl micro installation goes to maintenance mode

Additional configuration in /etc/openqa/worker.ini for vh081(vh082) shall be:
```
SPECIFIED_USB_BOOT_ENTRY=Cruzer Blade // please check specifically for vh082 the usb disk being used for holding ISO
DELETE_KEY=backspace
CTRL_X_TO_BOOT=1
```

- Related ticket: https://progress.opensuse.org/issues/159378
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1662
- Verification run: 
  - vh081: http://10.67.129.77/tests/602#, PASS
  - vh015: http://10.67.129.77/tests/600, PASS
  - kermit: http://openqa.suse.de/tests/14165146, PASS