### PR TITLE
containers: Allow to skip any BATS subtests

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -24,6 +24,8 @@ sub run_tests {
     my %params = @_;
     my ($rootless, $remote, $skip_tests) = ($params{rootless}, $params{remote}, $params{skip_tests});
 
+    return if ($skip_tests eq "all");
+
     my $log_file = "bats-" . ($rootless ? "user" : "root") . "-" . ($remote ? "remote" : "local") . ".tap";
     my $args = ($rootless ? "--rootless" : "--root");
     $args .= " --remote" if ($remote);

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -22,6 +22,8 @@ sub run_tests {
     my %params = @_;
     my ($rootless, $skip_tests) = ($params{rootless}, $params{skip_tests});
 
+    return if ($skip_tests eq "all");
+
     my $log_file = "runc-" . ($rootless ? "user" : "root") . ".tap";
 
     assert_script_run "cp -r tests/integration.orig tests/integration";

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -23,6 +23,8 @@ sub run_tests {
     my %params = @_;
     my ($rootless, $skip_tests) = ($params{rootless}, $params{skip_tests});
 
+    return if ($skip_tests eq "all");
+
     my $log_file = "skopeo-" . ($rootless ? "user" : "root") . ".tap";
 
     assert_script_run "cp -r systemtest.orig systemtest";


### PR DESCRIPTION
Allow use of `(SKOPEO|PODMAN|RUNC)_BATS_SKIP_(ROOT,USER)(?:_(LOCAL|REMOTE))=all` to skip BATS tests. These tests take time and sometimes we need to skip it to make debugging easier.

Verifications run: https://openqa.suse.de/tests/14242149 (failing for other reason).