### PR TITLE
Update BCI-Tests repo from non-main branch

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -91,7 +91,7 @@ sub run {
     assert_script_run('source bci/bin/activate') if ($bci_virtualenv);
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
-    assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard origin");
+    assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard");
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
     assert_script_run("export CONTAINER_RUNTIME=$engine");
     $version =~ s/-SP/./g;


### PR DESCRIPTION
When trying to run bci_test from a different repo/branch than origin/main, the command `git fetch && git reset --hard origin` fails, as previously a single branch defined in BCI_TESTS_BRANCH has been cloned. This is solved by removing the `origin` from the command

- Verification runs:
  - http://10.146.5.131/tests/102#step/bci_test_podman/11
  - http://10.146.5.131/tests/104#
  - http://10.146.5.131/tests/105#
  - http://10.146.5.131/tests/106
  - http://10.146.5.131/tests/107#
