### PR TITLE
Adjust the saptune test on power9

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -837,6 +837,11 @@ sub reboot {
         wait_still_screen(30);
         $self->wait_boot(textmode => 1, nologin => get_var('NOAUTOLOGIN', '0'));
     }
+    elsif (is_pvm_hmc) {
+        power_action('reboot', textmode => 1);
+        reconnect_mgmt_console;
+        $self->wait_boot(textmode => 1, nologin => get_var('NOAUTOLOGIN', '0'));
+    }
     else {
         power_action('reboot', textmode => 1);
         $self->wait_boot(nologin => 1, bootloader_time => 300);

--- a/schedule/sles4sap/hana/saptune_on_pvm.yaml
+++ b/schedule/sles4sap/hana/saptune_on_pvm.yaml
@@ -1,0 +1,74 @@
+---
+name: pvm_hana_gnome
+description: >
+  SLES4SAP Installation on pvm_hmc and HANA installation and test.
+  Set HANA to the installation master path over NFS or SMB in the yaml job group.
+vars:
+  AUTOMATED_REGISTER: 'false'
+  DESKTOP: 'textmode'
+  INSTANCE_ID: '00'
+  INSTANCE_SID: 'HA1'
+  INSTANCE_TYPE: 'HDB'
+  MULTIPATH_CONFIRM: 'yes'
+schedule:
+  - installation/bootloader
+  - installation/welcome
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - '{{sles4sap15_product}}'
+  - installation/partitioning
+  - installation/partitioning_smalldisk_storageng
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/handle_reboot
+  - installation/first_boot
+  - console/system_prepare
+  - sles4sap/saptune/mr_test
+conditional_schedule:
+  sles4sap15_product:
+    VERSION:
+      15:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP1:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP2:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP3:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP4:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP5:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP6:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP7:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+  sles4sap12_desktop:
+    VERSION:
+      12-SP2:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues
+      12-SP3:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues
+      12-SP4:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues
+      12-SP5:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues


### PR DESCRIPTION
We run saptune 'notes' and 'solutions' on power9 lpar. So we need a add a yaml file to define the test modules.
There are some changes on saptune test, such as on power platform, the default value of `transparent_hugepage` is changed to 'madvise'. So we need to adjust our code to check that.

Related: https://jira.suse.com/browse/TEAM-9086

VRs: 

solutions on Power9: https://openqa.suse.de/tests/14527132# (Pass)
notes on Power9:       https://openqa.suse.de/tests/14527124# (Pass)
sles4sap_gnome_saptune_baremeta (x86) : https://openqa.suse.de/tests/14527098# (Pass)
delete_rename (ppc64): https://openqa.suse.de/tests/14527138#  (Pass)
delete_rename (uefi):  https://openqa.suse.de/tests/14527137# (Pass)
gnome_saptune_solutions (uefi): https://openqa.suse.de/tests/14527136# (Pass)
gnome_saptune_overrides (uefi): https://openqa.suse.de/tests/14527135# (Pass)
gnome_saptune_overrides (ppc64): https://openqa.suse.de/tests/14527134# (Pass)
gnome_saptune_notes(uefi): https://openqa.suse.de/tests/14527133#  (Pass)