### PR TITLE
Revert suseconnect-ng fix for s390x

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -318,7 +318,7 @@ sub register_addons_cmd {
             }
             elsif (grep(/$name/, keys %ADDONS_REGCODE)) {
                 my $opt = "";
-                if (is_sle("=15-SP4") && !(is_s390x)) {
+                if (is_sle("=15-SP4")) {
                     $opt = " --auto-agree-with-licenses";
                 }
                 add_suseconnect_product($name, undef, undef, "-r " . $ADDONS_REGCODE{$name} . $opt, 300, $retry);


### PR DESCRIPTION
##
### Revert s390x temporary condition once suseconnect-ng package is updated

- Related ticket: https://progress.opensuse.org/issues/154726
- Needles: N/A
- Verification run: 
   - [**VR**](https://openqa.suse.de/tests/overview?distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23revert_suseconnect-ng&version=15-SP6)
  
##  