### PR TITLE
Wsl systemd

### DIFF
--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -8,7 +8,7 @@
 
 use Mojo::Base qw(windowsbasetest);
 use testapi;
-use utils qw(enter_cmd_slow);
+use utils qw(zypper_call enter_cmd_slow);
 use version_utils qw(is_opensuse);
 use wsl qw(is_fake_scc_url_needed);
 
@@ -17,27 +17,39 @@ sub run {
 
     assert_screen(['windows_desktop', 'powershell-as-admin-window']);
     $self->open_powershell_as_admin if match_has_tag('windows_desktop');
-    # In openSUSE the WSL shell is not root, so there's need to run become_root
-    # in order to write in the /etc/wsl.conf file
+
+    # Check that systemd is not enabled by default.
+    $self->run_in_powershell(
+        cmd => '$port.WriteLine($(wsl /bin/bash -c "systemctl is-system-running"))',
+        code => sub {
+            die("Systemd is running by default...")
+              unless wait_serial("offline");
+        }
+    );
     $self->run_in_powershell(
         cmd => q(wsl),
         code => sub {
-            become_root if (is_opensuse);
-            enter_cmd("ps 1 | grep '/init'");
-            enter_cmd("stat /init | grep 'init'");
-            enter_cmd("echo -e '[boot]\nsystemd=true' > /etc/wsl.conf");
-            wait_still_screen stilltime => 3, timeout => 10;
+            # become_root is now preferred and expected behavior:
+            # https://bugzilla.suse.com/show_bug.cgi?id=1225075
+            become_root;
+            enter_cmd("zypper in -y -t pattern wsl_systemd");
+            wait_still_screen stilltime => 3, timeout => 10, similarity_level => 43;
             save_screenshot;
             enter_cmd("exit");
-            # In openSUSE there's need to exit twice, one from the root and another
+            wait_still_screen stilltime => 3, timeout => 10, similarity_level => 43;
+            # There's need to exit twice, one from the root and another
             # one from the WSL
-            enter_cmd("exit") if (is_opensuse);
+            enter_cmd("exit");
         }
     );
     $self->run_in_powershell(cmd => q(wsl --shutdown));
-    $self->run_in_powershell(cmd => q(wsl /bin/bash -c "ps 1 | grep '/sbin/init'"));
-    $self->run_in_powershell(cmd => q(wsl /bin/bash -c "stat /sbin/init | grep 'systemd'"));
-    $self->run_in_powershell(cmd => q(wsl /bin/bash -c "systemctl list-unit-files --type=service | head -n 20"));
+    $self->run_in_powershell(
+        cmd => '$port.WriteLine($(wsl /bin/bash -c "systemctl is-system-running"))',
+        code => sub {
+            die("systemd is offline...")
+              unless wait_serial("running", timeout => 120);
+        }
+    );
     $self->run_in_powershell(cmd => q(wsl /bin/bash -c "exit"));
 }
 


### PR DESCRIPTION
YaST firstboot check for enabling the systemd feature won't be available in openSUSE versions, so the wiki has been updated to show the installing process.

Nevertheless, there's a new cleaner and smoother way of enabling systemd by installing a zypper pattern rather than writing in config files, so we should enable the feature this way: 
https://en.opensuse.org/openSUSE:WSL#Enabling_systemd

- Related ticket: https://progress.opensuse.org/issues/156814

- Verification runs:

Version: 15-SP6 / Flavor: Windows 10 BIOS: https://openqa.suse.de/tests/14541449#
Version: 15-SP6 / Flavor: Windows 10 UEFI: https://openqa.suse.de/tests/14541450#
Version: 15-SP6 / Flavor: Windows 11 UEFI: https://openqa.suse.de/tests/14541451#

Tumbleweed Win 10 BIOS: https://openqa.opensuse.org/tests/4255480#
Tumbleweed Win 10 UEFI: https://openqa.opensuse.org/tests/4255485#
Tumbleweed Win 11 UEFI: https://openqa.opensuse.org/tests/4255486#
