### PR TITLE
Fix HanaSR sporadically fails on ssh cmd 124 error

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -1286,7 +1286,7 @@ sub wait_for_idle {
 
     my $rc = $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5', timeout => $timeout, rc_only => 1, proceed_on_failure => 1);
     if ($rc == 124) {
-        record_info("cs_wait_for_idle", "cs_wait_for_idle timed out after $timeout. Gathering info and retrying");
+        record_info("WARN cs_wait_for_idle", "cs_wait_for_idle timed out after $timeout. Gathering info and retrying");
         $self->run_cmd(cmd => 'cs_clusterstate', proceed_on_failure => 1);
         $self->run_cmd(cmd => 'crm_mon -r -R -n -N -1', proceed_on_failure => 1);
         $self->run_cmd(cmd => 'SAPHanaSR-showAttr', proceed_on_failure => 1);

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -31,7 +31,7 @@ sub run {
     my $target_site = $run_args->{$site_name};
     die("Target site '$site_name' data is missing. This might indicate deployment issue.")
       unless $target_site;
-    my $sbd_delay;
+    my $sbd_delay = 0;
 
     # Switch to control to target site (currently PROMOTED)
     $self->{my_instance} = $target_site;
@@ -63,9 +63,9 @@ sub run {
     $self->{my_instance}->wait_for_ssh(username => 'cloudadmin');
 
     # SBD delay is active only after reboot
-    if (($takeover_action eq 'crash' and $sbd_delay != 0) ||
-        # Add SBD delay for 'stop' to fix sporadic 'takeover failed to complete' issue on EC2
-        ($takeover_action eq 'stop' and check_var('PUBLIC_CLOUD_PROVIDER', 'EC2'))) {
+    if ($takeover_action eq 'crash' || $takeover_action eq 'stop') {
+        # Add SBD delay for to fix sporadic 'takeover failed to complete' issue on EC2
+        # Also fix sporadic issues (ssh timed out) mentioned in TEAM-9601
         record_info('SBD SLEEP', "Waiting $sbd_delay sec for SBD delay timeout.");
         # test needs to wait a little more than sbd delay
         sleep($sbd_delay + 30);

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -33,7 +33,7 @@ sub run {
     my $hana_start_timeout = bmwqemu::scale_timeout(600);
     # $site_b = $instance of secondary instance located in $run_args->{$instances}
     my $site_b = $run_args->{$hana_sites[1]};
-    my $sbd_delay;
+    my $sbd_delay = 0;
     select_serial_terminal;
 
     # Switch to control Site B (currently replica mode)
@@ -67,7 +67,7 @@ sub run {
     $self->{my_instance}->wait_for_ssh(username => 'cloudadmin');
 
     # SBD delay is active only after reboot
-    if ($db_action eq 'crash' and $sbd_delay != 0) {
+    if ($db_action eq 'crash' || $db_action eq 'stop') {
         record_info('SBD SLEEP', "Waiting $sbd_delay sec for SBD delay timeout.");
         # sleep needs to be a little longer than sbd start delay
         sleep($sbd_delay + 30);


### PR DESCRIPTION
Fix Public Cloud HanaSR sporadically failed on "Stop_site_b-primary/Crash_replica": ssh timed out, returned 124
TEAM-9601 - [PC] HanaSR sporadically failed on "Stop_site_b-primary/Crash_replica": ssh timed out, returned 124

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket:https://jira.suse.com/browse/TEAM-9601
- Needles: no
- Verification run:

I can not reproduce the "ssh cmd 124 error" with the PR. Here are the VRs I did:

- 15-SP4 Azure-SAP-BYOS SAPHanaSR-ScaleUp-PerfOpt-msi
https://openqa.suse.de/tests/15211524 (pass)
https://openqa.suse.de/tests/15211526 (pass)
https://openqa.suse.de/tests/15211527 (pass)
https://openqa.suse.de/tests/15211528 (pass)
https://openqa.suse.de/tests/15211529 (pass)
https://openqa.suse.de/tests/15211886 (pass)
https://openqa.suse.de/tests/15211887 (pass)
https://openqa.suse.de/tests/15211888 (pass)
https://openqa.suse.de/tests/15211531 (pass)
https://openqa.suse.de/tests/15211530#step/Stop_replica/217 (failed on "FAIL: NIECONN_REFUSED (Connection refused), NiRawConnect failed in plugin_fopen().")  (This is the first time I hit this issue but I think it might be not introduced by this PR. And here is a doc: https://www.suse.com/support/kb/doc/?id=000020548)

- 15-SP6 Azure-SAP-BYOS SAPHanaSR-ScaleUp-PerfOpt-msi
http://openqa.suse.de/tests/15212524 (pass)
http://openqa.suse.de/tests/15212525#step/Crash_site_a-primary/454 (failed on wait_for_ssh returns "Timeout 600 sec", it is known/old issue for example: http://openqa.suse.de/tests/15125998#step/Crash_site_b-primary/454)
http://openqa.suse.de/tests/15212527 (pass)
http://openqa.suse.de/tests/15212528 (pass)
http://openqa.suse.de/tests/15212529 (pass)

- 15-SP6 Azure-SAP-PAYG SAPHanaSR-ScaleUp-PerfOpt-spn
http://openqa.suse.de/tests/15212781 (pass)
http://openqa.suse.de/tests/15212782 (pass)
http://openqa.suse.de/tests/15212783 (pass)
http://openqa.suse.de/tests/15212784 (pass)
http://openqa.suse.de/tests/15212785 (pass)

- 12-SP5 Azure-SAP-BYOS SAPHanaSR-ScaleUp-PerfOpt-msi
http://openqa.suse.de/tests/15223822 (pass)
http://openqa.suse.de/tests/15223823 (pass)
http://openqa.suse.de/tests/15223824 (pass)
http://openqa.suse.de/tests/15223825 (pass)
http://openqa.suse.de/tests/15223826#step/Crash_site_b-primary/452 (failed on ssh_script_output timed out, it is known/old issue for example: http://openqa.suse.de/tests/14952911#step/Crash_site_b-primary/454)

- 15-SP5 HanaSr-Aws-Byos hanasr_aws_test_fencing_sbd
http://openqaworker15.qa.suse.cz/tests/294939#step/Crash_site_a-primary/686 (still failed but made testing proceeded)
http://openqaworker15.qa.suse.cz/tests/294940#step/Crash_site_a-primary/686 (still failed but made testing proceeded)
http://openqaworker15.qa.suse.cz/tests/294941#step/Crash_site_a-primary/686 (still failed but made testing proceeded)
http://openqaworker15.qa.suse.cz/tests/294942#step/Crash_site_a-primary/686 (still failed but made testing proceeded)
http://openqaworker15.qa.suse.cz/tests/294943#step/Crash_site_a-primary/686 (still failed but made testing proceeded)
(the original failure FYI: http://openqaworker15.qa.suse.cz/tests/294935#step/Crash_site_a-primary/565)
