### PR TITLE
Fix drive detection

### DIFF
--- a/tests/microos/verify_setup.pm
+++ b/tests/microos/verify_setup.pm
@@ -105,11 +105,8 @@ sub disk_tests {
             my $label = basename($fs->{device});
             ## vmware does not add a third drive as provisioning information is passed via guestinfo options
             ## aarch64 can swap the drive labels
-            if (is_aarch64 || is_vmware) {
-                $partitions->{$label} = script_output("readlink -e $fs->{device}");
-            } elsif (script_run("readlink -e $fs->{device} | grep $partitions->{$label}")) {
-                push @errors, "Partition label $label is assigned to wrong partition or drive";
-            }
+            $partitions->{$label} = script_output("readlink -e $fs->{device}");
+            record_info('Test drive', "Partition label $label is $partitions->{$label}");
             delete $fs->{device};
 
             if (exists $fs->{with_mount_unit} && $fs->{with_mount_unit} == 1 &&


### PR DESCRIPTION
Verification of drives configured by ignition and combustion had a test bug. The condition should have been removed in earlier PRs when the config was updated.

- ticket: https://progress.opensuse.org/issues/164922

VRs:

* http://kepler.suse.cz/tests/23985#step/verify_setup/149
* http://kepler.suse.cz/tests/23984#step/verify_setup/172
* http://kepler.suse.cz/tests/23984#step/verify_setup/172

