### PR TITLE
Add a backreference to jobs cloned via PR descriptions

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -14,6 +14,7 @@ env:
   GH_REPO: ${{ github.event.pull_request.head.repo.full_name }}
   GH_REF: ${{ github.event.pull_request.head.ref }}
   GH_PR_BODY: ${{ github.event.pull_request.body }}
+  GH_PR_HTML_URL: ${{ github.event.pull_request.html_url }}
 
 jobs:
   trigger_and_monitor_openqa:


### PR DESCRIPTION
It was mentioned in https://progress.opensuse.org/issues/130940#note-17 that it would be nice to have if jobs cloned via PR comments would have a reference back to the relevant comment. Those jobs will be covered by https://github.com/os-autoinst/scripts/pull/324. This PR will enable adding back references also for jobs cloned via PR descriptions.