### PR TITLE
bugfix: Stop AHB test module from creating a duplicate instance 

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -41,7 +41,7 @@ sub load_maintenance_publiccloud_tests {
     } elsif (get_var('PUBLIC_CLOUD_NETCONFIG')) {
         loadtest('publiccloud/cloud_netconfig', run_args => $args);
     } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {
-        loadtest('publiccloud/ahb');
+        loadtest('publiccloud/ahb', run_args => $args);
     } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {
         loadtest("publiccloud/bsc_1205002", run_args => $args);
     } elsif (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {

--- a/tests/publiccloud/ahb.pm
+++ b/tests/publiccloud/ahb.pm
@@ -30,11 +30,13 @@ our $azure_endpoint = get_var(
 
 sub run {
     my ($self, $args) = @_;
+    my $instance = $args->{my_instance};
+    my $provider = $args->{my_provider};
+
+
     select_serial_terminal;
     my $job_id = get_current_job_id();
 
-    my $provider = $self->provider_factory();
-    my $instance = $provider->create_instance();
     # resource group
     # get instance resource group
     my $resource_group_command = "curl -s -H Metadata:true --noproxy \"*\" \"$azure_endpoint/resourceGroupName?api-version=$api_version&format=text\"";


### PR DESCRIPTION
`ahb.pm` had internal logic to create an instance. `ahb.pm` was also loaded after we run `prepare_instance.pm` so the result would be two separate instances.

I have cleaned up the logic and have removed the instance creation part from `ahb.pm`.

- Related ticket: https://progress.opensuse.org/issues/168562
- Verification runs:
  - Duplicate Instances (BEFORE): http://dirtman.qe.prg2.suse.org/tests/96
  - Single Instance (AFTER): http://dirtman.qe.prg2.suse.org/tests/154
