### PR TITLE
Fix the invalid config in crm for 15-SP7

### DIFF
--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -148,9 +148,15 @@ sub run {
     # Create the HA resource
     if (is_node(1)) {
         assert_script_run "EDITOR=\"sed -ie '\$ a primitive $drbd_rsc ocf:linbit:drbd params drbd_resource=$drbd_rsc'\" crm configure edit";
-        assert_script_run
-          "EDITOR=\"sed -ie '\$ a ms ms_$drbd_rsc $drbd_rsc meta master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true'\" crm configure edit";
 
+        if (is_sle('>=15-SP4')) {
+            assert_script_run
+              "EDITOR=\"sed -ie '\$ a clone ms_$drbd_rsc $drbd_rsc meta clone-max=2 clone-node-max=1 promotable=true notify=true'\" crm configure edit";
+        }
+        else {
+            assert_script_run
+"EDITOR=\"sed -ie '\$ a ms ms_$drbd_rsc $drbd_rsc meta master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true'\" crm configure edit";
+        }
         # Sometimes we need to cleanup the resource
         rsc_cleanup $drbd_rsc;
 

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -11,6 +11,7 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use utils 'zypper_call', 'write_sut_file';
+use version_utils 'is_sle';
 use testapi;
 use lockapi;
 use hacluster;
@@ -98,8 +99,9 @@ EDITOR='sed -ie \"s/^\\(group base-group.*\\)/\\1 $fs_rsc/\"' crm configure edit
         }
         else {
             if ($resource eq 'drbd_passive') {
+                my $role = is_sle('>=15-SP4') ? "Promoted" : "Master";
                 $edit_crm_config_script .= "
-EDITOR='sed -ie \"\$ a colocation colocation_$fs_rsc inf: $fs_rsc ms_$resource:Master\"' crm configure edit
+EDITOR='sed -ie \"\$ a colocation colocation_$fs_rsc inf: $fs_rsc ms_$resource:$role\"' crm configure edit
 EDITOR='sed -ie \"\$ a order order_$fs_rsc Mandatory: ms_$resource:promote $fs_rsc:start\"' crm configure edit
 ";
             }


### PR DESCRIPTION
For 15-SP7, `crm_verify -LV` will fail in 'config not valid', because
    'master' is deprecated and need to use 'clone' instead. 'Master' role
    need to by replaced by 'Promoted'. According to these, make this
    changes.
For QAM test, 15-SP4, 15-SP5, 15-SP6 support 'Promoted' role, for lower
    versions, keep to use 'master' role.

Related: https://jira.suse.com/browse/TEAM-9635

VRs:
15-SP7:  https://openqa.suse.de/tests/15548051# (Failed in other reason, and check the exit code of command 'crm_verify -LV, it's 0')

QAM: 
15-SP6: https://openqa.suse.de/tests/15548532# (Softfail)
15-SP5: https://openqa.suse.de/tests/15548031# (Softfail)
15-SP4: https://openqa.suse.de/tests/15548038# (Passed)
15-SP3: https://openqa.suse.de/tests/15548525# (Passed)
15-SP2: https://openqa.suse.de/tests/15548518# (Passed)
12-SP5: https://openqa.suse.de/tests/15548522# (Passed)
