### PR TITLE
console/sysstat.pm: Support for sysstat 12.7.5

### DIFF
--- a/tests/console/sysstat.pm
+++ b/tests/console/sysstat.pm
@@ -78,7 +78,11 @@ sub run {
     } else {
         validate_script_output "sar -b", sub { /tps      rtps      wtps   bread\/s   bwrtn\/s/ };
     }
-    validate_script_output "sar -B", sub { /pgpgin\/s pgpgout\/s   fault\/s  majflt\/s  pgfree\/s pgscank\/s pgscand\/s pgsteal\/s    %vmeff/ };
+    if (version->parse(script_output('rpm --qf "%{VERSION}\n" -q sysstat')) >= version->parse('12.7.5')) {
+        validate_script_output "sar -B", sub { /pgpgin\/s pgpgout\/s   fault\/s  majflt\/s  pgfree\/s pgscank\/s pgscand\/s pgsteal\/s  pgprom\/s   pgdem\/s/ };
+    } else {
+        validate_script_output "sar -B", sub { /pgpgin\/s pgpgout\/s   fault\/s  majflt\/s  pgfree\/s pgscank\/s pgscand\/s pgsteal\/s    %vmeff/ };
+    }
     validate_script_output "sar -H", sub { /kbhugfree kbhugused  %hugused/ };
     validate_script_output "sar -S", sub { /kbswpfree kbswpused  %swpused  kbswpcad   %swpcad/ };
 


### PR DESCRIPTION
From sysstat.changes:
 * [Quan quan Cao]: sar/sadc: Add new metrics pgprom/s and pgdem/s.
 * sar: Remove %vmeff metric.

- Related ticket: https://progress.opensuse.org/issues/162194
- Verification run: https://openqa.opensuse.org/tests/4342953
