### PR TITLE
Avoid explicit ssh private keys in autoyast template

### DIFF
--- a/data/virtualization/autoyast/guest_12.xml.ep
+++ b/data/virtualization/autoyast/guest_12.xml.ep
@@ -335,7 +335,7 @@
 <![CDATA[
 #!/bin/bash
 mkdir -p -m 700 /root/.ssh
-echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' >> /root/.ssh/authorized_keys
+echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_key
 cat > /etc/init.d/after.local<< EOF
 #!/bin/sh

--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -362,7 +362,7 @@
 <![CDATA[
 #!/bin/bash
 mkdir -p -m 700 /root/.ssh
-echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' >> /root/.ssh/authorized_keys
+echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_key
 ]]></source>
 </script>

--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -305,48 +305,20 @@ cat >> /root/.config/fontconfig/fonts.conf <<EOF
   </alias>
 </fontconfig>
 EOF
+]]>
+        </source>
+      </script>
+      <script>
+        <filename>config_ssh.sh</filename>
+        <source><![CDATA[
 mkdir -p -m 700 /root/.ssh
 cat >> /root/.ssh/id_rsa<< EOF
------BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
-NhAAAAAwEAAQAAAYEAtFzEfa/DTa+fPvAZmw/gsk0HfYkKoiGI2OOYFYhKpdPkea2oVh0A
-cbkgMZCWzzC7ncptX33Ut/jg7gVTvJxwAWe3hmj2SUEEztGNm6SVworP9BsT1A/eBCfjSP
-+P6s6crsOQm3ztjGs13hd/JgUTv3HmeeGSJGTLqkx6uZKfq4atislAcbpvbVgu7h4dCRQq
-Ea6NvLkUoDZ97lUjHtaQIoXasJWegmg8Hzf9/mhKg08/3vxONQCiYw8ew2gjumpSm5J9lf
-A9mpbYY5we2bSjbGH5IkOlfarvZRLYHhUHhGSZJVj26vgmC3L6+xcrPDOegADagc2uSnPG
-uwC2WTRG6225rAsvmr0vz7X7ey1zYw3zU1F0PjUQzR7b3PVJhzsfXHaJIFOeIcQH8b/Ctr
-HL2lngUCRwLu+qDTK5xsSiDHTQR9GWzbnUoC5R1fWfzyGGFze18R3CbiIPYY6Nq8lHT3UQ
-OChmnmTfa1569PPKiVLQyY9DAWkUgmbauc1miclJAAAFiG6RBSlukQUpAAAAB3NzaC1yc2
-EAAAGBALRcxH2vw02vnz7wGZsP4LJNB32JCqIhiNjjmBWISqXT5HmtqFYdAHG5IDGQls8w
-u53KbV991Lf44O4FU7yccAFnt4Zo9klBBM7RjZuklcKKz/QbE9QP3gQn40j/j+rOnK7DkJ
-t87YxrNd4XfyYFE79x5nnhkiRky6pMermSn6uGrYrJQHG6b21YLu4eHQkUKhGujby5FKA2
-fe5VIx7WkCKF2rCVnoJoPB83/f5oSoNPP978TjUAomMPHsNoI7pqUpuSfZXwPZqW2GOcHt
-m0o2xh+SJDpX2q72US2B4VB4RkmSVY9ur4Jgty+vsXKzwznoAA2oHNrkpzxrsAtlk0Rutt
-uawLL5q9L8+1+3stc2MN81NRdD41EM0e29z1SYc7H1x2iSBTniHEB/G/wraxy9pZ4FAkcC
-7vqg0yucbEogx00EfRls251KAuUdX1n88hhhc3tfEdwm4iD2GOjavJR091EDgoZp5k32te
-evTzyolS0MmPQwFpFIJm2rnNZonJSQAAAAMBAAEAAAGBAKhduOcDPjO079kW1TBVABIxqf
-5cAVscJt0giIYBNn3acXvMykmoxRNkF1Ntf/plqZ5AqxzrH7mlUIOg4Ww+NKh7I20Lam0z
-jsNqBuD2IP78Cef7puTc8wm6Goe4WaZ9vPG/iaw8UJw2MJDkKkNZlfeu4dGA6qWimiSdRC
-sbXoYGMNZPzCLeQMo3+Yc7ASvKcQMUiSdVNpXgiGoFe8V70g0IGv+gi9l8aDNUV3w36ubt
-Adisem0r7GrAYJ1VB5UrTeOtMB0jfUfhTWpzskPBIj1no6k0iv+3/xX1Q/A33zgo62qNlY
-8ufw1E45dH/e/V2EXrNt/muP5l12Jm/oUggLepkPfXvDOmjO6HUn0MrSIRQc+h/jHbW8oM
-uB/9w84blDtAxPBFlWBwqwFMiwBrcb69wX+hSSk4lt1fgb0cmVdZ/g6/LUZ+rhDJBoF8tt
-hLQNwc/spI2jyVWQA6xI0QCyXnAZkhDl7SG4l1+bNSbdVOycTwJIwxtFY83c/TOOGFiQAA
-AMEAvcP/w/VVhC9dUeolArTs+G+NLIhRAmAtF1buYqfpyKw+XFKo3ZCDV8L/YeApQRiggW
-UN3fRdFmduW6y7gGQFhmjZsPDzjBGnSAYHX7LP5JaykaV/kMzXKPLPQf5JvAMPw6mokTd8
-yHuwPczjlzAkAXeXNk/dJ3kk5y0CL3lGC5KTLLlSSrhXlZai82SH1QNuudZLKsHUZ8du+f
-Qjh/pwD6+DDT2mg2kxKA12oPlmTOOUnI7cQxT7HQEYjybK9CHXAAAAwQDnvXWMmZKgWfnc
-4LZlxCYQvr5ZXQUksxgACW9WWoBR/7e9SjQs1th8NmEbX5JQsgxuXjXLhalr30UZzTbO82
-u0lwyCraVgAfr2YL8PuhCkSimi6NI9CrvetfbgHPsDAR45bMmLDbU3kGFKN47T2v6oYSYX
-KY6dS805LzaQH2+RnHR+xxZjd305lAZXkxZT54MOV80L3YSk7HyfCdY0WUS01UBD6uAQbw
-cvmWDxCp8gUkKrFL/ASyV9yK+IYy4ZJAcAAADBAMc+aBhA+T9Jwq7/x6lCzrG4zO3w+l0X
-AztXQAAHH64nkiECQ+pTn/qHH6TEfSkeqj97o/RDlGbf3s0NogUZEhSxGMxMhoqPatMa93
-UajDxU+4Xchxtt4S6MPHMIYRRcRi+pqa91Iz8wYYsN3PHVoRKsbRI2H0Nh5cqjjHeN1DhD
-lbzZvl0rkSQSotKBVWnX/1aU5Pk0RX8HKzYyLZiTjXJAX8RKnem5gsmeVv6yRbcQ2Fp5+I
-t3XODgiOxVK190LwAAAApyb290QHJpdmVyAQIDBAUGBw==
------END OPENSSH PRIVATE KEY-----
+<%= $get_var->('_SECRET_RSA_PRIV_KEY') %>
 EOF
-echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' > /root/.ssh/id_rsa.pub
+sed -i 's/9A/\n/g' /root/.ssh/id_rsa
+chmod 600 /root/.ssh/id_rsa
+echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> > /root/.ssh/id_rsa.pub
+
 
 cat >> /root/.ssh/config << EOF
 StrictHostKeyChecking no

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -349,7 +349,7 @@ mkdir -p /root/.config/fontconfig
 cat >> /root/.config/fontconfig/fonts.conf <<EOF
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-<fontconfig> 
+<fontconfig>
   <alias>
     <family>sans-serif</family>
     <prefer>
@@ -358,49 +358,19 @@ cat >> /root/.config/fontconfig/fonts.conf <<EOF
   </alias>
 </fontconfig>
 EOF
+]]>
+        </source>
+      </script>
+      <script>
+        <filename>config_ssh.sh</filename>
+        <source><![CDATA[
 mkdir -p -m 700 /root/.ssh
 cat >> /root/.ssh/id_rsa<< EOF
------BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
-NhAAAAAwEAAQAAAYEAtFzEfa/DTa+fPvAZmw/gsk0HfYkKoiGI2OOYFYhKpdPkea2oVh0A
-cbkgMZCWzzC7ncptX33Ut/jg7gVTvJxwAWe3hmj2SUEEztGNm6SVworP9BsT1A/eBCfjSP
-+P6s6crsOQm3ztjGs13hd/JgUTv3HmeeGSJGTLqkx6uZKfq4atislAcbpvbVgu7h4dCRQq
-Ea6NvLkUoDZ97lUjHtaQIoXasJWegmg8Hzf9/mhKg08/3vxONQCiYw8ew2gjumpSm5J9lf
-A9mpbYY5we2bSjbGH5IkOlfarvZRLYHhUHhGSZJVj26vgmC3L6+xcrPDOegADagc2uSnPG
-uwC2WTRG6225rAsvmr0vz7X7ey1zYw3zU1F0PjUQzR7b3PVJhzsfXHaJIFOeIcQH8b/Ctr
-HL2lngUCRwLu+qDTK5xsSiDHTQR9GWzbnUoC5R1fWfzyGGFze18R3CbiIPYY6Nq8lHT3UQ
-OChmnmTfa1569PPKiVLQyY9DAWkUgmbauc1miclJAAAFiG6RBSlukQUpAAAAB3NzaC1yc2
-EAAAGBALRcxH2vw02vnz7wGZsP4LJNB32JCqIhiNjjmBWISqXT5HmtqFYdAHG5IDGQls8w
-u53KbV991Lf44O4FU7yccAFnt4Zo9klBBM7RjZuklcKKz/QbE9QP3gQn40j/j+rOnK7DkJ
-t87YxrNd4XfyYFE79x5nnhkiRky6pMermSn6uGrYrJQHG6b21YLu4eHQkUKhGujby5FKA2
-fe5VIx7WkCKF2rCVnoJoPB83/f5oSoNPP978TjUAomMPHsNoI7pqUpuSfZXwPZqW2GOcHt
-m0o2xh+SJDpX2q72US2B4VB4RkmSVY9ur4Jgty+vsXKzwznoAA2oHNrkpzxrsAtlk0Rutt
-uawLL5q9L8+1+3stc2MN81NRdD41EM0e29z1SYc7H1x2iSBTniHEB/G/wraxy9pZ4FAkcC
-7vqg0yucbEogx00EfRls251KAuUdX1n88hhhc3tfEdwm4iD2GOjavJR091EDgoZp5k32te
-evTzyolS0MmPQwFpFIJm2rnNZonJSQAAAAMBAAEAAAGBAKhduOcDPjO079kW1TBVABIxqf
-5cAVscJt0giIYBNn3acXvMykmoxRNkF1Ntf/plqZ5AqxzrH7mlUIOg4Ww+NKh7I20Lam0z
-jsNqBuD2IP78Cef7puTc8wm6Goe4WaZ9vPG/iaw8UJw2MJDkKkNZlfeu4dGA6qWimiSdRC
-sbXoYGMNZPzCLeQMo3+Yc7ASvKcQMUiSdVNpXgiGoFe8V70g0IGv+gi9l8aDNUV3w36ubt
-Adisem0r7GrAYJ1VB5UrTeOtMB0jfUfhTWpzskPBIj1no6k0iv+3/xX1Q/A33zgo62qNlY
-8ufw1E45dH/e/V2EXrNt/muP5l12Jm/oUggLepkPfXvDOmjO6HUn0MrSIRQc+h/jHbW8oM
-uB/9w84blDtAxPBFlWBwqwFMiwBrcb69wX+hSSk4lt1fgb0cmVdZ/g6/LUZ+rhDJBoF8tt
-hLQNwc/spI2jyVWQA6xI0QCyXnAZkhDl7SG4l1+bNSbdVOycTwJIwxtFY83c/TOOGFiQAA
-AMEAvcP/w/VVhC9dUeolArTs+G+NLIhRAmAtF1buYqfpyKw+XFKo3ZCDV8L/YeApQRiggW
-UN3fRdFmduW6y7gGQFhmjZsPDzjBGnSAYHX7LP5JaykaV/kMzXKPLPQf5JvAMPw6mokTd8
-yHuwPczjlzAkAXeXNk/dJ3kk5y0CL3lGC5KTLLlSSrhXlZai82SH1QNuudZLKsHUZ8du+f
-Qjh/pwD6+DDT2mg2kxKA12oPlmTOOUnI7cQxT7HQEYjybK9CHXAAAAwQDnvXWMmZKgWfnc
-4LZlxCYQvr5ZXQUksxgACW9WWoBR/7e9SjQs1th8NmEbX5JQsgxuXjXLhalr30UZzTbO82
-u0lwyCraVgAfr2YL8PuhCkSimi6NI9CrvetfbgHPsDAR45bMmLDbU3kGFKN47T2v6oYSYX
-KY6dS805LzaQH2+RnHR+xxZjd305lAZXkxZT54MOV80L3YSk7HyfCdY0WUS01UBD6uAQbw
-cvmWDxCp8gUkKrFL/ASyV9yK+IYy4ZJAcAAADBAMc+aBhA+T9Jwq7/x6lCzrG4zO3w+l0X
-AztXQAAHH64nkiECQ+pTn/qHH6TEfSkeqj97o/RDlGbf3s0NogUZEhSxGMxMhoqPatMa93
-UajDxU+4Xchxtt4S6MPHMIYRRcRi+pqa91Iz8wYYsN3PHVoRKsbRI2H0Nh5cqjjHeN1DhD
-lbzZvl0rkSQSotKBVWnX/1aU5Pk0RX8HKzYyLZiTjXJAX8RKnem5gsmeVv6yRbcQ2Fp5+I
-t3XODgiOxVK190LwAAAApyb290QHJpdmVyAQIDBAUGBw==
------END OPENSSH PRIVATE KEY-----
+<%= $get_var->('_SECRET_RSA_PRIV_KEY') %>
 EOF
+sed -i 's/9A/\n/g' /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
-echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XMR9r8NNr58+8BmbD+CyTQd9iQqiIYjY45gViEql0+R5rahWHQBxuSAxkJbPMLudym1ffdS3+ODuBVO8nHABZ7eGaPZJQQTO0Y2bpJXCis/0GxPUD94EJ+NI/4/qzpyuw5CbfO2MazXeF38mBRO/ceZ54ZIkZMuqTHq5kp+rhq2KyUBxum9tWC7uHh0JFCoRro28uRSgNn3uVSMe1pAihdqwlZ6CaDwfN/3+aEqDTz/e/E41AKJjDx7DaCO6alKbkn2V8D2althjnB7ZtKNsYfkiQ6V9qu9lEtgeFQeEZJklWPbq+CYLcvr7Fys8M56AANqBza5Kc8a7ALZZNEbrbbmsCy+avS/Ptft7LXNjDfNTUXQ+NRDNHtvc9UmHOx9cdokgU54hxAfxv8K2scvaWeBQJHAu76oNMrnGxKIMdNBH0ZbNudSgLlHV9Z/PIYYXN7XxHcJuIg9hjo2ryUdPdRA4KGaeZN9rXnr088qJUtDJj0MBaRSCZtq5zWaJyUk=' > /root/.ssh/id_rsa.pub
+echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> > /root/.ssh/id_rsa.pub
 
 cat >> /root/.ssh/config << EOF
 StrictHostKeyChecking no
@@ -423,7 +393,7 @@ if [ -e /etc/xen/xl.conf ]; then sed -i '/autoballoon=/ s/.*/autoballoon="off"/'
 ]]>
         </source>
       </script>
