### PR TITLE
x11/libreoffice/libreoffice_recent_documents: Wait a bit before alt-f

### DIFF
--- a/tests/x11/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11/libreoffice/libreoffice_recent_documents.pm
@@ -42,7 +42,8 @@ sub run {
     # Check Recent Documents
     wait_still_screen;
     x11_start_program('oowriter');
-
+    # Make sure it's loaded and accepts input.
+    wait_still_screen(2);
     send_key "alt-f";
     # The menu may disappear due to boo#1156745, so we wait here
     wait_still_screen(2);


### PR DESCRIPTION
On aarch64 this failed reliably because alt-f had no effect.

- Verification run: https://openqa.opensuse.org/tests/4414969
