### PR TITLE
Open receive update flag for autoupgrade profile.

### DIFF
--- a/data/yam/autoyast/autoyast_scc_up.xml
+++ b/data/yam/autoyast/autoyast_scc_up.xml
@@ -66,5 +66,6 @@
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
     <reg_server>{{SCC_URL}}</reg_server>
+    <install_updates config:type="boolean">true</install_updates>
   </suse_register>
 </profile>


### PR DESCRIPTION
The current autoupgrade profile didn't open the receive update flag. Open it to receive latest updates during migration via autoyast profile to fix the failure in migration VR.

- Related ticket: https://progress.opensuse.org/issues/161225
- Needles: n/a
- Failure: [migration job](https://openqa.suse.de/tests/15525185#step/installation/1) 
- Verification run: [create 12sp5 image ](https://openqa.suse.de/tests/15523512); [migration job](https://openqa.suse.de/tests/15526343) 
- Related mr: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/334
