### PR TITLE
Disable GRUB_TIMEOUT to avoid grub_test.pm failed

### DIFF
--- a/data/autoyast_sle15/autoyast_sles4sap.xml.ep
+++ b/data/autoyast_sle15/autoyast_sles4sap.xml.ep
@@ -342,7 +342,12 @@
     <init-scripts config:type="list">
       <script>
         <debug config:type="boolean">true</debug>
-	<source><![CDATA[sed -i 's/^\(Autostart[[:blank:]]*=\).*/\1 1/' /hana/shared/{{INSTANCE_SID}}/profile/{{INSTANCE_SID}}_HDB{{INSTANCE_ID}}_$(hostname)]]></source>
+        <source><![CDATA[
+# disable GRUB_TIMEOUT to avoid grub_test.pm failed since grub menu timeout
+sed -i '/GRUB_TIMEOUT=/ s/=.*$/=-1/' /etc/default/grub 2>&1 || exit 1
+grub2-mkconfig -o /boot/grub2/grub.cfg 2>&1 || exit 1
+sed -i 's/^\(Autostart[[:blank:]]*=\).*/\1 1/' /hana/shared/{{INSTANCE_SID}}/profile/{{INSTANCE_SID}}_HDB{{INSTANCE_ID}}_$(hostname)]]>
+        </source>
       </script>
     </init-scripts>
   </scripts>


### PR DESCRIPTION
Fix [TEAM-9296](https://jira.suse.com/browse/TEAM-9296), autoyast_sles4sap_hana test case failed sometimes because of grub2 menu timeout, this PR fixed it by disabling grub timeout.

- Related ticket: https://jira.suse.com/browse/TEAM-9296
- Needles: None
- Verification run: 
    https://openqa.suse.de/tests/14267063 (ppc)
    https://openqa.suse.de/tests/14267064 (ppc)
    https://openqa.suse.de/tests/14267065 (ppc)
    https://openqa.suse.de/tests/14288221 (x86_64)
    https://openqa.suse.de/tests/14288222 (x86_64)
