### PR TITLE
Use snapper rollback to get to state before patch

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -815,6 +815,7 @@ sub fully_patch_system {
     }
 
     die "Zypper failed with $ret" if ($ret != 0 && $ret != 102);
+    return $ret;
 }
 
 =head2 ssh_fully_patch_system


### PR DESCRIPTION
```
Updates can have multiple patches, the idea is to test each patch separately. After patch rollback to state after full system patch and run another patch.

- export reboot_and_login, run after fully_patch_system if reboot is needed, after patch, not at the end of test, and after snapper rollback
- return zypper return code in fully_patch_system to know if reboot is needed
- no need to disable update repos, rollback snapshot has repos disabled
```

- Related ticket: https://progress.opensuse.org/issues/161855
- Verification run: https://dzedro.suse.cz/tests/1112#step/update_install/775
https://openqa.suse.de/tests/14551103 x86_64
https://openqa.suse.de/tests/14551104 s390x
https://openqa.suse.de/tests/14551105 ppc64le
https://openqa.suse.de/tests/14551109 aarch64
https://openqa.suse.de/tests/14551110 Desktop