### PR TITLE
Add CAP_NET_RAW to ping tests

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -202,19 +202,19 @@ sub check_containers_connectivity {
     # Connectivity to host check
     my $container_route = container_route($container_name, $runtime);
     assert_script_run "ping $_4 -c3 " . $container_route;
-    assert_script_run "$runtime run --rm $image ping -4 -c3 " . $container_route;
+    assert_script_run "$runtime run --rm --cap-add=CAP_NET_RAW $image ping -4 -c3 " . $container_route;
 
     # Cross-container connectivity check
     assert_script_run "ping $_4 -c3 " . $container_ip;
-    assert_script_run "$runtime run --rm $image ping -4 -c3 " . $container_ip;
+    assert_script_run "$runtime run --rm --cap-add=CAP_NET_RAW $image ping -4 -c3 " . $container_ip;
 
     # Outside IP connectivity check
     script_retry "ping $_4 -c3 8.8.8.8", retry => 3, delay => 120;
-    script_retry "$runtime run --rm $image ping -4 -c3 8.8.8.8", retry => 3, delay => 120;
+    script_retry "$runtime run --rm --cap-add=CAP_NET_RAW $image ping -4 -c3 8.8.8.8", retry => 3, delay => 120;
 
     # Outside IP+DNS connectivity check
     script_retry "ping $_4 -c3 google.com", retry => 3, delay => 120;
-    script_retry "$runtime run --rm $image ping -4 -c3 google.com", retry => 3, delay => 120;
+    script_retry "$runtime run --rm --cap-add=CAP_NET_RAW $image ping -4 -c3 google.com", retry => 3, delay => 120;
 
     # Kill the container running on background
     assert_script_run "$runtime kill $container_name";


### PR DESCRIPTION
Ping tests need the CAP_NET_RAW capability to work. This commit adds it to the podman run commands.

- Related ticket: https://progress.opensuse.org/issues/161042 (follow-up failure)
- Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19396
- Related failure: https://openqa.suse.de/tests/14459696
- Verification run: TBD
