### PR TITLE
Generate unique vnet code

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   convert_region_to_long
   convert_region_to_short
   generate_deployer_name
+  get_workload_vnet_code
 );
 
 =head2 %sdaf_region_matrix
@@ -307,7 +308,9 @@ sub generate_resource_group_name {
 
 =head2 generate_deployer_name
 
-    generate_deployer_name();
+    generate_deployer_name([job_id=>$job_id]);
+
+B<$job_id>: Specify job id to be used. Default: current job ID
 
 Generates resource name for deployer VM in format B<test_id-OpenQA_Deployer_VM>.
 
@@ -317,4 +320,22 @@ sub generate_deployer_name {
     my (%args) = @_;
     $args{job_id} //= get_current_job_id();
     return "$args{job_id}-OpenQA_Deployer_VM";
+}
+
+=head2 get_workload_vnet_code
+
+    get_workload_vnet_code([job_id=>$job_id]);
+
+B<$job_id>: Specify job id to be used. Default: current job ID
+
+Returns VNET code used for workload zone and sap systems resources. VNET code must be unique for each landscape,
+therefore it contains test ID as an identifier.
+
+=cut
+
+sub get_workload_vnet_code {
+    my (%args) = @_;
+    $args{job_id} //= find_deployment_id();
+    die('no deployment ID found') unless $args{job_id};
+    return ("SUT$args{job_id}");
 }

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -37,6 +37,7 @@ subtest '[prepare_sdaf_project]' => sub {
     my %vnet_checks;
     $ms_sdaf->redefine(record_info => sub { return; });
     $ms_sdaf->redefine(git_clone => sub { return; });
+    $ms_sdaf->redefine(get_workload_vnet_code => sub { return 'SAP04'; });
     $ms_sdaf->redefine(log_dir => sub { return '/tmp/openqa_logs'; });
     $ms_sdaf->redefine(assert_script_run => sub {
             push(@git_commands, join('', $_[0])) if grep(/git/, $_[0]);
@@ -78,6 +79,7 @@ subtest '[prepare_sdaf_project] Check directory creation' => sub {
     $ms_sdaf->redefine(get_tfvars_path => sub { return $tfvars_file; });
     $ms_sdaf->redefine(log_dir => sub { return '/tmp/openqa_logs'; });
     $ms_sdaf->redefine(git_clone => sub { return; });
+    $ms_sdaf->redefine(get_workload_vnet_code => sub { return 'SAP04'; });
 
     set_var('SDAF_GIT_AUTOMATION_REPO', 'https://github.com/Azure/sap-automation/tree/main');
     set_var('SDAF_GIT_TEMPLATES_REPO', 'https://github.com/Azure/SAP-automation-samples/tree/main');
@@ -216,6 +218,8 @@ subtest '[set_common_sdaf_os_env]' => sub {
     $ms_sdaf->redefine(create_sdaf_os_var_file => sub { @file_content = @{$_[0]}; });
     $ms_sdaf->redefine(get_tfvars_path => sub { return 'RB-79'; });
     $ms_sdaf->redefine(deployment_dir => sub { return 'FF-4'; });
+    $ms_sdaf->redefine(get_workload_vnet_code => sub { return 'RX-77D'; });
+
 
     my @required_variables = (
         'env_code',

--- a/t/24_sdaf_naming_convention.t
+++ b/t/24_sdaf_naming_convention.t
@@ -126,6 +126,13 @@ subtest '[convert_region_to_short] Test invalid input' => sub {
     dies_ok { convert_region_to_short($_) } "Croak with invalid region name: $_" foreach @invalid_region_names;
 };
 
+subtest '[get_workload_vnet_code] ' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::naming_conventions', no_auto => 1);
+    dies_ok { get_workload_vnet_code() } 'Die with with no job id found';
 
+    $mock_lib->redefine(find_deployment_id => sub { return '0079'; });
+    is get_workload_vnet_code(), 'SUT0079', 'Return correct VNET code with default values';
+    is get_workload_vnet_code(job_id => '0087'), 'SUT0087', 'Return correct VNET code defined by named argument';
+};
 
 done_testing;

--- a/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm
@@ -10,7 +10,6 @@
 # Required OpenQA variables:
 #     'SDAF_ENV_CODE'  Code for SDAF deployment env.
 #     'SDAF_DEPLOYER_VNET_CODE' Deployer virtual network code.
-#     'SDAF_WORKLOAD_VNET_CODE' Virtual network code for workload zone.
 #     'PUBLIC_CLOUD_REGION' SDAF internal code for azure region.
 #     'SAP_SID' SAP system ID.
 #     'SDAF_DEPLOYER_RESOURCE_GROUP' Existing deployer resource group - part of the permanent cloud infrastructure.
@@ -34,7 +33,6 @@ sub check_required_vars {
     my @variables = qw(
       SDAF_ENV_CODE
       SDAF_DEPLOYER_VNET_CODE
-      SDAF_WORKLOAD_VNET_CODE
       PUBLIC_CLOUD_REGION
       SAP_SID
       SDAF_DEPLOYER_RESOURCE_GROUP

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_hanasr.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_hanasr.pm
@@ -9,7 +9,6 @@
 
 # Required OpenQA variables:
 #     'SDAF_ENV_CODE'  Code for SDAF deployment env.
-#     'SDAF_WORKLOAD_VNET_CODE' Virtual network code for workload zone.
 #     'PUBLIC_CLOUD_REGION' SDAF internal code for azure region.
 #     'SAP_SID' SAP system ID.
 #     'SDAF_DEPLOYER_RESOURCE_GROUP' Existing deployer resource group - part of the permanent cloud infrastructure.
@@ -28,9 +27,7 @@ use sles4sap::sap_deployment_automation_framework::deployment
   ansible_hanasr_show_status
   );
 use sles4sap::sap_deployment_automation_framework::naming_conventions
-  qw(get_sdaf_config_path
-  convert_region_to_short
-  );
+  qw(get_sdaf_config_path convert_region_to_short get_workload_vnet_code);
 use sles4sap::console_redirection
   qw(connect_target_to_serial
   disconnect_target_from_serial
@@ -46,7 +43,7 @@ sub run {
     serial_console_diag_banner('Module sdaf_deploy_hanasr.pm : start');
     my $sdaf_config_root_dir = get_sdaf_config_path(
         deployment_type => 'sap_system',
-        vnet_code => get_required_var('SDAF_WORKLOAD_VNET_CODE'),
+        vnet_code => get_workload_vnet_code(),
         env_code => get_required_var('SDAF_ENV_CODE'),
         sdaf_region_code => convert_region_to_short(get_required_var('PUBLIC_CLOUD_REGION')),
         sap_sid => get_required_var('SAP_SID')

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
@@ -15,7 +15,7 @@ use warnings;
 use sles4sap::sap_deployment_automation_framework::deployment
   qw(serial_console_diag_banner load_os_env_variables prepare_tfvars_file sdaf_execute_deployment az_login);
 use sles4sap::sap_deployment_automation_framework::naming_conventions
-  qw(generate_resource_group_name get_sdaf_config_path convert_region_to_short);
+  qw(generate_resource_group_name get_sdaf_config_path convert_region_to_short get_workload_vnet_code);
 use sles4sap::console_redirection;
 use serial_terminal qw(select_serial_terminal);
 use testapi;
@@ -29,7 +29,7 @@ sub run {
     select_serial_terminal();
     my $env_code = get_required_var('SDAF_ENV_CODE');
     my $sap_sid = get_required_var('SAP_SID');
-    my $workload_vnet_code = get_required_var('SDAF_WORKLOAD_VNET_CODE');
+    my $workload_vnet_code = get_workload_vnet_code();
     my $sdaf_region_code = convert_region_to_short(get_required_var('PUBLIC_CLOUD_REGION'));
 
     # SAP systems use same VNET as workload zone

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
@@ -5,9 +5,6 @@
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Deployment of the workload zone using SDAF automation
 
-# Required OpenQA variables:
-#     'SDAF_WORKLOAD_VNET_CODE' Virtual network code for workload zone.
-
 use parent 'sles4sap::sap_deployment_automation_framework::basetest';
 
 use strict;
@@ -32,9 +29,11 @@ sub run {
 
     # Setup Workload zone openQA variables - used for tfvars template
     set_var('SDAF_RESOURCE_GROUP', generate_resource_group_name(deployment_type => 'workload_zone'));
-    set_var('SDAF_VNET_CODE', get_required_var('SDAF_WORKLOAD_VNET_CODE'));
+
+    my $workload_vnet_code = get_workload_vnet_code();
+    set_var('SDAF_VNET_CODE', $workload_vnet_code);
     # 'vnet_code' variable changes with deployment type.
-    set_os_variable('vnet_code', get_required_var('SDAF_WORKLOAD_VNET_CODE'));
+    set_os_variable('vnet_code', $workload_vnet_code);
     prepare_tfvars_file(deployment_type => 'workload_zone');
     az_login();
     sdaf_execute_deployment(deployment_type => 'workload_zone');


### PR DESCRIPTION
In current version, SDAF uses same VNET name for all tests controlled by OpenQA 
variable. As all tests use network peering with control plane, each must have an 
unique name. This PR replaces OpenQA variable with unique name generated by a 
function. Name format 'SUT<deployment ID>'.

- Related ticket: https://jira.suse.com/browse/TEAM-9365
- Verification run: https://openqaworker15.qa.suse.cz/tests/295076#step/deploy_workload_zone/56
