### PR TITLE
Create page object for reboot screen in agama

### DIFF
--- a/lib/Distribution/Opensuse/AgamaDevel.pm
+++ b/lib/Distribution/Opensuse/AgamaDevel.pm
@@ -16,6 +16,7 @@ use Yam::Agama::Pom::GrubMenuPage;
 use Yam::Agama::Pom::GrubEntryEdition::GrubEntryEditionPage;
 use Yam::Agama::Pom::GrubEntryEdition::ppc64le::GrubEntryEditionPage;
 use Yam::Agama::Pom::AgamaUpAndRunningPage;
+use Yam::Agama::Pom::RebootPage;
 
 use Utils::Architectures;
 
@@ -33,6 +34,10 @@ sub get_grub_entry_edition {
 
 sub get_agama_up_an_running {
     return Yam::Agama::Pom::AgamaUpAndRunningPage->new();
+}
+
+sub get_reboot_page {
+    return Yam::Agama::Pom::RebootPage->new();
 }
 
 1;

--- a/lib/Yam/Agama/Pom/RebootPage.pm
+++ b/lib/Yam/Agama/Pom/RebootPage.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles installation reboot screen.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Yam::Agama::Pom::RebootPage;
+use strict;
+use warnings;
+
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    return bless {
+        tag_installation_complete => 'agama-install-finished',
+        tag_reboot_button => 'reboot'
+    }, $class;
+}
+
+sub expect_is_shown {
+    my ($self, %args) = @_;
+    assert_screen($self->{tag_installation_complete}, $args{timeout});
+}
+
+sub reboot {
+    my ($self) = @_;
+    assert_and_click($self->{tag_reboot_button});
+}
+
+1;

--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -6,3 +6,7 @@ schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests
   - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_product
+  - yam/validate/validate_user

--- a/test_data/yam/agama_tumbleweed.yaml
+++ b/test_data/yam/agama_tumbleweed.yaml
@@ -1,0 +1,2 @@
+---
+os_release_name: openSUSE Tumbleweed

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -12,30 +12,20 @@ use testapi;
 
 use testapi qw(
   assert_script_run
-  assert_screen
   get_required_var
-  enter_cmd
-  select_console
 );
 
 sub run {
     my $self = shift;
     my $test = get_required_var('AGAMA_TEST');
+    my $reboot_page = $testapi::distri->get_reboot_page();
 
     script_run("dmesg --console-off");
     assert_script_run("/usr/share/agama/system-tests/" . $test . ".cjs", timeout => 1200);
     script_run("dmesg --console-on");
 
-    select_console 'displaymanager';
-    save_screenshot();
-
-    assert_screen('agama-install-finished', 10);
-    assert_and_click('reboot');
-}
-
-sub post_run_hook {
-    my ($self) = shift;
-    $self->SUPER::post_run_hook;
+    select_console('installation');
+    $reboot_page->reboot();
 }
 
 1;

--- a/tests/yam/agama/auto.pm
+++ b/tests/yam/agama/auto.pm
@@ -12,8 +12,10 @@ use warnings;
 use testapi;
 
 sub run {
-    assert_screen('agama-install-finished', 1200);
-    assert_and_click('reboot');
+    my $reboot_page = $testapi::distri->get_reboot_page();
+
+    $reboot_page->expect_is_shown(timeout => 1200);
+    $reboot_page->reboot();
 
     # For agama test, it is too short time to match the grub2, so we create
     # a new needle to avoid too much needles loaded.


### PR DESCRIPTION
Added POM model of reboot page

- Related ticket: https://progress.opensuse.org/issues/165980
- Needles: N/A
- Verification run:
  - default:
    - x86_64: https://openqa.opensuse.org/tests/4456712 (05/09/2024)
    - aarch64: https://openqa.opensuse.org/tests/4456713 (05/09/2024)
  - auto:
    - x86_64: https://openqa.opensuse.org/tests/4456710 (05/09/2024)
    - aarch64: https://openqa.opensuse.org/tests/4456711 (05/09/2024)
