### PR TITLE
Combine host/guest installation and feature testsuites into one testsuite and move schedule logic into main.pm

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -129,7 +129,7 @@ sub test_network_interface {
     script_retry("nmap $guest -PN -p ssh | grep open", delay => 30, retry => 6, timeout => 180);
     my $nic = script_output "ssh root\@$guest \"grep '$mac' /sys/class/net/*/address | cut -d'/' -f5 | head -n1\"";
     die "$mac not found in guest $guest" unless $nic;
-    if (check_var('TEST', 'qam-xen-networking') || check_var('TEST', 'qam-kvm-networking') || $is_sriov_test eq "true") {
+    if (check_var('TEST', 'qam-xen-install-and-features-test') || check_var('TEST', 'qam-kvm-install-and-features-test') || $is_sriov_test eq "true") {
         assert_script_run("ssh root\@$guest \"echo BOOTPROTO=\\'dhcp\\' > /etc/sysconfig/network/ifcfg-$nic\"");
 
         # Restart the network - the SSH connection may drop here, so no return code is checked.


### PR DESCRIPTION
1. Check Hypervisor:

Proceed only if HOST_HYPERVISOR is set to xen, kvm, or qemu.

2. Host Installation:

If ENABLE_HOST_INSTALLATION is 1:
Use AutoYaST if AUTOYAST is set, loading corresponding tests.
Otherwise, perform unattended installation with a detailed set of steps.

3. VM Installation:

If ENABLE_VM_INSTALL is 1:
Load tests for console login, preparing and waiting for guests.
If PATCH_WITH_ZYPPER is 1:
Load patch and reboot tests based on UPDATE_PACKAGE.

4. SR-IOV Network Card PCI Passthrough:

If ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH and SLE version is >15, load relevant tests.

5. Other function Tests (unless UPDATE_PACKAGE is kernel-default or ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH is 1):

Load tests for:
> * Save and Restore (ENABLE_SAVE_AND_RESTORE is 1)
> * Guest Management (ENABLE_GUEST_MANAGEMENT is 1)
> * Final Test (ENABLE_FINAL is 1)
> * Storage (ENABLE_STORAGE is 1)
> * Windows (ENABLE_WINDOWS is 1)
> * Domain Metrics (ENABLE_DOM_METRICS is 1 and HOST_HYPERVISOR is xen)
> * IRQ Balance (ENABLE_IRQBALANCE is 1 and HOST_HYPERVISOR is xen)
> * Networking (ENABLE_VIR_NET is 1)
> * Virt-Manager (ENABLE_VIRTMANAGER is 1)
> * Hotplugging (ENABLE_HOTPLUGGING is 1)
> * Snapshots (ENABLE_SNAPSHOTS is 1 and HOST_HYPERVISOR is kvm).
> * Sriov test (ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH is 1 and > 15)

- Related ticket: https://progress.opensuse.org/issues/160847
- Needles: n/a
- Verification run: 
[Sriov test](http://10.100.103.128/tests/607)
[Feature test](http://10.100.103.128/tests/594) 
[installation step by step](http://10.100.103.128/tests/564) We don't install system this way, if use it in future, need fix some compatibility issue. 