### PR TITLE
FIX: Github workflows 

### DIFF
--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -1,5 +1,6 @@
 ---
 # yamllint disable-line rule:truthy
+name: checklist
 on: [pull_request_target]
 jobs:
   checklist_job:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on: [push, pull_request_target]
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -7,6 +7,10 @@ on:
   # The difference is that this runs always with the context of the master
   # branch. This is necessary to allow accessing the API credential secrets.
   workflow_dispatch:
+  workflow_run:
+    workflows: [checklist ci]
+    types:
+      - completed
 env:
   OPENQA_HOST: ${{ vars.OPENQA_URL }}
   OPENQA_API_KEY: ${{ secrets.OPENQA_API_KEY }}
@@ -18,6 +22,7 @@ env:
 jobs:
   trigger_and_monitor_openqa:
     runs-on: ubuntu-latest
+    environment: manual_approval
     container:
       image: registry.opensuse.org/devel/openqa/containers/tumbleweed:client
     steps:
@@ -44,6 +49,7 @@ jobs:
           CASEDIR="$GITHUB_SERVER_URL/$GH_REPO.git#$GH_REF"
   clone_mentioned_job:
     runs-on: ubuntu-latest
+    environment: manual_approval
     container:
       image: registry.opensuse.org/devel/openqa/containers/tumbleweed:client
     steps:


### PR DESCRIPTION
Add dependency between ci.yaml and openqa.yml
Add manual approval deployment enviroment to openqa.yml

https://progress.opensuse.org/issues/160430

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
