### PR TITLE
Adapt disk name change within sle15sp7 kvm guest in hotplug HDD test

### DIFF
--- a/tests/virtualization/universal/hotplugging_HDD.pm
+++ b/tests/virtualization/universal/hotplugging_HDD.pm
@@ -28,8 +28,8 @@ sub test_add_virtual_disk {
     my $disk_image = get_disk_image_name($guest, $disk_format);
 
     assert_script_run("rm -f $disk_image");
-    # Set disk size=9.99G to make it to be found more easily within the guest
-    assert_script_run "qemu-img create -f $disk_format $disk_image 9.99G";
+    # Set disk size=9.5G to make it to be found more easily within the guest
+    assert_script_run "qemu-img create -f $disk_format $disk_image 9.5G";
     my $domblk_target = 'vdz';
     $domblk_target = 'xvdz' if (is_xen_host);
     script_run("virsh detach-disk $guest ${domblk_target}", 240);
@@ -37,7 +37,7 @@ sub test_add_virtual_disk {
         assert_script_run "virsh domblklist $guest | grep ${domblk_target}";
         assert_script_run("ssh root\@$guest lsblk");
         # Attach disk check
-        assert_script_run("ssh root\@$guest lsblk | grep -iE '[x]?vd[a-z] +.*9.99G'", timeout => 60, fail_message => "Failed to attach disk for guest $guest");
+        assert_script_run("ssh root\@$guest lsblk | grep -iE '[x]?vd[a-z] +.*9.5G'", timeout => 60, fail_message => "Failed to attach disk for guest $guest");
         assert_script_run("virsh detach-disk $guest ${domblk_target}", 240);
         # Detach disk check
         assert_script_run("! ssh root\@$guest lsblk | grep -iE '[x]?vd[b-z]'", timeout => 60, fail_message => "Failed to detach disk for guest $guest");

--- a/tests/virtualization/universal/hotplugging_HDD.pm
+++ b/tests/virtualization/universal/hotplugging_HDD.pm
@@ -28,7 +28,8 @@ sub test_add_virtual_disk {
     my $disk_image = get_disk_image_name($guest, $disk_format);
 
     assert_script_run("rm -f $disk_image");
-    assert_script_run "qemu-img create -f $disk_format $disk_image 10G";
+    # Set disk size=9.99G to make it to be found more easily within the guest
+    assert_script_run "qemu-img create -f $disk_format $disk_image 9.99G";
     my $domblk_target = 'vdz';
     $domblk_target = 'xvdz' if (is_xen_host);
     script_run("virsh detach-disk $guest ${domblk_target}", 240);
@@ -36,7 +37,7 @@ sub test_add_virtual_disk {
         assert_script_run "virsh domblklist $guest | grep ${domblk_target}";
         assert_script_run("ssh root\@$guest lsblk");
         # Attach disk check
-        assert_script_run("ssh root\@$guest lsblk | grep -iE '[x]?vd[b-z]'", timeout => 60, fail_message => "Failed to attach disk for guest $guest");
+        assert_script_run("ssh root\@$guest lsblk | grep -iE '[x]?vd[a-z] +.*9.99G'", timeout => 60, fail_message => "Failed to attach disk for guest $guest");
         assert_script_run("virsh detach-disk $guest ${domblk_target}", 240);
         # Detach disk check
         assert_script_run("! ssh root\@$guest lsblk | grep -iE '[x]?vd[b-z]'", timeout => 60, fail_message => "Failed to detach disk for guest $guest");


### PR DESCRIPTION
The disk name changed to `vda` in sle15sp7. It was `vdb` in previous release.

- Related ticket: https://progress.opensuse.org/issues/167102
- Verification run: 
[uefi-gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.suse.de/tests/15489197#step/hotplugging_HDD/74)
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/15489200#step/hotplugging_HDD/78)

