### PR TITLE
Support CRASH_MEMORY on yast2 kdump

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -179,6 +179,7 @@ sub activate_kdump {
     # get kdump memory size bsc#1161421
     my $memory_total = script_output('kdumptool  calibrate | awk \'/Total:/ {print $2}\'');
     my $memory_kdump = $memory_total >= 2048 ? 1024 : 320;
+    $memory_kdump = get_var('CRASH_MEMORY') if get_var('CRASH_MEMORY');
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'kdump', yast2_opts => '--ncurses');
     my @initial_tags = qw(yast2-kdump-disabled yast2-kdump-enabled);
     push(@initial_tags,


### PR DESCRIPTION
Tested for https://bugzilla.suse.com/show_bug.cgi?id=1224464
