### PR TITLE
Split qesap Ansible retry

### DIFF
--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -1085,21 +1085,90 @@ subtest '[qesap_add_server_to_hosts]' => sub {
     ok((any { qr/sed.*\/etc\/hosts/ } @calls), 'AWS Region matches');
 };
 
-subtest '[qesap_terrafom_ansible_deploy_retry] generic Ansible failures, no retry' => sub {
+subtest '[qesap_terrafom_ansible_deploy_retry] no Ansible failures, no retry' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
-    my @calls;
+    my $qesap_execute_calls = 0;
 
-    $qesap->redefine(qesap_file_find_string => sub {
-            my (%args) = @_;
-            push @calls, $args{cmd};
-            #return 1 if $args{search_string} eq 'Missing sudo password';
-            return 0; });
-    $qesap->redefine(script_output => sub { return 'ALGA' });
+    $qesap->redefine(qesap_ansible_error_detection => sub { return 0; });
     $qesap->redefine(qesap_cluster_logs => sub { return; });
+    $qesap->redefine(qesap_execute => sub { $qesap_execute_calls++; return; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
-    my $ret = qesap_terrafom_ansible_deploy_retry(error_log => 'CORAL');
-    ok $ret == 1;
+    my $ret = qesap_terrafom_ansible_deploy_retry(error_log => 'CORAL', provider => 'NEMO');
+
+    ok $ret eq 0, "Return of qesap_terrafom_ansible_deploy_retry '$ret' is expected 0";
+    ok $qesap_execute_calls eq 0, "qesap_execute() never called (qesap_execute_calls: $qesap_execute_calls expected 0)";
+};
+
+subtest '[qesap_terrafom_ansible_deploy_retry] generic Ansible failures, no retry' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap_execute_calls = 0;
+
+    $qesap->redefine(qesap_ansible_error_detection => sub { return 1; });
+    $qesap->redefine(qesap_cluster_logs => sub { return; });
+    $qesap->redefine(qesap_execute => sub { $qesap_execute_calls++; return; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $ret = qesap_terrafom_ansible_deploy_retry(error_log => 'CORAL', provider => 'NEMO');
+
+    ok $ret == 1, "Return of qesap_terrafom_ansible_deploy_retry '$ret' is expected 1";
+    ok $qesap_execute_calls eq 0, "qesap_execute() never called (qesap_execute_calls: $qesap_execute_calls expected 0)";
+};
+
+subtest '[qesap_ansible_error_detection] no error' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my @input;
+
+    # Simulate we never find the string in the Ansible log file
+    $qesap->redefine(qesap_file_find_string => sub {
+            my (%args) = @_;
+            push @input, $args{file};
+            return 0; });
+    $qesap->redefine(script_output => sub {
+            push @input, shift;
+            return ''; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $ret = qesap_ansible_error_detection(error_log => 'SHELL');
+
+    note("\n  I-->  " . join("\n  I-->  ", @input));
+    ok $ret eq 0, "If no error detected return '$ret' is 0";
+    ok((any { qr/SHELL/ } @input), 'At least one of the serach is on the provided input file SHELL');
+};
+
+subtest '[qesap_ansible_error_detection] generic error' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+
+    # The specific search with qesap_file_find_string
+    # return nothing, but ...
+    $qesap->redefine(qesap_file_find_string => sub { return 0; });
+
+    # The generic one return something
+    $qesap->redefine(script_output => sub { return 'ALGA'; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $ret = qesap_ansible_error_detection(error_log => 'SHELL');
+    ok $ret eq 1, "If generic error detected return '$ret' is 1";
+};
+
+subtest '[qesap_ansible_error_detection] specific error' => sub {
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+
+    # The specific search with qesap_file_find_string
+    # return nothing, but ...
+    $qesap->redefine(qesap_file_find_string => sub {
+            my (%args) = @_;
+            if ($args{search_string} eq 'Timed out waiting for last boot time check') {
+                return 1;
+            }
+            return 0; });
+
+    # The generic one return something
+    $qesap->redefine(script_output => sub { return ''; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $ret = qesap_ansible_error_detection(error_log => 'SHELL');
+    ok $ret eq 2, "If generic error detected return '$ret' is 2";
 };
 
 done_testing;

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -41,7 +41,7 @@ sub run {
                 die("TEAM-9068 Ansible failed. Retry not supported for IBSM updates\n ret[0]: $ret[0]");
             }
             # Retry to deploy terraform + ansible
-            if (qesap_terrafom_ansible_deploy_retry(error_log => $ret[1])) {
+            if (qesap_terrafom_ansible_deploy_retry(error_log => $ret[1], provider => $provider)) {
                 die "Retry failed, original ansible return: $ret[0]";
             }
 

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -38,7 +38,7 @@ sub run {
     @ret = qesap_execute(cmd => 'ansible', cmd_options => '--profile', verbose => 1, timeout => 3600);
     if ($ret[0]) {
         # Retry to deploy terraform + ansible
-        if (qesap_terrafom_ansible_deploy_retry(error_log => $ret[1])) {
+        if (qesap_terrafom_ansible_deploy_retry(error_log => $ret[1], provider => $provider)) {
             die "Retry failed, original ansible return: $ret[0]";
         }
     }


### PR DESCRIPTION
Split error detection from retry. Add more unit testings. Move the read of the PC setting up from the lib to the test module.

- Related ticket: https://jira.suse.com/browse/TEAM-9092 https://jira.suse.com/browse/TEAM-9068

This PR is a preliminary step to re-think about the deployment retry mechanism, to be able to use retry also in MU testing.

# Verification run:

## qesap regression
 - sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/284922 :green_circle: no ansible failure
 -  sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/284923 :green_circle: no ansible failure, failure is later and not related to PR content
 -  sle-15-SP5-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE15_5_PAYG-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/284924 :green_circle: no ansible failure
- sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/284987 :green_circle: Ansible fails with a known error, error is correctly reported in http://openqaworker15.qa.suse.cz/tests/284987#step/deploy/63 and no retry is attempted.

## hanasr
 -  sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-05-27T04:03:11Z-hanasr_azure_test_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/284925 New error tail http://openqaworker15.qa.suse.cz/tests/284925#step/deploy_qesap_ansible/22 :green_circle:  job fails at Ansible retry, also retry  (error tail not used in retry)

 - sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2024-05-28T04:03:12Z-hanasr_aws_test_fencing_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/284988

 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-05-28T04:03:12Z-hanasr_azure_test_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/284989 :green_circle: Ansible PASS