### PR TITLE
Workaround of PR#822 to install a customized qa_lib_key and qa_lib_virtauto packages in personal IBS

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -107,7 +107,17 @@ sub install_package {
 }
 
 sub run {
+    if (is_x86_64) {
+        script_run("zypper ar -p 80 http://download.suse.de/ibs/home:/Julie_CAO:/branches:/workaround/SLE-15-SP6 workaround");
+        script_run("zypper --gpg-auto-import-keys ref -r workaround");
+        save_screenshot;
+    }
     install_package;
+    if (is_x86_64) {
+        script_run("zypper info qa_lib_virtauto");
+        script_run("zypper info qa_lib_keys");
+        save_screenshot;
+    }
 }
 
 


### PR DESCRIPTION
The workaround is temporary, it will be removed when https://github.com/SUSE/qa-automation/pull/822 is finally merged.

- Related ticket: https://progress.opensuse.org/issues/159087
- Verification run: 
[prj4_kvm](https://10.145.10.207/tests/14265359)
[prj3_xen_pv](https://openqa.suse.de/tests/14265328#)
[prj1](https://10.145.10.207/tests/14265977#)
[prj2](https://10.145.10.207/tests/14265978#details)
[UEFI](https://10.145.10.207/tests/14267734)
