### PR TITLE
Use REPO_999 instead of ISO for agama s390x zVM

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -90,7 +90,7 @@ sub prepare_parmfile {
     }
     else {
         if (get_var('AGAMA')) {
-            $params .= " root=live:ftp://" . get_var('REPO_HOST', 'openqa') . '/' . get_var('ISO');
+            $params .= " root=live:ftp://" . get_var('REPO_HOST', 'openqa') . '/' . get_var('REPO_999');
         }
         else {
             $params .= " install=" . $instsrc . $repo . " ";


### PR DESCRIPTION
- Related ticket: [poo#166253](https://progress.opensuse.org/issues/166253)
