### PR TITLE
Fix remmina failure on SLE15SP6

### DIFF
--- a/tests/x11/remote_desktop/onetime_vncsession_xvnc_remmina.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_xvnc_remmina.pm
@@ -25,7 +25,7 @@ sub run {
     # Start Remmina and login the remote server
     x11_start_program('remmina', target_match => 'remmina-launched');
     # The remmmina news turned off screen appears since the remmina got updated in 15SP3
-    if (is_sle('15-SP3+')) {
+    if (is_sle('15-SP3+') && is_sle('<=15-SP5')) {
         assert_screen("remmina-news-turned-off", 60);
         assert_and_click("remmina-close-news-turned-off");
     }
@@ -39,7 +39,7 @@ sub run {
     assert_screen 'remmina-hostkey-setting';
     send_key 'z';
     assert_screen 'remmina-hostkey-configured';
-    send_key 'esc';
+    assert_and_click 'remmina-preferences-close';
 
     # Add a new VNC connection
     assert_and_click 'remmina-plus-button';


### PR DESCRIPTION
Remmina got updated to version 1.4.35 in build 83.1
The Remmina news doesn't appear, so we need to update test code to handle this.
Besides, using esc to quit the Remmina Preference is not applicable any more， so use `assert_and_click` to close Remmina Preference window.

- Related ticket: https://progress.opensuse.org/issues/160114
- Needles: already added when debugging on osd 
- Verification run: https://openqa.suse.de/tests/14257653#step/onetime_vncsession_xvnc_remmina/21
(Note: The VR is failed due to the bug https://bugzilla.suse.com/show_bug.cgi?id=1224048)