### PR TITLE
containers: Use nmap's ncat for netavark upstream tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -307,7 +307,7 @@ sub load_container_tests {
             loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle || is_leap);
         }
         if (!check_var('NETAVARK_BATS_SKIP', 'all')) {
-            loadtest 'containers/netavark_integration' if (is_tumbleweed || is_sle || is_leap);
+            loadtest 'containers/netavark_integration' if (is_x86_64 && (is_tumbleweed || is_sle || is_leap));
         }
         if (!check_var('AARDVARK_BATS_SKIP', 'all')) {
             loadtest 'containers/aardvark_integration' if (is_tumbleweed);

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -19,6 +19,13 @@ my $test_dir = "/var/tmp";
 my $netavark = "";
 my $netavark_version = "";
 
+sub install_ncat {
+    my $ncat_version = get_required_var("NCAT_VERSION");
+
+    assert_script_run "rpm -vhU https://nmap.org/dist/ncat-$ncat_version.x86_64.rpm";
+    assert_script_run "ln -sf /usr/bin/ncat /usr/bin/nc";
+}
+
 sub run_tests {
     my $log_file = "netavark.tap";
 
@@ -38,13 +45,14 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns firewalld netcat-openbsd iproute2 iptables jq netavark);
+    my @pkgs = qw(aardvark-dns firewalld iproute2 iptables jq netavark);
     if (is_tumbleweed) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {
         push @pkgs, qw(dbus-1);
     }
     install_packages(@pkgs);
+    install_ncat;
 
     switch_cgroup_version($self, 2);
 


### PR DESCRIPTION
The [netavark upstream tests use nmap's ncat](https://github.com/containers/netavark/blob/main/test/README.md?plain=1#L17) instead of OpenBSD's netcat.  As we don't ship this package in our products due to licensing issues (NSPL vs GPL), we need to install it from [nmap.org](https://nmap.org/dist/).  Unfortunately it's only available for x86_64.

This will allows us to skip less tests on netavark at the expense of no coverage on other architectures.  We expect the code paths for differents arches don't differ wildly.

- Related ticket: none
- Verification runs:
  - Tumbleweed: https://openqa.opensuse.org/tests/4348689 (`NCAT_VERSION=7.95-2`)
  - 15-SP6: https://openqa.suse.de/tests/14959167 (`NCAT_VERSION=7.95-2`)
  - 15-SP5: https://openqa.suse.de/tests/14959195 (`NCAT_VERSION=7.94-1`)
  - 15-SP4: https://openqa.suse.de/t14959250 (`NCAT_VERSION=7.94-1`)
  - 15-SP3: https://openqa.suse.de/t14959172 (`NCAT_VERSION=7.94-1`)

