### PR TITLE
Remove deprecated die_on_timeout

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -1079,7 +1079,7 @@ sub podman_exec {
     croak 'Missing mandatory cmd argument' unless $args{cmd};
 
     return script_run("podman exec $args{name} $args{cmd}",
-        timeout => bmwqemu::scale_timeout(10), die_on_timeout => -1);
+        timeout => bmwqemu::scale_timeout(10));
 }
 
 =head3 cypress_configs


### PR DESCRIPTION
The call script_run(..., die_on_timeout => 0) is deprecated and soon to
be removed from os-autoinst.
This commit replaces the trento lib call by simply removing "die_on_timeout => 0"
as not actually needed or not necessary anymore after underlying bugs are fixed.

Related progress issue: https://progress.opensuse.org/issues/164712