### PR TITLE
Fix ppc64le online migration schedule for misc group

### DIFF
--- a/schedule/migration/autoyast_regression_test_online_pre@pvm.yaml
+++ b/schedule/migration/autoyast_regression_test_online_pre@pvm.yaml
@@ -18,6 +18,3 @@ schedule:
   - console/system_prepare
   - console/hostname
   - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - shutdown/cleanup_before_shutdown
-  - shutdown/shutdown


### PR DESCRIPTION
No need to shutdown system for ppc64le online migration parent jobs, so remove the shutdown test modules for online migration schedule.

- Related ticket: https://progress.opensuse.org/issues/159366
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP6&build=83.1&distri=sle&groupid=251
- Related mr: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/180