### PR TITLE
When restarting the job the HEAD is behind the main BCI remote repository

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -95,6 +95,7 @@ sub run {
     my $version = get_required_var('VERSION');
     my $test_envs = get_required_var('BCI_TEST_ENVS');
     my $bci_virtualenv = get_var('BCI_VIRTUALENV', 0);
+    my $bci_tests_branch = get_var('BCI_TESTS_BRANCH', 'origin/main');
     return if ($test_envs eq '-');
 
     reset_container_network_if_needed($engine);
@@ -102,7 +103,7 @@ sub run {
     assert_script_run('source bci/bin/activate') if ($bci_virtualenv);
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
-    assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard");
+    assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard $bci_tests_branch");
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
     assert_script_run("export CONTAINER_RUNTIME=$engine");
     $version =~ s/-SP/./g;


### PR DESCRIPTION
When restarting the job the HEAD is behind the main BCI-tests remote repository. Here is a restarted failed test runs -> [15-SP3-ltss image](https://openqa.suse.de/tests/14863860#step/bci_test_docker/21), [15-SP5-kernel-devel-module](https://openqa.suse.de/tests/14858108#step/bci_test_docker/21) even after a fix was provided. 
Verification run: [15-SP3-ltss](https://openqa.suse.de/tests/14864409#step/bci_test_docker/21), [15-SP5-kernel-devel-module](https://openqa.suse.de/tests/14863801#step/bci_test_docker/21)
