### PR TITLE
Enable ctdb test in Aggregates in osd

### DIFF
--- a/schedule/ha/bv/basic_cluster_node.yaml
+++ b/schedule/ha/bv/basic_cluster_node.yaml
@@ -37,10 +37,8 @@ vars:
   # Disable qemu snapshots to avoid unexpected fences in HA tests
   QEMU_DISABLE_SNAPSHOTS: '1'
   TIMEOUT_SCALE: '2'
-  # LVM locking daemon used since SLE 15
-  USE_LVMLOCKD: '1'
   USE_SUPPORT_SERVER: '1'
-  VIRTIO_CONSOLE: '0'
+  VIRTIO_CONSOLE: '1'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML
   # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-HA-BV.qcow2
 schedule:


### PR DESCRIPTION
Enable ctdb test in Aggregates in osd

- Related MR for osd: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/784
- Related MR for ow15:  https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/771
- Related ticket: https://jira.suse.com/browse/TEAM-9607
- Verification run: 
15sp6: http://openqa.suse.de/tests/15291380#dependencies (all passed)
15sp5: http://openqa.suse.de/tests/15304274#dependencies (all passed) 
15sp4: http://openqa.suse.de/tests/15303718#dependencies (all passed)
15sp3: http://openqa.suse.de/tests/15291705#dependencies (all passed)
15sp2: http://openqa.suse.de/tests/15294390#dependencies (all passed)
12sp5: http://openqa.suse.de/tests/15304261#dependencies (all passed) 
VRs for `VIRTIO_CONSOLE=1`:
15sp5: http://openqa.suse.de/tests/15304760#dependencies (all passed) (VIRTIO_CONSOLE=1)
12sp5: http://openqa.suse.de/tests/15304753#dependencies (all passed) (VIRTIO_CONSOLE=1)