### PR TITLE
P.C. GCE cleanup fix to upload log on errors

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -372,7 +372,7 @@ Return:
 sub wait_for_ssh {
     my ($self, %args) = @_;
     # Input parameters, see description in above head2 - Parameters section:
-    $args{timeout} //= 600;
+    $args{timeout} = get_var('PUBLIC_CLOUD_SSH_TIMEOUT', $args{timeout} // 600);
     $args{wait_stop} //= 0;
     $args{proceed_on_failure} //= $args{wait_stop};
     $args{systemup_check} //= not $args{wait_stop};

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -705,6 +705,25 @@ sub terraform_param_tags
     return encode_json($tags);
 }
 
+=head2 get_terraform_output
+
+Query the terraform data structure in json format.
+Input: <jq-query-format> string; <empty> = no query then full output of data structure.
+E.g: to get the VM instance name from json data structure, the call is: 
+    get_terraform_output(".vm_name.value[0]");
+To get the complete output structure, the call is:
+    get_terraform_output();
+
+=cut
+
+sub get_terraform_output {
+    my ($self, $jq_query) = @_;
+    assert_script_run('cd ~/terraform');
+    my $res = script_output("terraform output -json | jq -r '$jq_query' 2>/dev/null", proceed_on_failure => 1);
+    script_run('cd');
+    return $res;
+}
+
 sub escape_single_quote {
     my $s = shift;
     $s =~ s/'/'"'"'/g;


### PR DESCRIPTION
In recent P.C. GCE preprare_instance issue (poo#161384) the post fail hook `cleanup` routine didn't provided the serial/console log instance_serial.txt because the instance-id resulted empty, no more available at that exit point, and get-serial-port-output command failed.

Here that `id` is retrieved in a different way, used where expected link was empty.

In wait-ssh a timeout parameter added to decrease the default value, for debugging purpose, but it could still be useful in future needs.

See in test Logs available the file "<modulename>-instance_serial.txt" log

- Related ticket: https://progress.opensuse.org/issues/161732
- Needles: N/A
- Verification run: 
  -  https://openqa.suse.de/tests/14523157#step/prepare_instance/90
     FAIL due to GCE issue, 
     but the **instance_id is present** on error too and now `log present`
  -  https://openqa.suse.de/tests/14523287
     EC2 not affected by GCE issue, `log present` ok, failed for other cause: repos download not ready yet a.t.m.
