### PR TITLE
Handle patch installation with all new packages

### DIFF
--- a/tests/console/install_packages.pm
+++ b/tests/console/install_packages.pm
@@ -22,7 +22,13 @@ sub run {
     zypper_call('in -l perl-solv perl-Data-Dump');
     my $ex = script_run("~$username/data/lsmfip --verbose $packages > \$XDG_RUNTIME_DIR/install_packages.txt 2> /tmp/lsmfip.log");
     upload_logs '/tmp/lsmfip.log';
-    die "lsmfip failed" if $ex;
+    if ($ex) {
+        if (script_output('tail -1 /tmp/lsmfip.log') =~ /was requested but nothing was installed/) {
+            record_info('The packages to be released are new ones', 'We do not need to install older packages before');
+            return;
+        }
+        die "lsmfip failed";
+    }
     # make sure we install at least one package - otherwise this test is pointless
     # better have it fail and let a reviewer check the reason
     assert_script_run("test -s \$XDG_RUNTIME_DIR/install_packages.txt");


### PR DESCRIPTION
https://progress.opensuse.org/issues/164592

1. It could be a corner case which all packages to be installed are new
2. In this case ''zypper in -l -t patch patch_id" can not apply the patch as well

- Verification run: https://openqa.opensuse.org/tests/4366648
**The VR above didn't cover the code change since the release request was approved**