### PR TITLE
containers: Remove soft-failure for bsc#1226596

### DIFF
--- a/tests/containers/podman_remote.pm
+++ b/tests/containers/podman_remote.pm
@@ -18,6 +18,9 @@ use containers::utils qw(get_podman_version);
 my $podman_version;
 
 sub test_package {
+    # Skip on podman < 4.9.0
+    return if (version->parse($podman_version) < version->parse('4.9.0'));
+
     my $ret;
 
     # Allow installation failure so we can check for bsc#1126596 later on.
@@ -28,14 +31,8 @@ sub test_package {
         $ret = zypper_call("in podman-remote", exitcode => [0, 104]);
     }
 
-    if ($ret) {
-        if (is_sle_micro('>=5.1') && is_sle_micro('<=5.4') || is_sle('=15-SP3')) {
-            record_soft_failure("bsc#1226596 - podman-remote is not available");
-        } else {
-            # Fail only if podman > 4.9.0
-            die "podman-remote is not available!" if (version->parse($podman_version) > version->parse('4.9.0'));
-        }
-    }
+    # Fail only if podman > 4.9.0
+    die "podman-remote is not available!" if ($ret);
 }
 
 sub run {


### PR DESCRIPTION
Remove soft-failure for bsc#1226596

[bsc#1226596](https://bugzilla.suse.com/show_bug.cgi?id=1226596) seems to be fixed and it's now available on SLEM >=5.1 and SLES-15SP3+ according to:

```
susepkg -p any podman-remote | grep -e Micro -e SLES/15
SL-Micro/6.0 podman-remote 4.9.3-1.3
SLE-Micro/5.3 podman-remote 4.9.5-150400.4.30.1
SLE-Micro/5.4 podman-remote 4.9.5-150400.4.30.1
SLE-Micro/5.5 podman-remote 4.9.5-150500.3.15.1
SLES/15.3 podman-remote 4.9.5-150300.9.31.1
SLES/15.4 podman-remote 4.9.5-150400.4.27.1
SLES/15.5 podman-remote 4.9.5-150500.3.15.1
SLES/15.6 podman-remote 4.9.5-150500.3.15.1
SUSE-MicroOS/5.1 podman-remote 4.9.5-150300.9.31.1
SUSE-MicroOS/5.2 podman-remote 4.9.5-150300.9.31.1
```

- Verification run: not needed, I think.
