### PR TITLE
Add support for openssh 9.8

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -88,7 +88,7 @@ sub ssh_basic_check {
 
     # Check that we are really in the SSH session
     assert_script_run 'echo $SSH_TTY | grep "\/dev\/pts\/"';
-    assert_script_run 'ps ux | grep -E ".* \? .* sshd\:"';
+    assert_script_run 'ps ux | grep -E ".* \? .* sshd(-session)?\:"';
     assert_script_run "whoami | grep $ssh_testman";
     assert_script_run "mkdir .ssh";
 


### PR DESCRIPTION
openssh 9.8 now creates processes with a `sshd-session:` prefix, not `sshd:` so let's support both.

Issue found in https://openqa.opensuse.org/tests/4416658#step/sshd/64
- Verification run: https://openqa.opensuse.org/tests/4417033#
