### PR TITLE
xfstests: Add XFSTESTS_PART_SIZE parameter

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -457,6 +457,7 @@ XFSTESTS_NFS_VERSION | string | 4.1 | NFS only, version of test target NFS
 XFSTESTS_NFS_SERVER | boolean | | NFS multimation test only, mandatory. To tag this test job for NFS server in a NFS multimachine test. NFS test in a multimachine test either a client or a server.
 NFS_GRACE_TIME | integer | 15 | NFS only, set the nlm_grace_period in /etc/modprobe.d/lockd.conf used in NFS test.
 PARALLEL_WITH | string | | NFS multimation test only, value=<set-the-parent-job-name>. To set the NFS server job name in NFS client job in a NFS multimachine test. e.g. xfstests_nfs4.1-server
+XFSTESTS_PART_SIZE | string | | Partitions size in MB, separate with commas. Each size is allocated to test_dev, scratch_dev1 and so on in turn. Unconfigured partitions will divide the remaining space equally. E.g, value=5120,10240 then test_dev=5120M, scratch_dev1=10240M, and remain partitions share the rest space.
 
 
 Debug setting: advance setting to debugging issues, may cause test fail


### PR DESCRIPTION
1. remove XFSTESTS_BIG_SPACE parameter
2. set each device size in MB, separate with commas
3. Each size is allocated to test_dev, scratch_dev1 and so on in turn
4. E.g XFSTESTS_PART_SIZE=5120,10240 then test_dev=5120M, scratch_dev1=10240M, and remain partitions share the rest space. Or set the size for all devices at once, values exceeding the number of devices have no effect.

- Related ticket: https://progress.opensuse.org/issues/167012
- Needles: N/A
- Verification run:
http://10.67.133.133/tests/823 (no XFSTESTS_PART_SIZE parameter)
http://10.67.133.133/tests/822 (XFSTESTS_PART_SIZE=5120,10240,6100,6200,6300,6400,6500)
http://10.67.133.133/tests/821 (XFSTESTS_PART_SIZE=5120,10240,5100,5200,5300,5400)
http://10.67.133.133/tests/820 (XFSTESTS_PART_SIZE=10240)
http://10.67.133.133/tests/819 (XFSTESTS_PART_SIZE=5120,10240)
