### PR TITLE
Log openqa bad queries better

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1786,12 +1786,20 @@ sub qesap_is_job_finished {
 
     my $job_data = eval { decode_json($json_data) };
     if ($@) {
-        record_info("JSON error", "Failed to decode JSON data for job $job_id: $@");
-        return 0;    # Assume job is still running if we can't get its state
+        if ($json_data =~ /<h1>Page not found<\/h1>/) {
+            record_info(
+                "JOB NOT FOUND",
+                "Job $job_id was not found on the server " . get_required_var('OPENQA_HOSTNAME') .
+                  ". It may be deleted, from a different openqa server or from a manual deployment."
+            );
+        }
+        else {
+            record_info("OPENQA QUERY FAILED", "Failed to decode JSON data for job $job_id: $@");
+        }
+        return 0;    # assume job is still running if we can't get its info
     }
 
     my $job_state = $job_data->{job}->{state} // 'running';    # assume job is running if unable to get status
-
     return ($job_state ne 'running');
 }
 


### PR DESCRIPTION
This looks for a '404' return of openqa queries during the `delete_leftover_peerings` module, and outputs a more suggestive message to the user.

- Related ticket: https://jira.suse.com/browse/TEAM-9564
- Verification run: https://openqa.suse.de/tests/15066077, https://openqa.suse.de/tests/15125107
