### PR TITLE
SELinux as default MAC in enforcing mode in the tumbleweed installer (bsc#1230118)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2310,7 +2310,8 @@ sub load_system_prepare_tests {
     loadtest 'kernel/install_kernel_flavor' if get_var('KERNEL_FLAVOR');
     loadtest 'console/install_rt_kernel' if check_var('SLE_PRODUCT', 'SLERT');
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
-    loadtest 'console/check_selinux_fails' if get_var('SELINUX');
+    # Check SELinux failures if SELinux is enabled
+    loadtest 'console/check_selinux_fails' if get_var('SELINUX') || has_selinux_by_default;
     loadtest 'security/cc/ensure_crypto_checks_enabled' if check_var('SYSTEM_ROLE', 'Common_Criteria');
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1106,7 +1106,8 @@ sub load_inst_tests {
         if (check_var('VIDEOMODE', 'text') && is_ipmi) {
             loadtest "installation/disable_grub_graphics";
         }
-        loadtest "installation/enable_selinux" if get_var('SELINUX');
+        # Do not run enable_selinux in systems that have SELinux by default (bsc#1230118)
+        loadtest "installation/enable_selinux" if get_var('SELINUX') && !has_selinux_by_default;
 
         if (check_var("UPGRADE", "LOW_SPACE")) {
             loadtest "installation/disk_space_release";

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2311,7 +2311,7 @@ sub load_system_prepare_tests {
     loadtest 'console/install_rt_kernel' if check_var('SLE_PRODUCT', 'SLERT');
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
     # Check SELinux failures if SELinux is enabled
-    loadtest 'console/check_selinux_fails' if get_var('SELINUX') || has_selinux_by_default;
+    loadtest 'console/check_selinux_fails' if has_selinux;
     loadtest 'security/cc/ensure_crypto_checks_enabled' if check_var('SYSTEM_ROLE', 'Common_Criteria');
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1100,8 +1100,8 @@ sub load_inst_tests {
         loadtest "installation/resolve_dependency_issues" unless (get_var("DEPENDENCY_RESOLVER_FLAG") || get_var('KERNEL_64KB_PAGE_SIZE'));
         loadtest "installation/installation_overview";
         # On Xen PV we don't have GRUB on VNC
-        # SELinux relabel reboots, so grub needs to timeout
-        set_var('KEEP_GRUB_TIMEOUT', 1) if check_var('VIRSH_VMM_TYPE', 'linux') || get_var('SELINUX');
+        # SELinux relabel reboots on SLE <16 and Leap <16.0, so grub needs to timeout
+        set_var('KEEP_GRUB_TIMEOUT', 1) if check_var('VIRSH_VMM_TYPE', 'linux') || (get_var('SELINUX') && (is_sle('<16') || is_leap('<16.0')));
         loadtest "installation/disable_grub_timeout" unless get_var('KEEP_GRUB_TIMEOUT');
         if (check_var('VIDEOMODE', 'text') && is_ipmi) {
             loadtest "installation/disable_grub_graphics";

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -59,6 +59,7 @@ use constant {
           package_version_cmp
           get_version_id
           php_version
+          has_selinux_by_default
         )
     ],
     BACKEND => [
@@ -971,5 +972,14 @@ Returns true for tests using the images built by the "JeOS" package on OBS
 
 sub is_community_jeos {
     return (get_var('FLAVOR', '') =~ /JeOS-for-(AArch64|RISCV|RPi)/);
+}
+
+=head2 has_selinux_by_default
+
+Returns true if the distro has SELinux as default MAC
+=cut
+
+sub has_selinux_by_default {
+    return is_tumbleweed || (is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos);
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -60,6 +60,7 @@ use constant {
           get_version_id
           php_version
           has_selinux_by_default
+          has_selinux
         )
     ],
     BACKEND => [
@@ -980,6 +981,9 @@ Returns true if the distro has SELinux as default MAC
 =cut
 
 sub has_selinux_by_default {
-    return (is_tumbleweed && check_var("VERSION", "Staging:D")) || (is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos);
+    return (is_tumbleweed && check_var("VERSION", "Staging:D")) || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos;
 }
 
+sub has_selinux {
+    return get_var('SELINUX', has_selinux_by_default);
+}

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -980,6 +980,6 @@ Returns true if the distro has SELinux as default MAC
 =cut
 
 sub has_selinux_by_default {
-    return is_tumbleweed || (is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos);
+    return (is_tumbleweed && check_var("VERSION", "Staging:D")) || (is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos);
 }
 

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -112,4 +112,61 @@ subtest 'package_version_cmp' => sub {
         '5.3.18-200.1.g3e09edd > 5.3.18-198.1.g6b7890d');
 };
 
+subtest 'has_selinux_by_default' => sub {
+    use version_utils 'has_selinux_by_default';
+
+    # Test Leap (SELinux not enabled by default)
+    set_var('DISTRI', 'opensuse');
+    set_var('VERSION', '42.3');
+    ok !has_selinux_by_default, "check !has_selinux_by_default for Leap";
+
+    # Test MicroOS (SELinux enabled by default)
+    set_var('DISTRI', 'microos');
+    set_var('VERSION', '0');
+    ok has_selinux_by_default, "check has_selinux_by_default for MicroOS";
+
+    # Test SLE Micro invalid version (SELinux not enabled by default)
+    set_var('DISTRI', 'sle-micro');
+    set_var('VERSION', '0');
+    ok !has_selinux_by_default, "check !has_selinux_by_default for invalid sle-micro";
+
+    # Test SLE Micro 5.3 (SELinux not enabled by default)
+    set_var('VERSION', '5.3');
+    ok !has_selinux_by_default, "check !has_selinux_by_default for sle-micro 5.3";
+
+    # Test SLE Micro 5.4 (SELinux enabled by default)
+    set_var('VERSION', '5.4');
+    ok has_selinux_by_default, "check has_selinux_by_default for sle-micro 5.4";
+
+    # Test Tumbleweed (SELinux enabled by default only in Staging:D)
+    set_var('DISTRI', 'opensuse');
+    set_var('VERSION', 'Tumbleweed');
+    ok !has_selinux_by_default, "check !has_selinux_by_default for Tumbleweed";
+
+    set_var('VERSION', 'Staging:D');
+    ok has_selinux_by_default, "check has_selinux_by_default for Tumbleweed Staging:D";
+};
+
+subtest 'has_selinux' => sub {
+    use version_utils 'has_selinux';
+
+    # Test SLE Micro 5.4 (enabled by default)
+    set_var('DISTRI', 'sle-micro');
+    set_var('VERSION', '5.4');
+    ok has_selinux, "check has_selinux with default settings (sle-micro 5.4)";
+
+    # Test SLE Micro 5.3 (not enabled by default)
+    set_var('VERSION', '5.3');
+    ok !has_selinux, "check !has_selinux with default settings (sle-micro 5.3)";
+
+    # Test Tumbleweed (default enabled in Staging:D)
+    set_var('DISTRI', 'opensuse');
+    set_var('VERSION', 'Tumbleweed');
+    ok !has_selinux, "check !has_selinux for Tumbleweed without SELINUX=1 environment";
+    set_var('SELINUX', '1');
+    ok has_selinux, "check has_selinux for Tumbleweed with SELINUX=1";
+    set_var('SELINUX', '0');
+    ok !has_selinux, "check !has_selinux for Tumbleweed with SELINUX=0";
+};
+
 done_testing;

--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -13,7 +13,7 @@ use strict;
 use warnings;
 use testapi;
 use transactional qw(process_reboot);
-use version_utils qw(is_leap_micro is_microos is_sle_micro is_public_cloud);
+use version_utils qw(has_selinux_by_default is_leap_micro is_microos is_sle_micro is_public_cloud);
 use Utils::Systemd qw(systemctl);
 use Utils::Logging 'save_and_upload_log';
 use transactional qw(trup_call check_reboot_changes process_reboot);
@@ -57,7 +57,7 @@ sub run {
 
     # install and enable SELinux if not done by default
     if (!is_enforcing) {
-        if (is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos) {
+        if (has_selinux_by_default) {
             if (is_sle_micro('=5.4')) {
                 record_soft_failure("bsc#1211917 - SELinux not in enforcing mode on SLEM 5.4");
             } else {


### PR DESCRIPTION
1. Only keep grub timeout for tests that have SELINUX=1 set and are sle<16, microos-tools in SLE16 and tw contain a fix for this.
2. Introduce has_selinux_by_default to version_utils, which returns true if the distro has selinux by default.
3. Do not run enable_selinux in systems that have SELinux by default, since the test will fail as it is already enabled.
4. Check SELinux failures when SELinux is enabled by default and not only when SELINUX=1 is set.

In contrast to my previous draft I now keep the `SELINUX` variable for the distros where SELinux is not enabled by default and you want to enable it before running tests.

tw ZDUP/UPGRADE should not be affected (i think) because:
1. only for sle <16
2. noop
3. `SELINUX` will not be set for these tests
4. audit log should be empty, otherwise it is probably a product issue

- Related ticket: 
  - https://bugzilla.suse.com/show_bug.cgi?id=1230118
  - https://progress.opensuse.org/issues/166613
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4666691
  - failed previously: https://openqa.opensuse.org/tests/4456186
