### PR TITLE
Add a new test to verify python311-pipx

### DIFF
--- a/data/python/python3-pipx/package/__init__.py
+++ b/data/python/python3-pipx/package/__init__.py
@@ -1,0 +1,1 @@
+from .cli import hello

--- a/data/python/python3-pipx/package/cli.py
+++ b/data/python/python3-pipx/package/cli.py
@@ -1,0 +1,2 @@
+def hello():
+    print("Hello world from package!")

--- a/data/python/python3-pipx/setup.py
+++ b/data/python/python3-pipx/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='package',
+    version='0.1',
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'hello-world=package.cli:hello',
+        ],
+    },
+)

--- a/schedule/functional/stack_tests_python.yaml
+++ b/schedule/functional/stack_tests_python.yaml
@@ -14,6 +14,7 @@ conditional_schedule:
       opensuse:
         - console/python3_new_version_check
         - console/python3_setuptools
+        - console/python3_pipx
         - console/python_virtualenv
         - console/python3_beautifulsoup4
         - console/python3_websocket_client
@@ -27,6 +28,7 @@ conditional_schedule:
       15-SP6:
         - console/python3_new_version_check
         - console/python3_setuptools
+        - console/python3_pipx
         - console/python_virtualenv
         - console/python3_beautifulsoup4
         - console/python3_websocket_client
@@ -38,6 +40,7 @@ conditional_schedule:
       15-SP5:
         - console/python3_new_version_check
         - console/python3_setuptools
+        - console/python3_pipx
         - console/python_virtualenv
         - console/python3_beautifulsoup4
         - console/python3_websocket_client
@@ -49,6 +52,7 @@ conditional_schedule:
       15-SP4:
         - console/python3_new_version_check
         - console/python3_setuptools
+        - console/python3_pipx
         - console/python_virtualenv
         - console/python3_websocket_client
         - console/python3_beautifulsoup4

--- a/tests/console/python3_pipx.pm
+++ b/tests/console/python3_pipx.pm
@@ -1,0 +1,76 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: python311-pipx
+# Summary: testsuite python3-pipx
+# - verify the systems python3-pipx
+# - creating and installing source distribution package for a python
+# in the form of wheel file
+# - verify the available python3-pipx with creation of package locally.
+# - install also the package via pipx
+# Maintainer: QE Core <qe-core@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use version_utils;
+use python_version_utils;
+use utils "zypper_call";
+use feature qw(signatures);
+no warnings qw(experimental::signatures);
+
+sub run {
+    select_serial_terminal;
+    # Import the project directory for creating a source distribution package.
+    assert_script_run('curl -L -s ' . data_url('python/python3-pipx') . ' | cpio --make-directories --extract && cd data');
+    # Verify the system's python3 version
+    my $system_python_version = get_system_python_version();
+    record_info("System python version", "$system_python_version");
+    # Run the package creation and install test for system python
+    run_tests($system_python_version);
+    # Test all available new python3 versions in SLEs if any
+    if (is_sle() || is_leap('>15.5')) { run_tests($_) foreach (get_available_python_versions()); }
+}
+
+sub run_tests ($python3_spec_release) {
+    record_info("$python3_spec_release");
+    # Install pipx and wheel
+    if ((zypper_call("se -x $python3_spec_release-pipx", exitcode => [0, 104]) == 104) or (zypper_call("se -x $python3_spec_release-wheel", exitcode => [0, 104]) == 104)) {
+        record_info("Skip!", "either $python3_spec_release-pipx or $python3_spec_release-wheel doesn't exist");
+        return;
+    }
+    zypper_call("in $python3_spec_release-pipx $python3_spec_release-wheel");
+    my $python_binary = get_python3_binary($python3_spec_release);
+    my $version_number = (split("python", $python_binary))[1];
+    script_run("$python_binary setup.py bdist_wheel");
+    assert_script_run("pipx install dist/package-0.1-py3-none-any.whl --python=/usr/bin/$python_binary");
+    script_run("pipx list");
+    assert_script_run("export PATH=\$PATH:~/.local/bin");
+    validate_script_output("hello-world", sub { m/Hello world from package!/ });
+    validate_script_output("pipx uninstall package", sub { m/uninstalled package!/ });
+    validate_script_output("pipx list", sub { m/nothing has been installed with pipx/ });
+}
+
+sub cleanup {
+    if (is_sle() || is_leap('>15.5')) {
+        foreach my $python_version (get_available_python_versions()) {
+            zypper_call("rm $python_version-base", exitcode => [0, 104]);
+        }
+    }
+    assert_script_run("cd ..");
+    script_run("rm -r data");
+}
+
+sub post_run_hook {
+    cleanup();
+}
+
+sub post_fail_hook {
+    cleanup();
+}
+
+1;

--- a/tests/console/python3_setuptools.pm
+++ b/tests/console/python3_setuptools.pm
@@ -101,7 +101,6 @@ sub cleanup {
     assert_script_run("deactivate");    # leave the virtual env
     assert_script_run("cd ..");
     script_run("rm -r data");
-
 }
 
 sub post_run_hook {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/156472
- Needles: No
- Verification run: 
  SLE15-SP6:  [aarch64](https://openqa.suse.de/tests/14948447) | [s390x](https://openqa.suse.de/tests/14948448) | [x86_64](https://openqa.suse.de/tests/14948449)
SLE15-SP5: [aarch64](https://openqa.suse.de/tests/14948441) | [s390x](https://openqa.suse.de/tests/14948442) | [x86_64](https://openqa.suse.de/tests/14948443)
SLE15-SP4: [aarch64](https://openqa.suse.de/tests/14948444) | [s390x](https://openqa.suse.de/tests/14948445) | [x86_64](https://openqa.suse.de/tests/14948446)
LEAP15.6: [aarch64](https://openqa.opensuse.org/tests/4367120#step/python3_pipx/1) | [ppc64le](https://openqa.opensuse.org/tests/4367119#step/python3_pipx/1)| [x86_64](https://openqa.opensuse.org/tests/4367118#step/python3_pipx/1)
Tumbleweed: https://openqa.opensuse.org/tests/4347165
