### PR TITLE
bug_refs.json: Widen regex for bsc#1190662

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -131,7 +131,7 @@
         "type": "bug"
     },
     "bsc#1190662": {
-        "description": "/etc/udev/rules.d/41-qeth-.*Failed to write ATTR",
+        "description": "/etc/udev/rules.d/41-.*Failed to write ATTR",
         "products": {
             "sle-micro": [ "5.1", "5.2", "5.3", "5.4" , "5.5" ]
         },


### PR DESCRIPTION
Widen regex for bsc#1190662 per https://bugzilla.suse.com/show_bug.cgi?id=1190662#c29

Failing job: https://openqa.suse.de/tests/14992165#step/journal_check/11

- Related ticket: https://progress.opensuse.org/issues/163733
- Verification run: not needed imho.
