### PR TITLE
Install fence-agents-azure-arm as a workaround

### DIFF
--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_hanasr.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_hanasr.pm
@@ -77,6 +77,16 @@ sub run {
     az_login();
 
     for my $playbook_options (@execute_playbooks) {
+        # Package 'fence-agents-azure-arm' is not yet installed by SDAF, therefore a workaround has to be applied
+        if ($playbook_options->{playbook_filename} eq 'playbook_04_00_00_db_install.yaml') {
+            record_soft_failure("bsc#1226671 - New package 'fence-agents-azure=arm' has to be installed to prevent HA setup failure");
+            my @cmd = ('ansible', 'QES_DB',
+                "--private-key=$sdaf_config_root_dir/sshkey",
+                '--inventory=' . get_required_var('SAP_SID') . '_hosts.yaml',
+                '--module-name=shell',
+                '--args="sudo zypper in -y fence-agents-azure-arm"');
+            assert_script_run(join(' ', @cmd));
+        }
         sdaf_execute_playbook(%{$playbook_options}, sdaf_config_root_dir => $sdaf_config_root_dir);
     }
 


### PR DESCRIPTION
SDAF deployment is currently failing because of missing package 
'fence-agents-azure-arm'. This should be covered by SDAF but is currently 
missing. This PR installs the package using 'assert_script_run' as a temporary 
workaround. 

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1226671
- Original failure: https://openqaworker15.qa.suse.cz/tests/294581#step/deploy_hanasr/201
- Verification run: 
package installation : https://openqaworker15.qa.suse.cz/tests/294575#step/deploy_hanasr/179
crm status: https://openqaworker15.qa.suse.cz/tests/294575#step/deploy_hanasr/245