### PR TITLE
Remove soft failure bsc#1176901

### DIFF
--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -73,10 +73,8 @@ sub check_suseconnect {
         foreach (@$json) {
             my $iden = $_->{identifier};
             my $status = $_->{status};
-            if ($iden eq 'sle-module-packagehub-subpackages') {
-                record_soft_failure('bsc#1176901 - openQA test fails in system_prepare - \'sle-module-packagehub-subpackages\' is not registered ');
-                next;
-            }
+            # the subpackages unregistered is by design, bsc#1226477
+            next if ($iden eq 'sle-module-packagehub-subpackages');
             push(@addons, $iden);
             die "$iden register status is: $status" if ($status ne 'Registered');
         }


### PR DESCRIPTION
##
The subpacakge unregistered status is by design and comes from how we introduced subpackages repository to Package Hub.

- Related ticket: 
   - https://progress.opensuse.org/issues/158736
- Needles: 
   - N/A
- Verification run: 
   - https://openqa.suse.de/tests/14736660
##
