### PR TITLE
Change base from apparmortest to consoletest for add_users.pm

### DIFF
--- a/tests/security/yast2_users/add_users.pm
+++ b/tests/security/yast2_users/add_users.pm
@@ -9,7 +9,7 @@
 # Maintainer: QE Security <none@suse.de>
 # Tags: poo#71740 bsc#1176714
 
-use base apparmortest;
+use base 'consoletest';
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION
Using apparmortest as base breaks the test case in case SELinux is installed as main LSM, as the test tries to restart the systemd apparmor service. As there is no need to use apparmortest as base for this specific scenario, change base to consoletest.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
  - failed before: https://openqa.opensuse.org/tests/4515798 
  - good after: https://openqa.opensuse.org/tests/4521502
