### PR TITLE
Satisfy password quality check requirements

### DIFF
--- a/tests/console/cryptsetup.pm
+++ b/tests/console/cryptsetup.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2021 SUSE LLC
+# Copyright 2016-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Package: cryptsetup
@@ -21,7 +21,7 @@ use version_utils qw(is_sle);
 
 sub run {
     # Strengthen password to avoid password quality check failed on Tumbleweed
-    my $cryptpasswd = $testapi::password . '123';
+    my $cryptpasswd = $testapi::password . '_on-a-sunny-D4Y';
     select_serial_terminal;
 
     # Update related packages including latest systemd


### PR DESCRIPTION
Fix poo#165854

- Related ticket: https://progress.opensuse.org/issues/165854
- Verification run: https://openqa.suse.de/tests/15379176/modules/cryptsetup/steps/1/src