### PR TITLE
create_hdd_x86_64_uefi: Handle opensuse_welcome

### DIFF
--- a/schedule/security/create_hdd_autoyast/create_hdd_x86_64_uefi.yaml
+++ b/schedule/security/create_hdd_autoyast/create_hdd_x86_64_uefi.yaml
@@ -8,11 +8,16 @@ conditional_schedule:
         - update/zypper_clear_repos
         - console/zypper_ar
         - console/zypper_ref
+  opensuse_welcome:
+    VERSION:
+      Tumbleweed:
+        - installation/opensuse_welcome
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
   - installation/first_boot
+  - '{{opensuse_welcome}}'
   - console/system_prepare
   - '{{update_repos}}'
   - console/hostname


### PR DESCRIPTION
Add the missing opensuse_welcome step.

- Related ticket: https://progress.opensuse.org/issues/163535
- Verification run: https://openqa.opensuse.org/tests/4356140