### PR TITLE
Rename ipaddr2 lib functions about deployment

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -25,9 +25,9 @@ Library to manage ipaddr2 tests
 =cut
 
 our @EXPORT = qw(
-  ipaddr2_azure_deployment
+  ipaddr2_infra_deploy
+  ipaddr2_infra_destroy
   ipaddr2_bastion_key_accept
-  ipaddr2_destroy
   ipaddr2_create_cluster
   ipaddr2_configure_web_server
   ipaddr2_refresh_repo
@@ -88,9 +88,9 @@ sub ipaddr2_azure_storage_account {
     return $storage_account . get_current_job_id();
 }
 
-=head2 ipaddr2_azure_deployment
+=head2 ipaddr2_infra_deploy
 
-    my $rg = ipaddr2_azure_deployment();
+    my $rg = ipaddr2_infra_deploy();
 
 Create a deployment in Azure designed for this specific test.
 
@@ -132,7 +132,7 @@ Create a deployment in Azure designed for this specific test.
 =back
 =cut
 
-sub ipaddr2_azure_deployment {
+sub ipaddr2_infra_deploy {
     my (%args) = @_;
     foreach (qw(region os)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
@@ -1309,7 +1309,7 @@ sub ipaddr2_registeration_check {
     ipaddr2_registeration_set(id => 1, scc_code => '1234567890');
 
 Register the image. Notice that this library also support registration through
-ipaddr2_azure_deployment
+ipaddr2_infra_deploy
 
 =over 3
 
@@ -1421,14 +1421,14 @@ sub ipaddr2_deployment_logs {
     }
 }
 
-=head2 ipaddr2_destroy
+=head2 ipaddr2_infra_destroy
 
-    ipaddr2_destroy();
+    ipaddr2_infra_destroy();
 
 Destroy the deployment by deleting the resource group
 =cut
 
-sub ipaddr2_destroy {
+sub ipaddr2_infra_destroy {
     az_group_delete(name => ipaddr2_azure_resource_group(), timeout => 600);
 }
 

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -9,7 +9,7 @@ use List::Util qw(any none all);
 
 use sles4sap::ipaddr2;
 
-subtest '[ipaddr2_azure_deployment] no BYOS' => sub {
+subtest '[ipaddr2_infra_deploy] no BYOS' => sub {
     # There are some limitations in BYOS+CLOUD-INIT+SCC REG interactions
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
@@ -26,7 +26,7 @@ subtest '[ipaddr2_azure_deployment] no BYOS' => sub {
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
     $azcli->redefine(script_output => sub { push @calls, ['azure_cli', $_[0]]; return 'Fermi'; });
 
-    ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci');
+    ipaddr2_infra_deploy(region => 'Marconi', os => 'Meucci');
 
     # push the list of commands in another list, this one without the source
     # In this way it is easier to inspect the content
@@ -48,14 +48,14 @@ subtest '[ipaddr2_azure_deployment] no BYOS' => sub {
     unlike($cloud_init_content, qr/registercloudguest/, "cloud-init script does not register");
 };
 
-subtest '[ipaddr2_azure_deployment] cloud-init and byos but no SCC' => sub {
+subtest '[ipaddr2_infra_deploy] cloud-init and byos but no SCC' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
 
     dies_ok {
-        ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci:gen2:ByoS');
+        ipaddr2_infra_deploy(region => 'Marconi', os => 'Meucci:gen2:ByoS');
     } "cloud-init is enabled by default and image is BYOS but no scc_code provided";
 
     for my $call_idx (0 .. $#calls) {
@@ -65,7 +65,7 @@ subtest '[ipaddr2_azure_deployment] cloud-init and byos but no SCC' => sub {
     ok((!@calls), 'There are ' . $#calls . ' command calls and none expected');
 };
 
-subtest '[ipaddr2_azure_deployment] cloud-init byos and SCC' => sub {
+subtest '[ipaddr2_infra_deploy] cloud-init byos and SCC' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
@@ -81,7 +81,7 @@ subtest '[ipaddr2_azure_deployment] cloud-init byos and SCC' => sub {
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
     $azcli->redefine(script_output => sub { push @calls, ['azure_cli', $_[0]]; return 'Fermi'; });
 
-    ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci:gen2:ByoS', scc_code => '1234');
+    ipaddr2_infra_deploy(region => 'Marconi', os => 'Meucci:gen2:ByoS', scc_code => '1234');
 
 
     for my $call_idx (0 .. $#calls) {
@@ -96,7 +96,7 @@ subtest '[ipaddr2_azure_deployment] cloud-init byos and SCC' => sub {
     like($cloud_init_content, qr/registercloudguest/, "cloud-init script does not register");
 };
 
-subtest '[ipaddr2_azure_deployment] no cloud-init' => sub {
+subtest '[ipaddr2_infra_deploy] no cloud-init' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
@@ -108,7 +108,7 @@ subtest '[ipaddr2_azure_deployment] no cloud-init' => sub {
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
     $azcli->redefine(script_output => sub { push @calls, ['azure_cli', $_[0]]; return 'Fermi'; });
 
-    ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci:gen2:ByoS', cloudinit => 0);
+    ipaddr2_infra_deploy(region => 'Marconi', os => 'Meucci:gen2:ByoS', cloudinit => 0);
 
     # push th elist of commands in another list, this one withour the source
     # In this way it is easier to inspect the content
@@ -125,7 +125,7 @@ subtest '[ipaddr2_azure_deployment] no cloud-init' => sub {
     ok((none { /sudo cloud-init status/ } @cmds), 'No wait cloud-init when cloud-init is disabled');
 };
 
-subtest '[ipaddr2_azure_deployment] cloud-init and byos' => sub {
+subtest '[ipaddr2_infra_deploy] cloud-init and byos' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
@@ -138,7 +138,7 @@ subtest '[ipaddr2_azure_deployment] cloud-init and byos' => sub {
     $azcli->redefine(script_output => sub { push @calls, ['azure_cli', $_[0]]; return 'Fermi'; });
 
     dies_ok {
-        ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci:gen2:ByoS');
+        ipaddr2_infra_deploy(region => 'Marconi', os => 'Meucci:gen2:ByoS');
     } "cloud-init is enabled by default and image is BYOS";
 
     for my $call_idx (0 .. $#calls) {
@@ -148,7 +148,7 @@ subtest '[ipaddr2_azure_deployment] cloud-init and byos' => sub {
     ok((!@calls), 'There are ' . $#calls . ' command calls and none expected');
 };
 
-subtest '[ipaddr2_azure_deployment] no cloud-init' => sub {
+subtest '[ipaddr2_infra_deploy] no cloud-init' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
@@ -160,7 +160,7 @@ subtest '[ipaddr2_azure_deployment] no cloud-init' => sub {
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
     $azcli->redefine(script_output => sub { push @calls, ['azure_cli', $_[0]]; return 'Fermi'; });
 
-    ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci:gen2:ByoS', cloudinit => 0);
+    ipaddr2_infra_deploy(region => 'Marconi', os => 'Meucci:gen2:ByoS', cloudinit => 0);
 
     # push th elist of commands in another list, this one withour the source
     # In this way it is easier to inspect the content
@@ -176,7 +176,7 @@ subtest '[ipaddr2_azure_deployment] no cloud-init' => sub {
     ok((none { /sudo cloud-init status/ } @cmds), 'Cloud-init disabled');
 };
 
-subtest '[ipaddr2_azure_deployment] diagnostic' => sub {
+subtest '[ipaddr2_infra_deploy] diagnostic' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
@@ -189,7 +189,7 @@ subtest '[ipaddr2_azure_deployment] diagnostic' => sub {
     $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
     $azcli->redefine(script_output => sub { push @calls, $_[0]; return 'Fermi'; });
 
-    ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci', diagnostic => 1);
+    ipaddr2_infra_deploy(region => 'Marconi', os => 'Meucci', diagnostic => 1);
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /az storage account create/ } @calls), 'Create storage');
@@ -197,7 +197,7 @@ subtest '[ipaddr2_azure_deployment] diagnostic' => sub {
     ok((any { /az vm boot-diagnostics enable.*vm-02/ } @calls), 'Enable diagnostic for VM2');
 };
 
-subtest '[ipaddr2_azure_deployment] disable trusted launch' => sub {
+subtest '[ipaddr2_infra_deploy] disable trusted launch' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
@@ -212,19 +212,19 @@ subtest '[ipaddr2_azure_deployment] disable trusted launch' => sub {
             return; });
     $azcli->redefine(script_output => sub { push @calls, $_[0]; return 'Fermi'; });
 
-    ipaddr2_azure_deployment(region => 'Marconi', os => 'Meucci', trusted_launch => 0);
+    ipaddr2_infra_deploy(region => 'Marconi', os => 'Meucci', trusted_launch => 0);
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /--security-type.*Standard/ } @calls), 'Disable trustedLaunch by setting --security-type Standard');
 };
 
-subtest '[ipaddr2_destroy]' => sub {
+subtest '[ipaddr2_infra_destroy]' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my $az_called = 0;
     $ipaddr2->redefine(az_group_delete => sub { $az_called = 1; return; });
 
-    ipaddr2_destroy();
+    ipaddr2_infra_destroy();
 
     ok(($az_called eq 1), 'az_group_delete called');
 };

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -15,7 +15,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_configure_web_server
   ipaddr2_create_cluster
   ipaddr2_deployment_logs
-  ipaddr2_destroy
+  ipaddr2_infra_destroy
   ipaddr2_internal_key_accept
   ipaddr2_internal_key_gen
   ipaddr2_os_cloud_init_logs
@@ -83,7 +83,7 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_os_cloud_init_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    ipaddr2_destroy();
+    ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -10,10 +10,10 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
-  ipaddr2_azure_deployment
+  ipaddr2_infra_deploy
   ipaddr2_deployment_logs
   ipaddr2_deployment_sanity
-  ipaddr2_destroy
+  ipaddr2_infra_destroy
   ipaddr2_os_cloud_init_logs
 );
 
@@ -40,7 +40,7 @@ sub run {
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1));
     $deployment{scc_code} = get_var('SCC_REGCODE_SLES4SAP') if (get_var('SCC_REGCODE_SLES4SAP'));
     $deployment{trusted_launch} = 0 if (check_var('IPADDR2_TRUSTEDLAUNCH', 0));
-    ipaddr2_azure_deployment(%deployment);
+    ipaddr2_infra_deploy(%deployment);
 
     ipaddr2_deployment_sanity();
 }
@@ -53,7 +53,7 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_os_cloud_init_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    ipaddr2_destroy();
+    ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -11,7 +11,7 @@ use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
-  ipaddr2_destroy
+  ipaddr2_infra_destroy
   ipaddr2_os_cloud_init_logs
 );
 
@@ -23,7 +23,7 @@ sub run {
 
     select_serial_terminal;
 
-    ipaddr2_destroy();
+    ipaddr2_infra_destroy();
 }
 
 sub test_flags {
@@ -34,7 +34,7 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_os_cloud_init_logs();
-    ipaddr2_destroy();
+    ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/sanity.pm
+++ b/tests/sles4sap/ipaddr2/sanity.pm
@@ -12,7 +12,7 @@ use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_cluster_sanity
   ipaddr2_deployment_logs
-  ipaddr2_destroy
+  ipaddr2_infra_destroy
   ipaddr2_os_cloud_init_logs
   ipaddr2_os_sanity
 );
@@ -36,7 +36,7 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_os_cloud_init_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    ipaddr2_destroy();
+    ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -14,7 +14,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_crm_clear
   ipaddr2_crm_move
   ipaddr2_deployment_logs
-  ipaddr2_destroy
+  ipaddr2_infra_destroy
   ipaddr2_os_cloud_init_logs
   ipaddr2_os_connectivity_sanity
   ipaddr2_test_master_vm
@@ -90,7 +90,7 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_os_cloud_init_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    ipaddr2_destroy();
+    ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Rename function for infrastructure deploy and destroy to follow a
pattern like: <LIB>_<OBJECT>_<ACTION>

- Related ticket: TEAM-8721

#  Verification run:

 - sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/300236 :green_book: 
