### PR TITLE
Change guest list to the required guest list for kvm and xen 

### DIFF
--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -162,17 +162,17 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }
     } elsif (is_sle('=15-SP4')) {
-        my @allowed_guests = qw(sles12sp5HVM sles12sp5PV sles15sp4HVM sles15sp4PV sles15sp5HVM sles15sp5PV);
+        my @allowed_guests = qw(sles15sp4HVM sles15sp4PV sles15sp5HVM sles15sp5PV);
         foreach my $guest (keys %guests) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }
     } elsif (is_sle('=15-SP5')) {
-        my @allowed_guests = qw(sles12sp5HVM sles12sp5PV sles15sp5HVM sles15sp5PV);
+        my @allowed_guests = qw(sles12sp5HVM sles12sp5PV sles15sp5HVM sles15sp5PV sles15sp6HVM sles15sp6PV);
         foreach my $guest (keys %guests) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }
     } elsif (is_sle('=15-SP6')) {
-        my @allowed_guests = qw(sles12sp5HVM sles12sp5PV sles15sp5HVM sles15sp5PV sles15sp6HVM sles15sp6PV);
+        my @allowed_guests = qw(sles12sp5HVM sles12sp5PV sles15sp6HVM sles15sp6PV);
         foreach my $guest (keys %guests) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }
@@ -273,17 +273,17 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }
     } elsif (is_sle('=15-SP4')) {
-        my @allowed_guests = qw(sles12sp5 sles15sp4 sles15sp5);
+        my @allowed_guests = qw(sles15sp4 sles15sp5);
         foreach my $guest (keys %guests) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }
     } elsif (is_sle('=15-SP5')) {
-        my @allowed_guests = qw(sles12sp5 sles15sp5);
+        my @allowed_guests = qw(sles12sp5 sles15sp5 sles15sp6);
         foreach my $guest (keys %guests) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }
     } elsif (is_sle('=15-SP6')) {
-        my @allowed_guests = qw(sles12sp5 sles15sp5 sles15sp6);
+        my @allowed_guests = qw(sles12sp5 sles15sp6);
         foreach my $guest (keys %guests) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }


### PR DESCRIPTION
MU- Change guest list to the required guest list for kvm and xen on each host product.

- Related ticket: https://progress.opensuse.org/issues/162434
- Verification run: 
SLES15-SP6 KVM - http://openqa.qam.suse.cz/tests/76235#step/waitfor_guests/68
SLES15-SP6 XEN - http://openqa.qam.suse.cz/tests/76251#step/waitfor_guests/102
SLES15-SP5 KVM - http://openqa.qam.suse.cz/tests/76288#step/waitfor_guests/90
SLES15-SP5 XEN - http://openqa.qam.suse.cz/tests/76300#step/waitfor_guests/210
SLES 15-SP4 KVM - http://openqa.qam.suse.cz/tests/76377#step/waitfor_guests/66
SLES 15-SP4 XEN - http://openqa.qam.suse.cz/tests/76364#step/waitfor_guests/70
