### PR TITLE
Add "--gpg-auto-import-keys" option to install openSUSE-repos-NVIDIA

### DIFF
--- a/tests/console/opensuse_repos.pm
+++ b/tests/console/opensuse_repos.pm
@@ -35,8 +35,9 @@ sub run {
     assert_script_run("rpm -q $pkgname");
 
     # NVIDIA repo is available only for x86_64 and aarch64
+    # Add "--gpg-auto-import-keys" option due to poo#161798
     if (is_x86_64 || is_aarch64) {
-        zypper_call "in openSUSE-repos-NVIDIA";
+        zypper_call "--gpg-auto-import-keys in openSUSE-repos-NVIDIA";
         assert_script_run("rpm -q $pkgname-NVIDIA");
     }
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/161798

- Verification run: 
[VR](https://openqa.opensuse.org/tests/overview?version=15.5&distri=opensuse&build=rfan0607_repos_gpg)