### PR TITLE
Skip grub needle check for Micro 6.0+

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -10,7 +10,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_micro);
+use version_utils qw(is_sle_micro);
 use Utils::Architectures qw(is_aarch64);
 use microos "microos_login";
 use transactional "record_kernel_audit_messages";
@@ -18,12 +18,9 @@ use transactional "record_kernel_audit_messages";
 sub run {
 
     # default timeout in grub2 is set to 10s
-    # osd's arm machines tend to stall when trying to match grub2
+    # Sometimes, machines tend to stall when trying to match grub2
     # this leads to test failures because openQA does not assert grub2 properly
-    # SLEM updated GM and BETA images from https://openqa.suse.de/group_overview/377
-    # already have disabled grub timeout in order to install updates and reboot
-    # therefore *aarch64* images would hang in GRUB2
-    if ((is_micro && is_aarch64) && get_var('BOOT_HDD_IMAGE') && (get_var('HDD_1') !~ /GM-Updated/ && get_var('HDD_1') !~ /Beta-Updated/ && get_var('HDD_1') !~ /Default-Updated/)) {
+    if (is_aarch64 || is_sle_micro('>=6.0')) {
         shift->wait_boot_past_bootloader(textmode => 1);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
It has been observed that x86_64 is stalling when doing needle matchin of the grub screen, similar to what happened with aarch64 jobs for 6.0 maintenance and 6.1 jobs.

VRs:
[Microos x86_64](https://openqa.opensuse.org/tests/4482847#)
[MicroOS aarch64](https://openqa.opensuse.org/tests/4482848#)
[SLM 6.0 x86_64](https://openqa.suse.de/tests/15442938#)
[SLM 6.0 aarch64](https://openqa.suse.de/tests/15442939#)
[SLM 6.1 x86_64](https://openqa.suse.de/tests/15426133)
[SLM 6.1 aarch64](https://openqa.suse.de/tests/15442940#)
[SLM 5.5 x86_64](https://openqa.suse.de/tests/15442941#)
[SLM 5.5 aarch64](https://openqa.suse.de/tests/15442942#)