### PR TITLE
Skip auto agree with licenses in JeOS images

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -11,7 +11,7 @@ use testapi;
 use Utils::Architectures;
 use Utils::Backends qw(is_qemu);
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key quit_packagekit script_retry wait_for_purge_kernels);
-use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro is_hpc);
+use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro is_hpc is_jeos);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
 use YaST::workarounds;
@@ -318,7 +318,7 @@ sub register_addons_cmd {
             }
             elsif (grep(/$name/, keys %ADDONS_REGCODE)) {
                 my $opt = "";
-                if (is_sle("=15-SP4")) {
+                if (is_sle("=15-SP4") && !is_jeos) {
                     $opt = " --auto-agree-with-licenses";
                 }
                 add_suseconnect_product($name, undef, undef, "-r " . $ADDONS_REGCODE{$name} . $opt, 300, $retry);


### PR DESCRIPTION
The newer QR images might have this option. Images that are used as of now in Updates testing should not use it.

- Verification run: http://kepler.suse.cz/tests/23827#step/suseconnect_scc/71
