### PR TITLE
Disk size can equal to default size

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -25,7 +25,7 @@ sub run {
 
     # Verify that openQA resized the disk image
     my $disksize = script_output "sfdisk --show-size /dev/$disk";
-    die "Disk not bigger than the default size, got $disksize KiB" unless $disksize > (20 * 1024 * 1024);
+    die "Disk not bigger than the default size, got $disksize KiB" unless $disksize >= (20 * 1024 * 1024);
 
     # Verify that the GPT has no errors (PMBR mismatch, backup GPT not at the end)
     # by looking for nonempty stderr.


### PR DESCRIPTION
Disk size can equal to default size

- Related ticket: https://progress.opensuse.org/issues/167986
- Verification run: https://openqa.suse.de/tests/15711004#step/image_checks/6