### PR TITLE
Revert "Make cleanup non-fatal"

### DIFF
--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -28,6 +28,7 @@ sub cleanup {
         network_peering_present => $self->{network_peering_present},
         ansible_present => $self->{ansible_present}
     );
+
     if ($res) {
         $self->{cleanup_called} = 1;
         $self->{network_peering_present} = 0;
@@ -62,7 +63,16 @@ sub post_fail_hook {
         return;
     }
     qesap_cluster_logs();
-    eval { $self->cleanup(); } or bmwqemu::fctwarn("self::cleanup() failed -- $@");
+    $self->cleanup();
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    if ($self->test_flags()->{publiccloud_multi_module} or get_var('QESAP_NO_CLEANUP')) {
+        diag('Skip post run', "Skipping post run hook. \n Variable 'QESAP_NO_CLEANUP' defined or test_flag 'publiccloud_multi_module' active");
+        return;
+    }
+    $self->cleanup();
 }
 
 1;

--- a/tests/sles4sap/publiccloud/qesap_cleanup.pm
+++ b/tests/sles4sap/publiccloud/qesap_cleanup.pm
@@ -22,7 +22,7 @@ sub run {
             "Variable 'QESAP_NO_CLEANUP' set to value " . get_var('QESAP_NO_CLEANUP'));
         return 1;
     }
-    eval { $self->cleanup($run_args); } or bmwqemu::fctwarn("self::cleanup(\$run_args) failed -- $@");
+    $self->cleanup($run_args);
     $run_args->{network_peering_present} = $self->{network_peering_present};
     $run_args->{ansible_present} = $self->{ansible_present};
 }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#19455 because it makes IBSm deployment fail https://openqa.suse.de/tests/14538613#step/network_peering/72