### PR TITLE
Revert changes on tests/sles4sap/hana_cluster from 285bd34

### DIFF
--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -32,10 +32,6 @@ sub hanasr_angi_hadr_providers_setup {
     assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StartSystem HDB'";
 }
 
-sub is_fips_scenario {
-    return (get_var('FIPS_INSTALLATION') || get_var('FIPS_ENABLED'));
-}
-
 sub run {
     my ($self) = @_;
     my $instance_id = get_required_var('INSTANCE_ID');
@@ -73,7 +69,7 @@ sub run {
             '%VIRTUAL_IP_NETMASK%' => $virtual_netmask);
 
         foreach ($node1, $node2) {
-            add_to_known_hosts($_) unless is_fips_scenario;
+            add_to_known_hosts($_);
         }
         assert_script_run "scp -qr /usr/sap/${sid}/SYS/global/security/rsecssfs/* root\@${node2}:/usr/sap/${sid}/SYS/global/security/rsecssfs/";
         assert_script_run qq(su - $sapadm -c "hdbsql -u system -p $sles4sap::instance_password -i $instance_id -d SYSTEMDB \\"BACKUP DATA FOR FULL SYSTEM USING FILE ('backup')\\""), 900;


### PR DESCRIPTION
Commit 285bd34454e3472e5553ef8678f67b5584bfc39a included changes in schedules and in the test module `sles4sap/hana_cluster` for FIPS Vendor Affirmation tests. The changes on the test module are not required by the certification, and instead break the test, so this commit partially reverts 285bd34454e3472e5553ef8678f67b5584bfc39a (only changes on `tests/sles4sap/hana_cluster.pm`)

- Related ticket: https://progress.opensuse.org/issues/166637
- Needles: N/A
- Verification run: N/A (this reverts changes done on #20235 )
