### PR TITLE
xfstests: Implement LTP whitelist properly

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -540,10 +540,6 @@ sub run {
         my $whitelist = LTP::WhiteList->new($issues);
         my %skipped = map { $_ => 1 } $whitelist->list_skipped_tests($whitelist_env, $TEST_SUITE);
         %black_list = (%black_list, %skipped);
-        my $known_issues = $whitelist->{whitelist}->{$TEST_SUITE};
-        my @soft_fail = keys(%$known_issues);
-        push @soft_fail, split(',', get_var('XFSTESTS_SOFTFAIL'));
-        set_var('XFSTESTS_SOFTFAIL', join(',', @soft_fail));
     }
 
     my $status_log_content = "";

--- a/tests/xfstests/xfstests_failed.pm
+++ b/tests/xfstests/xfstests_failed.pm
@@ -19,12 +19,14 @@ sub run {
         record_info('out.bad', "$args->{outbad}");
         record_info('full', "$args->{fullog}");
         record_info('dmesg', "$args->{dmesg}");
+        record_info('softfail', "$args->{failinfo}");
     }
     elsif ($args->{status} =~ /^FAILED/) {
         $self->{result} = 'fail';
         record_info('out.bad', "$args->{outbad}");
         record_info('full', "$args->{fullog}");
         record_info('dmesg', "$args->{dmesg}");
+        record_info('known', "$args->{failinfo}") if defined($args->{failinfo});
     }
     else {
         $self->{result} = 'skip';


### PR DESCRIPTION
Implement LTP whitelist lookup in xfstests report generator. Properly match whitelist entries according to test environment and show failure description in the report.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/14737587
