### PR TITLE
containers: Install python311-PyYAML on SLEM 6.0+

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -55,6 +55,7 @@ sub run {
     my @pkgs = qw(aardvark-dns catatonit git-core gpg2 jq make netavark openssl podman sudo systemd-container);
     push @pkgs, qw(apache2-utils buildah glibc-devel-static go libgpgme-devel libseccomp-devel) unless is_sle_micro;
     push @pkgs, qw(libcriu2 python3-PyYAML) unless is_sle_micro('>=6.0');
+    push @pkgs, qw(python311-PyYAML) if is_sle_micro('>=6.0');
     push @pkgs, qw(skopeo) unless is_sle_micro('<5.5');
     push @pkgs, qw(socat) unless is_sle_micro('=5.1');
     push @pkgs, qw(podman-remote) unless is_sle('<=15-SP2');


### PR DESCRIPTION
On SLEM 6.0+ the package name for python3-PyYAML is python311-PyYAML

```
$ susepkg -p any \*PyYAML | grep Micro
SL-Micro/6.0 python311-PyYAML 6.0.1-1.9
SLE-Micro/5.3 python3-PyYAML 5.4.1-1.1
SLE-Micro/5.4 python3-PyYAML 5.4.1-1.1
SLE-Micro/5.5 python3-PyYAML 5.4.1-1.1
SUSE-MicroOS/5.0 python3-PyYAML 5.3.1-6.10.1
SUSE-MicroOS/5.1 python3-PyYAML 5.4.1-1.1
SUSE-MicroOS/5.2 python3-PyYAML 5.4.1-1.1
```
