### PR TITLE
Install openssl1.1 binary when legacy module isn't available

### DIFF
--- a/lib/security/openssl_misc_utils.pm
+++ b/lib/security/openssl_misc_utils.pm
@@ -13,7 +13,7 @@ use warnings;
 use testapi;
 use registration 'add_suseconnect_product';
 use utils 'zypper_call';
-use version_utils qw(is_sle is_sle_micro is_microos is_transactional is_tumbleweed);
+use version_utils qw(is_sle is_sle_micro is_microos is_transactional is_tumbleweed is_rt);
 
 use base 'Exporter';
 
@@ -23,6 +23,8 @@ use constant OPENSSL1_BINARY => "openssl-1_1";
 
 sub get_openssl_full_version {
     my $openssl_binary = shift // "openssl";
+    # for SLERT we don't install a package, we query the rpm file just downloaded in install_openssl
+    return script_output("rpm -qp --qf '%{version}\n' openssl*.rpm") if (is_rt && $openssl_binary eq OPENSSL1_BINARY);
     return script_output("rpm -q --qf '%{version}\n' $openssl_binary");
 }
 
@@ -38,15 +40,35 @@ sub has_default_openssl1 {
 }
 
 sub has_default_openssl3 {
-    return (is_sle('>=15-SP6') || is_sle_micro('>=6.0') || is_tumbleweed || is_microos('Tumbleweed'));
+    return (is_sle('>=15-SP6') || is_sle_micro('>=6.0') || is_tumbleweed || is_microos('Tumbleweed') || is_rt);
 }
 
 sub install_openssl {
     zypper_call 'in openssl' unless is_transactional;
     if (is_sle '>=15-SP6') {
+        if (is_rt)
+        {
+            install_11_workaround_when_no_legacy();
+            return;
+        }
         add_suseconnect_product('sle-module-legacy');
         zypper_call 'in openssl-1_1';
     }
+}
+
+# if we don't have legacy module (i.e. for SLERT) download the rpm , extract and place in $PATH
+sub install_11_workaround_when_no_legacy {
+    my $product_version = get_required_var 'VERSION';
+    my $arch = get_required_var 'ARCH';
+    my $legacy_repourl = "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Legacy/$product_version/$arch/product";
+    # lookup the repo index to find out the exact package name
+    # output will be somewhat like ./x86_64/openssl-1_1-1.1.1w-150600.3.10.x86_64.rpm
+    my $rpm_name = (split '/', script_output "curl -Lsk $legacy_repourl/INDEX.gz | gzip -cd | grep 'openssl-1_1.*\.rpm'")[-1];
+    assert_script_run "curl -skLO $legacy_repourl/$arch/$rpm_name";
+    # extract the RPM package content
+    assert_script_run "rpm2cpio $rpm_name | cpio -idmv";
+    # copy the openssl binary in $PATH
+    assert_script_run "cp ./usr/bin/openssl-1_1 /usr/local/bin";
 }
 
 1;


### PR DESCRIPTION
To address the lack of legacy module on SLE RT, and test the libopenssl1.1 we do a workaround and manually install only the binary from the legacy repository

- Related ticket: https://progress.opensuse.org/issues/167764
- Needles: no
- Verification runs: 
  - https://openqa.suse.de/tests/15692744
  - https://openqa.suse.de/tests/15699448


