### PR TITLE
New test for SSH key enrollment

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -211,7 +211,8 @@ sub run {
     # Skip ssh key enrollment (for now)
     unless (is_sle || is_sle_micro('<=6.0') || is_leap) {
         assert_screen 'jeos-ssh-enroll-or-not';
-        send_key 'n';
+        send_key 'y';
+        save_screenshot;
     }
 
     if (is_generalhw && is_aarch64 && !is_leap("<15.4") && !is_tumbleweed) {


### PR DESCRIPTION
Implement a test run that tests the new ssh key enrollment for openSUSE Tumbleweed MinimalVM and for openSUSE MicroOS

- Related ticket: https://progress.opensuse.org/issues/160664
- Verification run: :construction:
