### PR TITLE
Set xen serial console kernel options for EFI boot

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -39,6 +39,7 @@
       <serial>serial --speed=115200 --unit=<%= $get_var->('SERIALDEV') =~ s/ttyS//r %> --word=8 --parity=no --stop=1</serial>
       <timeout config:type="integer">15</timeout>
       <trusted_grub>false</trusted_grub>
+      <secure_boot>false</secure_boot>
       <terminal>console</terminal>
       % if ($check_var->('SYSTEM_ROLE', 'xen')) {
       <xen_append>loglevel=5 vt.color=0x07 splash=silent console=hvc0 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
@@ -47,7 +48,11 @@
       <append>loglevel=5 gfxpayload=1024x768 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
       % }
     </global>
-    <loader_type>default</loader_type>
+    % if ($check_var->('IPXE_UEFI', '1') or $check_var->('UEFI', '1')) {
+    <loader_type>grub2-efi</loader_type>
+    % } else {
+    <loader_type>grub2</loader_type>
+    % }
   </bootloader>
   <general>
     <ask-list config:type="list"/>
@@ -126,6 +131,16 @@
       <enable_snapshots config:type="boolean">false</enable_snapshots>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
+        % if ($check_var->('IPXE_UEFI', '1') or $check_var->('UEFI', '1')) {
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">vfat</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/boot/efi</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <size>512M</size>
+        </partition>
+        % }
         <partition>
           <create config:type="boolean">true</create>
           <filesystem config:type="symbol">btrfs</filesystem>
@@ -144,6 +159,13 @@
           <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
           <resize config:type="boolean">false</resize>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mountby config:type="symbol">uuid</mountby>
+          <size>2G</size>
         </partition>
       </partitions>
       <type config:type="symbol">CT_DISK</type>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -48,6 +48,7 @@
       <gfxmode>auto</gfxmode>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
+      <secure_boot>false</secure_boot>
       <serial>serial --speed=115200 --unit=<%= $get_var->('SERIALDEV') =~ s/ttyS//r %> --word=8 --parity=no --stop=1</serial>
       <timeout config:type="integer">15</timeout>
       <trusted_grub>false</trusted_grub>
@@ -121,6 +122,17 @@
       <enable_snapshots config:type="boolean">false</enable_snapshots>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
+	% if ($check_var->('IPXE_UEFI', '1') or $check_var->('UEFI', '1')) {
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">vfat</filesystem>
+          <format config:type="boolean">true</format>
+	  <partition_id t="integer">259</partition_id>
+	  <mount>/boot/efi</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <size>512M</size>
+        </partition>
+	% }
         <partition>
           <create config:type="boolean">true</create>
           <create_subvolumes config:type="boolean">true</create_subvolumes>
@@ -139,6 +151,13 @@
           <mountby config:type="symbol">uuid</mountby>
           <partition_id config:type="integer">131</partition_id>
           <resize config:type="boolean">false</resize>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mountby config:type="symbol">uuid</mountby>
+          <size>2G</size>
         </partition>
       </partitions>
       <type config:type="symbol">CT_DISK</type>

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -299,6 +299,9 @@ sub run {
     my $self = shift;
     $self->login_to_console;
     config_ssh_client if get_var('VIRT_AUTOTEST') and !get_var('AUTOYAST') and !is_s390x;
+    # Provide a screenshot to check if the kernel parameters are correct before tests begin
+    script_run("cat /proc/cmdline") if !is_s390x;
+    save_screenshot;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
- Set serial console kernel options for EFI boot on XEN in grub2 files on EFI partition(`/boot/efi/efi/xen-*.cfg`)
- Disable secure boot. Disable secure boot in BIOS and autoyast template for both sle15 and sle12sp5. Though autoyast guild for sle12sp5 does not  say it supports disable secure boot, but actually it does.
- Set EFI partition for UEFI boot on both sle15 and sle12 autoyast templates
- Upload EFI xen grub configuration files
- Not update packages for registered sles on x86


Related ticket: https://progress.opensuse.org/issues/153037
Verification run: 
- `vh082`:
[sle12sp5_xen_autoyast](http://10.67.129.27/tests/403)
[sle15sp6_kvm_full_feature_autoyast](http://10.67.129.27/tests/387)
[sle15sp5_kvm_UEFI_non-autoayst](http://10.67.129.27/tests/397)
[sle12sp5_kvm_full_feature_non-autoyast](http://10.67.129.27/tests/401)
[sle12sp5_xen_non-autoyast](http://10.67.129.27/tests/400)      //kernel panic

- `kermit`:
[sle15sp6_kvm_autoyast](https://openqa.suse.de/tests/14674402)
[sle12sp5_xen_uefi_guest_full_feature_autoyast](https://10.145.10.207/tests/14689116)   //fail on virtual_network_init, nothing to do with this PR
[sle15sp6_xen_autoyast](https://10.145.10.207/tests/14676208)
[sle12sp5_xen_uefi_guest_full_feature_non-autoyast](https://10.145.10.207/tests/14687693)  
[prj2_sle15sp5_kvm_autoyast](https://10.145.10.207/tests/14702095)   //failed due to scc failure, nothing to do with this PR
[prj2_12sp5_xen_autoyast](https://10.145.10.207/tests/14701998)   //dom0 kernel panic

- `scooter`:
[sle15sp6_xen_uefi_guest_full_feature_autoyast](http://openqa.suse.de/tests/14689600) 
[sle15sp6_kvm_uefi_guest_full_feature_autoyast](http://openqa.suse.de/t14701999)
[sle12sp5_kvm_non-autoyast](https://10.145.10.207/tests/14703840)    //fail on guest scc, nothing to do with PR
[prj4_sle15sp5_xen_non-autoyast](https://10.145.10.207/tests/14704604) 

- other non-uefi machines:
[sle15sp6_kvm_autoyast](https://openqa.suse.de/tests/14701722)
[sle15sp6_kvm_non-autoyast](https://10.145.10.207/tests/14701795)
[sle15sp6_xen_autoyast](http://openqa.suse.de/tests/14701412) 
[sle15sp5_xen_non-autoyast](https://openqa.suse.de/tests/14701792)   //failed on guest upgrade due to scc failure, nothing to do with this PR
[sle12sp5_kvm_non-autoyast](http://openqa.suse.de/t14694714)
[s390_sle15sp6](https://openqa.suse.de/tests/14694658)    //failure is not caused by PR
[s390_sle15sp6](http://openqa.suse.de/tests/14703290)    //failure is not caused by PR

