### PR TITLE
containers: Use our own nginx instead of dockerhub httpd

### DIFF
--- a/data/containers/nginx.conf
+++ b/data/containers/nginx.conf
@@ -1,0 +1,16 @@
+events {
+    worker_connections  1024;
+    use epoll;
+}
+
+http {
+  server {
+    listen 80;
+    listen [::]:80;
+
+    location / {
+        root   /srv/www/htdocs/;
+        index  index.html index.htm;
+    }
+  }
+}


### PR DESCRIPTION
Use our own nginx instead of DockerHub's httpd to avoid rate-limit issues.

- Related ticket: https://progress.opensuse.org/issues/162638
- Verification runs:
  - SLEM-5.1 x86_64: https://openqa.suse.de/tests/14728572
