### PR TITLE
Avoid running workflow for cloning via comments for all comments

### DIFF
--- a/.github/workflows/openqa-comment.yml
+++ b/.github/workflows/openqa-comment.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   clone_mentioned_job:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request }}
+    if: "github.event.issue.pull_request && contains(github.event.comment.body, 'openqa: Clone ')"
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_ACTIONS }}
     container:


### PR DESCRIPTION
Run the workflow only for comments that contain the relevant phrase. Note that the GitHub `contains()` function is not case sensitive which is in-line with how our GitHub workflow actually does the matching.

Related ticket: https://progress.opensuse.org/issues/130940

---

Tested on my fork where jobs where now irrelevant workflow actions end up skipped immediately (e.g. https://github.com/Martchus/os-autoinst-distri-opensuse/actions/runs/9222599851) but relevant ones are still executed (e.g. https://github.com/Martchus/os-autoinst-distri-opensuse/actions/runs/9222550135/job/25373924134).