### PR TITLE
create_hdd_x86_64_uefi: Skip opensuse_welcome on textmode

### DIFF
--- a/schedule/security/create_hdd_autoyast/create_hdd_x86_64_uefi.yaml
+++ b/schedule/security/create_hdd_autoyast/create_hdd_x86_64_uefi.yaml
@@ -8,10 +8,16 @@ conditional_schedule:
         - update/zypper_clear_repos
         - console/zypper_ar
         - console/zypper_ref
+  opensuse_welcome_if_not_textmode:
+    DESKTOP:
+      gnome:
+        - installation/opensuse_welcome
+      kde:
+        - installation/opensuse_welcome
   opensuse_welcome:
     VERSION:
       Tumbleweed:
-        - installation/opensuse_welcome
+        - '{{opensuse_welcome_if_not_textmode}}'
 schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start


### PR DESCRIPTION
This would be trivial if this wasn't one of those awful declarative schedules.

Verification runs:
- https://openqa.opensuse.org/tests/4358256 (gnome)
- https://openqa.opensuse.org/tests/4358257 (textmode)
