### PR TITLE
Use coherent quotation for sles4sap import

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -397,7 +397,7 @@ sub prepare_profile {
  _do_mount( $proto, $path, $target);
 
 Performs a call to the mount command (used by both C<mount_media> and C<copy_media>) with
-appropiate options depending on the protocol. Function internal to the class.
+appropriate options depending on the protocol. Function internal to the class.
 
 =cut
 
@@ -575,7 +575,8 @@ user cannot create as many processes as root.
 sub test_forkbomb {
     my $script = 'forkbomb.pl';
     assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/$script -o /tmp/$script; chmod +x /tmp/$script";
-    # The systemd-run command generates syslog output that may end up in the console, so save the output to a file
+    # The systemd-run command generates syslog output that may end up in the console,
+    # so save the output to a file
     assert_script_run "systemd-run --slice user -qt su - $sapadmin -c /tmp/$script | tr -d '\\r' > /tmp/user-procs", 600;
     my $user_procs = script_output "cat /tmp/user-procs";
     my $root_procs = script_output "/tmp/$script", 600;
@@ -618,7 +619,7 @@ sub test_instance_properties {
  $self->test_stop();
 
 Tests with B<sapcontrol> and functions B<Stop> and B<StopService> that the instance
-and services are succesfully stopped. Croaks on failure.
+and services are successfully stopped. Croaks on failure.
 
 =cut
 
@@ -1048,7 +1049,8 @@ sub startup_type {
     target_path=>$target_path);
 
 Unpacks and prepares swpm package from specified source dir into target directory using SAPCAR tool.
-After extraction it checks for 'sapinst' executable being present in target path. Croaks if executable is missing.
+After extraction it checks for 'sapinst' executable being present in target path.
+Croaks if executable is missing.
 
 B<sapcar_bin_path> Filename with full path to SAPCAR binary
 
@@ -1094,7 +1096,7 @@ Copies sapinst profile template from NFS to target dir and fills in required var
 
 B<profile_target_file> Full filename and path for sapinst install profile to be created
 
-B<profile_template_file> Template file location from which will the profile be sceated
+B<profile_template_file> Template file location from which will the profile be created
 
 B<sar_location_directory> Location of SAR files -  this is filled into template
 
@@ -1221,7 +1223,7 @@ sub get_nw_instance_name {
  $self->is_instance_type_supported($instance_type);
 
 Checks if instance type is supported.
-Returns $instance_type with sucess, croaks with missing argument or unsupported value detected.
+Returns $instance_type with success, croaks with missing argument or unsupported value detected.
 
 B<instance_type> Instance type (ASCS, ERS, PAS, AAS)
 
@@ -1358,7 +1360,7 @@ Allows remote execution of webmethods between instances, however not all webmeth
 
 Sapcontrol return codes:
 
-    RC 0 = webmethod call was successfull
+    RC 0 = webmethod call was successful
     RC 1 = webmethod call failed
     RC 2 = last webmethod call in progress (processes are starting/stopping)
     RC 3 = all processes GREEN

--- a/tests/sles4sap/ase_test.pm
+++ b/tests/sles4sap/ase_test.pm
@@ -7,7 +7,7 @@
 # Requires: sles4sap/ase_install
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use strict;
 use warnings;
 use Carp qw(croak);

--- a/tests/sles4sap/desktop_icons.pm
+++ b/tests/sles4sap/desktop_icons.pm
@@ -6,7 +6,7 @@
 # Summary: SLES for SAP Applications default desktop icons check
 # Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use version_utils 'is_sle';
 use strict;

--- a/tests/sles4sap/forkbomb.pm
+++ b/tests/sles4sap/forkbomb.pm
@@ -7,7 +7,7 @@
 # Requires: sles4sap/wizard_hana_install, ENV variables INSTANCE_SID
 # Maintainer: QE-SAP <qe-sap@suse.de>, Ricardo Branco <rbranco@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Backends;

--- a/tests/sles4sap/grafana_dashboards.pm
+++ b/tests/sles4sap/grafana_dashboards.pm
@@ -6,7 +6,7 @@
 # Summary: Basic tests for HA & SAP grafana dashboards
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use strict;
 use warnings;

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -7,7 +7,7 @@
 # Summary: Configure HANA-SR cluster
 # Maintainer: QE-SAP <qe-sap@suse.de>, Ricardo Branco <rbranco@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;

--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -7,7 +7,7 @@
 # Requires: sles4sap/wizard_hana_install, ENV variables INSTANCE_SID
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use strict;
 use warnings;
 use testapi;

--- a/tests/sles4sap/netweaver_cluster.pm
+++ b/tests/sles4sap/netweaver_cluster.pm
@@ -7,7 +7,7 @@
 # Summary: Configure NetWeaver cluster
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;

--- a/tests/sles4sap/netweaver_filesystems.pm
+++ b/tests/sles4sap/netweaver_filesystems.pm
@@ -7,7 +7,7 @@
 # Summary: Configure NetWeaver filesystems
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'systemctl';

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -7,7 +7,7 @@
 # Requires: ENV variable NW pointing to installation media
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;

--- a/tests/sles4sap/netweaver_network.pm
+++ b/tests/sles4sap/netweaver_network.pm
@@ -6,7 +6,7 @@
 # Summary: Configure NetWeaver network
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;

--- a/tests/sles4sap/netweaver_patch.pm
+++ b/tests/sles4sap/netweaver_patch.pm
@@ -7,7 +7,7 @@
 # Requires: ENV variable NW pointing to installation media
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;

--- a/tests/sles4sap/netweaver_test_instance.pm
+++ b/tests/sles4sap/netweaver_test_instance.pm
@@ -7,7 +7,7 @@
 # Requires: sles4sap/netweaver_install, ENV variables INSTANCE_SID, INSTANCE_TYPE and INSTANCE_ID
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use strict;

--- a/tests/sles4sap/netweaver_test_systemd.pm
+++ b/tests/sles4sap/netweaver_test_systemd.pm
@@ -6,7 +6,7 @@
 # Summary: Register systemd services for SAP NetWeaver and check for success
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -8,7 +8,7 @@
 # Working both on plain SLE and SLES4SAP products
 # Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;

--- a/tests/sles4sap/sap_suse_cluster_connector.pm
+++ b/tests/sles4sap/sap_suse_cluster_connector.pm
@@ -6,7 +6,7 @@
 # Summary: Test sap_suse_cluster_connector command
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use hacluster;

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -7,7 +7,7 @@
 # Working both on plain SLE and SLES4SAP products
 # Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use version_utils qw(is_staging is_sle is_upgrade);

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -6,7 +6,7 @@
 # Summary: saptune availability test
 # Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.de>
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils "zypper_call";

--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -9,7 +9,7 @@
 
 use strict;
 use warnings;
-use base "sles4sap";
+use base 'sles4sap';
 use autotest;
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/sles4sap/saptune/mr_test_run.pm
+++ b/tests/sles4sap/saptune/mr_test_run.pm
@@ -9,7 +9,7 @@
 
 package mr_test_run;
 
-use base "sles4sap";
+use base 'sles4sap';
 use testapi;
 use Utils::Backends;
 use utils;


### PR DESCRIPTION
Use always the same quotation style when including sles4sap base test. Fix typo in the library documentation.

- Verification run:
