### PR TITLE
Fix NM_wpas_enterprise failure on TW

### DIFF
--- a/tests/x11/network/NM_wpa2_enterprise.pm
+++ b/tests/x11/network/NM_wpa2_enterprise.pm
@@ -70,6 +70,7 @@ sub enter_NM_credentials {
     send_key 'ret';
 
     # enter anonymous identity
+    assert_and_click "anon_identity";
     type_string 'franz.nord@example.com';
 
     # select 'No CA certificate needed'


### PR DESCRIPTION
Add `assert_and_click` to make NM_wpas_enterprise more robust.

- Related ticket: https://progress.opensuse.org/issues/167096
- Needles: already added when debugging on O3
- Verification run: https://openqa.opensuse.org/tests/4494603#step/NM_wpa2_enterprise/32
