### PR TITLE
Skip redundant bootloader handler in vmware

### DIFF
--- a/data/jeos/g_cloudinit.cfg
+++ b/data/jeos/g_cloudinit.cfg
@@ -25,18 +25,14 @@ users:
     lock_passwd: true
     sudo: ALL=(ALL) NOPASSWD:ALL
     ssh_authorized_keys:
-      - %SSH_PUBK_RSA%
-      - %SSH_PUBK_ECDSA%
+     - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBmy+of7+yiKNnbJGm3TInXscr+IdXvgCfucfzr6UJtm0SvjDzwwgjvN2XNGqQSfN8u0lD+u/99tnvz74UBtqXg=
+     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDB2wi9ec3EVstG7jYzSMjPSlLleTqy3If3M/OTdp4Zv0/w5LUWm7uaSMUdrDQ7U+87Fu4lpvNfQU+l2ZD+TBN7WINa9XFJjpJ+bUdAq8fpLq+F6qiWOmCsPi34l0WnQj+p5UQclA27cRYhs0zOCXqSb8J6sEKp1OcUn0JPZX1wcZlX0DrCGdliyCmpnnaheEe/EVBPeUq4kU7hkmBTz3HBCgQ+5NzA3U7AhcdwP8RlrcLXpbyaMckllsaFiki6A6KBzOjzpeiB2mOzHSNoVVI1L38FYjWLNjyFY50BDDjMie99P/CyIZVAf+K8eUX49DmVTVmEwtiFQ5ftBW8P8ZMXMFpOrL9MLTLwORe42X0Yf+N66MKcUyE3g2a6K0GijctHdKG5E9cwbrUgDtlPR+z3svFVnctbI7nc9iPOYSh0Cj72xfAkS9Rjs8ABbfoB47a/lmeFBVLCbcbqzZr6w3UAQOM+W76VGoWglTnSFMEWyK87u/Y5WYkELIr6PNMJbtU=
 
-{% if v1.distro == 'sles' -%}
-# Register system
-bootcmd:
-  - SUSEConnect -r %SCC_REGCODE% %SCC_URL%
-{%- endif %}
-
+{% if v1.distro == 'opensuse' -%}
 # installs a package and starts a service during the first boot.
 packages:
   - lshw
+{%- endif %}
 
 write_files:
   - content: |

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -60,7 +60,7 @@ sub load_boot_from_disk_tests {
         loadtest 'jeos/firstrun';
     } elsif (check_var('FIRST_BOOT_CONFIG', 'cloud-init')) {
         unless (is_s390x) {
-            loadtest 'installation/bootloader_uefi';
+            loadtest 'installation/bootloader_uefi' unless is_vmware;
             loadtest 'installation/first_boot';
         }
         loadtest 'jeos/verify_cloudinit';


### PR DESCRIPTION
If vmware is provisioned by cloud-init, the bootloader handler is accidentaly scheduled twice

- Related ticket: https://progress.opensuse.org/issues/162938

#### Verification runs

* [sle-micro-6.1-Base-VMware](https://openqa.suse.de/tests/15282674#step/first_boot/1)
* [sle-micro-6.1-Default-VMware](https://openqa.suse.de/tests/15282682#step/first_boot/1)
