### PR TITLE
Switch booltoader to terminal in autoyast profile for full medium

### DIFF
--- a/data/autoyast_sle15/autoyast_no_scc_reg_full.xml.ep
+++ b/data/autoyast_sle15/autoyast_no_scc_reg_full.xml.ep
@@ -49,6 +49,7 @@ architectures.
   <bootloader>
     <global>
       <timeout config:type="integer">45</timeout>
+      <terminal>serial</terminal>
     </global>
   </bootloader>
   <firewall>


### PR DESCRIPTION
Fix poo@163145: Bare metal servers have issue with grub in graphical terminal mode during the boot. We need to set terminal to serial in autoyast profile to properly display grub menu in IPMI console.


- Related ticket: https://progress.opensuse.org/issues/163145
- Needles: none
- Verification run: 


aarch64  unarmed: https://openqa.suse.de/tests/14798662#step/handle_reboot/2
x86_64 worf: https://openqa.suse.de/tests/14798629#step/handle_reboot/2
x86_64 tyrion: https://openqa.suse.de/tests/14798631#step/handle_reboot/2