### PR TITLE
containers: Call remove_mounts_conf in BATS buildah test

### DIFF
--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules);
+use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules remove_mounts_conf);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -49,6 +49,8 @@ sub run {
     install_packages(@pkgs);
 
     delegate_controllers;
+
+    remove_mounts_conf;
 
     switch_cgroup_version($self, 2);
 


### PR DESCRIPTION
Call remove_mounts_conf in BATS buildah test

Failing test: https://openqa.suse.de/tests/14368044/logfile?filename=serial_terminal.txt

```
# time="2024-05-20T08:31:42-04:00" level=warning msg="Failed to mount subscriptions, skipping entry in /etc/containers/mounts.conf: open /etc/zypp/credentials.d/SCCcredentials: permission denied"
```

- Verification run:
  - sle-15-SP6-Online-x86_64-Build92.1-buildah_testsuite@64bit -> https://openqa.suse.de/t14402014 
 
Note: VR failing for other reason (`# Fatal glibc error: CPU does not support x86-64-v2`) but error message above not present.