### PR TITLE
Use "$testapi::password" instead of hardcode

### DIFF
--- a/data/autoinst.xml
+++ b/data/autoinst.xml
@@ -51,7 +51,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -69,7 +69,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast/autoyast_btrfs.xml
+++ b/data/autoyast/autoyast_btrfs.xml
@@ -149,7 +149,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -167,7 +167,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast/autoyast_eula.xml
+++ b/data/autoyast/autoyast_eula.xml
@@ -51,12 +51,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast/mini.xml
+++ b/data/autoyast/mini.xml
@@ -28,12 +28,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/autoyast_btrfs_luks1_separate_boot.xml
+++ b/data/autoyast_opensuse/autoyast_btrfs_luks1_separate_boot.xml
@@ -124,12 +124,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/autoyast_btrfs_luks2.xml
+++ b/data/autoyast_opensuse/autoyast_btrfs_luks2.xml
@@ -124,12 +124,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/autoyast_btrfs_quota.xml
+++ b/data/autoyast_opensuse/autoyast_btrfs_quota.xml
@@ -43,12 +43,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">true</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/autoyast_opensuse/autoyast_firstboot.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot.xml
@@ -33,12 +33,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/autoyast_opensuse/autoyast_firstboot_leap.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot_leap.xml
@@ -36,12 +36,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/autoyast_opensuse/autoyast_leap-micro.xml.ep
+++ b/data/autoyast_opensuse/autoyast_leap-micro.xml.ep
@@ -50,12 +50,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/autoyast_multi_btrfs.xml
+++ b/data/autoyast_opensuse/autoyast_multi_btrfs.xml
@@ -32,12 +32,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">true</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/autoyast_opensuse/autoyast_wicked_x86_64.xml.ep
+++ b/data/autoyast_opensuse/autoyast_wicked_x86_64.xml.ep
@@ -42,12 +42,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/opensuse_autoyast_local_tftp.xml
+++ b/data/autoyast_opensuse/opensuse_autoyast_local_tftp.xml
@@ -75,12 +75,12 @@ chmod 755 /srv/tftpboot
   <users config:type="list">
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/opensuse_autoyast_tftp.xml
+++ b/data/autoyast_opensuse/opensuse_autoyast_tftp.xml
@@ -91,7 +91,7 @@ chmod 755 /srv/tftpboot
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -109,7 +109,7 @@ chmod 755 /srv/tftpboot
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/opensuse_gnome.xml
+++ b/data/autoyast_opensuse/opensuse_gnome.xml
@@ -32,12 +32,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>  
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/opensuse_leap.xml.ep
+++ b/data/autoyast_opensuse/opensuse_leap.xml.ep
@@ -360,12 +360,12 @@
     <user>
       <fullname>bernhard</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/opensuse_leap_gnome.xml
+++ b/data/autoyast_opensuse/opensuse_leap_gnome.xml
@@ -32,12 +32,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/opensuse_leap_minimal.xml
+++ b/data/autoyast_opensuse/opensuse_leap_minimal.xml
@@ -26,12 +26,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/opensuse_minimal.xml
+++ b/data/autoyast_opensuse/opensuse_minimal.xml
@@ -23,12 +23,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>  
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_opensuse/rule-based_example/classes/general/users.xml
+++ b/data/autoyast_opensuse/rule-based_example/classes/general/users.xml
@@ -7,7 +7,7 @@
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>Bernhard M. Wiedemann</fullname>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -17,7 +17,7 @@
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_qam/12-common_base_installation.xml.ep
+++ b/data/autoyast_qam/12-common_base_installation.xml.ep
@@ -526,7 +526,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -544,7 +544,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_qam/12_installation.xml.ep
+++ b/data/autoyast_qam/12_installation.xml.ep
@@ -394,7 +394,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -412,7 +412,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_qam/15-common_base_installation.xml.ep
+++ b/data/autoyast_qam/15-common_base_installation.xml.ep
@@ -407,7 +407,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -425,7 +425,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -349,7 +349,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -367,7 +367,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_rt_sp1.xml
+++ b/data/autoyast_rt_sp1.xml
@@ -176,7 +176,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -194,7 +194,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoinst_h1_btrfs.xml
+++ b/data/autoyast_sle12/autoinst_h1_btrfs.xml
@@ -361,7 +361,7 @@ ls -lsa /
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -377,7 +377,7 @@ ls -lsa /
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoinst_h3_xfs.xml
+++ b/data/autoyast_sle12/autoinst_h3_xfs.xml
@@ -309,7 +309,7 @@ sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_c
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -325,7 +325,7 @@ sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_c
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
 

--- a/data/autoyast_sle12/autoinst_h5_btrfs_uuid.xml
+++ b/data/autoyast_sle12/autoinst_h5_btrfs_uuid.xml
@@ -436,7 +436,7 @@ ls -lsa /
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -452,7 +452,7 @@ ls -lsa /
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
 

--- a/data/autoyast_sle12/autoyast_error.xml
+++ b/data/autoyast_sle12/autoyast_error.xml
@@ -123,7 +123,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -141,7 +141,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_ext4.xml
+++ b/data/autoyast_sle12/autoyast_ext4.xml
@@ -142,7 +142,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -160,7 +160,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_firstboot.xml
+++ b/data/autoyast_sle12/autoyast_firstboot.xml
@@ -99,7 +99,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -117,7 +117,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_gnome.xml
+++ b/data/autoyast_sle12/autoyast_gnome.xml
@@ -98,7 +98,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -116,7 +116,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_multipath.xml
+++ b/data/autoyast_sle12/autoyast_multipath.xml
@@ -534,7 +534,7 @@ pre init scripts feature. See poo#20818.
       <gid>100</gid>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_sdk.xml
