### PR TITLE
xfstests: Set XFSTESTS_KNOWN_ISSUES variable

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -410,6 +410,7 @@ XFSTESTS_RANGES | string | | sub-tests ranges. This setting is mandatory. Suppor
 NO_SHUFFLE | boolean | 0 | the default sequence to run all subtests is a random sequence, it's designed to reduce the influence between each subtest. Set NO_SHUFFLE=1 to run in order
 XFSTESTS_BLACKLIST | string | | set the sub-tests will not run. Mostly use in the feature not supported, and exclude some critical issues to make whole tests stable. The final skip test list will also count those defined in XFSTESTS_GROUPLIST. It's also support "-" and "," to set skip range
 XFSTESTS_GROUPLIST | string | | it's an efficient way to set XFSTESTS_RANGES. Most likely use in test whole range in a single test, such as test special mount option. The range is supported in xfstests upstream, to know the whole range of group names could take a look at xfstests upstream README file. This parameter in openqa supports not only "include" tests, but also "exclude" tests. To add a "!" before a group name to exclude all subtests in that group. Here is an example: e.g. XFSTESTS_GROUPLIST=quick,!fuzz,!fuzzers,!realtime (Add all subtests in quick group, and exclude all dangerous subtests in fuzz, fuzzers, realtime groups)
+XFSTESTS_KNOWN_ISSUES | string | | Used to specify a url for a json file with well known xfstests issues. If an error occur which is listed, then the result is overwritten with softfailure.
 
 
 Run-time related: timeout control to avoid random fails when low performance


### PR DESCRIPTION
Implemented according to LTP_KNOWN_ISSUES
e.g.
XFSTESTS_KNOWN_ISSUES=https://openqa.suse.de/xfstests_known_issues.json If an error occur which is listed in json file,  then the result marded as SOFTFAIL.

- Related ticket: https://progress.opensuse.org/issues/158152
- Needles: N/A
- Verification run: http://10.67.133.133/tests/659
- https://openqa.suse.de/tests/14440494 (QAM)
