### PR TITLE
Remove HANA_OS_MAJOR_VERSION setting

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -74,7 +74,6 @@ sub run {
 
     # Collect OpenQA variables and default values
     set_var_output('NODE_COUNT', 1) unless ($ha_enabled);
-    set_var_output('HANA_OS_MAJOR_VERSION', (split('-', get_var('VERSION')))[0]);
     # Cluster needs at least 2 nodes
     die "HA cluster needs at least 2 nodes. Check 'NODE_COUNT' parameter." if ($ha_enabled && (get_var('NODE_COUNT') <= 1));
 


### PR DESCRIPTION
Remove setting that is no more used in qe-sap-deployment project neither in any conf.yaml templates used in OSADO.


- Related ticket: https://jira.suse.com/browse/TEAM-8096

# Verification run:

## sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-09-09T02:03:21Z-hanasr_aws_test_fencing_sbd@ec2_r4.8xlarge

-  http://openqaworker15.qa.suse.cz/tests/296558 :green_circle:  deployment is fine without the setting
 
## sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-09-09T02:03:21Z-hanasr_azure_test_saptune_msi@az_Standard_E4s_v3

- http://openqaworker15.qa.suse.cz/tests/296559 :green_circle:  deployment is fine without the setting
 