### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -7,7 +7,7 @@ jobs:
     name: Checklist job
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checklist
         uses: wyozi/contextual-qa-checklist-action@master
         with:

--- a/.github/workflows/ci-isotovideo.yml
+++ b/.github/workflows/ci-isotovideo.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "CI: Running isotovideo test"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run isotovideo tests
       run: make test-isotovideo
     - name: Error in isotovideo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         apt-get -y update

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: "CI: Generate documentation"
       run: script/generateLibDocs.sh
     - name: "CI: Deploy documentation"

--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/tumbleweed:client
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Determine the latest Tumbleweed build on o3
         id: latest_build
         run: >-

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,7 +12,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: TruffleHog OSS


### PR DESCRIPTION
As GitHub moves from node 16 to node 20 checkout v3 is deprecated.
