### PR TITLE
Uncheck hide development modules

### DIFF
--- a/schedule/yast/qam-yast_self_update_view_development.yaml
+++ b/schedule/yast/qam-yast_self_update_view_development.yaml
@@ -1,0 +1,39 @@
+---
+name: qam-yast_self_update_view_development
+description: installation using self_update as boot parameter
+vars:
+  YUI_REST_API: 1
+schedule:
+  - installation/bootloader_start
+  - installation/setup_libyui
+  - installation/product_selection/install_SLES
+  - installation/validate_self_update
+  - installation/licensing/accept_license
+  - installation/registration/register_via_scc
+  - installation/module_registration/view_development_versions
+  - installation/module_registration/register_extensions_and_modules
+  - installation/add_update_test_repo
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - '{{efi}}'
+conditional_schedule:
+  efi:
+    MACHINE:
+      uefi:
+        - console/consoletest_setup
+        - console/verify_efi_mok

--- a/schedule/yast/sle/flows/default_sle15sp6_x86_view_development.yaml
+++ b/schedule/yast/sle/flows/default_sle15sp6_x86_view_development.yaml
@@ -1,0 +1,51 @@
+---
+# Default ordered sequence of steps for sle15sp6 with maintenance updatesi,
+# add view_development_versions module.
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+product_selection:
+  - installation/product_selection/install_SLES
+self_update: []
+license_agreement:
+  - installation/licensing/accept_license
+registration:
+  - installation/registration/register_via_scc
+extension_module_selection:
+  - installation/module_registration/view_development_versions
+  - installation/module_registration/register_extensions_and_modules
+additional_products:
+  - installation/add_on_product_installation/add_additional_products
+add_on_product:
+  - installation/add_on_product/skip_install_addons
+system_role:
+  - installation/system_role/accept_selected_role_SLES_with_GNOME
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+default_systemd_target:
+  - installation/installation_settings/validate_default_target
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+security: []
+installation_settings:
+  - installation/launch_installation
+installation:
+  - installation/confirm_installation_maintenance
+  - installation/performing_installation/perform_installation
+installation_logs:
+  - installation/logs_from_installation_system
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+grub:
+  - installation/grub_test
+first_login:
+  - installation/first_boot
+system_preparation: []
+system_validation: []


### PR DESCRIPTION
Add schedule files to add module to uncheck hided development modules.

- Related ticket: https://progress.opensuse.org/issues/160700
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/231
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23check-out-hide-development-module&version=15-SP6&distri=sle

