### PR TITLE
User is allowed to turn registration off with autoyast

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -2,7 +2,11 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
+    % if ($check_var->('SCC_REGISTER', 'installation') or $check_var->('REGISTER', 'installation')) {
     <do_registration config:type="boolean">true</do_registration>
+    % } else {
+    <do_registration config:type="boolean">false</do_registration>
+    % }
     <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
     <install_updates config:type="boolean">true</install_updates>
     % if (keys %$addons) {

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -2,7 +2,11 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
+    % if ($check_var->('SCC_REGISTER', 'installation') or $check_var->('REGISTER', 'installation')) {
     <do_registration config:type="boolean">true</do_registration>
+    % } else {
+    <do_registration config:type="boolean">false</do_registration>
+    % }	
     <reg_server><%= defined $bmwqemu::vars{"HOST_SCC_URL"} ? $bmwqemu::vars{"HOST_SCC_URL"} : "" %></reg_server>
     <reg_code>{{SCC_REGCODE}}</reg_code>
     <install_updates config:type="boolean">true</install_updates>


### PR DESCRIPTION
* **User** should be allowed to turn registration off with autoyast. 

* **This** is not only for convenience purpose but also makes test execution with Beijing openQA more resilient due to upcoming disconnection from CC area and malfunctioning local registration server.

* **Verification Runs:** 
  * [sles15sp7 kvm with registration](https://openqa.suse.de/tests/15832391) 
  * [sles12sp5 xen with registration](https://openqa.suse.de/tests/15832390)
  * [sles15sp7 kvm without registration](https://openqa.suse.de/tests/15865115) 
  * [sles12sp5 xen without registration](https://openqa.suse.de/tests/15832469)
  * [sles12sp5 host GUI with registration](https://openqa.suse.de/tests/15865158)
