### PR TITLE
Load install_updates in slem 6.0 increment open_vm_tool test

### DIFF
--- a/schedule/virt_autotest/slem_open_vm_tools.yaml
+++ b/schedule/virt_autotest/slem_open_vm_tools.yaml
@@ -8,8 +8,14 @@ schedule:
     - jeos/firstrun
     - transactional/host_config
     - console/suseconnect_scc
+    - '{{install_updates}}'
     - console/system_prepare
     - console/check_network
     - console/system_state
     - console/integration_services
     - virt_autotest/esxi_open_vm_tools
+conditional_schedule:
+    install_updates:
+        FLAVOR:
+            Default-VMware-Updates:
+                - transactional/install_updates


### PR DESCRIPTION
SLE Micro 6.0 increment test has updates for VMDK image, which has a proper test open_vm_tools. But current yaml schedule does not load the necessary install_updates module. This PR is to make that conditionally scheduled based on the flavor type.


- Related ticket: https://progress.opensuse.org/issues/159375
- Verification run:
  - for update test(load install_updates):  https://openqa.suse.de/tests/14960416# (same failure with what https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19712 tries to solve)
  - regression test(not load install_updates): https://openqa.suse.de/tests/14960510 (ignore the failure, modules are correctly loaded)
