### PR TITLE
Clear location constrains at the end of ipaddr2

### DIFF
--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -424,6 +424,23 @@ subtest '[ipaddr2_crm_move]' => sub {
     ok((any { /crm resource move rsc_web_00.*24/ } @calls), "Expected crm command called");
 };
 
+subtest '[ipaddr2_crm_clear]' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+    $ipaddr2->redefine(ipaddr2_get_internal_vm_name => sub {
+            my (%args) = @_;
+            return 'UT-VM-' . $args{id}; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, $args{cmd}; });
+
+    ipaddr2_crm_clear(destination => 42);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /crm resource clear rsc_web_00/ } @calls), "Expected crm command called");
+};
+
 subtest '[ipaddr2_wait_for_takeover]' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -8,8 +8,20 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use serial_terminal 'select_serial_terminal';
-use sles4sap::ipaddr2;
+use serial_terminal qw( select_serial_terminal );
+use sles4sap::ipaddr2 qw(
+  ipaddr2_bastion_key_accept
+  ipaddr2_bastion_pubip
+  ipaddr2_configure_web_server
+  ipaddr2_create_cluster
+  ipaddr2_deployment_logs
+  ipaddr2_destroy
+  ipaddr2_internal_key_accept
+  ipaddr2_internal_key_gen
+  ipaddr2_os_cloud_init_logs
+  ipaddr2_registeration_check
+  ipaddr2_registeration_set
+);
 
 sub run {
     my ($self) = @_;

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -8,8 +8,14 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use serial_terminal 'select_serial_terminal';
-use sles4sap::ipaddr2;
+use serial_terminal qw( select_serial_terminal );
+use sles4sap::ipaddr2 qw(
+  ipaddr2_azure_deployment
+  ipaddr2_deployment_logs
+  ipaddr2_deployment_sanity
+  ipaddr2_destroy
+  ipaddr2_os_cloud_init_logs
+);
 
 sub run {
     my ($self) = @_;

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -8,8 +8,12 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use serial_terminal 'select_serial_terminal';
-use sles4sap::ipaddr2;
+use serial_terminal qw( select_serial_terminal );
+use sles4sap::ipaddr2 qw(
+  ipaddr2_deployment_logs
+  ipaddr2_destroy
+  ipaddr2_os_cloud_init_logs
+);
 
 sub run {
     my ($self) = @_;

--- a/tests/sles4sap/ipaddr2/sanity.pm
+++ b/tests/sles4sap/ipaddr2/sanity.pm
@@ -8,8 +8,14 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use serial_terminal 'select_serial_terminal';
-use sles4sap::ipaddr2;
+use serial_terminal qw( select_serial_terminal );
+use sles4sap::ipaddr2 qw(
+  ipaddr2_cluster_sanity
+  ipaddr2_deployment_logs
+  ipaddr2_destroy
+  ipaddr2_os_cloud_init_logs
+  ipaddr2_os_sanity
+);
 
 sub run {
     my ($self) = @_;

--- a/tests/sles4sap/ipaddr2/test.pm
+++ b/tests/sles4sap/ipaddr2/test.pm
@@ -8,8 +8,19 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use serial_terminal 'select_serial_terminal';
-use sles4sap::ipaddr2;
+use serial_terminal qw( select_serial_terminal );
+use sles4sap::ipaddr2 qw(
+  ipaddr2_bastion_pubip
+  ipaddr2_crm_clear
+  ipaddr2_crm_move
+  ipaddr2_deployment_logs
+  ipaddr2_destroy
+  ipaddr2_os_cloud_init_logs
+  ipaddr2_os_connectivity_sanity
+  ipaddr2_test_master_vm
+  ipaddr2_test_other_vm
+  ipaddr2_wait_for_takeover
+);
 
 sub run {
     my ($self) = @_;
@@ -67,8 +78,8 @@ sub run {
     ipaddr2_test_master_vm(bastion_ip => $bastion_ip, id => 1);
     ipaddr2_test_other_vm(bastion_ip => $bastion_ip, id => 2);
 
-    #test_step "Clear all location constrain used during the test"
-    #ssh_node1 'sudo crm resource clear '"${MY_MOVE_RES}"
+    # Clear all location constrain used during the test
+    ipaddr2_crm_clear(bastion_ip => $bastion_ip);
 }
 
 sub test_flags {


### PR DESCRIPTION
End the Ipaddr2 test module by removing all location constraints in the cluster created along the test.

- Related ticket: https://jira.suse.com/browse/TEAM-9428

# Verification run:

 - sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/296043