### PR TITLE
Update OS variant for SL Micro guest

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
@@ -29,7 +29,7 @@
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw.xz</guest_installation_media>
     <guest_installation_fine_grained/>
-    <guest_os_variant>opensusetumbleweed</guest_os_variant>
+    <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
@@ -29,7 +29,7 @@
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw.xz</guest_installation_media>
     <guest_installation_fine_grained/>
-    <guest_os_variant>opensusetumbleweed</guest_os_variant>
+    <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
@@ -29,7 +29,7 @@
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-qcow-Build12345.qcow2</guest_installation_media>
     <guest_installation_fine_grained/>
-    <guest_os_variant>opensusetumbleweed</guest_os_variant>
+    <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition.xml
@@ -29,7 +29,7 @@
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-qcow-Build12345.qcow2</guest_installation_media>
     <guest_installation_fine_grained/>
-    <guest_os_variant>opensusetumbleweed</guest_os_variant>
+    <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
@@ -28,7 +28,7 @@
   <guest_installation_wait/>
   <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-Build12345.raw.xz</guest_installation_media>
   <guest_installation_fine_grained/>
-  <guest_os_variant>opensusetumbleweed</guest_os_variant>
+  <guest_os_variant>slm6.0</guest_os_variant>
   <guest_storage_path/>
   <guest_storage_type>disk</guest_storage_type>
   <guest_storage_format>qcow2</guest_storage_format>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition.xml
@@ -28,7 +28,7 @@
   <guest_installation_wait/>
   <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-Build12345.raw.xz</guest_installation_media>
   <guest_installation_fine_grained/>
-  <guest_os_variant>opensusetumbleweed</guest_os_variant>
+  <guest_os_variant>slm6.0</guest_os_variant>
   <guest_storage_path/>
   <guest_storage_type>disk</guest_storage_type>
   <guest_storage_format>qcow2</guest_storage_format>


### PR DESCRIPTION
* **osinfo-query** database has been updated on SL Micro 6.1 host.

* **Although** there is no ```slm6.1``` in the database at the moment, at least ```slm6.0``` is available. 

* **Using** ```slm6.0``` is better than ```opensusetumbleweed``` for SL Micro 6.1 guest to be installed.

* **Verification Runs:**
  * [sl micro guest on sl micro host](https://openqa.suse.de/tests/15175388)
  * [sles15sp6 on sle micro host](https://openqa.suse.de/tests/15175389)
