### PR TITLE
lib/containers/urls: Add publish location for Leap 15.6

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -188,6 +188,18 @@ our %images_list = (
                 }
             },
             available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+        },
+        '15.6' => {
+            released => sub { 'registry.opensuse.org/opensuse/leap:15.6' },
+            totest => sub {
+                my $arch = shift;
+                if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
+                    'registry.opensuse.org/opensuse/leap/15.6/images/totest/containers/opensuse/leap:15.6';
+                } elsif ($arch eq 'arm') {
+                    'registry.opensuse.org/opensuse/leap/15.6/arm/images/totest/containers/opensuse/leap:15.6';
+                }
+            },
+            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
         }
     },
     'sle-micro' => {


### PR DESCRIPTION
Manual work that wasn't necessary with the old code.

- Verification run: https://openqa.opensuse.org/tests/4116229
