### PR TITLE
Whitelist CVE-2023-20569 check for cc_atsec

### DIFF
--- a/tests/security/atsec/check_processor_vulnerability_mitigations.pm
+++ b/tests/security/atsec/check_processor_vulnerability_mitigations.pm
@@ -37,19 +37,29 @@ sub run {
     my $summary = script_output("grep 'SUMMARY' $log_file");
     record_info('SUMMARY', $summary);
 
+    # Check if the CPU is Intel or not
+    # Used for CVE-2023-20569 whitelisting
+    my $is_not_intel = script_run("grep -i 'model name' /proc/cpuinfo | grep -m 1 -qi 'intel'");
+
     foreach my $item (split(/\s/, $summary)) {
         if ($item !~ /(^CVE-.*):(\w+)/) {
             next;
         }
         my $name = $1;
         my $result = $2;
+
+        # CVE-2018-3639 will fail on aarch64 OSD worker.
+        # The reason is CPU doesn't support SSBD.
+        my $aarch64_failure = is_aarch64 && $name eq 'CVE-2018-3639';
+
+        # CVE-2023-20569 will fail on workers with specific CPUs.
+        # Check for the failure only on x86_64 Intel.
+        # poo#168697
+        my $x86_64_failure = is_x86_64 && $is_not_intel && $name eq 'CVE-2023-20569';
+
         if ($result ne 'OK') {
             record_info($name, "Check failed: $item, please see $log_file for more details", result => 'fail');
-
-            # CVE-2018-3639 will be KO on aarch64 OSD worker.
-            # The reason is CPU doesn't support SSBD.
-            # In this case, we consider job pass
-            $self->result('fail') unless (is_aarch64 && $name eq 'CVE-2018-3639');
+            $self->result('fail') unless $aarch64_failure || $x86_64_failure;
             next;
         }
         record_info($name, $item);


### PR DESCRIPTION
The check is ignored on all CPUs except 64bit Intel.

Related ticket: https://progress.opensuse.org/issues/168697

Verification runs:
- 15-SP3: https://openqa.suse.de/tests/15770794
- 15-SP4: https://openqa.suse.de/tests/15770798
- 15-SP4@uefi: https://openqa.suse.de/tests/15770800
- 15-SP5: https://openqa.suse.de/tests/15770801
- 15-SP5@uefi: https://openqa.suse.de/tests/15770802
