### PR TITLE
Fix a command execution timeout failure

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -489,7 +489,7 @@ EOF
     # Workaround for bsc#1199448
     my $node_helper = 'node-helper.yaml';
     assert_script_run("curl " . data_url("virt_autotest/kubevirt_tests/$node_helper") . " -o $node_helper");
-    assert_script_run("sed -e \"s/$kubevirt_ver/\${KUBEVIRT_VERSION}/g\"");
+    assert_script_run("sed -i 's/\${KUBEVIRT_VERSION}/$kubevirt_ver/g' $node_helper");
     assert_script_run("kubectl apply -f $node_helper");
     assert_script_run("kubectl -n kubevirt-tests rollout status daemonset node-helper --timeout=50m");
 


### PR DESCRIPTION
Fix a setup command failure for kubevirt test - http://10.67.129.96/tests/3322#step/kubevirt_tests_server/276

- Related ticket: https://progress.opensuse.org/issues/160910
- Verification run: http://10.67.129.96/tests/3344
