### PR TITLE
Schedule salt smoke tests on micro-os

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -205,6 +205,7 @@ sub load_common_tests {
     # Staging has no access to repos and the MicroOS-DVD does not contain ansible
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
     loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro);
+    loadtest 'console/salt' unless is_sle_micro;
     # On s390x zvm setups we need more time to wait for system to boot up.
     # Skip this test with sd-boot. The reason is not what you'd think though:
     # With sd-boot, host_config does not perform a reboot and a snapshot is made while the serial terminal


### PR DESCRIPTION
https://progress.opensuse.org/issues/87982

- Verification run: 
[regression](http://openqa.suse.de/tests/15745342#)
[microos](https://openqa.opensuse.org/tests/4584834)

Skip the sle-micro test due to  https://bugzilla.suse.com/show_bug.cgi?id=1231882