### PR TITLE
Add step to select SLES product only on 15SP4

### DIFF
--- a/schedule/security/create_hdd_cc_libyui/cc_qr_s390x_15SP4.yaml
+++ b/schedule/security/create_hdd_cc_libyui/cc_qr_s390x_15SP4.yaml
@@ -4,7 +4,8 @@ description: >
   Installation using the Common Criteria role and full disk
   encryption on QR SLES.
 schedule:
-  access_beta: []
+  access_beta:
+    - installation/product_selection/install_SLES
   system_role:
     - installation/system_role/select_common_criteria_role
     - installation/common_criteria_configuration/common_criteria_encryption_pwd


### PR DESCRIPTION
Under s390x arch, the 15SP4 install requires an extra step

- Related ticket: https://progress.opensuse.org/issues/162584
- Needles: n/a
- Verification runs:
    - https://openqa.suse.de/tests/14863510 
    - https://openqa.suse.de/tests/14862201 
    - https://openqa.suse.de/tests/14863511     
    - https://openqa.suse.de/tests/14863642
    
    
