### PR TITLE
Remove view development module from sles15sp6 maintenance update

### DIFF
--- a/schedule/yast/qam-yast_self_update_view_development.yaml
+++ b/schedule/yast/qam-yast_self_update_view_development.yaml
@@ -10,7 +10,6 @@ schedule:
   - installation/validate_self_update
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
-  - installation/module_registration/view_development_versions
   - installation/module_registration/register_extensions_and_modules
   - installation/add_update_test_repo
   - installation/addon_products_sle

--- a/schedule/yast/sle/flows/default_sle15sp6_x86.yaml
+++ b/schedule/yast/sle/flows/default_sle15sp6_x86.yaml
@@ -1,6 +1,5 @@
 ---
-# Default ordered sequence of steps for sle15sp6 with maintenance updatesi,
-# add view_development_versions module.
+# Default ordered sequence of steps for sle15sp6 with maintenance updates
 bootloader:
   - installation/bootloader_start
 setup_libyui:
@@ -13,7 +12,6 @@ license_agreement:
 registration:
   - installation/registration/register_via_scc
 extension_module_selection:
-  - installation/module_registration/view_development_versions
   - installation/module_registration/register_extensions_and_modules
 additional_products:
   - installation/add_on_product_installation/add_additional_products


### PR DESCRIPTION
##
### Remove view development module from sles15sp6 maintenance update

- Related ticket: Quick PR
- Related MR:
    - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/277
- Needles: N/A
- Verification Run:
   - [**VR**](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=hjluo%2Fos-autoinst-distri-opensuse%23remove_sle15sp6_x86_view_development)
