### PR TITLE
Fix schedule of booloader_uefi

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -57,7 +57,7 @@ sub load_boot_from_disk_tests {
     # read FIRST_BOOT_CONFIG in order to know how the image will be configured
     # ignition|combustion|ignition+combustion is considered as default path
     if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
-        loadtest 'installation/bootloader_uefi' unless is_vmware || is_s390x;
+        loadtest 'installation/bootloader_uefi' unless is_vmware || is_s390x || is_bootloader_sdboot;
         loadtest 'jeos/firstrun';
     } elsif (check_var('FIRST_BOOT_CONFIG', 'cloud-init')) {
         unless (is_s390x) {


### PR DESCRIPTION
In jeos-firstboot test cases the bootloader_uefi module was loaded wrongly even systemd-boot was used.

 - microos- Tumbleweed-MicroOS-Image-sdboot-x86_64-Build20241029-microos-wizard@uefi -> https://openqa.opensuse.org/tests/4606687
 - microos-Tumbleweed-MicroOS-Image-sdboot-x86_64-Build20241029-microos-wizard-tpm@uefi -> https://openqa.opensuse.org/tests/4606689