### PR TITLE
Move cursor during Agama auto installation

### DIFF
--- a/lib/Yam/Agama/Pom/RebootPage.pm
+++ b/lib/Yam/Agama/Pom/RebootPage.pm
@@ -22,7 +22,26 @@ sub new {
 
 sub expect_is_shown {
     my ($self, %args) = @_;
-    assert_screen($self->{tag_installation_complete}, $args{timeout});
+    my $timeout = $args{timeout};
+    if ($timeout <= 1200) {
+        assert_screen($self->{tag_installation_complete}, ${timeout});
+    } else {
+        my $mouse_x = 1;
+        while (1) {
+            die "timeout ($timeout) hit on during installation" if $timeout <= 0;
+            if (check_screen $self->{tag_installation_complete}, 30) {
+                last;
+            } else {
+                $timeout -= 30;
+                diag("left total timeout: $timeout");
+                diag('installation not finished, move mouse around a bit to keep screen unlocked');
+                mouse_set(($mouse_x + 10) % 1024, 1);
+                sleep 1;
+                mouse_set($mouse_x, 1);
+                next;
+            }
+        }
+    }
 }
 
 sub reboot {

--- a/schedule/yam/agama_auto_gnome.yaml
+++ b/schedule/yam/agama_auto_gnome.yaml
@@ -1,0 +1,15 @@
+---
+name: agama_auto_gnome
+description: >
+  Prepare url for agama.auto boot parameter, boot.
+  perform auto-installation with agama gnome patterns.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - yam/agama/switch_to_product
+  - installation/first_boot
+  - installation/opensuse_welcome
+  - console/system_prepare
+  - yam/validate/validate_product
+  - yam/validate/validate_first_user

--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -14,7 +14,7 @@ use testapi;
 sub run {
     my $reboot_page = $testapi::distri->get_reboot();
 
-    $reboot_page->expect_is_shown(timeout => 2400);
+    $reboot_page->expect_is_shown(timeout => ((get_var('DESKTOP') eq 'gnome') ? 2400 : 1200));
 
     select_console 'root-console';
     Yam::Agama::agama_base::upload_agama_logs();

--- a/tests/yam/agama/switch_to_product.pm
+++ b/tests/yam/agama/switch_to_product.pm
@@ -1,0 +1,20 @@
+## Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Switch VERSION to the auto installed system name and
+#          reset consoles for gnome desktop/
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base Yam::Agama::agama_base;
+use strict;
+use warnings;
+use testapi qw(reset_consoles get_var set_var);
+use scheduler 'get_test_suite_data';
+
+sub run {
+    my $self = shift;
+    reset_consoles if (get_var('DESKTOP') eq 'gnome');
+    set_var('VERSION', 'Tumbleweed') if (get_test_suite_data()->{os_release_name} =~ /Tumbleweed/);
+}
+
+1;


### PR DESCRIPTION
##
### Move cursor during installation to prevent the screen locked

- Related ticket:  https://progress.opensuse.org/issues/167060
- Needles: `first_boot-displaymanager-20241009`
- Verification run: 
   -  [**20_cases**](https://openqa.opensuse.org/tests/overview?arch=x86_64&flavor=&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=&build=hjluo&version=agama-9.0&distri=opensuse#)

##   
