### PR TITLE
wicked: add iputils and backend=wicked to opensuse autoyast profile

### DIFF
--- a/data/autoyast_opensuse/autoyast_wicked_x86_64.xml.ep
+++ b/data/autoyast_opensuse/autoyast_wicked_x86_64.xml.ep
@@ -16,6 +16,7 @@
     </mode>
   </general>
   <networking>
+    <backend>wicked</backend>
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
   <bootloader>
@@ -35,8 +36,9 @@
       <package>zypper</package>
       <package>wicked</package>
       <package>wicked-service</package>
-      </packages>
-      <do_online_update config:type="boolean">true</do_online_update>
+      <package>iputils</package>
+    </packages>
+    <do_online_update config:type="boolean">true</do_online_update>
   </software>
   <users config:type="list">
     <user>


### PR DESCRIPTION
I was missing `ping` on a fresh installed LEAP 15.5 with that autoyast profile. Also make wicked as default network backend.

- Verification run: http://openqa.wicked.suse.de/tests/219962
