### PR TITLE
Enable bsc_1205002.pm for Latest builds

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -131,6 +131,8 @@ sub load_latest_publiccloud_tests {
             loadtest('publiccloud/cloud_netconfig', run_args => $args);
         } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {
             loadtest('publiccloud/ahb', run_args => $args);
+        } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {
+            loadtest("publiccloud/bsc_1205002", run_args => $args);
         } else {
             loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
             loadtest "publiccloud/ssh_interactive_start", run_args => $args;


### PR DESCRIPTION
We want to run the **bsc_1205002.pm** test module for Latest builds. This change adds the necessary check and moves the BSC test after the instance is created with `prepare_instance.pm`.

- Related ticket: https://progress.opensuse.org/issues/168157
- Verification run: http://dirtman.qe.prg2.suse.org/tests/162#
