### PR TITLE
Refactor bats

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Common functions for BATS test suites
+# Maintainer: qa-c@suse.de
+
+package containers::bats;
+
+use base Exporter;
+use Exporter;
+
+use base "consoletest";
+use testapi;
+use utils;
+use strict;
+use warnings;
+use version_utils;
+use registration qw(add_suseconnect_product get_addon_fullname);
+use transactional qw(trup_call check_reboot_changes);
+use serial_terminal qw(select_user_serial_terminal);
+
+our @EXPORT = qw(add_packagehub remove_mounts_conf switch_to_user);
+
+sub add_packagehub {
+    if (is_sle_micro) {
+        my $sle_version = "";
+        if (is_sle_micro('<5.3')) {
+            $sle_version = "15.3";
+        } elsif (is_sle_micro('<5.5')) {
+            $sle_version = "15.4";
+        } elsif (is_sle_micro('<6.0')) {
+            $sle_version = "15.5";
+        }
+        trup_call "register -p PackageHub/$sle_version/" . get_required_var('ARCH');
+        zypper_call "--gpg-auto-import-keys ref";
+    } elsif (is_sle) {
+        add_suseconnect_product(get_addon_fullname('phub'));
+    }
+}
+
+sub remove_mounts_conf {
+    if (script_run("test -f /etc/containers/mounts.conf -o -f /usr/share/containers/mounts.conf") == 0) {
+        if (is_transactional) {
+            trup_call "run rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
+            check_reboot_changes;
+        } else {
+            script_run "rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
+        }
+    }
+}
+
+sub switch_to_user {
+    if (script_run("grep $testapi::username /etc/passwd") != 0) {
+        my $serial_group = script_output "stat -c %G /dev/$testapi::serialdev";
+        assert_script_run "useradd -m -G $serial_group $testapi::username";
+        assert_script_run "echo '${testapi::username}:$testapi::password' | chpasswd";
+        ensure_serialdev_permissions;
+        select_console "user-console";
+    } else {
+        select_user_serial_terminal();
+    }
+}

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -21,7 +21,17 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 use transactional qw(trup_call check_reboot_changes);
 use serial_terminal qw(select_user_serial_terminal);
 
