### PR TITLE
Remove bootloader_uefi from vmware

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -51,7 +51,6 @@ sub load_boot_from_disk_tests {
         loadtest 'installation/bootloader_start';
     } elsif (is_vmware()) {
         loadtest 'installation/bootloader_svirt';
-        loadtest 'installation/bootloader_uefi';
     }
 
     # read FIRST_BOOT_CONFIG in order to know how the image will be configured


### PR DESCRIPTION
- **Remove bootloader_uefi from vmware** as we rely on the first_run module to finish the setup
- VR https://openqa.suse.de/tests/15029607 (using EXCLUDE_MODULES) 