### PR TITLE
Improve security audit log checks

### DIFF
--- a/tests/security/audit/auditctl.pm
+++ b/tests/security/audit/auditctl.pm
@@ -1,4 +1,4 @@
-# Copyright 2022 SUSE LLC
+# Copyright 2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-Later
 #
 # Summary: Controlling the Audit system using auditctl
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Architectures qw(is_x86_64);
 
 sub run {
     my $audit_rules = '/etc/audit/rules.d/audit.rules';
@@ -57,6 +58,16 @@ sub run {
 
     # Double check the audit rule file
     validate_script_output("cat $audit_rules", sub { m/-a task,never/ });
+
+    # Add a rule which will log the arch in audit logs on x86
+    if (is_x86_64) {
+        # Delete all existing rules
+        assert_script_run('auditctl -D');
+
+        my $pid_rule = 'auditctl -a always,exit -F arch=x86_64 -S getpid -k get_pid';
+        # Add the pid_rule
+        assert_script_run($pid_rule);
+    }
 }
 
 1;

--- a/tests/security/audit/ausearch.pm
+++ b/tests/security/audit/ausearch.pm
@@ -1,4 +1,4 @@
-# Copyright 2022 SUSE LLC
+# Copyright 2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-Later
 #
 # Summary: Verify the "ausearch" utility can search the audit log file for certain events using various keys or
@@ -50,6 +50,10 @@ sub run {
 
     # On 15-SP3 and lower, there may not be messages that contain 'x86_64'
     if (!is_sle('<=15-SP3')) {
+        # Check if the get_pid rule is listed which was added in auditctl.pm
+        validate_script_output('auditctl -l', sub { m/get_pid/ });
+        # Trigger the get_pid rule
+        script_run('ps -q 1');
         # Search for events based on a specific CPU architecture
         validate_script_output("ausearch -i --arch x86_64", sub { m/arch=x86_64/ });
     }


### PR DESCRIPTION
Adding an audit rule for a system call on x86_64.
When the new rule is triggered by a simple 'ps' command the log line will include the arch.
The tool 'ausearch' can filter audit events by using the arch filter.

Related ticket: https://progress.opensuse.org/issues/169060

VRs:

15-SP2: https://openqa.suse.de/tests/15820139
15-SP3: https://openqa.suse.de/tests/15820138
15-SP4: https://openqa.suse.de/tests/15820112
15-SP5: https://openqa.suse.de/tests/15820096
15-SP6: https://openqa.suse.de/tests/15820114
15-SP7: https://openqa.suse.de/tests/15820142