### PR TITLE
Fix xfstests installation issue

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -27,6 +27,7 @@ use transactional;
 
 my $STATUS_LOG = '/opt/status.log';
 my $VERSION_LOG = '/opt/version.log';
+my @PACKAGES = (qw(xfstests fio), split(/ /, get_var('XFSTESTS_PACKAGES')));
 
 sub install_xfstests_from_repo {
     if (is_sle) {
@@ -56,7 +57,7 @@ sub install_xfstests_from_repo {
         reboot_on_changes;
     }
     else {
-        zypper_call('in xfstests fio fsverity-utils');
+        zypper_call('in ' . join(' ', @PACKAGES));
     }
     if (is_sle) {
         script_run 'ln -s /var/lib/xfstests /opt/xfstests';

--- a/variables.md
+++ b/variables.md
@@ -430,6 +430,7 @@ XFSTESTS_REPO | string | | repo to install xfstests package
 DEPENDENCY_REPO | string | | ibs/obs repo to install related test package to solve dependency issues. e.g. fio
 XFSTESTS_DEVICE | string | | manually set a test disk for both TEST_DEV and SCRATCH_DEV
 XFSTESTS_INSTALL | boolean | false | Install xfstests and dependency package.
+XFSTESTS_PACKAGES | string | | Install additional required packages of xfstests. e.g. 'fsverity-utils libcap-progs'
 
 
 Filesystem specific setting:


### PR DESCRIPTION
There is no fsverity-utils in many repositories, so add a parameter 'XFSTESTS_PACKAGES' to optionally install package.

- Related ticket: https://progress.opensuse.org/issues/159711
- Needles: N/A
- Verification run: 
http://10.67.133.133/tests/603#step/install/43 (only install xfstests fio)
http://10.67.133.133/tests/604#step/install/43 (additional fsverity-utils libcap-progs)
https://openqa.suse.de/tests/14165278 (verified on QAM group)
