### PR TITLE
htpasswd: Use go 1.22.4

### DIFF
--- a/data/containers/htpasswd/go.mod
+++ b/data/containers/htpasswd/go.mod
@@ -1,5 +1,5 @@
 module htpasswd
 
-go 1.22.5
+go 1.22.4
 
 require golang.org/x/crypto v0.25.0


### PR DESCRIPTION
The aarch64 version of `registry.opensuse.org/opensuse/bci/golang:latest` has go 1.22.4 instead of go 1.22.5:
https://openqa.suse.de/tests/15025751#step/skopeo_integration/96
