### PR TITLE
Remove assert for networkctl status when networkd is inactive

### DIFF
--- a/tests/console/check_default_network_manager.pm
+++ b/tests/console/check_default_network_manager.pm
@@ -26,7 +26,8 @@ sub run {
         zypper_call 'in systemd-network';
         systemctl 'is-enabled systemd-networkd', expect_false => 1;
         systemctl 'is-active systemd-networkd', expect_false => 1;
-        assert_script_run 'networkctl status';
+        script_run 'networkctl status';
+        assert_script_run 'networkctl';
     }
 
     my $network_daemon = script_output 'readlink /etc/systemd/system/network.service | sed \'s#.*/\(.*\)\.service#\1#\'';


### PR DESCRIPTION
With systemd 256, `networkctl status` no longer returns 0 when systemd-networkd is disabled/inactive.  I checked this behaviour in Ubuntu 24.10 which ships Systemd 256.  

- Related ticket: https://progress.opensuse.org/issues/164652
- Verification run: not needed
