### PR TITLE
containers: Remove redundant platform checks for BATS tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -293,16 +293,16 @@ sub load_container_tests {
 
     if (get_var('PODMAN_BATS_SKIP')) {
         if (!check_var('SKOPEO_BATS_SKIP', 'all')) {
-            loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle('>=15-SP4') || is_leap('>=15.4') || is_sle_micro('>=5.5'));
+            loadtest 'containers/skopeo_integration';
         }
         if (!check_var('PODMAN_BATS_SKIP', 'all')) {
             loadtest 'containers/podman_integration';
         }
         if (!check_var('RUNC_BATS_SKIP', 'all')) {
-            loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
+            loadtest 'containers/runc_integration';
         }
         if (!check_var('NETAVARK_BATS_SKIP', 'all')) {
-            loadtest 'containers/netavark_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
+            loadtest 'containers/netavark_integration';
         }
         if (!check_var('AARDVARK_BATS_SKIP', 'all')) {
             loadtest 'containers/aardvark_integration' if (is_tumbleweed);
@@ -311,7 +311,7 @@ sub load_container_tests {
     }
 
     if (get_var('BUILDAH_BATS_SKIP')) {
-        loadtest 'containers/buildah_integration' if (is_tumbleweed || is_sle('>=15-SP4') || is_leap('>=15.4'));
+        loadtest 'containers/buildah_integration';
         return;
     }
 


### PR DESCRIPTION
The checks are redundant as we schedule these tests from YAML.  We only need to restrict the `aardvark-dns` test to Tumbleweed.  This clears the way to adding the tests for 15-SP3 that got podman 4.9.5 (and soon 15-SP2).

Verification runs: Not needed.