### PR TITLE
Added support for SAPHanaSR-angi package

### DIFF
--- a/data/sles4sap/angi_hana_cluster.conf
+++ b/data/sles4sap/angi_hana_cluster.conf
@@ -1,0 +1,48 @@
+primitive rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaTopology \
+    op start interval=0 timeout=600 \
+    op stop interval=0 timeout=300 \
+    op monitor interval=50 timeout=600 \
+    params SID=%SID% InstanceNumber=%HDB_INSTANCE%
+primitive rsc_SAPHanaFil_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaFilesystem \
+    op start interval=0 timeout=10 \
+    op stop interval=0 timeout=20 \
+    op monitor interval=120 timeout=120 \
+    params SID=%SID% InstanceNumber=%HDB_INSTANCE% ON_FAIL_ACTION="fence"
+primitive rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaController \
+    op start interval=0 timeout=3600 \
+    op stop interval=0 timeout=3600 \
+    op promote interval=0 timeout=900 \
+    op demote interval=0 timeout=320 \
+    op monitor interval=60 role=Promoted timeout=700 \
+    op monitor interval=61 role=Unpromoted timeout=700 \
+    params SID=%SID% \
+           InstanceNumber=%HDB_INSTANCE% \
+           PREFER_SITE_TAKEOVER=true \
+           DUPLICATE_PRIMARY_TIMEOUT=7200 \
+           AUTOMATED_REGISTER=%AUTOMATED_REGISTER% \
+    meta priority=100
+primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% ocf:heartbeat:IPaddr2 \
+    op monitor interval=10 timeout=20 \
+    params ip=%VIRTUAL_IP_ADDRESS% \
+           cidr_netmask=%VIRTUAL_IP_NETMASK% \
+           nic=eth0
+colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: \
+    rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started \
+    mst_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%:Promoted
+order ord_saphana_%SID%_HDB%HDB_INSTANCE% Optional: \
+    cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
+    mst_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%
+clone cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
+    rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
+    meta clone-node-max=1 \
+         interleave=true
+clone mst_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% \
+    rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% \
+    meta clone-node-max=1 \
+         promotable=true \
+         interleave=true \
+         maintenance=true
+clone cln_SAPHanaFil_%SID%_HDB%HDB_INSTANCE% \
+    rsc_SAPHanaFil_%SID%_HDB%HDB_INSTANCE% \
+    meta clone-node-max=1 \
+         interleave=true

--- a/data/sles4sap/angi_susHanaHADR_AIO.template
+++ b/data/sles4sap/angi_susHanaHADR_AIO.template
@@ -1,0 +1,20 @@
+[ha_dr_provider_sushanasr]
+provider = susHanaSR
+path = /usr/share/SAPHanaSR-angi/
+execution_order = 1
+
+[ha_dr_provider_sustkover]
+provider = susTkOver
+path = /usr/share/SAPHanaSR-angi/
+execution_order = 2
+
+[ha_dr_provider_suschksrv]
+provider = susChkSrv
+path = /usr/share/SAPHanaSR-angi/
+execution_order = 3
+action_on_lost=stop
+
+[trace]
+ha_dr_sushanasr = info
+ha_dr_suschksrv = info
+ha_dr_sustkover = info

--- a/data/sles4sap/hana_cluster.conf
+++ b/data/sles4sap/hana_cluster.conf
@@ -1,4 +1,4 @@
-primitive rsc_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaTopology \
+primitive rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaTopology \
         params SID=%SID% InstanceNumber=%HDB_INSTANCE% \
         op monitor interval=10 timeout=600 \
         op start interval=0 timeout=600 \
@@ -19,10 +19,10 @@ primitive stonith-sbd stonith:external/sbd \
         params pcmk_delay_max=15
 ms msl_SAPHana_%SID%_HDB%HDB_INSTANCE% rsc_SAPHana_%SID%_HDB%HDB_INSTANCE% \
         meta clone-max=2 clone-node-max=1 interleave=true maintenance=true
-clone cln_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% \
+clone cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
         meta clone-node-max=1 interleave=true
 colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started msl_SAPHana_%SID%_HDB%HDB_INSTANCE%:Master