+++ b/data/autoyast_sle12/autoyast_sdk.xml
@@ -100,7 +100,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -118,7 +118,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_sdk_ha.xml
+++ b/data/autoyast_sle12/autoyast_sdk_ha.xml
@@ -110,7 +110,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -128,7 +128,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_sles12sp3+alladdons_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+alladdons_allpatterns_reg_full_s390x.xml
@@ -389,7 +389,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -407,7 +407,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_sles12sp3+alladdons_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+alladdons_default_reg_full_s390x.xml
@@ -346,7 +346,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -364,7 +364,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_allpatterns_reg_full_s390x.xml
@@ -304,7 +304,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -322,7 +322,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_default_reg_full_s390x.xml
@@ -268,7 +268,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -286,7 +286,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_sles12sp3_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3_allpatterns_reg_full_s390x.xml
@@ -248,7 +248,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -266,7 +266,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_sles12sp3_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3_default_reg_full_s390x.xml
@@ -216,7 +216,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -234,7 +234,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_wicked_aarch64.xml
+++ b/data/autoyast_sle12/autoyast_wicked_aarch64.xml
@@ -63,12 +63,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_wicked_ppc64le.xml
+++ b/data/autoyast_sle12/autoyast_wicked_ppc64le.xml
@@ -70,12 +70,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_wicked_x86_64.xml
+++ b/data/autoyast_sle12/autoyast_wicked_x86_64.xml
@@ -49,12 +49,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/autoyast_wicked_x86_64.xml.ep
+++ b/data/autoyast_sle12/autoyast_wicked_x86_64.xml.ep
@@ -68,12 +68,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/ay.xml
+++ b/data/autoyast_sle12/ay.xml
@@ -407,7 +407,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -425,7 +425,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-868614_autoinst.xml
+++ b/data/autoyast_sle12/bug-868614_autoinst.xml
@@ -115,7 +115,7 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -124,7 +124,7 @@
       <fullname>root</fullname>
       <gid>0</gid>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-870998_autoinst.xml
+++ b/data/autoyast_sle12/bug-870998_autoinst.xml
@@ -339,7 +339,7 @@ sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_c
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -355,7 +355,7 @@ sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_c
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
 

--- a/data/autoyast_sle12/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle12/bug-872532_ix64ph1069.xml
@@ -867,7 +867,7 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -887,7 +887,7 @@
       </password_settings>
       <shell>/usr/sbin/nologin</shell>
       <uid>491</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>scard</username>
     </user>
     <user>
@@ -905,7 +905,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bin</username>
     </user>
     <user>
@@ -923,7 +923,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>495</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>puppet</username>
     </user>
     <user>
@@ -941,7 +941,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>492</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>statd</username>
     </user>
     <user>
@@ -959,7 +959,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>12</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>games</username>
     </user>
     <user>
@@ -977,7 +977,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
     <user>
@@ -995,7 +995,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>499</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>messagebus</username>
     </user>
     <user>
@@ -1013,7 +1013,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>65534</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nobody</username>
     </user>
     <user>
@@ -1031,7 +1031,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>74</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ntp</username>
     </user>
     <user>
@@ -1049,7 +1049,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>25</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>at</username>
     </user>
     <user>
@@ -1067,7 +1067,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>9</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>news</username>
     </user>
     <user>
@@ -1085,7 +1085,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>4</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>lp</username>
     </user>
     <user>
@@ -1103,7 +1103,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>2</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>daemon</username>
     </user>
     <user>
@@ -1121,7 +1121,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>497</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>polkitd</username>
     </user>
     <user>
@@ -1139,7 +1139,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>10</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>uucp</username>
     </user>
     <user>
@@ -1157,7 +1157,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>40</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ftp</username>
     </user>
     <user>
@@ -1175,7 +1175,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>30</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>wwwrun</username>
     </user>
     <user>
@@ -1193,7 +1193,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>494</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>openslp</username>
     </user>
     <user>
@@ -1211,7 +1211,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>13</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>man</username>
     </user>
     <user>
@@ -1229,7 +1229,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>498</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>sshd</username>
     </user>
     <user>
@@ -1247,7 +1247,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>51</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>postfix</username>
     </user>
     <user>
@@ -1265,7 +1265,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>496</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nscd</username>
     </user>
     <user>
@@ -1283,7 +1283,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>493</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>rpc</username>
     </user>
     <user>
@@ -1301,7 +1301,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>8</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>mail</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-876411_sles12_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle12/bug-876411_sles12_btrfs_h5_autoinst.xml
@@ -934,7 +934,7 @@ find / -name YaST2-Second-Stage.service
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -954,7 +954,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>65534</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nobody</username>
     </user>
     <user>
@@ -972,7 +972,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bin</username>
     </user>
     <user>
@@ -990,7 +990,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/false</shell>
       <uid>495</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>puppet</username>
     </user>
     <user>
@@ -1008,7 +1008,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/false</shell>
       <uid>498</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>sshd</username>
     </user>
     <user>
@@ -1026,7 +1026,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/false</shell>
       <uid>30</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>wwwrun</username>
     </user>
     <user>
@@ -1044,7 +1044,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>492</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>statd</username>
     </user>
     <user>
@@ -1062,7 +1062,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>9</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>news</username>
     </user>
     <user>
@@ -1080,7 +1080,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>40</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ftp</username>
     </user>
     <user>
@@ -1098,7 +1098,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>13</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>man</username>
     </user>
     <user>
@@ -1116,7 +1116,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>496</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nscd</username>
     </user>
     <user>
@@ -1134,7 +1134,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>493</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>rpc</username>
     </user>
     <user>
