### PR TITLE
containers: Limit netavark/aardvark upstream tests to x86_64

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -301,6 +301,8 @@ sub load_container_tests {
         if (!check_var('RUNC_BATS_SKIP', 'all')) {
             loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         }
+        # Some packages are only available on x86_64: ncat
+        return unless (is_x86_64);
         if (!check_var('NETAVARK_BATS_SKIP', 'all')) {
             loadtest 'containers/netavark_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         }


### PR DESCRIPTION
Limit netavark/aardvark upstream tests to x86_64 as some packages are not available on aarch64.

Failing tests:
- https://openqa.opensuse.org/tests/4273008#step/netavark_integration/25