### PR TITLE
Use libyui for qam-textmode+sle15 job

### DIFF
--- a/schedule/qam/common/qam-textmode-libyui.yaml
+++ b/schedule/qam/common/qam-textmode-libyui.yaml
@@ -1,0 +1,51 @@
+---
+name: qam-textmode-libyui
+vars:
+  YUI_REST_API: 1
+  DUD_ADDONS: sdk
+schedule:
+  self_update:
+    - installation/validate_self_update
+  system_role:
+    - installation/system_role/select_role_text_mode
+  system_validation:
+    - qa_automation/patch_and_reboot
+    - locale/keymap_or_locale
+    - console/system_prepare
+    - console/check_network
+    - console/system_state
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/force_scheduled_tasks
+    - console/textinfo
+    - console/hostname
+    - console/installation_snapshots
+    - console/zypper_in
+    - console/zypper_lifecycle
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/firewall_enabled
+    - console/glibc_sanity
+    - console/salt
+    - network/snmp
+    - console/sshd
+    - console/ssh_cleanup
+    - console/ncurses
+    - console/yast2_bootloader
+    - console/yast2_i
+    - console/yast2_lan
+    - console/yast2_nfs_server
+    - console/mtab
+    - console/mariadb_srv
+    - console/rsync
+    - console/curl_https
+    - console/http_srv
+    - console/dns_srv
+    - console/apache
+    - console/shibboleth
+    - console/apache_ssl
+    - console/apache_nss
+    - console/postgresql_server
+    - console/orphaned_packages_check
+    - console/coredump_collect
+...


### PR DESCRIPTION
Use libyui for qam-textmode+sle15 job

- Related ticket: https://progress.opensuse.org/issues/124733
- Related MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/781
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=20240822-1&groupid=220
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=20240822-1&groupid=220
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=20240822-1&groupid=220
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP3&build=20240822-1&groupid=220