### PR TITLE
Tidy library import section

### DIFF
--- a/lib/security/openssl_fips_hash_common.pm
+++ b/lib/security/openssl_fips_hash_common.pm
@@ -8,12 +8,11 @@
 
 package security::openssl_fips_hash_common;
 
-use base Exporter;
-use Exporter;
-
 use strict;
 use warnings;
 use testapi;
+
+use base 'Exporter';
 
 our $tmp_file = "/tmp/hello.txt";
 


### PR DESCRIPTION
Followup from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19590, a small fix on the library header

