### PR TITLE
Create non-root user in jeos-firstboot wizard

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -224,6 +224,7 @@ VIDEOMODE | string | | Indicates/defines video mode used for the installation. E
 VIRSH_OPENQA_BASEDIR | string | /var/lib | The OPENQA_BASEDIR configured on the svirt host (only relevant for the svirt backend).
 UNENCRYPTED_BOOT | boolean | false | Indicates/defines existence of unencrypted boot partition in the SUT.
 WAYLAND | boolean | false | Enables wayland tests in the system.
+WIZARD_SKIP_USER | boolean | false | Skip non-root user creation in jeos-firstboot. This feature was added from sle-micro 6.1
 XDMUSED | boolean | false | Indicates availability of xdm.
 XFS_MKFS_OPTIONS | string | | Define additional mkfs parameters. Used only in publiccloud test runs.
 XFS_TEST_DEVICE | string | | Define the device used for xfs tests. Used only in publiccloud test runs.


### PR DESCRIPTION
A new feature has been implemented and jeos-firstboot wizard can create a non root user directly in the UI. As of now the feature has landed in sle-micro 6.1 only.

- ticket: [test fails in firstrun - handle non-root user creation screen](https://progress.opensuse.org/issues/165180)

- Verification run: 
  * [base](http://kepler.suse.cz/tests/23949#step/firstrun/31)
  * [encrypted](http://kepler.suse.cz/tests/23950#step/firstrun/15)
  * [encrypted & skip user](http://kepler.suse.cz/tests/23951#step/firstrun/35)
  * [skip user](http://kepler.suse.cz/tests/23948#step/firstrun/13)
