### PR TITLE
Use podman instead of docker in hawk_gui test module

### DIFF
--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -3,7 +3,7 @@
 # Copyright 2016-2020 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: docker MozillaFirefox
+# Package: podman MozillaFirefox
 # Summary: check HAWK GUI with the a python+selenium script and firefox
 # Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.com>
 
@@ -15,17 +15,13 @@ use lockapi;
 use hacluster;
 use x11test;
 use x11utils;
-use version_utils 'is_desktop_installed';
+use version_utils qw(is_desktop_installed get_os_release);
+use containers::common qw(install_podman_when_needed);
 
-sub install_docker {
-    my $docker_url = "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.5.tgz";
-
-    assert_script_run "curl -s $docker_url | tar zxf - --strip-components 1 -C /usr/bin", 120;
-    # Allow the user to run docker. We can't add him to the docker group without restarting X.
-    # The final colon is to avoid a bash syntax error when assert_script_run() appends a semicolon
-    assert_script_run "/usr/bin/dockerd -G users --insecure-registry registry.suse.de >/dev/null 2>&1 & :";
+sub install_podman {
+    my ($running_version, $sp, $host_distri) = get_os_release;
+    install_podman_when_needed($host_distri);
 }
-
 
 sub run {
     my ($self) = @_;
@@ -47,14 +43,14 @@ sub run {
     }
 
     select_console 'root-console';
-    install_docker;
+    install_podman;
 
     # TODO: Use another namespace using team group name
     # Docker image source in https://github.com/ricardobranco777/hawk_test
     # It will be eventually moved to https://github.com/ClusterLabs/hawk/e2e_test
-    my $docker_image = "registry.opensuse.org/devel/openqa/ci/tooling/containers_15_4/hawk_test:latest";
+    my $image = "registry.opensuse.org/devel/openqa/ci/tooling/containers_15_4/hawk_test:latest";
 
-    assert_script_run("docker pull $docker_image", 240);
+    assert_script_run("podman pull $image", 240);
 
     # Rest of the test needs to be performed on the x11 console, but with the
     # HA_CLUSTER setting that console is not yet activated; newer versions of gdm
@@ -83,9 +79,13 @@ sub run {
     assert_script_run "mkdir -m 1777 $path";
     assert_script_run "xhost +";
     barrier_wait("HAWK_GUI_CPU_TEST_START_$cluster_name");
-    my $docker_cmd = "docker run --rm --name test --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=\$DISPLAY -v \$PWD/$path:/$path ";
-    $docker_cmd .= "$docker_image -b $browser -H $node1 -S $node2 -s $testapi::password -r /$results --virtual-ip $virtual_ip";
-    enter_cmd "$docker_cmd 2>&1 | tee $logs; echo $pyscr-\$PIPESTATUS > $retcode";
+    # become root because podman command needs elevated permissions
+    # and then cd to the user's home directory.
+    become_root;
+    assert_script_run("cd /home/$testapi::username");
+    my $test_cmd = "podman run --rm --name test --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=\$DISPLAY -v \$PWD/$path:/$path ";
+    $test_cmd .= "$image -b $browser -H $node1 -S $node2 -s $testapi::password -r /$results --virtual-ip $virtual_ip";
+    enter_cmd "$test_cmd 2>&1 | tee $logs; echo $pyscr-\$PIPESTATUS > $retcode";
     assert_screen "hawk-$browser", 60;
 
     my $loop_count = 360;    # 30 minutes (360*5)
@@ -105,10 +105,14 @@ sub run {
     }
     if ($loop_count < 0) {
         record_info("$browser failed", "Test with browser [$browser] could not be completed in 30 minutes", result => 'softfail');
-        script_run "docker container kill test";
+        script_run "podman container kill test";
     }
 
     save_screenshot;
+
+    # Probably not necessary, but as podman command ran as root, change ownership of the
+    # test files to $testapi::username just to be on the safe side
+    assert_script_run "chown -R $testapi::username $path";
 
     assert_screen "generic-desktop";
     barrier_wait("HAWK_GUI_CPU_TEST_FINISH_$cluster_name");


### PR DESCRIPTION
The `ha/hawk_gui` test module uses a python+selenium test packaged in a docker/podman container to ensure all required dependencies are installed. Early versions of the module would install a fixed docker version downloaded from download.docker.com, which will then be used to download the docker image and run the container, but starting on 15-SP6, this old version of docker clashes with the cgroups configuration of the base 15-SP6 system, preventing the container from running. This commit switches the docker commands for podman, as the latter is supported by SUSE and we can always get the latest version using `zypper in`. These changes also mean that HAWK client tests need to run from a system where podman can be installed (i.e., repositories where podman package is available are already added to the testing system.)

- Related ticket: https://jira.suse.com/browse/TEAM-8974
- Needles: N/A

**Verification runs:**

- 15-SP6 client, 15-SP6 cluster: http://mango.qe.nue2.suse.org/tests/5910
- 15-SP6 client, 12-SP5 cluster: http://mango.qe.nue2.suse.org/tests/5914
- QAM Incidents in osd's HA Development Job Group: https://openqa.suse.de/group_overview/79?limit_builds=50

**IMPORTANT**

Please do not merge this without updating first the **HDD_1** setting in the HAWK client jobs in the osd job groups.