### PR TITLE
Skip encryption related modules in grub2

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -507,6 +507,9 @@ sub uefi_bootmenu_params {
         # skip additional movement downwards in
         # sle15sp4+, leap15.4+ and TW (grub 2.06)
         $linux += 4 if is_sle('>12-SP5') && is_sle('<15-SP4');
+        if (get_var('FLAVOR', '') =~ /encrypt/i) {
+            $linux += is_sle_micro('6.1+') ? 11 : 10;
+        }
         send_key "down" for (1 .. $linux);
     }
     else {

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -91,6 +91,7 @@ sub run {
 
     # aarch64 firmware 'tianocore' can take longer to load
     my $bootloader_timeout = is_aarch64 ? 90 : 15;
+    $bootloader_timeout += 90 if get_var('FLAVOR', '') =~ /encrypted/i;
     if (get_var('UEFI_HTTP_BOOT') || get_var('UEFI_HTTPS_BOOT')) {
         tianocore_http_boot;
     }


### PR DESCRIPTION
In order to locate kernel paramaters, the test needs to skip additional
modules in case of encrypted images.
The grub2 menu takes longer to appear in case of encrypted images

- ticket: https://progress.opensuse.org/issues/169126


#### Verification runs

 - [sle-micro-6.1-Base-RT-encrypted](https://openqa.suse.de/tests/15817612#step/bootloader_uefi/5)
 - [sle-micro-6.1-Default-encrypted](https://openqa.suse.de/tests/15818317#step/bootloader_uefi/5)
 - [sle-micro-6.0-Default-encrypted-Updates-Staging](https://openqa.suse.de/tests/15818405#step/bootloader_uefi/5)
 - [sle-micro-6.1-Base-encrypted](https://openqa.suse.de/tests/15818425#step/bootloader_uefi/5)
