### PR TITLE
P.C. gce cleanup fix continue on cd error

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -718,7 +718,7 @@ To get the complete output structure, the call is:
 
 sub get_terraform_output {
     my ($self, $jq_query) = @_;
-    assert_script_run('cd ~/terraform');
+    script_run('cd ~/terraform');
     my $res = script_output("terraform output -json | jq -r '$jq_query' 2>/dev/null", proceed_on_failure => 1);
     script_run('cd');
     return $res;


### PR DESCRIPTION
the change dir failing because of assert, but directory already ok for terraform output therefore `assert` removed.


- Related ticket: https://progress.opensuse.org/issues/161732
- Needles: None
- Verification run: see next VR in body
