### PR TITLE
virt_autotest: Add ppc64le image to osd SL Micro6 Virt

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -236,7 +236,7 @@ sub load_qemu_tests {
     loadtest 'microos/rebuild_initrd' if is_s390x;
     loadtest 'qemu/info';
     loadtest 'qemu/qemu' unless is_rt;
-    loadtest 'qemu/kvm' unless (is_aarch64 or is_rt);
+    loadtest 'qemu/kvm' unless (is_aarch64 or is_ppc64le or is_rt);
     # qemu-linux-user package not available in SLEM
     loadtest 'qemu/user' unless (is_sle_micro || is_leap_micro);
 }

--- a/tests/qemu/qemu.pm
+++ b/tests/qemu/qemu.pm
@@ -49,7 +49,8 @@ sub run {
     }
     elsif (is_ppc64le) {
         is_qemu_preinstalled or install_qemu('qemu-ppc');
-        enter_cmd "qemu-system-ppc64 -nographic";
+        record_soft_failure('workaround for bsc#1230042 - plan to remove this workaround until PPC images test on PowerVM');
+        enter_cmd "qemu-system-ppc64 -vga none -nographic";
         assert_screen ['qemu-open-firmware-ready', 'qemu-ppc64-no-trans-mem'], 60;
         if (match_has_tag 'qemu-ppc64-no-trans-mem') {
             # this should only happen on SLE12SP5


### PR DESCRIPTION
Add ppc64le image to osd SL Micro6.1 Virt 

- Related ticket: https://progress.opensuse.org/issues/164093
- Verification run: 
[sle-micro-6.1-Default-ppc-4096-SelfInstall-ppc64le-Build16.2-slem_installation_virt](https://openqa.suse.de/tests/15428924)
[sle-micro-6.1-Default-ppc-512-SelfInstall-ppc64le-Build16.2-slem_installation_virt](https://openqa.suse.de/tests/15437728)
[sle-micro-6.1-Default-ppc-4096-ppc64le-Build16.2-slem_virtualization](https://openqa.suse.de/tests/15437748)
[sle-micro-6.1-Default-ppc-512-ppc64le-Build16.2-slem_virtualization](https://openqa.suse.de/tests/15437729)