### PR TITLE
[DRAFT]Install refactor

### DIFF
--- a/schedule/sles4sap/qam/common/qam_incident_install.yaml
+++ b/schedule/sles4sap/qam/common/qam_incident_install.yaml
@@ -13,6 +13,7 @@ description: >
 vars:
   BOOT_HDD_IMAGE: '1'
   INSTALLTEST: '1'
+  TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
   - boot/boot_to_desktop
   - qam-updinstall/update_install_start

--- a/tests/qam-updinstall/prepatch.pm
+++ b/tests/qam-updinstall/prepatch.pm
@@ -9,13 +9,14 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 
+use serial_terminal 'select_serial_terminal';
 use utils qw(fully_patch_system);
 use power_action_utils qw(prepare_system_shutdown power_action);
 
 sub run{
-    my $self = @_;
-    select_serial_terminal();
-    record_info("Prepatch", "Bringig the image to a released state.");
+    my ($self) = @_;
+    select_serial_terminal;
+    record_info("Prepatch", "Bringing the image to a released state.");
     fully_patch_system;
     prepare_system_shutdown;
     power_action("reboot");

--- a/tests/qam-updinstall/prepatch.pm
+++ b/tests/qam-updinstall/prepatch.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFA
+# Maintainer: qe-core <qe-core@suse.de>, qe-sap <qe-sap@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+
+use utils qw(fully_patch_system);
+use power_action_utils qw(prepare_system_shutdown power_action);
+
+sub run{
+    my $self = @_;
+    select_serial_terminal();
+    record_info("Prepatch", "Bringig the image to a released state.");
+    fully_patch_system;
+    prepare_system_shutdown;
+    power_action("reboot");
+    $self->wait_boot(bootloader_time => 200);
+    record_info("Done", "SUT up to date");
+}
+
+1;

--- a/tests/qam-updinstall/repo_quirks.pm
+++ b/tests/qam-updinstall/repo_quirks.pm
@@ -9,10 +9,14 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 
+use serial_terminal 'select_serial_terminal';
+use utils 'zypper_call';
+use version_utils 'is_sle';
+
 sub run{
     my $self = @_;
-    select_serial_terminal();
-    zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);autotest::loadtest("tests/qam-updinstall/repo_quirks.pm");
+    select_serial_terminal;
+    zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);
     zypper_call(q{mr -f $(zypper lr | awk -F '|' '/SLES15-SP4-15.4-0/ {print $2}')}, exitcode => [0, 3]) if get_var('FLAVOR') =~ /TERADATA/;
     zypper_call("ar -f http://dist.suse.de/ibs/SUSE/Updates/SLE-Live-Patching/12-SP3/" . get_var('ARCH') . "/update/ sle-module-live-patching:12-SP3::update") if is_sle('=12-SP3');
 }

--- a/tests/qam-updinstall/repo_quirks.pm
+++ b/tests/qam-updinstall/repo_quirks.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFA
+# Maintainer: qe-core <qe-core@suse.de>, qe-sap <qe-sap@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+
+sub run{
+    my $self = @_;
+    select_serial_terminal();
+    zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);autotest::loadtest("tests/qam-updinstall/repo_quirks.pm");
+    zypper_call(q{mr -f $(zypper lr | awk -F '|' '/SLES15-SP4-15.4-0/ {print $2}')}, exitcode => [0, 3]) if get_var('FLAVOR') =~ /TERADATA/;
+    zypper_call("ar -f http://dist.suse.de/ibs/SUSE/Updates/SLE-Live-Patching/12-SP3/" . get_var('ARCH') . "/update/ sle-module-live-patching:12-SP3::update") if is_sle('=12-SP3');
+}
+
+1;

--- a/tests/qam-updinstall/smelt_info.pm
+++ b/tests/qam-updinstall/smelt_info.pm
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    my ($self, $run_args) = @_;
+    record_info($run_args->{msg});
+    $run_args->{msg} = 'Bye';
+}
+
+1;

--- a/tests/qam-updinstall/smelt_info.pm
+++ b/tests/qam-updinstall/smelt_info.pm
@@ -2,12 +2,46 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
+
 use serial_terminal 'select_serial_terminal';
