### PR TITLE
Make cleanup non-fatal

### DIFF
--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -28,7 +28,6 @@ sub cleanup {
         network_peering_present => $self->{network_peering_present},
         ansible_present => $self->{ansible_present}
     );
-
     if ($res) {
         $self->{cleanup_called} = 1;
         $self->{network_peering_present} = 0;
@@ -63,16 +62,7 @@ sub post_fail_hook {
         return;
     }
     qesap_cluster_logs();
-    $self->cleanup();
-}
-
-sub post_run_hook {
-    my ($self) = @_;
-    if ($self->test_flags()->{publiccloud_multi_module} or get_var('QESAP_NO_CLEANUP')) {
-        diag('Skip post run', "Skipping post run hook. \n Variable 'QESAP_NO_CLEANUP' defined or test_flag 'publiccloud_multi_module' active");
-        return;
-    }
-    $self->cleanup();
+    eval { $self->cleanup(); } or bmwqemu::fctwarn("self::cleanup() failed -- $@");
 }
 
 1;

--- a/tests/sles4sap/publiccloud/qesap_cleanup.pm
+++ b/tests/sles4sap/publiccloud/qesap_cleanup.pm
@@ -22,7 +22,7 @@ sub run {
             "Variable 'QESAP_NO_CLEANUP' set to value " . get_var('QESAP_NO_CLEANUP'));
         return 1;
     }
-    $self->cleanup($run_args);
+    eval { $self->cleanup($run_args); } or bmwqemu::fctwarn("self::cleanup(\$run_args) failed -- $@");
     $run_args->{network_peering_present} = $self->{network_peering_present};
     $run_args->{ansible_present} = $self->{ansible_present};
 }


### PR DESCRIPTION
This pr makes the cleanup face of the cloud deployment non-fatal, to avoid altering the result of the test in case of failure.

It also gets rid of the `post_run_hook` that was intended to be used in a single-module scenario, since we don't have such a scenario or plan to implement one.

- Related ticket: https://jira.suse.com/browse/TEAM-9015
- Verification run: http://openqaworker15.qa.suse.cz/tests/285566 (PASS)



Note: when the cleanup fails, the test is green, but no message is seen in the UI - the fail message gets printed to `autoinst.log` instead.

http://openqaworker15.qa.suse.cz/tests/285587 (CLEANUP FAIL AT THE END)
