### PR TITLE
WIP: PC Tools image - change root fs to btrfs

### DIFF
--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -119,7 +119,7 @@
       <partitions config:type="list">
         <partition>
           <mountby config:type="symbol">device</mountby>
-          <filesystem config:type="symbol">ext4</filesystem>
+          <filesystem config:type="symbol">btrfs</filesystem>
           <mount>/</mount>
         </partition>
       </partitions>


### PR DESCRIPTION
ext4 fs has problem with max lenght of filename if is used unicode

