### PR TITLE
Fix Agama: add dmesg before and after assert_script_run

### DIFF
--- a/tests/yam/agama/import_agama_profile.pm
+++ b/tests/yam/agama/import_agama_profile.pm
@@ -7,13 +7,15 @@
 use base Yam::Agama::patch_agama_base;
 use strict;
 use warnings;
-use testapi qw(assert_script_run data_url get_required_var select_console);
+use testapi qw(assert_script_run data_url get_required_var select_console script_run);
 
 sub run {
     select_console 'root-console';
     my $profile = get_required_var('AGAMA_PROFILE');
     my $profile_url = data_url($profile);
+    script_run("dmesg --console-off");
     assert_script_run("/usr/bin/agama profile import $profile_url", timeout => 300);
+    script_run("dmesg --console-on");
 }
 
 1;

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -8,7 +8,7 @@
 use base Yam::Agama::patch_agama_base;
 use strict;
 use warnings;
-use testapi;
+use testapi qw(assert_script_run get_required_var select_console);
 
 sub run {
     select_console 'root-console';


### PR DESCRIPTION
- Related ticket: [poo#166133](https://progress.opensuse.org/issues/166133)
- Verification run: [overview](https://openqa.opensuse.org/tests/overview?build=build-issues-166133&version=agama-10.0)
