### PR TITLE
Change waiting time for grub2

### DIFF
--- a/data/yam/autoyast/autoyast_scc_up.xml
+++ b/data/yam/autoyast/autoyast_scc_up.xml
@@ -8,7 +8,7 @@
       <boot_mbr>true</boot_mbr>
       <boot_root>true</boot_root>
       <generic_mbr>false</generic_mbr>
-      <timeout config:type="integer">-1</timeout>
+      <timeout config:type="integer">10</timeout>
     </global>
     <loader_type>{{LOADER_TYPE}}</loader_type>
   </bootloader>


### PR DESCRIPTION
It is not work for migration test via autoyast, so we need set a suitable value for the wait time for grub2 in profile.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/14422280#details  Migration test via autoyast
  https://openqa.suse.de/tests/14422367#  Interactive migration test
