### PR TITLE
Use json output for snapper

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1850,7 +1850,7 @@ sub load_extra_tests_filesystem {
         loadtest 'console/snapper_thin_lvm' unless is_jeos;
     }
     loadtest 'console/snapper_used_space' if (is_sle('15-SP1+') || (is_opensuse && !is_leap('<15.1')));
-    loadtest "console/udisks2" unless (is_sle('<=15-SP2') || get_var('VIRSH_VMM_FAMILY') =~ /xen/);
+    loadtest "console/udisks2" unless (is_sle('<=15-SP2') || get_var('VIRSH_VMM_FAMILY', 'none') =~ /xen/);
     loadtest "network/cifs" if (is_sle('>=15-sp3') || is_opensuse);
     loadtest "network/samba/server" if (is_sle('>=15-sp3') || is_opensuse);
     # Note: Until the snapshot restoration has been fixed (poo#109929), zfs should be the last test run

--- a/tests/console/snapper_used_space.pm
+++ b/tests/console/snapper_used_space.pm
@@ -29,9 +29,9 @@ Ensure column for size is displayed or not if flag is provided
 =cut
 sub ensure_size_displayed {
     # Displays the exclusive space used by each snapshot
-    assert_script_run "snapper list | awk -F '|' '{print \$6}' | grep -E 'Used Space|iB'";
+    assert_script_run "snapper -t 0 list | awk -F '|' '{print \$6}' | grep -E 'Used Space|iB'";
     # if flag set to disable it will be display Cleanup column instead
-    assert_script_run "snapper list --disable-used-space | awk -F '|' '{print \$6}' | grep -E 'Cleanup|number'";
+    assert_script_run "snapper -t 0 list --disable-used-space | awk -F '|' '{print \$6}' | grep -E 'Cleanup|number'";
 }
 
 =head2 query_space_single_snapshot
@@ -44,11 +44,11 @@ sub query_space_single_snapshot {
     # Create snapshot
     assert_script_run 'snapper create --cleanup number --print-number';
     # Check data is not exclusive to that snapshot
-    assert_script_run 'snapper list | tail -n1 | ' . COLUMN_FILTER . ' | grep KiB';
+    assert_script_run 'snapper -t 0 list | tail -n1 | ' . COLUMN_FILTER . ' | grep KiB';
     # Remove file
     assert_script_run REMOVE_BIG_FILE;
     # Check data is exclusive to that snapshot and used space grows 1GiB
-    assert_script_run 'snapper list | tail -n1 | ' . COLUMN_FILTER . ' | grep \'1.00 GiB\'';
+    assert_script_run 'snapper -t 0 list | tail -n1 | ' . COLUMN_FILTER . ' | grep \'1.00 GiB\'';
 }
 
 =head2 query_space_several_snapshot
@@ -64,7 +64,7 @@ sub query_space_several_snapshot {
         assert_script_run "snapper create --command $command --description $description $args";
     }
     # Check that correct used space does not show up in any of the snapshots.
-    assert_script_run 'snapper list | tail -n4 | ' . COLUMN_FILTER . ' | grep KiB';
+    assert_script_run 'snapper -t 0 list | tail -n4 | ' . COLUMN_FILTER . ' | grep KiB';
     # Filter snapshots containing the data (intermediate ones)
     my @ids = split(/\n/, script_output('btrfs subvolume list / | ' . SUBVOLUME_FILTER));
     # Create a new higher level qgroup


### PR DESCRIPTION
Newer version of snapper support json output. It is more convenient for parsing the data in snapper tests.

- ticket: https://progress.opensuse.org/issues/160026

#### Verification runs

* [12-SP5](http://kepler.suse.cz/tests/23327#step/snapper_create/1)
* [15-SP4](http://kepler.suse.cz/tests/23326#step/snapper_create/1)
* [TW - stagging](http://kepler.suse.cz/tests/23325#step/snapper_create/1)