### PR TITLE
containers: Fix for skopeo upstream tests not running on aarch64

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -292,7 +292,7 @@ sub load_container_tests {
     }
 
     if (get_var('PODMAN_BATS_SKIP')) {
-        loadtest 'containers/skopeo_integration' if (is_x86_64 && (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_sle_micro('5.5')));
+        loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_sle_micro('5.5'));
         loadtest 'containers/podman_integration';
         return;
     }

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -94,12 +94,16 @@ sub run {
     }
 
     assert_script_run "podman system reset -f";
-    if (is_transactional) {
-        trup_call "run rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
-        check_reboot_changes;
-    } else {
-        script_run "rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
+
+    if (script_run("test -f /etc/containers/mounts.conf -o -f /usr/share/containers/mounts.conf") == 0) {
+        if (is_transactional) {
+            trup_call "run rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
+            check_reboot_changes;
+        } else {
+            script_run "rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
+        }
     }
+
     switch_cgroup_version($self, 2);
 
     # Create user if not present


### PR DESCRIPTION
Fix for skopeo upstream tests not running on aarch64:

`# time="2024-04-30T07:30:37+02:00" level=warning msg="Failed to mount subscriptions, skipping entry in /etc/containers/mounts.conf: open /etc/zypp/credentials.d/SCCcredentials: permission denied"`

- Related ticket: https://progress.opensuse.org/issues/159774
- Verification runs:
  - sle-15-SP4-Server-DVD-Updates-aarch64-Build20240429-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14172388
  - sle-15-SP5-Server-DVD-Updates-aarch64-Build20240429-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14172389