### PR TITLE
Quickfix: Make bci_prepare conditional

### DIFF
--- a/schedule/containers/create_hdd_autoyast.yaml
+++ b/schedule/containers/create_hdd_autoyast.yaml
@@ -16,6 +16,10 @@ conditional_schedule:
         FIPS:
             '1':
                 - fips/fips_setup
+    bci_prepare:
+        BCI_PREPARE:
+            '1':
+                - containers/bci_prepare
 schedule:
     - autoyast/prepare_profile
     - installation/bootloader_start
@@ -28,7 +32,7 @@ schedule:
     - containers/install_updates
     - console/system_prepare
     - '{{fips}}'
-    - containers/bci_prepare
+    - '{{bci_prepare}}'
     - shutdown/cleanup_before_shutdown
     - shutdown/shutdown
     - '{{svirt_upload_assets}}'


### PR DESCRIPTION
bci_prepare should only be execuded based on job settings, not everywhere.

- Related failure: https://openqa.suse.de/tests/14193422#
- Verification run: https://openqa.suse.de/tests/14235099 and https://openqa.suse.de/tests/14235100

Merge together with https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1629
