### PR TITLE
Add workaround to prevent network interface order change

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -69,6 +69,9 @@ sub setup_environment {
         assert_script_run("/usr/share/qa/qaset/bin/deploy_hana_perf.sh HANA $mitigation_switch $qaset_kernel_tag");
         assert_script_run("ls /root/qaset/deploy_hana_perf_env.done");
 
+        # workaround to prevent network interface random order
+        assert_script_run('dracut -f --add-drivers "tg3"') if (check_var('PROJECT_M_ROLE', 'PROJECT_M_ABAP'));
+
         return if (get_var('PROJECT_M_ROLE', "") =~ /PROJECT_M_HANA|PROJECT_M_ABAP/);
 
         if (my $qaset_config = get_var("QASET_CONFIG")) {


### PR DESCRIPTION
Add workaround to prevent network interface order change: load tg3 driver before bnxt_en
- Related ticket: [TEAM-9042](https://jira.suse.com/browse/TEAM-9042)
- Needles: N/A
- Verification run:  http://10.67.129.4/tests/73223