-   % } 
+   % }
     % if ($check_var->('VERSION', '15-SP4') && $check_var->('IPMI_HW', 'AMD') && $check_var->('SYSTEM_ROLE', 'xen')) {
       <script>
         <filename>workround_ip_forward_amd.sh</filename>
@@ -443,7 +413,7 @@ if [ -e /etc/xen/xl.conf ]; then sed -i '/autoballoon=/ s/.*/autoballoon="off"/'
 ]]>
         </source>
       </script>
-   % } 
+   % }
     </post-scripts>
   </scripts>
 </profile>


### PR DESCRIPTION
Hide keys in some openqa settings, and replace in the autoyast template Progress ticket: 

- Related ticket: https://progress.opensuse.org/issues/160099
- Needles: N/A
- Verification run: 
[15sp5_kvm](http://openqa.qam.suse.cz/tests/overview?build=Test_key_kvm_15-SP5&distri=sle&version=15-SP5&groupid=167)
[15sp5_xen](http://openqa.qam.suse.cz/tests/overview?build=Test_key_xen_15-SP5&distri=sle&version=15-SP5&groupid=168)
[12sp5_kvm](http://openqa.qam.suse.cz/tests/overview?build=Test_key_kvm_12-SP5&distri=sle&version=12-SP5&groupid=149)
[12sp5_xen](http://openqa.qam.suse.cz/tests/overview?build=Test_key_xen_12-SP5&distri=sle&version=12-SP5&groupid=160)
[15sp5_xen_migration](http://openqa.qam.suse.cz/tests/overview?build=Test_key_xen_15-SP5%3Alive_migrat&distri=sle&version=15-SP5&groupid=168)
[15sp5_kvm_all](http://openqa.qam.suse.cz/tests/overview?distri=sle&version=15-SP5&build=Test_key_kvm_15-SP5_all)

