### PR TITLE
Define new name for the project *osado*

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Status of [openSUSE Tumbleweed](https://get.opensuse.org/tumbleweed/) tests:
 
 ---
 *osado* – or with long name *os-autoinst-distri-opensuse* – is repo which
-contains tests, which are executed by openQA for openSUSE and SLE
+contains the [test distribution](https://en.wikipedia.org/wiki/Software_distribution) of the suite and harness, executed by openQA for openSUSE and SLE
 distributions.
 
 Why the name *osado*? Two reasons:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-os-autoinst/openQA tests for openSUSE and SUSE Linux Enterprise 
+*osado* - os-autoinst/openQA tests for openSUSE and SUSE Linux Enterprise
 
 [![Build Status](https://github.com/os-autoinst/os-autoinst-distri-opensuse/workflows/ci/badge.svg)](https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions)
 
@@ -9,9 +9,14 @@ Status of [openSUSE Tumbleweed](https://get.opensuse.org/tumbleweed/) tests:
 | KDE on Tumbleweed | [![KDE on Tumbleweed](https://openqa.opensuse.org/tests/latest/badge?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=kde&version=Tumbleweed&show_build=1)](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=kde&version=Tumbleweed) |
 
 ---
+*osado* – or with long name *os-autoinst-distri-opensuse* – is repo which
+contains tests, which are executed by openQA for openSUSE and SLE
+distributions.
 
-os-autoinst-distri-opensuse is repo which contains tests, which are executed
-by openQA for openSUSE and SLE distributions.
+Why the name *osado*? Two reasons:
+1. It means "bold" or "daring" in Spanish and this is what this project tries
+   to be :)
+2. *osado* is an acronym of **os**-**a**utoinst-**d**istri-**o**pensuse
 
 Needles for openSUSE distributions are located in [os-autoinst-needles-opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse)
 


### PR DESCRIPTION
The new name is based on a brainstorming conducted within a SUSE Slack
conversation with vote. The most promising alternatives had been:
* arepa
* osdo
* oto