### PR TITLE
LTP: Install recommended packages also on transactional

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -457,7 +457,7 @@ sub install_from_repo {
     my @pkgs = split(/\s* \s*/, get_var('LTP_PKG', get_default_pkg));
 
     if (is_transactional) {
-        assert_script_run("transactional-update -n -c pkg install " . join(' ', @pkgs), 180);
+        assert_script_run("transactional-update -n -c pkg install --recommends " . join(' ', @pkgs), 180);
     } else {
         zypper_call("in --recommends " . join(' ', @pkgs));
     }


### PR DESCRIPTION
We use --recommends when installing on common distro. We need to add it also for transactional distros (e.g. Micro)

Verification run: [TODO](https://openqa.suse.de/tests/overview?build=LTP/fix-ltp-install-on-micro)

@coolgw @czerw FYI