### PR TITLE
Workaround to remove python3-argcomplete before migration

### DIFF
--- a/tests/migration/online_migration/zypper_patch.pm
+++ b/tests/migration/online_migration/zypper_patch.pm
@@ -41,6 +41,14 @@ sub run {
         modify_kernel_multiversion("disable");
     }
     workaround_bsc_1220091;
+    # Workaround of bsc#1224249, remove python3-argcomplete-1.9.2-150000.3.8.1 before migration
+    # because the higher python3-argcomplete version is not synced to SLES15SP6 update channel yet
+    # It will be only few weeks after the GM, will remove this workaround then
+    my $pkg = 'python3-argcomplete-1.9.2-150000.3.8.1';
+    if ((check_var("MIGRATION_METHOD", "zypper")) && (script_run("rpm -q $pkg")) == 0) {
+        record_soft_failure "Workaround for bsc#1224249: remove $pkg before migration";
+        zypper_call("rm $pkg");
+    }
     cleanup_disk_space if get_var('REMOVE_SNAPSHOTS');
     power_action('reboot', keepconsole => 1, textmode => 1);
     reconnect_mgmt_console if is_pvm;


### PR DESCRIPTION
This is a workaround for bsc#1224249, that is to remove package of
python3-argcomplete-1.9.2-150000.3.8.1 before migraiton, becuase the 
higher python3-argcomplete version 1.9.2-150000.3.8.1 is not synced
to SLES15SP6 update channel yet, which caused a failure when doing 
zypper migration. We will remove this workaround when the package is
synced to 15SP6 update channel after GM.

- Related ticket: n/a
- Needles: n/a
- Verification run: 
- https://openqa.suse.de/tests/14413370#step/zypper_patch/21  (To verify zypper migration)
- https://openqa.suse.de/tests/14413371#step/zypper_patch/16  (To confirm it doesn't affect yast2 migration jobs)
