### PR TITLE
WIP: Fix install_qatest load_bnxt_en.service compatible issue

### DIFF
--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -83,7 +83,7 @@ Description=Load bnxt_en driver manually
 After=sshd.service
 [Service]
 Type=oneshot
-ExecStart=modprobe bnxt_en
+ExecStart=/sbin/modprobe bnxt_en
 TimeoutSec=0
 RemainAfterExit=no
 TasksMax=12000


### PR DESCRIPTION
Running the service causes failure on 15-SP2 with "load_bnxt_en.service:6: Executable path is not absolute: modprobe bnxt_en"
- Related ticket: https://progress.opensuse.org/issues/169240
- Needles: N/A
- Verification run: N/A
