### PR TITLE
Add access_beta_distribution for SLE 15 SP7

### DIFF
--- a/schedule/yast/sle/flows/default_x86_64_flavor_full.yaml
+++ b/schedule/yast/sle/flows/default_x86_64_flavor_full.yaml
@@ -4,7 +4,8 @@ bootloader:
   - installation/bootloader_start
 setup_libyui:
   - installation/setup_libyui
-access_beta: []
+access_beta:
+  - installation/access_beta_distribution
 product_selection:
   - installation/product_selection/install_SLES
 license_agreement:


### PR DESCRIPTION
##
### Add back test module access_beta_distribution in YaST group for 15SP7 

- Related ticket: https://progress.opensuse.org/issues/164871
- Needles: N/A
- Verification run: 
   -  https://openqa.suse.de/t15199034
   -  https://openqa.suse.de/t15199062


##