### PR TITLE
xfstests: Add a missing bugzilla library reference

### DIFF
--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -27,6 +27,7 @@ use mmapi;
 use version_utils 'is_public_cloud';
 use LTP::utils;
 use LTP::WhiteList;
+use bugzilla;
 
 # Heartbeat variables, need to sync with tests/xfstests/run.pm
 my $HB_PATN = '<h>';    #shorter label <heartbeat> to getting stable under heavy stress


### PR DESCRIPTION
In xfstests_utils used a function in bugzilla library. But the `use bugzilla` is missing on the top. 

- Related ticket: https://progress.opensuse.org/issues/167842
- Verification run: https://openqa.suse.de/tests/15832520
