### PR TITLE
IpAddr2 test: ssh to bastion

### DIFF
--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -19,8 +19,9 @@ sub run {
 
     select_serial_terminal;
 
-    # Prepare all the ssh connections within the 2 internal VMs
-    my $ssh_cmd = ipaddr2_ssh_cmd();
+    record_info("STAGE 1", "Prepare all the ssh connections within the 2 internal VMs");
+    my $bastion_ip = ipaddr2_bastion_pubip();
+    ipaddr2_bastion_key_accept(bastion_ip => $bastion_ip);
 }
 
 sub test_flags {


### PR DESCRIPTION
Add test step to check that bastion VM is reachable to its public IP and that ssh connection is allowed


- Related ticket: https://jira.suse.com/browse/TEAM-9467

# Verification run:

 - sle-15-SP5-SapCloud-Azure-Payg-x86_64-Buildmpagot_VR-ipaddr2_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/286561