### PR TITLE
Revert "containers: Install pasta from upstream for buildah upstream tests"

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -20,19 +20,9 @@ use version_utils qw(is_transactional is_sle is_sle_micro is_tumbleweed);
 use transactional qw(trup_call check_reboot_changes);
 use serial_terminal qw(select_user_serial_terminal);
 use registration qw(add_suseconnect_product get_addon_fullname);
-use Utils::Architectures qw(is_aarch64 is_x86_64);
+use Utils::Architectures 'is_aarch64';
 
-our @EXPORT = qw(install_bats install_htpasswd install_ncat install_pasta remove_mounts_conf switch_to_user delegate_controllers enable_modules patch_logfile);
-
-sub install_pasta {
-    return unless (is_x86_64 && script_run("which pasta") != 0);
-
-    my @files = ("pasta", "pasta.avx2", "passt", "qrap");
-    foreach my $file (@files) {
-        script_retry("curl -o /usr/local/bin/$file https://passt.top/builds/latest/x86_64/$file", retry => 5, delay => 60, timeout => 300);
-        assert_script_run "chmod +x /usr/local/bin/$file";
-    }
-}
+our @EXPORT = qw(install_bats install_htpasswd install_ncat remove_mounts_conf switch_to_user delegate_controllers enable_modules patch_logfile);
 
 sub install_ncat {
     return if (script_run("rpm -q ncat") == 0);

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats install_pasta patch_logfile switch_to_user delegate_controllers enable_modules remove_mounts_conf);
+use containers::bats qw(install_bats patch_logfile switch_to_user delegate_controllers enable_modules remove_mounts_conf);
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -32,7 +32,7 @@ sub run_tests {
     script_run "rm -rf $tmp_dir/buildah_tests.*";
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "env PATH=/usr/local/bin:\$PATH BATS_TMPDIR=$tmp_dir TMPDIR=$tmp_dir BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 4200;
+    script_run "env BATS_TMPDIR=$tmp_dir TMPDIR=$tmp_dir BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 4200;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 
@@ -51,7 +51,6 @@ sub run {
     my @pkgs = qw(buildah docker git-core glibc-devel-static go jq libgpgme-devel libseccomp-devel make openssl podman runc selinux-tools);
     push @pkgs, qw(crun) if is_tumbleweed;
     install_packages(@pkgs);
-    install_pasta unless is_tumbleweed;
 
     delegate_controllers;
 


### PR DESCRIPTION
Do not install pasta to make some tests pass.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1232522
- Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1898
- Verification runs (expected failures as we harvest them for the MR):
  -  sle-15-SP7-Online-x86_64-Build32.2-buildah_testsuite@64bit -> https://openqa.suse.de/tests/15809232
  - sle-15-SP6-Server-DVD-Updates-x86_64-Build20241029-1-buildah_testsuite@64bit -> https://openqa.suse.de/tests/15809233
  - sle-15-SP5-Server-DVD-Updates-x86_64-Build20241029-1-buildah_testsuite@64bit -> https://openqa.suse.de/tests/15809234
  - sle-15-SP4-Server-DVD-Updates-x86_64-Build20241029-1-buildah_testsuite@64bit -> https://openqa.suse.de/tests/15809235