### PR TITLE
Skip patterns-base-x11_raspberrypi for aarch64 all pattern in patch_sle

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2489,6 +2489,8 @@ sub install_patterns {
         next if (($pt =~ /common-criteria/) && check_var('PATTERNS', 'all'));
         # if pattern is fips or fips-certified and PATTERNS is all, skip
         next if (($pt =~ /fips|fips-certified/) && check_var('PATTERNS', 'all'));
+        # if pattern is x11_raspberrypi and PATTERNS is all for aarch64, skip
+        next if (($pt =~ /x11_raspberrypi/) && check_var('PATTERNS', 'all') && is_aarch64);
         zypper_call("in -t pattern $pt", timeout => 1800);
     }
 }


### PR DESCRIPTION
##
### $`\textcolor{Green}{\textsf{Skip patterns-base-x11\_raspberrypi for aarch64 all pattern in patch\_sle}}`$
- Failed case:
  - https://openqa.suse.de/tests/15160304#step/patch_sle/148
- Related ticket: 
  * Quick PR
- Needles: 
  * N/A
- Verification run: 
  * https://openqa.suse.de/tests/15161257
  * https://openqa.suse.de/tests/15161258
##
