### PR TITLE
Choose boot from local on agama based grub_test

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -41,6 +41,7 @@ sub grub_test {
     stop_grub_timeout;
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 11, 5) if get_var('XEN');
+    send_key_until_needlematch("bootmenu-boot-local", 'down', 11, 5)) if get_var("AGAMA")
     if ((is_aarch64 && is_sle && get_var('PLYMOUTH_DEBUG'))
         || get_var('GRUB_KERNEL_OPTION_APPEND'))
     {


### PR DESCRIPTION
Addition of grub_tests to Leap 16.0 caused that we're stuck on agama-install media boot screen on any  cases where usb boot has topmost priority. This ensure that we click on Boot local option.

- Verification run: https://openqa.opensuse.org/tests/4471486