### PR TITLE
PC upload_img add check of image version status

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -150,6 +150,8 @@ sub get_image_version {
     }
     record_info('REGION OK', 'The ' . $self->provider_client->region . ' is listed in the targetRegions(' . join(',', @regions_list) . ') of this image version.');
 
+    die("Image version $image Found in failed state") if (decode_azure_json($json)->{provisioningState} eq "Failed");
+
     return $image;
 }
 


### PR DESCRIPTION
In PC `azure` upload_img, add a status of existing image version in cloud.
Never checked before, it allowed wrong images to pass provisioning and impact next depending tests, like in [test 14192564](https://openqa.suse.de/tests/14192564).

- Verification run: https://openqa.suse.de/tests/14196811
