### PR TITLE
Remove release package from SCC_ADDONS_DROP

### DIFF
--- a/tests/yam/migration/setup_registration.pm
+++ b/tests/yam/migration/setup_registration.pm
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
+use utils 'zypper_call';
 use registration 'register_addons_cmd';
 
 sub run {
@@ -19,8 +20,11 @@ sub run {
     @filter{@addons_drop} = {};
 
     select_console('root-console');
-    assert_script_run('SUSEConnect -d');
     assert_script_run('SUSEConnect --debug --cleanup');
+    foreach my $addon (@addons_drop) {
+        my $pkg_name = ($addon eq 'ltss') ? "sles-$addon-release" : "sle-module-$addon-release";
+        zypper_call("rm $pkg_name");
+    }
     assert_script_run('SUSEConnect --debug --regcode ' . get_required_var('SCC_REGCODE'), 200);
     my $addons_to_register = join(',', grep !exists $filter{$_}, @addons);
     register_addons_cmd($addons_to_register);


### PR DESCRIPTION
##
##### We need to remove the addon's release-package in `SCC_ADDONS_DROP`, cause the `SUSEConnect -d`  is not always work.
- Related ticket: 
  * https://progress.opensuse.org/issues/161231
- Related MR:
  * https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/218
- Failed case:
   * https://openqa.suse.de/tests/14504584#step/setup_registration/10
- Needles: 
  * N/A
- Verification run: 
  * https://openqa.suse.de/tests/14515615 15sp3 to 15sp4
  * https://openqa.suse.de/tests/14515619 sles12sp5_15sp2
##
