### PR TITLE
autoyast: Fix mapping of get_var function in template library

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -216,7 +216,9 @@ sub expand_template {
         extra_repos => expand_extra_repos,
         patterns => expand_patterns,
         # pass reference to get_required_var function to be able to fetch other variables
-        get_var => \&get_required_var,
+        get_required_var => \&get_required_var,
+        # pass reference to get_var function to be able to fetch other variables
+        get_var => \&get_var,
         # pass reference to check_var
         check_var => \&check_var,
         is_ltss => get_var('SCC_REGCODE_LTSS') ? '1' : '0'


### PR DESCRIPTION
Fix poo#162917: Function get_var is mapped to get_required_var in autoyast library. It is impossible to check if variable exists autoyast templates. Mapping of get_var is fixed and new get_required_var was introduced.

It was introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6251, unfortunately  PR doesn't contain any explanation or justification for such change.

- Related ticket: https://progress.opensuse.org/issues/162917
- Needles:  none
- Verification run: 
 Maintenance AY installation: https://openqa.suse.de/tests/14744051

Job which was previously failing and is fixed: https://openqa.suse.de/tests/14738025

