### PR TITLE
Bump timeout for zypper install

### DIFF
--- a/schedule/security/fips_crypt_core.yaml
+++ b/schedule/security/fips_crypt_core.yaml
@@ -14,6 +14,7 @@ schedule:
     - fips/openssl/dirmngr_setup
     - fips/openssl/dirmngr_daemon
     - console/openssl_alpn
+    - fips/mozilla_nss/nss_smoke
     - fips/gnutls/gnutls_base_check
     - fips/gnutls/gnutls_server
     - fips/gnutls/gnutls_client
@@ -25,7 +26,6 @@ schedule:
     - fips/openssh/openssh_fips
     # ssh disabled in env mode, see poo#125648
     - '{{ssh}}'
-    - fips/mozilla_nss/nss_smoke
 conditional_schedule:
     repo_setup:
         BETA:

--- a/tests/fips/mozilla_nss/nss_smoke.pm
+++ b/tests/fips/mozilla_nss/nss_smoke.pm
@@ -7,7 +7,9 @@
 # Maintainer: qa-c team <qa-c@suse.de>
 #             QE Security
 
-use Mojo::Base qw(consoletest);
+use strict;
+use warnings;
+use base "consoletest";
 use testapi;
 use version_utils qw(is_sle is_transactional);
 use transactional qw(trup_call process_reboot);
@@ -34,7 +36,7 @@ sub run {
         trup_call("pkg install $zypper_options mozilla-nss mozilla-nss-tools");
         process_reboot(trigger => 1);
     } else {
-        zypper_call("in $zypper_options mozilla-nss mozilla-nss-tools");
+        zypper_call("in $zypper_options mozilla-nss mozilla-nss-tools", timeout => 180);
     }
     record_info('mozilla-nss', script_output('rpm -q mozilla-nss'));
     record_info('mozilla-nss-tools', script_output('rpm -q mozilla-nss-tools'));


### PR DESCRIPTION
Increase timeout to address flakiness on slower aarch64

- Related ticket: https://progress.opensuse.org/issues/164006
- Needles: no
- Verification runs:
	- https://openqa.suse.de/tests/14992501#step/nss_smoke/1
	- https://openqa.suse.de/tests/14992500#step/nss_smoke/1
	- https://openqa.suse.de/tests/14992534#step/nss_smoke/1
