### PR TITLE
Refactor openssl FIPS hash tests to be generic

### DIFF
--- a/lib/security/openssl_fips_hash_common.pm
+++ b/lib/security/openssl_fips_hash_common.pm
@@ -1,0 +1,57 @@
+# openssl fips test
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: openssl-fips common function for Hash test cases
+#
+# Maintainer: QE Security <none@suse.de>
+
+package security::openssl_fips_hash_common;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+
+our $tmp_file = "/tmp/hello.txt";
+
+our @EXPORT = 'run_fips_hash_tests';
+
+# With FIPS approved HASH algorithms, openssl should work
+sub test_approved_hash_algos {
+    my $openssl_binary = shift;
+    my @approved_hash = ("sha1", "sha224", "sha256", "sha384", "sha512");
+    for my $hash (@approved_hash) {
+        assert_script_run "$openssl_binary dgst -$hash $tmp_file";
+    }
+}
+
+# With non-approved HASH algorithms, openssl will report failure
+# Remove md2 and sha, and add rmd160 and md5-sha1 from invalid hash check in fips mode
+sub test_invalid_hash_algos {
+    my $openssl_binary = shift;
+    my @invalid_hash = ("md4", "md5", "mdc2", "rmd160", "ripemd160", "whirlpool", "md5-sha1");
+    for my $hash (@invalid_hash) {
+        eval {
+            validate_script_output "$openssl_binary dgst -$hash $tmp_file 2>&1 || true", sub { m/$hash is not a known digest|unknown option|Unknown digest|dgst: Unrecognized flag|disabled for FIPS|disabled for fips|unsupported:crypto/ };
+        };
+        if ($@) {
+            record_soft_failure 'bsc#1193859';
+            validate_script_output "$openssl_binary dgst -$hash $tmp_file 2>&1 || true", sub { m/disabled for fips|disabled for FIPS|unknown option|Unknown digest|dgst: Unrecognized flag|unsupported:crypto/ };
+        }
+    }
+}
+
+# entry point; run tests by default with system's openssl binary
+# call with a parameter like "/usr/bin/openssl-1_1" to run test with other binaries
+sub run_fips_hash_tests {
+    my $openssl_binary = shift // "openssl";
+    assert_script_run "echo Hello > $tmp_file";
+    test_approved_hash_algos($openssl_binary);
+    test_invalid_hash_algos($openssl_binary);
+    script_run "rm -f $tmp_file";
+}
+
+1;

--- a/schedule/security/fips_crypt_core.yaml
+++ b/schedule/security/fips_crypt_core.yaml
@@ -9,6 +9,7 @@ schedule:
     - fips/fips_setup
     - fips/openssl/openssl_fips_alglist
     - fips/openssl/openssl_fips_hash
+    - fips/openssl/openssl_1_1_fips_hash
     - fips/openssl/openssl_fips_cipher
     - fips/openssl/dirmngr_setup
     - fips/openssl/dirmngr_daemon

--- a/tests/fips/openssl/openssl_1_1_fips_hash.pm
+++ b/tests/fips/openssl/openssl_1_1_fips_hash.pm
@@ -1,4 +1,4 @@
-# openssl fips test
+# openssl1.1 fips test
 #
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
@@ -6,8 +6,8 @@
 # Test description: In fips mode, openssl only works with the FIPS
 # approved HASH algorithms: SHA1 and SHA2 (224, 256, 384, 512)
 #
-# Package: openssl
-# Summary: Hash test cases for openssl-fips (system default openssl  package)
+# Package: openssl1.1
+# Summary: Hash test cases for openssl-fips (legacy openssl 1.1 package)
 #
 # Maintainer: QE Security <none@suse.de>
 
@@ -17,18 +17,22 @@ use serial_terminal 'select_serial_terminal';
 use strict;
 use warnings;
 use utils qw(zypper_call);
-use version_utils qw(is_transactional);
 use security::openssl_fips_hash_common;
+use version_utils 'is_sle';
+use registration 'add_suseconnect_product';
+
 
 sub install_pkg {
-    # openssl pre-installed in SLE Micro
-    zypper_call 'in openssl' unless is_transactional;
+    add_suseconnect_product('sle-module-legacy');
+    zypper_call 'in openssl-1_1';
 }
 
 sub run {
     select_serial_terminal;
+    return if is_sle('<15-SP6');
     install_pkg();
-    run_fips_hash_tests();
+    my $openssl_bin = '/usr/bin/openssl-1_1';
+    run_fips_hash_tests($openssl_bin);
 }
 
 sub test_flags {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/159780
- Needles: no
- Verification runs:
	- https://openqa.suse.de/tests/14718572
	- https://openqa.suse.de/tests/14718565
	- https://openqa.suse.de/tests/14718553
	- https://openqa.suse.de/tests/14718554


