### PR TITLE
containers: Use 'dnf' instead of 'yum'

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -48,7 +48,7 @@ sub install_podman_when_needed {
     my @pkgs = qw(podman);
     if (script_run("which podman") != 0) {
         if ($host_os =~ /centos|rhel/) {
-            script_retry "yum -y install @pkgs --nobest --allowerasing", timeout => 300;
+            script_retry "dnf -y install @pkgs --nobest --allowerasing", timeout => 300;
         } elsif ($host_os eq 'ubuntu') {
             script_retry("apt-get -y install @pkgs", timeout => 300);
         } else {
@@ -130,8 +130,8 @@ sub install_buildah_when_needed {
             script_retry("apt-get update", timeout => 900);
             script_retry("apt-get -y install buildah", timeout => 300);
         } elsif ($host_os eq 'rhel') {
-            script_retry('yum update -y', timeout => 300);
-            script_retry('yum install -y buildah', timeout => 300);
+            script_retry('dnf update -y', timeout => 300);
+            script_retry('dnf install -y buildah', timeout => 300);
         } else {
             activate_containers_module if $host_os =~ 'sle';
             zypper_call('in buildah', timeout => 300);

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -120,7 +120,7 @@ sub run {
         assert_script_run("pip3 --quiet install tox", timeout => 600);
     } elsif ($host_distri =~ /centos|rhel/) {
         foreach my $pkg (@packages) {
-            script_retry("yum install -y $pkg", timeout => 300);
+            script_retry("dnf install -y $pkg", timeout => 300);
         }
         activate_virtual_env if ($bci_virtualenv);
         assert_script_run('pip3 --quiet install --upgrade pip', timeout => 600);

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -49,9 +49,9 @@ sub run {
             script_retry("apt-get update -qq -y", timeout => $update_timeout);
         } elsif ($host_distri eq 'centos') {
             assert_script_run("dhclient -v");
-            script_retry("yum update -q -y --nobest", timeout => $update_timeout);
+            script_retry("dnf update -q -y --nobest", timeout => $update_timeout);
         } elsif ($host_distri eq 'rhel') {
-            script_retry("yum update -q -y", timeout => $update_timeout);
+            script_retry("dnf update -q -y", timeout => $update_timeout);
         }
     }
 

--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -29,9 +29,9 @@ sub run {
         script_retry("apt-get update -qq -y", timeout => $update_timeout);
     } elsif ($host_distri eq 'centos') {
         assert_script_run("dhclient -v");
-        script_retry("yum update -q -y --nobest", timeout => $update_timeout);
+        script_retry("dnf update -q -y --nobest", timeout => $update_timeout);
     } elsif ($host_distri eq 'rhel') {
-        script_retry("yum update -q -y", timeout => $update_timeout);
+        script_retry("dnf update -q -y", timeout => $update_timeout);
     } else {
         die "Unsupported OS version";
     }

--- a/tests/containers/update_host.pm
+++ b/tests/containers/update_host.pm
@@ -38,9 +38,9 @@ sub run {
         script_retry("apt-get update -y", timeout => $update_timeout);
     } elsif ($host_distri eq 'centos') {
         assert_script_run("dhclient -v");
-        script_retry("yum update -y --nobest", timeout => $update_timeout);
+        script_retry("dnf update -y --nobest", timeout => $update_timeout);
     } elsif ($host_distri eq 'rhel') {
-        script_retry("yum update -y", timeout => $update_timeout);
+        script_retry("dnf update -y", timeout => $update_timeout);
         $self->disable_selinux();
     } else {
         die("Host OS not supported");


### PR DESCRIPTION
In both CentOS and Liberty Linux the yum tool has been succeeded by dnf and has become a symbolic link to it, which makes it safe to switch all occurrences in lib/containers and tests/containers.

- Link: https://progress.opensuse.org/issues/166634
- Verification runs: http://rmarliere-openqa.qe.prg2.suse.org/tests/2340 http://rmarliere-openqa.qe.prg2.suse.org/tests/2341
