### PR TITLE
Delete unnecessary pxe boot setting

### DIFF
--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -71,7 +71,7 @@ sub run {
             set_grub_on_vh('/mnt', '', 'xen') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));
             set_grub_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE', 'kvm'));
             adjust_for_ipmi_xen('/mnt') if (get_var('REGRESSION') && (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen')));
-            set_pxe_efiboot('/mnt') if is_aarch64;
+            set_pxe_efiboot('/mnt') if (is_aarch64 && !(get_var("VIRT_AUTOTEST")));
         }
     }
     else {

--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -31,7 +31,7 @@ sub post_execute_script_configuration {
     #online upgrade actually
     if (is_remote_backend && is_aarch64 && is_installed_equal_upgrade_major_release) {
         set_grub_on_vh('', '', 'kvm');
-        set_pxe_efiboot('');
+        set_pxe_efiboot('') if (!(get_var("VIRT_AUTOTEST")));
     }
 }
 


### PR DESCRIPTION
It is not necessary to execute set_pxe_efiboot.
System can boot into system normally, not pxe boot any more.

- Related ticket: https://progress.opensuse.org/issues/168019
- Needles: na
- Verification run: 
     - https://openqa.oqa.prg2.suse.org/tests/15646742
     - https://openqa.oqa.prg2.suse.org/tests/15656589
