### PR TITLE
Use same sap_hana_install_sid in qesap regression

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -29,7 +29,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
@@ -32,7 +32,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -29,7 +29,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -28,7 +28,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HA0'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -31,7 +31,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HA0'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -31,7 +31,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HA0'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
@@ -28,7 +28,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HA0'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -26,7 +26,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HA0'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
@@ -25,7 +25,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HA0'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -26,7 +26,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HA0'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -31,7 +31,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
@@ -33,7 +33,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -31,7 +31,7 @@ ansible:
   hana_vars:
     sap_hana_install_software_directory: /hana/shared/install
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
-    sap_hana_install_sid: 'HDB'
+    sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'
     sap_domain: 'qe-test.example.com'
     primary_site: 'goofy'


### PR DESCRIPTION
All the conf.yaml for all qesap regression test use value HQ0. This value is the same across all qesap regression openQA  tests and it is different from the `HDB` one that combine with `HDB` hardcoded in some cluster resource names within the qe-sap-deployment Ansible code, resulting in name having it twice.


- Related ticket: https://jira.suse.com/browse/TEAM-9426

# Verification run:
## Aws
### qesap_aws.yaml
 - sle-12-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE12_5_BYOS-qesap_aws_saptune_test -> http://openqaworker15.qa.suse.cz/tests/299496 :green_circle: 

### qesap_aws_fencing.yaml
- sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_native_test -> http://openqaworker15.qa.suse.cz/tests/299497 :green_circle: 
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_sbd_test -> http://openqaworker15.qa.suse.cz/tests/299498 :green_circle: 

### qesap_aws_sapconf.yaml
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_sapconf_test -> http://openqaworker15.qa.suse.cz/tests/299501 :green_circle: 

## Azure
### qesap_azure.yaml
 - sle-12-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-qesap_azure_saptune_test -> http://openqaworker15.qa.suse.cz/tests/299502 :green_circle: 
 
### qesap_azure_fencing_msi.yaml
 - sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/299505 :green_circle: 

### qesap_azure_fencing_spn.yaml
- sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test_spn@64bit -> http://openqaworker15.qa.suse.cz/tests/299506 :green_circle:  job is failing but later in terraform destroy
 
### qesap_azure_roles.yaml
 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit -> http://openqaworker15.qa.suse.cz/tests/299508 :green_circle:  job is failing but later in terraform destroy
 
 
### conf.yaml data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
### conf.yaml data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
### conf.yaml data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml

## Gcp

### qesap_gcp.yaml
 - sle-15-SP3-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_3_PAYG-qesap_gcp_saptune_test -> http://openqaworker15.qa.suse.cz/tests/299503 :green_circle:  job fails but failure is later after the deployment end and related to vim package not to any cluster setup
 
### qesap_gcp_fencing.yaml
 - sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sbd_test@64bit -> http://openqaworker15.qa.suse.cz/tests/299509 :green_circle: 
 
### qesap_gcp_sapconf.yam
 - sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test -> http://openqaworker15.qa.suse.cz/tests/299507
