### PR TITLE
lib/utils.pm: Make clear_console on serial_terminal a no-op

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -388,7 +388,7 @@ So this function will simply type C<clear\n>.
 =cut
 
 sub clear_console {
-    enter_cmd "clear";
+    enter_cmd "clear" unless is_serial_terminal;
 }
 
 =head2 assert_gui_app


### PR DESCRIPTION
There's no reason to use clear on serial_terminal, it's a simple FIFO.

This works around some issues with "enter_cmd" confusing a later script_run,
leading to significant wait_serial timeouts.

The wait_serial failures like https://openqa.opensuse.org/tests/4443132#step/ssh_cleanup/1 waste 18min (!) each in this case as TIMEOUT_SCALE=12.

Verification runs:

https://openqa.opensuse.org/tests/4445067
https://openqa.opensuse.org/tests/4445068
https://openqa.opensuse.org/tests/4445069