### PR TITLE
openjdk_fips: test 11 17 and 21

### DIFF
--- a/tests/fips/openjdk/openjdk_fips.pm
+++ b/tests/fips/openjdk/openjdk_fips.pm
@@ -16,18 +16,16 @@ use warnings;
 use testapi;
 use utils;
 use openjdktest;
-use version_utils qw(is_sle is_leap is_tumbleweed);
+use registration qw(add_suseconnect_product);
+use version_utils qw(is_sle);
 
 sub run {
     my $self = @_;
 
-    my @java_versions = (17);
-    if (is_sle('<=15-SP5') || is_leap('<=15.5')) {
-        push @java_versions, 11;
-    } elsif (is_sle('>=15-SP6') || is_leap('<=15.6') || is_tumbleweed) {
+    my @java_versions = qw(11 17);
+    if (is_sle '>=15-SP6') {
+        add_suseconnect_product 'sle-module-legacy';
         push @java_versions, 21;
-    } else {
-        die "Unsupported SLE/openSUSE version for this test.";
     }
 
     foreach my $version (@java_versions) {


### PR DESCRIPTION
* add legacy repo for 15.6 and greater
* remove opensuse since FIPS is not supported there

Ticket: https://progress.opensuse.org/issues/166160
VRs:
* 15.7: https://openqa.suse.de/tests/15414364
* 15.6: https://openqa.suse.de/tests/15414363
* 15.4: https://openqa.suse.de/tests/15414362