### PR TITLE
containers: Increase retries & timeout for pulling images

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -168,7 +168,7 @@ sub test_container_image {
 
     my $smoketest = qq[/bin/sh -c '/bin/uname -r; /bin/echo "Heartbeat from $image"'];
 
-    $runtime->pull($image, timeout => 420);
+    $runtime->pull($image, timeout => 600);
     $runtime->check_image_in_host($image);
     $runtime->create_container(image => $image, name => 'testing', cmd => $smoketest);
     return if $runtime->runtime eq 'buildah';

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -177,7 +177,7 @@ sub pull {
     }
     my $die = $args{die} // 1;
     # At least on publiccloud, this image pull can take long and occasinally fails due to network issues
-    return $self->_engine_script_retry("pull $image_name", timeout => $args{timeout} // 300, retry => 3, delay => 30, die => $die);
+    return $self->_engine_script_retry("pull $image_name", timeout => $args{timeout} // 300, retry => 6, delay => 60, die => $die);
 }
 
 =head2 enum_images


### PR DESCRIPTION
Increase retries & timeout for pulling images

- Failing test: https://openqa.suse.de/tests/14526113#step/podman_3rd_party_images/182
- Related ticket: https://progress.opensuse.org/issues/161819
- Verification run: https://openqa.suse.de/tests/14527042
