### PR TITLE
Reorder libica tests, with smoke as first one

### DIFF
--- a/schedule/security/fips_crypt_libica.yaml
+++ b/schedule/security/fips_crypt_libica.yaml
@@ -7,8 +7,8 @@ schedule:
     - console/consoletest_setup
     - '{{repo_setup}}'
     - fips/fips_setup
-    - fips/libica_upstream_testsuite
     - fips/libica
+    - fips/libica_upstream_testsuite
 conditional_schedule:
     repo_setup:
         BETA:

--- a/tests/fips/libica.pm
+++ b/tests/fips/libica.pm
@@ -1,4 +1,4 @@
-# Copyright 2023 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Smoke test for libica on s390x with enabled FIPS mode
@@ -46,6 +46,10 @@ sub run {
     validate_script_output('icainfo -c', qr/Built-in\s+FIPS\s+support:\s+FIPS\s+140-[3-9].*active/);
     assert_script_run('icastats -k');
     assert_script_run('icastats -S');
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;

--- a/tests/fips/libica_upstream_testsuite.pm
+++ b/tests/fips/libica_upstream_testsuite.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests - FIPS tests
 #
-# Copyright 2023 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: run upstream libica testsuite (build time) on s390x with enabled FIPS mode
@@ -43,6 +43,10 @@ sub run {
 
 sub post_run_hook {
     zypper_call("rr libica-tests");
+}
+
+sub test_flags {
+    return {fatal => 0};
 }
 
 1;


### PR DESCRIPTION
We enable the smoke test to run, this is needed to have an evidence and submit a proper bug report.

- Related ticket: https://progress.opensuse.org/issues/162437
- Needles: no
- Verification run:  https://openqa.suse.de/tests/14744724 

(the VR is supposed to fail because the test highlights a product bug)

