### PR TITLE
Pub.Cloud upload logs: fix array size check

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -282,7 +282,7 @@ sub upload_check_logs_tar {
     my $cmd = 'sudo ls -x ' . join(' ', @files) . " 2>/dev/null";
     my $res = $self->ssh_script_output(cmd => $cmd, proceed_on_failure => 1);
     my @logs = split(" ", $res);
-    return 1 unless ($#logs);
+    return 1 unless (scalar(@logs) > 0);
     # Upload existing logs to openqa  UI
     $cmd = "sudo tar -czvf $remote_tar " . join(" ", @logs);
     $res = $self->ssh_script_run(cmd => $cmd, proceed_on_failure => 1);


### PR DESCRIPTION
The guard check of the array size _passed_ for `empty` array, so when no log present the tar still was triggered, but failed.

The default max index was used `$#logs` that is `= 0` for size=1 and `=-1` for empty arrays.
Therefore, a test expression `($#Array)` for empty arrays (=-1) is true, but false (=0) for size=1 arrays.

To check array size we should use `scalar(@array)`.

- Related ticket: https://progress.opensuse.org/issues/160038