### PR TITLE
Agama: Use first default option for bootloader, skip grub-test  poo#164141

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -328,6 +328,9 @@ sub boot_into_snapshot {
 sub select_bootmenu_option {
     my ($timeout) = @_;
     assert_screen 'inst-bootmenu', $timeout;
+    if (get_var('AGAMA')) {
+        return 1;
+    }
     if (get_var('LIVECD')) {
         # live CDs might have a very short timeout of the initial bootmenu
         # (1-2s with recent kiwi versions) so better stop the timeout

--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -4,7 +4,6 @@ description:    >
 schedule:
   - installation/bootloader
   - installation/agama
-  - installation/grub_test
   - installation/first_boot
   - installation/opensuse_welcome
   - console/system_prepare

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -45,6 +45,9 @@ sub run {
     my $boot_cmd = 'ret';
     # Tumbleweed livecd has been switched to grub with kiwi 9.17.41 except 32bit
     # when LIVECD_LOADER has set grub2 then change the boot command for grub2
+    if (get_var('AGAMA')) {
+        return;
+    }
     if (is_livecd && check_var('LIVECD_LOADER', 'grub2')) {
         $boot_cmd = 'ctrl-x';
         uefi_bootmenu_params;


### PR DESCRIPTION
This one was forgotten from local changes. We need to go for first option and not failsafe which is current behavior.
Also let's drop grub tests for now we're going straight to firstboot.

old behavior: https://openqa.opensuse.org/tests/4372531
new fixed behavior: https://openqa.opensuse.org/tests/4372607