### PR TITLE
Add AY profile without SCC registration for Full medium

### DIFF
--- a/data/autoyast_sle15/autoyast_no_scc_reg_full.xml.ep
+++ b/data/autoyast_sle15/autoyast_no_scc_reg_full.xml.ep
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<!--
+Autoyast profile for SLE installation from Full medium without SCC registration
+and from provided HTTP repositories. It currently supports x86_64 and aarch64
+architectures.
+-->
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm t="boolean">false</confirm>
+    </mode>
+  </general>
+  <suse_register>
+    <do_registration config:type="boolean">false</do_registration>
+  </suse_register>
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[{{MIRROR_HTTP}}]]></media_url>
+        <product>sle-module-basesystem</product>
+        <product_dir>/Module-Basesystem</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[{{MIRROR_HTTP}}]]></media_url>
+        <product>sle-module-server-applications</product>
+        <product_dir>/Module-Server-Applications</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[{{MIRROR_HTTP}}]]></media_url>
+        <product>sle-module-desktop-applications</product>
+        <product_dir>/Module-Desktop-Applications</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[{{MIRROR_HTTP}}]]></media_url>
+        <product>sle-module-development-tools</product>
+        <product_dir>/Module-Development-Tools</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <partitioning config:type="list">
+    % if ($get_var->('AY_INSTALLATION_DRIVE_DEVICE')) {
+    <drive>
+     <device><%= $get_var->('AY_INSTALLATION_DRIVE_DEVICE') %></device>
+     <initialize config:type="boolean">true</initialize>
+    </drive>
+    % }
+  </partitioning>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">45</timeout>
+    </global>
+  </bootloader>
+  <firewall>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+    <zones config:type="list">
+      <zone>
+        <name>public</name>
+        <services config:type="list">
+          <service>ssh</service>
+        </services>
+        <ports config:type="list">
+          <port>22/tcp</port>
+        </ports>
+      </zone>
+    </zones>
+  </firewall>
+  <services-manager>
+    % if ($check_var->('DESKTOP', 'gnome')) {
+    <default_target>graphical</default_target>
+    % }
+    % if ($check_var->('DESKTOP', 'textmode')) {
+    <default_target>multi-user</default_target>
+    % }
+    <services>
+      <disable config:type="list"/>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <products config:type="list">
+      <product><%= uc $get_var->('SLE_PRODUCT') %></product>
+    </products>
+    % if ($get_var->('KERNEL_FLAVOR')) {
+    <kernel><%= $get_var->('KERNEL_FLAVOR') %></kernel>
+    % }
+    <patterns config:type="list">
+      % for my $pattern (@$patterns) {
+      <pattern><%= $pattern %></pattern>
+      % }
+    </patterns>
+  </software>
+  <users t="list">
+    <user t="map">
+      <authorized_keys t="list"/>
+      <encrypted t="boolean">true</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$.N86vYKuQteL0GYY$bJ21i0aJFgdnrwLGI3mc4u.dmYUH0Jf2gcmZPA0PJQr6WaQkLt/DojjsKxadG31ZwWam/cqSjmREls8WWKG7Q0</user_password>
+      <username>bernhard</username>
+    </user>
+    <user t="map">
+      <authorized_keys t="list"/>
+      <encrypted t="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <home_btrfs_subvolume t="boolean">false</home_btrfs_subvolume>
+      <password_settings t="map">
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$JqTWoXNwcwQ1356j$bT7n.1B52Us/pFvz6MaI6a6Wtb41iSvTELWgDvlA1s5wCuZ.SafTgqdJogP4/yHxSoNxcmknojKnGA8C9zbR81</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/schedule/kernel/ay_prepare_baremetal.yaml
+++ b/schedule/kernel/ay_prepare_baremetal.yaml
@@ -1,0 +1,19 @@
+---
+name: ay_prepare_baremetal
+schedule:
+- autoyast/prepare_profile
+- installation/bootloader_start
+- autoyast/installation
+- autoyast/console
+- autoyast/login
+- autoyast/repos
+- autoyast/logs
+- autoyast/autoyast_reboot
+- installation/handle_reboot
+- installation/first_boot
+- console/hostname
+- console/system_prepare
+- console/force_scheduled_tasks
+- shutdown/grub_set_bootargs
+- shutdown/cleanup_before_shutdown
+- shutdown/shutdown


### PR DESCRIPTION
Enhancement poo#162710: We need to test bare metal on maintenance Full-QR flavor. It must be tested without SCC registration from openQA assets. This profile has registration disabled and add repositories from MIRROR_HTTP variable. It sets graphical target based on DESKTOP variable. Installed patterns can be configured by PATTERNS.
Variable AY_INSTALLATION_DRIVE_DEVICE allows to specify installation disk. It is mainly intended for bare metal servers with multiple devices. 

PR also includes new schedule for autoyast installation on bare metal for kernel testing.


- Related ticket: https://progress.opensuse.org/issues/162710
- Needles: none
- Verification run:  https://openqa.suse.de/tests/overview?build=testdev9&version=15-SP5&groupid=472&distri=sle
