### PR TITLE
containers: Limit podman upstream tests to x86_64

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -21,7 +21,14 @@ use transactional qw(trup_call check_reboot_changes);
 use serial_terminal qw(select_user_serial_terminal);
 use registration qw(add_suseconnect_product get_addon_fullname);
 
-our @EXPORT = qw(install_bats install_htpasswd remove_mounts_conf switch_to_user delegate_controllers enable_modules patch_logfile);
+our @EXPORT = qw(install_bats install_htpasswd install_ncat remove_mounts_conf switch_to_user delegate_controllers enable_modules patch_logfile);
+
+sub install_ncat {
+    my $ncat_version = get_required_var("NCAT_VERSION");
+
+    assert_script_run "rpm -vhU https://nmap.org/dist/ncat-$ncat_version.x86_64.rpm";
+    assert_script_run "ln -sf /usr/bin/ncat /usr/bin/nc";
+}
 
 sub install_htpasswd {
     return if (script_run("which htpasswd") == 0);

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -302,7 +302,7 @@ sub load_container_tests {
             loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle || is_leap || is_sle_micro('>=5.5'));
         }
         if (!check_var('PODMAN_BATS_SKIP', 'all')) {
-            loadtest 'containers/podman_integration';
+            loadtest 'containers/podman_integration' if (is_x86_64);
         }
         if (!check_var('RUNC_BATS_SKIP', 'all')) {
             loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle || is_leap);

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -12,19 +12,12 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats patch_logfile enable_modules);
+use containers::bats qw(install_bats install_ncat patch_logfile enable_modules);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
 my $netavark = "";
 my $netavark_version = "";
-
-sub install_ncat {
-    my $ncat_version = get_required_var("NCAT_VERSION");
-
-    assert_script_run "rpm -vhU https://nmap.org/dist/ncat-$ncat_version.x86_64.rpm";
-    assert_script_run "ln -sf /usr/bin/ncat /usr/bin/nc";
-}
 
 sub run_tests {
     my $log_file = "netavark.tap";

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -15,7 +15,7 @@ use utils qw(script_retry);
 use version_utils qw(is_sle is_sle_micro is_tumbleweed is_microos);
 use containers::common;
 use Utils::Architectures qw(is_x86_64 is_aarch64);
-use containers::bats qw(install_bats install_htpasswd patch_logfile remove_mounts_conf switch_to_user delegate_controllers enable_modules);
+use containers::bats qw(install_bats install_htpasswd install_ncat patch_logfile remove_mounts_conf switch_to_user delegate_controllers enable_modules);
 
 my $test_dir = "/var/tmp";
 my $podman_version = "";
@@ -52,7 +52,7 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark netcat-openbsd openssl podman sudo systemd-container);
+    my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark openssl podman sudo systemd-container);
     push @pkgs, qw(apache2-utils buildah go) unless is_sle_micro;
     push @pkgs, qw(python3-PyYAML) unless is_sle_micro('>=6.0');
     push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');
@@ -68,6 +68,7 @@ sub run {
     }
     install_packages(@pkgs);
     install_htpasswd if is_sle_micro;
+    install_ncat;
 
     record_info("podman version", script_output("podman version"));
 


### PR DESCRIPTION
The [podman upstream tests use nmap's ncat](https://github.com/containers/podman/blob/main/test/system/README.md?plain=1#L84) instead of OpenBSD's netcat.  As we don't ship this package due to licensing issues (NSPL vs GPL), we need to install it from [nmap.org](https://nmap.org/dist/).  Unfortunately it's only available for x86_64.

This avoids the error messages seen in logs that force us to skip these tests:

```
# #| expected: =~ 127.0.0.1:5932: Address already in use
# #|   actual:    nc: Address already in use
```
https://openqa.opensuse.org/tests/4391501/logfile?filename=serial_terminal.txt

Verification runs: TBD