### PR TITLE
Add agama test for leap for auto-installation

### DIFF
--- a/data/yam/agama/auto/default_leap.json
+++ b/data/yam/agama/auto/default_leap.json
@@ -1,0 +1,13 @@
+{
+  "product": {
+    "id": "Leap_16.0"
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "nots3cr3t",
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "nots3cr3t"
+  }
+}

--- a/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
+++ b/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
@@ -16,7 +16,7 @@ use testapi;
 sub new {
     my ($class, $args) = @_;
     return bless {
-        tag_array_ref_any_first_screen_shown => [qw(agama-product-selection agama-configuring-the-product)]
+        tag_array_ref_any_first_screen_shown => [qw(agama-product-selection agama-configuring-the-product agama-installing)]
     }, $class;
 }
 

--- a/test_data/yam/agama_leap.yaml
+++ b/test_data/yam/agama_leap.yaml
@@ -1,0 +1,2 @@
+---
+os_release_name: Leap


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/167087
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/overview?version=agama-9.0&distri=opensuse&build=lemon-suse%2Fos-autoinst-distri-opensuse%23add-agama-test-for-leap
