### PR TITLE
Fix change_password failure on TW

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -55,6 +55,7 @@ sub switch_user {
 
 sub change_pwd {
     assert_and_click "users-password";
+    assert_and_click "current-password";
     type_password;
     wait_still_screen;
     assert_and_click "new-password";
@@ -74,7 +75,14 @@ sub add_user {
     assert_and_click "focus-name-field";
     type_string $newUser;
     assert_screen("input-username-test");
+    if (check_screen('username-empty')) {
+        assert_and_click 'username-empty';
+        type_string $newUser;
+    }
     assert_and_click "set-password-option";
+    if (!check_screen('adduser-password-window')) {
+        assert_and_click "adduser-next";
+    }
     assert_and_click "set-newuser-password";
     type_string $pwd4newUser;
     assert_and_click "confirm-newuser-password";


### PR DESCRIPTION
GNOME 47 UI changed, so we need to make some adjustment to test code.

- Related ticket: https://progress.opensuse.org/issues/168082
- Needles: already added when debugging on o.s.d and o3
- Verification run: 

> TW: https://openqa.opensuse.org/tests/4562121
> 15SP7: https://openqa.nue.suse.com/tests/15699443
