### PR TITLE
wsl/enable_systemd.pm: Set cgroup_no_v1=all for the WSL2 host VM

### DIFF
--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -9,7 +9,7 @@
 use Mojo::Base qw(windowsbasetest);
 use testapi;
 use utils qw(zypper_call enter_cmd_slow);
-use version_utils qw(is_opensuse);
+use version_utils qw(is_opensuse is_tumbleweed);
 use wsl qw(is_fake_scc_url_needed);
 
 sub run {
@@ -42,6 +42,8 @@ sub run {
             enter_cmd("exit");
         }
     );
+    # Hopefully temporary workaround for https://github.com/microsoft/WSL/issues/11857
+    $self->run_in_powershell(cmd => q(echo "[wsl2]`nkernelCommandLine = cgroup_no_v1=all" >> ~/.wslconfig)) if is_tumbleweed;
     $self->run_in_powershell(cmd => q(wsl --shutdown));
     $self->run_in_powershell(
         cmd => '$port.WriteLine($(wsl /bin/bash -c "systemctl is-system-running"))',


### PR DESCRIPTION
This is needed to not use legacy cgroupv1.

Not adding a softfail because this is something that needs to be addressed in WSL, not Tumbleweed.

- Related tickets: https://bugzilla.opensuse.org/show_bug.cgi?id=1228438 https://github.com/microsoft/WSL/issues/11857
- Verification run: https://openqa.opensuse.org/tests/4370169
