### PR TITLE
Install p7zip if missing

### DIFF
--- a/lib/oscap_tests.pm
+++ b/lib/oscap_tests.pm
@@ -920,7 +920,7 @@ sub oscap_security_guide_setup {
     }
 
     zypper_call('ref -s', timeout => 180);
-    zypper_call('in openscap-utils scap-security-guide', timeout => 180);
+    zypper_call('in openscap-utils scap-security-guide p7zip', timeout => 180);
     set_ds_file();
 
     $f_ssg_ds = is_sle ? $f_ssg_sle_ds : $f_ssg_tw_ds;


### PR DESCRIPTION
Small fix for case if p7zip not installed

- Related ticket: https://progress.opensuse.org/issues/165042
- Verification run: https://openqa.suse.de/tests/15201502
