### PR TITLE
containers: add new apparmor test

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -266,6 +266,8 @@ sub load_container_tests {
         loadtest 'boot/boot_to_desktop' unless is_public_cloud;
     }
 
+    loadtest 'containers/apparmor.pm';
+
     if (is_container_image_test() && !(is_jeos || is_sle_micro || is_microos || is_leap_micro) && $runtime !~ /k8s|openshift/) {
         # Container Image tests common
         loadtest 'containers/host_configuration';

--- a/tests/containers/apparmor.pm
+++ b/tests/containers/apparmor.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: apparmor-utils
+# Summary: Test if apparmor is running
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use services::apparmor;
+
+sub run {
+    select_console 'root-console';
+    services::apparmor::check_service();
+    services::apparmor::check_aa_status();
+}
+
+1;


### PR DESCRIPTION
Add a basic test that checks for the existence of the apparmor service.

- Related ticket: https://progress.opensuse.org/issues/161996
- Verification run: https://openqa.suse.de/tests/14961373#step/apparmor/1
