### PR TITLE
Revert "Skip cockpit test for SLM 6.0"

### DIFF
--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -79,15 +79,12 @@ sub run {
     $instance->softreboot();
     $instance->run_ssh_command(cmd => 'rpm -q ' . $test_package);
 
-    # cockpit is absent in SLM 6.0
-    unless (is_sle_micro('=6.0')) {
-        # cockpit test
-        $instance->run_ssh_command(cmd => '! curl localhost:9090');
-        $instance->run_ssh_command(cmd => 'sudo systemctl enable --now cockpit.socket');
-        $instance->run_ssh_command(cmd => 'systemctl status cockpit.service | grep inactive');
-        $instance->run_ssh_command(cmd => 'curl http://localhost:9090');
-        $instance->run_ssh_command(cmd => 'systemctl status cockpit.service | grep active');
-    }
+    # cockpit test
+    $instance->run_ssh_command(cmd => '! curl localhost:9090');
+    $instance->run_ssh_command(cmd => 'sudo systemctl enable --now cockpit.socket');
+    $instance->run_ssh_command(cmd => 'systemctl status cockpit.service | grep inactive');
+    $instance->run_ssh_command(cmd => 'curl http://localhost:9090');
+    $instance->run_ssh_command(cmd => 'systemctl status cockpit.service | grep active');
 
     # additional tr-up tests
     $instance->run_ssh_command(cmd => 'sudo transactional-update -n up', timeout => 360);


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#19218. After some communication with developers and PMs it was clarified that we do need to support cockpit in SL Micro 6.0 