### PR TITLE
Exclude yast2 modules from qam-minimal-full

### DIFF
--- a/schedule/qam/common/qam-minimal-full.yaml
+++ b/schedule/qam/common/qam-minimal-full.yaml
@@ -51,8 +51,6 @@ schedule:
 - console/glibc_tunables
 - console/zypper_in
 - console/zypper_log
-- console/yast2_i
-- console/yast2_bootloader
 - console/firewall_enabled
 - console/sshd
 - console/ssh_cleanup


### PR DESCRIPTION
- Related ticket:  https://progress.opensuse.org/issues/166988
- Verification run: https://openqa.suse.de/tests/overview?build=cedvid%2Fos-autoinst-distri-opensuse%2320238
