### PR TITLE
Extend git_clone() function

### DIFF
--- a/lib/Utils/Git.pm
+++ b/lib/Utils/Git.pm
@@ -23,14 +23,22 @@ C<Utils::Git> - Library for various git related functions
 
 =head2 git_clone
 
-    git_clone('https://github.com/myrepo/tree/main' [, branch=>'development', quiet=>'1', skip_ssl_verification=>'true',
+    git_clone('https://github.com/myrepo/tree/main'
+        [, branch=>'development',
+        depth=>1,
+        single_branch=>1,
+        skip_ssl_verification=>'true',
         output_log_file=>'git_clone.log']);
 
 B<repository>: Git repository url. Mandatory argument.
 
-B<branch>: Clone specific branch. Default: not defined
+B<branch>: Clone and checkout specific branch (or tag). Default: not defined
 
-B<quiet>: Minimize output verbosity. Default: false
+B<single_branch>:  Enable cloning of branch (or tag) only. Branch is the one specified in `branch` argument.
+    This can speed up cloning process by omitting unnecessary branches. Default: not defined
+
+B<depth>: Shallow clone with truncated history to the specified number of commits.
+    This speeds up cloning process by not cloning whole commit history. Default: not defined
 
 B<skip_ssl_verification>: Disable SSL verification. Can be useful in case of self signed certificates.
     Define this parameter B<ONLY> if you want to skip verification. Default: undef
@@ -52,7 +60,14 @@ sub git_clone {
     $git_cmd =~ s/git/git -c http.sslVerify=false/ if $args{skip_ssl_verification};
 
     # Checkout branch
-    $git_cmd .= " -b $args{branch}" if $args{branch};
+    $git_cmd .= " --branch $args{branch}" if $args{branch};
+
+    # Pro tip: cloning with --single-branch and --depth=1 gives you infinite cloning speed boost.
+    # Clone single branch
+    $git_cmd .= " --single-branch" if $args{single_branch};
+
+    # Shallow clone -  add --depth option
+    $git_cmd .= " --depth $args{depth}" if $args{depth};
 
     # Append repository
     $git_cmd .= " $repository";

--- a/lib/sles4sap/sdaf_deployment_library.pm
+++ b/lib/sles4sap/sdaf_deployment_library.pm
@@ -628,10 +628,14 @@ sub prepare_sdaf_project {
 
     git_clone(get_required_var('SDAF_GIT_AUTOMATION_REPO'),
         branch => get_var('SDAF_GIT_AUTOMATION_BRANCH'),
+        depth => '1',
+        single_branch => 'yes',
         output_log_file => log_dir() . '/git_clone_automation.log');
 
     git_clone(get_required_var('SDAF_GIT_TEMPLATES_REPO'),
         branch => get_var('SDAF_GIT_TEMPLATES_BRANCH'),
+        depth => '1',
+        single_branch => 'yes',
         output_log_file => log_dir() . '/git_clone_templates.log');
 
     assert_script_run("cp -Rp sap-automation-samples/Terraform/WORKSPACES $deployment_dir/WORKSPACES");

--- a/t/23_utils_git.t
+++ b/t/23_utils_git.t
@@ -18,9 +18,16 @@ subtest '[git_clone] Compose command' => sub {
     git_clone($repository);
     is join(' ', @calls), "git clone $repository", "Check base command composition";
 
-    git_clone($repository, skip_ssl_verification => 'true', output_log_file => 'output.log', branch => 'world_domination');
+    git_clone($repository, skip_ssl_verification => 'true',
+        output_log_file => 'output.log',
+        branch => 'world_domination',
+        single_branch => 'yes',
+        depth => 'not_too_deep'
+    );
     ok(grep(/git.*-c http.sslVerify=false.*clone/, @calls), 'Option "-c http.sslVerify=false " must be between "git" and "clone"');
-    ok(grep(/clone.*-b world_domination.*$repository/, @calls), 'Checkout branch - option must be between "clone" repository url');
+    ok(grep(/clone.*--branch world_domination.*$repository/, @calls), 'Checkout branch - option must be between "clone" repository url');
+    ok(grep(/clone.*--depth not_too_deep.*$repository/, @calls), 'Argument "--depth" for shallow clone - option must be between "clone" repository url');
+    ok(grep(/clone.*--single-branch.*$repository/, @calls), 'Argument "--single-branch" for cloning a single branch only');
     ok(grep(/2>&1 | tee output.log$/, @calls), 'Log output to a file');
     ok(grep(/^set -o pipefail;/, @calls), 'Set bash command to fail immediately with logging');
 };


### PR DESCRIPTION
This PR extends git_clone() function to make shallow clone and not cloning 
unnecessary branches or tags. This can speed up clonign bigger projects. Both 
functionalities are optional but set as default for SDAF project. 

- Verification run: https://openqaworker15.qa.suse.cz/tests/286691#step/sdaf_deployer_setup/38

VR failure related to:  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19555