### PR TITLE
SL Micro 6.1 default encrypted image in raw.xz format

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
@@ -27,7 +27,7 @@
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw.xz</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
@@ -27,7 +27,7 @@
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw</guest_installation_media>
+    <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw.xz</guest_installation_media>
     <guest_installation_fine_grained/>
     <guest_os_variant>opensusetumbleweed</guest_os_variant>
     <guest_storage_path/>


### PR DESCRIPTION
* **SL Micro 6.1** default encrypted image is in  raw.xz format instead of raw format which was used by SL Micro 6.0.

* **Verification Runs:**
  * [SL Micro 6.1 on SL Micro 6.1 ignition+combustion](https://openqa.suse.de/tests/14981208)
  * [SL Micro 6.1 on SL Micro 6.1 ignition](https://openqa.suse.de/tests/14981416)
