### PR TITLE
containers: Add new directory for runc test helpers

### DIFF
--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -64,7 +64,7 @@ sub run {
     assert_script_run "cd $test_dir/runc-$runc_version/";
 
     # Compile helpers used by the tests
-    script_run "make \$(ls contrib/cmd/)";
+    script_run "make \$(basename -a contrib/cmd/* tests/cmd/*)";
 
     run_tests(rootless => 1, skip_tests => get_var('RUNC_BATS_SKIP_USER', ''));
 


### PR DESCRIPTION
Since https://github.com/opencontainers/runc/commit/f76489f0afe680f227a67c703f234f6c2d4357e8 all helpers changed directory.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1230234
- Failing test: https://openqa.opensuse.org/tests/4541669
- Verification run: https://openqa.opensuse.org/tests/4543726
