### PR TITLE
Enlarge welcome timeout value on s390x

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -117,7 +117,7 @@ sub run {
     while ($iterations++ < scalar(@welcome_tags)) {
         # See poo#19832, sometimes manage to match same tag twice and test fails due to broken sequence
         wait_still_screen 5;
-        my $timeout = is_aarch64 || is_ppc64le ? '1000' : '500';
+        my $timeout = is_aarch64 || is_ppc64le || is_s390x ? '1000' : '500';
         assert_screen(\@welcome_tags, $timeout);
         # Normal exit condition
         if (match_has_tag 'local-registration-server') {


### PR DESCRIPTION
Sometimes it is not enough time to update installer on s390x, so need enlarge the timeout value.

Failed job: https://openqa.suse.de/tests/14419377#step/welcome/21

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/14421334#step/welcome/6
