### PR TITLE
Add guests profiles for SL Micro 6.1 tests

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_sev_es_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_sev_es_x86_64.xml
@@ -5,7 +5,7 @@
     <guest_version_major>15</guest_version_major>
     <guest_version_minor>6</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build/>
+    <guest_build>gm</guest_build>
     <host_hypervisor_uri/>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
@@ -25,7 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP6-Full-x86_64-Build12345-Media1/</guest_installation_media>
+    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/ovmf-x86_64-vars.bin</guest_boot_settings>
     <guest_secure_boot>false</guest_secure_boot>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_with_power_management_x86_64.xml
@@ -5,7 +5,7 @@
     <guest_version_major>15</guest_version_major>
     <guest_version_minor>6</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build/>
+    <guest_build>gm</guest_build>
     <host_hypervisor_uri/>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
@@ -25,7 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP6-Full-x86_64-Build12345-Media1/</guest_installation_media>
+    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -5,7 +5,7 @@
     <guest_version_major>15</guest_version_major>
     <guest_version_minor>6</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build/>
+    <guest_build>gm</guest_build>
     <host_hypervisor_uri/>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
@@ -25,7 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP6-Full-x86_64-Build12345-Media1</guest_installation_media>
+    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -5,7 +5,7 @@
     <guest_version_major>15</guest_version_major>
     <guest_version_minor>6</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build/>
+    <guest_build>gm</guest_build>
     <host_hypervisor_uri/>
     <host_virt_type>xen</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
@@ -25,7 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP6-Full-x86_64-Build12345-Media1</guest_installation_media>
+    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_xen_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_xen_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -5,7 +5,7 @@
     <guest_version_major>15</guest_version_major>
     <guest_version_minor>6</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build/>
+    <guest_build>gm</guest_build>
     <host_hypervisor_uri/>
     <host_virt_type>xen</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
@@ -25,7 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug#display=3#ipv4only=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP6-Full-x86_64-Build12345-Media1</guest_installation_media>
+    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms.bin,loader_type=pflash,loader_ro=yes</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>slm</guest_os_name>
-    <guest_version>6.0</guest_version>
+    <guest_version>6.1</guest_version>
     <guest_version_major>6</guest_version_major>
-    <guest_version_minor>0</guest_version_minor>
+    <guest_version_minor>1</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
     <guest_build/>
     <host_hypervisor_uri/>
@@ -27,7 +27,7 @@
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-encrypted-Build12345.raw</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>slm</guest_os_name>
-    <guest_version>6.0</guest_version>
+    <guest_version>6.1</guest_version>
     <guest_version_major>6</guest_version_major>
-    <guest_version_minor>0</guest_version_minor>
+    <guest_version_minor>1</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
     <guest_build/>
     <host_hypervisor_uri/>
@@ -15,19 +15,19 @@
     <guest_domain_name/>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>host-model</guest_cpumodel>
+    <guest_cpumodel>mode=host-passthrough,check=none,migratable=on</guest_cpumodel>
     <guest_metadata/>
-    <guest_boot_settings>hd</guest_boot_settings>
+    <guest_boot_settings>uefi,arch=x86_64,firmware.feature0.name=secure-boot,firmware.feature0.enabled=yes,firmware.feature0.name=enrolled-keys,firmware.feature0.enabled=yes</guest_boot_settings>
     <guest_xpath/>
     <guest_installation_automation_method>ignition</guest_installation_automation_method>
-    <guest_installation_automation_platform>qemu</guest_installation_automation_platform>
-    <guest_installation_automation_file>ignition_config_non_encrypted_image.ign</guest_installation_automation_file>
+    <guest_installation_automation_platform>metal</guest_installation_automation_platform>
+    <guest_installation_automation_file>ignition_config_encrypted_image.ign</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
     <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-qcow-Build12345.qcow2</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>
