### PR TITLE
Fix cloud-init log collection

### DIFF
--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -57,7 +57,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_os_cloud_init_logs() if (check_var('IPADDR2_CLOUDINIT', 1));
+    ipaddr2_os_cloud_init_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -39,7 +39,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_os_cloud_init_logs() if (check_var('IPADDR2_CLOUDINIT', 1));
+    ipaddr2_os_cloud_init_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/sanity.pm
+++ b/tests/sles4sap/ipaddr2/sanity.pm
@@ -29,7 +29,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_os_cloud_init_logs() if (check_var('IPADDR2_CLOUDINIT', 1));
+    ipaddr2_os_cloud_init_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/test.pm
+++ b/tests/sles4sap/ipaddr2/test.pm
@@ -78,7 +78,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_os_cloud_init_logs() if (check_var('IPADDR2_CLOUDINIT', 1));
+    ipaddr2_os_cloud_init_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     ipaddr2_destroy();
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Properly takes in account IPADDR_CLOUDINIT setting default when deciding if log collection is needed or not.


- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run: