### PR TITLE
ltp: Add timeout to rpm -qi in log_versions

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -100,7 +100,7 @@ sub log_versions {
     my $kernel_config = script_output('for f in "/boot/config-$(uname -r)" "/usr/lib/modules/$(uname -r)/config" /proc/config.gz; do if [ -f "$f" ]; then echo "$f"; break; fi; done');
     my $run_cmd = is_transactional ? 'transactional-update -c run ' : '';
 
-    script_run("$run_cmd rpm -qi $kernel_pkg > $kernel_pkg_log 2>&1");
+    script_run("$run_cmd rpm -qi $kernel_pkg > $kernel_pkg_log 2>&1", timeout => 120);
     upload_logs($kernel_pkg_log, failok => 1);
 
     if (get_var('LTP_COMMAND_FILE') || get_var('LIBC_LIVEPATCH')) {


### PR DESCRIPTION
Fix poo#166595: rpm -qi run in transaction need more time to complete.

- Related ticket: https://progress.opensuse.org/issues/166595
- Needles: none
- Verification run: https://openqa.suse.de/tests/15390511
