### PR TITLE
Run zypper ref before using zypper in sanity test

### DIFF
--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -789,4 +789,16 @@ subtest '[ipaddr2_test_other_vm]' => sub {
     ok((scalar @calls > 0), "Some calls");
 };
 
+subtest '[ipaddr2_refresh_repo]' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+
+    ipaddr2_refresh_repo(id => '42');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /zypper ref/ } @calls), 'Call zypper ref');
+};
+
 done_testing;

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -21,6 +21,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_os_cloud_init_logs
   ipaddr2_registeration_check
   ipaddr2_registeration_set
+  ipaddr2_refresh_repo
 );
 
 sub run {
@@ -39,8 +40,8 @@ sub run {
 
     if (check_var('IPADDR2_CLOUDINIT', 0)) {
         if (get_var('SCC_REGCODE_SLES4SAP')) {
-            # Register was not part of cloud-init
-            record_info("TEST STAGE", "Register");
+            # Registration was not part of cloud-init
+            record_info("TEST STAGE", "Registration");
             foreach (1 .. 2) {
                 my $is_registered = ipaddr2_registeration_check(
                     bastion_ip => $bastion_ip,
@@ -55,6 +56,13 @@ sub run {
         record_info("TEST STAGE", "Install the web server");
         foreach (1 .. 2) {
             ipaddr2_configure_web_server(bastion_ip => $bastion_ip, id => $_);
+        }
+    } else {
+
+        foreach (1 .. 2) {
+            ipaddr2_refresh_repo(
+                bastion_ip => $bastion_ip,
+                id => $_);
         }
     }
 


### PR DESCRIPTION
It is to avoid zypper exit code 106 in BYOS images configured with cloud-init, the first time zypper is called for a sanity check

Related ticket: https://jira.suse.com/browse/TEAM-8721

# Verification run:

## Default IPADDR2_CLOUDINIT 1

### BYOS
 sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test

-  http://openqaworker15.qa.suse.cz/tests/298312 :green_circle: 
 
 ### PAYG
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test

- http://openqaworker15.qa.suse.cz/tests/298319 :green_circle: 

## IPADDR2_CLOUDINIT 0 (maybe not relevant for this PR)

sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test
- http://openqaworker15.qa.suse.cz/tests/298296
- http://openqaworker15.qa.suse.cz/tests/298304
- http://openqaworker15.qa.suse.cz/tests/298320

 sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test
 -  http://openqaworker15.qa.suse.cz/tests/298297
 -  http://openqaworker15.qa.suse.cz/tests/298303
- http://openqaworker15.qa.suse.cz/tests/298321