### PR TITLE
containers: Temporarily skip installation of podman-remote on SLEM 6.1

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -59,7 +59,8 @@ sub run {
     push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');
     push @pkgs, qw(socat) unless is_sle_micro('=5.1');
     # https://bugzilla.suse.com/show_bug.cgi?id=1226596
-    push @pkgs, qw(podman-remote) unless (is_sle_micro('<5.5') || is_sle('<=15-SP3'));
+    # https://bugzilla.suse.com/show_bug.cgi?id=1227431
+    push @pkgs, qw(podman-remote) unless (is_sle_micro('<5.5') || is_sle_micro('>6.0') || is_sle('<=15-SP3'));
     # passt requires podman 5.0
     push @pkgs, qw(criu passt) if (is_tumbleweed || is_microos);
     # Needed for podman machine


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1227431
- Verification runs:
  - sle-micro-6.1-Base-x86_64-Build3.12-slem_podman_testsuite@64bit -> https://openqa.suse.de/t14848128 (failing due to tests that must be skipped).
