### PR TITLE
xfstests: Fix missing source of bugzilla function

### DIFF
--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -23,6 +23,7 @@ use mmapi;
 use version_utils 'is_public_cloud';
 use LTP::utils;
 use LTP::WhiteList;
+use bugzilla;
 use xfstests_utils;
 use lockapi;
 


### PR DESCRIPTION
Add bugzilla source into run_subtest to solve the problem that "undefined subroutine &xfstests_utils::bugzilla_buginfo".

- Related ticket: https://progress.opensuse.org/issues/167842
- Verification run: https://openqa.suse.de/tests/15647194
(prove bugzilla message works https://openqa.suse.de/tests/15647194#step/generic-363/83)