### PR TITLE
Run kiwi container tests only on SLES

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -35,6 +35,17 @@ sub skip_testrun {
     # Skip Spack on SLES12-SP5 (https://bugzilla.suse.com/show_bug.cgi?id=1224345)
     return 1 if (check_var('BCI_IMAGE_NAME', 'spack') && check_version('<15', get_required_var('HOST_VERSION')));
 
+    # Skip Kiwi on RES, CentOS, Ubuntu
+    return 1 if (
+        check_var('BCI_IMAGE_NAME', 'kiwi') &&
+        (
+            check_var('HOST_VERSION', 'LIBERTY9') ||
+            check_var('HOST_VERSION', 'centos') ||
+            check_var('HOST_VERSION', 'ubuntu') ||
+            check_var('HOST_VERSION', 'res8')
+        )
+    );
+
     return 0;
 }
 


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/166604
- Verification run: [centos]( https://openqa.suse.de/tests/15414842), [Liberty9]( https://openqa.suse.de/tests/15414841),  [Ubuntu](https://openqa.suse.de/tests/15414840
), [SLE-15-SP6](https://openqa.suse.de/tests/15414819)