### PR TITLE
OpenSSL3 should fail with default PKCS padding in FIPS mode

### DIFF
--- a/tests/fips/openssl/openssl_pubkey_rsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_rsa.pm
@@ -45,10 +45,14 @@ sub run_fips_rsa_tests {
 
         my $openssl_version = script_output("$openssl_binary version -v | awk '{print \$2}'");
         if (package_version_cmp($openssl_version, '3.0.0') > 0) {
-            # Encrypt with public key
-            assert_script_run "$openssl_binary pkeyutl -encrypt -in $file_raw -inkey $rsa_pubkey -pubin -out $file_enc -pkeyopt rsa_padding_mode:oaep";
-            # Decrypt with private key
-            assert_script_run "$openssl_binary pkeyutl -decrypt -in $file_enc -inkey $rsa_prikey -out $file_dec -pkeyopt rsa_padding_mode:oaep";
+            my $encrypt_cmd = "$openssl_binary pkeyutl -encrypt -in $file_raw -inkey $rsa_pubkey -pubin -out $file_enc";
+            my $decrypt_cmd = "$openssl_binary pkeyutl -decrypt -in $file_enc -inkey $rsa_prikey -out $file_dec";
+            # should fail without oaep padding and pass with oeap padding
+            validate_script_output "$encrypt_cmd 2>&1", sub { m/illegal or unsupported padding mode/ }, proceed_on_failure => 1;    # Encrypt with public key
+            validate_script_output "$decrypt_cmd 2>&1", sub { m/illegal or unsupported padding mode/ }, proceed_on_failure => 1;    # Decrypt with private key
+            my $oaep_options = " -pkeyopt rsa_padding_mode:oaep";
+            assert_script_run $encrypt_cmd . $oaep_options;    # Encrypt with public key
+            assert_script_run $decrypt_cmd . $oaep_options;    # Decrypt with private key
         } else {
             # Encrypt with public key
             assert_script_run "$openssl_binary rsautl -encrypt -in $file_raw -inkey $rsa_pubkey -pubin -out $file_enc";


### PR DESCRIPTION
Add negative testing for PKCS padding

- Related ticket: https://progress.opensuse.org/issues/165869
- Needles: n/a
- Verification runs:
  - https://openqa.suse.de/tests/15589865
  - https://openqa.suse.de/tests/15589866
  - https://openqa.suse.de/tests/15589867