### PR TITLE
Set firewall setting in profile for 12SP5 on s390x

### DIFF
--- a/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_s390x.xml
@@ -35,14 +35,20 @@
     </mode>
     <final_reboot config:type="boolean">true</final_reboot>
   </general>
-  <networking>
   <firewall>
+    <FW_CONFIGURATIONS_DMZ>sshd vnc-server</FW_CONFIGURATIONS_DMZ>
+    <FW_CONFIGURATIONS_EXT>sshd vnc-server</FW_CONFIGURATIONS_EXT>
+    <FW_CONFIGURATIONS_INT>sshd vnc-server</FW_CONFIGURATIONS_INT>
+    <FW_IGNORE_FW_BROADCAST_EXT>yes</FW_IGNORE_FW_BROADCAST_EXT>
+    <FW_LOAD_MODULES>nf_conntrack_netbios_ns</FW_LOAD_MODULES>
+    <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
+    <FW_LOG_DROP_CRIT>yes</FW_LOG_DROP_CRIT>
+    <FW_SERVICES_ACCEPT_EXT>0.0.0.0/0,tcp,22</FW_SERVICES_ACCEPT_EXT>
+    <FW_STOP_KEEP_ROUTING_STATE>no</FW_STOP_KEEP_ROUTING_STATE>
     <enable_firewall config:type="boolean">true</enable_firewall>
     <start_firewall config:type="boolean">true</start_firewall>
-    <FW_ALLOW_PING_FW>yes</FW_ALLOW_PING_FW>
-    <FW_DEV_EXT>eth0</FW_DEV_EXT>
-    <FW_SERVICES_ACCEPT_EXT>0/0,tcp,22</FW_SERVICES_ACCEPT_EXT>
   </firewall>
+  <networking>
     <dhcp_options>
       <dhclient_client_id/>
       <dhclient_hostname_option>AUTO</dhclient_hostname_option>
@@ -234,6 +240,8 @@
       <disable config:type="list"/>
       <enable config:type="list">
         <service>sshd</service>
+	<service>SuSEfirewall2</service>
+        <service>SuSEfirewall2_init</service>
       </enable>
     </services>
   </services-manager>


### PR DESCRIPTION
We need set correct firewall setting in profile for 12SP5 on s390x to make sure firewall start and port opened.

- Related ticket: https://progress.opensuse.org/issues/158194
- Needles: N/A
- Verification run: 
-  Installation: https://openqa.suse.de/tests/14212170#
                         https://openqa.suse.de/tests/14212213#details
   Migration:  https://openqa.suse.de/tests/14212239#
