### PR TITLE
console/apparmor: Add smoke test after updates

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1157,6 +1157,7 @@ sub load_consoletests {
     loadtest 'console/prjconf_excluded_rpms' if is_livesystem;
     loadtest "console/system_prepare" unless is_opensuse;
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests && !get_var('QAM_MINIMAL');
+    loadtest 'console/apparmor' if is_updates_tests && !get_var('QAM_MINIMAL');
     loadtest "console/check_network";
     loadtest "console/system_state";
     loadtest "console/prepare_test_data";

--- a/tests/console/apparmor.pm
+++ b/tests/console/apparmor.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: apparmor-utils
+# Summary: Test apparmor utilities
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use base "consoletest";
+use services::apparmor;
+use strict;
+use testapi;
+use utils;
+use warnings;
+
+sub run {
+    select_console 'root-console';
+    my $is_running = (systemctl("status apparmor", ignore_failure => 1) == 0);
+    if ($is_running) {
+        services::apparmor::check_function;
+    }
+}
+
+1;


### PR DESCRIPTION
This PR introduces a new smoke test for apparmor, scheduled after patch_and_reboot under the console tests. It's another try on the ticket, past iteration was [19778](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19778), which broke some tests and had to be limited to Tumbleweed in [19804](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19804) then finally removed in [19817](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19817).

- Related ticket: https://progress.opensuse.org/issues/161996
- Verification run: https://openqa.opensuse.org/tests/4382867#step/apparmor/43