@@ -1152,7 +1152,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/false</shell>
       <uid>51</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>postfix</username>
     </user>
     <user>
@@ -1170,7 +1170,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/false</shell>
       <uid>8</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>mail</username>
     </user>
     <user>
@@ -1188,7 +1188,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>12</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>games</username>
     </user>
     <user>
@@ -1206,7 +1206,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>494</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>openslp</username>
     </user>
     <user>
@@ -1224,7 +1224,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/false</shell>
       <uid>499</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>messagebus</username>
     </user>
     <user>
@@ -1242,7 +1242,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/usr/sbin/nologin</shell>
       <uid>491</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>scard</username>
     </user>
     <user>
@@ -1260,7 +1260,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>2</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>daemon</username>
     </user>
     <user>
@@ -1278,7 +1278,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
     <user>
@@ -1296,7 +1296,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>25</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>at</username>
     </user>
     <user>
@@ -1314,7 +1314,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>497</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>polkitd</username>
     </user>
     <user>
@@ -1332,7 +1332,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>10</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>uucp</username>
     </user>
     <user>
@@ -1350,7 +1350,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>4</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>lp</username>
     </user>
     <user>
@@ -1368,7 +1368,7 @@ find / -name YaST2-Second-Stage.service
       </password_settings>
       <shell>/bin/false</shell>
       <uid>74</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ntp</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-877438_ix64ph1029.xml
+++ b/data/autoyast_sle12/bug-877438_ix64ph1029.xml
@@ -108,7 +108,7 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -117,7 +117,7 @@
       <fullname>root</fullname>
       <gid>0</gid>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-879147_autoinst.xml
+++ b/data/autoyast_sle12/bug-879147_autoinst.xml
@@ -279,7 +279,7 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -288,7 +288,7 @@
       <fullname>root</fullname>
       <gid>0</gid>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-881307_autoinst.xml
+++ b/data/autoyast_sle12/bug-881307_autoinst.xml
@@ -353,7 +353,7 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -364,7 +364,7 @@
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-887126_autoinst.xml
+++ b/data/autoyast_sle12/bug-887126_autoinst.xml
@@ -535,13 +535,13 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
   </users>

--- a/data/autoyast_sle12/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle12/bug-887653_autoinst_jy-snapshot.xml
@@ -230,7 +230,7 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -249,7 +249,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
     <user>
@@ -265,7 +265,7 @@
         <warn/>
       </password_settings>
       <shell>/bin/bash</shell>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>testusr</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-888296_autoinst.xml
+++ b/data/autoyast_sle12/bug-888296_autoinst.xml
@@ -1546,7 +1546,7 @@
       <shell>/bin/bash</shell>
       <username>bernhard</username>
       <uid>1001</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
@@ -1563,7 +1563,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ix64ph1045</username>
     </user>
     <user>
@@ -1581,7 +1581,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>498</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>sshd</username>
     </user>
     <user>
@@ -1599,7 +1599,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>2</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>daemon</username>
     </user>
     <user>
@@ -1617,7 +1617,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>491</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>statd</username>
     </user>
     <user>
@@ -1635,7 +1635,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>490</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ftpsecure</username>
     </user>
     <user>
@@ -1653,7 +1653,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>25</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>at</username>
     </user>
     <user>
@@ -1671,7 +1671,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>12</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>games</username>
     </user>
     <user>
@@ -1689,7 +1689,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>13</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>man</username>
     </user>
     <user>
@@ -1707,7 +1707,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>499</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>messagebus</username>
     </user>
     <user>
@@ -1725,7 +1725,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>51</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>postfix</username>
     </user>
     <user>
@@ -1743,7 +1743,7 @@
       </password_settings>
       <shell>/usr/sbin/nologin</shell>
       <uid>489</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>scard</username>
     </user>
     <user>
@@ -1761,7 +1761,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>40</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ftp</username>
     </user>
     <user>
@@ -1779,7 +1779,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>65534</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nobody</username>
     </user>
     <user>
@@ -1797,7 +1797,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>30</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>wwwrun</username>
     </user>
     <user>
@@ -1815,7 +1815,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>496</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nscd</username>
     </user>
     <user>
@@ -1833,7 +1833,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>4</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>lp</username>
     </user>
     <user>
@@ -1851,7 +1851,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>74</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ntp</username>
     </user>
     <user>
@@ -1869,7 +1869,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>10</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>uucp</username>
     </user>
     <user>
@@ -1887,7 +1887,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>8</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>mail</username>
     </user>
     <user>
@@ -1905,7 +1905,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>492</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>pulse</username>
     </user>
     <user>
@@ -1923,7 +1923,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>493</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>rtkit</username>
     </user>
     <user>
@@ -1941,7 +1941,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>9</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>news</username>
     </user>
     <user>
@@ -1959,7 +1959,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bin</username>
     </user>
     <user>
@@ -1977,7 +1977,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>495</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>rpc</username>
     </user>
     <user>
@@ -1995,7 +1995,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
     <user>
@@ -2013,7 +2013,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>497</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>polkitd</username>
     </user>
     <user>
@@ -2031,7 +2031,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>494</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>openslp</username>
     </user>
   </users>

--- a/data/autoyast_sle12/bug-892069_autoinst.xml
+++ b/data/autoyast_sle12/bug-892069_autoinst.xml
@@ -529,7 +529,7 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -548,7 +548,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1001</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>maier</username>
     </user>
     <user>
@@ -566,7 +566,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>499</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>messagebus</username>
     </user>
     <user>
@@ -584,7 +584,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>498</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>sshd</username>
     </user>
     <user>
@@ -602,7 +602,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>12</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>games</username>
     </user>
     <user>
