### PR TITLE
containers: Run podman upstream tests on its own job

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -298,12 +298,9 @@ sub load_container_tests {
         return;
     }
 
-    if (get_var('PODMAN_BATS_SKIP')) {
+    if (get_var('SKOPEO_BATS_SKIP') || get_var('RUNC_BATS_SKIP') || get_var('NETAVARK_BATS_SKIP') || get_var('AARDVARK_BATS_SKIP')) {
         if (!check_var('SKOPEO_BATS_SKIP', 'all')) {
             loadtest 'containers/skopeo_integration' if (is_tumbleweed || is_microos || is_sle || is_leap || is_sle_micro('>=5.5'));
-        }
-        if (!check_var('PODMAN_BATS_SKIP', 'all')) {
-            loadtest 'containers/podman_integration';
         }
         if (!check_var('RUNC_BATS_SKIP', 'all')) {
             loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle || is_leap);
@@ -313,6 +310,13 @@ sub load_container_tests {
         }
         if (!check_var('AARDVARK_BATS_SKIP', 'all')) {
             loadtest 'containers/aardvark_integration' if (is_tumbleweed);
+        }
+        return;
+    }
+
+    if (get_var('PODMAN_BATS_SKIP')) {
+        if (!check_var('PODMAN_BATS_SKIP', 'all')) {
+            loadtest 'containers/podman_integration';
         }
         return;
     }


### PR DESCRIPTION
Run podman testsuite on its own job as it takes very long.

Related to https://github.com/os-autoinst/opensuse-jobgroups/pull/526