### PR TITLE
Move Public Cloud ssh opts to CLI in HanaSR tests

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -242,7 +242,11 @@ sub scp {
     $from =~ s/^remote:/$url/;
     $to =~ s/^remote:/$url/;
 
-    my $ssh_cmd = sprintf('scp %s "%s" "%s"', $self->ssh_opts, $from, $to);
+    # Sanitize ssh_opts by removing -E options which are not accepted by 'scp'
+    my $ssh_opts = $self->ssh_opts;
+    $ssh_opts =~ s/\-E\s[^\s]+//g;
+
+    my $ssh_cmd = sprintf('scp %s "%s" "%s"', $ssh_opts, $from, $to);
 
     return script_run($ssh_cmd, %args);
 }

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -161,8 +161,11 @@ subtest "[stop_hana]" => sub {
 subtest "[stop_hana] crash" => sub {
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $sles4sap_publiccloud->redefine(type_string => sub { note(join(' ', 'TYPED -->', @_)); });
     $sles4sap_publiccloud->redefine(wait_for_sync => sub { return; });
     $sles4sap_publiccloud->redefine(wait_hana_node_up => sub { return; });
+    $sles4sap_publiccloud->redefine(serial_term_prompt => sub { return '# '; });
+    $sles4sap_publiccloud->redefine(wait_serial => sub { return; });
 
     my $self = sles4sap_publiccloud->new();
     my $mock_pc = Test::MockObject->new();
@@ -172,6 +175,7 @@ subtest "[stop_hana] crash" => sub {
             my ($self, %args) = @_;
             push @calls, $args{cmd};
             return 'BABUUUUUUUUM' });
+    $mock_pc->mock('ssh_opts', sub { return '-i .ssh/id_rsa'; });
     $self->{my_instance} = $mock_pc;
 
     $self->stop_hana(method => 'crash');

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -210,6 +210,7 @@ sub run {
     foreach my $instance (@$instances) {
         record_info 'Instance', join(' ', 'IP: ', $instance->public_ip, 'Name: ', $instance->instance_id);
         $self->{my_instance} = $instance;
+        $self->set_cli_ssh_opts unless (get_var('MR_TEST', 0));    # Set CLI SSH opts in HanaSR test, not in saptune/mr_test tests
         my $expected_hostname = $instance->{instance_id};
         $instance->wait_for_ssh();
         # Does not fail for some reason.


### PR DESCRIPTION
A regression was introduced into the HanaSR Crash tests in the cloud by 892dffc96dc6fe061a442c790049479751bdac3f which moved common SSH options out of the CLI and into a local `.ssh/config`. A fix for this regression was proposed in 0fe1c3226629e6e7d795237adb05809aaf9da3a5, but this turned out to be not entirely stable, so instead this commit rolls back 0fe1c3226629e6e7d795237adb05809aaf9da3a5 and selectively rolls back some of the changes from 892dffc96dc6fe061a442c790049479751bdac3f only when the test code runs in the HanaSR scenario. To this end, HanaSR tests will inject CLI SSH options including `-F none` via `publiccloud::instance::ssh_opts` class attribute right after class instances are created.

Changes include:

* A new method in `sles4sap_publiccloud_basetest` class to set the CLI SSH options in the current `publiccloud::instance` class instance, adding `-F none` so no local SSH config is used in HanaSR tests by default.
* Changes in `sles4sap_publiccloud::stop_hana()` to make it use the SSH options defined in the class instance.
* Sending a Ctrl-C after the `echo b > /proc/sysrq-trigger` crash command if the terminal prompt on the local machine is not seen after 30 seconds also in `sles4sap_publiccloud::stop_hana()`.
* Sanitizing of SSH options in `publiccloud::instance::scp()`. Since new code adds different `-E`, `-F`, and `-i` options besides `-o` options, code was added into this function to remove options not supported by `scp` command.
* Changes on `sles4sap/publiccloud/qesap_terraform` to set the SSH CLI options depending on the type of test.

- Related ticket: https://jira.suse.com/browse/TEAM-9658
- Needles: N/A

# Verification Runs

The following are VRs in several service packs (12-SP5, 15-SP4, 15-SP5 and 15-SP6) using both PAYG and BYOS images and all three fencing mechanism (SBD, native MSI, native SPN)

* https://openqa.suse.de/tests/15416414 :green_circle: 
* https://openqa.suse.de/tests/15416416 :green_circle: 
* https://openqa.suse.de/tests/15414777 :green_circle: 
* https://openqa.suse.de/tests/15416894 :green_circle: 
* https://openqa.suse.de/tests/15416895 :green_circle: 
* https://openqa.suse.de/tests/15416896 :green_circle: 
* https://openqa.suse.de/tests/15416897 :red_circle: (time out in `cs_wait_for_idle` after 720 seconds. Unrelated to the PR. restarted as https://openqa.suse.de/tests/15426076 :green_circle: )
* https://openqa.suse.de/tests/15416898 :green_circle: 
* https://openqa.suse.de/tests/15414820 :green_circle: 
* https://openqa.suse.de/tests/15414821 :green_circle: 
* https://openqa.suse.de/tests/15414822 :green_circle: 
* https://openqa.suse.de/tests/15416899 :green_circle: 
* https://openqa.suse.de/tests/15416900 :red_circle: (ansible failure unrelated to the PR, restarted as https://openqa.suse.de/tests/15427610)
* https://openqa.suse.de/tests/15416901 :green_circle: 
* https://openqa.suse.de/tests/15416902 :green_circle: 
* https://openqa.suse.de/tests/15416903 :green_circle: 
* https://openqa.suse.de/tests/15416904 :green_circle: 
* https://openqa.suse.de/tests/15416905 :green_circle: 
* https://openqa.suse.de/tests/15416906 :green_circle: 
* https://openqa.suse.de/tests/15416907 :green_circle: 
* https://openqa.suse.de/tests/15416908 :green_circle: 
* https://openqa.suse.de/tests/15416909 :green_circle: 
* https://openqa.suse.de/tests/15416910 :green_circle: 
* https://openqa.suse.de/tests/15416911 :green_circle: 
* https://openqa.suse.de/tests/15416912 :green_circle: 
* https://openqa.suse.de/tests/15416913 :green_circle: 
* https://openqa.suse.de/tests/15416947 :green_circle: 
* https://openqa.suse.de/tests/15416946 :green_circle: 
* https://openqa.suse.de/tests/15426086 :green_circle: 

And below is a mixture of saptune jobs in Azure, AWS, GCP, in 12-SP5 and 15-SP5 only:

* https://openqaworker15.qa.suse.cz/tests/297063 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297062 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297061 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297060 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297058 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297057 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297056 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297055 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297054 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297053 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297052 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297130 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297149 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297150 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297151 :green_circle: 
* https://openqaworker15.qa.suse.cz/tests/297152 :green_circle: 