### PR TITLE
Use Permalink for Confluence page

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -6,4 +6,4 @@ paths:
   "tests/**.pm":
     - Consider conducting at least one [verification run](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/CONTRIBUTING.md#preparing-a-new-pull-request)
   "lib/publiccloud/**.pm":
-    - Provide VRs for both QE-C as well as QE-SAP (check [Confluence](https://confluence.suse.com/display/qasle/QE+-+Public+Cloud#QEPublicCloud-UseofPublicCloudmodulesoutsideofQE-CSquad) for more info)
+    - Provide VRs for both QE-C as well as QE-SAP (check [Confluence](https://confluence.suse.com/x/xACQF#QEPublicCloud-UseofPublicCloudmodulesoutsideofQE-CSquad) for more info)


### PR DESCRIPTION
Confluence page links are not stable against page renaming. Using the shortlink provides a permalink, which will redirect always to the same page, even if moved or renamed.

- Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20249
