### PR TITLE
Add SEV kernel options in SLE 15 autoyast

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -58,8 +58,22 @@
       <!-- For some special beremetal machines, such as unreal2/3, their serial console:
       SERIALDEV='ttyS2', XEN_SERIAL_CONSOLE="com1=115200,8n1,0x3e8,5 console=com1" -->
       <xen_kernel_append><%= defined $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} ? $bmwqemu::vars{"XEN_SERIAL_CONSOLE"} : "console=com2,115200" %> vga=gfx-1024x768x16 loglvl=all guest_loglvl=all sync_console</xen_kernel_append>
-      % } else {
-      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 <%= $check_var->('AMD', '1') ? "" : "intel_iommu=on" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+      % }
+      % if ($check_var->('SYSTEM_ROLE', 'kvm')) {
+        % if ($check_var->('AMD', '1')) {
+          % if ($check_var->('VIRT_SEV_ES_GUEST_INSTALL', '1')) {
+            <!-- Do not add mem_encrypt=on option on 15-SP6 KVM host due to bsc#1224107 -->
+            % if ($check_var->('VERSION', '15-SP6')) { 
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 kvm_amd.sev=1 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+            % } else {
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 mem_encrypt=on kvm_amd.sev=1 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+            % }
+          % } else {
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+          % }
+        % } else { 
+      <append>splash=silent console=<%= $get_var->('SERIALDEV') %>,115200 console=tty loglevel=5 intel_iommu=on <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></append>
+        % }
       % }
     </global>
     <loader_type>default</loader_type>

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -400,7 +400,10 @@ sub enable_sev_in_kernel {
     $args{root_dir} //= '';
     $args{root_dir} .= '/' unless $args{root_dir} =~ /\/$/;
     croak("No AMD EPYC cpu on $args{dst_machine}, so sev can not be enabled in kernel.") unless (script_run("lscpu | grep -i \'AMD EPYC\'") == 0);
-    add_kernel_options(dst_machine => $args{dst_machine}, root_dir => $args{root_dir}, kernel_opts => 'mem_encrypt=on kvm_amd.sev=1');
+    # Do not add mem_encrypt=on option on 15-SP6 KVM host due to bsc#1224107
+    my $kernel_opts = "kvm_amd.sev=1";
+    $kernel_opts .= " mem_encrypt=on" if (!check_var('VERSION', '15-SP6'));
+    add_kernel_options(dst_machine => $args{dst_machine}, root_dir => $args{root_dir}, kernel_opts => $kernel_opts);
 }
 
 =head2 add_kernel_options


### PR DESCRIPTION
* **According** to [libvirt recommendations](https://libvirt.org/kbase/launch_security_sev.html), AMD SEV options ```mem_encrypt=on kvm_amd.sev=1``` should be added onto kernel command line although it makes no difference from functionality perspective. 

* **Product** bug [bsc#1224107](https://bugzilla.suse.com/show_bug.cgi?id=1224107) leads to removing ```mem_encrypt=on``` from kernel command line on 15-SP6 KVM host.

* **In** order to make overall layout more neat/readable and also leave room for future more advanced options for SEV family features and other options, the content of <append> element is based on more rich and advanced test suite settings in IF condition.

* **Also** make similar changes to subroutine ```enable_sev_in_kernel``` which will be called in non-autoyast installation.

* **Verification Runs:**
  * [15sp6 on 15sp6 KVM non-SEV](https://openqa.suse.de/tests/14950300)
  * [15sp6 on 15sp5 KVM non-SEV](https://openqa.suse.de/tests/14960427)
  * [15sp6 on 15sp6 Xen non-SEV](https://openqa.suse.de/tests/14960415)
  * [15sp6 on 15sp5 Xen non-SEV](https://openqa.suse.de/tests/14950303)
  * [15sp6 on 12sp5 KVM non-SEV](https://openqa.suse.de/tests/14960417)
  * [15sp6 on 15sp6 KVM SEV](https://openqa.suse.de/tests/14991535)
  * [15sp5 on 15sp6 KVM SEV](https://openqa.suse.de/tests/14967144)
  * [15sp6 on 15sp5 KVM SEV](https://openqa.suse.de/tests/14991545)
  * [non-autoyast 15sp6 on 15sp6 KVM SEV](https://openqa.suse.de/tests/14991546)
  * [non-autoyast 15sp6 on 15sp5 KVM SEV](https://openqa.suse.de/tests/14991547)
  * [uefi 15sp6 on 15sp6 KVM non-SEV](https://openqa.suse.de/tests/14967874)
  * [uefi 15sp6 on 15sp5 Xen non-SEV](https://openqa.suse.de/tests/14967875)