### PR TITLE
kdump: Determine kernel debuginfo automatically on transactional systems

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -33,7 +33,8 @@ my $install_debug_info_timeout = 4000;
 
 sub install_transactional_kernel_debuginfo {
     return undef if get_var('SKIP_KERNEL_DEBUGINFO');
-    my $cmd = 'transactional-update --continue --non-interactive pkg install kernel-default-debuginfo';
+    my $debuginfo = determine_kernel_debuginfo_package;
+    my $cmd = "transactional-update --continue --non-interactive pkg install ${debuginfo}";
     assert_script_run($cmd, timeout => $install_debug_info_timeout);
 }
 
@@ -437,7 +438,8 @@ sub check_function {
         elsif (!get_var('SKIP_KERNEL_DEBUGINFO')) {
             my $vmcore = script_output("ls -1t $vmcore_glob");
             my $vmlinux = script_output("ls -1t $vmlinux_glob");
-            my $vmlinuxd = script_output('rpm -ql kernel-default-debuginfo | grep vmlinux');
+            my $debuginfo = determine_kernel_debuginfo_package;
+            my $vmlinuxd = script_output("rpm -ql ${debuginfo} | grep vmlinux");
             my $zypper_call = 'zypper -n in crash';
             my $crash_call = "echo exit | crash /host/$vmcore /host/$vmlinux /host/$vmlinuxd";
             my $bash_cmd = "$zypper_call && $crash_call";


### PR DESCRIPTION
Fix poo#165273: There was hard coded package name for kernel debuginfo on transactional systems. We should determine correct debuginfo from active kernel as we do on non-transactional systems.

- Related ticket: https://progress.opensuse.org/issues/165273
- Needles: none
- Verification run: 
SL Micro: https://openqa.suse.de/tests/15177234
SL Micro RT: https://openqa.suse.de/tests/15177233 <-- Fix for this scenario

