### PR TITLE
Remove openssh-server-config-disallow-rootlogin before a reboot in s390x

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -62,7 +62,7 @@ use maintenance_smelt qw(get_packagebins_in_modules get_incident_packages);
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use version_utils qw(is_sle);
-use Utils::Architectures qw(is_aarch64 is_ppc64le);
+use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use Data::Dumper qw(Dumper);
 
 my @conflicting_packages = (
@@ -388,6 +388,12 @@ sub run {
             else {
                 zypper_call("in -l $solver_focus $_", exitcode => [0, 102, 103], log => "new_${_}_conflicts.log", timeout => 1500);
             }
+        }
+
+        if (is_s390x) {
+            # Make sure that openssh-server-config-disallow-rootlogin is not installed
+            # since in s390 we need to ssh to the system to reconnect to the tty after a reboot
+            zypper_call("rm openssh-server-config-disallow-rootlogin", exitcode => [0, 104]);
         }
 
         record_info 'Reboot after patch', "system is bootable after patch $patch";


### PR DESCRIPTION
When testing any patch that rebuilds openssh, openqa fails only when testing in s390x (like in https://openqa.suse.de/tests/14804700). This happens because the test installs all packages that are part of the patch (which includes openssh-server-config-disallow-rootlogin, even if that package is never installed automatically) to test that the system can reboot successfully afterwards. The problem is that in s390x, after a reboot, openqa needs to ssh to the system to reconnect the tty, which now fails because that package disallows root to do a ssh password login.

Make sure that openssh-server-config-disallow-rootlogin is not installed since in s390 we need to ssh to the system to reconnect to the tty after a reboot.

Note that I haven't tested this patch, since I don't have a personal instance to run this with.