### PR TITLE
Utilize agama.install_url

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -17,6 +17,15 @@ use testapi;
 use version_utils qw(is_leap is_sle);
 use utils;
 
+# Borrowed from grub2_tests.pm
+sub edit_cmdline {
+    send_key 'e';
+    my $jump_down = is_sle('<15-sp4') ? '12' : '8';
+    for (1 .. $jump_down) { send_key 'down'; }
+    send_key_until_needlematch 'grub2-edit-linux-line', 'down';
+    send_key 'end';
+}
+
 sub agama_set_root_password_dialog
 {
     wait_still_screen 5;

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -21,7 +21,7 @@ use utils;
 sub edit_cmdline {
     send_key 'e';
     my $jump_down = is_sle('<15-sp4') ? '12' : '8';
-    for (1 .. $jump_down) { send_key 'down'; }
+    send_key 'down' for (1 .. $jump_down);
     send_key_until_needlematch 'grub2-edit-linux-line', 'down';
     send_key 'end';
 }

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -45,12 +45,14 @@ sub run {
     my $boot_cmd = 'ret';
     # Tumbleweed livecd has been switched to grub with kiwi 9.17.41 except 32bit
     # when LIVECD_LOADER has set grub2 then change the boot command for grub2
-    if (get_var('AGAMA')) {
-        return;
-    }
     if (is_livecd && check_var('LIVECD_LOADER', 'grub2')) {
         $boot_cmd = 'ctrl-x';
         uefi_bootmenu_params;
+    }
+    # Agama gets extra param from bootmenu_default_params
+    # including agama.install_url
+    if (get_var('AGAMA')) {
+        $boot_cmd = 'ctrl-x';
     }
     my @params;
     push @params, bootmenu_default_params;


### PR DESCRIPTION
* introduced in https://github.com/openSUSE/agama/pull/1545

* USE REPO_0 var which contains the repo path (was AGAMA_INSTALL_URL in test suite)

- Related ticket: https://progress.opensuse.org/issues/164141
- Verification run: https://openqa.opensuse.org/tests/4454073#live
`openqa-clone-job --within-instance https://openqa.opensuse.org/tests/4438312 --skip-chained-deps YAML_SCHEDULE=schedule/install/agama_install.yaml  REPO_0=Leap-16.0-aarch64-ppc64le-s390x-x86_64-Build2.4 AGAMA=1 _GROUP=0 _LIVETEST=0  LIVETEST=0 CASEDIR=git@github.com:lkocman/os-autoinst-distri-opensuse.git#agama_install_url
`
