### PR TITLE
lib/power_action_utils.pm: Handle Plasma in reboot_x11

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -72,7 +72,7 @@ sub prepare_system_shutdown {
 
  reboot_x11();
 
-Reboot from Gnome Desktop and handle authentification scenarios during shutdown.
+Reboot from a desktop session and handle authentication scenarios during shutdown.
 
 Run C<prepare_system_shutdown> if shutdown needs authentification.
 
@@ -116,6 +116,14 @@ sub reboot_x11 {
 
             send_key 'ret';    # Confirm
         }
+    }
+    elsif (check_var('DESKTOP', 'kde')) {
+        # Open the reboot/logout greeter and select the reboot option
+        send_key 'ctrl-alt-delete';
+        assert_and_click 'sddm_reboot_option_btn';
+    }
+    else {
+        die 'Unhandled desktop';
     }
 }
 

--- a/tests/x11/reboot_plasma5.pm
+++ b/tests/x11/reboot_plasma5.pm
@@ -12,11 +12,11 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use power_action_utils;
 
 sub run {
     my ($self) = @_;
-    send_key "ctrl-alt-delete";    # reboot
-    assert_and_click 'sddm_reboot_option_btn';
+    power_action 'reboot';
     $self->wait_boot(bootloader_time => 300);
     # Ensure the desktop runner is reactive again before going into other test
     # modules


### PR DESCRIPTION
Needed for power_action 'reboot'. Port reboot_plasma5 to use it.

Failure: https://openqa.opensuse.org/tests/4399620

Verification runs:
 - opensuse-Tumbleweed-DVD-x86_64-Build20240812-kde_dual_windows10@64bit_win -> https://openqa.opensuse.org/tests/4401321
 - opensuse-Tumbleweed-NET-x86_64-Build20240812-update_tw2twnext_kde@64bit-3G -> https://openqa.opensuse.org/tests/4401301