### PR TITLE
Control DB image using OpenQA parameter

### DIFF
--- a/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars
+++ b/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars
@@ -231,13 +231,13 @@ database_vm_use_DHCP = true
 # in this case os_type must also be specified
 
 database_vm_image = {
-  os_type = "LINUX",
-  source_image_id = "",
-  publisher = "SUSE",
-  offer = "sles-sap-15-sp5",
-  sku = "gen2",
-  version = "latest",
-  type = "marketplace"
+  os_type = "%SDAF_DB_IMAGE_OS_TYPE%",
+  source_image_id = "%SDAF_DB_SOURCE_IMAGE_ID%",
+  publisher = "%SDAF_DB_IMAGE_PUBLISHER%",
+  offer = "%SDAF_DB_IMAGE_OFFER%",
+  sku = "%SDAF_DB_IMAGE_SKU%",
+  version = "%SDAF_DB_IMAGE_VERSION%",
+  type = "%SDAF_DB_IMAGE_TYPE%"
 }
 
 # database_vm_zones is an optional list defining the availability zones to deploy the database servers

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -863,6 +863,7 @@ sub ansible_hanasr_show_status {
         "--inventory=$args{sap_sid}_hosts.yaml",
         '--module-name=shell');
 
+    record_info('OS info', script_output(join(' ', @cmd, '--args="cat /etc/os-release"', '2> /dev/null')));
     record_info('CRM status', script_output(join(' ', @cmd, '--args="sudo crm status full"', '2> /dev/null')));
     record_info('HANA SR', script_output(join(' ', @cmd, '--args="sudo SAPHanaSR-showAttr"', '2> /dev/null')));
 }


### PR DESCRIPTION
This PR adds funtion to control DB vm OS image by parsing OpenQA parameter 
'PUBLIC_CLOUD_IMAGE_ID'.

- Related ticket: https://jira.suse.com/browse/TEAM-9681
- Verification run: 

15SP6: :red_circle:  - failure not related = playbook timeout
PUBLIC_CLOUD_IMAGE_ID = suse:sles-sap-15-sp6:gen2:latest
https://openqaworker15.qa.suse.cz/tests/301485#
https://openqaworker15.qa.suse.cz/tests/301485/logfile?filename=deploy_sap_system_attempt-1.txt
```
      + source_image_reference {
          + offer     = "sles-sap-15-sp6"
          + publisher = "suse"
          + sku       = "gen2"
          + version   = "latest"
        }
```

15SP5: :orange_circle: 
PUBLIC_CLOUD_IMAGE_ID =  suse:sles-sap-15-sp5:gen2:latest
https://openqaworker15.qa.suse.cz/tests/301466#step/deploy_hanasr/255

15SP4: :orange_circle:
PUBLIC_CLOUD_IMAGE_ID =  suse:sles-sap-15-sp4:gen2:latest
https://openqaworker15.qa.suse.cz/tests/301464#step/deploy_hanasr/255

15SP3: :red_circle: 
PUBLIC_CLOUD_IMAGE_ID =  suse:sles-sap-15-sp3:gen2:latest
https://openqaworker15.qa.suse.cz/tests/301487#
- failure not related - a workaround is applied on 15SP3 while it shouldn't
- image being used can be found in terraform output 

```
      + source_image_reference {
          + offer     = "sles-sap-15-sp3"
          + publisher = "suse"
          + sku       = "gen2"
          + version   = "latest"
        }
```