### PR TITLE
New test for correct btrfs setup

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1828,6 +1828,7 @@ sub load_extra_tests_filesystem {
     loadtest "console/autofs";
     loadtest 'console/lvm';
     if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
+        loadtest 'console/btrfs_check' if (is_jeos || is_sle_micro);
         loadtest 'console/snapper_undochange';
         loadtest 'console/snapper_create';
         # Needs zsh, not available in staging

--- a/tests/console/btrfs_check.pm
+++ b/tests/console/btrfs_check.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: btrfs_check
+# Summary: Test that btrfs is setup properly
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use List::Util qw(any);
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+
+    # Prepare the arrays of subvolumes for comparing
+    # TODO: the subvolumes list vary depending on the arch and the version
+    my @kiwi_volumes = qw(@ @/.snapshots @/home @/opt @/root @/srv @/usr/local @/var);
+    my @test_volumes = split("\n", script_output("btrfs subvolume list / | cut -d ' ' -f 9"));
+    record_info('test_volumes', "@test_volumes");
+    record_info('kiwi_volumes', "@kiwi_volumes");
+
+    # Compare that the lists of subvolumes match
+    foreach my $kiwi (@kiwi_volumes) {
+        die "Subvolume $kiwi not present" unless (any { $_ eq $kiwi } @test_volumes);
+    }
+}
+
+1;


### PR DESCRIPTION
The main idea is to check for the correct btrfs layout on the disk. Snapshots and rollbacks are already covered in other test modules.

- Related ticket: https://progress.opensuse.org/issues/66613
- Verification runs:
  - http://10.146.5.131/tests/69
  - https://openqa.suse.de/tests/14366334
  - http://10.146.5.131/tests/70
  - https://openqa.suse.de/tests/14366448
  - https://openqa.suse.de/tests/14366449
  - https://openqa.suse.de/tests/14366450
  - https://openqa.suse.de/tests/14366514
