### PR TITLE
Add legacy module for ntp in 15-SP4

### DIFF
--- a/tests/security/ntpd.pm
+++ b/tests/security/ntpd.pm
@@ -23,7 +23,7 @@ use registration 'add_suseconnect_product';
 
 sub run {
     select_serial_terminal;
-    add_suseconnect_product('sle-module-legacy') if is_sle('>=15-SP5');
+    add_suseconnect_product('sle-module-legacy') if is_sle('>=15-SP4');
     services::ntpd::install_service();
     services::ntpd::enable_service();
     services::ntpd::start_service();


### PR DESCRIPTION
ntp moved to legacy also for 15-SP4

- Related ticket: https://progress.opensuse.org/issues/164553
- Needles: no
- Verification run: https://openqa.suse.de/tests/15030643

testsuite requires also SCC_REGCODE_LIVE