### PR TITLE
Fix one_line_checks for cloud-init tests

### DIFF
--- a/tests/microos/one_line_checks.pm
+++ b/tests/microos/one_line_checks.pm
@@ -14,7 +14,8 @@ use utils;
 
 sub run_rcshell_checks {
     # Check that system is using UTC timezone
-    assert_script_run 'date +"%Z" | grep -x UTC';
+    my $timezone = get_var('FIRST_BOOT_CONFIG', '') =~ /cloud-init/ ? 'CEST' : 'UTC';
+    assert_script_run "date +\"%Z\" | grep -x $timezone";
 }
 
 sub run_common_checks {


### PR DESCRIPTION
cloud-init user data sets CEST instead of UTC in image configuration.

As a part of https://progress.opensuse.org/issues/162938, fix timezone check.

##### Verification runs

* [microos](http://kepler.suse.cz/tests/23980#step/one_line_checks/1)
* [sle-micro](http://kepler.suse.cz/tests/23981#step/one_line_checks/1)