### PR TITLE
Add PasswordAuthentication=no to first ssh command in publiccloud::instance::wait_for_ssh

### DIFF
--- a/data/publiccloud/ssh_config
+++ b/data/publiccloud/ssh_config
@@ -4,4 +4,5 @@ StrictHostKeyChecking no
 HostKeyAlgorithms +ssh-rsa
 IdentityFile %SSH_KEY%
 ControlPersist 86400
+PasswordAuthentication no
 

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -414,7 +414,8 @@ sub wait_for_ssh {
         script_run("ssh-keyscan $args{public_ip} | tee -a ~/.ssh/known_hosts");
         while (($duration = time() - $start_time) < $args{timeout}) {
             # timeout recalculated removing consumed time until now
-            $sysout = $self->ssh_script_output(cmd => 'sudo systemctl is-system-running',
+            # We don't support password authentication so it would just block the terminal
+            $sysout = $self->ssh_script_output(cmd => 'sudo systemctl is-system-running', ssh_opts => '-o PasswordAuthentication=no',
                 timeout => $args{timeout} - $duration, proceed_on_failure => 1, username => $args{username});
             # result check
             if ($sysout =~ m/initializing|starting/) {    # still starting


### PR DESCRIPTION
It now newly sporadically happens that GCE instance just after creation requires SSH password authentication. We don't support this scenario and the password prompt blocks our terminal so the whole test dies. This is disabling the password authentication leaving us only key authentication which should be always available.

- Related discussion ticket: [Slack](https://suse.slack.com/archives/C02CGKBCGT1/p1722921086073299)
- Failed test run: [openqa.suse.de/t15110954#step/prepare_instance/84](https://openqa.suse.de/tests/15110954#step/prepare_instance/84)
- Verification run: [pdostal-server.suse.cz/t7120](https://pdostal-server.suse.cz/tests/7120)
