### PR TITLE
Skip salt test in staging

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -205,7 +205,7 @@ sub load_common_tests {
     # Staging has no access to repos and the MicroOS-DVD does not contain ansible
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
     loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro);
-    loadtest 'console/salt' unless is_sle_micro;
+    loadtest 'console/salt' unless (is_staging || is_sle_micro);
     # On s390x zvm setups we need more time to wait for system to boot up.
     # Skip this test with sd-boot. The reason is not what you'd think though:
     # With sd-boot, host_config does not perform a reboot and a snapshot is made while the serial terminal


### PR DESCRIPTION
- type: Factory staging blocker
- failure: https://openqa.opensuse.org/tests/4591384

Skip salt smoke test in staging testing as the salt packages are missing in staging test assets.

- microos-Staging:M-Staging-MicroOS-Image-sdboot-x86_64-BuildM.83.4-microos-wizard-tpm@uefi-staging -> https://openqa.opensuse.org/tests/4591486
