### PR TITLE
Retry mechanism in ssh service for script_output

### DIFF
--- a/t/28_instance.t
+++ b/t/28_instance.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::MockModule;
+use Test::MockObject;
+use Test::Exception;
+use Test::More;
+use Test::Mock::Time;
+use testapi;
+use List::Util qw(any none sum);
+
+use publiccloud::instance;
+
+subtest "[retry_on_script_output]" => sub {
+    my $pc_instance = Test::MockModule->new('publiccloud::instance');
+    my $result = "";
+    my $data_test = (
+        username => 'test'
+    );
+    $pc_instance->redefine(ssh_script_output => sub { return "running"; });
+    $pc_instance->redefine(record_info => sub {
+            note(join(' ', 'RECORD_INFO --> System is running.', @_)); });
+
+    $result = publiccloud::instance->retry_on_script_output($pc_instance, $data_test);
+    ok $result eq 'running';
+};
+
+subtest "[retry_on_script_output_stop]" => sub {
+    my $pc_instance = Test::MockModule->new('publiccloud::instance');
+    my $result = "";
+    my $data_test = (
+        username => 'test'
+    );
+    $pc_instance->redefine(ssh_script_output => sub { return "stopped"; });
+    $pc_instance->redefine(record_info => sub {
+            note(join(' ', 'RECORD_INFO --> Failed after retries.', @_)); });
+
+    $result = publiccloud::instance->retry_on_script_output($pc_instance, $data_test);
+    ok $result eq 'stopped';
+};
+
+done_testing;


### PR DESCRIPTION
Retried on failure in the script_output for ssh
Ticket: https://jira.suse.com/browse/TEAM-9651
- Verification run: https://openqaworker15.qa.suse.cz/tests/299921#
