### PR TITLE
Clean old settings from yam profiles

### DIFF
--- a/data/yam/autoyast/autoyast_scc_up.xml
+++ b/data/yam/autoyast/autoyast_scc_up.xml
@@ -3,11 +3,6 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <bootloader>
     <global>
-      <activate>false</activate>
-      <boot_extended>false</boot_extended>
-      <boot_mbr>true</boot_mbr>
-      <boot_root>true</boot_root>
-      <generic_mbr>false</generic_mbr>
       <timeout config:type="integer">10</timeout>
     </global>
     <loader_type>{{LOADER_TYPE}}</loader_type>


### PR DESCRIPTION
As https://suse.slack.com/archives/C02CLB2LB7Z/p1730470463015239, we need remove old settings from yam profiles and reserve 'timeout'.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/15846766  15SP4
  https://openqa.suse.de/tests/15846769   15SP2
  https://openqa.suse.de/tests/15846772   15SP3