### PR TITLE
[Virtualization]: wipe all disks before installation for sles and slm

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -40,6 +40,9 @@
       <timeout config:type="integer">15</timeout>
       <trusted_grub>false</trusted_grub>
       <secure_boot>false</secure_boot>
+      % if ($check_var->('IPXE_UEFI', '1')) {
+      <update_nvram>true</update_nvram>
+      % }
       <terminal>console</terminal>
       % if ($check_var->('SYSTEM_ROLE', 'xen')) {
       <xen_append>vt.color=0x07 splash=silent console=hvc0 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "loglvl=all guest_loglvl=all" : "loglvl=debug guest_loglvl=debug" %> <%= defined $bmwqemu::vars{"OPT_KERNEL_PARAMS"} ? $bmwqemu::vars{"OPT_KERNEL_PARAMS"} : "" %></xen_append>
@@ -302,6 +305,28 @@
     </user>
   </users>
   <scripts>
+    <pre-scripts config:type="list">
+      <script>
+        <filename>pre_erase_all_disks.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+disks=$(lsblk -n -l -o NAME -d -e 7,11,254);
+for disk in $disks;do
+    echo "Wiping /dev/$disk..."
+    wipefs -af /dev/$disk
+    sync
+    parted -s /dev/$disk mklabel gpt
+    sync
+done
+echo "All disks are wiped out."
+lsblk
+]]>
+        </source>
+        <feedback config:type="boolean">false</feedback>
+        <notification>Please wait while pre-script is running...</notification>
+      </script>
+    </pre-scripts>
     <init-scripts config:type="list">
       % if ($check_var->('SYSTEM_ROLE', 'xen') && $check_var->('XEN_DEFAULT_BOOT_IS_SET', 1)) {
       <script>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -49,6 +49,9 @@
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <secure_boot>false</secure_boot>
+      % if ($check_var->('IPXE_UEFI', '1')) {
+      <update_nvram>true</update_nvram>
+      % }
       <serial>serial --speed=115200 --unit=<%= $get_var->('SERIALDEV', 'ttyS1') =~ s/ttyS//r %> --word=8 --parity=no --stop=1</serial>
       <timeout config:type="integer">15</timeout>
       <trusted_grub>false</trusted_grub>
@@ -280,6 +283,27 @@
     </user>
   </users>
   <scripts>
+    <pre-scripts config:type="list">
+      <script>
+        <filename>pre_erase_all_disks.sh</filename>
+        <interpreter>/bin/bash -x</interpreter>
+        <source><![CDATA[
+disks=$(lsblk -n -l -o NAME -d -e 7,11,254);
+for disk in $disks;do
+    echo "Wiping /dev/$disk..."
+    wipefs -af /dev/$disk
+    sync
+    parted -s /dev/$disk mklabel gpt
+    sync
+done
+echo "All disks are wiped out."
+lsblk
+]]>
+        </source>
+        <feedback config:type="boolean">false</feedback>
+        <notification>Please wait while pre-script is running...</notification>
+      </script>
+    </pre-scripts>
     <chroot-scripts config:type="list">
       <script>
         <!-- Keep ssh connection alive for long-time run test -->

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -316,8 +316,8 @@ sub run {
         if (check_screen(\@tags, $ssh_vnc_wait_time)) {
             save_screenshot;
             sleep 2;
-            return if is_usb_boot;
             prepare_disks if (!is_upgrade && !get_var('KEEP_DISKS'));
+            return if is_usb_boot;
         }
         else {
             save_screenshot;

--- a/tests/installation/usb_install.pm
+++ b/tests/installation/usb_install.pm
@@ -24,7 +24,6 @@ use LWP::Simple 'head';
 use Utils::Backends 'use_ssh_serial_console';
 
 sub run {
-    assert_screen('sshd-server-started', 5);
     use_ssh_serial_console;
     assert_script_run("set -o pipefail");
 

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -306,12 +306,24 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    if (check_var('PERF_KERNEL', '1')) {
+    if (check_var('PERF_KERNEL', '1') || check_var('VIRT_AUTOTEST', '1')) {
         select_console 'log-console';
         save_screenshot;
         script_run "save_y2logs /tmp/y2logs.tar.bz2";
         upload_logs "/tmp/y2logs.tar.bz2";
         save_screenshot;
+        if (check_var('VIRT_AUTOTEST', '1')) {
+            # show efi boot entry
+            if (check_var('IPXE_UEFI', '1')) {
+                record_info('UEFI entries', script_output('efibootmgr -v'));
+                record_info('Boot partition contents', script_output('ls -R /boot/efi'));
+            }
+            if (get_var('AUTOYAST', '')) {
+                script_run "tar czvf /tmp/autoinstall.tar.gz /var/adm/autoinstall";
+                upload_logs "/tmp/autoinstall.tar.gz";
+            }
+            $self->SUPER::post_fail_hook;
+        }
     }
     else {
         $self->SUPER::post_fail_hook;


### PR DESCRIPTION
This PR aims to solve the problem in https://progress.opensuse.org/issues/166712#note-23, for which if a job with secure boot enabled is installed onto a disk, that is different from the disk that our virtualization jobs will install on(for both sles and sle micro), the installed virtualization host OS will not boot successfully.

Solution is to erase disks before real installation starts:
- for sles, add in autoyast pre-script the disk erasing script
- for sle micro, at ipxe_install, call prepare_disks


- Related ticket: https://progress.opensuse.org/issues/166712
- Verification run: 
```
- kermit(uefi)
  - guided_btrfs secure boot test: https://openqa.suse.de/tests/15547054 (trigger the issue)
  - sles vt 12sp5 kvm host: https://openqa.suse.de/tests/15547055
  - guided_btrfs secure boot test: https://openqa.suse.de/tests/15547303# (trigger the issue)
  - sles vt 15sp6 xen host: https://openqa.suse.de/tests/15547634#

- scooter(uefi)
  - guided_btrfs secure boot test: https://openqa.suse.de/tests/15547066 (trigger the issue)
  - sles 15sp7 kvm host: https://openqa.suse.de/tests/15547061
  - guided_btrfs secure boot test(forgot the job link)
  - sle micro:  https://openqa.suse.de/tests/15549009#step/ipxe_install/63
  - post-fail hook verification: https://openqa.suse.de/tests/15547254#

- regression test on non-uefi machine
  - 15sp7 xen : worker amd-zen3-gpu-sut1,https://openqa.suse.de/tests/15547635#
- regression test on uefi machine(baremetal-1): 
  - https://openqa.suse.de/tests/15557849
```