### PR TITLE
Move tfvars file related functions to a separate library

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/configure_tfvars.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/configure_tfvars.pm
@@ -1,0 +1,119 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+package sles4sap::sap_deployment_automation_framework::configure_tfvars;
+
+use strict;
+use warnings;
+use testapi;
+use Exporter qw(import);
+use Carp qw(croak);
+use utils qw(file_content_replace);
+use sles4sap::sap_deployment_automation_framework::deployment qw(get_os_variable);
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployment_id);
+
+=head1 SYNOPSIS
+
+Library with common functions for Microsoft SDAF deployment automation that help with preparation of tfvars file.
+
+=cut
+
+our @EXPORT = qw(
+  prepare_tfvars_file
+);
+
+=head2 prepare_tfvars_file
+
+    prepare_tfvars_file(deployment_type=>$deployment_type);
+
+=over 1
+
+=item B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+
+=back
+
+Downloads tfvars template files from openQA data dir and places them into correct place within SDAF repo structure.
+Returns full path of the tfvars file.
+
+=cut
+
+sub prepare_tfvars_file {
+    my (%args) = @_;
+    croak 'Deployment type not specified' unless $args{deployment_type};
+    my %tfvars_os_variable = (
+        deployer => 'deployer_parameter_file',
+        sap_system => 'sap_system_parameter_file',
+        workload_zone => 'workload_zone_parameter_file',
+        library => 'library_parameter_file'
+    );
+    croak "Unknown deployment type: $args{deployment_type}" unless $tfvars_os_variable{$args{deployment_type}};
+
+    my %tfvars_template_url = (
+        deployer => data_url('sles4sap/sap_deployment_automation_framework/DEPLOYER.tfvars'),
+        sap_system => data_url('sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars'),
+        workload_zone => data_url('sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars'),
+        library => data_url('sles4sap/sap_deployment_automation_framework/LIBRARY.tfvars')
+    );
+
+    # replace default vnet name with shorter one to avoid naming restrictions
+    set_workload_vnet_name();
+
+    my $tfvars_file = get_os_variable($tfvars_os_variable{$args{deployment_type}});
+
+    assert_script_run join(' ', 'curl', '-v', '-fL', $tfvars_template_url{$args{deployment_type}}, '-o', $tfvars_file);
+    assert_script_run("test -f $tfvars_file");
+    replace_tfvars_variables($tfvars_file);
+    upload_logs($tfvars_file, log_name => "$args{deployment_type}.tfvars.txt");
+    return $tfvars_file;
+}
+
+=head2 replace_tfvars_variables
+
+    replace_tfvars_variables();
+
+=over 1
+
+=item B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+
+=back
+
+Replaces placeholder pattern B<%OPENQA_VARIABLE%> with corresponding OpenQA variable value.
+If OpenQA variable is not set, placeholder is replaced with empty value.
+
+=cut
+
+sub replace_tfvars_variables {
+    my ($tfvars_file) = @_;
+    croak 'Variable "$tfvars_file" undefined' unless defined($tfvars_file);
+    my @variables = split("\n", script_output("grep -oP \'(\?<=%)[A-Z_]+(?=%)\' $tfvars_file"));
+    my %to_replace = map { '%' . $_ . '%' => get_var($_, '') } @variables;
+    file_content_replace($tfvars_file, %to_replace);
+}
+
+=head2 set_workload_vnet_name
+
+    set_workload_vnet_name([job_id=>$job_id]);
+
+=over 1
+
+=item B<$job_id>: Specify job id to be used. Default: current deployment job ID
+
+=back
+
+Returns VNET name used for workload zone and sap systems resources. VNET name must be unique for each landscape,
+therefore it contains test ID as an identifier.
+
+=cut
+
+sub set_workload_vnet_name {
+    my (%args) = @_;
+    $args{job_id} //= find_deployment_id();
+    die('no deployment ID found') unless $args{job_id};
+    # Try to keep vnet name as short as possible. Later this is used in the name for the peering in a format:
+    # deployer-vnet_to_workload-vnet
+    # if it is too long you might hit name length limit and test ID gets clipped.
+    set_var('SDAF_SUT_VNET_NAME', 'OpenQA-' . $args{job_id});
+}

--- a/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
@@ -337,5 +337,8 @@ sub get_workload_vnet_code {
     my (%args) = @_;
     $args{job_id} //= find_deployment_id();
     die('no deployment ID found') unless $args{job_id};
-    return ("SUT$args{job_id}");
+    # Try to keep vnet code as short as possible. Later this is used in the name for the peering in a format:
+    # deployer-vnet_to_workload-vnet
+    # if it is too long you might hit name length limit and test ID gets clipped.
+    return ($args{job_id});
 }

