### PR TITLE
Remove more dependencies from BCI

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -40,42 +40,35 @@ sub packages_to_install {
     script_run("timeout 20 pkcon quit") if (is_sle || is_opensuse);
 
     # common packages
-    my @packages = ('git-core', 'python3', 'gcc', 'jq');
+    my @packages = ('git-core', 'python3', 'jq');
     if ($host_distri eq 'ubuntu') {
-        push @packages, ('python3-dev', 'python3-pip');
+        push @packages, ('python3-pip');
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri eq 'rhel' && $version > 7) {
-        push @packages, ('platform-python-devel', 'python3-pip');
+        push @packages, ('python3-pip');
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri =~ /centos|rhel/) {
-        push @packages, ('python3-devel', 'python3-pip');
+        push @packages, ('python3-pip');
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri eq 'sles' || $host_distri =~ /leap/) {
         my $version = "$version.$sp";
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
-        if ($version eq "12.5") {
+        if ($version =~ /12\./) {
             script_retry("SUSEConnect --auto-agree-with-licenses -p sle-sdk/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             # PackageHub is needed for jq
             script_retry("SUSEConnect -p PackageHub/12.5/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             script_retry('zypper -n in jq', retry => 3);
-            push @packages, ('python36-devel', 'python36-pip');
+            # Note tox is not available on SLES12
+            push @packages, qw(python36-pip);
             die "virtualenv is not supported on 12-SP5" if ($bci_virtualenv);
         } elsif ($version =~ /15\.[1-3]/) {
-            # Desktop module is needed for SDK module, which is required for python3-devel
-            script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
-            script_retry("SUSEConnect -p sle-module-development-tools/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
-            push @packages, ('python3-devel', 'skopeo');
+            push @packages, ('skopeo');
         } else {
-            # Desktop module is needed for SDK module, which is required for python311-devel
-            if ($host_distri !~ /leap/) {
-                script_retry("SUSEConnect -p sle-module-desktop-applications/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
-                script_retry("SUSEConnect -p sle-module-development-tools/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
-                script_retry("SUSEConnect -p sle-module-python3/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
-            }
-            push @packages, qw(python311 python311-devel skopeo python311-pip python311-tox);
+            script_retry("SUSEConnect -p sle-module-python3/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout) if ($host_distri =~ /sles/);
+            push @packages, qw(python311 skopeo python311-pip python311-tox);
         }
     } elsif ($host_distri =~ /opensuse/) {
-        push @packages, qw(python3-devel skopeo python3-pip python3-tox);
+        push @packages, qw(skopeo python3-pip python3-tox);
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } else {
         die("Host is not supported for running BCI tests.");


### PR DESCRIPTION
Recent changes in the BCI-Tests allows us to also remove the python3-devel dependency.

- Related ticket: https://progress.opensuse.org/issues/168706

### Verification runs

- [sle-Centos-Container-Host-x86_64-BuildGM-update_centos@64bit](https://openqa.suse.de/tests/15782685)
- [sle-Ubuntu-Container-Host-x86_64-BuildGM-update_ubuntu@64bit](https://openqa.suse.de/tests/15782686)
- [sle-mls9-Container-Host-x86_64-BuildGM-update_mls9@64bit](https://openqa.suse.de/tests/15782687)
- [sle-Leap15.6-Container-Host-x86_64-BuildGM-update_leap@64bit](https://openqa.suse.de/tests/15782688)
- [sle-micro-5.5-Container-Image-Updates-x86_64-BuildGM-update_slem@64bit](https://openqa.suse.de/tests/15782689)
- [sle-micro-5.5-Container-Image-Updates-s390x-BuildGM-update_slem@s390x-kvm](https://openqa.suse.de/tests/15782690)
- [sle-micro-5.5-Container-Image-Updates-aarch64-BuildGM-update_slem@aarch64-virtio](https://openqa.suse.de/tests/15782691)
- [sle-12-SP5-Container-Host-x86_64-BuildGM-create_hdd_autoyast_containers@64bit](https://openqa.suse.de/tests/15782682)
- [sle-12-SP5-Container-Host-s390x-BuildGM-create_hdd_autoyast_containers@s390x-kvm](https://openqa.suse.de/tests/15782801)
- [sle-12-SP5-Container-Host-ppc64le-BuildGM-create_hdd_autoyast_containers@ppc64le](https://openqa.suse.de/tests/15782684)
- [sle-15-SP6-Container-Host-x86_64-BuildGM-create_hdd_fips_autoyast_containers@64bit](https://openqa.suse.de/tests/15782692)
- [sle-15-SP6-Container-Host-s390x-BuildGM-create_hdd_fips_autoyast_containers@s390x-kvm](https://openqa.suse.de/tests/15782693)
- [sle-15-SP6-Container-Host-ppc64le-BuildGM-create_hdd_fips_autoyast_containers@ppc64le](https://openqa.suse.de/tests/15782694)
- [sle-15-SP6-Container-Host-aarch64-BuildGM-create_hdd_fips_autoyast_containers@aarch64-virtio](https://openqa.suse.de/tests/15782626)

* [Create 15-SP6 HDD](https://openqa.suse.de/tests/15782865) and [BCI run](https://openqa.suse.de/tests/15792427)