### PR TITLE
Fix condtition for qemu pattern name

### DIFF
--- a/tests/qemu/qemu.pm
+++ b/tests/qemu/qemu.pm
@@ -18,11 +18,11 @@ use version_utils qw(is_sle_micro is_leap_micro is_transactional);
 
 # 'patterns-microos-kvm_host' is required for SUMA client use case
 sub is_qemu_preinstalled {
-    if (is_sle_micro('<6.0') || is_leap_micro) {
+    if (is_sle_micro('<6.0') || is_leap_micro('<6.0')) {
         assert_script_run('rpm -q patterns-microos-kvm_host');
         return 1;
     }
-    elsif (is_sle_micro('>=6.0')) {
+    elsif (is_sle_micro('>=6.0') || is_leap_micro('>=6.0')) {
         assert_script_run('rpm -q patterns-base-kvm_host');
         return 1;
     }


### PR DESCRIPTION
The module incorectly assumed that leap and sle have different naming schemes.

- Related ticket:  https://progress.opensuse.org/issues/162032

- Verification run: [SLEM 5.4 & 6.0](https://openqa.suse.de/tests/overview?distri=sle-micro&build=apappas_micro6_qemu) [Leap Micro 6 - aarch64](https://openqa.opensuse.org/tests/4261398) [Leap Micro 6 - x86](https://openqa.opensuse.org/tests/4261472) 