### PR TITLE
Fix wizard_hana_install script timeout on ppc64le

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -40,8 +40,8 @@ sub run {
 
     # Keep only the generic HANA partitioning profile and link it to the needed model
     # NOTE: fix name is used here (Dell), but something more flexible should be done later!
-    enter_cmd "rm -f /usr/share/YaST2/data/y2sap//hana_partitioning_Dell*.xml";
-    enter_cmd "ln -s hana_partitioning.xml '/usr/share/YaST2/data/y2sap/hana_partitioning_Dell Inc._generic.xml'";
+    assert_script_run "rm -f /usr/share/YaST2/data/y2sap//hana_partitioning_Dell*.xml";
+    assert_script_run "ln -s hana_partitioning.xml '/usr/share/YaST2/data/y2sap/hana_partitioning_Dell Inc._generic.xml'";
 
     # Add host's IP to /etc/hosts
     $self->add_hostname_to_hosts;


### PR DESCRIPTION
Using assert_script_run instead of enter_cmd to avoid this error.

TEAM-9310 - [15-SP6][sles4sap][ppc64le] sles4sap_scc_gnome_hana_wizard sporadically failed on "wizard_hana_install": script timeout

- Related ticket: https://jira.suse.com/browse/TEAM-9310
- Needles: NA
- Verification run:
https://openqa.suse.de/tests/14429620#next_previous (run 10+ times all runs are passed)