### PR TITLE
Update version check to include SP7 and micro6.1

### DIFF
--- a/tests/console/perl_bootloader.pm
+++ b/tests/console/perl_bootloader.pm
@@ -22,7 +22,7 @@ sub run {
     my ($self) = @_;
     # https://progress.opensuse.org/issues/165686
     # package name is now 'update-bootloader', it will remain 'perl-Bootloader' for older products
-    my $package = (!is_sle("<=15-SP6") && !is_leap("<=15.6") && !is_sle_micro("<=6.0")) ? 'update-bootloader' : 'perl-Bootloader';
+    my $package = (!is_sle("<=15-SP7") && !is_leap("<=15.6") && !is_sle_micro("<=6.1")) ? 'update-bootloader' : 'perl-Bootloader';
     select_serial_terminal;
 
     if (script_run "rpm -q $package") {


### PR DESCRIPTION
Related to [poo#165686](https://progress.opensuse.org/issues/165686) and [PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20066)

I am updating the version check to include 15-SP7 and sle-micro6.1 as the perl-Bootloader module is scheduled on these products. 
It will fail without the change since the package is still named `perl-Bootloader` on these products.

- Verification run: https://openqa.suse.de/tests/overview?build=cedvid%2Fos-autoinst-distri-opensuse%2320268