### PR TITLE
Create main_security schedule

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -15,6 +15,7 @@ use main_common;
 use main_ltp_loader 'load_kernel_tests';
 use main_containers qw(load_container_tests is_container_test);
 use main_publiccloud qw(load_publiccloud_download_repos);
+use main_security qw(load_security_tests is_security_test);
 use testapi qw(check_var get_required_var get_var set_var);
 use version_utils;
 use utils;
@@ -402,6 +403,8 @@ sub load_tests {
         # Container tests didn't execute journal check. However, if doing so, there
         # are some errors to be investigated. We need to remove this return;
         return 1;
+    } elsif (is_security_test) {
+        load_security_tests;
     } elsif (check_var('EXTRA', 'networking')) {
         load_network_tests;
     } elsif (check_var('EXTRA', 'provisioning')) {

--- a/lib/main_security.pm
+++ b/lib/main_security.pm
@@ -1,0 +1,92 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: module loader of security tests
+# Maintainer: QE Security <none@suse.de>
+
+package main_security;
+use Mojo::Base 'Exporter';
+use Exporter;
+use utils;
+use version_utils;
+use main_common qw(loadtest boot_hdd_image);
+use testapi qw(get_var);
+use Utils::Architectures;
+use Utils::Backends;
+
+our @EXPORT = qw(
+  is_security_test
+  load_security_tests
+);
+
+sub is_security_test {
+    return get_var('SECURITY', 1);
+}
+
+sub load_selinux_tests {
+    loadtest('security/selinux/selinux_setup');
+    loadtest('security/selinux/sestatus');
+    loadtest('security/selinux/semanage_fcontext');
+    loadtest('security/selinux/semanage_boolean');
+    loadtest('security/selinux/fixfiles');
+    loadtest('security/selinux/print_se_context');
+    loadtest('security/selinux/audit2allow');
+    loadtest('security/selinux/semodule');
+    loadtest('security/selinux/setsebool');
+    loadtest('security/selinux/restorecon');
+    loadtest('security/selinux/chcon');
+    loadtest('security/selinux/chcat');
+    loadtest('security/selinux/set_get_enforce');
+    loadtest('security/selinux/selinuxexeccon');
+}
+
+sub load_container_selinux_tests {
+    loadtest('security/selinux/selinux_setup');
+    loadtest('security/selinux/sestatus');
+    loadtest('security/selinux/container_selinux');
+}
+
+sub load_fde_misc_tests {
+    loadtest('security/selinux/selinux_setup');
+    loadtest('security/tpm2/tpm2_verify_presence');
+    loadtest('security/tpm2/tpm2_fail_key_unsealing');
+    loadtest('security/fde_regenerate_key');
+}
+
+sub fips_ker_mode_tests_crypt_core {
+    loadtest('security/selinux/selinux_setup');
+    loadtest('fips/fips_setup');
+    loadtest('fips/openssl/openssl_fips_alglist');
+    loadtest('fips/openssl/openssl_fips_hash');
+    loadtest('fips/openssl/openssl_fips_cipher');
+    loadtest('console/openssl_alpn');
+    loadtest('fips/gnutls/gnutls_base_check');
+    loadtest('fips/gnutls/gnutls_server');
+    loadtest('fips/gnutls/gnutls_client');
+    loadtest('fips/openssl/openssl_pubkey_rsa');
+    loadtest('fips/openssl/openssl_pubkey_dsa');
+    loadtest('fips/openssl/openssl_fips_dhparam');
+    loadtest('fips/openssh/openssh_fips');
+    loadtest('console/sshd');
+    loadtest('console/ssh_cleanup');
+}
+
+
+sub load_security_tests {
+    if (get_var('TEST') eq 'selinux') {
+        load_selinux_tests;
+    }
+    elsif (get_var('TEST') eq 'container_selinux') {
+        load_container_selinux_tests;
+    }
+    elsif (get_var('TEST') eq 'fde_misc') {
+        load_fde_misc_tests;
+    }
+    elsif (get_var('TEST') eq 'fips_ker_mode_tests_crypt_core') {
+        fips_ker_mode_tests_crypt_core;
+    }
+}
+
+


### PR DESCRIPTION
This is a proposal, feel free to reject.
What this tries to address is:
- Eliminate the logic of booting all kind of images/archs in the yaml (that logic is already part of main_micro_alp.pm)
- Eliminate the logic to check if we need to install updates or not, which would make the yaml schedule more complex. This is already addressed in main_micro_alp.pm

VRs:
- https://openqa.suse.de/tests/14727666
- https://openqa.suse.de/tests/14727665
- https://openqa.suse.de/tests/14727673
- https://openqa.suse.de/tests/14727674 (the failure here needs investigation, not produced by this PR)