### PR TITLE
Bring linux-login prompt back by pressing enter

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -59,13 +59,8 @@ sub reboot_and_wait_up {
                 #Xen console may output additional messages about vm on sol whose output is disrupted.
                 #So in order to get login prompt back on screen, 'ret' key should be fired up. But the
                 #os name banner might not be available anymore, only 'linux-login' needle can be matched.
-                if (is_xen_host) {
-                    send_key 'ret' for (0 .. 2);
-                    assert_screen [qw(text-login linux-login)], 600;
-                }
-                else {
-                    assert_screen [qw(text-login linux-login)], 600;
-                }
+                send_key 'ret' for (0 .. 2);
+                assert_screen [qw(text-login linux-login)], 600;
                 enter_cmd "root";
                 assert_screen "password-prompt";
                 type_password;


### PR DESCRIPTION
* **Previously** pressing enter key is only enabled on xen host, which is also needed on kvm host now as well. Because linux login prompt may be overwritten by messages pop up on ipmi sol console.

* **Failure** example, [failure 1](https://openqa.suse.de/tests/15645634#step/reboot_and_wait_up_upgrade/20).

* **Verification Runs:** 
  * [offline upgrade kvm](https://openqa.suse.de/tests/15647573)
  * [offline upgrade xen](https://openqa.suse.de/tests/15647563)
  * [online upgrade kvm](https://openqa.suse.de/tests/15647570)
  * [online upgrade xen](https://openqa.suse.de/tests/15647568)
