### PR TITLE
containers/firewall: Allow netcat container little time to start

### DIFF
--- a/tests/containers/firewall.pm
+++ b/tests/containers/firewall.pm
@@ -39,8 +39,9 @@ sub run {
     my $image = "registry.opensuse.org/opensuse/busybox:latest";
     assert_script_run "$runtime pull $image";
     assert_script_run "$runtime run -d --name $container_name -p 1234:1234 $image nc -l -p 1234";
+    script_retry "ss -tln sport = :1234", delay => 5, retry => 3;
     assert_script_run "echo Hola Mundo >/dev/tcp/127.0.0.1/1234";
-    assert_script_run "$runtime logs $container_name | grep Hola";
+    script_retry "$runtime logs $container_name | grep Hola", delay => 5, retry => 3;
 
     assert_script_run "$runtime stop $container_name ";
     assert_script_run "$runtime rm -vf $container_name ";


### PR DESCRIPTION
The container firewall test was failing imo because of it can take a little bit of time for container to start (especially the first container). This adds check for that.

- Related ticket: [poo#162629](https://progress.opensuse.org/issues/162629)
- Verification run: https://openqa.suse.de/tests/14702724#
