### PR TITLE
log_versions: Increase timeout on kernel pkg check

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -100,7 +100,7 @@ sub log_versions {
     my $kernel_config = script_output('for f in "/boot/config-$(uname -r)" "/usr/lib/modules/$(uname -r)/config" /proc/config.gz; do if [ -f "$f" ]; then echo "$f"; break; fi; done');
     my $run_cmd = is_transactional ? 'transactional-update -c run ' : '';
 
-    script_run("$run_cmd rpm -qi $kernel_pkg > $kernel_pkg_log 2>&1");
+    script_run("$run_cmd rpm -qi $kernel_pkg > $kernel_pkg_log 2>&1", 120);
     upload_logs($kernel_pkg_log, failok => 1);
 
     if (get_var('LTP_COMMAND_FILE') || get_var('LIBC_LIVEPATCH')) {


### PR DESCRIPTION
It's timing out on aarch64, in log the command passes it needs a bit more time

- Related ticket: https://openqa.suse.de/tests/15389442#next_previous
- Verification run: https://openqa.suse.de/tests/overview?distri=sle-micro&version=6.0&build=jpupava_timeout