### PR TITLE
P.C. get instance empty and skip serial log SAP

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -636,7 +636,7 @@ sub cleanup {
 
     $self->get_image_version() if (get_var('PUBLIC_CLOUD_BUILD'));
 
-    if (defined($args->{my_instance}->{instance_id})) {
+    if (!check_var('PUBLIC_CLOUD_SLES4SAP', 1) && defined($args->{my_instance}->{instance_id})) {
         my $id = $args->{my_instance}->{instance_id};
         script_run("az vm boot-diagnostics get-boot-log --ids $id | jq -r '.' > bootlog.txt", timeout => 120, die_on_timeout => 0);
         upload_logs("bootlog.txt", failok => 1);

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -214,13 +214,13 @@ sub cleanup {
     script_run('cd');
 
     select_host_console(force => 1);
+    if (!check_var('PUBLIC_CLOUD_SLES4SAP', 1) && defined($instance_id)) {
+        script_run("aws ec2 get-console-output --instance-id $instance_id | jq -r '.Output' > console.txt");
+        upload_logs("console.txt", failok => 1);
 
-    script_run("aws ec2 get-console-output --instance-id $instance_id | jq -r '.Output' > console.txt");
-    upload_logs("console.txt", failok => 1);
-
-    script_run("aws ec2 get-console-screenshot --instance-id $instance_id | jq -r '.ImageData' | base64 --decode > console.jpg");
-    upload_logs("console.jpg", failok => 1);
-
+        script_run("aws ec2 get-console-screenshot --instance-id $instance_id | jq -r '.ImageData' | base64 --decode > console.jpg");
+        upload_logs("console.jpg", failok => 1);
+    }
     $self->terraform_destroy() if ($self->terraform_applied);
     $self->delete_keypair();
 }

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -171,11 +171,13 @@ sub cleanup {
     my $project = $self->{provider_client}->{project_id};
     my $instance_id = $self->get_terraform_output(".vm_name.value[0]");
     # gce provides full serial log, so extended timeout
-    if (defined($instance_id) and $instance_id =~ /$self->{resource_name}/) {
-        script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region --port=1 > instance_serial.txt", timeout => 180);
-        upload_logs("instance_serial.txt", failok => 1);
-    } else {
-        record_info("Warn", "instance_id " . ($instance_id) ? $instance_id : "empty", result => 'fail');
+    if (!check_var('PUBLIC_CLOUD_SLES4SAP', 1) && defined($instance_id)) {
+        if ($instance_id =~ /$self->{resource_name}/) {
+            script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region --port=1 > instance_serial.txt", timeout => 180);
+            upload_logs("instance_serial.txt", failok => 1);
+        } else {
+            record_info("Warn", "instance_id " . ($instance_id) ? $instance_id : "empty", result => 'fail');
+        }
     }
     $self->SUPER::cleanup();
 }

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -165,14 +165,13 @@ sub start_instance
 
 sub cleanup {
     my ($self, $args) = @_;
-
     select_host_console(force => 1);
 
     my $region = $self->{provider_client}->{region};
     my $project = $self->{provider_client}->{project_id};
     my $instance_id = $self->get_terraform_output(".vm_name.value[0]");
     # gce provides full serial log, so extended timeout
-    if ($instance_id =~ /$self->{resource_name}/) {
+    if (defined($instance_id) and $instance_id =~ /$self->{resource_name}/) {
         script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region --port=1 > instance_serial.txt", timeout => 180);
         upload_logs("instance_serial.txt", failok => 1);
     } else {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -719,7 +719,8 @@ To get the complete output structure, the call is:
 sub get_terraform_output {
     my ($self, $jq_query) = @_;
     my $res = script_output("terraform output -json | jq -r '$jq_query' 2>/dev/null", proceed_on_failure => 1);
-    return $res;
+    # jq 'null' shall return empty
+    return $res unless ($res =~ /null/);
 }
 
 sub escape_single_quote {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -718,9 +718,9 @@ To get the complete output structure, the call is:
 
 sub get_terraform_output {
     my ($self, $jq_query) = @_;
-    my $res = script_output("terraform output -json | jq -r '$jq_query' 2>/dev/null", proceed_on_failure => 1);
+    my $res = script_output("terraform output -no-color -json | jq -r '$jq_query' 2>/dev/null", proceed_on_failure => 1);
     # jq 'null' shall return empty
-    return $res unless ($res =~ /null/);
+    return $res unless ($res =~ /^null$/);
 }
 
 sub escape_single_quote {


### PR DESCRIPTION
P.C. `get_terraform_output` shall return empty on jq null
P.C. serial logs skipped for SAP, after PR#19519

- Related ticket: https://progress.opensuse.org/issues/161732
- Needles: none
- Verification run: see body PR
