### PR TITLE
jeos/firstrun.pm: Fix check for GPT vs MBR partition table

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 use lockapi qw(mutex_create mutex_wait);
 use testapi;
-use version_utils qw(is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro is_vmware is_bootloader_sdboot is_community_jeos);
+use version_utils qw(is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro is_vmware is_bootloader_sdboot);
 use Utils::Architectures;
 use Utils::Backends;
 use jeos qw(expect_mount_by_uuid);
@@ -109,7 +109,9 @@ sub verify_bsc {
 sub verify_partition_label {
     my $label = 'gpt';
 
-    if (is_s390x || (is_aarch64 && get_var('HDD_1') =~ /.*raw\.xz$/ && !is_community_jeos)) {
+    # The RPi firmware needs MBR. s390x images also use MBR.
+    # Note: JeOS-for-RaspberryPi means "kiwi-templates-Minimal" and JeOS-for-RPi means "community JeOS".
+    if (is_s390x || check_var('FLAVOR', 'JeOS-for-RaspberryPi') || check_var('FLAVOR', 'JeOS-for-RPi')) {
         $label = 'dos';
     }
 


### PR DESCRIPTION
Replace the previous condition with a more targeted and correct one. This fixes the check for community JeOS on RPi.

- Related ticket: https://openqa.opensuse.org/tests/4452052#step/firstrun/54
- Verification run: https://openqa.opensuse.org/tests/4499469#live
