### PR TITLE
Re-enable openldap testing for 15SP5+

### DIFF
--- a/data/sssd/openldap/slapd.conf
+++ b/data/sssd/openldap/slapd.conf
@@ -7,7 +7,6 @@ include /etc/openldap/schema/core.schema
 include /etc/openldap/schema/cosine.schema
 include /etc/openldap/schema/inetorgperson.schema
 include /etc/openldap/schema/rfc2307bis.schema
-include /etc/openldap/schema/policy.schema
 include /etc/openldap/schema/yast.schema
 include /etc/openldap/schema/sudo.schema
 TLSCACertificateFile /etc/ssl/ca-bundle.pem

--- a/data/sssd/openldap/sudo.schema
+++ b/data/sssd/openldap/sudo.schema
@@ -1,0 +1,78 @@
+#
+# OpenLDAP schema file for Sudo
+# Save as /etc/openldap/schema/sudo.schema and restart slapd.
+# For a version that uses online configuration, see schema.olcSudo.
+#
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.1
+    NAME 'sudoUser'
+    DESC 'User(s) who may  run sudo'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.2
+    NAME 'sudoHost'
+    DESC 'Host(s) who may run sudo'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.3
+    NAME 'sudoCommand'
+    DESC 'Command(s) to be executed by sudo'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.4
+    NAME 'sudoRunAs'
+    DESC 'User(s) impersonated by sudo (deprecated)'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.5
+    NAME 'sudoOption'
+    DESC 'Options(s) followed by sudo'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.6
+    NAME 'sudoRunAsUser'
+    DESC 'User(s) impersonated by sudo'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.7
+    NAME 'sudoRunAsGroup'
+    DESC 'Group(s) impersonated by sudo'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.8
+    NAME 'sudoNotBefore'
+    DESC 'Start of time interval for which the entry is valid'
+    EQUALITY generalizedTimeMatch
+    ORDERING generalizedTimeOrderingMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.9
+    NAME 'sudoNotAfter'
+    DESC 'End of time interval for which the entry is valid'
+    EQUALITY generalizedTimeMatch
+    ORDERING generalizedTimeOrderingMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 )
+
+attributetype ( 1.3.6.1.4.1.15953.9.1.10
+    NAME 'sudoOrder'
+    DESC 'an integer to order the sudoRole entries'
+    EQUALITY integerMatch
+    ORDERING integerOrderingMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+
+objectclass ( 1.3.6.1.4.1.15953.9.2.1 NAME 'sudoRole' SUP top STRUCTURAL
+    DESC 'Sudoer Entries'
+    MUST ( cn )
+    MAY ( sudoUser $ sudoHost $ sudoCommand $ sudoRunAs $ sudoRunAsUser $
+          sudoRunAsGroup $ sudoOption $ sudoOrder $ sudoNotBefore $
+          sudoNotAfter $ description )
+    )

--- a/schedule/functional/openldap_sssd.yaml
+++ b/schedule/functional/openldap_sssd.yaml
@@ -1,0 +1,15 @@
+name: openldap_sssd
+description:    >
+    This is for openldap and sssd authentication test
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - network/setup_multimachine
+    - '{{openldap_sssd}}'
+conditional_schedule:
+    openldap_sssd:
+        HOSTNAME:
+            ldapserver:
+                - console/openldap/openldap_server
+            ldapclient:
+                - console/openldap/openldap_client

--- a/tests/console/openldap/openldap_client.pm
+++ b/tests/console/openldap/openldap_client.pm
@@ -1,0 +1,63 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Reenable openldap testing for 15SP5+
+#
+# Maintainer: QE Core <qe-core@suse.de>
+# Tags: poo#165258
+#
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use lockapi;
+use serial_terminal 'select_serial_terminal';
+use version_utils 'is_sle';
+use registration 'add_suseconnect_product';
+
+sub run {
+    select_serial_terminal;
+    assert_script_run qq(sed -i 's/server/ldapserver/g' /etc/hosts);
+    assert_script_run qq(sed -i 's/client/ldapclient/g' /etc/hosts);
+
+    add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1) if is_sle;
+    zypper_call('in sssd sssd-ldap openldap2-client sshpass');
+
+
+    mutex_wait('Openldap_server_READY');
+
+    # Configure sssd on client
+    assert_script_run("curl " . data_url("sssd/openldap/sssd.conf") . " -o /etc/sssd/sssd.conf");
+    assert_script_run("curl " . data_url("sssd/openldap/nsswitch.conf") . " -o /etc/nsswitch.conf");
+    assert_script_run("curl " . data_url("sssd/openldap/ldapserver.crt") . " -o /etc/sssd/ldapserver.crt");
+    assert_script_run("curl " . data_url("sssd/openldap/config") . " --create-dirs -o ~/.ssh/config");
+    systemctl('disable --now nscd.service');
+    systemctl('enable --now sssd.service');
+
+    # Remote user indentify
+    validate_script_output("id bob", sub { m/(?=.*uid=5009\(bob\))(?=.*gid=5000\(testgroup\))/ });
+    # Remote user authentification
+    assert_script_run("pam-config -a --sss --mkhomedir");
+    validate_script_output('sshpass -p open5use ssh adam@localhost whoami', sub { m/adam/ });
+    # Change password of remote user
+    assert_script_run('sshpass -p open5use ssh bob@localhost \'echo -e "open5use\nn0vell88\nn0vell88" | passwd\'');
+    validate_script_output('sshpass -p n0vell88 ssh bob@localhost echo "login as new password!"', sub { m/new password/ });
+    validate_script_output('ldapwhoami -x -H ldap://ldapserver -D uid=bob,ou=users,dc=sssdtest,dc=com -w n0vell88', sub { m/bob/ });
+    # Sudo run a command as another user
+    assert_script_run("echo 'Defaults !targetpw' >/etc/sudoers.d/notargetpw");
+    validate_script_output('sshpass -p open5use ssh adam@localhost "echo open5use|sudo -S -l"', sub { m#/usr/bin/cat# });
+    assert_script_run(qq(su -c 'echo "file read only by owner bob" > hello && chmod 600 hello' -l bob));
+    validate_script_output('sshpass -p open5use ssh adam@localhost "echo open5use|sudo -S -u bob /usr/bin/cat /home/bob/hello"',
+        sub { m/file read only by owner bob/ });
+    # Change back password of remote user
+    assert_script_run('sshpass -p n0vell88 ssh bob@localhost \'echo -e "n0vell88\nopen5use\nopen5use" | passwd\'');
+    validate_script_output('sshpass -p open5use ssh bob@localhost echo "Password changed back!"', sub { m/Password changed back/ });
+}
+
+sub post_fail_hook {
+    upload_logs("/var/log/messages");
+    upload_logs("/etc/sssd/sssd.conf");
+}
+
+1;

--- a/tests/console/openldap/openldap_server.pm
+++ b/tests/console/openldap/openldap_server.pm
@@ -1,0 +1,51 @@
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: Reenable openldap testing for 15SP5+
+#
+# Maintainer: QE Core <qe-core@suse.de>
+# Tags: poo#165258
+
+use base 'consoletest';
+use testapi;
+use strict;
+use warnings;
+use utils;
+use lockapi;
+use mmapi 'wait_for_children';
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+
+    zypper_call('in openldap2_5 openldap2-client');
+    assert_script_run qq(sed -i 's/server/ldapserver/g' /etc/hosts);
+    assert_script_run qq(sed -i 's/client/ldapclient/g' /etc/hosts);
+
+    # Setup openldap database and import testing data
+    assert_script_run('cd /etc/openldap');
+    assert_script_run('curl -s --remote-name-all ' . data_url('sssd/openldap/{user.ldif,slapd.conf,ldapserver.key,ldapserver.crt,ldapserver.csr}'));
+    assert_script_run('curl -o /etc/openldap/schema/sudo.schema ' . data_url('sssd/openldap/sudo.schema'));
+    # Modify sysconfig file and enable LDAPI
+    assert_script_run qq(sed -i "/^OPENLDAP_LDAPI_INTERFACES/c\\OPENLDAP_LDAPI_INTERFACES='yes'" /etc/sysconfig/openldap);
+    # Add entries to a SLAPD database
+    assert_script_run('slapadd -b dc=sssdtest,dc=com -l /etc/openldap/user.ldif');
+    assert_script_run('chown -R ldap:ldap /var/lib/ldap/');
+    # Start OpenLDAP Server Daemon
+    systemctl('start slapd.service');
+
+    # Add lock for client
+    mutex_create("Openldap_server_READY");
+
+    # Finish job
+    wait_for_children;
+}
+
+sub post_fail_hook {
+    upload_logs('/var/log/messages');
+    upload_logs('/etc/openldap/slapd.conf');
+    upload_logs('/etc/openldap/user.ldif');
+    upload_logs('/etc/sysconfig/openldap');
+}
+
+1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/165258

**openldap2_5 package is not available on sle15sp7 now, so skip this test**
- Verification run:
[sle15sp6](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=20240825-1&groupid=564)
[sle15sp5](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&build=20240825-1&groupid=564)