### PR TITLE
Enable SSH Enrollment for Firsboot in SLE 16

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -276,7 +276,7 @@ sub run {
         assert_screen 're-encrypt-finished', 600;
     }
 
-    unless (is_sle || is_sle_micro('<=6.0') || is_leap) {
+    if (is_tumbleweed || is_microos || is_sle_micro('>6.0') || is_sle('>=16')) {
         assert_screen 'jeos-ssh-enroll-or-not', 120;
 
         if (get_var('SSH_ENROLL_PAIR')) {
@@ -294,9 +294,6 @@ sub run {
         } else {
             send_key 'n';
         }
-    }
-
-    if (is_tumbleweed || is_sle_micro('>6.0') || is_microos) {
         create_user_in_ui();
     }
 


### PR DESCRIPTION

[Tumbleweed Minimal-VM](https://openqa.opensuse.org/tests/4504116)
[MicroOS](https://openqa.opensuse.org/tests/4504115)
[Micro 6.1](https://openqa.suse.de/tests/15518880#)
[SLE16](https://openqa.suse.de/tests/15518129#step/firstrun/13) -> failure not related, bug found