### PR TITLE
ipxe: Add option to disable installer auto update

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -93,6 +93,7 @@ sub set_bootscript {
     $cmdline_extra .= " console=$console " if $console;
     $cmdline_extra .= " root=/dev/ram0 initrd=initrd " if (check_var('IPXE_UEFI', '1'));
     $cmdline_extra .= " textmode=1 " if get_var('IPXE_UEFI') or check_var('VIDEOMODE', 'text');
+    $cmdline_extra .= " self_update=0 " if (check_var("INSTALLER_NO_SELF_UPDATE", 1));
 
     # Support passing EXTRA_PXE_CMDLINE to bootscripts
     $cmdline_extra .= get_var('EXTRA_PXE_CMDLINE') . ' ' if get_var('EXTRA_PXE_CMDLINE');


### PR DESCRIPTION
Enhancement poo#162170: We need the option to disable installer auto update for maintenance QR release testing.

- Related ticket: https://progress.opensuse.org/issues/162170
- Needles: none
- Verification run: 
worf:  https://openqa.suse.de/tests/14798809
tyrion: https://openqa.suse.de/tests/14798811

