### PR TITLE
install_kotd: List installed kernels

### DIFF
--- a/tests/kernel/install_kotd.pm
+++ b/tests/kernel/install_kotd.pm
@@ -38,7 +38,9 @@ sub run {
     # Install latest kernel
     zypper_call("in -l kernel-default");
     # Check for multiple kernel installation
-    assert_script_run '[ "$(zypper se -s kernel-default | grep -c i+)" = "1" ]', fail_message => 'More than one kernel was installed';
+    my $packlist = zypper_search('-sx kernel-default');
+    die 'More than one kernel was installed'
+      unless 1 == scalar grep { $$_{status} =~ m/^i/ } @$packlist;
     # Reboot system after kernel installation
     power_action('reboot');
 }


### PR DESCRIPTION
Use `zypper_search()` helper function to check installed kernel packages instead of opaque shell command which doesn't produce any usable debugging output.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - aarch64: https://openqa.opensuse.org/tests/4371385#step/install_kotd/48
  - x86_64: https://openqa.opensuse.org/tests/4371378#step/install_kotd/48