### PR TITLE
Replace sleep with system-up checks 

### DIFF
--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -162,6 +162,7 @@ subtest "[stop_hana] crash" => sub {
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $sles4sap_publiccloud->redefine(wait_for_sync => sub { return; });
+    $sles4sap_publiccloud->redefine(wait_hana_node_up => sub { return; });
 
     my $self = sles4sap_publiccloud->new();
     my $mock_pc = Test::MockObject->new();


### PR DESCRIPTION
SPN tests seem to take a longer time for nodes to come back up during `crash_` modules, so this replaces the fixed sleep with a function that waits until `is_system_running` returns.

- Related ticket: https://jira.suse.com/browse/TEAM-9215
- Verification run: 
https://openqa.suse.de/tests/14822488
https://openqa.suse.de/tests/14826409
https://openqa.suse.de/tests/14826533
sbd example: https://openqa.suse.de/tests/14859429
