### PR TITLE
scap_workbench: some tweaks to improve on test robustness

### DIFF
--- a/schedule/security/scap_workbench.yaml
+++ b/schedule/security/scap_workbench.yaml
@@ -1,9 +1,13 @@
 name: scap_workbench
 description:    >
     This is for scap_workbench test
+vars:
+    QEMURAM: 4096
+    QEMUCPUS: 2
 schedule:
     - '{{bootloader}}'
     - boot/boot_to_desktop
+    - x11/disable_screensaver
     - security/scap_workbench/scap_workbench
 conditional_schedule:
     bootloader:

--- a/tests/security/scap_workbench/scap_workbench.pm
+++ b/tests/security/scap_workbench/scap_workbench.pm
@@ -13,7 +13,7 @@ use utils;
 use version_utils 'is_sle';
 
 sub authentication_required {
-    if (check_screen('Authentication-Required', timeout => 120)) {
+    if (check_screen('Authentication-Required', timeout => 240)) {
         type_password($testapi::password);
         assert_and_click('authenticate');
     }
@@ -38,18 +38,32 @@ sub run {
     enter_cmd("scap-workbench $content_to_load &");
     # Customize profile
     record_info('Customize profile');
-    assert_and_click('scap-workbench-Customize', timeout => 180);
-    assert_and_click('scap-workbench-Customize-Profile-OK', timeout => 180);
-    assert_and_click('scap-workbench-Customize-OK', timeout => 180);
-
+    wait_still_screen();
+    wait_screen_change {
+        assert_and_click('scap-workbench-Customize', timeout => 180);
+    };
+    # close the customization dialog
+    wait_screen_change {
+        assert_and_click('scap-workbench-Customize-Profile-OK', timeout => 180);
+    };
+    # close the right panel that should appear displaying the customized profile.
+    # if it's not present, select first element in order to show it
+    if (!check_screen 'scap-workbench-Customize-OK') {
+        send_key 'tab';
+    }
+    wait_screen_change {
+        assert_and_click('scap-workbench-Customize-OK', timeout => 180);
+    };
+    wait_still_screen();
     # Scan system
     record_info('Scan system');
     assert_and_click('scap-workbench-Scan');
     authentication_required();
+    wait_still_screen();
     # SLE file has 3x size so requires more time to scan
     if (is_sle()) {
         assert_and_click('scap-workbench-Diagnostics-Close', timeout => 600);
-        assert_screen('scap-workbench-Scan-Done');
+        assert_screen('scap-workbench-Scan-Done', timeout => 300);
     }
 
     # Show report after 'Scan'
@@ -96,7 +110,7 @@ sub run {
     authentication_required();
     if (is_sle()) {
         assert_and_click('scap-workbench-Diagnostics-Close', timeout => 600);
-        assert_screen('scap-workbench-Scan-Done');
+        assert_screen('scap-workbench-Scan-Done', timeout => 300);
     }
 
     # Turn to root console


### PR DESCRIPTION
- Disable screensaver during scan
- give more RAM and CPU resources to the SUT 
- tweaks to timeouts and needles handling


- Related ticket: https://progress.opensuse.org/issues/160988
- Needles: no
- Verification runs:
   - https://openqa.suse.de/tests/14480163
   - https://openqa.suse.de/tests/14480164
   - https://openqa.suse.de/tests/14480165
   - https://openqa.suse.de/tests/14480166
   - https://openqa.suse.de/tests/14480167
   - https://openqa.suse.de/tests/14480168
   - https://openqa.suse.de/tests/14480169
   - https://openqa.suse.de/tests/14480170
   - https://openqa.suse.de/tests/14480171
   - https://openqa.suse.de/tests/14480172
   - https://openqa.suse.de/tests/14480173
   - https://openqa.suse.de/tests/14480174
   - https://openqa.suse.de/tests/14480175
   - https://openqa.suse.de/tests/14480176
   - https://openqa.suse.de/tests/14480177

