### PR TITLE
containers: Use registry.opensuse.org/opensuse/busybox instead of BCI

### DIFF
--- a/tests/containers/firewall.pm
+++ b/tests/containers/firewall.pm
@@ -36,7 +36,7 @@ sub run {
     }
 
     # Run netcat in container and check that we can reach it
-    my $image = "registry.opensuse.org/opensuse/bci/bci-busybox:latest";
+    my $image = "registry.opensuse.org/opensuse/busybox:latest";
     assert_script_run "$runtime pull $image";
     assert_script_run "$runtime run -d --name $container_name -p 1234:1234 $image nc -l -p 1234";
     assert_script_run "echo Hola Mundo >/dev/tcp/127.0.0.1/1234";

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -135,7 +135,7 @@ sub run {
         subnet => '10.64.0.0/16',
     };
     my $ctr2 = {
-        image => 'registry.opensuse.org/opensuse/bci/bci-busybox',
+        image => 'registry.opensuse.org/opensuse/busybox',
         name => 'busybox_ctr',
         ip => '10.64.0.8',
         mac => '92:aa:33:44:55:66',

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -60,9 +60,9 @@ sub run {
 
     # Run a container passing secret1 as default and secret2 as an env variable
     record_info("Access secrets");
-    script_retry("podman pull registry.opensuse.org/opensuse/bci/bci-busybox:latest",
+    script_retry("podman pull registry.opensuse.org/opensuse/busybox:latest",
         retry => 3, delay => 10, timeout => 120);
-    validate_script_output("podman run --name secret-test --secret secret1 --secret secret2,type=env,target=TOP_SECRET2 bci-busybox:latest /bin/sh -c 'cat /run/secrets/secret1; echo; printenv TOP_SECRET2'", sub { m/T0p_S3cr3t1\nT0p_S3cr3t2/ });
+    validate_script_output("podman run --name secret-test --secret secret1 --secret secret2,type=env,target=TOP_SECRET2 registry.opensuse.org/opensuse/busybox:latest /bin/sh -c 'cat /run/secrets/secret1; echo; printenv TOP_SECRET2'", sub { m/T0p_S3cr3t1\nT0p_S3cr3t2/ });
 
     # Commit the container and check that the secrets are not in it
     record_info("Commit cont", "Commit container secret-test");

--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -45,7 +45,7 @@ sub run {
     assert_script_run("mkdir -p $test_dir");
 
     # Create Dockerfile with VOLUME defined
-    assert_script_run("echo -e 'FROM registry.opensuse.org/opensuse/bci/bci-busybox:latest\\nVOLUME /$test_dir' > $test_dir/Dockerfile");
+    assert_script_run("echo -e 'FROM registry.opensuse.org/opensuse/busybox:latest\\nVOLUME /$test_dir' > $test_dir/Dockerfile");
 
     # Build image
     assert_script_run("$runtime build -t $test_image -f $test_dir/Dockerfile $test_dir/");


### PR DESCRIPTION
Use the same busybox image used in the libraries for consistency.

https://suse.slack.com/archives/C02CGKBCGT1/p1716885408648449

Verifications runs:
  - sle-15-SP6-Server-DVD-Updates-x86_64-Build20240527-1-podman_tests@64bit -> https://openqa.suse.de/tests/14463386