### PR TITLE
Add barrier creation to NFS server job if IPXE=1

### DIFF
--- a/schedule/storage/nfs.yaml
+++ b/schedule/storage/nfs.yaml
@@ -9,9 +9,14 @@ vars:
   BOOT_HDD_IMAGE: 1
 
 conditional_schedule:
+  nfs_barriers:
+    IPXE:
+      1:
+        - kernel/nfs_barriers
   nfstest:
     ROLE:
       nfs_server:
+        - '{{nfs_barriers}}'
         - kernel/nfs_server
       nfs_client:
         - kernel/nfs_client


### PR DESCRIPTION
For baremetal we don't want to run a support server, but we need the barriers. We can create them with a conditional schedule for the NFS server job.

- Related ticket: https://progress.opensuse.org/issues/138089
- Needles: -
- Verification runs:
  nfs_support_server: https://openqa.suse.de/tests/14703624
  nfs_client: https://openqa.suse.de/tests/14703623
  nfs_server: https://openqa.suse.de/tests/14703622
