### PR TITLE
Move SSH Enrollment test to JeOS

### DIFF
--- a/schedule/jeos/ssh-enroll.yaml
+++ b/schedule/jeos/ssh-enroll.yaml
@@ -1,5 +1,16 @@
 name: jeos-ssh-enroll
+
 description: >
   Test the first boot wizard ssh enrollment. Maintainer: qa-c@suse.de
+
+vars:
+  DESKTOP: textmode
+  FIRST_BOOT_CONFIG: wizard
+  HDD_2: ''
+  NICTYPE: tap
+  NUMDISKS: '1'
+  SSH_ENROLL_PAIR: '1'
+  WORKER_CLASS: tap
+
 schedule:
   - jeos/firstrun

--- a/schedule/jeos/ssh-enroll.yaml
+++ b/schedule/jeos/ssh-enroll.yaml
@@ -1,0 +1,5 @@
+name: jeos-ssh-enroll
+description: >
+  Test the first boot wizard ssh enrollment. Maintainer: qa-c@suse.de
+schedule:
+  - jeos/firstrun

--- a/schedule/jeos/supportserver.yaml
+++ b/schedule/jeos/supportserver.yaml
@@ -1,11 +1,25 @@
 name: jeos-supportserver
 description: >
   Create a support server for multimachine tests. Maintainer: qa-c@suse.de
+
+vars:
+  BOOT_HDD_IMAGE: '1'
+  DESKTOP: gnome
+  NICTYPE: tap
+  NUMDISKS: '1'
+  SSH_ENROLL_PAIR: '1'
+  SUPPORT_SERVER: '1'
+  SUPPORT_SERVER_ROLES: dhcp,dns
+  WORKER_CLASS: tap
+  # add this one to the scenario in openqa or the group yaml:
+  # +HDD_1: 'support_server_tumbleweed@64bit.qcow2'
+
 conditional_schedule:
   ssh_enroll:
     SSH_ENROLL_PAIR:
       '1':
         - jeos/ssh_enroll
+
 schedule:
   - support_server/login
   - support_server/setup

--- a/schedule/jeos/supportserver.yaml
+++ b/schedule/jeos/supportserver.yaml
@@ -1,6 +1,6 @@
-name: microos_supportserver
+name: jeos-supportserver
 description: >
-  Create a support server for multimachine tests
+  Create a support server for multimachine tests. Maintainer: qa-c@suse.de
 conditional_schedule:
   ssh_enroll:
     SSH_ENROLL_PAIR:

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -282,7 +282,7 @@ sub run {
             sleep 30;    # make sure we have an IP
             mutex_create 'SSH_ENROLL_PAIR';
             send_key 'y';
-            assert_screen 'jeos-ssh-enroll-pairing', 600;
+            check_screen 'jeos-ssh-enroll-pairing', 20;
             assert_screen 'jeos-ssh-enroll-paired', 120;
             send_key 'y';
             assert_screen 'jeos-ssh-enroll-import', 120;


### PR DESCRIPTION
Since NICTYPE=tap [breaks](https://openqa.opensuse.org/tests/4454841) MicroOS Health Checker, move the first run wizard SSH enrollment test into JeOS/MinimalVM context. While at it, add some required variables to the schedule files so that the group definition can be cleaner.

- Related ticket:
https://progress.opensuse.org/issues/160664
- Verification runs:
http://rmarliere-openqa.qe.prg2.suse.org/tests/2282
http://rmarliere-openqa.qe.prg2.suse.org/tests/2283
- Schedule:
https://github.com/os-autoinst/opensuse-jobgroups/pull/509
