### PR TITLE
hpc: Add repository refresh to warewulf-container

### DIFF
--- a/tests/hpc/ww4.pm
+++ b/tests/hpc/ww4.pm
@@ -76,6 +76,8 @@ sub run ($self) {
     test_case('Service configuration', 'ww4', $rt);
     # Build overlay, mandatory since warewulf4 version 4.5
     assert_script_run "wwctl overlay build";
+    # Refresh repositories inside the container
+    validate_script_output("echo 'zypper -n refresh && echo warewulf-container-refreshed' | wwctl container shell warewulf-container", sub { m/warewulf-container-refreshed/ });
     barrier_wait('WWCTL_READY');
     record_info 'WWCTL_READY', strftime("\%H:\%M:\%S", localtime);
     mutex_unlock 'ww4_ready';


### PR DESCRIPTION
Enhancement poo#163454: This improvement will check warewulf shell functionality. It will also validate repositories inside container.

- Related ticket: https://progress.opensuse.org/issues/163454
- Needles: none
- Verification run: 
VR with expected failure: https://openqa.suse.de/tests/14850566#step/ww4/143
VR without fail: https://openqa.suse.de/tests/14892476#step/ww4/143
