### PR TITLE
Skip floppy device if it is present

### DIFF
--- a/data/microos/butane/script
+++ b/data/microos/butane/script
@@ -24,9 +24,14 @@ detect_free_drive() {
 
     for d in ${drives[@]}; do
         # 64bit worker boots the image with cd-rom (sr0) device
-        # skip this device in case it is detected
-        [[ "$d" =~ ^sr[0-9]$ ]] && continue
-        blkid /dev/"$d" &> /dev/null || echo "/dev/$d"
+        # vmware adds floppy drive
+        # skip any of this device in case it is detected
+        [[ "$d" =~ ^(sr|fd)[0-9]$ ]] && continue
+        blkid /dev/"$d" &> /dev/null
+        if [[ "$?" -eq 2 ]]; then
+            printf "%s" "/dev/$d"
+            return 0
+        fi
     done
 }
 

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -68,7 +68,7 @@ sub load_boot_from_disk_tests {
         if (is_s390x()) {
             loadtest 'boot/boot_to_desktop';
         } elsif (is_vmware) {
-            ;
+            loadtest 'installation/first_boot';
         } else {
             loadtest 'microos/disk_boot';
         }


### PR DESCRIPTION
VMWare guest machines have a floppy device and combustion script can detect them. In case it is present, combustion should skip them.

- ticket: [[vmware] add combustion & ignition support](https://progress.opensuse.org/issues/164922)
- VR: sle-micro-6.1-Default-VMware-x86_64-Build12.2-combustion@svirt-vmware70 -> https://openqa.suse.de/tests/15276847#