### PR TITLE
Add test for crypto-policies switching and sshd configuration

### DIFF
--- a/schedule/security/crypto_policies.yaml
+++ b/schedule/security/crypto_policies.yaml
@@ -1,0 +1,8 @@
+name: crypto_policies
+description: >
+    This is for crypto-policies testing
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - security/crypto_policies/crypto_policies_setup
+    - security/crypto_policies/crypto_policies_sshd

--- a/tests/security/crypto_policies/crypto_policies_setup.pm
+++ b/tests/security/crypto_policies/crypto_policies_setup.pm
@@ -1,0 +1,28 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Setup system for crypto-policies testing, basic smoke tests
+# Maintainer: QE Security <none@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+
+sub run {
+    my ($self) = @_;
+    select_serial_terminal;
+    zypper_call 'in crypto-policies crypto-policies-scripts';
+    validate_script_output('update-crypto-policies --show', sub { m/DEFAULT/ });
+    #try to set a fake non existent policy, should give error
+    my $msg = script_output('update-crypto-policies --set FOOBAR', proceed_on_failure => 1);
+    die unless ($msg =~ m/not found/);
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/security/crypto_policies/crypto_policies_sshd.pm
+++ b/tests/security/crypto_policies/crypto_policies_sshd.pm
@@ -1,0 +1,43 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Switch crypto-policies, reboot and verify sshd is running
+# Maintainer: QE Security <none@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use power_action_utils 'power_action';
+use Utils::Backends 'is_pvm';
+use Utils::Architectures;
+
+sub run {
+    my ($self) = @_;
+    select_serial_terminal;
+    systemctl 'enable --now sshd.service';
+    for my $policy ('LEGACY', 'BSI', 'FUTURE', 'DEFAULT') {
+        $self->set_policy($policy);
+        # check the service is running after policy change
+        validate_script_output 'systemctl status sshd.service', sub { m/active \(running\)/ };
+    }
+}
+
+sub set_policy {
+    my ($self, $policy) = @_;
+    assert_script_run "update-crypto-policies --set $policy";
+    power_action('reboot', textmode => 1);
+    reconnect_mgmt_console if is_pvm();
+    $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
+    select_serial_terminal;
+    # ensure the current policy has been applied
+    validate_script_output 'update-crypto-policies --show', sub { m/$policy/ };
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;


### PR DESCRIPTION
This is a new test part of a series for covering [crypto-policies](https://en.opensuse.org/SDB:Crypto-policies). 

- Related ticket: https://progress.opensuse.org/issues/159897
- Needles: no
- Verification runs:
  - https://openqa.suse.de/tests/14414457
  - https://openqa.suse.de/tests/14414458
  - https://openqa.suse.de/tests/14414459
