### PR TITLE
Upgrade SLES12SP5 MU released to SLES15SP6 MU unreleased

### DIFF
--- a/data/yam/autoyast/autoupgrade_with_maintenance_unreleased_updates.xml.ep
+++ b/data/yam/autoyast/autoupgrade_with_maintenance_unreleased_updates.xml.ep
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>false</activate>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>true</boot_mbr>
+      <boot_root>true</boot_root>
+      <generic_mbr>false</generic_mbr>
+      <timeout config:type="integer">5</timeout>
+    </global>
+    <loader_type></loader_type>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <second_stage config:type="boolean">false</second_stage>
+    </mode>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <report>
+    <errors>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <warnings>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <yesno_messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <software>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+  </software>
+  <upgrade>
+    <stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>
+  </upgrade>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+  </suse_register>
+  <add-on>
+    <add_on_others config:type="list">
+      % for my $repo (@$repos) {
+      <listentry>
+        <media_url><%= $repo %></media_url>
+      </listentry>
+      % }
+    </add_on_others>
+  </add-on>
+</profile>

--- a/data/yam/autoyast/support_images/sles12sp5_install_with_scc_addons_x86_64.xml.ep
+++ b/data/yam/autoyast/support_images/sles12sp5_install_with_scc_addons_x86_64.xml.ep
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email><%= $get_var->('SCC_EMAIL') %></email>
+        <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        % if (keys %$addons) {
+        <addons config:type="list">
+            % while (my ($key, $addon) = each (%$addons)) {
+            <addon>
+                <name><%= $addon->{name} %></name>
+                <version><%= $addon->{version} %></version>
+                <arch><%= $addon->{arch} %></arch>
+                % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sles')) {
+                <reg_code><%= $get_var->('SCC_REGCODE_WE') %></reg_code>
+                % }
+                % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sled')) {
+                <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+                % }
+                % if ($key eq 'rt') {
+                <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
+                % }
+                % if ($key eq 'ltss') {
+                <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+                % }
+            </addon>
+            % }
+        </addons>
+        %}
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">45</timeout>
+        </global>
+    </bootloader>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+        <signature-handling>
+            <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+            <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+            <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+            <import_gpg_key config:type="boolean">true</import_gpg_key>
+        </signature-handling>
+    </general>
+    <partitioning config:type="list">
+        <drive>
+            <initialize config:type="boolean">true</initialize>
+            <use>all</use>
+        </drive>
+    </partitioning>
+    <networking>
+        <interfaces config:type="list">
+            <interface>
+                <bootproto>dhcp</bootproto>
+                <device>eth0</device>
+                <dhclient_set_default_route>yes</dhclient_set_default_route>
+                <startmode>auto</startmode>
+            </interface>
+        </interfaces>
+    </networking>
+    <firewall>
+        <enable_firewall config:type="boolean">true</enable_firewall>
+        <start_firewall config:type="boolean">true</start_firewall>
+        <zones config:type="list">
+            <zone>
+                <name>public</name>
+                <interfaces config:type="list">
+                    <interface>eth0</interface>
+                </interfaces>
+                <services config:type="list">
+                    <service>ssh</service>
+                </services>
+                <ports config:type="list">
+                    <port>22/tcp</port>
+                    <port>30000-50000/tcp</port>
+                </ports>
+            </zone>
+        </zones>
+    </firewall>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+    <keyboard>
+        <keyboard_values>
+            <delay/>
+            <discaps config:type="boolean">false</discaps>
+            <numlock>bios</numlock>
+            <rate/>
+        </keyboard_values>
+        <keymap>english-us</keymap>
+    </keyboard>
+    <language>
+        <language>en_US</language>
+        <languages/>
+    </language>
+    <ntp-client>
+        <ntp_policy>auto</ntp_policy>
+    </ntp-client>
+    <software>
+        <products config:type="list">
+            <product><%= uc $get_var->('SLE_PRODUCT') %></product>
+        </products>
+        <patterns config:type="list">
+            % for my $pattern (@$patterns) {
+            <pattern><%= $pattern %></pattern>
+            % }
+        </patterns>
+    </software>
+    <services-manager>
+        % if ($check_var->('DESKTOP', 'gnome')) {
+        <default_target>graphical</default_target>
+        % }
+        % if ($check_var->('DESKTOP', 'textmode')) {
+        <default_target>multi-user</default_target>
+        % }
+        <services>
+            <disable config:type="list"/>
+            <enable config:type="list">
+                <service>sshd</service>
+            </enable>
+        </services>
+    </services-manager>
+    <timezone>
+        <hwclock>UTC</hwclock>
+        <timezone>Europe/Berlin</timezone>
+    </timezone>
+    <users config:type="list">
+        <user>
+            <encrypted config:type="boolean">true</encrypted>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <user_password>$6$A5x/aKtAldy8V2Q5$5tFn6SW808brpHQHJUVgHL0zpI3VSFkIrlr5r1xE0mnHTzJY29S4p.aIUv4xGeXU7Z0FWe/vFaBoKOIEyQgJH1</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">true</encrypted>
+            <user_password>$6$Viz.6zkOLg.HGiYS$uwvqo4HVVn9/n7UByRDCwf/3h7.jVunrhugXfuxQve7db8kS0Q0flCXajdB/8Odh5tbwfnWf.cT1K8QgWlsci1</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <scripts>
+        <post-scripts config:type="list">
+            <script>
+                <filename>post.sh</filename>
+                <interpreter>shell</interpreter>
+                <source><![CDATA[
+#!/bin/sh
+# zypper process is locked by some ruby process, modify the repo file
+cd /etc/zypp/repos.d
+sed -i 's/enabled=1/enabled=0/' $(ls|grep -i nvidia)
+zypper lr
+% if ( $get_var->('VERSION') =~ /15-SP[3-5]/ ) {
+    # Regarding rpm lock see Q9@ https://documentation.suse.com/de-de/sles/15-SP1/html/SLES-all/app-ay-faq.html
+    # quote : "during the post-script phase, YaST still has an exclusive lock on the RPM database."
+    # the package cannot be installed the autoyast way, because of the changing package name (eg libyui-rest-api15)
+    # only zypper allows to install "by capability".
+    mv /var/run/zypp.pid /var/run/zypp.sav
+    zypper -n in libyui-rest-api
+    mv /var/run/zypp.sav /var/run/zypp.pid
+% }
+exit 0
+]]></source>
+            </script>
+        </post-scripts>
+    </scripts>
+</profile>

