### PR TITLE
Fix Elemental boot on aarch64

### DIFF
--- a/tests/elemental/installation.pm
+++ b/tests/elemental/installation.pm
@@ -52,6 +52,7 @@ sub run {
     # Bypass Grub on aarch64 as it can take too long to match the first grub2 needle
     if (is_aarch64) {
         $self->wait_boot_past_bootloader(textmode => 1);
+        sleep bmwqemu::scale_timeout(30);
     } else {
         $self->wait_boot(textmode => 1);
     }


### PR DESCRIPTION
Aarch64 worker can be slower than x86_64 one, so we need to add a small wait before connecting to the serial console.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/14542880
