### PR TITLE
[SDAF] Destroy orphaned resources

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -15,7 +15,7 @@ use testapi;
 use Exporter qw(import);
 use sles4sap::sap_deployment_automation_framework::deployment qw(sdaf_cleanup az_login load_os_env_variables);
 use sles4sap::sap_deployment_automation_framework::deployment_connector
-  qw(find_deployer_resources destroy_deployer_vm get_deployer_vm_name find_deployment_id get_deployer_ip);
+  qw(find_deployer_resources destroy_deployer_vm get_deployer_vm_name find_deployment_id get_deployer_ip destroy_orphaned_resources);
 use sles4sap::console_redirection;
 
 our @EXPORT = qw(full_cleanup);
@@ -86,6 +86,11 @@ sub full_cleanup {
 
     # Destroys deployer VM and its resources
     destroy_deployer_vm();
+
+    # Clean up orphaned resources inside permanent deployer job group
+    # Resource retention time can be controlled by OpenQA parameter: SDAF_DEPLOYER_VM_RETENTION_SEC
+    record_info('Remove orphans', 'Cleaning up orphaned resources');
+    destroy_orphaned_resources();
 }
 
 sub post_fail_hook {

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -27,9 +27,12 @@ use testapi;
 use Exporter qw(import);
 use Mojo::JSON qw(decode_json);
 use Scalar::Util qw(looks_like_number);
+use List::MoreUtils qw( duplicates );
+use utils qw(write_sut_file);
 use Carp qw(croak);
+use Time::Piece;
 use mmapi qw(get_parents get_job_autoinst_vars get_children get_job_info get_current_job_id);
-use sles4sap::azure_cli qw(az_resource_delete);
+use sles4sap::azure_cli qw(az_resource_delete az_resource_list);
 use Data::Dumper;
 
 our @EXPORT = qw(
@@ -39,6 +42,7 @@ our @EXPORT = qw(
   find_deployment_id
   find_deployer_resources
   destroy_deployer_vm
+  destroy_orphaned_resources
 );
 
 =head2 check_ssh_availability
@@ -53,7 +57,7 @@ Function dies only with internal errors, VM status should be evaluated and handl
 
 =item * B<deployer_ip_addr>: Deployer VM IP address
 
-=item * B<wait_started>: Probe SSH port in loop untill it is available or B<wait_timeoout> is reached.
+=item * B<wait_started>: Probe SSH port in loop until it is available or B<wait_timeout> is reached.
 
 =item * B<wait_timeout>: Time in sec to stop probing SSH port.
 
@@ -254,6 +258,49 @@ sub find_deployer_resources {
 }
 
 
+=head2 destroy_resources
+
+    destroy_resources(resource_cleanup_list=>['resource_A', 'resource_B'] [, timeout=>900]);
+
+Destroys all resources specified by B<resources> argument in ARRAYREF format.
+
+=over
+
+=item * B<timeout> Timeout for AZ command to destroy resources. Default: 800
+
+=item * B<resource_cleanup_list> ARRAYREF specifying resources to be deleted. If empty, function will just return.
+
+=back
+
+=cut
+
+sub destroy_resources {
+    my (%args) = @_;
+    croak("Argument 'resource_cleanup_list' must be ARRAYREF.\nGot:" . ref($args{resource_cleanup_list})) unless
+      ref($args{resource_cleanup_list}) eq 'ARRAY';
+
+    $args{timeout} //= '800';
+    my $retries = 3;    # retry to delete 3x
+    my $deployer_resource_group = get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
+
+    unless ($args{resource_cleanup_list}) {
+        record_info('Destroy resources', 'No resources defined, cleanup skipped.');
+        return;
+    }
+
+    my @resource_cleanup_list = @{$args{resource_cleanup_list}};
+
+    for my $attempt (1 .. $retries) {
+        record_info("Attempt #$attempt");
+
+        last unless az_resource_delete(ids => join(' ', @resource_cleanup_list),
+            resource_group => $deployer_resource_group, verbose => 'yes', timeout => $args{timeout});
+        sleep 5;    # Just give things few secs to avoid command spamming.
+        die "Failed to clean up resources:\n" . join("\n", @resource_cleanup_list) if ($attempt == $retries);
+    }
+    record_info('Destroy resources', 'All resources destroyed');
+}
+
 =head2 destroy_deployer_vm
 
     destroy_deployer_vm([timeout=>900]);
@@ -270,29 +317,68 @@ Cleanup deployer VM resources only, B<deployer resource group itself will stay i
 
 sub destroy_deployer_vm {
     my (%args) = @_;
-    $args{timeout} //= '800';
-    my $retries = 3;    # retry to delete 3x
-
     # Deployer VM is located in permanent deployer resource group. This RG **MUST STAY INTACT**
-    my @resource_cleanup_list = @{find_deployer_resources(return_value => 'id')};
-    unless (@resource_cleanup_list) {
+    my $resource_cleanup_list = find_deployer_resources(return_value => 'id');
+    # Early exit  in case there is nothing to clean up
+    unless (@{$resource_cleanup_list}) {
         record_info('Deployer cleanup', 'No resources related to deployer VM found');
         return;
     }
 
     record_info('Deployer cleanup',
-        "Following resources are being destroyed:\n" . join("\n", @{find_deployer_resources()}));
+        "Following resources are being destroyed:\n" . join("\n", @{$resource_cleanup_list}));
 
-    for my $attempt (1 .. $retries) {
-        record_info("Attempt #$attempt");
-        az_resource_delete(ids => join(' ', @resource_cleanup_list),
-            resource_group => get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP'), verbose => 'yes', timeout => $args{timeout});
-        sleep 5;    # Just give things few secs to avoid command spamming.
-
-        # Check if all resources were cleaned up
-        @resource_cleanup_list = @{find_deployer_resources()};
-        last unless @resource_cleanup_list;
-        die "Failed to clean up resources:\n" . join("\n", @resource_cleanup_list) if ($attempt == $retries);
-    }
+    destroy_resources(timeout => $args{timeout}, resource_cleanup_list => $resource_cleanup_list);
     record_info('Deployer cleanup', 'All resources destroyed');
+}
+
+=head2 destroy_orphaned_deployers
+
+    destroy_orphaned_deployers([timeout=>9999]);
+
+Destroys orphaned deployer VM resources existing inside permanent deployer resource group.
+Function lists all resources and their creation time belonging to deployer RG which are tagged with 'deployment_id'.
+Resource being tagged with 'deployment_id' means it was created by an OpenQA test.
+Resource names are as well checked against OpenQA naming convention as another prevention from unwanted resource deletion.
+Resources older than 'SDAF_DEPLOYER_VM_RETENTION_SEC' seconds (Default 7H) are considered as orphans and deleted.
+Be very careful with changes here (especially with regexes and az cli filters) as mistakes can lead to damage on
+permanent SDAF infrastructure.
+
+=over
+
+=item * B<timeout>: Timeout for az destroy command. Default: 1200
+
+=back
+
+=cut
+
+sub destroy_orphaned_resources {
+    my (%args) = @_;
+    $args{timeout} //= 1200;
+    # List all resources containing 'deployment_id' tag - this should filter out only resources created by an openQA test.
+    my $all_resources = az_resource_list(
+        resource_group => get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP'),
+        query => '[?tags.deployment_id].{resource_id:id, creation_time:createdTime}'
+    );
+    my @orphaned_resources;
+
+    foreach (@$all_resources) {
+        # Couple of notes to time formats:
+        # - for format explanation check 'man strftime' - az cli returns date in ISO 8601 format
+        # - Time::Piece does not recognize microseconds, they need to be neutered using regex
+        $_->{creation_time} =~ s/\.\d+(?=\+\d\d)//;
+
+        # - Time::Piece does not recognize az cli timezone format `+02:00`, only `+0200`
+        #   - therefore we have to do some colonoscopy and remove `:` from az cli output
+        $_->{creation_time} =~ s/(?<=\+\d\d):(?=\d\d$)//;
+        my $time = Time::Piece->strptime($_->{creation_time}, '%Y-%m-%dT%H:%M:%S%z')->epoch();
+        # naming convention check. Resources coming from OpenQA have name like: <test_id>-OpenQA_Deployer_VM*
+        next unless $_->{resource_id} =~ m/\d+-OpenQA_Deployer_VM/;
+        # Mark for deletion resources older than 'SDAF_DEPLOYER_VM_RETENTION_SEC' or default 7H
+        push(@orphaned_resources, $_->{resource_id}) if $time < time() - get_var('SDAF_DEPLOYER_VM_RETENTION_SEC', '25200');
+    }
+    # Do nothing in case there is nothing to delete
+    return unless @orphaned_resources;
+    record_info('az destroy', "Following orphaned resources will be destroyed:\n" . join("\n", @orphaned_resources));
+    destroy_resources(timeout => $args{timeout}, resource_cleanup_list => \@orphaned_resources);
 }

--- a/tests/sles4sap/sap_deployment_automation_framework/cleanup.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/cleanup.pm
@@ -4,18 +4,19 @@
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-# Summary: Triggers cleanup of the workload zone and SUT using SDAF automation.
-# It also removes all SDAF test related files from deployer VM.
+# Summary: Triggers SDAF cleanup.
+# Executes 'remover.sh' script which is part of SDAF
+# Removes deployer VM clone and it's resources
+# Cleans up resources which are orphaned
 # Post run hooks are generally disabled during normal module run so the infrastructure persists between test modules.
-# Cleanup is triggered only with B<SDAF_DO_CLEANUP> set to true, which is done by scheduling this module at the end of test flow.
+# To skip cleanup use OpenQA parameter 'SDAF_RETAIN_DEPLOYMENT'
 
 use parent 'opensusebasetest';
 use strict;
 use testapi;
 use warnings;
 use serial_terminal qw(select_serial_terminal);
-use sles4sap::sap_deployment_automation_framework::deployment
-  qw(serial_console_diag_banner);
+use sles4sap::sap_deployment_automation_framework::deployment qw(serial_console_diag_banner);
 use sles4sap::sap_deployment_automation_framework::basetest qw(full_cleanup);
 
 sub test_flags {


### PR DESCRIPTION
Currently if a test is cancelled, all deployer VM resources will remain in 
permanent deployer group until cleaned up manually. This PR adds a cleanup 
routine which searches for orphaned deplyoer VM resources and destroys them 
without harming the permanent deployer infrastructure. Function is executed as a 
part of standard SDAF test cleanup. A resource is considered as `orphaned` if it 
is older than retention time defined by OpenQA parameter 
`SDAF_DEPLOYER_VM_RETENTION_SEC` with default value of 7H.

**Related ticket:** https://jira.suse.com/browse/TEAM-9728

**Verification runs**

Scenario 1: Destroy with default 7H retention time
  List of all VM resources: https://mordor.suse.cz/tests/660#step/deploy_workload_zone/390
  Deleted only older than 7H: https://mordor.suse.cz/tests/660#step/deploy_workload_zone/391

Scenario 2: Override default value using parameter `SDAF_DEPLOYER_VM_RETENTION_SEC=600`
  List of all  VM resources: https://mordor.suse.cz/tests/662#step/deploy_workload_zone/390
  Deleted only older than 10 min: https://mordor.suse.cz/tests/662#step/deploy_workload_zone/391