### PR TITLE
Ignore failure bsc#1223178 in sshd test module only for ppc64le

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -26,6 +26,7 @@ use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
 use serial_terminal 'select_serial_terminal';
 use utils qw(systemctl exec_and_insert_password zypper_call random_string clear_console);
+use Utils::Architectures 'is_ppc64le';
 use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap is_opensuse is_public_cloud);
 use services::sshd;
 use ssh_crypto_policy;
@@ -104,10 +105,13 @@ sub test_cryptographic_policies() {
 
 sub check_journal {
     # bsc#1175310 bsc#1181308 - Detect serious errors as they can be invisible because sshd may silently recover
+    # bsc#1223178 - [Build 80.1] openQA test fails in sshd: Segfault or fatal journal entry detected in journal
     if (script_run("journalctl -b -u sshd.service | grep -A6 -B24 'segfault\\|fatal'") == 0) {
-        my $journalctl = script_output("journalctl -b -u sshd.service | grep 'segfault\\|fatal'", proceed_on_failure => 1);
+        my $journalctl = script_output("journalctl -b -u sshd.service | grep -E 'segfault|fatal'", proceed_on_failure => 1);
         if (is_sle('<15') && $journalctl =~ /diffie-hellman-group1-sha1/) {
             record_info("diffie-hellman-group1-sha1", "Expected message - bsc#1185584 diffie-hellman-group1-sha1 is not enabled on this product");
+        } elsif (is_ppc64le && $journalctl =~ /Timeout before authentication/) {
+            record_info("Timeout before authentication", "bsc#1223178 - [Build 80.1] openQA test fails in sshd: Segfault or fatal journal entry detected in journal");
         } else {
             die("Please check the journalctl! Segfault or fatal journal entry detected.");
         }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/159891
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/14234820#step/sshd/426