### PR TITLE
containers: Use own busybox image instead of DockerHub images

### DIFF
--- a/tests/containers/kubectl.pm
+++ b/tests/containers/kubectl.pm
@@ -81,8 +81,8 @@ sub run {
     ## Test jobs
     record_info('Testing: jobs and pods', 'job and pod test runs');
     # The testing.registry must be registered in k8s as private registry and point to REGISTRY variable.
-    assert_script_run("kubectl create job sayhello --image=docker.io/library/alpine -- echo 'Hello World'");
-    assert_script_run("kubectl create job gimme-date --image=docker.io/library/busybox -- date");
+    assert_script_run("kubectl create job sayhello --image=registry.opensuse.org/opensuse/busybox -- echo 'Hello World'");
+    assert_script_run("kubectl create job gimme-date --image=registry.opensuse.org/opensuse/busybox -- date");
     validate_script_output("kubectl get jobs --no-headers", qr/sayhello/);
     validate_script_output("kubectl get jobs --no-headers", qr/gimme-date/);
     assert_script_run('kubectl wait jobs/sayhello --for=condition=complete --timeout=300s', timeout => 330);


### PR DESCRIPTION
Use own busybox image instead of DockerHub images

- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20240624-containers_host_kubectl@64bit -> https://openqa.opensuse.org/t4298767