### PR TITLE
Check flavor to enable encryption handling

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -208,19 +208,8 @@ sub run {
         send_key 'ret';
     }
 
-    # Skip ssh key enrollment (for now)
-    unless (is_sle || is_sle_micro('<=6.0') || is_leap) {
-        assert_screen 'jeos-ssh-enroll-or-not';
-        send_key 'n';
-    }
-
-    if (is_generalhw && is_aarch64 && !is_leap("<15.4") && !is_tumbleweed) {
-        assert_screen 'jeos-please-configure-wifi';
-        send_key 'n';
-    }
-
     # Only execute this block on SLE Micro 6.0+ when using the encrypted image.
-    if ((is_sle_micro('>=6.0')) && get_var("ENCRYPTED_IMAGE")) {
+    if (get_var('FLAVOR') =~ m/-encrypted/i) {
         # Select FDE with pass and tpm
         assert_screen "alp-fde-pass-tpm";
         # with the latest ALP 9.2/SLEM 3.4 build, this step takes more time than usual.
@@ -231,9 +220,21 @@ sub run {
         wait_still_screen 2;
         type_password;
         send_key "ret";
-        # Disk encryption is gonna take time. Once this is done we can proceed with login.
-        wait_still_screen 5;
+        # Disk encryption is gonna take time
+        assert_screen 're-encrypt-finished', 600;
     }
+
+    # Skip ssh key enrollment (for now)
+    unless (is_sle || is_sle_micro('<=6.0') || is_leap) {
+        assert_screen 'jeos-ssh-enroll-or-not', 120;
+        send_key 'n';
+    }
+
+    if (is_generalhw && is_aarch64 && !is_leap("<15.4") && !is_tumbleweed) {
+        assert_screen 'jeos-please-configure-wifi';
+        send_key 'n';
+    }
+
 
     if (is_bootloader_sdboot) {
         # Verify that /etc/issue shows the recovery key


### PR DESCRIPTION
Use flavor instead of `ENCRYPTED_IMAGE=1`.

- ticket: https://progress.opensuse.org/issues/163448
- needle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1666

#### Verification runs (failures are unrelated to the changes):

* [sle-micro-6.0-Default-encrypted-x86_64-Build10.23-slem_k3s@uefi](http://kepler.suse.cz/tests/23645#step/firstrun/12)
* [sle-micro-6.1-Base-encrypted-x86_64-Build3.12-default@uefi-virtio-vga](http://kepler.suse.cz/tests/23648#step/firstrun/12)
* [microos](http://kepler.suse.cz/tests/23637#step/firstrun/8)
* [15sp6](http://kepler.suse.cz/tests/23647#step/firstrun/9) 