### PR TITLE
WIP: Add check for failed actions in prevalidate

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_prevalidate.pm
+++ b/tests/sles4sap/publiccloud/qesap_prevalidate.pm
@@ -54,6 +54,9 @@ sub run {
         }
     }
 
+    # Check cluster for overall readiness (nodes online, in sync and crm output contains no failed resources)
+    $self->wait_for_cluster(wait_time => 60, max_retries => 10);
+
     return unless $ha_enabled;
 
     record_info(


### PR DESCRIPTION
This PR adds a general cluster health check (including crm otput check) in `qesap_prevalidate`, in order to fail at this stage, before `hanasr_takeover` begins.

- Related ticket: https://jira.suse.com/browse/TEAM-9768
- Verification run: 
WRONG SPN ID THAT LEADS TO FAILING STONITH RESOURCES: http://openqaworker15.qa.suse.cz/tests/300814#step/qesap_prevalidate/1179
RUN WITHOUT ERRORS: http://openqaworker15.qa.suse.cz/tests/300815
