### PR TITLE
[SDAF] Create snapshot based deployer

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -11,8 +11,11 @@ use strict;
 use warnings;
 use testapi;
 use parent 'opensusebasetest';
-use sles4sap::sap_deployment_automation_framework::deployment;
-use sles4sap::console_redirection;
+use sles4sap::sap_deployment_automation_framework::deployment qw(sdaf_cleanup az_login load_os_env_variables);
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployer_resources);
+use sles4sap::console_redirection qw(connect_target_to_serial disconnect_target_from_serial);
+use sles4sap::azure_cli qw(az_resource_delete);
+
 
 sub post_fail_hook {
     if (get_var('SDAF_RETAIN_DEPLOYMENT')) {
@@ -21,12 +24,22 @@ sub post_fail_hook {
     }
 
     record_info('Post fail', 'Executing post fail hook');
-    # Cleanup SDAF files form Deployer VM
+    # Trigger SDAF remover script to destroy 'workload zone' and 'sap systems' resources
+    # Clean up all config files, keys, etc.. on deployer VM
     connect_target_to_serial();
     load_os_env_variables();
     az_login();
     sdaf_cleanup();
     disconnect_target_from_serial();
+
+    # Cleanup deployer VM resources only
+    # Deployer VM is located in permanent deployer resource group. This RG **MUST STAY INTACT**
+    my @resource_cleanup_list = @{find_deployer_resources(return_value => 'id')};
+    record_info('Resources destroy',
+        "Following resources are being destroyed:\n" . join("\n", @{find_deployer_resources()}));
+
+    az_resource_delete(ids => join(' ', @resource_cleanup_list),
+        resource_group => get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP'), timeout => '600');
 }
 
 1;

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -1,0 +1,237 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 SYNOPSIS
+
+This library contains various functions that help finding and connecting openQA job to the correct deployment VM.
+Deployment VM is recognized from other VMs by being tagged with B<deployment_id> tag. Deployment ID is an unique
+identifier which is an OpenQA job ID of a job that created this VM.
+In single machine test Deployment ID equals test ID. This is not always true in case of multi-machine jobs.
+Deployment ID might be an ID of the parent job which executed the deployment itself.
+
+B<Example>:
+Job: 123456 - deployment module - created deployer VM tagged with "deployment_id=123456",
+Job: 123457 (child of 123456) - some test module
+Deployment ID returned from both jobs: 123456 - because it matches with existing VM tagged with "deployment_id=123456"
+
+=cut
+
+package sles4sap::sap_deployment_automation_framework::deployment_connector;
+
+use strict;
+use warnings;
+use testapi;
+use Exporter qw(import);
+use Mojo::JSON qw(decode_json);
+use Scalar::Util qw(looks_like_number);
+use Carp qw(croak);
+use mmapi qw(get_parents get_job_autoinst_vars get_children get_job_info get_current_job_id);
+use Data::Dumper;
+
+our @EXPORT = qw(
+  get_deployer_vm
+  get_deployer_ip
+  check_deployer_ssh
+  find_deployment_id
+  find_deployer_resources
+);
+
+=head2 check_deployer_ssh
+
+    check_deployer_ssh($deployer_ip_addr [, ssh_port=>42 ,$wait_started=>'true', wait_timeout=>'42']);
+
+Checks if deployer VM is running and listening on ssh port. Returns found state.
+Optionally function can wait till VM reaches requested state until timeout.
+Function dies only with internal errors, VM status should be evaluated and handled by caller.
+
+B<deployer_ip_addr>: Deployer VM IP address
+
+B<wait_started>: Probe SSH port in loop untill it is available or B<wait_timeoout> is reached.
+
+B<wait_timeout>: Time in sec to stop probing SSH port.
+
+B<ssh_port>: Specify custom SSH port number. Default: 22
+
+=cut
+
+sub check_deployer_ssh {
+    my ($deployer_ip_addr, %args) = @_;
+    croak 'Deployer IP not specified.' unless $deployer_ip_addr;
+    $args{wait_timeout} //= 180;
+    $args{ssh_port} //= 22;
+    my $ssh_available = 0;
+
+    my $nc_cmd = 'nc -zv';
+    # With `-w 10` netcat keeps waiting 10s for server response instead of returning immediately
+    $nc_cmd .= ' -w 10' if $args{wait_started};
+    $nc_cmd .= " $deployer_ip_addr $args{ssh_port}";
+
+    my $start_time = time();
+    until ($ssh_available) {
+        $ssh_available = 1 if !script_run($nc_cmd, quiet => 1);
+        last unless $args{wait_started};
+        last if (time() - $start_time) >= $args{wait_timeout};
+        record_info('SSH N/A', 'SSH unavailable, retrying in 10s');
+        sleep 10;    # just a separation between loops, to avoid bombarding the server constantly
+    }
+    my $status = $ssh_available ? 'available' : 'unavailable';
+    record_info('SSH check', "SSH connection to '$deployer_ip_addr -p $args{ssh_port}': $status");
+    return $ssh_available;
+}
+
+=head2 get_deployer_ip
+
+    get_deployer_ip(deployer_resource_group=>$deployer_resource_group, deployer_vm_name=>$deployer_vm_name);
+
+Returns first public IP of deployer VM that is reachable and can be used for SDAF deployment connection.
+
+B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+
+B<deployer_vm_name>: Deployer VM resource name
+
+=cut
+
+sub get_deployer_ip {
+    my (%args) = @_;
+    $args{deployer_resource_group} //= get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
+    croak 'Missing "deployer_vm_name" argument' unless $args{deployer_vm_name};
+
+    my $az_query_cmd = join(' ', 'az', 'vm', 'list-ip-addresses', '--resource-group', $args{deployer_resource_group},
+        '--name', $args{deployer_vm_name}, '--query', '"[].virtualMachine.network.publicIpAddresses[].ipAddress"', '-o', 'json');
+
+    my $ip_addr = decode_json(script_output($az_query_cmd));
+    # Find first IP connection working
+    for my $ip (@{$ip_addr}) {
+        return $ip if check_deployer_ssh($ip, wait_started => 'yes');
+    }
+    return undef;
+}
+
+=head2 get_deployer_vm
+
+    get_deployer_vm(deployer_resource_group=>$deployer_resource_group, deployment_id=>'123456');
+
+Returns deployer VM name which is tagged with B<deployment_id> specified in parameter. This means that the VM was used
+to deploy the infrastructure under this ID and contains whole SDAF setup.
+Function returns VM name or undef if no VM was found.
+Function dies if there is more than one VM found, because two VM's must not have same ID.
+
+B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+
+B<deployment_id>: Deployment ID
+
+=cut
+
+sub get_deployer_vm {
+    my (%args) = @_;
+    $args{deployer_resource_group} //= get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
+    $args{deployment_id} //= find_deployment_id();
+    croak 'Missing mandatory argument $args{deployment_id}' unless $args{deployment_id};
+
+    # Following query lists VMs within a resource group that were tagged with specified deployment id.
+    my $az_cmd = join(' ',
+        'az vm list',
+        "--resource-group $args{deployer_resource_group}",
+        "--query \"\[?tags.deployment_id == '$args{deployment_id}'].name\"",
+        '--output json'
+    );
+
+    my @vm_list = @{decode_json(script_output($az_cmd))};
+    diag((caller(0))[3] . " - VMs found: " . join(', ', @vm_list));
+    die "Multiple VMs with same IDs found. Each VM must have unique ID!\n
+    Following VMs found tagged with: deployment_id=$args{deployment_id}"
+      if @vm_list > 1;
+
+    return $vm_list[0];
+}
+
+=head2 get_parent_ids
+
+    get_parent_ids();
+
+Returns B<ARRAYREF> of all parent job IDs acquired from current job data.
+
+=cut
+
+sub get_parent_ids {
+    my $job_info = get_job_info(get_current_job_id());
+    # This will loop through all parent job types (chained, parallel, etc...) and creates a list of IDs
+    my @parent_ids = map { @{$job_info->{parents}{$_}} } keys(%{$job_info->{parents}});
+    diag((caller(0))[3] . "Parent job data: " . Dumper($job_info->{parents}));
+    foreach (@parent_ids) { die "Returned parent ID must be a number: '$_'" unless looks_like_number($_); }
+    return \@parent_ids;
+}
+
+=head2 find_deployment_id
+
+    find_deployment_id(deployer_resource_group=>$deployer_resource_group);
+
+Finds deployment ID for currently running test. Deployment ID is ID of an OpenQA test which created deployer VM.
+In case of multi-machine test this can be either parent test ID or current job id as well.
+This function collects all OpenQA job IDs related to current test run and checks if any of them match an existing
+deployer VM tagged with this ID.
+
+B<Example>:
+Job: 123456 - deployment module - created deployer VM tagged with "deployment_id=123456",
+Job: 123457 (child of 123456) - some test module
+Deployment ID returned from both jobs: 123456 - because it matches with existing VM tagged with "deployment_id=123456"
+
+B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+
+=cut
+
+sub find_deployment_id {
+    my (%args) = @_;
+    $args{deployer_resource_group} //= get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
+    my @check_list = (get_current_job_id(), @{get_parent_ids()});
+
+    diag("Job IDs found: " . Dumper(@check_list));
+    my @ids_found;
+    for my $deployment_id (@check_list) {
+        my $vm_name =
+          get_deployer_vm(deployer_resource_group => $args{deployer_resource_group}, deployment_id => $deployment_id);
+        push(@ids_found, $deployment_id) if $vm_name;
+    }
+    die "More than one deployment found.\nJobs IDs: " .
+      join(', ', @check_list) . "\nVMs found: " . join(', ', @ids_found) if @ids_found > 1;
+
+    return ($ids_found[0]);
+}
+
+=head2 get_deployer_resources
+
+    get_deployer_resources(deployer_resource_group=>$deployer_resource_group [, deployment_id=>'123456', return_ids=1]);
+
+Returns ARRAYREF of all resources belonging to B<deployer_resource_group> tagged with B<deployment_id>.
+
+B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+
+B<deployment_id>: Deployment ID
+
+B<return_value>: Control the content of the returned array. It can either return array of resource IDs or resource names.
+    Values allowed: id, name
+    Default: name
+
+=cut
+
+sub find_deployer_resources {
+    my (%args) = @_;
+    $args{deployer_resource_group} //= get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
+    $args{deployment_id} //= find_deployment_id();
+    $args{return_value} //= 'name';
+    croak "Argument 'return_value' accepts only 'id' or 'name'" unless grep(/$args{return_value}/, ('id', 'name'));
+
+    my $az_cmd = join(' ',
+        'az resource list',
+        "--resource-group $args{deployer_resource_group}",
+        "--query \"[?tags.deployment_id == '$args{deployment_id}'].$args{return_value}\"",
+        '--output json'
+    );
+
+    my @resource_list = @{decode_json(script_output($az_cmd))};
+
+    return \@resource_list;
+}

--- a/schedule/sles4sap/sap_deployment_automation_framework/deploy_hana_sr.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/deploy_hana_sr.yml
@@ -4,9 +4,9 @@ description: |
   Deploy SAP Hana SR scenario using 'SAP deployment automation framework'
 schedule:
   - boot/boot_to_desktop
+  - sles4sap/sap_deployment_automation_framework/create_deployer_vm
   - sles4sap/sap_deployment_automation_framework/connect_to_deployer
   - sles4sap/sap_deployment_automation_framework/configure_deployer
   - sles4sap/sap_deployment_automation_framework/deploy_workload_zone
   - sles4sap/sap_deployment_automation_framework/deploy_sap_systems
   - sles4sap/sap_deployment_automation_framework/deploy_hanasr
-  - sles4sap/sap_deployment_automation_framework/cleanup

--- a/schedule/sles4sap/sap_deployment_automation_framework/test_hana_sr.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/test_hana_sr.yml
@@ -1,0 +1,8 @@
+---
+name: sap_deployment_automation_framework
+description: |
+  Hana SR test scenario executed on deployment created by 'SAP Deployment automation framework'
+schedule:
+  - boot/boot_to_desktop
+  - sles4sap/sap_deployment_automation_framework/connect_to_deployer
+  - sles4sap/sap_deployment_automation_framework/cleanup

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -649,4 +649,65 @@ subtest '[az_network_peering_delete]' => sub {
     ok((any { /az network vnet peering delete/ } @calls), 'Correct composition of the main command');
 };
 
+
+subtest '[az_disk_create] Create disk by cloning' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+
+    az_disk_create(resource_group => 'Pa_a_Pi', name => 'Od_Kuka_do_Kuka', source => 'Harvepino');
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/az disk create/, @calls), 'Test base command');
+    ok(grep(/--resource-group Pa_a_Pi/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--name Od_Kuka_do_Kuka/, @calls), 'Check for argument "--name"');
+    ok(grep(/--source Harvepino/, @calls), 'Check for argument "--source"');
+
+    az_disk_create(resource_group => 'Pa_a_Pi', name => 'Od_Kuka_do_Kuka', size_gb => '42');
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/--size-gb 42/, @calls), 'Check for argument "--size-gb"');
+};
+
+subtest '[az_disk_create] Create empty disk defining size' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+
+    az_disk_create(resource_group => 'Pa_a_Pi', name => 'Od_Kuka_do_Kuka', size_gb => '42');
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/--size-gb 42/, @calls), 'Check for argument "--size-gb"');
+};
+
+
+subtest '[az_disk_create] Check exceptions' => sub {
+    dies_ok { az_disk_create(resource_group => 'Pa_a_Pi', size_gb => '42') } "Croak with missing mandatory argument 'resource_group'";
+    dies_ok { az_disk_create(name => 'Od_Kuka_do_Kuka', size_gb => '42') } "Croak with missing mandatory argument 'name'";
+    dies_ok { az_disk_create(resource_group => 'Pa_a_Pi', name => 'Od_Kuka_do_Kuka') } "Croak with missing mandatory argument 'size_gb'";
+    dies_ok { az_disk_create(resource_group => 'Pa_a_Pi', name => 'Od_Kuka_do_Kuka') } "Croak with missing mandatory argument 'source'";
+    dies_ok { az_disk_create(resource_group => 'Pa_a_Pi', name => 'Od_Kuka_do_Kuka', size_gb => '42', source => 'Slovenska_televizia') } "Croak with both 'size_gb' and 'source' defined at the same time";
+};
+
+subtest '[az_resource_delete]' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+
+    az_resource_delete(resource_group => 'Pa_a_Pi', name => 'Od_Kuka_do_Kuka');
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/az resource delete/, @calls), 'Test base command');
+    ok(grep(/--resource-group Pa_a_Pi/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--name Od_Kuka_do_Kuka/, @calls), 'Check for argument "--name"');
+
+    az_resource_delete(resource_group => 'Pa_a_Pi', ids => 'od Kuka do Kuka');
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/--ids od Kuka do Kuka/, @calls), 'Check for argument "--ids"');
+};
+
+subtest '[az_resource_delete]' => sub {
+    dies_ok { az_resource_delete(ids => 'od Kuka do Kuka') } "Dies with missing argument 'resource_group'";
+    dies_ok { az_resource_delete(resource_group => 'Pa_a_Pi') } "Dies with missing argument 'name'";
+    dies_ok { az_resource_delete(resource_group => 'Pa_a_Pi') } "Dies with missing argument 'ids'";
+    dies_ok { az_resource_delete(resource_group => 'Pa_a_Pi', ids => 'od Kuka do Kuka', name => 'Od_Kuka_do_Kuka') }
+    "Dies with both 'ids' and 'name' being defined";
+};
+
 done_testing;

