### PR TITLE
Adaption for KVM mitigation change from sle15sp5 to sle15sp6

### DIFF
--- a/tests/cpu_bugs/kvm_guest_mitigations.pm
+++ b/tests/cpu_bugs/kvm_guest_mitigations.pm
@@ -35,10 +35,10 @@ my $mitigations_auto_on_skylake_passthrough = {"mitigations=auto" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: IBRS, IBPB: conditional, RSB filling.*'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: IBRS; IBPB: conditional; STIBP: disabled; RSB filling; PBRSB-eIBRS: Not affected; BHI: SW loop, KVM: SW loop'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Mitigation: PTI'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Mitigation: Clear CPU buffers; SMT Host state unknown'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl and seccomp'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl'],
                 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Mitigation: Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spectre_v1' => ['Mitigation: usercopy/swapgs barriers and __user pointer sanitization'],
@@ -51,10 +51,10 @@ my $mitigations_auto_on_custom = {"mitigations=auto" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines,.*IBPB: conditional, IBRS_FW*'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines; IBPB: conditional; IBRS_FW; STIBP: disabled; RSB filling; PBRSB-eIBRS: Not affected; BHI: Retpoline'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Mitigation: PTI'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Mitigation: Clear CPU buffers; SMT Host state unknown'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl and seccomp'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl'],
                 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit' => ['KVM: Mitigation: VMX unsupported'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spectre_v1' => ['Mitigation: usercopy/swapgs barriers and __user pointer sanitization'],
