### PR TITLE
Improve security audit log checking

### DIFF
--- a/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars
+++ b/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars
@@ -231,13 +231,13 @@ database_vm_use_DHCP = true
 # in this case os_type must also be specified
 
 database_vm_image = {
-  os_type = "LINUX",
-  source_image_id = "",
-  publisher = "SUSE",
-  offer = "sles-sap-15-sp5",
-  sku = "gen2",
-  version = "latest",
-  type = "marketplace"
+  os_type = "%SDAF_DB_IMAGE_OS_TYPE%",
+  source_image_id = "%SDAF_DB_SOURCE_IMAGE_ID%",
+  publisher = "%SDAF_DB_IMAGE_PUBLISHER%",
+  offer = "%SDAF_DB_IMAGE_OFFER%",
+  sku = "%SDAF_DB_IMAGE_SKU%",
+  version = "%SDAF_DB_IMAGE_VERSION%",
+  type = "%SDAF_DB_IMAGE_TYPE%"
 }
 
 # database_vm_zones is an optional list defining the availability zones to deploy the database servers

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -507,6 +507,9 @@ sub uefi_bootmenu_params {
         # skip additional movement downwards in
         # sle15sp4+, leap15.4+ and TW (grub 2.06)
         $linux += 4 if is_sle('>12-SP5') && is_sle('<15-SP4');
+        if (get_var('FLAVOR', '') =~ /encrypt/i) {
+            $linux += is_sle_micro('6.1+') ? 11 : 10;
+        }
         send_key "down" for (1 .. $linux);
     }
     else {

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -57,6 +57,7 @@ sub load_boot_from_disk_tests {
     # read FIRST_BOOT_CONFIG in order to know how the image will be configured
     # ignition|combustion|ignition+combustion is considered as default path
     if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
+        loadtest 'installation/bootloader_uefi' unless is_vmware || is_s390x;
         loadtest 'jeos/firstrun';
     } elsif (check_var('FIRST_BOOT_CONFIG', 'cloud-init')) {
         unless (is_s390x) {

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -57,7 +57,7 @@ sub load_boot_from_disk_tests {
     # read FIRST_BOOT_CONFIG in order to know how the image will be configured
     # ignition|combustion|ignition+combustion is considered as default path
     if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
-        loadtest 'installation/bootloader_uefi' unless is_vmware || is_s390x;
+        loadtest 'installation/bootloader_uefi' unless is_vmware || is_s390x || is_bootloader_sdboot;
         loadtest 'jeos/firstrun';
     } elsif (check_var('FIRST_BOOT_CONFIG', 'cloud-init')) {
         unless (is_s390x) {

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -40,6 +40,9 @@ sub try_nfsv2 {
         return;
     }
 
+    # If available, make sure it's disabled by default
+    assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
+
     # Stop testing NFSv2 on tumbleweed, support is removed in nfs-utils
     if (is_sle('15+')) {
         file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -44,7 +44,7 @@ sub try_nfsv2 {
     assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
 
     # Stop testing NFSv2 on tumbleweed, support is removed in nfs-utils
-    if (is_sle('15+')) {
+    if (is_sle('15+') && is_sle("<15-sp7")) {
         file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");
         systemctl 'restart nfs-server';
         assert_script_run "cat /proc/fs/nfsd/versions | grep '+2'";

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -40,9 +40,6 @@ sub try_nfsv2 {
         return;
     }
 
-    # If available, make sure it's disabled by default
-    assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
-
     # Stop testing NFSv2 on tumbleweed, support is removed in nfs-utils
     if (is_sle('15+')) {
         file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -863,6 +863,7 @@ sub ansible_hanasr_show_status {
         "--inventory=$args{sap_sid}_hosts.yaml",
         '--module-name=shell');
 
+    record_info('OS info', script_output(join(' ', @cmd, '--args="cat /etc/os-release"', '2> /dev/null')));
     record_info('CRM status', script_output(join(' ', @cmd, '--args="sudo crm status full"', '2> /dev/null')));
     record_info('HANA SR', script_output(join(' ', @cmd, '--args="sudo SAPHanaSR-showAttr"', '2> /dev/null')));
 }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1059,9 +1059,9 @@ that the boot partition is encrypted.
 =cut
 
 sub is_boot_encrypted {
-    my $is_cc_full_enc_lvm_s390x = check_var('SYSTEM_ROLE', 'Common_Criteria') && check_var('FULL_LVM_ENCRYPT', '1') && is_s390x;
+    my $is_enc_cc_s390x = check_var('SYSTEM_ROLE', 'Common_Criteria') && check_var('FULL_LVM_ENCRYPT', '1') && is_s390x;
 
-    return 0 if get_var('UNENCRYPTED_BOOT') && !$is_cc_full_enc_lvm_s390x;
+    return 0 if get_var('UNENCRYPTED_BOOT') && !$is_enc_cc_s390x;
     return 0 if !get_var('ENCRYPT') && !get_var('FULL_LVM_ENCRYPT');
     # for Leap 42.3 and SLE 12 codestream the boot partition is not encrypted
     # Only aarch64 needs separate handling, it has unencrypted boot for fresh
@@ -1095,7 +1095,9 @@ without LVM configuration (cr_swap,cr_home etc).
 =cut
 
 sub need_unlock_after_bootloader {
-    my $need_unlock_after_bootloader = is_leap('<15.6') || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || (!get_var('LVM', '0') && !get_var('FULL_LVM_ENCRYPT', '0'));
+    my $is_enc_cc_s390x = check_var('SYSTEM_ROLE', 'Common_Criteria') && check_var('FULL_LVM_ENCRYPT', '1') && is_s390x;
+
+    my $need_unlock_after_bootloader = is_leap('<15.6') || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || (!get_var('LVM', '0') && !get_var('FULL_LVM_ENCRYPT', '0')) || $is_enc_cc_s390x;
     return 0 if is_boot_encrypted && !$need_unlock_after_bootloader;
     # MicroOS with sdboot supports automatic TPM based unlocking.
     return 0 if is_microos && is_bootloader_sdboot && get_var('QEMUTPM');

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -411,6 +411,7 @@ else {
         || is_systemd_test())
     {
         loadtest "console/system_prepare";
+        loadtest "x11/disable_screensaver" if (check_var('FLAVOR', 'NET') && check_var('UPGRADE', '1') && check_var('ORIGINAL_VERSION', '15.0'));
         load_system_update_tests();
         load_rescuecd_tests();
         if (consolestep_is_applicable) {

--- a/schedule/functional/upgrade_Leap_15.1_gnome.yaml
+++ b/schedule/functional/upgrade_Leap_15.1_gnome.yaml
@@ -20,6 +20,7 @@ schedule:
     - installation/first_boot
     - installation/opensuse_welcome
     - console/system_prepare
+    - x11/disable_screensaver
     - update/zypper_clear_repos
     - console/zypper_ar
     - console/zypper_ref

--- a/schedule/security/create_hdd_cc_libyui/aarch64/cc_qr_15sp6.yaml
+++ b/schedule/security/create_hdd_cc_libyui/aarch64/cc_qr_15sp6.yaml
@@ -1,0 +1,21 @@
+---
+name: create_hdd_common_criteria
+description: >
+  Installation using the Common Criteria role and full disk
+  encryption on QR SLES.
+schedule:
+  access_beta: []
+  system_role:
+    - installation/system_role/select_common_criteria_role
+    - installation/common_criteria_configuration/common_criteria_configuration
+  grub: []
+  first_login:
+    - security/boot_disk
+  system_preparation:
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - security/cc/ensure_crypto_checks_enabled
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/schedule/security/create_hdd_cc_libyui/s390x/cc_beta.yaml
+++ b/schedule/security/create_hdd_cc_libyui/s390x/cc_beta.yaml
@@ -9,8 +9,7 @@ schedule:
     - installation/system_role/select_common_criteria_role
     - installation/common_criteria_configuration/common_criteria_configuration
   first_login:
-    - installation/boot_encrypt
-    - installation/first_boot
+    - security/boot_disk
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/schedule/security/create_hdd_cc_libyui/s390x/cc_maint_fde.yaml
+++ b/schedule/security/create_hdd_cc_libyui/s390x/cc_maint_fde.yaml
@@ -15,8 +15,7 @@ schedule:
   software:
     - installation/select_patterns
   first_login:
-    - installation/boot_encrypt
-    - installation/first_boot
+    - security/boot_disk
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/schedule/security/create_hdd_cc_libyui/s390x/cc_qr.yaml
+++ b/schedule/security/create_hdd_cc_libyui/s390x/cc_qr.yaml
@@ -9,8 +9,7 @@ schedule:
     - installation/system_role/select_common_criteria_role
     - installation/common_criteria_configuration/common_criteria_configuration
   first_login:
-    - installation/boot_encrypt
-    - installation/first_boot
+    - security/boot_disk
   system_preparation:
     - console/hostname
     - console/system_prepare

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -103,10 +103,6 @@ sub run {
 
     $podman->cleanup_system_host();
 
-    # it is turned off in
-    # https://github.com/os-autoinst/os-autoinst-distri-opensuse/blame/master/lib/containers/common.pm#L303
-    assert_script_run 'sysctl -w net.ipv6.conf.all.disable_ipv6=0';
-
     assert_script_run('curl ' . data_url('containers/nginx.conf') . ' -o nginx.conf');
 
     ## TEST1

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -91,6 +91,7 @@ sub run {
 
     # aarch64 firmware 'tianocore' can take longer to load
     my $bootloader_timeout = is_aarch64 ? 90 : 15;
+    $bootloader_timeout += 90 if get_var('FLAVOR', '') =~ /encrypted/i;
     if (get_var('UEFI_HTTP_BOOT') || get_var('UEFI_HTTPS_BOOT')) {
         tianocore_http_boot;
     }

--- a/tests/microos/one_line_checks.pm
+++ b/tests/microos/one_line_checks.pm
@@ -15,7 +15,7 @@ use utils;
 sub run_rcshell_checks {
     # Check that system is using UTC timezone
     my $timezone = get_var('FIRST_BOOT_CONFIG', '') =~ /cloud-init/ ? 'CES?T' : 'UTC';
-    assert_script_run "date +\"%Z\" | grep -xE $timezone";
+    validate_script_output("date +\"%Z\"", sub { m/$timezone/ });
 }
 
 sub run_common_checks {

--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -230,7 +230,7 @@ sub run {
     foreach (@packages) {
         %bins = (%bins, get_packagebins_in_modules({package_name => $_, modules => \@modules}));
         # hash of hashes with keys 'name', 'supportstatus' and 'package'.
-        # e.g. https://smelt.suse.de/api/v1/basic/maintained/grub2
+        # e.g. %SMELT_URL%/api/v1/basic/maintained/grub2
         record_info("$_", Dumper(\%bins));
     }
     die "Parsing binaries from SMELT data failed" if not keys %bins;

--- a/tests/security/audit/auditctl.pm
+++ b/tests/security/audit/auditctl.pm
@@ -1,4 +1,4 @@
-# Copyright 2022 SUSE LLC
+# Copyright 2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-Later
 #
 # Summary: Controlling the Audit system using auditctl
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Architectures;
 
 sub run {
     my $audit_rules = '/etc/audit/rules.d/audit.rules';
@@ -57,6 +58,16 @@ sub run {
 
     # Double check the audit rule file
     validate_script_output("cat $audit_rules", sub { m/-a task,never/ });
+
+    # Add a rule which will log the arch in audit logs on x86
+    if (is_x86_64) {
+        # Delete all existing rules
+        assert_script_run('auditctl -D');
+
+        my $pid_rule = 'auditctl -a always,exit -F arch=x86_64 -S getpid -k get_pid';
+        # Add the pid_rule
+        assert_script_run($pid_rule);
+    }
 }
 
 1;

--- a/tests/security/audit/ausearch.pm
+++ b/tests/security/audit/ausearch.pm
@@ -1,4 +1,4 @@
-# Copyright 2022 SUSE LLC
+# Copyright 2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-Later
 #
 # Summary: Verify the "ausearch" utility can search the audit log file for certain events using various keys or
@@ -50,6 +50,10 @@ sub run {
 
     # On 15-SP3 and lower, there may not be messages that contain 'x86_64'
     if (!is_sle('<=15-SP3')) {
+        # Check if the get_pid rule is listed which was added in auditctl.pm
+        validate_script_output('auditctl -l', sub { m/get_pid/ });
+        # Trigger the get_pid rule
+        script_run('ps -q 1');
         # Search for events based on a specific CPU architecture
         validate_script_output("ausearch -i --arch x86_64", sub { m/arch=x86_64/ });
     }

--- a/variables.md
+++ b/variables.md
@@ -292,7 +292,7 @@ QESAP_INSTALL_GITHUB_BRANCH | string | | Git branch. Ignored if QESAP_INSTALL_VE
 QESAP_INSTALL_GITHUB_NO_VERIFY | string | | Configure http.sslVerify false. Ignored if QESAP_VER is configured.
 QESAP_ROLES_INSTALL_GITHUB_REPO | string | github.com/sap-linuxlab/community.sles-for-sap | Git repository where to clone from. Ignored if QESAP_ROLES_INSTALL_VERSION is configured.
 QESAP_ROLES_INSTALL_GITHUB_BRANCH | string | | Git branch. Ignored if QESAP_ROLES_INSTALL_VERSION is configured.
-
+SMELT_URL | string | https://smelt.suse.de | Defines the URL for the SUSE Maintenance Extensible Lightweight Toolset, SMELT for short.
 
 ### Publiccloud specific variables
 


### PR DESCRIPTION
Adding an audit rule for a system call on x86_64.
When the new rule is triggered by a simple 'ps' command the log line will include the arch. 
The tool 'ausearch' can filter audit events by using the arch filter. 

- Related ticket: https://progress.opensuse.org/issues/169060

VRs:

15-SP2: https://openqa.suse.de/tests/15820139
15-SP3: https://openqa.suse.de/tests/15820138
15-SP4: https://openqa.suse.de/tests/15820112
15-SP5: https://openqa.suse.de/tests/15820096
15-SP6: https://openqa.suse.de/tests/15820114
15-SP7: https://openqa.suse.de/tests/15820142