+use maintenance_smelt qw(get_packagebins_in_modules get_incident_packages);
+use version_utils 'is_sle';
 
 sub run {
     my ($self, $run_args) = @_;
-    record_info($run_args->{msg});
-    $run_args->{msg} = 'Bye';
+
+    my $incident_id = get_required_var('INCIDENT_ID');
+    my $repos = get_required_var('INCIDENT_REPO');
+
+    my @modules = split(/,/, $repos);
+    foreach (@modules) {
+        # substitue SLES_SAP for LTSS repo at this point is SAP ESPOS
+        $_ =~ s/SAP_(\d+(-SP\d)?)/$1-LTSS/ if is_sle('15+');
+        next if s{http.*SUSE_Updates_(.*)/?}{$1};
+        die 'Modules regex failed. Modules could not be extracted from repos variable.';
+    }
+
+    # Get packages affected by the incident.
+    my @packages = get_incident_packages($incident_id);
+    $run_args->{packages} = \@packages;
+
+    # Get binaries that are in each package across the modules that are in the repos.
+    my %bins;
+    foreach (@packages) {
+        %bins = (%bins, get_packagebins_in_modules({package_name => $_, modules => \@modules}));
+        # hash of hashes with keys 'name', 'supportstatus' and 'package'.
+        # e.g. https://smelt.suse.de/api/v1/basic/maintained/grub2
+    }
+    die "Parsing binaries from SMELT data failed" if not keys %bins;
+    $run_args->{bins} = \%bins;
+
+    my @l2 = grep { ($bins{$_}->{supportstatus} eq 'l2') } keys %bins;
+    my @l3 = grep { ($bins{$_}->{supportstatus} eq 'l3') } keys %bins;
+    my @unsupported = grep { ($bins{$_}->{supportstatus} eq 'unsupported') } keys %bins;
+
+    $run_args->{l2} = \@l2;
+    $run_args->{l3} = \@l3;
+    $run_args->{unsupported} = \@unsupported;
 }
 
 1;

--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -160,18 +160,10 @@ sub run {
     my @new_binaries_conflicts;    #New binaries with conflict will be installed alone e.g. libwx_base-suse-nostl-devel conflicts with libwx_base-devel
     my %bins;
 
-    if (get_var('BUILD') =~ /tomcat/ && get_var('HDD_1') =~ /SLED/) {
-        record_info('not shipped', 'tomcat is not shipped to Desktop https://suse.slack.com/archives/C02D16TCP99/p1706675337430879');
-        return;
-    }
 
     select_serial_terminal;
 
     my $zypper_version = script_output(q(rpm -q zypper|awk -F. '{print$2}'));
-
-    zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);
-    zypper_call(q{mr -f $(zypper lr | awk -F '|' '/SLES15-SP4-15.4-0/ {print $2}')}, exitcode => [0, 3]) if get_var('FLAVOR') =~ /TERADATA/;
-    zypper_call("ar -f http://dist.suse.de/ibs/SUSE/Updates/SLE-Live-Patching/12-SP3/" . get_var('ARCH') . "/update/ sle-module-live-patching:12-SP3::update") if is_sle('=12-SP3');
 
     # Extract module name from repo url.
     my @modules = split(/,/, $repos);
@@ -182,9 +174,6 @@ sub run {
         die 'Modules regex failed. Modules could not be extracted from repos variable.';
     }
     record_info('Modules', "@modules");
-
-    # Patch the SUT to a released state and reboot if reboot is needed;
-    reboot_and_login if fully_patch_system == 102;
 
     set_var('MAINT_TEST_REPO', $repos);
     my $repos_count = add_test_repositories;

--- a/tests/qam-updinstall/update_install_start.pm
+++ b/tests/qam-updinstall/update_install_start.pm
@@ -25,17 +25,13 @@ sub run {
         return;
     }
 
-    record_info("Repo quirks");
+    # Apply repo quirks unrelated to the incident. e.g NVIDIA repo
     autotest::loadtest("tests/qam-updinstall/repo_quirks.pm");
 
