### PR TITLE
Switch guests to br0

### DIFF
--- a/data/virtualization/autoyast/guest_12.xml.ep
+++ b/data/virtualization/autoyast/guest_12.xml.ep
@@ -106,31 +106,17 @@
       <hostname><%= $vm_name %></hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">true</write_hostname>
-      <nameservers config:type="list">
-      <nameserver>192.168.122.1</nameserver>
-      </nameservers>
     </dns>
     <interfaces config:type="list">
       <interface>
-        <bootproto>static</bootproto>
+        <bootproto>dhcp</bootproto>
         <device>eth0</device>
-        <ipaddr>{{IP}}</ipaddr>
-        <netmask>255.255.255.0</netmask>
-        <network>192.168.122.0</network>
-        <prefixlen>24</prefixlen>
         <startmode>auto</startmode>
       </interface>
     </interfaces>
     <ipv6 config:type="boolean">true</ipv6>
     <keep_install_network config:type="boolean">true</keep_install_network>
     <managed config:type="boolean">false</managed>
-    <net-udev config:type="list">
-      <rule>
-        <name>eth0</name>
-        <rule>ATTR{address}</rule>
-        <value>{{MAC}}</value>
-      </rule>
-    </net-udev>
     <routing>
       <ipv4_forward config:type="boolean">false</ipv4_forward>
       <ipv6_forward config:type="boolean">false</ipv6_forward>
@@ -138,7 +124,6 @@
         <route>
           <destination>default</destination>
           <device>-</device>
-          <gateway>192.168.122.1</gateway>
           <netmask>-</netmask>
         </route>
       </routes>

--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -160,32 +160,17 @@
       <hostname><%= $vm_name %></hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">true</write_hostname>
-      <nameservers config:type="list">
-      <nameserver>192.168.122.1</nameserver>
-      </nameservers>
     </dns>
     <interfaces config:type="list">
       <interface>
-      <bootproto>static</bootproto>
+      <bootproto>dhcp</bootproto>
       <device>eth0</device>
-      <ipaddr>{{IP}}</ipaddr>
-      <netmask>255.255.255.0</netmask>
-      <network>192.168.122.0</network>
-      <!-- gateway>192.168.122.1</gateway -->
-      <prefixlen>24</prefixlen>
       <startmode>auto</startmode>
       </interface>
     </interfaces>
     <ipv6 config:type="boolean">true</ipv6>
     <keep_install_network config:type="boolean">true</keep_install_network>
     <managed config:type="boolean">false</managed>
-    <net-udev config:type="list">
-      <rule>
-       <name>eth0</name>
-       <rule>ATTR{address}</rule>
-       <value>{{MAC}}</value>
-      </rule>
-    </net-udev>
     <routing>
       <ipv4_forward config:type="boolean">false</ipv4_forward>
       <ipv6_forward config:type="boolean">false</ipv6_forward>
@@ -193,7 +178,6 @@
         <route>
           <destination>default</destination>
           <device>-</device>
-          <gateway>192.168.122.1</gateway>
           <netmask>-</netmask>
         </route>
       </routes>

--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -34,115 +34,79 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             name => 'sles15sp2HVM',
             autoyast => 'autoyast_xen/sles15sp2HVM_PRG.xml',
             extra_params => '--connect xen:/// --virt-type xen --hvm --os-variant sle15sp1',    # sle15sp2 is unknown on 12.3
