### PR TITLE
containers: Install pasta from upstream for podman upstream tests

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -15,7 +15,7 @@ use utils qw(script_retry);
 use version_utils qw(is_sle is_sle_micro is_tumbleweed is_microos);
 use containers::common;
 use Utils::Architectures qw(is_x86_64 is_aarch64);
-use containers::bats qw(install_bats install_htpasswd install_ncat patch_logfile remove_mounts_conf switch_to_user delegate_controllers enable_modules);
+use containers::bats qw(install_bats install_htpasswd install_ncat install_pasta patch_logfile remove_mounts_conf switch_to_user delegate_controllers enable_modules);
 
 my $test_dir = "/var/tmp";
 my $podman_version = "";
@@ -70,6 +70,7 @@ sub run {
     install_packages(@pkgs);
     install_htpasswd if is_sle_micro;
     install_ncat;
+    install_pasta unless (is_tumbleweed || is_microos);
 
     record_info("podman version", script_output("podman version"));
 


### PR DESCRIPTION
The podman upstream tests need pasta and this is only available as a package on Tumbleweed.

- Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1843
- Verification runs: 
  - sle-15-SP7-Online-x86_64-Build23.2-podman_testsuite@64bit -> https://openqa.suse.de/tests/15571759
