### PR TITLE
containers: Enable aardvark-dns testing on SLE 15-SP4+

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -305,7 +305,7 @@ sub load_container_tests {
             loadtest 'containers/netavark_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         }
         if (!check_var('AARDVARK_BATS_SKIP', 'all')) {
-            loadtest 'containers/aardvark_integration' if (is_tumbleweed);
+            loadtest 'containers/aardvark_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
         }
         return;
     }


### PR DESCRIPTION
Enable aardvark-dns upstream tests on 15-SP4+

Verification runs:
- sle-15-SP5-Server-DVD-Updates-x86_64-Build20240618-2-podman_testsuite@64bit -> https://openqa.suse.de/t14676336
- sle-15-SP4-Server-DVD-Updates-x86_64-Build20240618-2-podman_testsuite@64bit -> https://openqa.suse.de/t14676338