### PR TITLE
Add BCI_VIRTUALENV

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -36,6 +36,7 @@ BCI_TIMEOUT | string | | Timeout given to the command to test each environment. 
 BCI_TARGET | string | ibs-cr | Container project to be tested. `ibs-cr` is the CR project, `ibs` is the released images project
 BCI_SKIP | boolean | false | Switch to disable BCI test runs. Necessary for fine-granular test disablement
 BCI_PREPARE | boolean | false | Launch the bci_prepare step again. Useful to re-initialize the BCI-Test repo when using a different BCI_TESTS_REPO
+BCI_VIRTUALENV | boolean | false | Use a virtualenv for pip dependencies in BCI tests
 BOOTLOADER | string | grub2 | Which bootloader is used by the image (and in the future also: will be selected during installation)
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.


### PR DESCRIPTION
Adds a description for BCI_VIRTUALENV.

Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19499