### PR TITLE
Add missing gnutls package to nested image used to test swtpm

### DIFF
--- a/tests/security/create_swtpm_hdd/build_hdd.pm
+++ b/tests/security/create_swtpm_hdd/build_hdd.pm
@@ -21,7 +21,8 @@ sub run {
     select_serial_terminal;
 
     # Install runtime dependencies
-    zypper_call("in wget");
+    # gnutls is needed for certtool, as later tests will create a self signed CA
+    zypper_call("in wget gnutls");
 
     # Install tpm and tpm2 related packages, then we can verify the swtpm function
     zypper_call("in tpm-tools tpm-quote-tools tpm2-0-tss tpm2-tss-engine tpm2.0-abrmd tpm2.0-tools trousers");

--- a/tests/security/swtpm/swtpm_env_setup.pm
+++ b/tests/security/swtpm/swtpm_env_setup.pm
@@ -27,7 +27,7 @@ sub run {
     }
 
     # Install the required packages for libvirt environment setup
-    zypper_call("in qemu libvirt swtpm virt-install virt-manager wget");
+    zypper_call("in qemu libvirt swtpm virt-install virt-manager wget gnutls");
 
     # Start libvirtd daemon and start the default libvirt network
     assert_script_run("systemctl start libvirtd");


### PR DESCRIPTION
Missing required certtool to create a self-signed CA

- Related ticket: https://progress.opensuse.org/issues/166460
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/15414810