### PR TITLE
Do not stop on failures in toolbox test runs

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -172,4 +172,9 @@ sub clean_container_host {
     assert_script_run("$runtime system prune -a -f", 300);
 }
 
+sub test_flags {
+    # Explicitly set this for because of bsc#1227509 and because snapshotting is disabled on ppc64le.
+    # Without snapshotting fatal => 1 is assumed
+    return {fatal => 0};
+}
 1;


### PR DESCRIPTION
Explicitly set `fatal => 0` so that on failures the test runs continues. This is needed because on ppc64le snapshotting is disabled by default for PowerPC and this causes `fatal => 1` to be assumed by default.

- Related failure: https://openqa.suse.de/tests/15539149#step/toolbox/1
- Verification run: https://openqa.suse.de/tests/15711120
