### PR TITLE
Fix change_password failure on TW

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -54,12 +54,7 @@ sub switch_user {
 }
 
 sub change_pwd {
-    send_key "alt-p";
-    wait_still_screen;
-    send_key "ret";
-    wait_still_screen;
-    send_key "alt-p";
-    wait_still_screen;
+    assert_and_click "users-password";
     type_password;
     wait_still_screen;
     assert_and_click "new-password";
@@ -76,6 +71,7 @@ sub change_pwd {
 sub add_user {
     assert_and_click "add-user";
     assert_screen("before-input-username-test");
+    assert_and_click "focus-name-field";
     type_string $newUser;
     assert_screen("input-username-test");
     assert_and_click "set-password-option";


### PR DESCRIPTION
The shortcut for changing password is not alt-p in latest TW 
So, use assert_and_click to avoid shortcut inconsistency 
Add assert_and_click "focus-name-field" to make test more robust

- Related ticket: https://progress.opensuse.org/issues/161045
- Needles: already added when debugging on o3 and osd
- Verification run: 

> TW Wayland https://openqa.opensuse.org/tests/4255499
> TW X11 https://openqa.opensuse.org/tests/4255305
> 15SP6 X11 https://openqa.suse.de/tests/14515832
> 15SP6 Wayland https://openqa.suse.de/tests/14525364