### PR TITLE
ENSA2 test set maintenance from one node

### DIFF
--- a/tests/sles4sap/ensa/netweaver_ensa2_cluster.pm
+++ b/tests/sles4sap/ensa/netweaver_ensa2_cluster.pm
@@ -16,8 +16,6 @@ use lockapi;
 
 sub run {
     my ($self) = @_;
-    # Set maintenance to 'true'
-    assert_script_run("crm configure property maintenance-mode='true'");
     my $instance_type = get_required_var('INSTANCE_TYPE');
     my $install_data = $self->netweaver_installation_data();
 
@@ -52,10 +50,12 @@ sub run {
         file_content_replace("$temp_dir/$template_file", '--sed-modifier' => 'g', %template_variables);
 
         upload_logs("$temp_dir/$template_file");
+        # Set maintenance to 'true'
+        assert_script_run("crm configure property maintenance-mode='true'");
         assert_script_run("crm configure load update $temp_dir/$template_file");
+        assert_script_run("crm configure property maintenance-mode='false'");
         barrier_wait('ENSA_CLUSTER_SETUP');
     }
-    assert_script_run("crm configure property maintenance-mode='false'");
     wait_until_resources_started();
     $self->sap_show_status_info(cluster => 1, netweaver => 1,
         instance_id => $install_data->{instances}{$instance_type}{instance_id});


### PR DESCRIPTION
When need to enter in cluster maintenance mode, only execute crm command to do it in one and let the cluster propagate the info. cluster node.

- Related ticket: TEAM-9471

# Verification run:

 - sle-15-SP5-Server-DVD-SAP-Incidents-x86_64-Build:33600:aws-cli-sles4sap_ensa_supportserver@64bit-4gbram -> http://openqaworker15.qa.suse.cz/tests/286772
 - sle-15-SP5-Server-DVD-SAP-Incidents-x86_64-Build:33600:aws-cli-sles4sap_ensa_ascs_node@64bit-sap -> http://openqaworker15.qa.suse.cz/tests/286771
 - sle-15-SP5-Server-DVD-SAP-Incidents-x86_64-Build:33600:aws-cli-sles4sap_ensa_ers_node@64bit-sap -> http://openqaworker15.qa.suse.cz/tests/286770

