### PR TITLE
Propagate deployment status

### DIFF
--- a/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
+++ b/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
@@ -28,6 +28,10 @@ sub test_flags {
 
 sub run {
     my ($self, $run_args) = @_;
+
+    # Needed to have peering and ansible state propagated in post_fail_hook
+    $self->import_context($run_args);
+
     my $instances = $self->{instances} = $run_args->{instances};
     my $provider_client = $run_args->{instances}[0]{provider}{provider_client};
     my $fence_agent_configuration = get_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi');


### PR DESCRIPTION
Get peering and Ansible status from the test modue argument allows post_fails_hook to properly cleanup peering in case of error.


# Verification run: 
 -  WITHOUT PEERING sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-08-06T02:03:21Z-hanasr_azure_test_saptune_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/293149. Status is now propagated http://openqaworker15.qa.suse.cz/tests/293149#step/Verify_azure_fence_agent_MSI/1
- WITH PEERING  sle-12-SP5-Azure-SAP-PAYG-Incidents-saptune-x86_64-Build:34935:systemd-sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/293150