-our @EXPORT = qw(add_packagehub remove_mounts_conf switch_to_user);
+our @EXPORT = qw(install_bats add_packagehub remove_mounts_conf switch_to_user);
+
+sub install_bats {
+    return if (script_run("which bats") == 0);
+
+    my $bats_version = get_var("BATS_VERSION", "1.11.0");
+
+    script_retry("curl -sL https://github.com/bats-core/bats-core/archive/refs/tags/v$bats_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
+    assert_script_run "cd bats-core-$bats_version";
+    assert_script_run "bash ./install.sh /usr/local";
+}
 
 sub add_packagehub {
     if (is_sle_micro) {

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -48,9 +48,10 @@ sub run {
     select_serial_terminal;
 
     add_packagehub;
+    install_bats;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns bats catatonit jq make netavark netcat-openbsd openssl podman python3-PyYAML socat sudo systemd-container);
+    my @pkgs = qw(aardvark-dns catatonit jq make netavark netcat-openbsd openssl podman python3-PyYAML socat sudo systemd-container);
     push @pkgs, qw(apache2-utils buildah criu go gpg2) unless is_sle_micro;
     push @pkgs, qw(podman-remote skopeo) unless is_sle_micro('<5.5');
     # NOTE: passt should be pulled in as a dependency on podman 5.0+

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -9,15 +9,14 @@
 
 use Mojo::Base 'containers::basetest';
 use testapi;
-use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
+use serial_terminal qw(select_serial_terminal);
 use containers::utils qw(get_podman_version);
-use utils qw(zypper_call script_retry ensure_serialdev_permissions);
-use version_utils qw(get_os_release is_transactional is_sle is_sle_micro is_tumbleweed is_microos is_leap is_leap_micro);
-use transactional qw(trup_call check_reboot_changes);
-use registration qw(add_suseconnect_product get_addon_fullname);
+use utils qw(script_retry);
+use version_utils qw(is_sle is_sle_micro is_tumbleweed is_microos is_leap is_leap_micro);
 use containers::common;
 use Utils::Architectures qw(is_x86_64 is_aarch64);
 use Utils::Systemd qw(systemctl);
+use containers::bats qw(install_bats add_packagehub remove_mounts_conf switch_to_user);
 
 my $test_dir = "/var/tmp";
 my $podman_version = "";
@@ -47,26 +46,11 @@ sub run_tests {
 sub run {
     my ($self) = @_;
     select_serial_terminal;
-    my ($running_version, $sp, $host_distri) = get_os_release;
-    install_podman_when_needed($host_distri);
 
-    if (is_sle_micro) {
-        my $sle_version = "";
-        if (is_sle_micro('<5.3')) {
-            $sle_version = "15.3";
-        } elsif (is_sle_micro('<5.5')) {
-            $sle_version = "15.4";
-        } elsif (is_sle_micro('<6.0')) {
-            $sle_version = "15.5";
-        }
-        trup_call "register -p PackageHub/$sle_version/" . get_required_var('ARCH');
-        zypper_call "--gpg-auto-import-keys ref";
-    } elsif (is_sle) {
-        add_suseconnect_product(get_addon_fullname('phub'));
-    }
+    add_packagehub;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns bats catatonit jq make netavark netcat-openbsd openssl python3-PyYAML socat sudo systemd-container);
+    my @pkgs = qw(aardvark-dns bats catatonit jq make netavark netcat-openbsd openssl podman python3-PyYAML socat sudo systemd-container);
     push @pkgs, qw(apache2-utils buildah criu go gpg2) unless is_sle_micro;
     push @pkgs, qw(podman-remote skopeo) unless is_sle_micro('<5.5');
     # NOTE: passt should be pulled in as a dependency on podman 5.0+
@@ -95,27 +79,11 @@ sub run {
 
     assert_script_run "podman system reset -f";
 
-    if (script_run("test -f /etc/containers/mounts.conf -o -f /usr/share/containers/mounts.conf") == 0) {
-        if (is_transactional) {
-            trup_call "run rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
-            check_reboot_changes;
-        } else {
-            script_run "rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
-        }
-    }
+    remove_mounts_conf;
 
     switch_cgroup_version($self, 2);
 
-    # Create user if not present
-    if (script_run("grep $testapi::username /etc/passwd") != 0) {
-        my $serial_group = script_output "stat -c %G /dev/$testapi::serialdev";
-        assert_script_run "useradd -m -G $serial_group $testapi::username";
-        assert_script_run "echo '${testapi::username}:$testapi::password' | chpasswd";
-        ensure_serialdev_permissions;
-        select_console "user-console";
-    } else {
-        select_user_serial_terminal();
-    }
+    switch_to_user;
 
     # Download podman sources
     my $test_dir = "/var/tmp";

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -42,9 +42,10 @@ sub run {
     select_serial_terminal;
 
     add_packagehub;
+    install_bats;
 
     # Install tests dependencies
-    my @pkgs = qw(apache2-utils bats go jq openssl podman skopeo);
+    my @pkgs = qw(apache2-utils jq openssl podman skopeo);
     install_packages(@pkgs);
 
     remove_mounts_conf;

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -28,6 +28,10 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('SKOPEO_BATS_SKIP', '') . " " . $skip_tests);
     script_run "rm systemtest/$_.bats" foreach (@skip_tests);
 
+    # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
+    my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";
+    assert_script_run "sed -i 's/arch=.*/arch=$goarch/' systemtest/010-inspect.bats";
+
     # Default quay.io/libpod/registry:2 image used by the test only has amd64 image
     my $registry = is_x86_64 ? "" : "docker.io/library/registry:2";
 


### PR DESCRIPTION
This PR:
- Refactors common code in podman & skopeo upstream tests to `containers::bats`
- Installs `bats` from upstream.

Related ticket: https://progress.opensuse.org/issues/155470
Verification runs:
- opensuse-Tumbleweed-DVD-x86_64-Build20240429-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/tests/4120284 (failing for other reason).
- sle-15-SP5-Server-DVD-Updates-x86_64-Build20240429-1-podman_testsuite@64bit -> https://openqa.suse.de/t14175639
- sle-15-SP4-Server-DVD-Updates-aarch64-Build20240429-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14177130

TODO:
- In next PR, drop packagehub dependencies completely.