### PR TITLE
Minor fixes to BATS tests

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -29,8 +29,8 @@ sub install_bats {
     my $bats_version = get_var("BATS_VERSION", "1.11.0");
 
     script_retry("curl -sL https://github.com/bats-core/bats-core/archive/refs/tags/v$bats_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
-    assert_script_run "cd bats-core-$bats_version";
-    assert_script_run "bash ./install.sh /usr/local";
+    assert_script_run "bash bats-core-$bats_version/install.sh /usr/local";
+    assert_script_run "rm -rf bats-core-$bats_version";
 
     script_run "mkdir -m 0750 /etc/sudoers.d/";
     assert_script_run "echo 'Defaults secure_path=\"/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin\"' > /etc/sudoers.d/usrlocal";

--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -22,14 +22,12 @@ my $aardvark_version = "";
 sub run_tests {
     my $log_file = "aardvark.tap";
 
-    assert_script_run "cp -r test.orig test";
     my @skip_tests = split(/\s+/, get_var('AARDVARK_BATS_SKIP', ''));
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "AARDVARK=$aardvark bats --tap test | tee -a $log_file", 2000;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
-    assert_script_run "rm -rf test";
 }
 
 sub run {
@@ -60,7 +58,6 @@ sub run {
     $aardvark_version = script_output "$aardvark --version | awk '{ print \$2 }'";
     script_retry("curl -sL https://github.com/containers/aardvark-dns/archive/refs/tags/v$aardvark_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/aardvark-dns-$aardvark_version/";
-    assert_script_run "cp -r test test.orig";
 
     run_tests;
 }

--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -25,7 +25,7 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('AARDVARK_BATS_SKIP', ''));
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "AARDVARK=$aardvark bats --tap test | tee -a $log_file", 2000;
+    script_run "AARDVARK=$aardvark BATS_TMPDIR=/var/tmp bats --tap test | tee -a $log_file", 2000;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 }

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -30,7 +30,7 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('BUILDAH_BATS_SKIP', '') . " " . $skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 3600;
+    script_run "BATS_TMPDIR=/var/tmp TMPDIR=/var/tmp BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 4200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf tests";

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -26,14 +26,12 @@ sub run_tests {
 
     my $log_file = "buildah-" . ($rootless ? "user" : "root") . ".tap";
 
-    assert_script_run "cp -r tests.orig tests";
     my @skip_tests = split(/\s+/, get_var('BUILDAH_BATS_SKIP', '') . " " . $skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "BATS_TMPDIR=/var/tmp TMPDIR=/var/tmp BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 4200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
-    assert_script_run "rm -rf tests";
 
     assert_script_run "buildah prune -a -f";
 }
@@ -68,7 +66,6 @@ sub run {
     $buildah_version = script_output "buildah --version | awk '{ print \$3 }'";
     script_retry("curl -sL https://github.com/containers/buildah/archive/refs/tags/v$buildah_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/buildah-$buildah_version/";
-    assert_script_run "cp -r tests tests.orig";
 
     # Compile helpers used by the tests
     assert_script_run "make bin/imgtype bin/copy bin/tutorial", timeout => 600;

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats switch_to_user delegate_controllers enable_modules remove_mounts_conf);
+use containers::bats qw(install_bats patch_logfile switch_to_user delegate_controllers enable_modules remove_mounts_conf);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -28,10 +28,10 @@ sub run_tests {
 
     assert_script_run "cp -r tests.orig tests";
     my @skip_tests = split(/\s+/, get_var('BUILDAH_BATS_SKIP', '') . " " . $skip_tests);
-    script_run "rm tests/$_.bats" foreach (@skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 3600;
+    patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     assert_script_run "rm -rf tests";
 

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -25,7 +25,7 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', ''));
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "PATH=/usr/local/bin:\$PATH NETAVARK=$netavark bats --tap test | tee -a $log_file", 1200;
+    script_run "PATH=/usr/local/bin:\$PATH BATS_TMPDIR=/var/tmp NETAVARK=$netavark bats --tap test | tee -a $log_file", 1200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 }

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -22,14 +22,12 @@ my $netavark_version = "";
 sub run_tests {
     my $log_file = "netavark.tap";
 
-    assert_script_run "cp -r test.orig test";
     my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', ''));
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "PATH=/usr/local/bin:\$PATH NETAVARK=$netavark bats --tap test | tee -a $log_file", 1200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
-    assert_script_run "rm -rf test";
 }
 
 sub run {
@@ -64,7 +62,6 @@ sub run {
     $netavark_version = script_output "$netavark --version | awk '{ print \$2 }'";
     script_retry("curl -sL https://github.com/containers/netavark/archive/refs/tags/v$netavark_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/netavark-$netavark_version/";
-    assert_script_run "cp -r test test.orig";
 
     run_tests;
 }

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -36,7 +36,7 @@ sub run_tests {
 
     assert_script_run "echo $log_file .. > $log_file";
     background_script_run "podman system service --timeout=0" if ($remote);
-    script_run "env PODMAN=/usr/bin/podman QUADLET=$quadlet hack/bats $args | tee -a $log_file", 6000;
+    script_run "env BATS_TMPDIR=/var/tmp PODMAN=/usr/bin/podman QUADLET=$quadlet hack/bats $args | tee -a $log_file", 6000;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     script_run 'kill %1' if ($remote);

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -32,7 +32,6 @@ sub run_tests {
 
     my $quadlet = script_output "rpm -ql podman | grep podman/quadlet";
 
-    assert_script_run "cp -r test/system.orig test/system";
     my @skip_tests = split(/\s+/, get_required_var('PODMAN_BATS_SKIP') . " " . $skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
@@ -40,7 +39,6 @@ sub run_tests {
     script_run "env PODMAN=/usr/bin/podman QUADLET=$quadlet hack/bats $args | tee -a $log_file", 6000;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
-    assert_script_run "rm -rf test/system";
     script_run 'kill %1' if ($remote);
 
     assert_script_run "podman system reset -f";
@@ -92,7 +90,6 @@ sub run {
     script_retry("curl -sL https://github.com/containers/podman/archive/refs/tags/v$podman_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run("cd $test_dir/podman-$podman_version/");
     assert_script_run "sed -i 's/bats_opts=()/bats_opts=(--tap)/' hack/bats";
-    assert_script_run "cp -r test/system test/system.orig";
 
     # user / local
     run_tests(rootless => 1, remote => 0, skip_tests => get_var('PODMAN_BATS_SKIP_USER_LOCAL', ''));

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -26,14 +26,12 @@ sub run_tests {
 
     my $log_file = "runc-" . ($rootless ? "user" : "root") . ".tap";
 
-    assert_script_run "cp -r tests/integration.orig tests/integration";
     my @skip_tests = split(/\s+/, get_var('RUNC_BATS_SKIP', '') . " " . $skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
     script_run "RUNC=/usr/bin/runc RUNC_USE_SYSTEMD=1 bats --tap tests/integration | tee -a $log_file", 1200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
-    assert_script_run "rm -rf tests/integration";
 }
 
 sub run {
@@ -64,7 +62,6 @@ sub run {
     $runc_version = script_output "runc --version  | awk '{ print \$3 }'";
     script_retry("curl -sL https://github.com/opencontainers/runc/archive/refs/tags/v$runc_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/runc-$runc_version/";
-    assert_script_run "cp -r tests/integration tests/integration.orig";
 
     # Compile helpers used by the tests
     assert_script_run "make \$(ls contrib/cmd/)";

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -29,7 +29,7 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('RUNC_BATS_SKIP', '') . " " . $skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "RUNC=/usr/bin/runc RUNC_USE_SYSTEMD=1 bats --tap tests/integration | tee -a $log_file", 1200;
+    script_run "BATS_TMPDIR=/var/tmp RUNC=/usr/bin/runc RUNC_USE_SYSTEMD=1 bats --tap tests/integration | tee -a $log_file", 1200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 }

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -27,7 +27,6 @@ sub run_tests {
 
     my $log_file = "skopeo-" . ($rootless ? "user" : "root") . ".tap";
 
-    assert_script_run "cp -r systemtest.orig systemtest";
     my @skip_tests = split(/\s+/, get_var('SKOPEO_BATS_SKIP', '') . " " . $skip_tests);
 
     # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
@@ -41,7 +40,6 @@ sub run_tests {
     script_run "SKOPEO_BINARY=/usr/bin/skopeo SKOPEO_TEST_REGISTRY_FQIN=$registry bats --tap systemtest | tee -a $log_file", 1200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
-    assert_script_run "rm -rf systemtest";
 }
 
 sub run {
@@ -71,7 +69,6 @@ sub run {
     $skopeo_version = script_output "skopeo --version  | awk '{ print \$3 }'";
     script_retry("curl -sL https://github.com/containers/skopeo/archive/refs/tags/v$skopeo_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/skopeo-$skopeo_version/";
-    assert_script_run "cp -r systemtest systemtest.orig";
 
     run_tests(rootless => 1, skip_tests => get_var('SKOPEO_BATS_SKIP_USER', ''));
 

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -37,7 +37,7 @@ sub run_tests {
     my $registry = is_x86_64 ? "" : "docker.io/library/registry:2";
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "SKOPEO_BINARY=/usr/bin/skopeo SKOPEO_TEST_REGISTRY_FQIN=$registry bats --tap systemtest | tee -a $log_file", 1200;
+    script_run "BATS_TMPDIR=/var/tmp SKOPEO_BINARY=/usr/bin/skopeo SKOPEO_TEST_REGISTRY_FQIN=$registry bats --tap systemtest | tee -a $log_file", 1200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 }


### PR DESCRIPTION
This PR:
- Removes unneeded backup of tests directory.
- Fixes space issues with buildah tests.
- Setups BATS_TMPDIR to avoid tmpfs /tmp

Verification runs:
- opensuse-Tumbleweed-DVD-x86_64-Build20240613-containers_host_buildah_testsuite@64bit -> https://openqa.opensuse.org/tests/4275638
- opensuse-Tumbleweed-DVD-x86_64-Build20240613-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/tests/4275640 (failing for other reasons)