### PR TITLE
containers: Add test for podman-remote package

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -139,9 +139,9 @@ sub load_host_tests_podman {
     loadtest 'containers/podman_quadlet' if is_tumbleweed;
     # https://github.com/containers/podman/issues/5732#issuecomment-610222293
     # exclude rootless podman on public cloud because of cgroups2 special settings
-    unless (is_sle('<15-sp2') || is_openstack || is_public_cloud) {
+    unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podman_remote' if is_sle '>15-sp2';
+        loadtest 'containers/podman_remote';
     }
     load_secret_tests($run_args);
     load_volume_tests($run_args);


### PR DESCRIPTION
This PR adds a test for the availability of the `podman-remote` package.  We [missed](https://bugzilla.suse.com/show_bug.cgi?id=1224050) it in SLEM 6.0 and [again](https://bugzilla.suse.com/show_bug.cgi?id=1226596) with SLES 15-SP3 with the podman 4.9.x update.  There is a planned podman update for SLES 15-SP2 and we need to catch this failure.

Current list of SUSE products with `podman-remote` (edited for brevity):

```
$ podman run --rm ghcr.io/ricardobranco777/susepkg -p any podman-remote
[...]
SL-Micro/6.0 podman-remote 4.9.3-1.3
SLE-Micro/5.5 podman-remote 4.9.5-150500.3.12.1
SLES/15.4 podman-remote 4.9.5-150400.4.27.1
SLES/15.5 podman-remote 4.9.5-150500.3.12.1
SLES/15.6 podman-remote 4.9.5-150500.3.12.1
[...]
```

- Related ticket: https://progress.opensuse.org/issues/162788
- Verification runs:
  - sle-15-SP2-Server-DVD-Updates-x86_64-Build20240625-1-podman_tests@64bit -> https://openqa.suse.de/tests/14736962
  - sle-15-SP3-Server-DVD-Updates-x86_64-Build20240625-1-podman_tests@64bit -> https://openqa.suse.de/tests/14736930


NOTE: I don't see the need to test the podman-remote command itself, or at least not yet, as it's similar to `podman --remote` that our test covers:
https://github.com/containers/podman/blob/main/docs/tutorials/remote_client.md#client-machine