### PR TITLE
containers: Fixes for BATS tests on SLEM < 5.5

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -293,7 +293,7 @@ sub load_container_tests {
 
     if (get_var('PODMAN_BATS_SKIP')) {
         if (!check_var('SKOPEO_BATS_SKIP', 'all')) {
-            loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle || is_leap || is_sle_micro);
+            loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle || is_leap || is_sle_micro('>=5.5'));
         }
         if (!check_var('PODMAN_BATS_SKIP', 'all')) {
             loadtest 'containers/podman_integration';

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -52,12 +52,14 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark netcat-openbsd openssl podman python3-passlib skopeo socat sudo systemd-container);
+    my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark netcat-openbsd openssl podman sudo systemd-container);
     push @pkgs, qw(go buildah) unless is_sle_micro;
-    # podman-remote is not yet available & python3-PyYAML was dropped in SLM 6.0
+    push @pkgs, qw(python3-passlib) if (is_tumbleweed || is_sle || is_sle_micro('=5.5'));
+    push @pkgs, qw(python3-PyYAML) unless is_sle_micro('>=6.0');
+    push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');
+    push @pkgs, qw(socat) unless is_sle_micro('=5.1');
     # https://bugzilla.suse.com/show_bug.cgi?id=1226596
-    # https://bugzilla.suse.com/show_bug.cgi?id=1224050
-    push @pkgs, qw(podman-remote python3-PyYAML) unless (is_sle_micro('>=6.0') || is_sle('<=15-SP3'));
+    push @pkgs, qw(podman-remote) unless (is_sle_micro('<5.5') || is_sle('<=15-SP3'));
     # passt requires podman 5.0
     push @pkgs, qw(criu passt) if (is_tumbleweed || is_microos);
     # Needed for podman machine


### PR DESCRIPTION
Some packages are not available on some versions of SLEM.

I checked the available packages with `podman run --rm ghcr.io/ricardobranco777/susepkg -p any $package`

- Related ticket: https://progress.opensuse.org/issues/162164
- Verification runs:
  - SLEM-5.1 aarch64: https://openqa.suse.de/t14718805
  - SLEM-5.1 x86_64: https://openqa.suse.de/t14718804
  - SLEM-5.2 aarch64: https://openqa.suse.de/t14718811
  - SLEM-5.2 x86_64: https://openqa.suse.de/t14718810
  - SLEM-5.3 aarch64: https://openqa.suse.de/t14718809
  - SLEM-5.3 x86_64: https://openqa.suse.de/t14718808
  - SLEM-5.4 aarch64: https://openqa.suse.de/t14718807
  - SLEM-5.4 x86_64: https://openqa.suse.de/t14718806
  
NOTE: All jobs will fail due to not-yet skipped subtests. These jobs are for harvesting them to add them to SKIP variables.