### PR TITLE
P.C. SLM update shall use registercloudguest

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -109,7 +109,7 @@ sub registercloudguest {
     my ($instance) = @_;
     my $regcode = get_required_var('SCC_REGCODE');
     my $path = is_sle('>15') && is_sle('<15-SP3') ? '/usr/sbin/' : '';
-    my $suseconnect = $path . get_var("PUBLIC_CLOUD_SCC_ENDPOINT", (is_transactional) ? "transactional-update register" : "registercloudguest");
+    my $suseconnect = $path . get_var("PUBLIC_CLOUD_SCC_ENDPOINT", "registercloudguest");
     my $cmd_time = time();
     # Check what version of registercloudguest binary we use
     $instance->ssh_script_run(cmd => "rpm -qa cloud-regionsrv-client");


### PR DESCRIPTION
P.C. SL-Micro test actually perform **registration** using by default the `transactional-update` selected for transactionals while `registercloudguest` for other cases. 

Instead, for p.c. registrations _always_ the default shall be the `registercloudguest` command, refer to https://bugzilla.suse.com/show_bug.cgi?id=1224014 

- Related ticket: https://progress.opensuse.org/issues/161177
- Needles: N/A
- Verification run, all PASS ok:

cloned SLM test on master, using forced `PUBLIC_CLOUD_SCC_ENDPOINT=registercloudguest`:
- sle-micro-5.5-EC2-BYOS-Updates-aarch64-Build20240528-1-slem_basic @ec2_c6g.large
  https://openqa.suse.de/tests/14481055#step/registration/17

cloned SLM on new code using by default `registercloudguest`:
- sle-micro-5.5-EC2-BYOS-Updates-aarch64-Build20240528-1-slem_basic @ec2_c6g.large
  https://openqa.suse.de/tests/14481057#step/registration/17

- sle-micro-5.5-EC2-BYOS-Updates-aarch64-Build20240528-1-publiccloud_ltp_cve @ec2_c6g.large
  https://openqa.suse.de/tests/14481066#step/registration/17

- sle-micro-6.0-Azure-BYOS-x86_64-Build0027-slem_basic @az_Standard_B2s 
  https://openqa.suse.de/tests/14481071#step/registration/17
