### PR TITLE
update_install: Add new mpich-hpc-macros-devel conflict

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -73,6 +73,8 @@ my @conflicting_packages = (
     'python-azure-agent-config-hpc', 'python-azure-agent-config-default',
     'regionServiceClientConfigAzure', 'regionServiceClientConfigEC2', 'regionServiceClientConfigGCE',
     'libcontainers-openSUSE-policy',
+    'mpich_4_0_2-gnu-hpc-macros-devel', 'mpich-ofi_4_0_2-gnu-hpc-macros-devel',
+    'openmpi4-config', 'pmix-mca-params',
     'rmt-server-pubcloud',
     'kernel-default-base', 'kernel-default-extra'
 );


### PR DESCRIPTION
```
mpich_4_0_2-gnu-hpc-macros-devel-4.0.2-150500.3.2.1.s390x conflicts with 'namespace:otherproviders(mpich-hpc-macros-devel)' provided by the to be installed mpich-ofi_4_0_2-gnu-hpc-macros-devel-4.0.2-150500.3.2.1.s390x

https://build.suse.de/projects/SUSE:SLE-15-SP6:GA/packages/mpich/files/mpich.spec?expand=1
Provides:       %{pname}-hpc-macros-devel = %{version}
Conflicts:      otherproviders(%{pname}-hpc-macros-devel)

openmpi4-config-4.1.4-150500.3.2.1.s390x conflicts with 'namespace:otherproviders(pmix-runtime-config)' provided by the to be installed pmix-mca-params-3.2.3-150300.3.10.1.noarch

https://build.suse.de/projects/SUSE:SLE-15:GA/packages/openmpi/files/openmpi.spec?expand=1
Provides:       %{pname}-runtime-config = %{version}
Conflicts:      otherproviders(openmpi-runtime-config)
```

- Related ticket: https://openqa.suse.de/tests/14694999#step/update_install/1050 https://openqa.suse.de/tests/14694968#step/update_install/379
- Verification run: https://openqa.suse.de/tests/14695155
