### PR TITLE
Sle12sp5 guests enter LTSS

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_kvm_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_kvm_hvm_uefi_with_power_management_x86_64.xml
@@ -93,5 +93,5 @@
     <guest_registration_server/>
     <guest_registration_username>www@suse.com</guest_registration_username>
     <guest_registration_password/>
-    <guest_registration_extensions/>
+    <guest_registration_extensions>SLES-LTSS</guest_registration_extensions>
 </guest>

--- a/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -93,5 +93,5 @@
     <guest_registration_server/>
     <guest_registration_username>www@suse.com</guest_registration_username>
     <guest_registration_password/>
-    <guest_registration_extensions/>
+    <guest_registration_extensions>SLES-LTSS</guest_registration_extensions>
 </guest>


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/166187

Related PRs:
https://github.com/SUSE/qa-automation/pull/843
https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/212

Verification run: 
[uefi-gi-guest_sles12sp5-on-host_developing-kvm](https://10.145.10.207/tests/15755206)
[uefi-gi-guest_developing-on-host_sles12sp5-kvm](https://10.145.10.207/tests/15754988)
[uefi-gi-guest_sles12sp5-on-host_developing-xen](https://10.145.10.207/tests/15757184)   
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-xen](https://10.145.10.207/tests/15754985)
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](https://10.145.10.207/tests/15756628)  
[gi-guest_developing-on-host_sles12sp5-kvm](https://10.145.10.207/tests/15754962)
[gi-guest_developing-on-host_sles12sp5-kvm](https://10.145.10.207/tests/15754958)   //non-autoyast installl
[gi-guest_sles12sp5-on-host_developing-xen](https://10.145.10.207/tests/15745442)
[prj2_host_upgrade_sles12sp5_to_developing_kvm](https://10.145.10.207/tests/15756778)  
