### PR TITLE
update_install: Add nfsidmap-devel conflict

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -78,6 +78,7 @@ my @conflicting_packages = (
     'rmt-server-pubcloud',
     'systemtap-sdt-devel',
     'xen-tools-domU',
+    'nfsidmap-devel',
     'kernel-firmware-nvidia-gspx-G06-cuda', 'nvidia-open-driver-G06-signed-cuda-kmp-default',
     'nv-prefer-signed-open-driver', 'nvidia-open-driver-G06-signed-cuda-kmp-azure',
     'nvidia-open-driver-G06-signed-cuda-kmp-64kb',


### PR DESCRIPTION
```
%package -n nfsidmap0-devel
Summary:        NFSv4 ID Mapping Library development libraries - legacy
Group:          Development/Libraries/C and C++
Version:        0.26
Release:        0
Requires:       libnfsidmap0 = %{version}
Conflicts:	nfsidmap-devel
```

- Related ticket: https://openqa.suse.de/tests/15238376#step/update_install/187
- Verification run: https://openqa.suse.de/tests/overview?build=%3A35068%3Anfs-utils&groupid=546&flavor=Server-DVD-Incidents-Install
