### PR TITLE
New test sequence for zypper patch on cloud

### DIFF
--- a/lib/sles4sap/cloud_zypper_patch.pm
+++ b/lib/sles4sap/cloud_zypper_patch.pm
@@ -1,0 +1,285 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Library sub and shared data for the cloud zypper patch test.
+
+package sles4sap::cloud_zypper_patch;
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+use Carp qw(croak);
+use Exporter qw(import);
+use mmapi qw(get_current_job_id);
+use sles4sap::azure_cli;
+use publiccloud::utils qw(get_ssh_private_key_path);
+
+
+=head1 SYNOPSIS
+
+Library to manage the sles4sap cloud zypper patch tests
+=cut
+
+our @EXPORT = qw(
+  zp_azure_deploy
+  zp_azure_destroy
+  zp_azure_netpeering
+  zp_ssh_connect
+  zp_add_repos
+  zp_zypper_patch
+);
+
+use constant DEPLOY_PREFIX => 'zp';
+
+our $user = 'cloudadmin';
+our $pub_ip = DEPLOY_PREFIX . '_pub_ip';
+our $vnet = DEPLOY_PREFIX . '_vnet';
+
+
+=head2 zp_azure_resource_group
+
+  my $rg = zp_azure_resource_group();
+
+Get the Azure resource group name for this test
+=cut
+
+sub zp_azure_resource_group {
+    return DEPLOY_PREFIX . get_current_job_id();
+}
+
+=head2 zp_azure_deploy
+
+    zp_azure_deploy(region => 'northeurope', os => 'SUSE:sles-sap-15-sp5:gen2:latest');
+
+Create a deployment in Azure designed for this specific test.
+
+1. Create a resource group to contain all
+2. Create a vnet and subnet in it
+3. Create one Public IP
+4. Create 1 VM
+
+=over 2
+
+=item B<region> - existing resource group
+
+=item B<os> - existing Load balancer NAME
+
+=back
+=cut
+
+sub zp_azure_deploy {
+    my (%args) = @_;
+    foreach (qw(region os)) {
+        croak("Argument < $_ > missing") unless $args{$_}; }
+
+    az_version();
+
+    my $rg = zp_azure_resource_group();
+
+    az_group_create(
+        name => $rg,
+        region => $args{region});
+
+    my $subnet = DEPLOY_PREFIX . '-snet';
+    az_network_vnet_create(
+        resource_group => $rg,
+        region => $args{region},
+        vnet => $vnet);
+
+    az_network_publicip_create(
+        resource_group => $rg,
+        name => $pub_ip,
+        sku => 'Basic',
+        allocation_method => 'Static');
+
+    az_vm_create(
+        resource_group => $rg,
+        name => DEPLOY_PREFIX . '_vm',
+        region => $args{region},
+        image => $args{os},
+        username => $user,
+        vnet => $vnet,
+        snet => $subnet,
+        ssh_pubkey => get_ssh_private_key_path() . '.pub',
+        public_ip => $pub_ip);
+}
+
+=head2 zp_azure_destroy
+
+    zp_azure_destroy();
+
+Destroy the deployment by deleting the resource group and created network peering
+
+=over 1
+
+=item B<target_rg> - (optional) name of the resource group of the IBSm
+
+=back
+=cut
+
+sub zp_azure_destroy {
+    my (%args) = @_;
+    my $rg = zp_azure_resource_group();
+    az_group_delete(name => $rg, timeout => 600);
+
+    if ($args{target_rg}) {
+        my $target_vnet = az_network_vnet_get(resource_group => $args{target_rg});
+        my $target_vnet_name = @$target_vnet[0];
+        az_network_peering_delete(
+            name => zp_ibsm2sut_peering_name(target_rg => $args{target_rg}, target_vnet_name => $target_vnet_name),
+            resource_group => $args{target_rg},
+            vnet => $target_vnet_name);
+    }
+}
+
+=head2 zp_ibsm2sut_peering_name
+
+    my $peering_name = zp_ibsm2sut_peering_name(target_rg => get_required_var('ZP_IBSM_RG'));
+
+Get the Azure resource group name for this test
+
+=over 2
+
+=item B<target_rg> - name of the resource group of the IBSm
+
+=item B<target_vnet_name> - (optional) name of the VNET of the IBSm, if not provided it is calculated internally
+
+=back
+=cut
+
+sub zp_ibsm2sut_peering_name {
+    my (%args) = @_;
+    croak("Argument < target_rg > missing") unless $args{target_rg};
+    my $target_vnet_name;
+    if ($args{target_vnet_name}) {
+        $target_vnet_name = $args{target_vnet_name};
+    } else {
+        my $target_vnet = az_network_vnet_get(resource_group => $args{target_rg});
+        $target_vnet_name = @$target_vnet[0];
+    }
+
+    return join('-', $args{target_rg}, $target_vnet_name, $vnet);
+}
+
+=head2 zp_azure_netpeering
+
+    zp_azure_netpeering(target_rg => get_required_var('ZP_IBSM_RG'))
+
+=over 1
+
+=item B<target_rg> - name of the resource group of the IBSm
+
+=back
+=cut
+
+sub zp_azure_netpeering {
+    my (%args) = @_;
+    croak("Argument < target_rg > missing") unless $args{target_rg};
+
+    my $rg = zp_azure_resource_group();
+
+    my $target_vnet = az_network_vnet_get(resource_group => $args{target_rg});
+    my $target_vnet_name = @$target_vnet[0];
+
+    az_network_peering_create(
+        name => join('-', $rg, $vnet, $target_vnet_name),
+        source_rg => $rg,
+        source_vnet => $vnet,
+        target_rg => $args{target_rg},
+        target_vnet => $target_vnet_name);
+    az_network_peering_create(
+        name => zp_ibsm2sut_peering_name(target_rg => $args{target_rg}, target_vnet_name => $target_vnet_name),
+        source_rg => $args{target_rg},
+        source_vnet => $target_vnet_name,
+        target_rg => $rg,
+        target_vnet => $vnet);
+
+    az_network_peering_list(resource_group => $rg, vnet => $vnet);
+    az_network_peering_list(resource_group => $args{target_rg}, vnet => $target_vnet_name);
+}
+
+=head2 zp_ssh_connect
+    
+    zp_ssh_connect()
+
+First ssh connections
+=cut 
+
+sub zp_ssh_connect {
+    my $pubip_addr = az_network_publicip_get(
+        resource_group => zp_azure_resource_group(),
+        name => $pub_ip);
+
+    assert_script_run("ssh -o StrictHostKeyChecking=accept-new $user\@$pubip_addr whoami");
+    assert_script_run("ssh $user\@$pubip_addr whoami");
+    assert_script_run("ssh $user\@$pubip_addr whoami | grep $user");
+}
+
+=head2 zp_add_repos
+
+    zp_add_repos()
+
+Add MU repos to the zypper list
+=cut
+
+sub zp_add_repos {
+    my (%args) = @_;
+    foreach (qw(ip name repos)) {
+        croak("Argument < $_ > missing") unless $args{$_}; }
+
+    my @repos = split(/,/, $args{repos});
+    my $count = 0;
+    my $pubip_addr = az_network_publicip_get(
+        resource_group => zp_azure_resource_group(),
+        name => $pub_ip);
+    my $cmd;
+
+    $cmd = join(' ', 'ssh',
+        "$user\@$pubip_addr",
+        "'sudo echo \"$args{ip} $args{name}\" | sudo tee -a /etc/hosts'");
+    #"'sudo sed -i \\\$a $args{ip} $args{name} /etc/hosts'");
+    assert_script_run($cmd);
+
+    $cmd = join(' ', 'ssh',
+        "$user\@$pubip_addr",
+        "'sudo cat /etc/hosts'");
+    assert_script_run($cmd);
+
+    while (defined(my $maintrepo = shift @repos)) {
+        next if $maintrepo =~ /^\s*$/;
+        if ($maintrepo =~ /Development-Tools/ or $maintrepo =~ /Desktop-Applications/) {
+            record_info("MISSING REPOS",
+                "There are repos in this incident, that are not uploaded to IBSM. ($maintrepo). Later errors, if they occur, may be due to these.");
+            next;
+        }
+        $cmd = join(' ', 'ssh',
+            "$user\@$pubip_addr",
+            "'sudo zypper --no-gpg-checks ar -f -n TEST_$count $maintrepo TEST_$count'");
+        assert_script_run($cmd);
+        $count++;
+    }
+    $cmd = join(' ', 'ssh',
+        "$user\@$pubip_addr",
+        "'sudo zypper -n ref'");
+    assert_script_run($cmd);
+}
+
+=head2 zp_zypper_patch
+
+    zp_zypper_patch()
+
+Run zypper patch
+=cut
+
+sub zp_zypper_patch {
+    my $pubip_addr = az_network_publicip_get(
+        resource_group => zp_azure_resource_group(),
+        name => $pub_ip);
+    my $cmd = join(' ', 'ssh',
+        "$user\@$pubip_addr",
+        "'sudo zypper --non-interactive patch --auto-agree-with-licenses --no-recommends'");
+    assert_script_run($cmd);
+}
+
+1;