--- a/t/24_sdaf_naming_convention.t
+++ b/t/24_sdaf_naming_convention.t
@@ -18,7 +18,7 @@ subtest '[deployment_dir]' => sub {
     my $mock_lib = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::naming_conventions', no_auto => 1);
     my @calls;
     $mock_lib->redefine(get_var => sub { return '/tmp' });
-    $mock_lib->redefine(get_current_job_id => sub { return '42' });
+    $mock_lib->redefine(find_deployment_id => sub { return '42' });
     $mock_lib->redefine(assert_script_run => sub { push(@calls, $_[0]); return });
 
     is deployment_dir(), '/tmp/Azure_SAP_Automated_Deployment_42', 'Return deployment path';
@@ -32,6 +32,7 @@ subtest '[deployment_dir]' => sub {
 subtest '[log_dir]' => sub {
     my $mock_lib = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::naming_conventions', no_auto => 1);
     my @calls;
+    $mock_lib->redefine(find_deployment_id => sub { return '0079' });
     $mock_lib->redefine(deployment_dir => sub { return '/narnia' });
     $mock_lib->redefine(assert_script_run => sub { push(@calls, $_[0]); return });
 
@@ -71,7 +72,7 @@ subtest '[get_tfvars_path] Test passing scenarios' => sub {
     );
 
     $mock_lib->redefine(get_sdaf_config_path => sub { return '/narnia'; });
-    $mock_lib->redefine(get_current_job_id => sub { return '0079'; });
+    $mock_lib->redefine(find_deployment_id => sub { return '0079'; });
 
     foreach (keys(%expected_results)) {
         is get_tfvars_path(%arguments, deployment_type => $_), $expected_results{$_},
@@ -82,7 +83,7 @@ subtest '[get_tfvars_path] Test passing scenarios' => sub {
 
 subtest '[generate_resource_group_name]' => sub {
     my $mock_lib = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::naming_conventions', no_auto => 1);
-    $mock_lib->redefine(get_current_job_id => sub { return '0079'; });
+    $mock_lib->redefine(find_deployment_id => sub { return '0079'; });
     my @expected_failures = ('something_funky', 'workload', 'zone', 'sut', 'lib', 'deploy');
     my %expected_pass = (
         workload_zone => 'SDAF-OpenQA-workload_zone-0079',
@@ -100,7 +101,6 @@ subtest '[generate_resource_group_name]' => sub {
         is $rg, $expected_pass{$type}, "Pass with '$type' and resource group '$rg";
     }
 };
-
 
 subtest '[convert_region_to_long] Test conversion' => sub {
     is convert_region_to_long('SECE'), 'swedencentral', 'Convert abbreviation "SECE" to "swedencentral"';

--- a/t/25_deployment_connector.t
+++ b/t/25_deployment_connector.t
@@ -1,0 +1,189 @@
+use strict;
+use warnings;
+use Test::Mock::Time;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use testapi;
+use Data::Dumper;
+use Scalar::Util qw(reftype);
+use List::Util qw(any none);
+use sles4sap::sap_deployment_automation_framework::deployment_connector;
+
+subtest '[get_deployer_vm] Test expected failures' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    $mock_function->redefine(diag => sub { return; });
+    $mock_function->redefine(script_output => sub { return '
+[
+  "0079-Zaku_II",
+  "0079-MSM-07"
+]
+'; });
+
+    dies_ok { get_deployer_vm(deployer_resource_group => 'Char') } 'Croak with missing mandatory arg: deployment_id';
+    dies_ok { get_deployer_vm(deployer_resource_group => 'Char', deployment_id => '0079') } 'Die with multiple VMs tagged with same ID';
+};
+
+subtest '[get_deployer_vm] Check command composition' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    my @calls;
+    $mock_function->redefine(diag => sub { return; });
+    $mock_function->redefine(script_output => sub { push(@calls, @_); return '[
+  "0079-Zaku_II"
+]'
+    });
+
+    my $result = get_deployer_vm(deployer_resource_group => 'Char', deployment_id => '0079');
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((grep /az vm list/, @calls), 'Check main az command');
+    ok((grep /--resource-group Char/, @calls), 'Check --resource-group argument');
+    ok((grep /--query "\[\?tags.deployment_id == '0079'].name"/, @calls), 'Check --query argument');
+    ok((grep /--output json/, @calls), 'Output must be in json format');
+    is $result, '0079-Zaku_II', 'Return VM name';
+
+    $mock_function->redefine(script_output => sub { push(@calls, @_); return '[]' });
+    is get_deployer_vm(deployer_resource_group => 'Char', deployment_id => '0079'), undef, 'Return empty string if no VM found';
+};
+
+subtest '[find_deployment_id]' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    $mock_function->redefine(get_current_job_id => sub { return '0079'; });
+    $mock_function->redefine(get_parent_ids => sub { return ['0083', '0087']; });
+    $mock_function->redefine(get_deployer_vm => sub { return '0079' if grep(/0079/, @_); });
+
+    is find_deployment_id(deployer_resource_group => 'Char'), '0079', 'Current job ID belongs to VM';
+
+    $mock_function->redefine(get_current_job_id => sub { return; });
+    is find_deployment_id(deployer_resource_group => 'Char'), undef, 'Return undef if no ID found';
+
+    $mock_function->redefine(get_deployer_vm => sub { return '0083' if grep(/0083/, @_); });
+    is find_deployment_id(deployer_resource_group => 'Char'), '0083', 'Parent job ID belongs to VM';
+};
+
+subtest '[find_deployer_resources] Check command composition' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    my @calls;
+    $mock_function->redefine(diag => sub { return; });
+    $mock_function->redefine(script_output => sub { push(@calls, @_); return '[
+  "0079-Zaku_II_VM_OS",
+  "0079-Zaku_II_VMNSG",
+  "0079-Zaku_II_VMPublicIP",
+  "0079-Zaku_II_VMVMNIC",
+  "0079-Zaku_II_VM"
+]'
+    });
+
+    my $result = find_deployer_resources(deployer_resource_group => 'Char', deployment_id => '0079');
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((grep /az resource list/, @calls), 'Check main az command');
+    ok((grep /--resource-group Char/, @calls), 'Check --resource-group argument');
+    ok((grep /--query "\[\?tags.deployment_id == '0079'].name"/, @calls), 'Query resource names');
+    ok((grep /--output json/, @calls), 'Output must be in json format');
+
+    find_deployer_resources(deployer_resource_group => 'Char', deployment_id => '0079', return_value => 'id');
+    ok((grep /--query "\[\?tags.deployment_id == '0079'].id"/, @calls), 'Query resource IDs');
+
+    is ref($result), 'ARRAY', 'Return results in array';
+
+    dies_ok { find_deployer_resources(deployer_resource_group => 'Char', deployment_id => '0079', return_value => 'Amuro'); }
+    'Croak with incorrect "return_value" argument';
+};
+
+subtest '[get_deployer_ip]' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    my @calls;
+    $mock_function->redefine(record_info => sub { return; });
+    $mock_function->redefine(check_deployer_ssh => sub { return 1; });
+    $mock_function->redefine(script_output => sub { push @calls, $_[0]; return '[
+  "192.168.1.1",
+  "192.168.1.2"
+]' });
+
+    get_deployer_ip(deployer_resource_group => 'OpenQA_SDAF_0087', deployer_vm_name => 'Zeta');
+    ok(grep(/az vm list-ip-addresses/, @calls), 'Test base command');
+    ok(grep(/--resource-group/, @calls), 'Check for --resource-group argument');
+    ok(grep(/--name/, @calls), 'Check for vm name --name argument');
+    ok(grep(/--query \"\[].virtualMachine.network.publicIpAddresses\[].ipAddress\"/, @calls),
+        'Check for vm name --query argument');
+    ok(grep(/-o json/, @calls), 'Output result in json format');
+};
+
+subtest '[get_deployer_ip] Test expected failures' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    $mock_function->redefine(record_info => sub { return; });
+    my @incorrect_ip_addresses = (
+        '192.168.0.500',
+        '192.168.o.5',
+        '192.168.0.',
+        '2001:db8:85a3::8a2e:370:7334'
+    );
+
+    dies_ok { get_deployer_ip(deployer_vm_name => 'RMS-106_Hizack') } 'Fail with missing deployer resource group argument';
+    dies_ok { get_deployer_ip(deployer_resource_group => 'RX-178_Mk-II') } 'Fail with missing deployer resource group argument';
+    for my $ip_input (@incorrect_ip_addresses) {
+        $mock_function->redefine(script_output => sub { return $ip_input; });
+        dies_ok { get_deployer_ip(deployer_resource_group => 'OpenQA_SDAF_0087') } "Detect incorrect IP addr pattern: $ip_input";
+    }
+};
+
+
+subtest '[check_deployer_ssh]' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    my @calls;
+
+    $mock_function->redefine(script_run => sub { push(@calls, $_[0]); return 0; });
+    $mock_function->redefine(record_info => sub { return; });
+
+    my $ssh_avail = check_deployer_ssh('1.2.3.4');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok(($ssh_avail eq 1), "ssh_avail= $ssh_avail as expected 1");
+    ok((none { /nc.*-w/ } @calls), 'No -w in nc if wait_started is not enabled');
+    ok((any { /nc.*\s+1\.2\.3\.4/ } @calls), 'IP in nc command');
+};
+
+subtest '[check_deployer_ssh] timeout but no wait_started' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    my @calls;
+
+    $mock_function->redefine(script_run => sub { push(@calls, $_[0]); return 1; });
+    $mock_function->redefine(record_info => sub { return; });
+    my $ssh_avail = check_deployer_ssh('1.2.3.4');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok(($ssh_avail eq 0), "ssh_avail=$ssh_avail as expected 0");
+    ok((none { /nc.*-w/ } @calls), 'No -w in nc if wait_started is not enabled');
+    ok((any { /nc.*\s+1\.2\.3\.4/ } @calls), 'IP in nc command');
+};
+
+subtest '[check_deployer_ssh] timeout and wait_started=0' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    my @calls;
+
+    $mock_function->redefine(script_run => sub { push(@calls, $_[0]); return 1; });
+    $mock_function->redefine(record_info => sub { return; });
+    my $ssh_avail = check_deployer_ssh('1.2.3.4', wait_started => 0);
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok(($ssh_avail eq 0), "ssh_avail=$ssh_avail as expected 0");
+    ok((none { /nc.*-w/ } @calls), 'No -w in nc if wait_started is not enabled');
+    ok((any { /nc.*\s+1\.2\.3\.4/ } @calls), 'IP in nc command');
+};
+
+subtest '[check_deployer_ssh] Test command looping' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    my $loop_count = 0;
+    $mock_function->redefine(diag => sub { $loop_count++; return; });
+    $mock_function->redefine(record_info => sub { return; });
+    my $ip_addr = '10.10.10.10';
+
+    $mock_function->redefine(script_run => sub { return 1 if $loop_count == 2; $loop_count++; return 0 });
+
+    check_deployer_ssh($ip_addr, wait_started => '1');
+    ok(($loop_count > 0), "Test retry loop with \$args{wait_started}. Loop count: $loop_count");
+
+};
+
+
+done_testing;

