### PR TITLE
Move PTF test to a dedicated container

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -2368,7 +2368,7 @@ sub qesap_az_list_container_files {
         'az storage blob list',
         '--account-name', $args{storage},
         '--container-name', $args{container},
-        '--sas-token', $args{token},
+        '--sas-token', "'$args{token}'",
         '--prefix', $args{prefix},
         '--query "[].{name:name}" --output tsv');
     my $ret = script_output($cmd);

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -793,7 +793,7 @@ sub delete_network_peering {
     Detects HANA/HA scenario from function arguments and returns a list of ansible playbooks to include
     in the "ansible: create:" section of config.yaml file.
 
-=over 3
+=over 7
 
 =item B<ha_enabled> - Enable the installation of HANA and the cluster configuration
 
@@ -806,9 +806,11 @@ sub delete_network_peering {
 
 =item B<ptf_files> - list of PTF files (optional)
 
-=item B<token> - SAS token to access the PTF files (optional)
+=item B<ptf_token> - SAS token to access the PTF files (optional)
 
-=item B<container> - name of the container for PTF files
+=item B<ptf_account> - name of the account for the ptf container
+
+=item B<ptf_container> - name of the container for PTF files
 
 =back
 =cut
@@ -837,9 +839,13 @@ sub create_playbook_section_list {
     }
 
     # Add playbook to download and install PTFs, if any
-    if ($args{ptf_files} && $args{token} && $args{container}) {
-        $args{token} =~ s/\\\&/\&/g;
-        push @playbook_list, "ptf_installation.yaml -e ptf_files=$args{ptf_files} -e sas_token=$args{token} -e container=$args{container} -e storage=" . get_required_var('HANA_ACCOUNT');
+    if ($args{ptf_files} && $args{ptf_token} && $args{ptf_container} && $args{ptf_account}) {
+        push @playbook_list, join(' ',
+            'ptf_installation.yaml',
+            "-e ptf_files=$args{ptf_files}",
+            "-e sas_token='$args{ptf_token}'",
+            "-e container=$args{ptf_container}",
+            "-e storage=$args{ptf_account}");
         push @playbook_list, "additional_fence_agent_tasks.yaml";
     }
 

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -624,6 +624,23 @@ subtest '[create_playbook_section_list] registration => suseconnect' => sub {
 };
 
 
+subtest '[create_playbook_section_list] ptf' => sub {
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
+    $sles4sap_publiccloud->redefine(is_azure => sub { return 1 });
+    set_var('SCC_REGCODE_SLES4SAP', 'Magellano');
+    set_var('USE_SAPCONF', 'Colombo');
+    my $ansible_playbooks = create_playbook_section_list(
+        ptf_files => 'Marcantonio Colonna',
+        ptf_token => 'Seb4sti4n0Ven1er',
+        ptf_container => 'VettorPisani',
+        ptf_account => 'LorenzoMarcello');
+    set_var('SCC_REGCODE_SLES4SAP', undef);
+    set_var('USE_SAPCONF', undef);
+    note("\n  -->  " . join("\n  -->  ", @$ansible_playbooks));
+    ok((any { /ptf_installation\.yaml.*/ } @$ansible_playbooks), 'ptf_installation playbook');
+};
+
+
 subtest '[enable_replication]' => sub {
     my $self = sles4sap_publiccloud->new();
     $self->{my_instance}->{instance_id} = 'vmhana01';

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -376,10 +376,10 @@ subtest '[qesap_az_create_sas_token] with custom permissions' => sub {
 
 subtest '[qesap_az_list_container_files] missing arguments' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
-    dies_ok { qesap_az_list_container_files(storage => 'GALBADIA', token => 'SAS', prefix => 'SQUALL') } 'Missing container argument';
-    dies_ok { qesap_az_list_container_files(container => 'BALAMB', token => 'SAS', prefix => 'SQUALL') } 'Missing storage argument';
-    dies_ok { qesap_az_list_container_files(container => 'BALAMB', storage => 'GALBADIA', prefix => 'SQUALL') } 'Missing token argument';
-    dies_ok { qesap_az_list_container_files(container => 'BALAMB', storage => 'GALBADIA', token => 'SAS') } 'Missing prefix argument';
+    dies_ok { qesap_az_list_container_files(storage => 'TAD', token => 'SAS', prefix => 'GURGLE') } 'Missing container argument';
+    dies_ok { qesap_az_list_container_files(container => 'BLOAT', token => 'SAS', prefix => 'GURGLE') } 'Missing storage argument';
+    dies_ok { qesap_az_list_container_files(container => 'BLOAT', storage => 'TAD', prefix => 'GURGLE') } 'Missing token argument';
+    dies_ok { qesap_az_list_container_files(container => 'BLOAT', storage => 'TAD', token => 'SAS') } 'Missing prefix argument';
 };
 
 subtest '[qesap_az_list_container_files] bad output' => sub {
@@ -387,21 +387,21 @@ subtest '[qesap_az_list_container_files] bad output' => sub {
     my @calls;
     my $so_ret = '';
     $qesap->redefine(script_output => sub { return $so_ret; });
-    dies_ok { qesap_az_list_container_files(container => 'BALAMB', storage => 'GALBADIA', token => 'SAS', prefix => 'SQUALL') } 'Empty return string';
+    dies_ok { qesap_az_list_container_files(container => 'BLOAT', storage => 'TAD', token => 'SAS', prefix => 'GURGLE') } 'Empty return string';
     $so_ret = ' ';
-    dies_ok { qesap_az_list_container_files(container => 'BALAMB', storage => 'GALBADIA', token => 'SAS', prefix => 'SQUALL') } 'Space-only return string';
+    dies_ok { qesap_az_list_container_files(container => 'BLOAT', storage => 'TAD', token => 'SAS', prefix => 'GURGLE') } 'Space-only return string';
 };
 
 subtest '[qesap_az_list_container_files] command composition' => sub {
     my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
     my @calls;
-    $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'SQUALL/ifrit.rpm\nSQUALL/shiva.src.rpm' });
-    qesap_az_list_container_files(container => 'BALAMB', storage => 'GALBADIA', token => 'SAS', prefix => 'SQUALL');
+    $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'GURGLE/ifrit.rpm\nGURGLE/shiva.src.rpm' });
+    qesap_az_list_container_files(container => 'BLOAT', storage => 'TAD', token => 'SAS', prefix => 'GURGLE');
     ok((any { /az storage blob list.*/ } @calls), 'Main az command `az storage blob list` properly composed');
-    ok((any { /.*--account-name GALBADIA.*/ } @calls), 'storage argument is used for --account-name');
-    ok((any { /.*--container-name BALAMB.*/ } @calls), 'container argument is used for --container-name');
-    ok((any { /--sas-token SAS.*/ } @calls), 'token argument is used for --sas-token');
-    ok((any { /.*--prefix SQUALL*/ } @calls), 'prefix argument used for --prefix');
+    ok((any { /.*--account-name TAD.*/ } @calls), 'storage argument is used for --account-name');
+    ok((any { /.*--container-name BLOAT.*/ } @calls), 'container argument is used for --container-name');
+    ok((any { /--sas-token 'SAS'.*/ } @calls), 'token argument is used for --sas-token');
+    ok((any { /.*--prefix GURGLE*/ } @calls), 'prefix argument used for --prefix');
 };
 
 subtest '[qesap_az_get_native_fencing_type]' => sub {


### PR DESCRIPTION
Move PTF to a dedicated container. So it means it used it's own short live token and different folder structure.

Related ticket: https://jira.suse.com/browse/TEAM-9453

# Verification

## No PTF
 - AZURE http://openqaworker15.qa.suse.cz/tests/288522 :green_circle:   http://openqaworker15.qa.suse.cz/tests/288576
 - AWS http://openqaworker15.qa.suse.cz/tests/288529 :green_circle:  fails later after the HANA installation, to SAS token mechanism works

## PTF
 -  AZURE http://openqaworker15.qa.suse.cz/tests/288531 :green_circle:  fails in Ansible but in `TASK [Install additional Python packages]` It is after the task about PTF installation.
 -  AWS http://openqaworker15.qa.suse.cz/tests/288530 :green_circle:  PTF installation is fine http://openqaworker15.qa.suse.cz/tests/288530/logfile?filename=deploy_qesap_ansible-ansible.ptf_installation.log.txt