### PR TITLE
Use validate_script_output

### DIFF
--- a/tests/microos/one_line_checks.pm
+++ b/tests/microos/one_line_checks.pm
@@ -15,7 +15,7 @@ use utils;
 sub run_rcshell_checks {
     # Check that system is using UTC timezone
     my $timezone = get_var('FIRST_BOOT_CONFIG', '') =~ /cloud-init/ ? 'CES?T' : 'UTC';
-    assert_script_run "date +\"%Z\" | grep -xE $timezone";
+    validate_script_output("date +\"%Z\"", sub { m/$timezone/ });
 }
 
 sub run_common_checks {


### PR DESCRIPTION
Use `validate_script_output` instead of assert_script_run with grep so that we can see the failing output in case of test issues.

* Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20512
