### PR TITLE
lib/sles4sap_publiccloud: no need to wait_for_ssh, it's already up

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -429,8 +429,7 @@ sub stop_hana {
 
         # wait for node to be ready
         wait_hana_node_up($self->{my_instance}, timeout => 900);
-        my $out = $self->{my_instance}->wait_for_ssh(timeout => 900, scan_ssh_host_key => 1);
-        record_info("Wait ssh is back again", "out:" . ($out // 'undefined'));
+        record_info("Wait ssh is back again");
     }
     else {
         my $sapadmin = lc(get_required_var('INSTANCE_SID')) . 'adm';


### PR DESCRIPTION
This is a follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19673.

If `wait_hana_node_up` succeeds, there is not point to run `wait_for_ssh` which may hang and timeout and fail.

- Related ticket: https://jira.suse.com/browse/TEAM-9652
- Needles: none
- Verification run: https://openqaworker15.qa.suse.cz/tests/301594#step/Crash_site_a-primary/542 (10 VRs in total, 8 success, 1 fails in Kill_site which is not relevant with this PR, 1 fails in Crash_site which is also not directly related with this PR.  Before this PR, the failure rate for "spn" case is around 40%.)