### PR TITLE
Remove wsl patterns from autoyast profiles for support images

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_allpatterns_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_allpatterns_aarch64.xml
@@ -61,9 +61,6 @@
       <pattern>print_server</pattern>
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11_enhanced</pattern>
       <pattern>x11_raspberrypi</pattern>

--- a/data/autoyast_sle15/create_hdd/create_hdd_gnome_sdk_allpatterns_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_gnome_sdk_allpatterns_aarch64.xml
@@ -65,9 +65,6 @@
       <pattern>print_server</pattern>
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11_raspberrypi</pattern>
       <pattern>x11</pattern>
       <pattern>x11_enhanced</pattern>

--- a/data/yam/autoyast/autoyast_pcm_lgm_allpatterns_ppc64le.xml.ep
+++ b/data/yam/autoyast/autoyast_pcm_lgm_allpatterns_ppc64le.xml.ep
@@ -109,9 +109,6 @@
       <pattern>fips</pattern>
       <pattern>ofed</pattern>
       <pattern>sap_server</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
     </patterns>
   </software>
   <networking>

--- a/data/yam/autoyast/create_hdd_gnome_allpatterns_aarch64.xml
+++ b/data/yam/autoyast/create_hdd_gnome_allpatterns_aarch64.xml
@@ -61,9 +61,6 @@
       <pattern>print_server</pattern>
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11_enhanced</pattern>
       <pattern>x11_raspberrypi</pattern>

--- a/data/yam/autoyast/create_hdd_gnome_sdk_allpatterns_aarch64.xml
+++ b/data/yam/autoyast/create_hdd_gnome_sdk_allpatterns_aarch64.xml
@@ -65,9 +65,6 @@
       <pattern>print_server</pattern>
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11_raspberrypi</pattern>
       <pattern>x11</pattern>
       <pattern>x11_enhanced</pattern>

--- a/data/yam/autoyast/support_images/create_hdd_hpc_development_node_aarch64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_development_node_aarch64.xml.ep
@@ -340,9 +340,6 @@
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_enhanced</pattern>

--- a/data/yam/autoyast/support_images/create_hdd_hpc_development_node_x86_64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_development_node_x86_64.xml.ep
@@ -341,9 +341,6 @@
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_enhanced</pattern>

--- a/data/yam/autoyast/support_images/create_hdd_hpc_management_server_aarch64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_management_server_aarch64.xml.ep
@@ -351,9 +351,6 @@
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_enhanced</pattern>

--- a/data/yam/autoyast/support_images/create_hdd_hpc_textmode_aarch64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_textmode_aarch64.xml.ep
@@ -340,9 +340,6 @@
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_enhanced</pattern>

--- a/data/yam/autoyast/support_images/create_hdd_hpc_textmode_x86_64.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_hpc_textmode_x86_64.xml.ep
@@ -341,9 +341,6 @@
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_enhanced</pattern>

--- a/data/yam/autoyast/support_images/sles15sp4_install_gnome_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_gnome_all_patterns_aarch64.xml
@@ -78,9 +78,6 @@ exit 0
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>

--- a/data/yam/autoyast/support_images/sles15sp4_install_gnome_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_gnome_all_patterns_x86_64.xml
@@ -78,9 +78,6 @@ exit 0
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_aarch64.xml
@@ -78,9 +78,6 @@ exit 0
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>

--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_x86_64.xml
@@ -78,9 +78,6 @@ exit 0
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>

--- a/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_aarch64.xml
@@ -78,9 +78,6 @@ exit 0
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>

--- a/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_x86_64.xml
@@ -78,9 +78,6 @@ exit 0
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_aarch64.xml
@@ -78,9 +78,6 @@ exit 0
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_x86_64.xml
@@ -78,9 +78,6 @@ exit 0
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
       <pattern>sw_management-32bit</pattern>
-      <pattern>wsl_base</pattern>
-      <pattern>wsl_gui</pattern>
-      <pattern>wsl_systemd</pattern>
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2466,6 +2466,8 @@ sub install_patterns {
         }
         # For Public cloud module test we need install 'Tools' but not 'Instance' pattern if outside of public cloud images.
         next if (($pt =~ /OpenStack/) && ($pt !~ /Tools/) && !is_public_cloud);
+        # skip installation of wsl_base, wsl_gui and wsl_systemd patterns due to bsc#1226314.
+        next if (($pt =~ /wsl_base|wsl_gui|wsl_systemd/) && check_var('PATTERNS', 'all'));
         # if pattern is common-criteria and PATTERNS is all, skip, poo#73645
         next if (($pt =~ /common-criteria/) && check_var('PATTERNS', 'all'));
         zypper_call("in -t pattern $pt", timeout => 1800);


### PR DESCRIPTION
Remove wsl_base, wsl_gui and wsl_systemd patterns from autoyast profiles for support images. Based on bsc#1226314, we don't set wsl environment in migration testing, so we don't add these patterns.

- Related ticket: https://progress.opensuse.org/issues/162677
- Needles: n/a
- Verification run: 
- https://openqa.suse.de/tests/14714416# (x86_64: support image of parent)
- https://openqa.suse.de/tests/14714448# (x86_64: support image of child)
- https://openqa.suse.de/tests/14714578# (x86_64: migration job to verify support image)
- https://openqa.suse.de/tests/14714402# (aarch64: support image of parent)
- https://openqa.suse.de/tests/14714451# (aarch64: support image of child)
- https://openqa.suse.de/tests/14714452# (aarch64: migration job to verify support image)
- Related mr: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/241 (remove the pattern for ppc64le)