### PR TITLE
Fix console selection in Agama

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -684,6 +684,13 @@ sub init_consoles {
             });
     }
 
+    if (get_var('AGAMA')) {
+        $self->add_console('installation', 'tty-console', {tty => 2});
+    }
+    else {
+        $self->add_console('installation', 'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
+    }
+
     return;
 }
 


### PR DESCRIPTION
Fixed console selection in Agama from F7 to F2

- Related ticket: https://progress.opensuse.org/issues/165830
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4474428#
