### PR TITLE
Use NFS v3 instead v4 for virt prj3 tests to get around bsc#1230971 and mark softfail

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -71,15 +71,15 @@
           % if ($check_var->('VIRT_SEV_ES_GUEST_INSTALL', '1')) {
             <!-- Do not add mem_encrypt=on option on 15-SP6 KVM host due to bsc#1224107 -->
             % if ($check_var->('VERSION', '15-SP6')) { 
-      <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty kvm_amd.sev=1 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS') %></append>
+      <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty kvm_amd.sev=1 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS', '') %></append>
             % } else {
-      <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty mem_encrypt=on kvm_amd.sev=1 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS') %></append>
+      <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty mem_encrypt=on kvm_amd.sev=1 <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS', '') %></append>
             % }
           % } else {
-      <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS') %></append>
+      <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS', '') %></append>
           % }
         % } else { 
-      <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty intel_iommu=on <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS') %></append>
+      <append>splash=silent console=<%= $get_var->('SERIALDEV', 'ttyS1') %>,115200 console=tty intel_iommu=on <%= defined $bmwqemu::vars{"ENABLE_CONSOLE_KERNEL_LOG"} ? "ignore_loglevel" : "loglevel=5" %> <%= $get_var->('OPT_KERNEL_PARAMS', '') %></append>
         % }
       % }
     </global>

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -29,7 +29,7 @@ use Carp;
 our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest is_sev_es_guest guest_is_sle is_guest_ballooned is_xen_host is_kvm_host
   is_monolithic_libvirtd turn_on_libvirt_debugging_log restart_libvirtd check_libvirtd restart_modular_libvirt_daemons check_modular_libvirt_daemons
   reset_log_cursor check_failures_in_journal check_host_health check_guest_health print_cmd_output_to_file collect_virt_system_logs setup_rsyslog_host download_script download_script_and_execute upload_virt_logs enable_nm_debug upload_nm_debug_log
-  ssh_setup setup_common_ssh_config add_alias_in_ssh_config install_default_packages parse_subnet_address_ipv4 backup_file manage_system_service check_port_state is_registered_system do_system_registration check_system_registration subscribe_extensions_and_modules check_activate_network_interface wait_for_host_reboot
+  ssh_setup setup_common_ssh_config add_alias_in_ssh_config install_default_packages parse_subnet_address_ipv4 backup_file manage_system_service check_port_state is_registered_sles is_registered_system do_system_registration check_system_registration subscribe_extensions_and_modules check_activate_network_interface wait_for_host_reboot
   create_guest import_guest ssh_copy_id add_guest_to_hosts ensure_default_net_is_active ensure_guest_started remove_additional_disks remove_additional_nic start_guests is_guest_online ensure_online wait_guest_online restore_downloaded_guests save_original_guest_xmls restore_original_guests save_guests_xml_for_change restore_xml_changed_guests shutdown_guests wait_guests_shutdown remove_vm recreate_guests download_vm_import_disks get_guest_regcode
 );
 
@@ -910,6 +910,16 @@ sub check_port_state {
     }
     record_info("Port $dst_port is not open", "The port $dst_port is not open on machine $dst_machine") if ($port_state == 0);
     return $port_state;
+}
+
+#Detect whether SUT host is installed with scc registration
+sub is_registered_sles {
+    if (!get_var('SCC_REGISTER') || check_var('SCC_REGISTER', 'none') || check_var('SCC_REGISTER', '')) {
+        return 0;
+    }
+    else {
+        return 1;
+    }
 }
 
 =head2 is_registered_system

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -24,6 +24,7 @@ use main_publiccloud;
 use main_security;
 use Utils::Architectures;
 use DistributionProvider;
