### PR TITLE
Test fails in snapper_create

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -129,6 +129,8 @@ sub get_last_snap_number {
     }
 
     my $snaps = decode_json(script_output('snapper --jsonout list --disable-used-space'));
+    record_info('debug1', script_output('snapper --jsonout list --disable-used-space'));
+    record_info('debug2', $snaps);
     my $last = (@{$snaps->{root}})[-1];
     return $last->{number};
 }

--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -129,8 +129,6 @@ sub get_last_snap_number {
     }
 
     my $snaps = decode_json(script_output('snapper --jsonout list --disable-used-space'));
-    record_info('debug1', script_output('snapper --jsonout list --disable-used-space'));
-    record_info('debug2', $snaps);
     my $last = (@{$snaps->{root}})[-1];
     return $last->{number};
 }

--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -203,6 +203,7 @@ sub run {
         foreach my $disk_path (@disk_paths) {
             hyperv_cmd("$ps Add-VMHardDiskDrive -VMName $name -Path $disk_path");
         }
+        record_info(get_var('WORKER_HOSTNAME'));
         hyperv_cmd("$ps Set-VMComPort -VMName $name -Number 1 -Path '\\\\.\\pipe\\$name'");
         ($ret, $vmguid, undef) = console('svirt')->run_cmd(qq/$ps (Get-VM -VMName $name).id.guid/, wantarray => 1);
         die "Have not find any GUID for $name" if $ret != 0;


### PR DESCRIPTION
After booting, setting up, patching and registering a system based on an already existing JeOS hard disk image of the latest SLE version for Hyper-V provided in the VHDX format, multiple filesystem tools like lsof, autofs, lvm, snapper and btrfs are tested. The test is conducted on an x86_64 VM on Hyper-V.

- Related ticket: https://progress.opensuse.org/issues/160733
- Verification run: :construction:
- Creating new app: https://github.com/pablo-herranz/namedpipe-tcp-bridge
