### PR TITLE
podman_netavark: Use root-console instead of log-console

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -58,7 +58,7 @@ sub is_container_running {
 # clean up routine only for systems that run CNI as default network backend
 sub _cleanup {
     my $podman = shift->containers_factory('podman');
-    select_console 'log-console';
+    select_console 'root-console';
     remove_subtest_setup;
 
     if (is_cni_default) {
@@ -94,6 +94,7 @@ sub run {
         return 1;
     }
 
+    # Note: The TW upgrade scenario still uses CNI!
     if (is_cni_default || is_cni_in_tw) {
         switch_to_netavark;
     } else {


### PR DESCRIPTION
In the cleanup process, use the root-console instead of the log-console to avoid issues on VMware.

- Related ticket: https://progress.opensuse.org/issues/165342
- Verification run: https://openqa.suse.de/tests/15224163#step/podman_netavark/186
