### PR TITLE
xfstests: fix typo of known issue message

### DIFF
--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -166,8 +166,8 @@ sub run {
             }
             else {
                 $self->{result} = 'fail';
-                record_info('known', "$targs->{failinfo}") if defined($args->{failinfo});
-                record_info('bugzilla', "$targs->{bugzilla}") if defined($args->{bugzilla});
+                record_info('known', "$targs->{failinfo}") if defined($targs->{failinfo});
+                record_info('bugzilla', "$targs->{bugzilla}") if defined($targs->{bugzilla});
             }
         }
         else {


### PR DESCRIPTION
There are no known issues or Bugzilla messages for failed tests due to typos. Just correct it.


- Related ticket: https://progress.opensuse.org/issues/168274
- Needles: N/A
- Verification run: http://10.67.133.133/tests/827#step/btrfs-161/83