### PR TITLE
[WIP]Add openSUSEway test

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -167,6 +167,7 @@ sub load_otherDE_tests {
         if ($de =~ /^enlightenment$/) { load_enlightenment_tests(); }
         if ($de =~ /^mate$/) { load_mate_tests(); }
         if ($de =~ /^lxqt$/) { load_lxqt_tests(); }
+        if ($de =~ /^sway/) { load_sway_tests(); }
         load_shutdown_tests;
         return 1;
     }
@@ -188,6 +189,10 @@ sub load_lxqt_tests {
 
 sub load_mate_tests {
     loadtest "x11/mate_terminal";
+}
+
+sub load_sway_tests {
+    loadtest "x11/configure_sway";
 }
 
 sub install_online_updates {

--- a/schedule/sway.yaml
+++ b/schedule/sway.yaml
@@ -1,0 +1,15 @@
+name:           test sway
+description:    >
+    Tests sway
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/hostname
+  - update/zypper_clear_repos
+  - console/install_sway_pattern
+  - console/consoletest_finish
+  - x11/sway_reconfigure_openqa
+  - x11/reboot_icewm
+  - console/configure_sway
+  - shutdown/shutdown

--- a/tests/x11/configure_sway.pm
+++ b/tests/x11/configure_sway.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright 2012-2016 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Framework to test other Desktop Environments
+#    Non-Primary desktop environments are generally installed by means
+#    of a pattern. For those tests, we assume a minimal-X based installation
+#    where the pattern is being installed on top.
+# Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
+use base "consoletest";
+use serial_terminal 'select_serial_terminal';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use power_action_utils 'power_action';
+
+sub run {
+    my ($self) = @_;
+    select_serial_terminal;
+
+    script_run("mkdir -p ~/.config/sway");
+    script_run("cp /etc/sway/config ~/.config/sway/");
+    zypper_call("in dmenu");
+    assert_script_run(qq(sed -i "s/^set \$menu/set \$menu dmenu_path | dmenu -nb '#173f4f' -sb '#35b9ab' -nf '#73ba25' -sf '#173f4f' -fn 'Source Sans Pro-14' | xargs swaymsg exec --/" ~/.config/sway/config));
+    script_run('echo -e "[Desktop]\\nSession=sway" > ~/.dmrc');
+    power_action('reboot', textmode => 1);
+    $self->wait_boot;
+    send_key("super-d");
+    assert_screen 'sway-menu-bar';
+}
+
+1;

--- a/tests/x11/sway_reconfigure_openqa.pm
+++ b/tests/x11/sway_reconfigure_openqa.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Other Desktop Environments: sway
+#          Update the openQA internal configuration after the DE has been installed
+# Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    
+    set_var('DESKTOP', 'sway');
+    
+    set_var('DISPLAYMANAGER', 'lightdm');
+    set_var('DM_NEEDS_USERNAME', 0);
+    
+    $self->result('ok');
+}
+
+1;


### PR DESCRIPTION
Duplicate of this [test](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/sway/sway.pm)
This is one installing the pattern openSUSEway instead of stock sway.

- Related ticket: https://progress.opensuse.org/issues/158700
- Verification run: https://openqa.opensuse.org/tests/overview/?build=cedvid%2Fos-autoinst-distri-opensuse%2319333
