### PR TITLE
containers: Record podman version in upstream tests

### DIFF
--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -49,7 +49,7 @@ sub run {
     switch_cgroup_version($self, 2);
 
     $aardvark = script_output "rpm -ql aardvark-dns | grep podman/aardvark-dns";
-    record_info("aardvark version", script_output("$aardvark --version"));
+    record_info("aardvark-dns version", script_output("$aardvark --version"));
 
     my $test_dir = "/var/tmp";
     assert_script_run "cd $test_dir";

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -72,6 +72,8 @@ sub run {
     assert_script_run "curl -o /usr/local/bin/htpasswd " . data_url("containers/htpasswd");
     assert_script_run "chmod +x /usr/local/bin/htpasswd";
 
+    record_info("podman version", script_output("podman version"));
+
     delegate_controllers;
 
     assert_script_run "podman system reset -f";


### PR DESCRIPTION
Record podman version in upstream tests as we do in other modules.

We also use `podman info` but I plan to use this information from script that processes `record_info` for package version on all upstream tests.