### PR TITLE
Add FULL-QR-Kernel flavors to addon_products_sle module

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -170,7 +170,7 @@ sub run {
             $sr_number++ unless (is_sle('15+') && $sr_number == 1);
             # in full_installer the dialog to choose the installation media
             # does not appear, thus we have to skip it
-            unless ((check_var('FLAVOR', 'Full')) || check_var('FLAVOR', 'Full-QR') || (is_sle('15-SP3+') && (check_var('FLAVOR', 'Server-DVD-Updates'))) || ((is_sle('15-SP2+') && get_var('MEDIA_UPGRADE'))) || (check_var('INSTALL_FOR_MIGRATION', '1'))) {
+            unless ((check_var('FLAVOR', 'Full')) || check_var('FLAVOR', 'Full-QR') || (get_var('FLAVOR') =~ /Full-QR-Kernel/) || (is_sle('15-SP3+') && (check_var('FLAVOR', 'Server-DVD-Updates'))) || ((is_sle('15-SP2+') && get_var('MEDIA_UPGRADE'))) || (check_var('INSTALL_FOR_MIGRATION', '1'))) {
                 assert_screen 'addon-menu-active';
                 wait_screen_change { send_key 'alt-d' };    # DVD
                 send_key $cmd{next};


### PR DESCRIPTION
Enhancement poo#165378: There are new flavors Full-QR-Kernel-Azure, FULL-QR-KERNEL-RT and FULL-QR-KERNEL-BASE. We need to add them to maintenance QR testing.

- Related ticket: https://progress.opensuse.org/issues/165378
- Needles: none
- Verification run: 
Full-QR-Kernel-Base:  https://openqa.suse.de/tests/15233309
Full-QR-Kernel-RT: https://openqa.suse.de/tests/15233307
Full-QR-Kernel-Azure: https://openqa.suse.de/tests/15233291
Full-QR: https://openqa.suse.de/tests/15233309
