### PR TITLE
containers: Use our own nginx & haproxy images

### DIFF
--- a/data/containers/docker-compose.yml
+++ b/data/containers/docker-compose.yml
@@ -1,9 +1,7 @@
-version: "3.3"
 services:
 
   nginx:
-    # The REGISTRY is variable and will be replaced
-    image: REGISTRY/library/nginx
+    image: registry.opensuse.org/opensuse/nginx
     networks:
       - backend
     volumes:
@@ -11,10 +9,9 @@ services:
     restart: on-failure
 
   haproxy:
-    # The REGISTRY is variable and will be replaced
-    image: REGISTRY/library/haproxy
+    image: registry.opensuse.org/opensuse/haproxy
     volumes:
-      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro,Z
+      - ./haproxy.cfg:/etc/haproxy/haproxy.cfg:ro,Z
     ports:
       - "8080:80"
     # Port 80 is privileged but haproxy 2.4 runs as user by default.

--- a/tests/containers/compose.pm
+++ b/tests/containers/compose.pm
@@ -36,7 +36,6 @@ sub basic_test {
     assert_script_run("curl -O " . data_url("containers/docker-compose.yml"));
     assert_script_run("curl -O " . data_url("containers/haproxy.cfg"));
 
-    file_content_replace("docker-compose.yml", REGISTRY => get_var('REGISTRY', 'docker.io'));
     assert_script_run "$runtime compose pull", 600;
 
     # Start all containers in background
@@ -51,7 +50,7 @@ sub basic_test {
     assert_script_run 'curl -s http://127.0.0.1:8080/ | grep "Welcome to nginx!"';
 
     # Change the index.html in nginx /usr/share/nginx/html volume a check it
-    assert_script_run "$runtime compose exec nginx /bin/sh -c 'echo Hello > /usr/share/nginx/html/index.html'";
+    assert_script_run "$runtime compose exec nginx /bin/sh -c 'echo Hello > /srv/www/htdocs/index.html'";
     assert_script_run 'curl -s http://127.0.0.1:8080/ | grep "Hello"';
 
     assert_script_run "$runtime compose logs | tee $runtime-compose-logs.txt";


### PR DESCRIPTION
Use our own nginx & haproxy images.  Remove dependency on registry mirror.  We should drink our own champagne.

- Related ticket: https://progress.opensuse.org/issues/162530
- Failing test: https://openqa.opensuse.org/tests/4282546
- Verification run: https://openqa.opensuse.org/tests/4283066
