### PR TITLE
Fix encrypted device num issue

### DIFF
--- a/test_data/yast/encryption/crypt_no_lvm_enc_luks2.yaml
+++ b/test_data/yast/encryption/crypt_no_lvm_enc_luks2.yaml
@@ -1,0 +1,3 @@
+crypttab:
+  num_devices_encrypted: 2
+<<: !include test_data/yast/encryption/default_enc_luks2.yaml

--- a/test_data/yast/encryption/full_lvm_enc_luks2.yaml
+++ b/test_data/yast/encryption/full_lvm_enc_luks2.yaml
@@ -19,5 +19,5 @@ lvm:
       - name: lv-root
         role: operating-system
 crypttab:
-  num_devices_encrypted: 2
+  num_devices_encrypted: 1
 <<: !include test_data/yast/encryption/default_enc_luks2.yaml


### PR DESCRIPTION
Create a new test_data for 'crypt_no_lvm', and recover the encrypted device num for test_data/yast/encryption/full_lvm_enc_luks2,yaml.   Need update 'crypt_no_lvm' in https://openqa.opensuse.org/admin/test_suites after this PR merged.

- Related ticket: https://progress.opensuse.org/issues/160841
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4223503#  crypt_no_lvm
  https://openqa.opensuse.org/tests/4223504#  cryptlvm
