### PR TITLE
Load pciutils test before year_2038_detection

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -152,6 +152,7 @@ schedule:
     - console/dstat
     - x11/evolution/evolution_prepare_servers
     - console/mutt
+    - console/pciutils
     - '{{sle_tests}}'
     - console/mdadm
     - console/systemd_nspawn
@@ -175,5 +176,4 @@ schedule:
     - console/coredump_collect
     - console/valgrind
     - console/sssd_389ds_functional
-    - console/pciutils
     - console/zypper_log_packages

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -30,8 +30,8 @@ schedule:
   - console/systemtap
   - console/vsftpd
   - network/samba/samba_adcli
-  - '{{version_specific}}'
   - console/pciutils
+  - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:
   version_specific:


### PR DESCRIPTION
https://progress.opensuse.org/issues/167560

**This is a workaround, upcoming fix is https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20310**

VR: 
http://openqa.suse.de/t15558346
http://openqa.suse.de/t15558347
http://openqa.suse.de/t15558348