@@ -620,7 +620,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>496</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nscd</username>
     </user>
     <user>
@@ -638,7 +638,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>65534</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nobody</username>
     </user>
     <user>
@@ -656,7 +656,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>8</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>mail</username>
     </user>
     <user>
@@ -674,7 +674,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bin</username>
     </user>
     <user>
@@ -692,7 +692,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>2</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>daemon</username>
     </user>
     <user>
@@ -710,7 +710,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>9</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>news</username>
     </user>
     <user>
@@ -728,7 +728,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>10</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>uucp</username>
     </user>
     <user>
@@ -746,7 +746,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>495</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>rpc</username>
     </user>
     <user>
@@ -764,7 +764,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
     <user>
@@ -782,7 +782,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>4</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>lp</username>
     </user>
     <user>
@@ -800,7 +800,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>494</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>openslp</username>
     </user>
     <user>
@@ -818,7 +818,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>497</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>polkitd</username>
     </user>
     <user>
@@ -836,7 +836,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>30</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>wwwrun</username>
     </user>
     <user>
@@ -854,7 +854,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>13</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>man</username>
     </user>
     <user>
@@ -872,7 +872,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>40</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ftp</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_SuSEfirewall.xml
+++ b/data/autoyast_sle15/autoyast_SuSEfirewall.xml
@@ -36,12 +36,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_btrfs_luks1_separate_boot.xml
+++ b/data/autoyast_sle15/autoyast_btrfs_luks1_separate_boot.xml
@@ -184,7 +184,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -202,7 +202,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_btrfs_luks2.xml
+++ b/data/autoyast_sle15/autoyast_btrfs_luks2.xml
@@ -184,7 +184,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -202,7 +202,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_firewalld.xml
+++ b/data/autoyast_sle15/autoyast_firewalld.xml
@@ -35,12 +35,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_aarch64.xml.ep
@@ -139,12 +139,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
+++ b/data/autoyast_sle15/autoyast_hpc_x86_64.xml.ep
@@ -125,12 +125,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_rt.xml
+++ b/data/autoyast_sle15/autoyast_rt.xml
@@ -146,7 +146,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -164,7 +164,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_sle-micro.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro.xml.ep
@@ -45,12 +45,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_sle-micro53_updates.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro53_updates.xml.ep
@@ -48,12 +48,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
@@ -53,12 +53,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_wicked_aarch64.xml
+++ b/data/autoyast_sle15/autoyast_wicked_aarch64.xml
@@ -75,12 +75,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
+++ b/data/autoyast_sle15/autoyast_wicked_ppc64le.xml
@@ -87,12 +87,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/autoyast_wicked_x86_64.xml
+++ b/data/autoyast_sle15/autoyast_wicked_x86_64.xml
@@ -78,12 +78,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sle15/mini_s390x.xml
+++ b/data/autoyast_sle15/mini_s390x.xml
@@ -45,12 +45,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/autoyast_sle15/mini_staging.xml
+++ b/data/autoyast_sle15/mini_staging.xml
@@ -33,12 +33,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -130,12 +130,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/autoyast_sles11/11sp4_autoyast.xml
+++ b/data/autoyast_sles11/11sp4_autoyast.xml
@@ -65,12 +65,12 @@
   <users config:type="list">
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
 	  <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>bernhard</username>
           </user>
   </users>

--- a/data/autoyast_sles11/11sp4_autoyast_dns.xml
+++ b/data/autoyast_sles11/11sp4_autoyast_dns.xml
@@ -404,12 +404,12 @@
   <users config:type="list">
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
 	  <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>bernhard</username>
           </user>
   </users>

--- a/data/autoyast_sles11/11sp4_autoyast_ftp.xml
+++ b/data/autoyast_sles11/11sp4_autoyast_ftp.xml
@@ -96,12 +96,12 @@ echo -e "\nlisten=NO\nlisten_ipv6=NO" >> /etc/vsftpd.conf
   <users config:type="list">
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>bernhard</username>
           </user>
 

--- a/data/autoyast_sles11/11sp4_autoyast_http.xml
+++ b/data/autoyast_sles11/11sp4_autoyast_http.xml
@@ -436,12 +436,12 @@ Tmr9shvqBQKa2NyWfUBcct9hvmlrZD6fnc9a4+3nTxv3TJRwxBUc9Q==
   <users config:type="list">
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>bernhard</username>
           </user>
   </users>

--- a/data/autoyast_sles11/11sp4_autoyast_tftp.xml
+++ b/data/autoyast_sles11/11sp4_autoyast_tftp.xml
@@ -47,12 +47,12 @@ chmod 755 /srv/tftpboot
   <users config:type="list">
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>bernhard</username>
           </user>
 

--- a/data/autoyast_sles11/11sp4_autoyast_x11-gnome.xml
+++ b/data/autoyast_sles11/11sp4_autoyast_x11-gnome.xml
@@ -74,13 +74,13 @@
   <users config:type="list">
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <username>bernhard</username>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
 
           </user>
   </users>

--- a/data/autoyast_sles11/11sp4_autoyast_x11-minimalx.xml
+++ b/data/autoyast_sles11/11sp4_autoyast_x11-minimalx.xml
@@ -73,13 +73,13 @@
   <users config:type="list">
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <username>bernhard</username>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
           </user>
   </users>
 

--- a/data/autoyast_sles11/11sp4_autoyast_x11.xml
+++ b/data/autoyast_sles11/11sp4_autoyast_x11.xml
@@ -183,12 +183,12 @@
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <username>root</username>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
           </user>
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <username>bernhard</username>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
           </user>
   </users>
 

