### PR TITLE
containers: podman-remote is now available on 15-SP3

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -58,8 +58,7 @@ sub run {
     push @pkgs, qw(python3-PyYAML) unless is_sle_micro('>=6.0');
     push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');
     push @pkgs, qw(socat) unless is_sle_micro('=5.1');
-    # https://bugzilla.suse.com/show_bug.cgi?id=1226596
-    push @pkgs, qw(podman-remote) unless (is_sle_micro('<5.5') || is_sle('<=15-SP3'));
+    push @pkgs, qw(podman-remote) unless (is_sle_micro('<5.5') || is_sle('<=15-SP2'));
     # passt requires podman 5.0
     push @pkgs, qw(criu passt) if (is_tumbleweed || is_microos);
     # Needed for podman machine


### PR DESCRIPTION
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1226596
- Verification run: not needed

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1737

```
$ podman run --rm ghcr.io/ricardobranco777/susepkg:latest -p any podman-remote | grep SLES/
SLES/15.3 podman-remote 4.9.5-150300.9.31.1
SLES/15.4 podman-remote 4.9.5-150400.4.27.1
SLES/15.5 podman-remote 4.9.5-150500.3.15.1
SLES/15.6 podman-remote 4.9.5-150500.3.15.1
```

Jobs for harvesting `PODMAN_BATS_SKIP_{ROOT,USER}_REMOTE` variables:
- x86_64: https://openqa.suse.de/tests/14933852
- aarch64: https://openqa.suse.de/tests/14933853
