### PR TITLE
Add back test module access_beta_distribution in YaST group

### DIFF
--- a/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing.yaml
@@ -11,6 +11,7 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
+  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc

--- a/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
+++ b/schedule/yast/encryption/cryptlvm+cancel_existing_pvm.yaml
@@ -11,6 +11,7 @@ vars:
 schedule:
   - installation/bootloader_start
   - installation/setup_libyui
+  - installation/access_beta_distribution
   - installation/product_selection/install_SLES
   - installation/licensing/accept_license
   - installation/registration/register_via_scc


### PR DESCRIPTION
##

### **Add back test module access_beta_distribution in YaST group**

- Related ticket: https://progress.opensuse.org/issues/164871
- Needles: N/A
- Verification run: 
   - https://openqa.suse.de/tests/15210658
   - https://openqa.suse.de/tests/15210659

##
