### PR TITLE
Check for Hyper-V 2016 with UEFI, configure VM network adapter, and log related soft failure.

### DIFF
--- a/lib/virt_autotest/hyperv_utils.pm
+++ b/lib/virt_autotest/hyperv_utils.pm
@@ -1,0 +1,79 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Utilities for executing commands on Hyper-V hosts, allowing interaction
+#          with Hyper-V plugins and managing the Hyper-V environment within openQA tests.
+# Maintainer: Roy.Cai@suse.com, qe-virt@suse.de
+
+package virt_autotest::hyperv_utils;
+
+
+use base 'Exporter';
+use Exporter;
+use base 'installbasetest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+
+# Export 'hyperv_cmd' so it can be used outside the package
+our @EXPORT = qw(
+  hyperv_cmd
+  hyperv_cmd_with_retry
+);
+
+sub hyperv_cmd {
+    my ($cmd, $args) = @_;
+    $args->{ignore_return_code} ||= 0;
+    my $ret = console('svirt')->run_cmd($cmd);
+    diag "Command on Hyper-V returned: $ret";
+    die 'Command on Hyper-V failed' unless ($args->{ignore_return_code} || !$ret);
+    return $ret;
+}
+
+sub hyperv_cmd_with_retry {
+    my ($cmd, $args) = @_;
+    die 'Command not provided' unless $cmd;
+
+    my $attempts = $args->{attempts} // 7;
+    my $sleep = $args->{sleep} // 300;
+    # Common messages
+    my @msgs = $args->{msgs} // (
+        'Failed to create the virtual hard disk',
+        'The operation cannot be performed while the object is in use',
+        'The process cannot access the file because it is being used by another process',
+        'Access is denied.'
+    );
+    for my $retry (1 .. $attempts) {
+        my ($ret, $stdout, $stderr) = console('svirt')->run_cmd($cmd, wantarray => 1);
+        # return when powershell returns 0 (SUCCESS)
+        return if $ret == 0;
+
+        diag "Attempt $retry/$attempts: Command failed";
+        my $msg_found = 0;
+        foreach my $msg (@msgs) {
+            diag "Looking for message: '$msg'";
+            # Narrow the error message for an easy match
+            # Remove Windows-style new lines (<CR><LF>)
+            $stdout =~ s/\r\n//g;
+            $stderr =~ s/\r\n//g;
+            # Error message is not the expected error message in this cycle,
+            # try the next one
+            if ($stdout =~ /$msg/ || $stderr =~ /$msg/) {
+                $msg_found = 1;
+                # Error message is the expected one, sleep
+                diag "Sleeping for $sleep seconds...";
+                sleep $sleep;
+                last;
+            }
+        }
+        # Error we don't know if we should attempt to recover from
+        die 'Command failed with unhandled error' unless $msg_found;
+    }
+    die 'Run out of attempts';
+}
+
+1;

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -26,6 +26,7 @@ use migration 'modify_kernel_multiversion';
 use strict;
 use Utils::Architectures 'is_ppc64le';
 use warnings;
