### PR TITLE
Fix permission error in workflow for cloning jobs from comments

### DIFF
--- a/.github/workflows/openqa-comment.yml
+++ b/.github/workflows/openqa-comment.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request }}
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_ACTIONS }}
     container:
       image: registry.opensuse.org/devel/openqa/containers/tumbleweed:client
     steps:


### PR DESCRIPTION
The default workflow token is not enough to determine the commentator's team membership so I created a token manually.

Related ticket: https://progress.opensuse.org/issues/130940

---

I created the token with https://github.com/os-autoinst-bot and already added it to our organization secrets. It has the minimum access required for this workflow. (Creating a token like this worked on my fork. Not sure how else to test this.)