### PR TITLE
Fix the regression introduced by PR#19968

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1020,7 +1020,7 @@ kernel.
 sub is_not_maintenance_update {
     my $package = shift;
     # Allow to skip an openQA module if package is not targeted by maintenance update
-    if (get_var('MAINTENANCE')) {
+    if (get_var('MAINTENANCE') && get_var('INCIDENT_ID')) {
         # If package is listed in BUILD, no need to check for more
         return 0 if (get_var('BUILD') =~ /$package|kernel/);
         # Package name is not in BUILD setting, but it can still be targeted by the


### PR DESCRIPTION
Fix the regression introduced by PR#19968

https://openqa.suse.de/tests/15197050#step/drbd_passive/2 for example.
```
# Test died: Could not retrieve required variable INCIDENT_ID at /usr/lib/os-autoinst/testapi.pm line 707.
	testapi::get_required_var("INCIDENT_ID") called at sle/lib/hacluster.pm line 1028
```
- Related ticket: No
- Needles: NO
- Verification run: NO
