### PR TITLE
Add fips/openjdk/prepare_env test module to create_hdd job

### DIFF
--- a/schedule/sles4sap/qam/common/qam_install_sles4sap.yaml
+++ b/schedule/sles4sap/qam/common/qam_install_sles4sap.yaml
@@ -125,3 +125,4 @@ conditional_schedule:
     FIPS_ENABLED:
       1:
         - fips/fips_setup
+        - fips/openjdk/prepare_env


### PR DESCRIPTION
The module `fips/openjdk/prepare_env` needs to be included after `fips/fips_setup` in the create_hdd job if we intend to use the generated qcow2 image to be tested later with `fips/openjdk/openjdk_fips` test module.

- Related ticket: https://progress.opensuse.org/issues/166637
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/15527215#
