### PR TITLE
Add back repos to HA image

### DIFF
--- a/data/autoyast_qam/15_installtest.xml.ep
+++ b/data/autoyast_qam/15_installtest.xml.ep
@@ -18,7 +18,6 @@
         <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/<%= $get_var->('VERSION') %>-LTSS/<%= $get_var->('ARCH') %>/update/]]></media_url>
       </listentry>
         % }
-        % unless ($check_var->('HA_QAM', '1') and !$check_var->('SAP_QAM', '1')) {
       <listentry>
         <name>sle-module-containers:<%= $get_var->('VERSION') %>::pool</name>
         <alias>sle-module-containers:<%= $get_var->('VERSION') %>::pool</alias>
@@ -59,7 +58,6 @@
         <alias>sle-module-web-scripting:<%= $get_var->('VERSION') %>::update</alias>
         <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Updates/SLE-Module-Web-Scripting/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
       </listentry>
-        % }
       % }
       <listentry>
         <name><%= uc $get_var->('SLE_PRODUCT') %>:<%= $get_var->('VERSION') %>::pool</name>


### PR DESCRIPTION
It is required for package dependencies
0f749e4d01ff49efcadfb4786cbb6bf68720a099

- Related ticket: https://openqa.suse.de/tests/overview?build=%3A33467%3Aphp7&groupid=310 php failing only on HA because of missing sle-module-web-scripting repo
