### PR TITLE
publiccloud/xfstests: Remove generate_report from schedule

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -54,9 +54,8 @@ sub load_maintenance_publiccloud_tests {
         } elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
             load_container_tests();
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
-            loadtest "publiccloud/xfsprepare";
-            loadtest "xfstests/run";
-            loadtest "xfstests/generate_report";
+            loadtest "publiccloud/xfsprepare", run_args => $args;
+            loadtest "xfstests/run", run_args => $args;
         } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
             loadtest "publiccloud/smoketest";
             # flavor_check is concentrated on checking things which make sense only for image which is registered
@@ -72,7 +71,7 @@ sub load_maintenance_publiccloud_tests {
             loadtest "publiccloud/nvidia", run_args => $args;
         }
 
-        loadtest("publiccloud/ssh_interactive_end", run_args => $args);
+        loadtest("publiccloud/ssh_interactive_end", run_args => $args) unless get_var('PUBLIC_CLOUD_XFS');
     }
 }
 
@@ -155,11 +154,10 @@ sub load_latest_publiccloud_tests {
             } elsif (get_var('PUBLIC_CLOUD_XFS')) {
                 loadtest "publiccloud/xfsprepare", run_args => $args;
                 loadtest "xfstests/run", run_args => $args;
-                loadtest "xfstests/generate_report", run_args => $args;
             } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
                 loadtest("publiccloud/azure_nfs", run_args => $args);
             }
-            loadtest("publiccloud/ssh_interactive_end", run_args => $args);
+            loadtest("publiccloud/ssh_interactive_end", run_args => $args) unless get_var('PUBLIC_CLOUD_XFS');
         }
     }
     elsif (get_var('PUBLIC_CLOUD_UPLOAD_IMG')) {

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -86,7 +86,7 @@ my $TIMEOUT_NO_HEARTBEAT = get_var('XFSTESTS_TIMEOUT', 2000);
 
 
 sub run {
-    my $self = shift;
+    my ($self, $args) = @_;
     is_public_cloud() ? select_console('root-console') : select_serial_terminal();
     return if get_var('XFSTESTS_NFS_SERVER');
     my $enable_heartbeat = 1;
@@ -150,6 +150,7 @@ sub run {
             autotest::loadtest("tests/xfstests/run_subtest.pm", name => $test, run_args => $targs);
             mutex_lock 'last_subtest_run_finish';
             autotest::loadtest 'tests/xfstests/generate_report.pm';
+            autotest::loadtest("tests/publiccloud/ssh_interactive_end.pm", run_args => $args) if is_public_cloud();
         }
         else {
             autotest::loadtest("tests/xfstests/run_subtest.pm", name => $test, run_args => $targs);


### PR DESCRIPTION
Since commit 58a03ea5500f ("xfstests: subtest run could rollback"), each XFS test is now scheduled from within xfstests/run.pm, which also schedules xfstests/generate_report.pm at the end so remove those from Public Cloud main schedule. Also leave publiccloud/ssh_interactive_end to be scheduled later too, otherwise the XFS tests would take place after the SUT has been destroyed already.

- Related ticket: https://progress.opensuse.org/issues/167539
- Verification run: http://rmarliere-openqa.qe.prg2.suse.org/tests/2387 (with CASEDIR pointed towards this PR branch)

