### PR TITLE
Expect a failure with DSA and OpenSSL 3 in FIPS

### DIFF
--- a/tests/fips/openssl/openssl_pubkey_dsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_dsa.pm
@@ -26,7 +26,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use strict;
 use warnings;
-use version_utils qw(is_transactional);
+use version_utils qw(is_transactional is_sle is_sle_micro);
 
 sub run {
     select_serial_terminal;
@@ -71,8 +71,14 @@ sub run {
 }
 
 sub test_flags {
-    #poo160197 workaround since rollback seems not working with swTPM
-    return {no_rollback => is_transactional() ? 1 : 0};
+    return {
+        #poo160197 workaround since rollback seems not working with swTPM
+        no_rollback => is_transactional() ? 1 : 0,
+
+        # The test is expect to fail on 15-SP6+ and SLE Micro 6.0+ in FIPS mode with OpenSSL 3
+        # poo#161891
+        ignore_failure => (is_sle('>=15-SP6') or is_sle_micro('>=6.0')) ? 1 : 0
+    };
 }
 
 1;


### PR DESCRIPTION
DSA in FIPS mode with OpenSSL 3 is expected to fail. This will ignore all failures on 15-SP6+ and SL Micro 6.0+, which use OpenSSL 3. This will help us with review, since we won't have to manually soft-fail every new test run.

Related ticket: https://progress.opensuse.org/issues/161891

## Verification runs

- 15-SP6:
    - x86_64: https://openqa.suse.de/tests/15190739
    - s390x: https://openqa.suse.de/tests/15199374
    - aarch64: https://openqa.suse.de/tests/15191003
- 15-SP5:
    - x86_64: https://openqa.suse.de/tests/15191028
    - s390x: https://openqa.suse.de/tests/15199376
    - aarch64: https://openqa.suse.de/tests/15191023