### PR TITLE
Fix string type

### DIFF
--- a/data/gdb/test2.c
+++ b/data/gdb/test2.c
@@ -12,7 +12,7 @@ char *str_dup(char *src, int len){
 
 int main()
 {
-  char *cstr = 'five';
-  char * newstr = str_dup(cstr, 5);
+  char *cstr = (char*)'five';
+  char * newstr = str_dup(cstr, 32); // len is intentionally longer to cause an access violation
   return 0;
 }

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -78,7 +78,7 @@ sub run {
     wait_serial_or_die('in main \(\) at test2\.c:16');
     enter_gdb_cmd("info locals");
     enter_gdb_cmd("up");
-    wait_serial_or_die(qr/1\s+.*\s+in main \(\) at test2\.c:16\s+16\s+char \* newstr = str_dup\(cstr, 5\);/);
+    wait_serial_or_die(qr/1\s+.*\s+in main \(\) at test2\.c:16\s+16\s+char \* newstr = str_dup\(cstr, 32\);/);
     enter_gdb_cmd("info locals");
     wait_serial_or_die("<error: Cannot access memory at ");
     enter_gdb_cmd("quit");


### PR DESCRIPTION
gcc14 has become stricter towards multi-character constants. This commit adds a (char*) cast to avoid compilation errors.

- Related ticket: https://progress.opensuse.org/issues/165896
- Verification run: [Tumbleweed](https://duck-norris.qe.suse.de/tests/14811) | [15-SP6](https://openqa.suse.de/tests/15689883) | [15-SP5](https://openqa.suse.de/tests/15689884) | [15-SP4](https://openqa.suse.de/tests/15689885) | [15-SP3](https://openqa.suse.de/tests/15689886) | [15-SP2](https://openqa.suse.de/tests/15689887) | [12-SP5](https://openqa.suse.de/tests/15689891)
