### PR TITLE
Adapt password typing for slower arch

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -159,9 +159,9 @@ sub create_user_in_ui {
     assert_screen 'jeos-create-non-root-check';
     send_key "down";
 
-    type_password;
+    type_password $testapi::password, max_interval => 50, wait_screen_change => 15, wait_still_screen => 10;
     wait_screen_change(sub { send_key "down" }, 25);
-    type_password;
+    type_password $testapi::password, max_interval => 50, wait_screen_change => 15, wait_still_screen => 10;
     send_key 'ret';
 
     $user_created = 1;


### PR DESCRIPTION
In https://openqa.opensuse.org/tests/4444816#step/firstrun/15 the password typing results in incomplete typing string which yields a cracklib error that the string is too short.

- ticket: https://progress.opensuse.org/issues/165800

##### Verification runs

 - opensuse-Tumbleweed-JeOS-for-RPi-aarch64-Build20240829-jeos@RPi3 -> https://openqa.opensuse.org/tests/4445634
 - opensuse-Tumbleweed-JeOS-for-RPi-aarch64-Build20240829-jeos@RPi4 -> https://openqa.opensuse.org/tests/4445635

 - opensuse-Tumbleweed-JeOS-for-RPi-aarch64-Build20240829-jeos@RPi4 -> https://openqa.opensuse.org/tests/4445636
 - opensuse-Tumbleweed-JeOS-for-RPi-aarch64-Build20240829-jeos@RPi3 -> https://openqa.opensuse.org/tests/4445637
