### PR TITLE
start_install: Increase timeout

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -97,7 +97,7 @@ sub run {
                 send_key 'alt-o';
             }
         }
-        assert_screen "startinstall";
+        assert_screen "startinstall", 90;
 
         # confirm
         send_key $cmd{install};


### PR DESCRIPTION
Sometimes it can take more time until startinstall pop-up show

- Related ticket: https://openqa.suse.de/tests/15647143#step/start_install/1