### PR TITLE
Fly red flag for found failures in journal log

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -301,9 +301,11 @@ sub check_failures_in_journal {
     if ($failures) {
         if (get_var('KNOWN_BUGS_FOUND_IN_JOURNAL')) {
             record_soft_failure("Found failures: \n" . $failures . "There are known kernel bugs " . get_var('KNOWN_BUGS_FOUND_IN_JOURNAL') . ". Please look into journal files to determine if it is a known bug. If it is a new issue, please take action as described in poo#151361.");
+            record_info("Found failures in journal log", "Found failures: \n" . $failures . "There are known kernel bugs " . get_var('KNOWN_BUGS_FOUND_IN_JOURNAL') . ". Please look into journal files to determine if it is a known bug. If it is a new issue, please take action as described in poo#151361.", result => 'fail');
         }
         else {
             record_soft_failure("Found new failures: " . $failures . " please take actions as described in poo#151361.\n");
+            record_info("Found failures in journal log", "Found new failures: " . $failures . " please take actions as described in poo#151361.\n", result => 'fail');
         }
         script_run("rsync root\@$machine:$logfile $logfile", die_on_timeout => 0) if $machine ne 'localhost';
         upload_logs($logfile);


### PR DESCRIPTION
* **Subroutine** ```check_failures_in_journal``` only fails test module softly if there are found failures in journal log, which looks similar to all other softfailures resulting from workaround for product bugs although they should be treated as errors. 

* **In** order to mark these errors as real failures and also make them more eye-catching, use record_info to fly red flag.

* **Verification Runs:**
  * [15sp6 on 15sp5](https://openqa.suse.de/tests/15028228)
  * [15sp6 on 15sp6](https://openqa.suse.de/tests/15028230)
