### PR TITLE
Revert "Revert "Move qesap_az_validate_uuid_pattern""

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -35,6 +35,7 @@ use YAML::PP;
 use utils qw(file_content_replace);
 use version_utils 'is_sle';
 use publiccloud::utils qw(get_credentials);
+use sles4sap::azure_cli;
 use mmapi 'get_current_job_id';
 use testapi;
 use Exporter 'import';
@@ -102,7 +103,6 @@ our @EXPORT = qw(
   qesap_az_enable_system_assigned_identity
   qesap_az_assign_role
   qesap_az_get_tenant_id
-  qesap_az_validate_uuid_pattern
   qesap_az_create_sas_token
   qesap_az_list_container_files
   qesap_az_diagnostic_log
@@ -2258,7 +2258,7 @@ sub qesap_az_enable_system_assigned_identity {
             "-n '$args{vm_name}'",
             "--query 'systemAssignedIdentity'",
             '-o tsv'));
-    die 'Returned output does not match ID pattern' if qesap_az_validate_uuid_pattern($identity_id) eq 0;
+    die 'Returned output does not match ID pattern' if az_validate_uuid_pattern(uuid => $identity_id) eq 0;
     return $identity_id;
 }
 
@@ -2304,26 +2304,8 @@ sub qesap_az_get_tenant_id {
     my $az_cmd = "az account show --only-show-errors";
     my $az_cmd_args = "--subscription $subscription_id --query 'tenantId' -o tsv";
     my $tenant_id = script_output(join(' ', $az_cmd, $az_cmd_args));
-    croak 'Returned output does not match ID pattern' if qesap_az_validate_uuid_pattern($tenant_id) eq 0;
+    croak 'Returned output does not match ID pattern' if az_validate_uuid_pattern(uuid => $tenant_id) eq 0;
     return $tenant_id;
-}
-
-=head2 qesap_az_validate_uuid_pattern
-
-    qesap_az_validate_uuid_pattern( uuid_string=>$uuid_string )
-
-    Function checks input string against uuid pattern
-    which is commonly used as an identifier for azure resources.
-    returns uuid (true) on match, 0 (false) on mismatch.
-
-=cut
-
-sub qesap_az_validate_uuid_pattern {
-    my ($uuid_string) = @_;
-    my $pattern = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
-    return $uuid_string if ($uuid_string =~ /$pattern/);
-    diag("String did not match UUID pattern:\nString: '$uuid_string'\nPattern: '$pattern'");
-    return 0;
 }
 
 =head2 qesap_az_create_sas_token

--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -55,6 +55,7 @@ our @EXPORT = qw(
   az_network_peering_delete
   az_disk_create
   az_resource_delete
+  az_validate_uuid_pattern
 );
 
 
