### PR TITLE
wait_for_cluster also care about Pacemaker version

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -1142,11 +1142,12 @@ sub wait_for_cluster {
 
     $args{wait_time} //= 10;
     $args{max_retries} //= 7;
+    my $online_str = check_version('>=2.1.7', $self->pacemaker_version()) ? '[1-9]+' : 'online';
 
     while ($args{max_retries} > 0) {
         my $crm_output = $self->run_cmd(cmd => $crm_mon_cmd, quiet => 1);
 
-        my $hanasr_ready = check_hana_topology(input => $self->get_hana_topology());
+        my $hanasr_ready = check_hana_topology(input => $self->get_hana_topology(), node_state_match => $online_str);
         my $crm_ok = check_crm_output(input => $crm_output);
 
         if ($hanasr_ready && $crm_ok) {


### PR DESCRIPTION
Pacemaker version >=2.1.7 change 'SAPHanaSR-showAttr --format=script' output format. Adapt this wait method to support both new and old format.

Like doing https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19049 for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18859

- Related ticket: TEAM-9022

# Verification run:
 - sle-15-SP6-Azure-SAP-BYOS-x86_64-Build0510-azure_sap_byos_hanasr_sapconf@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/282025
