### PR TITLE
LTP: Add support for risc-v Tumbleweed repository

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -425,6 +425,7 @@ sub add_ltp_repo {
             $repo = "openSUSE_Factory";
             $repo = "openSUSE_Factory_ARM" if (is_aarch64() || is_arm());
             $repo = "openSUSE_Factory_PowerPC" if is_ppc64le();
+            $repo = "openSUSE_Factory_RISCV" if is_riscv();
             $repo = "openSUSE_Factory_zSystems" if is_s390x();
         } else {
             die sprintf("Unexpected combination of version (%s) and architecture (%s) used", get_var('VERSION'), get_var('ARCH'));


### PR DESCRIPTION
Link: https://progress.opensuse.org/issues/152849

Verification run: https://openqa.opensuse.org/tests/overview?build=risc-v-ltp
