### PR TITLE
Makes cloud-init execution optional

### DIFF
--- a/data/sles4sap/cloud-init-web.txt
+++ b/data/sles4sap/cloud-init-web.txt
@@ -1,8 +1,0 @@
-#cloud-config
-package_upgrade: false
-packages:
-  - nginx
-runcmd:
-  - 'echo "I am $(hostname)" > /srv/www/htdocs/index.html'
-  - sudo systemctl enable nginx.service
-  - sudo systemctl start nginx.service

--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -1067,10 +1067,9 @@ sub az_vm_diagnostic_log_get {
     my $vm_data = az_vm_list(resource_group => $args{resource_group}, query => '[].{id:id,name:name}');
     my $az_get_logs_cmd = 'az vm boot-diagnostics get-boot-log --ids';
     foreach (@{$vm_data}) {
-        #record_info('az vm boot-diagnostics json', "id: $_->{id} name: $_->{name}");
         my $boot_diagnostics_log = '/tmp/boot-diagnostics_' . $_->{name} . '.txt';
-        script_run(join(' ', $az_get_logs_cmd, $_->{id}, '|&', 'tee', $boot_diagnostics_log));
-        push(@diagnostic_log_files, $boot_diagnostics_log);
+        push(@diagnostic_log_files, $boot_diagnostics_log) unless
+          script_run(join(' ', $az_get_logs_cmd, $_->{id}, '|&', 'tee', $boot_diagnostics_log));
     }
     return @diagnostic_log_files;
 }

--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -11,9 +11,11 @@ use warnings FATAL => 'all';
 use testapi;
 use Carp qw(croak);
 use Exporter qw(import);
+use Mojo::JSON qw(decode_json);
 use mmapi 'get_current_job_id';
 use sles4sap::azure_cli;
 use publiccloud::utils;
+use utils qw(write_sut_file);
 
 
 =head1 SYNOPSIS
@@ -26,12 +28,15 @@ our @EXPORT = qw(
   ipaddr2_bastion_key_accept
   ipaddr2_destroy
   ipaddr2_create_cluster
+  ipaddr2_configure_web_server
   ipaddr2_deployment_sanity
   ipaddr2_deployment_logs
   ipaddr2_os_sanity
   ipaddr2_bastion_pubip
   ipaddr2_internal_key_accept
   ipaddr2_internal_key_gen
+  ipaddr2_registeration_check
+  ipaddr2_registeration_set
 );
 
 use constant DEPLOY_PREFIX => 'ip2t';
@@ -44,6 +49,10 @@ our $storage_account = DEPLOY_PREFIX . 'storageaccount';
 our $priv_ip_range = '192.168.';
 our $frontend_ip = $priv_ip_range . '0.50';
 our $key_id = 'id_rsa';
+our @nginx_cmds = (
+    'sudo zypper install -y nginx',
+    'echo "I am $(hostname)" > /srv/www/htdocs/index.html',
+    'sudo systemctl enable --now nginx.service');
 
 =head2 ipaddr2_azure_resource_group
 
@@ -82,13 +91,30 @@ Create a deployment in Azure designed for this specific test.
 5. Create 1 additional VM that get
 6. Create a Load Balancer with 2 VM in backend and with an IP as frontend
 
-=over 3
+=over 5
 
 =item B<region> - existing resource group
 
 =item B<os> - existing Load balancer NAME
 
 =item B<diagnostic> - enable diagnostic features if 1
+
+=item B<cloudinit> - enable cloud-init features if 1. This feature is used to install
+                      the web server using cloud-init, by providing an external
+                      cloud-init config file. This feature cannot be used for BYOS images
+                      as installing additional packages is not supported before
+                      the image registration. This feature could be problematic
+                      when testing maintenance update: problem is that the config file
+                      also perform a `zypper patch`. It happens at the first boot
+                      during the deployment so before anyother part of the test can add
+                      additional repo to test.
+
+=item B<scc_code> - if cloudinit is enabled, it is also possible to add
+                    register command in it. This argument is just ignored if cloudinit is 0.
+                    This argument become mandatory is cloudinit is 1 and image is BYOS.
+                    This is because cloud-init also try to install nginx,
+                    but installing packages is not possible for BYOS images,
+                    before registering.
 
 =back
 =cut
