### PR TITLE
WIP: Not reload netcard order in 15-SP2

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -16,6 +16,7 @@ use testapi;
 use Utils::Architectures;
 use repo_tools 'add_qa_head_repo';
 use mmapi 'wait_for_children';
+use version_utils "is_sle";
 use ipmi_backend_utils;
 
 sub install_pkg {
@@ -76,7 +77,7 @@ sub setup_environment {
         assert_script_run("ls /root/qaset/deploy_hana_perf_env.done");
 
         # workaround to prevent network interface random order
-        if (check_var('PROJECT_M_ROLE', 'PROJECT_M_ABAP')) {
+        if (check_var('PROJECT_M_ROLE', 'PROJECT_M_ABAP') && is_sle('>=15-SP3')) {
             my $service_file = << 'EOF';
 [Unit]
 Description=Load bnxt_en driver manually


### PR DESCRIPTION
The netcard order issue only happens on 15-SP6 for now, and for different version, the format of service file has difference. So we only need to do this for 15-SP6, in case in other version it reports service format is wrong.

