### PR TITLE
Fix TD vmware test

### DIFF
--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -30,7 +30,7 @@ sub run {
     elsif (is_qemu) {
         my $host_os_ver = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
         foreach my $guest (keys %virt_autotest::common::guests) {
-            run_tests($guest) if ($guest eq $host_os_ver || $guest eq "${host_os_ver}PV" || $guest eq "${host_os_ver}HVM");
+            run_tests($guest) if ($guest eq $host_os_ver || $guest eq "${host_os_ver}TD" || $guest eq "${host_os_ver}PV" || $guest eq "${host_os_ver}HVM");
         }
     }
 }


### PR DESCRIPTION
 The change introduces an additional check for "TD" ensuring that tests are also executed for guests。

- Related ticket: https://progress.opensuse.org/issues/166010
- Needles: NA
- Verification run: [sles 15 SP4 TD test](https://openqa.suse.de/tests/15305686)
