### PR TITLE
Fix the problem of linux login during guest poweron

### DIFF
--- a/tests/installation/add_serial_console.pm
+++ b/tests/installation/add_serial_console.pm
@@ -33,8 +33,8 @@ sub run {
     assert_script_run('sed -ie \'s/GRUB_TERMINAL.*//\' /etc/default/grub');
     # VMware needs to always stop in Grub and wait for interaction.
     # Migration seems to reset it.
-    if (get_var('KEEP_GRUB_TIMEOUT')) {
-        assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=8/\' /etc/default/grub');
+    if (get_var('GRUB_TIMEOUT')) {
+        assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=' . get_var('GRUB_TIMEOUT') . '/\' /etc/default/grub');
     } else {
         assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub');
     }


### PR DESCRIPTION
Fix the needle match failure for open-vm-tools tests - https://openqa.suse.de/tests/14384793#step/esxi_open_vm_tools/61

- Related ticket: https://progress.opensuse.org/issues/159081
- Verification run: https://openqa.suse.de/tests/14423446
