### PR TITLE
Add GCP generic HansSR conf.yaml template

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#   Settings are meant to be controlled via OpenQA variables and managed by test:
+#   tests/sles4sap/publiccloud/qesap_ansible.pm
+provider: 'gcp'
+apiver: 3
+terraform:
+  variables:
+    # GENERAL VARIABLES #
+    project: 'ei-sle-qa-sap-8469'
+    gcp_credentials_file: '/root/google_credentials.json'
+    region: '%PUBLIC_CLOUD_REGION%'
+    deployment_name: '%QESAP_DEPLOYMENT_NAME%'
+    admin_user: 'cloudadmin'
+    public_key: '%SLES4SAP_PUBSSHKEY%'
+    os_image: '%SLES4SAP_OS_IMAGE_NAME%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+
+    # HANA
+    hana_count: '%NODE_COUNT%'
+    hana_ha_enabled: '%HA_CLUSTER%'
+    hana_vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
+    hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    hana_data_disk_type: 'pd-standard'
+    hana_log_disk_type: 'pd-standard'
+ansible:
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_key_name: '%HANA_KEYNAME%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  destroy:
+    - deregister.yaml


### PR DESCRIPTION
Add GCP generic HansSR conf.yaml template

Related ticket:  
TEAM-9645 - Add GCP variant for HanaSR regression in ow15  

Other related PR/MR:  
MR: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/792
MR: https://gitlab.suse.de/qa-css/qe-sap-deployment-bot/-/merge_requests/51  
 
VR:  
https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=add-hanasr-GCP&groupid=42 (the crash failure is known)

Images used:

-   PUBLIC_CLOUD_IMAGE_ID=suse-byos-cloud/sles-15-sp6-sap-byos-v20240807-x86-64
-   PUBLIC_CLOUD_IMAGE_ID=suse-sap-cloud/sles-15-sp6-sap-v20240807-x86-64 (job id=298413,298414,298415,298416)

Hanasr cases:

-   hanasr_gcp_test_saptune_fencing_native_stop_kill
-   hanasr_gcp_test_saptune_fencing_native_crash
-   hanasr_gcp_test_fencing_sbd_stop_kill
-   hanasr_gcp_test_fencing_sbd_crash
