### PR TITLE
Include opensuse_welcome after live installation on aarch64 again

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -254,8 +254,6 @@ sub opensuse_welcome_applicable {
     return 0 unless is_tumbleweed || is_leap(">=15.3");
     # since not all DEs honor xdg/autostart, we are filtering based on desktop environments
     return 0 unless $desktop =~ /gnome|kde|lxde|lxqt|mate|xfce/;
-    # Not available on the TW aarch64 kde live (poo#157174).
-    return 0 if (is_tumbleweed && is_kde_live && is_aarch64);
     return 1;
 }
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -24,6 +24,7 @@ use version_utils qw(is_jeos is_gnome_next is_krypton_argon is_leap is_tumblewee
 use main_common;
 use main_ltp_loader 'load_kernel_tests';
 use known_bugs;
+use Utils::Architectures qw(is_aarch64);
 use YuiRestClient;
 
 init_main();
@@ -339,7 +340,12 @@ else {
         }
         load_boot_tests();
         loadtest "installation/finish_desktop";
-        loadtest "installation/opensuse_welcome" if opensuse_welcome_applicable;
+        # Not available on the TW aarch64 kde live (poo#157174).
+        # Can't be part of opensuse_welcome_applicable because it's present after
+        # live installation.
+        unless (check_var('FLAVOR', 'KDE-Live') && is_tumbleweed && is_aarch64) {
+            loadtest "installation/opensuse_welcome" if opensuse_welcome_applicable;
+        }
         if (get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {
             loadtest "installation/live_installation";
             load_inst_tests();


### PR DESCRIPTION
With LIVE_INSTALLATION=1 on the TW aarch64 KDE-Live, opensuse_welcome is not present in the live environment, but later in the installed system.

- Related ticket: https://openqa.opensuse.org/tests/4419472#step/first_boot/1
- Verification run: https://openqa.opensuse.org/tests/4419932#live
