### PR TITLE
hpc: Improve spack master setup

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -387,7 +387,7 @@ however the newest spack updates contain C<spack_get_libs.sh>.
 sub prepare_spack_env {
     my ($self, $mpi) = @_;
     $mpi //= 'mpich';
-    zypper_call "in spack", timeout => 1200;
+    zypper_call "in spack mpich mpich-devel", timeout => 1200;
     assert_script_run "echo source /usr/share/spack/setup-env.sh >> /home/$testapi::username/.bashrc";
     type_string('pkill -u root');    # this kills sshd
     select_serial_terminal(0);

--- a/tests/hpc/spack_master.pm
+++ b/tests/hpc/spack_master.pm
@@ -60,11 +60,6 @@ sub run ($self) {
     test_case('Compilation', 'Program compiled successfully', $compile_rt);
     barrier_wait('MPI_BINARIES_READY');
 
-    type_string "sudo systemctl restart sshd\n";
-    sleep 3;
-    type_string("$testapi::password\n");
-    record_info('ssh', 'check sshd service before continue');
-    systemctl 'status sshd';
     # Testing compiled code
     record_info('INFO', 'Run MPI over single machine');
     $rt = assert_script_run("mpirun $exports_path{'bin'}/$mpi_bin");


### PR DESCRIPTION
Fix poo#159831: We should use mpich libraries provided by SLE and not ones provided by spack repositories. sshd restart, which is not needed at all, was removed.


- Related ticket: https://progress.opensuse.org/issues/159831
- Needles: none
- Verification run: https://openqa.suse.de/tests/14185459
