### PR TITLE
Add support for Elemental based on SLE Micro 5.5

### DIFF
--- a/data/elemental/cloud-config.yaml
+++ b/data/elemental/cloud-config.yaml
@@ -1,4 +1,4 @@
-name: "Post-installation configuration"
+name: "initramfs configuration"
 stages:
   initramfs:
   - name: "Setup users"
@@ -8,6 +8,3 @@ stages:
         kind: "shadow"
         username: "root"
         password: "%TEST_PASSWORD%"
-  after-install-chroot:
-  - commands:
-    - grub2-editenv /run/elemental/efi/grub_oem_env set timeout=-1

--- a/data/elemental/install.yaml
+++ b/data/elemental/install.yaml
@@ -1,0 +1,5 @@
+name: "Post-installation configuration"
+stages:
+  after-install:
+  - commands:
+    - grub2-editenv %PATH%/grub_oem_env set timeout=-1

--- a/tests/elemental/installation.pm
+++ b/tests/elemental/installation.pm
@@ -12,14 +12,36 @@ use testapi;
 use power_action_utils qw(power_action);
 use serial_terminal qw(select_serial_terminal);
 use utils qw(file_content_replace);
+use version_utils qw(is_sle_micro);
 use Utils::Architectures;
+
+=head2 get_filename
+
+ get_filename(file => '/path/to/file');
+
+Extract the filename from F</path/to/file> and return it.
+
+=cut
+
+sub get_filename {
+    my %args = @_;
+
+    my @spl = split('/', $args{file});
+
+    return $spl[$#spl];
+}
 
 sub run {
     my ($self) = @_;
-    my $cloudconfig = "/tmp/cloud-config.yaml";
+    my @config_files = ('/oem/install.yaml', '/tmp/cloud-config.yaml');
+    my $grub_env_path = is_sle_micro('<6.0') ? '/run/cos/state' : '/run/elemental/efi';
+    my $hook = is_sle_micro('<6.0') ? 'after-install' : 'after-install-chroot';
     my %boot_entries = (
         active => {
             tag => 'elemental-bootmenu-default'
+        },
+        passive => {
+            tag => 'elemental-bootmenu-passive'
         },
         recovery => {
             tag => 'elemental-bootmenu-recovery'
@@ -34,34 +56,42 @@ sub run {
         $self->wait_boot(textmode => 1);
     }
 
-    ## No GUI, easier and quicker to use the serial console
+    # We have to use this dirty workaround for older images...
+    sleep bmwqemu::scale_timeout(20) if (is_sle_micro('<6.0'));
+
+    # No GUI, easier and quicker to use the serial console
     select_serial_terminal();
 
-    # Stop the installation service, to avoid issue with mnanual Elemental deployment
+    # Stop the installation service, to avoid issue with manual Elemental deployment
     assert_script_run('systemctl stop elemental-register-install.service');
 
-    # Add a simple cloud-config
+    # Encode root password
     my $rootpwd = script_output('openssl passwd -6 ' . get_var('TEST_PASSWORD'));
-    assert_script_run('curl ' . data_url('elemental/cloud-config.yaml') . ' -o ' . $cloudconfig);
-    file_content_replace($cloudconfig, '%TEST_PASSWORD%' => $rootpwd);
+
+    # Add configuration files
+    foreach my $config_file (@config_files) {
+        assert_script_run('curl ' . data_url('elemental/' . get_filename(file => $config_file)) . ' -o ' . $config_file);
+        file_content_replace($config_file, '%TEST_PASSWORD%' => $rootpwd);
+        file_content_replace($config_file, '%PATH%' => $grub_env_path);
+    }
 
     # Install Elemental OS on HDD
-    assert_script_run('elemental install /dev/vda --debug --cloud-init ' . $cloudconfig);
+    assert_script_run('elemental install /dev/vda --debug --cloud-init /tmp/*.yaml');
 
     # Loop on all entries to test them
-    my @loop_count;
     foreach my $boot_entry (keys %boot_entries) {
+        # Fallback/passive Grub entry doesn't exist anymore in newer version
+        next if (is_sle_micro('>=6.0') && $boot_entry eq 'passive');
+
+        # Variables
         my $state = $boot_entries{$boot_entry};
         my $state_file = "/run/cos/${boot_entry}_mode";
-
-        # Incrememnt the loop counter
-        push @loop_count, $_;
 
         # Reboot to test the Grub entry
         power_action('reboot', keepconsole => 1, textmode => 1);
 
-        # Use new root password after the first reboot (so after OS installation)
-        $testapi::password = get_var('TEST_PASSWORD') if @loop_count == 1;
+        # Force the use of new root password
+        $testapi::password = get_var('TEST_PASSWORD');
 
         # Select SUT for bootloader
         select_console('sut');


### PR DESCRIPTION
Add support for Stable OS images of Elemental, based on SLE Micro 5.5.

- Related ticket: https://github.com/rancher/elemental/issues/1414
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1665

Verification runs:
- [aarch64 regression test](https://openqa.suse.de/tests/14531605)
- [x86_64 regression test](https://openqa.suse.de/tests/14531606)
- Validation of the new one done on my local lab (osd cannot be used for this test), see following screenshot.
![Screenshot from 2024-06-05 18-23-24](https://github.com/os-autoinst/os-autoinst-distri-opensuse/assets/25102165/551f91c1-f564-4893-b6e5-745f950604ff)