### PR TITLE
Refactoring image urls

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -48,279 +48,103 @@ sub get_opensuse_registry_prefix {
     }
 }
 
-our %images_list = (
-    sle => {
-        '12-SP3' => {
-            released => sub { 'registry.suse.com/suse/sles12sp3' },
-            totest => sub {
-                'registry.suse.de/suse/sle-12-sp3/docker/update/cr/totest/images/suse/sles12sp3';
-            },
-            available_arch => ['x86_64', 'ppc64le', 's390x']
+my %sles_containers = (
+    '12-SP5' => {
+        released => sub { 'registry.suse.com/suse/sles12sp5' },
+        totest => sub {
+            'registry.suse.de/suse/sle-12-sp5/docker/update/cr/totest/images/suse/sles12sp5';
         },
-        '12-SP4' => {
-            released => sub { 'registry.suse.com/suse/sles12sp4' },
-            totest => sub {
-                'registry.suse.de/suse/sle-12-sp4/docker/update/cr/totest/images/suse/sles12sp4';
-            },
-            available_arch => ['x86_64', 'ppc64le', 's390x']
-        },
-        '12-SP5' => {
-            released => sub { 'registry.suse.com/suse/sles12sp5' },
-            totest => sub {
-                'registry.suse.de/suse/sle-12-sp5/docker/update/cr/totest/images/suse/sles12sp5';
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.0' },
-            totest => sub {
-                'registry.suse.de/suse/sle-15/update/cr/totest/images/suse/sle15:15.0';
-            },
-            available_arch => ['x86_64', 'ppc64le', 's390x']
-        },
-        '15-SP1' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.1' },
-            totest => sub {
-                'registry.suse.de/suse/sle-15-sp1/update/cr/totest/images/suse/sle15:15.1';
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15-SP2' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.2' },
-            totest => sub {
-                'registry.suse.de/suse/sle-15-sp2/update/cr/totest/images/suse/sle15:15.2';
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15-SP3' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.3' },
-            totest => sub {
-                'registry.suse.de/suse/sle-15-sp3/update/cr/totest/images/suse/sle15:15.3';
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15-SP4' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.4' },
-            totest => sub {
-                'registry.suse.de/suse/sle-15-sp4/ga/test/images/suse/sle15:15.4';
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15-SP5' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.5' },
-            totest => sub {
-                'registry.suse.de/suse/sle-15-sp5/ga/test/containers/suse/sle15:15.5';
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        }
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
     },
-    opensuse => {
-        Tumbleweed => {
-            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
-            totest => sub {
-                'registry.opensuse.org/' . get_opensuse_registry_prefix . 'opensuse/tumbleweed';
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+    '15-SP2' => {
+        released => sub { 'registry.suse.com/suse/sle15:15.2' },
+        totest => sub {
+            'registry.suse.de/suse/sle-15-sp2/update/cr/totest/images/suse/sle15:15.2';
         },
-        '15.0' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.0' },
-            totest => sub {
-                'registry.opensuse.org/opensuse/leap/15.0/images/totest/images/opensuse/leap:15.0';
-            },
-            available_arch => ['x86_64']
-        },
-        '15.1' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.1' },
-            totest => sub {
-                my $arch = shift;
-                if ($arch eq 'x86_64') {
-                    'registry.opensuse.org/opensuse/leap/15.1/images/totest/containers/opensuse/leap:15.1';
-                } elsif ($arch eq 'arm') {
-                    'registry.opensuse.org/opensuse/leap/15.1/arm/images/totest/containers/opensuse/leap:15.1';
-                }
-            },
-            available_arch => ['x86_64', 'arm']
-        },
-        '15.2' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.2' },
-            totest => sub {
-                my $arch = shift;
-                if ($arch eq 'x86_64') {
-                    'registry.opensuse.org/opensuse/leap/15.2/images/totest/containers/opensuse/leap:15.2';
-                } elsif ($arch eq 'arm') {
-                    'registry.opensuse.org/opensuse/leap/15.2/arm/images/totest/containers/opensuse/leap:15.2';
-                }
-            },
-            available_arch => ['x86_64', 'arm']
-        },
-        '15.3' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.3' },
-            totest => sub {
-                my $arch = shift;
-                if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
-                    'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3';
-                } elsif ($arch eq 'arm') {
-                    'registry.opensuse.org/opensuse/leap/15.3/arm/images/totest/containers/opensuse/leap:15.3';
-                }
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
-        },
-        '15.4' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.4' },
-            totest => sub {
-                my $arch = shift;
-                if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
-                    'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4';
-                } elsif ($arch eq 'arm') {
-                    'registry.opensuse.org/opensuse/leap/15.4/arm/images/totest/containers/opensuse/leap:15.4';
-                }
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
-        },
-        '15.5' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.5' },
-            totest => sub {
-                my $arch = shift;
-                if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
-                    'registry.opensuse.org/opensuse/leap/15.5/images/totest/containers/opensuse/leap:15.5';
-                } elsif ($arch eq 'arm') {
-                    'registry.opensuse.org/opensuse/leap/15.5/arm/images/totest/containers/opensuse/leap:15.5';
-                }
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
-        },
-        '15.6' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.6' },
-            totest => sub {
-                my $arch = shift;
-                if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
-                    'registry.opensuse.org/opensuse/leap/15.6/images/totest/containers/opensuse/leap:15.6';
-                } elsif ($arch eq 'arm') {
-                    'registry.opensuse.org/opensuse/leap/15.6/arm/images/totest/containers/opensuse/leap:15.6';
-                }
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
-        }
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
     },
-    'sle-micro' => {
-        '15' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.0' },
-            totest => sub { },
-            available_arch => ['x86_64', 'ppc64le', 's390x']
+    '15-SP3' => {
+        released => sub { 'registry.suse.com/suse/sle15:15.3' },
+        totest => sub {
+            'registry.suse.de/suse/sle-15-sp3/update/cr/totest/images/suse/sle15:15.3';
         },
-        '15-SP1' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.1' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15-SP2' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.2' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15-SP3' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.3' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15-SP4' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.4' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '15-SP5' => {
-            released => sub { 'registry.suse.com/suse/sle15:15.5' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
-        },
-        '5.0' => {
-            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 's390x']
-        },
-        '5.1' => {
-            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 's390x']
-        },
-        '5.2' => {
-            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 's390x']
-        },
-        '5.3' => {
-            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64', 's390x']
-        }
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
     },
