### PR TITLE
Add legacy module for ntp testing on SLE 15.6

### DIFF
--- a/tests/security/ntpd.pm
+++ b/tests/security/ntpd.pm
@@ -17,9 +17,13 @@ use utils;
 use services::ntpd;
 use serial_terminal qw(select_serial_terminal);
 use Utils::Logging 'save_and_upload_log';
+use version_utils 'is_sle';
+use registration 'add_suseconnect_product';
+
 
 sub run {
     select_serial_terminal;
+    add_suseconnect_product('sle-module-legacy') if is_sle('>=15-SP6');
     services::ntpd::install_service();
     services::ntpd::enable_service();
     services::ntpd::start_service();


### PR DESCRIPTION
ntp test was failing because package has been moved to legacy module. 

- Related ticket: https://progress.opensuse.org/issues/160080
- Needles: nope
- Verification runs:
  - https://openqa.suse.de/tests/14296985
  - https://openqa.suse.de/tests/14296986
  - https://openqa.suse.de/tests/14296987
