### PR TITLE
security/audit: autrace was dropped with audit 4

### DIFF
--- a/schedule/security/audit.yaml
+++ b/schedule/security/audit.yaml
@@ -1,13 +1,18 @@
 name: audit
 description:    >
     Audit test for sle and Tumbleweed
+conditional_schedule:
+    audit_ver_lt_4:
+        DISTRI:
+            sle:
+                - security/audit/autrace
 schedule:
     - boot/boot_to_desktop
     - console/consoletest_setup
     - security/audit/auditd
     - security/audit/auditctl
-    - security/audit/autrace
     - security/audit/ausearch
+    - '{{audit_ver_lt_4}}'
     - security/audit/aureport
     - security/audit/aulastlog
     - security/audit/aulast


### PR DESCRIPTION
Only test those two modules on SLE, where we still have audit < 4.

- Related ticket: https://progress.opensuse.org/issues/167662
- Needles: N/A
- Verification run: N/A (removal of test module on TW)
