### PR TITLE
[virtualization][MU]: Set PATCH_WITH_ZYPPER and UPDATE_PACKAGE in code

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -110,6 +110,7 @@ our @EXPORT = qw(
   replace_opensuse_repos_tests
   rescuecdstep_is_applicable
   set_defaults_for_username_and_password
+  set_mu_virt_vars
   setup_env
   snapper_is_applicable
   ssh_key_import
@@ -2436,7 +2437,7 @@ sub load_host_installation_modules {
 
 sub set_mu_virt_vars {
     # Set UPDATE_PACKAGE based on BUILD(format example, BUILD=:33310:dtb-armv7l)
-    my $BUILD = get_var('BUILD', '');
+    my $BUILD = get_required_var('BUILD');
     $BUILD =~ /^:(\d+):([^:]+)$/im;
 
     die "BUILD value is $BUILD, but does not match required format." if (!$2);

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2434,8 +2434,36 @@ sub load_host_installation_modules {
     loadtest "installation/reboot_after_installation";
 }
 
+sub set_mu_virt_vars {
+    # Set UPDATE_PACKAGE based on BUILD(format example, BUILD=:33310:dtb-armv7l)
+    my $BUILD = get_var('BUILD', '');
+    $BUILD =~ /^:(\d+):([^:]+)$/im;
+
+    die "BUILD value is $BUILD, but does not match required format." if (!$2);
+
+    my $_pkg = $2;
+    my $_update_package = '';
+    if ($_pkg =~ /qemu|xen|virt-manager|libguestfs|libslirp|open-vm-tools/) {
+        $_update_package = $_pkg;
+    } elsif ($_pkg =~ /libvirt/) {
+        $_update_package = 'libvirt-client';
+    } else {
+        $_update_package = 'kernel-default';
+    }
+
+    set_var('UPDATE_PACKAGE', $_update_package);
+    bmwqemu::save_vars();
+    diag("BUILD is $BUILD, UPDATE_PACKAGE is set to " . get_var('UPDATE_PACKAGE', ''));
+
+    # Set PATCH_WITH_ZYPPER
+    set_var('PATCH_WITH_ZYPPER', 1) unless (check_var('PATCH_WITH_ZYPPER', 0));
+}
+
 sub load_hypervisor_tests {
     return unless (get_var('HOST_HYPERVISOR') =~ /xen|kvm|qemu/);
+
+    # Some vars will affect loadtest logic, so need to be run on top
+    set_mu_virt_vars;
 
     if (check_var('ENABLE_HOST_INSTALLATION', 1)) {
         if (get_var('AUTOYAST')) {

--- a/schedule/virtualization/vmware_hyperv.yaml
+++ b/schedule/virtualization/vmware_hyperv.yaml
@@ -3,6 +3,7 @@ description:    >
     Maintainer: pdostal@suse.cz, nan.zhang@suse.com
     Testing Kernel on VMware / Hyper-V SLE hosts
 schedule:
+    - virtualization/universal/init_mu_virt_vars
     - support_server/login
     - virtualization/external/prepare
     - virtualization/universal/ssh_hypervisor_init

--- a/tests/virtualization/universal/init_mu_virt_vars.pm
+++ b/tests/virtualization/universal/init_mu_virt_vars.pm
@@ -1,0 +1,26 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: This file sets the necessary MU virtualization
+#   test variables, which can not be given by MU CI tools
+#   (bot-ng) during job triggering
+# Maintainer: xlai@suse.com, or QE-Virtualization <qe-virt@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use main_common;
+
+sub run {
+    if (get_var('REGRESSION') =~ /xen|kvm|qemu|hyperv|vmware/) {
+        set_mu_virt_vars;
+        record_info "Set necessary variables for MU virtualization test is done!";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
This PR mainly does below:
- use var BUILD info to set UPDATE_PACKAGE in main.pm, BUILD format eg BUILD=:33310:dtb-armv7l -- :<incident-id>:<update-package-name> (libvirt pkg needs value translation)
- PATCH_WITH_ZYPPER, set to 1 for official test, and allow customized value 0 if passing down by user 


Related ticket: A4 task openqa part, https://progress.opensuse.org/issues/160856

**Note: this PR shall be merged together with https://progress.opensuse.org/issues/160859**

Verification run: 
```
verification run on http://10.67.129.77/

Unit test:
PASS: qemu pkg
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-KVM-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-kvm-migration-src,qam-kvm-migration-dst BUILD=":123456:qemu"
{"count":2,"failed":[],"ids":[769,770],"scheduled_product_id":315}

PASS: xen pkg
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-XEN-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-xen-migration-src,qam-xen-migration-dst BUILD=":123456:xen"
{"count":2,"failed":[],"ids":[777,778],"scheduled_product_id":316}

PASS: libvirt pkg
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-KVM-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-kvm-migration-src,qam-kvm-migration-dst BUILD=":123456:libvirt"
{"count":2,"failed":[],"ids":[779,780],"scheduled_product_id":321}

PASS: kernel-default pkg, trigger value `"BUILD" : ":123456:dtb-armv7l"`
http://10.67.129.77/tests/749/file/vars.json


PATCH_WITH_ZYPPER
- default 1: good
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="12-SP5" FLAVOR=Server-DVD-Virt-XEN-GuestMigration-Incidents TERADATA= GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-xen-migration-src,qam-xen-migration-dst BUILD=":123456:xen"
{"count":2,"failed":[],"ids":[763,764],"scheduled_product_id":312}

- customized 0: good
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="12-SP5" FLAVOR=Server-DVD-Virt-XEN-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-xen-migration-src,qam-xen-migration-dst BUILD=":123456:xen"
{"count":2,"failed":[],"ids":[765,766],"scheduled_product_id":313}



Verification runs on OSD for vmware&hyperv :
- 15sp3 hyperv kernel pkg: https://openqa.suse.de/tests/15304805/file/vars.json (commented off the check of the updated pkg installed from TEST_X repo)
- 15sp4 vmware TERADATA, open-vm-tools pkg: https://openqa.suse.de/tests/15304809/file/vars.json (commented off the check of the updated pkg installed from TEST_X repo)


A3,A4 together, full verification jobs:

PASS
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-KVM-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-kvm-migration-src,qam-kvm-migration-dst BUILD=":123456:qemu"
{"count":2,"failed":[],"ids":[769,770],"scheduled_product_id":315}

PASS
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-XEN-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-xen-migration-src,qam-xen-migration-dst BUILD=":123456:xen"
{"count":2,"failed":[],"ids":[777,778],"scheduled_product_id":316}

PASS
qa2-dhcp-77:/var/lib/openqa/tests/sle # openqa-cli api  -X POST isos ARCH="x86_64" DISTRI="sle" VERSION="15-SP5" FLAVOR=Server-DVD-Virt-KVM-GuestMigration-Incidents TERADATA=  PATCH_WITH_ZYPPER=0  GUEST_ADMINISTRATION=0 INTERVAL_LOG=0 TEST=qam-kvm-migration-src,qam-kvm-migration-dst BUILD=":123456:libvirt"
{"count":2,"failed":[],"ids":[779,780],"scheduled_product_id":321}

```