### PR TITLE
Skip TOTP for sle micro

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -297,6 +297,16 @@ sub run {
         create_user_in_ui();
     }
 
+    if (is_sle_micro('>6.0')) {
+        assert_screen 'jeos-totp-for-cockpit';
+        for (1 .. 2) {
+            wait_screen_change(sub {
+                    send_key 'tab';
+            }, 10);
+        }
+        send_key 'ret';
+    }
+
     if (is_generalhw && is_aarch64 && !is_leap("<15.4") && !is_tumbleweed) {
         assert_screen 'jeos-please-configure-wifi';
         send_key 'n';


### PR DESCRIPTION
TOTP screen is brand new and for now we can just skip the option in order to unblock other tests. Further testing requirements should be discussed later.

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1674
- Verification run: http://kepler.suse.cz/tests/24001#step/firstrun/13
