### PR TITLE
Test access to usb device from a container

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -229,6 +229,9 @@ sub run {
             });
     }
 
+    if ($vmm_family eq 'xen' && $vmm_type eq 'linux') {
+        $svirt->add_usb_hub();
+    }
     $svirt->add_vnc({port => get_var('VIRSH_INSTANCE', 1) + 5900});
 
     my %ifacecfg = ();


### PR DESCRIPTION
USBPV functionality is about to be added by
https://github.com/os-autoinst/os-autoinst/pull/2552.

Hence we can check whether `/dev` devices are accessible in priviledge containers.

I have also added a 2 more checks for syscalls availability and more about accessibility of kernel file systems.

- ticket: https://progress.opensuse.org/issues/138410

#### Verification runs

* [sle-15-SP7-JeOS-for-kvm-and-xen-x86_64-Build1.40-jeos-containers-podman@svirt-xen-pv](http://kepler.suse.cz/tests/24054#step/podman_privileged_mode/42)
* [sle-15-SP7-JeOS-for-kvm-and-xen-x86_64-Build1.40-jeos-containers-podman@svirt-xen-hvm](http://kepler.suse.cz/tests/24055#step/podman_privileged_mode/42)