@@ -46,13 +46,13 @@
     <guest_ipaddr/>
     <guest_ipaddr_static>false</guest_ipaddr_static>
     <guest_macaddr/>
-    <guest_graphics>vnc</guest_graphics>
+    <guest_graphics>spice</guest_graphics>
     <guest_controller/>
     <guest_input/>
-    <guest_serial>pty</guest_serial>
+    <guest_serial>pty,target.type=isa-serial</guest_serial>
     <guest_parallel/>
-    <guest_channel/>
-    <guest_console/>
+    <guest_channel>type=unix#spicevmc</guest_channel>
+    <guest_console>pty,target.type=serial</guest_console>
     <guest_hostdev/>
     <guest_filesystem/>
     <guest_sound/>
@@ -60,9 +60,9 @@
     <guest_video/>
     <guest_smartcard/>
     <guest_redirdev/>
-    <guest_memballoon/>
-    <guest_tpm/>
-    <guest_rng/>
+    <guest_memballoon>virtio</guest_memballoon>
+    <guest_tpm>model=tpm-tis,backend.type=emulator,backend.version=2.0</guest_tpm>
+    <guest_rng>virtio,backend.model=random</guest_rng>
     <guest_panic/>
     <guest_memdev/>
     <guest_vsock/>
@@ -74,7 +74,7 @@
     <guest_memtune/>
     <guest_blkiotune/>
     <guest_memorybacking/>
-    <guest_features/>
+    <guest_features>vmport.state=off,smm=on</guest_features>
     <guest_clock/>
     <guest_power_management/>
     <guest_events/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>slm</guest_os_name>
-    <guest_version>6.0</guest_version>
+    <guest_version>6.1</guest_version>
     <guest_version_major>6</guest_version_major>
-    <guest_version_minor>0</guest_version_minor>
+    <guest_version_minor>1</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
     <guest_build/>
     <host_hypervisor_uri/>
@@ -15,19 +15,19 @@
     <guest_domain_name/>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>mode=host-passthrough,check=none,migratable=on</guest_cpumodel>
+    <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata/>
-    <guest_boot_settings>uefi,arch=x86_64,firmware.feature0.name=secure-boot,firmware.feature0.enabled=yes,firmware.feature0.name=enrolled-keys,firmware.feature0.enabled=yes</guest_boot_settings>
+    <guest_boot_settings>hd</guest_boot_settings>
     <guest_xpath/>
-    <guest_installation_automation_method>ignition</guest_installation_automation_method>
-    <guest_installation_automation_platform>metal</guest_installation_automation_platform>
-    <guest_installation_automation_file>ignition_config_encrypted_image.ign</guest_installation_automation_file>
+    <guest_installation_automation_method>ignition+combustion</guest_installation_automation_method>
+    <guest_installation_automation_platform>qemu</guest_installation_automation_platform>
+    <guest_installation_automation_file>ignition_config_non_encrypted_image.ign#combustion_script</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
     <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-encrypted-Build12345.raw</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-qcow-Build12345.qcow2</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>
@@ -46,13 +46,13 @@
     <guest_ipaddr/>
     <guest_ipaddr_static>false</guest_ipaddr_static>
     <guest_macaddr/>
-    <guest_graphics>spice</guest_graphics>
+    <guest_graphics>vnc</guest_graphics>
     <guest_controller/>
     <guest_input/>
-    <guest_serial>pty,target.type=isa-serial</guest_serial>
+    <guest_serial>pty</guest_serial>
     <guest_parallel/>
-    <guest_channel>type=unix#spicevmc</guest_channel>
-    <guest_console>pty,target.type=serial</guest_console>
+    <guest_channel/>
+    <guest_console/>
     <guest_hostdev/>
     <guest_filesystem/>
     <guest_sound/>
@@ -60,9 +60,9 @@
     <guest_video/>
     <guest_smartcard/>
     <guest_redirdev/>
