### PR TITLE
Detecting needle 'jeos-ssh-enroll-or-not' for SL Micro 6.1

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -202,12 +202,6 @@ sub run {
         send_key 'ret';
     }
 
-    # Skip ssh key enrollment (for now)
-    unless (is_sle || is_sle_micro('<=6.0') || is_leap) {
-        assert_screen 'jeos-ssh-enroll-or-not';
-        send_key 'n';
-    }
-
     if (is_generalhw && is_aarch64 && !is_leap("<15.4") && !is_tumbleweed) {
         assert_screen 'jeos-please-configure-wifi';
         send_key 'n';
@@ -227,6 +221,12 @@ sub run {
         send_key "ret";
         # Disk encryption is gonna take time. Once this is done we can proceed with login.
         wait_still_screen 5;
+    }
+
+    # Skip ssh key enrollment
+    unless (is_sle || is_sle_micro('<=6.0') || is_leap) {
+        assert_screen 'jeos-ssh-enroll-or-not', 1000;
+        send_key 'n';
     }
 
     if (is_bootloader_sdboot) {


### PR DESCRIPTION
* **SSH** key enrollment and corresponding needle 'jeos-ssh-enroll-or-not' detecting are available for SL Micro 6.1. 

* **Needle** 'jeos-ssh-enroll-or-not' detecting should be performed after the disk encryption, otherwise test run with encrypted image will fail like [this](https://openqa.suse.de/tests/14783986#step/firstrun/11).

* **Verification Runs:**
  * [test run](https://openqa.suse.de/tests/14784025)
