### PR TITLE
Adapt raid_encrypted_home_x86_64.xml file for SLES15SP3 installation

### DIFF
--- a/data/yam/autoyast/raid_encrypted_home_x86_64.xml.ep
+++ b/data/yam/autoyast/raid_encrypted_home_x86_64.xml.ep
@@ -232,7 +232,6 @@
       <package>xfsprogs</package>
       <package>wicked</package>
       <package>sle-module-server-applications-release</package>
-      <package>sle-module-python3-release</package>
       <package>sle-module-basesystem-release</package>
       <package>openssh</package>
       <package>mdadm</package>

--- a/tests/console/validate_raid_encrypt_home.pm
+++ b/tests/console/validate_raid_encrypt_home.pm
@@ -14,6 +14,7 @@ use testapi;
 use Mojo::JSON qw(decode_json);
 use scheduler 'get_test_suite_data';
 use Test::Assert ':all';
+use filesystem_utils qw(is_lsblk_able_to_display_mountpoints);
 
 sub run {
     select_console 'root-console';
@@ -22,7 +23,7 @@ sub run {
 
     assert_equals($md_name, $lsblk_output->{blockdevices}[0]{name}, "Multi-disk name not found");
     assert_equals('crypt', $lsblk_output->{blockdevices}[0]{children}[0]{type}, "Encrypted type not found");
-    assert_equals('/home', $lsblk_output->{blockdevices}[0]{children}[0]{mountpoints}[0], "Encrypted mount point not found");
+    assert_equals('/home', is_lsblk_able_to_display_mountpoints ? $lsblk_output->{blockdevices}[0]{children}[0]{mountpoints}[0] : $lsblk_output->{blockdevices}[0]{children}[0]{mountpoint}, "Encrypted mount point not found");
 }
 
 1;


### PR DESCRIPTION
Add testsuites of autoyast_raid_encrypted_home for SLES15SP3/4/5. Adapt the current autoyast profile and validation for 15SP3.

- Related ticket: https://progress.opensuse.org/issues/163310
- Needles: n/a
- Verification run: 
- https://openqa.suse.de/tests/14958639# (15SP3)
- https://openqa.suse.de/tests/14958640# (15SP4)
- https://openqa.suse.de/tests/14958641# (15SP5)
- Related mr: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/274
