### PR TITLE
Fix ha_qdevice_node2 qnetd failure: crm need no PW

### DIFF
--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -15,6 +15,7 @@ use testapi;
 use lockapi;
 use hacluster;
 use utils qw(zypper_call exec_and_insert_password);
+use version_utils 'is_sle';
 
 sub handle_diskless_sbd_scenario_cluster_node {
     my $cluster_name = get_cluster_name;
@@ -34,7 +35,10 @@ sub qdevice_status {
     $num_nodes-- if ($expected_status eq 'stopped');
 
     # We have to enable ssh passwordless between qnetd server and node2
-    exec_and_insert_password($qnetd_status_cmd) if is_node(2);
+    # But from 15-SP6 Build83.1 the qdevice "Add all nodes' keys to qnetd authorized_keys"
+    if (is_sle('<15-SP6')) {
+        exec_and_insert_password($qnetd_status_cmd) if is_node(2);
+    }
 
     # Check qdevice status
     $output = script_output "$qnetd_status_cmd" if ($expected_status ne 'stopped');


### PR DESCRIPTION
Fix ha_qdevice_node2 qnetd failure: new crm pkg doesn't need key anymore
TEAM-9291 - [15-SP6][HA] ha_qdevice_node2 failed on qnetd: no candidate needle with tag(s) 'password-prompt' matched


- Related ticket: https://jira.suse.com/browse/TEAM-9291 ([15-SP6][HA] ha_qdevice_node2 failed on qnetd: no candidate needle with tag(s) 'password-prompt' matched)
- Needles: NA
- Verification run: 


15-SP6: http://openqa.suse.de/tests/14225237 (passed)

Incident:
15-SP5: http://openqa.suse.de/tests/14224031 (passed)
15-SP4: http://openqa.suse.de/tests/14225247 (passed)
15-SP3: http://openqa.suse.de/tests/14225250 (passed)
15-SP2: http://openqa.suse.de/tests/14225255 (passed)
12-SP5: no qdevice cases scheduled in OSD

Aggregate:
15-SP5: http://openqa.suse.de/tests/14225292 (passed)
15-SP4: http://openqa.suse.de/tests/14225272 (passed)
15-SP3: http://openqa.suse.de/tests/14225262 (passed)
15-SP2: http://openqa.suse.de/tests/14225288 (passed)
12-SP5: no qdevice cases scheduled in OSD