### PR TITLE
Add virtualenv

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -34,6 +34,8 @@ sub packages_to_install {
     my $arch = get_required_var('ARCH');
     my $scc_timeout = 1200;    # SCC can take really long timetimes
 
+    my $bci_virtualenv = get_var('BCI_VIRTUALENV', 0);
+
     # Avoid PackageKit to conflict about lock with zypper
     script_run("pkcon quit", die_on_timeout => 0) if (is_sle || is_opensuse);
 
@@ -41,20 +43,25 @@ sub packages_to_install {
     my @packages = ('git-core', 'python3', 'gcc', 'jq');
     if ($host_distri eq 'ubuntu') {
         push @packages, ('python3-dev', 'python3-pip', 'golang', 'postgresql-server-dev-all');
+        push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri eq 'rhel' && $version > 7) {
         push @packages, ('platform-python-devel', 'python3-pip', 'golang', 'postgresql-devel');
+        push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri =~ /centos|rhel/) {
         push @packages, ('python3-devel', 'python3-pip', 'golang', 'postgresql-devel');
+        push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri eq 'sles' || $host_distri =~ /leap/) {
         # SDK is needed for postgresql
         my $version = "$version.$sp";
         push @packages, ('postgresql-server-devel');
+        push @packages, ('python3-virtualenv') if ($bci_virtualenv);
         if ($version eq "12.5") {
             script_retry("SUSEConnect --auto-agree-with-licenses -p sle-sdk/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             # PackageHub is needed for jq
             script_retry("SUSEConnect -p PackageHub/12.5/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             script_retry('zypper -n in jq', retry => 3);
             push @packages, ('python36-devel', 'python36-pip');
+            die "virtualenv is not supported on 12-SP5" if ($bci_virtualenv);
         } elsif ($version =~ /15\.[1-3]/) {
             # Desktop module is needed for SDK module, which is required for go and postgresql-devel
             script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
@@ -71,10 +78,16 @@ sub packages_to_install {
         }
     } elsif ($host_distri =~ /opensuse/) {
         push @packages, qw(python3-devel go skopeo postgresql-server-devel python3-pip python3-tox);
+        push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } else {
         die("Host is not supported for running BCI tests.");
     }
     return @packages;
+}
+
+sub activate_virtual_env {
+    assert_script_run('virtualenv bci');
+    assert_script_run('source bci/bin/activate');
 }
 
 sub run {
@@ -89,6 +102,7 @@ sub run {
     my $engines = get_required_var('CONTAINER_RUNTIMES');
     my $bci_tests_repo = get_required_var('BCI_TESTS_REPO');
     my $bci_tests_branch = get_var('BCI_TESTS_BRANCH');
+    my $bci_virtualenv = get_var('BCI_VIRTUALENV', 0);
 
     record_info('Install', 'Install needed packages');
     my @packages = packages_to_install($version, $sp, $host_distri);
@@ -101,18 +115,21 @@ sub run {
         foreach my $pkg (@packages) {
             script_retry("apt-get -y install $pkg", timeout => 300);
         }
+        activate_virtual_env if ($bci_virtualenv);
         assert_script_run('pip3 --quiet install --upgrade pip', timeout => 600);
         assert_script_run("pip3 --quiet install tox", timeout => 600);
     } elsif ($host_distri =~ /centos|rhel/) {
         foreach my $pkg (@packages) {
             script_retry("yum install -y $pkg", timeout => 300);
         }
+        activate_virtual_env if ($bci_virtualenv);
         assert_script_run('pip3 --quiet install --upgrade pip', timeout => 600);
         assert_script_run("pip3 --quiet install tox", timeout => 600);
     } elsif ($host_distri =~ /sles|opensuse/) {
         foreach my $pkg (@packages) {
             zypper_call("--quiet in $pkg", timeout => 300);
         }
+        activate_virtual_env if ($bci_virtualenv);
         if (!grep(/-tox/, @packages)) {
             assert_script_run('pip --quiet install --upgrade pip', timeout => 600);
             assert_script_run("pip --quiet install tox --ignore-installed six", timeout => 600);
@@ -130,6 +147,7 @@ sub run {
     my $branch = $bci_tests_branch ? "-b $bci_tests_branch" : '';
     script_run('rm -rf /root/BCI-tests');
     assert_script_run("git clone $branch -q --depth 1 $bci_tests_repo /root/BCI-tests");
+    assert_script_run('deactivate') if ($bci_virtualenv);
 }
 
 sub test_flags {

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -83,9 +83,12 @@ sub run {
     my $bci_target = get_var('BCI_TARGET', 'ibs-cr');
     my $version = get_required_var('VERSION');
     my $test_envs = get_required_var('BCI_TEST_ENVS');
+    my $bci_virtualenv = get_var('BCI_VIRTUALENV', 0);
     return if ($test_envs eq '-');
 
     reset_container_network_if_needed($engine);
+
+    assert_script_run('source bci/bin/activate') if ($bci_virtualenv);
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard origin");
@@ -102,6 +105,7 @@ sub run {
         $self->run_tox_cmd($env);
     }
 
+    assert_script_run('deactivate') if ($bci_virtualenv);
 
     # Mark the job as failed if any of the tests failed
     die("$error_count tests failed.") if ($error_count > 0);


### PR DESCRIPTION
Adds virtualenv for the BCI test environment to prevent overwriting system packages.

- Related ticket: https://progress.opensuse.org/issues/158976
- Verification runs: [Generate Image](https://openqa.suse.de/tests/14569151) | [BCI test run](https://openqa.suse.de/tests/14569424)

Merge together with https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1688