### PR TITLE
WSL Beta license

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -73,7 +73,13 @@ sub license {
             send_key 'alt-n';
         }
         # Accept license
-        assert_screen 'wsl-license';
+        # assert_screen 'wsl-license' or wsl-liscense-beta;
+        if (check_var("BETA", "1")) {
+            assert_screen 'wsl-license-beta', timeout => 240;
+        }
+        else {
+            assert_screen 'wsl-license', timeout => 240;
+        }
         send_key 'alt-a';
         assert_screen 'license-accepted';
         send_key 'alt-n';


### PR DESCRIPTION
Added WSL Beta license logic.

Add firstrun-wsl-licence-beta needle
Add wsl/firstrun logic to account for BETA variable

- Related ticket: https://progress.opensuse.org/issues/160448

- Verification run: 
https://openqa.suse.de/tests/14341874 --> checking for Beta license.
https://openqa.suse.de/tests/14342607 --> current run with Beta undefined
https://openqa.suse.de/tests/14342606 --> sled fails because the WE license is still in beta. According to https://bugzilla.suse.com/show_bug.cgi?id=1224351 , once GMC is pushed to update.suse.com, we will get the GM license. For now, this test will fail, as expected. 

Additionally, I have removed the BETA variable from latest WSL runs, as they are supposed to be running in GM state already: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1649
