### PR TITLE
Fix starting of rancher image

### DIFF
--- a/tests/containers/slem_rancher.pm
+++ b/tests/containers/slem_rancher.pm
@@ -21,7 +21,7 @@ sub run {
     my $image = get_var('CONTAINER_IMAGE_TO_TEST', 'registry.suse.de/suse/sle-15-sp3/update/products/microos52/update/cr/totest/images/suse/sle-micro-rancher/5.2:latest');
 
     assert_script_run("podman pull $image");
-    assert_script_run("podman run --name slem_image -dt $image /bin/bash");
+    assert_script_run("podman run --name slem_image -dt $image sleep infinity");
 
     record_info('Kernel', 'Test that kernel files are present');
     validate_script_output("podman exec slem_image /bin/sh -c 'ls /boot'", sub { /initrd/ });


### PR DESCRIPTION
sleep is better suited for keeping an image running than bash.

- Related ticket: https://progress.opensuse.org/issues/160967
- Related failure: https://openqa.suse.de/tests/14427929/modules/slem_rancher/steps/9
- Verification run: https://duck-norris.qe.suse.de/tests/14669
