### PR TITLE
Update workload zone tfvars file

### DIFF
--- a/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars
+++ b/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars
@@ -336,7 +336,10 @@ resourcegroup_name = "%SDAF_RESOURCE_GROUP%"
 # If defined provides the DNS label for the Virtual Network
 dns_label="openqa.net"
 
-#If defined provides the lsit of DNS servers to attach to the Virtual NEtwork
+# Boolean value indicating if storage accounts and key vaults should be registered to the corresponding dns zones
+register_storage_accounts_keyvaults_with_dns = false
+
+# If defined provides the lsit of DNS servers to attach to the Virtual NEtwork
 #dns_server_list = []
 
 #########################################################################################


### PR DESCRIPTION
With upcoming changes in SDAF including various bugfixes that left our tests 
broken, there is a need for additional parameter 
`register_storage_accounts_keyvaults_with_dns = false` in workload zone tfvars file. Fix 
will work after bumping SDAF version inside OpenQA JobGroup. 

- Related ticket: https://jira.suse.com/browse/TEAM-9722

**- Verification runs:**
**Before**: https://openqaworker15.qa.suse.cz/tests/300994#step/deploy_workload_zone/188

**LAB env:** https://mordor.suse.cz/tests/688#

**PRD env:** https://openqaworker15.qa.suse.cz/tests/301061#
