### PR TITLE
containers: Enable netavark & aardvark-dns upstream tests in SLE

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -302,7 +302,7 @@ sub load_container_tests {
             loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         }
         if (!check_var('NETAVARK_BATS_SKIP', 'all')) {
-            loadtest 'containers/netavark_integration' if (is_tumbleweed);
+            loadtest 'containers/netavark_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         }
         if (!check_var('AARDVARK_BATS_SKIP', 'all')) {
             loadtest 'containers/aardvark_integration' if (is_tumbleweed);

--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -19,15 +19,10 @@ my $test_dir = "/var/tmp";
 my $aardvark_version = "";
 
 sub run_tests {
-    my %params = @_;
-    my ($skip_tests) = ($params{skip_tests});
-
-    return if ($skip_tests eq "all");
-
     my $log_file = "aardvark.tap";
 
     assert_script_run "cp -r test.orig test";
-    my @skip_tests = split(/\s+/, get_var('AARDVARK_BATS_SKIP', '') . " " . $skip_tests);
+    my @skip_tests = split(/\s+/, get_var('AARDVARK_BATS_SKIP', ''));
     script_run "rm test/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
@@ -58,7 +53,7 @@ sub run {
     assert_script_run "cd $test_dir/aardvark-dns-$aardvark_version/";
     assert_script_run "cp -r test test.orig";
 
-    run_tests(skip_tests => get_var('AARDVARK_BATS_SKIP', ''));
+    run_tests;
 }
 
 sub cleanup() {

--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -13,9 +13,10 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use containers::bats qw(install_bats enable_modules);
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
+my $aardvark = "";
 my $aardvark_version = "";
 
 sub run_tests {
@@ -26,7 +27,7 @@ sub run_tests {
     script_run "rm test/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "AARDVARK=/usr/libexec/podman/aardvark-dns bats --tap test | tee -a $log_file", 1200;
+    script_run "AARDVARK=$aardvark bats --tap test | tee -a $log_file", 2000;
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf test";
 }
@@ -39,16 +40,24 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns dbus-1-daemon firewalld iproute2 iptables jq netavark slirp4netns);
+    my @pkgs = qw(aardvark-dns firewalld iproute2 iptables jq netavark slirp4netns);
+    if (is_tumbleweed) {
+        push @pkgs, qw(dbus-1-daemon ncat);
+    } elsif (is_sle) {
+        push @pkgs, qw(dbus-1);
+    }
     install_packages(@pkgs);
 
-    record_info("aardvark version", script_output("/usr/libexec/podman/aardvark-dns --version"));
+    switch_cgroup_version($self, 2);
+
+    $aardvark = script_output "rpm -ql aardvark-dns | grep podman/aardvark-dns";
+    record_info("aardvark version", script_output("$aardvark --version"));
 
     my $test_dir = "/var/tmp";
     assert_script_run "cd $test_dir";
 
     # Download aardvark sources
-    $aardvark_version = script_output "/usr/libexec/podman/aardvark-dns --version | awk '{ print \$2 }'";
+    $aardvark_version = script_output "$aardvark --version | awk '{ print \$2 }'";
     script_retry("curl -sL https://github.com/containers/aardvark-dns/archive/refs/tags/v$aardvark_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/aardvark-dns-$aardvark_version/";
     assert_script_run "cp -r test test.orig";

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -19,15 +19,10 @@ my $test_dir = "/var/tmp";
 my $netavark_version = "";
 
 sub run_tests {
-    my %params = @_;
-    my ($skip_tests) = ($params{skip_tests});
-
-    return if ($skip_tests eq "all");
-
     my $log_file = "netavark.tap";
 
     assert_script_run "cp -r test.orig test";
-    my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', '') . " " . $skip_tests);
+    my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', ''));
     script_run "rm test/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
@@ -61,7 +56,7 @@ sub run {
     assert_script_run "cd $test_dir/netavark-$netavark_version/";
     assert_script_run "cp -r test test.orig";
 
-    run_tests(skip_tests => get_var('NETAVARK_BATS_SKIP', ''));
+    run_tests;
 }
 
 sub cleanup() {


### PR DESCRIPTION
- Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1648
- Related ticket: https://progress.opensuse.org/issues/160254
- Verification runs:
  - sle-15-SP6-Server-DVD-Updates-x86_64-Build20240514-1-podman_testsuite@64bit -> https://openqa.suse.de/t14318703
  - sle-15-SP6-Server-DVD-Updates-aarch64-Build20240514-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14318704
  - sle-15-SP4-Server-DVD-Updates-x86_64-Build20240515-1-podman_testsuite@64bit -> https://openqa.suse.de/t14318705
  - sle-15-SP4-Server-DVD-Updates-aarch64-Build20240515-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14318706
  - sle-15-SP5-Server-DVD-Updates-x86_64-Build20240515-1-podman_testsuite@64bit -> https://openqa.suse.de/t14318707
  - sle-15-SP5-Server-DVD-Updates-aarch64-Build20240515-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14318708