-    record_info("Prepatch", "Bringig the image to a released state.");
-    fully_patch_system;
-    prepare_system_shutdown;
-    power_action("reboot");
-    record_info("Done", "SUT up to date");
+    # Bring the SUT to a fully released state
+    autotest::loadtest("tests/qam-updinstall/prepatch.pm");
 
-
-    $self->wait_boot(bootloader_time => 200);
+    
 
     if (get_required_var('BUILD') =~ /^MR:/) {
         record_info("Maintenance Request Build", "Scheduling qam-updinstall/update_install_mr");

--- a/tests/qam-updinstall/update_install_start.pm
+++ b/tests/qam-updinstall/update_install_start.pm
@@ -18,30 +18,28 @@ use power_action_utils qw(prepare_system_shutdown power_action);
 
 
 sub run {
-    my $self = shift;
+    my ($self, $run_args) = @_;
 
+    # TODO: Fix this in the bot.
     if (get_var('BUILD') =~ /tomcat/ && get_var('HDD_1') =~ /SLED/) {
         record_info('not shipped', 'tomcat is not shipped to Desktop https://suse.slack.com/archives/C02D16TCP99/p1706675337430879');
         return;
     }
 
+    $run_args->{msg} = 'Hi!';
     # Apply repo quirks unrelated to the incident. e.g NVIDIA repo
-    autotest::loadtest("tests/qam-updinstall/repo_quirks.pm");
+    autotest::loadtest("tests/qam-updinstall/repo_quirks.pm", name => 'Repo Quirks', run_args => $run_args, @_);
 
     # Bring the SUT to a fully released state
-    autotest::loadtest("tests/qam-updinstall/prepatch.pm");
+    autotest::loadtest("tests/qam-updinstall/prepatch.pm", name => "Prepatch", run_args => $run_args, @_);
 
-    
+    # Query SMELT for incident info
+    autotest::loadtest("tests/qam-updinstall/smelt_info.pm", name => 'hello', run_args => $run_args, @_);
+    autotest::loadtest("tests/qam-updinstall/smelt_info.pm", name => 'bye',  run_args => $run_args, @_);
 
-    if (get_required_var('BUILD') =~ /^MR:/) {
-        record_info("Maintenance Request Build", "Scheduling qam-updinstall/update_install_mr");
-        autotest::loadtest("tests/qam-updinstall/update_install_mr.pm");
-    }
-    else {
-        record_info("update_install", "Scheduling qam-updinstall/update_install");
-        autotest::loadtest("tests/qam-updinstall/smelt_info.pm");
-        autotest::loadtest("tests/qam-updinstall/update_install.pm");
-    }
+ 
+    autotest::loadtest("tests/qam-updinstall/update_install.pm", name => "Installation", run_args => $run_args, @_);
+
 }
 
 1;

--- a/tests/qam-updinstall/update_install_start.pm
+++ b/tests/qam-updinstall/update_install_start.pm
@@ -34,10 +34,8 @@ sub run {
     autotest::loadtest("tests/qam-updinstall/prepatch.pm", name => "Prepatch", run_args => $run_args, @_);
 
     # Query SMELT for incident info
-    autotest::loadtest("tests/qam-updinstall/smelt_info.pm", name => 'hello', run_args => $run_args, @_);
-    autotest::loadtest("tests/qam-updinstall/smelt_info.pm", name => 'bye',  run_args => $run_args, @_);
+    autotest::loadtest("tests/qam-updinstall/smelt_info.pm", name => 'SMELT Info', run_args => $run_args, @_);
 
- 
     autotest::loadtest("tests/qam-updinstall/update_install.pm", name => "Installation", run_args => $run_args, @_);
 
 }


### PR DESCRIPTION
This PR is a PoC on breaking down the update_install.pm into multiple modules in order to seperate out the different jobs it does. As it works now the PoC doesn't alter the scenario in any way.

The original update_install.pm is now broken down to:
1. repo_quirks.pm. Here we handle special case repos like teradata and nvidia
2. prepatch.pm. This installs all the *RELEASED* updates
3. smelt_info.pm. Here we query smelt to find out which are the binaries we are expected to install in this scenario
 
The way this works is by using run_args to pass objects between the modules. 

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: https://openqaworker15.qa.suse.cz/tests/286302#