### PR TITLE
Create zypper resolver and upload it

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -384,6 +384,7 @@ PUBLIC_CLOUD_EMBARGOED_UPDATES_DETECTED | boolean | true | Internal variable wri
 PUBLIC_CLOUD_INFRA | boolean | false | Would trigger special flow in [check_registercloudguest.pm](tests/publiccloud/check_registercloudguest.pm) needed for run test against special test infra (DO NOT use the variable if you don't know what is about)
 PUBLIC_CLOUD_INFRA_RMT_V4 | string | "" | Defines IPv4 registration server in test infra. Must be used together with PUBLIC_CLOUD_INFRA. (DO NOT use the variable if you don't know what is about)
 PUBLIC_CLOUD_INFRA_RMT_V6 | string | "" | Defines IPv6 registration server in test infra. Must be used together with PUBLIC_CLOUD_INFRA. (DO NOT use the variable if you don't know what is about)
+PUBLIC_CLOUD_GEN_RESOLVER | boolean | 0 | Control use of `--debug-resolver` option during maintenance updates testing . In case option was used also controls uploading of resolver case into the test
 
 
 ### Wicked testsuite specific variables


### PR DESCRIPTION
When aggregate run failing and you creating product bug developers often requesting resolver case ( run zypper with special flag `debug-resolver` ) currently this can be done only manually . After merging this PR this time may be saved .

VR: http://autobot.qe.nue2.suse.org/tests/4399