### PR TITLE
Ignore crmsh deprecation messages when migrating from 12-SP5

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -947,19 +947,24 @@ sub set_lvm_config {
 
 =head2 add_lock_mgr
 
- add_lock_mgr( $lock_manager );
+ add_lock_mgr( $lock_manager, [ force => bool ] );
 
 Configures a B<$lock_manager> resource in the cluster configuration on SUT.
 B<$lock_mgr> usually is either B<clvmd> or B<lvmlockd>, but any other cluster
 primitive could work as well.
 
+Takes a second named argument B<force> which if set to true will add C<--force>
+to the B<crmsh> command. Should be used with care. Defaults to false.
+
 =cut
 
 sub add_lock_mgr {
-    my ($lock_mgr) = @_;
+    my ($lock_mgr, %args) = @_;
+    $args{force} //= 0;
+    my $cmd = join(' ', 'crm', ($args{force} ? '--force' : ''), 'configure', 'edit');
 
-    assert_script_run "EDITOR=\"sed -ie '\$ a primitive $lock_mgr ocf:heartbeat:$lock_mgr'\" crm configure edit";
-    assert_script_run "EDITOR=\"sed -ie 's/^\\(group base-group.*\\)/\\1 $lock_mgr/'\" crm configure edit";
+    assert_script_run "EDITOR=\"sed -ie '\$ a primitive $lock_mgr ocf:heartbeat:$lock_mgr'\" $cmd";
+    assert_script_run "EDITOR=\"sed -ie 's/^\\(group base-group.*\\)/\\1 $lock_mgr/'\" $cmd";
 
     # Wait to get clvmd/lvmlockd running on all nodes
     sleep 5;

--- a/tests/ha/migrate_clvmd_to_lvmlockd.pm
+++ b/tests/ha/migrate_clvmd_to_lvmlockd.pm
@@ -46,7 +46,7 @@ sub run {
         # Stop all affected resources, and remove clvm resource from cluster
         for my $rsc (qw(fs_cluster_md vg_cluster_md cluster_md clvm clvmd)) {
             $rsc_not_exists{$rsc} = script_run "crm resource stop $rsc";
-            assert_script_run "crm configure delete $rsc" if ($rsc =~ /clvm/ && !$rsc_not_exists{$rsc});
+            assert_script_run "crm --force configure delete $rsc" if ($rsc =~ /clvm/ && !$rsc_not_exists{$rsc});
         }
 
         # With clvm resource removed from the cluster, configure lvmlockd
@@ -57,7 +57,7 @@ sub run {
         exec_csync;
 
         # Add lvmlockd resource to cluster
-        add_lock_mgr('lvmlockd');
+        add_lock_mgr('lvmlockd', force => 1);
         save_state;
 
         # Restart cluster_md


### PR DESCRIPTION
During SLES+HA migration tests from 12 to 15, test code needs to deal with any `clvmd` resources configured in the cluster, as `clvmd` was available in SLES 12, but not in SLES 15. This is handled by the `ha/migrate_clvmd_to_lvmlockd` test module, which will check for `clvmd` resources in the cluster, and if they are present, will perform the necessary steps to remove the `clvmd` resource and configure in its place a `lvmlockd` resource, applying also the required changes to the LVM configuration.

Starting with the `crmsh` version available in 15-SP7, the commands to remove `clvmd` are failing as now `crmsh` reports more cases of deprecated resources and deprecated attributes syntax; it also requires a confirmation due to these warnings. The request for confirmation is making the test module `ha/migrate_clvmd_to_lvmlockd` fail, so this commit adds `--force` to the failing `crmsh` commands to ignore the warnings.

Even though normally it would not be safe to ignore `crmsh` warnings, in this case since it's a migration scenario from SLES 12-SP5 to 15-SP7, we must assume cluster configurations under SLES 12 will have many deprecated resources and attributes syntax, but even with these, the cluster should come back online after a migration, so we're choosing to ignore the warnings only in this module which deals only with migrations from SLES 12.

- Related ticket: https://jira.suse.com/browse/TEAM-9773
- Needles: N/A
- Verification run: [Support Server](http://mango.qe.nue2.suse.org/tests/6237), [Node 1](http://mango.qe.nue2.suse.org/tests/6238), [Node 2](http://mango.qe.nue2.suse.org/tests/6239)
