### PR TITLE
Add back test module access_beta_distribution in YaST for 15SP7

### DIFF
--- a/schedule/yast/sle/flows/default_aarch64.yaml
+++ b/schedule/yast/sle/flows/default_aarch64.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 product_selection: []
 license_agreement:
   - installation/licensing/accept_license

--- a/schedule/yast/sle/flows/default_ipmi.yaml
+++ b/schedule/yast/sle/flows/default_ipmi.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:

--- a/schedule/yast/sle/flows/default_ppc64le.yaml
+++ b/schedule/yast/sle/flows/default_ppc64le.yaml
@@ -5,7 +5,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:

--- a/schedule/yast/sle/flows/default_s390x_kvm.yaml
+++ b/schedule/yast/sle/flows/default_s390x_kvm.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 license_agreement:
   - installation/licensing/accept_license
 registration:

--- a/schedule/yast/sle/flows/default_s390x_kvm_textmode.yaml
+++ b/schedule/yast/sle/flows/default_s390x_kvm_textmode.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 license_agreement:
   - installation/licensing/accept_license
 registration:

--- a/schedule/yast/sle/flows/default_s390x_svirt.yaml
+++ b/schedule/yast/sle/flows/default_s390x_svirt.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 license_agreement:
   - installation/licensing/accept_license
 registration:

--- a/schedule/yast/sle/flows/default_s390x_zvm.yaml
+++ b/schedule/yast/sle/flows/default_s390x_zvm.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 license_agreement:
   - installation/licensing/accept_license
 configure_dasd_disks:

--- a/schedule/yast/sle/flows/default_svirt-hyperv.yaml
+++ b/schedule/yast/sle/flows/default_svirt-hyperv.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:

--- a/schedule/yast/sle/flows/default_svirt-xen-hvm.yaml
+++ b/schedule/yast/sle/flows/default_svirt-xen-hvm.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:

--- a/schedule/yast/sle/flows/default_svirt-xen-pv.yaml
+++ b/schedule/yast/sle/flows/default_svirt-xen-pv.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:

--- a/schedule/yast/sle/flows/default_x86_64.yaml
+++ b/schedule/yast/sle/flows/default_x86_64.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:


### PR DESCRIPTION
##
### Add back test module access_beta_distribution in YaST group for 15SP7 

- Related ticket: https://progress.opensuse.org/issues/164871
- Needles: N/A
- Verification run: 
   - https://openqa.suse.de/tests/15188872
   - https://openqa.suse.de/tests/15188873
   - https://openqa.suse.de/tests/15188874

##