### PR TITLE
Add timeout for script_run "test -e $inventory"

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1273,7 +1273,11 @@ sub qesap_cluster_log_cmds {
 sub qesap_cluster_logs {
     my $provider = get_required_var('PUBLIC_CLOUD_PROVIDER');
     my $inventory = qesap_get_inventory(provider => $provider);
-    if (script_run("test -e $inventory") == 0)
+
+    # ETX is the same as pressing Ctrl-C on a terminal,
+    # make sure the serial terminal is NOT blocked
+    type_string('', terminate_with => 'ETX');
+    if (script_run("test -e $inventory", 60) == 0)
     {
         foreach my $host ('hana[0]', 'hana[1]') {
             foreach my $cmd (qesap_cluster_log_cmds()) {

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -595,6 +595,7 @@ subtest '[qesap_cluster_logs]' => sub {
             return 'BOUBLE BOUBLE BOUBLE'; });
     $qesap->redefine(qesap_get_inventory => sub { return '/BERMUDAS/TRIANGLE'; });
     $qesap->redefine(script_run => sub { return 0; });
+    $qesap->redefine(type_string => sub { return; });
     $qesap->redefine(upload_logs => sub { push @save_file_calls, $_[0]; return; });
     $qesap->redefine(qesap_cluster_log_cmds => sub { return ({Cmd => 'crm status', Output => 'crm_status.txt'}); });
     $qesap->redefine(qesap_upload_crm_report => sub { my (%args) = @_; push @crm_report_calls, $args{host}; return 0; });
@@ -628,6 +629,7 @@ subtest '[qesap_cluster_logs] multi log command' => sub {
             return 'BOUBLE BOUBLE BOUBLE'; });
     $qesap->redefine(qesap_get_inventory => sub { return '/BERMUDAS/TRIANGLE'; });
     $qesap->redefine(script_run => sub { return 0; });
+    $qesap->redefine(type_string => sub { return; });
     $qesap->redefine(upload_logs => sub { return; });
     $qesap->redefine(qesap_cluster_log_cmds => sub { return ({Cmd => 'crm status', Output => 'crm_status.txt', Logs => ['ignore_me.txt', 'ignore_me_too.txt']}); });
     $qesap->redefine(qesap_upload_crm_report => sub { return 0; });


### PR DESCRIPTION
Avoid sles4sap_publiccloud_basetest post_fail_hook to fail in case of timeout at script_run("test -e $inventory")

- Related ticket: https://jira.suse.com/browse/TEAM-9586
- Needles: N/A
- Verification run: https://openqaworker15.qa.suse.cz/tests/294923#step/Stop_site_a-primary/261