--- a/schedule/yast/maintenance/autoupgrade_sles12sp5_to_sles15spx_maintenance.yaml
+++ b/schedule/yast/maintenance/autoupgrade_sles12sp5_to_sles15spx_maintenance.yaml
@@ -1,0 +1,28 @@
+---
+name: autoupgrade_sles12sp5_to_sles15spx_maintenance.yaml
+description: >
+  Performs a migration from system with released maintenance updates to a target system using its unreleased maintenance updates.
+schedule:
+  - migration/version_switch_origin_system
+  - boot/boot_to_desktop
+  - migration/online_migration/register_system
+  - migration/prepare_scc_addons
+  - migration/prepare_maintenance_repos
+  - yam/migration/reboot_to_boot_screen
+  - migration/version_switch_upgrade_target
+  - autoyast/prepare_profile
+  - installation/bootloader
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - migration/post_upgrade
+  - console/consoletest_setup
+  - console/zypper_lr
+  - console/zypper_ref

--- a/tests/migration/prepare_maintenance_repos.pm
+++ b/tests/migration/prepare_maintenance_repos.pm
@@ -1,0 +1,20 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Prepare maintenance updates repos.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my @maint_test_repo = ();
+    foreach my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
+        push(@maint_test_repo, split(/,/, get_var(uc($addon) . '_TEST_REPOS')));
+    }
+    set_var('MAINT_TEST_REPO', join(',', @maint_test_repo));
+}
+
+1;

--- a/tests/migration/prepare_scc_addons.pm
+++ b/tests/migration/prepare_scc_addons.pm
@@ -1,0 +1,23 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Swap the values of SCC_ADDONS before migration.
+#
+# In migration maintenance updates tests, SCC_ADDONS is used for both
+# registering original system and adding target system modules maintenance
+# updates repos. But for SLE 12 and SLE 15, the modules name are different.
+# So swap SCC_ADDONS values to upgraded SLE 15 modules before migration.
+#
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+    set_var('SCC_ADDONS', get_var('SCC_ADDONS_2'));
+}
+
+1;


### PR DESCRIPTION
Add a testsuite to generate the support image of SLES12SP5 via autoyast installation; 
Add upgrade autoyast profile and yaml schedule files for migration from maintenance update released to maintenance update unreleased testsuites; 
To make the job add target product's maintenance update repos, reset the SCC_ADDONS values because the modules names of SLES12SP5 and SLES15SP5 are different, and there's a blessed modules which would be added during migration fron 12SP5 to 15SPx.

- Related ticket: https://progress.opensuse.org/issues/154951
- Needles: n/a
- Verification run: [publish support image](https://openqa.suse.de/tests/14698146#); [migrate to 15SP6 + MU](https://openqa.suse.de/tests/14786768#)
- Related mr: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/235
