### PR TITLE
Remove workaround for bsc#1189543

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -910,11 +910,6 @@ sub scc_deregistration {
         quit_packagekit;
         wait_for_purge_kernels;
         assert_script_run('SUSEConnect --version');
-        if ((check_var('UPGRADE_TARGET_VERSION', '15-SP3')) && (is_sle('15-SP1+'))) {
-            # Workaround for bsc#1189543, need register python2 before de-register system
-            record_soft_failure 'bsc#1189543 - Stale python2 module blocks de-registration after system migration';
-            add_suseconnect_product('sle-module-python2');
-        }
         # We don't need to pass $debug_flag to SUSEConnect, because it's already set
         my $deregister_ret = script_run("SUSEConnect --de-register --debug > /tmp/SUSEConnect.debug 2>&1", 300);
         if ($deregister_ret) {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/151891
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/14310970#step/scc_deregistration/11
- For installation process, it is not needed to have the workaround for python2, all test passed without the workaround http://openqa.suse.de/tests/overview?version=15-SP6&build=lemon-suse%2Fos-autoinst-distri-opensuse%23revisit-bsc%231189543&distri=sle
