### PR TITLE
Ipaddr2 stabilize

### DIFF
--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -27,6 +27,11 @@ sub run {
 
     # Init all the PC gears (ssh keys, CSP credentials)
     my $provider = $self->provider_factory();
+    # remove configuration file created by the PC factory
+    # as it interfere with ssh behavior.
+    # in particular it has setting about verbosity that
+    # break test steps that relay to remote ssh comman output
+    assert_script_run('rm ~/.ssh/config');
 
     my %deployment = (
         region => $provider->provider_client->region,


### PR DESCRIPTION
A regression was introduced into the IpAddr2 tests  by 892dffc96dc6fe061a442c790049479751bdac3f which moved common SSH options out of the CLI and into a local `.ssh/config`. 

- Related ticket:  https://jira.suse.com/browse/TEAM-8721

# Verification run: 
 
## 15sp5
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test@64bit
- http://openqaworker15.qa.suse.cz/tests/297307 :green_circle: 

sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test@64bit
 - http://openqaworker15.qa.suse.cz/tests/297309