### PR TITLE
Skip loading kontact and khelpcenter on unsupported architecture

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1385,7 +1385,7 @@ sub load_x11tests {
         if (!get_var('LIVECD')) {
             # Extension got (temporarily) pulled by Mozilla
             # loadtest "x11/plasma_browser_integration";
-            loadtest "x11/khelpcenter";
+            loadtest "x11/khelpcenter" unless !(is_x86_64 || is_aarch64 || is_riscv);
         }
         loadtest "x11/systemsettings";
         loadtest "x11/dolphin";
@@ -1426,7 +1426,7 @@ sub load_x11tests {
         if (!is_krypton_argon && !is_kde_live) {
             loadtest "x11/amarok";
         }
-        loadtest "x11/kontact" unless is_kde_live;
+        loadtest "x11/kontact" unless is_kde_live || !(is_x86_64 || is_aarch64 || is_riscv);
         if (!get_var("USBBOOT") && !is_livesystem) {
             if (get_var("PLASMA5")) {
                 loadtest "x11/reboot_plasma5";

--- a/t/data/test_schedule.out
+++ b/t/data/test_schedule.out
@@ -50,7 +50,6 @@ tests/x11/firefox.pm
 tests/x11/ooffice.pm
 tests/x11/oomath.pm
 tests/x11/oocalc.pm
-tests/x11/khelpcenter.pm
 tests/x11/systemsettings.pm
 tests/x11/dolphin.pm
 tests/x11/konsole.pm
@@ -58,7 +57,6 @@ tests/x11/glxgears.pm
 tests/x11/desktop_mainmenu.pm
 tests/x11/kate.pm
 tests/x11/amarok.pm
-tests/x11/kontact.pm
 tests/x11/reboot_plasma5.pm
 tests/console/zypper_log_packages.pm
 tests/shutdown/shutdown.pm


### PR DESCRIPTION
- Related tickets: 
  - kontact https://progress.opensuse.org/issues/159981
  - khelpcenter https://progress.opensuse.org/issues/159978
- Verification run: https://openqa.opensuse.org/tests/overview?build=cedvid%2Fos-autoinst-distri-opensuse%2319297
