### PR TITLE
containers: Add missing libcriu2 dependency

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -52,7 +52,7 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns catatonit gpg2 jq make netavark openssl podman sudo systemd-container);
+    my @pkgs = qw(aardvark-dns catatonit gpg2 jq libcriu2 make netavark openssl podman sudo systemd-container);
     push @pkgs, qw(apache2-utils buildah go) unless is_sle_micro;
     push @pkgs, qw(python3-PyYAML) unless is_sle_micro('>=6.0');
     push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');


### PR DESCRIPTION
Avoid error message: 
```
# [06:19:25.633778599] could not load `libcriu.so.2'
```

The package is available on our products:

```
$ susepkg -p any libcriu2 | grep -e Micro -e SLES/
SLE-Micro/5.3 libcriu2 3.16.1-bp154.1.33
SLE-Micro/5.4 libcriu2 3.16.1-bp154.1.33
SLE-Micro/5.5 libcriu2 3.17.1-bp155.2.7
SLES/15.1 libcriu2 3.15-bp151.4.3.1
SLES/15.2 libcriu2 3.15-bp152.4.3.1
SLES/15.3 libcriu2 3.15-bp153.2.3.1
SLES/15.4 libcriu2 3.16.1-bp154.1.33
SLES/15.5 libcriu2 3.17.1-bp155.2.7
SLES/15.6 libcriu2 3.18-bp156.1.6
SUSE-MicroOS/5.1 libcriu2 3.15-bp153.2.3.1
SUSE-MicroOS/5.2 libcriu2 3.15-bp153.2.3.1
```