### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -42,18 +42,16 @@ sub packages_to_install {
     # common packages
     my @packages = ('git-core', 'python3', 'gcc', 'jq');
     if ($host_distri eq 'ubuntu') {
-        push @packages, ('python3-dev', 'python3-pip', 'golang', 'postgresql-server-dev-all');
+        push @packages, ('python3-dev', 'python3-pip');
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri eq 'rhel' && $version > 7) {
-        push @packages, ('platform-python-devel', 'python3-pip', 'golang', 'postgresql-devel');
+        push @packages, ('platform-python-devel', 'python3-pip');
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri =~ /centos|rhel/) {
-        push @packages, ('python3-devel', 'python3-pip', 'golang', 'postgresql-devel');
+        push @packages, ('python3-devel', 'python3-pip');
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri eq 'sles' || $host_distri =~ /leap/) {
-        # SDK is needed for postgresql
         my $version = "$version.$sp";
-        push @packages, ('postgresql-server-devel');
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
         if ($version eq "12.5") {
             script_retry("SUSEConnect --auto-agree-with-licenses -p sle-sdk/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
@@ -63,21 +61,21 @@ sub packages_to_install {
             push @packages, ('python36-devel', 'python36-pip');
             die "virtualenv is not supported on 12-SP5" if ($bci_virtualenv);
         } elsif ($version =~ /15\.[1-3]/) {
-            # Desktop module is needed for SDK module, which is required for go and postgresql-devel
+            # Desktop module is needed for SDK module, which is required for python3-devel
             script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             script_retry("SUSEConnect -p sle-module-development-tools/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
-            push @packages, ('python3-devel', 'go', 'skopeo');
+            push @packages, ('python3-devel', 'skopeo');
         } else {
-            # Desktop module is needed for SDK module, which is required for go and postgresql-devel
+            # Desktop module is needed for SDK module, which is required for python311-devel
             if ($host_distri !~ /leap/) {
                 script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
                 script_retry("SUSEConnect -p sle-module-development-tools/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
                 script_retry("SUSEConnect -p sle-module-python3/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             }
-            push @packages, qw(python311 python311-devel go skopeo python311-pip python311-tox);
+            push @packages, qw(python311 python311-devel skopeo python311-pip python311-tox);
         }
     } elsif ($host_distri =~ /opensuse/) {
-        push @packages, qw(python3-devel go skopeo postgresql-server-devel python3-pip python3-tox);
+        push @packages, qw(python3-devel skopeo python3-pip python3-tox);
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } else {
         die("Host is not supported for running BCI tests.");


### PR DESCRIPTION
The go dependency was never needed and the postgresql dependency became obsolete with BCI-Tests switching from psycopg2 to pg8000. This commit removes those two dependencies.


- Related PR: https://github.com/SUSE/BCI-tests/pull/621

### Verification runs
 - [sle-Centos-Container-Host-x86_64-BuildGM-update_centos@64bit](https://openqa.suse.de/tests/15757564)
 - [sle-Ubuntu-Container-Host-x86_64-BuildGM-update_ubuntu@64bit](https://openqa.suse.de/tests/15757565)
 - [sle-mls9-Container-Host-x86_64-BuildGM-update_mls9@64bit](https://openqa.suse.de/tests/15757566)
 - [sle-micro-5.5-Container-Image-Updates-x86_64-BuildGM-update_slem@64bit](https://openqa.suse.de/tests/15757567)
 - [sle-micro-5.5-Container-Image-Updates-aarch64-BuildGM-update_slem@aarch64-virtio](https://openqa.suse.de/tests/15757568)
 - [sle-micro-6.1-Container-Image-Updates-x86_64-BuildGM-update_slem@64bit](https://openqa.suse.de/tests/15757569)
 - [sle-micro-6.1-Container-Image-Updates-aarch64-BuildGM-update_slem@aarch64-virtio](https://openqa.suse.de/tests/15757570)
 - [sle-15-SP6-Container-Host-x86_64-BuildGM-create_hdd_autoyast_containers@64bit](https://openqa.suse.de/tests/15757571)
 - [sle-15-SP6-Container-Host-aarch64-BuildGM-create_hdd_autoyast_containers@aarch64-virtio](https://openqa.suse.de/tests/15757572)
 - [sle-15-SP2-Container-Host-x86_64-BuildGM-create_hdd_autoyast_containers@64bit](https://openqa.suse.de/tests/15757573)
 - [sle-15-SP2-Container-Host-aarch64-BuildGM-create_hdd_autoyast_containers@aarch64-virtio](https://openqa.suse.de/tests/15757574)
 - [sle-15-SP5-Container-Host-x86_64-BuildGM-create_hdd_autoyast_containers@64bit](https://openqa.suse.de/tests/15757575)
 - [sle-15-SP5-Container-Host-aarch64-BuildGM-create_hdd_autoyast_containers@aarch64-virtio](https://openqa.suse.de/tests/15757576)
