### PR TITLE
Use desktop runner to refresh screen

### DIFF
--- a/tests/x11/toolkits/fltk.pm
+++ b/tests/x11/toolkits/fltk.pm
@@ -21,8 +21,10 @@ sub run {
     script_run './fltk', 0;
     assert_screen [qw(ui-toolkit-fltk ui-toolkit-fltk-nomsg-display)];
     if (match_has_tag 'ui-toolkit-fltk-nomsg-display') {
-        wait_screen_change { send_key 'alt-f4' };
-        script_run './fltk', 0;
+        # Use desktop runner to refresh screen
+        record_info('Refresh screen', 'Use desktop runner to refresh screen');
+        wait_screen_change { send_key 'alt-f2' };
+        wait_screen_change { send_key 'esc' };
         assert_screen 'ui-toolkit-fltk';
     }
     wait_screen_change { send_key 'alt-f4' };


### PR DESCRIPTION
Use desktop runner to refresh screen to make sure the expected needle can show correctly.

- Related ticket: https://progress.opensuse.org/issues/167320
- Verification run: https://openqa.suse.de/tests/15710657#next_previous (Rerun ten times cannot reproduce this sporadic issue.)
  x86_64: https://openqa.suse.de/tests/15711009#
  aarch64: https://openqa.suse.de/tests/15711023#