### PR TITLE
Implement ipaddr2 test module

### DIFF
--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -28,6 +28,8 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
+    ipaddr2_os_cloud_init_logs();
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/test.pm
+++ b/tests/sles4sap/ipaddr2/test.pm
@@ -18,6 +18,63 @@ sub run {
       unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
 
     select_serial_terminal;
+
+    my $bastion_ip = ipaddr2_bastion_pubip();
+
+    # 1. get the webpage using the LB floating IP. It should be from VM1 at the test beginning
+    # 2. move the cluster resource on the VM2
+    # 3. get the webpage using the LB floating IP. It should be from VM2
+
+    # This step is using crm to explicitly move rsc_ip_00 to VM-02
+    # as the IP resource is grouped with the az loadbalancer one,
+    # the load balancer entity in Azure is notified about the move
+    # and change the routing from the frontend IP to the
+    # backend IP of the VM-02
+    ipaddr2_crm_move(bastion_ip => $bastion_ip, destination => 2);
+    sleep 30;
+
+    # use curl to probe the webserver using the frontend IP
+    # until the reply come from the VM-02
+    die "Takeover does not happens in time" unless ipaddr2_wait_for_takeover(bastion_ip => $bastion_ip, destination => 2);
+    #test_connectivity
+    ipaddr2_test_master_vm(bastion_ip => $bastion_ip, id => 2);
+    #test_other_vm "${MYNAME}-vm-01"
+
+    #ssh_node1 'sudo crm configure show' | grep -E "cli-prefer-.*${MYNAME}-vm-02" || test_die "Cluster should now have one cli-prefer- with ${MYNAME}-vm-02"
+    #ssh_node1 'sudo crm configure show' | grep -c cli-prefer- | grep 1 || test_die "Cluster should now have one cli-prefer-"
+
+    # Slow down, take a break, then check again, nothing should be changed.
+    #test_step "Check again later"
+    #sleep 30
+    #test_connectivity
+    #test_web "${MYNAME}-vm-02"
+
+#################################################################################
+    # Repeat the same but this time from VM-02 to VM-01
+    #test_step "Move back the IpAddr2 resource to VM1"
+    #ssh_node1 'sudo crm resource move '"${MY_MOVE_RES} ${MYNAME}-vm-01" || test_die "Error in resource move"
+    #sleep 30
+
+    #wait_for_takeover "${MYNAME}-vm-01"
+    #test_connectivity
+    #test_on_vm "${MYNAME}-vm-01"
+    #test_other_vm "${MYNAME}-vm-02"
+
+    #test_step "Clear all location constrain used during the test"
+    #ssh_node1 'sudo crm resource clear '"${MY_MOVE_RES}"
+    #sleep 30
+
+    #test_step "Check cluster after the clear"
+    #ssh_node1 'sudo crm configure show' | grep -c cli-prefer- | grep 0 || test_die "Cluster should no more have some cli-prefer-"
+    #ssh_node1 'sudo crm status'
+
+    # Slow down, take a break, then check again, nothing should be changed.
+    #test_step "Check again later"
+    #sleep 30
+    #test_connectivity
+    #test_web "${MYNAME}-vm-01"
+
+
 }
 
 sub test_flags {


### PR DESCRIPTION
Crate a test module that move the cluster resource associated to the web
server and check that the Azure load balancer is alerted and change the
VM where the virtual IP is pointed to.


- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run:

## BYOS
sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit

### IPADDR2_CLOUDINIT=0 SCC_REGCODE_SLES4SAP
- http://openqaworker15.qa.suse.cz/tests/294146 :green_circle: 

### IPADDR2_CLOUDINIT=1 SCC_REGCODE_SLES4SAP
 - http://openqaworker15.qa.suse.cz/tests/294147 :red_circle: zypper in nginx exit with ZYPPER_EXIT_INF_REPOS_SKIPPED

## PAYG
sle-15-SP5-SapCloud-Azure-Payg-x86_64-Buildmpagot_VR-ipaddr2_azure_test@64bit 

### IPADDR2_CLOUDINIT=0
 -  http://openqaworker15.qa.suse.cz/tests/294148 :green_circle: 

### IPADDR2_CLOUDINIT=1
 -   http://openqaworker15.qa.suse.cz/tests/294149 :green_circle: 
