### PR TITLE
kernel: Add support for maintenance staging updates

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -51,6 +51,9 @@ sub load_kernel_tests {
         if (get_var('FLAVOR', '') =~ /Incidents-Kernel/) {
             loadtest_kernel 'update_kernel';
         }
+        if (is_transactional && (get_var('FLAVOR', '') =~ /-Staging/)) {
+            loadtest 'transactional/install_updates';
+        }
         loadtest_kernel 'install_ltp';
 
         if (get_var('LIBC_LIVEPATCH')) {


### PR DESCRIPTION
Enhancement poo#162502: We need to test maintenance staging updates
for SL Micro. There is already existing test module
transactional/install_update, which adds repositories and installs
updates. Module is included in main_ltp and will be scheduled on
transactional system and staging FLAVOR.


Job group configuration: https://gitlab.suse.de/kernel-qa/kernelqa-openqa-yaml/-/merge_requests/529

- Related ticket: https://progress.opensuse.org/issues/162509
- Needles: never
- Verification run: https://openqa.suse.de/tests/14679848
