### PR TITLE
Timeshift in prague's timezone

### DIFF
--- a/tests/microos/one_line_checks.pm
+++ b/tests/microos/one_line_checks.pm
@@ -14,8 +14,8 @@ use utils;
 
 sub run_rcshell_checks {
     # Check that system is using UTC timezone
-    my $timezone = get_var('FIRST_BOOT_CONFIG', '') =~ /cloud-init/ ? 'CEST' : 'UTC';
-    assert_script_run "date +\"%Z\" | grep -x $timezone";
+    my $timezone = get_var('FIRST_BOOT_CONFIG', '') =~ /cloud-init/ ? 'CES?T' : 'UTC';
+    assert_script_run "date +\"%Z\" | grep -xE $timezone";
 }
 
 sub run_common_checks {


### PR DESCRIPTION
When setting timezone to central Europe, the test need to count with a time shift possibility hence instead of CEST `date` command returns CET.

- failure: https://openqa.suse.de/tests/15800060#step/one_line_checks/3
- Verification run: http://kepler.suse.cz/tests/24076#step/one_line_checks/1