### PR TITLE
containers: Avoid registry mirror in 3rd party module

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -153,16 +153,16 @@ sub supports_image_arch {
 }
 
 sub get_3rd_party_images {
-    my $registry = get_var('REGISTRY', 'docker.io');
     my @images = (
         "registry.opensuse.org/opensuse/leap",
         "registry.opensuse.org/opensuse/tumbleweed",
-        "$registry/library/alpine",
-        "$registry/library/debian");
+        "public.ecr.aws/docker/library/alpine",
+        "public.ecr.aws/debian/debian",
+    );
 
     # Following images are not available on 32-bit arm
     push @images, (
-        "$registry/library/fedora",
+        "registry.fedoraproject.org/fedora",
         "registry.access.redhat.com/ubi8/ubi",
         "registry.access.redhat.com/ubi8/ubi-minimal",
         "registry.access.redhat.com/ubi8/ubi-micro",
@@ -184,8 +184,8 @@ sub get_3rd_party_images {
     # - poo#72124 Ubuntu image (occasionally) fails on s390x.
     # - CentOS image not available on s390x.
     push @images, (
-        "$registry/library/ubuntu",
-        "$registry/library/centos"
+        "public.ecr.aws/ubuntu/ubuntu",
+        "public.ecr.aws/docker/library/centos"
     ) unless (is_arm || is_s390x || is_ppc64le);
 
     # RedHat UBI7 images are not built for aarch64 and 32-bit arm


### PR DESCRIPTION
Avoid registry mirror in 3rd party module.

- Verification runs (each arch and runtime is covered):
  - opensuse-Tumbleweed-DVD-x86_64-Build20240604-containers_host_podman@64bit -> https://openqa.opensuse.org/t4251004
  - opensuse-Tumbleweed-DVD-aarch64-Build20240604-containers_host_podman@aarch64 -> https://openqa.opensuse.org/t4251006
  - sle-15-SP5-Server-DVD-Updates-s390x-Build20240604-1-docker_tests@s390x-kvm -> https://openqa.suse.de/t14531929
  - sle-15-SP6-Online-ppc64le-Build92.1-docker_tests@ppc64le -> https://openqa.suse.de/t14534867

