### PR TITLE
Only create and assign permission for MSI

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -71,7 +71,7 @@ sub run {
             my $instances = create_instance_data(provider => $provider_instance);
             foreach my $instance (@$instances) {
                 record_info 'New Instance', join(' ', 'IP: ', $instance->public_ip, 'Name: ', $instance->instance_id);
-                if (get_var('FENCING_MECHANISM') eq 'native' && $provider eq 'AZURE') {
+                if (get_var('FENCING_MECHANISM') eq 'native' && $provider eq 'AZURE' && !check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn')) {
                     qesap_az_setup_native_fencing_permissions(
                         vm_name => $instance->instance_id,
                         resource_group => qesap_az_get_resource_group());

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -208,7 +208,7 @@ sub run {
         # We expect hostnames reported by terraform to match the actual hostnames in Azure and GCE
         die "Expected hostname $expected_hostname is different than actual hostname [$real_hostname]"
           if ((is_azure() || is_gce()) && ($expected_hostname ne $real_hostname));
-        if (get_var('FENCING_MECHANISM') eq 'native' && get_var('PUBLIC_CLOUD_PROVIDER') eq 'AZURE') {
+        if (get_var('FENCING_MECHANISM') eq 'native' && get_var('PUBLIC_CLOUD_PROVIDER') eq 'AZURE' && !check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn')) {
             qesap_az_setup_native_fencing_permissions(
                 vm_name => $instance->instance_id,
                 resource_group => qesap_az_get_resource_group());

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -25,7 +25,7 @@ sub run {
     upload_logs($inventory, failok => 1);
 
     # Set up azure native fencing
-    if (get_var('QESAPDEPLOY_FENCING') eq 'native' && $provider eq 'AZURE') {
+    if (get_var('QESAPDEPLOY_FENCING') eq 'native' && $provider eq 'AZURE' && !check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn')) {
         my @nodes = qesap_get_nodes_names(provider => $provider);
         foreach my $host_name (@nodes) {
             if ($host_name =~ /hana/) {


### PR DESCRIPTION
Function `qesap_az_setup_native_fencing_permissions` is used to create
and assign the permission to resource, so we only need to do this for
MSI cases when using Azure fence agent.

Related: https://jira.suse.com/browse/TEAM-9699

VRs:
Azure-SAP-PAYG:
SAPHanaSR-ScaleUp-PerfOpt-spn@az_Standard_E4s_v3: https://openqa.suse.de/tests/15710747# (Passed)
SAPHanaSR-ScaleUp-PerfOpt-msi@az_Standard_E4s_v3: https://openqa.suse.de/tests/15710746# (Passed)
Azure-SAP-BYOS:
SAPHanaSR-ScaleUp-PerfOpt-msi@az_Standard_E4s_v3: https://openqa.suse.de/tests/15710741# (Passed)
SAPHanaSR-ScaleUp-PerfOpt-spn@az_Standard_E4s_v3: https://openqa.suse.de/tests/15710745# (Passed)

