### PR TITLE
data/journal_check/bug_refs.json: boo#1193426 happens on 15.6 as well

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -207,7 +207,7 @@
     "boo#1193426": {
         "description": "libapparmor.*: Can't create cache directory '/var/cache/apparmor/.*': Read-only file system",
         "products": {
-            "opensuse": ["Tumbleweed", "15.4", "15.5"]
+            "opensuse": ["Tumbleweed", "15.4", "15.5", "15.6"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
- Verification run: https://openqa.opensuse.org/tests/4120141
