### PR TITLE
Remove xorg-x11-Xvnc from autoyast file

### DIFF
--- a/data/yam/autoyast/sles15sp5_gnome_unregistered_no_self_update.xml.ep
+++ b/data/yam/autoyast/sles15sp5_gnome_unregistered_no_self_update.xml.ep
@@ -82,7 +82,6 @@
     </patterns>
     <packages t="list">
       <package>openssh</package>
-      <package>xorg-x11-Xvnc</package>
     </packages>
     <products t="list">
       <product>SLES</product>


### PR DESCRIPTION
VRs: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=20240711-1&groupid=431

This commit removes `xorg-x11-Xvnc` from `data/yam/autoyast/sles15sp5_gnome_unregistered_no_self_update.xml.ep`