### PR TITLE
Split the qesap regression test module

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -110,6 +110,7 @@ our @EXPORT = qw(
   qesap_terraform_clean_up_retry
   qesap_terrafom_ansible_deploy_retry
   qesap_ansible_error_detection
+  qesap_test_postfail
 );
 
 =head1 DESCRIPTION
@@ -2525,7 +2526,6 @@ sub qesap_terrafom_ansible_deploy_retry {
     return $detected_error;
 }
 
-
 =head2 qesap_ansible_error_detection
 
     qesap_ansible_error_detection( error_log=>$error_log )
@@ -2572,6 +2572,58 @@ sub qesap_ansible_error_detection {
     }
     record_info('ANSIBLE ISSUE', $error_message) unless $ret_code eq 0;
     return $ret_code;
+}
+
+=head2 qesap_test_postfail
+
+  qesap_test_postfail()
+
+  Post fail tasks suitable for post_fail_hook of the test modules.
+  This API is mainly designed for qesap regresstion test modules.
+
+=over 2
+
+=item B<PROVIDER> - cloud provider name as from PUBLIC_CLOUD_PROVIDER setting
+
+=item B<NET_PEERING_ID> - ID of the network peering, for Azure it has to be the name 
+                          of the Resource Group of the mirror, for AWS it has to be the
+                          something different from an empty string, for example
+                          the setting about the IP RANGE.
+
+=back
+=cut
+
+sub qesap_test_postfail {
+    my (%args) = @_;
+    croak 'Missing mandatory provider argument' unless $args{provider};
+    $args{net_peering_id} //= '';
+
+    qesap_cluster_logs();
+    qesap_upload_logs();
+    if ($args{provider} eq 'AZURE') {
+        if ($args{net_peering_id} ne '') {
+            my $rg = qesap_az_get_resource_group();
+            qesap_az_vnet_peering_delete(source_group => $rg, target_group => $args{net_peering_id});
+        }
+    }
+    elsif ($args{provider} eq 'EC2') {
+        if ($args{net_peering_id} ne '') {
+            qesap_aws_delete_transit_gateway_vpc_attachment(name => qesap_calculate_deployment_name('qesapval') . '*');
+        }
+    }
+    # TODO : GCP is not supported yet.
+    qesap_execute(
+        cmd => 'ansible',
+        cmd_options => '-d',
+        logname => 'qesap_exec_ansible_destroy.log.txt',
+        verbose => 1,
+        timeout => 300);
+    qesap_execute(
+        cmd => 'terraform',
+        cmd_options => '-d',
+        logname => 'qesap_exec_terraform_destroy.log.txt',
+        verbose => 1,
+        timeout => 1200);
 }
 
 1;

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1344,7 +1344,6 @@ sub qesap_aws_get_region_subnets {
     my (%args) = @_;
     croak 'Missing mandatory vpc_id argument' unless $args{vpc_id};
 
-    # Get the VPC tag Workspace
     my $cmd = join(' ', 'aws ec2 describe-subnets',
         '--filters', "\"Name=vpc-id,Values=$args{vpc_id}\"",
         '--query "Subnets[].{AZ:AvailabilityZone,SI:SubnetId}"',
@@ -1379,10 +1378,12 @@ sub qesap_aws_get_vpc_id {
     my (%args) = @_;
     croak 'Missing mandatory resource_group argument' unless $args{resource_group};
 
+    # tag names has to be aligned to
+    # https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/aws/infrastructure.tf
     my $cmd = join(' ', 'aws ec2 describe-instances',
         '--region', get_required_var('PUBLIC_CLOUD_REGION'),
         '--filters',
-        '"Name=tag-key,Values=Workspace"',
+        '"Name=tag-key,Values=workspace"',
         "\"Name=tag-value,Values=$args{resource_group}\"",
         '--query',
         # the two 0 index result in select only the vpc of vmhana01
@@ -1586,7 +1587,8 @@ sub qesap_aws_get_mirror_tg {
 
 =head3 qesap_aws_get_vpc_workspace
 
-    Get the VPC tag Workspace
+    Get the VPC tag workspace defined in
+    https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/aws/infrastructure.tf
 
 =over 1
 
@@ -1602,14 +1604,14 @@ sub qesap_aws_get_vpc_workspace {
     return qesap_aws_filter_query(
         cmd => 'describe-vpcs',
         filter => "\"Name=vpc-id,Values=$args{vpc_id}\"",
-        query => '"Vpcs[*].Tags[?Key==\`Workspace\`].Value"'
+        query => '"Vpcs[*].Tags[?Key==\`workspace\`].Value"'
     );
 }
 
 =head3 qesap_aws_get_routing
 
     Get the Routing table: searching Routing Table with external connection
-    and get the Workspace tag
+    and get the RouteTableId
 
 =over 1
 

--- a/schedule/sles4sap/qesapdeploy/qesap.yml
+++ b/schedule/sles4sap/qesapdeploy/qesap.yml
@@ -8,5 +8,8 @@ schedule:
     - boot/boot_to_desktop
     - sles4sap/qesapdeployment/configure
     - sles4sap/qesapdeployment/deploy
+    - sles4sap/qesapdeployment/test_system
     - sles4sap/qesapdeployment/test_cluster
+    - sles4sap/qesapdeployment/test_mirror
+    - sles4sap/qesapdeployment/test_crash
     - sles4sap/qesapdeployment/destroy

--- a/tests/sles4sap/publiccloud/network_peering.pm
+++ b/tests/sles4sap/publiccloud/network_peering.pm
@@ -28,6 +28,7 @@ sub run {
         qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_resource_group);
     } elsif (is_ec2) {
         my $vpc_id = qesap_aws_get_vpc_id(resource_group => $self->deployment_name() . '*');
+        die "No vpc_id in this deployment" if $vpc_id eq 'None';
         my $ibs_mirror_target_ip = get_required_var('IBSM_IPRANGE');    # '10.254.254.240/28'
         die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
     }

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -14,19 +14,7 @@ use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
 sub run {
     my ($self) = @_;
     my $provider_setting = get_required_var('PUBLIC_CLOUD_PROVIDER');
-    my $inventory = qesap_get_inventory(provider => $provider_setting);
 
-    my $chdir = qesap_get_terraform_dir(provider => $provider_setting);
-    assert_script_run("terraform -chdir=$chdir output");
-    my @remote_cmd = (
-        'pwd', 'uname -a',
-        'cat /etc/os-release',
-        'sudo SUSEConnect --status-text',
-        'zypper ref', 'zypper lr',
-        'zypper in -f -y vim',
-        'zypper -n in ClusterTools2'
-    );
-    qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 300) for @remote_cmd;
     qesap_ansible_cmd(cmd => 'ls -lai /hana/', provider => $provider_setting, filter => 'hana');
     my $crm_status = qesap_ansible_script_output(
         cmd => 'crm status',
@@ -53,57 +41,13 @@ sub run {
 
     qesap_ansible_cmd(cmd => $crm_mon_cmd, provider => $provider_setting, filter => '"hana[0]"');
     qesap_cluster_logs();
-
-    if ($provider_setting eq 'AZURE') {
-        if (get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP")) {
-            my $rg = qesap_az_get_resource_group();
-            my $ibs_mirror_rg = get_var('QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP');
-            qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_rg);
-            qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));
-            qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibs_mirror_rg);
-        }
-    }
-    elsif ($provider_setting eq 'EC2') {
-        if (get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")) {
-            my $deployment_name = qesap_calculate_deployment_name('qesapval');
-            my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name);
-            die "No vpc_id in this deployment" if $vpc_id eq 'None';
-            my $ibs_mirror_target_ip = get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE');    # '10.254.254.240/28'
-            die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
-            qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));
-            die 'Error in network peering delete.' if !qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
-        }
-    }
 }
 
 sub post_fail_hook {
     my ($self) = shift;
-    qesap_cluster_logs();
-    qesap_upload_logs();
-    if (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
-        if (get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP")) {
-            my $rg = qesap_az_get_resource_group();
-            my $ibs_mirror_rg = get_required_var('QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP');
-            qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibs_mirror_rg);
-        }
-    }
-    elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
-        if (get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")) {
-            qesap_aws_delete_transit_gateway_vpc_attachment(name => qesap_calculate_deployment_name('qesapval') . '*');
-        }
-    }
-    qesap_execute(
-        cmd => 'ansible',
-        cmd_options => '-d',
-        logname => 'qesap_exec_ansible_destroy.log.txt',
-        verbose => 1,
-        timeout => 300);
-    qesap_execute(
-        cmd => 'terraform',
-        cmd_options => '-d',
-        logname => 'qesap_exec_terraform_destroy.log.txt',
-        verbose => 1,
-        timeout => 1200);
+    qesap_test_postfail(
+        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
+        net_peering_is => get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP", get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -67,6 +67,7 @@ sub run {
         if (get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")) {
             my $deployment_name = qesap_calculate_deployment_name('qesapval');
             my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name);
+            die "No vpc_id in this deployment" if $vpc_id eq 'None';
             my $ibs_mirror_target_ip = get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE');    # '10.254.254.240/28'
             die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
             qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));

