### PR TITLE
Automate iPXE host installation for SL Micro 6.1

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/combustion/script.aarch64.ep
+++ b/data/virt_autotest/host_unattended_installation_files/combustion/script.aarch64.ep
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+# combustion: network
 
 grub2_config() {
     file=/etc/default/grub
@@ -8,14 +8,23 @@ grub2_config() {
     sed -i -r 's/^(\s|#)*GRUB_TERMINAL_INPUT=.*$/GRUB_TERMINAL_INPUT="gfxterm console"/g' $file
     sed -i -r 's/^(\s|#)*GRUB_TERMINAL_OUTPUT=.*$/GRUB_TERMINAL_OUTPUT="gfxterm console"/g' $file
     sed -i 's/console=tty0//g' $file
-    sed -i 's/console=tty[^ ]*/console=SERIALCONSOLE,115200/g' $file
+    sed -i 's/console=tty[^ ]*/console={{SERIALCONSOLE}},115200/g' $file
     echo "DEBUG: now $file is,"
     cat $file
     grub2-mkconfig -o /boot/grub2/grub.cfg
 }
 
 # Redirect output to the console
-# Comment off to workaround https://bugzilla.suse.com/show_bug.cgi?id=1222411#c9
- exec > >(exec tee -a /dev/SERIALCONSOLE) 2>&1
-    grub2_config # Configure grub2 in the system
+exec > >(exec tee -a /dev/{{SERIALCONSOLE}}) 2>&1
 
+# Configure grub2 in the system
+grub2_config
+
+# Keyboard
+systemd-firstboot --force --keymap=us
+
+# Leave a marker
+echo "Configured aarch64 machine with combustion" > /etc/issue.d/combustion
+
+# Close outputs and wait for tee to finish.
+exec 1>&- 2>&-; wait;

--- a/data/virt_autotest/host_unattended_installation_files/combustion/script.x86_64.ep
+++ b/data/virt_autotest/host_unattended_installation_files/combustion/script.x86_64.ep
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+# combustion: network
 
 grub2_config() {
     file=/etc/default/grub
@@ -8,14 +8,23 @@ grub2_config() {
     sed -i -r 's/^(\s|#)*GRUB_TERMINAL_INPUT=.*$/GRUB_TERMINAL_INPUT="gfxterm console"/g' $file
     sed -i -r 's/^(\s|#)*GRUB_TERMINAL_OUTPUT=.*$/GRUB_TERMINAL_OUTPUT="gfxterm console"/g' $file
     sed -i 's/console=tty0//g' $file
-    sed -i 's/console=tty[^ ]*/console=SERIALCONSOLE,115200/g' $file
+    sed -i 's/console=tty[^ ]*/console={{SERIALCONSOLE}},115200/g' $file
     echo "DEBUG: now $file is,"
     cat $file
     grub2-mkconfig -o /boot/grub2/grub.cfg
 }
 
 # Redirect output to the console
-# Comment off to workaround https://bugzilla.suse.com/show_bug.cgi?id=1222411#c9
- exec > >(exec tee -a /dev/SERIALCONSOLE) 2>&1
-    grub2_config # Configure grub2 in the system
+exec > >(exec tee -a /dev/{{SERIALCONSOLE}}) 2>&1
 
+# Configure grub2 in the system
+grub2_config
+
+# Keyboard
+systemd-firstboot --force --keymap=us
+
+# Leave a marker
+echo "Configured x86_64 machine with combustion" > /etc/issue.d/combustion
+
+# Close outputs and wait for tee to finish.
+exec 1>&- 2>&-; wait;

--- a/data/virt_autotest/host_unattended_installation_files/ignition/config.ign.aarch64.ep
+++ b/data/virt_autotest/host_unattended_installation_files/ignition/config.ign.aarch64.ep
@@ -1,0 +1,56 @@
+{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "root",
+        "passwordHash": "$5$yWyONd1vdHjF/ZUp$HDJnaXL8B/zPAenwqBLUiPJfAw/L.emrVoSHX/LjkwA"
+      },
+      {
+        "name": "qevirt",
+        "passwordHash": "$2a$10$EGcS6zo6jG4YxMxmIMZiE.x/vf5nkn2dP.hH8YEbSPI1rUO1zZQyK"
+      }
+    ]
+  },
+  "storage": {
+    "filesystems": [
+      {
+        "device": "/dev/disk/by-label/ROOT",
+        "format": "btrfs",
+        "mountOptions": [
+          "subvol=/@/home"
+        ],
+        "path": "/home",
+        "wipeFilesystem": false
+      }
+    ],
+    "files": [
+      {
+        "path": "/etc/ssh/sshd_config",
+        "mode": 420,
+        "overwrite": true,
+        "contents": {
+          "source": "data:text/plain;charset=utf-8;base64,IyAgICAgICAkT3BlbkJTRDogc3NoZF9jb25maWcsdiAxLjEwNCAyMDIxLzA3LzAyIDA1OjExOjIxIGR0dWNrZXIgRXhwICQKCiMgVGhpcyBpcyB0aGUgc3NoZCBzZXJ2ZXIgc3lzdGVtLXdpZGUgY29uZmlndXJhdGlvbiBmaWxlLiAgU2VlCiMgc3NoZF9jb25maWcoNSkgZm9yIG1vcmUgaW5mb3JtYXRpb24uCgojIFRoaXMgc3NoZCB3YXMgY29tcGlsZWQgd2l0aCBQQVRIPS91c3IvYmluOi9iaW46L3Vzci9zYmluOi9zYmluCgojIFRvIG1vZGlmeSB0aGUgc3lzdGVtLXdpZGUgc3NoZCBjb25maWd1cmF0aW9uLCBjcmVhdGUgYSAiKi5jb25mIiBmaWxlIHVuZGVyCiMgIi9ldGMvc3NoL3NzaGRfY29uZmlnLmQvIiB3aGljaCB3aWxsIGJlIGF1dG9tYXRpY2FsbHkgaW5jbHVkZWQgYmVsb3cuCiMgRG9uJ3QgZWRpdCB0aGlzIGNvbmZpZ3VyYXRpb24gZmlsZSBpdHNlbGYgaWYgcG9zc2libGUgdG8gYXZvaWQgdXBkYXRlCiMgcHJvYmxlbXMuCkluY2x1ZGUgL2V0Yy9zc2gvc3NoZF9jb25maWcuZC8qLmNvbmYKCiMgVGhlIHN0cmF0ZWd5IHVzZWQgZm9yIG9wdGlvbnMgaW4gdGhlIGRlZmF1bHQgc3NoZF9jb25maWcgc2hpcHBlZCB3aXRoCiMgT3BlblNTSCBpcyB0byBzcGVjaWZ5IG9wdGlvbnMgd2l0aCB0aGVpciBkZWZhdWx0IHZhbHVlIHdoZXJlCiMgcG9zc2libGUsIGJ1dCBsZWF2ZSB0aGVtIGNvbW1lbnRlZC4gIFVuY29tbWVudGVkIG9wdGlvbnMgb3ZlcnJpZGUgdGhlCiMgZGVmYXVsdCB2YWx1ZS4KSW5jbHVkZSAvdXNyL2V0Yy9zc2gvc3NoZF9jb25maWcuZC8qLmNvbmYKCiNQb3J0IDIyCiNBZGRyZXNzRmFtaWx5IGFueQojTGlzdGVuQWRkcmVzcyAwLjAuMC4wCiNMaXN0ZW5BZGRyZXNzIDo6CgojSG9zdEtleSAvZXRjL3NzaC9zc2hfaG9zdF9yc2Ffa2V5CiNIb3N0S2V5IC9ldGMvc3NoL3NzaF9ob3N0X2VjZHNhX2tleQojSG9zdEtleSAvZXRjL3NzaC9zc2hfaG9zdF9lZDI1NTE5X2tleQoKIyBDaXBoZXJzIGFuZCBrZXlpbmcKI1Jla2V5TGltaXQgZGVmYXVsdCBub25lCgojIExvZ2dpbmcKI1N5c2xvZ0ZhY2lsaXR5IEFVVEgKI0xvZ0xldmVsIElORk8KCiMgQXV0aGVudGljYXRpb246CgojTG9naW5HcmFjZVRpbWUgMm0KUGVybWl0Um9vdExvZ2luIHllcwojU3RyaWN0TW9kZXMgeWVzCiNNYXhBdXRoVHJpZXMgNgojTWF4U2Vzc2lvbnMgMTAKClB1YmtleUF1dGhlbnRpY2F0aW9uIHllcwoKIyBUaGUgZGVmYXVsdCBpcyB0byBjaGVjayBib3RoIC5zc2gvYXV0aG9yaXplZF9rZXlzIGFuZCAuc3NoL2F1dGhvcml6ZWRfa2V5czIKIyBidXQgdGhpcyBpcyBvdmVycmlkZGVuIHNvIGluc3RhbGxhdGlvbnMgd2lsbCBvbmx5IGNoZWNrIC5zc2gvYXV0aG9yaXplZF9rZXlzCkF1dGhvcml6ZWRLZXlzRmlsZSAgICAgIC5zc2gvYXV0aG9yaXplZF9rZXlzCgojQXV0aG9yaXplZFByaW5jaXBhbHNGaWxlIG5vbmUKCiNBdXRob3JpemVkS2V5c0NvbW1hbmQgbm9uZQojQXV0aG9yaXplZEtleXNDb21tYW5kVXNlciBub2JvZHkKCiMgRm9yIHRoaXMgdG8gd29yayB5b3Ugd2lsbCBhbHNvIG5lZWQgaG9zdCBrZXlzIGluIC9ldGMvc3NoL3NzaF9rbm93bl9ob3N0cwojSG9zdGJhc2VkQXV0aGVudGljYXRpb24gbm8KIyBDaGFuZ2UgdG8geWVzIGlmIHlvdSBkb24ndCB0cnVzdCB+Ly5zc2gva25vd25faG9zdHMgZm9yCiMgSG9zdGJhc2VkQXV0aGVudGljYXRpb24KI0lnbm9yZVVzZXJLbm93bkhvc3RzIG5vCiMgRG9uJ3QgcmVhZCB0aGUgdXNlcidzIH4vLnJob3N0cyBhbmQgfi8uc2hvc3RzIGZpbGVzCiNJZ25vcmVSaG9zdHMgeWVzCgojIFRvIGRpc2FibGUgdHVubmVsZWQgY2xlYXIgdGV4dCBwYXNzd29yZHMsIGNoYW5nZSB0byBubyBoZXJlIQpQYXNzd29yZEF1dGhlbnRpY2F0aW9uIHllcwpQZXJtaXRFbXB0eVBhc3N3b3JkcyBubwoKIyBDaGFuZ2UgdG8gbm8gdG8gZGlzYWJsZSBzL2tleSBwYXNzd29yZHMKI0tiZEludGVyYWN0aXZlQXV0aGVudGljYXRpb24geWVzCgojIEtlcmJlcm9zIG9wdGlvbnMKI0tlcmJlcm9zQXV0aGVudGljYXRpb24gbm8KI0tlcmJlcm9zT3JMb2NhbFBhc3N3ZCB5ZXMKI0tlcmJlcm9zVGlja2V0Q2xlYW51cCB5ZXMKI0tlcmJlcm9zR2V0QUZTVG9rZW4gbm8KCiMgR1NTQVBJIG9wdGlvbnMKI0dTU0FQSUF1dGhlbnRpY2F0aW9uIG5vCiNHU1NBUElDbGVhbnVwQ3JlZGVudGlhbHMgeWVzCiNHU1NBUElTdHJpY3RBY2NlcHRvckNoZWNrIHllcwojR1NTQVBJS2V5RXhjaGFuZ2Ugbm8KCiMgU2V0IHRoaXMgdG8gJ3llcycgdG8gZW5hYmxlIFBBTSBhdXRoZW50aWNhdGlvbiwgYWNjb3VudCBwcm9jZXNzaW5nLAojIGFuZCBzZXNzaW9uIHByb2Nlc3NpbmcuIElmIHRoaXMgaXMgZW5hYmxlZCwgUEFNIGF1dGhlbnRpY2F0aW9uIHdpbGwKIyBiZSBhbGxvd2VkIHRocm91Z2ggdGhlIEtiZEludGVyYWN0aXZlQXV0aGVudGljYXRpb24gYW5kCiMgUGFzc3dvcmRBdXRoZW50aWNhdGlvbi4gIERlcGVuZGluZyBvbiB5b3VyIFBBTSBjb25maWd1cmF0aW9uLAojIFBBTSBhdXRoZW50aWNhdGlvbiB2aWEgS2JkSW50ZXJhY3RpdmVBdXRoZW50aWNhdGlvbiBtYXkgYnlwYXNzCiMgdGhlIHNldHRpbmcgb2YgIlBlcm1pdFJvb3RMb2dpbiBwcm9oaWJpdC1wYXNzd29yZCIuCiMgSWYgeW91IGp1c3Qgd2FudCB0aGUgUEFNIGFjY291bnQgYW5kIHNlc3Npb24gY2hlY2tzIHRvIHJ1biB3aXRob3V0CiMgUEFNIGF1dGhlbnRpY2F0aW9uLCB0aGVuIGVuYWJsZSB0aGlzIGJ1dCBzZXQgUGFzc3dvcmRBdXRoZW50aWNhdGlvbgojIGFuZCBLYmRJbnRlcmFjdGl2ZUF1dGhlbnRpY2F0aW9uIHRvICdubycuClVzZVBBTSB5ZXMKCiNBbGxvd0FnZW50Rm9yd2FyZGluZyB5ZXMKI0FsbG93VGNwRm9yd2FyZGluZyB5ZXMKI0dhdGV3YXlQb3J0cyBubwpYMTFGb3J3YXJkaW5nIHllcwojWDExRGlzcGxheU9mZnNldCAxMAojWDExVXNlTG9jYWxob3N0IHllcwojUGVybWl0VFRZIHllcwpQcmludE1vdGQgbm8KVENQS2VlcEFsaXZlIHllcwojUGVybWl0VXNlckVudmlyb25tZW50IG5vCiNDb21wcmVzc2lvbiBkZWxheWVkCkNsaWVudEFsaXZlSW50ZXJ2YWwgNjAKQ2xpZW50QWxpdmVDb3VudE1heCA0ODAKI1VzZUROUyBubwojUGlkRmlsZSAvcnVuL3NzaGQucGlkCiNNYXhTdGFydHVwcyAxMDozMDoxMDAKI1Blcm1pdFR1bm5lbCBubwojQ2hyb290RGlyZWN0b3J5IG5vbmUKI1ZlcnNpb25BZGRlbmR1bSBub25lCgojIG5vIGRlZmF1bHQgYmFubmVyIHBhdGgKI0Jhbm5lciBub25lCgojIG92ZXJyaWRlIGRlZmF1bHQgb2Ygbm8gc3Vic3lzdGVtcwpTdWJzeXN0ZW0gICAgICAgc2Z0cCAgICAvdXNyL2xpYmV4ZWMvc3NoL3NmdHAtc2VydmVyCgojIFRoaXMgZW5hYmxlcyBhY2NlcHRpbmcgbG9jYWxlIGVudmlyb21lbnQgdmFyaWFibGVzIExDXyogTEFORywgc2VlIHNzaGRfY29uZmlnKDUpLgpBY2NlcHRFbnYgTEFORyBMQ19DVFlQRSBMQ19OVU1FUklDIExDX1RJTUUgTENfQ09MTEFURSBMQ19NT05FVEFSWSBMQ19NRVNTQUdFUwpBY2NlcHRFbnYgTENfUEFQRVIgTENfTkFNRSBMQ19BRERSRVNTIExDX1RFTEVQSE9ORSBMQ19NRUFTVVJFTUVOVApBY2NlcHRFbnYgTENfSURFTlRJRklDQVRJT04gTENfQUxMCgojIEV4YW1wbGUgb2Ygb3ZlcnJpZGluZyBzZXR0aW5ncyBvbiBhIHBlci11c2VyIGJhc2lzCiNNYXRjaCBVc2VyIGFub25jdnMKIyAgICAgICBYMTFGb3J3YXJkaW5nIG5vCiMgICAgICAgQWxsb3dUY3BGb3J3YXJkaW5nIG5vCiMgICAgICAgUGVybWl0VFRZIG5vCiMgICAgICAgRm9yY2VDb21tYW5kIGN2cyBzZXJ2ZXI="
+        }
+      },
+      {
+        "path": "/etc/locale.conf",
+        "mode": 420,
+        "overwrite": true,
+        "contents": {
+          "source": "data:,LANG=en_US.UTF-8"
+        }
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "name": "sshd.service",
+        "enabled": true
+      }
+    ]
+  }
+}

