### PR TITLE
Add Minimal-VM flavor to is_jeos query

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -111,7 +111,7 @@ Returns true if called on jeos
 =cut
 
 sub is_jeos {
-    return get_var('FLAVOR', '') =~ /JeOS/;
+    return get_var('FLAVOR', '') =~ /(JeOS|Minimal-VM)/;
 }
 
 =head2 is_vmware


### PR DESCRIPTION
VR: https://openqa.suse.de/tests/15113686 (before it didn't get to the edit screen due to [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/installation/bootloader_uefi.pm#L139) and [this](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/lib/bootloader_setup.pm#L386) conditions not matching.