### PR TITLE
Correct Oracle Linux guest os version

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/oracle_linux_8_10_graphical_server_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/oracle_linux_8_10_graphical_server_x86_64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>oraclelinux</guest_os_name>
-    <guest_version>r8-u9</guest_version>
+    <guest_version>r8-u10</guest_version>
     <guest_version_major>8</guest_version_major>
     <guest_version_minor>10</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>

--- a/data/virt_autotest/guest_params_xml_files/oracle_linux_9_4_graphical_server_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/oracle_linux_9_4_graphical_server_x86_64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>oraclelinux</guest_os_name>
-    <guest_version>r9-u3</guest_version>
+    <guest_version>r9-u4</guest_version>
     <guest_version_major>9</guest_version_major>
     <guest_version_minor>4</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>


### PR DESCRIPTION
* **Oracle** Linux guest os version should match with major/minor version and version of actual medium to be used for guest installation.

* **Verification Runs:** 
  * [verification run](https://openqa.suse.de/tests/15745220)