### PR TITLE
Exclude ltss_es in deregister_dropped_modules

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -107,7 +107,7 @@ sub register_system_in_textmode {
 # need to remove these modules before migration, add the dropped modules to the
 # setting of DROPPED_MODULES.
 sub deregister_dropped_modules {
-    return unless ((get_var('DROPPED_MODULES')) || (get_var('SCC_ADDONS', '') =~ /ltss/));
+    return unless ((get_var('DROPPED_MODULES')) || ((get_var('SCC_ADDONS', '') =~ /ltss/) && (get_var('SCC_ADDONS', '') !~ /ltss_es/)));
 
     my $droplist = get_var('DROPPED_MODULES', '');
     $droplist .= ',ltss' if (get_var('SCC_ADDONS', '') =~ /ltss/);


### PR DESCRIPTION
Exclude `ltss_es` in function deregister_dropped_modules as `ltss` is not active.

Related ticket: [TEAM-9709](https://jira.suse.com/browse/TEAM-9709)
12-SP5 LTSS & LTSS Extended Security Setup - SLES+HA

- Verification run: https://openqa.suse.de/tests/15832771#dependencies (passed)