### PR TITLE
containers: Don't install pasta if not available

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -15,7 +15,7 @@ use utils qw(script_retry);
 use version_utils qw(is_sle is_sle_micro is_tumbleweed is_microos);
 use containers::common;
 use Utils::Architectures qw(is_x86_64 is_aarch64);
-use containers::bats qw(install_bats install_htpasswd install_ncat install_pasta patch_logfile remove_mounts_conf switch_to_user delegate_controllers enable_modules);
+use containers::bats qw(install_bats install_htpasswd install_ncat patch_logfile remove_mounts_conf switch_to_user delegate_controllers enable_modules);
 
 my $test_dir = "/var/tmp";
 my $podman_version = "";
@@ -70,7 +70,6 @@ sub run {
     install_packages(@pkgs);
     install_htpasswd if is_sle_micro;
     install_ncat;
-    install_pasta unless (is_tumbleweed || is_microos);
 
     record_info("podman version", script_output("podman version"));
 


### PR DESCRIPTION
We shouldn't install `pasta` if not available for obvious reasons.

This makes the [140-diff](https://github.com/containers/podman/blob/main/test/system/140-diff.bats) test to fail, so we're gonna add this to PODMAN_BATS_SKIP_USER_LOCAL & PODMAN_BATS_SKIP_USER_REMOTE.

- Verification run: https://openqa.suse.de/tests/15739973  (fails on 140-diff).
- Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1872