### PR TITLE
nfs: Incease test timeout

### DIFF
--- a/tests/network/nfs.pm
+++ b/tests/network/nfs.pm
@@ -33,7 +33,7 @@ sub nfs_test {
       = qw(nfs_start_stop nfs_mount_umount nfs_read nfs_write nfs_dontwrite nfs_usermapping_rootsquash nfs_usermapping_norootsquash nfs_usermapping_allsquash);
     foreach my $test_case (@test_cases) {
         record_info("$nfs_ver: $test_case");
-        assert_script_run("/usr/share/qa/qa_test_nfs/run-wrapper.sh $test_case.sh $nfs_ver", timeout => 300);
+        assert_script_run("/usr/share/qa/qa_test_nfs/run-wrapper.sh $test_case.sh $nfs_ver", timeout => 400);
     }
 }
 


### PR DESCRIPTION
test is slightly slower, but is not failing

- Related ticket: https://progress.opensuse.org/issues/160706
- Verification run:
https://openqa.suse.de/tests/14414376
https://openqa.suse.de/tests/14414377