### PR TITLE
containers: libcriu2 is not available on SLEM 6.0+

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -57,7 +57,7 @@ sub run {
     push @pkgs, qw(libcriu2 python3-PyYAML) unless is_sle_micro('>=6.0');
     push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');
     push @pkgs, qw(socat) unless is_sle_micro('=5.1');
-    push @pkgs, qw(podman-remote) unless (is_sle_micro('<5.5') || is_sle('<=15-SP2'));
+    push @pkgs, qw(podman-remote) unless is_sle('<=15-SP2');
     # passt requires podman 5.0
     push @pkgs, qw(criu passt) if (is_tumbleweed || is_microos);
     # Needed for podman machine

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -52,9 +52,9 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns catatonit git-core gpg2 jq libcriu2 make netavark openssl podman sudo systemd-container);
+    my @pkgs = qw(aardvark-dns catatonit git-core gpg2 jq make netavark openssl podman sudo systemd-container);
     push @pkgs, qw(apache2-utils buildah glibc-devel-static go libgpgme-devel libseccomp-devel) unless is_sle_micro;
-    push @pkgs, qw(python3-PyYAML) unless is_sle_micro('>=6.0');
+    push @pkgs, qw(libcriu2 python3-PyYAML) unless is_sle_micro('>=6.0');
     push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');
     push @pkgs, qw(socat) unless is_sle_micro('=5.1');
     push @pkgs, qw(podman-remote) unless (is_sle_micro('<5.5') || is_sle('<=15-SP2'));


### PR DESCRIPTION
 libcriu2 is not available on SLEM 6.0+

```
$ susepkg -p any libcriu2 | grep Micro
SLE-Micro/5.3 libcriu2 3.16.1-bp154.1.33
SLE-Micro/5.4 libcriu2 3.16.1-bp154.1.33
SLE-Micro/5.5 libcriu2 3.17.1-bp155.2.7
SUSE-MicroOS/5.1 libcriu2 3.15-bp153.2.3.1
SUSE-MicroOS/5.2 libcriu2 3.15-bp153.2.3.1
```
