### PR TITLE
Disable package upgrade in cloud-init

### DIFF
--- a/data/sles4sap/cloud-init-web.txt
+++ b/data/sles4sap/cloud-init-web.txt
@@ -1,5 +1,5 @@
 #cloud-config
-package_upgrade: true
+package_upgrade: false
 packages:
   - nginx
 runcmd:


### PR DESCRIPTION
- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run: 

## PAYG
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test@64bit 
 - http://openqaworker15.qa.suse.cz/tests/290798 :red_circle: error about VM state in starting and not running
 -  http://openqaworker15.qa.suse.cz/tests/290801 Deployment is fine but then `is-system-running` report `degradated`
 - http://openqaworker15.qa.suse.cz/tests/290802 :green_circle: again fail on `is-system-running` but this time as `starting` 

## BYOS
sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit 
 - http://openqaworker15.qa.suse.cz/tests/290799 :red_circle: exotic error about not existing SubNet
 -  http://openqaworker15.qa.suse.cz/tests/290800 :green_apple: 
