### PR TITLE
xfstests: fix generate_report issue

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -541,7 +541,9 @@ sub run {
         my %skipped = map { $_ => 1 } $whitelist->list_skipped_tests($whitelist_env, $TEST_SUITE);
         %black_list = (%black_list, %skipped);
         my $known_issues = $whitelist->{whitelist}->{$TEST_SUITE};
-        set_var('XFSTESTS_SOFTFAIL', (get_var('XFSTESTS_SOFTFAIL') . join(',', keys(%$known_issues))));
+        my @soft_fail = keys(%$known_issues);
+        push @soft_fail, split(',', get_var('XFSTESTS_SOFTFAIL'));
+        set_var('XFSTESTS_SOFTFAIL', join(',', @soft_fail));
     }
 
     my $status_log_content = "";


### PR DESCRIPTION
We got error in generate_report.pm if both XFSTESTS_SOFTFAIL and XFSTESTS_KNOWN_ISSUES are set. Fix it by resolving conflict.

- Related ticket: https://progress.opensuse.org/issues/162566
- Needles: N/A
- Verification run: 
http://10.67.133.133/tests/662 (both XFSTESTS_SOFTFAT and XFSTESTS_KNOWN_ISSUES are set)
http://10.67.133.133/tests/663 (only XFSTESTS_KNOWN_ISSUES)