### PR TITLE
Drop system-workarounds for Leap 16.0

### DIFF
--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -6,5 +6,4 @@ schedule:
   - installation/agama
   - installation/first_boot
   - installation/opensuse_welcome
-  - installation/system_workarounds
   - console/system_prepare


### PR DESCRIPTION
It seems that we no longer not need system_workarounds, as the console issue was caused by missing console_reset();