### PR TITLE
Correct install medium for sle15sp7 UEFI guest on XEN

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -5,7 +5,7 @@
     <guest_version_major>15</guest_version_major>
     <guest_version_minor>7</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build>gm</guest_build>
+    <guest_build/>
     <host_hypervisor_uri/>
     <host_virt_type>xen</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>


### PR DESCRIPTION
A small fix. 

- Related ticket: https://progress.opensuse.org/issues/163682
- Verification run: 
[uefi-gi-guest_developing-on-host_developing-xen](http://openqa.suse.de/tests/15388338)
