### PR TITLE
P.C. create_instance logs list fix

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -278,14 +278,15 @@ Return C<1> true explicit, as stateless and never impact calling code.
 
 sub upload_check_logs_tar {
     my ($self, @files) = @_;
-    my $remote_tar = $autotest::current_test->{name};
-    $remote_tar = "/tmp/" . $remote_tar . "_logs.tar.gz";
-    my $res = $self->ssh_script_output(cmd => 'sudo ls ' . join(' ', @files) . ' 2>/dev/null', proceed_on_failure => 1);
-    return 1 unless ($res);
-
+    my $remote_tar = "/tmp/" . $autotest::current_test->{name} . "_logs.tar.gz";
+    my $cmd = 'sudo ls -x ' . join(' ', @files) . " 2>/dev/null";
+    my $res = $self->ssh_script_output(cmd => $cmd, proceed_on_failure => 1);
+    my @logs = split(" ", $res);
+    return 1 unless ($#logs);
     # Upload existing logs to openqa  UI
-    $res = $self->ssh_script_run(cmd => "sudo tar -czvf $remote_tar $res", proceed_on_failure => 1);
-    $self->upload_log("$remote_tar", log_name => basename($remote_tar), failok => 1) if ($res);
+    $cmd = "sudo tar -czvf $remote_tar " . join(" ", @logs);
+    $res = $self->ssh_script_run(cmd => $cmd, proceed_on_failure => 1);
+    $self->upload_log("$remote_tar", log_name => basename($remote_tar), failok => 1) if ($res == 0);
     return 1;
 }
 


### PR DESCRIPTION
During logs upload in `create_instance`, the ssh `ls` check returns the 'list of file to upload' with an unexpected '\t' in place of space separator, causing names fusion in the tar command, then error. See i.e. job [14271031](https://openqa.suse.de/tests/14271031#step/prepare_instance/209).

After attempts to purify the spaces of the string representing the file-list, the better stable and successful solution resulted to convert filenames in array then join members in the tar command.

- Related ticket: https://progress.opensuse.org/issues/160038
- Needles: None
- Verification run:
  - https://openqa.suse.de/tests/14277229#step/prepare_instance/207
