### PR TITLE
update_install: Substitute SAP fo LTSS channel

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -203,6 +203,7 @@ sub run {
     foreach (@modules) {
         # substitue SLES_SAP for LTSS repo at this point is SAP ESPOS
         $_ =~ s/SAP_(\d+(-SP\d)?)/$1-LTSS/ if is_sle('15+');
+        $_ =~ s/SAP_(\d+(-SP\d)?)/SERVER_$1-LTSS/ if is_sle('=12-sp5');
         next if s{http.*SUSE_Updates_(.*)/?}{$1};
         die 'Modules regex failed. Modules could not be extracted from repos variable.';
     }


### PR DESCRIPTION
There is no SAP/ESPO channel on LTSS product in SMELT, see https://smelt.suse.de/maintained/
Workaround is to replace SAP with LTSS to get data from SMELT

- Related ticket: https://openqa.suse.de/tests/15746165#step/update_install/24
- Verification run: https://dzedro.suse.cz/tests/1642#step/update_install/24