### PR TITLE
Fix method import in Agama default test

### DIFF
--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -13,6 +13,7 @@ use testapi qw(
   get_required_var
   script_run
   assert_script_run
+  record_soft_failure
 );
 
 use Utils::Architectures;


### PR DESCRIPTION
Minor fix of method import in Agama test

- Related ticket: https://progress.opensuse.org/issues/167248
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/15711106
