### PR TITLE
Fix gnote and libreoffice failure on gnome46

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -919,8 +919,10 @@ sub gnote_search_and_close {
 sub cleanup_gnote {
     my ($self, $needle) = @_;
     send_key 'esc';    #back to all notes interface
-    assert_and_click($needle, button => 'right');
-    assert_and_click "delete-new-note";
+    assert_and_click($needle);
+    wait_still_screen(2);
+    send_key "delete";
+    wait_still_screen(2);
     assert_and_click "really-delete-note";
     send_key 'alt-f4';
 }

--- a/tests/x11/gnote/gnote_search_title.pm
+++ b/tests/x11/gnote/gnote_search_title.pm
@@ -21,8 +21,6 @@ use testapi;
 sub run {
     my ($self) = @_;
     $self->gnote_launch();
-    send_key "down" if check_screen 'gnote-start-here-matched_TW';
-    send_key "ret";
     $self->gnote_search_and_close('here', 'gnote-search-title-here');
 }
 

--- a/tests/x11/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11/libreoffice/libreoffice_double_click_file.pm
@@ -38,7 +38,8 @@ sub run {
             send_key 'alt-f4';
         }
         else {
-            send_key 'ctrl-q';
+            # due to bsc#1224395 the ctrl-q do not work on libreoffice math
+            assert_and_click 'close-libreoffice';
         }
     }
     send_key 'ctrl-q' unless check_screen 'generic-desktop', 0;


### PR DESCRIPTION
With GNOTE 46, right-clicking a note to delete it is no longer possible
So, we need to use a different way to delete a note, here we will use `send_key "delete";`

Besides, due to bsc#1224395 the ctrl-q do not work on libreoffice math
So, I am updating the code to use  `assert_and_click 'close-libreoffice';`

- Related ticket: https://progress.opensuse.org/issues/157672
- Needles: already added when debugging on o3 and osd
- Verification run: 
>  TW Wayland:  https://openqa.opensuse.org/tests/4215188#
(The [libreoffice_mainmenu_components](https://openqa.opensuse.org/tests/4215188/modules/libreoffice_mainmenu_components/steps/1/src) failed due to https://bugzilla.opensuse.org/show_bug.cgi?id=1225089)
>  TW X11: https://openqa.opensuse.org/tests/4219308#
>  SLE15SP6 X11: https://openqa.suse.de/tests/14429217#
>  SLE15SP6 Wayland: https://openqa.suse.de/tests/14429241#
