### PR TITLE
Add device encryption passphrase for Common Criteria

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -16,11 +16,21 @@ use testapi;
 use version_utils qw(is_leap is_storage_ng is_sle is_tumbleweed);
 use partition_setup qw(%partition_roles is_storage_ng_newui);
 use utils 'type_string_slow';
+
+sub handle_common_criteria {
+    wait_still_screen;
+    assert_screen 'Common-Criteria-Disk-Encryption-Passphrase';
+    send_key 'alt-e';
+    type_password;
+    send_key 'alt-v';
+    type_password;
+    send_key 'alt-n';
+    wait_still_screen;
+    send_key 'alt-y';    # to confirm "the password too simple" dialog
+}
+
 sub run {
-    if (check_var('SYSTEM_ROLE', 'Common_Criteria')) {
-        assert_screen 'Common-Criteria-Evaluated-Configuration-RN-Next';
-        send_key 'alt-n';
-    }
+    handle_common_criteria if (check_var('SYSTEM_ROLE', 'Common_Criteria'));
     assert_screen 'partitioning-edit-proposal-button', 180;
     if (check_var('PARTITION_EDIT', 'ext4_btrfs')) {
         send_key 'alt-g';


### PR DESCRIPTION
This change address the new CC install step asking for a device encryption passphrase.

- Related ticket: https://progress.opensuse.org/issues/160892
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/60485bac65a535d8a615ffe54e526bd71f57f935
- Verification runs:
  - https://openqa.suse.de/tests/14846869#step/partitioning/1
  - https://openqa.suse.de/tests/14846870#step/partitioning/1
  - https://openqa.suse.de/tests/14846871#step/partitioning/1
  - https://openqa.suse.de/tests/14846872#step/partitioning/1


note: the VR fails in a later step due to [bsc#1227456](https://bugzilla.suse.com/show_bug.cgi?id=1227456), this PR will just make the install forward enough so the bug is more evident 