@@ -1368,10 +1369,11 @@ Arguments B<name> and B<ids> are mutually exclusive.
 
 sub az_resource_delete {
     my (%args) = @_;
-    $args{timeout} //= 60;
     croak "Mandatory argument 'resource_group' missing" unless $args{resource_group};
     croak "Arguments 'name' and 'ids' are mutually exclusive" if $args{ids} and $args{name};
     croak "Argument 'name' or 'ids' has to be specified" unless $args{ids} or $args{name};
+    $args{timeout} //= 60;
+
     my @az_command = ('az resource delete',
         "--resource-group $args{resource_group}"
     );
@@ -1380,3 +1382,28 @@ sub az_resource_delete {
 
     assert_script_run(join(' ', @az_command), timeout => $args{timeout});
 }
+
+=head2 az_validate_uuid_pattern
+
+    az_validate_uuid_pattern( uuid => $uuid_string )
+
+    Function checks input string against uuid pattern
+    which is commonly used as an identifier for Azure resources.
+    returns uuid (true) on match, 0 (false) on mismatch.
+
+=over 1
+
+=item B<uuid> UUID string to test.
+
+=back
+=cut
+
+sub az_validate_uuid_pattern {
+    my (%args) = @_;
+    croak "Mandatory argument 'uuid' missing" unless $args{uuid};
+    my $pattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+    return $args{uuid} if ($args{uuid} =~ /$pattern/i);
+    diag("String did not match UUID pattern:\nString: '$args{uuid}'\nPattern: '$pattern'");
+    return 0;
+}
+

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -199,22 +199,6 @@ subtest '[qesap_az_assign_role]' => sub {
     ok((any { /az role assignment/ } @calls), 'az command properly composed');
 };
 
-subtest '[qesap_az_validate_uuid_pattern]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
-    $qesap->redefine(diag => sub { return; });
-    my $good_uuid = 'c0ffeeee-c0ff-eeee-1234-123456abcdef';
-    my @bad_uuid_list = ('OhCaptainMyCaptain',    # complete nonsense
-        'c0ffeee-c0ff-eeee-1234-123456abcdef',    # First 7 characters inttead of 8
-        'c0ffeeee-c0ff-eeee-xxxx-123456abcde',    # Using non hexadecimal values 'x'
-        'c0ffeeee_c0ff-eeee-1234-123456abcdef');    # Underscore instead of dash
-
-    is qesap_az_validate_uuid_pattern($good_uuid), $good_uuid, "Return UUID if valid: $good_uuid ";
-
-    foreach my $bad_uuid (@bad_uuid_list) {
-        is qesap_az_validate_uuid_pattern($bad_uuid), 0, "Return '0' with invalid UUID: $bad_uuid";
-    }
-};
-
 subtest '[qesap_az_enable_system_assigned_identity] Missing arguments' => sub {
     my $vm_name = 'CaptainHook';
 
@@ -239,7 +223,7 @@ subtest '[qesap_az_get_tenant_id]' => sub {
 
     my $valid_uuid = 'c0ffeeee-c0ff-eeee-1234-123456abcdef';
     $qesap->redefine(script_output => sub { return $valid_uuid; });
-    $qesap->redefine(qesap_az_validate_uuid_pattern => sub { return $valid_uuid; });
+    #$qesap->redefine(az_validate_uuid_pattern => sub { return $valid_uuid; });
     is qesap_az_get_tenant_id($valid_uuid), 'c0ffeeee-c0ff-eeee-1234-123456abcdef', 'Returned value is a valid UUID';
 };
 

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -750,4 +750,28 @@ subtest '[az_network_vnet_subnet_update]' => sub {
     ok((any { /az network vnet subnet update/ } @calls), 'Correct composition of the main command');
 };
 
+subtest '[az_validate_uuid_pattern] valid UUID' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    $azcli->redefine(diag => sub { return; });
+    my @uuid_list = ('c0ffeeee-c0ff-eeee-1234-123456abcdef',
+        'C0fFeeee-c0ff-EEEE-1234-123456ABcdEF');
+
+    foreach my $good_uuid (@uuid_list) {
+        is az_validate_uuid_pattern(uuid => $good_uuid), $good_uuid, "Return UUID if valid: $good_uuid ";
+    }
+};
+
+subtest '[az_validate_uuid_pattern] invalid UUID' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    $azcli->redefine(diag => sub { return; });
+    my @uuid_list = ('OhCaptainMyCaptain',    # complete nonsense
+        'c0ffeee-c0ff-eeee-1234-123456abcdef',    # First 7 characters inttead of 8
+        'c0ffeeee-c0ff-eeee-xxxx-123456abcde',    # Using non hexadecimal values 'x'
+        'c0ffeeee_c0ff-eeee-1234-123456abcdef');    # Underscore instead of dash
+
+    foreach my $bad_uuid (@uuid_list) {
+        is az_validate_uuid_pattern(uuid => $bad_uuid), 0, "Return '0' with invalid UUID: $bad_uuid";
+    }
+};
+
 done_testing;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#20322

Re-add https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20288

Related ticket: https://jira.suse.com/browse/TEAM-9365

SDAF test is failing from Friday, no clue about how it could be related to this PR but try to remove it.