### PR TITLE
PC: Correct PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT default value

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -517,7 +517,7 @@ sub terraform_apply {
             my $vpc_security_group_ids = script_output("aws ec2 describe-security-groups --region '" . $self->provider_client->region . "' --filters 'Name=group-name,Values=tf-sg' --query 'SecurityGroups[0].GroupId' --output text");
             my $availability_zone = script_output("aws ec2 describe-instance-type-offerings --location-type availability-zone  --filters Name=instance-type,Values=" . $instance_type . "  --region '" . $self->provider_client->region . "' --query 'InstanceTypeOfferings[0].Location' --output 'text'");
             my $subnet_id = script_output("aws ec2 describe-subnets --region '" . $self->provider_client->region . "' --filters 'Name=tag:Name,Values=tf-subnet' 'Name=availabilityZone,Values=" . $availability_zone . "' --query 'Subnets[0].SubnetId' --output text");
-            my $ipv6_address_count = get_var('PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT', 1);
+            my $ipv6_address_count = get_var('PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT', 0);
             $cmd .= "-var 'vpc_security_group_ids=$vpc_security_group_ids' ";
             $cmd .= "-var 'availability_zone=$availability_zone' ";
             $cmd .= "-var 'subnet_id=$subnet_id' ";


### PR DESCRIPTION
- Related ticket: [poo#159003](https://progress.opensuse.org/issues/159003)
- Verification runs:

### GCE
 * [PUBLIC_CLOUD_GCE_STACK_TYPE=IPV4_ONLY](https://pdostal-server.suse.cz/tests/7117#step/instance_overview/15) (default)
 * [PUBLIC_CLOUD_GCE_STACK_TYPE=IPV4_IPV6](https://pdostal-server.suse.cz/tests/7116#step/instance_overview/15)

There is no `IPV6_ONLY` mode available and the `IPV4_IPV6` mode will be scheduled later.

### EC2
 * [PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT=0](https://pdostal-server.suse.cz/tests/7113#step/instance_overview/21) (default)
 * [PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT=1](https://pdostal-server.suse.cz/tests/7112#step/instance_overview/21)
 * [PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT=2](https://pdostal-server.suse.cz/tests/7111#step/instance_overview/21) (just out of curiosity)

The red jobs are due [bsc#1228774](https://bugzilla.suse.com/show_bug.cgi?id=1228774). The IPv6 mode should be possible but is not yet implemented. We also need to upgrade the scheduling later.