### PR TITLE
containers: Drop packagehub dependencies for upstream tests

### DIFF
--- a/data/containers/htpasswd
+++ b/data/containers/htpasswd
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+# Python clone of `htpasswd -Bbn username password`
+
+import sys
+from passlib.apache import HtpasswdFile
+
+if sys.argv[1] != "-Bbn" or len(sys.argv) != 4:
+    sys.exit("ERROR: " + " ".join(sys.argv))
+
+ht = HtpasswdFile(default_scheme="bcrypt")
+ht.set_password(sys.argv[2], sys.argv[3])
+print(ht.to_string().decode("utf-8"))

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -16,8 +16,7 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use version_utils;
-use registration qw(add_suseconnect_product get_addon_fullname);
+use version_utils qw(is_transactional);
 use transactional qw(trup_call check_reboot_changes);
 use serial_terminal qw(select_user_serial_terminal);
 
@@ -31,23 +30,6 @@ sub install_bats {
     script_retry("curl -sL https://github.com/bats-core/bats-core/archive/refs/tags/v$bats_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd bats-core-$bats_version";
     assert_script_run "bash ./install.sh /usr/local";
-}
-
-sub add_packagehub {
-    if (is_sle_micro) {
-        my $sle_version = "";
-        if (is_sle_micro('<5.3')) {
-            $sle_version = "15.3";
-        } elsif (is_sle_micro('<5.5')) {
-            $sle_version = "15.4";
-        } elsif (is_sle_micro('<6.0')) {
-            $sle_version = "15.5";
-        }
-        trup_call "register -p PackageHub/$sle_version/" . get_required_var('ARCH');
-        zypper_call "--gpg-auto-import-keys ref";
-    } elsif (is_sle) {
-        add_suseconnect_product(get_addon_fullname('phub'));
-    }
 }
 
 sub remove_mounts_conf {

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -49,6 +49,8 @@ sub switch_to_user {
         assert_script_run "useradd -m -G $serial_group $testapi::username";
         assert_script_run "echo '${testapi::username}:$testapi::password' | chpasswd";
         ensure_serialdev_permissions;
+    }
+    if (is_transactional) {
         select_console "user-console";
     } else {
         select_user_serial_terminal();

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -292,7 +292,7 @@ sub load_container_tests {
     }
 
     if (get_var('PODMAN_BATS_SKIP')) {
-        loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4'));
+        loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_sle_micro('>=5.5'));
         loadtest 'containers/podman_integration';
         return;
     }

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -58,12 +58,13 @@ sub run {
 
     switch_to_user;
 
-    # Download skopeo sources
     my $test_dir = "/var/tmp";
-    $skopeo_version = script_output "skopeo --version  | awk '{ print \$3 }'";
     assert_script_run "cd $test_dir";
+
+    # Download skopeo sources
+    $skopeo_version = script_output "skopeo --version  | awk '{ print \$3 }'";
     script_retry("curl -sL https://github.com/containers/skopeo/archive/refs/tags/v$skopeo_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
-    assert_script_run "cd skopeo-$skopeo_version/";
+    assert_script_run "cd $test_dir/skopeo-$skopeo_version/";
     assert_script_run "cp -r systemtest systemtest.orig";
 
     run_tests(rootless => 1, skip_tests => get_var('SKOPEO_BATS_SKIP_USER', ''));
@@ -75,6 +76,7 @@ sub run {
 }
 
 sub cleanup() {
+    assert_script_run "cd ~";
     script_run("rm -rf $test_dir/skopeo-$skopeo_version/");
 }
 

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -13,7 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use Utils::Architectures qw(is_x86_64);
-use containers::bats qw(install_bats add_packagehub remove_mounts_conf switch_to_user);
+use containers::bats qw(install_bats remove_mounts_conf switch_to_user);
 
 my $test_dir = "/var/tmp";
 my $skopeo_version = "";
@@ -45,12 +45,14 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    add_packagehub;
     install_bats;
 
     # Install tests dependencies
-    my @pkgs = qw(apache2-utils jq openssl podman skopeo);
+    my @pkgs = qw(jq openssl podman python3-passlib skopeo);
     install_packages(@pkgs);
+
+    assert_script_run "curl -o /usr/local/bin/htpasswd " . data_url("containers/htpasswd");
+    assert_script_run "chmod +x /usr/local/bin/htpasswd";
 
     remove_mounts_conf;
 


### PR DESCRIPTION
We can drop the `apache2-utils` dependency (available only on PackageHub for SLE & SLEM) by providing a bare-bones Python implementation of the `htpasswd` command, which is called as `htpasswd -Bbn USERNAME PASSWORD` in the [podman](https://github.com/containers/podman/blob/main/test/system/helpers.registry.bash#L60) and [skopeo](https://github.com/containers/skopeo/blob/main/systemtest/helpers.bash#L321) upstream tests.

We can also drop the `go` dependency and limit the `criu` (checkpoint-restore) tests to Tumbleweed with the SKIP variables.

This allows us to enable the skopeo upstream tests for SLEM 5.5+.

- Related ticket: https://progress.opensuse.org/issues/159756
- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20240501-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/t4144211 (failing for other reasons)
  - sle-15-SP4-Server-DVD-Updates-x86_64-Build20240501-1-podman_testsuite@64bit -> https://openqa.suse.de/t14185225
  - sle-15-SP5-Server-DVD-Updates-x86_64-Build20240501-1-podman_testsuite@64bit -> https://openqa.suse.de/t14185224
  - sle-micro-5.5-Default-Updates-x86_64-Build20240429-1-slem_podman_testsuite@64bit -> https://openqa.suse.de/t14185913