### PR TITLE
Add QA:HEAD repo for sshd testing on Micro

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -51,8 +51,12 @@ sub prepare_test_data {
         zypper_call("in psmisc -busybox-psmisc");
     }
 
+    # on Micro, the 'expect' package is in the IBS QA:Head repo
+    zypper_ar(get_required_var('QA_HEAD_REPO'), name => 'qa_head', no_gpg_check => 1) if is_transactional();
+
     # Install software needed for this test module
     install_package("netcat-openbsd expect psmisc");
+
 }
 
 sub configure_service {


### PR DESCRIPTION
Added expect and its dependencies to QA:Head repo, enabled repo on Micro

- Related ticket: https://progress.opensuse.org/issues/164751
- Needles: none
- Verification run: https://progress.opensuse.org/issues/164751

please note that now sshd tests fails due to known bug: https://bugzilla.suse.com/show_bug.cgi?id=1227370