### PR TITLE
Add time syncronization step to IPMI test

### DIFF
--- a/lib/web_browser.pm
+++ b/lib/web_browser.pm
@@ -53,7 +53,6 @@ sub setup_web_browser_env {
             script_run("SUSEConnect -p PackageHub/$version/$arch", 300);
         }
     }
-    zypper_call("--no-refresh --no-gpg-checks search -it pattern fips") if get_var('FIPS_ENABLED');
 }
 
 =head2 run_web_browser_text_based

--- a/schedule/security/fips_ipmi/fips_crypt_web.yaml
+++ b/schedule/security/fips_ipmi/fips_crypt_web.yaml
@@ -3,6 +3,7 @@ description:    >
     This is for the crypt_web fips tests.
 schedule:
     - boot/boot_to_desktop
+    - console/timesync
     - console/curl_https
     - console/wget_https
     - console/w3m_https

--- a/tests/console/timesync.pm
+++ b/tests/console/timesync.pm
@@ -1,0 +1,21 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enable ntp and wait for clock to be syncronized
+# before proceeding. Useful for bare-metal IPMI tests
+# Maintainer: QE Security <none@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+    assert_script_run 'timedatectl set-ntp true';
+    assert_script_run 'chronyc makestep';
+    assert_script_run 'chronyc waitsync 120 0.5', 1210;
+}
+
+1;

--- a/tests/console/w3m_https.pm
+++ b/tests/console/w3m_https.pm
@@ -17,7 +17,6 @@ use web_browser qw(setup_web_browser_env run_web_browser_text_based);
 
 sub run {
     select_console("root-console");
-    zypper_call("--no-refresh --no-gpg-checks search -it pattern fips") if get_var('FIPS_ENABLED');
     zypper_call("--no-refresh --no-gpg-checks in w3m");
     run_web_browser_text_based("w3m", "-dump_head");
 }


### PR DESCRIPTION
w3m test was failing due to clock not syncronized on bare-metal SUT.

Added a simple time syncronization step to the IPMI schedule and removed useless FIPS pattern search in web modules

- Related ticket: https://progress.opensuse.org/issues/166337
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/15378807

(note: VR fails on links because PackageHub is not yet available on 15-SP7, see [poo#166307](https://progress.opensuse.org/issues/166307)) 