### PR TITLE
Fix kselftests known issues usage

### DIFF
--- a/lib/LTP/kirk.pm
+++ b/lib/LTP/kirk.pm
@@ -99,7 +99,7 @@ sub run
     $cmd .= "--suite-timeout $args{timeout} ";
     $cmd .= "--framework $args{framework} " if $args{framework};
     $cmd .= "--sut $args{sut} " if $args{sut};
-    $cmd .= "--skip-tests $args{skip} " if $args{skip};
+    $cmd .= "--skip-tests '$args{skip}' " if $args{skip};
     $cmd .= "--env $args{envs} " if $args{envs};
     $cmd .= "--run-suite $args{suite} " if $args{suite};
     $cmd .= "$args{opts} " if $args{opts};

--- a/tests/kernel/kselftests.pm
+++ b/tests/kernel/kselftests.pm
@@ -25,9 +25,10 @@ sub run_tests
     my $env = prepare_whitelist_environment();
     $env->{kernel} = script_output('uname -r');
 
+    my $suite = get_var('KSELFTESTS_SUITE', '');
     my $issues = get_var('KSELFTESTS_KNOWN_ISSUES', '');
     my $whitelist = LTP::WhiteList->new($issues);
-    my @skipped = $whitelist->list_skipped_tests($env, 'kselftests');
+    my @skipped = $whitelist->list_skipped_tests($env, $suite);
     my $skip_tests;
     if (@skipped) {
         $skip_tests = join("|", @skipped);
@@ -43,8 +44,6 @@ sub run_tests
         {src => $root, dst => $root},
         {src => "/tmp", dst => "/tmp"}
     );
-
-    my $suite = get_var('KSELFTESTS_SUITE', '');
 
     LTP::kirk->run(
         framework => "kselftests:root=$root",


### PR DESCRIPTION
This patch fixes kirk module that was bugged due to wrong --skip-tests usage and correct the way we fetch known issues file from qam.

- Verification run: https://openqa.suse.de/tests/15328453#

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>