### PR TITLE
Override parent post_run_hook

### DIFF
--- a/tests/ha/cluster_boot_mgmt.pm
+++ b/tests/ha/cluster_boot_mgmt.pm
@@ -27,4 +27,15 @@ sub run {
     }
 }
 
+sub post_run_hook {
+    # this post_run is almost identical to the parent's post_run function
+    # excluding the 'record_avc_selinux_alerts' call, which causes
+    # needle failures due to unexpected console output
+    my ($self) = @_;
+
+    # start next test in home directory
+    enter_cmd "cd";
+    $self->clear_and_verify_console;
+}
+
 1;


### PR DESCRIPTION
This pr overrides the `post_run_hook` for `cluster_boot_mgmt` to remove `record_avc_selinux_alerts ` which caused needle failures.

Tests were failing due to unexpected output from the above function, which is included in the parent `post_run`, which led the needle (which expected a clean terminal) to not match. This pr overrides the post run hook, and only removes this function (everything else is copied from the parent function).

Example of failure: https://openqa.suse.de/tests/15463069#step/cluster_boot_mgmt#1/19

- Related ticket: -
- Verification run: https://openqa.suse.de/tests/15463569#dependencies
