### PR TITLE
slem: Ignore bsc#1227930

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -135,7 +135,7 @@
         "products": {
             "sle-micro": [ "5.1", "5.2", "5.3", "5.4" , "5.5" ]
         },
-        "type": "bug"
+        "type": "ignore"
     },
     "bsc#1182961": {
         "description": "could not read from '/sys/module/pcc_cpufreq/initstate': No such device",


### PR DESCRIPTION
Can be ignored according to https://bugzilla.suse.com/show_bug.cgi?id=1190662#c29

Related ticket: https://progress.opensuse.org/issues/163733