### PR TITLE
KDE enablement for agama.pm

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -119,13 +119,19 @@ sub run {
     assert_and_click('agama-show-tabs');
 
     # default is just a minimal server style install
-    if (check_var('DESKTOP', 'gnome')) {
+    if (get_var('DESKTOP')) {
         assert_and_click('agama-software-tab');
 
-        wait_still_screen 5;
+        wait_still_screen(5);
         assert_and_click('agama-change-software-selection');
-        wait_still_screen 5;
-        assert_and_click('agama-software-selection-gnome-desktop-wayland');
+        wait_still_screen(5);
+
+        if (check_var('DESKTOP', 'gnome')) {
+            assert_and_click('agama-software-selection-gnome-desktop-wayland');
+        } elsif (check_var('DESKTOP', 'kde')) {
+            assert_and_click('agama-software-selection-kde-desktop-wayland');
+        }
+
         assert_and_click('agama-software-selection-close');
     }
 


### PR DESCRIPTION
Enable KDE on Leap 16.0 installation with agama

Related PR https://github.com/os-autoinst/opensuse-jobgroups/pull/517
kde-agama in https://openqa.opensuse.org/admin/test_suites

Verification run https://openqa.opensuse.org/tests/4457957#live