### PR TITLE
Avoid mem_encrypt=on due to bsc#1224107

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -69,8 +69,8 @@
       % if ($check_var->('SYSTEM_ROLE', 'kvm')) {
         % if ($check_var->('AMD', '1')) {
           % if ($check_var->('VIRT_SEV_ES_GUEST_INSTALL', '1')) {
-            <!-- Do not add mem_encrypt=on option on 15-SP6 KVM host due to bsc#1224107 -->
-            % if ($check_var->('VERSION', '15-SP6')) { 
+            <!-- Do not add mem_encrypt=on on kernel command line for amd-zen3-gpu-sut1 which is the only machine affected by bsc#1224107 -->
+            % if ($get_var->('WORKER_CLASS', 'EMPTY_WORKER_CLASS') =~ /amd-zen3-gpu-sut1/) { 
       <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty kvm_amd.sev=1 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS', '') %></append>
             % } else {
       <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty mem_encrypt=on kvm_amd.sev=1 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS', '') %></append>


### PR DESCRIPTION
* **Do** not use ```mem_encrypt=on``` on kernel command line for qualified AMD machines, because there is product bug to be fixed. Please refer to bsc#1224107 for more information.

* **At** the moment, only ```amd-zen3-gpu-sut1-1``` machine is affected by bsc#1224107. Do not add ```mem_encrypt=on``` on its kernel command line.

* **Verification Runs:**
  * [sev/es 15sp6 on 15sp7 with amd-zen3-gpu-sut1](https://openqa.suse.de/tests/17340219)
  * [sev/es 15sp7 on 15sp6 with amd-zen3-gpu-sut1](https://openqa.suse.de/tests/17293882)
  * [sev/es 15sp7 on 15sp7 with amd-zen3-gpu-sut1](https://openqa.suse.de/tests/17293883)
  * [sev/es guest installation with WORKER_CLASS=amd-zen3-gpu-sut1](https://openqa.suse.de/tests/17349659)
  * [sev/es test with bare-metal3](https://openqa.suse.de/tests/17340221)
  * [sev/es test with bare-metal2](https://openqa.suse.de/tests/17294760)
  * [guest installation on 15sp7 xen](https://openqa.suse.de/tests/17318303)
  * [uefi guest installation on 15sp6 xen](https://openqa.suse.de/tests/17318305)
  * [guest installation on 15sp7 kvm](https://openqa.suse.de/tests/17340224)
  * [uefi guest installation on 15sp6 kvm](https://openqa.suse.de/tests/17340225)

