### PR TITLE
Record the package list before and after zypper path

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1247,6 +1247,10 @@ sub qesap_cluster_log_cmds {
         {
             Cmd => 'cat /var/log/cloudregister',
             Output => 'cloudregister.txt',
+        },
+        {
+            Cmd => 'rpm -qa',
+            Output => 'rpm-qa.txt',
         }
     );
     if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -63,6 +63,11 @@ sub run {
     upload_logs('/tmp/kernel_changelog.log');
     upload_logs('/tmp/repos_list.txt');
 
+    if (get_var('SAVE_LIST_OF_PACKAGES')) {
+        assert_script_run("rpm -qa > /tmp/rpm_packages_list_after_patch.txt");
+        upload_logs('/tmp/rpm_packages_list_after_patch.txt');
+    }
+
     # DESKTOP can be gnome, but patch is happening in shell, thus always force reboot in shell
     power_action('reboot', textmode => 1);
     reconnect_mgmt_console if is_pvm;

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -76,6 +76,11 @@ sub run {
 
     # Workaround for textmode based test, as there is no SAP profiles with textmode yet
     zypper_call 'in libgomp1' if check_var('SYSTEM_ROLE', 'textmode');
+
+    if (get_var('SAVE_LIST_OF_PACKAGES')) {
+        script_run("rpm -qa > /tmp/rpm_packages_list.txt");
+        upload_logs("/tmp/rpm_packages_list.txt");
+    }
 }
 
 sub test_flags {

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -29,6 +29,14 @@ sub run {
 
     my $ha_enabled = get_required_var('HA_CLUSTER') =~ /false|0/i ? 0 : 1;
     select_serial_terminal;
+
+    # Record packages list before deploying ansible if needed
+    if (get_var('SAVE_LIST_OF_PACKAGES')) {
+        my $in = $self->{instances}->[0];
+        $in->ssh_script_run(cmd => 'rpm -qa > /tmp/rpm-qa-before-patch-system.txt');
+        $in->upload_log('/tmp/rpm-qa-before-patch-system.txt');
+    }
+
     # mark as done in advance and also in case of
     # QESAP_DEPLOYMENT_IMPORT as the status flag is mostly
     # used to decide if to call the cleanup


### PR DESCRIPTION
Sometimes we need to know the packages changes during our test when we debugging a failure, especially for QAM test. Ensure that all of our tests, whether they run on prem or in the cloud, record the list of packages and their versions before and after the zypper patch command.

Related: https://jira.suse.com/browse/TEAM-7106

VRs:
**cloud-based:**
SAPHanaSR-ScaleUp-PerfOpt:  https://openqa.suse.de/tests/15304469#downloads  (Added a file: `deploy_qesap_ansible-rpm-qa-before-patch-system.txt`)
sles4sap_gnome_saptune_delete_rename:  https://openqa.suse.de/tests/15303939#downloads (Added a file: `patch_and_reboot-rpm-qa-before-patch-system.txt`)

QAM:
create_hdd_ha_textmode_maintenance: https://openqa.suse.de/tests/15318162#downloads (Add `rpm_list.txt` in test module `patch_and_reboot`).  (This the the parent job of qdevice and qnetd)

sles4sap_horizontal_migration_sapconf: https://openqa.suse.de/tests/15318062#downloads (Add `rpm-list.txt` in test module `patterns`)
sles4sap_horizontal_migration_saptune: https://openqa.suse.de/tests/15318063#downloads (Add `rpm-list.txt` in test module `patterns`)

Aggregates:
sles4sap_scc_gnome_netweaver:  https://openqa.suse.de/tests/15318141#downloads (Add `rpm-list.txt` in test module `patterns`)
sles4sap_scc_textmode_sapconf: https://openqa.suse.de/tests/15318142#downloads (Add `rpm-list.txt` in test module `patterns`)