--- a/schedule/sles4sap/cloud-components/cloud_zypper_patch.yml
+++ b/schedule/sles4sap/cloud-components/cloud_zypper_patch.yml
@@ -1,0 +1,13 @@
+---
+name: cloud_zypper_patch
+description: |
+  Create a VM in the cloud, connect a repo, run zypper patch
+vars:
+    TEST_CONTEXT: 'OpenQA::Test::RunArgs'
+schedule:
+    - boot/boot_to_desktop
+    - sles4sap/cloud_zypper_patch/deploy
+    - sles4sap/cloud_zypper_patch/network_peering
+    - sles4sap/cloud_zypper_patch/add_repo
+    - sles4sap/cloud_zypper_patch/zypper_patch
+    - sles4sap/cloud_zypper_patch/destroy

--- a/t/25_cloud_zypper_patch.t
+++ b/t/25_cloud_zypper_patch.t
@@ -1,0 +1,131 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use Test::Mock::Time;
+use List::Util qw(any none all);
+
+use sles4sap::cloud_zypper_patch;
+
+subtest '[zp_azure_deploy]' => sub {
+    my $zp = Test::MockModule->new('sles4sap::cloud_zypper_patch', no_auto => 1);
+
+    my $called = 0;
+    $zp->redefine(az_version => sub { $called++; });
+    $zp->redefine(zp_azure_resource_group => sub { $called++; return 'SPIAGGIA'; });
+    $zp->redefine(az_group_create => sub { $called++; });
+    $zp->redefine(az_network_vnet_create => sub { $called++; });
+    $zp->redefine(az_network_publicip_create => sub { $called++; });
+    $zp->redefine(az_vm_create => sub { $called++; });
+
+    zp_azure_deploy(region => 'SABBIA', os => 'MARE');
+
+    ok $called eq 6;
+};
+
+subtest '[zp_azure_deploy] integration test' => sub {
+    my $zp = Test::MockModule->new('sles4sap::cloud_zypper_patch', no_auto => 1);
+    $zp->redefine(get_current_job_id => sub { return 'SPIAGGIA'; });
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
+    $azcli->redefine(script_output => sub { push @calls, ['azure_cli', $_[0]]; return 'PALETTA'; });
+
+    zp_azure_deploy(region => 'SABBIA', os => 'MARE');
+
+    for my $call_idx (0 .. $#calls) {
+        note("sles4sap::" . $calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
+    }
+
+    # Todo : expand it
+    ok $#calls > 0, "There are some command calls";
+};
+
+subtest '[zp_azure_destroy]' => sub {
+    my $zp = Test::MockModule->new('sles4sap::cloud_zypper_patch', no_auto => 1);
+    my $called = 0;
+    $zp->redefine(zp_azure_resource_group => sub { $called++; return 'SPIAGGIA'; });
+    $zp->redefine(az_group_delete => sub { $called++; });
+
+    zp_azure_destroy();
+
+    ok $called eq 2;
+};
+
+subtest '[zp_azure_destroy] network peering' => sub {
+    my $zp = Test::MockModule->new('sles4sap::cloud_zypper_patch', no_auto => 1);
+    my $called = 0;
+    $zp->redefine(zp_azure_resource_group => sub { $called++; return 'SPIAGGIA'; });
+    $zp->redefine(az_group_delete => sub { $called++; });
+    my @vnets = ('ONDE');
+    $zp->redefine(az_network_vnet_get => sub { $called++; return \@vnets; });
+    $zp->redefine(az_network_peering_delete => sub { $called++; });
+
+    zp_azure_destroy(target_rg => 'PEDALO`');
+
+    ok $called eq 4;
+};
+
+subtest '[zp_azure_netpeering]' => sub {
+    my $zp = Test::MockModule->new('sles4sap::cloud_zypper_patch', no_auto => 1);
+    my $called = 0;
+    $zp->redefine(zp_azure_resource_group => sub { $called++; return 'SPIAGGIA'; });
+    my @vnets = ('ONDE');
+    $zp->redefine(az_network_vnet_get => sub { $called++; return \@vnets; });
+    $zp->redefine(az_network_peering_create => sub { $called++; });
+    $zp->redefine(az_network_peering_list => sub { $called++; });
+
+    zp_azure_netpeering(target_rg => 'OMBRELLONI');
+
+    ok $called > 0;
+};
+
+subtest '[zp_ssh_connect]' => sub {
+    my $zp = Test::MockModule->new('sles4sap::cloud_zypper_patch', no_auto => 1);
+    my @calls;
+    $zp->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $zp->redefine(zp_azure_resource_group => sub { return 'SPIAGGIA'; });
+    $zp->redefine(az_network_publicip_get => sub { return 'GRANCHIETTI'; });
+
+    zp_ssh_connect();
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /ssh.*StrictHostKeyChecking=accept-new.*cloudadmin\@GRANCHIETTI/ } @calls),
+        'StrictHostKeyChecking');
+};
+
+subtest '[zp_add_repos]' => sub {
+    my $zp = Test::MockModule->new('sles4sap::cloud_zypper_patch', no_auto => 1);
+    my @calls;
+    $zp->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $zp->redefine(zp_azure_resource_group => sub { return 'SPIAGGIA'; });
+    $zp->redefine(az_network_publicip_get => sub { return 'GRANCHIETTI'; });
+    $zp->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    zp_add_repos(
+        ip => 'CREMASOLARE',
+        name => 'PANINO',
+        repos => 'SDRAIO,Development-Tools,SEDIA,ASCIUGAMANO');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /ssh.*zypper.*ar.*TEST_0.*SDRAIO/ } @calls), "SDRAIO repo is in TEST_0");
+    ok((any { /ssh.*zypper.*ar.*TEST_1.*SEDIA/ } @calls), "SEDIA repo is in TEST_1");
+    ok((any { /ssh.*zypper.*ar.*TEST_2.*ASCIUGAMANO/ } @calls), "ASCIUGAMANO repo is in TEST_2");
+};
+
+subtest '[zp_add_repos]' => sub {
+    my $zp = Test::MockModule->new('sles4sap::cloud_zypper_patch', no_auto => 1);
+    my @calls;
+    $zp->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $zp->redefine(zp_azure_resource_group => sub { return 'SPIAGGIA'; });
+    $zp->redefine(az_network_publicip_get => sub { return 'GRANCHIETTI'; });
+
+    zp_zypper_patch();
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /ssh.*zypper.*patch/ } @calls), "SDRAIO repo is in TEST_0");
+};
+
+done_testing;

