### PR TITLE
OpenStack:Remove boot time measurements

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -617,7 +617,7 @@ sub measure_boottime() {
     my ($self, $instance, $type) = @_;
     my $data_collect = get_var('PUBLIC_CLOUD_PERF_COLLECT', 1);
 
-    return 0 unless ($data_collect);
+    return 0 if (!$data_collect || is_openstack);
 
     my $ret = {
         kernel_release => undef,

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -354,8 +354,11 @@ sub create_instances {
         }
         # check guestregister conditional, default yes:
         $instance->wait_for_guestregister() if ($args{check_guestregister});
+
         # Performance data: boottime
-        if (!is_openstack && is_ok_url($url)) {
+        next if is_openstack;
+
+        if (is_ok_url($url)) {
             local $@;
             eval {
                 my $btime = $instance->measure_boottime($instance, 'first');


### PR DESCRIPTION
MinimalVM team does not require boot time measurements of their images. Removing this execution path we can save relatively significant runtime and mostly we get rid of expected failures as connection to Larry should not work in these tests.

- ticket: [MinimalVM ltp test trying to connect publiccloud-ng](https://progress.opensuse.org/issues/161081)
- Verification run: http://kepler.suse.cz/tests/23444#step/prepare_openstack/191
