### PR TITLE
containers: Increase timeout for podman upstream tests

### DIFF
--- a/tests/containers/aardvark_integration.pm
+++ b/tests/containers/aardvark_integration.pm
@@ -25,7 +25,7 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('AARDVARK_BATS_SKIP', ''));
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "AARDVARK=$aardvark BATS_TMPDIR=/var/tmp bats --tap test | tee -a $log_file", 2000;
+    script_run "env AARDVARK=$aardvark BATS_TMPDIR=/var/tmp bats --tap test | tee -a $log_file", 2000;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 }

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -32,7 +32,7 @@ sub run_tests {
     script_run "rm -rf $tmp_dir/buildah_tests.*";
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "BATS_TMPDIR=$tmp_dir TMPDIR=$tmp_dir BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 4200;
+    script_run "env BATS_TMPDIR=$tmp_dir TMPDIR=$tmp_dir BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 4200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -25,7 +25,7 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', ''));
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "PATH=/usr/local/bin:\$PATH BATS_TMPDIR=/var/tmp NETAVARK=$netavark bats --tap test | tee -a $log_file", 1200;
+    script_run "env PATH=/usr/local/bin:\$PATH BATS_TMPDIR=/var/tmp NETAVARK=$netavark bats --tap test | tee -a $log_file", 1200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 }

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -36,7 +36,7 @@ sub run_tests {
 
     assert_script_run "echo $log_file .. > $log_file";
     background_script_run "podman system service --timeout=0" if ($remote);
-    script_run "env BATS_TMPDIR=/var/tmp PODMAN=/usr/bin/podman QUADLET=$quadlet hack/bats $args | tee -a $log_file", 7000;
+    script_run "env BATS_TMPDIR=/var/tmp PODMAN=/usr/bin/podman QUADLET=$quadlet hack/bats $args | tee -a $log_file", 8000;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
     script_run 'kill %1' if ($remote);

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -29,7 +29,7 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('RUNC_BATS_SKIP', '') . " " . $skip_tests);
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "BATS_TMPDIR=/var/tmp RUNC=/usr/bin/runc RUNC_USE_SYSTEMD=1 bats --tap tests/integration | tee -a $log_file", 1200;
+    script_run "env BATS_TMPDIR=/var/tmp RUNC=/usr/bin/runc RUNC_USE_SYSTEMD=1 bats --tap tests/integration | tee -a $log_file", 2000;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 }

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -37,7 +37,7 @@ sub run_tests {
     my $registry = is_x86_64 ? "" : "docker.io/library/registry:2";
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "BATS_TMPDIR=/var/tmp SKOPEO_BINARY=/usr/bin/skopeo SKOPEO_TEST_REGISTRY_FQIN=$registry bats --tap systemtest | tee -a $log_file", 1200;
+    script_run "env BATS_TMPDIR=/var/tmp SKOPEO_BINARY=/usr/bin/skopeo SKOPEO_TEST_REGISTRY_FQIN=$registry bats --tap systemtest | tee -a $log_file", 1200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 }


### PR DESCRIPTION

Increase timeout for podman upstream tests and use `env` like done in all tests like done in podman.