--- a/tests/sles4sap/sap_deployment_automation_framework/cleanup.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/cleanup.pm
@@ -13,26 +13,44 @@ use parent 'sles4sap::sap_deployment_automation_framework::basetest';
 use strict;
 use testapi;
 use warnings;
-use sles4sap::sap_deployment_automation_framework::deployment;
-use sles4sap::console_redirection;
+use sles4sap::sap_deployment_automation_framework::deployment
+  qw(serial_console_diag_banner
+  sdaf_cleanup
+  az_login
+  load_os_env_variables);
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployer_resources);
+use sles4sap::console_redirection qw(connect_target_to_serial disconnect_target_from_serial);
+use sles4sap::azure_cli qw(az_resource_delete);
 
 sub test_flags {
     return {fatal => 1};
 }
 
 sub run {
-    serial_console_diag_banner('end: sdaf_cleanup.pm');
+    serial_console_diag_banner('Start: sdaf_cleanup.pm');
     if (get_var('SDAF_RETAIN_DEPLOYMENT')) {
         record_info('Cleanup OFF', 'OpenQA variable "SDAF_RETAIN_DEPLOYMENT" is active, skipping cleanup.');
         return;
     }
 
-    # Cleanup SDAF files form Deployer VM
+    # Trigger SDAF remover script to destroy 'workload zone' and 'sap systems' resources
+    # Clean up all config files, keys, etc.. on deployer VM
     connect_target_to_serial();
     load_os_env_variables();
     az_login();
     sdaf_cleanup();
     disconnect_target_from_serial();
+
+    # Cleanup deployer VM resources only
+    # Deployer VM is located in permanent deployer resource group. This RG **MUST STAY INTACT**
+    my @resource_cleanup_list = @{find_deployer_resources(return_value => 'id')};
+    record_info('Resources destroy',
+        "Following resources are being destroyed:\n" . join("\n", @{find_deployer_resources()}));
+
+    az_resource_delete(ids => join(' ', @resource_cleanup_list),
+        resource_group => get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP'), timeout => '600');
+
+    serial_console_diag_banner('End: sdaf_cleanup.pm');
 }
 
 1;

--- a/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
@@ -9,23 +9,32 @@ use parent 'sles4sap::sap_deployment_automation_framework::basetest';
 use strict;
 use warnings;
 use testapi;
-use sles4sap::sap_deployment_automation_framework::deployment;
-use sles4sap::console_redirection;
+use sles4sap::sap_deployment_automation_framework::deployment
+  qw(serial_console_diag_banner
+  az_login
+  sdaf_prepare_ssh_keys
+  );
+use sles4sap::sap_deployment_automation_framework::deployment_connector
+  qw(get_deployer_vm
+  get_deployer_ip
+  );
+use sles4sap::console_redirection qw(redirection_init);
 use serial_terminal qw(select_serial_terminal);
 
 sub test_flags {
     return {fatal => 1};
 }
 sub run {
-
     select_serial_terminal();
     serial_console_diag_banner('Module sdaf_redirect_console_to_deployer.pm : start');
-
-    # autossh is required for console redirection to work
-    assert_script_run('zypper in -y autossh');
-
     az_login();
-    my $deployer_ip = sdaf_get_deployer_ip(deployer_resource_group => get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP'));
+
+    my $deployer_vm_name = get_deployer_vm;
+    # VM can be created by scheduling 'tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm'
+    die 'Deployer VM not found. Check if VM exists.' unless $deployer_vm_name;
+    record_info('VM found', "Deployer VM found: $deployer_vm_name");
+
+    my $deployer_ip = get_deployer_ip(deployer_vm_name => $deployer_vm_name);
     # SDAF does not need privileged user to run.
     my $ssh_user = get_var('REDIRECT_TARGET_USER', 'azureadm');
     # Variables to share data between test modules.
@@ -33,6 +42,8 @@ sub run {
     set_var('REDIRECT_DESTINATION_IP', $deployer_ip);    # IP addr to redirect console to
     sdaf_prepare_ssh_keys(deployer_key_vault => get_required_var('SDAF_KEY_VAULT'));
 
+    # autossh is required for console redirection to work
+    assert_script_run('zypper in -y autossh');
     redirection_init();
     serial_console_diag_banner('Module sdaf_redirect_console_to_deployer.pm : end');
 }

--- a/tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm
@@ -1,0 +1,87 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Test module for creating SDAF Deployer VM by cloning existing OS snapshot, containing all SDAF tools.
+#   Snapshot is a permanent clone of original Deployer disk and must be created beforehand.
+#   This test module expects it to already exists with default name 'deployer_snapshot_latest' or defined by
+#   OpenQA parameter SDAF_DEPLOYER_SNAPSHOT
+
+# Required OpenQA variables:
+# 'SDAF_DEPLOYER_RESOURCE_GROUP' Existing deployer resource group - part of the permanent cloud infrastructure.
+
+# Optional:
+# 'SDAF_DEPLOYER_SNAPSHOT' define existing snapshot name to be used as a source
+# 'SDAF_DEPLOYER_MACHINE' override default value for VM size
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+use strict;
+use warnings;
+use sles4sap::sap_deployment_automation_framework::deployment qw(serial_console_diag_banner az_login);
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(get_deployer_ip);
+use sles4sap::sap_deployment_automation_framework::naming_conventions qw(generate_deployer_name);
+use sles4sap::azure_cli qw(az_disk_create);
+use serial_terminal qw(select_serial_terminal);
+use mmapi qw(get_current_job_id);
+use testapi;
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+sub run {
+    select_serial_terminal();
+    serial_console_diag_banner('Module sdaf_clone_deployer.pm : start');
+
+    my $deployer_resource_group = get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
+    my $snapshot_source_disk = get_var('SDAF_DEPLOYER_SNAPSHOT', 'deployer_snapshot_latest');
+    my $deployer_vm_size = get_var('SDAF_DEPLOYER_MACHINE', 'Standard_B2als_v2');    # Small VM to control costs
+    my $new_deployer_vm_name = generate_deployer_name();
+    my $deployer_disk_name = "$new_deployer_vm_name\_OS";
+
+    # VM resource tags are used for sharing information between test modules and test jobs
+    # 'deployment_id' (equals test ID) tag identifies which test used the VM for deployment.
+    # Check SYNOPSIS section of: sles4sap::sap_deployment_automation_framework::deployment_connector
+    # for more details
+    my @deployment_tags = ("deployment_id=" . get_current_job_id());
+
+    az_login();
+
+    record_info('VM create', "Creating deployer vm with parameters:\n
+    Resource group: $deployer_resource_group\n
+    VM name: $new_deployer_vm_name\n
+    VM size: $deployer_vm_size
+    Cloned snapshot:$snapshot_source_disk\n");
+
+    # Create OS disk from snapshot
+    az_disk_create(
+        resource_group => $deployer_resource_group,
+        name => $deployer_disk_name,
+        source => $snapshot_source_disk,
+        tags => join(' ', @deployment_tags)
+    );
+
+    # Create new VM clone
+    my $vm_create_cmd = join(' ', 'az vm create',
+        "--resource-group $deployer_resource_group",
+        "--name $new_deployer_vm_name",
+        "--attach-os-disk $deployer_disk_name",
+        "--size $deployer_vm_size",
+        "--os-type Linux",
+        "--tags " . join(' ', @deployment_tags)    # This tag is used to find correct deployer VM by other modules
+    );
+    assert_script_run($vm_create_cmd, timeout => 600);
+
+    # Collect deployer IP to be shown in the result page
+    # get_deployer_ip() also checks VM is listening to SSH port. This serves as an availability check.
+    my $deployer_ip = get_deployer_ip(deployer_resource_group => $deployer_resource_group,
+        deployer_vm_name => $new_deployer_vm_name);
+    die 'Deployer public IP address not found or is not listening to SSH port.' unless $deployer_ip;
+
+    record_info('VM created', "Deployer VM was created with public IP: $deployer_ip");
+
+    serial_console_diag_banner('Module sdaf_clone_deployer.pm : stop');
+}
+
+1;

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_hanasr.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_hanasr.pm
@@ -20,9 +20,20 @@
 use parent 'sles4sap::sap_deployment_automation_framework::basetest';
 use strict;
 use warnings;
-use sles4sap::sap_deployment_automation_framework::deployment;
-use sles4sap::sap_deployment_automation_framework::naming_conventions;
-use sles4sap::console_redirection;
+use sles4sap::sap_deployment_automation_framework::deployment
+  qw(serial_console_diag_banner
+  load_os_env_variables
+  az_login
+  sdaf_execute_playbook
+  );
+use sles4sap::sap_deployment_automation_framework::naming_conventions
+  qw(get_sdaf_config_path
+  convert_region_to_short
+  );
+use sles4sap::console_redirection
+  qw(connect_target_to_serial
+  disconnect_target_from_serial
+  );
 use serial_terminal qw(select_serial_terminal);
 use testapi;
 


### PR DESCRIPTION
This PR adds library, test modules and schedules for creating snapshot based 
deployer VM for each test run. This removes single point of failure or using 
permanent VM, interference between tests and allows usage in MM tests.
Cleanup routine is for now only simple one, but it will be improved in TEAM-9459.

- Related ticket: 
https://jira.suse.com/browse/TEAM-9455

- Verification run:
https://openqaworker15.qa.suse.cz/tests/288212