### PR TITLE
Enroll TPM2 key after ramdisk modification

### DIFF
--- a/tests/security/luks2/unlock_luks2_vol_tpm2.pm
+++ b/tests/security/luks2/unlock_luks2_vol_tpm2.pm
@@ -8,12 +8,16 @@
 
 use strict;
 use warnings;
-use base 'consoletest';
-use base 'opensusebasetest';
+use base qw(consoletest opensusebasetest);
 use testapi;
 use utils qw(quit_packagekit zypper_call);
+use Utils::Backends 'is_pvm';
+use power_action_utils 'power_action';
+
 
 sub run {
+    my $self = shift;
+
     select_console 'root-console';
     quit_packagekit;
     zypper_call('in expect');
@@ -25,19 +29,25 @@ sub run {
     # Make sure the encryption type is LUKS2
     validate_script_output("cryptsetup status $luks2_volu", sub { m/LUKS2/ });
 
-    # Enroll the LUKS2 volume with TPM device
-    assert_script_run(
-"expect -c 'spawn systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7 $luks2_part; expect \"current passphrase*\"; send \"$testapi::password\\n\"; interact'"
-    );
-
-    # Set ENCRYPT=0 now, since we don't need unlock the disk via password
-    set_var('ENCRYPT', 0);
-
     # Find the entry for the LUKS2 volume in /etc/crypttab (it may appear referenced by its UUID) and add the tpm2-device= option
     assert_script_run q(sed -i 's/x-initrd.attach/x-initrd.attach,tpm2-device=auto/g' /etc/crypttab);
 
     # Regenerate the initrd.
     assert_script_run('dracut -f');
+
+    # reboot to make new initrd effective
+    power_action('reboot', textmode => 1, keepconsole => is_pvm());
+    reconnect_mgmt_console() if is_pvm();
+    $self->wait_boot();
+    select_console 'root-console';
+
+    # Enroll the LUKS2 volume with TPM device
+    assert_script_run(
+        "expect -c 'spawn systemd-cryptenroll --tpm2-device=auto $luks2_part; expect \"current passphrase*\"; send \"$testapi::password\\n\"; interact'"
+    );
+
+    # Set ENCRYPT=0 now, since we don't need unlock the disk via password
+    set_var('ENCRYPT', 0);
 }
 
 1;

--- a/tests/security/tpm2/tpm2_env_setup.pm
+++ b/tests/security/tpm2/tpm2_env_setup.pm
@@ -61,6 +61,11 @@ sub run {
         die "missing tpm_server path\n" if ($server eq '');
         assert_script_run("su -s /bin/bash - $tss_user -c '$server &'");
     }
+    # workaround for permission denied
+    my $udev_rules = "/etc/udev/rules.d/tpm-udev.rules";
+    assert_script_run(q{echo 'KERNEL=="tpm[0-9]", MODE="0660", OWNER="tss", GROUP="tss"' >} . $udev_rules);
+    assert_script_run(q{echo 'KERNEL=="tpmrm[0-9]", MODE="0660", OWNER="tss", GROUP="tss"' >>} . $udev_rules);
+    assert_script_run('udevadm control --reload-rules && udevadm trigger');
 
     # Restart the tpm2-abrmd service
     assert_script_run("systemctl enable tpm2-abrmd");


### PR DESCRIPTION
Likely the test was passing only on some worker class due to a different worker configuration or speed. 
This change introduces a more reliable and logical operations workflow, and workaround a permission denied on `/dev/tpm*` devices.

- Related ticket: https://progress.opensuse.org/issues/161300
- Needles: nope
- Verification runs: 
    - https://openqa.suse.de/tests/14601422
    - https://openqa.suse.de/tests/14601423
    - https://openqa.suse.de/tests/14601424

