### PR TITLE
install_kotd: Force installation only from KOTD repo

### DIFF
--- a/tests/kernel/install_kotd.pm
+++ b/tests/kernel/install_kotd.pm
@@ -36,7 +36,7 @@ sub run {
     zypper_ar($kotd_repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
     zypper_ar($kmp_repo, name => 'KMP', priority => 90, no_gpg_check => 1) if $kmp_repo;
     # Install latest kernel
-    zypper_call("in -l kernel-default");
+    zypper_call("in -lr KOTD kernel-default");
     # Check for multiple kernel installation
     my $packlist = zypper_search('-sx kernel-default');
     die 'More than one kernel was installed'

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -383,9 +383,9 @@ sub install_kotd {
     remove_kernel_packages;
     zypper_ar($repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
     if (is_transactional) {
-        trup_call("-c pkg install ${kernel_flavor} kernel-devel");
+        trup_call("-c pkg install -r KOTD ${kernel_flavor} kernel-devel");
     } else {
-        zypper_call("in -l ${kernel_flavor} kernel-devel");
+        zypper_call("in -lr KOTD ${kernel_flavor} kernel-devel");
     }
 }
 


### PR DESCRIPTION
Add zypper command line parameter to force installation of kernel-default only from the KOTD repo. Even though the repo has high priority, zypper might otherwise fall back to other repos if the kernel package is somehow missing.

- Related ticket: N/A
- Needles: N/A
- Verification runs: 
  - Tumbleweed aarch64 (KOTD package missing): https://openqa.opensuse.org/tests/4372675
  - Tumbleweed x86_64 (KOTD package present): https://openqa.opensuse.org/tests/4372676
  - SLEM 5.1: https://openqa.suse.de/tests/15054809
  - SLES-12SP5: https://openqa.suse.de/tests/15054814