### PR TITLE
Add master node check

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -83,6 +83,11 @@ sub run {
     $self->wait_for_cluster(wait_time => 60, max_retries => 10);
     die "Required hana resource is NOT running on $self->{my_instance}, aborting" unless $self->is_hana_resource_running();
     $self->display_full_status();
+    if ($self->get_promoted_hostname() eq $target_site->{instance_id}) {
+        die(uc($site_name) . " '$target_site->{instance_id}' is in MASTER mode, when it shouldn't be.");
+    } else {
+        record_info("MASTER CHECK", "'$target_site->{instance_id}' is NOT master, as expected");
+    }
 
     record_info('Done', 'Test finished');
 }


### PR DESCRIPTION
Adds check about the state of the master node in the end of the `hana_sr_takeover` module. If the master node is the same as in the beginning of the module, the test fails.

- Related ticket: https://jira.suse.com/browse/TEAM-9214
- Verification run: https://openqa.suse.de/tests/14414267#step/Stop_site_a-primary/650 (**PASS** - issue is too sporadic to reproduce)