+use virt_autotest::hyperv_utils 'hyperv_cmd';
 
 sub run {
     my ($self) = @_;
@@ -34,6 +35,17 @@ sub run {
     ensure_serialdev_permissions;
 
     prepare_serial_console;
+
+    # This code checks if the environment is Hyper-V 2016 with UEFI. If true,
+    # it adds a new VM network adapter connected to a virtual switch and logs a known UEFI boot issue.
+    if (check_var('HYPERV_VERSION', '2016') && is_uefi_boot) {
+        my $virsh_instance = get_required_var("VIRSH_INSTANCE");
+        my $hyperv_switch_name = get_var('HYPERV_VIRTUAL_SWITCH', 'ExternalVirtualSwitch');
+        hyperv_cmd("powershell -Command "
+              . "\"if ((Get-VMNetworkAdapter -VMName openQA-SUT-${virsh_instance} | Where-Object { \$_.SwitchName -eq '${hyperv_switch_name}' }) -eq \$null) "
+              . "{ Add-VMNetworkAdapter -VMName openQA-SUT-${virsh_instance} -SwitchName ${hyperv_switch_name} }\"");
+        record_soft_failure('bsc#1217800 - [Baremetal windows server 2016][guest VM UEFI]UEFI Boot Issues with Different Build ISOs on Hyper-V Guests');
+    }
 
     if (!check_var('DESKTOP', 'textmode')) {
         # Make sure packagekit is not running, or it will conflict with SUSEConnect.

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -20,6 +20,7 @@ use mmapi;
 use power_action_utils 'power_action';
 use Utils::Backends qw(is_pvm has_ttys);
 use YuiRestClient;
+use virt_autotest::hyperv_utils 'hyperv_cmd';
 
 sub run {
     select_console 'installation' unless get_var('REMOTE_CONTROLLER');
@@ -45,6 +46,18 @@ sub run {
         # Await server's response "OK, done" (custom_pxeboot.pm)
         mutex_wait("custom_pxe_ready", $jobid_server);
     }
+
+    # If the current test is running on a Hyper-V host with version 2016 and UEFI is enabled:
+    # - Get the VM instance name stored in the VIRSH_INSTANCE variable
+    # - Run a PowerShell command to remove the network adapter from the VM (openQA-SUT) in Hyper-V
+    # - Record a soft failure with a reference to bug bsc#1217800, which is related to UEFI boot issues
+    #   encountered on Hyper-V guests using different ISO builds on bare-metal Windows Server 2016.
+    if (check_var('HYPERV_VERSION', '2016') && is_uefi_boot) {
+        my $virsh_instance = get_var("VIRSH_INSTANCE");
+        hyperv_cmd("powershell -Command Remove-VMNetworkAdapter -VMName openQA-SUT-${virsh_instance}");
+        record_soft_failure('bsc#1217800 - [Baremetal windows server 2016][guest VM UEFI]UEFI Boot Issues with Different Build ISOs on Hyper-V Guests');
+    }
+
     # Reboot
     # alt-o is the "OK" button in popup "the system will reboot in X seconds..."
     if (has_ttys) {

--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -13,14 +13,33 @@ use warnings;
 use parent "y2_installbase";
 
 use testapi;
-use utils qw(assert_screen_with_soft_timeout handle_untrusted_gpg_key);
+use utils qw(assert_screen_with_soft_timeout handle_untrusted_gpg_key is_uefi_boot);
 use version_utils qw(is_sle is_sle_micro);
 use registration qw(skip_registration assert_registration_screen_present fill_in_registration_data verify_scc investigate_log_empty_license);
+use virt_autotest::hyperv_utils 'hyperv_cmd';
 
 sub run {
     return record_info('Skip reg.', 'SCC registration is not required in media based upgrade since SLE15') if (is_sle('15+') && get_var('MEDIA_UPGRADE'));
     if (check_var('SCC_REGISTER', 'installation') || (check_var('REGISTER', 'installation'))) {
         record_info('SCC reg.', 'SCC registration');
+        # This code checks if the environment is Hyper-V 2016 with UEFI. If true,
+        # it adds a new VM network adapter connected to a virtual switch and logs a known UEFI boot issue.
+        if (check_var('HYPERV_VERSION', '2016') && is_uefi_boot) {
+            my $virsh_instance = get_var("VIRSH_INSTANCE");
+            my $hyperv_switch_name = get_var('HYPERV_VIRTUAL_SWITCH', 'ExternalVirtualSwitch');
+            hyperv_cmd("powershell -Command "
+                  . "\"if ((Get-VMNetworkAdapter -VMName openQA-SUT-${virsh_instance} | Where-Object { \$_.SwitchName -eq '${hyperv_switch_name}' }) -eq \$null) "
+                  . "{ Connect-VMNetworkAdapter -VMName openQA-SUT-${virsh_instance} -SwitchName ${hyperv_switch_name} }\"");
+            record_soft_failure('bsc#1217800 - [Baremetal windows server 2016][guest VM UEFI]UEFI Boot Issues with Different Build ISOs on Hyper-V Guests');
+            assert_screen 'scc_registration-net';
+            send_key_until_needlematch "scc-registration-net-selected", "tab", 10 if check_var('DESKTOP', 'textmode');
+            send_key 'alt-i';
+            assert_screen 'scc_registration-net-setup';
+            send_key 'alt-y';
+            send_key 'alt-n';
+            assert_screen 'scc_registration-net-dhcp';
+            send_key 'alt-n';
+        }
         assert_registration_screen_present();
         fill_in_registration_data();
         wait_still_screen();

--- a/tests/shutdown/hyperv_upload_assets.pm
+++ b/tests/shutdown/hyperv_upload_assets.pm
@@ -13,15 +13,7 @@ use testapi;
 use version_utils;
 
 use File::Basename 'fileparse_set_fstype';
-
-sub hyperv_cmd {
-    my ($cmd, $args) = @_;
-    $args->{ignore_return_code} ||= 0;
-    my $ret = console('svirt')->run_cmd($cmd);
-    diag "Command on Hyper-V returned: $ret";
-    die 'Command on Hyper-V failed' unless ($args->{ignore_return_code} || !$ret);
-    return $ret;
-}
+use virt_autotest::hyperv_utils 'hyperv_cmd';
 
 sub extract_assets {
     my ($args) = @_;


### PR DESCRIPTION
Check for Hyper-V 2016 with UEFI, configure VM network adapter, and log related soft failure.

1. Added hyperv_utils.pm for Hyper-V command execution.
2. Disable network card when create VM, record soft failure. (module: [bootloader_hyperv](https://openqa.oqa.prg2.suse.org/tests/15702722#step/bootloader_hyperv/29))
3. Enable network card when scc registration, record soft failure (module: 
[scc_registration](https://openqa.oqa.prg2.suse.org/tests/15702722#step/scc_registration/4))
4. Disable network card when the first boot, record soft failure (module: [reboot_after_installation](https://openqa.oqa.prg2.suse.org/tests/15702722#step/reboot_after_installation/5))
5. Enable network card when function test, record soft failure (module: [system_prepare](https://openqa.oqa.prg2.suse.org/tests/15702722#step/system_prepare/16))

- Related ticket: https://progress.opensuse.org/issues/151645
- Needles: 
     - scc_registration-net-dhcp-20241015 
     - scc_registration-net-setup-20241015 
     - scc_registration-net-20241015 
     - scc_registration-net-dhcp-20241016 
     - scc_registration-net-setup-20241016 
     - scc-registration-net-selected-20241016
     - scc_registration-net-20241016 

- Verification run:  
     - [online_upgrade_sles15sp6_hyperv@svirt-hyperv2016](https://openqa.oqa.prg2.suse.org/tests/15702724)
     - [default_install_svirt@svirt-hyperv2016-uefi](https://openqa.oqa.prg2.suse.org/tests/15702723)
     - [textmode_svirt@svirt-hyperv2016-uefi](https://openqa.oqa.prg2.suse.org/tests/15702722)
     - [textmode_svirt@svirt-hyperv2022-uefi](https://openqa.oqa.prg2.suse.org/tests/15702746)
     - [default_install_svirt@svirt-hyperv2022-uefi](https://openqa.oqa.prg2.suse.org/tests/15702747)
