### PR TITLE
Add deregistration case for MU migration tests

### DIFF
--- a/schedule/yast/maintenance/create_hdd_maintenance_deregistered.yaml
+++ b/schedule/yast/maintenance/create_hdd_maintenance_deregistered.yaml
@@ -1,0 +1,11 @@
+---
+name: create_hdd_maintenance_deregistered
+description: '|
+  This job is to deregister the system and publish a qcow
+  file for maintenance updates migration test cases.'
+schedule:
+  - boot/boot_to_desktop
+  - console/scc_deregistration
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/tests/yam/migration/setup_registration.pm
+++ b/tests/yam/migration/setup_registration.pm
@@ -20,7 +20,6 @@ sub run {
 
     select_console('root-console');
     assert_script_run('SUSEConnect --debug --cleanup');
-    script_run('SUSEConnect -d', proceed_on_failure => 1);
     assert_script_run('SUSEConnect --debug --regcode ' . get_required_var('SCC_REGCODE'), 200);
     my $addons_to_register = join(',', grep !exists $filter{$_}, @addons);
     register_addons_cmd($addons_to_register);


### PR DESCRIPTION
##
Now we are adding a  intermidiate case to deregister the production for the follow up  maintenance updates migration test cases and publish a deregisted qcow file. 

- Related ticket:  
    -  https://progress.opensuse.org/issues/161231
- Related MR:
    - [**MR_236**](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/236)
- Needles: 
    - N/A
  
- Verification run: 
     -  create_hdd_migr_maintenance_desktop_dev
        - https://openqa.suse.de/tests/14715101
     - migr_sles15sp3_sp4_dev
       -  https://openqa.suse.de/tests/14715106
  - 12sp5->15spx regression test:
     - https://openqa.suse.de/t14715262
     - https://openqa.suse.de/t14715263
     - https://openqa.suse.de/t14715264
 ##   