### PR TITLE
Support sles12sp5 LTSS aarch64 test

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -371,11 +371,7 @@ sub register_addons {
                 assert_and_click("scc-code-field-$addon", timeout => 240);
             }
             # avoid duplicated tests to manage LTSS regcode by integrating new variables
-            if ($addon eq "ltss") {
-                my $os_sp_version = get_var("HDDVERSION");
-                $os_sp_version =~ s/-/_/g;
-                $regcode = get_var("SCC_REGCODE_LTSS_$os_sp_version", $regcode);
-            }
+            $regcode = get_ltss_regcode($regcode) if $addon eq "ltss";
             type_string $regcode;
             save_screenshot;
             $regcodes_entered++;
@@ -383,6 +379,20 @@ sub register_addons {
     }
 
     return $regcodes_entered;
+}
+
+sub get_ltss_regcode {
+    my $regcode = shift;
+    if (my $os_version = get_var("HDDVERSION")) {
+        $os_version =~ s/-/_/g;
+        return get_var("SCC_REGCODE_LTSS_$os_version", $regcode);
+    }
+    elsif ($os_version = get_var("VERSION_TO_INSTALL")) {
+        # Check if VERSION_TO_INSTALL contains "12" or "15"
+        return get_var("SCC_REGCODE_LTSS_12", $regcode) if $os_version =~ /12/;
+        return get_var("SCC_REGCODE_LTSS_15", $regcode) if $os_version =~ /15/;
+    }
+    return $regcode;
 }
 
 sub assert_registration_screen_present {

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -1254,7 +1254,7 @@ in to preserve order. For multiple guest patterns, an empty registration
 code for specific guest pattern will not be filled out by any default
 value and at the same time this  means registration code is not needed
 for it at all. This subroutine has one argument separator and returns
-generated registration codes joined together by specified separator.  
+generated registration codes joined together by specified separator.
 
 =cut
 
@@ -1269,7 +1269,14 @@ sub get_guest_regcode {
     my $regcode_ltss = get_var("GUEST_SCC_REGCODE_LTSS", "");
     my $count = ($args{separator} eq '|' ? scalar(split("\\$args{separator}", $guest)) : scalar(split("$args{separator}", $guest)));
     $regcode = join("$args{separator}", (get_var("SCC_REGCODE", "")) x $count) if (!$regcode);
-    $regcode_ltss = join("$args{separator}", (get_var("SCC_REGCODE_LTSS_15", "")) x $count) if (!$regcode_ltss);
+    if (!$regcode_ltss) {
+        my @guest_parts = split($args{separator}, $guest);
+        my @regcode_ltss_parts;
+        for my $part (@guest_parts) {
+            push @regcode_ltss_parts, ($part =~ /12/ ? get_var("SCC_REGCODE_LTSS_12", "") : $part =~ /15/ ? get_var("SCC_REGCODE_LTSS_15", "") : "");
+        }
+        $regcode_ltss = join($args{separator}, @regcode_ltss_parts);
+    }
     return $regcode, $regcode_ltss;
 }
 


### PR DESCRIPTION
Change sles12sp5 aarch64 test to LTSS

Progress ticket: https://progress.opensuse.org/issues/169222

Solution:

Add SCC_ADDONS ltss
Add new key: SCC_REGCODE_LTSS_12
Using VERSION_TO_INSTALL(12-SP5) when installing Bare Metal sles12SP5 LTSS.
Using GUEST_LIST(sles-12-sp5-64) when installing Guest sles12SP5 LTSS.

Related PR or MR:
[qa-automation](https://github.com/SUSE/qa-automation/pull/844)
[os-autoinst-distri-opensuse](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20501)
[openqa-job-group-yaml](https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/213)

VR:
[Baremetal](http://openqa.qa2.suse.asia/tests/76579#step/scc_registration/22)
[Guest](http://openqa.qa2.suse.asia/tests/76579#step/scc_registration/22) Failure reason:[cannot connect dist .suse.de from Beijing lab](https://progress.opensuse.org/issues/169222)
More test on sles15sp7, passed.
https://openqa.oqa.prg2.suse.org/tests/15874159#