--- a/tests/sles4sap/cloud_zypper_patch/add_repo.pm
+++ b/tests/sles4sap/cloud_zypper_patch/add_repo.pm
@@ -1,0 +1,38 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Add all additional zypper repositories defined in INCIDENT_REPO
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use sles4sap::cloud_zypper_patch;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    my ($self) = @_;
+
+    die('Azure is the only CSP supported for the moment')
+      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+
+    select_serial_terminal;
+
+    zp_ssh_connect();
+    zp_add_repos(ip => get_required_var('IBSM_IP'),
+        name => 'download.suse.de',
+        repos => get_var('INCIDENT_REPO'));
+}
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/cloud_zypper_patch/deploy.pm
+++ b/tests/sles4sap/cloud_zypper_patch/deploy.pm
@@ -1,0 +1,41 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: create a deployment with a single VM on Microsoft Azure cloud.
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use sles4sap::cloud_zypper_patch;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+
+sub run {
+    my ($self) = @_;
+
+    die('Azure is the only CSP supported for the moment')
+      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+
+    select_serial_terminal;
+
+    # Init all the PC gears (ssh keys, CSP credentials)
+    my $provider = $self->provider_factory();
+
+    zp_azure_deploy(
+        region => $provider->provider_client->region,
+        os => get_required_var('CLUSTER_OS_VER'));
+}
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    zp_azure_destroy();
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/cloud_zypper_patch/destroy.pm
+++ b/tests/sles4sap/cloud_zypper_patch/destroy.pm
@@ -1,0 +1,35 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: destroy the cloud deployment
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use sles4sap::cloud_zypper_patch;
+
+sub run {
+    my ($self) = @_;
+
+    die('Azure is the only CSP supported for the moment')
+      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+
+    select_serial_terminal;
+
+    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/cloud_zypper_patch/network_peering.pm
+++ b/tests/sles4sap/cloud_zypper_patch/network_peering.pm
@@ -1,0 +1,36 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Create a network peering to the IBSm
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use sles4sap::cloud_zypper_patch;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+
+sub run {
+    my ($self) = @_;
+
+    die('Azure is the only CSP supported for the moment')
+      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+
+    select_serial_terminal;
+
+    zp_azure_netpeering(target_rg => get_required_var('ZP_IBSM_RG'));
+}
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/cloud_zypper_patch/zypper_patch.pm
+++ b/tests/sles4sap/cloud_zypper_patch/zypper_patch.pm
@@ -1,0 +1,36 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: perform a zypper patch on the SUT
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use sles4sap::cloud_zypper_patch;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+
+sub run {
+    my ($self) = @_;
+
+    die('Azure is the only CSP supported for the moment')
+      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+
+    select_serial_terminal;
+
+    zp_zypper_patch();
+}
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    $self->SUPER::post_fail_hook;
+}
+
+1;


### PR DESCRIPTION
New test sequence and relative test modules. Aim of this one is to be minimal, require few time and reduced set of cloud resources.
Test sequence:
1. create a VM on the cloud,
2. network peering to the IBSm
3. add repos
4. run zypper patch.

To give a scale of times:

- this test takes **7min 30sec** and cost **€0.01**
- qesap regression (without netpeering and add repo) **50min**
- hanasr (without netpeering and add repo) **2h 20min**


Related ticket : https://jira.suse.com/browse/TEAM-9492

# Verification run:  
http://openqaworker15.qa.suse.cz/tests/287324