+use virt_autotest::utils qw(is_registered_sles);
 
 BEGIN {
     unshift @INC, dirname(__FILE__) . '/../../lib';
@@ -863,8 +864,8 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/install_package";
         loadtest "virt_autotest/update_package";
         # Skip reset_partition for s390x due to there just be 42Gib disk space for each s390x LPAR
-        loadtest "virt_autotest/reset_partition" if (!is_s390x and get_var('VIRT_PRJ1_GUEST_INSTALL'));
-        loadtest "virt_autotest/reboot_and_wait_up_normal" if (!get_var('AUTOYAST') && get_var('REPO_0_TO_INSTALL'));
+        loadtest "virt_autotest/reset_partition" if is_x86_64 && get_var('VIRT_PRJ1_GUEST_INSTALL') && !get_var('LTSS');
+        loadtest "virt_autotest/reboot_and_wait_up_normal" if !is_registered_sles && get_var('REPO_0_TO_INSTALL');
         loadtest "virt_autotest/download_guest_assets" if get_var("SKIP_GUEST_INSTALL") && is_x86_64;
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -142,6 +142,7 @@ sub run {
     script_run('[ -d /var/log/qa/ctcs2/ ] && rm -rf /var/log/qa/ctcs2/', 30);
     script_run('[ -d /tmp/prj3_migrate_admin_log/ ] && rm -rf /tmp/prj3_migrate_admin_log/', 30);
 
+    record_soft_failure("Use NFS v3 instead v4 to get around bsc#1230971");
     $self->run_test($timeout, "", "yes", "yes", "$log_dirs", "$upload_log_name");
 }
 

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -16,7 +16,7 @@ use version_utils 'is_sle';
 use virt_utils;
 use ipmi_backend_utils;
 use Utils::Architectures;
-use virt_autotest::utils qw(is_xen_host is_kvm_host);
+use virt_autotest::utils qw(is_xen_host is_kvm_host is_registered_sles);
 
 sub update_package {
     my $self = shift;
@@ -49,8 +49,8 @@ sub update_package {
 sub run {
     my $self = shift;
     #workaroud: skip update package for registered sles as the packages are already up-to-date
-    $self->update_package() unless (!!get_var('AUTOYAST') || (is_registered_sles && !is_s390x));
-    if (!!get_var('AUTOYAST') || (is_registered_sles && !is_s390x)) {
+    $self->update_package() unless is_registered_sles && !is_s390x;
+    if (is_registered_sles && !is_s390x) {
         my @files_to_upload = ("/boot/grub2/grub.cfg", "/etc/default/grub");
         push(@files_to_upload, script_output("ls /boot/efi/efi/sles/xen-*.cfg")) if is_xen_host and is_uefi_boot;
         upload_logs($_, failok => 1) foreach (@files_to_upload);

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -25,7 +25,7 @@ use virt_autotest::utils;
 use version_utils qw(is_sle is_alp get_os_release);
 
 our @EXPORT
-  = qw(enable_debug_logging update_guest_configurations_with_daily_build locate_sourcefile get_repo_0_prefix repl_repo_in_sourcefile repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk get_guest_list download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles is_registered_sles);
+  = qw(enable_debug_logging update_guest_configurations_with_daily_build locate_sourcefile get_repo_0_prefix repl_repo_in_sourcefile repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk get_guest_list download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles);
 
 sub enable_debug_logging {
 
@@ -737,16 +737,6 @@ sub is_developing_sles {
     }
     else {
         return 0;
-    }
-}
-
-#Detect whether SUT host is installed with scc registration
-sub is_registered_sles {
-    if (!get_var('SCC_REGISTER') || check_var('SCC_REGISTER', 'none') || check_var('SCC_REGISTER', '')) {
-        return 0;
-    }
-    else {
-        return 1;
     }
 }
 


### PR DESCRIPTION
Related ticket: [poo#170245](https://progress.opensuse.org/issues/170245)
Related PR: https://github.com/SUSE/qa-automation/pull/851

Verification runs:
[prj3_sle15sp7_kvm](https://10.145.10.207/tests/16011127)
[prj3_sle15sp7_xen](https://10.145.10.207/tests/16013111)
[sle15sp6_kvm](https://10.145.10.207/tests/16026152)
[gi-guest_developing-on-host_developing-kvm](https://10.145.10.207/tests/16021267)
[uefi-gi-guest_developing-on-host_sles12sp5-kvm](https://10.145.10.207/tests/16021305)

