### PR TITLE
containers: Use a different netcat than ncat

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -301,8 +301,6 @@ sub load_container_tests {
         if (!check_var('RUNC_BATS_SKIP', 'all')) {
             loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         }
-        # Some packages are only available on x86_64: ncat
-        return unless (is_x86_64);
         if (!check_var('NETAVARK_BATS_SKIP', 'all')) {
             loadtest 'containers/netavark_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         }

--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -40,7 +40,7 @@ sub run {
     # Install tests dependencies
     my @pkgs = qw(aardvark-dns firewalld iproute2 iptables jq netavark slirp4netns);
     if (is_tumbleweed) {
-        push @pkgs, qw(dbus-1-daemon ncat);
+        push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {
         push @pkgs, qw(dbus-1);
     }

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -38,17 +38,13 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns firewalld iproute2 iptables jq netavark);
+    my @pkgs = qw(aardvark-dns firewalld netcat-openbsd iproute2 iptables jq netavark);
     if (is_tumbleweed) {
-        push @pkgs, qw(dbus-1-daemon ncat);
+        push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {
         push @pkgs, qw(dbus-1);
     }
     install_packages(@pkgs);
-
-    # netavark needs nmap's ncat instead of openbsd-netcat which we override via PATH above
-    # otherwise we can use nc but ignore failures due to openbsd-netcat not handling SIGTERM
-    assert_script_run "cp /usr/bin/ncat /usr/local/bin/nc" unless is_sle;
 
     switch_cgroup_version($self, 2);
 


### PR DESCRIPTION
Though the netavark upstream tests need nmap's ncat, it isn't available on all our products and architectures due to licensing issues.  Let's try with `netcat-openbsd`.

Verification runs: TBD
