### PR TITLE
Be more resilient with s390x CMS responses

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -138,7 +138,7 @@ EO_frickin_boot_parms
         eval {
             # ensure that we are in cms mode before executing qaboot
             $s3270->sequence_3270("String(\"#cp i cms\")", "ENTER", "ENTER", "ENTER", "ENTER",);
-            $r = $s3270->expect_3270(output_delim => qr/CMS/, timeout => 20);
+            $r = $s3270->expect_3270(output_delim => qr/CMS/, timeout => 90);
             $s3270->sequence_3270("String(\"qaboot $repo_host $dir_with_suse_ins\")", "ENTER", "Wait(InputField)",);
             # wait for qaboot dumping us into xedit. If this fails, probably the
             # download of kernel or initrd timed out and we retry

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -138,7 +138,7 @@ EO_frickin_boot_parms
         eval {
             # ensure that we are in cms mode before executing qaboot
             $s3270->sequence_3270("String(\"#cp i cms\")", "ENTER", "ENTER", "ENTER", "ENTER",);
-            $r = $s3270->expect_3270(output_delim => qr/CMS/, timeout => 90);
+            $r = $s3270->expect_3270(output_delim => qr/CMS/, timeout => 300);
             $s3270->sequence_3270("String(\"qaboot $repo_host $dir_with_suse_ins\")", "ENTER", "Wait(InputField)",);
             # wait for qaboot dumping us into xedit. If this fails, probably the
             # download of kernel or initrd timed out and we retry


### PR DESCRIPTION
We have seen consisent timeouts expecting the response from CMS causing
s390x openQA jobs to fail. This could also be reproduced while
interacting manually with the hypervisor over x3270 sessions. After a
reset of the hypervisor the response seems to be quicker but still too
slow to respond within 20s. I could see sometimes the header line of the
CMS response to appear but not the end marker 'CMS' within the expected
time. This commit bums the timeout to be more resilient.

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19513 https://openqa.suse.de/tests/14600543
```

1 job has been created:
 - sle-12-SP5-Server-DVD-Incidents-Minimal-s390x-Build:34269:kernel-ec2-qam-minimal@s390x-zVM -> https://openqa.suse.de/tests/14602752 (failed), same failure as before, no joy

maybe only one hypervisor host has been reset. We might need another reset on osdzvm13. Trying to distinguish:

```
for i in 2 3; do openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19513 https://openqa.suse.de/tests/14600543 WORKER_CLASS+=,osdzvm1$i TEST+=-osdzvm1$i; done
```

 - sle-12-SP5-Server-DVD-Incidents-Minimal-s390x-Build:34269:kernel-ec2-qam-minimal@s390x-zVM -> https://openqa.suse.de/tests/14602782 osdzvm12
 - sle-12-SP5-Server-DVD-Incidents-Minimal-s390x-Build:34269:kernel-ec2-qam-minimal@s390x-zVM -> https://openqa.suse.de/tests/14602783 osdzvm13


Related progress issue: https://progress.opensuse.org/issues/162239