### PR TITLE
Make wizard_hana_install.pm deal with hana_partitioning*.xml files on 12-SP5

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -40,8 +40,9 @@ sub run {
 
     # Keep only the generic HANA partitioning profile and link it to the needed model
     # NOTE: fix name is used here (Dell), but something more flexible should be done later!
-    assert_script_run "rm -f /usr/share/YaST2/data/y2sap//hana_partitioning_Dell*.xml";
-    assert_script_run "ln -s hana_partitioning.xml '/usr/share/YaST2/data/y2sap/hana_partitioning_Dell Inc._generic.xml'";
+    my $previous_dir = is_sle('15+') ? '/usr/share/YaST2/data/y2sap/' : '/usr/share/YaST2/include/sap-installation-wizard';
+    assert_script_run "rm -f $previous_dir/hana_partitioning_Dell*.xml";
+    assert_script_run "ln -s hana_partitioning.xml '$previous_dir/hana_partitioning_Dell Inc._generic.xml'";
 
     # Add host's IP to /etc/hosts
     $self->add_hostname_to_hosts;


### PR DESCRIPTION
there is different directory for hana_partitioning*.xml on 12-SP5 with 15+, this PR makes wizard_hana_install.pm work on both of 12-SP5 and 15+

- Related ticket: https://jira.suse.com/browse/TEAM-9454
- Needles: null
- Verification run: https://openqa.suse.de/tests/14770655#step/wizard_hana_install/2
