### PR TITLE
Fix python 3.11 usage

### DIFF
--- a/tests/security/oscap_profile_tests/oscap_security_guide_setup.pm
+++ b/tests/security/oscap_profile_tests/oscap_security_guide_setup.pm
@@ -22,6 +22,9 @@ sub run {
         $oscap_tests::ansible_remediation = get_required_var('OSCAP_ANSIBLE_REMEDIATION');
         $oscap_tests::ansible_profile_ID = is_sle ? $oscap_tests::sle_version . '-' . get_required_var('OSCAP_ANSIBLE_PROFILE_ID') : $oscap_tests::ansible_playbook_standart;
     }
+    if (get_required_var('OSCAP_UPLOAD_DEBUG_LOGS')) {
+        $oscap_tests::oscap_upload_debug_logs = get_required_var('OSCAP_UPLOAD_DEBUG_LOGS');
+    }
 
     $self->oscap_security_guide_setup();
 }


### PR DESCRIPTION
Fix python3.11 usage in oscap_tests and optimizing amount of uploaded logS.

- Related ticket: https://progress.opensuse.org/issues/165908
- Verification runs: 
https://openqa.suse.de/tests/15282732#
https://openqa.suse.de/tests/15282742#
https://openqa.suse.de/tests/15282745#
https://openqa.suse.de/tests/15282758#
https://openqa.suse.de/tests/15282759#