### PR TITLE
Add 'Default' to images with disabled grub timeout

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -22,6 +22,7 @@ use constant {
           is_microos
           is_leap_micro
           is_sle_micro
+          is_micro
           is_alp
           is_selfinstall
           is_gnome_next
@@ -281,6 +282,18 @@ sub is_sle_micro {
 
     # Version check
     return check_version($query, $version, qr/\d{1,}\.\d/);
+}
+
+=head2 is_micro
+
+Check if distribution is any of MicroOS, Leap Micro or SL-Micro
+=cut
+
+sub is_micro {
+    my $query = shift;
+    my $version = shift // get_var('VERSION');
+
+    return is_microos($query, $version) || is_leap_micro($query, $version) || is_sle_micro($query, $version);
 }
 
 =head2 is_alp

--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -10,7 +10,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle_micro is_leap_micro);
+use version_utils qw(is_micro);
 use Utils::Architectures qw(is_aarch64);
 use microos "microos_login";
 use transactional "record_kernel_audit_messages";
@@ -23,7 +23,7 @@ sub run {
     # SLEM updated GM and BETA images from https://openqa.suse.de/group_overview/377
     # already have disabled grub timeout in order to install updates and reboot
     # therefore *aarch64* images would hang in GRUB2
-    if ((get_var('HDD_1') !~ /GM-Updated/ && get_var('HDD_1') !~ /Beta-Updated/ && (is_sle_micro || is_leap_micro)) && is_aarch64 && get_var('BOOT_HDD_IMAGE')) {
+    if ((is_micro && is_aarch64) && get_var('BOOT_HDD_IMAGE') && (get_var('HDD_1') !~ /GM-Updated/ && get_var('HDD_1') !~ /Beta-Updated/ && get_var('HDD_1') !~ /Default-Updated/)) {
         shift->wait_boot_past_bootloader(textmode => 1);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
Adds the Default-Updated to the images where a grub timeout is expected to be disabled.

Also introduce the is_micro catch-all routine to simplify further checks of this and similar kinds.

- Related ticket: https://progress.opensuse.org/issues/160796
- Related failure: https://openqa.suse.de/tests/14554334#step/disk_boot/4
- Verification run: [aarch64](https://openqa.suse.de/tests/14564455) | [x86_64](https://openqa.suse.de/tests/14564452)
