### PR TITLE
Agama improve grub handling in zdup and usb boot

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -64,7 +64,8 @@ sub handle_installer_medium_bootup {
     assert_screen 'inst-bootmenu', 180;
 
     # Layout of live is different from installation media
-    my $key = is_livecd() ? 'down' : 'up';
+    # Agama has same layout of live
+    my $key = is_livecd() || get_var("AGAMA") ? 'down' : 'up';
     send_key_until_needlematch 'inst-bootmenu-boot-harddisk', $key;
     send_key 'ret';
 

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -476,7 +476,7 @@ When bootloader appears, make sure to boot from local disk when it is on aarch64
 sub wait_grub_to_boot_on_local_disk {
     # assuming the cursor is on 'installation' by default and 'boot from
     # harddisk' is above
-    my $switch_key = (is_opensuse && get_var('LIVECD')) ? 'down' : 'up';
+    my $switch_key = (is_opensuse && get_var('LIVECD')) || get_var('AGAMA') ? 'down' : 'up';
     send_key_until_needlematch 'inst-bootmenu-boot-harddisk', "$switch_key";
     boot_local_disk;
     my @tags = qw(grub2 tianocore-mainmenu);

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -826,7 +826,8 @@ sub activate_console {
     # Select configure serial and redirect to root-ssh instead
     return use_ssh_serial_console if (get_var('BACKEND', '') =~ /ikvm|ipmi|spvm|pvm_hmc/ && $console =~ m/^(root-console|install-shell|log-console)$/);
     if ($console eq 'install-shell') {
-        if (get_var("LIVECD")) {
+        # Agama behaves similarly as LIVE but we set a fixed password there
+        if (get_var("LIVECD") && !get_var('AGAMA')) {
             # LIVE CDs do not run inst-consoles as started by inst-linux (it's regular live run, auto-starting yast live installer)
             my $vt = get_root_console_tty();
             assert_screen "tty${vt}-selected", 10;
@@ -1009,3 +1010,4 @@ sub console_selected {
 }
 
 1;
+

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -174,9 +174,12 @@ sub run {
         diag("left total await_install timeout: $timeout");
         if (!$ret) {
             # Handle any error dialogs that could happen
+            send_key "down";    # ensure screen doesn't get black shortly after we hit congratulations
             last;
         }
     }
+    # Let's end at agama-congratulations screens
+    assert_screen('agama-congratulations');
 }
 
 =head2 post_fail_hook

--- a/tests/installation/agama_reboot.pm
+++ b/tests/installation/agama_reboot.pm
@@ -52,7 +52,7 @@ sub run {
     # workaround for lack of disable bootloader timeout
     # https://github.com/openSUSE/agama/issues/1594
     # simply send space until we hit grub2
-    send_key_until_needlematch("bootloader-grub2", 'spc', 50, 3);
+    send_key_until_needlematch("grub2", 'spc', 50, 3);
 
 }
 


### PR DESCRIPTION
Following change gets us properly through grub on zdup scenario with USB boot and Agama.
This also ensures that we do not boot into Agama again after successful installation with USBBOOT.

* Handle same boot from local as for LIVE, while Agama is not LIVE, because we do have password set etc.

* Ensure that USB boot with agama goes for boot local
   after installation
    
* Unlike with LIVE expect password on agama-installer which
   otherwise behaves a lot like live
    
* Ensure that we boot local on zdup case with agama-installer

* On certain cases I managed to hit black screen shortly after congratulations window appeared
   press a down button to eliminate it

* Use same needle as for grub_test which is simply grub2 not bootloader-grub2


Verification runs:
 - opensuse-16.0-agama-installer-Leap-x86_64-Build36.40-kde-agama@USBboot_64-3G -> https://openqa.opensuse.org/tests/4475397

 - opensuse-16.0-agama-installer-Leap-x86_64-Build36.40-zdup-Leap-15.6-gnome@64bit-2G -> https://openqa.opensuse.org/tests/4475398


