### PR TITLE
PC: Parse img_proof logs into external results

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -163,6 +163,7 @@ sub parse_img_proof_output {
             $ret->{fail} = $4;
             $ret->{error} = $5;
         }
+        $ret->{output} .= $line . "\n";
     }
 
     for my $k (qw(ip logfile results tests pass skip fail error)) {


### PR DESCRIPTION
Parse the `img-proof` output and logfile into openQA external test result.

- Related ticket: https://progress.opensuse.org/issues/168538
- Verification run: https://pdostal-server.suse.cz/tests/7744
