### PR TITLE
pc: Use common VPC for uploading in EC2

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -130,6 +130,27 @@ sub upload_img {
     my $vpc_subnet = get_var('PUBLIC_CLOUD_EC2_UPLOAD_VPCSUBNET');
     my $instance_type = get_required_var('PUBLIC_CLOUD_EC2_UPLOAD_INSTANCE_TYPE');
 
+    if (!$sec_group) {
+        $sec_group = script_output("aws ec2 describe-security-groups --output text "
+              . "--region " . $self->provider_client->region . " "
+              . "--filters 'Name=group-name,Values=tf-sg' "
+              . "--query 'SecurityGroups[0].GroupId'"
+        );
+    }
+    if (!$vpc_subnet) {
+        my $vpc_id = script_output("aws ec2 describe-vpcs --output text "
+              . "--region " . $self->provider_client->region . " "
+              . "--filters 'Name=tag:Name,Values=tf-vpc' "
+              . "--query 'Vpcs[0].VpcId'"
+        );
+        # Grab subnet with CidrBlock defined in https://gitlab.suse.de/qac/infra/-/blob/master/aws/tf/main.tf
+        $vpc_subnet = script_output("aws ec2 describe-subnets --output text "
+              . "--region " . $self->provider_client->region . " "
+              . "--filters 'Name=vpc-id,Values=$vpc_id' 'Name=cidr-block,Values=10.11.4.0/22' "
+              . "--query 'Subnets[0].SubnetId'"
+        );
+    }
+
     # ec2uploadimg will fail without this file, but we can have it empty
     # because we passing all needed info via params anyway
     assert_script_run('echo " " > /root/.ec2utils.conf');

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -159,7 +159,7 @@ sub upload_img {
           . "--backing-store ssd "
           . "--grub2 "
           . "--machine '" . $img_arch . "' "
-          . "-n '" . $self->prefix . '-' . $img_name . "' "
+          . "-n '" . $self->prefix . 'testit-' . $img_name . "' "
           . "--virt-type hvm --sriov-support "
           . (is_byos() ? '' : '--use-root-swap ')
           . '--ena-support '

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -32,7 +32,7 @@ sub run {
 
     if (my $img_id = $provider->find_img($img_name)) {
         record_info('Info', "Image $img_id already exists!");
-        return;
+        #return;
     }
 
     # Download the given image via wget. Note that by default wget retries 20 times before giving up


### PR DESCRIPTION
Use pre-created "tf-vpc" VPC when uploading images to EC2.  This avoids creating new VPC's, thus avoiding the `maximum number of VPCs has been reached` error.

- Related ticket: https://progress.opensuse.org/issues/158323
- Verification run: https://openqa.suse.de/tests/14423487

Note: VR tested with deleted commit:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/0b38c31e1d36cc721d07bd00c2917fbebb1d9861..39a19e5171b3deb76e8afe540805cc2ef5c9644e