-order ord_SAPHana_%SID%_HDB%HDB_INSTANCE% Optional: cln_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% msl_SAPHana_%SID%_HDB%HDB_INSTANCE%
+order ord_SAPHana_%SID%_HDB%HDB_INSTANCE% Optional: cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% msl_SAPHana_%SID%_HDB%HDB_INSTANCE%
 property SAPHanaSR: \
         hana_prd_site_srHook_SECONDARY_SITE_NAME=SOK
 property cib-bootstrap-options: \

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -951,7 +951,8 @@ sub do_hana_takeover {
     }
     sleep bmwqemu::scale_timeout(10);
     if ($args{cluster}) {
-        assert_script_run "crm resource cleanup rsc_SAPHana_${sid}_HDB$instance_id", $args{timeout};
+        my $hana_resource = get_var('USE_SAP_HANA_SR_ANGI') ? "rsc_SAPHanaCtl_${sid}_HDB$instance_id" : "rsc_SAPHana_${sid}_HDB$instance_id";
+        assert_script_run "crm resource cleanup $hana_resource", $args{timeout};
         assert_script_run 'crm_resource --cleanup', $args{timeout};
     }
 }

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -139,7 +139,15 @@ sub run {
     my $RAM = $self->get_total_mem();
     die "RAM=$RAM. The SUT needs at least 24G of RAM" if $RAM < 24000;
 
-    zypper_call('in SAPHanaSR SAPHanaSR-doc ClusterTools2') if get_var('HA_CLUSTER');
+    # Check for SAPHanaSR-angi package going to be used
+    if (get_var('USE_SAP_HANA_SR_ANGI')) {
+        script_run('[ $(rpm -q SAPHanaSR-doc) ] && rpm -e --nodeps SAPHanaSR-doc');
+        script_run('[ $(rpm -q SAPHanaSR) ] && rpm -e --nodeps SAPHanaSR');
+        zypper_call('install SAPHanaSR-angi supportutils-plugin-ha-sap ClusterTools2') if get_var('HA_CLUSTER');
+    }
+    else {
+        zypper_call('install SAPHanaSR SAPHanaSR-doc ClusterTools2') if get_var('HA_CLUSTER');
+    }
 
     # Add host's IP to /etc/hosts
     $self->add_hostname_to_hosts;

--- a/tests/sles4sap/trento/test_hana_restore_stopped.pm
+++ b/tests/sles4sap/trento/test_hana_restore_stopped.pm
@@ -1,4 +1,4 @@
-# Copyright SUSE LLC
+# Copyright 2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Trento restore stopped HANA DB
@@ -37,6 +37,10 @@ sub run {
     my $prov = get_required_var('PUBLIC_CLOUD_PROVIDER');
     # vmhana01 hard-coded in place of the generic Ansible filter from $primary_host.
     # The Ansible generic filter is only valid for Ansible, here it is crm.
+    # # From SLE16 SAPHanaSR package will be deprecated and SAPHanaSR-angi takes it place
+    # # Then something like the following will be necessary to integrate to the code hereafter
+    # # my $rsc_name = get_var('USE_SAP_HANA_SR_ANGI') ? "SAPHanaCtl" : "SAPHana";
+    # # qesap_ansible_cmd(cmd => "sudo crm resource refresh rsc_${rsc_name}_HDB_HDB00 vmhana01", provider => $prov, filter => $primary_host);
     qesap_ansible_cmd(cmd => "sudo crm resource refresh rsc_SAPHana_HDB_HDB00 vmhana01",
         provider => $prov,
         filter => $primary_host);


### PR DESCRIPTION
SAPHanaSR will be replaced by SAPHanaSR-angi on SLES 16, but it's already available as a technical preview in 15-SP4 - SP6. We are adapting our test to cover both packages.

Introduce new setting: USE_SAP_HANA_SR_ANGI(bool)

Related ticket: https://jira.suse.com/browse/TEAM-9425

Verification runs:

USE_SAP_HANA_SR_ANGI(true): https://openqa.suse.de/tests/15102530#dependencies
w/o USE_SAP_HANA_SR_ANGI(): https://openqa.suse.de/tests/15102979#dependencies
