### PR TITLE
Fix snapper column parsing

### DIFF
--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -72,7 +72,7 @@ sub run {
     check_package(stage => 'in');
 
     # Find snapshot number for rollback
-    my $snap = script_output "snapper list | tail -1 | cut -d'|' -f1 | tr -d ' *'";
+    my $snap = script_output "snapper list --columns number | tail -1 | tr -d ' *'";
 
     # Don't use tests requiring repos in staging
     unless (is_opensuse && is_staging) {


### PR DESCRIPTION
I compared output from https://openqa.opensuse.org/tests/4157911#step/transactional_update/68 with running snapper locally on TW, character `| (0x7c)` changed to `│ (0x2502)`.

Parsing columns is built-in snapper option now, it should prevent this problem.

```
~ snapper list # openQA
8│single││ThuMay218:03:382024│root│12.09MiB│number│SnapshotUpdateof#7│

~ snapper list # locally
57  | post   |    56 | Thu 02 May 2024 01:54:24 PM CEST | root | number  |
```

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1223840
- Verification run: I didn't test this PR in openQA - I don't have local env anymore. Please review accordingly

