### PR TITLE
Fix name of function that get the POM for grub

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -31,7 +31,7 @@ sub run {
         return;
     }
 
-    my $grub_menu = $testapi::distri->get_grub();
+    my $grub_menu = $testapi::distri->get_grub_menu();
     my $grub_entry_edition = $testapi::distri->get_grub_entry_edition();
     my $agama_up_an_running = $testapi::distri->get_agama_up_an_running();
 


### PR DESCRIPTION
- Related ticket: [poo#163943](https://progress.opensuse.org/issues/163943), fix for [#20043](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20043)
- Verification run: https://openqa.opensuse.org/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%23agama-bootparams&version=agama-9.0&distri=opensuse
