### PR TITLE
Extend runc upstream tests to SLE 15-SP4 & 15-SP5

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -292,9 +292,9 @@ sub load_container_tests {
     }
 
     if (get_var('PODMAN_BATS_SKIP')) {
-        loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_sle_micro('>=5.5'));
+        loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_leap('>=15.4') || is_sle_micro('>=5.5'));
         loadtest 'containers/podman_integration';
-        loadtest 'containers/runc_integration' if (is_tumbleweed);
+        loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         return;
     }
 

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -292,9 +292,15 @@ sub load_container_tests {
     }
 
     if (get_var('PODMAN_BATS_SKIP')) {
-        loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_leap('>=15.4') || is_sle_micro('>=5.5'));
-        loadtest 'containers/podman_integration';
-        loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
+        if (!check_var('SKOPEO_BATS_SKIP', 'all')) {
+            loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_leap('>=15.4') || is_sle_micro('>=5.5'));
+        }
+        if (!check_var('PODMAN_BATS_SKIP', 'all')) {
+            loadtest 'containers/podman_integration';
+        }
+        if (!check_var('RUNC_BATS_SKIP', 'all')) {
+            loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
+        }
         return;
     }
 

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -63,8 +63,8 @@ sub run {
     assert_script_run "cd $test_dir/runc-$runc_version/";
     assert_script_run "cp -r tests/integration tests/integration.orig";
 
-    # Compile some stuff
-    assert_script_run "make recvtty sd-helper seccompagent fs-idmap memfd-bind pidfd-kill remap-rootfs";
+    # Compile helpers used by the tests
+    assert_script_run "make \$(ls contrib/cmd/)";
 
     run_tests(rootless => 1, skip_tests => get_var('RUNC_BATS_SKIP_USER', ''));
 


### PR DESCRIPTION
This PR:
- Extends runc upstream tests to SLE 15-SP4 & 15-SP5
- Minor fix for helpers used in test.

Related ticket: https://progress.opensuse.org/issues/159801
Verification runs:
- sle-15-SP5-Server-DVD-Updates-x86_64-Build20240506-1-podman_testsuite@64bit -> https://openqa.suse.de/t14226173
- sle-15-SP4-Server-DVD-Updates-x86_64-Build20240506-1-podman_testsuite@64bit -> https://openqa.suse.de/t14226228
- sle-15-SP4-Server-DVD-Updates-aarch64-Build20240506-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14227035
- sle-15-SP5-Server-DVD-Updates-aarch64-Build20240506-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14227036

VR for last commit: https://openqa.suse.de/tests/14227177

Note: Jobs failed but will be fixed with respective SKIP setting in https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1627