### PR TITLE
Hotfix: Unschedule apparmor test

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -266,7 +266,7 @@ sub load_container_tests {
         loadtest 'boot/boot_to_desktop' unless is_public_cloud;
     }
 
-    loadtest 'containers/apparmor' unless is_transactional;
+    loadtest 'containers/apparmor' if (is_tumbleweed);
 
     if (is_container_image_test() && !(is_jeos || is_sle_micro || is_microos || is_leap_micro) && $runtime !~ /k8s|openshift/) {
         # Container Image tests common


### PR DESCRIPTION
Temporarily limit the apparmor test to Tumbleweed only due to failures on the SLES side of things.

* Related failures e.g. [this](https://openqa.suse.de/tests/overview?groupid=417&version=15-SP3&build=20240723-1&distri=sle) and [this](https://openqa.suse.de/tests/overview?distri=sle&build=20240723-1&version=15-SP5&groupid=419)
* Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19778
* Verification run: https://openqa.suse.de/tests/14999796 (schedule is OK)