### PR TITLE
Fix SLE15-SP3,SP4 broken podman test

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -110,7 +110,7 @@ sub run {
 
     new_registration($instance);
 
-    test_container_runtimes($instance) if (is_sle('>=15-SP2'));
+    test_container_runtimes($instance) if (is_sle('>=15-SP5'));
 
     force_new_registration($instance);
 


### PR DESCRIPTION
A bug was introduced with some of the container logic in this pr: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20260. SP2 to SP4 do not have `podman` in the default repos. SP5 and onwards do.

I've bumped the version on the check that runs the container logic.

- Failed tests: https://openqa.suse.de/tests/15636752#step/check_registercloudguest/163 
- Verification run: http://dirtman.qe.prg2.suse.org/tests/91#
