### PR TITLE
Add az_key_name handling

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -22,6 +22,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
@@ -25,6 +25,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -22,6 +22,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -21,6 +21,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -24,6 +24,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -24,6 +24,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
@@ -21,6 +21,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -19,6 +19,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
@@ -18,6 +18,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -19,6 +19,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -24,6 +24,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
@@ -26,6 +26,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -24,6 +24,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -29,6 +29,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -31,6 +31,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -33,6 +33,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -31,6 +31,7 @@ ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_sas_token: '%HANA_TOKEN%'
+  az_key_name: '%HANA_KEYNAME%'
   hana_media:
     - '%HANA_SAR%'
     - '%HANA_CLIENT_SAR%'

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -57,6 +57,7 @@ sub run {
     $variables{HANA_ACCOUNT} = get_required_var('QESAPDEPLOY_HANA_ACCOUNT');
     $variables{HANA_CONTAINER} = get_required_var('QESAPDEPLOY_HANA_CONTAINER');
     if (get_var('QESAPDEPLOY_HANA_KEYNAME')) {
+        $variables{HANA_KEYNAME} = get_required_var('QESAPDEPLOY_HANA_KEYNAME');
         $variables{HANA_TOKEN} = qesap_az_create_sas_token(storage => get_required_var('QESAPDEPLOY_HANA_ACCOUNT'),
             container => (split("/", get_required_var('QESAPDEPLOY_HANA_CONTAINER')))[0],
             keyname => get_required_var('QESAPDEPLOY_HANA_KEYNAME'),


### PR DESCRIPTION
Add az_key_name in any relevant qe-sap-deployment template. For the moment add it near to the SAS token that later can be removed when token generation is moved to Ansible.

- Related ticket: https://jira.suse.com/browse/TEAM-9540

# Verification run:

## Without https://github.com/SUSE/qe-sap-deployment/pull/263
There are new fields in the conf.yaml but later the qe-sap-deployment simply ignore them
 - sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test@64bit -> https://openqa.suse.de/tests/15305761 :green_circle: even if no `az_key_name` is here https://openqa.suse.de/tests/15305761#step/configure/203

## With https://github.com/SUSE/qe-sap-deployment/pull/263
There are new fields in the conf.yaml and qe-sap-deployment place them in the hana_media.yaml
- sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test@64bit -> https://openqa.suse.de/tests/15305779 :green_circle: `az_key_name` written in the hana_media.yaml file https://openqa.suse.de/tests/15305779#step/configure/203
