### PR TITLE
Add reboot scenario after raid installation

### DIFF
--- a/schedule/yam/test_cases/raid0_sle_gpt.yaml
+++ b/schedule/yam/test_cases/raid0_sle_gpt.yaml
@@ -20,3 +20,4 @@ schedule:
   system_validation:
     - console/validate_md_raid
     - console/validate_raid
+    - console/console_reboot

--- a/schedule/yam/test_cases/raid_sle_gpt.yaml
+++ b/schedule/yam/test_cases/raid_sle_gpt.yaml
@@ -14,3 +14,4 @@ schedule:
   system_validation:
     - console/validate_md_raid
     - console/validate_raid
+    - console/console_reboot


### PR DESCRIPTION
Use rebooter to reboot system with RAID configration

- Related ticket: https://progress.opensuse.org/issues/166256
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&build=18.1&groupid=220
