### PR TITLE
Save /var/log/cloudregister during qesap tests

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1244,6 +1244,10 @@ sub qesap_cluster_log_cmds {
             Cmd => 'cat /var/log/zypp/history',
             Output => 'zypp.history.txt',
         },
+        {
+            Cmd => 'cat /var/log/cloudregister',
+            Output => 'cloudregister.txt',
+        }
     );
     if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
         push @log_list, {


### PR DESCRIPTION
# Verification run:

## Azure

sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_saptune_test@64bit
 - http://openqaworker15.qa.suse.cz/tests/289758 :green_circle:  http://openqaworker15.qa.suse.cz/tests/289758/logfile?filename=deploy-hana0-cloudregister.txt

 sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-07-17T02:03:22Z-hanasr_azure_test_saptune_msi@64bit 
 -  http://openqaworker15.qa.suse.cz/tests/289762
 
PAYG where registration does not take place 
 sle-12-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-qesap_azure_saptune_test@64bit
 - http://openqaworker15.qa.suse.cz/tests/289761

## AWS

 sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_native_test@64bit
 - http://openqaworker15.qa.suse.cz/tests/289759

## GCE

sle-15-SP4-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_4_BYOS-qesap_gcp_sapconf_test@64bit
 - http://openqaworker15.qa.suse.cz/tests/289760 :green_circle:  http://openqaworker15.qa.suse.cz/tests/289760/logfile?filename=deploy-hana1-cloudregister.txt