### PR TITLE
Enhance hanaSR module "sap_suse_cluster_connector"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2748,11 +2748,11 @@ sub load_ha_cluster_tests {
             loadtest 'sles4sap/netweaver_filesystems';
             loadtest 'sles4sap/netweaver_install';
             loadtest 'sles4sap/netweaver_cluster';
+            loadtest 'sles4sap/sap_suse_cluster_connector' if (check_var('HA_CLUSTER_INIT', 'yes'));
         } elsif (get_var('HANA')) {
             loadtest 'sles4sap/hana_install';
             loadtest 'sles4sap/hana_cluster';
         }
-        loadtest 'sles4sap/sap_suse_cluster_connector' if (check_var('HA_CLUSTER_INIT', 'yes'));
     }
     else {
         # Test Hawk Web interface

--- a/schedule/kernel/sles4sap/hana_cluster_node.yaml
+++ b/schedule/kernel/sles4sap/hana_cluster_node.yaml
@@ -54,7 +54,6 @@ schedule:
   - '{{cluster_setup}}'
   - sles4sap/hana_cluster
   - sles4sap/monitoring_services
-  - '{{sap_suse_cluster_connector}}'
   - '{{wmp_check_process}}'
   - sles4sap/hana_test
   - ha/fencing
@@ -73,10 +72,6 @@ conditional_schedule:
         - ha/ha_cluster_init
       no:
         - ha/ha_cluster_join
-  sap_suse_cluster_connector:
-    HA_CLUSTER_INIT:
-      yes:
-        - sles4sap/sap_suse_cluster_connector
   boot_to_desktop_node01:
     HA_CLUSTER_INIT:
       yes:

--- a/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP2/qam-sles4sap_wmp_hana_node1.yaml
@@ -36,7 +36,6 @@ schedule:
   - sles4sap/wmp_setup
   - ha/ha_cluster_init
   - sles4sap/hana_cluster
-  - sles4sap/sap_suse_cluster_connector
   - sles4sap/wmp_check_process
   - ha/fencing
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP3/qam-sles4sap_wmp_hana_node1.yaml
@@ -36,7 +36,6 @@ schedule:
   - sles4sap/wmp_setup
   - ha/ha_cluster_init
   - sles4sap/hana_cluster
-  - sles4sap/sap_suse_cluster_connector
   - sles4sap/wmp_check_process
   - ha/fencing
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP4/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP4/qam-sles4sap_wmp_hana_node1.yaml
@@ -36,7 +36,6 @@ schedule:
   - sles4sap/wmp_setup
   - ha/ha_cluster_init
   - sles4sap/hana_cluster
-  - sles4sap/sap_suse_cluster_connector
   - sles4sap/wmp_check_process
   - ha/fencing
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP5/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP5/qam-sles4sap_wmp_hana_node1.yaml
@@ -36,7 +36,6 @@ schedule:
   - sles4sap/wmp_setup
   - ha/ha_cluster_init
   - sles4sap/hana_cluster
-  - sles4sap/sap_suse_cluster_connector
   - sles4sap/wmp_check_process
   - ha/fencing
   - boot/boot_to_desktop

--- a/schedule/qam/15-SP6/qam-sles4sap_wmp_hana_node1.yaml
+++ b/schedule/qam/15-SP6/qam-sles4sap_wmp_hana_node1.yaml
@@ -36,7 +36,6 @@ schedule:
   - sles4sap/wmp_setup
   - ha/ha_cluster_init
   - sles4sap/hana_cluster
-  - sles4sap/sap_suse_cluster_connector
   - sles4sap/wmp_check_process
   - ha/fencing
   - boot/boot_to_desktop

--- a/schedule/qam/common/qam-sles4sap_hana_node01.yml
+++ b/schedule/qam/common/qam-sles4sap_hana_node01.yml
@@ -16,7 +16,6 @@ schedule:
   - ha/ha_cluster_init
   - sles4sap/hana_install
   - sles4sap/hana_cluster
-  - sles4sap/sap_suse_cluster_connector
   - ha/fencing
   - boot/boot_to_desktop
   - ha/check_after_reboot

--- a/schedule/sles4sap/ensa/ensa_nodes.yaml
+++ b/schedule/sles4sap/ensa/ensa_nodes.yaml
@@ -49,6 +49,7 @@ schedule:
   - sles4sap/ensa/netweaver_ensa2_cluster
   - sles4sap/ensa/netweaver_ensa2_cluster_connector
   - sles4sap/ensa/netweaver_ensa2_web_methods
+  - sles4sap/sap_suse_cluster_connector
   - ha/check_logs
 conditional_schedule:
   cluster_setup:

--- a/schedule/sles4sap/hana/hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/hana_cluster_node.yaml
@@ -53,7 +53,6 @@ schedule:
   - '{{cluster_setup}}'
   - sles4sap/hana_cluster
   - sles4sap/monitoring_services
-  - '{{sap_suse_cluster_connector}}'
   - '{{wmp_check_process}}'
   - sles4sap/hana_test
   - ha/fencing
@@ -72,10 +71,6 @@ conditional_schedule:
         - ha/ha_cluster_init
       no:
         - ha/ha_cluster_join
-  sap_suse_cluster_connector:
-    HA_CLUSTER_INIT:
-      yes:
-        - sles4sap/sap_suse_cluster_connector
   boot_to_desktop_node01:
     HA_CLUSTER_INIT:
       yes:

--- a/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
@@ -73,7 +73,6 @@ schedule:
   - sles4sap/hana_install
   - '{{cluster_setup}}'
   - sles4sap/hana_cluster
-  - '{{sap_suse_cluster_connector}}'
   - ha/fencing
   - '{{boot_to_desktop}}'
   - ha/check_after_reboot
@@ -96,10 +95,6 @@ conditional_schedule:
         - ha/ha_cluster_init
       no:
         - ha/ha_cluster_join
-  sap_suse_cluster_connector:
-    HA_CLUSTER_INIT:
-      yes:
-        - sles4sap/sap_suse_cluster_connector
   boot_to_desktop:
     HA_CLUSTER_INIT:
       yes:

--- a/schedule/sles4sap/qam/common/qam_hana_cluster_node.yaml
+++ b/schedule/sles4sap/qam/common/qam_hana_cluster_node.yaml
@@ -52,7 +52,6 @@ schedule:
   - '{{wmp_setup}}'
   - '{{cluster_setup}}'
   - sles4sap/hana_cluster
-  - '{{sap_suse_cluster_connector}}'
   - '{{wmp_check_process}}'
   - sles4sap/hana_test
   - ha/fencing
@@ -72,10 +71,6 @@ conditional_schedule:
         - ha/ha_cluster_init
       no:
         - ha/ha_cluster_join
-  sap_suse_cluster_connector:
-    HA_CLUSTER_INIT:
-      yes:
-        - sles4sap/sap_suse_cluster_connector
   boot_to_desktop_node01:
     HA_CLUSTER_INIT:
       yes:


### PR DESCRIPTION
Enhance test module "sap_suse_cluster_connector":
- Replace `sleep 10` with `wait_for_idle_cluster`
- Show test module failures for smm command
- Module is no longer scheduled in HANA scenarios.
- Module passes on NetWeaver scenarios.
- Add module to ASCS/ERS  scenarios and passes.


Related ticket: 
https://jira.suse.com/browse/TEAM-9612 
(TEAM-9612 - Enhance hanaSR test module "sap_suse_cluster_connector" according to the research of TEAM-9571)
  
Verification run:    
  
- VRs for code changes in `sap_suse_cluster_connector.pm`:
  15sp6 qam-SAPHanaSR_ScaleUp_PerfOpt_WMP_node01
  (YAML_SCHEDULE=schedule/sles4sap/qam/common/qam_hana_cluster_node.yaml)
    https://openqa.suse.de/tests/15252602#step/sap_suse_cluster_connector/55 (**failed: make "smm" failed on purpose**)
    https://openqa.suse.de/tests/15252890#dependencies (pass, not scheduled sap_suse_cluster_connector) 

- VRs, for adding `sap_suse_cluster_connector` to `sles4sap_ensa_<ascs|ers>_node` of Incidents job groups":
(YAML_SCHEDULE=schedule/sles4sap/ensa/ensa_nodes.yaml)
  15-SP6: https://openqa.suse.de/tests/15263762#dependencies (passed)
  15-SP5: https://openqa.suse.de/tests/15263758#dependencies (passed)
  15-SP4: https://openqa.suse.de/tests/15273961#dependencies (passed)
  15-SP3: https://openqa.suse.de/tests/15263764#dependencies (passed)
  15-SP2: https://openqa.suse.de/tests/15263768#dependencies (passed)
  12-SP5: https://openqa.suse.de/tests/15263754#dependencies (passed)

- VRs for Pre-release (no code change in this PR but did VRs):
(YAML_SCHEDULE=schedule/sles4sap/netweaver/netweaver_cluster_node.yaml)
  15sp6 b93.5 sles4sap_nw_node01 (already added sap_suse_cluster_connector, no need to modify)
    passed http://openqa.suse.de/tests/15253021 (scheduled sap_suse_cluster_connector)  
    
  15sp7 b10.1 sles4sap_nw_node01 (already added sap_suse_cluster_connector, no need to modify)
    passed http://openqa.suse.de/tests/15235498#step/sap_suse_cluster_connector/42
	
- VRs for "schedule/kernel/sles4sap/hana_cluster_node.yaml":
  No VR as I did not find the test cases in OSD and OW15.

- VRs for "schedule/sles4sap/hana/hana_cluster_node.yaml":
(not scheduled sap_suse_cluster_connector）
  15sp7: http://openqa.suse.de/tests/15274660#dependencies (failed as before but no "sap_suse_cluster_connector" scheduled as expected)

- VRs for "schedule/sles4sap/hana/pvm_hana_cluster_node.yaml":
(not scheduled sap_suse_cluster_connector）
  15sp7: https://openqa.suse.de/tests/15275103#dependencies  (failed as before but no "sap_suse_cluster_connector" scheduled as expected)
 	
- VRs for Aggregate job group:
	qam_sles4sap_wmp_hana_node01:
	(YAML_SCHEDULE=schedule/qam/15-SP<6|5|4|3|2>/qam-sles4sap_wmp_hana_node1.yaml)
	(not scheduled sap_suse_cluster_connector）
	  15sp6: https://openqa.suse.de/tests/15252892#dependencies (passed)
	  15sp2: https://openqa.suse.de/tests/15274535#dependencies (passed)
	  15sp3: https://openqa.suse.de/tests/15274530#dependencies (passed)
	  15sp4: https://openqa.suse.de/tests/15274543#dependencies (passed)
	  15sp5: https://openqa.suse.de/tests/15274542#dependencies (passed)  

	qam-sles4sap_hana_node01:
	(YAML_SCHEDULE=schedule/qam/common/qam-sles4sap_hana_node01.yml)
	(not scheduled sap_suse_cluster_connector）
	  12sp5: https://openqa.suse.de/tests/15274575#dependencies (passed)