### PR TITLE
lib/nfs_common.pm: allow nfs v2 to be enabled by default

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -40,9 +40,6 @@ sub try_nfsv2 {
         return;
     }
 
-    # If available, make sure it's disabled by default
-    assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
-
     # Stop testing NFSv2 on tumbleweed, support is removed in nfs-utils
     if (is_sle('15+')) {
         file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");


### PR DESCRIPTION
SLE kernel commit 9e3254dd9b4f ("Update config files: Enable NFSD_V2 (bsc#1230914)") re-enabled nfsv2 support, and as such it is now expected to show up as enabled by default in the kernel (at least for SLE15).

Remove the assertion that assumes nfsv2 should be disabled by default, if present.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1232437