### PR TITLE
Ipaddr2 test deployment wait VM to run

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -81,7 +81,7 @@ Create a deployment in Azure designed for this specific test.
 5. Create 1 additional VM that get
 6. Create a Load Balancer with 2 VM in backend and with an IP as frontend
 
-=over 2
+=over 3
 
 =item B<region> - existing resource group
 
@@ -270,6 +270,12 @@ sub ipaddr2_azure_deployment {
         frontend_ip => $lb_fe,
         name => $lb . "_rule",
         port => '80');
+
+    foreach my $i (1 .. 2) {
+        az_vm_wait_running(
+            resource_group => $rg,
+            name => ipaddr2_get_internal_vm_name(id => $i));
+    }
 }
 
 =head2 ipaddr2_bastion_pubip

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -15,6 +15,7 @@ subtest '[ipaddr2_azure_deployment]' => sub {
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
     $ipaddr2->redefine(data_url => sub { return '/Faggin'; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
@@ -27,7 +28,7 @@ subtest '[ipaddr2_azure_deployment]' => sub {
     }
 
     # Todo : expand it
-    ok $#calls > 0, "There are some command calls";
+    ok(($#calls > 0), "There are some command calls");
     ok((none { /az storage account create/ } @calls), 'Do not create storage');
 };
 
@@ -37,6 +38,7 @@ subtest '[ipaddr2_azure_deployment] diagnostic' => sub {
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
     $ipaddr2->redefine(data_url => sub { return '/Faggin'; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
@@ -72,7 +74,7 @@ subtest '[ipaddr2_bastion_key_accept]' => sub {
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /StrictHostKeyChecking=accept-new/ } @calls), 'Correct call ssh command');
     ok((any { /1\.2\.3\.4/ } @calls), 'Bastion IP in the ssh command');
-    ok scalar @calls eq 2, "Exactly 2 calls";
+    ok((scalar @calls eq 2), "Exactly 2 calls and get " . (scalar @calls));
 };
 
 subtest '[ipaddr2_bastion_key_accept] without providing the bastion_ip' => sub {
@@ -85,7 +87,7 @@ subtest '[ipaddr2_bastion_key_accept] without providing the bastion_ip' => sub {
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /StrictHostKeyChecking=accept-new/ } @calls), 'Correct call ssh command');
     ok((any { /1\.2\.3\.4/ } @calls), 'Bastion IP in the ssh command');
-    ok scalar @calls eq 2, "Exactly 2 calls";
+    ok((scalar @calls eq 2), "Exactly 2 calls and get " . (scalar @calls));
 };
 
 subtest '[ipaddr2_deployment_sanity] Pass' => sub {


### PR DESCRIPTION
Add waiting function at the end of the deployment.


- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run:

 - sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/287686