### PR TITLE
Split installation of KOTD kernel-default and kernel-devel into two steps

### DIFF
--- a/lib/package_utils.pm
+++ b/lib/package_utils.pm
@@ -43,7 +43,9 @@ sub install_package {
         record_info('install_package', $args{skip_trup}) if $args{skip_trup} =~ /\w+/;
         return if $args{skip_trup};
         $packages .= ' ' . $args{trup_extra} // '';
-        $ret = trup_call('pkg in -l ' . $packages, timeout => $args{timeout});
+        my $cmd = 'pkg in -l ' . $packages;
+        $cmd = '-c ' . $cmd if $args{trup_continue} // 0;
+        $ret = trup_call($cmd, timeout => $args{timeout});
         check_reboot_changes if $args{trup_reboot};
     }
     else {

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -382,11 +382,8 @@ sub install_kotd {
     fully_patch_system;
     remove_kernel_packages;
     zypper_ar($repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
-    if (is_transactional) {
-        trup_call("-c pkg install -r KOTD ${kernel_flavor} kernel-devel");
-    } else {
-        zypper_call("in -lr KOTD ${kernel_flavor} kernel-devel");
-    }
+    install_package("-r KOTD $kernel_flavor", trup_continue => 1);
+    install_package('kernel-devel', trup_continue => 1);
 }
 
 sub boot_to_console {


### PR DESCRIPTION
Forcing kernel installation specifically from the KOTD repository blocks installation of `kernel-default-devel` package due to required dependencies which need to be installed from non-KOTD repos. Installing `kernel-devel` in a separate step without repo restrictions fixes the dependency issue and correctly pulls in `kernel-default-devel`.

Also add `trup_continue` keyword parameter to `install_package()` to allow multi-step installation on transactional systems.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLEM 5.1: https://openqa.suse.de/tests/15090993
  - SLES-12SP5: https://openqa.suse.de/tests/15090994
