### PR TITLE
Introduce smoke tests for PCI Utils

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -174,4 +174,5 @@ schedule:
     - console/coredump_collect
     - console/valgrind
     - console/sssd_389ds_functional
+    - console/pciutils
     - console/zypper_log_packages

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -31,6 +31,7 @@ schedule:
   - console/vsftpd
   - network/samba/samba_adcli
   - '{{version_specific}}'
+  - console/pciutils
   - console/coredump_collect
 conditional_schedule:
   version_specific:

--- a/tests/console/pciutils.pm
+++ b/tests/console/pciutils.pm
@@ -1,0 +1,31 @@
+#SUSE"s openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: pciutils
+# Summary: PED-8229, Introduce smoke tests for PCI Utils
+# Maintainer: QE-Core <qe-core@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use version_utils 'is_sle';
+use registration 'add_suseconnect_product';
+
+sub run {
+    select_serial_terminal;
+
+    add_suseconnect_product('sle-module-development-tools') if is_sle('>=15');
+    zypper_call('in cpupower powertop pciutils');
+    record_info('pciutis version:', script_output('rpm -q pciutils'));
+
+    # Run basic powertop, sysinfo and cpupower tests
+    assert_script_run('powertop -r /tmp/powertop_report');
+    assert_script_run('cpupower frequency-info');
+}
+
+1;


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/165252
- Verification run: 
[opensuse](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=rfan0927)
[sle](https://openqa.suse.de/tests/overview?build=rfan0927&distri=sle)

**Please ignore the failure on sle15sp7, it is https://bugzilla.suse.com/show_bug.cgi?id=1230995**