### PR TITLE
Don't rollback the snapshot on Micro

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -11,6 +11,7 @@ use base 'opensusebasetest';
 use testapi qw(is_serial_terminal :DEFAULT);
 use utils;
 use version_utils;
+use package_utils;
 use strict;
 use warnings;
 
@@ -51,7 +52,7 @@ sub prepare_test_data {
     }
 
     # Install software needed for this test module
-    zypper_call("in netcat-openbsd expect psmisc");
+    install_package("netcat-openbsd expect psmisc");
 }
 
 sub configure_service {

--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -32,7 +32,8 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 0, always_rollback => 1};
+    #poo160197 workaround since rollback seems not working with swTPM
+    return {fatal => 0, always_rollback => is_transactional ? 0 : 1};
 }
 
 1;

--- a/tests/fips/openssl/openssl_pubkey_dsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_dsa.pm
@@ -26,6 +26,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use strict;
 use warnings;
+use version_utils qw(is_transactional);
 
 sub run {
     select_serial_terminal;
@@ -67,6 +68,11 @@ sub run {
     }
 
     script_run 'cd - && rm -rf fips-test';
+}
+
+sub test_flags {
+    #poo160197 workaround since rollback seems not working with swTPM
+    return {no_rollback => is_transactional() ? 1 : 0};
 }
 
 1;


### PR DESCRIPTION
As a partial workaround, we avoid to restore snapshot when running on transactional products.

- Related ticket: https://progress.opensuse.org/issues/160197
- Needles: no
- Verification run: https://openqa.suse.de/tests/14893202 

(VR is failing because sshd tests are not ready to run on Micro yet)
