### PR TITLE
Enable persistent and console kernel log

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -42,10 +42,10 @@
       <secure_boot>false</secure_boot>
       <terminal>console</terminal>
       % if ($check_var->('SYSTEM_ROLE', 'xen')) {
-      <xen_append>loglevel=5 vt.color=0x07 splash=silent console=hvc0 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
-      <xen_kernel_append><%= defined $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} ? $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} : "com2=115200,8n1 console=com2" %>,vga loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
+      <xen_append>vt.color=0x07 splash=silent console=hvc0 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "loglvl=all guest_loglvl=all" : "loglvl=debug guest_loglvl=debug" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
+      <xen_kernel_append><%= defined $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} ? $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} : "com2=115200,8n1 console=com2" %>,vga <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "loglvl=all guest_loglvl=all" : "loglvl=debug guest_loglvl=debug" %> sync_console</xen_kernel_append>
       % } else {
-      <append>loglevel=5 gfxpayload=1024x768 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+      <append>gfxpayload=1024x768 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
       % }
     </global>
     % if ($check_var->('IPXE_UEFI', '1') or $check_var->('UEFI', '1')) {
@@ -334,6 +334,33 @@ sed -i 's/CR/\n/g' /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> > /root/.ssh/id_rsa.pub
 echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+      <script>
+        <!-- enable persistent kernel log as per ENABLE_PERSISTENT_KERNEL_LOG -->
+        <filename>enable_persistent_kernel_log.sh</filename>
+        <source><![CDATA[
+% if ($get_var->('ENABLE_PERSISTENT_KERNEL_LOG')) {
+    config_file="/etc/rsyslog.conf"
+    if [ -f $config_file ];then
+        if ! grep -q -e "^\$ModLoad imklog.so$" $config_file;then
+            echo "\$ModLoad imklog.so" >> $config_file
+        fi
+        if ! grep -q -e "^kern.*$" $config_file;then
+            rm -f -r /var/log/kern.log
+            echo "kern.*                                  /var/log/kern.log" >> $config_file
+        fi              
+        echo "Enabled persistent kernel log" > /etc/issue.d/enable_persisten_kernel_log 
+        exit 0      
+    else                
+        echo "Failed to enable kernel persistent log due to missing $config_file" > /etc/issue.d/enable_persisten_kernel_log     
+        exit 1      
+    fi
+% } else {
+    echo "Do not enable persistent kernel log because ENABLE_PERSISTENT_KERNEL_LOG=0" > /etc/issue.d/enable_persisten_kernel_log                        
+    exit 0              
+% }             
 ]]>
         </source>
       </script>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -54,25 +54,25 @@
       <trusted_grub>false</trusted_grub>
       <terminal>console</terminal>
       % if ($check_var->('SYSTEM_ROLE', 'xen')) {
-      <xen_append>splash=silent quiet console=tty loglevel=5 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
+      <xen_append>splash=silent quiet console=tty <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "loglvl=all guest_loglvl=all" : "loglvl=debug guest_loglvl=debug" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
       <!-- For some special beremetal machines, such as unreal2/3, their serial console:
       SERIALDEV='ttyS2', XEN_SERIAL_CONSOLE="com1=115200,8n1,0x3e8,5 console=com1" -->
-      <xen_kernel_append><%= defined $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} ? $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} : "console=com2,115200" %> vga=gfx-1024x768x16 loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
+      <xen_kernel_append><%= defined $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} ? $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} : "console=com2,115200" %> vga=gfx-1024x768x16 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "loglvl=all guest_loglvl=all" : "loglvl=debug guest_loglvl=debug" %> sync_console</xen_kernel_append>
       % }
       % if ($check_var->('SYSTEM_ROLE', 'kvm')) {
         % if ($check_var->('AMD', '1')) {
           % if ($check_var->('VIRT_SEV_ES_GUEST_INSTALL', '1')) {
             <!-- Do not add mem_encrypt=on option on 15-SP6 KVM host due to bsc#1224107 -->
             % if ($check_var->('VERSION', '15-SP6')) { 
-      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 kvm_amd.sev=1 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty kvm_amd.sev=1 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
             % } else {
-      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 mem_encrypt=on kvm_amd.sev=1 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty mem_encrypt=on kvm_amd.sev=1 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
             % }
           % } else {
-      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
           % }
         % } else { 
-      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 intel_iommu=on <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty intel_iommu=on <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
         % }
       % }
     </global>
@@ -324,6 +324,33 @@ sed -i 's/CR/\n/g' /root/.ssh/id_rsa
 chmod 600 /root/.ssh/id_rsa
 echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> > /root/.ssh/id_rsa.pub
 echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> >> /root/.ssh/authorized_keys
+]]>
+        </source>
+      </script>
+      <script>
+        <!-- enable persistent kernel log as per ENABLE_PERSISTENT_KERNEL_LOG -->
+        <filename>enable_persistent_kernel_log.sh</filename>
+        <source><![CDATA[
+% if ($get_var->('ENABLE_PERSISTENT_KERNEL_LOG')) {
+    config_file="/etc/rsyslog.conf"
+    if [ -f $config_file ];then
+        if ! grep -q -e "^\$ModLoad imklog.so$" $config_file;then
+            echo "\$ModLoad imklog.so" >> $config_file
+        fi
+        if ! grep -q -e "^kern.*$" $config_file;then
+	    rm -f -r /var/log/kern.log
+            echo "kern.*                                  /var/log/kern.log" >> $config_file
+        fi		
+        echo "Enabled persistent kernel log" > /etc/issue.d/enable_persisten_kernel_log	
+        exit 0	    
+    else		
+        echo "Failed to enable kernel persistent log due to missing $config_file" > /etc/issue.d/enable_persisten_kernel_log	
+        exit 1		
+    fi
+% } else {
+    echo "Do not enable persistent kernel log because ENABLE_PERSISTENT_KERNEL_LOG=0" > /etc/issue.d/enable_persisten_kernel_log			
+    exit 0		
+% }
 ]]>
         </source>
       </script>

