### PR TITLE
[WIP] Allow to skip kernel taint via LTP_KERNEL_TAINT_SOFTFAIL

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: This module installs the LTP (Linux Test Project) and then reboots.
-# Maintainer: Richard palethorpe <rpalethorpe@suse.com>
-# Usage details are at the end of this file.
+# Maintainer: QE Kernel <kernel-qa@suse.de>
+# For usage see the bottom and tests/kernel/run_ltp.pm.
+
 use 5.018;
 use warnings;
 use base 'opensusebasetest';

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -493,5 +493,11 @@ C<tcpdump>: Capture all packets sent or received during each test.
 C<crashdump>: Save kernel crashdump on test timeout.
 C<tasktrace>: Print backtrace of all processes and show blocked tasks
 
+=head2 LTP_KERNEL_TAINT_SOFTFAIL
+
+Flags to softfail (bitfield number).
+
+https://www.kernel.org/doc/html/latest/admin-guide/tainted-kernels.html
+
 =cut
 

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Executes a single LTP test case
-# Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
-# More documentation is at the bottom
+# Maintainer: QE Kernel <kernel-qa@suse.de>
+# For usage see the bottom and tests/kernel/install_ltp.pm.
 
 use 5.018;
 use warnings;

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -34,7 +34,7 @@ sub run {
     }
 
     script_run('df -h');
-    check_kernel_taint($self, 1);
+    check_kernel_taint($self, 0);
 
     if (get_var('LTP_COMMAND_FILE')) {
         my $ver_linux_log = '/tmp/ver_linux_after.txt';

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Cleanup and shutdown after installing or running the LTP
-# Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
+# Maintainer: QE Kernel <kernel-qa@suse.de>
+# For usage see tests/kernel/run_ltp.pm and tests/kernel/install_ltp.pm
 
 use 5.018;
 use warnings;


### PR DESCRIPTION
Verification run: 
- http://quasar.suse.cz/tests/3453#step/shutdown_ltp/12 opensuse-Tumbleweed-DVD-x86_64-Build20240614-ltp_commands@64bit with `LTP_KERNEL_TAINT_SOFTFAIL=12288`
- http://quasar.suse.cz/tests/3456##step/shutdown_ltp/12 sle-15-SP2-Server-DVD-Incidents-Kernel-x86_64-Build:34354:kernel-livepatch-SLE15-SP2_Update_48-ltp_commands@64bit
- https://openqa.suse.de/tests/overview?build=check_kernel_taint_skiplist
- https://openqa.opensuse.org/tests/overview?build=check_kernel_taint_skiplist

@mdoucha @czerw FYI

Related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19533

<s>TODO: https://openqa.suse.de/tests/14669192#step/shutdown_ltp/12  sle-15-SP2-Server-DVD-Incidents-Kernel-s390x-Buildcheck_kernel_taint_skiplist-ltp_ipc@pevik_os-autoinst-distri-opensuse_check_kernel_taint_skiplist@s390x-kvm requires to whitelist `0x19000 - Auxiliary taint` maybe arch specific? (@mdoucha WDYT?)</s>

FYI `0x19000 - Auxiliary taint` has been replaced in 3rd commit with suse specific `Modules with external support loaded`:
https://openqa.suse.de/tests/14674993#step/shutdown_ltp/12