### PR TITLE
containers: Cleanup after each run of BATS tests in buildah

### DIFF
--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -34,6 +34,8 @@ sub run_tests {
     script_run "BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 3600;
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf tests";
+
+    assert_script_run "buildah prune -a -f";
 }
 
 sub run {

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -42,6 +42,8 @@ sub run_tests {
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf test/system";
     script_run 'kill %1' if ($remote);
+
+    assert_script_run "podman system reset -f";
 }
 
 sub run {


### PR DESCRIPTION
Fix space issues in BATS tests

- Failing test: https://openqa.suse.de/tests/14506430
- Verification runs:
  - sle-15-SP6-Server-DVD-Updates-x86_64-Build20240602-1-podman_testsuite@64bit -> https://openqa.suse.de/t14507861
  - opensuse-Tumbleweed-DVD-x86_64-Build20240531-containers_host_buildah_testsuite@64bit -> https://openqa.opensuse.org/t4243602