### PR TITLE
Skip version check in Tumbleweed when BUILD setting is non-numeric

### DIFF
--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -62,10 +62,9 @@ sub run {
         $checker{CPE_NAME} = "cpe:/o:opensuse:tumbleweed:$checker{VERSION}";
         $checker{PRETTY_NAME} = $checker{NAME};
 
-        # Return early if BUILD is os-autoinst/os-autoinst-distri-opensuse
-        if (get_var('BUILD') =~ m/os-autoinst-distri-opensuse/) {
-            record_info "PR/Verification run", "os-autoinst/os-autoinst-distri-opensuse detected, skipping check";
-            return;
+        if ($checker{VERSION} !~ m/^\d+$/) {
+            record_info 'BUILD Non-Numeric', 'Non-Numeric BUILD setting in Tumbleweed. Skipping VERSION, VERSION_ID and CPE_NAME check';
+            delete $checker{$_} for qw(VERSION VERSION_ID CPE_NAME);
         }
     }
 


### PR DESCRIPTION
The test module `console/check_os_release` is used to verify the contents of `/etc/os-release` in Tumbleweed, Leap and SLES (and SLES for SAP Applications). Since Tumbleweed is a rolling release, instead of a version number, `/etc/os-release` has a date, which the test module gets from the BUILD setting to check for correctness. However, during verification runs, usually the value of the BUILD setting is replaced with something different, which can cause a verification run from an unrelated commit to fail on `console/check_os_release`. This commit checks that BUILD is a number and if it's not, it will skip the VERSION, VERSION_ID and CPE_NAME check in Tumbleweed. Leap and SLES code remains the same.

- Related ticket: N/A
- Needles: N/A

**Verification runs:**

- [Tumbleweed, BUILD: 20240603](http://mango.qe.nue2.suse.org/tests/5946#step/check_os_release/1)
- [Tumbleweed, BUILD: NonNumericBuild](http://mango.qe.nue2.suse.org/tests/5945#step/check_os_release/1)
- [Leap 15.6, BUILD: 709.1](http://mango.qe.nue2.suse.org/tests/5925#step/check_os_release/1)
- [Leap 15.6, BUILD: NonNumericBuild](http://mango.qe.nue2.suse.org/tests/5926#step/check_os_release/1)
- [SLES for SAP 12-SP5](http://mango.qe.nue2.suse.org/tests/5941#step/check_os_release/1)
- [SLES for SAP 15-SP2](http://mango.qe.nue2.suse.org/tests/5927#step/check_os_release/1)
- [SLES for SAP 15-SP3](http://mango.qe.nue2.suse.org/tests/5930#step/check_os_release/1)
- [SLES for SAP 15-SP4](http://mango.qe.nue2.suse.org/tests/5932#step/check_os_release/1)
- [SLES for SAP 15-SP5](http://mango.qe.nue2.suse.org/tests/5933#step/check_os_release/1)
- [SLES for SAP 15-SP6](http://mango.qe.nue2.suse.org/tests/5934#step/check_os_release/1)
- [SLES 12-SP5](http://mango.qe.nue2.suse.org/tests/5936#step/check_os_release/1)
- [SLES 15-SP2](http://mango.qe.nue2.suse.org/tests/5937#step/check_os_release/1)
- [SLES 15-SP3](http://mango.qe.nue2.suse.org/tests/5938#step/check_os_release/1)
- [SLES 15-SP4](http://mango.qe.nue2.suse.org/tests/5942#step/check_os_release/1)
- [SLES 15-SP5](http://mango.qe.nue2.suse.org/tests/5943#step/check_os_release/1)
- [SLES 15-SP6](http://mango.qe.nue2.suse.org/tests/5944#step/check_os_release/1)