### PR TITLE
Add connectivity sanity check in ipaddr2 test

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -620,8 +620,8 @@ Return a decoded json hash according to the provided jmespath query
 
 sub az_vm_list {
     my (%args) = @_;
-    foreach (qw(resource_group query)) {
-        croak("Argument < $_ > missing") unless $args{$_}; }
+    croak("Argument < resource_group > missing") unless $args{resource_group};
+    $args{query} //= '[].name';
 
     my $az_cmd = join(' ',
         'az vm list',

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -276,15 +276,29 @@ subtest '[az_vm_create] with no public IP' => sub {
 subtest '[az_vm_list]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { push @calls, $_[0]; return '["Mirandolina","Truffaldino"]'; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '["Mirandolina","Truffaldino"]'; });
 
-    my $res = az_vm_list(resource_group => 'Arlecchino', query => 'ZAMZAM');
+    my $res = az_vm_list(resource_group => 'Arlecchino');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /az vm list/ } @calls), 'Correct composition of the main command');
     ok((any { /-g Arlecchino/ } @calls), 'Correct composition of the -g argument');
-    ok((any { /--query.*ZAMZAM/ } @calls), 'Correct composition of the --query argument');
     ok((any { /Mirandolina/ } @$res), 'Correct result decoding');
+};
+
+subtest '[az_vm_list] query' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '["Mirandolina","Truffaldino"]'; });
+
+    my $res = az_vm_list(resource_group => 'Arlecchino', query => 'ZAMZAM');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /--query.*ZAMZAM/ } @calls), 'Correct composition of the --query argument');
 };
 
 subtest '[az_vm_instance_view_get]' => sub {

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -22,6 +22,9 @@ sub run {
     record_info("STAGE 1", "Prepare all the ssh connections within the 2 internal VMs");
     my $bastion_ip = ipaddr2_bastion_pubip();
     ipaddr2_bastion_key_accept(bastion_ip => $bastion_ip);
+
+    # check basic stuff that has to work before to start
+    ipaddr2_os_connectivity_sanity(bastion_ip => $bastion_ip);
 }
 
 sub test_flags {


### PR DESCRIPTION
Add ipaddr2_os_connectivity_sanity method
Make query optional in az_vm_list with default to NAME 
Add verbosity each time is using StrictHostKeyChecking=accept-new

- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run: 

## PAYG
 sle-15-SP5-SapCloud-Azure-Payg-x86_64-Buildmpagot_VR-ipaddr2_azure_test@64bit
- http://openqaworker15.qa.suse.cz/tests/287110
- http://openqaworker15.qa.suse.cz/tests/287117

## BYOS
 sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit
- http://openqaworker15.qa.suse.cz/tests/287112 :green_circle: 