### PR TITLE
Revert "containers: Workaround for bsc#1217828"

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -63,11 +63,6 @@ sub run {
     assert_script_run "curl -o /usr/local/bin/htpasswd " . data_url("containers/htpasswd");
     assert_script_run "chmod +x /usr/local/bin/htpasswd";
 
-    # Make sure to use netavark if CNI is installed
-    if (script_run("rpm -q cni") == 0) {
-        assert_script_run(q(echo -e '[Network]\nnetwork_backend="netavark"' >> /etc/containers/containers.conf));
-    }
-
     delegate_controllers;
 
     assert_script_run "podman system reset -f";


### PR DESCRIPTION
A previous PR was done to address issues with SLE 15-SP6 (not released yet) but it's using an older version of podman than 15-SP5.  So we're reverting it.

- Related ticket: https://progress.opensuse.org/issues/159957
- Verification runs:
  - sle-15-SP4-Server-DVD-Updates-x86_64-Build20240506-1-podman_testsuite@64bit -> https://openqa.suse.de/t14224143
  - sle-15-SP5-Server-DVD-Updates-x86_64-Build20240506-1-podman_testsuite@64bit -> https://openqa.suse.de/t14224142
  - sle-micro-5.5-Default-Updates-x86_64-Build20240506-1-slem_podman_testsuite@64bit -> https://openqa.suse.de/t14225284 (will be fixed in the YAML schedule with SKIP variables).