### PR TITLE
Fix libgit2 test

### DIFF
--- a/tests/console/libgit2.pm
+++ b/tests/console/libgit2.pm
@@ -50,9 +50,11 @@ sub run {
 }
 
 sub clean_up {
-    assert_script_run "pip3.$python_sub_version uninstall pygit2 -y --break-system-packages";
+    zypper_call "rm python3$python_sub_version-pygit2";
+    my $out = script_output "python3.$python_sub_version pygit2_test.py", proceed_on_failure => 1;
     zypper_call "rm python3$python_sub_version";
     assert_script_run "rm -rf libgit2";
+    die("uninstalling of python3$python_sub_version-pygit2 failed") if (index($out, "ModuleNotFoundError") == -1);
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Modified cleanup code in the test to uninstall the installed pygit2

This PR fixes the following issue in LEAP 15.6

```
Usage:   
  pip3.11 uninstall [options] <package> ...
  pip3.11 uninstall [options] -r <requirements file> ...

no such option: --break-system-packages
```

- Related ticket: https://progress.opensuse.org/issues/164931
- Needles: NO
- Verification run: 
  Tumbleweed: https://openqa.opensuse.org/tests/4401059#step/libgit2/20
 LEAP 15.6-  https://openqa.opensuse.org/tests/4401074#step/libgit2/19
