### PR TITLE
Remove fatal flag from openssl_tlsv1_3

### DIFF
--- a/tests/fips/openssl/openssl_tlsv1_3.pm
+++ b/tests/fips/openssl/openssl_tlsv1_3.pm
@@ -51,7 +51,7 @@ sub test_flags {
     return {
         #poo160197 workaround since rollback seems not working with swTPM
         no_rollback => is_transactional ? 1 : 0,
-        fatal => 1
+        fatal => 0
     };
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/167533 
- Needles: no
- Verification run: https://openqa.suse.de/tests/15568911
(test fails due to known bug: https://bugzilla.suse.com/show_bug.cgi?id=1220681 )
