### PR TITLE
Add JUnit ansible output to qesap regression

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -193,6 +193,7 @@ sub sles4sap_cleanup {
         for (1 .. 3) {
             my @cleanup_cmd_rc = qesap_execute(
                 verbose => '--verbose',
+                logname => join('_', 'qesap', $command, 'destroy', $_, 'log.txt'),
                 cmd => $command,
                 cmd_options => '-d',
                 timeout => 1200

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -438,9 +438,17 @@ Deploy a SAP Landscape using a previously configured qe-sap-deployment
 =cut
 
 sub cluster_deploy {
-    my @ret = qesap_execute(cmd => 'terraform', verbose => 1, timeout => bmwqemu::scale_timeout(1800));
+    my @ret = qesap_execute(
+        cmd => 'terraform',
+        verbose => 1,
+        timeout => bmwqemu::scale_timeout(1800),
+        logname => 'terraform.log.txt');
     die "'qesap.py terraform' return: $ret[0]" if ($ret[0]);
-    @ret = qesap_execute(cmd => 'ansible', verbose => 1, timeout => bmwqemu::scale_timeout(3600));
+    @ret = qesap_execute(
+        cmd => 'ansible',
+        verbose => 1,
+        timeout => bmwqemu::scale_timeout(3600),
+        logname => 'ansible.log.txt');
     die "'qesap.py ansible' return: $ret[0]" if ($ret[0]);
     my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
     upload_logs($inventory);
@@ -452,9 +460,17 @@ Destroy the qe-sap-deployment SAP Landscape
 =cut
 
 sub cluster_destroy {
-    my @ret = qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => bmwqemu::scale_timeout(300));
+    my @ret = qesap_execute(
+        cmd => 'ansible', cmd_options => '-d',
+        verbose => 1,
+        timeout => bmwqemu::scale_timeout(300),
+        logname => 'ansible_destroy.log.txt');
     die "'qesap.py ansible -d' return: $ret[0]" if ($ret[0]);
-    @ret = qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => bmwqemu::scale_timeout(3600));
+    @ret = qesap_execute(
+        cmd => 'terraform', cmd_options => '-d',
+        verbose => 1,
+        timeout => bmwqemu::scale_timeout(3600),
+        logname => 'terraform_destroy.log.txt');
     die "'qesap.py terraform -d' return: $ret[0]" if ($ret[0]);
 }
 

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -35,7 +35,11 @@ sub run {
     $run_args->{ansible_present} = $self->{ansible_present} = 1;
     # skip ansible deployment in case of reusing infrastructure
     unless (get_var('QESAP_DEPLOYMENT_IMPORT')) {
-        my @ret = qesap_execute(cmd => 'ansible', timeout => 3600, verbose => 1);
+        my @ret = qesap_execute(
+            cmd => 'ansible',
+            logname => 'qesap_exec_ansible.log.txt',
+            timeout => 3600,
+            verbose => 1);
         if ($ret[0]) {
             if (check_var('IS_MAINTENANCE', '1')) {
                 die("TEAM-9068 Ansible failed. Retry not supported for IBSM updates\n ret[0]: $ret[0]");

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -155,7 +155,13 @@ sub run {
 
     # Regenerate config files (This workaround will be replaced with full yaml generator)
     qesap_prepare_env(provider => $provider_setting, only_configure => 1);
-    my @ret = qesap_execute_conditional_retry(cmd => 'terraform', verbose => 1, timeout => 3600, retries => 2, error_string => 'An internal execution error occurred. Please retry later');
+    my @ret = qesap_execute_conditional_retry(
+        cmd => 'terraform',
+        logname => 'qesap_exec_terraform.log.txt',
+        verbose => 1,
+        timeout => 3600,
+        retries => 2,
+        error_string => 'An internal execution error occurred. Please retry later');
     die 'Terraform deployment FAILED. Check "qesap*" logs for details.' if ($ret[0]);
 
     $provider->terraform_applied(1);

--- a/tests/sles4sap/qesapdeployment/destroy.pm
+++ b/tests/sles4sap/qesapdeployment/destroy.pm
@@ -13,9 +13,19 @@ use qesapdeployment;
 
 sub run {
     select_serial_terminal;
-    my @ansible_ret = qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
+    my @ansible_ret = qesap_execute(
+        cmd => 'ansible',
+        cmd_options => '-d',
+        logname => 'qesap_exec_ansible_destroy.log.txt',
+        verbose => 1,
+        timeout => 300);
     qesap_cluster_logs() if ($ansible_ret[0]);
-    my @terraform_ret = qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1800);
+    my @terraform_ret = qesap_execute(
+        cmd => 'terraform',
+        cmd_options => '-d',
+        logname => 'qesap_exec_terraform_destroy.log.txt',
+        verbose => 1,
+        timeout => 1800);
     die "'qesap.py ansible -d' return: $ansible_ret[0]" if ($ansible_ret[0]);
     die "'qesap.py terraform -d' return: $terraform_ret[0]" if ($terraform_ret[0]);
 }

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -91,8 +91,18 @@ sub post_fail_hook {
             qesap_aws_delete_transit_gateway_vpc_attachment(name => qesap_calculate_deployment_name('qesapval') . '*');
         }
     }
-    qesap_execute(cmd => 'ansible', cmd_options => '-d', verbose => 1, timeout => 300);
-    qesap_execute(cmd => 'terraform', cmd_options => '-d', verbose => 1, timeout => 1200);
+    qesap_execute(
+        cmd => 'ansible',
+        cmd_options => '-d',
+        logname => 'qesap_exec_ansible_destroy.log.txt',
+        verbose => 1,
+        timeout => 300);
+    qesap_execute(
+        cmd => 'terraform',
+        cmd_options => '-d',
+        logname => 'qesap_exec_terraform_destroy.log.txt',
+        verbose => 1,
+        timeout => 1200);
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Add the gluescript argument to generate JUnit Ansible report and add openQA code to consume and present it.
Enable it only for the main Ansible qesap_exec of the qesap regression test.
Simplify the qesap_exec internals making `logname` as mandatory and removing the algorithm to calculate it.

:warning: this PR needs qe-sap-deployment version greater or equal than 0.26.0


- Related ticket: TEAM-6844

# Verification

##  qesap regression

### 15-SP6

#### SBD
 sle-15-SP6-Qesap-Azure-Byos-Ibs-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS_IBS-qesap_azure_uri@az_Standard_E8s_v3 

 #####  http://openqaworker15.qa.suse.cz/tests/283546 :green_circle: 

Job is failing (known issue) but features or interest are working:
- ansible is called with the new `--junit` argument
- openQA "slurps" the result and present it properly in http://openqaworker15.qa.suse.cz/tests/283546#external
- the mandatory argument `logname` is configured and result in logs creation like http://openqaworker15.qa.suse.cz/tests/283546/logfile?filename=configure-qesap_configure.log.txt http://openqaworker15.qa.suse.cz/tests/283546/logfile?filename=deploy-qesap_exec_terraform.log.txt http://openqaworker15.qa.suse.cz/tests/283546/logfile?filename=deploy-qesap_exec_ansible.log.txt http://openqaworker15.qa.suse.cz/tests/283546/logfile?filename=deploy-qesap_exec_terraform_destroy.log.txt http://openqaworker15.qa.suse.cz/tests/283546/logfile?filename=deploy-qesap_exec_ansible_destroy.log.txt
- the old Ansible error detection keeps working as before http://openqaworker15.qa.suse.cz/tests/283546#step/deploy/104

#### Native fencing
sle-15-SP6-Qesap-Azure-Byos-Ibs-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS_IBS-qesap_azure_uri@az_Standard_E8s_v3
##### http://openqaworker15.qa.suse.cz/tests/283545 :green_circle: 
 Job is failing but here the point is that all the qesap.py (only `configure` and `terraform` in this job) are properly generated and uploaded. Build fails as the conf.yaml is not one support `os_uri`.

### 15-SP5
 
 ##### http://openqaworker15.qa.suse.cz/tests/283547 :green_circle: 
sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sbd_test@64bit 

- the http://openqaworker15.qa.suse.cz/tests/283547#external report is generated also in case of pass ( :red_circle: order does not reflect the execution order but it is quite like something internal in openQA)
- new log filename are there 

##### http://openqaworker15.qa.suse.cz/tests/283548 :green_circle: 
sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit -> 

## HanaSR
This PR does not add `--junit` to any HanaSR tests, but VR are executed to validate the lib changes that has impact on HanaSR tests too

### 15-SP5

 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-05-21T04:03:14Z-hanasr_azure_test_msi@64bit 

##### http://openqaworker15.qa.suse.cz/tests/283550 :green_circle: 

logs filename are properly composed, http://openqaworker15.qa.suse.cz/tests/283550/logfile?filename=deploy_qesap_ansible-qesap_exec_ansible.log.txt

 
### 15-SP3

 - sle-15-SP3-HanaSr-Azure-Byos-x86_64-Build15-SP3_2024-05-21T04:03:14Z-hanasr_azure_test_msi@64bit 

##### http://openqaworker15.qa.suse.cz/tests/283549 :green_circle: 