### PR TITLE
Reduce yaml files for skip_registration

### DIFF
--- a/schedule/yam/test_cases/skip_registration.yaml
+++ b/schedule/yam/test_cases/skip_registration.yaml
@@ -21,14 +21,5 @@ schedule:
     - console/system_prepare
     - console/force_scheduled_tasks
   system_validation:
-    - console/installation_snapshots
-    - console/zypper_lr
-    - console/zypper_ref
-    - console/ncurses
-    - update/zypper_up
-    - console/zypper_lifecycle
-    - console/orphaned_packages_check
-    - console/consoletest_finish
-    - shutdown/grub_set_bootargs
     - shutdown/cleanup_before_shutdown
     - shutdown/shutdown


### PR DESCRIPTION
We want to revert the reduce of skip_registration due to some ppc64le modules are not compatible with the rest.

- Related ticket: https://progress.opensuse.org/issues/163280
- MR: IN PROGRESS
- Needles: N/A
- Verification run:
    - x86_64: https://openqa.suse.de/tests/15749857
    - aarch64: https://openqa.suse.de/tests/15749859
    - ppc64le: https://openqa.suse.de/tests/15749860
