### PR TITLE
containers: Add runc upstream tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -294,6 +294,7 @@ sub load_container_tests {
     if (get_var('PODMAN_BATS_SKIP')) {
         loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_sle_micro('>=5.5'));
         loadtest 'containers/podman_integration';
+        loadtest 'containers/runc_integration' if (is_tumbleweed);
         return;
     }
 

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -15,8 +15,7 @@ use utils qw(script_retry);
 use version_utils qw(is_sle is_sle_micro is_tumbleweed is_microos is_leap is_leap_micro);
 use containers::common;
 use Utils::Architectures qw(is_x86_64 is_aarch64);
-use Utils::Systemd qw(systemctl);
-use containers::bats qw(install_bats remove_mounts_conf switch_to_user);
+use containers::bats qw(install_bats remove_mounts_conf switch_to_user delegate_controllers);
 
 my $test_dir = "/var/tmp";
 my $podman_version = "";
@@ -65,18 +64,7 @@ sub run {
     assert_script_run "curl -o /usr/local/bin/htpasswd " . data_url("containers/htpasswd");
     assert_script_run "chmod +x /usr/local/bin/htpasswd";
 
-    # Workarounds for tests to work:
-    # - Avoid default mounts for containers
-    # - Switch to cgroups v2
-
-    # Required modifications to make cgroups v2 work on SLES<15-SP6.
-    # See https://susedoc.github.io/doc-sle/main/html/SLES-tuning/cha-tuning-cgroups.html#sec-cgroups-user-sessions
-    if (is_sle('<15-SP6') || is_leap('<15.6') || is_sle_micro('<6.0')) {
-        assert_script_run "mkdir /etc/systemd/system/user@.service.d/";
-        assert_script_run 'echo -e "[Service]\nDelegate=pids memory" > /etc/systemd/system/user@.service.d/60-delegate.conf';
-        systemctl "daemon-reload";
-        systemctl "--user daemon-reexec";
-    }
+    delegate_controllers;
 
     assert_script_run "podman system reset -f";
 

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -1,0 +1,91 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: runc
+# Summary: Upstream runc integration tests
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use utils qw(script_retry);
+use containers::common;
+use containers::bats qw(install_bats switch_to_user delegate_controllers);
+use version_utils qw(is_tumbleweed);
+
+my $test_dir = "/var/tmp";
+my $runc_version = "";
+
+sub run_tests {
+    my %params = @_;
+    my ($rootless, $skip_tests) = ($params{rootless}, $params{skip_tests});
+
+    my $log_file = "runc-" . ($rootless ? "user" : "root") . ".tap";
+
+    assert_script_run "cp -r tests/integration.orig tests/integration";
+    my @skip_tests = split(/\s+/, get_var('RUNC_BATS_SKIP', '') . " " . $skip_tests);
+    script_run "rm tests/integration/$_.bats" foreach (@skip_tests);
+
+    assert_script_run "echo $log_file .. > $log_file";
+    script_run "RUNC=/usr/bin/runc RUNC_USE_SYSTEMD=1 bats --tap tests/integration | tee -a $log_file", 1200;
+    parse_extra_log(TAP => $log_file);
+    assert_script_run "rm -rf tests/integration";
+}
+
+sub run {
+    my ($self) = @_;
+    select_serial_terminal;
+
+    install_bats;
+
+    # Install tests dependencies
+    my @pkgs = qw(git-core glibc-devel-static go iptables jq libseccomp-devel make runc);
+    push @pkgs, "criu" if is_tumbleweed;
+    install_packages(@pkgs);
+
+    delegate_controllers;
+
+    switch_to_user;
+
+    my $test_dir = "/var/tmp";
+    assert_script_run "cd $test_dir";
+
+    # Download runc sources
+    $runc_version = script_output "runc --version  | awk '{ print \$3 }'";
+    script_retry("curl -sL https://github.com/opencontainers/runc/archive/refs/tags/v$runc_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
+    assert_script_run "cd $test_dir/runc-$runc_version/";
+    assert_script_run "cp -r tests/integration tests/integration.orig";
+
+    # Compile some stuff
+    assert_script_run "make recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill remap-rootfs";
+
+    switch_cgroup_version($self, 2);
+
+    run_tests(rootless => 1, skip_tests => get_var('RUNC_BATS_SKIP_USER', ''));
+
+    select_serial_terminal;
+    assert_script_run("cd $test_dir/runc-$runc_version/");
+
+    run_tests(rootless => 0, skip_tests => get_var('RUNC_BATS_SKIP_ROOT', ''));
+}
+
+sub cleanup() {
+    assert_script_run "cd ~";
+    script_run("rm -rf $test_dir/runc-$runc_version/");
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    cleanup();
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    cleanup();
+    $self->SUPER::post_run_hook;
+}
+
+1;


### PR DESCRIPTION
Add runc upstream tests

- Related ticket: https://progress.opensuse.org/issues/159801
- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20240501-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/tests/4158763 (failing in podman module for other reason)
  - opensuse-Tumbleweed-DVD-aarch64-Build20240501-containers_host_podman_testsuite@aarch64 -> https://openqa.opensuse.org/tests/4158762 (failing in podman module for other reason)

NOTE: Must use `QEMUCPUS=2`.  Changed in https://github.com/os-autoinst/opensuse-jobgroups/pull/448