### PR TITLE
Skip skopeo in slem older than 5.5 

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -131,7 +131,8 @@ sub load_host_tests_podman {
     load_container_engine_privileged_mode($run_args);
     loadtest 'containers/podman_bci_systemd';
     loadtest 'containers/podman_pods';
-    loadtest('containers/podman_network_cni') unless (is_sle_micro('6.0+') || (is_sle_micro('=5.5') && is_public_cloud));
+    # fresh install of sle-micro comes with netavark
+    loadtest('containers/podman_network_cni') unless (is_sle_micro('6.0+') || (is_sle_micro('=5.5') && is_public_cloud) || (check_var('FLAVOR', 'DVD-Updates') && is_sle_micro));
     # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
     load_firewall_test($run_args);
     loadtest 'containers/podman_ipv6' if (is_gce && is_sle('>=15-SP5'));
@@ -139,12 +140,13 @@ sub load_host_tests_podman {
     loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
     # Buildah is not available in SLE Micro, MicroOS and staging projects
     load_buildah_tests($run_args) unless (is_sle('<15') || is_sle_micro || is_microos || is_leap_micro || is_staging);
+    loadtest 'containers/skopeo' unless (is_sle('<15') || is_sle_micro('<5.5'));
     loadtest 'containers/podman_quadlet' if is_tumbleweed;
     # https://github.com/containers/podman/issues/5732#issuecomment-610222293
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podman_remote';
+        loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
     }
     load_secret_tests($run_args);
     load_volume_tests($run_args);
@@ -179,7 +181,7 @@ sub load_host_tests_docker {
         loadtest 'containers/buildx';
         loadtest 'containers/rootless_docker';
     }
-    loadtest('containers/skopeo', run_args => $run_args, name => $run_args->{runtime} . "_skopeo") unless (is_sle('<15'));
+    loadtest('containers/skopeo') unless (is_sle('<15') || is_sle_micro('<5.5'));
     load_volume_tests($run_args);
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -23,9 +23,12 @@ sub is_cni_in_tw {
 }
 
 # podman >=4.8.0 defaults to netavark
+# fresh install of sle-micro comes with netavark
 sub is_cni_default {
     my $podman_version = get_podman_version();
-    return package_version_cmp($podman_version, '4.8.0') < 0 || is_sle_micro('<5.5') || (is_sle_micro('=5.5') && !is_public_cloud);
+    return package_version_cmp($podman_version, '4.8.0') < 0 ||
+      (is_sle_micro('<5.5') && !check_var('FLAVOR', 'DVD-Updates')) ||
+      (is_sle_micro('=5.5') && !is_public_cloud);
 }
 
 sub remove_subtest_setup {


### PR DESCRIPTION
Do not schedule skopeo test module for older sle-micro's than 5.5

- Verification run:

 - sle-micro-5.4-Default-Updates-x86_64-Build20240708-1-slem_docker@64bit -> https://openqa.suse.de/tests/14863457
 - sle-micro-5.5-Default-Updates-x86_64-Build20240708-1-slem_podman_testsuite@64bit -> https://openqa.suse.de/tests/14863503
 - sle-micro-5.5-Default-Updates-x86_64-Build20240708-1-slem_docker@64bit -> https://openqa.suse.de/tests/14863508
  - sle-micro-5.5-Default-Updates-x86_64-Build20240708-1-slem_podman@64bit -> https://openqa.suse.de/tests/14863515
  - sle-micro-5.1-DVD-Updates-x86_64-Build20240708-1-slem_installation_podman@64bit -> https://openqa.suse.de/tests/14863976