### PR TITLE
Refactor SDAF library

### DIFF
--- a/lib/sles4sap/sdaf_deployment_library.pm
+++ b/lib/sles4sap/sdaf_deployment_library.pm
@@ -20,6 +20,7 @@ use File::Basename;
 use Regexp::Common qw(net);
 use utils qw(write_sut_file file_content_replace);
 use Scalar::Util 'looks_like_number';
+use sles4sap::sdaf_naming_conventions;
 
 =head1 SYNOPSIS
 
@@ -54,11 +55,9 @@ our @EXPORT = qw(
   az_login
   sdaf_prepare_ssh_keys
   sdaf_get_deployer_ip
-  get_sdaf_config_path
   serial_console_diag_banner
   set_common_sdaf_os_env
   prepare_sdaf_project
-  generate_resource_group_name
   set_os_variable
   get_os_variable
   prepare_tfvars_file
@@ -66,155 +65,8 @@ our @EXPORT = qw(
   load_os_env_variables
   sdaf_cleanup
   sdaf_execute_playbook
-  convert_region_to_long
-  convert_region_to_short
 );
 
-# SDAF uses own internal 4 character abbreviations for PC region names
-# This is a matrix used for translation.  It contains only commonly used regions, if you need to extend the list
-# you can find definitions in the function B<get_region_code> located in sdaf shell script:
-# https://github.com/Azure/sap-automation/blob/3c5d0d882f5892ae2159e262062e29c2b3fe59d9/deploy/scripts/deploy_utils.sh#L403
-
-my %sdaf_region_matrix = (
-    CEUS => 'centralus',
-    EAAS => 'eastasia',
-    EAUS => 'eastus',
-    EUS2 => 'eastus2',
-    EUSG => 'eastusstg',
-    GENO => 'germanynorth',
-    GEWC => 'germanywestcentral',
-    NCUS => 'northcentralus',
-    NOEU => 'northeurope',
-    NOEA => 'norwayeast',
-    NOWE => 'norwaywest',
-    SECE => 'swedencentral',
-    WCUS => 'westcentralus',
-    WEEU => 'westeurope',
-    WEUS => 'westus',
-    WUS2 => 'westus2',
-    WUS3 => 'westus3'
-);
-
-=head2 convert_region_to_long
-
-    convert_region_to_long($sdaf_region_code);
-
-B<$sdaf_region_code>: Region name abbreviation containing 4 uppercase alphanumeric characters
-
-Performs region name conversion from 4 letter SDAF abbreviation to full region name.
-You can find definitions in the function B<get_region_code> located in sdaf shell script:
-
-L<https://github.com/Azure/sap-automation/blob/3c5d0d882f5892ae2159e262062e29c2b3fe59d9/deploy/scripts/deploy_utils.sh#L403>
-
-=cut
-
-sub convert_region_to_long {
-    my ($sdaf_region_code) = @_;
-    croak 'Missing mandatory argument "$region"' unless $sdaf_region_code;
-    croak "Abbreviation must use 4 uppercase alphanumeric characters. Got: '$sdaf_region_code'" unless $sdaf_region_code =~ /^[A-Z0-9]{4}$/;
-    croak "Requested region abbreviation not found: '$sdaf_region_code'" unless $sdaf_region_matrix{$sdaf_region_code};
-    return ($sdaf_region_matrix{$sdaf_region_code});
-}
-
-=head2 convert_region_to_short
-
-    convert_region_to_short($region);
-
-B<$region>: Full region name. Can contain only lowercase alphanumeric characters.
-
-Performs region name conversion from full region name to 4 letter SDAF abbreviation.
-You can find definitions in the function B<get_region_code> located in sdaf shell script:
-
-L<https://github.com/Azure/sap-automation/blob/3c5d0d882f5892ae2159e262062e29c2b3fe59d9/deploy/scripts/deploy_utils.sh#L403>
-
-=cut
-
-sub convert_region_to_short {
-    my ($region) = @_;
-    croak 'Missing mandatory argument "$region"' unless $region;
-    croak "Abbreviation must use lowercase alphanumeric characters. Got: '$region'" unless $region =~ /^[a-z0-9]+$/;
-
-    my @found_results = grep { $_ if $sdaf_region_matrix{$_} eq $region } keys(%sdaf_region_matrix);
-
-    croak "Value for region '$region' not found" unless @found_results;
-    croak "Found multiple values belonging to region '$region': (" . join(', ', @found_results) . ')'
-      unless @found_results == 1;
-
-    return ($found_results[0]);
-}
-
-=head2 homedir
-
-    homedir();
-
-Returns home directory path for current user from env variable $HOME.
-
-=cut
-
-sub homedir {
-    return (script_output('echo $HOME'));
-}
-
-=head2 deployment_dir
-
-    deployment_dir([create=>1]);
-
-B<create>: Create directory if it does not exist.
-
-Returns deployment directory path with job ID appended as unique identifier.
-Optionally it can create directory if it does not exists.
-
-=cut
-
-sub deployment_dir {
-    my (%args) = @_;
-    my $deployment_dir = get_var('DEPLOYMENT_ROOT_DIR', '/tmp') . '/Azure_SAP_Automated_Deployment_' . get_current_job_id();
-    assert_script_run("mkdir -p $deployment_dir") if $args{create};
-    return $deployment_dir;
-}
-
-=head2 log_dir
-
-    log_dir([create=>1]);
-
-B<create>: Create directory if it does not exist.
-
-Returns logging directory path with job ID appended as unique identifier.
-Optionally creates the directory.
-
-=cut
-
-sub log_dir {
-    my (%args) = @_;
-    my $log_dir = deployment_dir() . '/openqa_logs';
-    assert_script_run("mkdir -p $log_dir") if $args{create};
-    return $log_dir;
-}
-
-=head2 sdaf_scripts_dir
-
-    sdaf_scripts_dir();
-
-Returns directory containing SDAF scripts.
-
-=cut
-
-sub sdaf_scripts_dir {
-    return deployment_dir() . '/sap-automation/deploy/scripts';
-}
-
-=head2 env_variable_file
-
-    env_variable_file();
-
-Returns full path to a file containing all required SDAF OS env variables.
-Sourcing this file is essential for running SDAF.
-
-=cut
-
-sub env_variable_file {
-    return deployment_dir() . '/sdaf_variables';
-}
 
 =head2 log_command_output
 
@@ -583,99 +435,6 @@ sub serial_console_diag_banner {
     script_run($input_text, quiet => 1, die_on_timeout => 0, timeout => 1);
 }
 
-=head2 get_sdaf_config_path
-
-    get_sdaf_config_path(
-        deployment_type=>$deployment_type,
-        env_code=>$env_code,
-        sdaf_region_code=>$sdaf_region_code,
-        [vnet_code=>$vnet_code,
-        sap_sid=>$sap_sid,
-        job_id=>$job_id]);
-
-Returns path to config root directory for deployment type specified.
-Root config directory is deployment type specific and usually contains tfvar file, inventory file, SUT ssh keys, etc...
-
-B<deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
-
-B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
-
-B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
-
-B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
-
-B<sap_sid>: SDAF parameter for sap system ID
-
-B<job_id>: Specify job id instead of using current one. Default: current job id
-
-=cut
-
-sub get_sdaf_config_path {
-    my (%args) = @_;
-    my @supported_types = ('workload_zone', 'sap_system', 'library', 'deployer');
-    croak "Invalid deployment type: $args{deployment_type}\nCurrently supported ones are: " . join(', ', @supported_types)
-      unless grep(/^$args{deployment_type}$/, @supported_types);
-
-    my @mandatory_args = qw(deployment_type env_code sdaf_region_code);
-    # library does not require 'vnet_code'
-    push @mandatory_args, 'vnet_code' unless $args{deployment_type} eq 'library';
-    # only sap_system requires 'sap_sid'
-    push @mandatory_args, 'sap_sid' if $args{deployment_type} eq 'sap_system';
-
-    foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless defined($args{$_}); }
-
-    my %config_paths = (
-        workload_zone => "LANDSCAPE/$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-INFRASTRUCTURE",
-        deployer => "DEPLOYER/$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-INFRASTRUCTURE",
-        library => "LIBRARY/$args{env_code}-$args{sdaf_region_code}-SAP_LIBRARY",
-        sap_system => "SYSTEM/$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-$args{sap_sid}"
-    );
-
-    return (join('/', deployment_dir(), 'WORKSPACES', $config_paths{$args{deployment_type}}));
-}
-
-=head2 get_tfvars_path
-
-    get_tfvars_path(
-        deployment_type=>$deployment_type,
-        env_code=>$env_code,
-        sdaf_region_code=>$sdaf_region_code,
-        [vnet_code=>$vnet_code,
-        sap_sid=>$sap_sid]);
-
-Returns full tfvars filepath respective to deployment type.
-
-B<deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
-
-B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
-
-B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
-
-B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
-
-B<sap_sid>: SDAF parameter for sap system ID. Required only for 'sap_system' deployment type
-
-=cut
-
-sub get_tfvars_path {
-    my (%args) = @_;
-
-    # Argument (%args) validation is done by 'get_sdaf_config_path()'
-    my $config_root_path = get_sdaf_config_path(%args);
-
-    my $job_id = get_current_job_id();
-
-    my %file_names = (
-        workload_zone => "$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-INFRASTRUCTURE-$job_id.tfvars",
-        deployer => "$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-INFRASTRUCTURE-$job_id.tfvars",
-        library => "$args{env_code}-$args{sdaf_region_code}-SAP_LIBRARY-$job_id.tfvars",
-        sap_system => "$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-$args{sap_sid}-$job_id.tfvars"
-    );
-
-
-    return "$config_root_path/$file_names{$args{deployment_type}}";
-}
-
 =head2 prepare_tfvars_file
 
     prepare_tfvars_file(deployment_type=>$deployment_type);
