### PR TITLE
Register Micro Extention for sle-micro

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -14,6 +14,7 @@ use utils qw(zypper_call script_retry script_output_retry);
 use version_utils qw(is_sle is_jeos is_sle_micro is_transactional is_staging);
 use registration qw(register_addons_cmd verify_scc investigate_log_empty_license);
 use transactional qw(trup_call process_reboot);
+use registration;
 
 sub run {
     return if get_var('HDD_SCC_REGISTERED');
@@ -41,6 +42,7 @@ sub run {
     if (is_transactional) {
         trup_call('register' . $cmd);
         trup_call('--continue run zypper --gpg-auto-import-keys refresh') if is_staging;
+        add_suseconnect_product('SL-Micro-Extras') if (is_sle_micro('>=6.0'));
         process_reboot(trigger => 1);
     }
     else {


### PR DESCRIPTION
Register Micro Extention for sle-micro 6.0
NOTE: currently version<6.0 has no extention and 6.1 exist issue.

- Related ticket: https://progress.opensuse.org/issues/164382
- Needles: na
- Verification run: 

sle-micro 6.0
x86
https://openqa.suse.de/tests/15252872#step/suseconnect_scc/85
aarch64
https://openqa.suse.de/tests/15252910#step/suseconnect_scc/86
s390x
https://openqa.suse.de/tests/15252909#step/suseconnect_scc/79

sle-micro 6.1
https://openqa.suse.de/tests/15474414#step/suseconnect_scc/79 
aarch64
https://openqa.suse.de/tests/15437717#step/suseconnect_scc/80
390
https://openqa.suse.de/tests/15437716#step/suseconnect_scc/73


