### PR TITLE
Add grub_tests into agama_install schedule

### DIFF
--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -4,6 +4,7 @@ description:    >
 schedule:
   - installation/bootloader
   - installation/agama
+  - installation/grub_test
   - installation/first_boot
   - installation/opensuse_welcome
   - console/system_prepare

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -192,6 +192,11 @@ sub run {
     reset_consoles();
     assert_and_click('agama-reboot-after-install');
 
+    # workaround for lack of disable bootloader timeout
+    # https://github.com/openSUSE/agama/issues/1594
+    # simply send space until we hit grub2
+    send_key_until_needlematch("bootloader-grub2", 'spc', 50, 3);
+
 }
 
 =head2 post_fail_hook


### PR DESCRIPTION
* Use workaround by sending esc until we hit grub2-bootloader gh#openSUSE/agama/issues/1594
* usb devices tend to boot back the installer

- Verification run: https://openqa.opensuse.org/tests/4467404#live