### PR TITLE
Upload some zypper logs during qesap tests

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1202,6 +1202,14 @@ sub qesap_cluster_log_cmds {
             Cmd => 'cat /var/tmp/hdblcm.log',
             Output => 'hdblcm.log.txt',
         },
+        {
+            Cmd => 'cat /var/log/zypper.log',
+            Output => 'zypper.log.txt',
+        },
+        {
+            Cmd => 'cat /var/log/zypp/history',
+            Output => 'zypp.history.txt',
+        },
     );
     if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
         push @log_list, {


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1224249

# Verification run:
 - sle-15-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:33974:python3-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/285074 :green_circle: upload works http://openqaworker15.qa.suse.cz/tests/285074/logfile?filename=deploy_qesap_ansible-hana0-zypper.log.txt
 
 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_fencing_native_test@64bit -> http://openqaworker15.qa.suse.cz/tests/285075 :green_circle:  http://openqaworker15.qa.suse.cz/tests/285075/logfile?filename=deploy-hana1-zypp.history.txt
