### PR TITLE
znc: use the same parameters for --makeconf as the service uses

### DIFF
--- a/tests/console/znc.pm
+++ b/tests/console/znc.pm
@@ -15,7 +15,7 @@ sub run {
     select_console('root-console');
     zypper_call('in znc');
 
-    script_run("su znc -s /bin/bash -c 'znc --makeconf' | tee /dev/$serialdev; echo zncconf-status-\$? > /dev/$serialdev", 0);
+    script_run("su znc -s /bin/bash -c \"\$(grep ExecStart= /usr/lib/systemd/system/znc.service | sed 's/ExecStart=//') --makeconf\" | tee /dev/$serialdev; echo zncconf-status-\$? > /dev/$serialdev", 0);
 
     wait_serial('Listen on port') || die "znc --makeconf failed";
     enter_cmd("12345");


### PR DESCRIPTION
This is important as different versions pass different --datadir= parameters (or omit it, which then implies ~/.znc).

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1224023
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4217047#step/znc/10