### PR TITLE
Allow SPN secret overwrite in azure_fence_agent

### DIFF
--- a/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
+++ b/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
@@ -38,8 +38,8 @@ sub run {
     my $resource_group = qesap_az_get_resource_group();
     my $subscription_id = $provider_client->{subscription};
     my $tenant_id = check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn') ? qesap_az_get_tenant_id($subscription_id) : '';
-    my $spn_application_id = get_var('_SECRET_AZURE_SPN_APPLICATION_ID');
-    my $spn_application_password = get_var('_SECRET_AZURE_SPN_APP_PASSWORD');
+    my $spn_application_id = get_var('AZURE_SPN_APPLICATION_ID', get_required_var('_SECRET_AZURE_SPN_APPLICATION_ID'));
+    my $spn_application_password = get_var('AZURE_SPN_APP_PASSWORD', get_required_var('_SECRET_AZURE_SPN_APP_PASSWORD'));
     my @cluster_nodes = @{$self->list_cluster_nodes()};
 
     die 'Resoruce group not found' unless $resource_group;


### PR DESCRIPTION
Allow same secret overwrite mechanism already in use in qesap_terraform.

- Related ticket: https://jira.suse.com/browse/TEAM-9719

# Verification run:

## correct credential
 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-10-11T02:03:21Z-hanasr_azure_test_saptune_spn az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/299680 
 
 ## wrong id AZURE_SPN_APPLICATION_ID=banana, right password
 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-10-11T02:03:21Z-hanasr_azure_test_saptune_spn az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/299681 :green_circle:  properly detect wrong credential http://openqaworker15.qa.suse.cz/tests/299681#step/Verify_azure_fence_agent_SPN/98 `Application with identifier 'banana' was not found in the directory ...`

## right id, wrong password AZURE_SPN_APP_PASSWORD=banana
 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-10-11T02:03:21Z-hanasr_azure_test_saptune_spn az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/299682  :green_circle:  properly detect wrong credential `Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID`

## all wrong credentials
 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-10-11T02:03:21Z-hanasr_azure_test_saptune_spn az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/299683 :green_circle:  properly detect wrong credential 