### PR TITLE
Apply workaround for needle 'yast2-instserver-nfs'

### DIFF
--- a/tests/yast2_gui/yast2_instserver.pm
+++ b/tests/yast2_gui/yast2_instserver.pm
@@ -51,7 +51,7 @@ sub test_nfs_instserver {
     # select nfs
     send_key_and_wait("alt-f", 2);
     send_key_and_wait("alt-n", 2);
-    assert_screen('yast2-instserver-nfs');
+    apply_workaround_poo124652('yast2-instserver-nfs', 200);
     # use default nfs config
     send_key_and_wait("alt-n", 2);
     is_sle('>=15-SP4') ? apply_workaround_poo124652('yast2-instserver-ui', 200) : assert_screen('yast2-instserver-ui', 200);


### PR DESCRIPTION
Apply workaround for needle 'yast2-instserver-nfs'

- Verification run: https://openqa.suse.de/tests/14736977#step/yast2_instserver/39