### PR TITLE
Don't need select product for aarch64

### DIFF
--- a/schedule/qam/QR/15-SP6/crypt_no_lvm.yaml
+++ b/schedule/qam/QR/15-SP6/crypt_no_lvm.yaml
@@ -15,7 +15,7 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/product_selection/install_SLES
+  - '{{product_selection}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_module_desktop
@@ -39,5 +39,12 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - console/validate_encrypt
+conditional_schedule:
+  product_selection:
+    ARCH:
+      x86_64:
+        - installation/product_selection/install_SLES
+      ppc64le:
+        - installation/product_selection/install_SLES
 test_data:
   <<: !include test_data/qam/QR/15-SP6/encryption/encrypt_no_lvm.yaml

--- a/schedule/qam/QR/15-SP6/encryption/cryptlvm_sle_15.yaml
+++ b/schedule/qam/QR/15-SP6/encryption/cryptlvm_sle_15.yaml
@@ -9,7 +9,7 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
-  - installation/product_selection/install_SLES
+  - '{{product_selection}}'
   - installation/licensing/accept_license
   - installation/registration/register_via_scc
   - installation/module_registration/register_module_desktop
@@ -37,3 +37,10 @@ schedule:
   - console/yast2_i
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  product_selection:
+    ARCH:
+      x86_64:
+        - installation/product_selection/install_SLES
+      ppc64le:
+        - installation/product_selection/install_SLES

--- a/schedule/qam/QR/15-SP6/lvm_raid1/lvm+raid1_sle15_aarch64.yaml
+++ b/schedule/qam/QR/15-SP6/lvm_raid1/lvm+raid1_sle15_aarch64.yaml
@@ -1,0 +1,20 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+  YUI_REST_API: 1
+schedule:
+  product_selection: []
+  expert_partitioning:
+    - installation/partitioning/setup_raid1_lvm
+  suggested_partitioning: []
+  default_systemd_target:
+    - installation/installation_settings/validate_default_target
+  system_validation:
+    - console/validate_lvm_raid1
+test_data:
+  <<: !include test_data/qam/QR/15-SP6/lvm_raid1/lvm+raid1.yaml


### PR DESCRIPTION
Don't need select product for aarch64

- Related ticket: https://progress.opensuse.org/issues/164967
- Verification run: https://openqa.suse.de/tests/15111266
https://openqa.suse.de/tests/15111259#
https://openqa.suse.de/tests/15111260#
https://openqa.suse.de/tests/15111509#
- Related MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/775
