### PR TITLE
Revert "Remove release package from SCC_ADDONS_DROP"

### DIFF
--- a/tests/yam/migration/setup_registration.pm
+++ b/tests/yam/migration/setup_registration.pm
@@ -10,7 +10,6 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use utils 'zypper_call';
 use registration 'register_addons_cmd';
 
 sub run {
@@ -20,11 +19,8 @@ sub run {
     @filter{@addons_drop} = {};
 
     select_console('root-console');
+    assert_script_run('SUSEConnect -d');
     assert_script_run('SUSEConnect --debug --cleanup');
-    foreach my $addon (@addons_drop) {
-        my $pkg_name = ($addon eq 'ltss') ? "sles-$addon-release" : "sle-module-$addon-release";
-        zypper_call("rm $pkg_name");
-    }
     assert_script_run('SUSEConnect --debug --regcode ' . get_required_var('SCC_REGCODE'), 200);
     my $addons_to_register = join(',', grep !exists $filter{$_}, @addons);
     register_addons_cmd($addons_to_register);


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#19443

The PR introcuded problems in migration from SP2 to [SP3](https://openqa.suse.de/tests/14546428#step/setup_registration/18) and [SP4](https://openqa.suse.de/tests/14546472#step/setup_registration/18). 

