### PR TITLE
[PoC] Introduce HPVS testing in IBM Cloud

### DIFF
--- a/data/containers/ibm_hpvs/bci-busybox
+++ b/data/containers/ibm_hpvs/bci-busybox
@@ -1,0 +1,6 @@
+services:
+  busybox-nc-test:
+    image: registry.suse.com/bci/IMG@DGST
+    ports:
+      - "8222:5000"
+    command: /bin/sh -c 'while true;do /bin/echo -e "Have a lot of fun" | nc -n -v -l -p 5000; done'

--- a/data/containers/ibm_hpvs/workload.yaml
+++ b/data/containers/ibm_hpvs/workload.yaml
@@ -1,0 +1,11 @@
+env: |
+  type: env
+  logging:
+    logDNA:
+      hostname: syslog-a.eu-de.logging.cloud.ibm.com
+      ingestionKey: INGESTIONKEY
+      port: 6514
+workload: |
+  type: workload
+  compose:
+    archive: ARCHIVE

--- a/schedule/ibm.yaml
+++ b/schedule/ibm.yaml
@@ -1,0 +1,4 @@
+name: hpvs
+schedule:
+  - boot/boot_to_desktop
+  - containers/prepare_hpvs

--- a/tests/containers/prepare_hpvs.pm
+++ b/tests/containers/prepare_hpvs.pm
@@ -1,0 +1,170 @@
+# SUSE's openQA tests
+#
+# Copyright 2022-2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: IBM HPVS container runner
+#   A smoke test that BCI containers can run in IBM's Hyper Protect Platform
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use utils qw(script_retry file_content_replace);
+use version_utils;
+use testapi;
+use Mojo::JSON qw(decode_json);
+use serial_terminal 'select_serial_terminal';
+
+my $ibm = {
+    api => get_var('IBM_API'),
+    region => 'eu-gb',
+    ingestionKey => get_var('LOG_KEY'),
+    instance => 'testing-openqa',
+    vpc => 'vpc-openqa-testing'
+};
+
+sub ibmcloud {
+    assert_script_run("ibmcloud @_");
+}
+
+sub get_image_digest {
+    my $img = shift;
+    script_retry("podman pull registry.suse.com/bci/$img", retry => 3, delay => 30);
+
+    my $o = decode_json(script_output("podman inspect $img"));
+    return $o->[0]->{Digest};
+}
+
+sub _create_compose {
+    my $img = shift;
+    my $img_w_tag = $img . ':latest';
+    assert_script_run("curl -f -v -O " . data_url("containers/ibm_hpvs/$img"));
+
+    my $dgst = get_image_digest($img_w_tag);
+    file_content_replace($img, IMG => $img_w_tag, DGST => $dgst);
+    record_info('compose', script_output("cat $img"));
+
+    assert_script_run "mv $img docker-compose.yaml";
+    assert_script_run 'tar czvf compose.tgz docker-compose.yaml';
+    assert_script_run 'base64 -w0 compose.tgz > compose.b64';
+    my $o = script_output('cat compose.b64');
+    chomp $o;
+
+    return $o;
+}
+
+sub create_workload {
+    my $img = shift;
+    my $archive = _create_compose($img);
+    my $template = '/tmp/workload.yaml';
+
+    # download workload contract template
+    assert_script_run("curl -f -v -o $template " . data_url("containers/ibm_hpvs/workload.yaml"));
+    file_content_replace($template, INGESTIONKEY => $ibm->{ingestionKey}, ARCHIVE => $archive);
+
+    return sprintf('--user-data @%s', $template);
+}
+
+sub find_entity {
+    my $q = shift;
+    my $search = {
+        image => {
+            query => 'ibmcloud is images --status available --user-data-format cloud_init --output json',
+            regex => qr/ibm-hyper-protect.*s390x/i
+        },
+        net => {
+            query => 'ibmcloud is subnets --output json',
+            regex => qr/^openqa-net$/
+        },
+        'float-ip' => {
+            query => 'ibmcloud is ips --output json',
+            regex => qr/^openqa-ips$/
+        }
+    };
+
+    my $res;
+    my $raw = decode_json(script_output($search->{$q}->{query}));
+    foreach (@{$raw}) {
+        if ($_->{name} =~ $search->{$q}->{regex}) {
+            $res = $_;
+            last;
+        }
+    }
+
+    return $res;
+}
+
+sub run {
+    select_serial_terminal();
+
+    # install ibm cloud cli
+    script_retry('curl -fsSL https://clis.cloud.ibm.com/install/linux -o IBMCloud.sh', retry => 3, delay => 30);
+    assert_script_run('sh -x IBMCloud.sh');
+    assert_script_run('which ibmcloud');
+
+    # login and install VPC tools
+    ibmcloud("config  --color false");
+    ibmcloud("login -a https://cloud.ibm.com -r $ibm->{region} --apikey $ibm->{api}");
+    ibmcloud("resources");
+    ibmcloud("plugin install vpc-infrastructure");
+
+    # find hyper-protect s390x image
+    my $image = find_entity('image');
+
+    # find pre-defined subnet in VPC
+    my $sub = find_entity('net');
+
+    if (!$image || !$sub) {
+        die "We are missing image name or subnet";
+    }
+
+    # prepare instance
+    my $eth0 = qq[--primary-network-interface '{"name": "eth0", "allow_ip_spoofing": false, "subnet": {"id":"$sub->{id}"}}'];
+    my $user_data = create_workload('bci-busybox');
+    ibmcloud("is instance-create $ibm->{instance} $ibm->{vpc} $ibm->{region}-1 bz2e-1x4 --image $image->{name} $eth0 $user_data");
+
+    # load pre-defined public ip
+    my $fip = find_entity('float-ip');
+    ibmcloud("is floating-ip-update $fip->{id} --nic eth0 --in $ibm->{instance}");
+
+    # test needs to wait while hyper protect services are finished
+    my $i;
+    for ($i = 0; $i < 5; $i++) {
+        sleep 60;
+        my $state = decode_json(script_output("ibmcloud is instance $ibm->{instance} --output json", proceed_on_failure => 1));
+        if ($state->{status} eq 'running') {
+            last;
+        }
+    }
+
+    if ($i == 5) {
+        ibmcloud "is instance $ibm->{instance}";
+        die "Instance $ibm->{instance} hasn't booted!";
+    }
+
+    script_retry("nc -zvw10 $fip->{address} 8222", retry => 5, delay => 45);
+}
+
+sub _cleanup {
+    ibmcloud("is instance-delete -f $ibm->{instance}");
+    upload_logs('./docker-compose.yaml');
+    upload_logs('/tmp/workload.yaml');
+}
+
+sub post_fail_hook {
+    _cleanup;
+}
+
+sub post_run_hook {
+    _cleanup;
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
[IBM Hyper Protect Platform](https://www.ibm.com/downloads/cas/GPVMWPM3) is another "host system" where we need to run our containers. The specific is that there is no access on the VM itself, container is configure through `compose` and `workload contract` yamls.

VPC, network and floating IP segment is as of now configure manually, but should be moved into qe-c infra repository.

Other that this test can be considered as an IBMCloud CLI smoke test as well

- ticket: [[IBM-HPVS] Establish workflow to run custom BCI container commands and obtain the logs](https://progress.opensuse.org/issues/163190)
- Verification run: http://kepler.suse.cz/tests/23785#step/prepare_hpvs/129
