### PR TITLE
Transactional update soft reboot support in MicroOS

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -17,11 +17,45 @@ use power_action_utils 'power_action';
 use Utils::Architectures qw(is_aarch64);
 use Utils::Backends qw(is_ipmi);
 
-our @EXPORT = qw(microos_reboot microos_login);
+our @EXPORT = qw(microos_reboot handle_microos_reboot microos_login);
+
+sub soft_reboot_consoles_fix {
+    my (%args) = @_;
+    $args{timeout} //= 600;
+    $args{interval} //= 10;
+    my $start_time = time;    # Track the start time
+    my $succeeded = 0;
+
+    while (!$succeeded && (time - $start_time < $args{timeout})) {
+        $succeeded = 1 if check_screen('linux-login-microos', $args{interval});
+        last if $succeeded;
+        record_soft_failure "Fixaround for bsc#1231986";
+        record_info("Jump to tty3");
+        send_key check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f3' : 'ctrl-alt-f3';
+        sleep 2;
+
+        record_info("Jump to tty1");
+        send_key check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f1' : 'ctrl-alt-f1';
+        sleep 2;
+
+        record_info("Jump to tty2");
+        send_key check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f2' : 'ctrl-alt-f2';
+        sleep 2;
+
+    }
+    die "linux-login-microos screen not found after timeout" unless $succeeded;
+}
 
 # Assert login prompt and login as root
 sub microos_login {
+    my (%args) = @_;
+    $args{soft_reboot} //= 0;
+
+    reset_consoles();
+
     my $login_timeout = (is_aarch64 || is_selfinstall) ? 300 : 150;
+    soft_reboot_consoles_fix() if $args{soft_reboot};
+
     assert_screen 'linux-login-microos', $login_timeout;
 
     if (is_microos 'VMX') {
@@ -37,11 +71,7 @@ sub microos_login {
     assert_script_run 'clear';
 }
 
-# Process reboot with an option to trigger it
-sub microos_reboot {
-    my $trigger = shift // 0;
-    power_action('reboot', observe => !$trigger, keepconsole => 1);
-
+sub handle_microos_reboot {
     # sol console has to be selected for ipmi backend before asserting grub needle.
     select_console 'sol', await_console => 0 if is_ipmi();
     # No grub bootloader on xen-pv
@@ -51,6 +81,13 @@ sub microos_reboot {
     send_key('ret') unless get_var('KEEP_GRUB_TIMEOUT');
     unlock_if_encrypted if need_unlock_after_bootloader;
     microos_login;
+}
+
+# Process reboot with an option to trigger it
+sub microos_reboot {
+    my $trigger = shift // 0;
+    power_action('reboot', observe => !$trigger, keepconsole => 1);
+    handle_microos_reboot;
 }
 
 1;


### PR DESCRIPTION
Add support for soft-reboot in `transactional-update reboot pkg install`

- Related ticket: https://progress.opensuse.org/issues/163352
- Verification run: https://openqa.opensuse.org/tests/overview?build=volodymyrkatkalov%2Fos-autoinst-distri-opensuse%23reboot_mgr_soft_reboot_fix&distri=microos&version=Staging%3AE
https://openqa.opensuse.org/tests/overview?build=volodymyrkatkalov%2Fos-autoinst-distri-opensuse%23reboot_mgr_soft_reboot_fix&distri=microos&version=Staging%3AD