### PR TITLE
containers: Add buildah upstream tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -310,6 +310,11 @@ sub load_container_tests {
         return;
     }
 
+    if (get_var('BUILDAH_BATS_SKIP')) {
+        loadtest 'containers/buildah_integration' if (is_tumbleweed);
+        return;
+    }
+
     if (get_var('FIPS_ENABLED')) {
         loadtest "fips/fips_setup";
         foreach (split(',\s*', $runtime)) {

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -1,0 +1,96 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: buildah
+# Summary: Upstream buildah integration tests
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use utils qw(script_retry);
+use containers::common;
+use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules);
+use version_utils qw(is_sle);
+
+my $test_dir = "/var/tmp";
+my $buildah_version = "";
+
+sub run_tests {
+    my %params = @_;
+    my ($rootless, $skip_tests) = ($params{rootless}, $params{skip_tests});
+
+    return if ($skip_tests eq "all");
+
+    my $log_file = "buildah-" . ($rootless ? "user" : "root") . ".tap";
+
+    assert_script_run "cp -r tests.orig tests";
+    my @skip_tests = split(/\s+/, get_var('BUILDAH_BATS_SKIP', '') . " " . $skip_tests);
+    script_run "rm tests/$_.bats" foreach (@skip_tests);
+
+    assert_script_run "echo $log_file .. > $log_file";
+    script_run "BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 3600;
+    parse_extra_log(TAP => $log_file);
+    assert_script_run "rm -rf tests";
+}
+
+sub run {
+    my ($self) = @_;
+    select_serial_terminal;
+
+    install_bats;
+    enable_modules if is_sle;
+
+    # Install tests dependencies
+    my @pkgs = qw(buildah crun docker git-core glibc-devel-static go jq libgpgme-devel libseccomp-devel make openssl podman runc selinux-tools);
+    install_packages(@pkgs);
+
+    delegate_controllers;
+
+    switch_cgroup_version($self, 2);
+
+    record_info("buildah version", script_output("buildah --version"));
+    record_info("buildah info", script_output("buildah info"));
+
+    switch_to_user;
+
+    my $test_dir = "/var/tmp";
+    assert_script_run "cd $test_dir";
+
+    # Download buildah sources
+    $buildah_version = script_output "buildah --version | awk '{ print \$3 }'";
+    script_retry("curl -sL https://github.com/containers/buildah/archive/refs/tags/v$buildah_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
+    assert_script_run "cd $test_dir/buildah-$buildah_version/";
+    assert_script_run "cp -r tests tests.orig";
+
+    # Compile helpers used by the tests
+    assert_script_run "make bin/imgtype bin/copy bin/tutorial", timeout => 600;
+
+    run_tests(rootless => 1, skip_tests => get_var('BUILDAH_BATS_SKIP_USER', ''));
+
+    select_serial_terminal;
+    assert_script_run("cd $test_dir/buildah-$buildah_version/");
+
+    run_tests(rootless => 0, skip_tests => get_var('BUILDAH_BATS_SKIP_ROOT', ''));
+}
+
+sub cleanup() {
+    assert_script_run "cd ~";
+    script_run("rm -rf $test_dir/buildah-$buildah_version/");
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    cleanup();
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    cleanup();
+    $self->SUPER::post_run_hook;
+}
+
+1;


### PR DESCRIPTION
Add buildah upstream tests from https://github.com/containers/buildah/tree/main/tests

- Related ticket: https://progress.opensuse.org/issues/160257
- Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/456
- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20240513-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/tests/4188708


Notes:
- Used `BUILDAH_BATS_SKIP="commit copy run" BUILDAH_BATS_SKIP_USER="add basic bud chroot overlay rmi sbom squash"`
- Test uses images available only for amd64, not arm64.