### PR TITLE
Move Public Cloud common ssh opts to ~/.ssh/config

### DIFF
--- a/data/publiccloud/ssh_config
+++ b/data/publiccloud/ssh_config
@@ -1,8 +1,8 @@
 ControlMaster auto
 ControlPath /tmp/ssh_%r_%h_%p
-StrictHostKeyChecking no
 HostKeyAlgorithms +ssh-rsa
 IdentityFile %SSH_KEY%
 ControlPersist 86400
 PasswordAuthentication no
+LogLevel VERBOSE
 

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -280,11 +280,6 @@ sub permit_root_login {
 sub prepare_ssh_tunnel {
     my ($instance) = @_;
 
-    # configure ssh client
-    my $ssh_config_url = data_url('publiccloud/ssh_config');
-    assert_script_run("curl $ssh_config_url -o ~/.ssh/config");
-    file_content_replace("~/.ssh/config", "%SSH_KEY%" => get_ssh_private_key_path());
-
     # Create the ssh alias
     assert_script_run(sprintf(q(echo -e 'Host sut\n  Hostname %s' >> ~/.ssh/config), $instance->public_ip));
 

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -41,7 +41,6 @@ sub run {
     $args->{my_provider} = $provider;
     my $instance = $provider->create_instance(%instance_args);
     $args->{my_instance} = $instance;
-    $instance->ssh_opts("");    # Clear $instance->ssh_opts which ombit the known hosts file and strict host checking by default
 
     $instance->network_speed_test();
     $instance->check_cloudinit() if (is_cloudinit_supported);


### PR DESCRIPTION
This refactoring pull request aims to:
 * Include ~/.ssh/config in every test run so we don't specify common options in every command.
 * Use `ssh_opts` only in specific use cases and leave it otherwise empty.
 * Fix `ssh-keyscan` so it's not scanned twice and both root's as well as user's known_hosts file is updated.
 * Do not force ssh pseudo-terminal allocation as it breaks the ssh multiplexing. It's better to stay with default settings and use `-t` only if needed.
 * Get rid of `-o UserKnownHostsFile=/dev/null` and `-o StrictHostKeyChecking=no` as those might hide real issues and when we expect host key change we use `ssh-keyscan` to fetch it.

- Related ticket: [poo#165039](https://progress.opensuse.org/issues/165039)
- Verification runs:
[Build20240901-1](https://pdostal-server.suse.cz/tests/overview?build=20240901-1&distri=sle&version=15-SP6) of sle-15-SP6-GCE-BYOS-Updates.x86_64	[publiccloud_containers@64bit](https://pdostal-server.suse.cz/tests/7396)	[30 1](https://pdostal-server.suse.cz/tests/7396)	9 minutes ago
[Build20240901-1](https://pdostal-server.suse.cz/tests/overview?build=20240901-1&distri=sle&version=15-SP6) of sle-15-SP6-EC2-BYOS-Updates.x86_64	[publiccloud_img_proof@64bit](https://pdostal-server.suse.cz/tests/7394)	[24 3](https://pdostal-server.suse.cz/tests/7394)	19 minutes ago
[Build20240901-1](https://pdostal-server.suse.cz/tests/overview?build=20240901-1&distri=sle&version=15-SP6) of sle-15-SP6-Azure-BYOS-Updates.x86_64	[publiccloud_img_proof@64bit](https://pdostal-server.suse.cz/tests/7395)	[24 2](https://pdostal-server.suse.cz/tests/7395)	20 minutes ago
[Build20240901-1](https://pdostal-server.suse.cz/tests/overview?build=20240901-1&distri=sle&version=15-SP6) of sle-15-SP6-GCE-BYOS-Updates.aarch64	[publiccloud_img_proof@64bit](https://pdostal-server.suse.cz/tests/7393)	[23 2](https://pdostal-server.suse.cz/tests/7393)	26 minutes ago
[Build20240901-1](https://pdostal-server.suse.cz/tests/overview?build=20240901-1&distri=sle&version=15-SP6) of sle-15-SP6-GCE-BYOS-Updates.aarch64	[publiccloud_cloud_netconfig@64bit](https://pdostal-server.suse.cz/tests/7392)	[7](https://pdostal-server.suse.cz/tests/7392)	28 minutes ago
[Build20240901-1](https://pdostal-server.suse.cz/tests/overview?build=20240901-1&distri=sle&version=15-SP6) of sle-15-SP6-Azure-BYOS-Updates.x86_64	[publiccloud_consoletests@64bit](https://pdostal-server.suse.cz/tests/7391) [(restarted)](https://pdostal-server.suse.cz/tests/7397)	[23](https://pdostal-server.suse.cz/tests/7391)	about an hour ago