### PR TITLE
Enable agama_auto_gnome for Leap 16.0

### DIFF
--- a/data/yam/agama/auto/gnome_leap.json
+++ b/data/yam/agama/auto/gnome_leap.json
@@ -1,0 +1,18 @@
+{
+  "product": {
+    "id": "Leap_16.0"
+  },
+  "software": {
+    "patterns": [
+      "gnome"
+    ]
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "nots3cr3t",
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "nots3cr3t"
+  }
+}


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/168070
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4565336#
