### PR TITLE
Containers: toolbox new external uri parameter

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -60,7 +60,7 @@ sub run {
     select_console 'root-console';
     $self->create_user;
 
-    my $toolbox_image_to_test = get_var('CONTAINER_IMAGE_TO_TEST');
+    my $toolbox_image_to_test = get_var('CONTAINER_IMAGE_TO_TEST_STANDALONE');
 
     if ($toolbox_image_to_test) {
         # We need to extract the registry from the full image uri, e.g.

--- a/variables.md
+++ b/variables.md
@@ -181,6 +181,7 @@ REBOOT_TIMEOUT | integer | 0 | Set and handle reboot timeout available in YaST i
 REGISTRY | string | docker.io | Registry to pull third-party container images from
 CONTAINER_IMAGE_VERSIONS | string | | List of comma-separated versions from `get_suse_container_urls()`
 CONTAINER_IMAGE_TO_TEST | string | | Single URL string of a specific container image to test.
+CONTAINER_IMAGE_TO_TEST_STANDALONE | string | | URL of a container image to test individually, like toolbox, unrelated to get_image_uri() checks.
 REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.
 REMOTE_REPOINST | boolean | | Use linuxrc features to install OS from specified repository (install) while booting installer from DVD (instsys)
 REPO_* | string | | Url pointing to the mirrored repo. REPO_0 contains installation iso.


### PR DESCRIPTION
`toolbox.pm` module used `CONTAINER_IMAGE_TO_TEST` as ondemand image url to pull, whose logic was unrelated to usage in other containers elaborations.

When used in the Container Hosts test group, it caused impacts in other places, like this: https://openqa.suse.de/tests/15725818#step/image_podman/114.

To avoid impacts on elaborations of get_image_uri() and loops on CONTAINER_IMAGE_VERSIONS in image.pm, 
name has been changed with a new independent one: `CONTAINER_IMAGE_TO_TEST_STANDALONE`.

- Related ticket: https://progress.opensuse.org/issues/162689
- Needles: none.
- Verification run:  see next PR posts.

Note:
this PR is followup of [PR 20383](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20383#issuecomment-2414736569), that was created for introduction of SLE-micro 6.1 ppc64le tests: this is split N.2 related to code in it contained.

At the moment, due to SLE-M 6.1 images affected by bsc, toolbox tests need explicit CONTAINER_IMAGE_TO_TEST image setting.

Moreover, to trigger certificates loading from `host_config`, also HOST_VERSION=6.1 needed.

We'll see that using new name (ending by _STANDALONE)  in toolbox test, it will pass and  other containers elaborations will work as expected, not impacted.
