### PR TITLE
Update chrome test

### DIFF
--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -35,7 +35,9 @@ sub preserve_privacy_of_non_human_openqa_workers {
 sub click_ad_privacy_feature {
     assert_and_click 'google-chrome-ad-privacy-feature-more';
     assert_and_click 'google-chrome-ad-privacy-feature-no';
-    assert_and_click 'google-chrome-ad-privacy-feature-more';
+    if (check_screen 'google-chrome-ad-privacy-feature-more', 5) {
+        assert_and_click 'google-chrome-ad-privacy-feature-more';
+    }
     assert_and_click 'google-chrome-ad-privacy-feature-ok';
 }
 


### PR DESCRIPTION
The button "More" is not always showing up, changed the test to reflect this.

- Related ticket: https://progress.opensuse.org/issues/159849
- Verification run: https://openqa.opensuse.org/tests/overview/?build=os-autoinst%2Fos-autoinst-distri-opensuse%2319224
