### PR TITLE
Change record_soft_failure to record_info

### DIFF
--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -79,7 +79,7 @@ sub run {
             assert_script_run "ip r s | grep dhcp";
             # verify that static ip is not recorded in /etc/hosts
             if ($is_set_in_etc_host->($static_ip)) {
-                record_info 'bsc#1115644 yast2 lan does not update /etc/hosts after shifting from static ip to dynamic';
+                record_info 'bsc#1115644', 'yast2 lan does not update /etc/hosts after shifting from static ip to dynamic';
                 assert_script_run qq{sed -i '/$static_ip/d' /etc/hosts};
                 assert_script_run q{cat /etc/hosts};
             }

--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -79,7 +79,7 @@ sub run {
             assert_script_run "ip r s | grep dhcp";
             # verify that static ip is not recorded in /etc/hosts
             if ($is_set_in_etc_host->($static_ip)) {
-                record_soft_failure 'bsc#1115644 yast2 lan does not update /etc/hosts after shifting from static ip to dynamic';
+                record_info 'bsc#1115644 yast2 lan does not update /etc/hosts after shifting from static ip to dynamic';
                 assert_script_run qq{sed -i '/$static_ip/d' /etc/hosts};
                 assert_script_run q{cat /etc/hosts};
             }


### PR DESCRIPTION
Change record_soft_failure to record_info.  
According https://bugzilla.suse.com/show_bug.cgi?id=1115644#c75, this is not one issue. Change the soft_failure to record_info.

- Related ticket: https://progress.opensuse.org/issues/158748
- Verification run: https://openqa.suse.de/tests/14776071