### PR TITLE
Cleanup cluster configuration

### DIFF
--- a/data/sles4sap/angi_hana_cluster.conf
+++ b/data/sles4sap/angi_hana_cluster.conf
@@ -28,15 +28,15 @@ primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% ocf:heartbeat:IPaddr2 \
            nic=eth0
 colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: \
     rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started \
-    mst_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%:Promoted
+    cln_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%:Promoted
 order ord_saphana_%SID%_HDB%HDB_INSTANCE% Optional: \
     cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
-    mst_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%
+    cln_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%
 clone cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
     rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
     meta clone-node-max=1 \
          interleave=true
-clone mst_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% \
+clone cln_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% \
     rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% \
     meta clone-node-max=1 \
          promotable=true \

--- a/data/sles4sap/hana_cluster_cln.conf
+++ b/data/sles4sap/hana_cluster_cln.conf
@@ -1,0 +1,34 @@
+primitive rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaTopology \
+        params SID=%SID% InstanceNumber=%HDB_INSTANCE% \
+        op monitor interval=10 timeout=600 \
+        op start interval=0 timeout=600 \
+        op stop interval=0 timeout=300
+primitive rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHana \
+        params SID=%SID% InstanceNumber=%HDB_INSTANCE% PREFER_SITE_TAKEOVER=true AUTOMATED_REGISTER=%AUTOMATED_REGISTER% DUPLICATE_PRIMARY_TIMEOUT=7200 \
+        op start interval=0 timeout=3600 \
+        op stop interval=0 timeout=3600 \
+        op promote interval=0 timeout=3600 \
+        op monitor interval=60 role=Promoted timeout=700 \
+        op monitor interval=61 role=Unpromoted timeout=700
+primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% IPaddr2 \
+        params ip=%VIRTUAL_IP_ADDRESS% cidr_netmask=%VIRTUAL_IP_NETMASK% nic=eth0 \
+        op start timeout=20 interval=0 \
+        op stop timeout=20 interval=0 \
+        op monitor interval=10 timeout=20
+primitive stonith-sbd stonith:external/sbd \
+        params pcmk_delay_max=15
+clone cln_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% \
+        meta clone-max=2 clone-node-max=1 interleave=true promotable=true maintenance=true
+clone cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
+        meta clone-node-max=1 interleave=true
+colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started cln_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%:Promoted
+order ord_SAPHana_%SID%_HDB%HDB_INSTANCE% Optional: cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% cln_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%
+property SAPHanaSR: \
+        hana_prd_site_srHook_SECONDARY_SITE_NAME=SOK
+property cib-bootstrap-options: \
+    stonith-action="reboot" \
+    stonith-timeout="120" \
+    priority-fencing-delay="60"
+rsc_defaults rsc-options: \
+        resource-stickiness=1000 \
+        migration-threshold=5000

--- a/data/sles4sap/hana_cluster_msl.conf
+++ b/data/sles4sap/hana_cluster_msl.conf
@@ -3,7 +3,7 @@ primitive rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaTopology \
         op monitor interval=10 timeout=600 \
         op start interval=0 timeout=600 \
         op stop interval=0 timeout=300
-primitive rsc_SAPHana_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHana \
+primitive rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHana \
         params SID=%SID% InstanceNumber=%HDB_INSTANCE% PREFER_SITE_TAKEOVER=true AUTOMATED_REGISTER=%AUTOMATED_REGISTER% DUPLICATE_PRIMARY_TIMEOUT=7200 \
         op start interval=0 timeout=3600 \
         op stop interval=0 timeout=3600 \
@@ -17,12 +17,12 @@ primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% IPaddr2 \
         op monitor interval=10 timeout=20
 primitive stonith-sbd stonith:external/sbd \
         params pcmk_delay_max=15
-ms msl_SAPHana_%SID%_HDB%HDB_INSTANCE% rsc_SAPHana_%SID%_HDB%HDB_INSTANCE% \
+ms msl_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% \
         meta clone-max=2 clone-node-max=1 interleave=true maintenance=true
 clone cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% \
         meta clone-node-max=1 interleave=true
-colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started msl_SAPHana_%SID%_HDB%HDB_INSTANCE%:Master
-order ord_SAPHana_%SID%_HDB%HDB_INSTANCE% Optional: cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% msl_SAPHana_%SID%_HDB%HDB_INSTANCE%
+colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started msl_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%:Master
+order ord_SAPHana_%SID%_HDB%HDB_INSTANCE% Optional: cln_SAPHanaTpg_%SID%_HDB%HDB_INSTANCE% msl_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%
 property SAPHanaSR: \
         hana_prd_site_srHook_SECONDARY_SITE_NAME=SOK
 property cib-bootstrap-options: \

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -32,6 +32,8 @@ use Carp qw(croak);
 our @EXPORT = qw(
   $instance_password
   $systemd_cgls_cmd
+  $resource_alias
+  $resource_role
   SAPINIT_RE
   SYSTEMD_RE
   SYSTEMCTL_UNITS_RE
@@ -92,6 +94,8 @@ our $product;
 our $ps_cmd;
 our $instance_password = get_var('INSTANCE_PASSWORD', 'Qwerty_123');
 our $systemd_cgls_cmd = 'systemd-cgls --no-pager -u SAP.slice';
+our $resource_alias = is_sle(">=15-SP4") ? 'cln' : 'msl';
+our $resource_role = is_sle(">=15-SP4") ? "Promoted" : "Master";
 
 =head2 SAPINIT_RE & SYSTEMD_RE
 
@@ -953,7 +957,7 @@ sub do_hana_takeover {
     }
     sleep bmwqemu::scale_timeout(10);
     if ($args{cluster}) {
-        my $hana_resource = get_var('USE_SAP_HANA_SR_ANGI') ? "rsc_SAPHanaCtl_${sid}_HDB$instance_id" : "rsc_SAPHana_${sid}_HDB$instance_id";
+        my $hana_resource = "rsc_SAPHanaCtl_${sid}_HDB$instance_id";
         assert_script_run "crm resource cleanup $hana_resource", $args{timeout};
         assert_script_run 'crm_resource --cleanup', $args{timeout};
     }

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -53,7 +53,10 @@ sub run {
 
     if (is_node(1)) {
         # Create the resource configuration
-        my $cluster_conf = get_var('USE_SAP_HANA_SR_ANGI') ? 'angi_hana_cluster.conf' : 'hana_cluster.conf';
+        # hana_cluster_msl.conf is used in 15-SP3, 15-SP2, 12-SP5 becuase these version don't support promote role.
+        # hana_cluster_cln.conf is used in 15-SP4 and above version.
+        # angi_hana_cluster.conf is used for angi testing.
+        my $cluster_conf = get_var('USE_SAP_HANA_SR_ANGI') ? 'angi_hana_cluster.conf' : "hana_cluster_$sles4sap::resource_alias.conf";
         assert_script_run 'curl -f -v ' . autoinst_url . "/data/sles4sap/$cluster_conf -o /tmp/$cluster_conf";
         $cluster_conf = '/tmp/' . $cluster_conf;
 
@@ -79,7 +82,7 @@ sub run {
         hanasr_angi_hadr_providers_setup($sid, $instance_id, $sapadm) if get_var('USE_SAP_HANA_SR_ANGI');
 
         # Commits configuration changes into the cluster
-        my $resource = get_var('USE_SAP_HANA_SR_ANGI') ? "mst_SAPHanaCtl_${sid}_HDB$instance_id" : "msl_SAPHana_${sid}_HDB$instance_id";
+        my $resource = $sles4sap::resource_alias . "_SAPHanaCtl_${sid}_HDB$instance_id";
         my @crm_cmds = ("crm configure load update $cluster_conf",
             "crm resource refresh $resource",
             "crm resource maintenance $resource off");

--- a/tests/sles4sap/sap_suse_cluster_connector.pm
+++ b/tests/sles4sap/sap_suse_cluster_connector.pm
@@ -71,7 +71,7 @@ sub run {
     }
 
     # List nodes
-    my @hana_resources = get_var('USE_SAP_HANA_SR_ANGI') ? ('ip', 'SAPHanaFil', 'SAPHanaTpg', 'SAPHanaCtl') : ('ip', 'SAPHanaTpg', 'SAPHana');
+    my @hana_resources = get_var('USE_SAP_HANA_SR_ANGI') ? ('ip', 'SAPHanaFil', 'SAPHanaTpg', 'SAPHanaCtl') : ('ip', 'SAPHanaTpg', 'SAPHanaCtl');
     my @resources = get_var('NW') ? ('ip', 'fs', 'sap') : @hana_resources;
     foreach my $rsc_type (@resources) {
         my $rsc = "rsc_${rsc_type}_${instance_sid}_$instance_type$instance_id";
@@ -88,10 +88,7 @@ sub run {
     }
 
     # Test Stop/Start of SAP resource
-    my $hana_resource_name
-      = get_var('USE_SAP_HANA_SR_ANGI')
-      ? "rsc_SAPHanaCtl_${instance_sid}_$instance_type$instance_id"
-      : "rsc_SAPHana_${instance_sid}_$instance_type$instance_id";
+    my $hana_resource_name = $sles4sap::resource_alias . "_SAPHanaCtl_${instance_sid}_$instance_type$instance_id";
     my $rsc = get_var('NW') ? "rsc_sap_${instance_sid}_$instance_type$instance_id" : $hana_resource_name;
     wait_for_idle_cluster;
     exec_conn_cmd(binary => $binary, cmd => "$_ --res $rsc --act stop", timeout => 120) foreach qw(fra cpa);


### PR DESCRIPTION
1. From 15-SP4 to 15-SP7, use 'promoted' and 'unpromoted'.
2. For 15-SP3, 15-SP2 and 12-SP5, use 'Master' because these version
don't support 'promoted' role
3. Uniform the resource name in hana_cluster and angi_hana_cluster
configuratoin files for 15-SP4~15-SP7.

Related: https://jira.suse.com/browse/TEAM-9635

VRs:
15-SP7: https://openqa.suse.de/tests/15486508#  (softfail)
15-SP6: https://openqa.suse.de/tests/15517245#  (Softfail)
15-SP5: https://openqa.suse.de/tests/15485544#  (Softfail)
15-SP4: https://openqa.suse.de/tests/15485537#  (Passed)
15-SP3: https://openqa.suse.de/tests/15517248#  (Passed)
15-SP2: https://openqa.suse.de/tests/15486505#  (Passed)
12-SP5: https://openqa.suse.de/tests/15485651#  (Passed)

Angi VR:
15-SP6: https://openqa.suse.de/tests/15486526#  (Softfail)
15-SP7: https://openqa.suse.de/tests/15517244# (Softfail)