### PR TITLE
lib/qesapdeployment: use object-id to prevent slowness in cloud

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -2303,7 +2303,8 @@ sub qesap_az_assign_role {
     my $subscription_id = script_output('az account show --query "id" -o tsv');
     my $az_cmd = join(' ', 'az role assignment',
         'create --only-show-errors',
-        "--assignee '$args{assignee}'",
+        "--assignee-object-id '$args{assignee}'",
+        '--assignee-principal-type ServicePrincipal',
         "--role '$args{role}'",
         "--scope '/subscriptions/$subscription_id/resourceGroups/$args{resource_group}'");
     assert_script_run($az_cmd);


### PR DESCRIPTION
From `az role assignment create --help` :

````
    --assignee-object-id          : Use this parameter instead of '--assignee' to bypass Graph API
                                    invocation in case of insufficient privileges. This parameter
                                    only works with object ids for users, groups, service
                                    principals, and managed identities. For managed identities use
                                    the principal id. For service principals, use the object id and
                                    not the app id.
    --assignee-principal-type     : Use with --assignee-object-id to avoid errors caused by
                                    propagation latency in Microsoft Graph.  Allowed values:
                                    ForeignGroup, Group, ServicePrincipal, User.
````

This should solve the problem mentioned in the ticket.  However since this error happens in cloud infra, so we can't reproduce the error on our side.  But according to the documentation, this commit should fix it.  The VRs verify that this change does not break current test.

- Related ticket: https://jira.suse.com/browse/TEAM-9672
- Needles: none
- Verification run:
MSI: https://openqaworker15.qa.suse.cz/tests/297792#step/deploy_qesap_terraform/495
SPN: https://openqaworker15.qa.suse.cz/tests/297793#step/deploy_qesap_terraform/495