### PR TITLE
Update selfinstall test schedule

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -491,14 +491,16 @@ sub uefi_bootmenu_params {
         }
 
         # navigate to gfxpayload=keep
-        my $gfx = is_sle('=12-SP5') ? 2 : 3;
-        send_key "down" for (1 .. $gfx);
-        wait_screen_change(sub { send_key "end"; }, 5);
-        # delete "keep" word
-        send_key "backspace" for (1 .. 4);
-        # hardcoded the value of gfxpayload to 1024x768
-        type_string "1024x768";
-        assert_screen "gfxpayload_changed", 10;
+        if (!get_var('OFW')) {
+            my $gfx = is_sle('=12-SP5') ? 2 : 3;
+            send_key "down" for (1 .. $gfx);
+            wait_screen_change(sub { send_key "end"; }, 5);
+            # delete "keep" word
+            send_key "backspace" for (1 .. 4);
+            # hardcoded the value of gfxpayload to 1024x768
+            type_string "1024x768";
+            assert_screen "gfxpayload_changed", 10;
+        }
 
         # navigate to the beginning of the line containing *linux* command
         wait_screen_change(sub { send_key "home"; }, 5);
@@ -510,6 +512,7 @@ sub uefi_bootmenu_params {
         if (get_var('FLAVOR', '') =~ /encrypt/i) {
             $linux += is_sle_micro('6.1+') ? 11 : 10;
         }
+        $linux-- if get_var('OFW');
         send_key "down" for (1 .. $linux);
     }
     else {

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -48,6 +48,7 @@ sub load_config_tests {
 }
 
 sub load_boot_from_disk_tests {
+    return if is_ppc64le && get_var('MACHINE') !~ /ppc64le-emu/i;
     # add additional image handling module for svirt workers
     if (is_s390x()) {
         loadtest 'installation/bootloader_start';

--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -20,8 +20,6 @@ $needle::cleanuphandler = sub {
     unregister_needle_tags('ENV-BACKEND-ipmi');
     unregister_needle_tags('ENV-FLAVOR-JeOS-for-kvm');
     unregister_needle_tags('ENV-JEOS-1');
-    unregister_needle_tags('ENV-OFW-0');
-    unregister_needle_tags('ENV-OFW-1');
     unregister_needle_tags('ENV-UEFI-1') unless get_var('UEFI');
     unregister_needle_tags('ENV-PXEBOOT-0');
     unregister_needle_tags('ENV-PXEBOOT-1');
@@ -31,9 +29,12 @@ $needle::cleanuphandler = sub {
     unregister_needle_tags("ENV-VERSION-12-SP1");
     unregister_needle_tags("ENV-VERSION-12-SP2");
     unregister_needle_tags("ENV-VERSION-12-SP3");
+    unregister_needle_tags("ENV-VERSION-12-SP4");
+    unregister_needle_tags("ENV-VERSION-12-SP5");
     unregister_needle_tags("ENV-VERSION-11-SP4");
     unregister_needle_tags("ENV-12ORLATER-1");
     unregister_needle_tags("ENV-FLAVOR-Server-DVD");
+    unregister_needle_tags('ENV-OFW-1') unless get_var('OFW');
 };
 
 


### PR DESCRIPTION
The schedule update is required for non-selfinstall ppc64le test scenarios.
The bootloader handler is mandatory for jeos-wizard test scenario as
`console` parameters are missing and jeos-wizard won't be shown in the current `tty`.

- ticket: https://progress.opensuse.org/issues/169243
- Verification run: http://kepler.suse.cz/tests/24152#step/bootloader_uefi/4