--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -243,12 +243,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/cpu_bugs/autoyast/SLE-12-SP4/autoyast_gnome.xml.ep
+++ b/data/cpu_bugs/autoyast/SLE-12-SP4/autoyast_gnome.xml.ep
@@ -132,7 +132,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -142,7 +142,7 @@
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/cpu_bugs/autoyast/SLE-15-SP0/sles-15-kvm-guest-autoyast.xml
+++ b/data/cpu_bugs/autoyast/SLE-15-SP0/sles-15-kvm-guest-autoyast.xml
@@ -306,7 +306,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -316,7 +316,7 @@
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/cpu_bugs/autoyast/SLE-15-SP1/sles-15-kvm-guest-autoyast.xml
+++ b/data/cpu_bugs/autoyast/SLE-15-SP1/sles-15-kvm-guest-autoyast.xml
@@ -306,7 +306,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -316,7 +316,7 @@
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/filesystem/autoyast_filesystem.xml
+++ b/data/filesystem/autoyast_filesystem.xml
@@ -56,12 +56,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/filesystem/autoyast_filesystem_ext4_btrfs.xml
+++ b/data/filesystem/autoyast_filesystem_ext4_btrfs.xml
@@ -56,12 +56,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/filesystem/autoyast_filesystem_withouthome_kernel.xml.ep
+++ b/data/filesystem/autoyast_filesystem_withouthome_kernel.xml.ep
@@ -90,12 +90,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/filesystem/autoyast_filesystem_withouthome_yast.xml.ep
+++ b/data/filesystem/autoyast_filesystem_withouthome_yast.xml.ep
@@ -102,12 +102,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/qam/dracut/12-SP2_custom_lvm.xml.ep
+++ b/data/qam/dracut/12-SP2_custom_lvm.xml.ep
@@ -439,7 +439,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -457,7 +457,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/qam/dracut/12-SP2_custom_usr.xml.ep
+++ b/data/qam/dracut/12-SP2_custom_usr.xml.ep
@@ -365,7 +365,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -383,7 +383,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/qam/dracut/12_custom_lvm.xml.ep
+++ b/data/qam/dracut/12_custom_lvm.xml.ep
@@ -439,7 +439,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -457,7 +457,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/qam/dracut/12_custom_usr.xml.ep
+++ b/data/qam/dracut/12_custom_usr.xml.ep
@@ -269,7 +269,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -287,7 +287,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/qam/dracut/15_custom_lvm.xml.ep
+++ b/data/qam/dracut/15_custom_lvm.xml.ep
@@ -287,7 +287,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -305,7 +305,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/qam/dracut/15_custom_usr.xml.ep
+++ b/data/qam/dracut/15_custom_usr.xml.ep
@@ -271,7 +271,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -289,7 +289,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/security/autoyast_sles15_stig.xml
+++ b/data/security/autoyast_sles15_stig.xml
@@ -63,12 +63,12 @@
   <user>
     <encrypted config:type="boolean">false</encrypted>
     <username>root</username>
-    <user_password>nots3cr3t</user_password>
+    <user_password>{{PASSWORD}}</user_password>
   </user>
   <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
   </user>  
 </users>

--- a/data/supportserver/autoyast_supportserver_non_x86.xml
+++ b/data/supportserver/autoyast_supportserver_non_x86.xml
@@ -75,12 +75,12 @@
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <username>root</username>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
           </user>
 	  <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <username>bernhard</username>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
           </user>
   </users>
 

--- a/data/supportserver/autoyast_supportserver_x86.xml
+++ b/data/supportserver/autoyast_supportserver_x86.xml
@@ -75,12 +75,12 @@
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <username>root</username>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <username>bernhard</username>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
     </user>
   </users>
 

--- a/data/supportserver/autoyast_supportserver_x86_sle15.xml
+++ b/data/supportserver/autoyast_supportserver_x86_sle15.xml
@@ -193,12 +193,12 @@
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <username>root</username>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <username>bernhard</username>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
     </user>
   </users>
   <services-manager>

--- a/data/x11/autoyast_remote_desktop_sle12sp2_gnome.xml
+++ b/data/x11/autoyast_remote_desktop_sle12sp2_gnome.xml
@@ -74,7 +74,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -92,7 +92,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/autoyast_pcm_lgm_allpatterns_ppc64le.xml.ep
+++ b/data/yam/autoyast/autoyast_pcm_lgm_allpatterns_ppc64le.xml.ep
@@ -157,7 +157,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -175,7 +175,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/autoyast_sle_powervm.xml.ep
+++ b/data/yam/autoyast/autoyast_sle_powervm.xml.ep
@@ -165,7 +165,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -183,7 +183,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/bcache.xml
+++ b/data/yam/autoyast/bcache.xml
@@ -153,7 +153,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -171,7 +171,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/btrfs.xml
+++ b/data/yam/autoyast/btrfs.xml
@@ -157,7 +157,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -175,7 +175,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/btrfs_quota.xml
+++ b/data/yam/autoyast/btrfs_quota.xml
@@ -37,12 +37,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/bug-872532_ix64ph1069.xml
+++ b/data/yam/autoyast/bug-872532_ix64ph1069.xml
@@ -751,7 +751,7 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -769,7 +769,7 @@
       </password_settings>
       <shell>/usr/sbin/nologin</shell>
       <uid>491</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>scard</username>
     </user>
     <user>
@@ -787,7 +787,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bin</username>
     </user>
     <user>
@@ -805,7 +805,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>495</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>puppet</username>
     </user>
     <user>
@@ -823,7 +823,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>492</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>statd</username>
     </user>
     <user>
@@ -841,7 +841,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>12</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>games</username>
     </user>
     <user>
@@ -859,7 +859,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
     <user>
