### PR TITLE
Skip zypper-docker container build test in sle15sp6

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -193,7 +193,8 @@ sub test_opensuse_based_image {
         # that are not the same version as the host, so we skip this test.
         test_zypper_on_container($runtime, $image);
         build_and_run_image(base => $image, runtime => $runtime);
-        if (is_sle && $runtime->runtime eq 'docker') {
+        # zypper-docker package has been excluded from sle starting with 15-SP6
+        if (is_sle('<15-SP6') && $runtime->runtime eq 'docker') {
             build_with_zypper_docker(image => $image, runtime => $runtime, version => $version);
         }
     }


### PR DESCRIPTION
sle 15-sp6 does not have `zypper-docker` anymore hence all tests that are using it should be skipped.

- ticket: https://progress.opensuse.org/issues/159945

####  Verification runs

http://kepler.suse.cz/tests/23265#
http://kepler.suse.cz/tests/23266
http://kepler.suse.cz/tests/23264
