### PR TITLE
Add ipaddr2 deployment sanity test

### DIFF
--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -58,4 +58,57 @@ subtest '[ipaddr2_destroy]' => sub {
     ok((any { /az group delete/ } @calls), 'Correct composition of the main command');
 };
 
+subtest '[ipaddr2_deployment_sanity] Pass' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    my @calls;
+    $ipaddr2->redefine(script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
+    $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+
+
+    $azcli->redefine(script_output => sub {
+            push @calls, ['azure_cli', $_[0]];
+            # Simulate az cli to return 2 resource groups
+            # one for the current jobId Volta and another one
+            if ($_[0] =~ /az group list*/) { return '["ip2tVolta","ip2tFermi"]'; }
+            # Simulate az cli to return exactly one name for the bastion VM name
+            if ($_[0] =~ /az vm list*/) { return '["ip2t-vm-bastion", "ip2t-vm-01", "ip2t-vm-02"]'; }
+            if ($_[0] =~ /az vm get-instance-view*/) { return '[ "PowerState/running", "VM running" ]'; }
+    });
+
+    ipaddr2_deployment_sanity();
+
+    for my $call_idx (0 .. $#calls) {
+        note("sles4sap::" . $calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
+    }
+    ok 1;
+};
+
+subtest '[ipaddr2_deployment_sanity] Fails rg num' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    my @calls;
+    $ipaddr2->redefine(script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+
+    # Simulate az cli to return 2 resource groups
+    # one for the current jobId Volta and another one
+    $ipaddr2->redefine(get_current_job_id => sub { return 'Majorana'; });
+    $azcli->redefine(script_output => sub {
+            push @calls, ['azure_cli', $_[0]];
+            if ($_[0] =~ /az group list*/) { return '["ip2tVolta","ip2tFermi"]'; }
+            if ($_[0] =~ /az vm list*/) { return '["ip2t-vm-bastion"]'; }
+    });
+
+    dies_ok { ipaddr2_deployment_sanity() } "Sanity check if there's any rg with the expected name";
+
+    for my $call_idx (0 .. $#calls) {
+        note("sles4sap::" . $calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
+    }
+    ok scalar @calls > 0, "Some calls to script_run and script_output";
+};
+
 done_testing;

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -22,7 +22,10 @@ sub run {
     # Init all the PC gears (ssh keys, CSP credentials)
     my $provider = $self->provider_factory();
 
-    ipaddr2_azure_deployment(region => $provider->provider_client->region, os => get_required_var('CLUSTER_OS_VER'));
+    ipaddr2_azure_deployment(
+        region => $provider->provider_client->region,
+        os => get_required_var('CLUSTER_OS_VER'));
+    ipaddr2_deployment_sanity();
 }
 
 sub test_flags {


### PR DESCRIPTION
Add function to validate the deployment in Azure.
Fix the IP range for the deployment VNET and SUBNET


- Related ticket: https://jira.suse.com/browse/TEAM-8721

# Verification run:

 ## PAYG
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test@64bit

- http://openqaworker15.qa.suse.cz/tests/285000 :red_circle: sporadic failure
- http://openqaworker15.qa.suse.cz/tests/285002 :green_circle: 

## BYOS
sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit

- http://openqaworker15.qa.suse.cz/tests/285001 :green_circle: 

