### PR TITLE
Implement port 22 status detection

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -175,10 +175,8 @@ sub sles4sap_cleanup {
             'network_peering_present:', $args{network_peering_present} // 'undefined',
             'ansible_present:', $args{ansible_present} // 'undefined'));
 
-    my $ret = 0;
-
     # Do not run destroy if already executed
-    return $ret if ($args{cleanup_called});
+    return 0 if ($args{cleanup_called});
 
     # If there's an open ssh connection to the VMs, return to host console first
     select_host_console(force => 1);
@@ -202,6 +200,8 @@ sub sles4sap_cleanup {
     # Regardless of Ansible result, Terraform destroy
     # must be executed.
     push(@cmd_list, 'terraform');
+
+    my $ret = 0;
     for my $command (@cmd_list) {
         record_info('Cleanup', "Executing $command cleanup");
 
@@ -408,13 +408,26 @@ sub stop_hana {
             rc_only => 1,
             ssh_opts => $crash_ssh_opts);
 
-        # Wait till ssh disappear
-        record_info("Wait ssh disappear start");
-        my $out = $self->{my_instance}->wait_for_ssh(timeout => 60, wait_stop => 1);
-        record_info("Wait ssh disappear end", "out:" . ($out // 'undefined'));
+        # Wait till ssh port 22 disappear
+        record_info('Wait ssh disappear', 'START');
+        my $start_time = time();
+        my $exit_code;
+        my $nc_error_occurrence = 0;
+        while (((time() - $start_time) < 900) and ($nc_error_occurrence < 5)) {
+            $exit_code = script_run('nc -vz -w 1 ' . $self->{my_instance}->{public_ip} . ' 22', quiet => 1);
+            $nc_error_occurrence += 1 if (!defined($exit_code) or $exit_code ne 0);
+        }
+        my $end_msg = join("\n",
+            'END',
+            "started at $start_time",
+            'elapsed:' . (time() - $start_time),
+            "nc_error_occurrence:$nc_error_occurrence",
+            "last exit_code:$exit_code");
+        record_info('Wait ssh disappear', $end_msg);
+
         # wait for node to be ready
         wait_hana_node_up($self->{my_instance}, timeout => 900);
-        $out = $self->{my_instance}->wait_for_ssh(timeout => 900);
+        my $out = $self->{my_instance}->wait_for_ssh(timeout => 900);
         record_info("Wait ssh is back again", "out:" . ($out // 'undefined'));
     }
     else {

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -187,6 +187,7 @@ subtest "[stop_hana]" => sub {
 };
 
 subtest "[stop_hana] crash" => sub {
+    my @calls;
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $sles4sap_publiccloud->redefine(type_string => sub { note(join(' ', 'TYPED -->', @_)); });
@@ -194,17 +195,18 @@ subtest "[stop_hana] crash" => sub {
     $sles4sap_publiccloud->redefine(wait_hana_node_up => sub { return; });
     $sles4sap_publiccloud->redefine(serial_term_prompt => sub { return '# '; });
     $sles4sap_publiccloud->redefine(wait_serial => sub { return; });
+    $sles4sap_publiccloud->redefine(script_run => sub { push @calls, $_[0]; return 1; });
 
     my $self = sles4sap_publiccloud->new();
     my $mock_pc = Test::MockObject->new();
     $mock_pc->set_true('wait_for_ssh');
-    my @calls;
     $mock_pc->mock('run_ssh_command', sub {
             my ($self, %args) = @_;
             push @calls, $args{cmd};
             return 'BABUUUUUUUUM' });
     $mock_pc->mock('ssh_opts', sub { return '-i .ssh/id_rsa'; });
     $self->{my_instance} = $mock_pc;
+    $self->{my_instance}->{public_ip} = '1.2.3.4';
 
     $self->stop_hana(method => 'crash');
     note("\n  C -->  " . join("\n  C -->  ", @calls));


### PR DESCRIPTION
Implement code in sles4sap PC lib to detect when remote SUT port 22 become unavailable.


- Related ticket: https://jira.suse.com/browse/TEAM-9652

# Verification run: 

 - sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-10-04T02:03:19Z-hanasr_aws_test_saptune_fencing_native_crash@ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/299297