### PR TITLE
Set boot parameter 'console' on grub2 entry after installation for Leap 16.0

### DIFF
--- a/lib/Distribution/Opensuse/AgamaDevel.pm
+++ b/lib/Distribution/Opensuse/AgamaDevel.pm
@@ -23,6 +23,7 @@ use Yam::Agama::Pom::RebootTextmodePage;
 use Yam::Agama::Pom::EnterPassphraseBasePage;
 use Yam::Agama::Pom::EnterPassphraseForRootPage;
 use Yam::Agama::Pom::EnterPassphraseForSwapPage;
+use Yam::Agama::Pom::GrubMenuBaseBug1231658Page;
 
 use Utils::Architectures;
 
@@ -30,6 +31,11 @@ sub get_grub_menu_agama {
     return Yam::Agama::Pom::GrubMenuAgamaPage->new({
             grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()
     });
+}
+
+sub get_grub_menu_base {
+    return is_aarch64() ? Yam::Agama::Pom::GrubMenuBaseBug1231658Page->new()
+      : Yam::Agama::Pom::GrubMenuBasePage->new();
 }
 
 sub get_grub_menu_installed_system {
@@ -40,7 +46,6 @@ sub get_grub_menu_installed_system {
 
 sub get_grub_entry_edition {
     return is_ppc64le() ? Yam::Agama::Pom::GrubEntryEditionPage->new({
-            number_kernel_line => 3,
             max_interval => utils::VERY_SLOW_TYPING_SPEED})
       : Yam::Agama::Pom::GrubEntryEditionPage->new();
 }

--- a/lib/Distribution/Opensuse/Leap/16Latest.pm
+++ b/lib/Distribution/Opensuse/Leap/16Latest.pm
@@ -13,13 +13,11 @@ use parent Distribution::Opensuse::AgamaDevel;
 use strict;
 use warnings FATAL => 'all';
 
-use Yam::Agama::Pom::GrubMenuBasePage;
 use Yam::Agama::Pom::GrubMenuLeapPage;
 
 sub get_grub_menu_installed_system {
-    return Yam::Agama::Pom::GrubMenuLeapPage->new({
-            grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()
-    });
+    my $self = shift;
+    return Yam::Agama::Pom::GrubMenuLeapPage->new({grub_menu_base => $self->get_grub_menu_base()});
 }
 
 1;

--- a/lib/Distribution/Sle/16Latest.pm
+++ b/lib/Distribution/Sle/16Latest.pm
@@ -13,4 +13,11 @@ use parent Distribution::Sle::AgamaDevel;
 use strict;
 use warnings FATAL => 'all';
 
+use Yam::Agama::Pom::GrubMenuSlesPage;
+
+sub get_grub_menu_installed_system {
+    my $self = shift;
+    return Yam::Agama::Pom::GrubMenuSlesPage->new({grub_menu_base => $self->get_grub_menu_base()});
+}
+
 1;

--- a/lib/Yam/Agama/Pom/GrubEntryEditionPage.pm
+++ b/lib/Yam/Agama/Pom/GrubEntryEditionPage.pm
@@ -15,15 +15,13 @@ use testapi;
 sub new {
     my ($class, $args) = @_;
     return bless {
-        number_kernel_line => $args->{number_kernel_line} // 4,
-        max_interval => $args->{number_kernel_line},
+        max_interval => undef,
         key_boot => 'ctrl-x'
     }, $class;
 }
 
 sub move_cursor_to_end_of_kernel_line {
-    my ($self) = @_;
-    for (1 .. $self->{number_kernel_line}) { send_key('down') }
+    send_key_until_needlematch "linux-line-selected", "down", 26;
     wait_screen_change { send_key('end') };
     wait_still_screen(1);
 }

--- a/lib/Yam/Agama/Pom/GrubMenuBaseBug1231658Page.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuBaseBug1231658Page.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles common grub screen actions, workaround for bsc#1231658.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Yam::Agama::Pom::GrubMenuBaseBug1231658Page;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    return bless {
+        key_edit_entry => 'e'
+    }, $class;
+}
+
+sub edit_current_entry {
+    my ($self) = @_;
+    wait_screen_change { send_key($self->{key_edit_entry}) };
+}
+
+sub select_first_entry {
+    my $grub_menu = $testapi::distri->get_grub_menu_agama();
+    my $grub_entry_edition = $testapi::distri->get_grub_entry_edition();
+    my @params = ('console=ttyAMA0 console=tty');
+
+    record_soft_failure "bsc#1231658 - [Agama] Installer boot parameter 'console' unset after installation";
+    $grub_menu->edit_current_entry();
+    $grub_entry_edition->move_cursor_to_end_of_kernel_line();
+    $grub_entry_edition->type(\@params);
+    $grub_entry_edition->boot();
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/168205
- Needles: N/A
- Verification run:
openSUSE leap: https://openqa.opensuse.org/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23debug-leap-agama-issue&version=16.0&distri=opensuse
openSUSE devel: https://openqa.opensuse.org/tests/overview?version=agama-9.0&distri=opensuse&build=lemon-suse%2Fos-autoinst-distri-opensuse%23debug-leap-agama-issue
SLES 16.0 devel: https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23debug-leap-agama-issue&distri=sle&version=agama-10.0
SLES 16.0 : https://openqa.suse.de/tests/overview?version=16.0&distri=sle&build=lemon-suse%2Fos-autoinst-distri-opensuse%23debug-leap-agama-issue 
