### PR TITLE
Add container test runs for RISC-V

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -99,7 +99,7 @@ my %opensuse_containers = (
         totest => sub {
             'registry.opensuse.org/' . get_opensuse_registry_prefix . 'opensuse/tumbleweed';
         },
-        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm', 'riscv64']
     },
     '15.4' => {
         released => sub { 'registry.opensuse.org/opensuse/leap:15.4' },
@@ -155,13 +155,16 @@ sub supports_image_arch {
 sub get_3rd_party_images {
     my $registry = get_var('REGISTRY', 'docker.io');
     my @images = (
-        "registry.opensuse.org/opensuse/leap",
         "registry.opensuse.org/opensuse/tumbleweed",
-        "$registry/library/alpine",
-        "$registry/library/debian"
+        "$registry/library/alpine"
+    );
+
+    push @images, (
+        "registry.opensuse.org/opensuse/leap",
+        "$registry/library/debian",
         # Temporarily disabled as it needs x86-64-v2
         # "quay.io/centos/centos:stream9"
-    );
+    ) unless (is_riscv);
 
     # Following images are not available on 32-bit arm
     push @images, (
@@ -170,7 +173,7 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi8/ubi-minimal",
         "registry.access.redhat.com/ubi8/ubi-micro",
         "registry.access.redhat.com/ubi8/ubi-init"
-    ) unless (is_arm);
+    ) unless (is_arm || is_riscv);
 
     # - ubi9 images require z14+ s390x machine, they are not ready in OSD yet.
     #     on z13: "Fatal glibc error: CPU lacks VXE support (z14 or later required)".
@@ -182,7 +185,7 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi9/ubi-minimal",
         "registry.access.redhat.com/ubi9/ubi-micro",
         "registry.access.redhat.com/ubi9/ubi-init"
-    ) unless (is_arm || is_s390x || is_ppc64le || !is_x86_64_v2);
+    ) unless (is_arm || is_s390x || is_ppc64le || is_riscv || !is_x86_64_v2);
 
     push @images, (
         "$registry/library/ubuntu"
@@ -193,7 +196,7 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi7/ubi",
         "registry.access.redhat.com/ubi7/ubi-minimal",
         "registry.access.redhat.com/ubi7/ubi-init"
-    ) unless (is_arm || is_aarch64 || check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
+    ) unless (is_arm || is_aarch64 || is_riscv || check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
 
     return (\@images);
 }

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -130,10 +130,10 @@ sub load_host_tests_podman {
     load_3rd_party_image_test($run_args) unless is_staging;
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
-    loadtest 'containers/podman_bci_systemd';
+    loadtest 'containers/podman_bci_systemd' unless (is_riscv);
     loadtest 'containers/podman_pods';
     # fresh install of sle-micro comes with netavark
-    loadtest('containers/podman_network_cni') unless (is_sle_micro('6.0+') || (is_sle_micro('=5.5') && is_public_cloud) || (check_var('FLAVOR', 'DVD-Updates') && is_sle_micro));
+    loadtest('containers/podman_network_cni') unless (is_tumbleweed || is_sle_micro('6.0+') || (is_sle_micro('=5.5') && is_public_cloud) || (check_var('FLAVOR', 'DVD-Updates') && is_sle_micro));
     # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
     load_firewall_test($run_args);
     # IPv6 is not available on Azure

--- a/tests/containers/podman_bci_systemd.pm
+++ b/tests/containers/podman_bci_systemd.pm
@@ -10,6 +10,7 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use version_utils qw(is_opensuse);
 use utils;
 
 sub run {
@@ -21,6 +22,7 @@ sub run {
     record_info("Podman version", script_output("podman version"));
 
     record_info('Test', 'Launch a container with systemd');
+    my $image = is_opensuse ? "registry.opensuse.org/opensuse/bci/bci-init" : "registry.suse.com/bci/bci-init:latest";
     assert_script_run("podman run -d -p 80:80 --health-cmd='curl http://localhost' --name nginx registry.suse.com/bci/bci-init:latest");
 
     record_info('Test', 'Install nginx');

--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -85,7 +85,7 @@ sub run {
         # Kube generate
         record_info('Test', 'Generate the yaml from a pod');
         assert_script_run('podman pod create testing-pod');
-        my $image = "registry.suse.com/bci/bci-busybox:latest";
+        my $image = is_opensuse ? "registry.opensuse.org/opensuse/bci/bci-busybox:latest" : "registry.suse.com/bci/bci-busybox:latest";
         script_retry("podman pull $image", timeout => 300, delay => 60, retry => 3);
         assert_script_run("podman container create --pod testing-pod --name container $image sh -c \"sleep 3600\"");
         assert_script_run("podman kube generate testing-pod | tee pod.yaml");

--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -14,7 +14,7 @@ use utils qw(validate_script_output_retry);
 use containers::utils qw(reset_container_network_if_needed);
 use Utils::Architectures;
 use Utils::Backends qw(is_xen_pv is_hyperv);
-use version_utils qw(is_public_cloud is_sle is_vmware);
+use version_utils qw(is_public_cloud is_sle is_vmware is_opensuse);
 use utils qw(script_retry);
 
 sub run {
@@ -26,7 +26,7 @@ sub run {
     $self->{runtime} = $engine;
     reset_container_network_if_needed($runtime);
 
-    my $image = "registry.suse.com/bci/bci-base:latest";
+    my $image = is_opensuse ? "registry.opensuse.org/opensuse/tumbleweed:latest" : "registry.suse.com/bci/bci-base:latest";
     script_retry("$runtime pull $image", timeout => 300, delay => 120, retry => 3);
 
     record_info('Test', 'Launch a container with privileged mode');
@@ -52,7 +52,7 @@ sub run {
     # poo#155422 --> there's no podman in SLE12-SP3 and so netavark fails
     unless (is_sle('=12-sp3')) {
         assert_script_run("$runtime run -d --privileged --name outer-container $image sleep 100000");
-        assert_script_run("$runtime exec outer-container zypper in -r SLE_BCI -y podman");
+        assert_script_run("$runtime exec outer-container zypper in -y podman");
         # overlayfs can be used starting with kernel 4.18 by unprivileged users in an user namespace
         assert_script_run("$runtime exec -it outer-container podman run -it $image ls");
     }

--- a/tests/containers/skopeo.pm
+++ b/tests/containers/skopeo.pm
@@ -11,7 +11,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';    # used in select_serial_terminal
 use utils 'zypper_call';    # used in zypper_call
-use version_utils qw(is_transactional is_vmware);
+use version_utils qw(is_transactional is_vmware is_opensuse);
 use transactional;
 use containers::common qw(install_packages);
 
@@ -28,7 +28,7 @@ sub run {
     select_serial_terminal() unless is_vmware;    # Select most suitable text console
 
     # Set a variable for my remote image
-    my $remote_image = 'registry.suse.com/bci/bci-busybox:latest';
+    my $remote_image = is_opensuse ? "registry.opensuse.org/opensuse/bci/bci-busybox:latest" : "registry.suse.com/bci/bci-busybox:latest";
     # Set a variable for my local image
     my $local_image = 'localhost:5050/bci-busybox:latest';
 
@@ -95,7 +95,8 @@ sub run {
     assert_script_run("diff -urN $dir1 $dir2", fail_message => 'Copied images are not identical.');
 
     ######### Spin-up an instance of the latest Registry
-    assert_script_run("$runtime run --rm -d -p 5050:5000 --name skopeo-registry registry.suse.com/suse/registry:latest",
+    my $registry_image = is_opensuse ? "registry.opensuse.org/opensuse/registry:latest" : "registry.suse.com/suse/registry:latest";
+    assert_script_run("$runtime run --rm -d -p 5050:5000 --name skopeo-registry $registry_image",
         fail_message => "Failed to start local registry container");
 
     ######### Pull the image into a our local repository


### PR DESCRIPTION
Update container URLs to make the container test runs work on RISC-V.

- Related ticket: https://progress.opensuse.org/issues/166589
- Verification run: [TW RISC-V](https://openqa.opensuse.org/tests/4530538) | [TW x86_64](https://openqa.opensuse.org/tests/4530770) | [SLEM 6.0](https://openqa.suse.de/tests/15590591)
