### PR TITLE
Ipaddr2 cluster setup for 12sp5

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -1211,6 +1211,16 @@ sub ipaddr2_create_cluster {
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
 
     ipaddr2_ssh_internal(id => 1,
+        cmd => 'rpm -qf $(sudo which crm)',
+        bastion_ip => $args{bastion_ip});
+    ipaddr2_ssh_internal(id => 1,
+        cmd => 'sudo crm --version',
+        bastion_ip => $args{bastion_ip});
+    ipaddr2_ssh_internal(id => 1,
+        cmd => 'zypper se -s -i crmsh',
+        bastion_ip => $args{bastion_ip});
+
+    ipaddr2_ssh_internal(id => 1,
         cmd => 'sudo crm cluster init -y --name DONALDUCK',
         bastion_ip => $args{bastion_ip});
 

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -324,6 +324,23 @@ subtest '[ipaddr2_create_cluster]' => sub {
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /.*41.*cluster init/ } @calls), 'crm cluster init on VM1');
     ok((any { /.*42.*cluster join/ } @calls), 'crm cluster join on VM2');
+    # by default it run in rootless mode
+    # so the join has also to specify the user
+    ok((any { /.*cluster join.*-c.*cloudadmin@/ } @calls), 'crm cluster join use user name');
+};
+
+subtest '[ipaddr2_create_cluster] root' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    my @calls;
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return 'Moriondo'; });
+
+    ipaddr2_create_cluster(rootless => 0);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /.*41.*cluster init/ } @calls), 'crm cluster init on VM1');
+    ok((any { /.*42.*cluster join/ } @calls), 'crm cluster join on VM2');
+    ok((none { /.*cluster join.*-c.*cloudadmin@/ } @calls), 'crm cluster join not use user name');
 };
 
 subtest '[ipaddr2_deployment_sanity] Pass' => sub {
@@ -433,6 +450,52 @@ subtest '[ipaddr2_internal_key_gen]' => sub {
     note("\n  -->  " . join("\n  -->  ", @calls));
 
     ok((any { /ssh-keygen/ } @calls), 'Generate the keys if they does not exist');
+    # search through all the ssh-keygen and extract the ssh key file path after -f
+    # then check if there's a scp uploading it
+    foreach my $cmd (@calls) {
+        ok((any { qr/scp.*$1.*@.*/ } @calls), "There is at least one scp command uploading key $1") if ($cmd =~ qr/ssh-keygen.*-f (.*)/);
+    }
+    # search through all the scp and extract the target path
+    # then check if there's a mv command moving it from the remote /tmp to the remote home folder
+    foreach my $cmd (@calls) {
+        ok((any { qr/mv.*$1.*/ } @calls), "There is at least one mv command moving the uploaded key $1") if ($cmd =~ qr/scp.*@.*:(.*)/);
+    }
+};
+
+subtest '[ipaddr2_internal_key_gen] custom user' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+    # return 1 means file does not exist.
+    #$ipaddr2->redefine(script_run => sub { push @calls, $_[0]; return 1; });
+    $ipaddr2->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'BeniaminoFiammaPubKeyBeniaminoFiammaPubKey'; });
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+
+    ipaddr2_internal_key_gen(user => 'EliaLocatelli');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+
+    ok((any { /mv.*\/home\/EliaLocatelli.*/ } @calls), 'Move the key in the remote user home folder');
+};
+
+subtest '[ipaddr2_internal_key_gen] root' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+    # return 1 means file does not exist.
+    #$ipaddr2->redefine(script_run => sub { push @calls, $_[0]; return 1; });
+    $ipaddr2->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'BeniaminoFiammaPubKeyBeniaminoFiammaPubKey'; });
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+
+    ipaddr2_internal_key_gen(user => 'root');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+
+    ok((any { /mv.*\/root\/.*/ } @calls), 'Move the key in the remote root home folder');
 };
 
 subtest '[ipaddr2_deployment_logs]' => sub {

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -39,6 +39,7 @@ sub run {
     my %int_key_args = (bastion_ip => $bastion_ip);
     # unsupported option "accept-new" for default ssh used in 12sp5
     $int_key_args{key_checking} = 'no' if (check_var('IPADDR2_KEYCHECK_OLD', '1'));
+    $int_key_args{user} = 'root' if check_var('IPADDR2_ROOTLESS', '0');
 
     ipaddr2_internal_key_accept(%int_key_args);
     ipaddr2_internal_key_gen(%int_key_args);
@@ -72,7 +73,7 @@ sub run {
     }
 
     record_info("TEST STAGE", "Init and configure the Pacemaker cluster");
-    ipaddr2_create_cluster(bastion_ip => $bastion_ip);
+    ipaddr2_create_cluster(bastion_ip => $bastion_ip, rootless => get_var('IPADDR2_ROOTLESS', '1'));
 }
 
 sub test_flags {

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -13,7 +13,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_key_accept
   ipaddr2_bastion_pubip
   ipaddr2_configure_web_server
-  ipaddr2_create_cluster
+  ipaddr2_cluster_create
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_internal_key_accept
@@ -39,9 +39,10 @@ sub run {
     my %int_key_args = (bastion_ip => $bastion_ip);
     # unsupported option "accept-new" for default ssh used in 12sp5
     $int_key_args{key_checking} = 'no' if (check_var('IPADDR2_KEYCHECK_OLD', '1'));
-    $int_key_args{user} = 'root' if check_var('IPADDR2_ROOTLESS', '0');
-
     ipaddr2_internal_key_accept(%int_key_args);
+
+    # default for ipaddr2_internal_key_gen is cloudadmin
+    $int_key_args{user} = 'root' unless check_var('IPADDR2_ROOTLESS', '1');
     ipaddr2_internal_key_gen(%int_key_args);
 
     if (check_var('IPADDR2_CLOUDINIT', 0)) {
@@ -73,7 +74,7 @@ sub run {
     }
 
     record_info("TEST STAGE", "Init and configure the Pacemaker cluster");
-    ipaddr2_create_cluster(bastion_ip => $bastion_ip, rootless => get_var('IPADDR2_ROOTLESS', '1'));
+    ipaddr2_cluster_create(bastion_ip => $bastion_ip, rootless => get_var('IPADDR2_ROOTLESS', '0'));
 }
 
 sub test_flags {


### PR DESCRIPTION
# Changes description:

Code was using rootless cluster init and join mode by default. This mode is not supported in crmsh version delivered in 12sp5.
Change the code to add support for root mode:
1. Allow specifying user in function that generate ssh keys for the internal VMs. It allows calling it for root.
2. Change remote note syntax in cluster join command.
3. Add setting `IPADDR2_ROOTLESS` to control both.

# Related ticket:
https://jira.suse.com/browse/TEAM-9743


# Verification run:

## Without any IPADDR2_ROOTLESS value
### 15sp5
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test
- http://openqaworker15.qa.suse.cz/tests/300340 :green_circle:  result in using root mode everywhere

### 12sp5
- http://openqaworker15.qa.suse.cz/tests/300343 :green_circle: `crm cluster join` is now fine http://openqaworker15.qa.suse.cz/tests/300343#step/configure/191. Cluster is later not healthy, but issue is another issue (socat  missing) that I 'd like to handle in a different PR.  

## IPADDR2_ROOTLESS=0
### 15sp5
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test 
 - http://openqaworker15.qa.suse.cz/tests/300341 :green_circle: 
 
### 12sp5
sle-12-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-ipaddr2_azure_test 
 - http://openqaworker15.qa.suse.cz/tests/300344 :green-circle: `crm cluster join` is now fine http://openqaworker15.qa.suse.cz/tests/300343#step/configure/191. Cluster is later not healthy, but issue is another issue (socat  missing) that I 'd like to handle in a different PR.  

## IPADDR2_ROOTLESS=1
### 15sp5
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test 
 - http://openqaworker15.qa.suse.cz/tests/300234 :green_circle: 
 - http://openqaworker15.qa.suse.cz/tests/300342 :green_apple: 

### 12sp5
ROOTLESS mode is not supported in pacemaker available for this version.
- http://openqaworker15.qa.suse.cz/tests/300345 so as expected it fails in `crm cluster join` in https://openqaworker15.qa.suse.cz/tests/300345#step/configure/191