-    microos => {
-        Tumbleweed => {
-            released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
-            totest => sub {
-                'registry.opensuse.org/' . get_opensuse_registry_prefix . 'opensuse/tumbleweed';
-            },
-            available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+    '15-SP4' => {
+        released => sub { 'registry.suse.com/suse/sle15:15.4' },
+        totest => sub {
+            'registry.suse.de/suse/sle-15-sp4/ga/test/images/suse/sle15:15.4';
         },
-        '15.1' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.1' },
-            totest => sub {
-                my $arch = shift;
-                if ($arch eq 'x86_64') {
-                    'registry.opensuse.org/opensuse/leap/15.1/images/totest/containers/opensuse/leap:15.1';
-                } elsif (grep { $_ eq $arch } qw/aarch64 arm/) {
-                    'registry.opensuse.org/opensuse/leap/15.1/arm/images/totest/containers/opensuse/leap:15.1';
-                }
-            },
-            available_arch => ['x86_64', 'aarch64', 'arm']
-        },
-        '15.2' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.2' },
-            totest => sub {
-                my $arch = shift;
-                if ($arch eq 'x86_64') {
-                    'registry.opensuse.org/opensuse/leap/15.2/images/totest/containers/opensuse/leap:15.2';
-                } elsif (grep { $_ eq $arch } qw/aarch64 arm/) {
-                    'registry.opensuse.org/opensuse/leap/15.2/arm/images/totest/containers/opensuse/leap:15.2';
-                }
-            },
-            available_arch => ['x86_64', 'aarch64', 'arm']
-        },
-        '15.3' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.3' },
-            totest => sub {
-                my $arch = shift;
-                if ($arch eq 'x86_64') {
-                    'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3';
-                } elsif (grep { $_ eq $arch } qw/aarch64 arm/) {
-                    'registry.opensuse.org/opensuse/leap/15.3/arm/images/totest/containers/opensuse/leap:15.3';
-                }
-            },
-            available_arch => ['x86_64', 'aarch64', 'arm']
-        }
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
     },
-    'leap-micro' => {
-        '15.2' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.2' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64']
+    '15-SP5' => {
+        released => sub { 'registry.suse.com/suse/sle15:15.5' },
+        totest => sub {
+            'registry.suse.de/suse/sle-15-sp5/ga/test/containers/suse/sle15:15.5';
         },
-        '15.3' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.3' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64']
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
+    },
+    '15-SP6' => {
+        released => sub { 'registry.suse.com/suse/sle15:15.6' },
+        totest => sub {
+            'registry.suse.de/suse/sle-15-sp6/ga/test/containers/suse/sle15:15.6';
         },
-        '15.4' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.4' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64']
-        },
-        '15.5' => {
-            released => sub { 'registry.opensuse.org/opensuse/leap:15.5' },
-            totest => sub { },
-            available_arch => ['x86_64', 'aarch64']
-        }
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x']
     }