-    <guest_memballoon>virtio</guest_memballoon>
-    <guest_tpm>model=tpm-tis,backend.type=emulator,backend.version=2.0</guest_tpm>
-    <guest_rng>virtio,backend.model=random</guest_rng>
+    <guest_memballoon/>
+    <guest_tpm/>
+    <guest_rng/>
     <guest_panic/>
     <guest_memdev/>
     <guest_vsock/>
@@ -74,7 +74,7 @@
     <guest_memtune/>
     <guest_blkiotune/>
     <guest_memorybacking/>
-    <guest_features>vmport.state=off,smm=on</guest_features>
+    <guest_features/>
     <guest_clock/>
     <guest_power_management/>
     <guest_events/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>slm</guest_os_name>
-    <guest_version>6.0</guest_version>
+    <guest_version>6.1</guest_version>
     <guest_version_major>6</guest_version_major>
-    <guest_version_minor>0</guest_version_minor>
+    <guest_version_minor>1</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
     <guest_build/>
     <host_hypervisor_uri/>
@@ -19,15 +19,15 @@
     <guest_metadata/>
     <guest_boot_settings>hd</guest_boot_settings>
     <guest_xpath/>
-    <guest_installation_automation_method>ignition+combustion</guest_installation_automation_method>
+    <guest_installation_automation_method>ignition</guest_installation_automation_method>
     <guest_installation_automation_platform>qemu</guest_installation_automation_platform>
-    <guest_installation_automation_file>ignition_config_non_encrypted_image.ign#combustion_script</guest_installation_automation_file>
+    <guest_installation_automation_file>ignition_config_non_encrypted_image.ign</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
     <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-qcow-Build12345.qcow2</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-qcow-Build12345.qcow2</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <guest>
   <guest_os_name>slm</guest_os_name>
-  <guest_version>6.0</guest_version>
+  <guest_version>6.1</guest_version>
   <guest_version_major>6</guest_version_major>
-  <guest_version_minor>0</guest_version_minor>
+  <guest_version_minor>1</guest_version_minor>
   <guest_os_word_length>64</guest_os_word_length>
   <guest_build/>
   <host_hypervisor_uri/>
@@ -26,7 +26,7 @@
   <guest_installation_method_others/>
   <guest_installation_extra_args/>
   <guest_installation_wait/>
-  <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-Build12345.raw.xz</guest_installation_media>
+  <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-Build12345.raw.xz</guest_installation_media>
   <guest_installation_fine_grained/>
   <guest_os_variant>opensusetumbleweed</guest_os_variant>
   <guest_storage_path/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <guest>
   <guest_os_name>slm</guest_os_name>
-  <guest_version>6.0</guest_version>
+  <guest_version>6.1</guest_version>
   <guest_version_major>6</guest_version_major>
-  <guest_version_minor>0</guest_version_minor>
+  <guest_version_minor>1</guest_version_minor>
   <guest_os_word_length>64</guest_os_word_length>
   <guest_build/>
   <host_hypervisor_uri/>
@@ -26,7 +26,7 @@
   <guest_installation_method_others/>
   <guest_installation_extra_args/>
   <guest_installation_wait/>
-  <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.0-Default-Build12345.raw.xz</guest_installation_media>
+  <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-Build12345.raw.xz</guest_installation_media>
   <guest_installation_fine_grained/>
   <guest_os_variant>opensusetumbleweed</guest_os_variant>
   <guest_storage_path/>


### PR DESCRIPTION
* **Add** profiles for SL Micro 6.1 guests, including default-encrypted, default-raw and default-qcow, which are installed by using ignition or ignition+combustion.

* **Also** update profiles for SLE 15-SP6 guests which already passed GM. 

* **Verification Runs:**
  * [15sp6 on SL Micro 6.1](https://openqa.suse.de/tests/14736796)
  * [SL Micro 6.1 on SL Micro 6.1](https://openqa.suse.de/tests/14736870) 
