### PR TITLE
Improve robustness of cloud-init wait

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -823,7 +823,7 @@ sub az_vm_wait_cloudinit {
         '--run-as-user', $args{username},
         '--timeout-in-seconds', $args{timeout},
         '--script "sudo cloud-init status --wait"');
-    assert_script_run($az_cmd, timeout => ($args{timeout} + 10));
+    assert_script_run($az_cmd, timeout => ($args{timeout} + 300));
 }
 
 =head2 az_nic_id_get
@@ -974,13 +974,15 @@ sub az_ipconfig_update {
 
 Add the IpConfig to a LB address pool
 
-=over 3
+=over 4
 
 =item B<resource_group> - existing resource group
 
 =item B<lb_name> - existing Load balancer NAME
 
 =item B<address_pool> - existing Load balancer address pool name
+
+=item B<timeout> - timeout, default 60
 
 =back
 =cut
@@ -989,6 +991,7 @@ sub az_ipconfig_pool_add {
     my (%args) = @_;
     foreach (qw(resource_group lb_name address_pool ipconfig_name nic_name)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
+    $args{timeout} //= 60;
 
     my $az_cmd = join(' ', 'az network nic ip-config address-pool add',
         '--resource-group', $args{resource_group},
@@ -996,7 +999,7 @@ sub az_ipconfig_pool_add {
         '--address-pool', $args{address_pool},
         '--ip-config-name', $args{ipconfig_name},
         '--nic-name', $args{nic_name});
-    assert_script_run($az_cmd);
+    assert_script_run($az_cmd, timeout => $args{timeout});
 }
 
 =head2 az_vm_diagnostic_log_enable

--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -247,7 +247,8 @@ sub ipaddr2_azure_deployment {
             lb_name => $lb,
             address_pool => $lb_be,
             ipconfig_name => $ip_config,
-            nic_name => $nic_name);
+            nic_name => $nic_name,
+            timeput => 120);
     }
 
     # Health probe is using the port exposed by the cluster RA azure-lb


### PR DESCRIPTION
The API to wait the end of the cloud-init execution has an internal (within Azure) and external (in openQA testapi) timeout. The external one is larger to give some time to the az cli to terminate smoothly when the internal timeout elapses. Increase the delta from 10sec to 1 minute. Add timeout to other API too.
Improve diagnostic log upload code.



- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run:

## BYOS
sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit

- http://openqaworker15.qa.suse.cz/tests/289669 :green_circle: 
 
 ## PAYG
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test@64bit
- http://openqaworker15.qa.suse.cz/tests/289670 :red_circle: 60sec of delta seems not enough
-  http://openqaworker15.qa.suse.cz/tests/289739 
