### PR TITLE
yast2_apparmor: Enable serial console

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -678,6 +678,7 @@ sub yast2_apparmor_cleanup {
     select_console("root-console");
     send_key "ctrl-c";
     clear_console;
+    select_serial_terminal;
 
     # Upload logs for reference
     upload_logs("$audit_log");

--- a/tests/security/yast2_apparmor/manually_add_profile_ncurses.pm
+++ b/tests/security/yast2_apparmor/manually_add_profile_ncurses.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use serial_terminal qw(select_serial_terminal);
 
 sub run {
     my ($self) = shift;
@@ -36,6 +37,7 @@ sub run {
     # Enter "Manually Add Profile" to generate a profile for a program
     # "marked as a program that should not have its own profile",
     # it should be failed
+    select_console 'root-console';
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'apparmor');
     assert_screen("yast2_apparmor");
     wait_screen_change { send_key "down" };
@@ -111,6 +113,7 @@ sub run {
     # Wait till app is closed
     wait_serial("$module_name-0", 200) || die "'yast2 apparmor' didn't finish";
     enter_cmd("reset");
+    select_serial_terminal;
 
     # Check the profiles were generated, e.g., cat it for reference
     assert_script_run("cat $test_profile_bk");

--- a/tests/security/yast2_apparmor/scan_audit_logs_ncurses.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs_ncurses.pm
@@ -12,6 +12,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils 'is_sle';
+use serial_terminal qw(select_serial_terminal);
 
 sub run {
     my ($self) = shift;
@@ -20,6 +21,9 @@ sub run {
     my $test_profile_bk = "/tmp/usr.sbin.nscd";
     my $entry = 'include <abstractions\/base>';
     my $audit_log = $apparmortest::audit_log;
+
+    zypper_call('in nscd');
+    systemctl('start nscd');
 
     # Set the testing profile to "enforce" mode
     assert_script_run("aa-enforce $test_file");
@@ -31,6 +35,7 @@ sub run {
     systemctl("is-active apparmor");
 
     # Enter "yast2 apparmor"
+    select_console 'root-console';
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'apparmor');
     assert_screen("yast2_apparmor");
 
@@ -93,6 +98,7 @@ sub run {
     # Wait till app is closed
     wait_serial("$module_name-0", 200) || die "'yast2 apparmor' didn't finish";
     enter_cmd("reset");
+    select_serial_terminal;
 
     # Upload test profile for reference
     upload_logs($test_profile);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/165527 https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20034
- Verification run: https://openqa.opensuse.org/tests/4428299