### PR TITLE
Add support to bare metal for direct image installation of SL Micro

### DIFF
--- a/data/microos/ignition/config.ign
+++ b/data/microos/ignition/config.ign
@@ -1,0 +1,11 @@
+{
+        "ignition": { "version": "3.0.0" },
+        "passwd": {
+                "users": [
+                        {
+                                "name": "root",
+                                "passwordHash": "$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/"
+                        }
+                ]
+        }
+}

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -34,7 +34,17 @@ sub load_kernel_tests {
 
     if (get_var('INSTALL_LTP')) {
         if (is_transactional) {
-            is_s390x ? loadtest 'boot/boot_to_desktop' : loadtest 'microos/disk_boot';
+            # Handle specific boot requirements for different backends and architectures
+            if (is_s390x) {
+                loadtest 'boot/boot_to_desktop';
+            }
+            elsif ((is_ipmi || is_pvm)) {
+                loadtest 'installation/ipxe_install' if is_ipmi;
+                loadtest 'microos/install_image';
+            }
+            else {
+                loadtest 'microos/disk_boot';
+            }
             replace_opensuse_repos_tests if is_repo_replacement_required;
             loadtest 'transactional/host_config';
             loadtest 'console/suseconnect_scc' if is_sle_micro;

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -260,7 +260,7 @@ sub handle_livecd_reboot_failure {
 
 =head2 power_action
 
- power_action($action [,observe => $observe] [,keepconsole => $keepconsole] [,textmode => $textmode]);
+ power_action($action [,observe => $observe] [,keepconsole => $keepconsole] [,textmode => $textmode] [,force => boolean ]);
 
 Executes the selected power action (e.g. poweroff, reboot).
 
@@ -271,6 +271,7 @@ C<$keepconsole> prevents a console change, which we do by default to make sure t
 desktop which was in text console at the time of C<power_action> call, is switched to the expected
 console, that is 'root-console' for textmode, 'x11' otherwise. The actual execution happens in a shell
 for textmode or with GUI commands otherwise unless explicitly overridden by setting C<$textmode> to either 0 or 1.
+C<$force> sets force option to reboot command in textmode.
 
 =cut
 
@@ -280,6 +281,7 @@ sub power_action {
     $args{keepconsole} //= 0;
     $args{textmode} //= check_var('DESKTOP', 'textmode');
     $args{first_reboot} //= 0;
+    $args{force} //= 0;
     die "'action' was not provided" unless $action;
 
     prepare_system_shutdown;
@@ -290,7 +292,7 @@ sub power_action {
 
     unless ($args{observe}) {
         if ($args{textmode}) {
-            enter_cmd "$action";
+            $args{force} ? enter_cmd "$action -f" : enter_cmd "$action";
         }
         elsif ($action eq 'reboot') {
             reboot_x11;

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -114,7 +114,7 @@ sub process_reboot {
             }
             # Replace by wait_boot if possible
             select_console('sol', await_console => 0) if (is_ipmi);
-            assert_screen 'grub2', 150;
+            assert_screen 'grub2', 300;
             wait_screen_change { send_key 'ret' };
         }
         assert_screen 'linux-login', 200;

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -57,10 +57,17 @@ sub set_pxe_boot {
 }
 
 sub set_bootscript {
+    my $distri;
+    my $version;
+    if (get_var('IPXE_BOOT_FIXED')) {
+        $distri = get_var('IPXE_BOOT_FIXED_DISTRI', 'sle');
+        $version = get_var('IPXE_BOOT_FIXED_VERSION', '15-SP6');
+    } else {
+        $distri = is_sle_micro('>=6.1') ? "SL-Micro" : get_required_var('DISTRI');
+        $version = get_required_var('VERSION');
+    }
     my $host = get_required_var('SUT_IP');
-    my $distri = is_sle_micro('>=6.1') ? "SL-Micro" : get_required_var('DISTRI');
     my $arch = get_required_var('ARCH');
-    my $version = get_required_var('VERSION');
     my $autoyast = get_var('AUTOYAST', '');
     my $mirror_http = get_required_var('MIRROR_HTTP');
 

--- a/tests/microos/install_image.pm
+++ b/tests/microos/install_image.pm
@@ -1,0 +1,100 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Install SL Micro image on bare metal disk
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+use Utils::Backends;
+use Utils::Architectures 'is_x86_64';
+use power_action_utils 'power_action';
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+
+    # Use image name from HDD_1 variable
+    my $image = get_required_var('HDD_1');
+    # Use sda as target disk by default
+    my $device = get_var("MICRO_INSTALL_IMAGE_TARGET_DEVICE", "/dev/sda");
+    # Use partition prefix for nvme devices
+    my $prefix = $device =~ /nvme/ ? "p" : "";
+    # SL Micro x86_64 image has three partitions, aarch64 and ppc64le images have only two partitions
+    my $root_partition_id = is_x86_64 ? 3 : 2;
+    my $root_partition = "${device}" . $prefix . $root_partition_id;
+    # New partition id for ignition will be directly after root partition
+    my $ignition_partition_id = $root_partition_id + 1;
+    my $ignition_partition = "${device}" . $prefix . $ignition_partition_id;
+    record_info("Device information", "Device: ${device}\nRoot partition: ${root_partition}\nIgnition partition: ${ignition_partition}");
+
+    # Mount nfs share with images
+    assert_script_run("mount -o ro,noauto,nofail,nolock -t nfs openqa.suse.de:/var/lib/openqa/share /mnt");
+    assert_script_run("ls -als /mnt/factory/hdd/${image}");
+    # dd image to disk
+    assert_script_run("xzcat /mnt/factory/hdd/${image} | dd of=${device} bs=65536 status=progress", timeout => 300);
+    assert_script_run("sync");
+    assert_script_run("umount /mnt");
+
+    my $device_layout = script_output("lsblk");
+    record_info("Device layout", ${device_layout});
+
+    # Modify disk to be able to correctly boot and login
+    assert_script_run("mount ${root_partition} /mnt");
+    assert_script_run("btrfs property set /mnt ro false");
+    # Set correct serial console to be able to see login in first boot
+    assert_script_run("sed -i 's/console=ttyS0,115200/console=ttyS1,115200/g' /mnt/boot/grub2/grub.cfg") if is_x86_64;
+    # Upload original grub configuration
+    upload_logs("/mnt/etc/default/grub", failok => 1);
+    # Set permanent grub configuration
+    assert_script_run("sed -i 's/console=ttyS0,115200/console=ttyS1,115200/g' /mnt/etc/default/grub") if is_x86_64;
+    # Fully disable graphical terminal on legacy systems without UEFI
+    assert_script_run("sed -i 's/#GRUB_TERMINAL=console/GRUB_TERMINAL=console/g' /mnt/etc/default/grub") if (is_ipmi && !get_var('IPXE_UEFI'));
+    # We need to properly set grub terminal bsc#1230844, otherwise grub menu will not be visible in non graphical boot environments
+    assert_script_run("sed -i 's/GRUB_TERMINAL_INPUT=\".*\"/GRUB_TERMINAL_INPUT=\"console gfxterm\"/g' /mnt/etc/default/grub");
+    assert_script_run("sed -i 's/GRUB_TERMINAL_OUTPUT=\".*\"/GRUB_TERMINAL_OUTPUT=\"console gfxterm\"/g' /mnt/etc/default/grub");
+    # Enable root loging with password
+    assert_script_run("echo 'PermitRootLogin yes' > /mnt/etc/ssh/sshd_config.d/root.conf");
+    assert_script_run("btrfs property set /mnt ro true");
+    assert_script_run("umount /mnt");
+
+    # Setup ignition parition on the end of the same disk and resize root partition to use all the space
+    # script_output recommended in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20253/files#r1776549682
+    script_output("printf \"fix\n\" | parted ---pretend-input-tty ${device} print");
+    assert_script_run("parted ${device} --script mkpart primary ext4 98% 100%");
+    assert_script_run("parted ${device} --script print");
+    assert_script_run("mkfs.ext4 -F ${ignition_partition}");
+    assert_script_run("e2label ${ignition_partition} ignition");
+    assert_script_run("mount ${ignition_partition} /mnt/");
+    assert_script_run("mkdir /mnt/ignition");
+    assert_script_run("curl -v -o /mnt/ignition/config.ign " . data_url("microos/ignition/config.ign"));
+    assert_script_run('umount /mnt');
+
+    # Resize root filesystem to maximum size to use all space up to partition with ignition
+    assert_script_run("parted ${device} --script resize ${root_partition_id} 98%");
+    assert_script_run("mount ${root_partition} /mnt");
+    assert_script_run("btrfs filesystem resize max /mnt");
+    assert_script_run("umount /mnt");
+    my $final_disk_layout = script_output("parted ${device} --script print");
+    record_info("INFO", "${image} was installed on ${device}. System is going to be rebooted.\n\nFinal disk layout:\n ${final_disk_layout}");
+
+    # We have to use force option to reboot command as installer doesn't have fully running systemd environment
+    power_action("reboot", textmode => 1, force => 1);
+
+    # We can't use reconnect_mgmt_console as it expects fully configured grub, which we don't have at this stage yet
+    select_console "sol", await_console => 0 if is_ipmi;
+    select_console 'powerhmc-ssh', await_console => 0 if is_pvm_hmc;
+    assert_screen("linux-login", 600);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -141,6 +141,7 @@ LVM_THIN_LV | boolean | false | Use thin provisioning logical volumes for partit
 MACHINE | string | | Define machine name which defines worker specific configuration, including WORKER_CLASS.
 MEDIACHECK | boolean | false | Enables `installation/mediacheck` test module.
 MEMTEST | boolean | false | Enables `installation/memtest` test module.
+MICRO_INSTALL_IMAGE_TARGET_DEVICE | string | /dev/sda | Target disk device for bare metal SL Micro installation.
 MIRROR_{protocol} | string | | Specify source address
 MM_MTU | integer | 1380 | Specifies the MTU to set in SUTs of MM tests usually started with `NICTYPE=tap`.
 MOK_VERBOSITY | boolean | false | Enable verbosity feature of shim. Requires preinstalled `mokutil`.

--- a/variables.md
+++ b/variables.md
@@ -103,6 +103,9 @@ INSTALLONLY | boolean | false | Indicates that test suite conducts only installa
 INSTLANG | string | en_US | Installation locale settings.
 IPERF_REPO | string | | Link to repository with iperf tool for network performance testing. Currently used in Public Cloud Azure test
 IPXE | boolean | false | Indicates ipxe boot.
+IPXE_BOOT_FIXED | boolean | false | Indicates to ipxe boot fixed distribution independent on DISTRI and VERSION variables.
+IPXE_BOOT_FIXED_DISTRI | string | sle | Sets distribution name for fixed ipxe boot.
+IPXE_BOOT_FIXED_VERSION | string | 15-SP6 | Sets distribution version for fixed ipxe boot.
 IPXE_SET_HDD_BOOTSCRIPT | boolean | false | Upload second IPXE boot script for booting from HDD after the installation boot script gets executed. This is a workaround for cases where the installer fails to switch default boot order to HDD boot. See also PXE_BOOT_TIME.
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job


### PR DESCRIPTION
Enhancement poo#167021: SL Micro doesn't have installer like openSUSE
or SLE. Only raw images are supported. If we want to install SL Micro
to bare metal, we need to directly copy image to destination, this is
documented and supported way. The idea behind this extension, is to
use existing openQA boot modules for particular backends and boot SLE
installer, use installation console to mount nfs share from openQA and
deploy image to target disk. We need to modify grub configuration
before first boot, to be able to see menu in hardware consoles. root
password is configured by ignition, which has own separate parition on
the same disk. There are supported following backends and
architectures hmc/ppc64le, ipmi/x86_64/aarch64. Variables MIRROR_HTTP
and REPO_0 are needed to properly boot installer on hmc
backend. Variable IPXE_BOOT_FIXED must be defined for ipmi. There can
be used optional variables IPXE_BOOT_FIXED_DISTRI and
IPXE_BOOT_FIXED_VERSION to boot specific installer version. It is
possible to specify target disk on all backends  by variable
MICRO_INSTALL_IMAGE_TARGET_DEVICE, the default is /dev/sda.

- Related ticket: https://progress.opensuse.org/issues/167021
- Needles: 
- Verification run: 
aarch64: https://openqa.suse.de/tests/15539268
ppc64le:  https://openqa.suse.de/tests/15539270
x86_64 uefi: https://openqa.suse.de/tests/15539430
x86_64_ uefi  nvme0n1:  https://openqa.suse.de/tests/15539340 (fail in shutdown is not related)
x86_64 legacy: https://openqa.suse.de/tests/15539275
Whole job group including childrens(ltp_math): 
https://openqa.suse.de/tests/overview?distri=sle-micro&version=6.1&build=POC-1.11&groupid=472