### PR TITLE
 SLE-Micro Container Host for ppc64le - fixes

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -182,6 +182,8 @@ sub test_opensuse_based_image {
         } else {
             record_info "non-SLE host", "This host ($host_id) does not support zypper service";
         }
+    } elsif ($image_id =~ /^(sl|sle)-micro$/) {
+        validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="SUSE Linux Micro .*"/ };
     } else {
         $version =~ s/^Jump://i;
         validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -81,7 +81,7 @@ sub run {
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGE_VERSIONS
     my $versions = get_var('CONTAINER_IMAGE_VERSIONS', get_required_var('VERSION'));
     for my $version (split(/,/, $versions)) {
-        my $image = get_image_uri(version => $version);
+        my $image = get_image_uri(version => $version, distri => ($version =~ /-SP/ ? 'sle' : undef()));
 
         if (get_var('IMAGE_STORE_DATA')) {
             # If wanted, push image information to the DB

--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -60,7 +60,7 @@ sub run {
     select_console 'root-console';
     $self->create_user;
 
-    my $toolbox_image_to_test = get_var('CONTAINER_IMAGE_TO_TEST');
+    my $toolbox_image_to_test = get_var('CONTAINER_IMAGE_TO_TEST_EXTRA');
 
     if ($toolbox_image_to_test) {
         # We need to extract the registry from the full image uri, e.g.


### PR DESCRIPTION
Description:
- SLE-micro case added in `test_opensuse_based_image`;
- utils:`ensure_ca_certificates` missing CA uri-repos for sle-micro, management fixed;
- toolbox: when explicit uri needed, in place of CONTAINER_IMAGE_TO_TEST, introduced `CONTAINER_IMAGE_TO_TEST_EXTRA`, separation from BCI needed for that logic, otherwise causing next `get_image_uri` calls in SLE-M tests to override CONTAINER_IMAGE_VERSIONS.
- image::`get_image_uri` call, `distri` parameter defined;
- zypper_call: add retry input variable, to change the fixed 5 loops.

References:
- Related ticket: https://progress.opensuse.org/issues/162689
- Needles: N/A
- Verification run [other coming soon]:
  https://openqa.suse.de/tests/15649782
  https://openqa.suse.de/tests/15656966 