@@ -98,6 +124,11 @@ sub ipaddr2_azure_deployment {
     foreach (qw(region os)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
     $args{diagnostic} //= 0;
+    $args{cloudinit} //= 1;
+
+    if ($args{cloudinit} && ($args{os} =~ /byos/i) && !$args{scc_code}) {
+        croak("cloud-init deployment does not work with BYOS images without a registration code");
+    }
 
     az_version();
 
@@ -108,8 +139,12 @@ sub ipaddr2_azure_deployment {
         region => $args{region});
 
     # Create a VNET only needed later when creating the VM
-    my $vnet = DEPLOY_PREFIX . '-vnet';
-    my $subnet = DEPLOY_PREFIX . '-snet';
+    # Use $rg instead of DEPLOY_PREFIX to try to prevent
+    # some deployment failures like:
+    #    Subnet(ip2t-snet) does not exist, but failed to create a new subnet
+    #    with address prefix 10.0.0.0/24.
+    my $vnet = "$rg-vnet";
+    my $subnet = "$rg-snet";
     az_network_vnet_create(
         resource_group => $rg,
         region => $args{region},
@@ -166,22 +201,44 @@ sub ipaddr2_azure_deployment {
             name => ipaddr2_azure_storage_account());
     }
 
+    # If required, create on the fly the cloud-init script
+    my $cloud_init_file;
+    if ($args{cloudinit}) {
+        my $cloud_init_content = <<END;
+#cloud-config
+package_upgrade: false
+packages:
+  - nginx
+runcmd:
+  - 'echo "I am \$(hostname)" > /srv/www/htdocs/index.html'
+  - sudo systemctl enable --now nginx.service
+END
+
+        if ($args{scc_code}) {
+            $cloud_init_content .= <<END;
+bootcmd:
+  - registercloudguest --clean
+  - registercloudguest --force-new -r $args{scc_code}
+END
+        }
+        $cloud_init_file = '/tmp/cloud-init-web.txt';
+        write_sut_file($cloud_init_file, $cloud_init_content);
+        # upload to allow debugging
+        upload_logs($cloud_init_file);
+    }
+
     # Create 2:
     #   - VMs
     #   - for each of them open port 80
     #   - link their NIC/ipconfigs to the load balancer to be managed
     my $vm;
-    my $cloud_init_file = '/tmp/cloud-init-web.txt';
-    assert_script_run(join(' ',
-            'curl -v -fL',
-            data_url('sles4sap/cloud-init-web.txt'),
-            '-o', $cloud_init_file));
+    my %vm_create_args;
     foreach my $i (1 .. 2) {
         $vm = ipaddr2_get_internal_vm_name(id => $i);
         # the VM creation command refers to an external cloud-init
         # configuration file that is in charge to install and setup
         # the nginx server.
-        az_vm_create(
+        %vm_create_args = (
             resource_group => $rg,
             name => $vm,
             region => $args{region},
@@ -191,9 +248,12 @@ sub ipaddr2_azure_deployment {
             snet => $subnet,
             availability_set => $as,
             nsg => $nsg,
-            custom_data => $cloud_init_file,
             ssh_pubkey => get_ssh_private_key_path() . '.pub',
             public_ip => "");
+        if ($args{cloudinit}) {
+            $vm_create_args{custom_data} = $cloud_init_file;
+        }
+        az_vm_create(%vm_create_args);
 
         if ($args{diagnostic}) {
             az_vm_diagnostic_log_enable(resource_group => $rg,
@@ -201,10 +261,12 @@ sub ipaddr2_azure_deployment {
                 vm_name => $vm);
         }
 
-        az_vm_wait_cloudinit(
-            resource_group => $rg,
-            name => $vm,
-            username => $user);
+        if ($args{cloudinit}) {
+            az_vm_wait_cloudinit(
+                resource_group => $rg,
+                name => $vm,
+                username => $user);
+        }
 
         az_vm_openport(
             resource_group => $rg,
@@ -248,7 +310,7 @@ sub ipaddr2_azure_deployment {
             address_pool => $lb_be,
             ipconfig_name => $ip_config,
             nic_name => $nic_name,
-            timeput => 120);
+            timeput => 300);
     }
 
     # Health probe is using the port exposed by the cluster RA azure-lb
@@ -394,11 +456,11 @@ sub ipaddr2_internal_key_accept {
                 cmd => "nc -vz -w 1 $vm_name 22",
                 bastion_ip => $args{bastion_ip});
             # sleep before to evaluate as, even if port is open,
-            # it could take more time to be able to extablish
+            # it could take more time to be able to establish
             # the first ssh connection.
             sleep 10;
 
-            # this score mechanism panalize more those systems
+            # this score mechanism penalize more those systems
             # that are not ready when reaching this code.
             $score += (defined($exit_code) && $exit_code eq 0) ? +1 : -1;
             last if $score > 1;
@@ -438,7 +500,7 @@ sub ipaddr2_internal_key_accept {
     ipaddr2_internal_key_gen()
 
 Create, on the /tmp folder of the Worker, two ssh key set.
-One ssk yey pair for each internal VM
+One ssk key pair for each internal VM
 Then upload in each internal VM the ssh key pair using
 scp in Proxy mode
 
@@ -481,7 +543,7 @@ sub ipaddr2_internal_key_gen {
                 "-C \"Temp internal cluster key for $user on $vm_name\"",
                 '-f', "$this_tmp/$key_id"));
 
-        # Save the pubkey for later
+        # Save the ssh public key for later
         push @pubkey, script_output("cat $this_tmp/$key_id.pub");
         my $remote_key_tmp_path;
         my $remote_key_home_path;
@@ -508,7 +570,7 @@ sub ipaddr2_internal_key_gen {
         }
     }
 
-    # Put vm-01 pub key as authorized key in vm-02
+    # Put vm-01 ssh public key as authorized key in vm-02
     ipaddr2_ssh_internal(id => 2,
         cmd => "echo \"$pubkey[0]\" >> /home/$user/.ssh/authorized_keys",
         bastion_ip => $args{bastion_ip});
@@ -623,7 +685,7 @@ sub ipaddr2_os_connectivity_sanity {
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
 
     # proceed_on_failure needed as ping or nc
-    # coul dbe missing on the qcow2 running these commands
+    # could be missing on the qcow2 running these commands
     # (for example pc_tools)
     script_run("ping -c 3 $args{bastion_ip}", proceed_on_failure => 1);
     script_run("nc -vz -w 1 $args{bastion_ip} 22", proceed_on_failure => 1);
@@ -673,7 +735,7 @@ sub ipaddr2_os_network_sanity {
 
     ipaddr2_os_ssh_sanity()
 
-Run some OS level checks on the various VMs ssh keys and configs.
+Run some OS level checks on the various VMs ssh keys and configurations.
 die in case of failure
 
 =over 1
@@ -999,6 +1061,114 @@ sub ipaddr2_create_cluster {
         bastion_ip => $args{bastion_ip});
 }
 
+=head2 ipaddr2_registeration_check
+
+    my $is_registered = ipaddr2_registeration_check(id => 1);
+
+Check if image is registered. Return 1 is it is registered, 0 if at least one is not.
+
+=over 2
+
+=item B<id> - VM id where to install and configure the web server
+
+=item B<bastion_ip> - Public IP address of the bastion. Calculated if not provided.
+                      Providing it as an argument is recommended in order
+                      to avoid having to query Azure to get it.
+
+=back
+
+=cut
+
+sub ipaddr2_registeration_check {
+    my (%args) = @_;
+    croak("Argument < id > missing") unless $args{id};
+
+    $args{bastion_ip} //= ipaddr2_bastion_pubip();
+    my $registered = 1;
+    my $json = decode_json(ipaddr2_ssh_internal_output(
+            id => $args{id},
+            cmd => 'sudo SUSEConnect -s',
+            bastion_ip => $args{bastion_ip}));
+    foreach (@$json) {
+        if ($_->{status} =~ '^Not Registered') {
+            $registered = 0;
+            last;
+        }
+    }
+    return $registered;
+}
+
+=head2 ipaddr2_registeration_set
+
+    ipaddr2_registeration_set(id => 1, scc_code => '1234567890');
+
+Register the image. Notice that this library also support registration through
+ipaddr2_azure_deployment
+
+=over 3
+
+=item B<id> - VM id where to install and configure the web server
+
+=item B<scc_code> - registration code
+
+=item B<bastion_ip> - Public IP address of the bastion. Calculated if not provided.
+                      Providing it as an argument is recommended in order
+                      to avoid having to query Azure to get it.
+
+=back
+
+=cut
+
+sub ipaddr2_registeration_set {
+    my (%args) = @_;
+    foreach (qw(id scc_code)) {
+        croak("Argument < $_ > missing") unless $args{$_}; }
+
+    $args{bastion_ip} //= ipaddr2_bastion_pubip();
+
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => 'sudo registercloudguest --clean',
+        bastion_ip => $args{bastion_ip});
+
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => "sudo registercloudguest --force-new -r \"$args{scc_code}\"",
+        bastion_ip => $args{bastion_ip});
+}
+
+=head2 ipaddr2_configure_web_server
+
+    ipaddr2_configure_web_server(id => 1);
+
+This function is in charge to:
+    1. install the nginx package
+    2. create a webpage file
+    3. enable and start the system
+
+=over 2
+
+=item B<id> - VM id where to install and configure the web server
+
+=item B<bastion_ip> - Public IP address of the bastion. Calculated if not provided.
+                      Providing it as an argument is recommended in order
+                      to avoid having to query Azure to get it.
+
+=back
+
+=cut
+
+sub ipaddr2_configure_web_server {
+    my (%args) = @_;
+    croak("Argument < id > missing") unless $args{id};
+
+    $args{bastion_ip} //= ipaddr2_bastion_pubip();
+    ipaddr2_ssh_internal(id => $args{id},
+        cmd => $_,
+        bastion_ip =>
+          $args{bastion_ip}) for (@nginx_cmds);
+}
+
 =head2 ipaddr2_deployment_logs
 
     ipaddr2_deployment_logs()
@@ -1007,7 +1177,11 @@ Collect logs from the cloud infrastructure
 =cut
 
 sub ipaddr2_deployment_logs {
-    az_vm_diagnostic_log_get(resource_group => ipaddr2_azure_resource_group());
+    my @diagnostic_log_files = az_vm_diagnostic_log_get(
+        resource_group => ipaddr2_azure_resource_group());
+    while (my $file = pop @diagnostic_log_files) {
+        upload_logs($file, failok => 1);
+    }
 }
 
 =head2 ipaddr2_destroy

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -9,12 +9,16 @@ use List::Util qw(any none all);
 
 use sles4sap::ipaddr2;
 
-subtest '[ipaddr2_azure_deployment]' => sub {
+subtest '[ipaddr2_azure_deployment] no BYOS' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
-    $ipaddr2->redefine(data_url => sub { return '/Faggin'; });
+    my $cloud_init_content;
+    $ipaddr2->redefine(write_sut_file => sub {
+            $cloud_init_content = $_[1];
+            return; });
+    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
     $ipaddr2->redefine(az_vm_wait_running => sub { return; });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
@@ -30,10 +34,93 @@ subtest '[ipaddr2_azure_deployment]' => sub {
         note("sles4sap::" . $calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
         push @cmds, $calls[$call_idx][1];
     }
+    note("cloud_init_content:\n" .
+          "--------------------------\n" .
+          $cloud_init_content .
+          "\n--------------------------");
+
+    ok(($#calls > 0), "There are some command calls");
+    ok((none { /az storage account create/ } @cmds), 'Do not create storage');
+    ok((any { /az vm create.*custom-data/ } @cmds), 'Cloud-init enabled by default');
+    ok((any { /sudo cloud-init status/ } @cmds), 'Cloud-init enabled by default');
+    like($cloud_init_content, qr/nginx/, "cloud-init script is also about nginx");
+    unlike($cloud_init_content, qr/registercloudguest/, "cloud-init script does not register");
+};
+
+subtest '[ipaddr2_azure_deployment] cloud-init and byos but no SCC' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
+    my @calls;
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
+
+    dies_ok {
+        ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci:gen2:ByoS');
+    } "cloud-init is enabled by default and image is BYOS but no scc_code provided";
+
+    for my $call_idx (0 .. $#calls) {
+        note("sles4sap::" . $calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
+    }
+
+    ok((!@calls), 'There are ' . $#calls . ' command calls and none expected');
+};
+
+subtest '[ipaddr2_azure_deployment] cloud-init byos and SCC' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
+    my @calls;
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
+    my $cloud_init_content;
+    $ipaddr2->redefine(write_sut_file => sub {
+            $cloud_init_content = $_[1];
+            return; });
+    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
+
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
+    $azcli->redefine(script_output => sub { push @calls, ['azure_cli', $_[0]]; return 'Fermi'; });
+
+    ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci:gen2:ByoS', scc_code => '1234');
+
+
+    for my $call_idx (0 .. $#calls) {
+        note("sles4sap::" . $calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
+    }
+    note("cloud_init_content:\n" .
+          "--------------------------\n" .
+          $cloud_init_content .
+          "\n--------------------------");
+
+    like($cloud_init_content, qr/nginx/, "cloud-init script is also about nginx");
+    like($cloud_init_content, qr/registercloudguest/, "cloud-init script does not register");
+};
+
+subtest '[ipaddr2_azure_deployment] no cloud-init' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
+    my @calls;
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
+    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
+
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
+    $azcli->redefine(script_output => sub { push @calls, ['azure_cli', $_[0]]; return 'Fermi'; });
+
+    ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci:gen2:ByoS', cloudinit => 0);
+
+    # push th elist of commands in another list, this one withour the source
+    # In this way it is easier to inspect the content
+    my @cmds;
+    for my $call_idx (0 .. $#calls) {
+        note("sles4sap::" . $calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
+        push @cmds, $calls[$call_idx][1];
+    }
 
     # Todo : expand it
     ok(($#calls > 0), "There are some command calls");
-    ok((none { /az storage account create/ } @cmds), 'Do not create storage');
+    ok((none { /az vm create.*custom-data/ } @cmds), 'Cloud-init disabled');
+    ok((none { /sudo cloud-init status/ } @cmds), 'Cloud-init disabled');
 };
 
 subtest '[ipaddr2_azure_deployment] diagnostic' => sub {
@@ -41,7 +128,8 @@ subtest '[ipaddr2_azure_deployment] diagnostic' => sub {
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
-    $ipaddr2->redefine(data_url => sub { return '/Faggin'; });
+    $ipaddr2->redefine(write_sut_file => sub { return; });
+    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
     $ipaddr2->redefine(az_vm_wait_running => sub { return; });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
@@ -243,7 +331,9 @@ subtest '[ipaddr2_internal_key_gen]' => sub {
     my @calls;
     # return 1 means file does not exist.
     #$ipaddr2->redefine(script_run => sub { push @calls, $_[0]; return 1; });
-    $ipaddr2->redefine(script_output => sub { push @calls, $_[0]; return 'BeniaminoFiammaPubKeyBeniaminoFiammaPubKey'; });
+    $ipaddr2->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'BeniaminoFiammaPubKeyBeniaminoFiammaPubKey'; });
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
 
     ipaddr2_internal_key_gen();
@@ -257,11 +347,81 @@ subtest '[ipaddr2_deployment_logs]' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     my $called = 0;
     $ipaddr2->redefine(ipaddr2_azure_resource_group => sub { return 'Volta'; });
-    $ipaddr2->redefine(az_vm_diagnostic_log_get => sub { $called = 1; return; });
+    $ipaddr2->redefine(az_vm_diagnostic_log_get => sub { $called = 1; return ('aaaaa.log', 'bbbbbb.log'); });
+    $ipaddr2->redefine(upload_logs => sub { return; });
 
     ipaddr2_deployment_logs();
 
     ok(($called eq 1), "az_vm_diagnostic_log_get called");
 };
 
+subtest '[ipaddr2_configure_web_server]' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, ["VM$args{id}", $args{cmd}, ""];
+            return;
+    });
+
+    ipaddr2_configure_web_server(id => 42);
+
+    for my $call_idx (0 .. $#calls) {
+        note($calls[$call_idx][0] . " C-->  $calls[$call_idx][1]   $calls[$call_idx][2]");
+    }
+    ok((scalar @calls > 0), "Some calls to ipaddr2_ssh_internal");
+};
+
+subtest '[ipaddr2_registeration_check] all registered' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+    $ipaddr2->redefine(script_output => sub {
+            push @calls, $_[0];
+            # due to the itnernal implementation of the
+            # function under test, this status is equivalent to `Registered`
+            return '[{"status":"Bialetti"}]'; });
+
+    my $ret = ipaddr2_registeration_check(id => 42);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /SUSEConnect -s/ } @calls), 'SUSEConnect to check what is registered');
+    ok(($ret eq 1), "Is registered ret:$ret");
+};
+
+subtest '[ipaddr2_registeration_check] one not registered' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+    $ipaddr2->redefine(script_output => sub {
+            push @calls, $_[0];
+            # due to the itnernal implementation of the
+            # function under test, this status is equivalent to `Registered`
+            return '[{"status":"Bialetti"}, {"status":"Not Registered"}]'; });
+
+    my $ret = ipaddr2_registeration_check(id => 42);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok(($ret eq 0), "Is not registered ret:$ret");
+};
+
+subtest '[ipaddr2_registeration_set]' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, $args{cmd};
+            return;
+    });
+
+    ipaddr2_registeration_set(id => 42, scc_code => '1234567890');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /registercloudguest.*clean/ } @calls), 'registercloudguest clean');
+    ok((any { /registercloudguest.*-r.*1234567890/ } @calls), 'registercloudguest register');
+};
 done_testing;

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -19,13 +19,35 @@ sub run {
 
     select_serial_terminal;
 
-    record_info("STAGE 1", "Prepare all the ssh connections within the 2 internal VMs");
+    record_info("TEST STAGE", "Prepare all the ssh connections within the 2 internal VMs");
     my $bastion_ip = ipaddr2_bastion_pubip();
     ipaddr2_bastion_key_accept(bastion_ip => $bastion_ip);
     ipaddr2_internal_key_accept(bastion_ip => $bastion_ip);
     ipaddr2_internal_key_gen(bastion_ip => $bastion_ip);
 
-    record_info("STAGE 2", "Init and configure the Pacemaker cluster");
+    if (check_var('IPADDR2_CLOUDINIT', 0)) {
+        if (get_var('SCC_REGCODE_SLES4SAP')) {
+            # Register was not part of cloud-init
+            record_info("TEST STAGE", "Register");
+            foreach (1 .. 2) {
+                my $is_registered = ipaddr2_registeration_check(
+                    bastion_ip => $bastion_ip,
+                    id => $_);
+                record_info('is_registered', "$is_registered");
+                ipaddr2_registeration_set(
+                    bastion_ip => $bastion_ip,
+                    id => $_,
+                    scc_code => get_required_var('SCC_REGCODE_SLES4SAP')) if ($is_registered ne 1);
+            }
+        }
+        record_info("TEST STAGE", "Install the web server");
+        foreach (1 .. 2) {
+            ipaddr2_configure_web_server(bastion_ip => $bastion_ip, id => $_);
+        }
+    }
+
+
+    record_info("TEST STAGE", "Init and configure the Pacemaker cluster");
     ipaddr2_create_cluster(bastion_ip => $bastion_ip);
 }
 

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -22,10 +22,13 @@ sub run {
     # Init all the PC gears (ssh keys, CSP credentials)
     my $provider = $self->provider_factory();
 
-    ipaddr2_azure_deployment(
+    my %deployment = (
         region => $provider->provider_client->region,
         os => get_required_var('CLUSTER_OS_VER'),
-        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0));
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1));
+    $deployment{scc_code} = get_var('SCC_REGCODE_SLES4SAP') if (get_var('SCC_REGCODE_SLES4SAP'));
+    ipaddr2_azure_deployment(%deployment);
     ipaddr2_deployment_sanity();
 }
 


