### PR TITLE
No touching virtproxyd daemon as it is not installed on modular libvirt

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -57,7 +57,6 @@ sub check_modular_libvirt_daemons {
         @daemons = qw(network nodedev nwfilter secret storage lock);
         # For details, please refer to poo#137096
         (is_xen_host) ? push @daemons, 'xen' : push @daemons, ('qemu', 'log');
-        push @daemons, 'proxy' if is_sle;
     }
 
     foreach my $daemon (@daemons) {
@@ -83,7 +82,6 @@ sub restart_modular_libvirt_daemons {
         @daemons = qw(network nodedev nwfilter secret storage lock);
         # For details, please refer to poo#137096
         (is_xen_host) ? push @daemons, 'xen' : push @daemons, ('qemu', 'log');
-        push @daemons, 'proxy' if is_sle;
     }
 
     if (is_alp) {
@@ -216,7 +214,6 @@ sub turn_on_libvirt_debugging_log {
     my @libvirt_daemons = is_monolithic_libvirtd ? "libvirtd" : qw(virtqemud virtstoraged virtnetworkd virtnodedevd virtsecretd virtnwfilterd virtlockd);
     # For details, please refer to poo#137096
     push @libvirt_daemons, 'virtlogd' if is_kvm_host;
-    push @libvirt_daemons, 'virtproxyd' if is_sle;
 
     #turn on debug and log filter for libvirt services
     #disable log_level = 1 'debug' as it generage large output

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -116,6 +116,9 @@ sub test_network_interface {
         $target = script_output("dig +short libvirt.org");
         $target =~ /^[\d\.]+/ ? record_info("One more try succeed!") : die "Unable to test network connections!";
     }
+    else {
+        $target =~ s/\n.*//gm;
+    }
 
     record_info("Network test", "testing $mac");
     check_guest_ip("$guest", net => $net) if ((is_sle('>15') || is_alp) && ($isolated == 1) && get_var('VIRT_AUTOTEST'));


### PR DESCRIPTION
- Not involve `virtproxyd` daemon as it is not installed on modular libvirt. Related ticket: https://progress.opensuse.org/issues/162881
- fix failure https://10.145.10.207/tests/14798677#step/sriov_network_card_pci_passthrough/208

Verification run: 
[gi-guest_sles12sp5-on-host_developing-xen](http://openqa.suse.de/tests/14809044)
[uefi-gi-guest_developing-on-host_developing-xen](https://10.145.10.207/tests/14809046)
[prj4_guest_upgrade_sles15sp5_on_sles15sp5-kvm](https://10.145.10.207/tests/14809047)
[prj2_host_upgrade_sles12sp5_to_developing_kvm](https://10.145.10.207/tests/14809045)
[fix_network_test_failure_in_sriov_test](https://10.145.10.207/tests/14800754#step/sriov_network_card_pci_passthrough/208)
[another_sriov_pass_on_quinn](https://10.145.10.207/tests/14809046#step/sriov_network_card_pci_passthrough/247)
