### PR TITLE
Create GrubMenuAgamaPage with base class

### DIFF
--- a/lib/Distribution/Sle/AgamaDevel.pm
+++ b/lib/Distribution/Sle/AgamaDevel.pm
@@ -12,6 +12,7 @@ use strict;
 use warnings FATAL => 'all';
 use parent 'susedistribution';
 
+use Yam::Agama::Pom::GrubMenuBasePage;
 use Yam::Agama::Pom::GrubMenuAgamaPage;
 use Yam::Agama::Pom::GrubEntryEditionPage;
 use Yam::Agama::Pom::AgamaUpAndRunningSlePage;
@@ -20,7 +21,9 @@ use Yam::Agama::Pom::RebootPage;
 use Utils::Architectures;
 
 sub get_grub_menu_agama {
-    return Yam::Agama::Pom::GrubMenuAgamaPage->new();
+    return Yam::Agama::Pom::GrubMenuAgamaPage->new({
+            grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()
+    });
 }
 
 sub get_grub_entry_edition {

--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -8,6 +8,5 @@ schedule:
   - yam/agama/agama
   - installation/grub_test
   - installation/first_boot
-  - console/system_prepare
   - yam/validate/validate_product
   - yam/validate/validate_first_user


### PR DESCRIPTION
- Related ticket: [poo#167470](https://progress.opensuse.org/issues/167470)
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle&version=agama-10.0&build=jknphy%2Fos-autoinst-distri-opensuse%23fix-grub-menu-agama
