### PR TITLE
Fix netweaver_swpm_installation sapinst timed out

### DIFF
--- a/tests/sles4sap/ensa/netweaver_swpm_installation.pm
+++ b/tests/sles4sap/ensa/netweaver_swpm_installation.pm
@@ -90,7 +90,7 @@ sub run {
         '-noguiserver');
 
     record_info('SAPINST EXEC', "Executing sapinst command:\n$swpm_command");
-    assert_script_run($swpm_command, timeout => 300);
+    assert_script_run($swpm_command, timeout => 600);
 
     $self->sapcontrol_process_check(sidadm => $nw_install_data->{sidadm},
         instance_id => $instance_data->{instance_id},


### PR DESCRIPTION
Fix sles4sap_ensa_ascs_node failed on test module netweaver_swpm_installation: sapinst timed out on 12sp5

- Related ticket: [TEAM-9539](https://jira.suse.com/browse/TEAM-9539) - [qam][12-SP5] sles4sap_ensa_* failed on netweaver_swpm_installation: command "sapinst" timed out
- Verification run:
http://openqa.suse.de/tests/14981330 (passed, sapinst takes about 16 minutes)
http://openqa.suse.de/tests/14981334 (passed, sapinst takes about 16 minutes)
http://openqa.suse.de/tests/14981339 (passed, sapinst takes about 16 minutes)
http://openqa.suse.de/tests/14981340 (passed, sapinst takes about 16 minutes)
http://openqa.suse.de/tests/14981343 (passed, sapinst takes about 16 minutes)
http://openqa.suse.de/tests/14981359 (passed, sapinst takes about 16 minutes)
