### PR TITLE
containers: Add missing go dependency to podman upstream tests

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -55,7 +55,7 @@ sub run {
 
     # Install tests dependencies
     my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark netcat-openbsd openssl podman python3-passlib skopeo socat sudo systemd-container);
-    push @pkgs, qw(buildah) unless is_sle_micro;
+    push @pkgs, qw(go buildah) unless is_sle_micro;
     # podman-remote is not yet available & python3-PyYAML was dropped in SLM 6.0
     push @pkgs, qw(podman-remote python3-PyYAML) unless is_sle_micro('>=6.0');
     # passt requires podman 5.0


### PR DESCRIPTION
The `go` dependency was mistakenly dropped in https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/6153d0db18d14ce1440518bc6a7cc446bc344b01#diff-2632f5646811893cee7686c9813898d85d387aa047c6f2116fa75b8807e46953L55 

Verification runs:
- sle-15-SP5-Server-DVD-Updates-x86_64-Build20240609-1-podman_testsuite@64bit -> https://openqa.suse.de/t14565709 (failing for other reason)
- sle-15-SP5-Server-DVD-Updates-aarch64-Build20240609-1-podman_testsuite@aarch64-virtio -> https://openqa.suse.de/t14565710 (ditto above)