### PR TITLE
Add 15-SP6 & 15-SP7 on qam_install_sles4sap schedule

### DIFF
--- a/schedule/sles4sap/qam/common/qam_install_sles4sap.yaml
+++ b/schedule/sles4sap/qam/common/qam_install_sles4sap.yaml
@@ -75,6 +75,10 @@ conditional_schedule:
         - installation/system_role
       15-SP5:
         - installation/system_role
+      15-SP6:
+        - installation/system_role
+      15-SP7:
+        - installation/system_role
   qam_system_role:
     HORIZONTAL_MIGRATION:
       1:


### PR DESCRIPTION
Entries for 15-SP6 and 15-SP7 are missing in schedule `schedule/sles4sap/qam/common/qam_install_sles4sap.yaml` used in the installation of SLES and SLES for SAP Applications systems on QAM tests. This commit adds them.

No verification runs as change is trivial and shouldn't impact other tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
