### PR TITLE
[Virtualization][SLM] Specify disk id in usb host installation

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -463,12 +463,19 @@ sub uefi_bootmenu_params {
 
             # Pass bootparam to firstboot
             type_string_very_slow(" rd.kiwi.install.pass.bootparam ");
-            if (!check_screen('pass-bootparam-to-firstboot', 2)) {
-                next;
-            } else {
-                record_info('Successfully finished grub2 editing.');
-                return;
+            next if (!check_screen('pass-bootparam-to-firstboot', 2));
+
+            # Set disk to install
+            my $_disk = get_var('INSTALL_DISK_WWN', '');
+            record_info("INSTALL_DISK_WWN is $_disk.");
+            if ($_disk) {
+                type_string_very_slow(" rd.kiwi.oem.installdevice=/dev/disk/by-id/$_disk ");
+                save_screenshot;
             }
+
+            # All editing done
+            record_info('Successfully finished grub2 editing.');
+            return;
         }
         die "Failed to edit grub2 after $max_tries tries.";
     }

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -18,7 +18,7 @@ use ipmi_backend_utils qw(ipmitool);
 sub run {
     my ($self) = @_;
 
-    if (get_var('NUMDISKS') > 1) {
+    if (get_var('NUMDISKS') > 1 && !get_var('INSTALL_DISK_WWN', '')) {
         assert_screen 'selfinstall-screen', 180;
         send_key 'down' unless check_screen 'selfinstall-select-drive';
         assert_screen 'selfinstall-select-drive';


### PR DESCRIPTION
This PR aims to install SLE Micro to a specified disk, so that SLES VT tests can run on the same UEFI machine with SLE Micro test machine, without "secure boot" problem mentioned in https://progress.opensuse.org/issues/153037#note-36 by Julie.

- Related ticket: https://progress.opensuse.org/issues/166712
- Verification run: 
  - SLM 6.1 host: https://openqa.suse.de/tests/15426202#step/bootloader_uefi/27
  - SLM 6.0 GM host verification: https://openqa.suse.de/tests/15461667#step/login_console/5 (simulate 6.0  job by passing ISO=SL-Micro.x86_64-6.0-Default-SelfInstall-GM.iso)
  - more evidence jobs for claiming that installing on the same disk solves the "secure boot" problem: https://progress.opensuse.org/issues/166712#note-11
