### PR TITLE
lib/main_common.pm: Run jeos/diskusage based on FILESYSTEM not FLAVOR

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -645,9 +645,8 @@ sub load_jeos_tests {
     # this test case also disables grub timeout
     loadtest "jeos/grub2_gfxmode";
     unless (get_var('INSTALL_LTP') || get_var('SYSTEMD_TESTSUITE')) {
-        # Cloud image is the only one based on XFS and not BTRFS
         # jeos/diskusage as of now works only with BTRFS
-        loadtest "jeos/diskusage" unless get_var('FLAVOR') =~ /OpenStack-Cloud/;
+        loadtest "jeos/diskusage" unless get_var('FILESYSTEM', 'btrfs') =~ /btrfs/;
         loadtest "jeos/build_key";
         loadtest "console/prjconf_excluded_rpms";
     }


### PR DESCRIPTION
This test only works on btrfs, so check for that directly.

This makes it easier to also skip the module on RISC-V, which can't use btrfs in images ATM.

To not break the OpenStack-Cloud test, that medium type needs to have `FILESYSTEM=xfs` set now.

- Verification run: https://openqa.opensuse.org/tests/4270455#live