### PR TITLE
console/arping: Add missing record_info()

### DIFF
--- a/tests/console/arping.pm
+++ b/tests/console/arping.pm
@@ -51,6 +51,7 @@ sub run {
     }
 
     my $cmd = "arping -w2 $route";
+    record_info($cmd);
     my $rc = script_run($cmd);
     if ($rc) {
         my $bug;


### PR DESCRIPTION
Fixes: 10f13dbef ("console: Add simple arping tests")

Verification run:
- http://quasar.suse.cz/tests/3500#step/arping/72
- http://quasar.suse.cz/tests/3501#step/arping/72