### PR TITLE
Check console redirection status

### DIFF
--- a/lib/sles4sap/console_redirection.pm
+++ b/lib/sles4sap/console_redirection.pm
@@ -7,10 +7,12 @@
 package sles4sap::console_redirection;
 use strict;
 use warnings;
+use testapi qw(is_serial_terminal :DEFAULT);
 use testapi;
 use Carp qw(croak);
 use Exporter qw(import);
 use Regexp::Common qw(net);
+use serial_terminal qw(select_serial_terminal);
 
 =head1 SYNOPSIS
 
@@ -37,7 +39,12 @@ our @EXPORT = qw(
   check_serial_redirection
 );
 
-my $ssh_opt = '-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=120';
+my $ssh_opt = join(' ',
+    '-o StrictHostKeyChecking=no',
+    '-o ServerAliveInterval=60',
+    '-o ServerAliveCountMax=120',
+    '-o ConnectionAttempts=3',    # Retry connecting before failing
+);
 
 =head2 handle_login_prompt
 
@@ -87,10 +94,13 @@ B<ssh_user>: SSH login user for B<destination_ip> - default value is defined by 
 
 B<destination_ip>: Destination host IP - default value is defined by OpenQA parameter REDIRECT_DESTINATION_IP
 
+B<fail_ok>: Do not die, return 0 instead. Good for verifying if redirection works.
+
 Establishes ssh connection to destination host and redirects serial output to serial console on worker VM.
 Connection activates remote port forwarding of OpenQA QEMUPORT+1.
 This allows running standard OpenQA modules directly on a remote host accessed from worker VM via SSH.
-
+Returns 1 if redirection was successful, or dies if redirection fails.
+If B<fail_ok> is set to true, function does not fail, but returns 0.
 
 =cut
 
@@ -102,14 +112,9 @@ sub connect_target_to_serial {
     croak "IP address '$args{destination_ip}' is not valid." unless grep(/^$RE{net}{IPv4}$/, $args{destination_ip});
     croak 'Global variable "$serialdev" undefined' unless $serialdev;
 
-    # This captures initial machine id which serves as a baseline host.
-    # disconnect_target_from_serial() types 'exit + enter' in a loop until /etc/machine-id matches machine id defined
-    # by BASE_VM_ID. This means original host before redirection was reached.
-    set_var('BASE_VM_ID', script_output 'cat /etc/machine-id');
-
     if (check_serial_redirection()) {
         record_info('Redirect ON', "Console is already redirected to:" . script_output('hostname', quiet => 1));
-        return;
+        return 1;
     }
 
     # Save original value for 'AUTOINST_URL_HOSTNAME', and point requests to localhost
@@ -123,32 +128,34 @@ sub connect_target_to_serial {
     my $redirect_opts = "-R $redirect_port:$redirect_ip:$redirect_port";
     enter_cmd "ssh $ssh_opt $redirect_opts $args{ssh_user}\@$args{destination_ip} 2>&1 | tee -a /dev/$serialdev";
     handle_login_prompt($args{ssh_user});
-    die 'Failed redirecting console' unless check_serial_redirection();
+
+    my $redirection_active = check_serial_redirection();
+    if ($args{fail_ok} && !$redirection_active) {
+        record_info('Redirect FAIL', 'Redirection FAILED. Argument "fail_ok" is set, test will continue.');
+        return 0;
+    }
+    die 'Failed redirecting console' unless $redirection_active;
     record_info('Redirect ON', "Serial redirection established to: $args{destination_ip}");
+    return 1;
 }
 
 =head2 disconnect_target_from_serial
 
-    disconnect_target_from_serial( [, base_vm_machine_id=$base_vm_machine_id]);
-
-B<base_vm_machine_id>: ID of the base VM before redirection. Default is BASE_VM_ID value set by redirect_init()
+    disconnect_target_from_serial();
 
 Disconnects target from serial console by typing 'exit' command until host machine ID matches ID of the worker VM.
 
 =cut
 
 sub disconnect_target_from_serial {
-    my (%args) = @_;
-    $args{base_vm_machine_id} //= get_required_var('BASE_VM_ID');
     set_serial_term_prompt();
-    my $serial_redirection_status = check_serial_redirection(base_vm_machine_id => $args{base_vm_machine_id});
+    my $serial_redirection_status = check_serial_redirection();
     while ($serial_redirection_status != 0) {
         enter_cmd('exit');    # Enter command and wait for screen start changing
         $testapi::distri->{serial_term_prompt} = '';    # reset console prompt
         wait_serial(qr/Connection.*closed./, timeout => 10, quiet => 1);    # Wait for connection to close
         wait_serial(qr/# |> /, timeout => 10, quiet => 1);    # Wait for console prompt to appear
-        set_serial_term_prompt();    # after logout user might change and prompt with it.
-        $serial_redirection_status = check_serial_redirection($args{base_vm_machine_id});
+        $serial_redirection_status = check_serial_redirection();
     }
 
     # restore original 'AUTOINST_URL_HOSTNAME'
@@ -158,20 +165,27 @@ sub disconnect_target_from_serial {
 
 =head2 check_serial_redirection
 
-    check_serial_redirection( [, base_vm_machine_id=$base_vm_machine_id]);
+    check_serial_redirection();
 
-B<base_vm_machine_id>: ID of the base VM before redirection. Default is BASE_VM_ID value set by redirect_init()
-
-Compares current machine-id to the worker VM ID either defined by BASE_VM_ID variable or positional argument.
-Machine ID is used instead of IP addr since cloud VM IP might not be visible from the inside (for example via 'ip a')
+Checks if serial redirection is currently active by comparing worker VM machine id against id returned
+from serial console. VM ID is collected by opening 'log-console' which is not redirected.
 
 =cut
 
 sub check_serial_redirection {
-    my (%args) = @_;
-    $args{base_vm_machine_id} //= get_required_var('BASE_VM_ID');
+    # Do not select serial console if it is already done. This avoids log pollution and speeds up process.
+    if (is_serial_terminal()) {
+        select_serial_terminal();
+        set_serial_term_prompt();
+    }
+
+    # check machine ID under serial console
     my $current_id = script_output('cat /etc/machine-id', quiet => 1);
-    my $redirection_status = $current_id eq $args{base_vm_machine_id} ? 0 : 1;
+    # Switch 'log-console' (which is not redirected) to check machine ID on worker
+    select_console('log-console');
+    my $redirection_status = script_run("grep $current_id /etc/machine-id", quiet => 1);
+    select_serial_terminal();
+    set_serial_term_prompt();
     return $redirection_status;
 }
 


### PR DESCRIPTION
Currently console redirection status check is broken and relies on OpenQA 
parameter being set correctly prior to redirection. This PR replaces this with 
real time machine ID comparison executed in serial console and not redirected 
'log-console'.

- Related ticket: https://jira.suse.com/browse/TEAM-9459
- Verification run: https://mordor.suse.cz/tests/71#dependencies
