### PR TITLE
Add needle for Win11 aarch64 obsolete build popup

### DIFF
--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -174,10 +174,19 @@ sub wait_boot_windows {
         $self->run_in_powershell(cmd => 'exit', code => sub { });
     } else {
         record_info("Win boot", "Windows started properly");
-        assert_screen ['finish-setting', 'windows-desktop'], 240;
-        if (match_has_tag 'finish-setting') {
-            assert_and_click 'finish-setting';
+        assert_screen ['finish-setting', 'windows-desktop', 'obsolete-build-aarch64'], 240;
+        if (is_aarch64) {
+            # poo#166205 --> A pop-up for obsolete build has shown up. As we're in
+            # an early development state without access to official ARM ISOs, we
+            # must just click the pop-up and continue the test run
+            if (match_has_tag 'obsolete-build-aarch64') {
+                click_lastmatch;
+                # The 'finish-setting' screen stays after closing the pop-up so
+                # there's need to check screen again
+                assert_screen ['finish-setting', 'windows-desktop'];
+            }
         }
+        click_lastmatch if (match_has_tag 'finish-setting');
     }
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/166205
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/d843c54f01b44512e05afb04f88cbbf409730300/obsolete-build-aarch64-20240912.json
- Verification run: https://openqa.opensuse.org/tests/4474650 :green_circle: 
