### PR TITLE
Use choose_node to get remote node hostname

### DIFF
--- a/tests/sles4sap/sap_suse_cluster_connector.pm
+++ b/tests/sles4sap/sap_suse_cluster_connector.pm
@@ -82,7 +82,7 @@ sub run {
         validate_script_output("cat $log_file | cut -d : -f 4", sub { m/$hostname/ });
         record_info("Found $hostname in lsn output");
         # Check the "node list" contains remote node
-        my $remote_node = script_output("crm status bynode | grep -Po '(?<=\\* Node )(.*)(?=: online:\$)' | grep -v $hostname");
+        my $remote_node = choose_node(2);
         validate_script_output("cat $log_file | cut -d : -f 4", sub { m/$remote_node/ });
         record_info("Found $remote_node in lsn output");
     }


### PR DESCRIPTION
Use choose_node to get remote node hostname

Test cases hit a sporadic issue, for example: https://openqa.suse.de/tests/15468847#step/sap_suse_cluster_connector/78
The  serial output sporadically contains one unexpected line which makes `validate_script_output` failed:
```
[ 2944.689003] SAPInstance(rsc_sap_EN2_ASCS00)[23436]: INFO: systemd service SAPEN2_00 is active
```
So using `choose_node()` instead.

- Related ticket: No
- Needles: No
- Verification run:
https://openqa.suse.de/tests/15477943#step/sap_suse_cluster_connector/55 (passed)