### PR TITLE
White list journal check error 'Device luks is not active'

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -626,9 +626,9 @@
         "type": "bug"
     },
     "bsc#1218181": {
-        "description": "Device luks is still in use|Job.* deleted to break ordering cycle starting with.*",
+        "description": "Device luks is still in use|Device luks is not active\\.|Job.* deleted to break ordering cycle starting with.*",
         "products": {
-            "sle-micro": ["6.0"]
+            "sle-micro": ["6.0", "6.1"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
* **Agreement** has been achieved in bsc#1218181 that ```Device lusk is not active``` can be safely whitelisted to avoid further error reporting. 

* **Please** refer to [comment](https://bugzilla.suse.com/show_bug.cgi?id=1218181#c30) for details.

* **Verification Runs:**
  * [verification run](https://openqa.suse.de/tests/15318383) 

