### PR TITLE
Fix ipsec3host network related issue

### DIFF
--- a/lib/ipsecbase.pm
+++ b/lib/ipsecbase.pm
@@ -92,6 +92,9 @@ sub config_ipsec {
 }
 
 sub pre_run_hook {
+
+    mutex_wait 'support_server_ready';
+
     my ($self, $args) = @_;
     select_serial_terminal;
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1146,6 +1146,16 @@ sub set_hostname {
     if (is_qemu && systemctl('is-active NetworkManager', ignore_failure => 1) == 0) {
         my $state = script_output 'nmcli networking connectivity check', proceed_on_failure => 1;
 
+        if (!($state =~ /full/)) {
+            systemctl('restart NetworkManager');
+
+            for (my $i = 0; $i < 10; $i++) {
+                $state = script_output 'nmcli -w 5 networking connectivity check';
+                last if $state =~ /full/;
+                sleep 1;
+            }
+        }
+
         if ($state =~ /full/) {
             my @devs = split("\n", script_output('nmcli device'));
 


### PR DESCRIPTION
If support server start slow then other clients, client's network status will broken for test, so add mutex_wait for each client wait server setup complete. Also restart Network service if Neworkwork connection is still not ready.

- Verification run: https://openqa.opensuse.org/tests/4115375

Code for restart Network service if Neworkwork connection not ready will fix following error:
https://openqa.opensuse.org/tests/4115203#step/ipsec3hosts/49