### PR TITLE
containers: Enable runc upstream tests for SLEM

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -299,7 +299,7 @@ sub load_container_tests {
             loadtest 'containers/podman_integration';
         }
         if (!check_var('RUNC_BATS_SKIP', 'all')) {
-            loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
+            loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4') || is_sle_micro('>=5.5'));
         }
         return;
     }

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -13,7 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use containers::bats qw(install_bats switch_to_user delegate_controllers);
-use version_utils qw(is_tumbleweed);
+use version_utils qw(is_tumbleweed is_sle_micro);
 
 my $test_dir = "/var/tmp";
 my $runc_version = "";
@@ -41,7 +41,8 @@ sub run {
     install_bats;
 
     # Install tests dependencies
-    my @pkgs = qw(git-core glibc-devel-static go iptables jq libseccomp-devel make runc);
+    my @pkgs = qw(git-core iptables jq runc);
+    push @pkgs, "glibc-devel-static go libseccomp-devel make" unless is_sle_micro;
     push @pkgs, "criu" if is_tumbleweed;
     install_packages(@pkgs);
 
@@ -64,7 +65,7 @@ sub run {
     assert_script_run "cp -r tests/integration tests/integration.orig";
 
     # Compile helpers used by the tests
-    assert_script_run "make \$(ls contrib/cmd/)";
+    assert_script_run("make \$(ls contrib/cmd/)") unless is_sle_micro;
 
     run_tests(rootless => 1, skip_tests => get_var('RUNC_BATS_SKIP_USER', ''));
 


### PR DESCRIPTION
Enable runc upstream tests for SLEM

- Related ticket: https://progress.opensuse.org/issues/159801
- Verification runs:
  - sle-micro-5.5-Default-Updates-x86_64-Build20240507-1-slem_podman_testsuite@64bit -> https://openqa.suse.de/tests/14234945
  - sle-micro-5.5-Default-Updates-aarch64-Build20240507-1-slem_podman_testsuite@aarch64 -> https://openqa.suse.de/t14234990

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1630

Settings:
- `RUNC_BATS_SKIP=seccomp`
- `RUNC_BATS_SKIP_ROOT=cgroups`
- `RUNC_BATS_SKIP_USER=run userns`
