### PR TITLE
Do not call cleanup in ssh_interactive_end

### DIFF
--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -16,7 +16,7 @@ use utils;
 sub run {
     my ($self, $args) = @_;
     select_host_console(force => 1);
-    $args->{my_provider}->cleanup($args);
+    $args->{my_provider}->cleanup($args) unless check_var('PUBLIC_CLOUD_SLES4SAP', 1);
 }
 
 1;


### PR DESCRIPTION
Hotfix for mr_test after https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19453

Related ticket: https://progress.opensuse.org/issues/161732

# Verification

 - sle-15-SP2-GCE-SAP-BYOS-Incidents-saptune-x86_64-Build:34087:rpmlint-sles4sap_gnome_saptune_delete_rename@gce_n1_highmem_8 -> http://openqaworker15.qa.suse.cz/tests/286299

 - sle-15-SP6-Azure-SAP-BYOS-x86_64-Build0531-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/286300
