### PR TITLE
Remove deployment destroy from qesap regression

### DIFF
--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -45,9 +45,10 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    qesap_test_postfail(
-        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
-        net_peering_is => get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP", get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")));
+    # This test module does not have both
+    # fatal flag and qesap_test_postfail, so that in case of failure
+    # the next test_ module is executed too.
+    # Deployment destroy is delegated to the destroy test module
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/qesapdeployment/test_crash.pm
+++ b/tests/sles4sap/qesapdeployment/test_crash.pm
@@ -26,9 +26,10 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    qesap_test_postfail(
-        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
-        net_peering_is => get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP", get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")));
+    # This test module does not have both
+    # fatal flag and qesap_test_postfail, so that in case of failure
+    # the next test_ module is executed too.
+    # Deployment destroy is delegated to the destroy test module
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -39,9 +39,10 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    qesap_test_postfail(
-        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
-        net_peering_is => get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP", get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")));
+    # This test module does not have both
+    # fatal flag and qesap_test_postfail, so that in case of failure
+    # the next test_ module is executed too.
+    # Deployment destroy is delegated to the destroy test module
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/qesapdeployment/test_system.pm
+++ b/tests/sles4sap/qesapdeployment/test_system.pm
@@ -33,9 +33,10 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    qesap_test_postfail(
-        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
-        net_peering_is => get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP", get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")));
+    # This test module does not have both
+    # fatal flag and qesap_test_postfail, so that in case of failure
+    # the next test_ module is executed too.
+    # Deployment destroy is delegated to the destroy test module
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Remove cluster destroy from the test modules of qesap regression: in this way all test modules can run even if there's a failure in one of them. Deployment destroy is delegated to destroy module.

This is follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20156

Related ticket: https://jira.suse.com/browse/TEAM-9654

# Verification run:

 - sle-15-SP3-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_3_PAYG-qesap_gcp_sapconf_test
 -  http://openqaworker15.qa.suse.cz/tests/297853 This one is known to have test_system to fail due to a known package bug