### PR TITLE
Add timeout 10s delay for 'whoami' command in glibc_locale

### DIFF
--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -39,7 +39,9 @@ my %test_data_lang = (
 );
 
 sub switch_user {
-    enter_cmd("su - $testapi::username");
+    # In aarch64 the user change takes some time, causing the next command to get
+    # lost
+    enter_cmd("su - $testapi::username", wait_still_screen => 10);
     validate_script_output('whoami', sub { m/$testapi::username/ });
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/158799
- Verification run: https://openqa.opensuse.org/tests/4467126#step/glibc_locale/82