### PR TITLE
Create agama auto-installation selecting gnome pattern

### DIFF
--- a/data/yam/agama/auto/gnome_tumbleweed.json
+++ b/data/yam/agama/auto/gnome_tumbleweed.json
@@ -1,0 +1,18 @@
+{
+  "product": {
+    "id": "Tumbleweed"
+  },
+  "software": {
+    "patterns": [
+      "gnome"
+    ]
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "nots3cr3t",
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "nots3cr3t"
+  }
+}

--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -14,7 +14,7 @@ use testapi;
 sub run {
     my $reboot_page = $testapi::distri->get_reboot_page();
 
-    $reboot_page->expect_is_shown(timeout => 1200);
+    $reboot_page->expect_is_shown(timeout => 2400);
 
     select_console 'root-console';
     Yam::Agama::agama_base::upload_agama_logs();


### PR DESCRIPTION
##
### Create agama auto-installation selecting gnome pattern

- Related ticket: https://progress.opensuse.org/issues/167060
- Needles: N/A
- Verification run: 
   - [**agama_auto_gnome**](https://openqa.opensuse.org/tests/overview?arch=x86_64&flavor=&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=&version=agama-9.0&distri=opensuse&build=hjluo#)
   
## 