@@ -877,7 +877,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>499</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>messagebus</username>
     </user>
     <user>
@@ -895,7 +895,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>65534</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nobody</username>
     </user>
     <user>
@@ -913,7 +913,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>74</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ntp</username>
     </user>
     <user>
@@ -931,7 +931,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>25</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>at</username>
     </user>
     <user>
@@ -949,7 +949,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>9</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>news</username>
     </user>
     <user>
@@ -967,7 +967,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>4</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>lp</username>
     </user>
     <user>
@@ -985,7 +985,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>2</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>daemon</username>
     </user>
     <user>
@@ -1003,7 +1003,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>497</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>polkitd</username>
     </user>
     <user>
@@ -1021,7 +1021,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>10</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>uucp</username>
     </user>
     <user>
@@ -1039,7 +1039,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>40</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ftp</username>
     </user>
     <user>
@@ -1057,7 +1057,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>30</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>wwwrun</username>
     </user>
     <user>
@@ -1075,7 +1075,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>494</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>openslp</username>
     </user>
     <user>
@@ -1093,7 +1093,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>13</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>man</username>
     </user>
     <user>
@@ -1111,7 +1111,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>498</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>sshd</username>
     </user>
     <user>
@@ -1129,7 +1129,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>51</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>postfix</username>
     </user>
     <user>
@@ -1147,7 +1147,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>496</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nscd</username>
     </user>
     <user>
@@ -1165,7 +1165,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>493</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>rpc</username>
     </user>
     <user>
@@ -1183,7 +1183,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>8</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>mail</username>
     </user>
   </users>

--- a/data/yam/autoyast/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/yam/autoyast/bug-876411_btrfs_h5_autoinst.xml
@@ -786,7 +786,7 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
@@ -806,7 +806,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>65534</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nobody</username>
     </user>
     <user>
@@ -824,7 +824,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bin</username>
     </user>
     <user>
@@ -842,7 +842,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>495</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>puppet</username>
     </user>
     <user>
@@ -860,7 +860,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>498</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>sshd</username>
     </user>
     <user>
@@ -878,7 +878,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>30</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>wwwrun</username>
     </user>
     <user>
@@ -896,7 +896,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>492</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>statd</username>
     </user>
     <user>
@@ -914,7 +914,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>9</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>news</username>
     </user>
     <user>
@@ -932,7 +932,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>40</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ftp</username>
     </user>
     <user>
@@ -950,7 +950,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>13</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>man</username>
     </user>
     <user>
@@ -968,7 +968,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>496</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>nscd</username>
     </user>
     <user>
@@ -986,7 +986,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>493</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>rpc</username>
     </user>
     <user>
@@ -1004,7 +1004,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>51</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>postfix</username>
     </user>
     <user>
@@ -1022,7 +1022,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>8</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>mail</username>
     </user>
     <user>
@@ -1040,7 +1040,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>12</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>games</username>
     </user>
     <user>
@@ -1058,7 +1058,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>494</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>openslp</username>
     </user>
     <user>
@@ -1076,7 +1076,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>499</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>messagebus</username>
     </user>
     <user>
@@ -1094,7 +1094,7 @@
       </password_settings>
       <shell>/usr/sbin/nologin</shell>
       <uid>491</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>scard</username>
     </user>
     <user>
@@ -1112,7 +1112,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>2</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>daemon</username>
     </user>
     <user>
@@ -1130,7 +1130,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
     <user>
@@ -1148,7 +1148,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>25</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>at</username>
     </user>
     <user>
@@ -1166,7 +1166,7 @@
       </password_settings>
       <shell>/sbin/nologin</shell>
       <uid>497</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>polkitd</username>
     </user>
     <user>
@@ -1184,7 +1184,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>10</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>uucp</username>
     </user>
     <user>
@@ -1202,7 +1202,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>4</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>lp</username>
     </user>
     <user>
@@ -1220,7 +1220,7 @@
       </password_settings>
       <shell>/bin/false</shell>
       <uid>74</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>ntp</username>
     </user>
   </users>

--- a/data/yam/autoyast/bug-877438_ix64ph1029.xml
+++ b/data/yam/autoyast/bug-877438_ix64ph1029.xml
@@ -129,7 +129,7 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -137,7 +137,7 @@
       <fullname>root</fullname>
       <gid>0</gid>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/bug-879147_autoinst.xml
+++ b/data/yam/autoyast/bug-879147_autoinst.xml
@@ -294,13 +294,13 @@
       <user>
         <encrypted config:type="boolean">false</encrypted>
         <fullname>Bernhard M. Wiedemann</fullname>
-        <user_password>nots3cr3t</user_password>
+        <user_password>{{PASSWORD}}</user_password>
         <username>bernhard</username>
       </user>
       <user>
         <encrypted config:type="boolean">false</encrypted>
         <fullname>root</fullname>
-        <user_password>nots3cr3t</user_password>
+        <user_password>{{PASSWORD}}</user_password>
         <username>root</username>
       </user>
   </users>

--- a/data/yam/autoyast/bug-887126_autoinst.xml
+++ b/data/yam/autoyast/bug-887126_autoinst.xml
@@ -471,13 +471,13 @@
                 <user>
                    <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
+                   <user_password>{{PASSWORD}}</user_password>
                    <username>bernhard</username>
                 </user>
 
           <user>
                       <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
+                      <user_password>{{PASSWORD}}</user_password>
                       <username>root</username>
           </user>
   </users>

--- a/data/yam/autoyast/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/yam/autoyast/bug-887653_autoinst_jy-snapshot.xml
@@ -192,7 +192,7 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -210,7 +210,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
     <user>
