### PR TITLE
Add az diagnostic log collection

### DIFF
--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -30,6 +30,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -24,7 +24,8 @@ sub run {
 
     ipaddr2_azure_deployment(
         region => $provider->provider_client->region,
-        os => get_required_var('CLUSTER_OS_VER'));
+        os => get_required_var('CLUSTER_OS_VER'),
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0));
     ipaddr2_deployment_sanity();
 }
 
@@ -34,6 +35,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/sanity.pm
+++ b/tests/sles4sap/ipaddr2/sanity.pm
@@ -26,6 +26,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Add some code to collect the diagnostic logs from any VM in the resource group. Add it to some of the post fail hook of the ipaddr2 test.

- Related ticket: https://jira.suse.com/browse/TEAM-8721

# Verification run: 
sle-15-SP5-SapCloud-Azure-Payg-x86_64-Buildmpagot_VR-ipaddr2_azure_test@64bit 
- http://openqaworker15.qa.suse.cz/tests/287030  with a simulated failure --> http://openqaworker15.qa.suse.cz/tests/287030#step/configure/28 the log
- http://openqaworker15.qa.suse.cz/tests/286951  with a simulated failure and without the setting
