### PR TITLE
Agama: enable installation for full encryption on SLES

### DIFF
--- a/lib/Distribution/Sle/AgamaDevel.pm
+++ b/lib/Distribution/Sle/AgamaDevel.pm
@@ -10,35 +10,20 @@
 package Distribution::Sle::AgamaDevel;
 use strict;
 use warnings FATAL => 'all';
-use parent 'susedistribution';
+use parent 'Distribution::Opensuse::Leap::16Latest';
 
 use Yam::Agama::Pom::GrubMenuBasePage;
-use Yam::Agama::Pom::GrubMenuAgamaPage;
-use Yam::Agama::Pom::GrubEntryEditionPage;
+use Yam::Agama::Pom::GrubMenuSlesPage;
 use Yam::Agama::Pom::AgamaUpAndRunningSlePage;
-use Yam::Agama::Pom::RebootPage;
 
-use Utils::Architectures;
-
-sub get_grub_menu_agama {
-    return Yam::Agama::Pom::GrubMenuAgamaPage->new({
+sub get_grub_menu_installed_system {
+    return Yam::Agama::Pom::GrubMenuSlesPage->new({
             grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()
     });
 }
 
-sub get_grub_entry_edition {
-    return is_ppc64le() ? Yam::Agama::Pom::GrubEntryEditionPage->new({
-            number_kernel_line => 3,
-            max_interval => utils::VERY_SLOW_TYPING_SPEED})
-      : Yam::Agama::Pom::GrubEntryEditionPage->new();
-}
-
 sub get_agama_up_an_running {
     return Yam::Agama::Pom::AgamaUpAndRunningSlePage->new();
-}
-
-sub get_reboot {
-    return Yam::Agama::Pom::RebootPage->new();
 }
 
 1;

--- a/lib/Yam/Agama/Pom/GrubMenuSlesPage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuSlesPage.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles grub screen in SLES 16.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Yam::Agama::Pom::GrubMenuSlesPage;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    return bless {
+        grub_menu_base => $args->{grub_menu_base},
+        tag_first_entry_highlighted => 'grub-menu-sles16-highlighted',
+    }, $class;
+}
+
+sub expect_is_shown {
+    my ($self) = @_;
+    assert_screen($self->{tag_first_entry_highlighted}, 60);
+}
+
+sub edit_current_entry { shift->{grub_menu_base}->edit_current_entry() }
+sub select_first_entry { shift->{grub_menu_base}->select_first_entry() }
+
+1;


### PR DESCRIPTION
- Related ticket: [poo#167470](https://progress.opensuse.org/issues/167470)
- Needles: 
  + enter-passphrase-for-root-partition-20241015.json:    "enter-passphrase-for-root-partition"  
  + enter-passphrase-for-root-partition-x86_64-20241015.json:    "enter-passphrase-for-root-partition"
  + enter-passphrase-for-swap-partition-20241015.json:    "enter-passphrase-for-swap-partition"

- Verification run: [overview](https://openqa.suse.de/tests/overview?build=build-issues-167470)
