### PR TITLE
Update grub menu tag for more product

### DIFF
--- a/lib/Yam/Agama/Pom/GrubMenuTumbleweedPage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuTumbleweedPage.pm
@@ -15,7 +15,7 @@ sub new {
     my ($class, $args) = @_;
     return bless {
         grub_menu_base => $args->{grub_menu_base},
-        tag_first_entry_highlighted => 'grub-menu-openSUSE-Tumbleweed-highlighted',
+        tag_first_entry_highlighted => 'grub-menu-openSUSE-highlighted',
     }, $class;
 }
 


### PR DESCRIPTION


- Related ticket:  https://progress.opensuse.org/issues/167087
- Needles: 'grub-menu-openSUSE-Tumbleweed-highlighted' -> 'grub-menu-openSUSE-highlighted' merged in O3
- Verification run: https://openqa.opensuse.org/tests/4542567#step/boot_full_disk_encryption/2
