### PR TITLE
jeos: firstrun: handle SSH enrollment dialog on SL Micro 6.1 (poo#162656)

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -197,15 +197,15 @@ sub run {
         # Continues below to verify that /etc/issue shows the recovery key
     }
 
-    # Skip ssh key enrollment (for now)
-    unless (is_sle || is_sle_micro || is_leap) {
-        assert_screen 'jeos-ssh-enroll-or-not';
-        send_key 'n';
-    }
-
     if (is_sle || is_sle_micro) {
         assert_screen 'jeos-please-register';
         send_key 'ret';
+    }
+
+    # Skip ssh key enrollment (for now)
+    unless (is_sle || is_sle_micro('<=6.0') || is_leap) {
+        assert_screen 'jeos-ssh-enroll-or-not';
+        send_key 'n';
     }
 
     if (is_generalhw && is_aarch64 && !is_leap("<15.4") && !is_tumbleweed) {


### PR DESCRIPTION
A jeos-firstboot version supporting this feature landed in SLFO, so handle it the same way it's handled in TW.

Also move the unless block further down as the "please register" dialog actually is shown before.

- Related ticket: https://progress.opensuse.org/issues/162656
- Needles: added via Web UI
- Verification run (on 6.1): https://openqa.suse.de/tests/14694718


I tried to do a verification run on 6.0 as well, but I think the assets are not there anymore (or perhaps they got renamed? :thinking: )

I don't have enough privileges to do a run on Tumbleweed.