### PR TITLE
Add sleep to fix "Missing sudo password" on GCP

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -582,6 +582,12 @@ sub qesap_execute_conditional_retry {
         die "'qesap.py (after retry) $args{cmd}' return: $ret[0]";
     }
 
+    # Sleep $N for fixing ansible "Missing sudo password" issue on GCP
+    if (get_required_var('PUBLIC_CLOUD_PROVIDER') eq 'GCE') {
+        sleep 60;
+        record_info('Workaround: "sleep 60" for fixing ansible "Missing sudo password" issue on GCP');
+    }
+
     return @ret;
 }
 

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -405,6 +405,7 @@ subtest '[qesap_execute_conditional_retry] retry after fail with expected error 
     # Simulate that qesap_execute has always 'AERIS'
     # in the log
     $qesap->redefine(qesap_file_find_string => sub { return 1; });
+    $qesap->redefine(get_required_var => sub { return ''; });
 
     my @res = qesap_execute_conditional_retry(
         cmd => 'TIFA',


### PR DESCRIPTION
Add sleep to fix "Missing sudo password" on GCP

Add sleep to fix ansible ssh "Missing sudo password" issue on GCP VM.
[TEAM-9480](https://jira.suse.com/browse/TEAM-9480) - [timeboxed] "Missing sudo password" sporadically prevent any ansible connection to GCP VM

NOTE-1: checked OSD and OW15 only found this issue on "qesap-regression-latest" job group:
12-SP5 GCP PAYG + BYOS: not found this sporadic issue ATM
15-SP6 GCP PAYG + BYOS: were not triggered in OW15 "qesap-regression-latest" job group.
15-SP5 GCP PAYG + BYOS: found this sporadic issue
15-SP4 GCP PAYG + BYOS: found this sporadic issue
15-SP3 GCP PAYG + BYOS: found this sporadic issue
15-SP2 GCP PAYG + BYOS were not triggered in OW15 "qesap-regression-latest" job group.

NOTE-2:
Using `sleep 30` still can find this sporadic issue so I chose `sleep 60`.

- Related ticket: https://jira.suse.com/browse/TEAM-9480
- Needles: NA
- Verification run (Build='Lily-VR-TEAM-8479-missing-sudo-PW' ):
- 15-SP5 GCP BYOS: http://openqaworker15.qa.suse.cz/tests/287807#next_previous (ran 10 VRs, all failed on "sap-hana-cluster" and no "missing sudo password" found) 
- 15-SP4 GCP PAYG: http://openqaworker15.qa.suse.cz/tests/288144#next_previous (ran 10 VRs, all failed on "sap-hana-cluster" and no "missing sudo password" found)
- 15-SP3 GCP PAYG:  http://openqaworker15.qa.suse.cz/tests/288134#next_previous (ran 10 VRs, all failed on "sap-hana-cluster" and no "missing sudo password" found)

