### PR TITLE
update_install: Add systemtap-sdt-devel conflict

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -76,6 +76,7 @@ my @conflicting_packages = (
     'mpich_4_0_2-gnu-hpc-macros-devel', 'mpich-ofi_4_0_2-gnu-hpc-macros-devel',
     'openmpi4-config', 'pmix-mca-params',
     'rmt-server-pubcloud',
+    'systemtap-sdt-devel',
     'kernel-default-base', 'kernel-default-extra'
 );
 


### PR DESCRIPTION
```
%package sdt-devel
Summary:        Static probe support tools
Group:          Development/Tools/Debuggers
Requires:       %{name} = %{version}-%{release}
Conflicts:      systemtap-headers
```

- Related ticket: https://openqa.suse.de/tests/14761883#step/update_install/132
- Verification run: https://dzedro.suse.cz/tests/1175
