### PR TITLE
containers: Enable buildah upstream tests for SLE

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -311,7 +311,7 @@ sub load_container_tests {
     }
 
     if (get_var('BUILDAH_BATS_SKIP')) {
-        loadtest 'containers/buildah_integration' if (is_tumbleweed);
+        loadtest 'containers/buildah_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         return;
     }
 

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -13,7 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules);
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
 my $buildah_version = "";
@@ -44,7 +44,8 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(buildah crun docker git-core glibc-devel-static go jq libgpgme-devel libseccomp-devel make openssl podman runc selinux-tools);
+    my @pkgs = qw(buildah docker git-core glibc-devel-static go jq libgpgme-devel libseccomp-devel make openssl podman runc selinux-tools);
+    push @pkgs, qw(crun) if is_tumbleweed;
     install_packages(@pkgs);
 
     delegate_controllers;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/160257
- Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1645
- Verification runs:
  - sle-15-SP5-Server-DVD-Updates-x86_64-Build20240514-1-podman_testsuite@64bit -> https://openqa.suse.de/t14311790
  - sle-15-SP4-Server-DVD-Updates-x86_64-Build20240514-1-podman_testsuite@64bit -> https://openqa.suse.de/t14311792
  - sle-15-SP6-Server-DVD-Updates-x86_64-Build20240514-1-podman_testsuite@64bit -> https://openqa.suse.de/tests/14311851
