### PR TITLE
ltp: Enable repositories on Full installation medium

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -330,6 +330,9 @@ sub run {
     set_zypper_lock_timeout(300);
     add_we_repo_if_available;
 
+    # Enables repositories on full installation medium
+    zypper_enable_install_dvd if (get_var('FLAVOR') == 'Full-QR');
+
     if ($inst_ltp =~ /git/i) {
         install_build_dependencies;
         install_runtime_dependencies;


### PR DESCRIPTION
Enhancement poo#162659: We need to support LTP installation on Full medium without SCC registration. Needed repositories are already added by installation, but they are disabled by default. We just need to enable them.

- Related ticket: https://progress.opensuse.org/issues/162659
- Needles: none
- Verification run: 
Full-QR:  https://openqa.suse.de/tests/14702024#step/install_ltp/45
Online-QR (as example on non full flavor): https://openqa.suse.de/tests/14701996

