### PR TITLE
Add support for kernel livepatching on SL Micro 6.0+

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -62,7 +62,11 @@ sub load_kernel_tests {
             loadtest_kernel 'update_kernel';
         }
         if (is_transactional && (get_var('FLAVOR', '') =~ /-Staging|-Updates/)) {
-            loadtest 'transactional/install_updates';
+            if (get_var('KGRAFT')) {
+                loadtest_kernel 'update_kernel';
+            } else {
+                loadtest 'transactional/install_updates';
+            }
         }
         loadtest_kernel 'install_ltp';
 

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -15,7 +15,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Backends;
 use LTP::utils;
-use version_utils qw(is_jeos is_sle);
+use version_utils qw(is_jeos is_sle is_sle_micro);
 use utils 'assert_secureboot_status';
 use kdump_utils;
 
@@ -60,7 +60,7 @@ sub run {
 
     # check kGraft patch if KGRAFT=1
     if (check_var('KGRAFT', '1') && !check_var('REMOVE_KGRAFT', '1')) {
-        my $lp_tag = is_sle('>=15-sp4') ? 'lp' : 'lp-';
+        my $lp_tag = (is_sle('>=15-sp4') || is_sle_micro) ? 'lp' : 'lp-';
         assert_script_run("uname -v | grep -E '(/kGraft-|/${lp_tag})'");
     }
 

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -328,7 +328,7 @@ sub run {
 
     # check kGraft if KGRAFT=1
     if (check_var("KGRAFT", '1') && !check_var('REMOVE_KGRAFT', '1')) {
-        my $lp_tag = is_sle('>=15-sp4') ? 'lp' : 'lp-';
+        my $lp_tag = (is_sle('>=15-sp4') || is_sle_micro) ? 'lp' : 'lp-';
         assert_script_run("uname -v | grep -E '(/kGraft-|/${lp_tag})'");
     }
 


### PR DESCRIPTION
This change introduces support for SLE Micro 6.0 and newer. There is a
difference in the live patching setup compared to previous
versions. Unlike SLE or SLE Micro 5.x, there is no additional live
patching product. Live patches are now part of the main repository.

The testing logic has also changed. There are no maintenance
incidents, as updates are tested in stagings. The staging repository
is represented by the variable `OS_TEST_REPOS`, which is the same for
other staging tests and is not specific to live patching. Kernel and
live patches tested in staging repositories contain `stage` in their
names and have a `99999` version.



- Related ticket: none
- Needles: none

### Verification runs
#### Base-RT-Livepatches-Updates-Staging: 
- Staging H: https://openqa.suse.de/tests/overview?groupid=562&distri=sle-micro&version=6.0&build=H.34.1 (manually set to failed due to bug bsc#1231397)
- install_ltp: https://openqa.suse.de/tests/15656608#step/install_ltp/87
- boot_ltp: https://openqa.suse.de/tests/15656671#step/boot_ltp/64

#### Base-Livepatches-Updates-Staging:
- Staging B: https://openqa.suse.de/tests/overview?distri=sle-micro&version=6.0&build=B.38.1&groupid=562
- install_ltp: https://openqa.suse.de/tests/15657455#step/install_ltp/84
- boot_ltp:  https://openqa.suse.de/tests/15657456#step/boot_ltp/62
