### PR TITLE
Ignore error of missing disks with SL Micro 6.1

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -376,7 +376,7 @@
         "description": "Timed out waiting for device (/dev/disk/by-label/ignition|/dev/combustion/config|/UUID=)|dev-combustion-config.device: Job dev-combustion-config.device/start timed out.",
         "products": {
             "leap-micro": ["5.3"],
-            "sle-micro": ["5.3", "5.4" , "5.5", "6.0"],
+            "sle-micro": ["5.3", "5.4" , "5.5", "6.0", "6.1"],
             "microos":  ["Tumbleweed", "Slowroll", "Slowroll:Staging"],
             "opensuse":  ["Tumbleweed", "Slowroll", "Slowroll:Staging"],
             "sle": ["15-SP6"]


### PR DESCRIPTION
* **Error** of missing disks should be ignored with SL Micro 6.1 as well. Otherwise this error will be reported in [journal_check](https://openqa.suse.de/tests/14784025#step/journal_check/10).

* **Verification runs:**
  * [test run](https://openqa.suse.de/tests/14822049)