### PR TITLE
Fix for SLE Micro Extras during runtime scc registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -1075,7 +1075,10 @@ sub runtime_registration {
     if (is_transactional) {
         trup_call('register' . $cmd);
         trup_call('--continue run zypper --gpg-auto-import-keys refresh') if is_staging;
-        add_suseconnect_product('SL-Micro-Extras') if (is_sle_micro('>=6.0'));
+        if (is_sle_micro('>=6.0')) {
+            process_reboot(trigger => 1);
+            add_suseconnect_product('SL-Micro-Extras');
+        }
         process_reboot(trigger => 1);
     }
     else {


### PR DESCRIPTION
Fix for SLE Micro Extras during runtime scc registration

- Verification run:  http://openqa.suse.de/tests/15782345
