### PR TITLE
Fix curl in cloud_netconfig

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -654,7 +654,7 @@ sub query_metadata {
     # 169.254.169.254 in case of all public cloud providers.
     my $pc_meta_api_ip = '169.254.169.254';
 
-    my $query_meta_ipv4_cmd = qq(curl -H Metadata:true "http://$pc_meta_api_ip/metadata/instance/network/interface/$ifNum/ipv4/ipAddress/$addrCount/privateIpAddress?api-version=2023-07-01&format=text");
+    my $query_meta_ipv4_cmd = qq(curl -sw "\\n" -H Metadata:true "http://$pc_meta_api_ip/metadata/instance/network/interface/$ifNum/ipv4/ipAddress/$addrCount/privateIpAddress?api-version=2023-07-01&format=text");
     my $data = $instance->ssh_script_output($query_meta_ipv4_cmd);
 
     die("Failed to get interface IPs from metadata server") unless length($data);

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -299,9 +299,9 @@ sub query_metadata {
     # 169.254.169.254 in case of all public cloud providers.
     my $pc_meta_api_ip = '169.254.169.254';
 
-    my $access_token = $instance->ssh_script_output(qq(curl -X PUT http://$pc_meta_api_ip/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds:60"));
+    my $access_token = $instance->ssh_script_output(qq(curl -sw "\\n" -X PUT http://$pc_meta_api_ip/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds:60"));
     record_info("DEBUG", $access_token);
-    my $query_meta_ipv4_cmd = qq(curl -H "X-aws-ec2-metadata-token: $access_token" "http://$pc_meta_api_ip/latest/meta-data/local-ipv4");
+    my $query_meta_ipv4_cmd = qq(curl -sw "\\n" -H "X-aws-ec2-metadata-token: $access_token" "http://$pc_meta_api_ip/latest/meta-data/local-ipv4");
     my $data = $instance->ssh_script_output($query_meta_ipv4_cmd);
 
     die("Failed to get data from metadata server") unless length($data);

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -190,7 +190,7 @@ sub query_metadata {
     # 169.254.169.254 in case of all public cloud providers.
     my $pc_meta_api_ip = '169.254.169.254';
 
-    my $query_meta_ipv4_cmd = qq(curl -H "Metadata-Flavor: Google" "http://$pc_meta_api_ip/computeMetadata/v1/instance/network-interfaces/0/ip");
+    my $query_meta_ipv4_cmd = qq(curl -sw "\\n" -H "Metadata-Flavor: Google" "http://$pc_meta_api_ip/computeMetadata/v1/instance/network-interfaces/0/ip");
     my $data = $instance->ssh_script_output($query_meta_ipv4_cmd);
 
     return $data;

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -42,7 +42,6 @@ sub run {
     $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
 
     if (is_cloudinit_supported) {
-        record_info 'BOOM';
         $args->{my_instance}->check_cloudinit();
         permit_root_login($args->{my_instance});
     }


### PR DESCRIPTION
- Related ticket: #20102
- Verification runs: 
[Build20240902-1](https://pdostal-server.suse.cz/tests/overview?build=20240902-1&distri=sle&version=12-SP5) of sle-12-SP5-Azure-Basic-Updates.x86_64	[publiccloud_cloud_netconfig@64bit](https://pdostal-server.suse.cz/tests/7410)	[7](https://pdostal-server.suse.cz/tests/7410)	15 minutes ago
[Build20240902-1](https://pdostal-server.suse.cz/tests/overview?build=20240902-1&distri=sle&version=12-SP5) of sle-12-SP5-EC2-Updates.x86_64	[publiccloud_cloud_netconfig@64bit](https://pdostal-server.suse.cz/tests/7411)	[7](https://pdostal-server.suse.cz/tests/7411)	16 minutes ago
[Build20240901-1](https://pdostal-server.suse.cz/tests/overview?build=20240901-1&distri=sle&version=15-SP6) of sle-15-SP6-GCE-BYOS-Updates.aarch64	[publiccloud_cloud_netconfig@64bit](https://pdostal-server.suse.cz/tests/7392)	[7](https://pdostal-server.suse.cz/tests/7392)	about 5 hours ago