### PR TITLE
run_ltp.pm: softfail when kernel warning is expected by test

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -63,12 +63,12 @@ sub create_list_of_serial_failures {
 
     if (is_kernel_test()) {
         my $type = is_ltp_test() ? 'soft' : 'hard';
-        push @$serial_failures, {type => $type, message => 'Kernel Ooops found', pattern => quotemeta 'Oops:', post_boot_type => 'hard'};
+        push @$serial_failures, {type => $type, message => 'Kernel Oops found', pattern => quotemeta 'Oops:', post_boot_type => 'hard'};
         push @$serial_failures, {type => $type, message => 'Kernel BUG found', pattern => qr/kernel BUG at/i, post_boot_type => 'hard'};
         push @$serial_failures, {type => $type, message => 'WARNING CPU in kernel messages', pattern => quotemeta 'WARNING: CPU', post_boot_type => 'hard'};
         push @$serial_failures, {type => $type, message => 'Kernel stack is corrupted', pattern => quotemeta 'stack-protector: Kernel stack is corrupted', post_boot_type => 'hard'};
         push @$serial_failures, {type => $type, message => 'Kernel BUG found', pattern => quotemeta 'BUG: failure at', post_boot_type => 'hard'};
-        push @$serial_failures, {type => $type, message => 'Kernel Ooops found', pattern => quotemeta '-[ cut here ]-', post_boot_type => 'hard'};
+        push @$serial_failures, {type => $type, message => 'Kernel Oops found', pattern => quotemeta '-[ cut here ]-', post_boot_type => 'hard'};
         # bsc#1229025, but must be soft because any LTP test which intentionally triggers OOM killer will produce this call trace as well
         push @$serial_failures, {type => 'soft', message => 'Kernel Call Trace found', pattern => quotemeta 'Call Trace:'};
     }

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -332,6 +332,11 @@ sub pre_run_hook {
     # But change them to hard fail in this test module.
     for my $pattern (@{$self->{serial_failures}}) {
         my %tmp = %$pattern;
+
+        # don't switch to hard fail when test is expected to produce kernel warning
+        next if ($tmp{message} =~ m/warning/i && get_var('LTP_WARN_EXPECTED'));
+        next if ($tmp{message} =~ m/Oops/i && get_var('LTP_WARN_EXPECTED'));
+
         $tmp{type} = $tmp{post_boot_type} if defined($tmp{post_boot_type});
         push @pattern_list, \%tmp;
     }


### PR DESCRIPTION
Skip marking serial failures as hard fail  when test is expected to produce kernel warning.

Also created a new testsuite in o3 named  `ltp_kernel_warn_tests` for such tests with extra setting
LTP_WARN_EXPECTED=1 

 Verification run: https://openqa.opensuse.org/tests/4591649#step/block_dev/7