### PR TITLE
Disable TrustedLaunch and StrictHostKeyChecking accept-new for 12sp5

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -658,7 +658,7 @@ sub az_vm_as_create {
 
 Create a virtual machine
 
-=over 14
+=over 15
 
 =item B<resource_group> - existing resource group where to create the VM
 
@@ -690,6 +690,8 @@ Create a virtual machine
 =item B<ssh_pubkey> - optional inclusion in an availability set,
           if missing the command is configured to generate one
 
+=item B<security_type> - is used force a specific value for '--security-type'
+
 =back
 =cut
 
@@ -698,26 +700,35 @@ sub az_vm_create {
     foreach (qw(resource_group name image)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
 
-    $args{size} //= 'Standard_B1s';
-    my $region_cmd = $args{region} ? "-l $args{region}" : '';
-    my $as_cmd = $args{availability_set} ? "--availability-set $args{availability_set}" : '';
-    my $user_cmd = $args{username} ? "--admin-username $args{username}" : '';
-    my $nsg_cmd = $args{nsg} ? "--nsg $args{nsg}" : '';
-    my $cd_cmd = $args{custom_data} ? "--custom-data $args{custom_data}" : '';
-    my $nic_cmd = $args{nic} ? "--nics $args{nic}" : '';
-    my $pip_cmd = $args{public_ip} ? "--public-ip-address $args{public_ip}" : '';
-    my $vnet_cmd = $args{vnet} ? "--vnet-name $args{vnet}" : '';
-    my $snet_cmd = $args{snet} ? "--subnet $args{snet}" : '';
-    my $ssh_cmd = $args{ssh_pubkey} ? "--ssh-key-values $args{ssh_pubkey}" : '--authentication-type ssh --generate-ssh-keys';
 
-    my $az_cmd = join(' ', 'az vm create',
-        '--resource-group', $args{resource_group},
-        '-n', $args{name},
-        '--size', $args{size},
-        '--image', $args{image},
-        '--public-ip-address ""',
-        $region_cmd, $as_cmd, $vnet_cmd, $snet_cmd, $user_cmd, $nsg_cmd, $cd_cmd, $nic_cmd, $pip_cmd, $ssh_cmd);
-    assert_script_run($az_cmd, timeout => 600);
+    my @vm_create = ('az vm create');
+
+    push @vm_create, '--resource-group', $args{resource_group};
+    push @vm_create, '-n', $args{name};
+    push @vm_create, '--image', $args{image};
+    push @vm_create, '--public-ip-address ""';
+
+    $args{size} //= 'Standard_B1s';
+    push @vm_create, '--size', $args{size};
+
+    push @vm_create, '-l', $args{region} if $args{region};
+    push @vm_create, '--availability-set', $args{availability_set} if $args{availability_set};
+
+    push @vm_create, '--admin-username', $args{username} if $args{username};
+    push @vm_create, '--nsg', $args{nsg} if $args{nsg};
+    push @vm_create, '--custom-data', $args{custom_data} if $args{custom_data};
+    push @vm_create, '--nics', $args{nic} if $args{nic};
+    push @vm_create, '--public-ip-address', $args{public_ip} if $args{public_ip};
+    push @vm_create, '--vnet-name', $args{vnet} if $args{vnet};
+    push @vm_create, '--subnet', $args{snet} if $args{snet};
+    push @vm_create, '--security-type', $args{security_type} if $args{security_type};
+    if ($args{ssh_pubkey}) {
+        push @vm_create, '--ssh-key-values', $args{ssh_pubkey};
+    } else {
+        push @vm_create, '--authentication-type ssh --generate-ssh-keys';
+    }
+
+    assert_script_run(join(' ', @vm_create), timeout => 600);
 }
 
 =head2 az_vm_list

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -35,8 +35,13 @@ sub run {
     record_info("TEST STAGE", "Prepare all the ssh connections within the 2 internal VMs");
     my $bastion_ip = ipaddr2_bastion_pubip();
     ipaddr2_bastion_key_accept(bastion_ip => $bastion_ip);
-    ipaddr2_internal_key_accept(bastion_ip => $bastion_ip);
-    ipaddr2_internal_key_gen(bastion_ip => $bastion_ip);
+
+    my %int_key_args = (bastion_ip => $bastion_ip);
+    # unsupported option "accept-new" for default ssh used in 12sp5
+    $int_key_args{key_checking} = 'no' if (check_var('IPADDR2_KEYCHECK_OLD', '1'));
+
+    ipaddr2_internal_key_accept(%int_key_args);
+    ipaddr2_internal_key_gen(%int_key_args);
 
     if (check_var('IPADDR2_CLOUDINIT', 0)) {
         if (get_var('SCC_REGCODE_SLES4SAP')) {

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -39,7 +39,9 @@ sub run {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1));
     $deployment{scc_code} = get_var('SCC_REGCODE_SLES4SAP') if (get_var('SCC_REGCODE_SLES4SAP'));
+    $deployment{trusted_launch} = 0 if (check_var('IPADDR2_TRUSTEDLAUNCH', 0));
     ipaddr2_azure_deployment(%deployment);
+
     ipaddr2_deployment_sanity();
 }
 


### PR DESCRIPTION
Configure Standard security-type when creating VM using 12sp5 images.

Releted to [this article](https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch-faq?tabs=cli%2Cdebianbased#can-i-disable-trusted-launch-for-a-new-vm-deployment) 

- Related ticket: https://jira.suse.com/browse/TEAM-9714  https://jira.suse.com/browse/TEAM-9725

# Verification run:

sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test
 -  http://openqaworker15.qa.suse.cz/tests/298897 :green_circle: 
 -  http://openqaworker15.qa.suse.cz/tests/298981 :green_circle: 

sle-12-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-ipaddr2_azure_test IPADDR2_TRUSTEDLAUNCH=0
-  http://openqaworker15.qa.suse.cz/tests/298895 :green_circle:  / :red_circle:  `az vm create` is fixed but one more problem pop-up related to ssh `StrictHostKeyChecking`

sle-12-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-ipaddr2_azure_test IPADDR2_TRUSTEDLAUNCH=0 IPADDR2_KEYCHECK_OLD=1
- http://openqaworker15.qa.suse.cz/tests/298979 , http://openqaworker15.qa.suse.cz/tests/298980  :green_circle:  / :red_circle:  ssh `StrictHostKeyChecking` is fixed but one more problem pop-up related to `crm cluster join`
