### PR TITLE
containers: Fix missing dependency for skopeo upstream tests

### DIFF
--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -53,7 +53,7 @@ sub run {
     }
 
     # Install tests dependencies
-    my @pkgs = qw(apache2-utils bats go jq podman skopeo);
+    my @pkgs = qw(apache2-utils bats go jq openssl podman skopeo);
     install_packages(@pkgs);
 
     # Create user if not present


### PR DESCRIPTION
Fix missing openssl dependency on TW.

- Related ticket: https://progress.opensuse.org/issues/159741
- Failing test: https://openqa.opensuse.org/tests/4119203
- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20240429-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/t4119809
