### PR TITLE
utils: Add explicit checks for ping command and 0-size ping in ping_size_check

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2936,6 +2936,8 @@ sub ping_size_check {
     my $target = shift;
     my $size = shift;
     # Check connectivity with different packet size to target
+    assert_script_run('command -v ping >/dev/null', fail_message => 'ping application not found. Needed for ping_size_check');
+    assert_script_run("ping -M do -s 0 -c 1 $target", fail_message => "ping failed trying to reach target '$target'. Check network configuration on worker host'");
     # Fragmentation is disabled, maximum size is 1352 to fit in 1380 MTU in GRE tunel
     my $max_mtu = get_var('MM_MTU', 1380);
     my @sizes = $size ? $size : (100, 1000, 1252, 1350, 1352, 1400, 1430);


### PR DESCRIPTION
The "ping_size_check" mentioned misleading messages about "MTU size
problems" when the ping application is not even installed or if the ping
would fail regardless of the MTU size.

This commit adds two explicit checks with separate fail messages.

Verification run: `openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19557 https://openqa.suse.de/tests/14657729`

2 jobs have been created:
 - sle-15-SP3-Server-DVD-Updates-x86_64-Build20240617-1-cc_ipsec_server@64bit -> https://openqa.suse.de/tests/14680173
 - sle-15-SP3-Server-DVD-Updates-x86_64-Build20240617-1-cc_ipsec_client@64bit -> https://openqa.suse.de/tests/14680174

Related progress issue: https://progress.opensuse.org/issues/162320