### PR TITLE
Add support to publish qcow2 images on HA cluster schedules

### DIFF
--- a/schedule/ha/bv/basic_cluster_node.yaml
+++ b/schedule/ha/bv/basic_cluster_node.yaml
@@ -69,6 +69,7 @@ schedule:
   - '{{remove_node}}'
   - '{{graceful_shutdown}}'
   - ha/check_logs
+  - '{{create_hdd_tests}}'
 conditional_schedule:
   cluster_setup:
     HA_CLUSTER_INIT:
@@ -97,3 +98,17 @@ conditional_schedule:
     HA_GRACEFUL_SHUTDOWN:
       1:
         - ha/graceful_shutdown
+  create_hdd_tests:
+    CREATE_HDD:
+      1:
+        - migration/deregister_system
+        - ha/prepare_shutdown
+        - console/force_scheduled_tasks
+        - shutdown/grub_set_bootargs
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown
+        - '{{svirt_upload_assets}}'
+  svirt_upload_assets:
+    BACKEND:
+      svirt:
+        - shutdown/svirt_upload_assets

--- a/schedule/ha/bv/ha_supportserver.yaml
+++ b/schedule/ha/bv/ha_supportserver.yaml
@@ -33,3 +33,10 @@ schedule:
   - support_server/setup
   - ha/barrier_init
   - support_server/wait_children
+  - '{{create_hdd_tests}}'
+conditional_schedule:
+  create_hdd_tests:
+    CREATE_HDD:
+      1:
+        - support_server/clear_leases
+        - shutdown/shutdown

--- a/tests/support_server/clear_leases.pm
+++ b/tests/support_server/clear_leases.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: remove DHCP leases DB from support server
+# Maintainer: Alvaro Carvajal <acarvajal@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'systemctl';
+
+sub run {
+    my ($self) = @_;
+    systemctl 'stop dhcpd';
+    my $leases = '/var/lib/dhcp/db/dhcpd.leases';
+    assert_script_run "cp -f $leases ${leases}~";
+    assert_script_run "> $leases";
+}
+
+1;


### PR DESCRIPTION
This introduces into the basic HA cluster schedules:

- `schedule/ha/bv/basic_cluster_node.yaml`
- `schedule/ha/bv/ha_supportserver.yaml`

Support to use them to publish the qcow2 images after the cluster jobs finish, by adding the CREATE_HDD=1 setting in the jobs.

Also included in the commit is the a new module for the support server to clear the lease database from the DHCP server, as this would allow the migration jobs which run from the generated qcow2 to get the same IP addresses as the ones using during qcow2 creation without needing to fix the macaddresses of the SUTs.

**Note:** only tested in x86_64 so far, but I expect it to work in aarch64 and ppc64le with `qemu` backends. There is the possibility that these schedules are not fully compatible for `svirt` backend, but I believe we use different schedules for zalpha cluster (alpha on Z systems)

- Related ticket: https://jira.suse.com/browse/TEAM-9447
- Needles: N/A
- Verification run: [node 1](http://mango.qe.nue2.suse.org/tests/6011), [node 2](http://mango.qe.nue2.suse.org/tests/6012), [support server](http://mango.qe.nue2.suse.org/tests/6010)
