### PR TITLE
Add schedule with select_patterns module for yast-mru-install-minimal-with-addons

### DIFF
--- a/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_restapi_pcm.yaml
+++ b/schedule/yast/maintenance/yast_mru_install_minimal_with_addons_restapi_pcm.yaml
@@ -1,0 +1,16 @@
+---
+name: yast_mru_install_minimal_with_addons
+vars:
+  PATTERNS: base,enhanced_base
+  YUI_REST_API: 1
+schedule:
+  additional_products: []
+  add_on_product:
+    - installation/add_on_product/add_maintenance_repos
+  software:
+    - installation/select_patterns
+  security:
+    - installation/security/select_security_module_none
+  system_role:
+    - installation/system_role/select_role_text_mode
+...


### PR DESCRIPTION
test mru-yast-mru-install-minimal-with-addons@s390x fails due to pcm patterns taking over the top of the selection list on step: https://openqa.suse.de/tests/14287410#step/select_only_visible_patterns_from_top/10
Here, an additional schedule that uses select_patterns module, instead of select_only_visible_patterns_from_top is added.
VR: https://openqa.suse.de/tests/14291680

MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/193