### PR TITLE
Adapt distri pattern for Leap 16.0

### DIFF
--- a/lib/Distribution/Sle/16Latest.pm
+++ b/lib/Distribution/Sle/16Latest.pm
@@ -1,0 +1,16 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class represents current (i.e. latest) SLE 16 distribution and
+# provides access to its features.
+
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Distribution::Sle::16Latest;
+use parent Distribution::Opensuse::AgamaDevel;
+use strict;
+use warnings FATAL => 'all';
+
+1;

--- a/lib/DistributionProvider.pm
+++ b/lib/DistributionProvider.pm
@@ -14,6 +14,7 @@ use warnings FATAL => 'all';
 use version_utils;
 
 use Distribution::Sle::AgamaDevel;
+use Distribution::Sle::16Latest;
 use Distribution::Sle::15sp0;
 use Distribution::Sle::15sp2;
 use Distribution::Sle::15_current;
@@ -41,6 +42,7 @@ sub provide {
     return Distribution::Sle::15sp2->new() if is_sle('>15');
     return Distribution::Sle::15sp0->new() if is_sle('=15');
     return Distribution::Sle::12->new() if is_sle('12+');
+    return Distribution::Sle::16Latest->new() if is_leap('16.0+');
     return Distribution::Opensuse::Leap::15->new() if is_leap('15.0+');
     return Distribution::Opensuse::Leap::42->new() if is_leap('42.0+');
     return Distribution::Opensuse::Tumbleweed->new();


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/167087
- Needles: N/A
- Verification run: 
  https://openqa.opensuse.org/tests/4514146#step/agama_auto/1 agama-default-auto on x86_64
  https://openqa.opensuse.org/tests/4514164#   agama-default on aarch64
