### PR TITLE
Fix Elemental openQA test

### DIFF
--- a/data/elemental/cloud-config.yaml
+++ b/data/elemental/cloud-config.yaml
@@ -1,10 +1,13 @@
-name: "Default user"
+name: "Post-installation configuration"
 stages:
-   initramfs:
-   - name: "Setup users"
-     ensure_entities:
-     - path: /etc/shadow
-       entity: |
-          kind: "shadow"
-          username: "root"
-          password: "%TEST_PASSWORD%"
+  initramfs:
+  - name: "Setup users"
+    ensure_entities:
+    - path: /etc/shadow
+      entity: |
+        kind: "shadow"
+        username: "root"
+        password: "%TEST_PASSWORD%"
+  after-install-chroot:
+  - commands:
+    - grub2-editenv /run/elemental/efi/grub_oem_env set timeout=-1


### PR DESCRIPTION
On fast worker the OS can be restarted *after* checking for Grub, so better to delay the reboot command.

This commit also use `wait_boot` for installation to reduce the number of code lines.

- Related ticket: N/A
- Needles: added live
- Verification runs: [aarch64](https://openqa.suse.de/tests/14518459), [x86_64](https://openqa.suse.de/tests/14517726)