@@ -898,27 +657,6 @@ sub prepare_sdaf_project {
     }
 
     assert_script_run("mkdir -p $_") foreach @create_workspace_dirs;
-}
-
-=head2 generate_resource_group_name
-
-    generate_resource_group_name(deployment_type=>$deployment_type);
-
-B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
-
-Returns name of the resource group for the deployment type specified by B<$deployment_type> .
-Resource group pattern: I<SDAF-OpenQA-[deployment type]-[deployment id]-[OpenQA job id]>
-
-=cut
-
-sub generate_resource_group_name {
-    my (%args) = @_;
-    my @supported_types = ('workload_zone', 'sap_system', 'library', 'deployer');
-    croak "Unsupported deployment type: $args{deployment_type}\nCurrently supported ones are: @supported_types" unless
-      grep(/^$args{deployment_type}$/, @supported_types);
-    my $job_id = get_current_job_id();
-
-    return join('-', 'SDAF', 'OpenQA', $args{deployment_type}, $job_id);
 }
 
 =head2 resource_group_exists

--- a/lib/sles4sap/sdaf_naming_conventions.pm
+++ b/lib/sles4sap/sdaf_naming_conventions.pm
@@ -1,0 +1,303 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+#
+# Library used to generate simple strings according to SDAF naming conventions
+
+package sles4sap::sdaf_naming_conventions;
+
+use strict;
+use warnings;
+use testapi;
+use Exporter qw(import);
+use Carp qw(croak);
+use mmapi qw(get_current_job_id);
+
+=head1 SYNOPSIS
+
+Library contains functions that handle SDAF naming conventions used in various strings.
+Mostly used for generating resource  names, file names or file paths.
+Please try not to add here complex functions that do much beyond returning a string.
+
+=cut
+
+our @EXPORT = qw(
+  homedir
+  deployment_dir
+  log_dir
+  sdaf_scripts_dir
+  env_variable_file
+  get_sdaf_config_path
+  get_tfvars_path
+  generate_resource_group_name
+  convert_region_to_long
+  convert_region_to_short
+);
+
+=head2 %sdaf_region_matrix
+
+B<SDAF> uses own internal 4 character abbreviations for Public Cloud region names.
+
+This is an internal matrix used for translation.  It contains only commonly used regions,
+if you need to extend the list you can find definitions in the function B<get_region_code>
+located in sdaf shell script at:
+L<https://github.com/Azure/sap-automation/blob/3c5d0d882f5892ae2159e262062e29c2b3fe59d9/deploy/scripts/deploy_utils.sh#L403>
+
+=cut
+
+my %sdaf_region_matrix = (
+    CEUS => 'centralus',
+    EAAS => 'eastasia',
+    EAUS => 'eastus',
+    EUS2 => 'eastus2',
+    EUSG => 'eastusstg',
+    GENO => 'germanynorth',
+    GEWC => 'germanywestcentral',
+    NCUS => 'northcentralus',
+    NOEU => 'northeurope',
+    NOEA => 'norwayeast',
+    NOWE => 'norwaywest',
+    SECE => 'swedencentral',
+    WCUS => 'westcentralus',
+    WEEU => 'westeurope',
+    WEUS => 'westus',
+    WUS2 => 'westus2',
+    WUS3 => 'westus3'
+);
+
+=head2 convert_region_to_long
+
+    convert_region_to_long($sdaf_region_code);
+
+B<$sdaf_region_code>: Region name abbreviation containing 4 uppercase alphanumeric characters
+
+Performs region name conversion from 4 letter SDAF abbreviation to full region name.
+You can find definitions in the function B<get_region_code> located in sdaf shell script:
+
+L<https://github.com/Azure/sap-automation/blob/3c5d0d882f5892ae2159e262062e29c2b3fe59d9/deploy/scripts/deploy_utils.sh#L403>
+
+=cut
+
+sub convert_region_to_long {
+    my ($sdaf_region_code) = @_;
+    croak 'Missing mandatory argument "$region"' unless $sdaf_region_code;
+    croak "Abbreviation must use 4 uppercase alphanumeric characters. Got: '$sdaf_region_code'" unless $sdaf_region_code =~ /^[A-Z0-9]{4}$/;
+    croak "Requested region abbreviation not found: '$sdaf_region_code'" unless $sdaf_region_matrix{$sdaf_region_code};
+    return ($sdaf_region_matrix{$sdaf_region_code});
+}
+
+=head2 convert_region_to_short
+
+    convert_region_to_short($region);
+
+B<$region>: Full region name. Can contain only lowercase alphanumeric characters.
+
+Performs region name conversion from full region name to 4 letter SDAF abbreviation.
+You can find definitions in the function B<get_region_code> located in sdaf shell script:
+
+L<https://github.com/Azure/sap-automation/blob/3c5d0d882f5892ae2159e262062e29c2b3fe59d9/deploy/scripts/deploy_utils.sh#L403>
+
+=cut
+
+sub convert_region_to_short {
+    my ($region) = @_;
+    croak 'Missing mandatory argument "$region"' unless $region;
+    croak "Abbreviation must use lowercase alphanumeric characters. Got: '$region'" unless $region =~ /^[a-z0-9]+$/;
+
+    my @found_results = grep { $_ if $sdaf_region_matrix{$_} eq $region } keys(%sdaf_region_matrix);
+
+    croak "Value for region '$region' not found" unless @found_results;
+    croak "Found multiple values belonging to region '$region': (" . join(', ', @found_results) . ')'
+      unless @found_results == 1;
+
+    return ($found_results[0]);
+}
+
+=head2 homedir
+
+    homedir();
+
+Returns home directory path for current user from env variable $HOME.
+
+=cut
+
+sub homedir {
+    return (script_output('echo $HOME'));
+}
+
+=head2 deployment_dir
+
+    deployment_dir([create=>1]);
+
+B<create>: Create directory if it does not exist.
+
+Returns deployment directory path with job ID appended as unique identifier.
+Optionally it can create directory if it does not exists.
+
+=cut
+
+sub deployment_dir {
+    my (%args) = @_;
+    my $deployment_dir = get_var('DEPLOYMENT_ROOT_DIR', '/tmp') . '/Azure_SAP_Automated_Deployment_' . get_current_job_id();
+    assert_script_run("mkdir -p $deployment_dir") if $args{create};
+    return $deployment_dir;
+}
+
+=head2 log_dir
+
+    log_dir([create=>1]);
+
+B<create>: Create directory if it does not exist.
+
+Returns logging directory path with job ID appended as unique identifier.
+Optionally creates the directory.
+
+=cut
+
+sub log_dir {
+    my (%args) = @_;
+    my $log_dir = deployment_dir() . '/openqa_logs';
+    assert_script_run("mkdir -p $log_dir") if $args{create};
+    return $log_dir;
+}
+
+=head2 sdaf_scripts_dir
+
+    sdaf_scripts_dir();
+
+Returns directory containing SDAF scripts.
+
+=cut
+
+sub sdaf_scripts_dir {
+    return deployment_dir() . '/sap-automation/deploy/scripts';
+}
+
+=head2 env_variable_file
+
+    env_variable_file();
+
+Returns full path to a file containing all required SDAF OS env variables.
+Sourcing this file is essential for running SDAF.
+
+=cut
+
+sub env_variable_file {
+    return deployment_dir() . '/sdaf_variables';
+}
+
+=head2 get_sdaf_config_path
+
+    get_sdaf_config_path(
+        deployment_type=>$deployment_type,
+        env_code=>$env_code,
+        sdaf_region_code=>$sdaf_region_code,
+        [vnet_code=>$vnet_code,
+        sap_sid=>$sap_sid,
+        job_id=>$job_id]);
+
+Returns path to config root directory for deployment type specified.
+Root config directory is deployment type specific and usually contains tfvar file, inventory file, SUT ssh keys, etc...
+
+B<deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+
+B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
+
+B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
+
+B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
+
+B<sap_sid>: SDAF parameter for sap system ID
+
+B<job_id>: Specify job id instead of using current one. Default: current job id
+
+=cut
+
+sub get_sdaf_config_path {
+    my (%args) = @_;
+    my @supported_types = ('workload_zone', 'sap_system', 'library', 'deployer');
+    croak "Invalid deployment type: $args{deployment_type}\nCurrently supported ones are: " . join(', ', @supported_types)
+      unless grep(/^$args{deployment_type}$/, @supported_types);
+
+    my @mandatory_args = qw(deployment_type env_code sdaf_region_code);
+    # library does not require 'vnet_code'
+    push @mandatory_args, 'vnet_code' unless $args{deployment_type} eq 'library';
+    # only sap_system requires 'sap_sid'
+    push @mandatory_args, 'sap_sid' if $args{deployment_type} eq 'sap_system';
+
+    foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless defined($args{$_}); }
+
+    my %config_paths = (
+        workload_zone => "LANDSCAPE/$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-INFRASTRUCTURE",
+        deployer => "DEPLOYER/$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-INFRASTRUCTURE",
+        library => "LIBRARY/$args{env_code}-$args{sdaf_region_code}-SAP_LIBRARY",
+        sap_system => "SYSTEM/$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-$args{sap_sid}"
+    );
+
+    return (join('/', deployment_dir(), 'WORKSPACES', $config_paths{$args{deployment_type}}));
+}
+
+=head2 get_tfvars_path
+
+    get_tfvars_path(
+        deployment_type=>$deployment_type,
+        env_code=>$env_code,
+        sdaf_region_code=>$sdaf_region_code,
+        [vnet_code=>$vnet_code,
+        sap_sid=>$sap_sid]);
+
+Returns full tfvars filepath respective to deployment type.
+
+B<deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+
+B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
+
+B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
+
+B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
+
+B<sap_sid>: SDAF parameter for sap system ID. Required only for 'sap_system' deployment type
+
+=cut
+
+sub get_tfvars_path {
+    my (%args) = @_;
+
+    # Argument (%args) validation is done by 'get_sdaf_config_path()'
+    my $config_root_path = get_sdaf_config_path(%args);
+
+    my $job_id = get_current_job_id();
+
+    my %file_names = (
+        workload_zone => "$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-INFRASTRUCTURE-$job_id.tfvars",
+        deployer => "$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-INFRASTRUCTURE-$job_id.tfvars",
+        library => "$args{env_code}-$args{sdaf_region_code}-SAP_LIBRARY-$job_id.tfvars",
+        sap_system => "$args{env_code}-$args{sdaf_region_code}-$args{vnet_code}-$args{sap_sid}-$job_id.tfvars"
+    );
+
+
+    return "$config_root_path/$file_names{$args{deployment_type}}";
+}
+
+=head2 generate_resource_group_name
+
+    generate_resource_group_name(deployment_type=>$deployment_type);
+
+B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+
+Returns name of the resource group for the deployment type specified by B<$deployment_type> .
+Resource group pattern: I<SDAF-OpenQA-[deployment type]-[deployment id]-[OpenQA job id]>
+
+=cut
+
+sub generate_resource_group_name {
+    my (%args) = @_;
+    my @supported_types = ('workload_zone', 'sap_system', 'library', 'deployer');
+    croak "Unsupported deployment type: $args{deployment_type}\nCurrently supported ones are: @supported_types" unless
+      grep(/^$args{deployment_type}$/, @supported_types);
+    my $job_id = get_current_job_id();
+
+    return join('-', 'SDAF', 'OpenQA', $args{deployment_type}, $job_id);
+}

