### PR TITLE
containers: Fix for 250-systemd

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -94,6 +94,7 @@ sub run {
     script_retry("curl -sL https://github.com/containers/podman/archive/refs/tags/v$podman_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run("cd $test_dir/podman-$podman_version/");
     assert_script_run "sed -i 's/bats_opts=()/bats_opts=(--tap)/' hack/bats";
+    assert_script_run "rm -f contrib/systemd/system/podman-kube@.service.in";
 
     # Compile helpers used by the tests
     script_run "make podman-testing", timeout => 600;


### PR DESCRIPTION

Avoid error:

```
not ok 438 [255] podman-kube@.service template with rollback
# (from function `install_kube_template' in file test/system/helpers.systemd.bash, line 80,
#  in test file test/system/255-auto-update.bats, line 486)
#   `install_kube_template' failed with status 2
#
# [15:52:23.489399246] # /usr/bin/podman image exists quay.io/libpod/systemd-image:20240124
# make: *** No rule to make target 'contrib/systemd/system/podman-kube@.service'.  Stop.
```