### PR TITLE
LTP: Fix comparison warning

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -331,7 +331,7 @@ sub run {
     add_we_repo_if_available;
 
     # Enables repositories on full installation medium
-    zypper_enable_install_dvd if (get_var('FLAVOR') == 'Full-QR');
+    zypper_enable_install_dvd if (get_var('FLAVOR') eq 'Full-QR');
 
     if ($inst_ltp =~ /git/i) {
         install_build_dependencies;


### PR DESCRIPTION
Argument "Full-QR" isn't numeric in numeric eq (==) at tests/kernel/install_ltp.pm line 334.

Fixes: e85ccfcae ("ltp: Enable repositories on Full installation medium")

Verification run: https://openqa.suse.de/tests/overview?build=ltp-fix-warning
