### PR TITLE
Remove custom switches for all and metadata

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -97,12 +97,6 @@ sub run {
     assert_script_run("export TARGET=$bci_target");
     assert_script_run("export BCI_DEVEL_REPO=$bci_devel_repo") if $bci_devel_repo;
 
-    # Run common tests from test_all.py
-    $self->run_tox_cmd('all');
-
-    # Run metadata tests when needed
-    $self->run_tox_cmd('metadata') if get_var('BCI_TEST_METADATA');
-
     # Run environment specific tests
     for my $env (split(/,/, $test_envs)) {
         $self->run_tox_cmd($env);


### PR DESCRIPTION
Rely solemnly on the BCI_TEST_METADATA setting for selecting which BCI tests to run. This is needed because all is e.g. not expected to run for BCI repo tests.

- Verification run: https://openqa.suse.de/tests/14486416
- Merge together with https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1674 and https://gitlab.suse.de/qac/container-release-bot/-/merge_requests/252
