### PR TITLE
Fix SDAF deployer cleanup failures

### DIFF
--- a/lib/sles4sap/console_redirection.pm
+++ b/lib/sles4sap/console_redirection.pm
@@ -175,6 +175,11 @@ from serial console. VM ID is collected by opening 'log-console' which is not re
 sub check_serial_redirection {
     # Do not select serial console if it is already done. This avoids log pollution and speeds up process.
     if (is_serial_terminal()) {
+        # Teminate the process when scripts timed out
+        unless (wait_serial($testapi::distri->{serial_term_prompt})) {
+            type_string('', terminate_with => 'ETX');
+            type_string("\n");
+        }
         select_serial_terminal();
         set_serial_term_prompt();
     }

--- a/t/19_console_redirection.t
+++ b/t/19_console_redirection.t
@@ -112,6 +112,18 @@ subtest '[check_serial_redirection]' => sub {
     $redirect->redefine(script_run => sub { $executed_command = $_[0]; return '1'; });
     is check_serial_redirection(), '1', 'Return 1 if machine IDs do not match';
     is $executed_command, 'grep 7902847fcc554911993686a1d5eca2c8 /etc/machine-id', 'Check executed command';
+
+    # Test wait_serial is true
+    $redirect->redefine(is_serial_terminal => sub { return '1'; });
+    $redirect->redefine(wait_serial => sub { return '1'; });
+    $redirect->redefine(script_run => sub { return '0'; });
+    is check_serial_redirection(), '0', 'Return 0 if machine IDs match';
+
+    # Test wait_serial is false
+    $redirect->redefine(wait_serial => sub { return '0'; });
+    $redirect->redefine(type_string => sub { return; });
+    is check_serial_redirection(), '0', 'Return 0 if machine IDs match';
+
     unset_vars();
 };
 

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -338,6 +338,10 @@ subtest '[sdaf_execute_remover] Check command line arguments' => sub {
         ok(grep(/| tee .*\.log/, split(' ', $cmd)), 'Log command output');
         ok(grep(/\$\{PIPESTATUS\[0]}/, split(' ', $cmd)), 'Return command RC instead of tee');
     }
+
+    # Test remover retry
+    $ms_sdaf->redefine(script_run => sub { return 1; });
+    dies_ok { sdaf_cleanup() } 'Test failing remover script: retried 3 times and failed';
 };
 
 


### PR DESCRIPTION
Fix SDAF deployer cleanup failures
1. Add Ctrl-C if script timeout happens on "deployer VM", so following cleanup related command can be sent to serial terminal of "worker" successfully
2. Add retry for SDAF destroy
    
    
**Related ticket**: [TEAM-9647](https://jira.suse.com/browse/TEAM-9647)
[SDAF] SDAF_PRD_deploy_HanaSR failed to do deploy cleanup when failed on: configure_deployer & deploy_workload_zone



**Note**: 
1. It is very hard to reproduce the failing scenarios mentioned in JIRA ticket but I tried to modify the test code to make test case failed on expected test steps in order to verify the code changes as much as possible.
2. The retry code change in [lib/sles4sap/sap_deployment_automation_framework/deployment.pm](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20246/files#diff-c8fb77432ca461397513b9c0f6a5e501f7cb60ca440f86356d3093daf1371937) is hard to verify but at least it does not break anything.

**Verification run**:
- SDAF_PRD_deploy_HanaSR **passed** and code changes in lib/sles4sap/console_redirection.pm works: 
https://openqaworker15.qa.suse.cz/tests/298145/logfile?filename=autoinst-log.txt :green_circle:
```
sles4sap::console_redirection::check_serial_redirection -> lib/sles4sap/console_redirection.pm:179 called testapi::wait_serial
...
[2024-09-24T08:58:03.289822+02:00] [debug] [pid:14234] >>> testapi::wait_serial: # : fail
[2024-09-24T08:58:03.291873+02:00] [debug] [pid:14376] <<< consoles::serial_screen::type_string(json_cmd_token="VHAhhwwU", text="", cmd="backend_type_string", terminate_with="ETX")
[2024-09-24T08:58:03.293688+02:00] [debug] [pid:14376] <<< consoles::serial_screen::type_string(cmd="backend_type_string", text="\n", json_cmd_token="qkCQVnEe")
 ...
[2024-09-24T08:58:03.300980+02:00] [debug] [pid:14234] >>> testapi::wait_serial: : ok
```

- Make `az vm list` failed on time out on purpose (adding `sleep 100` to produce timeout) and the `CTRL-C` works and next command `whoai` can be executed successfully
https://openqaworker15.qa.suse.cz/tests/298144/logfile?filename=serial_terminal.txt :red_circle: 
```
# cat > /tmp/script40HJt.sh << 'EOT_40HJt'; echo 40HJt-$?-
> sleep 100; az vm list --resource-group OpenQA-SDAF-PRD-DEPLOYER-westeurope --query "[?tags.deployment_id == '298144'].name" --output json
> EOT_40HJt
40HJt-0-
# echo 40HJt; bash -oe pipefail /tmp/script40HJt.sh ; echo SCRIPT_FINISHED40HJt-$?-
40HJt
^C
# 
# whoami | grep root; echo 9Zjcg-$?-
root
9Zjcg-0-
```

- Make SDAF_PRD_deploy_HanaSR failed on purpose, it failed on **deploy_hanasr**, SDAF destroy and deploy cleanup were done successfully
    https://openqaworker15.qa.suse.cz/tests/298085#step/deploy_hanasr/281 :red_circle:
- Make SDAF_PRD_deploy_HanaSR failed on purpose, it failed on  **deploy_workload_zone**, SDAF destroy and deploy cleanup were done successfully
	https://openqaworker15.qa.suse.cz/tests/298081#step/deploy_workload_zone/419 :red_circle: 
