### PR TITLE
Setup localhost ssh env for ltp ftp test

### DIFF
--- a/data/kernel/pam_vsftpd
+++ b/data/kernel/pam_vsftpd
@@ -1,0 +1,2 @@
+auth required pam_unix.so
+account required pam_unix.so

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -50,6 +50,11 @@ sub run {
     select_console('root-console') if get_var('LTP_DEBUG');
     select_serial_terminal;
 
+    if (check_var_array('LTP_COMMAND_FILE', 'net.tcp_cmds')) {
+        setup_localhost_sshd;
+        setup_ftp;
+    }
+
     # Debug code for poo#81142
     script_run('gzip -9 </dev/fb0 >framebuffer.dat.gz');
     upload_logs('framebuffer.dat.gz', failok => 1);


### PR DESCRIPTION
Setup localhost ssh env for ltp ftp test

- Related ticket: https://progress.opensuse.org/issues/165848
- Needles: na
- Verification run: 

tw
https://openqa.opensuse.org/tests/4508002#
https://openqa.opensuse.org/tests/4514248#step/ftp/7
15-sp7
https://openqa.suse.de/tests/15526667#step/ftp/8
https://openqa.suse.de/tests/15547069#step/ftp/6
15-sp5
https://openqa.suse.de/tests/15527201
15sp6
https://openqa.suse.de/tests/15527202
15sp4
https://openqa.suse.de/tests/15526666
12sp5
https://openqa.suse.de/tests/15526662#step/ftp/8
12sp3
https://openqa.suse.de/tests/15526675#step/ftp/8

NOTES: another part of fix is on ltp side:
https://patchwork.ozlabs.org/project/ltp/patch/20240925035756.14873-1-wegao@suse.com/