### PR TITLE
Pynfs/cleanup

### DIFF
--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -15,7 +15,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use upload_system_log;
 
-sub display_results {
+sub display_pynfs_results {
     my $self = shift;
     my $skip = "";
     my $pass = "";
@@ -104,7 +104,7 @@ sub run {
     select_serial_terminal;
 
     if (get_var("PYNFS")) {
-        $self->display_results();
+        $self->display_pynfs_results();
     }
     elsif (get_var("CTHON04")) {
         $self->upload_cthon04_log();

--- a/tests/nfs/generate_report.pm
+++ b/tests/nfs/generate_report.pm
@@ -21,9 +21,9 @@ sub display_pynfs_results {
     my $pass = "";
     my $fail = 0;
 
-    my $folder = get_required_var('PYNFS');
+    my $version = get_required_var('NFSVERSION');
 
-    assert_script_run("cd ~/pynfs/$folder");
+    assert_script_run("cd ~/pynfs/nfs$version");
     upload_logs('results.json', failok => 1);
 
     my $content = script_output('cat results.json');

--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -96,13 +96,15 @@ sub setup_nfs_server {
 }
 
 sub run {
+    my $version = get_required_var("NFSVERSION");
+
     select_serial_terminal;
 
     # Disable PackageKit
     quit_packagekit;
 
     install_testsuite;
-    setup_nfs_server(get_var("NFSVERSION"));
+    setup_nfs_server($version);
 }
 
 sub test_flags {

--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -45,10 +45,11 @@ sub install_dependencies_cthon04 {
 
 sub install_testsuite {
     my $testsuite = shift;
-    if (get_var("PYNFS")) {
-        my $url = get_var('PYNFS_GIT_URL', 'git://git.linux-nfs.org/projects/cdmackay/pynfs.git');
-        my $rel = get_var('PYNFS_RELEASE');
+    my ($url, $rel);
 
+    if (get_var("PYNFS")) {
+        $url = get_var('PYNFS_GIT_URL', 'git://git.linux-nfs.org/projects/cdmackay/pynfs.git');
+        $rel = get_var('PYNFS_RELEASE');
         $rel = "-b $rel" if ($rel);
 
         install_dependencies_pynfs;
@@ -56,7 +57,10 @@ sub install_testsuite {
         assert_script_run('./setup.py build && ./setup.py build_ext --inplace');
     }
     elsif (get_var("CTHON04")) {
-        my $url = get_var('CTHON04_GIT_URL', 'git://git.linux-nfs.org/projects/steved/cthon04.git');
+        $url = get_var('CTHON04_GIT_URL', 'git://git.linux-nfs.org/projects/steved/cthon04.git');
+        $rel = get_var('CTHON04_RELEASE');
+        $rel = "-b $rel" if ($rel);
+
         install_dependencies_cthon04;
         assert_script_run("git clone -q --depth 1 $url && cd ./cthon04");
         assert_script_run('make');

--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -61,6 +61,10 @@ sub install_testsuite {
         assert_script_run("git clone -q --depth 1 $url && cd ./cthon04");
         assert_script_run('make');
     }
+    else {
+        die 'PYNFS or CTHON04 variable is mandatory';
+    }
+
     record_info('git version', script_output('git log -1 --pretty=format:"git-%h" | tee'));
 }
 

--- a/tests/nfs/pynfs_result.pm
+++ b/tests/nfs/pynfs_result.pm
@@ -22,7 +22,7 @@ sub run {
     my $data = $args->{data};
     my $test = $data->{code};
     my $message = $data->{failure}->{message};
-    my $is_v4 = get_required_var('PYNFS') eq 'nfs4.0';
+    my $is_v4 = get_required_var('NFSVERSION') eq '4.0';
     my $log = "$message\n\n$data->{failure}->{err}";
     my $softfail;
 

--- a/tests/nfs/run.pm
+++ b/tests/nfs/run.pm
@@ -59,7 +59,7 @@ Overrides the official pynfs repository URL.
 
 =head2 PYNFS_RELEASE
 
-This can be set to a release tag, commit hash, branch name or whatever else Git
+This can be set to a release tag, commit hash, branch name or whatever else git
 will accept.
 
 If not set, then the default clone action will be performed, which probably
@@ -81,6 +81,14 @@ Fill 3 or 4 in this parameter to set test NFSv3 or NFSv4.
 
 =head2 CTHON04_GIT_URL
 
-Similar PYNFS_GIT_URL, it overrides the official cthon04 repository URL.
+Overrides the official cthon04 repository URL.
+
+=head2 CTHON04_RELEASE
+
+This can be set to a release tag, commit hash, branch name or whatever else git
+will accept.
+
+If not set, then the default clone action will be performed, which probably
+means the latest master branch will be used.
 
 =cut

--- a/tests/nfs/run.pm
+++ b/tests/nfs/run.pm
@@ -17,19 +17,14 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use power_action_utils 'power_action';
 
-sub pynfs_server_test_all {
-    my $folder = get_required_var('PYNFS');
-
-    assert_script_run("cd ./$folder");
-    script_run('./testserver.py -v --rundeps --hidepass --json results.json --maketree localhost:/exportdir all', 3600);
-}
-
 sub run {
     select_serial_terminal;
 
     if (get_var("PYNFS")) {
-        script_run('cd ~/pynfs');
-        pynfs_server_test_all;
+        my $version = get_required_var('NFSVERSION');
+
+        assert_script_run("cd ~/pynfs/nfs$version");
+        script_run('./testserver.py -v --rundeps --hidepass --json results.json --maketree localhost:/exportdir all', 3600);
     }
     elsif (get_var("CTHON04")) {
         script_run('cd ~/cthon04');
@@ -49,7 +44,8 @@ sub run {
 BOOT_HDD_IMAGE=1
 DESKTOP=textmode
 HDD_1=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2
-PYNFS=nfs4.0
+PYNFS=1
+NFSVERSION=4.0
 UEFI_PFLASH_VARS=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed-uefi-vars.qcow2
 START_AFTER_TEST=create_hdd_minimal_base+sdk
 


### PR DESCRIPTION
Cleanup preparation for https://progress.opensuse.org/issues/160179. The main change is to introduce `NFSVERSION` to be mandatory to pynfs and turn `PYNFS` variable as simple bool.

I've already set `NFSVERSION` for pynfs tests in both o3 and osd (merge of this change will not break the results). 

Verification run:
pynfs 4.0 and 4.1 on SLE 15-SP[56] & Tumbleweed (tested with changed variables (`QEMURAM=4096` - to avoid bsc#1217488 `PYNFS=1` `NFSVERSION=4.0` or `4.1`)
- http://quasar.suse.cz/tests/3279
- http://quasar.suse.cz/tests/3274
- http://quasar.suse.cz/tests/3270
- http://quasar.suse.cz/tests/3269
- http://quasar.suse.cz/tests/3290
- http://quasar.suse.cz/tests/3291

cthon04 on SLE 15-SP[56] & Tumbleweed
- http://quasar.suse.cz/tests/3273
- http://quasar.suse.cz/tests/3275
- http://quasar.suse.cz/tests/3276
- http://quasar.suse.cz/tests/3277
- http://quasar.suse.cz/tests/3280
- http://quasar.suse.cz/tests/3281