### PR TITLE
Reconstruct MU guest migration test: merge chained tests into combined single testsuite

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2451,19 +2451,19 @@ sub load_hypervisor_tests {
 
     if (check_var('ENABLE_VM_INSTALL', 1)) {
         loadtest "virt_autotest/login_console";
-        loadtest "virtualization/universal/prepare_guests";
-        loadtest "virtualization/universal/waitfor_guests";
+        unless (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1')) {
+            loadtest "virtualization/universal/prepare_guests";
+            loadtest "virtualization/universal/waitfor_guests";
+        }
         if (check_var('PATCH_WITH_ZYPPER', 1)) {
             loadtest "virtualization/universal/patch_and_reboot";
-            if (my $update_package = get_var('UPDATE_PACKAGE')) {
-                if ($update_package eq 'kernel-default') {
-                    loadtest "virt_autotest/login_console";
-                    loadtest "virtualization/universal/list_guests";
-                    loadtest "virtualization/universal/patch_guests";
-                } elsif ($update_package eq 'xen' || $update_package eq 'qemu') {
-                    loadtest "virt_autotest/login_console";
-                    loadtest "virtualization/universal/list_guests";
-                }
+            if (check_var('UPDATE_PACKAGE', 'kernel-default')) {
+                loadtest "virt_autotest/login_console";
+                loadtest "virtualization/universal/list_guests";
+                loadtest "virtualization/universal/patch_guests";
+            } elsif (check_var('UPDATE_PACKAGE', 'xen') || check_var('UPDATE_PACKAGE', 'qemu')) {
+                loadtest "virt_autotest/login_console";
+                loadtest "virtualization/universal/list_guests" unless (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1'));
             }
         }
         loadtest "virtualization/universal/kernel";
@@ -2524,6 +2524,17 @@ sub load_hypervisor_tests {
     }
     # Load ENABLE_SNAPSHOTS at the end
     check_and_load_mu_virt_features('ENABLE_SNAPSHOTS', $virt_features{ENABLE_SNAPSHOTS}{modules}, $virt_features{ENABLE_SNAPSHOTS}{hypervisor});
+
+    # Guest migration tests
+    if (check_var('VIRT_NEW_GUEST_MIGRATION_SOURCE', '1')) {
+        loadtest "virt_autotest/login_console";
+        loadtest "virt_autotest/parallel_guest_migration_source";
+    }
+    if (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1')) {
+        loadtest "virt_autotest/parallel_guest_migration_barrier";
+        loadtest "virt_autotest/login_console";
+        loadtest "virt_autotest/parallel_guest_migration_destination";
+    }
 }
 
 sub load_extra_tests_syscontainer {

--- a/tests/virtualization/universal/patch_and_reboot.pm
+++ b/tests/virtualization/universal/patch_and_reboot.pm
@@ -30,7 +30,9 @@ sub run {
 
     if (get_var("UPDATE_PACKAGE") =~ /xen|kernel-default|qemu/) {
         script_run("virsh list --all | grep -v Domain-0");
-        script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
+        unless (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1')) {
+            script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
+        }
         script_run '( sleep 15 && reboot & )';
         save_screenshot;
         switch_from_ssh_to_sol_console(reset_console_flag => 'on');
@@ -39,7 +41,9 @@ sub run {
         restart_libvirtd;
         script_run("virsh list --all | grep -v Domain-0");
         # Check that all guests are still running
-        script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
+        unless (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1')) {
+            script_retry("nmap $_ -PN -p ssh | grep open", delay => 60, retry => 60) foreach (keys %virt_autotest::common::guests);
+        }
     }
 }
 sub post_run_hook {


### PR DESCRIPTION
This PR mainly implements A3 task https://progress.opensuse.org/issues/160850, so it does mainly below:
- move below testsuites into one kvm testsuite, eg with name qam-kvm-migration-src
qam_virt_kvm_install_host_migration_src
qam_virt_kvm_install_guests_migration_src
qam_virt_kvm_guests_migration_src
- move below testsuites into one kvm testsuite, eg with name qam-kvm-migration-dst
qam_virt_kvm_install_host_migration_dst
qam_virt_kvm_install_guests_migration_dst
qam_virt_kvm_guests_migration_dst
- qam-kvm-migration-src has PARALLEL_WITH relation with qam-kvm-migration-dst
- move below testsuites into one xen testsuite, eg with name qam-xen-migration-src
qam_virt_kvm_install_host_migration_src
qam_virt_kvm_install_guests_migration_src
qam_virt_kvm_guests_migration_src
- move below testsuites into one xen testsuite, eg with name qam-xen-migration-dst
qam_virt_xen_install_host_migration_dst
qam_virt_xen_install_guests_migration_dst
qam_virt_xen_guests_migration_dst
- qam-xen-migration-src has PARALLEL_WITH relation with qam-xen-migration-dst
- within each testsuite, it supports switch settings to enable or disable host installation, guest installation.


Job Group Yaml file(in development group now, will be updated to official job group when PR merged):
- http://openqa.qam.suse.cz/admin/job_templates/174?

Verification run: 
- 15sp5 kvm, PASS:
http://openqa.qam.suse.cz/tests/76068
http://openqa.qam.suse.cz/tests/76069

- 15sp5 xen, PASS:
  http://openqa.qam.suse.cz/tests/76248
  http://openqa.qam.suse.cz/tests/76249

- 12SP5 kvm, GUEST_ADMINISTRATION=1 INTERVAL_LOG=1: PASS
http://openqa.qam.suse.cz/tests/76220
http://openqa.qam.suse.cz/tests/76221

- 12sp5 xen  GUEST_ADMINISTRATION=1 INTERVAL_LOG=1: PASSED
http://openqa.qam.suse.cz/tests/76170
http://openqa.qam.suse.cz/tests/76171

- skip host and guest install for 15sp5 xen,  ENABLE_HOST_INSTALLATION=0 ENABLE_VM_INSTALL=0: PASS
 http://openqa.qam.suse.cz/tests/76172
 http://openqa.qam.suse.cz/tests/76173

- new verification after code rebase on merged A1 task(together with A4):
```
verification run on http://10.67.129.77/

PASS
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-KVM-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-kvm-migration-src,qam-kvm-migration-dst BUILD=":123456:qemu"
{"count":2,"failed":[],"ids":[769,770],"scheduled_product_id":315}

PASS
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-XEN-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-xen-migration-src,qam-xen-migration-dst BUILD=":123456:xen"
{"count":2,"failed":[],"ids":[777,778],"scheduled_product_id":316}

PASS
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-KVM-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-kvm-migration-src,qam-kvm-migration-dst BUILD=":123456:libvirt"
{"count":2,"failed":[],"ids":[779,780],"scheduled_product_id":321}

PASS(PATCH_WITH_ZYPPER=1, UPDATE_PACKAGE=libvirt, ignore the last migration sub-test failure)
http://10.67.129.77/tests/801#
http://10.67.129.77/tests/802#


WIP  (PATCH_WITH_ZYPPER=1,UPDATE_PACKAGE=xen)
http://openqa.qam.suse.cz/tests/77898
http://openqa.qam.suse.cz/tests/77897

```