### PR DESCRIPTION
Add setting to optionally disable cloud-init execution during the deployment. Az cloud-init is mostly in charge to configure the web server, if disabled the installation and configuration is executed later and by some ssh commands.

- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run: 

## PAYG

### CLOUDINIT
test with setting IPADDR2_CLOUDINIT=1
- http://openqaworker15.qa.suse.cz/tests/290913 :red_circle:  exotic ip2t-snet issue ??
- http://openqaworker15.qa.suse.cz/tests/290923 :red_circle: `[{"code":"InUseSubnetCannotBeUpdated","message":"Subnet ip2t290922-snet is in use and cannot be updated."`
- http://openqaworker15.qa.suse.cz/tests/290934 :green_circle:  it is using cloud-init (settings works), cloud-init script content is fine http://openqaworker15.qa.suse.cz/tests/290934/logfile?filename=deploy-cloud-init-web.txt and available as job attachment, `deployment` and `configure` stages are fine. It fails in `sanity` when `systemctl is-system-running` return `degradated`.

### NOCLOUDINIT
test with setting IPADDR2_CLOUDINIT=0
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test@64bit
- http://openqaworker15.qa.suse.cz/tests/290817 :red_circle: fails in az NIC 
- http://openqaworker15.qa.suse.cz/tests/290912 :red_circle:  exotic ip2t-snet issue ??
- http://openqaworker15.qa.suse.cz/tests/290922 :red_circle:  ip2t-snet issue
- http://openqaworker15.qa.suse.cz/tests/290935 :red_circle:  ip2t-snet issue

## BYOS


### CLOUDINIT
test with setting IPADDR2_CLOUDINIT=1

sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit with SCC code
-  http://openqaworker15.qa.suse.cz/tests/290906 :red_circle: fails in `az run-command` 
- http://openqaworker15.qa.suse.cz/tests/290919 :green_circle: it is using cloud-init and content is fine http://openqaworker15.qa.suse.cz/tests/290919/logfile?filename=deploy-cloud-init-web.txt, it has reg code in cloudinit script. `deployment` and `configure` are fine. Fails in `sanity`

test without SCC
http://openqaworker15.qa.suse.cz/tests/290815#step/deploy/65 :green_circle: fails as expected
 
### NOCLOUDINIT
test with setting IPADDR2_CLOUDINIT=0

 sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit with SCC code
 - http://openqaworker15.qa.suse.cz/tests/290911 :red_circle:  fails in az NIC command 
 - http://openqaworker15.qa.suse.cz/tests/290918 :red_circle: timeout as running registration http://openqaworker15.qa.suse.cz/tests/290918#step/configure/160
 -  http://openqaworker15.qa.suse.cz/tests/290995
 
 
