### PR TITLE
Install also optional patches

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -834,7 +834,7 @@ sub ssh_fully_patch_system {
     my $remote = shift;
     my $cmd_time = time();
     my $resolver_option = get_var('PUBLIC_CLOUD_GEN_RESOLVER') ? '--debug-solver' : '';
-    my $cmd = "ssh $remote 'sudo zypper -n patch $resolver_option --with-interactive -l'";
+    my $cmd = "ssh $remote 'sudo zypper -n patch $resolver_option --with-interactive -l --with-optional'";
     # first run, possible update of packager -- exit code 103
     my $ret = script_run($cmd, 1500);
     record_info('zypper patch', 'The command zypper patch took ' . (time() - $cmd_time) . ' seconds.');


### PR DESCRIPTION
From zypper patch manpage:
```
Note that the patch command does not apply optional patches (category optional or feature) by default. If you actually want to consider all optional patches as being needed, say
           patch --with-optional. Specific patches can be applied using the install command (e.g. zypper install patch:openSUSE-2014-7).
```

so without optional maintenance patch under test isn't installed if is marked as a optional and thus test is +- invalid

https://openqa.suse.de/tests/14942332