### PR TITLE
Revert "Making upload of zypper.log explicit on every failure"

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -120,7 +120,6 @@ sub _cleanup {
     # 1. Job should have 'PUBLIC_CLOUD_NO_CLEANUP' variable and result == 'fail'
     if ($self->{result} && $self->{result} eq 'fail' && get_var('PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE')) {
         upload_logs('/var/tmp/ssh_sut.log', failok => 1, log_name => 'ssh_sut_log.txt');
-        upload_logs('/var/log/zypper.log', failok => 1, log_name => 'zypper.log');
         upload_asset(script_output('ls ~/.ssh/id* | grep -v pub | head -n1'));
         return;
     }
@@ -150,7 +149,6 @@ sub _cleanup {
     }
 
     upload_logs('/var/tmp/ssh_sut.log', failok => 1, log_name => 'ssh_sut_log.txt');
-    upload_logs('/var/log/zypper.log', failok => 1, log_name => 'zypper.log');
 }
 
 sub post_fail_hook {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -842,7 +842,7 @@ sub ssh_fully_patch_system {
     record_info('zypper patch', 'The command zypper patch took ' . (time() - $cmd_time) . ' seconds.');
     if ($ret != 0 && $ret != 102 && $ret != 103) {
         if ($resolver_option) {
-            script_run("ssh $remote 'tar -czvf /tmp/solver.tar.gz /var/log/zypper.solverTestCase'");
+            script_run("ssh $remote 'tar -czvf /tmp/solver.tar.gz /var/log/zypper.solverTestCase /var/log/zypper.log'");
             script_run("scp $remote:/tmp/solver.tar.gz /tmp/solver.tar.gz");
             upload_logs('/tmp/solver.tar.gz', failok => 1);
         }
@@ -853,7 +853,7 @@ sub ssh_fully_patch_system {
     $ret = script_run($cmd, 6000);
     record_info('zypper patch', 'The second command zypper patch took ' . (time() - $cmd_time) . ' seconds.');
     if ($resolver_option) {
-        script_run("ssh $remote 'tar -czvf /tmp/solver.tar.gz /var/log/zypper.solverTestCase'");
+        script_run("ssh $remote 'tar -czvf /tmp/solver.tar.gz /var/log/zypper.solverTestCase /var/log/zypper.log'");
         script_run("scp $remote:/tmp/solver.tar.gz /tmp/solver.tar.gz");
         upload_logs('/tmp/solver.tar.gz', failok => 1);
     }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#19859, this PR was trying upload `zypper.log` from openQA VM instead of uploading `zypper.log` from SUT VM running in the cloud hence it should be reverted and we should create another one which will do it right 