### PR TITLE
Remove velociraptor tests

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -46,19 +46,16 @@ conditional_schedule:
         - console/openssl_nodejs
         - console/golang
         - console/redis
-        - console/velociraptor_client_event_collect
         - '{{arch_specific}}'
       15-SP5:
         - console/openssl_nodejs
         - console/golang
         - console/redis
-        - console/velociraptor_client_event_collect
         - '{{arch_specific}}'
       15-SP4:
         - console/openssl_nodejs
         - console/golang
         - console/redis
-        - console/velociraptor_client_event_collect
         - '{{arch_specific}}'
       15-SP3:
         - console/openssl_nodejs


### PR DESCRIPTION
They are now running on a development job group. https://openqa.suse.de/group_overview/616