--- a/data/virt_autotest/virt_logs_collector.sh
+++ b/data/virt_autotest/virt_logs_collector.sh
@@ -354,6 +354,7 @@ function collect_extra_logs_from_host() {
 	local libvirt_daemon_logs="${libvirt_log}/*d.log"
 	local xen_log="/var/log/xen"
 	local xen_boot_log="${xen_log}/xen-boot.log"
+        local kernel_log="/var/log/kern.log"
 
 	if [[ ${release} -lt 12 ]];then
 	   cp --parent -f -r ${libvirt_log} ${extra_logs_folder}
@@ -385,6 +386,11 @@ function collect_extra_logs_from_host() {
               ret_result=$(( ${ret_result} | $? ))
            fi
 	fi
+        
+	if [ -f ${kernel_log} ];then
+            cp --parent -f -r ${kernel_log}* ${extra_logs_folder} 
+            ret_result=$(( ${ret_result} | $? ))
+        fi
 
 	return ${ret_result}
 }


### PR DESCRIPTION
* **Enable** console kernel log on kvm system by adding ```ignor_loglevel``` on kernel command line in host autoyast profile if ```ENABLE_CONSOLE_KERNEL_LOG=1```.

* **Enable** console kernel log on xen system by adding ```guest_loglvl=all loglvl=all``` on kernel command line in host autoyast profile if  ```ENABLE_CONSOLE_KERNEL_LOG=1```.

* **Enable** persisten kernel log on SLES system by adding ```kern.* /var/log/kern.log``` in ```/etc/rsyslog.conf``` in host autoyast profile if ```ENABLE_PERSISTENT_KERNEL_LOG=1```. 

* **Also** provide subroutines ```enable_persistent_kernel_log``` and ```enable_console_kernel_log``` to enable persistent and console kernel log outside autoyast profies. They can be employed when necessary at any time for convenience.

* **Collect** persistent kernel log in ```data/virt_autotest/virt_logs_collector.sh```.

* **Verification Runs:**
  * [15sp6 on 15sp6 kvm without ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14892279)
  * [15sp6 on 15sp6 xen without ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14786109)
  * [15sp6 on 12sp5 kvm without ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14861222)
  * [15sp6 on 12sp5 xen without ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14861373)
  * [15sp6 on 12sp5 kvm passed with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14798449)
  * [15sp6 on 12sp5 kvm failed at feature test with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14821886)
  * [15sp6 on 12sp5 xen passed with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14798676)
  * [15sp6 on 12sp5 xen failed at guest installation with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14859169)
  * [15sp6 on 15sp6 kvm failed at feature test with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14798704)
  * [15sp6 on 15sp6 xen passed ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14798705)
  * [12sp5 on 15sp6 kvm passed with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14798941)
  * [12sp5 on 15sp6 xen failed at feature test with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14798943)
  * [uefi 15sp6 on 15sp6 kvm failed with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14821909)
  * [uefi 15sp6 on 15sp6 xen failed at guest installation with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14809160)
  * [uefi 15sp6 on 12sp5 kvm failed at guest installation with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14821071)
  * [uefi 15sp6 on 12sp5 xen failed at guest installation with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14821074)
  * [uefi 15sp6 on 15sp5 kvm failed at guest installation with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14809165)
  * [uefi 15sp6 on 15sp5 xen failed at guest installation with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14821911#downloads)
  * [host upgrade 15sp5 to 15sp6 kvm failed at step2 with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14810639)
  * [host upgrade 15sp5 to 15sp6 xen passed with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1](https://openqa.suse.de/tests/14809301)
  * [host upgrade 12sp5 to 15sp6 xen failed at step3 with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14859083)
  * [host upgrade 12sp5 to 15sp6 xen failed at generate_run_file with ENABLE_PERSISTENT_KERNEL_LOG=1 and ENABLE_CONSOLE_KERNEL_LOG=1 kern.log uploaded](https://openqa.suse.de/tests/14859080)
  * [function enable_persistent_kernel_log and enable_console_kernel_log work on 12sp5 kvm](https://openqa.suse.de/tests/14893257)
  * [function enable_persistent_kernel_log and enable_console_kernel_log work on 15sp5 kvm](https://openqa.suse.de/tests/14893259)
  * [function enable_persistent_kernel_log and enable_console_kernel_log work on 15sp6 kvm](https://openqa.suse.de/tests/14893258)
  *  [function enable_persistent_kernel_log and enable_console_kernel_log work on 12sp5 xen](https://openqa.suse.de/tests/14895340)
  *  [function enable_persistent_kernel_log and enable_console_kernel_log work on 15sp5 xen](https://openqa.suse.de/tests/14893605)
  *  [function enable_persistent_kernel_log and enable_console_kernel_log work on 15sp6 xen](https://openqa.suse.de/tests/14896193)