### PR TITLE
Create git clone function

### DIFF
--- a/lib/Utils/Git.pm
+++ b/lib/Utils/Git.pm
@@ -1,0 +1,66 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package Utils::Git;
+
+use base 'Exporter';
+use Exporter;
+use Carp 'croak';
+use strict;
+use warnings;
+use testapi qw(record_info assert_script_run upload_logs);
+
+our @EXPORT = qw(
+  git_clone
+);
+
+=head1 Utils::Git
+
+C<Utils::Git> - Library for various git related functions
+
+=cut
+
+
+=head2 git_clone
+
+    git_clone('https://github.com/myrepo/tree/main' [, branch=>'development', quiet=>'1', skip_ssl_verification=>'true',
+        output_log_file=>'git_clone.log']);
+
+B<repository>: Git repository url. Mandatory argument.
+
+B<branch>: Clone specific branch. Default: not defined
+
+B<quiet>: Minimize output verbosity. Default: false
+
+B<skip_ssl_verification>: Disable SSL verification. Can be useful in case of self signed certificates.
+    Define this parameter B<ONLY> if you want to skip verification. Default: undef
+
+B<output_log_file>: Log output into a file.
+
+Generic wrapper around C<git clone> command. Supports basic set of switches and output logging.
+
+=cut
+
+sub git_clone {
+    my ($repository, %args) = @_;
+    croak 'Missing mandatory argument "repository"' unless $repository;
+
+    # Base command
+    my $git_cmd = 'git clone';
+
+    # Skip SSL verification
+    $git_cmd =~ s/git/git -c http.sslVerify=false/ if $args{skip_ssl_verification};
+
+    # Checkout branch
+    $git_cmd .= " -b $args{branch}" if $args{branch};
+
+    # Append repository
+    $git_cmd .= " $repository";
+
+    # Enable logging
+    $git_cmd = "set -o pipefail; $git_cmd 2>&1 | tee $args{output_log_file}" if $args{output_log_file};
+
+    record_info('git clone', "Cloning repository: $repository\nCMD: $git_cmd");
+    assert_script_run($git_cmd);
+    upload_logs($args{output_log_file}) if $args{output_log_file};
+}

--- a/t/23_utils_git.t
+++ b/t/23_utils_git.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use testapi;
+use Test::MockModule;
+use Test::Exception;
+use Test::More;
+
+use Utils::Git;
+
+subtest '[git_clone] Compose command' => sub {
+    my $mock_git = Test::MockModule->new('Utils::Git', no_auto => 1);
+    my @calls;
+    $mock_git->redefine(assert_script_run => sub { @calls = $_[0]; return 0; });
+    $mock_git->redefine(upload_logs => sub { return 0; });
+    $mock_git->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $repository = 'https://funhub.com/spicy_code/global_variablEs-on1y';
+
+    git_clone($repository);
+    is join(' ', @calls), "git clone $repository", "Check base command composition";
+
+    git_clone($repository, skip_ssl_verification => 'true', output_log_file => 'output.log', branch => 'world_domination');
+    ok(grep(/git.*-c http.sslVerify=false.*clone/, @calls), 'Option "-c http.sslVerify=false " must be between "git" and "clone"');
+    ok(grep(/clone.*-b world_domination.*$repository/, @calls), 'Checkout branch - option must be between "clone" repository url');
+    ok(grep(/2>&1 | tee output.log$/, @calls), 'Log output to a file');
+    ok(grep(/^set -o pipefail;/, @calls), 'Set bash command to fail immediately with logging');
+};
+
+subtest '[git_clone] Test exceptions' => sub {
+    my $mock_git = Test::MockModule->new('Utils::Git', no_auto => 1);
+    $mock_git->redefine(assert_script_run => sub { return 0; });
+    $mock_git->redefine(record_info => sub { return 0; });
+    $mock_git->redefine(upload_logs => sub { return 0; });
+
+    dies_ok { git_clone() } 'Croak with missing repository argument';
+};
+
+done_testing;


### PR DESCRIPTION
This PR adds `git_clone` functions into SDAF library which allows better control 
over cloning SDAF repositories. Repositories are defined by parameters 
`SDAF_GIT_AUTOMATION_REPO` and `SDAF_GIT_TEMPLATES_REPO`. Repository can be 
cloned with default branch but also by specifying one using openQA parameter 
`SDAF_GIT_AUTOMATION_BRANCH` and `SDAF_GIT_TEMPLATES_BRANCH`. 

Related ticket: https://jira.suse.com/browse/TEAM-9311
Verification run: https://openqaworker15.qa.suse.cz/tests/285590#step/sdaf_deployer_setup/41


* Verification run clones repository with 'experimental' branch defined. Fails later since test is missing NAT GW setup atm.

