### PR TITLE
containers: Do not check_reboot_changes if package was not installed

### DIFF
--- a/tests/containers/podman_remote.pm
+++ b/tests/containers/podman_remote.pm
@@ -23,7 +23,7 @@ sub test_package {
     # Allow installation failure so we can check for bsc#1126596 later on.
     if (is_transactional) {
         $ret = trup_call("pkg install podman-remote", proceed_on_failure => 1);
-        check_reboot_changes;
+        check_reboot_changes if ($ret == 0);
     } else {
         $ret = zypper_call("in podman-remote", exitcode => [0, 104]);
     }


### PR DESCRIPTION
Do not check_reboot_changes if package was not installed

Failing test: https://openqa.suse.de/tests/14740400#step/podman_remote/59
Verification run: https://openqa.suse.de/tests/14744057