### PR TITLE
Change agama_grub2 to grub_test for x86_64 and aarch64

### DIFF
--- a/schedule/yam/agama_auto_ppc64le.yaml
+++ b/schedule/yam/agama_auto_ppc64le.yaml
@@ -1,0 +1,11 @@
+---
+name: agama_auto
+description: >
+  Prepare url for agama.auto boot parameter, boot, perform auto-installation with agama.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - yam/agama/agama_grub2
+  - installation/first_boot
+  - yam/validate/validate_product
+  - yam/validate/validate_first_user

--- a/schedule/yam/agama_ppc64le.yaml
+++ b/schedule/yam/agama_ppc64le.yaml
@@ -6,7 +6,7 @@ schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests
   - yam/agama/agama
-  - installation/grub_test
+  - yam/agama/agama_grub2
   - installation/first_boot
   - yam/validate/validate_product
   - yam/validate/validate_first_user


### PR DESCRIPTION
Fix of Agama post installation grub check.

- Related ticket: https://progress.opensuse.org/issues/167024
- Needles: N/A
- Verification run: In progress
