### PR TITLE
xfstests: Remove old qa-head repo before add new

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -31,6 +31,7 @@ my @PACKAGES = (qw(xfstests fio), split(/ /, get_var('XFSTESTS_PACKAGES')));
 
 sub install_xfstests_from_repo {
     if (is_sle) {
+        zypper_call('rr qa-head');
         add_qa_head_repo(priority => 100);
     }
     elsif (is_tumbleweed) {


### PR DESCRIPTION
The qam-klp_xfstests_* can't add tests by XFSTESTS_GROUPLIST. The problem is QA_HEAD_REPO is old, and after update the repo, I found the repo didn't change. The root cause is add_qa_head_repo checking it's already has QA_HEAD_REPO and didn't update it even it's different. So add zypper_call("rr qa-head") before add_qa_head_repo to solve this problem

- Related ticket:  https://progress.opensuse.org/issues/160784
- Verification run: 
- https://openqa.suse.de/tests/14422713
- One more VR to check if the QA_HEAD_REPO didn't set. https://openqa.suse.de/tests/14423116