### PR TITLE
Use REPO_0 for zdup by default with Agama

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -61,6 +61,11 @@ sub run {
     my $defaultrepo;
     if (get_var('SUSEMIRROR')) {
         $defaultrepo = "http://" . get_var("SUSEMIRROR");
+    } elsif (get_var('AGAMA')) {
+        # We no longer have offline media with Agama, zypper dup against the product repo
+        my $host = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
+        my $repo = get_var('REPO_0');
+        $defaultrepo = "$host/assets/repo/$repo";
     }
     else {
         #SUSEMIRROR not set, zdup from ftp source for online migration


### PR DESCRIPTION
Run zdup from 15.6 -> 16.0 against REPO_0 since we have now Agama and no longer have an offline media with repo

The dup itself is expected to fail, but REPO_0 repository should be accessible.

- Verification run:  https://openqa.opensuse.org/tests/4484666
