### PR TITLE
wicked: fix coredumpctl call for SLE-12-SP5

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -1118,7 +1118,7 @@ sub prepare_coredump {
             record_info("CORE DUMP", $core_dump, result => 'fail');
             die("Wicked coredump found in before_test, cleanup your installation first!");
         } else {
-            record_info("CORE DUMP", $core_dump, result => 'warn');
+            record_info("CORE DUMP", $core_dump, result => 'softfail');
         }
     }
     for my $pkg (qw(wicked-debuginfo wicked-debugsource)) {

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -1112,8 +1112,7 @@ sub prepare_coredump {
         assert_script_run("echo '$core_pattern' > /etc/sysctl.d/50-coredump.conf");
     }
 
-
-    my $core_dump = script_output('coredumpctl -q --no-pager --no-legend', proceed_on_failure => 1);
+    my $core_dump = script_output('coredumpctl --no-pager --no-legend 2> /dev/null', proceed_on_failure => 1);
     if (length($core_dump) != 0) {
         if ($core_dump =~ m/wicked/) {
             record_info("CORE DUMP", $core_dump, result => 'fail');


### PR DESCRIPTION
In the coredumpctl version of SLE-12-SP5 there is no -q argument.



Fixup: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18127

## Verify:
#### 12-SP5
https://openqa.suse.de/t14848126 - qam-wicked_basic_sut@cfconrad/os-autoinst-distri-opensuse#fixup_pr_18127 => passed
https://openqa.suse.de/t14848125 - qam-wicked_basic_ref@cfconrad/os-autoinst-distri-opensuse#fixup_pr_18127 => passed

#### 15-SP6
8054 scheduled jobs (2444 blocked by other jobs) (0 with priority < 10, 0 with priority == 10)
https://openqa.suse.de/t14848147 - wicked_basic_ref@cfconrad/os-autoinst-distri-opensuse#fixup_pr_18127 => passed
https://openqa.suse.de/t14848148 - wicked_basic_sut@cfconrad/os-autoinst-distri-opensuse#fixup_pr_18127 => passed



