### PR TITLE
xfstests: fix tar command issue

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -601,8 +601,7 @@ sub run {
     #Save status log before next step(if run.pm fail will load into a last good snapshot)
     save_tmp_file('status.log', $status_log_content);
     my $local_file = "/tmp/opt_logs.tar.gz";
-    my $back_pid = background_script_run("tar zcvf $local_file --absolute-names /opt/log/");
-    script_run("wait $back_pid");
+    script_run("tar zcvf $local_file --absolute-names /opt/log/", timeout => 600, die_on_timeout => 0);
     upload_logs($local_file, failok => 1, timeout => 180);
 }
 
@@ -613,8 +612,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     # Collect executed test logs
-    my $back_pid = background_script_run('tar zcvf /tmp/opt_logs.tar.gz --absolute-names /opt/log/');
-    script_run("wait $back_pid");
+    script_run('tar zcvf /tmp/opt_logs.tar.gz --absolute-names /opt/log/', timeout => 600, die_on_timeout => 0);
     upload_logs('/tmp/opt_logs.tar.gz', failok => 1, timeout => 180);
 }
 


### PR DESCRIPTION
we use background_script_run() for tar command, and then use wait() for test log upload. So that might cause a minor issue because there is a race condition between them.
Thus remove wait and use script_run() replace background_script_run()

- Related ticket: https://progress.opensuse.org/issues/159768
- Needles: N/A
- Verification run:
http://10.67.133.133/tests/610
https://openqa.suse.de/tests/14173175 (qam group)
