### PR TITLE
shutdown_ltp: Softfail on taint

### DIFF
--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -33,7 +33,7 @@ sub run {
     }
 
     script_run('df -h');
-    check_kernel_taint($self, 0);
+    check_kernel_taint($self, 1);
 
     if (get_var('LTP_COMMAND_FILE')) {
         my $ver_linux_log = '/tmp/ver_linux_after.txt';


### PR DESCRIPTION
Some archs have third-party modules which trigger additional taint flags. Some tests also load unsigned modules. Switch post-test taint check to softfail until we decide how to handle these issues properly.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
  - PPC64LE: https://openqa.suse.de/tests/14655810
  - s390x: https://openqa.suse.de/tests/14655866