### PR TITLE
lib/serial_terminal.pm: Handle serial tty prompt with util-linux 2.40

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -183,11 +183,11 @@ sub login {
         type_password;
         send_key 'ret';
     }
-    die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \s*$/x);
+    die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \x0F? \s*$/x);
 
     # Some (older) versions of bash don't take changes to the terminal during runtime into account. Re-exec it.
     enter_cmd('export TERM=dumb; stty cols 2048; exec $SHELL');
-    die 'Failed to confirm that shell re-exec was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \s*$/x);
+    die 'Failed to confirm that shell re-exec was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \x0F? \s*$/x);
     set_serial_prompt($prompt);
     # TODO: Send 'tput rmam' instead/also
     assert_script_run('export TERM=dumb');


### PR DESCRIPTION
Instead of ESC ( B it uses ASCII 0Fh (SI, Shift In).

- Related ticket: https://progress.opensuse.org/issues/159807
- Verification runs:
  * New util-linux: http://10.168.5.231/tests/1472 (needs temporary revert of 152ddd16113e0cec5b3c09696ce7db50147d7358, staging too old)
  * Old util-linux: https://openqa.opensuse.org/tests/4169639
