### PR TITLE
Enable 12sp5 ltss and ltss_es virt tests

### DIFF
--- a/data/virtualization/autoyast/guest_12.xml.ep
+++ b/data/virtualization/autoyast/guest_12.xml.ep
@@ -51,12 +51,21 @@
     <arch>{{ARCH}}</arch>
     <release_type/>
     </addon>
-    % if ($ltss_code) {
+    % if ($ltss_code && $check_var->('EXTENDED_SECURITY', '0')) {
     <addon>
       <name>SLES-LTSS</name>
       <version>{{VERSION}}</version>
       <arch>{{ARCH}}</arch>
       <reg_code><%= $ltss_code %></reg_code>
+      <release_type/>
+    </addon>
+    % }
+    % if ($ltss_es_code && $check_var->('EXTENDED_SECURITY', '1')) {
+    <addon>
+      <name>SLES-LTSS-Extended-Security</name>
+      <version>{{VERSION}}</version>
+      <arch>{{ARCH}}</arch>
+      <reg_code><%= $ltss_es_code %></reg_code>
       <release_type/>
     </addon>
     % }

--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -53,7 +53,11 @@
     <addons config:type="list">
       % while (my ($key, $addon) = each (%$addons)) {
       <addon>
+        % if ($check_var->('EXTENDED_SECURITY', '1')) {
+        <name>SLES-LTSS-Extended-Security</name>
+        % } else {
         <name><%= $addon->{name} %></name>
+        % }
         <version><%= $addon->{version} %></version>
         <arch><%= $addon->{arch} %></arch>
         <release_type/>
@@ -66,8 +70,11 @@
         % if ($key eq 'rt') {
         <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
         % }
-        % if ($key eq 'ltss') {
+        % if ($key eq 'ltss' and $check_var->('EXTENDED_SECURITY', '0')) {
         <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+        % }
+        % if ($key eq 'ltss' and $check_var->('EXTENDED_SECURITY', '1')) {
+        <reg_code><%= $get_var->('SCC_REGCODE_LTSS_ES') %></reg_code>
         % }
       </addon>
       % }

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2402,6 +2402,8 @@ sub set_mu_virt_vars {
     bmwqemu::save_vars();
     diag("BUILD is $BUILD, UPDATE_PACKAGE is set to " . get_var('UPDATE_PACKAGE', ''));
 
+    # Check if repo is LTSS-Extended-Security and sets EXTENDED_SECURITY to 1
+    set_var('EXTENDED_SECURITY', (get_var('INCIDENT_REPO') =~ /LTSS-Extended-Security/) ? 1 : 0);
     # Set PATCH_WITH_ZYPPER
     set_var('PATCH_WITH_ZYPPER', 1) unless (check_var('PATCH_WITH_ZYPPER', 0));
 }

--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -243,6 +243,9 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         sles12sp5 => {
             name => 'sles12sp5',
         },
+        sles12sp5ES => {
+            name => 'sles12sp5ES',
+        },
         sles15sp2 => {
             name => 'sles15sp2',
         },
@@ -262,7 +265,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             name => 'sles15sp6',
         },
     );
-    %guests = get_var('TERADATA') ? %guests{"sles${guest_version}TD"} : %guests{"sles${guest_version}"};
+    %guests = get_var('TERADATA') ? %guests{"sles${guest_version}TD"} : (get_var('INCIDENT_REPO') =~ /LTSS-Extended-Security/) ? %guests{"sles${guest_version}ES"} : %guests{"sles${guest_version}"};
 
 } elsif (get_var("REGRESSION", '') =~ /hyperv/) {
     %guests = (
@@ -271,6 +274,9 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         },
         sles12sp5 => {
             vm_name => 'sles-12.5_openQA-virtualization-maintenance',
+        },
+        sles12sp5ES => {
+            vm_name => 'sles-12.5_openQA-virtualization-maintenance-ES',
         },
         sles15sp2 => {
             vm_name => 'sles-15.2_openQA-virtualization-maintenance',
@@ -291,7 +297,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             vm_name => 'sles-15.6_openQA-virtualization-maintenance',
         },
     );
-    %guests = get_var('TERADATA') ? %guests{"sles${guest_version}TD"} : %guests{"sles${guest_version}"};
+    %guests = get_var('TERADATA') ? %guests{"sles${guest_version}TD"} : (get_var('INCIDENT_REPO') =~ /LTSS-Extended-Security/) ? %guests{"sles${guest_version}ES"} : %guests{"sles${guest_version}"};
 }
 
 our %imports = ();    # imports are virtual machines that we don't install but just import. We test those separately.

--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -39,7 +39,7 @@ sub run {
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));
     my $host_os_version = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
     foreach my $guest (@guests) {
-        if ($guest eq $host_os_version || $guest eq "${host_os_version}TD" || $guest eq "${host_os_version}PV" || $guest eq "${host_os_version}HVM") {
+        if ($guest eq $host_os_version || $guest eq "${host_os_version}TD" || $guest eq "${host_os_version}PV" || $guest eq "${host_os_version}HVM" || $guest eq "${host_os_version}ES") {
             if (check_var('PATCH_WITH_ZYPPER', '1')) {
                 assert_script_run("ssh root\@$guest dmesg --level=emerg,crit,alert,err -tx|sort -o /tmp/${guest}_dmesg_err_before.txt");
                 record_info("Patching $guest");

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -29,6 +29,7 @@ sub create_profile {
     my $path = $version >= 15 ? "virtualization/autoyast/guest_15.xml.ep" : "virtualization/autoyast/guest_12.xml.ep";
     my $scc_code = get_required_var("SCC_REGCODE");
     my %ltss_products = @{get_var_array("LTSS_REGCODES_SECRET")};
+    my %ltss_es_products = @{get_var_array("LTSS_ES_REGCODES_SECRET")};
     my $ca_str = "SLE_" . $version =~ s/\./_SP/r;
     my $sut_ip = get_required_var("SUT_IP");
     my $profile = get_test_data($path);
@@ -47,6 +48,7 @@ sub create_profile {
     my $vars = {
         vm_name => $vm_name,
         ltss_code => $ltss_products{$version},
+        ltss_es_code => $ltss_es_products{$version},
         repos => [split(/,/, $incident_repos)],
         check_var => \&check_var,
         get_var => \&get_required_var


### PR DESCRIPTION
Variable EXTENDED_SECURITY is set automatically if INCIDENT_REPO conatins ltts or ltss_se repo. No need for new test suites or job groups to run tests.

- Related ticket: https://progress.opensuse.org/issues/165243
- Needles: N/A
- Verification run: 

LTSS:
XEN Migration => http://openqa.qam.suse.cz/tests/81030#dependencies
KVM Migration => http://openqa.qam.suse.cz/tests/81032#dependencies
XEN           => http://openqa.qam.suse.cz/tests/81045
KVM           => http://openqa.qam.suse.cz/tests/81021
HyperV        => https://openqa.suse.de/tests/15732313
VMware        => https://openqa.suse.de/tests/15732314

LTSS_ES:
XEN Migration => http://openqa.qam.suse.cz/tests/81028#dependencies
KVM Migration => http://openqa.qam.suse.cz/tests/81025#dependencies
XEN           => http://openqa.qam.suse.cz/tests/81033
KVM           => http://openqa.qam.suse.cz/tests/81022
HyperV        => https://openqa.suse.de/tests/15732311
VMware        => https://openqa.suse.de/tests/15732312
