### PR TITLE
Integrate the web automation script for agama in openQA

### DIFF
--- a/lib/Yam/Agama/agama_base.pm
+++ b/lib/Yam/Agama/agama_base.pm
@@ -23,7 +23,7 @@ sub test_flags {
 }
 
 sub upload_traces {
-    my ($dest, $sources) = ("/tmp/traces.tar.gz", "test-results/");
+    my ($dest, $sources) = ("/tmp/puppeteer-log.tar.gz", "log/");
     script_run("tar czf $dest $sources");
     upload_logs($dest, failok => 1);
 }

--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -5,3 +5,4 @@ description: >
 schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests
+  - yam/agama/agama

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -1,33 +1,38 @@
-## Copyright 2023 SUSE LLC
+## Copyright 2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Run interactive installation with Agama,
-# run playwright tests directly from the Live ISO.
+# using a web automation tool to test directly from the Live ISO.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
 use base Yam::Agama::agama_base;
 use strict;
 use warnings;
+use testapi;
 
 use testapi qw(
   assert_script_run
   assert_screen
   get_required_var
   enter_cmd
+  select_console
 );
 
 sub run {
     my $self = shift;
     my $test = get_required_var('AGAMA_TEST');
 
-    assert_script_run("playwright test --trace on --project chromium --config /usr/share/e2e-agama-playwright tests/" . $test . ".spec.ts", timeout => 1200);
-    $self->upload_traces();
-    enter_cmd 'reboot';
+    assert_script_run("agama-integration-tests /usr/share/agama/integration-tests/build/" . $test . ".js", timeout => 1200);
+
+    select_console 'displaymanager';
+    save_screenshot();
+
+    assert_screen('agama-install-finished', 10);
+    assert_and_click('reboot');
 }
 
 sub post_run_hook {
     my ($self) = shift;
-    assert_screen([qw(grub2-agama encrypted-disk-password-prompt)], 120);
     $self->SUPER::post_run_hook;
 }
 

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -12,10 +12,7 @@ use testapi;
 use Utils::Architectures 'is_s390x';
 
 sub run {
-    unless (is_s390x) {
-        assert_screen('agama-product-selection', 120);
-        select_console 'root-console';
-    }
+    select_console 'root-console' unless is_s390x;
 
     my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
     assert_script_run("yupdate patch $repo $branch", timeout => 60);


### PR DESCRIPTION
We have included script preparation, launch and Puppeteer traces upload to OpenQA with, minor modifications.

- Related ticket: https://progress.opensuse.org/issues/165830
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4443241#
- Related PR: https://github.com/jknphy/agama-puppeteer/pull/3