### PR TITLE
update_kernel: Implement installation of specific kernel version

### DIFF
--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -46,6 +46,7 @@ sub remove_kernel_packages {
         push @packages, qw(kernel-xen kernel-xen-devel);
     }
 
+    my @retlist = @packages;
     push @packages, "multipath-tools"
       if is_sle('>=15-SP3') and !get_var('KGRAFT');
 
@@ -55,7 +56,7 @@ sub remove_kernel_packages {
         zypper_call('-n rm ' . join(' ', @packages), exitcode => [0, 104]);
     }
 
-    return @packages;
+    return @retlist;
 }
 
 1;

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -35,6 +35,7 @@ our @EXPORT = qw(
   trup_shell
   get_utt_packages
   enter_trup_shell
+  exit_trup_shell
   exit_trup_shell_and_reboot
   reboot_on_changes
   record_kernel_audit_messages
@@ -320,9 +321,25 @@ sub enter_trup_shell {
 
     $args{global_options} //= '';
     $args{shell_options} //= '';
-    enter_cmd("transactional-update $args{global_options} shell $args{shell_options}; echo trup_shell-status-\$? > /dev/$serialdev");
-    wait_still_screen;
+    my $cmd = "transactional-update $args{global_options} shell $args{shell_options}; echo trup_shell-status-\$?";
+    $cmd .= " >/dev/$serialdev" unless is_serial_terminal;
+    enter_cmd($cmd);
+    wait_still_screen unless is_serial_terminal;
     assert_script_run("uname -a");
+}
+
+=head2 exit_trup_shell
+
+  exit_trup_shell()
+
+Quit transactional update shell without rebooting.
+
+=cut
+
+sub exit_trup_shell {
+    enter_cmd("exit");
+    wait_serial('trup_shell-status-0') || croak("transactional-update shell did not finish");
+    wait_still_screen unless is_serial_terminal;
 }
 
 =head2 exit_trup_shell_and_reboot
@@ -335,9 +352,7 @@ reboot to take effect. This subroutine should be used together with enter_trup_s
 =cut
 
 sub exit_trup_shell_and_reboot {
-    enter_cmd("exit");
-    wait_serial('trup_shell-status-0') || croak("transactional-update shell did not finish");
-    wait_still_screen;
+    exit_trup_shell;
     reboot_on_changes();
 }
 

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -325,7 +325,7 @@ sub downgrade_kernel {
 
 sub find_version {
     my ($packname, $version_fragment) = @_;
-    my $verlist = zypper_search("-s -x -t package $packname");
+    my $verlist = zypper_search("-s --match-exact -t package $packname");
     my $version_arg = $version_fragment;
 
     $version_fragment =~ s/\./\\./g;


### PR DESCRIPTION
Implement installation of specific kernel version given in `KERNEL_VERSION` job variable. Transactional systems are also supported, which required some changes to the transactional utils library.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - SLEM-5.1: https://openqa.suse.de/tests/15225298
  - SLE-12SP5: https://openqa.suse.de/tests/15225299
  - kubevirt tests (for `enter_trup_shell()` in VNC): https://openqa.suse.de/tests/15225336