### PR TITLE
Restore combustion schedule poo#163858

### DIFF
--- a/lib/main_security.pm
+++ b/lib/main_security.pm
@@ -12,7 +12,7 @@ use Exporter;
 use utils;
 use version_utils;
 use main_common qw(loadtest boot_hdd_image);
-use testapi qw(get_var);
+use testapi qw(get_var check_var);
 use Utils::Architectures;
 use Utils::Backends;
 

--- a/lib/main_security.pm
+++ b/lib/main_security.pm
@@ -22,7 +22,7 @@ our @EXPORT = qw(
 );
 
 sub is_security_test {
-    return get_var('SECURITY', 1);
+    return check_var('SECURITY', 1);
 }
 
 sub load_selinux_tests {


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/163748

- Verification run: https://openqa.opensuse.org/tests/4342808#


The schedule was loading wrong because is_security_test subroutine was using get_var instead of check_var.
Get_var returns the content of the variable or the given default, which was set to 1, forcing the security schedule to be loaded instead. Changing to check_var fixes the problem.
