### PR TITLE
Pass SCC registration code in for guest installation instead of using plain ones

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -14,6 +14,7 @@ use Utils::Architectures;
 use Utils::Backends 'use_ssh_serial_console';
 use ipmi_backend_utils;
 use virt_utils;
+use virt_autotest::utils;
 
 sub get_script_run {
     my $pre_test_cmd = "";
@@ -35,8 +36,8 @@ sub get_script_run {
     handle_sp_in_settings_with_fcs("GUEST_PATTERN");
     my $guest_pattern = get_var('GUEST_PATTERN', 'sles-12-sp2-64-[p|f]v-def-net');
     my $parallel_num = get_var("PARALLEL_NUM", "2");
-
-    $pre_test_cmd = $pre_test_cmd . " -f " . $guest_pattern . " -n " . $parallel_num . " -r ";
+    my ($regcode, $regcode_ltss) = get_guest_regcode(separator => '|');
+    $pre_test_cmd .= " -f \"" . $guest_pattern . "\" -n " . $parallel_num . " -r " . " -e \"" . $regcode . "\" -E \"" . $regcode_ltss . "\"";
     $pre_test_cmd .= " 2>&1 | tee /tmp/s390x_guest_install_test.log" if (is_s390x);
 
     return $pre_test_cmd;

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -16,7 +16,7 @@ use mmapi;
 use virt_utils;
 use Data::Dumper;
 use Utils::Architectures;
-use virt_autotest::utils qw(is_xen_host);
+use virt_autotest::utils qw(is_xen_host get_guest_regcode);
 use Utils::Backends 'use_ssh_serial_console';
 use ipmi_backend_utils;
 
@@ -28,9 +28,10 @@ sub get_script_run {
     my $dst_pass = $self->get_var_from_parent('DST_PASS');
     handle_sp_in_settings_with_sp0("GUEST_LIST");
     my $guests = get_var("GUEST_LIST", "");
+    my ($guest_regcode, $guest_regcode_ltss) = get_guest_regcode;
     my $hypervisor = (is_xen_host) ? 'xen' : 'kvm';
     my $test_time = get_var("MAX_MIGRATE_TIME", "10800") - 90;
-    my $args = "-d $dst_ip -v $hypervisor -u $dst_user -p $dst_pass -i \"$guests\" -t $test_time";
+    my $args = "-d $dst_ip -v $hypervisor -u $dst_user -p $dst_pass -i \"$guests\" -o \"$guest_regcode\" -O \"$guest_regcode_ltss\" -t $test_time";
     my $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-guest-migrate-run " . $args;
     my $vm_xml_dir = "/tmp/download_vm_xml";
     if (get_var("SKIP_GUEST_INSTALL") && is_x86_64) {

--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -15,6 +15,7 @@ use base "virt_autotest_base";
 use virt_utils;
 use testapi;
 use Utils::Architectures;
+use virt_autotest::utils;
 
 sub get_script_run {
     #NOTE:Found that s390x arch used with the svirt backend
@@ -44,9 +45,12 @@ sub get_script_run {
     my $guest_list = get_required_var("GUEST_LIST");
 
     $pre_test_cmd = "$pre_test_cmd -p $product_upgrade -r $product_upgrade_repo -g \"$guest_list\"";
+    my ($guest_regcode, $guest_regcode_ltss) = get_guest_regcode;
     my $do_registration = check_var('GUEST_SCC_REGISTER', 'installation') ? "true" : "false";
     my $registration_server = get_var('SCC_URL', 'https://scc.suse.com');
     my $registration_code = get_var('SCC_REGCODE', 'INVALID_REGCODE');
+    $pre_test_cmd .= " -o \"$guest_regcode\"";
+    $pre_test_cmd .= " -O \"$guest_regcode_ltss\"";
     $pre_test_cmd .= " -e $do_registration";
     $pre_test_cmd .= " -s $registration_server";
     $pre_test_cmd .= " -c $registration_code";

--- a/tests/virt_autotest/host_upgrade_generate_run_file.pm
+++ b/tests/virt_autotest/host_upgrade_generate_run_file.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use virt_utils;
+use virt_autotest::utils;
 
 sub get_script_run {
     my $pre_test_cmd;
@@ -28,6 +29,7 @@ sub get_script_run {
     #Prefer to use offline media for upgrade to avoid registration via autoyast
     $upgrade_repo =~ s/-Online-/-Full-/ if ($upgrade_repo =~ /15-sp[2-9]/i);
     my $guest_list = get_var("GUEST_LIST", "");
+    my ($guest_regcode, $guest_regcode_ltss) = get_guest_regcode;
     my $do_registration = (check_var('SCC_REGISTER', 'installation') || check_var('REGISTER', 'installation') || get_var('AUTOYAST', '')) ? "true" : "false";
     my $registration_server = get_var('SCC_URL', 'https://scc.suse.com');
     my $registration_code = get_var('SCC_REGCODE', 'INVALID_REGCODE');
@@ -39,6 +41,8 @@ sub get_script_run {
     $pre_test_cmd .= " -u $upgrade";
     $pre_test_cmd .= " -r $upgrade_repo";
     $pre_test_cmd .= " -i $guest_list";
+    $pre_test_cmd .= " -o \"$guest_regcode\"";
+    $pre_test_cmd .= " -O \"$guest_regcode_ltss\"";
     $pre_test_cmd .= " -e $do_registration";
     $pre_test_cmd .= " -s $registration_server";
     $pre_test_cmd .= " -c $registration_code";

--- a/tests/virt_autotest/pvusb_run.pm
+++ b/tests/virt_autotest/pvusb_run.pm
@@ -14,6 +14,7 @@ use base "virt_autotest_base";
 use virt_utils;
 use testapi;
 use Utils::Architectures;
+use virt_autotest::utils;
 
 sub get_script_run {
     my $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-pvusb-run";
@@ -23,6 +24,8 @@ sub get_script_run {
     }
     handle_sp_in_settings_with_sp0("GUEST");
     my $guest = get_var("GUEST", "sles-12-sp3-64-fv-def-net");
+    my ($guest_regcode, $guest_regcode_ltss) = get_guest_regcode;
+    $pre_test_cmd .= " -o \"$guest_regcode\" -O \"$guest_regcode_ltss\"";
     $pre_test_cmd .= " -w \"" . $which_usb . "\"" . " -g $guest";
     my $vm_xml_dir = "/tmp/download_vm_xml";
     if (get_var("SKIP_GUEST_INSTALL") && is_x86_64) {

--- a/tests/virt_autotest/virt_v2v_dst.pm
+++ b/tests/virt_autotest/virt_v2v_dst.pm
@@ -14,6 +14,7 @@ use testapi;
 use lockapi;
 use mmapi;
 use virt_utils;
+use virt_autotest::utils;
 
 sub get_script_run {
     my ($self) = @_;
@@ -24,8 +25,8 @@ sub get_script_run {
     handle_sp_in_settings_with_sp0("GUEST_LIST");
     my $guests = get_var("GUEST_LIST");
     our $virt_v2v_log;
-
-    my $pre_test_cmd = "/usr/share/qa/virtautolib/lib/virt_v2v_test.sh -s $src_ip -u $src_user -p $src_pass -i \"$guests\" 2>&1 | tee $virt_v2v_log";
+    my ($guest_regcode, $guest_regcode_ltss) = get_guest_regcode;
+    my $pre_test_cmd = "/usr/share/qa/virtautolib/lib/virt_v2v_test.sh -s $src_ip -u $src_user -p $src_pass -i \"$guests\"  -o \"$guest_regcode\" -O \"$guest_regcode_ltss\" 2>&1 | tee $virt_v2v_log";
 
     return "$pre_test_cmd";
 }


### PR DESCRIPTION
* **Pass** SCC registration code for guest in to avoid security issue. 

* **Introduce** new options "-e" an "-E", which represent registration codes for product and its LTSS extension, to `tests/qa_test_virtualization/tools/test_virtualization-virt_install_withopt-run` script. 

* **Introduce** new options "-e" and "-E", which represent registration codes for product and its LTSS extension, to `libs/qa_lib_virtauto/qa_lib_virtauto/lib/virt-install.sh` for specific guest installation.

* **If** multiple guest patterns to be used, their corresponding registration codes should be provided in the same order and separated by pipe symbols. 

* **If** the new settings GUEST_SCC_REGCODE and GUEST_SCC_REGCODE_LTSS are not provided, host settings SCC_REGCODE and SCC_REGCODE_LTSS_15 will be used instead.

* **New** function ```get_guest_regcode``` in ```lib/virt_autotest/utils.pm``` implements functionality of getting guest registration code.

* **For** all other test scenarios, including host upgrade, guest upgrade, guest migration, virt v2v and pvusb, which also install guests, their respective scripts also need accept dynamically passed in SCC registration codes. They all rely on `libs/qa_lib_virtauto/qa_lib_virtauto/lib/virt-install.sh` and `install_vm_guests` in `libs/qa_lib_virtauto/qa_lib_virtauto/lib/virtlib` to install guests:

  * **Host Upgrade**, `tests/virt_autotest/host_upgrade_generate_run_file.pm`, `tests/qa_test_virtualization/generate/_generate_vh-update_tests.sh` and `libs/qa_lib_virtauto/qa_lib_virtauto/lib/vh-update.sh` accept registration codes for product and its LTSS extension via new options "-o" and "-O". 
  
  * **Guest Upgrade**, `tests/virt_autotest/guest_upgrade_run.pm`, `tests/qa_test_virtualization/tools/test_virtualization-guest-upgrade-run` and `libs/qa_lib_virtauto/qa_lib_virtauto/lib/test_full_guest_upgrade.sh` accept registration codes for product and its LTSS extension via new options "-o" and "-O".
 
  * **Guest Migration**, `tests/virt_autotest/guest_migration_src.pm`, `tests/qa_test_virtualization/tools/test_virtualization-guest-migrate-run` and `libs/qa_lib_virtauto/qa_lib_virtauto/lib/guest_migrate.sh` accept registration codes for product and its LTSS extension via new options "-o" and "-O".
 
  * **VIRT V2V**, `[tests/virt_autotest/virt_v2v_dst.pm`, `tests/qa_test_virtualization/tools/test_virtualization-virt-v2v-run` and `libs/qa_lib_virtauto/qa_lib_virtauto/lib/virt_v2v_test.sh` accept registration codes for product and its LTSS extension via new options "-o" and "-O".
  
  * **PVUSB**, `tests/virt_autotest/pvusb_run.pm`, `tests/qa_test_virtualization/tools/test_virtualization-pvusb-run` and `libs/qa_lib_virtauto/qa_lib_virtauto/lib/pvusb-test-run.sh` accept registration codes for product and its LTSS extension via new options "-o" and "-O".

  * **If** multiple guest patterns to be used, their corresponding registration codes should be provided in the same order and separated by comma symbols. 

  * **New** function `get_install_vm_regcode` in `libs/qa_lib_virtauto/qa_lib_virtauto/lib/virtlib` find product/LTSS registration codes for specific guest from passed in ones.

  * **All** these test scenarios reply on function `install_vm_guests` in `libs/qa_lib_virtauto/qa_lib_virtauto/lib/virtlib` to install guests.
  
  * **Function** `install_vm_guests` calls `get_install_vm_regcode` and passes returned product/LTSS registration codes to `libs/qa_lib_virtauto/qa_lib_virtauto/lib/virt-install.sh` for specific guest installation.

* **This** pull request should be merged together with [pr#827](https://github.com/SUSE/qa-automation/pull/827) and [pr#1091](https://github.com/SUSE/qa-testsuites/pull/1091).

* **Verification runs:**
  * [**12sp5 on 15sp6 kvm**](https://openqa.suse.de/tests/14475212)
  * [**15sp5 on 15sp6 xen**](https://openqa.suse.de/tests/14475213)
  * [**15sp6 on 15sp5 xen**](https://openqa.suse.de/tests/14475217) 
  * [**15sp6 on 15sp6 kvm with** empty GUEST_SCC_REGCODE and GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14473257)
  * [**15sp6 on 15sp6 xen without** GUEST_SCC_REGCODE and GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14460753)
  * [**aarch64 with** partial GUEST_SCC_REGCODE and partial GUEST_SCC_REGCODE_LTSS](http://openqa.qa2.suse.asia/tests/72094)
  * [**Multiple guest patterns 15-SP3(LTSS)/SP4(LTSS)/SP6 on 12sp5 kvm with** full GUEST_SCC_REGCODE and partial GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14475306)
  * [**Multiple guest patterns 12-SP5/15-SP5/15-SP6 on 15sp6 kvm with** full GUEST_SCC_REGCODE and partial GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14474999)
  * [**Multiple guest patterns 15-SP4(LTSS)/SP5/SP6 on 15sp6 kvm with** full GUEST_SCC_REGCODE and partial GUEST_SCC_REGCODE_LTSS Test1](https://openqa.suse.de/tests/14473305) [Test2](https://openqa.suse.de/tests/14473303)
  * [**Multiple guest patterns 15-SP5 and 15-SP6 on 15sp6 kvm with** full GUEST_SCC_REGCODE and empty GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14473276)
  * [**Multiple guest patterns 15-SP5 and 15-SP2 LTSS on 15sp6 xen with** full GUEST_SCC_REGCODE and partial GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14461931)
  * [**Multiple guest patterns 15-SP2 LTSS and 15-SP3 LTSS on 15sp5 kvm with** full GUEST_SCC_REGCODE and GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14461973)
  * [**Multiple guest patterns 15-SP2 LTSS and 15-SP6 on 15sp6 kvm with** full GUEST_SCC_REGCODE and partial GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14461980)
  * [**Multiple guest patterns 15-SP5 and 15-SP6 on 12sp5 xen with** GUEST_SCC_REGCODE and without GUEST_SCC_REGCODE_LTSS](https://openqa.suse.de/tests/14460760)
  * [**Manual host upgrade script verification passed**]
  * [**Manual guest upgrade script verification passed**]
  * [**host upgrade 12sp5 to 15sp6**](https://openqa.suse.de/tests/14498123)
  * [**host upgrade 15sp5 to 15sp6**](https://openqa.suse.de/tests/14498035)
  * [**host upgrade with multiple guests**](https://openqa.suse.de/tests/14491402)
  * [**guest upgrade 12sp5 to 15sp6 on 15sp6**](https://openqa.suse.de/tests/14487697)
  * [**guest ugprade 15sp5 to 15sp6 on 15sp5**](https://openqa.suse.de/tests/14487700)
  * [**guest upgrade multiple guests**](https://openqa.suse.de/tests/14498033)
  * [**Manual guest migration script verification passed**]
  * [**guest migration multiple guests** src](https://openqa.suse.de/tests/14498029) [dst](https://openqa.suse.de/tests/14498030)
  * [**guest migration** src](https://openqa.suse.de/tests/14498032) [dst](https://openqa.suse.de/tests/14498031)
  * [**Manual virt v2v script verification passed**]
  * [**Manual pvusb script verification passed**]