-            macaddress => '52:54:00:78:73:b0',
-            ip => '192.168.122.116',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP2-Full-GM/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.116/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp2PV => {
             name => 'sles15sp2PV',
             autoyast => 'autoyast_xen/sles15sp2PV_PRG.xml',
             extra_params => '--connect xen:/// --virt-type xen --paravirt --os-variant sle15sp1',    # sle15sp2 is unknown on 12.3
-            macaddress => '52:54:00:78:73:af',
-            ip => '192.168.122.115',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP2-Full-GM/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.115/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp3PV => {
             name => 'sles15sp3PV',
             autoyast => 'autoyast_xen/sles15sp3PV_PRG.xml',
             extra_params => '--os-variant sle15-unknown',
-            macaddress => '52:54:00:78:73:b1',
-            ip => '192.168.122.117',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP3-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.117/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp3HVM => {
             name => 'sles15sp3HVM',
             autoyast => 'autoyast_xen/sles15sp3HVM_PRG.xml',
             extra_params => '--os-variant sle15-unknown',
-            macaddress => '52:54:00:78:73:b2',
-            ip => '192.168.122.118',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP3-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.118/24,192.168.122.1,192.168.122.1"',
         },
         sles12sp5HVM => {
             name => 'sles12sp5HVM',
             autoyast => 'autoyast_xen/sles12sp5HVM_PRG.xml',
             extra_params => '--connect xen:/// --virt-type xen --hvm --os-variant sles12sp4',    # old system compatibility
-            macaddress => '52:54:00:78:73:ad',
-            ip => '192.168.122.113',
             distro => 'SLE_12_SP5',
             location => 'http://mirror.suse.cz/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.113/24,192.168.122.1,192.168.122.1"',
         },
         sles12sp5PV => {
             name => 'sles12sp5PV',
             autoyast => 'autoyast_xen/sles12sp5PV_PRG.xml',
             extra_params => '--connect xen:/// --virt-type xen --paravirt --os-variant sles12sp4',    # old system compatibility
-            macaddress => '52:54:00:78:73:ae',
-            ip => '192.168.122.114',
             distro => 'SLE_12_SP5',
             location => 'http://mirror.suse.cz/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.114/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp4PV => {
             name => 'sles15sp4PV',
             extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
-            macaddress => '52:54:00:78:73:a5',
-            ip => '192.168.122.110',
             distro => 'SLE_15_SP4',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP4-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.110/24,192.168.122.1,192.168.122.1"'
         },
         sles15sp4HVM => {
             name => 'sles15sp4HVM',
             extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
-            macaddress => '52:54:00:78:73:a6',
-            ip => '192.168.122.108',
             distro => 'SLE_15_SP4',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP4-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.108/24,192.168.122.1,192.168.122.1"'
         },
         sles15sp5PV => {
             name => 'sles15sp5PV',
             extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
-            macaddress => '52:54:00:78:73:a7',
-            ip => '192.168.122.119',
             distro => 'SLE_15_SP5',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP5-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.119/24,192.168.122.1,192.168.122.1"'
         },
         sles15sp5HVM => {
             name => 'sles15sp5HVM',
             extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
-            macaddress => '52:54:00:78:73:a8',
-            ip => '192.168.122.120',
             distro => 'SLE_15_SP5',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP5-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.120/24,192.168.122.1,192.168.122.1"'
         },
         sles15sp6PV => {
             name => 'sles15sp6PV',
             extra_params => '--os-variant sle15-unknown',
-            macaddress => '52:54:00:78:73:a9',
-            ip => '192.168.122.121',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.121/24,192.168.122.1,192.168.122.1"'
         },
         sles15sp6HVM => {
             name => 'sles15sp6HVM',
             extra_params => '--os-variant sle15-unknown',
-            macaddress => '52:54:00:78:73:a0',
-            ip => '192.168.122.122',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.122/24,192.168.122.1,192.168.122.1"'
         }
     );
     # Filter out guests not allowed for the detected SLE version
@@ -187,68 +151,47 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             name => 'sles12sp3',
             autoyast => 'autoyast_kvm/sles12sp3_PRG.xml',
             extra_params => '--os-variant sles12sp3',
-            macaddress => '52:54:00:78:73:a2',
-            ip => '192.168.122.102',
             distro => 'SLE_12_SP3',
             location => 'http://mirror.suse.cz/install/SLP/SLE-12-SP3-Server-GM/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.102/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp2 => {
             name => 'sles15sp2',
             autoyast => 'autoyast_kvm/sles15sp2_PRG.xml',
             extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade (originally sle15sp2)
-            macaddress => '52:54:00:78:73:af',
-            ip => '192.168.122.115',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP2-Full-GM/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.115/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp3 => {
             name => 'sles15sp3',
             autoyast => 'autoyast_kvm/sles15sp3_PRG.xml',
             extra_params => '--os-variant sle15-unknown',
-            macaddress => '52:54:00:78:73:b1',
-            ip => '192.168.122.117',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP3-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.117/24,192.168.122.1,192.168.122.1"',
         },
         sles12sp5 => {
             name => 'sles12sp5',
             autoyast => 'autoyast_kvm/sles12sp5_PRG.xml',
             extra_params => '--os-variant sles12sp4',    # old system compatibility
-            macaddress => '52:54:00:78:73:ad',
-            ip => '192.168.122.113',
             distro => 'SLE_12_SP5',
             location => 'http://mirror.suse.cz/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.113/24,192.168.122.1,192.168.122.1"',
         },
         sles15sp4 => {
             name => 'sles15sp4',
             extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
-            macaddress => '52:54:00:78:73:a6',
-            ip => '192.168.122.108',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP4-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.108/24,192.168.122.1,192.168.122.1"'
         },
         sles15sp5 => {
             name => 'sles15sp5',
             extra_params => '--os-variant sle15-unknown',    # problems after kernel upgrade
-            macaddress => '52:54:00:78:73:a7',
-            ip => '192.168.122.109',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP5-Full-LATEST/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.109/24,192.168.122.1,192.168.122.1"'
         },
         sles15sp6 => {
             name => 'sles15sp6',
             extra_params => '--os-variant sle15-unknown',
-            macaddress => '52:54:00:78:73:b8',
-            ip => '192.168.122.111',
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/',
-            linuxrc => 'ifcfg="eth0=192.168.122.111/24,192.168.122.1,192.168.122.1"'
         }
     );
     # Filter out guests not allowed for the detected SLE version

