### PR TITLE
Check BOOT_HDD_IMAGE var only on SLE

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -90,7 +90,7 @@ sub run {
     }
 
     # FIPS_INSTALLATION is only applicable for system installaton
-    die "FIPS_INSTALLATION is require to run this script for installation" unless get_var("BOOT_HDD_IMAGE");
+    die "FIPS_INSTALLATION is require to run this script for installation" if (is_sle() && !get_var("BOOT_HDD_IMAGE"));
     die "FIPS setup is only applicable for FIPS_ENABLED=1 image!" unless get_var("FIPS_ENABLED");
 
     if (get_var("FIPS_ENV_MODE")) {


### PR DESCRIPTION
Followup from #20248 , fixes Tumbleweed FIPS tests 
(note that FIPS is not officially supported on Tumbleweed)

- Related ticket: https://progress.opensuse.org/issues/167063
- Needles: no
- Verification runs:
	- https://openqa.opensuse.org/tests/4503506
	- https://openqa.opensuse.org/tests/4503505 

