### PR TITLE
Cloudregistration test module improvements

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -110,9 +110,7 @@ sub run {
 
     new_registration($instance);
 
-    if (is_sle('>=15')) {
-        test_container_runtimes($instance);
-    }
+    test_container_runtimes($instance) if (is_sle('>=15-SP2'));
 
     force_new_registration($instance);
 
@@ -161,18 +159,16 @@ sub test_container_runtimes {
     my ($instance) = @_;
     my $image = "registry.suse.com/bci/bci-base:latest";
 
-    record_info('Install docker');
-    #$instance->ssh_assert_script_run("source /etc/profile.local");
-    $instance->ssh_assert_script_run("sudo zypper install -y docker");
     record_info('Test docker');
+    $instance->ssh_assert_script_run("sudo rm -f /root/.docker/config.json");    # workaround for https://bugzilla.suse.com/show_bug.cgi?id=1231185
+    $instance->ssh_assert_script_run("sudo zypper install -y docker");
     $instance->ssh_assert_script_run("sudo systemctl start docker.service");
-    record_info("systemctl status docker.service", script_output("systemctl status docker.service"));
+    record_info("systemctl status docker.service", $instance->ssh_script_output("systemctl status docker.service"));
     $instance->ssh_assert_script_run("sudo docker pull $image");
     $instance->ssh_assert_script_run("sudo systemctl stop docker.service");
 
-    record_info('Install podman');
-    $instance->ssh_assert_script_run("sudo zypper install -y podman");
     record_info('Test podman');
+    $instance->ssh_assert_script_run("sudo zypper install -y podman");
     $instance->ssh_assert_script_run("podman pull $image");
     return 0;
 }

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -19,7 +19,9 @@ use strict;
 use utils;
 use publiccloud::utils;
 use publiccloud::ssh_interactive 'select_host_console';
-use version_utils 'is_sle';
+
+my $path = is_sle('=15-SP2') ? '/usr/sbin/' : '';    # 15-SP2 is the oldest version that needs fullpaths
+my $regcode_param = (is_byos()) ? "-r " . get_required_var('SCC_REGCODE') : '';
 
 sub run {
     my ($self, $args) = @_;
@@ -34,8 +36,6 @@ sub run {
         $instance = $self->{my_instance} = $provider->create_instance(check_guestregister => is_openstack ? 0 : 1);
     }
 
-    my $regcode_param = (is_byos()) ? "-r " . get_required_var('SCC_REGCODE') : '';
-    my $path = is_sle('>15') && is_sle('<15-SP3') ? '/usr/sbin/' : '';
 
     if (check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect')) {
         record_info('SKIP', 'PUBLIC_CLOUD_SCC_ENDPOINT is hardcoded to SUSEConnect - skipping registration testing. Falling back to registration module behavior');
@@ -94,7 +94,7 @@ sub run {
         }
     }
 
-    $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
+    cleanup_instance($instance);
     # It might take a bit for the system to remove the repositories
     foreach my $i (1 .. 4) {
         last if ($instance->ssh_script_output(cmd => 'LANG=C zypper -t lr | awk "/^\s?[[:digit:]]+/{c++} END {print c}"', timeout => 300) == 0);
@@ -106,14 +106,14 @@ sub run {
     if (is_byos()) {
         $instance->ssh_assert_script_run(cmd => 'sudo SUSEConnect --version');
         $instance->ssh_assert_script_run(cmd => "sudo SUSEConnect $regcode_param");
-        $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
+        cleanup_instance($instance);
     }
 
-    $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest $regcode_param", timeout => 300, retry => 3, delay => 120);
-    check_instance_registered($instance);
+    new_registration($instance);
 
-    $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest $regcode_param --force-new", timeout => 300, retry => 3, delay => 120);
-    check_instance_registered($instance);
+    test_container_runtimes($instance);
+
+    force_new_registration($instance);
 
     register_addons_in_pc($instance);
 
@@ -146,6 +146,44 @@ sub check_instance_unregistered {
             die($error);
         }
     }
+}
+
+sub new_registration {
+    my ($instance) = @_;
+    record_info('Starting registration...');
+    $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest $regcode_param", timeout => 300, retry => 3, delay => 120);
+    check_instance_registered($instance);
+    return 0;
+}
+
+sub test_container_runtimes {
+    my ($instance) = @_;
+
+    record_info('Testing docker');
+    $instance->ssh_assert_script_run("systemctl start docker.service");
+    record_info("systemctl status docker.service", script_output("systemctl status docker.service"));
+    $instance->ssh_assert_script_run("docker pull bci/bci-base");
+    $instance->ssh_assert_script_run("systemctl stop docker.service");
+
+    record_info('Testing podman');
+    $instance->ssh_assert_script_run("zypper install podman");
+    $instance->ssh_assert_script_run("podman pull bci/bci-base");
+    return 0;
+}
+
+sub cleanup_instance {
+    my ($instance) = @_;
+    record_info('Removing registration data');
+    $instance->ssh_assert_script_run(cmd => "sudo ${path}registercloudguest --clean");
+    check_instance_unregistered($instance);
+}
+
+sub force_new_registration {
+    my ($instance) = @_;
+    record_info('Forcing a new registration...');
+    $instance->ssh_script_retry(cmd => "sudo ${path}registercloudguest $regcode_param --force-new", timeout => 300, retry => 3, delay => 120);
+    check_instance_registered($instance);
+    return 0;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
We have a list of manual steps which are executed to verify [cloud-regionsrv-client](https://github.com/SUSE-Enceladus/cloud-regionsrv-client/tree/master). The steps can be found here: https://github.com/SUSE-Enceladus/cloud-regionsrv-client/blob/master/integration_test-process.txt

Our existing automated tests did not cover all of the steps listed so this PR aims to remedy that.

**This PR:**
- Adds missing steps to the test module.
- Removes duplicate imports (e.g. `use version_utils 'is_sle';`)
- Defines a few new functions. These are used to retain the existing logical flow of the test while adding some extra steps along the way.
- Swaps piped commands for simpler (imo) options. e.g. `ls /etc/zypp/credentials.d/ | wc -l` vs `ls -A /etc/zypp/credentials.d/`.
- Adds steps to verify container runtimes.
- Executes Tidy on the code, hence the last empty line.

**Additional info:**
- Related ticket: https://progress.opensuse.org/issues/165881
- Needles: N/A

**Verification runs:**
- SLE 12: 
  - http://dirtman.qe.prg2.suse.org/tests/72
  - http://dirtman.qe.prg2.suse.org/tests/86
- SLE 15-SP6 
  - http://dirtman.qe.prg2.suse.org/tests/84#step/check_registercloudguest/4
  - http://dirtman.qe.prg2.suse.org/tests/89#step/check_registercloudguest/4

