### PR TITLE
Use the proper Terraform variable for the machine

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -10,7 +10,7 @@ provider: 'azure'
 apiver: 3
 terraform:
   variables:
-    # GENERAL VARIABLES #
+    # GENERAL VARIABLES
     vnet_address_range: '%VNET_ADDRESS_RANGE%'
     subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
     az_region: '%PUBLIC_CLOUD_REGION%'
@@ -22,6 +22,6 @@ terraform:
     # HANA
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'
-    vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -20,6 +20,6 @@ terraform:
     # HANA
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'
-    vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -22,7 +22,7 @@ terraform:
     # HANA
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'
-    vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -24,7 +24,7 @@ terraform:
     # HANA
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'
-    vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -21,7 +21,7 @@ terraform:
     # HANA
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'
-    vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'


### PR DESCRIPTION
Remove vm_size terraform variable from all the qe-sap-deployment config.yaml templates and replace it with the specific one for the hana nodes.

- Related ticket: https://jira.suse.com/browse/TEAM-9627

# Verification run:
 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-08-29T02:03:22Z-hanasr_azure_test_sapconf_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/295673 :green_circle: 
 
http://openqaworker15.qa.suse.cz/tests/295673/file/deploy_qesap_terraform-sles4sap_azure_generic.yaml has `    hana_vm_size: Standard_E8s_v3`
it results in openqaworker15.qa.suse.cz/tests/295673/file/deploy_qesap_terraform-terraform.tfvars having `hana_vm_size = "Standard_E8s_v3"`

http://openqaworker15.qa.suse.cz/tests/295673/logfile?filename=deploy_qesap_terraform-terraform.plan.log.txt has

```
+ resource "azurerm_linux_virtual_machine" "hana" {
      + size                            = "Standard_E8s_v3"
```