### PR TITLE
Reapply "containers: Use busybox instead of tumbleweed image"

### DIFF
--- a/tests/containers/docker_runc.pm
+++ b/tests/containers/docker_runc.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2017-2023 SUSE LLC
+# Copyright 2017-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: runc docker-runc
@@ -32,8 +32,8 @@ sub run {
     record_info("$runc", script_output("$runc -v"));
     # Create root filesystem for the test container. We need docker for this preparation step.
     assert_script_run('rm -rf rootfs && mkdir rootfs');
-    my $tumbleweed = "registry.opensuse.org/opensuse/tumbleweed";
-    assert_script_run('docker export $(docker create ' . $tumbleweed . ') | tar -C rootfs -xvf -', fail_message => "Cannot export rootfs, see bsc#1152508");
+    my $image = "registry.opensuse.org/opensuse/busybox";
+    assert_script_run('docker export $(docker create ' . $image . ') | tar -C rootfs -xvf -', fail_message => "Cannot export rootfs, see bsc#1152508");
 
     # create the OCI specification file and verify that the template has been created
     record_info 'Test #2', 'Test: OCI Specification';

--- a/tests/containers/podman_network_cni.pm
+++ b/tests/containers/podman_network_cni.pm
@@ -20,9 +20,8 @@ sub run() {
 
     my ($self, $args) = @_;
     select_serial_terminal;
+
     my $podman = $self->containers_factory('podman');
-
-
     my $podman_version = get_podman_version();
     my $supports_network = (package_version_cmp($podman_version, '3.1.0') >= 0) ? 0 : 1;
 
@@ -55,12 +54,13 @@ sub run() {
 
     #connect, disconnect & reload
     unless ($supports_network) {
+        my $image = "registry.opensuse.org/opensuse/busybox";
         record_info('Prepare', 'Prepare three containers');
-        script_retry("podman pull registry.opensuse.org/opensuse/tumbleweed", timeout => 300, delay => 60, retry => 3);
+        script_retry("podman pull $image", timeout => 300, delay => 60, retry => 3);
 
-        assert_script_run('podman run -id --rm --name container1 -p 1234:1234 registry.opensuse.org/opensuse/tumbleweed');
-        assert_script_run('podman run -id --rm --name container2 -p 1235:1235 registry.opensuse.org/opensuse/tumbleweed');
-        assert_script_run('podman run -id --rm --name container3 -p 1236:1236 registry.opensuse.org/opensuse/tumbleweed');
+        assert_script_run("podman run -id --rm --name container1 -p 1234:1234 $image");
+        assert_script_run("podman run -id --rm --name container2 -p 1235:1235 $image");
+        assert_script_run("podman run -id --rm --name container3 -p 1236:1236 $image");
 
         my $container_id = script_output("podman inspect -f '{{.Id}}' container3");
 

--- a/tests/containers/podman_quadlet.pm
+++ b/tests/containers/podman_quadlet.pm
@@ -34,7 +34,7 @@ Description=The sleep container
 After=local-fs.target
 
 [Container]
-Image=registry.opensuse.org/opensuse/tumbleweed:latest
+Image=registry.opensuse.org/opensuse/busybox:latest
 Exec=sleep 1000
 Volume=sleeper.volume:/opt
 

--- a/tests/containers/podman_remote.pm
+++ b/tests/containers/podman_remote.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2023 SUSE LLC
+# Copyright 2023-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: podman
@@ -14,7 +14,7 @@ use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
 
 sub run {
     my ($self, $args) = @_;
-    my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
+    my $image = 'registry.opensuse.org/opensuse/busybox:latest';
 
     select_serial_terminal();
     my $podman = $self->containers_factory('podman');

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2023 SUSE LLC
+# Copyright 2012-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: docker-distribution-registry | distribution-registry
@@ -86,14 +86,14 @@ sub run {
 
     # Run docker tests
     my $docker = $self->containers_factory('docker');
-    my $tumbleweed = 'registry.opensuse.org/opensuse/tumbleweed';
-    registry_push_pull(image => $tumbleweed, runtime => $docker);
+    my $image = 'registry.opensuse.org/opensuse/busybox';
+    registry_push_pull(image => $image, runtime => $docker);
     $docker->cleanup_system_host();
 
     # Run podman tests
     if (is_leap('15.1+') || is_tumbleweed || is_sle("15-sp1+")) {
         my $podman = $self->containers_factory('podman');
-        registry_push_pull(image => $tumbleweed, runtime => $podman);
+        registry_push_pull(image => $image, runtime => $podman);
         $podman->cleanup_system_host();
     }
 }

--- a/tests/containers/seccomp.pm
+++ b/tests/containers/seccomp.pm
@@ -26,7 +26,7 @@ sub run {
     assert_script_run "grep SECCOMP /boot/config-\$(uname -r)";
     assert_script_run "$runtime info | grep -i seccomp";
 
-    my $image = "registry.opensuse.org/opensuse/tumbleweed";
+    my $image = "registry.opensuse.org/opensuse/busybox";
     my $policy = "policy.json";
 
     assert_script_run('curl ' . data_url("containers/$runtime-seccomp.json") . " -o $policy");

--- a/tests/containers/testenv_prepare.pm
+++ b/tests/containers/testenv_prepare.pm
@@ -25,7 +25,7 @@ sub run {
     my ($self) = @_;
 
     select_serial_terminal;
-    my $tumbleweed_container_image = "registry.opensuse.org/opensuse/tumbleweed:latest";
+    my $busybox_container_image = "registry.opensuse.org/opensuse/busybox:latest";
     my $nginx_container_image = "registry.opensuse.org/opensuse/nginx:latest";
 
     assert_script_run('curl -sLf --create-dirs -vo /home/nginx/nginx.conf ' . data_url('containers/nginx/') . 'nginx.conf');
@@ -38,7 +38,7 @@ sub run {
     assert_script_run("podman pod create --name test-pod0 -p 80:80");
 
     assert_script_run("podman run -d --name nginx-container --pod test-pod0 -v /home/nginx/nginx.conf:/etc/nginx/nginx.conf:ro,z -v /home/nginx/index.html:/usr/share/nginx/html/index.html:ro,z  $nginx_container_image");
-    assert_script_run("podman run -d --name Tumbleweed-container --pod test-pod0 $tumbleweed_container_image sleep infinity");
+    assert_script_run("podman run -d --name Busybox-container --pod test-pod0 $busybox_container_image sleep infinity");
 
     validate_script_output('podman pod ps', sub { m/test-pod0/ });
     record_info('podman pod ps', script_output("podman pod ps"));
@@ -54,13 +54,13 @@ sub run {
     systemctl("is-active pod-test-pod0.service");
 
     # Start 2 containers service and ensure its running
-    assert_script_run("systemctl enable --now container-Tumbleweed-container.service", timeout => 120);
-    systemctl("is-active container-Tumbleweed-container.service");
+    assert_script_run("systemctl enable --now container-Busybox-container.service", timeout => 120);
+    systemctl("is-active container-Busybox-container.service");
 
     assert_script_run("systemctl enable --now container-nginx-container.service", timeout => 120);
     systemctl("is-active container-nginx-container.service");
     # Verify the connection between containers in a pod
-    validate_script_output("podman exec -it Tumbleweed-container curl -s http://localhost:80", sub { m/Welcome to the nginx container!/ });
+    validate_script_output("podman exec -it Busybox-container curl -s http://localhost:80", sub { m/Welcome to the nginx container!/ });
 }
 
 1;


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19412.

The reason for the failures on TW was that busybox doesn't have error handling so it actually exited with 0 without printing anything. The reason it failed on SLE was because SLE uses runc which fails before busybox even gets to run. Just use the TW image again.

VR: https://openqa.opensuse.org/tests/4250591#live