### PR TITLE
containers: Fix switch_cgroup_version()

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -225,7 +225,8 @@ sub switch_cgroup_version {
 
     my $setting = ($version == 1) ? 0 : 1;
 
-    return if (script_output("cat /proc/cmdline") =~ "systemd\.unified_cgroup_hierarchy=$setting");
+    my $rc = script_run("ls /sys/fs/cgroup/cgroup.controllers");
+    return if ($version == 2 && $rc == 0 || $version == 1 && $rc != 0);
 
     record_info "cgroup v$version", "Switching to cgroup v$version";
     if (is_transactional) {


### PR DESCRIPTION
cgroups v2 is default since v255 and our way to check that it's set no longer works.  Thus we're needlessly adding a deprecated entry to /etc/default/grub and restarting the SUT on Tumbleweed and MicroOS.

The correct check is described [here](https://rootlesscontaine.rs/getting-started/common/cgroup2/#checking-whether-cgroup-v2-is-already-enabled)

https://openqa.opensuse.org/tests/4145118#step/podman_integration/24

- Verification runs:
  -  opensuse-Tumbleweed-DVD-x86_64-Build20240501-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/t4157722 (failing due to other issues).