### PR TITLE
Configure selfinstall images with jeos-firstboot

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -152,6 +152,9 @@ sub load_autoyast_installation_tests {
 sub load_selfinstall_boot_tests {
     loadtest 'installation/bootloader_uefi';
     loadtest 'microos/selfinstall';
+    if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
+        loadtest 'jeos/firstrun';
+    }
 }
 
 sub load_remote_target_tests {


### PR DESCRIPTION
For all images the fallback option is jeos-firstboot. We should make sure this test object is covered by openqa.

- ticket: [[sle-micro 6.1] test fails in selfinstall - adapt the test module and test suite schedule](https://progress.opensuse.org/issues/164162)
#### Verification run

* [combustion](http://kepler.suse.cz/tests/23841#)
* [wizard](http://kepler.suse.cz/tests/23840#)
* [ignition](http://kepler.suse.cz/tests/23842#)
