### PR TITLE
Handle common criteria install message for SLE < 15SP6

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -18,6 +18,11 @@ use partition_setup qw(%partition_roles is_storage_ng_newui);
 use utils 'type_string_slow';
 
 sub handle_common_criteria {
+    if (is_sle '<=15-SP5') {
+        assert_screen 'Common-Criteria-Evaluated-Configuration-RN-Next';
+        send_key 'alt-n';
+        return;
+    }
     wait_still_screen;
     assert_screen 'Common-Criteria-Disk-Encryption-Passphrase';
     send_key 'alt-e';


### PR DESCRIPTION
this is a fix for a regression introduced with #19683 

- Related ticket: https://progress.opensuse.org/issues/160892
- Needles: no
- Verification runs:
  - 15SP6: https://openqa.suse.de/tests/14859471#step/partitioning/1, https://openqa.suse.de/tests/14860281#step/partitioning/1
  - 15SP5: https://openqa.suse.de/tests/14859473#step/partitioning/1
  - 15SP4: https://openqa.suse.de/tests/14859472#step/partitioning/1
  - 15SP3: https://openqa.suse.de/tests/14860282#step/partitioning/1 
  

  
  

