### PR TITLE
Re-Add "Add container test runs for RISC-V"

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -99,7 +99,7 @@ my %opensuse_containers = (
         totest => sub {
             'registry.opensuse.org/' . get_opensuse_registry_prefix . 'opensuse/tumbleweed';
         },
-        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm']
+        available_arch => ['x86_64', 'aarch64', 'ppc64le', 's390x', 'arm', 'riscv64']
     },
     '15.4' => {
         released => sub { 'registry.opensuse.org/opensuse/leap:15.4' },
@@ -155,13 +155,16 @@ sub supports_image_arch {
 sub get_3rd_party_images {
     my $registry = get_var('REGISTRY', 'docker.io');
     my @images = (
-        "registry.opensuse.org/opensuse/leap",
         "registry.opensuse.org/opensuse/tumbleweed",
-        "$registry/library/alpine",
-        "$registry/library/debian"
+        "$registry/library/alpine"
+    );
+
+    push @images, (
+        "registry.opensuse.org/opensuse/leap",
+        "$registry/library/debian",
         # Temporarily disabled as it needs x86-64-v2
         # "quay.io/centos/centos:stream9"
-    );
+    ) unless (is_riscv);
 
     # Following images are not available on 32-bit arm
     push @images, (
@@ -170,7 +173,7 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi8/ubi-minimal",
         "registry.access.redhat.com/ubi8/ubi-micro",
         "registry.access.redhat.com/ubi8/ubi-init"
-    ) unless (is_arm);
+    ) unless (is_arm || is_riscv);
 
     # - ubi9 images require z14+ s390x machine, they are not ready in OSD yet.
     #     on z13: "Fatal glibc error: CPU lacks VXE support (z14 or later required)".
@@ -182,7 +185,7 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi9/ubi-minimal",
         "registry.access.redhat.com/ubi9/ubi-micro",
         "registry.access.redhat.com/ubi9/ubi-init"
-    ) unless (is_arm || is_s390x || is_ppc64le || !is_x86_64_v2);
+    ) unless (is_arm || is_s390x || is_ppc64le || is_riscv || !is_x86_64_v2);
 
     push @images, (
         "$registry/library/ubuntu"
@@ -193,7 +196,7 @@ sub get_3rd_party_images {
         "registry.access.redhat.com/ubi7/ubi",
         "registry.access.redhat.com/ubi7/ubi-minimal",
         "registry.access.redhat.com/ubi7/ubi-init"
-    ) unless (is_arm || is_aarch64 || check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
+    ) unless (is_arm || is_aarch64 || is_riscv || check_var('PUBLIC_CLOUD_ARCH', 'arm64'));
 
     return (\@images);
 }

--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -85,7 +85,7 @@ sub run {
         # Kube generate
         record_info('Test', 'Generate the yaml from a pod');
         assert_script_run('podman pod create testing-pod');
-        my $image = "registry.suse.com/bci/bci-busybox:latest";
+        my $image = is_opensuse ? "registry.opensuse.org/opensuse/bci/bci-busybox:latest" : "registry.suse.com/bci/bci-busybox:latest";
         script_retry("podman pull $image", timeout => 300, delay => 60, retry => 3);
         assert_script_run("podman container create --pod testing-pod --name container $image sh -c \"sleep 3600\"");
         assert_script_run("podman kube generate testing-pod | tee pod.yaml");

--- a/tests/containers/skopeo.pm
+++ b/tests/containers/skopeo.pm
@@ -11,7 +11,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';    # used in select_serial_terminal
 use utils 'zypper_call';    # used in zypper_call
-use version_utils qw(is_transactional is_vmware);
+use version_utils qw(is_transactional is_vmware is_opensuse);
 use transactional;
 use containers::common qw(install_packages);
 
@@ -28,7 +28,7 @@ sub run {
     select_serial_terminal() unless is_vmware;    # Select most suitable text console
 
     # Set a variable for my remote image
-    my $remote_image = 'registry.suse.com/bci/bci-busybox:latest';
+    my $remote_image = is_opensuse ? "registry.opensuse.org/opensuse/bci/bci-busybox:latest" : "registry.suse.com/bci/bci-busybox:latest";
     # Set a variable for my local image
     my $local_image = 'localhost:5050/bci-busybox:latest';
 
@@ -95,7 +95,8 @@ sub run {
     assert_script_run("diff -urN $dir1 $dir2", fail_message => 'Copied images are not identical.');
 
     ######### Spin-up an instance of the latest Registry
-    assert_script_run("$runtime run --rm -d -p 5050:5000 --name skopeo-registry registry.suse.com/suse/registry:latest",
+    my $registry_image = is_opensuse ? "registry.opensuse.org/opensuse/registry:latest" : "registry.suse.com/suse/registry:latest";
+    assert_script_run("$runtime run --rm -d -p 5050:5000 --name skopeo-registry $registry_image",
         fail_message => "Failed to start local registry container");
 
     ######### Pull the image into a our local repository


### PR DESCRIPTION
Undo the revert of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20381 and bring back https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20223 with the necessary fixes.

https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20223 updates container URLs to make the container test runs work on RISC-V. In addition the following fixes have been applied:

* PDB

- Related ticket: https://progress.opensuse.org/issues/166589

## Verification runs

- [Tumbleweed JeOS RISC-V](https://openqa.opensuse.org/tests/4635009)
- [microos-Tumbleweed-DVD-x86_64-Build20241109-container-host@64bit](https://openqa.opensuse.org/tests/4635317)
- [microos-Tumbleweed-DVD-x86_64-Build20241109-fips-container-host@64bit](https://openqa.opensuse.org/tests/4635318)
- [microos-Tumbleweed-MicroOS-Image-x86_64-Build20241109-microos@64bit](https://openqa.opensuse.org/tests/4635319)
- [microos-Tumbleweed-MicroOS-Image-x86_64-Build20241109-microos2microosnext@64bit](https://openqa.opensuse.org/tests/4635320)
- [opensuse-Tumbleweed-DVD-x86_64-Build20241109-containers_host_docker@64bit](https://openqa.opensuse.org/tests/4635321)
- [opensuse-Tumbleweed-DVD-x86_64-Build20241109-containers_host_podman@64bit](https://openqa.opensuse.org/tests/4635322)
- [sle-micro-6.0-Default-qcow-Updates-aarch64-Build36.2-slem_podman@aarch64](https://openqa.suse.de/tests/15910601)
- [sle-micro-6.0-Default-qcow-Updates-x86_64-Build36.2-slem_podman@uefi-virtio-vga](https://openqa.suse.de/tests/15910602)
- [sle-15-SP6-Server-DVD-Updates-x86_64-Build20241110-1-podman_tests@64bit](https://openqa.suse.de/tests/15910603)
- [sle-15-SP6-Server-DVD-Updates-aarch64-Build20241110-1-podman_tests@aarch64-virtio](https://openqa.suse.de/tests/15910604)
