### PR TITLE
containers: Add centos:stream9 to list of 3rd party images

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -156,7 +156,8 @@ sub get_3rd_party_images {
     my @images = (
         "registry.opensuse.org/opensuse/leap",
         "registry.opensuse.org/opensuse/tumbleweed",
-        "ghcr.io/linuxcontainers/alpine:latest"
+        "ghcr.io/linuxcontainers/alpine:latest",
+        "quay.io/centos/centos:stream9"
     );
 
     # Following images are not available on 32-bit arm

--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -153,10 +153,12 @@ sub supports_image_arch {
 }
 
 sub get_3rd_party_images {
+    my $registry = get_var('REGISTRY', 'docker.io');
     my @images = (
         "registry.opensuse.org/opensuse/leap",
         "registry.opensuse.org/opensuse/tumbleweed",
-        "ghcr.io/linuxcontainers/alpine:latest",
+        "$registry/library/alpine",
+        "$registry/library/debian",
         "quay.io/centos/centos:stream9"
     );
 
@@ -180,6 +182,10 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi9/ubi-micro",
         "registry.access.redhat.com/ubi9/ubi-init"
     ) unless (is_arm || is_s390x || is_ppc64le || !is_x86_64_v2);
+
+    push @images, (
+        "$registry/library/ubuntu"
+    ) if (is_x86_64);
 
     # RedHat UBI7 images are not built for aarch64 and 32-bit arm
     push @images, (


### PR DESCRIPTION
This PR:
- Adds official CentOS Stream 9 image to list of 3rd party images.
- Re-adds some 3rd party images removed due to issues with previous registry mirror.

Verification runs:
- microos-Tumbleweed-DVD-x86_64-Build20240701-container-host@64bit -> https://openqa.opensuse.org/tests/4314446
- microos-Tumbleweed-DVD-aarch64-Build20240701-container-host@aarch64-4G-HD40G -> https://openqa.opensuse.org/t4314448
- sle-15-SP6-Server-DVD-Updates-s390x-Build20240702-1-podman_tests@s390x-kvm -> https://openqa.suse.de/t14800811
