### PR TITLE
Add openssl_fips_* modules to mau-extratests schedule for SLES for SAP

### DIFF
--- a/schedule/sles4sap/qam/common/qam_sles4sap_fips_mau-extratests.yaml
+++ b/schedule/sles4sap/qam/common/qam_sles4sap_fips_mau-extratests.yaml
@@ -9,6 +9,9 @@ schedule:
   - sles4sap/patterns
   - fips/gnutls/gnutls_base_check
   - fips/openjdk/openjdk_fips
+  - fips/openssl/openssl_fips_alglist
+  - fips/openssl/openssl_fips_hash
+  - fips/openssl/openssl_fips_cipher
   - console/curl_ipv6
   - console/wget_ipv6
   - console/ca_certificates_mozilla


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/166637
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/15548322#step/openssl_fips_hash/84