--- a/tests/virtualization/universal/dom_install.pm
+++ b/tests/virtualization/universal/dom_install.pm
@@ -21,7 +21,7 @@ sub run {
     zypper_call '-t in vhostmd', exitcode => [0, 4, 102, 103, 106];
 
     foreach my $guest (keys %virt_autotest::common::guests) {
-        ensure_online($guest, use_virsh => 0);
+        ensure_online($guest, use_virsh => 0, HYPERVISOR => get_var('SUT_IP'));
         record_info "$guest", "Install vm-dump-metrics on xl-$guest";
         script_retry("ssh root\@$guest 'zypper -n in vm-dump-metrics'", delay => 120, retry => 3);
     }

--- a/tests/virtualization/universal/hotplugging_network_interfaces.pm
+++ b/tests/virtualization/universal/hotplugging_network_interfaces.pm
@@ -34,7 +34,7 @@ sub add_virtual_network_interface {
         if (get_var('VIRT_AUTOTEST') && is_kvm_host) {
             $interface_model_option = '--model virtio';
         }
-        script_retry("ssh root\@$guest ip l | grep " . $virt_autotest::common::guests{$guest}->{macaddress}, delay => 60, retry => 10, timeout => 60);
+        script_retry("ssh root\@$guest ip l", delay => 60, retry => 10, timeout => 60);
         assert_script_run("virsh domiflist $guest", 90);
         if (try_attach("virsh attach-interface --domain $guest --type bridge ${interface_model_option} --source br0 --mac " . $mac . " --live " . ${persistent_config_option})) {
             assert_script_run("virsh domiflist $guest | grep br0");

--- a/tests/virtualization/universal/hotplugging_network_interfaces.pm
+++ b/tests/virtualization/universal/hotplugging_network_interfaces.pm
@@ -34,7 +34,7 @@ sub add_virtual_network_interface {
         if (get_var('VIRT_AUTOTEST') && is_kvm_host) {
             $interface_model_option = '--model virtio';
         }
-        script_retry("ssh root\@$guest ip l", delay => 60, retry => 10, timeout => 60);
+        script_retry("ssh root\@$guest ip l | grep " . $virt_autotest::common::guests{$guest}->{macaddress}, delay => 60, retry => 10, timeout => 60);
         assert_script_run("virsh domiflist $guest", 90);
         if (try_attach("virsh attach-interface --domain $guest --type bridge ${interface_model_option} --source br0 --mac " . $mac . " --live " . ${persistent_config_option})) {
             assert_script_run("virsh domiflist $guest | grep br0");

--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -53,12 +53,15 @@ sub run {
         }
     }
 
-    # Update guests hash with IPs and /etc/hosts
+    # Update guests hash with IP/macaddress and add guests to /etc/hosts
     foreach my $guest (@guests) {
         my $guest_ip = script_output("cat /tmp/guests_ip/$guest");
-        record_info("IP: $guest_ip", "$guest IP: $guest_ip");
         # Update the guests hash with the current IP address for migration testing
         $virt_autotest::common::guests{$guest}{ip} = "$guest_ip";
+        # Update the guests hash with the guest macaddress
+        my $guest_mac = script_output("virsh domiflist $guest | awk 'NR>2 {print \$5}'");
+        $virt_autotest::common::guests{$guest}{macaddress} = "$guest_mac";
+        record_info("$guest networking", "$guest IP: $guest_ip MAC: $guest_mac");
         # Fill the current pairs of hostname & address to the /etc/hosts file
         add_guest_to_hosts($guest, $guest_ip);
     }

--- a/tests/virtualization/universal/xl_create.pm
+++ b/tests/virtualization/universal/xl_create.pm
@@ -16,16 +16,8 @@ use version_utils;
 sub run {
     record_info "XML", "Export the XML from virsh and convert it into Xen config file";
     assert_script_run "virsh dumpxml $_ > $_.xml" foreach (keys %virt_autotest::common::guests);
-    # SLES version is greater than 15-SP5, remove network from dumpxml file more information bsc#1222584
-    if (is_sle('>15-SP5')) {
-        assert_script_run "sed -i '/<interface type/,/<\\/interface>/d' $_.xml" foreach (keys %virt_autotest::common::guests);
-    }
     assert_script_run "virsh domxml-to-native xen-xl $_.xml > $_.xml.cfg" foreach (keys %virt_autotest::common::guests);
     # Add network configuration to xen-xl cfg files
-    if (is_sle('>15-SP5')) {
-        record_info "Name", "Add network to xen-xl cfg";
-        assert_script_run "echo 'vif = [ \"mac=$_->{macaddress},bridge=virbr0,script=vif-bridge\" ]' >> $_->{name}.xml.cfg" foreach (values %virt_autotest::common::guests);
-    }
     record_info "Name", "Change the name by adding suffix _xl";
     assert_script_run "sed -rie 's/(name = \\W)/\\1xl-/gi' $_.xml.cfg" foreach (keys %virt_autotest::common::guests);
     assert_script_run "cat $_.xml.cfg | grep name" foreach (keys %virt_autotest::common::guests);


### PR DESCRIPTION
Change to switch to bridge networking for guest is related to recommendation in [bsc#1222584](https://bugzilla.suse.com/show_bug.cgi?id=1222584#c19) 

- Related ticket: https://progress.opensuse.org/issues/160709
- Needles: N/A
- Verification run: 
KVM : [15-6](http://openqa.qam.suse.cz/tests/79038), [15-5](http://openqa.qam.suse.cz/tests/79039), [15-3](http://openqa.qam.suse.cz/tests/79084#), [12-5](http://openqa.qam.suse.cz/tests/79040)
XEN : [15-6](http://openqa.qam.suse.cz/tests/79057), [15-5](http://openqa.qam.suse.cz/tests/79047), [15-3](http://openqa.qam.suse.cz/tests/79086), [12-5](http://openqa.qam.suse.cz/tests/79041)
KVM Migration : [15-6](http://openqa.qam.suse.cz/tests/79059#dependencies), [15-5](http://openqa.qam.suse.cz/tests/79078), [15-4](http://openqa.qam.suse.cz/tests/79062#dependencies), [15-3](http://openqa.qam.suse.cz/tests/79065#dependencies), [15-2](http://openqa.qam.suse.cz/tests/79069#dependencies), [12-5](http://openqa.qam.suse.cz/tests/79066#dependencies)
XEN Migration : [15-6](http://openqa.qam.suse.cz/tests/79027#dependencies), [15-4]( http://openqa.qam.suse.cz/tests/79045#dependencies), [15-3](http://openqa.qam.suse.cz/tests/79034#dependencies), [12-5](http://openqa.qam.suse.cz/tests/79055#dependencies)

