### PR TITLE
Fix netavark cleanup for slem 5.5

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -27,7 +27,7 @@ sub is_cni_in_tw {
 sub is_cni_default {
     my $podman_version = get_podman_version();
     return package_version_cmp($podman_version, '4.8.0') < 0 ||
-      (is_sle_micro('<5.5') && !check_var('FLAVOR', 'DVD-Updates')) ||
+      (is_sle_micro('<6.0') && !check_var('FLAVOR', 'DVD-Updates')) ||
       (is_sle_micro('=5.5') && !is_public_cloud);
 }
 


### PR DESCRIPTION
Tests were switching back to CNI in fresh install scenarios in slem 5.5

