### PR TITLE
wicked: test dummy interfaces

### DIFF
--- a/data/wicked/ifcfg/dummy1
+++ b/data/wicked/ifcfg/dummy1
@@ -1,0 +1,2 @@
+STARTMODE='auto'
+BOOTPROTO='static'

--- a/data/wicked/ifcfg/foo0
+++ b/data/wicked/ifcfg/foo0
@@ -1,0 +1,4 @@
+BOOTPROTO='none'
+STARTMODE='auto'
+
+INTERFACETYPE='dummy'

--- a/data/wicked/ifcfg/foo1
+++ b/data/wicked/ifcfg/foo1
@@ -1,0 +1,4 @@
+BOOTPROTO='none'
+STARTMODE='auto'
+
+DUMMY='yes'

--- a/tests/wicked/basic/sut/t23_dummy_ifup_ifreload.pm
+++ b/tests/wicked/basic/sut/t23_dummy_ifup_ifreload.pm
@@ -1,0 +1,36 @@
+# Copyright 2024 SUSE LLC
+# Copyright 2024 Georg Pfuetzenreuter
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Package: wicked
+# Summary: Dummy - ifup, ifreload
+
+use base 'wickedbase';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+
+    my $config_base = '/etc/sysconfig/network/';
+    my @interfaces = qw( dummy1 foo0 foo1 );
+
+    foreach (@interfaces) {
+        my $interface = $_;
+        $self->get_from_data("wicked/ifcfg/$interface", "$config_base/$interface");
+
+        $self->wicked_command('ifup', "$interface");
+        $self->wicked_command('ifreload', "$interface");
+    }
+
+    foreach (@interfaces) {
+        die if ($self->get_test_result($_) eq 'FAILED');
+    }
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Add test coverage to assess whether dummy interfaces get created successfully using either one of the three supported declaration routes to detect issues such as boo#1229555 early.

- Related ticket: n/a
- Needles: n/a
- Verification run: tbd
