### PR TITLE
Ensure agama automation test get logs when issue happened

### DIFF
--- a/lib/Yam/Agama/agama_base.pm
+++ b/lib/Yam/Agama/agama_base.pm
@@ -4,31 +4,18 @@
 # Summary: base class for Agama tests
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-package Yam::agama::agama_base;
+package Yam::Agama::agama_base;
 use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use y2_base 'save_upload_y2logs';
 use Utils::Logging 'save_and_upload_log';
-use utils 'ensure_serialdev_permissions';
-use serial_terminal qw(select_serial_terminal);
-
-sub pre_run_hook {
-    $testapi::password = 'linux';
-}
 
 sub post_fail_hook {
     select_console 'root-console';
-    # "agama logs store" gathers output from dmesg, journalctl and y2logs.
     save_and_upload_log('agama logs store', "/tmp/agama-logs.tar.gz");
+    save_and_upload_log('journalctl -b > /tmp/journal.log', "/tmp/journal.log");
     upload_traces();
-}
-
-sub post_run_hook {
-    reset_consoles;
-    $testapi::username = "bernhard";
-    $testapi::password = 'nots3cr3t';
 }
 
 sub test_flags {

--- a/lib/Yam/Agama/patch_agama_base.pm
+++ b/lib/Yam/Agama/patch_agama_base.pm
@@ -4,16 +4,12 @@
 # Summary: base class for Patch Agama tests
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-package Yam::agama::patch_agama_base;
+package Yam::Agama::patch_agama_base;
 use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
 use y2_base 'save_upload_y2logs';
-
-sub pre_run_hook {
-    $testapi::password = 'linux';
-}
 
 sub post_fail_hook {
     my ($self) = @_;

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -5,7 +5,7 @@
 # run playwright tests directly from the Live ISO.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-use base Yam::agama::agama_base;
+use base Yam::Agama::agama_base;
 use strict;
 use warnings;
 

--- a/tests/yam/agama/auto.pm
+++ b/tests/yam/agama/auto.pm
@@ -5,7 +5,7 @@
 # reboot and reach login prompt.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-use base Yam::agama::agama_base;
+use base Yam::Agama::agama_base;
 use strict;
 use warnings;
 

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -5,7 +5,7 @@
 # integration test from GitHub.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-use base Yam::agama::patch_agama_base;
+use base Yam::Agama::patch_agama_base;
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/165833
- Needles: N/A
- Verification run: 
  https://openqa.opensuse.org/tests/4442184#step/auto/10    x86_64, upload logs after fail in auto
  https://openqa.opensuse.org/tests/4442256#step/boot_agama/9  x86_64, upload logs after fail in boot_agama
  https://openqa.opensuse.org/tests/4442186#step/auto/6   s390x, upload logs after fail in fail in auto
