### PR TITLE
Remove the configuration left by previous setup

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -676,6 +676,7 @@ sub pre_run_hook {
         assert_script_run q|sed -i -e '/^include \"\/etc\/named.conf.include\";/ s/^/#/' /etc/named.conf|;
     }
 
+    assert_script_run q|sed -i -e '/^include \"\/etc\/named.d\/openqa.zones\";/ s/^/#/' /etc/named.conf|;
     $self->SUPER::pre_run_hook;
 }
 


### PR DESCRIPTION
When doing migration, we need to cleanup the configuration which is done by previous step. We could see the code in function `setup_dns_server`, it adds `openqa.zones` to `/etc/named.conf`. So we need to remove it before configuring again.

Related: https://jira.suse.com/browse/TEAM-8653

VRs:
https://openqa.suse.de/tests/14318725#step/setup/9
https://openqa.suse.de/tests/14322174#step/setup/9

