### PR TITLE
CI: Fix call to openQA on empty output

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -29,7 +29,7 @@ jobs:
           echo build=$(openqa-cli api
           --host ${OPENQA_HOST:-https://openqa.opensuse.org}
           job_groups/${OPENQA_BUILD_LOOKUP_GROUP_ID:-1}/build_results only_tagged=1
-          | jq -r '[ .build_results[] | select(.tag.description=="published") | .build ][0]'
+          | jq -e -r '[ .build_results[] | select(.tag.description=="published") | .build ][0]'
 
           ) >> "$GITHUB_OUTPUT"
       - name: Trigger and monitor a basic openQA test on o3


### PR DESCRIPTION
This fixes a problem when the determination of the latest published Tumbleweed build actually did not return anything by adding the "-e" parameter to the "jq" invocation.