### PR TITLE
Fix the resource name in hanasr_angi test

### DIFF
--- a/tests/sles4sap/monitoring_services.pm
+++ b/tests/sles4sap/monitoring_services.pm
@@ -70,7 +70,7 @@ sub configure_hanadb_exporter {
     # Add monitoring resource in the HA stack
     wait_for_idle_cluster;
     if (get_var('HA_CLUSTER') and is_node(1)) {
-        my $hanadb_msl = "msl_SAPHana_$args{rsc_id}";
+        my $hanadb_msl = get_var('USE_SAP_HANA_SR_ANGI') ? "mst_SAPHanaCtl_$args{rsc_id}" : "msl_SAPHana_$args{rsc_id}";
         my $hanadb_exp_rsc = "rsc_exporter_$args{rsc_id}";
         $hanadb_exporter_port = 9668;
         $check_exporter = 'true';


### PR DESCRIPTION
The resource name is different in SAPHanaSR-angi and SAPHanaSR. So we need to distinguish it.

Related: https://jira.suse.com/browse/TEAM-9608

VRs:

x86: https://openqa.suse.de/tests/15338735 (Passed)
ppc64le: https://openqa.suse.de/tests/15346058 (Passed)

