### PR TITLE
Skip srX devices in a block device check

### DIFF
--- a/data/microos/butane/script
+++ b/data/microos/butane/script
@@ -23,6 +23,9 @@ detect_free_drive() {
     drives=( $(ls /sys/block/) )
 
     for d in ${drives[@]}; do
+        # 64bit worker boots the image with cd-rom (sr0) device
+        # skip this device in case it is detected
+        [[ "$d" =~ ^sr[0-9]$ ]] && continue
         blkid /dev/"$d" &> /dev/null || echo "/dev/$d"
     done
 }


### PR DESCRIPTION
`combustion` has been adapted to search for empty drive. `64bit` worker runs started to fail, as `sr0` device appeared in image tests. It is unclear from the qemu command why the VM assumes there is a cd-rom attached.

As of now, skip these devices in case they are detected by combustion script.

- ticket: [[sle-micro 6.1] Where does `/dev/sr0` come from?](https://progress.opensuse.org/issues/164159)


- Verification run: http://kepler.suse.cz/tests/23719#details
