### PR TITLE
Add migration testsuites for SLED15SP6 to SLED15SP7: AUTOYAST files

### DIFF
--- a/data/yam/autoyast/support_images/sled_install_all_patterns.xml
+++ b/data/yam/autoyast/support_images/sled_install_all_patterns.xml
@@ -150,25 +150,25 @@ exit 0
   <suse_register t="map">
     <addons t="list">
       <addon t="map">
-        <arch>x86_64</arch>
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
-        <version>15.5</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
-        <arch>x86_64</arch>
+        <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
-        <version>15.5</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
-        <arch>x86_64</arch>
+        <arch>{{ARCH}}</arch>
         <name>sle-we</name>
         <reg_code>{{SCC_REGCODE_WE}}</reg_code>
-        <version>15.5</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
-        <arch>x86_64</arch>
+        <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
-        <version>15.5</version>
+        <version>{{VERSION}}</version>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sled_install_default_patterns.xml
+++ b/data/yam/autoyast/support_images/sled_install_default_patterns.xml
@@ -144,25 +144,25 @@ exit 0
   <suse_register t="map">
     <addons t="list">
       <addon t="map">
-        <arch>x86_64</arch>
+        <arch>{{ARCH}}</arch>
         <name>sle-module-desktop-applications</name>
-        <version>15.5</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
-        <arch>x86_64</arch>
+        <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
-        <version>15.5</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
-        <arch>x86_64</arch>
+        <arch>{{ARCH}}</arch>
         <name>sle-we</name>
         <reg_code>{{SCC_REGCODE_WE}}</reg_code>
-        <version>15.5</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
-        <arch>x86_64</arch>
+        <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
-        <version>15.5</version>
+        <version>{{VERSION}}</version>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>


### PR DESCRIPTION
- Related ticket: [poo#165737](https://progress.opensuse.org/issues/165737)
- Verification run:
  + flavor [Server-DVD-Updates](https://openqa.suse.de/tests/overview?distri=sle&groupid=529&flavor=Server-DVD-Updates)
  + flavor [Migration-from-SLE15-SPx](https://openqa.suse.de/tests/overview?distri=sle&groupid=529&flavor=Migration-from-SLE15-SPx)
  + flavor [Migration-from-SLE15-SPx-Milestone](https://openqa.suse.de/tests/overview?distri=sle&groupid=529&flavor=Migration-from-SLE15-SPx-Milestone)
- Related `openqa-job-groups` [MR#352](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/352): to be merge after current PR
