### PR TITLE
Agama s390x ca-certificates-s390x workaround

### DIFF
--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -15,6 +15,18 @@ use testapi qw(
   get_required_var
 );
 
+use Utils::Architectures;
+use version_utils qw(is_sle);
+
+sub pre_run_hook {
+    if (is_sle() && is_s390x()) {
+        record_soft_failure("bsc#1231421");
+        assert_script_run("curl --insecure -o /tmp/ca-certificates-suse.rpm https://download.suse.de/browse/ibs/SUSE:/CA/SLE_15_SP7/noarch/ca-certificates-suse-1.0-150700.8.1.noarch.rpm");
+        assert_script_run("zypper -n install /tmp/ca-certificates-suse.rpm");
+        assert_script_run("systemctl restart agama");
+    }
+}
+
 sub run {
     my $self = shift;
 


### PR DESCRIPTION
We want to include a small workaround to install `ca-certificates-suse` package in Agama Live s390x ISO.

- Related ticket: https://progress.opensuse.org/issues/167248
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/15672986
