### PR TITLE
Add wait_for_idle_cluster after resource move

### DIFF
--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -181,7 +181,8 @@ EDITOR='sed -ie \"\$ a order order_$fs_rsc Mandatory: vg_$resource $fs_rsc\"\' c
                 }
 
                 # Migrate resource on the node
-                assert_script_run "crm resource migrate ms_$resource $node", $default_timeout;
+                assert_script_run "crm resource move ms_$resource $node", $default_timeout;
+                wait_for_idle_cluster;
                 ensure_resource_running("$fs_rsc", "is running on:[[:blank:]]*$node\[[:blank:]]*\$");
 
                 # Do a check of the cluster with a screenshot


### PR DESCRIPTION
The `ha/filesystem` module does a `crm resource migrate` when testing drbd_passive, moving the resource from one node to the other. In some slower architectures, the resource has not finished starting in the target node before testing which can cause failures. This commit works around the issue by calling on `cs_wait_for_cluster` right after the move operation to ensure the cluster is ready for the test. Also part of the commit is the change of `crm resource migrate` to `crm resource move` as the migrate command is deprecated in favor of `move`.

- Related ticket: https://jira.suse.com/browse/TEAM-9514
- Failing test: https://openqa.suse.de/tests/14953019#step/filesystem#1/43
- Needles: N/A

**Verification runs:**

- 15-SP4 QU @ s390x: https://openqa.suse.de/tests/14960504 & https://openqa.suse.de/tests/14960505
- 12-SP5 @ x86_64: http://mango.qe.nue2.suse.org/tests/6099 & http://mango.qe.nue2.suse.org/tests/6100
- 15-SP2 @ x86_64: http://mango.qe.nue2.suse.org/tests/6095 & http://mango.qe.nue2.suse.org/tests/6096
- 15-SP3 @ x86_64: http://mango.qe.nue2.suse.org/tests/6091 & http://mango.qe.nue2.suse.org/tests/6092
- 15-SP4 @ x86_64: http://mango.qe.nue2.suse.org/tests/6087 & http://mango.qe.nue2.suse.org/tests/6088
- 15-SP5 @ x86_64: http://mango.qe.nue2.suse.org/tests/6083 & http://mango.qe.nue2.suse.org/tests/6084
- 15-SP6 @ x86_64: http://mango.qe.nue2.suse.org/tests/6075 & http://mango.qe.nue2.suse.org/tests/6076