### PR TITLE
Enable verify_setup testmodule for MicroOS

### DIFF
--- a/data/microos/butane/script
+++ b/data/microos/butane/script
@@ -97,6 +97,8 @@ echo 'FONT=eurlatgr.psfu' >> /etc/vconsole.conf
 if ! grep -q tumbleweed /etc/os-release; then
     create_fs
     systemd_mount
+else
+    mount /home
 fi
 
 #

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -424,8 +424,7 @@ sub load_tests {
     } elsif (check_var('EXTRA', 'networking')) {
         load_network_tests;
     } elsif (check_var('EXTRA', 'provisioning')) {
-        # This module fails in MicroOS, never been run before. Need to investigate.
-        loadtest 'microos/verify_setup' unless is_microos;
+        loadtest 'microos/verify_setup';
         load_transactional_tests;
     } elsif (check_var('EXTRA', 'virtualization')) {
         load_qemu_tests;

--- a/tests/microos/verify_setup.pm
+++ b/tests/microos/verify_setup.pm
@@ -59,6 +59,8 @@ sub systemd_tests {
 
     foreach my $unit (@$units) {
         my $name = $unit->{name};
+        # tumbleweed nor microos does not come with mkfs.ext4
+        next if ($name eq "create_test_file.service" && is_tumbleweed);
         systemctl("is-enabled $name", expect_false => !$unit->{enabled});
         systemctl("is-active $name", expect_false => ($name =~ /sshd/) ? 0 : 1);
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/164341
- Verification run: https://openqa.opensuse.org/tests/4544698

Changes:
- Loads the verify_setup test for microos.
- Excludes mkfs.ext4 unit test if tumbleweed or microos as they don't have this file system.
- Changes butane script to mount /home if tumbleweed to fix user tests.
