### PR TITLE
Add aardvark-dns upstream tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -304,6 +304,9 @@ sub load_container_tests {
         if (!check_var('NETAVARK_BATS_SKIP', 'all')) {
             loadtest 'containers/netavark_integration' if (is_tumbleweed);
         }
+        if (!check_var('AARDVARK_BATS_SKIP', 'all')) {
+            loadtest 'containers/aardvark_integration' if (is_tumbleweed);
+        }
         return;
     }
 

--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -1,0 +1,81 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: aardvark-dns
+# Summary: Upstream aardvark-dns integration tests
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use utils qw(script_retry);
+use containers::common;
+use containers::bats qw(install_bats enable_modules);
+use version_utils qw(is_sle);
+
+my $test_dir = "/var/tmp";
+my $aardvark_version = "";
+
+sub run_tests {
+    my %params = @_;
+    my ($skip_tests) = ($params{skip_tests});
+
+    return if ($skip_tests eq "all");
+
+    my $log_file = "aardvark.tap";
+
+    assert_script_run "cp -r test.orig test";
+    my @skip_tests = split(/\s+/, get_var('AARDVARK_BATS_SKIP', '') . " " . $skip_tests);
+    script_run "rm test/$_.bats" foreach (@skip_tests);
+
+    assert_script_run "echo $log_file .. > $log_file";
+    script_run "AARDVARK=/usr/libexec/podman/aardvark-dns bats --tap test | tee -a $log_file", 1200;
+    parse_extra_log(TAP => $log_file);
+    assert_script_run "rm -rf test";
+}
+
+sub run {
+    my ($self) = @_;
+    select_serial_terminal;
+
+    install_bats;
+    enable_modules if is_sle;
+
+    # Install tests dependencies
+    my @pkgs = qw(aardvark-dns dbus-1-daemon firewalld iproute2 iptables jq netavark slirp4netns);
+    install_packages(@pkgs);
+
+    record_info("aardvark version", script_output("/usr/libexec/podman/aardvark-dns --version"));
+
+    my $test_dir = "/var/tmp";
+    assert_script_run "cd $test_dir";
+
+    # Download aardvark sources
+    $aardvark_version = script_output "/usr/libexec/podman/aardvark-dns --version | awk '{ print \$2 }'";
+    script_retry("curl -sL https://github.com/containers/aardvark-dns/archive/refs/tags/v$aardvark_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
+    assert_script_run "cd $test_dir/aardvark-dns-$aardvark_version/";
+    assert_script_run "cp -r test test.orig";
+
+    run_tests(skip_tests => get_var('AARDVARK_BATS_SKIP', ''));
+}
+
+sub cleanup() {
+    assert_script_run "cd ~";
+    script_run("rm -rf $test_dir/aardvark-$aardvark_version/");
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    cleanup();
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    cleanup();
+    $self->SUPER::post_run_hook;
+}
+
+1;

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -31,7 +31,7 @@ sub run_tests {
     script_run "rm test/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "NETAVARK=/usr/libexec/podman/netavark bats --tap test | tee -a $log_file", 1200;
+    script_run "PATH=/usr/local/bin:\$PATH NETAVARK=/usr/libexec/podman/netavark bats --tap test | tee -a $log_file", 1200;
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf test";
 }
@@ -44,8 +44,11 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns dbus-1-daemon firewalld iproute2 iptables jq netavark netcat-openbsd);
+    my @pkgs = qw(aardvark-dns dbus-1-daemon firewalld iproute2 iptables jq ncat netavark);
     install_packages(@pkgs);
+
+    # netavark needs nmap's ncat instead of openbsd-netcat which we override via PATH above
+    assert_script_run "cp /usr/bin/ncat /usr/local/bin/nc";
 
     record_info("netavark version", script_output("/usr/libexec/podman/netavark --version"));
 


### PR DESCRIPTION
This PR:
  - Adds aardvark-dns upstream tests from https://github.com/containers/netavark/tree/main/test
  - Uses nmap's ncat instead of openbsd-netcat for netavark test: https://github.com/containers/netavark/tree/main/test

---
- Related ticket: https://progress.opensuse.org/issues/160254
- Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/455
- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20240513-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/tests/4186976