### PR TITLE
Enable upgrade test from leap to tw on aarch64

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -435,7 +435,7 @@ sub wait_grub {
       if (is_aarch64_uefi_boot_hdd
         && !is_jeos
         && !$in_grub
-        && (!(isotovideo::get_version() >= 12 && get_var('UEFI_PFLASH_VARS')) || get_var('ONLINE_MIGRATION') || get_var('UPGRADE') || get_var('ZDUP')));
+        && (!(isotovideo::get_version() >= 12 && get_var('UEFI_PFLASH_VARS')) || get_var('ONLINE_MIGRATION') || get_var('UPGRADE') || get_var('ZDUP') || (get_var('LIVE_UPGRADE') && get_var('PATCH_BEFORE_MIGRATION'))));
     assert_screen(\@tags, $bootloader_time);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -13,13 +13,18 @@ use warnings;
 use testapi;
 use utils;
 use migration;
-use version_utils qw(is_jeos is_desktop_installed is_leap);
+use version_utils qw(is_jeos is_desktop_installed is_leap is_opensuse);
 use x11utils qw(turn_off_screensaver);
 use Utils::Backends 'is_pvm';
+use Utils::Architectures 'is_aarch64';
 
 sub run {
     my ($self) = @_;
 
+    if (is_opensuse && is_aarch64 && get_var('PATCH_BEFORE_MIGRATION')) {
+        record_info('Reboot the system and manually selecting boot entry');
+        send_key 'ctrl-alt-delete';
+    }
     $self->wait_boot(textmode => !is_desktop_installed(), bootloader_time => 300, ready_time => 600) unless is_jeos;
     if (get_var('ZDUP_IN_X')) {
         turn_off_screensaver;


### PR DESCRIPTION
https://progress.opensuse.org/issues/131312

- Patch the system before upgrade
- Handle boot from harddisk for aarch64

- Verification run: 
[leap to tw](https://openqa.opensuse.org/tests/overview?groupid=119&version=Tumbleweed&build=20240529&distri=opensuse)

PR to add the tests into job group: https://github.com/os-autoinst/opensuse-jobgroups/pull/471