### PR TITLE
Fix tag name in vpc_id AWS query

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1344,7 +1344,6 @@ sub qesap_aws_get_region_subnets {
     my (%args) = @_;
     croak 'Missing mandatory vpc_id argument' unless $args{vpc_id};
 
-    # Get the VPC tag Workspace
     my $cmd = join(' ', 'aws ec2 describe-subnets',
         '--filters', "\"Name=vpc-id,Values=$args{vpc_id}\"",
         '--query "Subnets[].{AZ:AvailabilityZone,SI:SubnetId}"',
@@ -1379,10 +1378,12 @@ sub qesap_aws_get_vpc_id {
     my (%args) = @_;
     croak 'Missing mandatory resource_group argument' unless $args{resource_group};
 
+    # tag names has to be aligned to
+    # https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/aws/infrastructure.tf
     my $cmd = join(' ', 'aws ec2 describe-instances',
         '--region', get_required_var('PUBLIC_CLOUD_REGION'),
         '--filters',
-        '"Name=tag-key,Values=Workspace"',
+        '"Name=tag-key,Values=workspace"',
         "\"Name=tag-value,Values=$args{resource_group}\"",
         '--query',
         # the two 0 index result in select only the vpc of vmhana01
@@ -1586,7 +1587,8 @@ sub qesap_aws_get_mirror_tg {
 
 =head3 qesap_aws_get_vpc_workspace
 
-    Get the VPC tag Workspace
+    Get the VPC tag workspace defined in
+    https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/aws/infrastructure.tf
 
 =over 1
 
@@ -1602,14 +1604,14 @@ sub qesap_aws_get_vpc_workspace {
     return qesap_aws_filter_query(
         cmd => 'describe-vpcs',
         filter => "\"Name=vpc-id,Values=$args{vpc_id}\"",
-        query => '"Vpcs[*].Tags[?Key==\`Workspace\`].Value"'
+        query => '"Vpcs[*].Tags[?Key==\`workspace\`].Value"'
     );
 }
 
 =head3 qesap_aws_get_routing
 
     Get the Routing table: searching Routing Table with external connection
-    and get the Workspace tag
+    and get the RouteTableId
 
 =over 1
 

--- a/tests/sles4sap/publiccloud/network_peering.pm
+++ b/tests/sles4sap/publiccloud/network_peering.pm
@@ -28,6 +28,7 @@ sub run {
         qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_resource_group);
     } elsif (is_ec2) {
         my $vpc_id = qesap_aws_get_vpc_id(resource_group => $self->deployment_name() . '*');
+        die "No vpc_id in this deployment" if $vpc_id eq 'None';
         my $ibs_mirror_target_ip = get_required_var('IBSM_IPRANGE');    # '10.254.254.240/28'
         die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
     }

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -67,6 +67,7 @@ sub run {
         if (get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")) {
             my $deployment_name = qesap_calculate_deployment_name('qesapval');
             my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name);
+            die "No vpc_id in this deployment" if $vpc_id eq 'None';
             my $ibs_mirror_target_ip = get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE');    # '10.254.254.240/28'
             die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
             qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));


### PR DESCRIPTION
In qe-sap-deployment v0.31.0, the tag name aplied to VPC has been changed from Workspace to workspace.
Adapt the test code to this change, improve robustness.


- Related ticket: https://jira.suse.com/browse/TEAM-9676

# Verification run:

 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test@64bit -> http://openqaworker15.qa.suse.cz/tests/297070 :green_circle: http://openqaworker15.qa.suse.cz/tests/297070#step/test_cluster/683  `vpc_id` returned by the query is no more `none`