### PR TITLE
Don't except always changes of snapshot in allow_openqa_port_selinux

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -19,7 +19,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_sle is_public_cloud get_version_id is_transactional is_openstack is_sle_micro);
-use transactional qw(check_reboot_changes trup_call process_reboot);
+use transactional qw(reboot_on_changes trup_call process_reboot);
 use registration;
 use maintenance_smelt qw(is_embargo_update);
 
@@ -334,7 +334,7 @@ sub allow_openqa_port_selinux {
     my $pkgs = 'policycoreutils-python-utils';
     if (is_transactional) {
         trup_call("pkg install $pkgs");
-        check_reboot_changes;
+        reboot_on_changes;
     } else {
         zypper_call("in $pkgs");
     }


### PR DESCRIPTION
in the case 'policycoreutils-python-utils' are already  installed previous code will fail the test with:

```
  Change expected: 1, happened: 0 at
  sle-micro/products/sle-micro/../../lib/transactional.pm line 147.
```

which is wrong and unrelated to the test, so this change behaviour is to check if there is a change and reboot the system if there is as needed on the transactional system

poo: https://progress.opensuse.org/issues/168406
VR: http://quasar.suse.cz/tests/182
