### PR TITLE
Fix the regession issue cause by pr#19326

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -676,7 +676,7 @@ sub pre_run_hook {
         assert_script_run q|sed -i -e '/^include \"\/etc\/named.conf.include\";/ s/^/#/' /etc/named.conf|;
     }
 
-    assert_script_run q|sed -i -e '/^include \"\/etc\/named.d\/openqa.zones\";/ s/^/#/' /etc/named.conf|;
+    assert_script_run q|sed -i -e '/^include \"\/etc\/named.d\/openqa.zones\";/ s/^/#/' /etc/named.conf| unless (script_run q|grep -E "^include \"/etc/named.d/openqa.zones\";" /etc/named.conf|);
     $self->SUPER::pre_run_hook;
 }
 


### PR DESCRIPTION
For some supportserver cases, the 'dns' is not needed, there is no `/etc/named.conf`. So we need to check before doing `sed`.

Related: https://github.com/os
-autoinst/os-autoinst-distri-opensuse/pull/19326

VR: 
https://openqa.suse.de/tests/14411116#
https://openqa.suse.de/tests/14411118#