### PR TITLE
jeos/firstrun.pm: Handle ssh enrollment dialog in TW Staging H

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -197,6 +197,12 @@ sub run {
         wait_serial(qr/^Encryption recovery key:\s+(([a-z]+-)+[a-z]+)/m) or die 'The encryption recovery key is missing';
     }
 
+    # Skip ssh key enrollment (for now)
+    if (is_tumbleweed && check_var('STAGING', 'H')) {
+        assert_screen 'jeos-ssh-enroll-or-not';
+        send_key 'n';
+    }
+
     if (is_sle || is_sle_micro) {
         assert_screen 'jeos-please-register';
         send_key 'ret';


### PR DESCRIPTION
Testing this properly needs an SSH connection which is complex to set up. Skip it for now.

- Verification run: https://openqa.opensuse.org/tests/4164378