--- a/t/24_sdaf_naming_convention.t
+++ b/t/24_sdaf_naming_convention.t
@@ -131,8 +131,8 @@ subtest '[get_workload_vnet_code] ' => sub {
     dies_ok { get_workload_vnet_code() } 'Die with with no job id found';
 
     $mock_lib->redefine(find_deployment_id => sub { return '0079'; });
-    is get_workload_vnet_code(), 'SUT0079', 'Return correct VNET code with default values';
-    is get_workload_vnet_code(job_id => '0087'), 'SUT0087', 'Return correct VNET code defined by named argument';
+    is get_workload_vnet_code(), '0079', 'Return correct VNET code with default values';
+    is get_workload_vnet_code(job_id => '0087'), '0087', 'Return correct VNET code defined by named argument';
 };
 
 done_testing;

--- a/t/27_sdaf_configure_tfvars.t
+++ b/t/27_sdaf_configure_tfvars.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Test::Mock::Time;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use testapi;
+use sles4sap::sap_deployment_automation_framework::configure_tfvars;
+
+subtest '[prepare_tfvars_file] Test missing or incorrect args' => sub {
+    my @incorrect_deployment_types = qw(funny_library eployer sap_ workload _zone);
+    dies_ok { prepare_tfvars_file(); } 'Fail without specifying "$deployment_type"';
+    dies_ok { prepare_tfvars_file(deployment_type => $_); } "Fail with incorrect deployment type: $_" foreach @incorrect_deployment_types;
+};
+
+subtest '[prepare_tfvars_file] Test curl commands' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::configure_tfvars', no_auto => 1);
+    my $curl_cmd;
+    $ms_sdaf->redefine(assert_script_run => sub { $curl_cmd = $_[0] if grep(/curl/, $_[0]); return 1; });
+    $ms_sdaf->redefine(upload_logs => sub { return 1; });
+    $ms_sdaf->redefine(replace_tfvars_variables => sub { return 1; });
+    $ms_sdaf->redefine(get_os_variable => sub { return $_[0]; });
+    $ms_sdaf->redefine(set_workload_vnet_name => sub { return 'vnet'; });
+
+    $ms_sdaf->redefine(data_url => sub { return 'http://openqa.suse.de/data/' . join('', @_); });
+
+    # '-o' is only for checking if correct parameter gets picked from %tfvars_os_variable
+    my %expected_results = (
+        deployer => 'curl -v -fL http://openqa.suse.de/data/sles4sap/sap_deployment_automation_framework/DEPLOYER.tfvars -o deployer_parameter_file',
+        sap_system => 'curl -v -fL http://openqa.suse.de/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars -o sap_system_parameter_file',
+        workload_zone => 'curl -v -fL http://openqa.suse.de/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars -o workload_zone_parameter_file',
+        library => 'curl -v -fL http://openqa.suse.de/data/sles4sap/sap_deployment_automation_framework/LIBRARY.tfvars -o library_parameter_file'
+    );
+
+    for my $type (keys %expected_results) {
+        prepare_tfvars_file(deployment_type => $type);
+        is $curl_cmd, $expected_results{$type}, "Return correct url and tfvars variable";
+    }
+};
+
+done_testing;
+

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
@@ -5,15 +5,13 @@
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Deployment of the SAP systems zone using SDAF automation
 
-# Required OpenQA variables:
-#     'SDAF_WORKLOAD_VNET_CODE' Virtual network code for workload zone.
-
 use parent 'sles4sap::sap_deployment_automation_framework::basetest';
 
 use strict;
 use warnings;
 use sles4sap::sap_deployment_automation_framework::deployment
-  qw(serial_console_diag_banner load_os_env_variables prepare_tfvars_file sdaf_execute_deployment az_login);
+  qw(serial_console_diag_banner load_os_env_variables sdaf_execute_deployment az_login);
+use sles4sap::sap_deployment_automation_framework::configure_tfvars qw(prepare_tfvars_file);
 use sles4sap::sap_deployment_automation_framework::naming_conventions
   qw(generate_resource_group_name get_sdaf_config_path convert_region_to_short get_workload_vnet_code);
 use sles4sap::console_redirection;

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use sles4sap::sap_deployment_automation_framework::deployment;
 use sles4sap::sap_deployment_automation_framework::naming_conventions;
+use sles4sap::sap_deployment_automation_framework::configure_tfvars qw(prepare_tfvars_file);
 use sles4sap::console_redirection;
 use serial_terminal qw(select_serial_terminal);
 use testapi;
@@ -38,7 +39,7 @@ sub run {
     az_login();
     sdaf_execute_deployment(deployment_type => 'workload_zone');
 
-    # diconnect the console
+    # disconnect the console
     disconnect_target_from_serial();
 
     # reset temporary variables


### PR DESCRIPTION
This PR creates separate library with functions related to handling tfvars file template.

- Related ticket: https://jira.suse.com/browse/TEAM-9681

- Verification run: https://mordor.suse.cz/tests/538#
- Failure due to bug in SDAF: https://github.com/Azure/sap-automation/issues/641
- TFVARS file was filled in correctly though: https://mordor.suse.cz/tests/538/logfile?filename=workload_zone.tfvars.txt
