### PR TITLE
Run unit test shuffled and timed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ tidy-full: tools/tidy
 .PHONY: unit-test
 unit-test:
 	prove -l -Ios-autoinst/ t/
+	prove --shuffle -l -Ios-autoinst/ t/
+	prove --timer -l -Ios-autoinst/ t/ 2>/dev/null | grep -E "t/.*\.t.*ok[[:space:]]+([0-9]+)[[:space:]]+ms" | sort -nrk 5,5
 
 .PHONY: test-compile
 test-compile: check-links


### PR DESCRIPTION
Add two additional commands in the unit-test target:
1. run the test with --shuffle argument: it randomly change the execution order. Comparing the result with the previous in-order execution can spot test dependency issues.
2. run test with --timer, parse and order the result to print the test in order of time to run. In can help to spot tests taking too much time as maybe using not "mocked" sleep.

- Verification run: 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/11272220692/job/31346686699?pr=20374#step:6:306