### PR TITLE
Remove host_config module for kubevirt tests on sle-micro

### DIFF
--- a/schedule/virt_autotest/slem-kubevirt-tests.yaml
+++ b/schedule/virt_autotest/slem-kubevirt-tests.yaml
@@ -15,7 +15,6 @@ conditional_schedule:
                 - installation/usb_install
                 - installation/bootloader_uefi
                 - microos/selfinstall
-                - transactional/host_config
                 - console/suseconnect_scc
     barrier_setup:
         SERVICE:

--- a/schedule/virt_autotest/slem_open_vm_tools.yaml
+++ b/schedule/virt_autotest/slem_open_vm_tools.yaml
@@ -6,7 +6,6 @@ schedule:
     - installation/bootloader_svirt
     - installation/bootloader_uefi
     - jeos/firstrun
-    - transactional/host_config
     - console/suseconnect_scc
     - '{{install_updates}}'
     - console/system_prepare


### PR DESCRIPTION
Remove host_config test module to workaround hard disk boot failure.

- Related ticket: https://progress.opensuse.org/issues/164287
- Verification run: 
    slem_open_vm_tools - https://openqa.suse.de/tests/15000500
    slem-kubevirt-tests-server - https://openqa.suse.de/tests/15007285
    slem-kubevirt-tests-agent - https://openqa.suse.de/tests/15007286
