### PR TITLE
sssd_389ds_functional: make cgroups rw for systemd

### DIFF
--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -79,7 +79,7 @@ sub run {
     my $container_run_389_ds = "$docker run -itd --shm-size=256m --name ds389_container --hostname ldapserver";
 
     if ($docker eq "docker") {
-        $container_run_389_ds .= " --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --restart=always";
+        $container_run_389_ds .= " --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --restart=always";
     }
 
     assert_script_run("$container_run_389_ds ds389_image");


### PR DESCRIPTION
This test runs systemd inside a container, which expects to be able to create subcgroups in /sys/fs/cgroup. Previously the test tried to mount /sys/fs/cgroup as read-only. Due to a series of unfortunate coincidences, this happened to work:

 * Due to kernel limitations, using "-v a:b:ro" with Docker would do a recursive bind-mount but the read-only flag would only be set on the top mount. Implementing proper recursive attributes only became possible with Linux 5.12 (with mount_setattr).

 * The tests seem to run on cgroupv1 or cgroup-hybrid systems, where /sys/fs/cgroup is a dummy tmpfs mount that has all of the actual subsystems mounted underneath it as child mounts.

The net result is that -v /sys/fs/cgroup:/sys/fs/cgroup:ro actually gave you a read-write set of cgroup subsystems by chance.

However, Docker 25 changes the behaviour of :ro to do what most users expect -- that it would apply recursively because the bind-mount is also recursive. This change causes systemd to fail to start, resulting the container bootlooping and this test failing. This resulted in the Docker 25 update being blocked by this broken test.

So, since the test has always needed a rw /sys/fs/cgroup, let's actually ask for that! This will work with old and new Docker versions.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1224416
