### PR TITLE
Revert "LTP: Temporarily fix PATH for sched_football"

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -152,11 +152,7 @@ sub export_ltp_env {
 
 # Set up basic shell environment for running LTP tests
 sub prepare_ltp_env {
-    # $LTPROOT/testcases/realtime/func/sched_football/ is workaround for upstream build system isse:
-    # https://lore.kernel.org/ltp/20240729073226.GA1223191@pevik/
-    # https://github.com/linux-test-project/ltp/issues/1078
-    assert_script_run('export LTPROOT=' . get_ltproot() . '; export LTP_COLORIZE_OUTPUT=n ' .
-          ' TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$LTPROOT/testcases/realtime/func/sched_football/:$PATH');
+    assert_script_run('export LTPROOT=' . get_ltproot() . '; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 
     # setup for LTP networking tests
     assert_script_run("export PASSWD='$testapi::password'");


### PR DESCRIPTION
This reverts commit e4d325027a9ec6db7fa8df018930eb61d314902f.

LTP fix was merged [1], workaround in openQA can be removed.

[1] https://github.com/linux-test-project/ltp/commit/7788860e739101ff5d031c8984294ce985dc242e
Signed-off-by: Petr Vorel <pvorel@suse.cz>

Let's merge tomorrow once LTP packages are build

Verification run: http://quasar.suse.cz/tests/3535#step/sched_football/8