### PR TITLE
GRUB_TERMINAL_INPUT/OUTPUT should also be handled

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -516,6 +516,8 @@ sub set_grub_terminal_and_timeout {
     if (($args{grub_to_change} == 1) or ($args{grub_to_change} == 3)) {
         my $grub_default_file = "$args{root_dir}etc/default/grub";
         $cmd = "sed -i -r \'s/^#{0,}GRUB_TERMINAL=.*\$/GRUB_TERMINAL=\"$args{terminals}\"/' $grub_default_file; "
+          . "sed -i -r \'s/^#{0,}GRUB_TERMINAL_INPUT=.*\$/GRUB_TERMINAL_INPUT=\"$args{terminals}\"/' $grub_default_file; "
+          . "sed -i -r \'s/^#{0,}GRUB_TERMINAL_OUTPUT=.*\$/GRUB_TERMINAL_OUTPUT=\"$args{terminals}\"/' $grub_default_file; "
           . "sed -i -r \'s/^#{0,}GRUB_TIMEOUT=.*\$/GRUB_TIMEOUT=$args{timeout}/' $grub_default_file";
         $cmd = "ssh root\@$args{dst_machine} " . "\"$cmd\"" if ($args{dst_machine} ne 'localhost');
         assert_script_run($cmd);


### PR DESCRIPTION
* **GRUB_TERMINAL_INPUT** and GRUB_TERMINAL_OUTPUT can also be present in /etc/default/grub file. They should be handled as well besides GRUB_TERMINAL in subroutine set_grub_terminal_and_timeout to have desired terminal settings.

* **Verification Runs:**
  *  [**UEFI host**  link1](http://10.100.228.134/tests/2931) [link2](http://10.100.204.18/tests/2931) [link3](http://10.67.18.153/tests/2931) [link4](http://10.149.193.170/tests/2931)
  *  [**non-UEFI host**  link1](http://10.100.228.134/tests/2939) [link2](http://10.100.204.18/tests/2939) [link3](http://10.67.18.153/tests/2939) [link4](http://10.149.193.170/tests/2939)