### PR TITLE
yast2_lan_hostname/dhcp_yes_eth: Skip if NetworkManager is used

### DIFF
--- a/tests/console/yast2_lan_hostname/dhcp_yes_eth.pm
+++ b/tests/console/yast2_lan_hostname/dhcp_yes_eth.pm
@@ -18,6 +18,12 @@ use YaST::Module;
 
 sub run {
     select_console 'root-console';
+
+    if (script_run('systemctl is-active NetworkManager.service') == 0) {
+        record_info('SKIP', 'Only supported with Wicked, not NetworkManager.');
+        return;
+    }
+
     my $network_interface = script_output('ls /sys/class/net | grep ^e');
     my $test_data = get_test_suite_data();
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/154465
- Verification run: https://openqa.opensuse.org/tests/4190718
