### PR TITLE
Remove unknown flag from old snapper

### DIFF
--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -40,7 +40,7 @@ sub run {
             push @snapper_cmd, "--userdata \"$description\"";
             assert_script_run(join ' ', @snapper_cmd);
             $first_snap_to_delete = $self->get_last_snap_number() unless ($first_snap_to_delete);
-            assert_script_run("snapper list --disable-used-space| tail -n1");
+            assert_script_run("snapper list | tail -n1");
             for (1 .. 3) { pop @snapper_cmd; }
             if ($type eq 'pre') {
                 # Add last snapshot id for pre type


### PR DESCRIPTION
`--disable-used-space` flag is not present in old snapper versions. Remove this flag from global calls.

##### Verification runs

* [sle12sp5](http://kepler.suse.cz/tests/23348#step/snapper_cleanup/1)
* [sle12sp3](http://kepler.suse.cz/tests/23347#step/snapper_cleanup/1)
