### PR TITLE
Remove the code related to calculate az_sas_token

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -111,23 +111,8 @@ sub run {
     # variable to hold the top level container where the PTF directory
     # is going to be
     my $ptf_container;
-    my $hana_token;
     my $ptf_token;
 
-    if (get_var('HANA_ACCOUNT') && get_var('HANA_CONTAINER') && get_var('HANA_KEYNAME')) {
-        my $hana_token = qesap_az_create_sas_token(
-            storage => get_required_var('HANA_ACCOUNT'),
-            container => (split("/", get_required_var('HANA_CONTAINER')))[0],
-            keyname => get_required_var('HANA_KEYNAME'),
-            # lifetime has to be enough to reach the point of the test that
-            # executes qe-sap-deployment Ansible playbook 'sap-hana-download-media.yaml'
-            lifetime => 90,
-            permission => 'r');
-        # escape needed by 'sed'
-        # but not implemented in file_content_replace() yet poo#120690
-        (my $escaped_hana_token = $hana_token) =~ s/\&/\\\&/g;
-        set_var("HANA_TOKEN", $escaped_hana_token);
-    }
     if (get_var('PTF_ACCOUNT') && get_var('PTF_CONTAINER') && get_var('PTF_KEYNAME')) {
         $ptf_token = qesap_az_create_sas_token(
             storage => get_required_var('PTF_ACCOUNT'),

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -56,20 +56,7 @@ sub run {
 
     $variables{HANA_ACCOUNT} = get_required_var('QESAPDEPLOY_HANA_ACCOUNT');
     $variables{HANA_CONTAINER} = get_required_var('QESAPDEPLOY_HANA_CONTAINER');
-    if (get_var('QESAPDEPLOY_HANA_KEYNAME')) {
-        $variables{HANA_KEYNAME} = get_required_var('QESAPDEPLOY_HANA_KEYNAME');
-        $variables{HANA_TOKEN} = qesap_az_create_sas_token(storage => get_required_var('QESAPDEPLOY_HANA_ACCOUNT'),
-            container => (split("/", get_required_var('QESAPDEPLOY_HANA_CONTAINER')))[0],
-            keyname => get_required_var('QESAPDEPLOY_HANA_KEYNAME'),
-            # lifetime has to be enough to reach the point of the test that
-            # executes qe-sap-deployment Ansible playbook 'sap-hana-download-media.yaml'
-            # and eventually any Ansible retry.
-            lifetime => 120);
-        record_info('TOKEN', $variables{HANA_TOKEN});
-        # escape needed by 'sed'
-        # but not implemented in file_content_replace() yet poo#120690
-        $variables{HANA_TOKEN} =~ s/\&/\\\&/g;
-    }
+    $variables{HANA_KEYNAME} = get_required_var('QESAPDEPLOY_HANA_KEYNAME');
     $variables{HANA_SAR} = get_required_var('QESAPDEPLOY_SAPCAR');
     $variables{HANA_CLIENT_SAR} = get_required_var('QESAPDEPLOY_IMDB_CLIENT');
     $variables{HANA_SAPCAR} = get_required_var('QESAPDEPLOY_IMDB_SERVER');


### PR DESCRIPTION
With https://jira.suse.com/browse/TEAM-9540, having the az_sas_token value defined in qesap.py's YAML configuration files is no longer necessary, as qesap.py will calculate a SAS token dynamically if a valid key name was provided in az_key_name.

this PR doesn't deal with trento code because it hasn't updated for a long time.

- Related ticket: https://jira.suse.com/browse/TEAM-9668
- Needles: None
- Verification run:
    - sle-15-SP6-Qesap-Aws-Byos-qesap_aws_r58xlarge_test                                                                      
        - https://openqaworker15.qa.suse.cz/tests/297682 :green_circle: 
    - 15-SP6-HanaSr-Aws-Byos-hanasr_aws_test_saptune_fencing_native
        - https://openqaworker15.qa.suse.cz/tests/297678 :green_circle: 
    - 15-SP5-HanaSr-Azure-Byos-hanasr_azure_test_sapconf_spn
        - https://openqaworker15.qa.suse.cz/tests/297681 :green_circle: 
    - 15-SP5-HanaSr-Aws-Byos-hanasr_aws_test_fencing_sbd
        - https://openqaworker15.qa.suse.cz/tests/297679 :green_circle: 
    - 12-SP5-HanaSr-Azure-Byos-hanasr_azure_test_msi
        - https://openqaworker15.qa.suse.cz/tests/297680 :green_circle: 
    - 12-SP5-HanaSr-Azure-Byos-hanasr_azure_test_msi
        - https://openqaworker15.qa.suse.cz/tests/297680 :green_circle: 