### PR TITLE
Add MLS to Host_version checks

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -42,7 +42,9 @@ sub skip_testrun {
             check_var('HOST_VERSION', 'LIBERTY9') ||
             check_var('HOST_VERSION', 'centos') ||
             check_var('HOST_VERSION', 'ubuntu') ||
-            check_var('HOST_VERSION', 'res8')
+            check_var('HOST_VERSION', 'res8') ||
+            check_var('HOST_VERSION', 'mls8') ||
+            check_var('HOST_VERSION', 'mls9')
         )
     );
 


### PR DESCRIPTION
As preparation step for moving from Libert/RES/RHEL to MLS, add mls to the host version checks.

- Related ticket: https://progress.opensuse.org/issues/167377
- Verification runs: https://openqa.suse.de/tests/15537850
