### PR TITLE
Only raw aarch64 have leftover sectors

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -33,7 +33,7 @@ sub run {
 
     # Verify that there is no unpartitioned space left
     my $left_sectors = 0;
-    if ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64) {
+    if ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow/) {
         $left_sectors = 2048;
     } elsif (is_sle_micro("6.0+") && is_aarch64) {
         $left_sectors = 0 if (get_var("HDD_1") =~ /qcow2/);


### PR DESCRIPTION
- type: test fix

Unpartition space is reported only in raw aarch64 images. Qcow2 images do not report any leftover sectors.

- failure: https://openqa.suse.de/tests/15757120#step/image_checks/10

#### Verification runs

 - sle-micro-6.0-Default-qcow-Updates-Staging-aarch64-BuildO.37.5-slem_image_default@aarch64 -> https://openqa.suse.de/tests/15757280
 - sle-micro-5.5-Default-Updates-aarch64-Build20241022-1-slem_image_default@aarch64 -> https://openqa.suse.de/tests/15757281
 - sle-micro-6.1-Default-qcow-aarch64-Build24.3-default@aarch64 -> https://openqa.suse.de/tests/15757282
 - sle-micro-6.1-Default-qcow-x86_64-Build24.3-combustion@uefi-virtio-vga -> https://openqa.suse.de/tests/15757283
 - sle-micro-6.1-Default-aarch64-Build24.3-combustion@aarch64 -> https://openqa.suse.de/tests/15757284