### PR TITLE
Fix some filesystem check failures on Tumbleweed

### DIFF
--- a/lib/filesystem_utils.pm
+++ b/lib/filesystem_utils.pm
@@ -339,8 +339,8 @@ sub get_used_partition_space {
 
  is_lsblk_able_to_display_mountpoints();
 
-Runs utility C<lsblk> using flag --help to retrieve to check for one specific
-column 'MOUNTPOINTS'.
+Runs utility C<lsblk> using flag -H or --help to check whether it supports
+the column 'MOUNTPOINTS'.
 
 From version util-linux-systemd-2.37 lsblk include new column MOUNTPOINTS
 with all the mountpoints including all the subvolumes in a btrfs system
@@ -352,6 +352,7 @@ Please check bsc#1192996 for further info.
 =cut
 
 sub is_lsblk_able_to_display_mountpoints {
+    return 1 if script_run('lsblk -H | grep -w MOUNTPOINTS') == 0;
     return script_run('lsblk --help | grep MOUNTPOINTS') == 0;
 }
 

--- a/test_data/yast/encryption/default_enc_luks2.yaml
+++ b/test_data/yast/encryption/default_enc_luks2.yaml
@@ -1,0 +1,11 @@
+---
+cryptsetup:
+  device_status:
+    message: is active and is in use.
+    properties:
+      type: LUKS2
+      cipher: aes-xts-plain64
+      key_location: keyring
+      mode: read/write
+backup_file_info: 'LUKS encrypted file, ver 2, header size [0-9]+, ID [0-9]+, algo sha256'
+backup_path: '/root/bkp_luks_header'

--- a/test_data/yast/encryption/full_lvm_enc_luks2.yaml
+++ b/test_data/yast/encryption/full_lvm_enc_luks2.yaml
@@ -1,0 +1,23 @@
+disks:
+  - name: vda
+    partitions:
+      - size: 2MiB
+        role: raw-volume
+        id: bios-boot
+      - role: raw-volume
+        id: linux-lvm
+        encrypt_device: 1
+lvm:
+  volume_groups:
+  - name: vg-system
+    devices:
+      - /dev/vda2
+    logical_volumes:
+      - name: lv-swap
+        size: 2000MiB
+        role: swap
+      - name: lv-root
+        role: operating-system
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/yast/encryption/default_enc_luks2.yaml

--- a/test_data/yast/encryption/lvm_encrypt_separate_boot_luks2.yaml
+++ b/test_data/yast/encryption/lvm_encrypt_separate_boot_luks2.yaml
@@ -1,0 +1,31 @@
+disks:
+  - name: vda
+    partitions:
+      - size: 2MiB
+        role: raw-volume
+        id: bios-boot
+      - size: 500MiB
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: ext2
+        mounting_options:
+          should_mount: 1
+          mount_point: /boot
+      - role: raw-volume
+        id: linux-lvm
+        encrypt_device: 1
+lvm:
+  volume_groups:
+  - name: vg-system
+    devices:
+      - /dev/vda3
+    logical_volumes:
+      - name: lv-swap
+        size: 2000MiB
+        role: swap
+      - name: lv-root
+        role: operating-system
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/yast/encryption/default_enc_luks2.yaml


### PR DESCRIPTION
LUKS2 is default on Tumbleweed meanwhile and `lsblk --help` no longer lists columns.

- Related tickets: https://progress.opensuse.org/issues/160153 https://progress.opensuse.org/issues/160260
- Verification runs:
  * lvm-encrypt-separate-boot: https://openqa.opensuse.org/tests/4190740#live
  * lvm-full-encrypt: https://openqa.opensuse.org/tests/4190868#live
  * autoyast_reinstall_gnome: https://openqa.opensuse.org/tests/4190922#live
