### PR TITLE
update_install: Add gnu-compilers-hpc-macros-devel conflict

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -83,6 +83,7 @@ my @conflicting_packages = (
     'nvidia-open-driver-G06-signed-cuda-kmp-64kb',
     'kernel-default-base', 'kernel-default-extra',
     'patterns-base-fips-certified',
+    'gnu-compilers-hpc-macros-devel', 'gnu12-compilers-hpc-macros-devel',
     'openssl-ibmca-engine', 'openssl-ibmca-provider', 'openssl-ibmca',
     'openmpi3-config', 'openmpi2-config'
 );


### PR DESCRIPTION
```
%package macros-devel
Summary:        Macro package for HPC GNU compiler environment
Group:          Development/Tools/Other
Provides:       %{pname}-hpc-macros-devel = %{version}
Conflicts:      otherproviders(%{pname}-hpc-macros-devel)
```

- Related ticket: https://progress.opensuse.org/issues/164568
- Verification run:
https://openqa.suse.de/tests/15051069 s390x
https://openqa.suse.de/tests/15051070 ppc64le