### PR TITLE
Change wait in stop_hana crash

### DIFF
--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -170,7 +170,7 @@ subtest "[stop_hana] crash" => sub {
     $mock_pc->mock('run_ssh_command', sub {
             my ($self, %args) = @_;
             push @calls, $args{cmd};
-            return 'BABUUUUUUUUM' });
+            return 'running' });
     $self->{my_instance} = $mock_pc;
 
     $self->stop_hana(method => 'crash');

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -60,7 +60,6 @@ sub run {
 
     # Stop/kill/crash HANA DB and wait till SSH is again available with pacemaker running.
     $self->stop_hana(method => $takeover_action);
-    $self->{my_instance}->wait_for_ssh(username => 'cloudadmin');
 
     # SBD delay is active only after reboot
     if (($takeover_action eq 'crash' and $sbd_delay != 0) ||


### PR DESCRIPTION
Change the code to not only rely on wait_for_ssh


- Related ticket: TEAM-9215

# Verification run:

## sle-15-SP5-Azure-SAP-PAYG-Incidents-x86_64-Build:33599:rpm-SAPHanaSR-ScaleUp-PerfOpt-spn@az_Standard_E8s_v3 

- http://openqaworker15.qa.suse.cz/tests/282095 :tomato:  failed in deployment (ansible rebot timeout)
- https://openqaworker15.qa.suse.cz/tests/282100 :tomato: failed in deployment (`Error: waiting for Virtual Machine "Virtual Machine`)
- https://openqaworker15.qa.suse.cz/tests/282103 :green_apple: version using too fast polling

## sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2024-05-03T04:03:15Z-hanasr_azure_test_sapconf_msi@64bit 

- http://openqaworker15.qa.suse.cz/tests/282096 :green_apple: version using too fast polling
- http://openqaworker15.qa.suse.cz/tests/282110 in first Crash test module it works http://openqaworker15.qa.suse.cz/tests/282110#step/Crash_site_a-primary/437 . In second crash test module it `die` and that is not ok http://openqaworker15.qa.suse.cz/tests/282110#step/Crash_site_b-primary/425 :tomato: 
