### PR TITLE
containers: Enable netavark & aardvark-dns upstream tests in SLE

### DIFF
--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -13,9 +13,10 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use containers::bats qw(install_bats enable_modules);
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
+my $aardvark = "";
 my $aardvark_version = "";
 
 sub run_tests {
@@ -31,7 +32,7 @@ sub run_tests {
     script_run "rm test/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "AARDVARK=/usr/libexec/podman/aardvark-dns bats --tap test | tee -a $log_file", 1200;
+    script_run "AARDVARK=$aardvark bats --tap test | tee -a $log_file", 1200;
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf test";
 }
@@ -44,16 +45,22 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns dbus-1-daemon firewalld iproute2 iptables jq netavark slirp4netns);
+    my @pkgs = qw(aardvark-dns firewalld iproute2 iptables jq netavark slirp4netns);
+    if (is_tumbleweed) {
+        push @pkgs, qw(dbus-1-daemon ncat);
+    } elsif (is_sle) {
+        push @pkgs, qw(dbus-1);
+    }
     install_packages(@pkgs);
 
-    record_info("aardvark version", script_output("/usr/libexec/podman/aardvark-dns --version"));
+    my $aardvark = script_output "rpm -ql aardvark-dns | grep podman/aardvark-dns";
+    record_info("aardvark version", script_output("$aardvark --version"));
 
     my $test_dir = "/var/tmp";
     assert_script_run "cd $test_dir";
 
     # Download aardvark sources
-    $aardvark_version = script_output "/usr/libexec/podman/aardvark-dns --version | awk '{ print \$2 }'";
+    $aardvark_version = script_output "$aardvark --version | awk '{ print \$2 }'";
     script_retry("curl -sL https://github.com/containers/aardvark-dns/archive/refs/tags/v$aardvark_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/aardvark-dns-$aardvark_version/";
     assert_script_run "cp -r test test.orig";

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -13,9 +13,10 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use containers::bats qw(install_bats enable_modules);
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
+my $netavark = "";
 my $netavark_version = "";
 
 sub run_tests {
@@ -31,7 +32,7 @@ sub run_tests {
     script_run "rm test/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "PATH=/usr/local/bin:\$PATH NETAVARK=/usr/libexec/podman/netavark bats --tap test | tee -a $log_file", 1200;
+    script_run "PATH=/usr/local/bin:\$PATH NETAVARK=$netavark bats --tap test | tee -a $log_file", 1200;
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf test";
 }
@@ -44,19 +45,26 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns dbus-1-daemon firewalld iproute2 iptables jq ncat netavark);
+    my @pkgs = qw(aardvark-dns firewalld iproute2 iptables jq netavark);
+    if (is_tumbleweed) {
+        push @pkgs, qw(dbus-1-daemon ncat);
+    } elsif (is_sle) {
+        push @pkgs, qw(dbus-1);
+    }
     install_packages(@pkgs);
 
     # netavark needs nmap's ncat instead of openbsd-netcat which we override via PATH above
-    assert_script_run "cp /usr/bin/ncat /usr/local/bin/nc";
+    # otherwise we can use nc but ignore failures due to openbsd-netcat not handling SIGTERM
+    assert_script_run "cp /usr/bin/ncat /usr/local/bin/nc" unless is_sle;
 
-    record_info("netavark version", script_output("/usr/libexec/podman/netavark --version"));
+    my $netavark = script_output "rpm -ql netavark | grep podman/netavark";
+    record_info("netavark version", script_output("$netavark --version"));
 
     my $test_dir = "/var/tmp";
     assert_script_run "cd $test_dir";
 
     # Download netavark sources
-    $netavark_version = script_output "/usr/libexec/podman/netavark --version | awk '{ print \$2 }'";
+    $netavark_version = script_output "$netavark --version | awk '{ print \$2 }'";
     script_retry("curl -sL https://github.com/containers/netavark/archive/refs/tags/v$netavark_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/netavark-$netavark_version/";
     assert_script_run "cp -r test test.orig";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/160254
- Verification runs:
  - sle-15-SP5-Server-DVD-Updates-x86_64-Build20240514-1-podman_testsuite@64bit -> https://openqa.suse.de/tests/14310785 (failed subtests to be added to respective SKIP variables)
  - 
TODO:
- More VR's
