### PR TITLE
Setup stable wallpaper background

### DIFF
--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -15,8 +15,8 @@ use wsl qw(is_fake_scc_url_needed);
 sub run {
     my $self = shift;
 
-    assert_screen(['windows_desktop', 'powershell-as-admin-window']);
-    $self->open_powershell_as_admin if match_has_tag('windows_desktop');
+    assert_screen(['windows-desktop', 'powershell-as-admin-window']);
+    $self->open_powershell_as_admin if match_has_tag('windows-desktop');
 
     # Check that systemd is not enabled by default.
     $self->run_in_powershell(

--- a/tests/wsl/install_wsl.pm
+++ b/tests/wsl/install_wsl.pm
@@ -75,7 +75,7 @@ sub run {
         $self->run_in_powershell(cmd => '$port.close()', code => sub { });
         $self->run_in_powershell(cmd => 'exit', code => sub { });
         # powershell window take a while to close. Check that the screen is showing the desktop before the next command.
-        assert_screen 'windows_desktop', timeout => 15;
+        assert_screen 'windows-desktop', timeout => 15;
         $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
         assert_and_click 'wsl-suse-startup-search';
     } elsif ($install_from eq 'msstore') {

--- a/tests/wsl/wsl_cmd_check.pm
+++ b/tests/wsl/wsl_cmd_check.pm
@@ -19,8 +19,8 @@ my %expected = (
 sub run {
     my $self = shift;
 
-    assert_screen(['windows_desktop', 'powershell-as-admin-window']);
-    $self->open_powershell_as_admin if match_has_tag('windows_desktop');
+    assert_screen(['windows-desktop', 'powershell-as-admin-window']);
+    $self->open_powershell_as_admin if match_has_tag('windows-desktop');
     $self->run_in_powershell(cmd => 'wsl --list --verbose', timeout => 60);
     $self->run_in_powershell(cmd => "wsl mount | Select-String -Pattern $expected{mount}", timeout => 60);
     $self->run_in_powershell(cmd => qq{wsl ls $expected{mount}}, timeout => 60);


### PR DESCRIPTION
Windows spotlight update overrides any effort to apply stable windows wallpaper background logic. After investigating microsoft forums, it seems that this bug has happened a few times already throughout the years and it is happening once again. 

Instead of waiting for a fix from Microsoft that might or might not come, I have adjusted the needle to check for windows desktop even if the background image is variable.

Setup a stable wallpaper background for windows for wsl tests.
- Adjusted appropriate needle.
- Fixed assert_screen typo for needle callback

- Related ticket:  https://progress.opensuse.org/issues/164661
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/windows-desktop-20240819.png
- Verification run: 

15sp5 win 10 bios: https://openqa.suse.de/tests/15215248
15sp5 win 10 uefi: https://openqa.suse.de/tests/15215249
15sp6 win 10 bios: https://openqa.suse.de/tests/15215251
16sp6 win 10 uefi: https://openqa.suse.de/tests/15215250

Tumbleweed win 10 bios: https://openqa.opensuse.org/tests/4420119
Tumbleweed win 10 uefi: https://openqa.opensuse.org/tests/4420120
