### PR TITLE
Add setting for installation via full media on power VM

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -89,7 +89,10 @@ sub run {
             diag "SUSEConnect --status-text locked: $out";
         }
         diag "SUSEConnect --status-text: $out";
-        if (!get_var('MEDIA_UPGRADE')) {
+        # System is unregistered for installation process via Full medium prepared for migration test,
+        # set INSTALL_FOR_MIGRATION=1 to skip the registration check. Use this setting to distinguish
+        # installation process for migration or migration process even in same migration flavor.
+        if (!get_var('MEDIA_UPGRADE') && !get_var('INSTALL_FOR_MIGRATION')) {
             services::registered_addons::full_registered_check;
         }
     }

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -170,7 +170,7 @@ sub run {
             $sr_number++ unless (is_sle('15+') && $sr_number == 1);
             # in full_installer the dialog to choose the installation media
             # does not appear, thus we have to skip it
-            unless ((check_var('FLAVOR', 'Full')) || check_var('FLAVOR', 'Full-QR') || (is_sle('15-SP3+') && (check_var('FLAVOR', 'Server-DVD-Updates'))) || ((is_sle('15-SP2+') && get_var('MEDIA_UPGRADE')))) {
+            unless ((check_var('FLAVOR', 'Full')) || check_var('FLAVOR', 'Full-QR') || (is_sle('15-SP3+') && (check_var('FLAVOR', 'Server-DVD-Updates'))) || ((is_sle('15-SP2+') && get_var('MEDIA_UPGRADE'))) || (check_var('INSTALL_FOR_MIGRATION', '1'))) {
                 assert_screen 'addon-menu-active';
                 wait_screen_change { send_key 'alt-d' };    # DVD
                 send_key $cmd{next};


### PR DESCRIPTION
The installation via full media will skip registration to ensure minimal patch for migration test, we need add condition to make it clear that it is a installation process prepared for migration test.

- Related ticket: https://progress.opensuse.org/issues/160017
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/197
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/14311858#