### PR TITLE
xfstests: Add kernel configure in output

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -76,8 +76,8 @@ sub log_create {
 
 sub collect_version {
     my $file = shift;
-    my $cmd = "(rpm -qa xfsprogs xfsdump btrfsprogs e2fsprogs coreutils kernel-default xfstests; uname -r; rpm -qi kernel-default) | tee $file";
-    script_run($cmd);
+    my $cmd = "(rpm -qa xfsprogs xfsdump btrfsprogs e2fsprogs coreutils kernel-default " . join(' ', @PACKAGES) . "; uname -r; rpm -qi kernel-default) | tee $file";
+    script_run($cmd, proceed_on_failure => 1);
     upload_logs($file, timeout => 60, log_name => basename($file));
 }
 

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -251,6 +251,7 @@ sub post_env_info {
     # record version info
     my $ver_log = get_var('VERSION_LOG', '/opt/version.log');
     record_info('Version', script_output("cat $ver_log"));
+    record_info('Kernel config', script_output('cat /boot/config-$(uname -r)'));
 
     # record partition size info
     my $size_info = get_var('XFSTESTS_TEST_DEV') . "    " . shift(@size) . "\n";


### PR DESCRIPTION
Add kernel configuration output for convenience when debugging. All package in setting XFSTESTS_PACKAGES will also check the version and add into output.

- Verification run:
- fio and fsverify-utils version added: http://10.67.133.133/tests/619#step/install/53
- kernel configuration added: http://10.67.133.133/tests/616#step/partition/77
- VR in old product version: https://openqa.suse.de/tests/14224126#step/install/53