@@ -226,7 +226,7 @@
         <warn/>
       </password_settings>
       <shell>/bin/bash</shell>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>testusr</username>
     </user>
   </users>

--- a/data/yam/autoyast/create_hdd_gnome.xml
+++ b/data/yam/autoyast/create_hdd_gnome.xml
@@ -48,12 +48,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/create_hdd_migration_ppc64le.xml.ep
+++ b/data/yam/autoyast/create_hdd_migration_ppc64le.xml.ep
@@ -351,7 +351,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -369,7 +369,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/disk_as_md_member.xml
+++ b/data/yam/autoyast/disk_as_md_member.xml
@@ -39,12 +39,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/disk_as_pv.xml
+++ b/data/yam/autoyast/disk_as_pv.xml
@@ -39,12 +39,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/error.xml
+++ b/data/yam/autoyast/error.xml
@@ -140,7 +140,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -158,7 +158,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/eula.xml
+++ b/data/yam/autoyast/eula.xml
@@ -77,12 +77,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/ext4.xml
+++ b/data/yam/autoyast/ext4.xml
@@ -173,7 +173,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -191,7 +191,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/firstboot.xml
+++ b/data/yam/autoyast/firstboot.xml
@@ -90,12 +90,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/gnome.xml
+++ b/data/yam/autoyast/gnome.xml
@@ -130,7 +130,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -148,7 +148,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/home_encrypted.xml
+++ b/data/yam/autoyast/home_encrypted.xml
@@ -102,12 +102,12 @@
       <user>
         <fullname>Bernhard M. Wiedemann</fullname>
         <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
       </user>
       <user>
         <encrypted config:type="boolean">false</encrypted>
-        <user_password>nots3cr3t</user_password>
+        <user_password>{{PASSWORD}}</user_password>
         <username>root</username>
       </user>
     </users>

--- a/data/yam/autoyast/invalid_default_target.xml
+++ b/data/yam/autoyast/invalid_default_target.xml
@@ -41,12 +41,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/iscsi_ibft.xml
+++ b/data/yam/autoyast/iscsi_ibft.xml
@@ -134,12 +134,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/keyboard_layout.xml
+++ b/data/yam/autoyast/keyboard_layout.xml
@@ -39,12 +39,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/lvm.xml
+++ b/data/yam/autoyast/lvm.xml
@@ -177,7 +177,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
       <home>/home/vagrant</home>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>vagrant</username>
     </user>
     <user>
@@ -187,7 +187,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/mini.xml
+++ b/data/yam/autoyast/mini.xml
@@ -33,12 +33,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/mini_remote.xml
+++ b/data/yam/autoyast/mini_remote.xml
@@ -51,12 +51,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/multi_btrfs.xml
+++ b/data/yam/autoyast/multi_btrfs.xml
@@ -99,7 +99,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>1000</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
@@ -117,7 +117,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>0</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/multipath.xml
+++ b/data/yam/autoyast/multipath.xml
@@ -541,7 +541,7 @@ pre init scripts feature. See poo#20818.
       <gid>100</gid>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
   </users>

--- a/data/yam/autoyast/nfs_share.xml
+++ b/data/yam/autoyast/nfs_share.xml
@@ -57,7 +57,7 @@
         </password_settings>
         <shell>/bin/bash</shell>
         <uid>1000</uid>
-        <user_password>nots3cr3t</user_password>
+        <user_password>{{PASSWORD}}</user_password>
         <username>bernhard</username>
     </user>
     <user>
@@ -75,7 +75,7 @@
         </password_settings>
         <shell>/bin/bash</shell>
         <uid>0</uid>
-        <user_password>nots3cr3t</user_password>
+        <user_password>{{PASSWORD}}</user_password>
         <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/non_existing_graphical_target.xml
+++ b/data/yam/autoyast/non_existing_graphical_target.xml
@@ -41,12 +41,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/non_secure_boot.xml
+++ b/data/yam/autoyast/non_secure_boot.xml
@@ -38,12 +38,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/resize_luks2.xml
+++ b/data/yam/autoyast/resize_luks2.xml
@@ -44,12 +44,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/reuse-encrypted.xml
+++ b/data/yam/autoyast/reuse-encrypted.xml
@@ -181,12 +181,12 @@
       <user>
         <fullname>Bernhard M. Wiedemann</fullname>
         <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
       </user>
       <user>
         <encrypted config:type="boolean">false</encrypted>
-        <user_password>nots3cr3t</user_password>
+        <user_password>{{PASSWORD}}</user_password>
         <username>root</username>
       </user>
     </users>

--- a/data/yam/autoyast/rule-based_example/classes/general/users.xml
+++ b/data/yam/autoyast/rule-based_example/classes/general/users.xml
@@ -5,7 +5,7 @@
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>Bernhard M. Wiedemann</fullname>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -15,7 +15,7 @@
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/salt.xml
+++ b/data/yam/autoyast/salt.xml
@@ -44,12 +44,12 @@
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
             <encrypted config:type="boolean">false</encrypted>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/sle_powervm.xml.ep
+++ b/data/yam/autoyast/sle_powervm.xml.ep
@@ -165,7 +165,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -183,7 +183,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/support_images/create_hdd_ha_ppc64le.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_ha_ppc64le.xml.ep
@@ -158,7 +158,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
@@ -176,7 +176,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/support_images/create_hdd_ha_sles.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_ha_sles.xml.ep
@@ -340,7 +340,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>1000</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
@@ -358,7 +358,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>0</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/support_images/create_hdd_maintenance.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_maintenance.xml.ep
@@ -172,7 +172,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>1000</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
@@ -190,7 +190,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>0</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/support_images/create_hdd_sles_regression_aarch64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_sles_regression_aarch64.xml.ep
@@ -383,7 +383,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>1000</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
@@ -401,7 +401,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>0</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/support_images/create_hdd_sles_regression_ppc64le.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_sles_regression_ppc64le.xml.ep
@@ -288,7 +288,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>1000</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
@@ -306,7 +306,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>0</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/support_images/create_hdd_sles_regression_s390x.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_sles_regression_s390x.xml.ep
@@ -207,7 +207,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>1000</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>bernhard</username>
         </user>
         <user>
