### PR TITLE
Support new hotkeys in SAP Installation Wizard in 15-SP5

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -85,7 +85,7 @@ sub run {
     send_key 'alt-s';    # SAP SID
     send_key_until_needlematch 'sap-wizard-sid-empty', 'backspace' if check_var('DESKTOP', 'textmode');
     type_string $sid;
-    if (is_sle('>=15-SP6')) {
+    if (is_sle('>=15-SP5')) {
         wait_screen_change { send_key 'alt-p' };    # SAP Password
     } else {
         wait_screen_change { send_key 'alt-a' };    # SAP Password


### PR DESCRIPTION
Now the SAP Installation Wizard vesion in 15-SP5 also uses the same hot keys as the version in 15-SP6, so we need to update the test to take this into account.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qe.nue2.suse.org/tests/5838
