### PR TITLE
Schedule diskusage module only for btrfs

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -646,7 +646,7 @@ sub load_jeos_tests {
     loadtest "jeos/grub2_gfxmode";
     unless (get_var('INSTALL_LTP') || get_var('SYSTEMD_TESTSUITE')) {
         # jeos/diskusage as of now works only with BTRFS
-        loadtest "jeos/diskusage" unless get_var('FILESYSTEM', 'btrfs') =~ /btrfs/;
+        loadtest "jeos/diskusage" if get_var('FILESYSTEM', 'btrfs') =~ /btrfs/;
         loadtest "jeos/build_key";
         loadtest "console/prjconf_excluded_rpms";
     }


### PR DESCRIPTION
By default, most of the images come with btrfs. If there is an exception as RISC or Cloud Minimal VM image, the correspoding filesystem should be specified by `FILESYSTEM=xyz`.

- [failure](https://openqa.suse.de/tests/15111521#step/diskusage/1)

#### Verification runs

* [sle-15-SP7-JeOS-for-kvm-and-xen -- BTRFS](http://kepler.suse.cz/tests/23872#step/diskusage/1)
* [sle-15-SP7-JeOS-for-OpenStack-Cloud -- XFS](http://kepler.suse.cz/tests/23871#)