--- a/tests/sles4sap/qesapdeployment/test_crash.pm
+++ b/tests/sles4sap/qesapdeployment/test_crash.pm
@@ -1,0 +1,35 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Test for qe-sap-deployment
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use qesapdeployment;
+use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
+
+sub run {
+    my ($self) = @_;
+    my $provider_setting = get_required_var('PUBLIC_CLOUD_PROVIDER');
+
+    # Not test so much for the moment,
+    # just that crash trough Ansible does not hang Ansible execution
+    qesap_ansible_cmd(
+        cmd => 'sudo echo b > /proc/sysrq-trigger &',
+        provider => $provider_setting,
+        filter => '"hana[0]"',
+        timeout => 300);
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    qesap_test_postfail(
+        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
+        net_peering_is => get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP", get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")));
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -1,0 +1,48 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Test for qe-sap-deployment
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use qesapdeployment;
+use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
+
+sub run {
+    my ($self) = @_;
+    my $provider_setting = get_required_var('PUBLIC_CLOUD_PROVIDER');
+
+    if ($provider_setting eq 'AZURE') {
+        if (get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP")) {
+            my $rg = qesap_az_get_resource_group();
+            my $ibs_mirror_rg = get_var('QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP');
+            qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_rg);
+            qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));
+            qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibs_mirror_rg);
+        }
+    }
+    elsif ($provider_setting eq 'EC2') {
+        if (get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")) {
+            my $deployment_name = qesap_calculate_deployment_name('qesapval');
+            my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name);
+            die "No vpc_id in this deployment" if $vpc_id eq 'None';
+            my $ibs_mirror_target_ip = get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE');    # '10.254.254.240/28'
+            die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
+            qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));
+            die 'Error in network peering delete.' if !qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
+        }
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    qesap_test_postfail(
+        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
+        net_peering_is => get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP", get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")));
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/sles4sap/qesapdeployment/test_system.pm
+++ b/tests/sles4sap/qesapdeployment/test_system.pm
@@ -1,0 +1,42 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Test for qe-sap-deployment
+# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+
+use strict;
+use warnings;
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use qesapdeployment;
+use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
+
+sub run {
+    my ($self) = @_;
+    my $provider_setting = get_required_var('PUBLIC_CLOUD_PROVIDER');
+
+    # Ignore return, just test the mechanism to find the inventory
+    qesap_get_inventory(provider => $provider_setting);
+
+    my $chdir = qesap_get_terraform_dir(provider => $provider_setting);
+    assert_script_run("terraform -chdir=$chdir output");
+    my @remote_cmd = (
+        'pwd', 'uname -a',
+        'cat /etc/os-release',
+        'sudo SUSEConnect --status-text',
+        'zypper ref', 'zypper lr',
+        'zypper in -f -y vim',
+        'zypper -n in ClusterTools2'
+    );
+    qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 300) for @remote_cmd;
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    qesap_test_postfail(
+        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
+        net_peering_is => get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP", get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")));
+    $self->SUPER::post_fail_hook;
+}
+
+1;


### PR DESCRIPTION
Split the module about testing the deployment in 4 modules each one to focus on a different test area. Introduce a new test step to trigger a Crash in a node.

- Related ticket: https://jira.suse.com/browse/TEAM-9654

# Verification run:

## Azure

### sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test
- http://openqaworker15.qa.suse.cz/tests/296642 :green_circle:  there are now 4 test module named `test_*`. Mirror test module correctly detect the setting and skip most of the stage that are not applicable.

## sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ibsmirror_peering_test
 - http://openqaworker15.qa.suse.cz/tests/296643 :green_circle:  test_mirror is running all the Azure related checks.

## AWS

###  - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test
- http://openqaworker15.qa.suse.cz/tests/296867 :red_circle: fails in `test_mirror` but it systematically fails in existing code too http://openqaworker15.qa.suse.cz/tests/297022#next_previous
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test@64bit -> http://openqaworker15.qa.suse.cz/tests/297127 after merging https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20171