### PR TITLE
check_kernel_taint: Implement configurable taint mask

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -19,7 +19,8 @@ use version_utils qw(is_sle is_transactional);
 
 our @EXPORT
   = qw(capture_state check_automounter is_patch_needed add_test_repositories disable_test_repositories enable_test_repositories
-  add_extra_customer_repositories ssh_add_test_repositories remove_test_repositories advance_installer_window get_patches check_patch_variables add_repo_if_not_present);
+  add_extra_customer_repositories ssh_add_test_repositories remove_test_repositories advance_installer_window get_patches check_patch_variables add_repo_if_not_present
+  has_published_assets);
 use constant ZYPPER_PACKAGE_COL => 1;
 use constant OLD_ZYPPER_STATUS_COL => 4;
 use constant ZYPPER_STATUS_COL => 5;
@@ -241,6 +242,11 @@ sub check_patch_variables {
     elsif (!$patch && !$incident_id) {
         die("Missing INCIDENT_PATCH or INCIDENT_ID");
     }
+}
+
+# Return count of PUBLISH_* job variables
+sub has_published_assets {
+    return scalar grep { m/^PUBLISH_/ } keys %bmwqemu::vars;
 }
 
 1;

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -14,6 +14,7 @@ use utils;
 use LTP::utils;
 use power_action_utils 'power_action';
 use upload_system_log;
+use qam;
 
 sub export_to_json {
     my ($test_result_export) = @_;
@@ -33,7 +34,7 @@ sub run {
     }
 
     script_run('df -h');
-    check_kernel_taint($self, 1);
+    check_kernel_taint($self, has_published_assets() ? 1 : 0);
 
     if (get_var('LTP_COMMAND_FILE')) {
         my $ver_linux_log = '/tmp/ver_linux_after.txt';

--- a/variables.md
+++ b/variables.md
@@ -132,6 +132,7 @@ LTP_REPO | string | | The repo which will be added and is used to install LTP pa
 LTP_RUN_NG_BRANCH | string | master | Define the branch of the LTP_RUN_NG_REPO.
 LTP_RUN_NG_REPO | string | https://github.com/metan-ucw/runltp-ng.git | Define the runltp-ng repo to be used. Default in publiccloud/run_ltp.pm is the upstream master branch from https://github.com/metan-ucw/runltp-ng.git.
 LTP_PC_RUNLTP_ENV | string | empty | Contains eventual internal environment new parameters for `runltp-ng`, defined with the `--env` option, initialized in a column-separated string format: "PAR1=xxx:PAR2=yyy:...". By default it is empty, undefined.
+LTP_TAINT_EXPECTED | integer | 0x80019801 | Bitmask of expected kernel taint flags.
 LVM | boolean | false | Use lvm for partitioning.
 LVM_THIN_LV | boolean | false | Use thin provisioning logical volumes for partitioning,
 MACHINE | string | | Define machine name which defines worker specific configuration, including WORKER_CLASS.


### PR DESCRIPTION
Add `LTP_TAINT_EXPECTED` variable which allows setting the expected list of kernel taint flags. Any flag not in the expected list will be treated as a test failure. Flags on the list will be reported in either case but without impact on the final result.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - livepatches, not tainted: https://openqa.suse.de/tests/14971088
  - livepatches, tainted: https://openqa.suse.de/tests/14971090
  - livepatches, taint whitelisted: https://openqa.suse.de/tests/14971091
  - boot_ltp, not tainted: https://openqa.suse.de/tests/15225281
  - boot_ltp, tainted: https://openqa.suse.de/tests/15225282
  - install_ltp, tainted: https://openqa.suse.de/tests/15225275