### PR TITLE
Fix testuser addition for cases where it is root

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1595,7 +1595,7 @@ If the user is not present, it will create it with the default password
 =cut
 
 sub ensure_testuser_present {
-    if (script_run("id 1000") != 0) {
+    if ($testapi::username ne 'root' && script_run("id $testapi::username") != 0) {
         assert_script_run("useradd -u 1000 -m $testapi::username");
         assert_script_run("echo '$testapi::username:$testapi::password' | chpasswd");
     }


### PR DESCRIPTION
Don't add a 'root' user with uid 1000 and don't add the testuser, if it's already present (even when not being uid 1000).

- Related failures: https://openqa.suse.de/tests/15401761#step/system_prepare/12 | https://openqa.opensuse.org/tests/4474167#step/host_config/6
- Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20172 (quickfix)
- Verification runs: [https://openqa.suse.de/tests/15414352](https://openqa.suse.de/tests/15414352#step/system_prepare/29) | [https://openqa.opensuse.org/tests/4474248](https://openqa.opensuse.org/tests/4474248#step/host_config/38)
