### PR TITLE
Ignore GPT header warnings in Cloud image

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -662,5 +662,13 @@
             "sle-micro": ["6.0"]
         },
         "type": "ignore"
+    },
+    "minimal vm cloud image - gpt": {
+        "description": "kernel: GPT:(Primary header thinks Alt. header is not at the end of the disk.|Alternate GPT header not at the end of the disk.|\\s+Use GNU Parted to correct GPT errors.|\\d+ != \\d+)",
+        "products": {
+            "sle": ["15-SP6"],
+            "opensuse": ["Tumbleweed"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
Minimal-VM image, configure by cloud-init yields several GPT warnings/errors. This is most likely result of growpart actions.

```
Jul 15 17:51:47.318523 localhost kernel: GPT:Primary header thinks Alt.
header is not at the end of the disk.
Jul 15 17:51:47.318531 localhost kernel: GPT:2097151 != 41943039
Jul 15 17:51:47.318538 localhost kernel: GPT:Alternate GPT header not at
the end of the disk.
Jul 15 17:51:47.318546 localhost kernel: GPT:2097151 != 41943039
Jul 15 17:51:47.318552 localhost kernel: GPT: Use GNU Parted to correct
GPT errors.
```

- ticket: https://progress.opensuse.org/issues/156151
- Verification run: http://kepler.suse.cz/tests/23655#step/journal_check/8
