### PR TITLE
Refactor publiccloud::basetest::_cleanup

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -107,26 +107,26 @@ my $should_use_runargs = sub {
 };
 
 sub load_latest_publiccloud_tests {
+    my $args = OpenQA::Test::RunArgs->new();
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
-        loadtest "publiccloud/img_proof";
+        loadtest "publiccloud/img_proof", run_args => $args;
     }
     elsif (get_var('PUBLIC_CLOUD_LTP')) {
-        loadtest 'publiccloud/run_ltp';
+        loadtest 'publiccloud/run_ltp', run_args => $args;
     }
     elsif (get_var('PUBLIC_CLOUD_SLES4SAP')) {
-        loadtest 'publiccloud/sles4sap';
+        loadtest 'publiccloud/sles4sap', run_args => $args;
     }
     elsif (get_var('PUBLIC_CLOUD_ACCNET')) {
-        loadtest 'publiccloud/az_accelerated_net';
+        loadtest 'publiccloud/az_accelerated_net', run_args => $args;
     }
     elsif (get_var('PUBLIC_CLOUD_FIO')) {
-        loadtest 'publiccloud/storage_perf';
+        loadtest 'publiccloud/storage_perf', run_args => $args;
     }
     elsif (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
-        loadtest("publiccloud/check_registercloudguest");
+        loadtest "publiccloud/check_registercloudguest", run_args => $args;
     }
     elsif (&$should_use_runargs()) {
-        my $args = OpenQA::Test::RunArgs->new();
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest("publiccloud/registration", run_args => $args);
         if (get_var('PUBLIC_CLOUD_NETCONFIG')) {
@@ -146,16 +146,16 @@ sub load_latest_publiccloud_tests {
             elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
                 load_container_tests();
             } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
-                loadtest "publiccloud/smoketest";
+                loadtest "publiccloud/smoketest", run_args => $args;
                 # flavor_check is concentrated on checking things which make sense only for image which is registered
                 # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense
-                loadtest "publiccloud/flavor_check" if (is_ec2() && !check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect'));
-                loadtest "publiccloud/sev" if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
-                loadtest "publiccloud/xen" if (get_var('PUBLIC_CLOUD_XEN'));
+                loadtest "publiccloud/flavor_check", run_args => $args if (is_ec2() && !check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect'));
+                loadtest "publiccloud/sev", run_args => $args if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
+                loadtest "publiccloud/xen", run_args => $args if (get_var('PUBLIC_CLOUD_XEN'));
             } elsif (get_var('PUBLIC_CLOUD_XFS')) {
-                loadtest "publiccloud/xfsprepare";
-                loadtest "xfstests/run";
-                loadtest "xfstests/generate_report";
+                loadtest "publiccloud/xfsprepare", run_args => $args;
+                loadtest "xfstests/run", run_args => $args;
+                loadtest "xfstests/generate_report", run_args => $args;
             } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
                 loadtest("publiccloud/azure_nfs", run_args => $args);
             }
@@ -163,9 +163,9 @@ sub load_latest_publiccloud_tests {
         }
     }
     elsif (get_var('PUBLIC_CLOUD_UPLOAD_IMG')) {
-        loadtest "publiccloud/upload_image";
+        loadtest "publiccloud/upload_image", run_args => $args;
     } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {
-        loadtest('publiccloud/ahb');
+        loadtest 'publiccloud/ahb', run_args => $args;
     } else {
         die "*publiccloud - Latest* expects PUBLIC_CLOUD_* job variable. None is matched from the expected ones.";
     }

--- a/tests/publiccloud/cloud_netconfig.pm
+++ b/tests/publiccloud/cloud_netconfig.pm
@@ -20,8 +20,6 @@ sub run {
     my ($self, $args) = @_;
     my $instance = $args->{my_instance};
     my $provider = $args->{my_provider};
-    $self->{instance} = $args->{my_instance};
-    $self->{provider} = $args->{my_provider};
     my $pers_net_rules = '/etc/udev/rules.d/75-persistent-net-generator.rules';
 
     $instance->ssh_assert_script_run('systemctl is-enabled cloud-netconfig.service');
@@ -95,16 +93,16 @@ sub run {
 }
 
 sub post_fail_hook {
-    my $self = shift;
+    my ($self) = @_;
 
-    debug($self->{instance}, $self->{provider});
+    debug($self->{run_args}->{my_instance}, $self->{run_args}->{my_provider});
     $self->SUPER::post_fail_hook;
 }
 
 sub post_run_hook {
-    my $self = shift;
+    my ($self) = @_;
 
-    debug($self->{instance}, $self->{provider});
+    debug($self->{run_args}->{my_instance}, $self->{run_args}->{my_provider});
     $self->SUPER::post_run_hook;
 }
 

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -42,14 +42,12 @@ sub run {
 
     select_host_console();
 
-    # QAM passes the instance as argument
-    if (get_var('PUBLIC_CLOUD_QAM')) {
-        $instance = $args->{my_instance};
-        $provider = $args->{my_provider};
-    } else {
-        $provider = $self->provider_factory();
-        $instance = $provider->create_instance(check_guestregister => is_ondemand ? 1 : 0);
+    unless ($args->{my_provider} && $args->{my_instance}) {
+        $args->{my_provider} = $self->provider_factory();
+        $args->{my_instance} = $args->{my_provider}->create_instance(check_guestregister => is_ondemand ? 1 : 0);
     }
+    $instance = $args->{my_instance};
+    $provider = $args->{my_provider};
 
     if (is_hardened) {
         # Fix permissions for /etc/ssh/sshd_config

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -34,13 +34,13 @@ sub run {
     my $additional_disk_type = get_var('PUBLIC_CLOUD_HDD2_TYPE', '');    # Optional variable, also if PUBLIC_CLOUD_HDD2_SIZE is set
 
     # Create public cloud instance
-    my $provider = $self->provider_factory();
     my %instance_args;
     $instance_args{check_connectivity} = 1;
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
-    $args->{my_provider} = $provider;
-    my $instance = $provider->create_instance(%instance_args);
-    $args->{my_instance} = $instance;
+    $args->{my_provider} = $self->provider_factory();
+    $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
+    my $provider = $args->{my_provider};
+    my $instance = $args->{my_instance};
 
     $instance->network_speed_test();
     $instance->check_cloudinit() if (is_cloudinit_supported);

--- a/tests/publiccloud/storage_perf.pm
+++ b/tests/publiccloud/storage_perf.pm
@@ -68,7 +68,7 @@ sub analyze_previous_series {
 
 
 sub run {
-    my ($self) = @_;
+    my ($self, $args) = @_;
 
     my $runtime = get_var('PUBLIC_CLOUD_FIO_RUNTIME', 300);
     my $disk_size = get_var('PUBLIC_CLOUD_HDD2_SIZE');
@@ -121,14 +121,14 @@ sub run {
 
     select_serial_terminal();
 
-    my $provider = $self->provider_factory();
-    my $instance;
+    $args->{my_provider} = $self->provider_factory();
     if ($use_nvme) {
-        $instance = $provider->create_instance();
+        $args->{my_instance} = $args->{my_provider}->create_instance();
+    } else {
+        $args->{my_instance} = $args->{my_provider}->create_instance(use_extra_disk => {size => $disk_size, type => $disk_type});
     }
-    else {
-        $instance = $provider->create_instance(use_extra_disk => {size => $disk_size, type => $disk_type});
-    }
+    my $instance = $args->{my_instance};
+    my $provider = $args->{my_provider};
 
     if (get_var('PUBLIC_CLOUD_QAM')) {
         $tags->{os_pc_build} = 'N/A';


### PR DESCRIPTION
Refactoring the `publiccloud::basetest::_cleanup` in a way that:

* Every test module creating `$provider` and `$instance` should save it to `$args`.
* Every custom `post_fail_hook` and `post_run_hook` should use `$self->{run_args` for accessing above objects.
* Every 'third party' (e.g. console, container, ...) test should not have `fatal` flag on Public Cloud runs.