### PR TITLE
Pass max_interval to GrubEntryEditionPage

### DIFF
--- a/lib/Yam/Agama/Pom/GrubEntryEditionPage.pm
+++ b/lib/Yam/Agama/Pom/GrubEntryEditionPage.pm
@@ -15,7 +15,7 @@ use testapi;
 sub new {
     my ($class, $args) = @_;
     return bless {
-        max_interval => undef,
+        max_interval => $args->{max_interval},
         key_boot => 'ctrl-x'
     }, $class;
 }


### PR DESCRIPTION
- Related ticket: [poo#168205](https://progress.opensuse.org/issues/168205)
- Verification run: https://openqa.suse.de/tests/overview?build=jknphy%2Fos-autoinst-distri-opensuse%23slowtype&distri=sle&version=16.0