### PR TITLE
Prevent erroneous disabling of ports with STP=off for sle12

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -110,8 +110,9 @@
         <bridge>yes</bridge>
         <bridge_forwarddelay>15</bridge_forwarddelay>
         <!-- Use specified interface instead of a list to avoid bonding issues which act as router and created illegal duplicate traffic for gateway of its subnet. -->
+	<!-- Turn BRIDGE_STP off as it might lead to network loop and machine will lose cable connection -->
         <bridge_ports><%= $get_var->('BRIDGE_PORT', 'eth0') %></bridge_ports>
-        <bridge_stp>on</bridge_stp>
+        <bridge_stp>off</bridge_stp>
         <startmode>auto</startmode>
       </interface>
     </interfaces>

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -210,7 +210,7 @@ sub run {
         check_screen([qw(load-linux-kernel load-initrd)], 240);
         # Loading initrd spend much time(fg. 10-15 minutes to Beijing SUT)
         # Downloading from O3 became much more quick, some needles may not be caught.
-        check_screen([qw(start-tw-install start-sle-install network-config-created)], 60);
+        check_screen([qw(start-tw-install start-sle-install network-config-created autoyast-installation)], 60);
         if (match_has_tag('start-tw-install')) {
             record_info("Install TW", "Start installing Tumbleweed...");
         }
@@ -218,7 +218,7 @@ sub run {
             record_info("Install SLE", "Start installing SLE...");
         }
         else {
-            record_info("Install others?", "Pls make sure the product that is expected to be installed.");
+            record_info("Installing", "Pls check if the expected product is being installed.");
         }
         assert_screen([qw(network-config-created loading-installation-system sshd-server-started autoyast-installation)], 300);
         return if get_var('AUTOYAST');


### PR DESCRIPTION
- sle12sp5 host failed with `BRIDGE_STP='on'`, fg. https://openqa.suse.de/tests/15389928#step/install_package/11. And a few machines might fail to boot, see https://sd.suse.com/servicedesk/customer/portal/1/SD-167626. The explaination is https://sd.suse.com/servicedesk/customer/portal/1/SD-153019
- remove `WITHOUT_AUTOYAST_SECOND_STAGE=1` settings from sle12sp5 test suites on OSD webUI as there has no error pop-up any more. 

- Related ticket: https://progress.opensuse.org/issues/163682
- Verification run: 
test pass with `BRIDGE_STP='off'`, 
http://openqa.suse.de/tests/15390580
http://openqa.suse.de/tests/15389917
http://openqa.suse.de/tests/15390101

