### PR TITLE
Support virtualization test for SL Micro 6.0 SelfInstall medium

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -144,9 +144,20 @@ sub load_autoyast_installation_tests {
     loadtest 'console/textinfo';
 }
 
+sub load_usb_installation_tests {
+    if (is_ipxe_boot) {
+        loadtest 'installation/ipxe_install';
+    }
+    else {
+        loadtest 'boot/boot_from_pxe';
+    }
+    loadtest 'installation/usb_install';
+}
+
 sub load_selfinstall_boot_tests {
     loadtest 'installation/bootloader_uefi';
     loadtest 'microos/selfinstall';
+    loadtest 'console/textinfo' if (is_ipmi);
 }
 
 sub load_remote_target_tests {
@@ -359,6 +370,7 @@ sub load_tests {
     if (get_var('BOOT_HDD_IMAGE')) {
         load_boot_from_disk_tests;
     } elsif (is_selfinstall) {
+        load_usb_installation_tests if (is_usb_boot);
         load_selfinstall_boot_tests;
     } elsif (get_var('AUTOYAST')) {
         load_autoyast_installation_tests;


### PR DESCRIPTION
* **New** subroutine ```load_usb_installation_tests``` to load either test module ```installation/ipxe_install``` or ```boot/boot_from_pxe``` based on whether SUT boots with ipxe or not, and installation/usb_install at the last.

* **Load** test modules using this new subroutine ```load_usb_installation_tests``` if medium is SelfInstall and installation source comes from usb stick.

* **Load** ```console/textinfo``` test in load_selfinstall_boot_tests for ipmi backend test run.

* **Verification Runs:**
  * [slem_installation_virt link1](http://10.100.228.134/tests/2747)  [link2](http://10.100.204.18/tests/2747) [link3](http://10.67.18.153/tests/2747) [link4](http://10.149.193.170/tests/2747)
  * [Functional slem_installation_default](https://openqa.suse.de/tests/14226109)
  * [Kernel install_ltp+sle-micro+Default](https://openqa.suse.de/tests/14226110)
  * [Container slem_fips_podman](https://openqa.suse.de/tests/14226112)
  * [File System alp-xfstests_ext4-generic-501-600](https://openqa.suse.de/tests/14226125)
  * [Migration slem_migration_5.5_to_6.0](https://openqa.suse.de/tests/14226127)
  * [Toolbox sle_micro_toolbox_image](https://openqa.suse.de/tests/14226128)