### PR TITLE
Basic agama.pm poo#164141

### DIFF
--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -4,7 +4,6 @@ description:    >
 schedule:
   - installation/bootloader
   - installation/agama
-  - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
   - installation/opensuse_welcome


### PR DESCRIPTION
* Use agama install steps for agama-based deployments either for agama-installer-openSUSE flavor, or in case AGAMA=1 is set
We'll probably need few iterations to get this working. I'll create needles on the first run. Any suggestions are welcome.

![image](https://github.com/user-attachments/assets/4dbed7d6-9be3-4d41-95ef-dcf2fef401dc)

Can be reproduced manually with https://download.opensuse.org/distribution/leap/16.0/appliances/iso/agama-installer-openSUSE.x86_64-9.0.0-openSUSE.iso
