### PR TITLE
Serial banner function improvement

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -399,8 +399,12 @@ sub az_get_ssh_key {
 
 B<input_text>: string that will be printed in uppercase surrounded by '#' to make it more visible in output
 
-Prints a simple line in serial console that highlights a point in output to make it more readable.
+Prints a banner in serial console that highlights a point in output to make it more readable.
 Can be used for example to mark start and end of a function or a point in test so it is easier to find while debugging.
+Below is an example of the printed banner:
+# ###############
+# # $input_text #
+# ###############
 
 =cut
 
@@ -416,7 +420,12 @@ sub serial_console_diag_banner {
     # max_length - length of the text - 4x2 dividing spaces
     my $symbol_fill = ($max_length - length($input_text) - 8) / 2;
     $input_text = '#' x $symbol_fill . ' ' x 4 . $input_text . ' ' x 4 . '#' x $symbol_fill;
-    script_run($input_text, quiet => 1, die_on_timeout => 0, timeout => 1);
+    my $fill_line = '#' x length($input_text);
+
+    foreach ($fill_line, $input_text, $fill_line) {
+        enter_cmd($_);
+    }
+    wait_serial(qr/:~|#|>/, timeout => 5, quiet => 1);
 }
 
 =head2 prepare_tfvars_file

--- a/tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm
@@ -47,7 +47,6 @@ sub run {
     my @deployment_tags = ("deployment_id=" . get_current_job_id());
 
     az_login();
-
     record_info('VM create', "Creating deployer vm with parameters:\n
     Resource group: $deployer_resource_group\n
     VM name: $new_deployer_vm_name\n


### PR DESCRIPTION
Serial banner function (serial_console_diag_banner) uses deprecated script_run 
argument 'die_on_timeout'. This PR changes approach to enter_cmd and wait_serial 
combination which is a correct way to achieve same result. This as well allows 
to make banner multi lined and visually more prominent in the serial log. 

- Related ticket: https://progress.opensuse.org/issues/164712
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19853
- Verification run: https://mordor.suse.cz/tests/169

VR will fail because of unrelated issue with SDAF deployment.
You can see in serial console that banner is printed correctly:
```
# echo Logged into $(tty); echo 1XrKo-$?-
Logged into /dev/hvc0
1XrKo-0-
# ###############################################################################
# #################    Module sdaf_clone_deployer.pm : start    #################
# ###############################################################################
```
