### PR TITLE
Add optional -G flag in zypper when adding MU repos

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -75,7 +75,8 @@ sub is_patch_needed {
 
 sub add_repo_if_not_present {
     my ($url, $name) = @_;
-    my $gpg = get_var('BUILD') =~ m/^MR:/ ? "-G" : "";
+    my $gpg = "";
+    $gpg = "-G" if (get_var('BUILD') =~ m/^MR:/ || get_var('MU_REPOS_NO_GPG_CHECK'));
     my $system_repos = zypper_repos('-u');
     zypper_call("--no-gpg-checks ar -f $gpg -n '$name' $url '$name'") unless grep { $_->{uri} eq $url } @$system_repos;
 }

--- a/variables.md
+++ b/variables.md
@@ -138,6 +138,7 @@ MM_MTU | integer | 1380 | Specifies the MTU to set in SUTs of MM tests usually s
 MOK_VERBOSITY | boolean | false | Enable verbosity feature of shim. Requires preinstalled `mokutil`.
 MOZILLATEST |||
 MOZILLA_NSS_DEVEL_REPO | string | | URL of the repository where to install the mozilla-nss packages from.
+MU_REPOS_NO_GPG_CHECK | boolean | false | Use -G option in zypper when adding the repositores from OS_TEST_REPOS variable
 NAME | string | | Name of the test run including distribution, build, machine name and job id.
 NAMESERVER | string | | Can be used to specify a name server's IP or FQDN.
 NET | boolean | false | Indicates net installation.


### PR DESCRIPTION
Some of the repositories for the new maintenance workflow do not contain proper keys (at least the prototype ones). This adds an optional variable to include the -G (no gpg checks) flag to zypper ar.

VR:
- https://openqa.suse.de/tests/14293011 (without flag, default behavior)
- https://openqa.suse.de/tests/14293010 (with flag)