### PR TITLE
Add kernel-default-devel for sle-micro

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1016,7 +1016,12 @@ sub zypper_install_available {
     my $packlist = join(' ', @_);
     my $result = zypper_search("-t package --match-exact $packlist");
 
-    return zypper_call('-t in ' . join(' ', map { $_->{name} } @$result));
+    if (is_transactional) {
+        return transactional::trup_call("-c pkg install " . join(' ', map { $_->{name} } @$result));
+    }
+    else {
+        return zypper_call('-t in ' . join(' ', map { $_->{name} } @$result));
+    }
 }
 
 =head2 set_zypper_lock_timeout

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -294,6 +294,17 @@ sub setup_network {
     }
 }
 
+sub install_ltp_extra_dep_package {
+    if (is_transactional) {
+        if ((get_var('FLAVOR', '') =~ /Base-RT-Updates|Base-RT|Base-RT-encrypted/)) {
+            zypper_install_available("kernel-rt-devel");
+        }
+        else {
+            zypper_install_available("kernel-default-devel");
+        }
+    }
+}
+
 sub run {
     my $self = shift;
     my $inst_ltp = get_var 'INSTALL_LTP';
@@ -362,6 +373,8 @@ sub run {
             install_selected_from_git;
         }
     }
+
+    install_ltp_extra_dep_package();
 
     log_versions 1;
 


### PR DESCRIPTION
Add kernel-default-devel for sle-micro

- Related ticket:https://progress.opensuse.org/issues/162827
- Verification run: 
install job:
https://openqa.suse.de/tests/15734750
running result:
https://openqa.suse.de/tests/15734751

NOTE:RT sle-micro not support currently.
sle-micro RT store source code into /usr/src/linux-rt(readonly filesystem), but LTP configuration set default path is /usr/src/linux

