### PR TITLE
Fix partition label check for Base and Default aarch64

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -111,7 +111,8 @@ sub verify_partition_label {
 
     # The RPi firmware needs MBR. s390x images also use MBR.
     # Note: JeOS-for-RaspberryPi means "kiwi-templates-Minimal" and JeOS-for-RPi means "community JeOS".
-    if (is_s390x || check_var('FLAVOR', 'JeOS-for-RaspberryPi') || check_var('FLAVOR', 'JeOS-for-RPi')) {
+    # In sle-micro the raw aarch64 images are used for RPi, hence they have contain `dos`
+    if (is_s390x || check_var('FLAVOR', 'JeOS-for-RaspberryPi') || check_var('FLAVOR', 'JeOS-for-RPi') || (is_sle_micro && is_aarch64 && get_var('FLAVOR', '') =~ /(^Base$|^Default$)/)) {
         $label = 'dos';
     }
 


### PR DESCRIPTION
`dos` partition table is used for images intended for RPi usage. Failing check https://openqa.suse.de/tests/15582485#

- Verification run: https://openqa.suse.de/tests/15589869#step/firstrun/72
