### PR TITLE
Add softfail for systemd-testkit version

### DIFF
--- a/tests/console/start_systemd_testkit_offline.pm
+++ b/tests/console/start_systemd_testkit_offline.pm
@@ -92,14 +92,22 @@ sub parse_results_from_output {
                 #   $openQA_result = $self->record_testresult('softfail');
                 #   $softfail_result = 119565;
                 #} else {
-                my $openQA_result = $self->record_testresult('fail');
+                #my $openQA_result = $self->record_testresult('fail');
                 #$softfail_result = 0;
                 #}
+                my ($openQA_result, $softfail_result);
+                if ($error_line =~ m/invalid version \'254\', expected \'234\'/) {
+                    $openQA_result = $self->record_testresult('softfail');
+                    $softfail_result = 1231034;
+                } else {
+                    my $openQA_result = $self->record_testresult('fail');
+                    $softfail_result = 0;
+                }
                 my $openQA_filename = $self->next_resultname('txt');
                 $openQA_result->{title} = $testunit;
                 $openQA_result->{text} = $openQA_filename;
-                #($softfail_result) ? $self->write_resultfile($openQA_filename, "# Softfail bsc#$softfail_result:\n$error_line\n") :
-                $self->write_resultfile($openQA_filename, "# Failure:\n$error_line\n");
+                ($softfail_result) ? $self->write_resultfile($openQA_filename, "# Softfail bsc#$softfail_result:\n$error_line\n") :
+                  $self->write_resultfile($openQA_filename, "# Failure:\n$error_line\n");
                 $self->{dents}++;
             }
 


### PR DESCRIPTION
Add softfail for systemd-testkit version

- Related ticket: https://progress.opensuse.org/issues/167515
- Verification run: https://openqa.suse.de/tests/15832181#