### PR TITLE
Enhance disk_boot for SLMicro

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -20,7 +20,9 @@ sub run {
     # default timeout in grub2 is set to 10s
     # Sometimes, machines tend to stall when trying to match grub2
     # this leads to test failures because openQA does not assert grub2 properly
-    if ((is_aarch64 || is_sle_micro('>=6.0')) && !main_micro_alp::is_dvd()) {
+    # KEEP_GRUB_TIMEOUT=0 will force the grub needle to match, useful when booting
+    # pre-configured images with disabled timeout. See opensusebasetest::handle_grub
+    if ((is_aarch64 || is_sle_micro('>=6.0')) && get_var('KEEP_GRUB_TIMEOUT', '1') && !main_micro_alp::is_dvd()) {
         shift->wait_boot_past_bootloader(textmode => 1);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
Some of the jobs that create HDDs for other jobs disable the grub timeout, and the grub screen will be waiting for input without timeout. We need a way to tell the job if it should expect that screen or not.

https://progress.opensuse.org/issues/166892

MicroOS:
[MicroOS DVD x86_64](https://openqa.opensuse.org/tests/4492280#)
[MicroOS image x86_64](https://openqa.opensuse.org/tests/4492281#)
[MicroOS image aarch64](https://openqa.opensuse.org/tests/4492282#)

SL Micro:
[5.5 create job aarch64](https://openqa.suse.de/tests/15477816#)
[5.5 toolbox test using that hdd aarch64](https://openqa.suse.de/tests/15477813#) with `KEEP_GRUB_TIMEOUT=0`
[5.5 toolbox test using that hdd x86_64](https://openqa.suse.de/tests/15477876) with `KEEP_GRUB_TIMEOUT=0`
[5.5 regular test x86_64](https://openqa.suse.de/tests/15477843#)
[5.5 regular test aarch64](https://openqa.suse.de/tests/15477844#)
[6.0 regular test x86_64](https://openqa.suse.de/tests/15477848#)
[6.0 regular test aarch64](https://openqa.suse.de/tests/15477849#)
