### PR TITLE
Workaround for sap-installation-wizard not finding HANA 32-bit client

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -118,9 +118,12 @@ sub run {
     if (check_var('DESKTOP', 'textmode')) {
         wait_serial('yast2-sap-installation-wizard-status-0', $timeout) || die "'yast2 sap-installation-wizard' didn't finish";
     } else {
-        assert_screen [qw(sap-wizard-installation-summary sap-wizard-finished sap-wizard-failed sap-wizard-error)], $timeout;
+        assert_screen [qw(sap-wizard-installation-summary sap-wizard-finished sap-wizard-failed sap-wizard-error sap-wizard-missing-32bit-client)], $timeout;
         send_key $cmd{ok};
         if (match_has_tag 'sap-wizard-installation-summary') {
+            assert_screen 'generic-desktop', 600;
+        } elsif (match_has_tag 'sap-wizard-missing-32bit-client') {
+            record_soft_failure "bsc#1227390 - Missing 32-bit client happened";
             assert_screen 'generic-desktop', 600;
         } else {
             # Wait for SAP wizard to finish writing logs


### PR DESCRIPTION
run HANA SPS05rev59(59.05) on 12-SP5 and there is an issue like this https://openqa.suse.de/tests/14810638#step/wizard_hana_install/41, so I create this PR for the workaround and mark the openQA job with the issue as `softfail`

- Related ticket: https://jira.suse.com/browse/TEAM-9454
- Needles: https://openqa.suse.de/tests/14801402#step/wizard_hana_install/41
- Verification run:
    https://openqa.suse.de/tests/14810638 (12-SP5)
    https://openqa.suse.de/tests/14810637 (15-SP2)
    https://openqa.suse.de/tests/14810640 (15-SP5)
