### PR TITLE
install_rt_kernel: Change GRUB OS name from SLES to SLE_RT

### DIFF
--- a/tests/console/install_rt_kernel.pm
+++ b/tests/console/install_rt_kernel.pm
@@ -18,6 +18,7 @@ sub run {
 
     zypper_call('rm kernel-default');
     zypper_call('in kernel-rt');
+    assert_script_run('sed -ie "s/^NAME=.*\$/NAME=\"SLE_RT\"/" /etc/os-release');
 }
 
 sub test_flags {


### PR DESCRIPTION
LTP tests for kernel-rt expect the SLERT boot option to be named `SLE_RT`. Automatically change os-release name during disk image creation.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/14292577
