### PR TITLE
containers: Minimize dependency on registry mirror

### DIFF
--- a/lib/containers/containerd_crictl.pm
+++ b/lib/containers/containerd_crictl.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020-2021 SUSE LLC
+# Copyright 2020-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: engine subclass for containerd with crictl specific implementations
@@ -10,7 +10,6 @@ package containers::containerd_crictl;
 use Mojo::Base 'containers::engine';
 use testapi;
 use containers::common 'install_containerd_when_needed';
-use containers::utils 'registry_url';
 use utils qw(zypper_call);
 use version_utils qw(is_leap is_sle);
 use Utils::Architectures;

--- a/lib/containers/containerd_nerdctl.pm
+++ b/lib/containers/containerd_nerdctl.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020-2021 SUSE LLC
+# Copyright 2020-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: engine subclass for containerd with nerdctl specific implementations
@@ -10,7 +10,6 @@ package containers::containerd_nerdctl;
 use Mojo::Base 'containers::engine';
 use testapi;
 use containers::common 'install_containerd_when_needed';
-use containers::utils 'registry_url';
 use utils qw(zypper_call);
 use version_utils qw(is_leap is_sle);
 use Utils::Architectures;

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020-2021 SUSE LLC
+# Copyright 2020-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Abstraction layer to operate docker and podman containers through same interfaces
@@ -11,7 +11,6 @@ use Mojo::Base -base;
 use testapi;
 use Carp 'croak';
 use Test::Assert 'assert_equals';
-use containers::utils qw(registry_url);
 use utils qw(systemctl file_content_replace script_retry);
 use version_utils qw(package_version_cmp);
 use containers::utils qw(get_podman_version);

--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -114,7 +114,7 @@ sub test_update_cmd {
 sub runtime_smoke_tests {
     my %args = @_;
     my $runtime = $args{runtime};
-    my $image = $args{image} // registry_url('alpine', '3.6');
+    my $image = $args{image} // "registry.opensuse.org/opensuse/busybox:latest";
 
     record_info('Smoke', "Smoke test running image: $image on runtime: $runtime.");
 

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -123,7 +123,7 @@ sub load_host_tests_podman {
     load_container_engine_test($run_args);
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud;
-    load_3rd_party_image_test($run_args);
+    load_3rd_party_image_test($run_args) unless is_staging;
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
     loadtest 'containers/podman_bci_systemd';

--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -156,7 +156,7 @@ sub run {
 
     basic_container_tests(runtime => $self->{runtime});
     # Build an image from Dockerfile and run it
-    build_and_run_image(runtime => $engine, dockerfile => 'Dockerfile.python3', base => registry_url('python', '3'));
+    build_and_run_image(runtime => $engine, dockerfile => 'Dockerfile.python3', base => 'registry.opensuse.org/opensuse/bci/python:latest');
 
     # Once more test the basic functionality
     runtime_smoke_tests(runtime => $engine);

--- a/tests/containers/firewall.pm
+++ b/tests/containers/firewall.pm
@@ -11,7 +11,6 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'script_retry';
-use containers::utils qw(registry_url);
 use containers::common 'check_containers_connectivity';
 use Utils::Systemd 'systemctl';
 
@@ -37,8 +36,9 @@ sub run {
     }
 
     # Run netcat in container and check that we can reach it
-    assert_script_run "$runtime pull " . registry_url('alpine');
-    assert_script_run "$runtime run -d --name $container_name -p 1234:1234 " . registry_url('alpine') . " nc -l -p 1234";
+    my $image = "registry.opensuse.org/opensuse/bci/bci-busybox:latest";
+    assert_script_run "$runtime pull $image";
+    assert_script_run "$runtime run -d --name $container_name -p 1234:1234 $image nc -l -p 1234";
     assert_script_run "echo Hola Mundo >/dev/tcp/127.0.0.1/1234";
     assert_script_run "$runtime logs $container_name | grep Hola";
 

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use version_utils qw(package_version_cmp is_transactional is_jeos is_leap is_sle_micro is_leap_micro is_sle is_microos is_public_cloud is_vmware);
 use containers::common qw(install_packages);
-use containers::utils qw(get_podman_version registry_url);
+use containers::utils qw(get_podman_version);
 use Utils::Systemd qw(systemctl);
 use Utils::Architectures qw(is_s390x);
 use main_common qw(is_updates_tests);
@@ -109,7 +109,7 @@ sub run {
         subnet_v6 => 'fd00::1:8:0/112'
     };
     my $ctr1 = {
-        image => registry_url('httpd'),
+        image => 'registry.opensuse.org/opensuse/httpd:latest',
         name => 'apache_ctr',
         ip => '10.90.0.8',
         mac => '76:22:33:44:55:66',

--- a/tests/containers/podman_network_cni.pm
+++ b/tests/containers/podman_network_cni.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2023 SUSE LLC
+# Copyright 2023-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: podman network
@@ -12,7 +12,7 @@ use testapi;
 use utils qw(script_retry);
 use serial_terminal 'select_serial_terminal';
 use version_utils qw(package_version_cmp);
-use containers::utils qw(registry_url container_ip);
+use containers::utils qw(container_ip);
 use containers::utils qw(get_podman_version);
 
 

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021-2023 SUSE LLC
+# Copyright 2021-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Test rootless mode on podman.
@@ -21,7 +21,7 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use containers::common;
 use containers::container_images;
-use containers::utils qw(registry_url get_podman_version);
+use containers::utils qw(get_podman_version);
 use version_utils qw(is_sle is_leap is_jeos is_transactional package_version_cmp is_tumbleweed);
 use Utils::Architectures;
 use Utils::Logging 'save_and_upload_log';


### PR DESCRIPTION
Minimize dependency on registry mirror.  Some uses of alpine can be perfectly done by smaller busybox image from OBS. Same with httpd shipped by openSUSE.

- Related ticket: https://progress.opensuse.org/issues/160823
- Verification runs:
  - microos-Staging:A-Staging-MicroOS-Image-ContainerHost-x86_64-BuildA.75.24-microos@64bit -> https://openqa.opensuse.org/t4223849
  - opensuse-Tumbleweed-DVD-x86_64-Build20240524-containers_image@64bit -> https://openqa.opensuse.org/t4224036