### PR TITLE
Add system_workarounds to get proper root console

### DIFF
--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -6,4 +6,5 @@ schedule:
   - installation/agama
   - installation/first_boot
   - installation/opensuse_welcome
+  - installation/system_workarounds
   - console/system_prepare


### PR DESCRIPTION
Just like in Leap 15.0 test suite ensure to execeute system_workarounds before system_prepare. It does seem that system-prepare already expects root-console with login. The login usually happens in previous module system_workarounds on 15.X.