### PR TITLE
Re-adding registry_url

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -11,7 +11,7 @@ use testapi;
 use registration;
 use version_utils;
 use utils qw(zypper_call systemctl file_content_replace script_retry script_output_retry);
-use containers::utils qw(container_ip container_route);
+use containers::utils qw(registry_url container_ip container_route);
 use transactional qw(trup_call check_reboot_changes process_reboot);
 use bootloader_setup 'add_grub_cmdline_settings';
 use serial_terminal 'select_serial_terminal';

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -202,19 +202,19 @@ sub check_containers_connectivity {
     # Connectivity to host check
     my $container_route = container_route($container_name, $runtime);
     assert_script_run "ping $_4 -c3 " . $container_route;
-    assert_script_run "$runtime run --rm $image ping -4 -c3 " . $container_route;
+    assert_script_run "$runtime run --rm --cap-add=CAP_NET_RAW $image ping -4 -c3 " . $container_route;
 
     # Cross-container connectivity check
     assert_script_run "ping $_4 -c3 " . $container_ip;
-    assert_script_run "$runtime run --rm $image ping -4 -c3 " . $container_ip;
+    assert_script_run "$runtime run --rm --cap-add=CAP_NET_RAW $image ping -4 -c3 " . $container_ip;
 
     # Outside IP connectivity check
     script_retry "ping $_4 -c3 8.8.8.8", retry => 3, delay => 120;
-    script_retry "$runtime run --rm $image ping -4 -c3 8.8.8.8", retry => 3, delay => 120;
+    script_retry "$runtime run --rm --cap-add=CAP_NET_RAW $image ping -4 -c3 8.8.8.8", retry => 3, delay => 120;
 
     # Outside IP+DNS connectivity check
     script_retry "ping $_4 -c3 google.com", retry => 3, delay => 120;
-    script_retry "$runtime run --rm $image ping -4 -c3 google.com", retry => 3, delay => 120;
+    script_retry "$runtime run --rm --cap-add=CAP_NET_RAW $image ping -4 -c3 google.com", retry => 3, delay => 120;
 
     # Kill the container running on background
     assert_script_run "$runtime kill $container_name";


### PR DESCRIPTION
Hotfix: registry_url was accidentally removed from the container::utils import.

Follow-up failure: https://openqa.suse.de/tests/14459696

- Related ticket: https://progress.opensuse.org/issues/161042
- Verification run: https://openqa.suse.de/tests/14460790
