### PR TITLE
[WIP] Repeat sending key to avoid not receiving

### DIFF
--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -268,7 +268,7 @@ sub login_vm_console {
     console('svirt')->start_serial_grab;
     select_console('sut');
     assert_screen('grub2', 200);
-    wait_screen_change { send_key 'ret' };
+    send_key('ret', wait_screen_change => 1) for (1 .. 3);
     assert_screen('linux-login', 120);
     select_console('root-console');
 }


### PR DESCRIPTION
Increase key sending times to avoid linux console login failure.
https://openqa.suse.de/tests/14884375#step/esxi_open_vm_tools/139

- Related ticket: https://progress.opensuse.org/issues/159492
- Verification run: 
