### PR TITLE
Fix supp_sles15sp4_all patterns-base-x11_raspberrypi issue on aarch64

### DIFF
--- a/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp4_install_textmode_all_patterns_aarch64.xml
@@ -73,7 +73,6 @@ exit 0
       <pattern>minimal_base</pattern>
       <pattern>minimal_base-32bit</pattern>
       <pattern>ofed</pattern>
-      <pattern>oracle_server</pattern>
       <pattern>print_server</pattern>
       <pattern>sap_server</pattern>
       <pattern>sw_management</pattern>
@@ -81,12 +80,8 @@ exit 0
       <pattern>x11</pattern>
       <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>
-      <pattern>xen_server</pattern>
-      <pattern>xen_tools</pattern>
       <pattern>yast2_basis</pattern>
       <pattern>yast2_desktop</pattern>
-      <pattern>gnome_basic</pattern>
-      <pattern>x11_raspberrypi</pattern>
       <pattern>yast2_server</pattern>
     </patterns>
     <products t="list">


### PR DESCRIPTION
##
### $`\textcolor{Green}{\textsf{Fix supp\_sles15sp4\_all patterns-base-x11\_raspberrypi issue on aarch64}}`$
- Failed case:
  -  https://openqa.suse.de/tests/15147774#step/installation/3
  - https://openqa.suse.de/tests/15147774#step/installation/57
- Related ticket: 
  * Quick PR
- Needles: 
  * N/A
- Verification run: 
  * https://openqa.suse.de/t15148431
##

