### PR TITLE
Append auto profile to boot params in s390x agama

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -117,6 +117,11 @@ sub prepare_parmfile {
         $params .= " autoyast=" . $url;
         set_var('AUTOYAST', $url);
     }
+    if (get_var('AGAMA_AUTO')) {
+        my $url = data_url(get_var('AGAMA_AUTO'));
+        $params .= " agama.auto=" . $url;
+        set_var('AGAMA_AUTO', $url);
+    }
     return split_lines($params);
 }
 


### PR DESCRIPTION
- Related ticket: [poo#163955](https://progress.opensuse.org/issues/163955)
- Verification run: [agama_auto_default](https://openqa.opensuse.org/tests/4435615#)
