### PR TITLE
containers: Enable modules for upstream tests in SLE

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -19,8 +19,9 @@ use warnings;
 use version_utils qw(is_transactional);
 use transactional qw(trup_call check_reboot_changes);
 use serial_terminal qw(select_user_serial_terminal);
+use registration qw(add_suseconnect_product get_addon_fullname);
 
-our @EXPORT = qw(install_bats add_packagehub remove_mounts_conf switch_to_user delegate_controllers);
+our @EXPORT = qw(install_bats remove_mounts_conf switch_to_user delegate_controllers enable_modules);
 
 sub install_bats {
     return if (script_run("which bats") == 0);
@@ -67,4 +68,10 @@ sub delegate_controllers {
         assert_script_run 'echo -e "[Service]\nDelegate=cpu cpuset io memory pids" > /etc/systemd/system/user@.service.d/60-delegate.conf';
         systemctl "daemon-reload";
     }
+}
+
+sub enable_modules {
+    add_suseconnect_product(get_addon_fullname('desktop'));
+    add_suseconnect_product(get_addon_fullname('sdk'));
+    add_suseconnect_product(get_addon_fullname('python3'));
 }

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -94,7 +94,7 @@ sub run {
     run_tests(rootless => 1, remote => 0, skip_tests => get_var('PODMAN_BATS_SKIP_USER_LOCAL', ''));
 
     # user / remote
-    run_tests(rootless => 1, remote => 1, skip_tests => get_var('PODMAN_BATS_SKIP_USER_REMOTE', '')) unless (is_sle_micro('<5.5'));
+    run_tests(rootless => 0, remote => 1, skip_tests => get_var('PODMAN_BATS_SKIP_USER_REMOTE', '')) if (script_run('which podman-remote') == 0);
 
     select_serial_terminal;
     assert_script_run("cd $test_dir/podman-$podman_version/");
@@ -103,7 +103,7 @@ sub run {
     run_tests(rootless => 0, remote => 0, skip_tests => get_var('PODMAN_BATS_SKIP_ROOT_LOCAL', ''));
 
     # root / remote
-    run_tests(rootless => 0, remote => 1, skip_tests => get_var('PODMAN_BATS_SKIP_ROOT_REMOTE', '')) unless (is_sle_micro('<5.5'));
+    run_tests(rootless => 0, remote => 1, skip_tests => get_var('PODMAN_BATS_SKIP_ROOT_REMOTE', '')) if (script_run('which podman-remote') == 0);
 }
 
 sub cleanup() {

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -12,10 +12,10 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use containers::utils qw(get_podman_version);
 use utils qw(script_retry);
-use version_utils qw(is_sle_micro is_tumbleweed is_microos);
+use version_utils qw(is_sle is_sle_micro is_tumbleweed is_microos);
 use containers::common;
 use Utils::Architectures qw(is_x86_64 is_aarch64);
-use containers::bats qw(install_bats remove_mounts_conf switch_to_user delegate_controllers);
+use containers::bats qw(install_bats remove_mounts_conf switch_to_user delegate_controllers enable_modules);
 
 my $test_dir = "/var/tmp";
 my $podman_version = "";
@@ -47,6 +47,7 @@ sub run {
     select_serial_terminal;
 
     install_bats;
+    enable_modules if is_sle;
 
     # Install tests dependencies
     my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark netcat-openbsd openssl podman python3-passlib skopeo socat sudo systemd-container);

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -12,8 +12,8 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats switch_to_user delegate_controllers);
-use version_utils qw(is_tumbleweed);
+use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules);
+use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
 my $runc_version = "";
@@ -39,6 +39,7 @@ sub run {
     select_serial_terminal;
 
     install_bats;
+    enable_modules if is_sle;
 
     # Install tests dependencies
     my @pkgs = qw(git-core glibc-devel-static go iptables jq libseccomp-devel make runc);

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -13,7 +13,8 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use Utils::Architectures qw(is_x86_64);
-use containers::bats qw(install_bats remove_mounts_conf switch_to_user);
+use containers::bats qw(install_bats remove_mounts_conf switch_to_user enable_modules);
+use version_utils qw(is_sle);
 
 my $test_dir = "/var/tmp";
 my $skopeo_version = "";
@@ -46,6 +47,7 @@ sub run {
     select_serial_terminal;
 
     install_bats;
+    enable_modules if is_sle;
 
     # Install tests dependencies
     my @pkgs = qw(jq openssl podman python3-passlib skopeo);


### PR DESCRIPTION
Enable modules for upstream tests in SLE.  Some packages like python3-*, go & glibc-* need these. 

Aggregate tests have been working til now because these modules came enabled.  Better safe than sorry.

- Verification runs:
  - sle-micro-6.0-Base-x86_64-Build10.23-slem_podman@64bit -> https://openqa.suse.de/t14236922
 