### PR TITLE
Quick fix for SUSEConnect -d

### DIFF
--- a/tests/yam/migration/setup_registration.pm
+++ b/tests/yam/migration/setup_registration.pm
@@ -10,7 +10,6 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use utils 'zypper_call';
 use registration 'register_addons_cmd';
 
 sub run {
@@ -21,10 +20,7 @@ sub run {
 
     select_console('root-console');
     assert_script_run('SUSEConnect --debug --cleanup');
-    foreach my $addon (@addons_drop) {
-        my $pkg_name = ($addon eq 'ltss') ? "sles-$addon-release" : "sle-module-$addon-release";
-        zypper_call("rm $pkg_name");
-    }
+    script_run('SUSEConnect -d', proceed_on_failure => 1);
     assert_script_run('SUSEConnect --debug --regcode ' . get_required_var('SCC_REGCODE'), 200);
     my $addons_to_register = join(',', grep !exists $filter{$_}, @addons);
     register_addons_cmd($addons_to_register);


### PR DESCRIPTION
##
#### We need to change the way we handle `SUSEConnect -d`

- Related ticket: https://progress.opensuse.org/issues/161231
- Needles: N/A
- Verification run: 
   - https://openqa.suse.de/t14549743 sles15sp2_sp4
   - https://openqa.suse.de/t14549744  sles15sp2_sp3
   - https://openqa.suse.de/tests/14549752 sles15sp3_sp4
##   