### PR TITLE
containers: Run podman cleanup on buildah upstream tests

### DIFF
--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats patch_logfile switch_to_user delegate_controllers enable_modules remove_mounts_conf);
+use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules remove_mounts_conf);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -28,10 +28,10 @@ sub run_tests {
 
     assert_script_run "cp -r tests.orig tests";
     my @skip_tests = split(/\s+/, get_var('BUILDAH_BATS_SKIP', '') . " " . $skip_tests);
+    script_run "rm tests/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 3600;
-    patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf tests";
 


### PR DESCRIPTION
Temporarily revert https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19514 only for buildah.  Most of the skipped tests fail due to `no space left on device` errors.  We need to figure out a way to assign more disk space only for these tests.

Failing test: https://openqa.opensuse.org/tests/4273289
Verification run: https://openqa.opensuse.org/tests/4273805