### PR TITLE
Fix Elemental test

### DIFF
--- a/data/elemental/cloud-config.yaml
+++ b/data/elemental/cloud-config.yaml
@@ -1,10 +1,10 @@
 name: "Default user"
 stages:
    initramfs:
-     - name: "Setup users"
-       ensure_entities:
-       - path: /etc/shadow
-         entity: |
-            kind: "shadow"
-            username: "root"
-            password: "%TEST_PASSWORD%"
+   - name: "Setup users"
+     ensure_entities:
+     - path: /etc/shadow
+       entity: |
+          kind: "shadow"
+          username: "root"
+          password: "%TEST_PASSWORD%"

--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -641,5 +641,19 @@
             "sle": ["15-SP6"]
         },
         "type": "bug"
+    },
+    "skip elemental systemd-journal check": {
+        "description": "Failed to resolve group 'systemd-journal': No such process",
+        "products": {
+            "sle-micro": ["6.0"]
+        },
+        "type": "ignore"
+    },
+    "skip elemental register check": {
+        "description": "Failed to start (e|E)lemental (r|R)egister",
+        "products": {
+            "sle-micro": ["6.0"]
+        },
+        "type": "ignore"
     }
 }

--- a/products/elemental
+++ b/products/elemental
@@ -1,1 +1,0 @@
-./sle-micro


### PR DESCRIPTION
Elemental is now more integrated with SL-Micro. Add support for Elemental image based on SL-Micro 6.0.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1663
- Triggering: https://gitlab.suse.de/openqa/salt-states-openqa/-/merge_requests/1167 + https://gitlab.suse.de/openqa/openqa-trigger-from-ibs-plugin/-/merge_requests/172
- Verification run: on my local lab, cannot be share. See screenshot. But anyway the modified code only impact the Elemental tests which are not running well anyway.
![Screenshot from 2024-05-13 11-03-58](https://github.com/os-autoinst/os-autoinst-distri-opensuse/assets/25102165/ccee0f35-0308-44dd-b968-47b57b108834)
