### PR TITLE
P.C. terraform output automatic folder management

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -175,7 +175,9 @@ sub cleanup {
     # gce provides full serial log, so extended timeout
     if (!check_var('PUBLIC_CLOUD_SLES4SAP', 1) && defined($instance_id)) {
         if ($instance_id ne "") {
-            script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region --port=1 > instance_serial.txt", timeout => 180);
+            my $res = script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region --port=1 > instance_serial.txt", timeout => 180);
+            script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --port=1 -> instance_serial.txt", timeout => 180)
+              if ($res != 0);    # zone::region mismatch, retry without zone
             upload_logs("instance_serial.txt", failok => 1);
         } else {
             record_info("Warn", "instance_id empty", result => 'fail');

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -170,14 +170,15 @@ sub cleanup {
 
     my $region = $self->{provider_client}->{region};
     my $project = $self->{provider_client}->{project_id};
-    my $instance_id = $self->get_terraform_output(".vm_name.value[0]");
+    my $query = check_var('PUBLIC_CLOUD_SLES4SAP', 1) ? ".hana_name.value[0]" : ".vm_name.value[0]";
+    my $instance_id = $self->get_terraform_output($query);
     # gce provides full serial log, so extended timeout
     if (!check_var('PUBLIC_CLOUD_SLES4SAP', 1) && defined($instance_id)) {
-        if ($instance_id =~ /$self->{resource_name}/) {
+        if ($instance_id ne "") {
             script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region --port=1 > instance_serial.txt", timeout => 180);
             upload_logs("instance_serial.txt", failok => 1);
         } else {
-            record_info("Warn", "instance_id " . ($instance_id) ? $instance_id : "empty", result => 'fail');
+            record_info("Warn", "instance_id empty", result => 'fail');
         }
     }
     $self->SUPER::cleanup();

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -170,14 +170,14 @@ sub cleanup {
 
     my $region = $self->{provider_client}->{region};
     my $project = $self->{provider_client}->{project_id};
-    my $query = check_var('PUBLIC_CLOUD_SLES4SAP', 1) ? ".hana_name.value[0]" : ".vm_name.value[0]";
+    my $query = ".vm_name.value[0]";
     my $instance_id = $self->get_terraform_output($query);
     # gce provides full serial log, so extended timeout
-    if (!check_var('PUBLIC_CLOUD_SLES4SAP', 1) && defined($instance_id)) {
-        if ($instance_id ne "") {
+    if (!check_var('PUBLIC_CLOUD_SLES4SAP', 1)) {
+        if ($instance_id) {
             my $res = script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region --port=1 > instance_serial.txt", timeout => 180);
             script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --port=1 -> instance_serial.txt", timeout => 180)
-              if ($res != 0);    # zone::region mismatch, retry without zone
+              if ($res);    # zone::region mismatch, retry without zone
             upload_logs("instance_serial.txt", failok => 1);
         } else {
             record_info("Warn", "instance_id empty", result => 'fail');

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -726,19 +726,31 @@ sub terraform_param_tags
 =head2 get_terraform_output
 
 Query the terraform data structure in json format.
+Automatic search and set valid terraform directory on helper image.
 Input: <jq-query-format> string; <empty> = no query then full output of data structure.
 E.g: to get the VM instance name from json data structure, the call is: 
     get_terraform_output(".vm_name.value[0]");
 To get the complete output structure, the call is:
-    get_terraform_output();
+    get_terraform_output(".");
 
 =cut
 
 sub get_terraform_output {
     my ($self, $jq_query) = @_;
-    my $res = script_output("terraform output -no-color -json | jq -r '$jq_query' 2>/dev/null", proceed_on_failure => 1);
-    # jq 'null' shall return empty
-    return $res unless ($res =~ /^null$/);
+    # cuurent dir saved
+    my $dir = script_output("pwd");
+    # terraform state file search first matching
+    my $cd = script_output("(find ~ -name *.tfstate -print | head -1 | xargs dirname) 2>/dev/null");
+    # state file missing: no data found
+    return "" if ($cd eq "");
+    # enter terraform dir. found
+    script_run("cd $cd") if ($cd ne $dir);
+    # get data
+    my $res = script_output("terraform output -no-color -json | jq -Mr '$jq_query'", proceed_on_failure => 1);
+    # restore saved dir
+    script_run("cd $dir") if ($cd ne $dir);
+    # return data or empty when "null" found
+    return ($res =~ /^null$/) ? "" : $res;
 }
 
 sub escape_single_quote {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -723,11 +723,12 @@ sub terraform_param_tags
     return encode_json($tags);
 }
 
-=head2 get_terraform_output
+=head2 get_terraform_output($jq_query, $tf_dir)
 
 Query the terraform data structure in json format.
 Automatic search and set valid terraform directory on helper image.
 Input: <jq-query-format> string; <empty> = no query then full output of data structure.
+       <tf_dir> string, optional terraform destination directory; when empty, dir.searched.
 E.g: to get the VM instance name from json data structure, the call is: 
     get_terraform_output(".vm_name.value[0]");
 To get the complete output structure, the call is:
@@ -736,21 +737,16 @@ To get the complete output structure, the call is:
 =cut
 
 sub get_terraform_output {
-    my ($self, $jq_query) = @_;
-    # cuurent dir saved
-    my $dir = script_output("pwd");
+    my ($self, $jq_query, $tf_dir) = @_;
     # terraform state file search first matching
-    my $cd = script_output("(find ~ -name *.tfstate -print | head -1 | xargs dirname) 2>/dev/null");
+    my $start = ($tf_dir) ? $tf_dir : '~';
+    $tf_dir = script_output("find $start -name \*.tfstate -exec dirname {} + -quit 2>/dev/null");
     # state file missing: no data found
-    return "" if ($cd eq "");
-    # enter terraform dir. found
-    script_run("cd $cd") if ($cd ne $dir);
-    # get data
-    my $res = script_output("terraform output -no-color -json | jq -Mr '$jq_query'", proceed_on_failure => 1);
-    # restore saved dir
-    script_run("cd $dir") if ($cd ne $dir);
-    # return data or empty when "null" found
-    return ($res =~ /^null$/) ? "" : $res;
+    return undef unless ($tf_dir);
+    # set terraform dir. and get data
+    my $res = script_output("terraform -chdir=$tf_dir output -no-color -json | jq -Mr '$jq_query'", proceed_on_failure => 1);
+    # return undef on jq 'null'
+    return ($res eq "null") ? undef : $res;
 }
 
 sub escape_single_quote {


### PR DESCRIPTION
Pub.Cl. `get_terraform_out` updated to auto-search right data folder, get data from there. Works from any place, even for SAP, no need to set terraform dir. 

Also, gce get serial log, updated to skip zone on `zone != region` failures.
Default query for eventual SAP use added too.

- Related ticket: https://progress.opensuse.org/issues/161732
- Needles: none
- Verification run: https://openqa.suse.de/tests/14680143
