### PR TITLE
Revert back to use tty7 as graphical one for agama

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -475,12 +475,7 @@ sub init_consoles {
             || is_svirt_except_s390x))
     {
         $self->add_console('install-shell', 'tty-console', {tty => 2});
-        if (get_var('AGAMA')) {
-            $self->add_console('installation', 'tty-console', {tty => 2});
-        }
-        else {
-            $self->add_console('installation', 'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
-        }
+        $self->add_console('installation', 'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
         $self->add_console('install-shell2', 'tty-console', {tty => 9});
         # On SLE15 X is running on tty2 see bsc#1054782
         $self->add_console('root-console', 'tty-console', {tty => get_root_console_tty});


### PR DESCRIPTION
Revert these lines regarding the graphical tty used by agama installer:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20189/files#diff-cdfc5d4c733095953bb02e1338918cc890bb886a8a775280b70917e5cdb2e797R478-R483
once this has been merged https://github.com/openSUSE/agama/pull/1619