### PR TITLE
containers: Run checks for podman-remote unconditionally

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -96,7 +96,7 @@ sub run {
     run_tests(rootless => 1, remote => 0, skip_tests => get_var('PODMAN_BATS_SKIP_USER_LOCAL', ''));
 
     # user / remote
-    run_tests(rootless => 1, remote => 1, skip_tests => get_var('PODMAN_BATS_SKIP_USER_REMOTE', '')) if (script_run('which podman-remote') == 0);
+    run_tests(rootless => 1, remote => 1, skip_tests => get_var('PODMAN_BATS_SKIP_USER_REMOTE', ''));
 
     select_serial_terminal;
     assert_script_run("cd $test_dir/podman-$podman_version/");
@@ -105,7 +105,7 @@ sub run {
     run_tests(rootless => 0, remote => 0, skip_tests => get_var('PODMAN_BATS_SKIP_ROOT_LOCAL', ''));
 
     # root / remote
-    run_tests(rootless => 0, remote => 1, skip_tests => get_var('PODMAN_BATS_SKIP_ROOT_REMOTE', '')) if (script_run('which podman-remote') == 0);
+    run_tests(rootless => 0, remote => 1, skip_tests => get_var('PODMAN_BATS_SKIP_ROOT_REMOTE', ''));
 }
 
 sub cleanup() {


### PR DESCRIPTION
The remote tests must be run unconditionally to fail loudly if `podman-remote` is unavailable.  The which was added to test SLM 6.0 but it now has podman-remote in the repos (https://bugzilla.suse.com/show_bug.cgi?id=1224050 was fixed).

If we ever need this skip this again we can now set `PODMAN_BATS_SKIP_USER_REMOTE=all` & `PODMAN_BATS_SKIP_ROOT_REMOTE=all`.

Verification run: Not needed as the products we test all have podman-remote:
- Tumbleweed: https://openqa.opensuse.org/tests/4205756#downloads
- 15-SP4: https://openqa.suse.de/tests/14375765#downloads
- 15-SP5: https://openqa.suse.de/tests/14376616#downloads
- 15-SP6: https://openqa.suse.de/tests/14375888#downloads
- SLEM 5.5 https://openqa.suse.de/tests/14374587#downloads
