### PR TITLE
WIP: Remove deregistration from setup_migration

### DIFF
--- a/tests/yam/migration/setup_registration.pm
+++ b/tests/yam/migration/setup_registration.pm
@@ -19,8 +19,6 @@ sub run {
     @filter{@addons_drop} = {};
 
     select_console('root-console');
-    assert_script_run('SUSEConnect --debug --cleanup');
-    script_run('SUSEConnect -d', proceed_on_failure => 1);
     assert_script_run('SUSEConnect --debug --regcode ' . get_required_var('SCC_REGCODE'), 200);
     my $addons_to_register = join(',', grep !exists $filter{$_}, @addons);
     register_addons_cmd($addons_to_register);


### PR DESCRIPTION
Now we'll do deregistration in the parent, so we'd remove the `SUSEConnect -d` from 
setup_migration.

- Related ticket: https://progress.opensuse.org/issues/161231
- Needles: N/A
- Verification run: 
   - TBA