### PR TITLE
Remove ha/ctbd test module from Rolling Upgrade schedule

### DIFF
--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01.yaml
@@ -27,7 +27,6 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
   - ha/haproxy
   - ha/await_upgrade_or_update
   - migration/version_switch_upgrade_target

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
@@ -27,7 +27,6 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
   - ha/haproxy
   - ha/await_upgrade_or_update
   - migration/version_switch_upgrade_target

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02.yaml
@@ -27,7 +27,6 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
   - ha/haproxy
   - ha/await_upgrade_or_update
   - migration/version_switch_upgrade_target

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
@@ -27,7 +27,6 @@ schedule:
   - ha/filesystem
   - ha/drbd_passive
   - ha/filesystem
-  - ha/ctdb
   - ha/haproxy
   - ha/await_upgrade_or_update
   - migration/version_switch_upgrade_target


### PR DESCRIPTION
`ha/ctdb` test module needs to run with a client node, and the rolling upgrade scenarios run without a client node. Test has been working so far as it was being skipped by the test code, but after commit de24f376a37ffe10d2d4d424c8ac1dbfa7c7d8a1 test is not skipped anymore leading to failures in Aggregates tests. This commit removes the test module from the schedules.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
