### PR TITLE
Make stable agama in ppc64le by processing grub2

### DIFF
--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -6,7 +6,7 @@ schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests
   - yam/agama/agama
-  - installation/grub_test
+  - yam/agama/agama_grub2
   - installation/first_boot
   - yam/validate/validate_product
   - yam/validate/validate_user

--- a/tests/yam/agama/agama_grub2.pm
+++ b/tests/yam/agama/agama_grub2.pm
@@ -1,0 +1,30 @@
+## Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Processing grub2 after installation finishes and reboot occurs
+# integration test from GitHub.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+
+sub run {
+    my $timeout = get_var('GRUB_TIMEOUT', 300);
+    assert_screen([qw(grub2 grub2-black-screen)], $timeout);
+    if (match_has_tag "grub2-black-screen") {
+        for (1 .. 9) {
+            send_key("up");
+            last if check_screen("grub2", 0);
+            sleep 0.5;
+        }
+    }
+    send_key 'ret';
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
##
### Make stable agama in ppc64le by processing grub2 after installation finishes and reboot occurs

- Related ticket: https://progress.opensuse.org/issues/167024
- Needles: N/A
- Verification run: 
    - [**agama_default**](https://openqa.opensuse.org/tests/overview?version=agama-9.0&build=hjluo%2Fos-autoinst-distri-opensuse%23agama_grub2&distri=opensuse)
    

##
