### PR TITLE
Enable kernel error checks on serial console for SLE Micro

### DIFF
--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -11,6 +11,7 @@ use utils;
 use testapi;
 use main_common qw(init_main is_updates_test_repo unregister_needle_tags join_incidents_to_repo);
 use main_micro_alp;
+use known_bugs;
 use DistributionProvider;
 
 init_main();
@@ -59,8 +60,8 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
 testapi::set_distribution(DistributionProvider->provide());
 
 # set failures
-#$testapi::distri->set_expected_serial_failures(create_list_of_serial_failures());
-#$testapi::distri->set_expected_autoinst_failures(create_list_of_autoinst_failures());
+$testapi::distri->set_expected_serial_failures(create_list_of_serial_failures());
+$testapi::distri->set_expected_autoinst_failures(create_list_of_autoinst_failures());
 
 if (load_yaml_schedule) {
     if (YuiRestClient::is_libyui_rest_api) {

--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -15,10 +15,6 @@ use DistributionProvider;
 
 init_main();
 
-my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
-require $distri;
-testapi::set_distribution(susedistribution->new());
-
 $needle::cleanuphandler = sub {
     unregister_needle_tags('ENV-BACKEND-ipmi');
     unregister_needle_tags('ENV-FLAVOR-JeOS-for-kvm');


### PR DESCRIPTION
Enable kernel error message checks on serial console for SLE Micro. There is currently no known kernel warning or error on SLE Micro that could be used to verify successful detection but further verification will be done in #20012.

Also remove a duplicate call to `set_distribution()` which causes multiple warnings about function redefinitions.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/15236883