### PR TITLE
xfstests: Fix match grub failed after reset

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -159,7 +159,10 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 0};
+    return {
+        fatal => 1,
+        milestone => 1,
+    };
 }
 
 sub post_fail_hook {

--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -78,6 +78,7 @@ my %softfail_list = generate_xfstests_list(get_var('XFSTESTS_SOFTFAIL'));
 
 sub run {
     my ($self, $args) = @_;
+    is_public_cloud() ? select_console('root-console') : select_serial_terminal();
     (my $test = $args->{name}) =~ s/-/\//;
     my $enable_heartbeat = $args->{enable_heartbeat};
     my $is_last_one = $args->{last_one};
@@ -187,7 +188,12 @@ sub test_flags {
 }
 
 sub post_fail_hook {
-    return;
+    my ($self, $msg) = @_;
+    $self->get_new_serial_output();
+    $self->fail_if_running();
+    if ($msg =~ qr/died/) {
+        die $msg . "\n";
+    }
 }
 
 1;


### PR DESCRIPTION
After resetting the system, if it directly goes into the login screen, we do not need to wait to match the grub page in wait_boot. To fix poo#167347.

- Related ticket: https://progress.opensuse.org/issues/167347 and https://progress.opensuse.org/issues/162884
- Verification run: 
1. https://openqa.suse.de/tests/15700091#step/xfs-009/38
  Checkpoint: to check if xfs/009 keep running and pass after xfs/008 crashed(test fail is expected), compare with previous fail https://openqa.suse.de/tests/15640564#step/xfs-009/1.
2. https://openqa.suse.de/tests/15700624#step/generic-300/2 (these test need to set QEMU_DISABLE_SNAPSHOTS=0 because it has QEMU_DISABLE_SNAPSHOTS=1 before), compare with previous fail https://openqa.suse.de/tests/15640463#step/generic-300/1
3. Verification run for nfs case: https://openqa.suse.de/tests/15700755
compare with previous fails https://openqa.suse.de/tests/15519040#step/generic-371/1
4. Verification run for public cloud: https://openqa.suse.de/tests/15711503