### PR TITLE
[fix] Cockpit is pre-installed in Default flavors only

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -298,7 +298,8 @@ sub run {
         create_user_in_ui();
     }
 
-    if (is_sle_micro('>6.0')) {
+    # Only Default flavors come with pre-installed cockpit
+    if (is_sle_micro('>6.0') && get_var('FLAVOR', '') =~ /default/i) {
         assert_screen 'jeos-totp-for-cockpit';
         for (1 .. 2) {
             wait_screen_change(sub {


### PR DESCRIPTION
- type: GMC validation test fix

Pre-installed cockpit package changes the workflow of jeos-firstboot as
it offers the user to configure OTP. This package is present only in
Default flavors of sle-micro 6.1+.

- failure: https://openqa.suse.de/tests/15756136#step/firstrun/13

#### Verification runs

 - sle-micro-6.1-Base-qcow-x86_64-Build24.3-default@uefi-virtio-vga -> https://openqa.suse.de/tests/15757000
 - sle-micro-6.1-Default-qcow-x86_64-Build24.3-default@uefi-virtio-vga -> https://openqa.suse.de/tests/15757001