### PR TITLE
Ensure socat is installed

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -238,6 +238,7 @@ sub ipaddr2_infra_deploy {
     }
 
     # If required, create on the fly the cloud-init script
+    # socat is only needed for 12sp5
     my $cloud_init_file;
     if ($args{cloudinit}) {
         my $cloud_init_content = <<END;
@@ -245,6 +246,7 @@ sub ipaddr2_infra_deploy {
 package_upgrade: false
 packages:
   - nginx
+  - socat
 runcmd:
   - 'echo "I am \$(hostname)" > /srv/www/htdocs/index.html'
   - sudo systemctl enable --now nginx.service
@@ -1480,7 +1482,7 @@ sub ipaddr2_configure_web_server {
     my (%args) = @_;
     croak("Argument < id > missing") unless $args{id};
     my @nginx_cmds = (
-        'sudo zypper install -y nginx',
+        'sudo zypper install -y nginx socat',    # socat is only needed for 12sp5
         'echo "I am $(hostname)" > /tmp/index.html',
         'sudo cp /tmp/index.html /srv/www/htdocs/index.html',
         'sudo systemctl enable --now nginx.service');


### PR DESCRIPTION
socat is needed for the healthprobe of the load balancer. Ensure it is always installed. 12sp5 does not have it installed by default.


- Related ticket: TEAM-8721

# Verification run:
 sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test
 -  http://openqaworker15.qa.suse.cz/tests/300672 :red_circle: something is calling `az group delete` during the nginx installation.
 -  http://openqaworker15.qa.suse.cz/tests/300675 :green_circle:
  
sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test_cloud_init
- http://openqaworker15.qa.suse.cz/tests/300673 :green_circle: 

sle-12-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-ipaddr2_azure_test
- http://openqaworker15.qa.suse.cz/tests/300674 :red_circle: cloud-init fails to install socat
```
Command: ['zypper', '--non-interactive', 'install', '--auto-agree-with-licenses', 'nginx', 'socat']
Exit code: 104
```
- http://openqaworker15.qa.suse.cz/tests/300676 :red_circle: 
- http://openqaworker15.qa.suse.cz/tests/300677  IPADDR2_CLOUDINIT=1
- http://openqaworker15.qa.suse.cz/tests/300761  IPADDR2_CLOUDINIT=1