### PR TITLE
Update the system first before installing incidents in SLE Micro

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -776,6 +776,8 @@ the second run will update the system.
 =cut
 
 sub fully_patch_system {
+    my (%args) = @_;
+    my $trup_call_timeout = $args{trup_call_timeout} // '1800';
     # special handle for 11-SP4 s390 install
     if (is_sle('=11-SP4') && is_s390x && is_backend_s390x) {
         # first run, possible update of packager -- exit code 103
@@ -787,10 +789,10 @@ sub fully_patch_system {
     my $ret = 1;
     if (is_transactional) {
         # Update package manager first, not possible to detect package manager update bsc#1216504
-        transactional::trup_call('patch');
+        transactional::trup_call('patch', timeout => $trup_call_timeout);
         transactional::reboot_on_changes();
         # Continue with patch
-        transactional::trup_call('patch');
+        transactional::trup_call('patch', timeout => $trup_call_timeout);
         transactional::reboot_on_changes();
         return;
     } else {


### PR DESCRIPTION
We are booting GA images for maintenance updates. Ideally, we should install the incidents under tests on an updated system. It has been observed that installing everything at once can cause false positives and packages not being updated.

With this approach, we first update the system and after reboot, we add and install the incidents using the patch option.

VR: https://openqa.suse.de/tests/14293397#step/install_updates/257
