### PR TITLE
Add LTSS in sle 12-SP5 to maintenance test runs

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -88,6 +88,7 @@ our %ADDONS_REGCODE = (
     'sle-module-live-patching' => get_var('SCC_REGCODE_LIVE'),
     'sle-live-patching' => get_var('SCC_REGCODE_LIVE'),
     'SLES-LTSS' => get_var('SCC_REGCODE_LTSS'),
+    'SLES-LTSS-Extended-Security' => get_var('SCC_REGCODE_LTSS_SEC'),
     'SUSE-Linux-Enterprise-RT' => get_var('SCC_REGCODE_RT'),
     ESPOS => get_var('SCC_REGCODE_ESPOS'),
 );
@@ -845,6 +846,7 @@ sub get_addon_fullname {
         legacy => 'sle-module-legacy',
         lgm => 'sle-module-legacy',
         ltss => is_hpc('15+') ? 'SLE_HPC-LTSS' : 'SLES-LTSS',
+        ltss_security => 'SLES-LTSS-Extended-Security',
         pcm => 'sle-module-public-cloud',
         rt => 'SUSE-Linux-Enterprise-RT',
         sapapp => 'sle-module-sap-applications',


### PR DESCRIPTION
Make sure that 12-SP5 hosts that we are using for container testing are deployed with LTSS module. In addition we also need to include the 'LTSS Extended Security' product (that's a different product than LTSS). LTSS on 12-sp5 will be officially released on 1.11.2024

- Related ticket: https://progress.opensuse.org/issues/166295
- Verification run: http://pherranz-openqa.qe.suse.de/tests/48
