### PR TITLE
Revert "Handle the server with multiple NVMe disks"

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -486,9 +486,9 @@ sub select_first_hard_disk {
               if ($matched_needle && $matched_needle->{needle}->has_tag("hard-disk-dev-$device-selected"));
         }
     }
-    # Check if sda is still/already selected, select the first disk device if none selected
-    assert_screen [qw(select-hard-disks-one-selected select-hard-disks-none-selected)];
-    assert_and_click 'hard-disk-dev-first-select' if (match_has_tag('select-hard-disks-none-selected'));
+    # Check if sda is still/already selected, if not select it
+    assert_screen [qw(select-hard-disks-one-selected hard-disk-dev-sda-not-selected)];
+    assert_and_click 'hard-disk-dev-sda-not-selected' if match_has_tag('hard-disk-dev-sda-not-selected');
     save_screenshot;
     send_key $cmd{next};
 }

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -80,8 +80,7 @@ sub run {
         assert_screen("inst-packageinstallationstarted", $started_timeout);
     }
     else {
-        my $time_out = is_ipmi ? 10 : 3;
-        wait_still_screen($time_out);    # wait so alt-i is pressed when installation overview is not being generated
+        wait_still_screen(3);    # wait so alt-i is pressed when installation overview is not being generated
         send_key $cmd{install};
         if (check_var('FAIL_EXPECTED', 'SMALL-DISK')) {
             assert_screen 'installation-proposal-error';


### PR DESCRIPTION
My bad, hana test needs /dev/sda as boot dev.

https://openqa.suse.de/tests/15167200#step/partitioning_firstdisk/5

Reverts os-autoinst/os-autoinst-distri-opensuse#19910