### PR TITLE
Make sure to reset console after getting logs

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -188,6 +188,8 @@ sub run {
     console('installation')->set_tty(get_agama_install_console_tty());
     upload_agama_logs();
     select_console('installation', await_console => 0);
+    # make sure newly booted system does not expect we're still logged in console
+    reset_consoles();
     assert_and_click('agama-reboot-after-install');
 
 }


### PR DESCRIPTION
It seems that we're confusing openQA which believes that we are already logged into console. 
The login happened during installation on agama-live. Therefore we need to call reset_consoles();

Test run https://openqa.opensuse.org/tests/4465322#live