### PR TITLE
JeOS zypper update license auto-agree added

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -46,7 +46,7 @@ sub run {
     #   updates as for SLE DVD installation, so we need to update manually.
     if (is_jeos) {
         record_info('Updates', script_output('zypper lu'));
-        zypper_call('up', timeout => 600);
+        zypper_call('up -l', timeout => 600);
         if (is_aarch64) {
             # Disable grub timeout for aarch64 cases so that the test doesn't stall
             assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub");


### PR DESCRIPTION
In _JeOS Maintenance Updates_ zypper update a new license agreement occurred, needing 'yes', but default 'no' caused tests to fail. `zypper update` command changed adding `-l` = `--auto-agree-with-licenses`

- Related ticket: https://progress.opensuse.org/issues/160913
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/14432777
