### PR TITLE
pc: Use a here-document instead of echo to write file

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -27,7 +27,7 @@ sub patch_json {
             $data->{tests}[$i]{outcome} = 'passed';
             record_soft_failure("bsc#1220269 - scap-security-guide fails");
             my $json = Mojo::JSON::encode_json($data);
-            assert_script_run "echo '$json' > $file";
+            assert_script_run "cat > $file <<EOF\n$json\nEOF";
             return;
         }
     }


### PR DESCRIPTION
Fix img-proof test on GCE.

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1643

Failing test: https://openqa.suse.de/tests/14298463#step/img_proof/203 (failing due to https://bugzilla.suse.com/show_bug.cgi?id=1224011)
Verification run: https://openqa.suse.de/tests/14299882 
