### PR TITLE
Reorganize order of sles4sap PC cleanup

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1246,6 +1246,7 @@ sub qesap_upload_crm_report {
         filter => "\"$args{host}\"",
         host_keys_check => 1,
         verbose => 1,
+        timeout => bmwqemu::scale_timeout(180),
         failok => $args{failok});
     my $local_path = qesap_ansible_fetch_file(provider => $args{provider},
         host => $args{host},

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -144,7 +144,9 @@ sub qesap_get_file_paths {
 
 sub qesap_create_folder_tree {
     my %paths = qesap_get_file_paths();
+    die 'Missing deployment_dir in paths' unless $paths{deployment_dir};
     assert_script_run("mkdir -p $paths{deployment_dir}", quiet => 1);
+    die 'Missing roles_dir in paths' unless $paths{roles_dir};
     assert_script_run("mkdir -p $paths{roles_dir}", quiet => 1);
 }
 
@@ -242,7 +244,7 @@ sub qesap_venv_cmd_exec {
     $cmd .= 'set -o pipefail ; ' if $args{log_file};
     $cmd .= join(' ', 'timeout', $args{timeout}, $args{cmd});
     # always use tee in append mode
-    $cmd .= "|& tee -a $args{log_file}" if $args{log_file};
+    $cmd .= " |& tee -a $args{log_file}" if $args{log_file};
 
     my $ret = script_run('source ' . QESAPDEPLOY_VENV . '/bin/activate');
     if ($ret) {
@@ -488,11 +490,10 @@ sub qesap_yaml_replace {
 
     Execute qesap glue script commands. Check project documentation for available options:
     https://github.com/SUSE/qe-sap-deployment
-    Function return a two element array:
+    Function returns a two element array:
       - first element is an integer representing the execution result
       - second element is the file path of the execution log
     This function is not expected to internally die, any failure has to be handled by the caller.
-    Only exception is about .venv activation.
 
 =over 5
 
@@ -2465,6 +2466,7 @@ sub qesap_az_diagnostic_log {
     foreach (@{$vm_data}) {
         record_info('az vm boot-diagnostics json', "id: $_->{id} name: $_->{name}");
         my $boot_diagnostics_log = '/tmp/boot-diagnostics_' . $_->{name} . '.txt';
+        # Ignore the return code, so also miss the pipefail setting
         script_run(join(' ', $az_get_logs_cmd, $_->{id}, '|&', 'tee', $boot_diagnostics_log));
         push(@diagnostic_log_files, $boot_diagnostics_log);
 

--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1327,9 +1327,6 @@ sub qesap_cluster_logs {
     my $provider = get_required_var('PUBLIC_CLOUD_PROVIDER');
     my $inventory = qesap_get_inventory(provider => $provider);
 
-    # ETX is the same as pressing Ctrl-C on a terminal,
-    # make sure the serial terminal is NOT blocked
-    type_string('', terminate_with => 'ETX');
     if (script_run("test -e $inventory", 60) == 0)
     {
         foreach my $host ('hana[0]', 'hana[1]') {

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -199,7 +199,8 @@ sub sles4sap_cleanup {
     # Only run the Ansible de-register if Ansible has been executed
     push(@cmd_list, 'ansible') if ($args{ansible_present});
 
-    # Terraform destroy can and must be executed in any case
+    # Regardless of Ansible result, Terraform destroy
+    # must be executed.
     push(@cmd_list, 'terraform');
     for my $command (@cmd_list) {
         record_info('Cleanup', "Executing $command cleanup");

--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -61,7 +61,7 @@ sub cleanup {
         ansible_present => $self->{ansible_present}
     );
 
-    if ($res) {
+    if ($res eq 0) {
         $self->{cleanup_called} = 1;
         $self->{network_peering_present} = 0;
         $self->{ansible_present} = 0;

--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -153,7 +153,6 @@ sub post_fail_hook {
         diag('Skip post fail', "Variable 'QESAP_NO_CLEANUP_ON_FAILURE' defined.");
         return;
     }
-    qesap_cluster_logs();
     eval { $self->cleanup(); } or bmwqemu::fctwarn("self::cleanup() failed -- $@");
 }
 

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -288,14 +288,12 @@ subtest '[qesap_execute] simplest call' => sub {
     $qesap->redefine(qesap_venv_cmd_exec => sub {
             my (%args) = @_;
             push @calls, $args{cmd};
-            return $expected_res;
-    });
+            return $expected_res; });
     $qesap->redefine(qesap_get_file_paths => sub {
             my %paths;
             $paths{deployment_dir} = '/BRUCE';
             $paths{qesap_conf_trgt} = '/BRUCE/MARIANATRENCH';
-            return (%paths);
-    });
+            return (%paths); });
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return ""; });
 
     my @res = qesap_execute(cmd => $cmd, logname => 'WALLABY_STREET');
@@ -774,6 +772,38 @@ subtest '[qesap_prepare_env] die for missing argument' => sub {
     dies_ok { qesap_prepare_env(); } "Expected die if called without provider arguments";
 };
 
+subtest '[qesap_prepare_env] integration test' => sub {
+    # As less mock as possible
+    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+
+    $qesap->redefine(qesap_get_file_paths => sub {
+            my %paths;
+            $paths{qesap_conf_src} = '/REEF';
+            $paths{qesap_conf_trgt} = '/SYDNEY.YAML';
+            $paths{terraform_dir} = '/SPLASH';
+            $paths{deployment_dir} = '/WAVE';
+            $paths{roles_dir} = '/BRUCE';
+            return (%paths);
+    });
+    $qesap->redefine(qesap_get_variables => sub { return; });
+    $qesap->redefine(qesap_upload_logs => sub { return; });
+    my @calls;
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'DENTIST'; });
+    $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    qesap_prepare_env(provider => 'DONALDUCK');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    foreach (@calls) {
+        # check that all command using the redirection also have the pipefail
+        my $cmd = $_;
+        like($cmd, qr/set -o pipefail/, "Command $cmd has pipe and set pipefail") if $cmd =~ /\|/;
+    }
+};
+
 sub create_qesap_prepare_env_mocks_noret {
     my $called_functions = shift;
     my $mock_func = shift;
@@ -891,7 +921,7 @@ subtest '[qesap_prepare_env] only_configure' => sub {
     }
 };
 
-subtest '[qesap_prepare_env/qesap_yaml_replace]' => sub {
+subtest '[qesap_prepare_env] qesap_yaml_replace' => sub {
     my %called_functions;
     my @mock_func = qw(qesap_get_variables);
     my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
@@ -909,7 +939,7 @@ subtest '[qesap_prepare_env/qesap_yaml_replace]' => sub {
     ok $called_functions{file_content_replace} eq 1, "file_content_replace called by qesap_yaml_replace";
 };
 
-subtest '[qesap_prepare_env/qesap_create_folder_tree/qesap_get_file_paths] default' => sub {
+subtest '[qesap_prepare_env] qesap_create_folder_tree/qesap_get_file_paths default' => sub {
     my %called_functions;
     my @mock_func = qw(qesap_get_variables
       qesap_yaml_replace
@@ -933,7 +963,7 @@ subtest '[qesap_prepare_env/qesap_create_folder_tree/qesap_get_file_paths] defau
     ok((any { qr/curl.*\/TORNADO -o \/root\/qe-sap-deployment\/scripts\/qesap\/MARLIN/ } @calls), 'Default location for the openQA conf.yaml templates');
 };
 
-subtest '[qesap_prepare_env/qesap_create_folder_tree/qesap_get_file_paths] user specified deployment_dir' => sub {
+subtest '[qesap_prepare_env] qesap_create_folder_tree/qesap_get_file_paths user specified deployment_dir' => sub {
     my %called_functions;
     my @mock_func = qw(qesap_get_variables
       qesap_yaml_replace
@@ -1006,7 +1036,7 @@ subtest '[qesap_prepare_env] AWS' => sub {
     ok($qesap_create_aws_credentials_called, '$qesap_create_aws_credentials called');
 };
 
-subtest '[qesap_prepare_env::qesap_create_aws_config]' => sub {
+subtest '[qesap_prepare_env] qesap_create_aws_config' => sub {
     my $qesap = create_qesap_prepare_env_mocks();
     my @calls;
     my @contents;
@@ -1029,7 +1059,7 @@ subtest '[qesap_prepare_env::qesap_create_aws_config]' => sub {
     like $contents[1], qr/region = eu-central-1/, "Expected region eu-central-1 is in the config file";
 };
 
-subtest '[qesap_prepare_env::qesap_create_aws_config] fix quote' => sub {
+subtest '[qesap_prepare_env] qesap_create_aws_config fix quote' => sub {
     my $qesap = create_qesap_prepare_env_mocks();
     my @calls;
     my @contents;
@@ -1048,7 +1078,7 @@ subtest '[qesap_prepare_env::qesap_create_aws_config] fix quote' => sub {
     ok((any { qr/eu-central-1/ } @calls), 'AWS Region matches');
 };
 
-subtest '[qesap_prepare_env::qesap_create_aws_config] not solved template' => sub {
+subtest '[qesap_prepare_env] qesap_create_aws_config not solved template' => sub {
     my $qesap = create_qesap_prepare_env_mocks();
     my @contents;
 
@@ -1065,7 +1095,7 @@ subtest '[qesap_prepare_env::qesap_create_aws_config] not solved template' => su
     like $contents[0], qr/region = eu-central-1/, "Expected region eu-central-1 is in the config file";
 };
 
-subtest '[qesap_prepare_env::qesap_create_aws_config] not solved template with quote' => sub {
+subtest '[qesap_prepare_env] qesap_create_aws_config not solved template with quote' => sub {
     my $qesap = create_qesap_prepare_env_mocks();
     my @contents;
 
@@ -1082,7 +1112,7 @@ subtest '[qesap_prepare_env::qesap_create_aws_config] not solved template with q
     like $contents[0], qr/region = eu-central-1/, "Expected region eu-central-1 is in the config file";
 };
 
-subtest '[qesap_prepare_env::qesap_create_aws_config] not solved template and variable with quote' => sub {
+subtest '[qesap_prepare_env] qesap_create_aws_config not solved template and variable with quote' => sub {
     my $qesap = create_qesap_prepare_env_mocks();
     my @contents;
     $qesap->redefine(script_output => sub { return '%REGION%'; });

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -655,7 +655,6 @@ subtest '[qesap_cluster_logs]' => sub {
             return 'BOUBLE BOUBLE BOUBLE'; });
     $qesap->redefine(qesap_get_inventory => sub { return '/BERMUDAS/TRIANGLE'; });
     $qesap->redefine(script_run => sub { return 0; });
-    $qesap->redefine(type_string => sub { return; });
     $qesap->redefine(upload_logs => sub { push @save_file_calls, $_[0]; return; });
     $qesap->redefine(qesap_cluster_log_cmds => sub { return ({Cmd => 'crm status', Output => 'crm_status.txt'}); });
     $qesap->redefine(qesap_upload_crm_report => sub { my (%args) = @_; push @crm_report_calls, $args{host}; return 0; });
@@ -689,7 +688,6 @@ subtest '[qesap_cluster_logs] multi log command' => sub {
             return 'BOUBLE BOUBLE BOUBLE'; });
     $qesap->redefine(qesap_get_inventory => sub { return '/BERMUDAS/TRIANGLE'; });
     $qesap->redefine(script_run => sub { return 0; });
-    $qesap->redefine(type_string => sub { return; });
     $qesap->redefine(upload_logs => sub { return; });
     $qesap->redefine(qesap_cluster_log_cmds => sub { return ({Cmd => 'crm status', Output => 'crm_status.txt', Logs => ['ignore_me.txt', 'ignore_me_too.txt']}); });
     $qesap->redefine(qesap_upload_crm_report => sub { return 0; });

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -44,8 +44,8 @@ subtest "[sles4sap_cleanup] no args and all pass" => sub {
     my $unlock_terminal = 0;
     $sles4sap_publiccloud->redefine(type_string => sub { $unlock_terminal = 1; });
     $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
-    #$sles4sap_publiccloud->redefine(upload_logs => sub { return; });
-    #$sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my @calls;
     $sles4sap_publiccloud->redefine(qesap_execute => sub {
@@ -68,8 +68,8 @@ subtest "[sles4sap_cleanup] ansible and all pass" => sub {
     $sles4sap_publiccloud->redefine(select_host_console => sub { return; });
     $sles4sap_publiccloud->redefine(type_string => sub { return; });
     $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
-    #$sles4sap_publiccloud->redefine(upload_logs => sub { return; });
-    #$sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my @calls;
     $sles4sap_publiccloud->redefine(qesap_execute => sub {
@@ -91,6 +91,7 @@ subtest "[sles4sap_cleanup] terraform to be called even if ansible fails" => sub
     $sles4sap_publiccloud->redefine(select_host_console => sub { return; });
     $sles4sap_publiccloud->redefine(type_string => sub { return; });
     $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
     $sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my @calls;

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -36,8 +36,9 @@ subtest "[run_cmd]" => sub {
     ok $ret eq 'BABUUUUUUUUM';
 };
 
-subtest "[sles4sap_cleanup] no arg and all pass" => sub {
-    # No args result in only terraform destroy to be called
+subtest "[sles4sap_cleanup] no args and all pass" => sub {
+    # sles4sap_cleanup is called with no args
+    # it result in only to perform terraform destroy
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(select_host_console => sub { return; });
     my $unlock_terminal = 0;
@@ -57,7 +58,8 @@ subtest "[sles4sap_cleanup] no arg and all pass" => sub {
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(any { /terraform/ } @calls, "Check if terraform is called");
-    ok($ret eq 1, "Expected return 1 ret:$ret");
+    ok(any { /ansible/ } @calls, "Check that ansible is not called");
+    ok($ret eq 0, "Expected return 0 ret:$ret");
     ok($unlock_terminal eq 1, "ETX called at the beginning to eventually unlock the terminal");
 };
 
@@ -81,27 +83,43 @@ subtest "[sles4sap_cleanup] ansible and all pass" => sub {
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(any { /terraform/ } @calls, "Check if terraform is called");
     ok(any { /ansible/ } @calls, "Check if ansible is called");
+    ok($ret eq 0, "Expected return 0 ret:$ret");
+};
+
+subtest "[sles4sap_cleanup] terraform to be called even if ansible fails" => sub {
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
+    $sles4sap_publiccloud->redefine(select_host_console => sub { return; });
+    $sles4sap_publiccloud->redefine(type_string => sub { return; });
+    $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my @calls;
+    $sles4sap_publiccloud->redefine(qesap_execute => sub {
+            my (%args) = @_;
+            push @calls, $args{cmd};
+            if ($args{cmd} =~ /ansible/) {
+                return (1, 0);
+            } else {
+                return (0, 0);
+    } });
+    my $self = sles4sap_publiccloud->new();
+
+    my $ret = $self->sles4sap_cleanup(ansible_present => 1);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok(any { /terraform/ } @calls, "Check if terraform is called");
+    ok(any { /ansible/ } @calls, "Check if ansible is called");
     ok($ret eq 1, "Expected return 1 ret:$ret");
 };
 
 subtest "[sles4sap_cleanup] no need to clean" => sub {
     # No args result in only terraform destroy to be called
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
-    $sles4sap_publiccloud->redefine(select_host_console => sub { return; });
-    $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
-    $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    my @calls;
-    $sles4sap_publiccloud->redefine(qesap_execute => sub {
-            my (%args) = @_;
-            push @calls, $args{cmd};
-            return (0, 0); });
+
     my $self = sles4sap_publiccloud->new();
     my $ret = $self->sles4sap_cleanup(cleanup_called => 1);
 
-    note("\n  -->  " . join("\n  -->  ", @calls));
-    ok((none { /terraform/ } @calls), "Check that terraform is not called");
-    ok((none { /ansible/ } @calls), "Check that ansible is not called");
     ok($ret eq 0, "Expected return 0 ret:$ret");
 };
 

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -40,8 +40,11 @@ subtest "[sles4sap_cleanup] no arg and all pass" => sub {
     # No args result in only terraform destroy to be called
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(select_host_console => sub { return; });
+    my $unlock_terminal = 0;
+    $sles4sap_publiccloud->redefine(type_string => sub { $unlock_terminal = 1; });
     $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
-    $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
+    #$sles4sap_publiccloud->redefine(upload_logs => sub { return; });
+    #$sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my @calls;
     $sles4sap_publiccloud->redefine(qesap_execute => sub {
@@ -55,13 +58,16 @@ subtest "[sles4sap_cleanup] no arg and all pass" => sub {
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(any { /terraform/ } @calls, "Check if terraform is called");
     ok($ret eq 1, "Expected return 1 ret:$ret");
+    ok($unlock_terminal eq 1, "ETX called at the beginning to eventually unlock the terminal");
 };
 
 subtest "[sles4sap_cleanup] ansible and all pass" => sub {
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(select_host_console => sub { return; });
+    $sles4sap_publiccloud->redefine(type_string => sub { return; });
     $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
-    $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
+    #$sles4sap_publiccloud->redefine(upload_logs => sub { return; });
+    #$sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my @calls;
     $sles4sap_publiccloud->redefine(qesap_execute => sub {

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -100,6 +100,7 @@ sub run {
 
 sub post_run_hook {
     my ($self) = shift;
+    qesap_cluster_logs();
     $self->SUPER::post_run_hook;
 }
 

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -100,7 +100,6 @@ sub run {
 
 sub post_run_hook {
     my ($self) = shift;
-    qesap_cluster_logs();
     $self->SUPER::post_run_hook;
 }
 


### PR DESCRIPTION
Be sure to always call terraform destroy.
Move the EXT to eventually unlock the terminal in a more generic place. Return immediately is cleanup has been already performed. Move log collection from the basetest to the library function.

- Related ticket: https://jira.suse.com/browse/TEAM-9586 and https://jira.suse.com/browse/TEAM-9684

# Verification run:

## qesap regression

### Azure

sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test
-  http://openqaworker15.qa.suse.cz/tests/297688 :green_circle: 

### AWS 

sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_native_test
 - http://openqaworker15.qa.suse.cz/tests/297698 :green_circle: 

sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_sbd_test
 -  http://openqaworker15.qa.suse.cz/tests/297695 :green_circle: test fails and terraform destroy is properly call in the cleanup http://openqaworker15.qa.suse.cz/tests/297695#step/deploy/744

### GCP 

sle-15-SP4-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_4_PAYG-qesap_gcp_sapconf_test
 -  http://openqaworker15.qa.suse.cz/tests/297694 :green_circle:  terraform destroy is correctly executed in case of failure http://openqaworker15.qa.suse.cz/tests/297694#step/test_system/596
 
## HanaSR

### Azure
15SP5_2024-09-17T02:03:20Z-hanasr_azure_test_sapconf_msi az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/297691 :green_circle: 

### AWS
sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-09-16T02:03:15Z-hanasr_aws_test_saptune_fencing_native ec2_r4.8xlarge

-  http://openqaworker15.qa.suse.cz/tests/297692  !!!!MOST IMPORTANT VR!!!!  :green_circle: http://openqaworker15.qa.suse.cz/tests/297692#step/Crash_site_a-primary/1178  Test fail, post_fail_hook start, Andible deregister fails but terraform destroy is called in any case  http://openqaworker15.qa.suse.cz/tests/297692#step/Crash_site_a-primary/1186



This VR only have the first of the two commits:
- http://openqaworker15.qa.suse.cz/tests/297536 :green_circle: test fails and cleanup is correctly executed:
    1. Internal status is tested at first http://openqaworker15.qa.suse.cz/tests/297536#step/Crash_site_a-primary/546  `cleanup_called: undefined` means that the cleanup has not been already executed before: it is fine to execute it now
    2. CTRL+C is executed before the `test -e inventory` http://openqaworker15.qa.suse.cz/tests/297536#step/Crash_site_a-primary/560
    3. `qesap_cluster_logs` start here http://openqaworker15.qa.suse.cz/tests/297536#step/Crash_site_a-primary/569
    4. `qesap.py ... ansible -d` start here http://openqaworker15.qa.suse.cz/tests/297536#step/Crash_site_a-primary/1099
    5. then Ansible return an error and terraform destroy is not called due to TEAM-9684 

## mr_test

sle-15-SP5-Azure-SAP-PAYG-Incidents-saptune-x86_64-Build:35618:cpupower-sles4sap_gnome_saptune_delete_rename@az_Standard_E4s_v3

 -  http://openqaworker15.qa.suse.cz/tests/297693