### PR TITLE
Add a workaround to enable wicked service

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -155,6 +155,12 @@ sub run {
     # during restart of the X/GDM stack
     if (is_sle_micro) {
         check_reboot_changes;
+        # Workaround to enable and start wicked service
+        if ((script_run('systemctl is-active wicked.service')) != 0) {
+            record_info('INFO', 'Workaround to enable and start wicked service');
+            systemctl 'enable wicked.service';
+            systemctl 'start wicked.service';
+        }
     } else {
         power_action('reboot', textmode => 1);
         reconnect_mgmt_console if is_pvm;


### PR DESCRIPTION
The wicked package version on target product is lower then it is on original product, wicked package is not changes during migration, and the wicked service is disbaled by systemd-presets-branding-SMO. Need to add a workaround to enable wicked service after migration.

- Related ticket: n/a
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/14463759