### PR TITLE
Add milestone flag for zypper_migration

### DIFF
--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -196,4 +196,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
+sub test_flags {
+    return {milestone => 1};
+}
+
 1;


### PR DESCRIPTION
We need create snapshot after migration to make sure rollback to correct version when issue happened.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/15414153#step/rollback/7