### PR TITLE
containers/podman_netavark: Save and restore IPv6 route in hooks

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -103,10 +103,6 @@ sub run {
 
     $podman->cleanup_system_host();
 
-    # it is turned off in
-    # https://github.com/os-autoinst/os-autoinst-distri-opensuse/blame/master/lib/containers/common.pm#L303
-    assert_script_run 'sysctl -w net.ipv6.conf.all.disable_ipv6=0';
-
     assert_script_run('curl ' . data_url('containers/nginx.conf') . ' -o nginx.conf');
 
     ## TEST1


### PR DESCRIPTION
As a workaround for bugs [bsc#1222239](https://bugzilla.suse.com/show_bug.cgi?id=1222239) [bsc#1232450](https://bugzilla.suse.com/show_bug.cgi?id=1232450), save the default IPv6 before TEST3 execution and restore it immediately after. This way, connectivity is not lost and subsequent test modules in the schedule won't fail due to that.

Also, remove the obsolete call `sysctl -w net.ipv6.conf.all.disable_ipv6=0` in podman_netavark.

- Related ticket: https://progress.opensuse.org/issues/168451
- Verification run: http://rmarliere-openqa.qe.prg2.suse.org/tests/151
