### PR TITLE
Add firewall settings for 15-SP7

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -88,7 +88,7 @@
     <keep_install_network config:type="boolean">true</keep_install_network>
     % }
   </networking>
-  % if ($get_var->('VERSION') =~ /15-SP[456]$/) {
+  % if ($get_var->('VERSION') =~ /15-SP[4567]$/) {
   <firewall>
     <enable_firewall config:type="boolean">true</enable_firewall>
     <start_firewall config:type="boolean">true</start_firewall>
@@ -99,6 +99,7 @@
           <interface>eth0</interface>
         </interfaces>
         <services config:type="list">
+          <service>vnc-server</service>
           <service>ssh</service>
         </services>
         <ports config:type="list">


### PR DESCRIPTION
The firewall settings were not added in autoyast_containers.xml which caused ssh error in s390x hosts

- Related ticket: https://progress.opensuse.org/issues/165812
- Verification runs:
  - [15-SP7](https://openqa.suse.de/tests/15294432) :green_circle:
  - [15-SP6](https://openqa.suse.de/tests/15294846) :green_circle:
  - [15-SP5](https://openqa.suse.de/tests/15294847) :green_circle:
  - [15-SP4](https://openqa.suse.de/tests/15294848) :construction: