### PR TITLE
Revert "Add a workaround to enable wicked service"

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -155,12 +155,6 @@ sub run {
     # during restart of the X/GDM stack
     if (is_sle_micro) {
         check_reboot_changes;
-        # Workaround to enable and start wicked service
-        if ((script_run('systemctl is-active wicked.service')) != 0) {
-            record_info('INFO', 'Workaround to enable and start wicked service');
-            systemctl 'enable wicked.service';
-            systemctl 'start wicked.service';
-        }
     } else {
         power_action('reboot', textmode => 1);
         reconnect_mgmt_console if is_pvm;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#19403

I revert this PR, because the SLEM 5.2 MU patch 33772 and SLEM 5.3 MU patch 33773  are both released. And the PR#19403 caused new failures on SLEM 5.3 to SLEM 5.4 and SLEM 5.4 to SLEM 5.5 migration.

- Ticket: https://progress.opensuse.org/issues/161111
- Verification runs: 
- https://openqa.suse.de/tests/14482436#step/zypper_migration/33 (slem5.2 to slem5.3 migration)
- https://openqa.suse.de/tests/14485759#step/zypper_migration/31 (slem5.3 to slem5.4 migration without PR#19403)
- https://openqa.suse.de/tests/14485760#step/zypper_migration/31 (slem5.4 to slem5.5 migration without PR#19403)