### PR TITLE
Rewrite opensuse_welcome_applicable and return 0 for the TW aarch64 KDE Live

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -210,12 +210,14 @@ sub any_desktop_is_applicable {
 }
 
 sub opensuse_welcome_applicable {
+    # No libqt5-qtwebengine on ppc64/ppc64le and s390.
+    return 0 if get_var('ARCH') =~ /ppc64|s390/;
     # openSUSE-welcome is expected to show up on openSUSE Tumbleweed and Leap 15.2 XFCE only
     # starting with Leap 15.3 opensuse-welcome is enabled on supported DEs not just XFCE
+    return 0 unless is_tumbleweed || is_leap(">=15.3");
     # since not all DEs honor xdg/autostart, we are filtering based on desktop environments
-    # except for ppc64/ppc64le because not built libqt5-qtwebengine sr#323144
-    my $desktop = shift // get_var('DESKTOP', '');
-    return ((($desktop =~ /gnome|kde|lxde|lxqt|mate|xfce/ && is_tumbleweed) || ($desktop =~ /xfce/ && is_leap("=15.2"))) && (get_var('ARCH') !~ /ppc64/)) || (($desktop =~ /gnome|kde|lxde|lxqt|mate|xfce/ && is_leap(">=15.3")) && (get_var('ARCH') !~ /ppc64|s390/));
+    return 0 unless get_var('DESKTOP') =~ /gnome|kde|lxde|lxqt|mate|xfce/;
+    return 1;
 }
 
 sub logcurrentenv {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -209,17 +209,6 @@ sub any_desktop_is_applicable {
     return get_var("DESKTOP") !~ /textmode/;
 }
 
-sub opensuse_welcome_applicable {
-    # No libqt5-qtwebengine on ppc64/ppc64le and s390.
-    return 0 if get_var('ARCH') =~ /ppc64|s390/;
-    # openSUSE-welcome is expected to show up on openSUSE Tumbleweed and Leap 15.2 XFCE only
-    # starting with Leap 15.3 opensuse-welcome is enabled on supported DEs not just XFCE
-    return 0 unless is_tumbleweed || is_leap(">=15.3");
-    # since not all DEs honor xdg/autostart, we are filtering based on desktop environments
-    return 0 unless get_var('DESKTOP') =~ /gnome|kde|lxde|lxqt|mate|xfce/;
-    return 1;
-}
-
 sub logcurrentenv {
     for my $k (@_) {
         my $e = get_var("$k");
@@ -254,6 +243,19 @@ sub gnomestep_is_applicable {
 
 sub kdestep_is_applicable {
     return check_var("DESKTOP", "kde");
+}
+
+sub opensuse_welcome_applicable {
+    # No libqt5-qtwebengine on ppc64/ppc64le and s390.
+    return 0 if get_var('ARCH') =~ /ppc64|s390/;
+    # openSUSE-welcome is expected to show up on openSUSE Tumbleweed and Leap 15.2 XFCE only
+    # starting with Leap 15.3 opensuse-welcome is enabled on supported DEs not just XFCE
+    return 0 unless is_tumbleweed || is_leap(">=15.3");
+    # since not all DEs honor xdg/autostart, we are filtering based on desktop environments
+    return 0 unless get_var('DESKTOP') =~ /gnome|kde|lxde|lxqt|mate|xfce/;
+    # Not available on the TW aarch64 kde live (poo#157174).
+    return 0 if (is_tumbleweed && is_kde_live && is_aarch64);
+    return 1;
 }
 
 sub packagekit_available {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/157174
- Verification run: https://openqa.opensuse.org/tests/4414961#live
