### PR TITLE
Support kubevirt test for MU slem 6.0 increment updates

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -318,7 +318,7 @@ Check if SLEM is in flavor of self installable iso
 =cut
 
 sub is_selfinstall {
-    return get_var('FLAVOR') =~ /selfinstall/i;
+    return get_var('FLAVOR') =~ /selfinstall/i || check_var('SELFINSTALL', '1');
 }
 
 =head2 is_tumbleweed

--- a/schedule/virt_autotest/slem-kubevirt-tests.yaml
+++ b/schedule/virt_autotest/slem-kubevirt-tests.yaml
@@ -16,6 +16,7 @@ conditional_schedule:
                 - installation/bootloader_uefi
                 - microos/selfinstall
                 - console/suseconnect_scc
+                - '{{install_updates}}'
     barrier_setup:
         SERVICE:
             rke2-server:
@@ -26,3 +27,7 @@ conditional_schedule:
                 - virt_autotest/kubevirt_tests_server
             rke2-agent:
                 - virt_autotest/kubevirt_tests_agent
+    install_updates:
+        FLAVOR:
+            Default-qcow-Updates:
+                - transactional/install_updates


### PR DESCRIPTION
For kubevirt tests on sle-micro 6.0 increment updates, loading install_updates test module.

- Related ticket: https://progress.opensuse.org/issues/164646
- Verification run: https://openqa.suse.de/tests/15067060