--- a/data/virt_autotest/host_unattended_installation_files/ignition/config.ign.x86_64.ep
+++ b/data/virt_autotest/host_unattended_installation_files/ignition/config.ign.x86_64.ep
@@ -1,0 +1,56 @@
+{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "root",
+        "passwordHash": "$5$yWyONd1vdHjF/ZUp$HDJnaXL8B/zPAenwqBLUiPJfAw/L.emrVoSHX/LjkwA"
+      },
+      {
+        "name": "qevirt",
+        "passwordHash": "$2a$10$EGcS6zo6jG4YxMxmIMZiE.x/vf5nkn2dP.hH8YEbSPI1rUO1zZQyK"
+      }
+    ]
+  },
+  "storage": {
+    "filesystems": [
+      {
+        "device": "/dev/disk/by-label/ROOT",
+        "format": "btrfs",
+        "mountOptions": [
+          "subvol=/@/home"
+        ],
+        "path": "/home",
+        "wipeFilesystem": false
+      }
+    ],
+    "files": [
+      {
+        "path": "/etc/ssh/sshd_config",
+        "mode": 420,
+        "overwrite": true,
+        "contents": {
+          "source": "data:text/plain;charset=utf-8;base64,IyAgICAgICAkT3BlbkJTRDogc3NoZF9jb25maWcsdiAxLjEwNCAyMDIxLzA3LzAyIDA1OjExOjIxIGR0dWNrZXIgRXhwICQKCiMgVGhpcyBpcyB0aGUgc3NoZCBzZXJ2ZXIgc3lzdGVtLXdpZGUgY29uZmlndXJhdGlvbiBmaWxlLiAgU2VlCiMgc3NoZF9jb25maWcoNSkgZm9yIG1vcmUgaW5mb3JtYXRpb24uCgojIFRoaXMgc3NoZCB3YXMgY29tcGlsZWQgd2l0aCBQQVRIPS91c3IvYmluOi9iaW46L3Vzci9zYmluOi9zYmluCgojIFRvIG1vZGlmeSB0aGUgc3lzdGVtLXdpZGUgc3NoZCBjb25maWd1cmF0aW9uLCBjcmVhdGUgYSAiKi5jb25mIiBmaWxlIHVuZGVyCiMgIi9ldGMvc3NoL3NzaGRfY29uZmlnLmQvIiB3aGljaCB3aWxsIGJlIGF1dG9tYXRpY2FsbHkgaW5jbHVkZWQgYmVsb3cuCiMgRG9uJ3QgZWRpdCB0aGlzIGNvbmZpZ3VyYXRpb24gZmlsZSBpdHNlbGYgaWYgcG9zc2libGUgdG8gYXZvaWQgdXBkYXRlCiMgcHJvYmxlbXMuCkluY2x1ZGUgL2V0Yy9zc2gvc3NoZF9jb25maWcuZC8qLmNvbmYKCiMgVGhlIHN0cmF0ZWd5IHVzZWQgZm9yIG9wdGlvbnMgaW4gdGhlIGRlZmF1bHQgc3NoZF9jb25maWcgc2hpcHBlZCB3aXRoCiMgT3BlblNTSCBpcyB0byBzcGVjaWZ5IG9wdGlvbnMgd2l0aCB0aGVpciBkZWZhdWx0IHZhbHVlIHdoZXJlCiMgcG9zc2libGUsIGJ1dCBsZWF2ZSB0aGVtIGNvbW1lbnRlZC4gIFVuY29tbWVudGVkIG9wdGlvbnMgb3ZlcnJpZGUgdGhlCiMgZGVmYXVsdCB2YWx1ZS4KSW5jbHVkZSAvdXNyL2V0Yy9zc2gvc3NoZF9jb25maWcuZC8qLmNvbmYKCiNQb3J0IDIyCiNBZGRyZXNzRmFtaWx5IGFueQojTGlzdGVuQWRkcmVzcyAwLjAuMC4wCiNMaXN0ZW5BZGRyZXNzIDo6CgojSG9zdEtleSAvZXRjL3NzaC9zc2hfaG9zdF9yc2Ffa2V5CiNIb3N0S2V5IC9ldGMvc3NoL3NzaF9ob3N0X2VjZHNhX2tleQojSG9zdEtleSAvZXRjL3NzaC9zc2hfaG9zdF9lZDI1NTE5X2tleQoKIyBDaXBoZXJzIGFuZCBrZXlpbmcKI1Jla2V5TGltaXQgZGVmYXVsdCBub25lCgojIExvZ2dpbmcKI1N5c2xvZ0ZhY2lsaXR5IEFVVEgKI0xvZ0xldmVsIElORk8KCiMgQXV0aGVudGljYXRpb246CgojTG9naW5HcmFjZVRpbWUgMm0KUGVybWl0Um9vdExvZ2luIHllcwojU3RyaWN0TW9kZXMgeWVzCiNNYXhBdXRoVHJpZXMgNgojTWF4U2Vzc2lvbnMgMTAKClB1YmtleUF1dGhlbnRpY2F0aW9uIHllcwoKIyBUaGUgZGVmYXVsdCBpcyB0byBjaGVjayBib3RoIC5zc2gvYXV0aG9yaXplZF9rZXlzIGFuZCAuc3NoL2F1dGhvcml6ZWRfa2V5czIKIyBidXQgdGhpcyBpcyBvdmVycmlkZGVuIHNvIGluc3RhbGxhdGlvbnMgd2lsbCBvbmx5IGNoZWNrIC5zc2gvYXV0aG9yaXplZF9rZXlzCkF1dGhvcml6ZWRLZXlzRmlsZSAgICAgIC5zc2gvYXV0aG9yaXplZF9rZXlzCgojQXV0aG9yaXplZFByaW5jaXBhbHNGaWxlIG5vbmUKCiNBdXRob3JpemVkS2V5c0NvbW1hbmQgbm9uZQojQXV0aG9yaXplZEtleXNDb21tYW5kVXNlciBub2JvZHkKCiMgRm9yIHRoaXMgdG8gd29yayB5b3Ugd2lsbCBhbHNvIG5lZWQgaG9zdCBrZXlzIGluIC9ldGMvc3NoL3NzaF9rbm93bl9ob3N0cwojSG9zdGJhc2VkQXV0aGVudGljYXRpb24gbm8KIyBDaGFuZ2UgdG8geWVzIGlmIHlvdSBkb24ndCB0cnVzdCB+Ly5zc2gva25vd25faG9zdHMgZm9yCiMgSG9zdGJhc2VkQXV0aGVudGljYXRpb24KI0lnbm9yZVVzZXJLbm93bkhvc3RzIG5vCiMgRG9uJ3QgcmVhZCB0aGUgdXNlcidzIH4vLnJob3N0cyBhbmQgfi8uc2hvc3RzIGZpbGVzCiNJZ25vcmVSaG9zdHMgeWVzCgojIFRvIGRpc2FibGUgdHVubmVsZWQgY2xlYXIgdGV4dCBwYXNzd29yZHMsIGNoYW5nZSB0byBubyBoZXJlIQpQYXNzd29yZEF1dGhlbnRpY2F0aW9uIHllcwpQZXJtaXRFbXB0eVBhc3N3b3JkcyBubwoKIyBDaGFuZ2UgdG8gbm8gdG8gZGlzYWJsZSBzL2tleSBwYXNzd29yZHMKI0tiZEludGVyYWN0aXZlQXV0aGVudGljYXRpb24geWVzCgojIEtlcmJlcm9zIG9wdGlvbnMKI0tlcmJlcm9zQXV0aGVudGljYXRpb24gbm8KI0tlcmJlcm9zT3JMb2NhbFBhc3N3ZCB5ZXMKI0tlcmJlcm9zVGlja2V0Q2xlYW51cCB5ZXMKI0tlcmJlcm9zR2V0QUZTVG9rZW4gbm8KCiMgR1NTQVBJIG9wdGlvbnMKI0dTU0FQSUF1dGhlbnRpY2F0aW9uIG5vCiNHU1NBUElDbGVhbnVwQ3JlZGVudGlhbHMgeWVzCiNHU1NBUElTdHJpY3RBY2NlcHRvckNoZWNrIHllcwojR1NTQVBJS2V5RXhjaGFuZ2Ugbm8KCiMgU2V0IHRoaXMgdG8gJ3llcycgdG8gZW5hYmxlIFBBTSBhdXRoZW50aWNhdGlvbiwgYWNjb3VudCBwcm9jZXNzaW5nLAojIGFuZCBzZXNzaW9uIHByb2Nlc3NpbmcuIElmIHRoaXMgaXMgZW5hYmxlZCwgUEFNIGF1dGhlbnRpY2F0aW9uIHdpbGwKIyBiZSBhbGxvd2VkIHRocm91Z2ggdGhlIEtiZEludGVyYWN0aXZlQXV0aGVudGljYXRpb24gYW5kCiMgUGFzc3dvcmRBdXRoZW50aWNhdGlvbi4gIERlcGVuZGluZyBvbiB5b3VyIFBBTSBjb25maWd1cmF0aW9uLAojIFBBTSBhdXRoZW50aWNhdGlvbiB2aWEgS2JkSW50ZXJhY3RpdmVBdXRoZW50aWNhdGlvbiBtYXkgYnlwYXNzCiMgdGhlIHNldHRpbmcgb2YgIlBlcm1pdFJvb3RMb2dpbiBwcm9oaWJpdC1wYXNzd29yZCIuCiMgSWYgeW91IGp1c3Qgd2FudCB0aGUgUEFNIGFjY291bnQgYW5kIHNlc3Npb24gY2hlY2tzIHRvIHJ1biB3aXRob3V0CiMgUEFNIGF1dGhlbnRpY2F0aW9uLCB0aGVuIGVuYWJsZSB0aGlzIGJ1dCBzZXQgUGFzc3dvcmRBdXRoZW50aWNhdGlvbgojIGFuZCBLYmRJbnRlcmFjdGl2ZUF1dGhlbnRpY2F0aW9uIHRvICdubycuClVzZVBBTSB5ZXMKCiNBbGxvd0FnZW50Rm9yd2FyZGluZyB5ZXMKI0FsbG93VGNwRm9yd2FyZGluZyB5ZXMKI0dhdGV3YXlQb3J0cyBubwpYMTFGb3J3YXJkaW5nIHllcwojWDExRGlzcGxheU9mZnNldCAxMAojWDExVXNlTG9jYWxob3N0IHllcwojUGVybWl0VFRZIHllcwpQcmludE1vdGQgbm8KVENQS2VlcEFsaXZlIHllcwojUGVybWl0VXNlckVudmlyb25tZW50IG5vCiNDb21wcmVzc2lvbiBkZWxheWVkCkNsaWVudEFsaXZlSW50ZXJ2YWwgNjAKQ2xpZW50QWxpdmVDb3VudE1heCA0ODAKI1VzZUROUyBubwojUGlkRmlsZSAvcnVuL3NzaGQucGlkCiNNYXhTdGFydHVwcyAxMDozMDoxMDAKI1Blcm1pdFR1bm5lbCBubwojQ2hyb290RGlyZWN0b3J5IG5vbmUKI1ZlcnNpb25BZGRlbmR1bSBub25lCgojIG5vIGRlZmF1bHQgYmFubmVyIHBhdGgKI0Jhbm5lciBub25lCgojIG92ZXJyaWRlIGRlZmF1bHQgb2Ygbm8gc3Vic3lzdGVtcwpTdWJzeXN0ZW0gICAgICAgc2Z0cCAgICAvdXNyL2xpYmV4ZWMvc3NoL3NmdHAtc2VydmVyCgojIFRoaXMgZW5hYmxlcyBhY2NlcHRpbmcgbG9jYWxlIGVudmlyb21lbnQgdmFyaWFibGVzIExDXyogTEFORywgc2VlIHNzaGRfY29uZmlnKDUpLgpBY2NlcHRFbnYgTEFORyBMQ19DVFlQRSBMQ19OVU1FUklDIExDX1RJTUUgTENfQ09MTEFURSBMQ19NT05FVEFSWSBMQ19NRVNTQUdFUwpBY2NlcHRFbnYgTENfUEFQRVIgTENfTkFNRSBMQ19BRERSRVNTIExDX1RFTEVQSE9ORSBMQ19NRUFTVVJFTUVOVApBY2NlcHRFbnYgTENfSURFTlRJRklDQVRJT04gTENfQUxMCgojIEV4YW1wbGUgb2Ygb3ZlcnJpZGluZyBzZXR0aW5ncyBvbiBhIHBlci11c2VyIGJhc2lzCiNNYXRjaCBVc2VyIGFub25jdnMKIyAgICAgICBYMTFGb3J3YXJkaW5nIG5vCiMgICAgICAgQWxsb3dUY3BGb3J3YXJkaW5nIG5vCiMgICAgICAgUGVybWl0VFRZIG5vCiMgICAgICAgRm9yY2VDb21tYW5kIGN2cyBzZXJ2ZXI="
+        }
+      },
+      {
+        "path": "/etc/locale.conf",
+        "mode": 420,
+        "overwrite": true,
+        "contents": {
+          "source": "data:,LANG=en_US.UTF-8"
+        }
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "name": "sshd.service",
+        "enabled": true
+      }
+    ]
+  }
+}

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -262,7 +262,8 @@ sub is_generalhw { check_var('BACKEND', 'generalhw'); }
 #The ssh connection timeout is counted as seconds
 sub set_ssh_console_timeout {
     my ($sshd_config_file, $sshd_timeout) = @_;
-    $sshd_config_file //= '/etc/ssh/sshd_config';
+    # Set defualt sshd_config_file if it is not provided or does not exist
+    $sshd_config_file = '/etc/ssh/sshd_config' if (!$sshd_config_file or script_run("ls $sshd_config_file") != 0);
     $sshd_timeout //= 28800;
     my $client_count_max = $sshd_timeout / 60;
     if (script_run("ls $sshd_config_file") == 0) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -124,6 +124,8 @@ our @EXPORT = qw(
   enable_persistent_kernel_log
   enable_console_kernel_log
   ensure_testuser_present
+  is_disk_image
+  is_ipxe_with_disk_image
 );
 
 our @EXPORT_OK = qw(
@@ -3152,6 +3154,34 @@ sub enable_console_kernel_log {
     record_info("Content of /boot/grub2/grub.cfg", script_output("cat /boot/grub2/grub.cfg"));
     assert_script_run("echo 8 > /proc/sys/kernel/printk");
     record_info("Content of /proc/sys/kernel/printk", script_output("cat /proc/sys/kernel/printk"));
+}
+
+=head2 is_disk_image
+
+ is_disk_image;
+
+Identify whether test runs with linux disk image built by kiwi or similar programs.
+HDD_1 is usually used if disk image is available on openQA server. Test run attempts
+downloading HDD_1, failure of which leads to failed test run. INSTALL_HDD_IMAGE is
+introduced for installation with disk image which might be located somewhere else
+and also more flexibility.
+=cut
+
+sub is_disk_image {
+    return 1 if ((get_var('HDD_1') or get_var('INSTALL_HDD_IMAGE')) and get_var('BOOT_HDD_IMAGE'));
+    return 0;
+}
+
+=head2 is_ipxe_with_disk_image
+
+ is_ipxe_with_disk_image;
+
+Identify whether test runs boots from ipxe and deploy linux disk image built by kiwi or similar programs
+=cut
+
+sub is_ipxe_with_disk_image {
+    return 1 if (is_ipxe_boot and is_disk_image);
+    return 0;
 }
 
 1;

--- a/schedule/virt_autotest/install_guest_on_slem_kvm_host_ipxe_install.yaml
+++ b/schedule/virt_autotest/install_guest_on_slem_kvm_host_ipxe_install.yaml
@@ -1,0 +1,58 @@
+---
+name: install_guest_on_slem_kvm_host_ipxe_install.yaml
+description: |
+  Maintainer: Wayne Chen (wchen@suse.com) qe-virt@suse.de
+  Virtualization Guest Installation on SLE Micro KVM Host
+
+vars:
+  IPXE: 1
+  IPXE_UEFI: 1
+  USB_BOOT: 0
+  BOOT_HDD_IMAGE: 1
+  VIRT_AUTOTEST: 1
+  VIRT_PRJ1_GUEST_INSTALL: 1
+  VIRT_UNIFIED_GUEST_INSTALL: 1
+  VIDEOMODE: text
+  DO_NOT_INSTALL_HOST: 0
+  SKIP_GUEST_INSTALL: 0
+  SYSTEM_ROLE: kvm
+  HOST_HYPERVISOR: kvm
+  PATTERNS: default,kvm
+  MAX_JOB_TIME: 10800
+schedule:
+  - "{{install_preparation}}"
+  - "{{bootup_and_install}}"
+  - virt_autotest/login_console
+  - virt_autotest/prepare_transactional_server
+  - "{{install_guest}}"
+conditional_schedule:
+  install_preparation:
+    FIRST_BOOT_CONFIG:
+      ignition:
+        - jeos/prepare_firstboot_config
+      combustion:
+        - jeos/prepare_firstboot_config
+      ignition+combustion:
+        - jeos/prepare_firstboot_config
+  bootup_and_install:
+    DO_NOT_INSTALL_HOST:
+      0:
+        - "{{bootup}}"
+        - "{{install}}"
+        - microos/selfinstall
+  bootup:
+    IPXE:
+      1:
+        - installation/ipxe_install
+      0:
+        - boot/boot_from_pxe
+  install:
+    USB_BOOT:
+      1:
+        - installation/usb_install
+        - installation/bootloader_uefi
+  install_guest:
+    SKIP_GUEST_INSTALL:
+      0:
+        - virt_autotest/unified_guest_installation
+...

--- a/schedule/virt_autotest/install_guest_on_slem_kvm_host_usb_install.yaml
+++ b/schedule/virt_autotest/install_guest_on_slem_kvm_host_usb_install.yaml
@@ -1,5 +1,5 @@
 ---
-name: install_guest_on_slem_kvm_host.yaml
+name: install_guest_on_slem_kvm_host_usb_install.yaml
 description: |
   Maintainer: Wayne Chen (wchen@suse.com) qe-virt@suse.de
   Virtualization Guest Installation on SLE Micro KVM Host

--- a/tests/jeos/prepare_firstboot_config.pm
+++ b/tests/jeos/prepare_firstboot_config.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Prepare ignition or combustion configuration file for first boot
+# configuration
+# Maintainer: Wayne Chen <wchen@suse.com>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use utils qw(is_ipxe_boot);
+use autoyast qw(expand_template expand_variables upload_profile);
+
+sub run {
+    my $self = shift;
+
+    my $firstboot_config = get_var("FIRST_BOOT_CONFIG");
+    if (!$firstboot_config) {
+        record_info("No firstboot config provided", "Please confirm setting FIRST_BOOT_CONFIG");
+        return;
+    }
+    if ($firstboot_config =~ /ignition/ig) {
+        my $ignition_path =
+          get_required_var('FIRSTBOOT_CONFIG_DIR') . "/ignition/config.ign." . get_required_var('ARCH') . ".ep";
+        set_var('IGNITION_PATH', autoinst_url("/files/" . $self->prepare_profile(path => $ignition_path)));
+        record_info("Ignition config is available at:", get_required_var('IGNITION_PATH'));
+    }
+    if ($firstboot_config =~ /combustion/ig) {
+        my $combustion_path =
+          get_required_var('FIRSTBOOT_CONFIG_DIR') . "/combustion/script." . get_required_var('ARCH') . ".ep";
+        set_var('COMBUSTION_PATH', autoinst_url("/files/" . $self->prepare_profile(path => $combustion_path)));
+        record_info("Combustion config is available at:", get_required_var('COMBUSTION_PATH'));
+    }
+}
+
+sub prepare_profile {
+    my ($self, %args) = @_;
+    $args{path} //= '';
+    die("Profile path must be provided") if (!$args{path});
+
+    my $profile = get_test_data($args{path});
+    $profile = expand_template($profile) if ($args{path} =~ s/^(.*)\.ep$/$1/);
+    $profile = expand_variables($profile);
+    my $path = $args{path};
+    $path = get_required_var('SUT_IP') . $args{path} if (is_ipxe_boot);
+    upload_profile(profile => $profile, path => $path);
+    return $path;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -24,8 +24,15 @@ sub run {
         assert_screen 'selfinstall-select-drive';
         send_key 'ret';
     }
-    assert_screen 'slem-selfinstall-overwrite-drive';
-    send_key 'ret';
+
+    unless (get_var('INSTALL_DISK_WWN')) {
+        assert_screen 'slem-selfinstall-overwrite-drive';
+        send_key 'ret';
+    }
+    else {
+        assert_screen('slem-selfinstall-write-drive', 350 / get_var('TIMEOUT_SCALE', 1));
+        check_screen('slem-selfinstall-verify-drive', 350 / get_var('TIMEOUT_SCALE', 1));
+    }
 
     my $no_cd;
     # workaround failed *kexec* execution on UEFI with SecureBoot
@@ -49,7 +56,7 @@ sub run {
     } else {
         microos_login;
         # The installed system is definitely up now, so the CD can be ejected
-        eject_cd() unless ($no_cd || is_usb_boot);
+        eject_cd() unless ($no_cd || is_usb_boot || is_ipxe_with_disk_image);
     }
 
     # Remove usb boot entry and empty usb disks to ensure installed system boots from hard disk


### PR DESCRIPTION
* **This** pull request aims to support automated SL Micro 6.1 iPXE installation by using PXE-capable kernel/initrd and pre-built disk image (indicated by ```rd.kiwi.install.image=MIRROR_HTTP/HDD_1```) which then will be deployed onto specified disk device (indicated by ```rd.kiwi.oem.installdevice=/dev/disk/by-id/INSTALL_DISK_WWN```) and configured by using ignition/combustion (indicated by ```FIRST_BOOT_CONFIG```).

* **Several** new subroutines in ```lib/utils.pm```:
  * ```is_disk_image``` indicates pre-built disk image will used for OS installation.
  * ```is_ipxe_with_disk_image```  indicates OS installation is performed with iPXE and disk image.

* **New** test module ```jeos/prepare_firstboot_config.pm```:
  * **Aims** to generate ignition or combustion configuration file based on template ```config.ign.ARCH.ep``` or ```script.ARCH.ep```.
  * **Setting** ```FIRSTBOOT_CONFIG_DIR``` provides flexibility of using customized folder to store configuration templates.
  * **Subroutine** ```prepare_profile``` does the actual job of expanding variables (like ```SERIALCONSOLE```) and uploading final configuration file.
  * **Save** addresses of configuration files to settings ```IGNITION_URL``` and ```COMBUSTION_URL```.
  
* **Changes** made to ```tests/installation/ipxe_install.pm```:
  * **Move** part of adding extra kernel command line outside ```set_bootscript``` and into a new subroutine ```set_bootscript_cmdline_extra``` to avoid inflated ```set_bootscript``` subroutine.
  * **Introduce** ```BOOTLOADER_ROOT_DEVICE``` and ```BOOTLOADER_INITRD``` which indicates whether root device and specified initrd are needed at boot time for UEFI machines. If they are not needed, set ```BOOTLOADER_ROOT_DEVICE=0``` and ```BOOTLOADER_INITRD=0```. If customized ones are needed, set ```BOOTLOADER_ROOT_DEVICE=/dev/xxx``` and ```BOOTLOADER_INITRD=initrd_addr``` instead of default ```root=/dev/ram0``` and ```initrd=initrd```. Not using ```BOOTLOADER_ROOT_DEVICE``` and ```BOOTLOADER_INITRD``` means using default settings.
  * **New** subroutine ```set_bootscript_image_config``` adds boot parameters for pre-built disk image on kernel command line to achieve non-interactive mode installation, which is called in ```set_bootscript_cmdline_extra```. Setting ```rd.kiwi.oem.installdevice``` is only added if ```FIRST_BOOT_CONFIG``` is being used, which means full automation, and ```INSTALL_DISK_WWN``` will be set to ```/dev/sda``` or ```/dev/vda``` if it not given.
  * **New** subroutine ```set_bootscript_firstboot_config``` adds boot parameters for first boot configuration on kernel command line to complete automated configuration, which is called in ```set_bootscript_cmdline_extra```.
  * **Only** needles ```load-linux-kernel``` and ```load-initrd``` need to be matched for OS installation with disk image. 

* **Changes** made to ```tests/microos/selfinstall.pm```:
  * **For** installation with specified disk device, there will be no prompt confirmation of disk device, only dialogues of writing into and verifying disk device are shown up. Corresponding needles ```slem-selfinstall-write-drive``` and ```slem-selfinstall-verify-drive``` will be matched.
  * **Due** to test runs under various circumstances, ```check_screen('slem-selfinstall-verify-drive')``` will be used after ```assert_screen('slem-selfinstall-write-drive')``` to avoid unnecessary failures.
  
* **New** ignition (```config.ign.x86_64.ep``` and ```config.ign.aarch64.ep```) and combustion (```script.x86_64.ep``` and ```script.aarch64.ep```) configuration templates, which are based on architecture to better facilitate first boot configuration process.  These templates need to be expanded, because there are different serial consoles and etc being used for different machines, by executing ```jeos/prepare_firstboot_config.pm``` at the beginning of test run. Final configuration files are served on URL (```IGNITION_URL``` and ```COMBUSTION_URL```) and will be provided on kernel command line directly.

* **Add** new schedule file ```schedule/virt_autotest/install_guest_on_slem_kvm_host_ipxe_install.yaml``` for iPXE installation and rename existing one to ```schedule/virt_autotest/install_guest_on_slem_kvm_host_usb_install.yaml```.

* **Trivial** changes are made to legacy ```combustion/script``` file to take ```GRUB_TERMINAL_INPUT``` and ```GRUB_TERMINAL_OUTPUT``` into consideration as well.

* **Verification Runs:**
  * [15sp7 on 15sp7 kvm](https://openqa.suse.de/tests/15398680)
  * [15sp7 on 15sp7 xen](https://openqa.suse.de/tests/15398681) 
  * [15sp6 on 15sp6 kvm](https://openqa.suse.de/tests/15291447)
  * [15sp6 on 15sp6 xen](https://openqa.suse.de/tests/15291448)
  * [15sp6 on 12sp5 kvm](https://openqa.suse.de/tests/15274281)
  * [15sp6 on 12sp5 xen](https://openqa.suse.de/tests/15281228)
  * [15sp6 on 15sp5 kvm](https://openqa.suse.de/tests/15274292)
  * [15sp6 on 15sp5 xen](https://openqa.suse.de/tests/15274295)
  * [sl-micro 6.1 on sl-micro 6.1 host](https://openqa.suse.de/tests/15397757)
  * [sles15sp6 on sl-micro 6.1 host](https://openqa.suse.de/tests/15370301)
  * [ipxe x86_64 host installation](http://10.200.140.9/tests/15)
  * [ipxe aarch64 host installation](http://10.200.140.9/tests/26)
  * In case you can not see job on my openQA server
![openqa_aarch64_ipxe_install_test_run_01](https://github.com/user-attachments/assets/0eac2989-af95-4ac2-8c9e-97d0905b9827)
![openqa_aarch64_ipxe_install_test_run_02](https://github.com/user-attachments/assets/659fe2e8-4d5e-47ed-820f-d59e805d689d)

* **Needles:** 
  * Needle slem-selfinstall-write-drive
![slem-selfinstall-write-drive](https://github.com/user-attachments/assets/65ea97fd-73c2-485a-b6c6-575c50a1d40b)
  * Needle slem-selfinstall-verify-drive 
![slem-selfinstall-verify-drive](https://github.com/user-attachments/assets/f435d00f-116b-4503-8b4b-1fbb64bb14e8)
