### PR TITLE
Remove workaround for bsc#1220568

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -35,9 +35,6 @@ sub run {
     if ($runtime eq 'docker') {
         install_docker_when_needed($host_distri);
         zypper_call('install skopeo');
-
-        # temporarily necessary due to https://bugzilla.suse.com/show_bug.cgi?id=1220568
-        zypper_call('install cni-plugins') if (is_sle("15-SP3+"));
     }
     record_info('Version', script_output('buildah --version'));
 


### PR DESCRIPTION
This workaround is not needed anymore because bsc#1220568 is fixed, and it breaks 15-SP7 test runs where cni is not available.

- Related failure: https://openqa.suse.de/tests/15568852#step/buildah_docker/107
- Verification run: [15-SP2](https://duck-norris.qe.suse.de/tests/14804#step/buildah_docker/1) | [15-SP3](https://duck-norris.qe.suse.de/tests/14805#step/buildah_docker/1) | [15-SP4](https://duck-norris.qe.suse.de/tests/14806#step/buildah_docker/1) | [15-SP5](https://duck-norris.qe.suse.de/tests/14807#step/buildah_docker/1) | [15-SP6](https://duck-norris.qe.suse.de/tests/14808#step/buildah_docker/1)
