### PR TITLE
containers: Ignore but not skip BATS tests

### DIFF
--- a/data/containers/bats_skip_notok.py
+++ b/data/containers/bats_skip_notok.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+This script is used to selectively comment "not ok" lines in TAP files so the
+openQA TAP parser ignores them
+"""
+
+import re
+import sys
+
+
+def flush(file, lines, comment_block=False):
+    """
+    Flush buffer optionally commenting the block
+    """
+    if len(lines) == 0:
+        return
+    if comment_block:
+        # We only comment the first line as the rest have "# " in them
+        print(f"#{lines[0]}", file=file)
+        if len(lines) > 1:
+            print("\n".join(lines[1:]), file=file)
+    else:
+        print("\n".join(lines), file=file)
+
+
+def comment_not_ok(path, tests):
+    """
+    Comment "not ok" lines in path for the specified tests
+    """
+    skipped = re.compile(rf"in test file .*/(?:{'|'.join(tests)})\.bats")
+    in_not_ok_block = False
+    comment_block = False
+    buffer = []
+
+    with open(path, "r", encoding="utf-8") as file:
+        lines = file.read().splitlines()
+
+    with open(path, "w", encoding="utf-8") as file:
+        for line in lines:
+            if line.startswith("not ok"):
+                flush(file, buffer, comment_block)
+                buffer = [line]
+                in_not_ok_block = True
+                comment_block = False
+            elif line.startswith("ok"):
+                flush(file, buffer, comment_block)
+                print(line, file=file)
+                buffer = []
+                in_not_ok_block = False
+                comment_block = False
+            elif in_not_ok_block:
+                buffer.append(line)
+                if skipped.search(line):
+                    comment_block = True
+            else:
+                print(line, file=file)
+        flush(file, buffer, comment_block)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        comment_not_ok(sys.argv[1], sys.argv[2:])

--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats enable_modules);
+use containers::bats qw(install_bats patch_logfile enable_modules);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -24,10 +24,10 @@ sub run_tests {
 
     assert_script_run "cp -r test.orig test";
     my @skip_tests = split(/\s+/, get_var('AARDVARK_BATS_SKIP', ''));
-    script_run "rm test/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "AARDVARK=$aardvark bats --tap test | tee -a $log_file", 2000;
+    patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf test";
 }

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules remove_mounts_conf);
+use containers::bats qw(install_bats patch_logfile switch_to_user delegate_controllers enable_modules remove_mounts_conf);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -28,10 +28,10 @@ sub run_tests {
 
     assert_script_run "cp -r tests.orig tests";
     my @skip_tests = split(/\s+/, get_var('BUILDAH_BATS_SKIP', '') . " " . $skip_tests);
-    script_run "rm tests/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 3600;
+    patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf tests";
 

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats enable_modules);
+use containers::bats qw(install_bats patch_logfile enable_modules);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -24,10 +24,10 @@ sub run_tests {
 
     assert_script_run "cp -r test.orig test";
     my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', ''));
-    script_run "rm test/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "PATH=/usr/local/bin:\$PATH NETAVARK=$netavark bats --tap test | tee -a $log_file", 1200;
+    patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf test";
 }

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules);
+use containers::bats qw(install_bats patch_logfile switch_to_user delegate_controllers enable_modules);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -28,10 +28,10 @@ sub run_tests {
 
     assert_script_run "cp -r tests/integration.orig tests/integration";
     my @skip_tests = split(/\s+/, get_var('RUNC_BATS_SKIP', '') . " " . $skip_tests);
-    script_run "rm tests/integration/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "RUNC=/usr/bin/runc RUNC_USE_SYSTEMD=1 bats --tap tests/integration | tee -a $log_file", 1200;
+    patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf tests/integration";
 }


### PR DESCRIPTION
We don't want to skip any BATS tests, just ignore the failures.  We have the problem that some skipped tests may pass and we're unknowingly skipping them.

This PR:
- Patches the TAP file generated by the `bats` command to comment the `not ok` lines for the "skipped" tests defined in BATS_SKIP variables.
- Warns us that we're skipping a test that is passing.

Implementation details:
- The Python program implements a state machine to parse and patch a TAP file like https://openqa.opensuse.org/tests/4268394/file/podman_integration-bats-user-local.tap

Verification runs:
- opensuse-Tumbleweed-DVD-x86_64-Build20240612-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/tests/4272333 (failing for other reasons, `.tap` files should have `#not ok` lines). This test is also telling us that some skipped tests passed: [1](https://openqa.opensuse.org/tests/4272333#step/aardvark_integration/62), [2](https://openqa.opensuse.org/tests/4272333#step/aardvark_integration/66) & [3](https://openqa.opensuse.org/tests/4272333#step/aardvark_integration/70)
- opensuse-Tumbleweed-DVD-x86_64-Build20240613-containers_host_buildah_testsuite@64bit -> https://openqa.opensuse.org/tests/4273019
- sle-15-SP5-Server-DVD-Updates-x86_64-Build20240613-1-podman_testsuite@64bit -> https://openqa.suse.de/tests/14617297
- sle-15-SP6-Server-DVD-Updates-x86_64-Build20240613-1-podman_testsuite@64bit -> https://openqa.suse.de/tests/14616371