### PR TITLE
Inject console parameters in GRUB2

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -57,6 +57,7 @@ sub load_boot_from_disk_tests {
     # read FIRST_BOOT_CONFIG in order to know how the image will be configured
     # ignition|combustion|ignition+combustion is considered as default path
     if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
+        loadtest 'installation/bootloader_uefi' unless is_vmware || is_s390x;
         loadtest 'jeos/firstrun';
     } elsif (check_var('FIRST_BOOT_CONFIG', 'cloud-init')) {
         unless (is_s390x) {


### PR DESCRIPTION
Due to https://bugzilla.suse.com/show_bug.cgi?id=1229336 the `console=` parameters are gone, jeos-firstboot wizard shows in ttyS0 instead of tty.
We need to inject these parameters at boottime and bring back the grub2 handler module. -> https://src.suse.de/products/SL-Micro/pulls/59/files

- [failure](https://openqa.suse.de/tests/15590388#step/firstrun/6)

#### Verification runs

* [sle-micro-6.1-Base-aarch64-Build21.3-default@aarch64](https://openqa.suse.de/tests/15598772)
* [slem6.1](http://kepler.suse.cz/tests/24038#step/bootloader_uefi/5)
* [microos-Tumbleweed-DVD-x86_64-Build20241002-microos-sdboot@uefi-2G](http://kepler.suse.cz/tests/24033#step/bootloader_uefi/5)
* [opensuse-Tumbleweed-DVD-x86_64-Build20241002-create_hdd_textmode_uefi@uefi](http://kepler.suse.cz/tests/24034#step/bootloader_uefi/6)
* [microos-Tumbleweed-MicroOS-Image-x86_64-Build20241002-microos-wizard@64bit](http://kepler.suse.cz/tests/24035#step/bootloader_uefi/4)
* [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20241002-jeos@64bit_virtio ](http://kepler.suse.cz/tests/24036#step/bootloader_uefi/5)
* [sle-15-SP2-JeOS-for-kvm-and-xen-Updates-x86_64-Build20241003-1-jeos-containers-docker@uefi-virtio-vga](http://kepler.suse.cz/tests/24037#step/bootloader_uefi/5)
* [12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20241002-1-jeos-kdump@64bit-virtio-vga](http://kepler.suse.cz/tests/24040#step/bootloader_uefi/5)
* [sle-15-SP7-Full-x86_64-Build23.2-skip_registration+workaround_modules@uefi](http://kepler.suse.cz/tests/24041#step/bootloader_uefi/7)
* [sle-15-SP6-JeOS-for-kvm-and-xen-Updates-x86_64-Build20241003-1-jeos-kdump@uefi-virtio-vga](http://kepler.suse.cz/tests/24042#step/bootloader_uefi/5)
