### PR TITLE
Unify perl pods for SDAF libraries

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/configure_tfvars.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/configure_tfvars.pm
@@ -29,15 +29,14 @@ our @EXPORT = qw(
 
     prepare_tfvars_file(deployment_type=>$deployment_type);
 
-=over 1
-
-=item B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
-
-=back
-
 Downloads tfvars template files from openQA data dir and places them into correct place within SDAF repo structure.
 Returns full path of the tfvars file.
 
+=over
+
+=item * B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+
+=back
 =cut
 
 sub prepare_tfvars_file {
@@ -74,15 +73,14 @@ sub prepare_tfvars_file {
 
     replace_tfvars_variables();
 
-=over 1
-
-=item B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
-
-=back
-
 Replaces placeholder pattern B<%OPENQA_VARIABLE%> with corresponding OpenQA variable value.
 If OpenQA variable is not set, placeholder is replaced with empty value.
 
+=over
+
+=item * B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+
+=back
 =cut
 
 sub replace_tfvars_variables {
@@ -97,15 +95,14 @@ sub replace_tfvars_variables {
 
     set_workload_vnet_name([job_id=>$job_id]);
 
-=over 1
-
-=item B<$job_id>: Specify job id to be used. Default: current deployment job ID
-
-=back
-
 Returns VNET name used for workload zone and sap systems resources. VNET name must be unique for each landscape,
 therefore it contains test ID as an identifier.
 
+=over
+
+=item * B<$job_id>: Specify job id to be used. Default: current deployment job ID
+
+=back
 =cut
 
 sub set_workload_vnet_name {

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -49,14 +49,17 @@ Checks if deployer VM is running and listening on ssh port. Returns found state.
 Optionally function can wait till VM reaches requested state until timeout.
 Function dies only with internal errors, VM status should be evaluated and handled by caller.
 
-B<deployer_ip_addr>: Deployer VM IP address
+=over
 
-B<wait_started>: Probe SSH port in loop untill it is available or B<wait_timeoout> is reached.
+=item * B<deployer_ip_addr>: Deployer VM IP address
 
-B<wait_timeout>: Time in sec to stop probing SSH port.
+=item * B<wait_started>: Probe SSH port in loop untill it is available or B<wait_timeoout> is reached.
 
-B<ssh_port>: Specify custom SSH port number. Default: 22
+=item * B<wait_timeout>: Time in sec to stop probing SSH port.
 
+=item * B<ssh_port>: Specify custom SSH port number. Default: 22
+
+=back
 =cut
 
 sub check_ssh_availability {
@@ -90,10 +93,13 @@ sub check_ssh_availability {
 
 Returns first public IP of deployer VM that is reachable and can be used for SDAF deployment connection.
 
-B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+=over
 
-B<deployer_vm_name>: Deployer VM resource name
+=item * B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
 
+=item * B<deployer_vm_name>: Deployer VM resource name
+
+=back
 =cut
 
 sub get_deployer_ip {
@@ -121,10 +127,13 @@ to deploy the infrastructure under this ID and contains whole SDAF setup.
 Function returns VM name or undef if no VM was found.
 Function dies if there is more than one VM found, because two VM's must not have same ID.
 
-B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+=over
 
-B<deployment_id>: Deployment ID
+=item * B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
 
+=item * B<deployment_id>: Deployment ID
+
+=back
 =cut
 
 sub get_deployer_vm_name {
@@ -181,8 +190,11 @@ Job: 123456 - deployment module - created deployer VM tagged with "deployment_id
 Job: 123457 (child of 123456) - some test module
 Deployment ID returned from both jobs: 123456 - because it matches with existing VM tagged with "deployment_id=123456"
 
-B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+=over
 
+=item * B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+
+=back
 =cut
 
 sub find_deployment_id {
@@ -209,14 +221,17 @@ sub find_deployment_id {
 
 Returns ARRAYREF of all resources belonging to B<deployer_resource_group> tagged with B<deployment_id>.
 
-B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
+=over
 
-B<deployment_id>: Deployment ID
+=item * B<deployer_resource_group>: Deployer resource group. Default: get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP')
 
-B<return_value>: Control the content of the returned array. It can either return array of resource IDs or resource names.
+=item * B<deployment_id>: Deployment ID
+
+=item * B<return_value>: Control the content of the returned array. It can either return array of resource IDs or resource names.
     Values allowed: id, name
     Default: name
 
+=back
 =cut
 
 sub find_deployer_resources {
@@ -246,8 +261,11 @@ sub find_deployer_resources {
 Collects resource id of all resources belonging to the deployer VM and deletes them.
 Cleanup deployer VM resources only, B<deployer resource group itself will stay intact>.
 
-B<timeout>: Timeout for destroy command. Default: 800
+=over
 
+=item * B<timeout>: Timeout for destroy command. Default: 800
+
+=back
 =cut
 
 sub destroy_deployer_vm {

--- a/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
@@ -74,13 +74,16 @@ my %sdaf_region_matrix = (
 
     convert_region_to_long($sdaf_region_code);
 
-B<$sdaf_region_code>: Region name abbreviation containing 4 uppercase alphanumeric characters
-
 Performs region name conversion from 4 letter SDAF abbreviation to full region name.
 You can find definitions in the function B<get_region_code> located in sdaf shell script:
 
 L<https://github.com/Azure/sap-automation/blob/3c5d0d882f5892ae2159e262062e29c2b3fe59d9/deploy/scripts/deploy_utils.sh#L403>
 
+=over
+
+=item * B<$sdaf_region_code>: Region name abbreviation containing 4 uppercase alphanumeric characters
+
+=back
 =cut
 
 sub convert_region_to_long {
@@ -95,13 +98,16 @@ sub convert_region_to_long {
 
     convert_region_to_short($region);
 
-B<$region>: Full region name. Can contain only lowercase alphanumeric characters.
-
 Performs region name conversion from full region name to 4 letter SDAF abbreviation.
 You can find definitions in the function B<get_region_code> located in sdaf shell script:
 
 L<https://github.com/Azure/sap-automation/blob/3c5d0d882f5892ae2159e262062e29c2b3fe59d9/deploy/scripts/deploy_utils.sh#L403>
 
+=over
+
+=item * B<$region>: Full region name. Can contain only lowercase alphanumeric characters.
+
+=back
 =cut
 
 sub convert_region_to_short {
@@ -134,11 +140,14 @@ sub homedir {
 
     deployment_dir([create=>1]);
 
-B<create>: Create directory if it does not exist.
-
 Returns deployment directory path with job ID appended as unique identifier.
 Optionally it can create directory if it does not exists.
 
+=over
+
+=item * B<create>: Create directory if it does not exist.
+
+=back
 =cut
 
 sub deployment_dir {
@@ -153,11 +162,14 @@ sub deployment_dir {
 
     log_dir([create=>1]);
 
-B<create>: Create directory if it does not exist.
-
 Returns logging directory path with job ID appended as unique identifier.
 Optionally creates the directory.
 
+=over
+
+=item * B<create>: Create directory if it does not exist.
+
+=back
 =cut
 
 sub log_dir {
@@ -205,18 +217,21 @@ sub env_variable_file {
 Returns path to config root directory for deployment type specified.
 Root config directory is deployment type specific and usually contains tfvar file, inventory file, SUT ssh keys, etc...
 
-B<deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+=over
 
-B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
+=item * B<deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
 
-B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
+=item * B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
 
-B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
+=item * B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
 
-B<sap_sid>: SDAF parameter for sap system ID
+=item * B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
 
-B<job_id>: Specify job id instead of using current one. Default: current job id
+=item * B<sap_sid>: SDAF parameter for sap system ID
 
+=item * B<job_id>: Specify job id instead of using current one. Default: current job id
+
+=back
 =cut
 
 sub get_sdaf_config_path {
@@ -254,16 +269,19 @@ sub get_sdaf_config_path {
 
 Returns full tfvars filepath respective to deployment type.
 
-B<deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+=over
 
-B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
+=item * B<deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
 
-B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
+=item * B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
 
-B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
+=item * B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
 
-B<sap_sid>: SDAF parameter for sap system ID. Required only for 'sap_system' deployment type
+=item * B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
 
+=item * B<sap_sid>: SDAF parameter for sap system ID. Required only for 'sap_system' deployment type
+
+=back
 =cut
 
 sub get_tfvars_path {
@@ -289,11 +307,14 @@ sub get_tfvars_path {
 
     generate_resource_group_name(deployment_type=>$deployment_type);
 
-B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
-
 Returns name of the resource group for the deployment type specified by B<$deployment_type> .
 Resource group pattern: I<SDAF-OpenQA-[deployment type]-[deployment id]-[OpenQA job id]>
 
+=over
+
+=item * B<$deployment_type>: Type of the deployment (workload_zone, sap_system, library... etc)
+
+=back
 =cut
 
 sub generate_resource_group_name {
@@ -310,10 +331,13 @@ sub generate_resource_group_name {
 
     generate_deployer_name([job_id=>$job_id]);
 
-B<$job_id>: Specify job id to be used. Default: current job ID
-
 Generates resource name for deployer VM in format B<test_id-OpenQA_Deployer_VM>.
 
+=over 1
+
+=item * B<$job_id>: Specify job id to be used. Default: current job ID
+
+=back
 =cut
 
 sub generate_deployer_name {
@@ -326,11 +350,14 @@ sub generate_deployer_name {
 
     get_workload_vnet_code([job_id=>$job_id]);
 
-B<$job_id>: Specify job id to be used. Default: current job ID
-
 Returns VNET code used for workload zone and sap systems resources. VNET code must be unique for each landscape,
 therefore it contains test ID as an identifier.
 
+=over
+
+=item * B<$job_id>: Specify job id to be used. Default: current job ID
+
+=back
 =cut
 
 sub get_workload_vnet_code {


### PR DESCRIPTION
This PR unifies perl POD formatting for all SDAF modules. It does not contain 
any functional change.

Formatting is organized in following format:

```
fuction name

    usage example
    
description

* argument 1:  description
* argument 2:  description
```