### PR TITLE
Temporarily disable verify_setup for ignition test as initial configuration.

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -424,7 +424,9 @@ sub load_tests {
     } elsif (check_var('EXTRA', 'networking')) {
         load_network_tests;
     } elsif (check_var('EXTRA', 'provisioning')) {
-        loadtest 'microos/verify_setup';
+        # verify_setup is not working correctly in microos with ignition
+        # for the initial configuration. Disabled temporarily to investigate!
+        loadtest 'microos/verify_setup' unless check_var('FIRST_BOOT_CONFIG', 'ignition') && is_microos;
         load_transactional_tests;
     } elsif (check_var('EXTRA', 'virtualization')) {
         load_qemu_tests;


### PR DESCRIPTION
Verify_setup is working correctly for Tumbleweed-MicroOS-Image with combustion as initial configuration but not with ignition.

Temporarily disable verify_setup for ignition test as initial configuration. 


- Related ticket: https://progress.opensuse.org/issues/164341

- Verification run: 


verify_setup should be present in all except **microos with ignition** -->

sle-micro with combustion: https://openqa.suse.de/tests/15657610
sle-micro with ignition: https://openqa.suse.de/tests/15657611
microos with combustion: https://openqa.opensuse.org/tests/4552809
microos with ignition: https://openqa.opensuse.org/tests/4552810
