### PR TITLE
Prevent bonding issue by removing extra network interface from bridge_ports on sle12 autoyast

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -109,12 +109,8 @@
         <bootproto>dhcp</bootproto>
         <bridge>yes</bridge>
         <bridge_forwarddelay>15</bridge_forwarddelay>
-        <!-- Use specified interface instead of a list to avoid ip lease inconsistency. Please refer to poo#135641. -->
-        % if ($check_var->('SUT_NETDEVICE', 'eth1') or $check_var->('SUT_NETDEVICE', 'em1')) {
-        <bridge_ports><%= $get_var->('SUT_NETDEVICE') %></bridge_ports>
-        % } else {
-        <bridge_ports>eth0 eth1 em1 em2</bridge_ports>
-	% }
+        <!-- Use specified interface instead of a list to avoid bonding issues which act as router and created illegal duplicate traffic for gateway of its subnet. -->
+        <bridge_ports><%= $get_var->('BRIDGE_PORT', 'eth0') %></bridge_ports>
         <!-- Turn bridge_stp off to unblock autoyast installation. Please refer to bsc#1222105 -->
         <bridge_stp>off</bridge_stp>
         <startmode>auto</startmode>


### PR DESCRIPTION
The incorrect network bridge configuration is causing problem:
```
The machine bare-metal2.oqa.prg2.suse.org act as router and created illegal duplicate traffics for gateway of the oqa.prg2.suse.org subnet.
We sow "DUP" responses for ping toward vlan gateway 10.145.10.254 not just in k2 VM but also in other machines like for example on DHCP servers.

We investigated the traffics and found evidences about problematic traffics in J11 TOR switches specifically on port 5 on both TORs. ports are used by the server bare-metal2.oqa.prg2.suse.org as eth0 and eth1 see: https://racktables.nue.suse.com/index.php?page=object&object_id=23403
Our suspicion is incorrect setup bond between eth0 and eth1 interfaces that want to be LACP bond, but that is not setup on our side and in he end act as loop in this vlan.
```

```
bare-metal2:/etc/sysconfig/network # cat ifcfg-br0
BOOTPROTO='dhcp'
BRIDGE='yes'
BRIDGE_FORWARDDELAY='15'
BRIDGE_PORTS='eth0 eth1 em1 em2'
BRIDGE_STP='off'
STARTMODE='auto'
```

The culprit is `BRIDGE_PORTS='eth0 eth1 em1 em2'`.   "make a bridge from two interfaces is bad practice"


- Verification run: 
[sle12sp5_kvm_on_gonzo](https://openqa.suse.de/tests/14912427)
[sle12sp5_kvm_on_fozzie](https://openqa.suse.de/tests/14912432)
[sle12sp5_kvm_on_amd-zen3](http://openqa.suse.de/tests/14912498)
[sle12sp5_kvm_on_blackbauhinia](http://openqa.suse.de/tests/14912509)
[sle12sp5_xen_on_fibnacci](https://openqa.suse.de/tests/14912467)
