### PR TITLE
Change regex to search for devices

### DIFF
--- a/tests/kernel/mellanox_config.pm
+++ b/tests/kernel/mellanox_config.pm
@@ -42,7 +42,7 @@ sub run {
     # install dependencies
     zypper_call('--quiet in pciutils mstflint', timeout => 200);
 
-    my @devices = split(' ', script_output("lspci | grep -i infiniband.*mellanox |cut  -d ' ' -f 1"));
+    my @devices = split(' ', script_output("lspci | grep -i mellanox.*ConnectX-5 |cut  -d ' ' -f 1"));
 
     die "There is no Mellanox card here" if !@devices;
 


### PR DESCRIPTION
Previously, we explicitely searched for "infiniband" devices from Mellanox.
However, if we have those configured as Ethernet devices, we won't find any devices. We know we only have ConnectX-5 devices for InfiniBand (but on the same machines we have ConnectX-4 LX which only do Ethernet - so let's explicitely search for ConnectX-5 devices instead.

