### PR TITLE
Add switch to re-prepare BCI

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -332,6 +332,7 @@ sub load_container_tests {
         if (is_container_image_test()) {
             if (get_var('BCI_TESTS')) {
                 unless (get_var('BCI_SKIP')) {
+                    loadtest('containers/bci_prepare') if (check_var('BCI_PREPARE', '1'));
                     loadtest('containers/bci_test', run_args => $run_args, name => 'bci_test_' . $run_args->{runtime});
                     # For Base image we also run traditional image.pm test
                     load_image_test($run_args) if (is_sle(">=15-SP3") && check_var('BCI_TEST_ENVS', 'base'));

--- a/variables.md
+++ b/variables.md
@@ -35,6 +35,7 @@ BCI_TESTS_BRANCH | string | | Branch to be cloned from bci-tests. Used by `bci_p
 BCI_TIMEOUT | string | | Timeout given to the command to test each environment. Used by `bci_test.pm`.
 BCI_TARGET | string | ibs-cr | Container project to be tested. `ibs-cr` is the CR project, `ibs` is the released images project
 BCI_SKIP | boolean | false | Switch to disable BCI test runs. Necessary for fine-granular test disablement
+BCI_PREPARE | boolean | false | Launch the bci_prepare step again. Useful to re-initialize the BCI-Test repo when using a different BCI_TESTS_REPO
 BOOTLOADER | string | grub2 | Which bootloader is used by the image (and in the future also: will be selected during installation)
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.


### PR DESCRIPTION
When doing runs with a custom git repository, we need to re-run bci_prepare.pm. This commit adds a new setting BCI_PREPARE that allows us to re-initialize the already existing git repository.

- Verification run: https://openqa.suse.de/tests/14318285#step/bci_prepare/73
