### PR TITLE
Locally disable ssh mux for the HanaSR crash test

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -372,7 +372,12 @@ sub stop_hana {
         $self->{my_instance}->run_ssh_command(cmd => 'sudo su -c "' . $cmd . '"',
             timeout => "0",
             # Try only extending ssh_opts
-            ssh_opts => "-o ServerAliveInterval=2 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR",
+            ssh_opts => join(' ',
+                '-o ServerAliveInterval=2',
+                '-o UserKnownHostsFile=/dev/null',
+                '-o StrictHostKeyChecking=no',
+                #'-o LogLevel=ERROR',
+                '-o ControlPath=none'),
             %args);
         # It is better to wait till ssh disappear
         record_info("Wait ssh disappear start");


### PR DESCRIPTION
Add ssh command line option to avoid to use ControlMaster for the specific command we use to crash the remote HANA node. It is about overwriting what the PC API configure in the ~/.ssh/config at the beginning of each job.

- Related ticket: https://progress.opensuse.org/issues/165039 and https://jira.suse.com/browse/TEAM-9215

# Verification run:

## Azure

###  sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-09-06T02:03:15Z-hanasr_azure_test_sapconf_msi@az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/296353

## AWS

### sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-09-06T02:03:15Z-hanasr_aws_test_fencing_sbd@ec2_r4.8xlarge
- http://openqaworker15.qa.suse.cz/tests/296352
