### PR TITLE
Is openssh installed on 15SP2

### DIFF
--- a/tests/fips/openssh/openssh_fips.pm
+++ b/tests/fips/openssh/openssh_fips.pm
@@ -36,7 +36,8 @@ sub run {
 
     # on Tumbleweed sshd is not active by default:
     # ensure sshd is installed and started before trying to connect
-    assert_script_run 'rpm -q openssh-server || zypper in -y openssh-server';
+    my $pkg_name = is_sle('<=15-SP2') ? "openssh" : "openssh-server";
+    assert_script_run "rpm -q " . $pkg_name . " || zypper in -y " . $pkg_name;
     assert_script_run 'systemctl is-active sshd || systemctl enable --now sshd';
 
     # on SL Micro we skip this check because it behaves differently


### PR DESCRIPTION
Verify if is openssh is installed, in case of SLE 15 SP2 package name differs 

Related ticket: https://progress.opensuse.org/issues/168904
Verification runs: 
-  15SP2: https://openqa.suse.de/tests/15772935#step/openssh_fips/17
-  15SP4: https://openqa.suse.de/tests/15772934#step/openssh_fips/17