### PR TITLE
Skip firewalld checks in Minimal-VM cloud image

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1265,7 +1265,7 @@ sub load_consoletests {
     }
     loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
 # textmode install comes without firewall by default atm on openSUSE. For virtualization server xen and kvm is disabled by default: https://fate.suse.com/324207
-    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server) {
+    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server && get_var('FLAVOR', '') !~ /JeOS-for-OpenStack-Cloud.*/) {
         loadtest "console/firewall_enabled";
     }
     if (is_jeos) {


### PR DESCRIPTION
firewall is not pre-installed in Cloud image.

- ticket: https://progress.opensuse.org/issues/156151
- Verification run: http://kepler.suse.cz/tests/23434#
