### PR TITLE
Fixed packagehub related test modules on TW and Leap

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -73,6 +73,7 @@ conditional_schedule:
                 - console/vmstat
                 - console/kdump_and_crash
                 - console/ansible
+                - console/libgit2
     opensuse_repos:
         DISTRI:
             opensuse:

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -12,7 +12,7 @@ schedule:
     - console/libgit2
     - console/ansible
     - network/cifs
-    - systemd_testsuite/prepare_systemd_and_testsuite
+    - '{{prepare_systemd_and_testsuite}}'
     - console/coredump_collect  # For coredumps during the suite. Please put near end.
     - console/zypper_log_packages  # Records packages installed in the suite. Please put at end.
 conditional_schedule:
@@ -20,3 +20,7 @@ conditional_schedule:
         ARCH:
             x86_64:
                 - console/wpa_supplicant
+    prepare_systemd_and_testsuite:
+        ARCH:
+            x86_64:
+                - systemd_testsuite/prepare_systemd_and_testsuite


### PR DESCRIPTION
Fixed packagehub related test modules on TW and Leap

- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20294
- Related MR: https://gitlab.suse.de/qe-core/qa-sle-functional-userspace/-/merge_requests/239
- Verification run:  https://openqa.opensuse.org/tests/4519896
   https://openqa.opensuse.org/tests/4519898