### PR TITLE
update_install: Fix the conflict rollback

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -334,8 +334,8 @@ sub run {
                 record_info 'Conflict rollback', "Rollback patch $patch with conflicting $single_package";
                 assert_script_run("snapper rollback $rollback_number");
                 reboot_and_login;
+                disable_test_repositories($repos_count);
             }
-            disable_test_repositories($repos_count);
         }
 
         # Install released version of installable binaries.


### PR DESCRIPTION
rollback has to be done after each conflict not after conflicts

- Related ticket: 1e3839969a1128be2e21b13e356ce90ed4f3ddb3