### PR TITLE
Boot agama in OSD in architectures using qemu

### DIFF
--- a/lib/Distribution/Sle/AgamaDevel.pm
+++ b/lib/Distribution/Sle/AgamaDevel.pm
@@ -7,41 +7,30 @@
 # for integration tests using the current state of code at GitHub for Agama.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-package Distribution::Opensuse::AgamaDevel;
+package Distribution::Sle::AgamaDevel;
 use strict;
 use warnings FATAL => 'all';
 use parent 'susedistribution';
 
 use Yam::Agama::Pom::GrubMenuPage;
 use Yam::Agama::Pom::GrubEntryEditionPage;
-use Yam::Agama::Pom::Opensuse::AgamaUpAndRunningPage;
+use Yam::Agama::Pom::Sle::AgamaUpAndRunningPage;
 use Yam::Agama::Pom::RebootPage;
-use Yam::Agama::Pom::RebootTextmodePage;
-
-use Utils::Architectures;
 
 sub get_grub_menu {
     return Yam::Agama::Pom::GrubMenuPage->new();
 }
 
 sub get_grub_entry_edition {
-    return is_ppc64le() ? Yam::Agama::Pom::GrubEntryEditionPage->new({
-            number_kernel_line => 3,
-            max_interval => utils::VERY_SLOW_TYPING_SPEED})
-      : Yam::Agama::Pom::GrubEntryEditionPage->new();
+    return Yam::Agama::Pom::GrubEntryEditionPage->new();
 }
 
 sub get_agama_up_an_running {
-    return Yam::Agama::Pom::Opensuse::AgamaUpAndRunningPage->new();
+    return Yam::Agama::Pom::Sle::AgamaUpAndRunningPage->new();
 }
 
 sub get_reboot_page {
-    if (is_s390x()) {
-        return Yam::Agama::Pom::RebootTextmodePage->new();
-    }
-    else {
-        return Yam::Agama::Pom::RebootPage->new();
-    }
+    return Yam::Agama::Pom::RebootPage->new();
 }
 
 1;

--- a/lib/DistributionProvider.pm
+++ b/lib/DistributionProvider.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings FATAL => 'all';
 use version_utils;
 
+use Distribution::Sle::AgamaDevel;
 use Distribution::Sle::15sp0;
 use Distribution::Sle::15sp2;
 use Distribution::Sle::15_current;
@@ -35,14 +36,15 @@ If there is no matched version, then returns Tumbleweed as the default one.
 =cut
 
 sub provide {
+    return Distribution::Sle::AgamaDevel->new() if is_sle() && get_var('VERSION', '') =~ /agama/;
     return Distribution::Sle::15_current->new() if (is_sle('>=15-sp3') || is_sle_micro);
     return Distribution::Sle::15sp2->new() if is_sle('>15');
     return Distribution::Sle::15sp0->new() if is_sle('=15');
     return Distribution::Sle::12->new() if is_sle('12+');
     return Distribution::Opensuse::Leap::15->new() if is_leap('15.0+');
     return Distribution::Opensuse::Leap::42->new() if is_leap('42.0+');
-    return Distribution::Opensuse::AgamaDevel->new() if get_var('VERSION', '') =~ /agama/;
     return Distribution::Opensuse::Tumbleweed->new();
+    return Distribution::Opensuse::AgamaDevel->new() if is_opensuse() && get_var('VERSION', '') =~ /agama/;
 }
 
 1;

--- a/lib/Yam/Agama/Pom/Opensuse/AgamaUpAndRunningPage.pm
+++ b/lib/Yam/Agama/Pom/Opensuse/AgamaUpAndRunningPage.pm
@@ -7,7 +7,7 @@
 # to other test modules or proper web automation tool. It acts only as a synchronization point.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
-package Yam::Agama::Pom::AgamaUpAndRunningPage;
+package Yam::Agama::Pom::Opensuse::AgamaUpAndRunningPage;
 use strict;
 use warnings;
 

--- a/lib/Yam/Agama/Pom/Sle/AgamaUpAndRunningPage.pm
+++ b/lib/Yam/Agama/Pom/Sle/AgamaUpAndRunningPage.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles that Agama is up and running in a generic way, delegating further testing
+# to other test modules or proper web automation tool. It acts only as a synchronization point.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Yam::Agama::Pom::Sle::AgamaUpAndRunningPage;
+use strict;
+use warnings;
+
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    return bless {
+        tag_array_ref_any_first_screen_shown => [qw(agama-installing agama-sle-overview)]
+    }, $class;
+}
+
+sub expect_is_shown {
+    my ($self) = @_;
+    assert_screen($self->{tag_array_ref_any_first_screen_shown}, 90);
+}
+
+1;

--- a/test_data/yam/agama_sle.yaml
+++ b/test_data/yam/agama_sle.yaml
@@ -1,0 +1,2 @@
+---
+os_release_name: SLE


### PR DESCRIPTION
We have added support for SLE agama schedule in OSD. Removed validation stage, it will need more work from developers.

- Related ticket: https://progress.opensuse.org/issues/167239
- Needles: N/A
- Verification run:
  - x86_64: https://openqa.suse.de/tests/15527936
  - aarch64: https://openqa.suse.de/tests/15527941
  - ppc64le: https://openqa.suse.de/tests/15527958# (Not working added grub needle)
  - s390x: Not tested probably needs another round.
