### PR TITLE
Add cluster sanity check to IpAddr2 test

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -1208,6 +1208,18 @@ sub ipaddr2_create_cluster {
     ipaddr2_ssh_internal(id => 1,
         cmd => join(' ',
             'sudo crm configure primitive',
+            WEB_RSC,
+            'ocf:heartbeat:nginx',
+            'configfile=/etc/nginx/nginx.conf',
+            'op start timeout="40s" interval="0"',
+            'op stop timeout="60s" interval="0"',
+            'op monitor interval="10s" timeout="60s"',
+            'meta migration-threshold="10"'),
+        bastion_ip => $args{bastion_ip});
+
+    ipaddr2_ssh_internal(id => 1,
+        cmd => join(' ',
+            'sudo crm configure primitive',
             'rsc_alb_00',
             'azure-lb',
             'port=62500',

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -57,6 +57,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
+    ipaddr2_os_cloud_init_logs() if (check_var('IPADDR2_CLOUDINIT', 1));
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -39,6 +39,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
+    ipaddr2_os_cloud_init_logs() if (check_var('IPADDR2_CLOUDINIT', 1));
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/sanity.pm
+++ b/tests/sles4sap/ipaddr2/sanity.pm
@@ -19,6 +19,7 @@ sub run {
 
     select_serial_terminal;
     ipaddr2_os_sanity();
+    ipaddr2_cluster_sanity();
 }
 
 sub test_flags {
@@ -28,6 +29,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
+    ipaddr2_os_cloud_init_logs() if (check_var('IPADDR2_CLOUDINIT', 1));
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/test.pm
+++ b/tests/sles4sap/ipaddr2/test.pm
@@ -26,6 +26,8 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
+    ipaddr2_os_cloud_init_logs() if (check_var('IPADDR2_CLOUDINIT', 1));
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Add some sanity check about the cluster.
Collect log from the cloud VM about cloud-init.

- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run:

# BYOS
sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit

## IPADDR2_CLOUDINIT=0 SCC_REGCODE_SLES4SAP
- http://openqaworker15.qa.suse.cz/tests/293871 :green_circle: 

## IPADDR2_CLOUDINIT=1 SCC_REGCODE_SLES4SAP
 - http://openqaworker15.qa.suse.cz/tests/293872

# PAYG
sle-15-SP5-SapCloud-Azure-Payg-x86_64-Buildmpagot_VR-ipaddr2_azure_test@64bit 

## IPADDR2_CLOUDINIT=0
 - http://openqaworker15.qa.suse.cz/tests/293873  :green_circle: 

## IPADDR2_CLOUDINIT=1
 - http://openqaworker15.qa.suse.cz/tests/291032 :red_circle: error creating ip2t-vm-02
 -  http://openqaworker15.qa.suse.cz/tests/293824 :red_circle: `crm_mon: command not found`
