### PR TITLE
Podman IPv6 ULA addressing

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -13,7 +13,7 @@ use utils;
 use version_utils;
 use main_common qw(loadtest boot_hdd_image);
 use testapi qw(check_var get_required_var get_var set_var);
-use publiccloud::utils 'is_gce';
+use publiccloud::utils 'is_azure';
 use Utils::Architectures;
 use Utils::Backends;
 use strict;
@@ -135,7 +135,8 @@ sub load_host_tests_podman {
     loadtest('containers/podman_network_cni') unless (is_sle_micro('6.0+') || (is_sle_micro('=5.5') && is_public_cloud) || (check_var('FLAVOR', 'DVD-Updates') && is_sle_micro));
     # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
     load_firewall_test($run_args);
-    loadtest 'containers/podman_ipv6' if (is_gce && is_sle('>=15-SP5'));
+    # IPv6 is not available on Azure
+    loadtest 'containers/podman_ipv6' if (is_public_cloud && is_sle('>=15-SP5') && !is_azure);
     # Netavark not supported in 15-SP1 and 15-SP2 (due to podman version older than 4.0.0)
     loadtest 'containers/podman_netavark' unless (is_staging || is_sle("<15-sp3") || is_ppc64le);
     # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
By switching to ULA addresses we don't have to have subnet from CSP.
This is because podman by default creates IPv6 NAT.

- Related tickets: [poo#134783](https://progress.opensuse.org/issues/134783)
- Verification run: [GCE](https://pdostal-server.suse.cz/tests/6940), [EC2](https://pdostal-server.suse.cz/tests/6939)
