### PR TITLE
Use correct casing for FIPS environment var

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -92,7 +92,7 @@ sub run {
     if (get_var("FIPS_ENV_MODE")) {
         die 'FIPS kernel mode is required for this test!' if check_var('SECURITY_TEST', 'crypt_kernel');
         install_fips;
-        foreach my $env ('OPENSSL_FIPS', 'OPENSSL_FORCE_FIPS_MODE', 'LIBGCRYPT_FORCE_FIPS_MODE', 'NSS_FIPS', 'GnuTLS_FORCE_FIPS_MODE') {
+        foreach my $env ('OPENSSL_FIPS', 'OPENSSL_FORCE_FIPS_MODE', 'LIBGCRYPT_FORCE_FIPS_MODE', 'NSS_FIPS', 'GNUTLS_FORCE_FIPS_MODE') {
             assert_script_run "echo 'export $env=1' >> /etc/bash.bashrc";
         }
         assert_script_run "update-crypto-policies --set FIPS" if is_sle('>=15-SP6');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/168700
- Needles: n/a
- Verification runs: 
   - https://openqa.suse.de/tests/15782850
   - https://openqa.suse.de/tests/15782864 

