### PR TITLE
Quickfix for staging blackout

### DIFF
--- a/schedule/staging/ext4@uefi-staging.yaml
+++ b/schedule/staging/ext4@uefi-staging.yaml
@@ -1,6 +1,6 @@
 ---
-name:           ext4@uefi-staging
-description:    >
+name: ext4@uefi-staging
+description: >
   Test for ext4 filesystem.
 vars:
   YUI_REST_API: 1
@@ -27,6 +27,7 @@ schedule:
   - installation/authentication/use_same_password_for_root
   - installation/authentication/default_user_simple_pwd
   - installation/resolve_dependency_issues
+  - installation/disable_grub_timeout
   - installation/launch_installation
   - installation/confirm_installation
   - installation/performing_installation/perform_installation


### PR DESCRIPTION
- Avoid that Grub is booting after a timeout by inserting `disable_grub_timeout` in the schedule. 
This solves the "blackout" in `handle_reboot`.

- Verification run: https://openqa.suse.de/tests/15846844#