### PR TITLE
Wait until guest get IP in setup_dns

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -863,7 +863,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/install_package";
         loadtest "virt_autotest/update_package";
         # Skip reset_partition for s390x due to there just be 42Gib disk space for each s390x LPAR
-        loadtest "virt_autotest/reset_partition" if (!is_s390x);
+        loadtest "virt_autotest/reset_partition" if (!is_s390x and get_var('VIRT_PRJ1_GUEST_INSTALL'));
         loadtest "virt_autotest/reboot_and_wait_up_normal" if (!get_var('AUTOYAST') && get_var('REPO_0_TO_INSTALL'));
         loadtest "virt_autotest/download_guest_assets" if get_var("SKIP_GUEST_INSTALL") && is_x86_64;
     }

--- a/tests/virt_autotest/setup_dns_service.pm
+++ b/tests/virt_autotest/setup_dns_service.pm
@@ -42,15 +42,8 @@ sub post_fail_hook {
     script_run("sed -irn '/^nameserver 192\\.168\\.123\\.1/d' /etc/resolv.conf");
     script_run("rm /var/lib/named/testvirt.net.zone; rm /var/lib/named/123.168.192.zone");
 
-    my $get_os_installed_release = "lsb_release -r | grep -oE \"[[:digit:]]{2}\"";
-    my $os_installed_release = script_output($get_os_installed_release, 30, type_command => 0, proceed_on_failure => 0);
-    if ($os_installed_release gt '11') {
-        script_run("systemctl stop named.service");
-        script_run("systemctl disable named.service");
-    }
-    else {
-        script_run("service named stop");
-    }
+    script_run("systemctl stop named.service");
+    script_run("systemctl disable named.service");
 
     my $vm_types = "sles|win";
     my $get_vm_hostnames = "virsh list  --all | grep -E \"${vm_types}\" | awk \'{print \$2}\'";


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/167569

- Wait until guests get an IP
- Remove `lsb_release` command in test script, because
  - the lsb_release package was not installed by unknown reasons
  - it is useless to get the SLE version any more
- Fix typo
- Add a few debug lines
- Run reset_partition.pm for prj1 tests only

Verification run: 
[sriov_pci_passthrough-guest_developing_fv-on-host_developing-xen](https://openqa.suse.de/tests/15562349)
[sriov_pci_passthrough-guest_sles15sp6_fv-on-host_developing-xen](https://10.145.10.207/tests/15562370)
[gi-guest_developing-on-host_developing-kvm](https://10.145.10.207/tests/15562329)
[gi-guest_win2022-on-host_developing-xen](https://10.145.10.207/tests/15562333)