@@ -225,7 +225,7 @@
             </password_settings>
             <shell>/bin/bash</shell>
             <uid>0</uid>
-            <user_password>nots3cr3t</user_password>
+            <user_password>{{PASSWORD}}</user_password>
             <username>root</username>
         </user>
     </users>

--- a/data/yam/autoyast/systemd_timesync.xml
+++ b/data/yam/autoyast/systemd_timesync.xml
@@ -55,12 +55,12 @@
     <user>
       <fullname>Bernhard M. Wiedemann</fullname>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>bernhard</username>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/yam/autoyast/tftp.xml
+++ b/data/yam/autoyast/tftp.xml
@@ -156,7 +156,7 @@ chmod 755 /srv/tftpboot
       <home>/home/vagrant</home>
       <shell>/bin/bash</shell>
       <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>vagrant</username>
     </user>
     <user>
@@ -166,7 +166,7 @@ chmod 755 /srv/tftpboot
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>{{PASSWORD}}</user_password>
       <username>root</username>
     </user>
   </users>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   expand_version
   adjust_network_conf
   expand_variables
+  adjust_user_password
   upload_profile
   inject_registration
   init_autoyast_profile
@@ -720,6 +721,26 @@ sub expand_variables {
     return $profile;
 }
 
+=head2 adjust_user_password
+
+ adjust_user_password($profile);
+
+ Password is defined at first, see lib/main_common.pm like below:
+ ---
+ $testapi::password = "xxxxxx";
+ $testapi::password = get_var("PASSWORD") if defined get_var("PASSWORD");
+ ---
+
+ $profile is the autoyast profile 'autoinst.xml'.
+
+=cut
+
+sub adjust_user_password {
+    my ($profile) = @_;
+    $profile =~ s/\{\{PASSWORD\}\}/$testapi::password/g;
+    return $profile;
+}
+
 =head2 upload_profile
 
  upload_profile(profile => $profile, path => $path)
@@ -845,6 +866,7 @@ Get profile from autoyast template
 Map version names
 Get IP address from system variables
 Get values from SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_REGCODE_HPC SCC_URL ARCH LOADER_TYPE
+Adjust user password
 Modify profile with obtained values
 Return new path in case of using AutoYaST templates
 
@@ -866,6 +888,7 @@ sub prepare_ay_file {
     $profile = expand_version($profile);
     $profile = adjust_network_conf($profile);
     $profile = expand_variables($profile);
+    $profile = adjust_user_password($profile);
 
     if (check_var('IPXE', '1')) {
         $path = get_required_var('SUT_IP') . $path;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -348,6 +348,7 @@ else {
         }
     }
     elsif (get_var("AUTOYAST")) {
+        loadtest 'autoyast/prepare_profile';
         load_boot_tests();
         load_autoyast_tests();
         load_reboot_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -561,7 +561,7 @@ sub load_default_tests {
 }
 
 sub load_default_autoyast_tests {
-    loadtest "autoyast/prepare_profile" if get_var "AUTOYAST_PREPARE_PROFILE";
+    loadtest "autoyast/prepare_profile";
     load_patching_tests if get_var('PATCH');
     load_boot_tests;
     load_autoyast_tests;

--- a/schedule/staging/autoyast_mini_no_product@64bit-staging.yaml
+++ b/schedule/staging/autoyast_mini_no_product@64bit-staging.yaml
@@ -6,6 +6,7 @@ vars:
     AUTOYAST: autoyast/mini.xml
     AUTOYAST_CONFIRM: 1
 schedule:
+    - autoyast/prepare_profile
     - installation/bootloader
     - autoyast/installation
     - autoyast/console

--- a/schedule/yast/autoyast_eula.yaml
+++ b/schedule/yast/autoyast_eula.yaml
@@ -9,6 +9,7 @@ vars:
   AUTOYAST_LICENSE: 1
   DESKTOP: textmode
 schedule:
+  - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
   - autoyast/console

--- a/schedule/yast/autoyast_reinstall.yaml
+++ b/schedule/yast/autoyast_reinstall.yaml
@@ -4,6 +4,7 @@ description: >
     Parent job produces autoyast profile after successful completion.
     This test uses generated profile to do autoyast installation.
 schedule:
+  - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
   # On Tumbleweed process Welcome pop-up screen

--- a/schedule/yast/opensuse/autoyast/autoyast_reinstall.yaml
+++ b/schedule/yast/opensuse/autoyast/autoyast_reinstall.yaml
@@ -4,6 +4,7 @@ description: >
     Parent job produces autoyast profile after successful completion.
     This test uses generated profile to do autoyast installation.
 schedule:
+  - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
   # On Tumbleweed process Welcome pop-up screen


### PR DESCRIPTION
https://progress.opensuse.org/issues/160325

1. Add test module `autoyast/prepare_profile` to schedule if no existing module to handle password changes
2. Add the test module to main.pm as well

- Verification run: 
[OpenSuSE](https://openqa.opensuse.org/tests/overview?build=rfan0530&distri=opensuse)
[SLE](http://openqa.suse.de/tests/overview?build=rfan0530&distri=sle)
[s390x](https://openqa.suse.de/tests/14485988)