### PR TITLE
Improve Public Cloud XFS tests

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -55,7 +55,6 @@ sub load_maintenance_publiccloud_tests {
             load_container_tests();
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
             loadtest "publiccloud/xfsprepare", run_args => $args;
-            loadtest "xfstests/run", run_args => $args;
         } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
             loadtest "publiccloud/smoketest";
             # flavor_check is concentrated on checking things which make sense only for image which is registered
@@ -153,7 +152,6 @@ sub load_latest_publiccloud_tests {
                 loadtest "publiccloud/xen", run_args => $args if (get_var('PUBLIC_CLOUD_XEN'));
             } elsif (get_var('PUBLIC_CLOUD_XFS')) {
                 loadtest "publiccloud/xfsprepare", run_args => $args;
-                loadtest "xfstests/run", run_args => $args;
             } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
                 loadtest("publiccloud/azure_nfs", run_args => $args);
             }

--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -32,7 +32,7 @@ sub establish_tunnel_console {
 }
 
 sub ssh_interactive_tunnel {
-    # Establish the ssh interarctive tunnel to the publiccloud instance.
+    # Establish the ssh interactive tunnel to the publiccloud instance.
     # Optional arguments: 'force => 1' - reestablish tunnel, also if already established.
     #                     'reconnect => 1' - reestablish the tunnel after disconnecting. Use this to re-establish the tunnels after e.g. an instance reboot
 

--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -144,6 +144,7 @@ sub get_unused_device {
 }
 
 sub run {
+    my ($self, $args) = @_;
     my $device = get_var("XFS_TEST_DEVICE", "/dev/sdb");
     my $hdd2_size = get_var('PUBLIC_CLOUD_HDD2_SIZE', 0);
     my $mnt_xfs = "/mnt/xfstests/xfs";
@@ -179,6 +180,8 @@ sub run {
     partition_disk($device, $mnt_xfs, $mnt_scratch);
     create_config($device, $mnt_xfs, $mnt_scratch);
     script_run("source $CONFIG_FILE");
+
+    autotest::loadtest("tests/xfstests/run.pm", run_args => $args);
 }
 
 1;

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -144,6 +144,7 @@ sub run {
         $targs->{name} = $test;
         $targs->{enable_heartbeat} = $enable_heartbeat;
         $targs->{last_one} = 0;
+        $targs->{my_instance} = $args->{my_instance} if is_public_cloud;
         if ($index == $subtest_num - 1) {
             mutex_create 'last_subtest_run_finish';
             $targs->{last_one} = 1;

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -143,7 +143,7 @@ sub run {
         $test =~ s/\//-/;
         $targs->{name} = $test;
         $targs->{enable_heartbeat} = $enable_heartbeat;
-        $targs->{lastone} = 0;
+        $targs->{last_one} = 0;
         if ($index == $subtest_num - 1) {
             mutex_create 'last_subtest_run_finish';
             $targs->{last_one} = 1;

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -87,7 +87,7 @@ my $TIMEOUT_NO_HEARTBEAT = get_var('XFSTESTS_TIMEOUT', 2000);
 
 sub run {
     my ($self, $args) = @_;
-    is_public_cloud() ? select_console('root-console') : select_serial_terminal();
+    select_serial_terminal;
     return if get_var('XFSTESTS_NFS_SERVER');
     my $enable_heartbeat = 1;
     $enable_heartbeat = 0 if (check_var 'XFSTESTS_NO_HEARTBEAT', '1');

--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -88,7 +88,7 @@ sub run {
     my $result_args;
     enter_cmd("echo $test > /dev/$serialdev");
     if ($enable_heartbeat == 0) {
-        $result_args = test_run_without_heartbeat($self, $test, $TIMEOUT_NO_HEARTBEAT, $FSTYPE, $BTRFS_DUMP, $RAW_DUMP, $SCRATCH_DEV, $SCRATCH_DEV_POOL, $INJECT_INFO, $LOOP_DEVICE, $ENABLE_KDUMP, $VIRTIO_CONSOLE, 0);
+        $result_args = test_run_without_heartbeat($self, $test, $TIMEOUT_NO_HEARTBEAT, $FSTYPE, $BTRFS_DUMP, $RAW_DUMP, $SCRATCH_DEV, $SCRATCH_DEV_POOL, $INJECT_INFO, $LOOP_DEVICE, $ENABLE_KDUMP, $VIRTIO_CONSOLE, 0, $args->{my_instance});
         $status = $result_args->{status};
         $time = $result_args->{time};
         $status_log_content = $result_args->{output};

--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -78,7 +78,7 @@ my %softfail_list = generate_xfstests_list(get_var('XFSTESTS_SOFTFAIL'));
 
 sub run {
     my ($self, $args) = @_;
-    is_public_cloud() ? select_console('root-console') : select_serial_terminal();
+    select_serial_terminal;
     (my $test = $args->{name}) =~ s/-/\//;
     my $enable_heartbeat = $args->{enable_heartbeat};
     my $is_last_one = $args->{last_one};

--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -55,7 +55,7 @@ my $LOOP_DEVICE = get_var('XFSTESTS_LOOP_DEVICE');
 # - RAW_DUMP: set it a non-zero value to enable raw dump by dd the super block.
 # - XFSTESTS_DEBUG: enable collect more info by set 1 to files under /proc/sys/kernel/, more than 1 info split by space
 #     e.g. "hardlockup_panic hung_task_panic panic_on_io_nmi panic_on_oops panic_on_rcu_stall..."
-my $INJECT_INFO = get_var('INJECT_INFO');
+my $INJECT_INFO = get_var('INJECT_INFO', '');
 my $BTRFS_DUMP = get_var('BTRFS_DUMP', 0);
 my $RAW_DUMP = get_var('RAW_DUMP', 0);
 

--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -16,7 +16,7 @@ use testapi;
 use utils;
 use Utils::Backends 'is_pvm';
 use serial_terminal 'select_serial_terminal';
-use power_action_utils qw(power_action prepare_system_shutdown);
+use power_action_utils qw(prepare_system_shutdown);
 use filesystem_utils qw(format_partition generate_xfstests_list);
 use lockapi;
 use mmapi;


### PR DESCRIPTION
This patch set aims to increase robustness and decrease run times of XFS tests targeting Public Cloud SUTs. The main changes are that xfsprepare.pm may fail and therefore the job must stop at that point and the serial terminal is used without heartbeat so that run times are faster. Along with that, some minor fixes regarding typos and unused imports.

- Related ticket: https://progress.opensuse.org/issues/162791
- Verification runs:
http://rmarliere-openqa.qe.prg2.suse.org/tests/48
http://rmarliere-openqa.qe.prg2.suse.org/tests/55
https://openqa.suse.de/tests/15725420
https://openqa.suse.de/tests/15738773
