### PR TITLE
The image check unpartitioned space is 4062 at selfinstall flavor

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -33,7 +33,7 @@ sub run {
 
     # Verify that there is no unpartitioned space left
     my $left_sectors = 0;
-    if ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow/) {
+    if ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow|SelfInstall/) {
         $left_sectors = 2048;
     } elsif (is_sle_micro("6.0+") && is_aarch64) {
         $left_sectors = 0 if (get_var("HDD_1") =~ /qcow2/);


### PR DESCRIPTION
The image check unpartitioned space is 4062 at selfinstall flavor aarch64 platform

- Related ticket: https://progress.opensuse.org/issues/169084
- Verification run: https://openqa.suse.de/tests/15810642
