### PR TITLE
Fix cloud-init schedule for sl-micro

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -58,7 +58,11 @@ sub load_boot_from_disk_tests {
     if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
         loadtest 'jeos/firstrun';
     } elsif (check_var('FIRST_BOOT_CONFIG', 'cloud-init')) {
-        loadtest 'boot/cloud_init';
+        unless (is_s390x) {
+            loadtest 'installation/bootloader_uefi';
+            loadtest 'installation/first_boot';
+        }
+        loadtest 'jeos/verify_cloudinit';
     } else {
         if (is_s390x()) {
             loadtest 'boot/boot_to_desktop';


### PR DESCRIPTION
cloud-init is supported in sl-micro from now on, we need to fix the test module schedule that would align MinimalVM's

- Verification run: http://kepler.suse.cz/tests/23453#
- https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1684