--- a/t/24_sdaf_naming_convention.t
+++ b/t/24_sdaf_naming_convention.t
@@ -1,0 +1,131 @@
+use strict;
+use warnings;
+use Test::Mock::Time;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use testapi;
+use sles4sap::sdaf_naming_conventions;
+
+subtest '[homedir]' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sdaf_naming_conventions', no_auto => 1);
+    $mock_lib->redefine(script_output => sub { return '/home/sweet/home' });
+    is homedir(), '/home/sweet/home', 'Return path';
+};
+
+subtest '[deployment_dir]' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sdaf_naming_conventions', no_auto => 1);
+    my @calls;
+    $mock_lib->redefine(get_var => sub { return '/tmp' });
+    $mock_lib->redefine(get_current_job_id => sub { return '42' });
+    $mock_lib->redefine(assert_script_run => sub { push(@calls, $_[0]); return });
+
+    is deployment_dir(), '/tmp/Azure_SAP_Automated_Deployment_42', 'Return deployment path';
+    ok(!@calls, "Call without creating deployment dir");
+    deployment_dir(create => 1);
+    note("\n  CMD: " . join("\n  -->  ", @calls));
+    ok(grep(/mkdir -p/, @calls), 'Check for "mkdir" command');
+    ok(grep(/\/tmp\/Azure_SAP_Automated_Deployment_42/, @calls), 'Create correct directory');
+};
+
+subtest '[log_dir]' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sdaf_naming_conventions', no_auto => 1);
+    my @calls;
+    $mock_lib->redefine(deployment_dir => sub { return '/narnia' });
+    $mock_lib->redefine(assert_script_run => sub { push(@calls, $_[0]); return });
+
+    is log_dir(), '/narnia/openqa_logs', 'Return log path';
+    ok(!@calls, "Call without creating log dir");
+    log_dir(create => 1);
+    note("\n  CMD: " . join("\n  -->  ", @calls));
+    ok(grep(/mkdir -p/, @calls), 'Check for "mkdir" command');
+    ok(grep(/\/narnia\/openqa_logs/, @calls), 'Create correct directory');
+};
+
+subtest '[sdaf_scripts_dir]' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sdaf_naming_conventions', no_auto => 1);
+    $mock_lib->redefine(deployment_dir => sub { return '/narnia' });
+    is sdaf_scripts_dir(), '/narnia/sap-automation/deploy/scripts', 'Append scripts path to deployment root';
+};
+
+subtest '[env_variable_file]' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sdaf_naming_conventions', no_auto => 1);
+    $mock_lib->redefine(deployment_dir => sub { return '/narnia' });
+    is env_variable_file(), '/narnia/sdaf_variables', 'Append variables filename to deployment root path';
+};
+
+subtest '[get_tfvars_path] Test passing scenarios' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sdaf_naming_conventions', no_auto => 1);
+    my %arguments = (
+        sap_sid => 'QAS',
+        vnet_code => 'SAP04',
+        sdaf_region_code => 'SECE',
+        env_code => 'LAB'
+    );
+    my %expected_results = (
+        workload_zone => '/narnia/LAB-SECE-SAP04-INFRASTRUCTURE-0079.tfvars',
+        sap_system => '/narnia/LAB-SECE-SAP04-QAS-0079.tfvars',
+        library => '/narnia/LAB-SECE-SAP_LIBRARY-0079.tfvars',
+        deployer => '/narnia/LAB-SECE-SAP04-INFRASTRUCTURE-0079.tfvars'
+    );
+
+    $mock_lib->redefine(get_sdaf_config_path => sub { return '/narnia'; });
+    $mock_lib->redefine(get_current_job_id => sub { return '0079'; });
+
+    foreach (keys(%expected_results)) {
+        is get_tfvars_path(%arguments, deployment_type => $_), $expected_results{$_},
+          "Pass with corrct tfvars path generated for $_: $expected_results{$_}";
+    }
+};
+
+
+subtest '[generate_resource_group_name]' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sdaf_naming_conventions', no_auto => 1);
+    $mock_lib->redefine(get_current_job_id => sub { return '0079'; });
+    my @expected_failures = ('something_funky', 'workload', 'zone', 'sut', 'lib', 'deploy');
+    my %expected_pass = (
+        workload_zone => 'SDAF-OpenQA-workload_zone-0079',
+        sap_system => 'SDAF-OpenQA-sap_system-0079',
+        deployer => 'SDAF-OpenQA-deployer-0079',
+        library => 'SDAF-OpenQA-library-0079'
+    );
+
+    for my $value (@expected_failures) {
+        dies_ok { generate_resource_group_name(deployment_type => $value); } "Fail with unsupported 'SDAF_DEPLOYMENT_TYPE' value: $value";
+    }
+
+    for my $type (keys %expected_pass) {
+        my $rg = generate_resource_group_name(deployment_type => $type);
+        is $rg, $expected_pass{$type}, "Pass with '$type' and resource group '$rg";
+    }
+};
+
+
+subtest '[convert_region_to_long] Test conversion' => sub {
+    is convert_region_to_long('SECE'), 'swedencentral', 'Convert abbreviation "SECE" to "swedencentral"';
+    is convert_region_to_long('WUS2'), 'westus2', 'Convert abbreviation "WUS2" to "westus2"';
+    is convert_region_to_long('WEEU'), 'westeurope', 'Convert abbreviation "WEEU" to "westeurope"';
+};
+
+subtest '[convert_region_to_long] Test invalid input' => sub {
+    my @invalid_abbreviations = qw(aabc ASDF WUS5 WEEUU WWEEU WEEU.);
+    dies_ok { convert_region_to_long() } 'Croak with missing mandatory argument';
+    dies_ok { convert_region_to_long($_) } "Croak with invalid region abbreviation: $_" foreach @invalid_abbreviations;
+};
+
+subtest '[convert_region_to_short] Test conversion' => sub {
+    is convert_region_to_short('swedencentral'), 'SECE', 'Convert full region name "swedencentral" to "SECE"';
+    is convert_region_to_short('westus2'), 'WUS2', 'Convert full region name "westus2" to "WUS2"';
+    is convert_region_to_short('westeurope'), 'WEEU', 'Convert full region name "westeurope" to "WEEU"';
+};
+
+subtest '[convert_region_to_short] Test invalid input' => sub {
+    my @invalid_region_names = qw(sweden central estus5 . estus);
+    dies_ok { convert_region_to_short() } 'Croak with missing mandatory argument';
+    dies_ok { convert_region_to_short($_) } "Croak with invalid region name: $_" foreach @invalid_region_names;
+};
+
+
+
+done_testing;

