### PR TITLE
containers: record_info package versions in upstream tests

### DIFF
--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -50,6 +50,7 @@ sub run {
 
     $aardvark = script_output "rpm -ql aardvark-dns | grep podman/aardvark-dns";
     record_info("aardvark-dns version", script_output("$aardvark --version"));
+    record_info("aardvark-dns package version", script_output("rpm -q aardvark-dns"));
 
     my $test_dir = "/var/tmp";
     assert_script_run "cd $test_dir";

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -56,6 +56,7 @@ sub run {
 
     record_info("buildah version", script_output("buildah --version"));
     record_info("buildah info", script_output("buildah info"));
+    record_info("buildah package version", script_output("rpm -q buildah"));
 
     switch_to_user;
 

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -58,6 +58,7 @@ sub run {
 
     $netavark = script_output "rpm -ql netavark | grep podman/netavark";
     record_info("netavark version", script_output("$netavark --version"));
+    record_info("netavark package version", script_output("rpm -q netavark"));
 
     my $test_dir = "/var/tmp";
     assert_script_run "cd $test_dir";

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -84,6 +84,7 @@ sub run {
     switch_cgroup_version($self, 2);
 
     record_info("podman info", script_output("podman info"));
+    record_info("podman package version", script_output("rpm -q podman"));
 
     switch_to_user;
 

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -52,6 +52,7 @@ sub run {
 
     record_info("runc version", script_output("runc --version"));
     record_info("runc features", script_output("runc features"));
+    record_info("runc package version", script_output("rpm -q runc"));
 
     switch_to_user;
 

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -57,6 +57,7 @@ sub run {
     assert_script_run "chmod +x /usr/local/bin/htpasswd";
 
     record_info("skopeo version", script_output("skopeo --version"));
+    record_info("skopeo package version", script_output("rpm -q skopeo"));
 
     remove_mounts_conf;
 


### PR DESCRIPTION
record_info the package version to use in tooling to compare version tested vs. published repo in separate script.

- Verification run: not needed
