### PR TITLE
update_install: Remove phub repo on all qemu updates

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -176,9 +176,10 @@ sub run {
     select_serial_terminal;
 
     # remove phub repos on qemu update ppc64le https://progress.opensuse.org/issues/162704
-    if (get_var('BUILD') =~ /qemu/ && is_ppc64le) {
-        record_info('remove phub', 'known conflict on qemu ppc64le with phub repo poo#162704');
-        zypper_call('rr sle-module-packagehub-subpackages:15-SP5::pool sle-module-packagehub-subpackages:15-SP5::update');
+    if (get_var('BUILD') =~ /qemu/ && get_var('INCIDENT_REPO') !~ /Packagehub-Subpackages/) {
+        my $version = get_var('VERSION');
+        record_info('remove phub', 'known conflict on qemu update with phub repo poo#162704');
+        zypper_call("rr sle-module-packagehub-subpackages:${version}::pool sle-module-packagehub-subpackages:${version}::update");
     }
 
     my $zypper_version = script_output(q(rpm -q zypper|awk -F. '{print$2}'));


### PR DESCRIPTION
Avoid known conflict
qemu-hw-usb-smartcard conflicts with 'qemu-tools'

- Related ticket: https://suse.slack.com/archives/C02D16TCP99/p1721872859703929
- Verification run: https://dzedro.suse.cz/tests/1213#step/update_install/13
