### PR TITLE
First fix slem updates

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -114,6 +114,9 @@ sub load_compose_tests {
 }
 
 sub load_firewall_test {
+    return if (is_public_cloud || is_openstack || is_microos ||
+        get_var('FLAVOR') =~ /dvd/i && (is_sle_micro('<6.0') || is_leap_micro('<6.0'))
+    );
     my ($run_args) = @_;
     loadtest('containers/firewall', run_args => $run_args, name => $run_args->{runtime} . "_firewall");
 }
@@ -130,7 +133,7 @@ sub load_host_tests_podman {
     loadtest 'containers/podman_pods';
     loadtest('containers/podman_network_cni') unless (is_sle_micro('6.0+') || (is_sle_micro('=5.5') && is_public_cloud));
     # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
-    load_firewall_test($run_args) unless (is_public_cloud || is_openstack || is_microos);
+    load_firewall_test($run_args);
     loadtest 'containers/podman_ipv6' if (is_gce && is_sle('>=15-SP5'));
     # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
     loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
@@ -158,7 +161,7 @@ sub load_host_tests_docker {
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
     # Firewall is not installed in Public Cloud, JeOS OpenStack and MicroOS but it is in SLE Micro
-    load_firewall_test($run_args) unless (is_public_cloud || is_openstack || is_microos);
+    load_firewall_test($run_args);
     unless (is_sle("<=15") && is_aarch64) {
         # these 2 packages are not avaiable for <=15 (aarch64 only)
         # zypper-docker is only available on SLES < 15-SP6

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -55,8 +55,11 @@ sub install_fips {
     # No crypto-policies in older SLE
     zypper_call("in -t pattern fips") if (is_sle('<=15-SP3') || get_var("FIPS_ENV_MODE"));
     # crypto-policies script reports Cannot handle transactional systems.
-    if (is_sle_micro) {
-        is_sle_micro('<6.0') ? trup_call("pkg install -t pattern fips") : trup_call("setup-fips");
+
+    if (is_sle_micro('<6.0')) {
+        trup_call("pkg install -t pattern microos-fips");
+    } else {
+        trup_call("setup-fips");
     }
 }
 


### PR DESCRIPTION
`patterns-microos-fips` is being used for sle-micro from 5.1 to 5.5.
Fips setup tests should look for this pattern instead of plain `fips`

As a technical debt caused by the split of responsibilities of sle-micro
testing. We have a wrong schedule of modules. firewalld is not present
in older sle-micro deployments done by the installator

- Related ticket: https://progress.opensuse.org/issues/163325
#### Verification run

 - sle-micro-5.5-DVD-Updates-x86_64-Build20240708-1-slem_installation_docker@64bit -> https://openqa.suse.de/tests/14862649#
 - sle-micro-5.5-Default-Updates-x86_64-Build20240708-1-slem_fips_docker@64bit -> https://openqa.suse.de/tests/14860280
