### PR TITLE
Add nat gateway setup

### DIFF
--- a/data/sles4sap/sdaf/WORKLOAD_ZONE.tfvars
+++ b/data/sles4sap/sdaf/WORKLOAD_ZONE.tfvars
@@ -84,6 +84,24 @@ public_network_access_enabled = true
 # place_delete_lock_on_resources, If defined, a delete lock will be placed on the key resources
 place_delete_lock_on_resources = false
 
+
+
+############################################################################################
+#                                                                                          #
+#                                  NAT Configuration                                       #
+#                                                                                          #
+############################################################################################
+
+deploy_nat_gateway = true
+nat_gateway_name   = "%SDAF_ENV_CODE%-%SDAF_REGION_CODE%-%SDAF_VNET_CODE%-NG_0001"
+# nat_gateway_public_ip_zones = ["1", "2", "3"]
+# nat_gateway_idle_timeout_in_minutes = 10
+nat_gateway_public_ip_tags = {
+  "ipTagType": "OpenQA-SDAF-automation",
+  "tag": "OpenQA-SDAF-automation"
+}
+
+
 #########################################################################################
 #                                                                                       #
 #  Admin Subnet variables                                                               #

--- a/lib/sles4sap/sdaf_deployment_library.pm
+++ b/lib/sles4sap/sdaf_deployment_library.pm
@@ -415,6 +415,9 @@ sub set_common_sdaf_os_env {
     $args{sdaf_tfstate_storage_account} //= get_required_var('SDAF_TFSTATE_STORAGE_ACCOUNT');
     $args{sdaf_key_vault} //= get_required_var('SDAF_KEY_VAULT');
 
+    # This is used later filling up tfvars files.
+    set_var('SDAF_REGION_CODE', $args{sdaf_region_code});
+
     my @variables = (
         "export env_code=$args{env_code}",
         "export deployer_vnet_code=$args{deployer_vnet_code}",
@@ -725,7 +728,7 @@ If OpenQA variable is not set, placeholder is replaced with empty value.
 sub replace_tfvars_variables {
     my ($tfvars_file) = @_;
     croak 'Variable "$tfvars_file" undefined' unless defined($tfvars_file);
-    my @variables = qw(SDAF_ENV_CODE PUBLIC_CLOUD_REGION SDAF_RESOURCE_GROUP SDAF_VNET_CODE SAP_SID);
+    my @variables = qw(SDAF_ENV_CODE PUBLIC_CLOUD_REGION SDAF_RESOURCE_GROUP SDAF_VNET_CODE SAP_SID SDAF_REGION_CODE);
     my %to_replace = map { '%' . $_ . '%' => get_var($_, '') } @variables;
     file_content_replace($tfvars_file, %to_replace);
 }


### PR DESCRIPTION
This PR adds NAT Gateway setup into workload zone deployment process, which is 
required for SUT to be able to reach scc repos. 

- Related ticket: https://jira.suse.com/browse/TEAM-9311
- Verification run: https://openqaworker15.qa.suse.cz/tests/285787#step/sdaf_deploy_hanasr/38

* VR fails but passes playbook `playbook_01_os_base_config.yaml` which previously failed due to SCC connection issues.
