### PR TITLE
Fix ppc64le sles4sap SAPHanaSR ha1adm timedout

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -753,7 +753,7 @@ sub check_replication_state {
     my $cmd = "su - $sapadm -c 'python exe/python_support/systemReplicationStatus.py'";
 
     # Replication check can only be done on PRIMARY node
-    my $output = script_output($cmd, proceed_on_failure => 1);
+    my $output = script_output($cmd, proceed_on_failure => 1, timeout => 200);
     return if $output !~ /mode:[\r\n\s]+PRIMARY/;
 
     # Loop until ACTIVE state or timeout is reached


### PR DESCRIPTION
Set timeout => 200 to fix the script timeout.

Fix sles4sap ppc64le SAPHanaSR_ScaleUp_PerfOpt_WMP_node01 sporadically failed on hana_cluster: script timeout: su - ha1adm -c 'python exe/python_support/systemReplicationStatus.py'

TEAM-9263 - [15-SP6][sles4sap][ppc64le] SAPHanaSR_ScaleUp_PerfOpt_WMP_node01 sporadically failed on hana_cluster: script timeout: su - ha1adm -c 'python exe/python_support/systemReplicationStatus.py'

- Related ticket: https://jira.suse.com/browse/TEAM-9263
- Needles: NA
- Verification run:
http://openqa.suse.de/tests/14161967 (passed)