### PR TITLE
Follow up #20505

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -40,6 +40,9 @@ sub try_nfsv2 {
         return;
     }
 
+    # If available, make sure it's disabled by default
+    assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
+
     # Stop testing NFSv2 on tumbleweed, support is removed in nfs-utils
     if (is_sle('15+')) {
         file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -44,7 +44,7 @@ sub try_nfsv2 {
     assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
 
     # Stop testing NFSv2 on tumbleweed, support is removed in nfs-utils
-    if (is_sle('15+')) {
+    if (is_sle('15+') && is_sle("<15-sp7")) {
         file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");
         systemctl 'restart nfs-server';
         assert_script_run "cat /proc/fs/nfsd/versions | grep '+2'";

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -40,9 +40,6 @@ sub try_nfsv2 {
         return;
     }
 
-    # If available, make sure it's disabled by default
-    assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
-
     # Stop testing NFSv2 on tumbleweed, support is removed in nfs-utils
     if (is_sle('15+')) {
         file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");


### PR DESCRIPTION
- **lib/nfs_common.pm: allow nfs v2 to be enabled by default**
- **Revert "lib/nfs_common.pm: allow nfs v2 to be enabled by default"**
- **NFS is dropped in SLE 15-SP7**



