### PR TITLE
Revert "Add barrier creation to NFS server job if IPXE=1"

### DIFF
--- a/schedule/storage/nfs.yaml
+++ b/schedule/storage/nfs.yaml
@@ -9,14 +9,9 @@ vars:
   BOOT_HDD_IMAGE: 1
 
 conditional_schedule:
-  nfs_barriers:
-    IPXE:
-      1:
-        - kernel/nfs_barriers
   nfstest:
     ROLE:
       nfs_server:
-        - '{{nfs_barriers}}'
         - kernel/nfs_server
       nfs_client:
         - kernel/nfs_client


### PR DESCRIPTION
This reverts commit e889a29dac06d1379019d1d95c4cef24c5613e66.

This schedule won't work like that - let's revert it and add a dedicated schedule for baremetal NFS