### PR TITLE
Skip QR generator in serial console

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -301,7 +301,10 @@ sub run {
     # Only Default flavors come with pre-installed cockpit
     if (is_sle_micro('>6.0') && get_var('FLAVOR', '') =~ /default/i) {
         assert_screen 'jeos-totp-for-cockpit';
-        for (1 .. 2) {
+        # serial console is too small for generated QR to show up with additional textbox
+        # another button is present in the UI in order to display the QR in a separated view
+        my $tabs = is_s390x ? 3 : 2;
+        for (1 .. $tabs) {
             wait_screen_change(sub {
                     send_key 'tab';
             }, 10);


### PR DESCRIPTION
- type: test fix

Size of serial console is too small to fit generated QR code with
additional text information. In this case jeos-firstboot offers an user
to show the QR code in isolated view.
This PR is skip the extra button that offers to generate QR in ttyS0.

- related bug: https://bugzilla.suse.com/show_bug.cgi?id=1231177
- Verification run: [sle-micro-6.1-Default-qcow-s390x-Build24.3-default@s390x-kvm](https://openqa.suse.de/tests/15757230)
