### PR TITLE
Ensure we run $self->wait_for_cluster in a cluster node

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_prevalidate.pm
+++ b/tests/sles4sap/publiccloud/qesap_prevalidate.pm
@@ -54,10 +54,16 @@ sub run {
         }
     }
 
-    # Check cluster for overall readiness (nodes online, in sync and crm output contains no failed resources)
-    $self->wait_for_cluster(wait_time => 60, max_retries => 10);
-
+    # Exit early if not in cluster scenario
     return unless $ha_enabled;
+
+    # Check cluster for overall readiness (nodes online, in sync and crm output contains no failed resources)
+    # First make sure that instance in $self->{my_instance} is a hana node
+    foreach my $instance (@{$self->{instances}}) {
+        $self->{my_instance} = $instance;
+        last if ($instance->{instance_id} =~ m/vmhana/);
+    }
+    $self->wait_for_cluster(wait_time => 60, max_retries => 10);
 
     record_info(
         'Instances:', "Detected HANA instances:


### PR DESCRIPTION
PR #20469 introduced a cluster check in `tests/sles4sap/publiccloud/qesap_prevalidate` to make sure we have a healthy cluster right after the deployment. It does this by calling `lib/sles4sap_publiccloud::wait_for_cluster()`, which relies on the cloud instance where the cluster is checked to be stored in `$self->{my_instance}`.

However, this was added after a loop that cycles through all the deployed cloud instances, and in the case of SBD, this includes the iSCSI server which is not a member of the cluster. Due to the way Perl orders lists within hashes, it can happen that the iSCSI server is the last entry in this list, leaving it stored in `$self->{my_instance}` and causing `$self->wait_for_cluster()` to fail as the commands are not run in a member of the cluster.

This commits works around the issue by cycling through the list of instances again to ensure a cluster node is set in `$self->{my_instance}`. It also includes a check for the *HA_CLUSTER* setting as it does not make sense to check for cluster health on non-cluster scenarios.

- Related ticket: https://jira.suse.com/browse/TEAM-9768
- Needles: N/A
- Verification run: https://openqaworker15.qa.suse.cz/tests/301336 (SBD), https://openqaworker15.qa.suse.cz/tests/301337 (MSI) & https://openqaworker15.qa.suse.cz/tests/301338 (SPN)
