### PR TITLE
LTP: Set default LTP_TAINT_EXPECTED based on distro

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -209,8 +209,8 @@ sub check_kernel_taint {
     # - Out of tree module was loaded (0x1000)
     # - Kernel was live patched (0x8000)
     # - Externally supported module was loaded or auxiliary taint (0x10000)
-    # - Unsupported module was loaded (0x80000000)
-    my $taint_mask = parse_int(get_var('LTP_TAINT_EXPECTED', 0x80019801));
+    # - Unsupported module was loaded (0x80000000) (SLE & Leap kernel specific, not in Tumbleweed kernel)
+    my $taint_mask = parse_int(get_var('LTP_TAINT_EXPECTED', is_tumbleweed ? 0x8001b801 : 0x80019801));
     my $taint_val = script_output('cat /proc/sys/kernel/tainted');
 
     for my $desc (@flag_desc) {

--- a/variables.md
+++ b/variables.md
@@ -132,7 +132,7 @@ LTP_REPO | string | | The repo which will be added and is used to install LTP pa
 LTP_RUN_NG_BRANCH | string | master | Define the branch of the LTP_RUN_NG_REPO.
 LTP_RUN_NG_REPO | string | https://github.com/metan-ucw/runltp-ng.git | Define the runltp-ng repo to be used. Default in publiccloud/run_ltp.pm is the upstream master branch from https://github.com/metan-ucw/runltp-ng.git.
 LTP_PC_RUNLTP_ENV | string | empty | Contains eventual internal environment new parameters for `runltp-ng`, defined with the `--env` option, initialized in a column-separated string format: "PAR1=xxx:PAR2=yyy:...". By default it is empty, undefined.
-LTP_TAINT_EXPECTED | integer | 0x80019801 | Bitmask of expected kernel taint flags.
+LTP_TAINT_EXPECTED | integer | 0x80019801 (SLE and Leap) 0x8001b801 (Tumbleweed) | Bitmask of expected kernel taint flags.
 LVM | boolean | false | Use lvm for partitioning.
 LVM_THIN_LV | boolean | false | Use thin provisioning logical volumes for partitioning,
 MACHINE | string | | Define machine name which defines worker specific configuration, including WORKER_CLASS.


### PR DESCRIPTION
The default value for LTP_TAINT_EXPECTED was for SLE. Therefore for Tumbleweed it needed to be set in the testsuite setup (https://openqa.opensuse.org/admin/test_suites).

Having a meaningful value is better for documentation purposes and is future prove in case we start testing Leap with LTP (Leap shares SLE kernel, thus variable setup in the testsuite would not work).

See: https://openqa.opensuse.org/tests/4421109#step/shutdown_ltp/12
