### PR TITLE
containers: Re-enable podman upstream tests on aarch64

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -303,7 +303,7 @@ sub load_container_tests {
             loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle || is_leap || is_sle_micro('>=5.5'));
         }
         if (!check_var('PODMAN_BATS_SKIP', 'all')) {
-            loadtest 'containers/podman_integration' if (is_x86_64);
+            loadtest 'containers/podman_integration';
         }
         if (!check_var('RUNC_BATS_SKIP', 'all')) {
             loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle || is_leap);

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -13,7 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use containers::bats qw(install_bats install_ncat patch_logfile enable_modules);
-use version_utils qw(is_sle is_tumbleweed);
+use version_utils qw(is_sle is_tumbleweed is_microos);
 
 my $test_dir = "/var/tmp";
 my $netavark = "";
@@ -39,7 +39,7 @@ sub run {
 
     # Install tests dependencies
     my @pkgs = qw(aardvark-dns firewalld iproute2 iptables jq netavark);
-    if (is_tumbleweed) {
+    if (is_tumbleweed || is_microos) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {
         push @pkgs, qw(dbus-1);

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -64,7 +64,7 @@ sub run {
     assert_script_run "cd $test_dir/runc-$runc_version/";
 
     # Compile helpers used by the tests
-    assert_script_run "make \$(ls contrib/cmd/)";
+    script_run "make \$(ls contrib/cmd/)";
 
     run_tests(rootless => 1, skip_tests => get_var('RUNC_BATS_SKIP_USER', ''));
 


### PR DESCRIPTION
Re-enable podman upstream tests on aarch64 by using the packaged nmap in https://download.opensuse.org/repositories/network:/utilities/

Verification runs:
  - SLE 15-SP3: https://openqa.suse.de/tests/15178335
  - SLE 15-SP4: https://openqa.suse.de/tests/15178336
  - SLE 15-SP5: https://openqa.suse.de/tests/15180020
  - SLE 15-SP6: https://openqa.suse.de/tests/15178534
  - SLEM 5.5: https://openqa.suse.de/tests/15179668
  - Tumbleweed: https://openqa.opensuse.org/tests/4403565