### PR TITLE
Include FIPS modules in SLES for SAP schedules

### DIFF
--- a/schedule/sles4sap/qam/common/qam_hana_cluster_node.yaml
+++ b/schedule/sles4sap/qam/common/qam_hana_cluster_node.yaml
@@ -40,6 +40,7 @@ schedule:
   - boot/boot_to_desktop
   - ha/wait_barriers
   - console/system_prepare
+  - '{{setup_fips}}'
   - console/consoletest_setup
   - console/check_os_release
   - console/hostname
@@ -91,3 +92,7 @@ conditional_schedule:
     WMP:
       1:
         - kernel/wmp_simple
+  setup_fips:
+    FIPS_INSTALLATION:
+      1:
+        - fips/fips_setup

--- a/schedule/sles4sap/qam/common/qam_install_sles4sap.yaml
+++ b/schedule/sles4sap/qam/common/qam_install_sles4sap.yaml
@@ -31,6 +31,7 @@ schedule:
   - installation/first_boot
   - '{{patch_and_reboot}}'
   - console/system_prepare
+  - '{{setup_fips}}'
   - '{{test_sles4sap}}'
   - '{{scc_deregister}}'
   - '{{generate_image}}'
@@ -120,3 +121,7 @@ conditional_schedule:
         - shutdown/grub_set_bootargs
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
+  setup_fips:
+    FIPS_ENABLED:
+      1:
+        - fips/fips_setup

--- a/schedule/sles4sap/qam/common/qam_sles4sap_fips_mau-extratests.yaml
+++ b/schedule/sles4sap/qam/common/qam_sles4sap_fips_mau-extratests.yaml
@@ -1,0 +1,45 @@
+---
+name: sles4sap_mau-extratests
+description: CLI extratests for SLES for SAP FIPS Vendor Affirmation
+schedule:
+  - boot/boot_to_desktop
+  - fips/fips_setup
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - sles4sap/patterns
+  - fips/gnutls/gnutls_base_check
+  - fips/openjdk/openjdk_fips
+  - console/curl_ipv6
+  - console/wget_ipv6
+  - console/ca_certificates_mozilla
+  - console/unzip
+  - console/rsync
+  - console/shells
+  - console/dstat
+  - console/supportutils
+  - console/mdadm
+  - console/quota
+  - console/vhostmd
+  - console/rpcbind
+  - console/timezone
+  - console/procps
+  - console/iotop
+  - console/kmod
+  - console/suse_module_tools
+  - console/aaa_base
+  - console/gd
+  - console/vsftpd
+  - console/coredump_collect
+  - console/osinfo_db
+  - console/ovn
+  - console/firewalld
+  - console/libgcrypt
+  - console/zziplib
+  - console/nginx
+  - console/sysctl
+  - '{{arch_specific}}'
+conditional_schedule:
+  arch_specific15_sp4:
+    ARCH:
+      x86_64:
+        - console/ansible

--- a/schedule/sles4sap/qam/common/qam_sles4sap_test.yaml
+++ b/schedule/sles4sap/qam/common/qam_sles4sap_test.yaml
@@ -8,6 +8,7 @@ vars:
 schedule:
   - boot/boot_to_desktop
   - console/system_prepare
+  - '{{setup_fips}}'
   - sles4sap/patterns
   - '{{module_to_test}}'
 conditional_schedule:
@@ -17,3 +18,7 @@ conditional_schedule:
         - sles4sap/sapconf
       saptune:
         - sles4sap/saptune
+  setup_fips:
+    FIPS_INSTALLATION:
+      1:
+        - fips/fips_setup

--- a/schedule/sles4sap/qam/common/qam_test_hana.yaml
+++ b/schedule/sles4sap/qam/common/qam_test_hana.yaml
@@ -13,6 +13,7 @@ vars:
 schedule:
   - boot/boot_to_desktop
   - console/system_prepare
+  - '{{setup_fips}}'
   - sles4sap/patterns
   - '{{cli_install}}'
   - '{{wizard_install}}'
@@ -26,3 +27,7 @@ conditional_schedule:
     WIZARD:
       1:
         - sles4sap/wizard_hana_install
+  setup_fips:
+    FIPS_INSTALLATION:
+      1:
+        - fips/fips_setup

--- a/schedule/sles4sap/qam/common/qam_test_netweaver.yaml
+++ b/schedule/sles4sap/qam/common/qam_test_netweaver.yaml
@@ -11,6 +11,12 @@ vars:
 schedule:
   - boot/boot_to_desktop
   - console/system_prepare
+  - '{{setup_fips}}'
   - sles4sap/patterns
   - sles4sap/netweaver_install
   - sles4sap/netweaver_test_instance
+conditional_schedule:
+  setup_fips:
+    FIPS_INSTALLATION:
+      1:
+        - fips/fips_setup

--- a/schedule/sles4sap/qam/common/sles4sap_fips_crypt_openjdk.yaml
+++ b/schedule/sles4sap/qam/common/sles4sap_fips_crypt_openjdk.yaml
@@ -1,0 +1,12 @@
+name: sles4sap_fips_crypt_openjdk
+description:    >
+    Schedule to test crypt and openjdk in SLES for SAP.
+schedule:
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - fips/fips_setup
+    - console/gpg
+    - sles4sap/patterns
+    - fips/gnutls/gnutls_base_check
+    - fips/openjdk/openjdk_fips
+    - fips/mozilla_nss/nss_smoke

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -32,6 +32,10 @@ sub hanasr_angi_hadr_providers_setup {
     assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StartSystem HDB'";
 }
 
+sub is_fips_scenario {
+    return (get_var('FIPS_INSTALLATION') || get_var('FIPS_ENABLED'));
+}
+
 sub run {
     my ($self) = @_;
     my $instance_id = get_required_var('INSTANCE_ID');
@@ -66,7 +70,7 @@ sub run {
             '%VIRTUAL_IP_NETMASK%' => $virtual_netmask);
 
         foreach ($node1, $node2) {
-            add_to_known_hosts($_);
+            add_to_known_hosts($_) unless is_fips_scenario;
         }
         assert_script_run "scp -qr /usr/sap/${sid}/SYS/global/security/rsecssfs/* root\@${node2}:/usr/sap/${sid}/SYS/global/security/rsecssfs/";
         assert_script_run qq(su - $sapadm -c "hdbsql -u system -p $sles4sap::instance_password -i $instance_id -d SYSTEMDB \\"BACKUP DATA FOR FULL SYSTEM USING FILE ('backup')\\""), 900;


### PR DESCRIPTION
Include FIPS modules in SLES for SAP schedules.

- Related ticket: https://progress.opensuse.org/issues/166637
- Needles: N/A
- Verification run: http://mango.qe.nue2.suse.org/tests/6221, https://openqa.suse.de/tests/overview?distri=sle&build=VR4PR20235&version=15-SP5

**Note**: verification runs are only checking the changes do not introduce regression in existing tests, as such they do not run with either `FIPS_ENABLED=1` or `FIPS_INSTALLATION=1`. These tests will be scheduled after the PR is merged.
