### PR TITLE
containers: Use a robust way to find runc test helpers

### DIFF
--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -64,7 +64,8 @@ sub run {
     assert_script_run "cd $test_dir/runc-$runc_version/";
 
     # Compile helpers used by the tests
-    script_run "make \$(basename -a contrib/cmd/* tests/cmd/*)";
+    my $cmds = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d -printf '%f ' || true";
+    script_run "make $cmds";
 
     run_tests(rootless => 1, skip_tests => get_var('RUNC_BATS_SKIP_USER', ''));
 


### PR DESCRIPTION
Use a more robust way to find runc test helpers, as we may get `*` if either `contrib/cmd` or `tests/cmd` is empty.

- Verification run: https://openqa.suse.de/tests/15635581