### PR TITLE
Fix the upload file name for crm report

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -626,7 +626,9 @@ sub ha_export_logs {
     script_run "touch $corosync_conf";
     script_run "crm report $report_opt -E $bootstrap_log $crm_log", 300;
     upload_logs("$bootstrap_log", failok => 1);
-    upload_logs("$crm_log.tar.bz2", failok => 1);
+
+    my $crm_log_name = script_output("ls $crm_log* | tail -1");
+    upload_logs("$crm_log_name", failok => 1);
 
     script_run "crm configure show > /tmp/crm.txt";
     upload_logs('/tmp/crm.txt');


### PR DESCRIPTION
Running 'crm report' will generate a compress file, we need to get the correct file name to upload it.

Related: https://jira.suse.com/browse/TEAM-9765

VRs:
https://openqa.suse.de/tests/15764743#step/check_logs/13  (Upload tar.bz2 successfully)
https://openqa.suse.de/tests/15764740#step/check_logs/13  (Upload tar.gz successfully)

