### PR TITLE
containers: add new apparmor test

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -266,6 +266,8 @@ sub load_container_tests {
         loadtest 'boot/boot_to_desktop' unless is_public_cloud;
     }
 
+    loadtest 'containers/apparmor';
+
     if (is_container_image_test() && !(is_jeos || is_sle_micro || is_microos || is_leap_micro) && $runtime !~ /k8s|openshift/) {
         # Container Image tests common
         loadtest 'containers/host_configuration';

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -266,7 +266,7 @@ sub load_container_tests {
         loadtest 'boot/boot_to_desktop' unless is_public_cloud;
     }
 
-    loadtest 'containers/apparmor';
+    loadtest 'containers/apparmor' unless is_transactional;
 
     if (is_container_image_test() && !(is_jeos || is_sle_micro || is_microos || is_leap_micro) && $runtime !~ /k8s|openshift/) {
         # Container Image tests common

--- a/tests/containers/apparmor.pm
+++ b/tests/containers/apparmor.pm
@@ -11,10 +11,25 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use services::apparmor;
 
-sub run {
-    select_console 'root-console';
+sub is_enabled {
+    # according to Linux' Documentation/admin-guide/LSM/index.rst,
+    # the current security modules can be found in /sys/kernel/security/lsm
+    return script_run 'grep apparmor /sys/kernel/security/lsm' == 0;
+}
+
+sub assert_running {
     services::apparmor::check_service();
     services::apparmor::check_aa_status();
+}
+
+sub run {
+    select_console 'root-console';
+
+    if (not is_enabled) {
+        return;
+    }
+
+    assert_running;
 }
 
 1;

--- a/tests/containers/apparmor.pm
+++ b/tests/containers/apparmor.pm
@@ -11,25 +11,8 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use services::apparmor;
 
-sub is_enabled {
-    # according to Linux' Documentation/admin-guide/LSM/index.rst,
-    # the current security modules can be found in /sys/kernel/security/lsm
-    return script_run 'grep apparmor /sys/kernel/security/lsm' == 0;
-}
-
-sub assert_running {
-    services::apparmor::check_service();
-    services::apparmor::check_aa_status();
-}
-
 sub run {
-    select_console 'root-console';
-
-    if (not is_enabled) {
-        return;
-    }
-
-    assert_running;
+    services::apparmor::check_function;
 }
 
 1;

--- a/tests/containers/apparmor.pm
+++ b/tests/containers/apparmor.pm
@@ -1,0 +1,20 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: apparmor-utils
+# Summary: Test apparmor utilities
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use services::apparmor;
+
+sub run {
+    select_console 'root-console';
+    services::apparmor::check_service();
+    services::apparmor::check_aa_status();
+}
+
+1;


### PR DESCRIPTION
Add a basic test that checks if the apparmor service is enabled and running.

- Related ticket: https://progress.opensuse.org/issues/161996
- Verification run: https://openqa.suse.de/tests/14969348#step/apparmor/1