--- a/tests/sles4sap/microsoft_sdaf/sdaf_deploy_hanasr.pm
+++ b/tests/sles4sap/microsoft_sdaf/sdaf_deploy_hanasr.pm
@@ -21,6 +21,7 @@ use parent 'sles4sap::microsoft_sdaf_basetest';
 use strict;
 use warnings;
 use sles4sap::sdaf_deployment_library;
+use sles4sap::sdaf_naming_conventions;
 use sles4sap::console_redirection;
 use serial_terminal qw(select_serial_terminal);
 use testapi;

--- a/tests/sles4sap/microsoft_sdaf/sdaf_deploy_sap_systems.pm
+++ b/tests/sles4sap/microsoft_sdaf/sdaf_deploy_sap_systems.pm
@@ -13,6 +13,7 @@ use parent 'sles4sap::microsoft_sdaf_basetest';
 use strict;
 use warnings;
 use sles4sap::sdaf_deployment_library;
+use sles4sap::sdaf_naming_conventions;
 use sles4sap::console_redirection;
 use serial_terminal qw(select_serial_terminal);
 use testapi;

--- a/tests/sles4sap/microsoft_sdaf/sdaf_deploy_workload_zone.pm
+++ b/tests/sles4sap/microsoft_sdaf/sdaf_deploy_workload_zone.pm
@@ -13,6 +13,7 @@ use parent 'sles4sap::microsoft_sdaf_basetest';
 use strict;
 use warnings;
 use sles4sap::sdaf_deployment_library;
+use sles4sap::sdaf_naming_conventions;
 use sles4sap::console_redirection;
 use serial_terminal qw(select_serial_terminal);
 use testapi;


### PR DESCRIPTION
This PR creates new library for functions that handle generating strings 
according to the SDAF naming conventions. Those are usually resource, directory, 
or file names. Functions are only moved from 
lib/sles4sap/sdaf_deployment_library.pm to make it less cluttered. 

- Related ticket: https://jira.suse.com/browse/TEAM-9455
- Verification run: https://openqaworker15.qa.suse.cz/tests/286563#

* test fails due to unrelated issue with playbook. Most of the code was executed at this point.
