### PR TITLE
Extend timeout delta usage in run_ssh_command

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -65,6 +65,10 @@ sub run_ssh_command {
     $args{no_quote} //= 0;
     my $rc_only = $args{rc_only} // 0;
     my $timeout = $args{timeout};
+    # Increase the hard timeout for script_run and script_output,
+    # otherwise possible error from 'timeout $args{timeout} ...'
+    # is not correctly processed, expecially in conjunction with proceed_on_failure
+    $args{timeout} += 20 unless ($args{timeout} == 0);
 
     my $cmd = $args{cmd};
     unless ($args{no_quote}) {
@@ -86,8 +90,6 @@ sub run_ssh_command {
         script_run($ssh_cmd, %args);
     }
     elsif ($rc_only) {
-        # Increase the hard timeout for script_run, otherwise our 'timeout $args{timeout} ...' has no effect
-        $args{timeout} += 2;
         $args{quiet} = 0;
         $args{die_on_timeout} = 1;
         # Run the command and return only the returncode here


### PR DESCRIPTION
Apply the 20sec delta not only for script_run but also for script_output

# Verification run:

 - sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-08-06T02:03:21Z-hanasr_aws_test_fencing_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/293151
 
 - sle-12-SP5-Azure-Incidents-x86_64-Build:34935:systemd-publiccloud_ltp_syscalls@az_Standard_B2s -> http://openqa.suse.de/tests/15102417

  - sle-15-SP5-Azure-BYOS-Updates-x86_64-Build20240805-1-publiccloud_ahb@64bit -> http://openqa.suse.de/tests/15102418
 
  - sle-15-SP5-Azure-Basic-Updates-x86_64-Build20240805-1-publiccloud_img_proof@64bit -> http://openqa.suse.de/tests/15102419