### PR TITLE
cryptsetup password quality check fix

### DIFF
--- a/tests/console/cryptsetup.pm
+++ b/tests/console/cryptsetup.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2021 SUSE LLC
+# Copyright 2016-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Package: cryptsetup
@@ -21,7 +21,9 @@ use version_utils qw(is_sle);
 
 sub run {
     # Strengthen password to avoid password quality check failed on Tumbleweed
-    my $cryptpasswd = $testapi::password . '123';
+    my @set = ('0' .. '9', 'A' .. 'F');
+    my $randstr = join '' => map $set[rand @set], 1 .. 10;
+    my $cryptpasswd = $testapi::password . '-' . $randstr;
     select_serial_terminal;
 
     # Update related packages including latest systemd


### PR DESCRIPTION
Changes to meet password quality check requirements

Fix poo#165854

- Related ticket: https://progress.opensuse.org/issues/165854
- Verification run: https://openqa.suse.de/tests/15376608/modules/cryptsetup/steps/1/src