### PR TITLE
Remove autossh dependency

### DIFF
--- a/t/19_console_redirection.t
+++ b/t/19_console_redirection.t
@@ -12,66 +12,77 @@ our $serialdev = 'ttyS0';    # this is a global OpenQA variable
 
 # make cleaning vars easier at the end of the unit test
 sub unset_vars {
-    my @variables = ('REDIRECT_DESTINATION_IP', 'REDIRECT_DESTINATION_USER', 'BASE_VM_ID', 'QEMUPORT');
+    my @variables = qw(REDIRECT_DESTINATION_IP REDIRECT_DESTINATION_USER BASE_VM_ID QEMUPORT
+      AUTOINST_URL_HOSTNAME_ORIGINAL AUTOINST_URL_HOSTNAME REDIRECTION_CONFIGURED);
     set_var($_, undef) foreach @variables;
 }
 
-subtest '[connect_target_to_serial] Expected failures' => sub {
+subtest '[connect_target_to_serial] Test exceptions' => sub {
     my $redirect = Test::MockModule->new('sles4sap::console_redirection', no_auto => 1);
-    $redirect->redefine(enter_cmd => sub { return 1; });
-    $redirect->redefine(handle_login_prompt => sub { return 1; });
-    $redirect->redefine(record_info => sub { return 1; });
-    $redirect->redefine(script_output => sub { return 'castleinthesky'; });
-    set_var('BASE_VM_ID', '7902847fcc554911993686a1d5eca2c8');
+    $redirect->redefine(enter_cmd => sub { return; });
+    $redirect->redefine(handle_login_prompt => sub { return; });
+    $redirect->redefine(record_info => sub { return; });
     $redirect->redefine(check_serial_redirection => sub { return 0; });
+
+    set_var('BASE_VM_ID', '7902847fcc554911993686a1d5eca2c8');
+    set_var('QEMUPORT', '1988');
 
     dies_ok { connect_target_to_serial(target_ip => '192.168.1.1') } 'Fail with missing ssh user';
-    dies_ok { connect_target_to_serial(ssh_user => 'totoro') } 'Fail with missing ip address';
+    dies_ok { connect_target_to_serial(ssh_user => 'Totoro') } 'Fail with missing ip address';
+    dies_ok { connect_target_to_serial(ssh_user => 'Totoro', target_ip => 'Satsuki') }
+    'Fail invalid IP';
+
     $redirect->redefine(check_serial_redirection => sub { return 1; });
-    dies_ok { connect_target_to_serial(ssh_user => 'totoro', target_ip => '192.168.1.1') } 'Fail with console already being redirected';
-    unset_vars();
+    dies_ok { connect_target_to_serial(ssh_user => 'Totoro', target_ip => '192.168.1.1') }
+    'Fail if function attempts redirect console second time';
+    set_var('BASE_VM_ID', undef);
+
+    dies_ok { connect_target_to_serial(ssh_user => 'Totoro', target_ip => '192.168.1.1') }
+    'Fail with "BASE_VM_ID" unset';
+
     dies_ok { connect_target_to_serial(ssh_user => ' ', target_ip => '192.168.1.1') } 'Fail with user defined as empty space';
-};
-
-subtest '[connect_target_to_serial] Test passing behavior' => sub {
-    my $redirect = Test::MockModule->new('sles4sap::console_redirection', no_auto => 1);
-    my $ssh_cmd;
-    $redirect->redefine(enter_cmd => sub { $ssh_cmd = $_[0]; return 1; });
-    $redirect->redefine(handle_login_prompt => sub { return 1; });
-    $redirect->redefine(record_info => sub { return 1; });
-    $redirect->redefine(check_serial_redirection => sub { return 0; });
-    $redirect->redefine(script_output => sub { return 'castleinthesky'; });
-    set_var('BASE_VM_ID', '7902847fcc554911993686a1d5eca2c8');
-    connect_target_to_serial(destination_ip => '192.168.1.1', ssh_user => 'totoro');
-    is $ssh_cmd, 'ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=120 totoro@192.168.1.1 2>&1 | tee -a /dev/ttyS0', 'Pass with corect command executed';
     unset_vars();
 };
 
-subtest '[handle_login_prompt] Test via "connect_to_serial"' => sub {
+subtest '[connect_target_to_serial] Check command composition' => sub {
     my $redirect = Test::MockModule->new('sles4sap::console_redirection', no_auto => 1);
-    my $type_pass_executed = 0;
-    $redirect->redefine(enter_cmd => sub { return 1; });
-    $redirect->redefine(type_password => sub { $type_pass_executed = 1; });
-    $redirect->redefine(send_key => sub { return 1; });
-    $redirect->redefine(set_serial_term_prompt => sub { return 1; });
-    $redirect->redefine(record_info => sub { return 1; });
-    $redirect->redefine(check_serial_redirection => sub { return 0; });
+    my @ssh_cmd;
+    my $redirection_status;
+    $redirect->redefine(enter_cmd => sub { @ssh_cmd = @_; return 1; });
+    # At this point Redirection is expected to work, therefore change $redirection_status to 1, so next check passed
+    $redirect->redefine(handle_login_prompt => sub { $redirection_status = 1; return; });
+    $redirect->redefine(record_info => sub { return; });
+    $redirect->redefine(check_serial_redirection => sub { return $redirection_status; });
     $redirect->redefine(script_output => sub { return 'castleinthesky'; });
     set_var('BASE_VM_ID', '7902847fcc554911993686a1d5eca2c8');
+    set_var('QEMUPORT', '1988');
 
-    my @command_prompts = ('laputa@castleinthesky:~>', 'castleinthesky:~ # ');
-    foreach (@command_prompts) {
-        $redirect->redefine(wait_serial => sub { return $_; });
-        connect_target_to_serial(destination_ip => '192.168.1.1', ssh_user => 'totoro');
-        is $type_pass_executed, 0, "Pass with command prompt detected: $_";
-        $type_pass_executed = 0;    # reset flag
-    }
+    connect_target_to_serial(destination_ip => '192.168.1.1', ssh_user => 'Totoro');
+    note('CMD:', join(' ', @ssh_cmd));
+    ok(grep(/ssh/, @ssh_cmd), 'Execute main command');
+    ok(grep(/-o StrictHostKeyChecking=no/, @ssh_cmd), 'Disable strict host key checking');
+    ok(grep(/-o ServerAliveInterval=60/, @ssh_cmd), 'Set option: "ServerAliveInterval"');
+    ok(grep(/-o ServerAliveCountMax=120/, @ssh_cmd), 'Set option: "ServerAliveCountMax"');
+    ok(grep(/Totoro\@192.168.1.1/, @ssh_cmd), 'Host login');
+    ok(grep(/2>&1 | tee -a \/dev\/ttyS0/, @ssh_cmd), 'Redirect output to serial device');
+    unset_vars();
+};
 
-    $redirect->redefine(wait_serial => sub { return '(laputa@castleinthesky) Password:'; });
-    $redirect->redefine(croak => sub { return; });    # Need to disable croak since wait_serial won't return second response here.
+subtest '[connect_target_to_serial] Scenario: console already redirected' => sub {
+    my $redirect = Test::MockModule->new('sles4sap::console_redirection', no_auto => 1);
+    # Simulate redirection is already active
+    $redirect->redefine(check_serial_redirection => sub { return 1; });
+    # monitor enter_cmd
+    my @calls;
+    $redirect->redefine(enter_cmd => sub { push @calls, $_[0]; });
+    $redirect->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $redirect->redefine(script_output => sub { return 'Castle in the sky'; });
 
-    connect_target_to_serial(destination_ip => '192.168.1.1', ssh_user => 'totoro');
-    is $type_pass_executed, 1, 'Pass with password prompt detected';
+    set_var('BASE_VM_ID', '7902847fcc554911993686a1d5eca2c8');
+    set_var('QEMUPORT', '1988');
+
+    connect_target_to_serial(destination_ip => '192.168.1.1', ssh_user => 'Totoro');
+    ok(!grep(/ssh/, @calls), 'Skip if redirection already active');
     unset_vars();
 };
 
@@ -88,6 +99,8 @@ subtest '[disconnect_target_from_serial]' => sub {
     ok disconnect_target_from_serial(base_vm_machine_id => '7902847fcc554911993686a1d5eca2c8'), 'Pass with machine ID defined by positional argument';
 
     set_var('BASE_VM_ID', '7902847fcc554911993686a1d5eca2c8');
+    set_var('QEMUPORT', '1988');
+
     ok disconnect_target_from_serial(), 'Pass with machine ID defined by parameter BASE_VM_ID';
     unset_vars();
 
@@ -98,7 +111,7 @@ subtest '[check_serial_redirection]' => sub {
     my $redirect = Test::MockModule->new('sles4sap::console_redirection', no_auto => 1);
     $redirect->redefine(script_output => sub { return '7902847fcc554911993686a1d5eca2c8'; });
     $redirect->redefine(record_info => sub { return; });
-
+    set_var('QEMUPORT', '1988');
     set_var('BASE_VM_ID', '7902847fcc554911993686a1d5eca2c8');
     is check_serial_redirection(), '0', 'Return 0 if machine IDs match';
     set_var('BASE_VM_ID', '999999999999999999999999');
@@ -108,68 +121,6 @@ subtest '[check_serial_redirection]' => sub {
 
     is check_serial_redirection(base_vm_machine_id => '123456'), '1', 'Pass with specifying ID via positional argument';
     dies_ok { check_serial_redirection() } 'Fail with BASE_VM_ID being unset';
-};
-
-subtest '[redirection_init]' => sub {
-    my $redirect = Test::MockModule->new('sles4sap::console_redirection', no_auto => 1);
-    $redirect->redefine(assert_script_run => sub { return 1; });
-    $redirect->redefine(script_run => sub { return 0; });
-    $redirect->redefine(connect_target_to_serial => sub { return 1; });
-    $redirect->redefine(disconnect_target_from_serial => sub { return 1; });
-    $redirect->redefine(remote_port_forward => sub { return 1; });
-    $redirect->redefine(record_info => sub { return 1; });
-    $redirect->redefine(script_output => sub {
-            return '7902847fcc554911993686a1d5eca2c8' if grep(/machine-id/, @_);
-            return 'ghibli' if grep(/whoami/, @_);
-            return 'totoro';
-    });
-
-    set_var('REDIRECT_DESTINATION_IP', '192.168.1.5');
-    set_var('REDIRECT_DESTINATION_USER', 'ghibli');
-    set_var('QEMUPORT', '15685');
-
-    ok redirection_init(), 'Pass with correct usage';
-    is get_var('BASE_VM_ID'), '7902847fcc554911993686a1d5eca2c8', 'Pass with BASE_VM_ID being set correctly';
-
-    $redirect->redefine(script_run => sub { return 1; });
-    dies_ok { redirection_init() } 'Fail with autossh package not being installed';
-    unset_vars();
-};
-
-subtest '[remote_port_forward] Test via redirection_init()' => sub {
-    my $redirect = Test::MockModule->new('sles4sap::console_redirection', no_auto => 1);
-    my @assert_script_run;
-    my $as_root;
-    $redirect->redefine(assert_script_run => sub { push(@assert_script_run, $_[0]) if grep /autossh/, $_[0]; return '1985'; });
-    $redirect->redefine(script_run => sub { return 0; });
-    $redirect->redefine(connect_target_to_serial => sub { return 1; });
-    $redirect->redefine(disconnect_target_from_serial => sub { return 1; });
-    $redirect->redefine(record_info => sub { return 1; });
-    $redirect->redefine(script_output => sub { return 'root' if grep(/whoami/, @_) and $as_root; return 'ghibli'; });
-
-    set_var('REDIRECT_DESTINATION_IP', '192.168.1.5');
-    set_var('REDIRECT_DESTINATION_USER', 'ghibli');
-    set_var('QEMUPORT', '15685');
-
-    redirection_init();
-    is $assert_script_run[0],
-      'sudo autossh -M 20000 -f -N -R 22022:localhost:22022 ghibli@192.168.1.5',
-      'Forward port 80 as normal user via sudo';
-    is $assert_script_run[1],
-      'sudo autossh -M 20001 -f -N -R 15686:10.0.2.2:15686 ghibli@192.168.1.5',
-      'Forward qemu port as normal user via sudo';
-
-    $as_root = 1;
-    redirection_init();
-
-    is $assert_script_run[2],
-      'autossh -M 20000 -f -N -R 22022:localhost:22022 ghibli@192.168.1.5',
-      'Forward port 80 as root without sudo';
-    is $assert_script_run[3],
-      'autossh -M 20001 -f -N -R 15686:10.0.2.2:15686 ghibli@192.168.1.5',
-      'Forward qemu port as root without sudo';
-
-    unset_vars();
 };
 
 done_testing;

--- a/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
@@ -18,7 +18,6 @@ use sles4sap::sap_deployment_automation_framework::deployment_connector
   qw(get_deployer_vm
   get_deployer_ip
   );
-use sles4sap::console_redirection qw(redirection_init);
 use serial_terminal qw(select_serial_terminal);
 
 sub test_flags {
@@ -34,17 +33,12 @@ sub run {
     die 'Deployer VM not found. Check if VM exists.' unless $deployer_vm_name;
     record_info('VM found', "Deployer VM found: $deployer_vm_name");
 
-    my $deployer_ip = get_deployer_ip(deployer_vm_name => $deployer_vm_name);
-    # SDAF does not need privileged user to run.
-    my $ssh_user = get_var('REDIRECT_TARGET_USER', 'azureadm');
     # Variables to share data between test modules.
-    set_var('REDIRECT_DESTINATION_USER', $ssh_user);
+    my $deployer_ip = get_deployer_ip(deployer_vm_name => $deployer_vm_name);
+    # This will allow using connect_target_to_serial() without specifying user/host to deployer every time.
+    set_var('REDIRECT_DESTINATION_USER', get_var('PUBLIC_CLOUD_USER', 'azureadm'));
     set_var('REDIRECT_DESTINATION_IP', $deployer_ip);    # IP addr to redirect console to
     sdaf_prepare_private_key(key_vault => get_required_var('SDAF_DEPLYOER_KEY_VAULT'));
-
-    # autossh is required for console redirection to work
-    assert_script_run('zypper in -y autossh');
-    redirection_init();
     serial_console_diag_banner('Module sdaf_redirect_console_to_deployer.pm : end');
 }
 

--- a/tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm
@@ -77,10 +77,9 @@ sub run {
     # get_deployer_ip() also checks VM is listening to SSH port. This serves as an availability check.
     my $deployer_ip = get_deployer_ip(deployer_resource_group => $deployer_resource_group,
         deployer_vm_name => $new_deployer_vm_name);
+
     die 'Deployer public IP address not found or is not listening to SSH port.' unless $deployer_ip;
-
     record_info('VM created', "Deployer VM was created with public IP: $deployer_ip");
-
     serial_console_diag_banner('Module sdaf_clone_deployer.pm : stop');
 }
 


### PR DESCRIPTION
Currently, console redirection has a dependency for autossh package, which is located only in package hub repository. This PR removes the dependency completely and simplyfies redirection process. Function `redirection_init` is not needed anymore. Redirection happens only using `connect_target_to_serial` and `disconnect_target_from_serial` functions.

- Related ticket: https://jira.suse.com/browse/TEAM-9459
- Verification run: https://openqaworker15.qa.suse.cz/tests/291092#dependencies
