### PR TITLE
Remove uefi bootloader for SL Micro VMWare images

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -47,11 +47,8 @@ sub load_config_tests {
 
 sub load_boot_from_disk_tests {
     # add additional image handling module for svirt workers
-    if (is_s390x()) {
+    if (is_s390 || is_vmware) {
         loadtest 'installation/bootloader_start';
-    } elsif (is_vmware()) {
-        loadtest 'installation/bootloader_svirt';
-        loadtest 'installation/bootloader_uefi';
     }
 
     # read FIRST_BOOT_CONFIG in order to know how the image will be configured


### PR DESCRIPTION
This module is causing issues with needle timeouts, but it is actually not needed. We can directly boot using firstrun or wizard.

VR: https://openqa.suse.de/tests/15029758

