### PR TITLE
Fix yast2_samba by adding mozilla-nss-package

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -378,7 +378,7 @@ sub setup_samba {
 
 sub run {
     select_console 'root-console';
-    zypper_call 'in samba yast2-samba-server yast2-auth-server';
+    zypper_call 'in samba yast2-samba-server yast2-auth-server mozilla-nss-tools';
 
     # setup ldap instance (openldap or 389-ds) for samba
     if (is_sle('<15') || is_leap('<15.0')) {


### PR DESCRIPTION
It seems like the certutil tool is no longer available by default, we now need to install mozilla-nss-package.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
