### PR TITLE
Fix is_openstack

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -574,7 +574,7 @@ sub load_system_role_tests {
 }
 
 sub load_jeos_openstack_tests {
-    return if (!is_openstack || get_var('JEOS_OPENSTACK_UPLOAD_IMG', 0));
+    return unless is_openstack;
     my $args = OpenQA::Test::RunArgs->new();
     loadtest 'boot/boot_to_desktop';
     if (get_var('JEOS_OPENSTACK_UPLOAD_IMG')) {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -777,7 +777,7 @@ NO_CLOUD variable is set in order to test the image in QEMU
 =cut
 
 sub is_openstack {
-    return get_var('FLAVOR', '') =~ /JeOS-for-OpenStack-Cloud.*/ && check_var('NO_CLOUD', '0');
+    return get_var('FLAVOR', '') =~ /JeOS-for-OpenStack-Cloud.*/ && !get_var('NO_CLOUD');
 }
 
 =head2 is_leap_migration


### PR DESCRIPTION
Bring back `get_var` as `check_var` is too specific and NO_CLOUD is not always defined.

http://kepler.suse.cz/tests/23428

