### PR TITLE
Fix python3 setuptools in 15-SP6

### DIFF
--- a/tests/console/python3_setuptools.pm
+++ b/tests/console/python3_setuptools.pm
@@ -55,7 +55,7 @@ sub run_tests ($python3_spec_release) {
 
 # Creating the source package with the name 'dist/user_package_setuptools-1.0.tar.gz' in the dist folder.
 sub build_package ($python_binary) {
-    assert_script_run("$python_binary -m venv myenv");
+    assert_script_run("$python_binary -m venv myenv --system-site-packages");
     assert_script_run("source myenv/bin/activate");
     assert_script_run("$python_binary setup.py sdist ");
     validate_script_output("ls", sub { m/dist/ });


### PR DESCRIPTION
Test in 15-SP6 is  failing due to  the default behavior. Its now fixed by using the system installed version creating the virtualenv with:

 $ python-version -m venv myenv --system-site-packages

- Related ticket: https://progress.opensuse.org/issues/160568
- Needles: NO
- Verification run: 