### PR TITLE
Convert 1st phase of continuous migration into support image

### DIFF
--- a/data/yam/autoyast/autoyast_scc_up.xml
+++ b/data/yam/autoyast/autoyast_scc_up.xml
@@ -8,7 +8,7 @@
       <boot_mbr>true</boot_mbr>
       <boot_root>true</boot_root>
       <generic_mbr>false</generic_mbr>
-      <timeout config:type="integer">5</timeout>
+      <timeout config:type="integer">-1</timeout>
     </global>
     <loader_type>{{LOADER_TYPE}}</loader_type>
   </bootloader>


### PR DESCRIPTION
##
##### ${{\color{Purple}\Huge{\textsf{   Convert 1st phase of continuous migration into support image.\}}}}\$
- Related ticket: 
  * https://progress.opensuse.org/issues/153823
- Related MR:
  * https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/166/
- Needles: 
  * N/A
- Verification run: 
   * [**Support_image**](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=supp_migr_sles_15sp4_15sp5_dev&modules=&module_re=&group_glob=&not_group_glob=&comment=&version=15-SP5&groupid=318&distri=sle#)
   * Migration for 2nd step:
     [**Migration_VR**](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=migr_sles_continuous_15sp4_15sp5_ph1_dev1&modules=&module_re=&group_glob=&not_group_glob=&comment=&build=89.1&version=15-SP6&distri=sle#)
##