+);
+
+my %opensuse_containers = (
+    Tumbleweed => {
+        released => sub { 'registry.opensuse.org/opensuse/tumbleweed' },
+        totest => sub {
+            'registry.opensuse.org/' . get_opensuse_registry_prefix . 'opensuse/tumbleweed';
+        },
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+    },
+    '15.4' => {
+        released => sub { 'registry.opensuse.org/opensuse/leap:15.4' },
+        totest => sub {
+            my $arch = shift;
+            if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
+                'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4';
+            } elsif ($arch eq 'arm') {
+                'registry.opensuse.org/opensuse/leap/15.4/arm/images/totest/containers/opensuse/leap:15.4';
+            }
+        },
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+    },
+    '15.5' => {
+        released => sub { 'registry.opensuse.org/opensuse/leap:15.5' },
+        totest => sub {
+            my $arch = shift;
+            if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
+                'registry.opensuse.org/opensuse/leap/15.5/images/totest/containers/opensuse/leap:15.5';
+            } elsif ($arch eq 'arm') {
+                'registry.opensuse.org/opensuse/leap/15.5/arm/images/totest/containers/opensuse/leap:15.5';
+            }
+        },
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+    },
+    '15.6' => {
+        released => sub { 'registry.opensuse.org/opensuse/leap:15.6' },
+        totest => sub {
+            my $arch = shift;
+            if (grep { $_ eq $arch } qw/x86_64 aarch64 ppc64le s390x/) {
+                'registry.opensuse.org/opensuse/leap/15.6/images/totest/containers/opensuse/leap:15.6';
+            } elsif ($arch eq 'arm') {
+                'registry.opensuse.org/opensuse/leap/15.6/arm/images/totest/containers/opensuse/leap:15.6';
+            }
+        },
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+    }
+);
+
+our %images_list = (
+    sle => {%sles_containers},
+    'sle-micro' => {%sles_containers},    # Note: SLEM runs tests on SLES containers using the CONTAINER_IMAGE_VERSIONS setting.
+    opensuse => {%opensuse_containers},
+    microos => {%opensuse_containers},
+    'leap-micro' => {%opensuse_containers}
 );
 
 sub supports_image_arch {
@@ -329,16 +153,16 @@ sub supports_image_arch {
 }
 
 sub get_3rd_party_images {
-    my $ex_reg = get_var('REGISTRY', 'docker.io');
+    my $registry = get_var('REGISTRY', 'docker.io');
     my @images = (
         "registry.opensuse.org/opensuse/leap",
         "registry.opensuse.org/opensuse/tumbleweed",
-        "$ex_reg/library/alpine",
-        "$ex_reg/library/debian");
+        "$registry/library/alpine",
+        "$registry/library/debian");
 
     # Following images are not available on 32-bit arm
     push @images, (
-        "$ex_reg/library/fedora",
+        "$registry/library/fedora",
         "registry.access.redhat.com/ubi8/ubi",
         "registry.access.redhat.com/ubi8/ubi-minimal",
         "registry.access.redhat.com/ubi8/ubi-micro",
@@ -360,8 +184,8 @@ sub get_3rd_party_images {
     # - poo#72124 Ubuntu image (occasionally) fails on s390x.
     # - CentOS image not available on s390x.
     push @images, (
-        "$ex_reg/library/ubuntu",
-        "$ex_reg/library/centos"
+        "$registry/library/ubuntu",
+        "$registry/library/centos"
     ) unless (is_arm || is_s390x || is_ppc64le);
 
     # RedHat UBI7 images are not built for aarch64 and 32-bit arm


### PR DESCRIPTION
Refactor the provided image urls. Remove old and unnecessary ones and add recent versions to the list of image URLs.

- Related ticket: https://progress.opensuse.org/issues/135257
- Verification run: [MicroOS](https://duck-norris.qe.suse.de/tests/14657#step/image_podman/38) | [Tumbleweed](https://duck-norris.qe.suse.de/tests/14664#step/image_podman/41) | [15-SP5](https://duck-norris.qe.suse.de/tests/14660#step/image_podman/632) | [15-SP4](https://duck-norris.qe.suse.de/tests/14661#step/image_podman/483) | [15-SP3](https://duck-norris.qe.suse.de/tests/14662#step/image_podman/334) | [12-SP5](https://duck-norris.qe.suse.de/tests/14663#step/image_docker/62) | [5.5](https://duck-norris.qe.suse.de/tests/14659#step/image_podman/38)
