### PR TITLE
LTP: Add 'Call Trace:' as failure in dmesg

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -65,6 +65,8 @@ sub create_list_of_serial_failures {
         push @$serial_failures, {type => $type, message => 'Kernel stack is corrupted', pattern => quotemeta 'stack-protector: Kernel stack is corrupted'};
         push @$serial_failures, {type => $type, message => 'Kernel BUG found', pattern => quotemeta 'BUG: failure at'};
         push @$serial_failures, {type => $type, message => 'Kernel Ooops found', pattern => quotemeta '-[ cut here ]-'};
+        # bsc#1229025, but must be soft because any LTP test which intentionally triggers OOM killer will produce this call trace as well
+        push @$serial_failures, {type => 'soft', message => 'Kernel Call Trace found', pattern => quotemeta 'Call Trace:'};
     }
 
     push @$serial_failures, {type => 'soft', message => 'Low memory problem detected bsc#1166955', pattern => quotemeta 'kswapd0 Kdump'};


### PR DESCRIPTION
At least syslog11 on unfixed SLERT-15SP6 produced this output in dmesg.

Verification run: https://openqa.suse.de/tests/15246031#step/boot_ltp/174
(I was not able to find a test which would fail like this any more - although I cloned https://openqa.suse.de/tests/15153541, which has failing 6.4.0-150600.10.3-rt, test run with 6.4.0-150600.10.5-rt, which is already fixed).