### PR TITLE
Set textmode during host installation with VIDEOMODE=text

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -91,10 +91,11 @@ sub set_bootscript {
     my $cmdline_extra;
     $cmdline_extra .= " regurl=$regurl " if ($regurl and !is_usb_boot);
     $cmdline_extra .= " console=$console " if $console;
+    $cmdline_extra .= " root=/dev/ram0 initrd=initrd " if (check_var('IPXE_UEFI', '1'));
+    $cmdline_extra .= " textmode=1 " if get_var('IPXE_UEFI') or check_var('VIDEOMODE', 'text');
 
-    # Support passing both EXTRA_PXE_CMDLINE to bootscripts
+    # Support passing EXTRA_PXE_CMDLINE to bootscripts
     $cmdline_extra .= get_var('EXTRA_PXE_CMDLINE') . ' ' if get_var('EXTRA_PXE_CMDLINE');
-    $cmdline_extra .= " root=/dev/ram0 initrd=initrd textmode=1" if (check_var('IPXE_UEFI', '1'));
 
     if ($autoyast ne '') {
         $cmdline_extra .= " autoyast=$autoyast sshd=1 sshpassword=$testapi::password ";


### PR DESCRIPTION
`unreal3` always failed to bootup after installation. I checked the screen via iKVM console, the it hung at bootloader with GUI mode. I suspect missing `textmode=1` option in bootscript is the cause. Validation runs have been made but as this bootup failure did not happened all the time, Let's see if it will fix the failure after the PR merged. Even if it does not fix the bootup failure, it will not introduce problems to our tests.  **Expect the PR can be merged before sle15sp6 GMC candidate build on May 17**.


- Related ticket: https://progress.opensuse.org/issues/160421
- Verification run: 
[sle15sp6_kvm_host](https://10.145.10.207/tests/14318324)
[sle15sp6_xen_host](https://10.145.10.207/tests/14318397)
[sle12sp5_kvm_host](https://10.145.10.207/tests/14318452)
[sle15sp5_xen_host](https://10.145.10.207/tests/14318693)
[prj3_15sp6_kvm_host](https://10.145.10.207/tests/14319214)