@@ -67,10 +67,10 @@ my $mitigations_auto_nosmt_on_skylake_passthrough = {"mitigations=auto,nosmt" =>
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto,nosmt'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: IBRS, IBPB: conditional, RSB filling.*'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: IBRS; IBPB: conditional; STIBP: disabled; RSB filling; PBRSB-eIBRS: Not affected; BHI: SW loop, KVM: SW loop'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Mitigation: PTI'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Mitigation: Clear CPU buffers; SMT Host state unknown'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl and seccomp'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl'],
                 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Mitigation: Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spectre_v1' => ['Mitigation: usercopy/swapgs barriers and __user pointer sanitization'],
@@ -83,10 +83,10 @@ my $mitigations_auto_nosmt_on_custom = {"mitigations=auto,nosmt" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto,nosmt'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines,.*IBPB: conditional, IBRS_FW*'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Retpolines; IBPB: conditional; IBRS_FW; STIBP: disabled; RSB filling; PBRSB-eIBRS: Not affected; BHI: Retpoline'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Mitigation: PTI'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Mitigation: Clear CPU buffers; SMT Host state unknown'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl and seccomp'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl'],
                 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit' => ['KVM: Mitigation: VMX unsupported'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spectre_v1' => ['Mitigation: usercopy/swapgs barriers and __user pointer sanitization'],
@@ -99,7 +99,7 @@ my $mitigations_off_on_skylake_passthrough = {"mitigations=off" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=off'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Vulnerable,.*IBPB: disabled,.*STIBP: disabled'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Vulnerable; IBPB: disabled; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Vulnerable'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Vulnerable'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Vulnerable; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Vulnerable'],
@@ -115,7 +115,7 @@ my $mitigations_off_on_custom = {"mitigations=off" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=off'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Vulnerable,.*IBPB: disabled,.*STIBP: disabled'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Vulnerable; IBPB: disabled; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Vulnerable'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Vulnerable'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Vulnerable; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Vulnerable'],
@@ -132,10 +132,10 @@ my $mitigations_auto_on_icelake_passthrough = {"mitigations=auto" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Enhanced / Automatic IBRS; IBPB: conditional; RSB filling; PBRSB-eIBRS: SW sequence; BHI: SW loop, KVM: SW loop'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Not affected'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl and seccomp'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl'],
                 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spectre_v1' => ['Mitigation: usercopy/swapgs barriers and __user pointer sanitization'],
@@ -148,10 +148,10 @@ my $mitigations_auto_nosmt_on_icelake_passthrough = {"mitigations=auto,nosmt" =>
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto,nosmt'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Enhanced / Automatic IBRS; IBPB: conditional; RSB filling; PBRSB-eIBRS: SW sequence; BHI: SW loop, KVM: SW loop'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Not affected'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl and seccomp'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl'],
                 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spectre_v1' => ['Mitigation: usercopy/swapgs barriers and __user pointer sanitization'],
@@ -164,7 +164,7 @@ my $mitigations_off_on_icelake_passthrough = {"mitigations=off" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=off'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Vulnerable,.*IBPB: disabled,.*STIBP: disabled'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Vulnerable; IBPB: disabled; STIBP: disabled; PBRSB-eIBRS: Vulnerable; BHI: Vulnerable'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Vulnerable'],
@@ -182,10 +182,10 @@ my $mitigations_auto_on_cascadelake_passthrough = {"mitigations=auto" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Actual:Mitigation: Enhanced / Automatic IBRS, IBPB: conditional, RSB filling'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Not affected'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl and seccomp'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl'],
                 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Mitigation: Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spectre_v1' => ['Mitigation: usercopy/swapgs barriers and __user pointer sanitization'],
@@ -198,10 +198,10 @@ my $mitigations_auto_nosmt_on_cascadelake_passthrough = {"mitigations=auto,nosmt
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=auto,nosmt'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Mitigation: Enhanced / Automatic IBRS; IBPB: conditional; RSB filling; PBRSB-eIBRS: SW sequence; BHI: SW loop, KVM: SW loop'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Not affected'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl and seccomp'],
+                'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Mitigation: Speculative Store Bypass disabled via prctl'],
                 'cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort' => ['Mitigation: Clear CPU buffers; SMT Host state unknown'],
                 'cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spectre_v1' => ['Mitigation: usercopy/swapgs barriers and __user pointer sanitization'],
@@ -214,7 +214,7 @@ my $mitigations_off_on_cascadelake_passthrough = {"mitigations=off" => {
         default => {
             expected => {
                 'cat /proc/cmdline' => ['mitigations=off'],
-                'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Vulnerable,.*IBPB: disabled,.*STIBP: disabled'],
+'cat /sys/devices/system/cpu/vulnerabilities/spectre_v2' => ['Vulnerable; IBPB: disabled; STIBP: disabled; PBRSB-eIBRS: Vulnerable; BHI: Vulnerable (Syscall hardening enabled)'],
                 'cat /sys/devices/system/cpu/vulnerabilities/meltdown' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/mds' => ['Not affected'],
                 'cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass' => ['Vulnerable'],

--- a/tests/cpu_bugs/mitigations.pm
+++ b/tests/cpu_bugs/mitigations.pm
@@ -103,12 +103,17 @@ sub run {
         my $ret = $obj->vulnerabilities();
         if ($ret eq 1) {
             #off
-            $mitigations_list{sysfs}->{off}->{$item} = $current_list->{sysfs}->{off};
+            if (exists $current_list->{sysfs}->{off}) {
+                $mitigations_list{sysfs}->{off}->{$item} = $current_list->{sysfs}->{off};
+                if ($item eq 'spectre_v2' && get_var('MICRO_ARCHITECTURE') =~ /Skylake/) {
+                    $mitigations_list{sysfs}->{off}->{$item} = "Vulnerable; IBPB: disabled; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected";
+                }
+            }
             #auto
             if (exists $current_list->{sysfs}->{auto}) {
                 $mitigations_list{sysfs}->{auto}->{$item} = $current_list->{sysfs}->{auto};
                 if ($item eq 'spectre_v2' && get_var('MICRO_ARCHITECTURE') =~ /Skylake/) {
-                    $mitigations_list{sysfs}->{auto}->{$item} = "Mitigation: IBRS, IBPB: conditional, RSB filling.*";
+                    $mitigations_list{sysfs}->{auto}->{$item} = "Mitigation: IBRS; IBPB: conditional; STIBP: conditional; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected";
                 }
             } elsif (exists $current_list->{sysfs}->{flush}) {
                 $mitigations_list{sysfs}->{auto}->{$item} = $current_list->{sysfs}->{flush};
@@ -135,7 +140,7 @@ sub run {
                     $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Retpolines,.*IBPB: conditional, IBRS_FW*";
                 }
                 if ($item eq 'spectre_v2' && get_var('MICRO_ARCHITECTURE') =~ /Skylake/) {
-                    $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: IBRS, IBPB: conditional, RSB filling.*";
+                    $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: IBRS; IBPB: conditional; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected";
                 }
 
             }
@@ -195,8 +200,8 @@ sub run {
             $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Not affected";
             if ($item eq 'spectre_v2') {
                 record_info("EIBRS", "This machine support EIBRS on spectre_v2");
-                $mitigations_list{sysfs}->{auto}->{$item} = "Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling";
-                $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling";
+                $mitigations_list{sysfs}->{auto}->{$item} = "Mitigation: Enhanced / Automatic IBRS; IBPB: conditional; RSB filling; PBRSB-eIBRS: SW sequence; BHI: SW loop, KVM: SW loop";
+                $mitigations_list{sysfs}->{'auto,nosmt'}->{$item} = "Mitigation: Enhanced / Automatic IBRS; IBPB: conditional; RSB filling; PBRSB-eIBRS: SW sequence; BHI: SW loop, KVM: SW loop";
                 $mitigations_list{sysfs}->{off}->{$item} = $current_list->{sysfs}->{off};
             }
         } else {

--- a/tests/cpu_bugs/spectre_v2.pm
+++ b/tests/cpu_bugs/spectre_v2.pm
@@ -20,7 +20,7 @@ use utils;
 use Mitigation;
 
 my $eibrs_string_on = "Mitigation: Enhanced IBRS, IBPB: always-on, RSB filling";
-my $eibrs_string_default = "Mitigation: Enhanced IBRS, IBPB: conditional, RSB filling";
+my $eibrs_string_default = "Mitigation: Enhanced / Automatic IBRS; IBPB: conditional; RSB filling";
 my $retpoline_string = "Mitigation: Retpolines,";
 
 our %mitigations_list =
@@ -33,7 +33,7 @@ our %mitigations_list =
     sysfs_name => "spectre_v2",
     sysfs => {
         on => "${retpoline_string}.*IBPB: always-on, IBRS_FW, STIBP: forced.*",
-        off => "Vulnerable,.*IBPB: disabled,.*STIBP: disabled",
+        off => "Vulnerable; IBPB: disabled; STIBP: disabled; PBRSB-eIBRS: Vulnerable; BHI: Vulnerable .Syscall hardening enabled.",
         auto => "${retpoline_string}.*IBPB: conditional, IBRS_FW, STIBP: conditional,.*",
         retpoline => "Mitigation: Retpolines.*",
         default => "",

--- a/tests/cpu_bugs/spectre_v4.pm
+++ b/tests/cpu_bugs/spectre_v4.pm
@@ -29,10 +29,10 @@ our %mitigations_list =
     sysfs => {
         on => "Mitigation: Speculative Store Bypass disabled",
         off => "Vulnerable",
-        auto => "Mitigation: Speculative Store Bypass disabled via prctl and seccomp",
+        auto => "Mitigation: Speculative Store Bypass disabled via prctl",
         prctl => "Mitigation: Speculative Store Bypass disabled via prctl",
         seccomp => "Mitigation: Speculative Store Bypass disabled via prctl and seccomp",
-        default => "Mitigation: Speculative Store Bypass disabled via prctl and seccomp",
+        default => "Mitigation: Speculative Store Bypass disabled via prctl",
     },
     cmdline => [
         "on",


### PR DESCRIPTION
Adaption for KVM mitigation change from sle15sp6 to sle15sp6.
- Related ticket:https://progress.opensuse.org/issues/151349;https://progress.opensuse.org/issues/151358
- Verification run: for kvm hypervisor and guest(passthrough and custom)have verification on skylake,icelake and cascadelake machines
http://10.67.129.4/tests/72683;http://10.67.129.4/tests/72657;http://10.67.129.4/tests/72684
http://10.67.129.4/tests/72686;http://10.67.129.4/tests/72663;http://10.67.129.4/tests/72659
http://10.67.129.4/tests/72745;http://10.67.129.4/tests/72749;http://10.67.129.4/tests/72747
