### PR TITLE
Add soft-failures for some SL Micro SELinux related bugs

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -500,6 +500,20 @@
         },
         "type": "bug"
     },
+    "bsc#1231391": {
+        "description": "pam_wtmpdb\\(login:session\\): (open_database_rw:.*unable to open database file|Cannot get ID from open session!)",
+        "products": {
+            "sle-micro": ["6.0"]
+        },
+        "type": "bug"
+    },
+    "bsc#1231455": {
+        "description": "systemd.* Failed to start SETroubleshoot daemon for processing new SELinux denial logs\\.",
+        "products": {
+            "sle-micro": ["5.5", "6.0"]
+        },
+        "type": "bug"
+    },
     "boo#1215368": {
         "description": "systemctl: invalid option -- '\\.'",
         "products": {


### PR DESCRIPTION
[1230970](https://bugzilla.suse.com/show_bug.cgi?id=1230970) pam_wtmpdb(login:session): Cannot get ID from open session
[1231391](https://bugzilla.suse.com/show_bug.cgi?id=1231391) Cannot create/open database (/var/lib/wtmpdb/wtmp.db): unable to open database file
[1231455](https://bugzilla.suse.com/show_bug.cgi?id=1231455) systemd[1]: Failed to start SETroubleshoot daemon....

https://openqa.suse.de/tests/15647694
https://openqa.suse.de/tests/15647695