### PR TITLE
containers: Use select_console for transactional systems

### DIFF
--- a/tests/containers/podman_remote.pm
+++ b/tests/containers/podman_remote.pm
@@ -65,7 +65,11 @@ sub run {
     assert_script_run "podman run -d --rm --name test-root $image sleep infinity";
 
     # Run the podman daemon as normal user
-    select_user_serial_terminal();
+    if (is_transactional) {
+        select_console "user-console";
+    } else {
+        select_user_serial_terminal();
+    }
     systemctl '--user enable --now podman.socket';
 
     # Pull and run a container named test-user


### PR DESCRIPTION
On transactional systems we must do `select_console "user-console"` like we do in other modules.

- Related ticket: https://progress.opensuse.org/issues/162923
- Failing test: https://openqa.suse.de/tests/14744149/modules/podman_remote/steps/75
- Verification run: https://openqa.suse.de/tests/14744673