### PR TITLE
Rework installation timeout for Agama

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -166,20 +166,14 @@ sub run {
     # BUG tracker: https://github.com/openSUSE/agama/issues/1474
     # copied from await_install.pm
     my $timeout = 2400;    # 40 minutes timeout for installation process
-    while (1) {
-        die "timeout ($timeout) hit during await_install" if $timeout <= 0;
-        my $ret = check_screen 'agama-install-in-progress', 30;
-        sleep 30;
+                           # Await installation with a timeout
+    while ($timeout > 0) {
+        my $ret = check_screen('agama-congratulations', 30);
         $timeout -= 30;
         diag("left total await_install timeout: $timeout");
-        if (!$ret) {
-            # Handle any error dialogs that could happen
-            send_key "down";    # ensure screen doesn't get black shortly after we hit congratulations
-            last;
-        }
+        last if $ret;
+        die "timeout ($timeout) hit during await_install" if $timeout <= 0;
     }
-    # Let's end at agama-congratulations screens
-    assert_screen('agama-congratulations');
 }
 
 =head2 post_fail_hook


### PR DESCRIPTION
* Combination of sleep and timeout in previous run was not good. We got into situation where screen was black etc

* This is bit more simple yet more time efficient

- Verification run 1: https://openqa.opensuse.org/tests/4487031#live
- Verification run 2: https://openqa.opensuse.org/tests/4487030#live
