### PR TITLE
Remove PUBLISH_HDD_1 setting from sap yaml schedule file

### DIFF
--- a/schedule/yast/maintenance/sap_autoyast_create_hdd_gnome_netweaver_sle12.yaml
+++ b/schedule/yast/maintenance/sap_autoyast_create_hdd_gnome_netweaver_sle12.yaml
@@ -15,7 +15,6 @@ vars:
   INSTANCE_ID: '00'
   INSTANCE_SID: QAD
   INSTANCE_TYPE: ASCS
-  PUBLISH_HDD_1: autoyast_SLES-%VERSION%-%ARCH%-SAP-updated.qcow2
   ROOTONLY: '1'
   SCC_DEREGISTER: '1'
   SCC_REGISTER: installation

--- a/schedule/yast/maintenance/sap_autoyast_create_hdd_textmode_netweaver_sle12.yaml
+++ b/schedule/yast/maintenance/sap_autoyast_create_hdd_textmode_netweaver_sle12.yaml
@@ -16,7 +16,6 @@ vars:
   INSTANCE_ID: '00'
   INSTANCE_SID: QAD
   INSTANCE_TYPE: ASCS
-  PUBLISH_HDD_1: autoyast_SLES-%VERSION%-%ARCH%-textmode-SAP-updated.qcow2
   ROOTONLY: '1'
   SCC_DEREGISTER: '1'
   SCC_REGISTER: installation


### PR DESCRIPTION
Remove PUBLISH_HDD_1 setting from sap yaml schedule file. The removed settings were already added to testsuites via [MR](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/317/diffs#0520e5d1ec21859704fc7ebca5a545e8dd0549fb).

- Related ticket: quick PR
- Needles: n/a
- Verification run:
-  [support image job on ppc64le](https://openqa.suse.de/tests/15289595), [migration job on ppc64le](https://openqa.suse.de/tests/15289669);
-  [support image job on x86_64](https://openqa.suse.de/tests/15303995), [migration job on x86_64](https://openqa.suse.de/tests/15304238#); 
