### PR TITLE
Fixes for podman upstream tests on SLEM 5.5

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -63,6 +63,11 @@ sub run {
     assert_script_run "curl -o /usr/local/bin/htpasswd " . data_url("containers/htpasswd");
     assert_script_run "chmod +x /usr/local/bin/htpasswd";
 
+    # Make sure to use netavark if CNI is installed
+    if (script_run("rpm -q cni") == 0) {
+        assert_script_run(q(echo -e '[Network]\nnetwork_backend="netavark"' >> /etc/containers/containers.conf));
+    }
+
     delegate_controllers;
 
     assert_script_run "podman system reset -f";

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -49,9 +49,8 @@ sub run {
     install_bats;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark netcat-openbsd openssl podman python3-passlib python3-PyYAML socat sudo systemd-container);
+    my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark netcat-openbsd openssl podman podman-remote python3-passlib python3-PyYAML skopeo socat sudo systemd-container);
     push @pkgs, qw(buildah) unless is_sle_micro;
-    push @pkgs, qw(podman-remote skopeo) unless is_sle_micro('<5.5');
     push @pkgs, qw(criu passt) if (is_tumbleweed || is_microos || is_sle_micro('>=6.0') || is_leap_micro('>=6.0'));
     # Needed for podman machine
     if (is_x86_64) {


### PR DESCRIPTION
This PR adds a workaround for [bsc#1217828](https://bugzilla.opensuse.org/show_bug.cgi?id=1217828).

- Related ticket: https://progress.opensuse.org/issues/159957
- Verification runs:
  - sle-micro-5.5-Default-Updates-x86_64-Build20240505-1-slem_podman_testsuite@64bit -> https://openqa.suse.de/t14219381 (cloned with `PODMAN_BATS_SKIP="030-run 070-build 140-diff 252-quadlet 410-selinux 505-networking-pasta 700-play" PODMAN_BATS_SKIP_ROOT_LOCAL="012-manifest 055-rm 060-mount 065-cp 120-load 150-login 195-run-namespaces 200-pod 250-systemd 255-auto-update 500-networking 520-checkpoint" PODMAN_BATS_SKIP_ROOT_REMOTE="060-mount 120-load 200-pod 500-networking 520-checkpoint" PODMAN_BATS_SKIP_USER_LOCAL="012-manifest 055-rm 065-cp 080-pause 150-login 195-run-namespaces 250-systemd 255-auto-update 600-completion" PODMAN_BATS_SKIP_USER_REMOTE="none"`)
  - sle-15-SP6-Server-DVD-Updates-x86_64-Build20240505-1-podman_testsuite@64bit -> https://openqa.suse.de/tests/14219384 (cloned with `PODMAN_BATS_SKIP="125-import 200-pod 252-quadlet 500-networking 700-play" PODMAN_BATS_SKIP_ROOT_LOCAL="012-manifest 120-load 150-login 195-run-namespaces 250-systemd" PODMAN_BATS_SKIP_ROOT_REMOTE="030-run 070-build 120-load" PODMAN_BATS_SKIP_USER_LOCAL="012-manifest 032-sig-proxy 035-logs 050-stop 075-exec 080-pause 150-login 195-run-namespaces 250-systemd 255-auto-update 550-pause-process 600-completion" PODMAN_BATS_SKIP_USER_REMOTE="030-run 032-sig-proxy 035-logs 050-stop 075-exec 080-pause 195-run-namespaces"`)