### PR TITLE
spec: Fix build of worker sub-package

### DIFF
--- a/os-autoinst-distri-opensuse-deps.spec
+++ b/os-autoinst-distri-opensuse-deps.spec
@@ -100,4 +100,6 @@ Convenience package pulling in os-autoinst-distri-openSUSE dependencies and the 
 
 %files
 
+%files worker
+
 %changelog


### PR DESCRIPTION
Every sub-package needs a files section even if empty.