### PR TITLE
Check kernel taint before and after running LTP tests

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -67,6 +67,7 @@ sub run {
     # module is used by non-LTP tests, i.e. kernel-live-patching
     return unless (get_var('LTP_COMMAND_FILE'));
 
+    check_kernel_taint($self, 1);
     prepare_ltp_env;
     init_ltp_tests($cmd_file);
 

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -388,6 +388,7 @@ sub run {
     } elsif ($cmd_file) {
         assert_secureboot_status(1) if get_var('SECUREBOOT');
         prepare_ltp_env() if (is_sle('<12'));
+        check_kernel_taint($self, 1);
         init_ltp_tests($cmd_file);
         schedule_tests($cmd_file);
     }

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -11,6 +11,7 @@ use warnings;
 use base 'opensusebasetest';
 use testapi;
 use utils;
+use LTP::utils;
 use power_action_utils 'power_action';
 use upload_system_log;
 
@@ -32,6 +33,7 @@ sub run {
     }
 
     script_run('df -h');
+    check_kernel_taint($self, 0);
 
     if (get_var('LTP_COMMAND_FILE')) {
         my $ver_linux_log = '/tmp/ver_linux_after.txt';


### PR DESCRIPTION
Baremetal LTP tests cannot detect kernel oops message on serial console, unlike QEMU tests. Check kernel taint procfile for taint flags before running tests.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - boot_ltp, tainted: https://openqa.suse.de/tests/14618689#step/boot_ltp/113
  - install_ltp, tainted: https://openqa.suse.de/tests/14618691#step/install_ltp/245
  - livepatches, not tainted: https://openqa.suse.de/tests/14618690#step/boot_ltp/116