### PR TITLE
xfstests: check bugzilla status with whitelist entries

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -541,7 +541,7 @@ sub run {
 
     heartbeat_start if $enable_heartbeat == 1;
 
-    # Generate xfstests blacklist and softfail list
+    # Generate xfstests blacklist
     my %black_list = (generate_xfstests_list($BLACKLIST), exclude_grouplist);
     if (my $issues = get_var('XFSTESTS_KNOWN_ISSUES')) {
         my $whitelist = LTP::WhiteList->new($issues);

--- a/tests/xfstests/xfstests_failed.pm
+++ b/tests/xfstests/xfstests_failed.pm
@@ -27,6 +27,7 @@ sub run {
         record_info('full', "$args->{fullog}");
         record_info('dmesg', "$args->{dmesg}");
         record_info('known', "$args->{failinfo}") if defined($args->{failinfo});
+        record_info('bugzilla', "$args->{bugzilla}") if defined($args->{bugzilla});
     }
     else {
         $self->{result} = 'skip';


### PR DESCRIPTION
Ignore whitelist if bugzilla closed

- Related ticket: https://progress.opensuse.org/issues/162920
- Needles: N/A
- Verification run: 
http://10.67.133.133/tests/697 (no bugzilla entry in whitelist)
http://10.67.133.133/tests/701 (bugzilla not closed)
http://10.67.133.133/tests/700 (bugzilla closed)
http://10.67.133.133/tests/698 (Failed to query bugzilla ticket)
http://10.67.133.133/tests/703 (keep_fail=1)