### PR TITLE
virt_autotest: Enable NVME Hard Drive Support

### DIFF
--- a/lib/virt_autotest/virtual_storage_utils.pm
+++ b/lib/virt_autotest/virtual_storage_utils.pm
@@ -90,6 +90,8 @@ sub destroy_virt_storage_pool {
 sub delete_physical_volume {
     my $lvm_disk_name = shift;
     my $timeout = 180;
+    # Enable NVME Hard Drive Support
+    $lvm_disk_name = ($lvm_disk_name =~ "nvme") ? "${lvm_disk_name}p" : $lvm_disk_name;
     validate_script_output("pvremove -y ${lvm_disk_name}1", sub { m/successfully wiped/ }, $timeout);
     assert_script_run 'pvdisplay';
     save_screenshot;


### PR DESCRIPTION
Enable NVME Hard Drive Support

- Related ticket: https://progress.opensuse.org/issues/163502
- Verification run: 
SATA Hard Drive
[amd-zen3-gpu-sut1-1](https://openqa.suse.de/tests/15007506#) PASS
[openqaipmi5](https://openqa.suse.de/tests/15007521#) PASS
[gonzo](https://openqa.suse.de/tests/15008383#) PASS
[fozzie](https://openqa.suse.de/tests/15008384#) PASS
[quinn](https://openqa.suse.de/tests/15008380#) PASS
NVME Hard Drive
[bare-metal1](https://openqa.suse.de/tests/15007507#step/libvirt_extend_storage_lvm/179) PASS
[bare-metal2](https://openqa.suse.de/tests/15007508#step/libvirt_extend_storage_lvm/179) PASS