### PR TITLE
Reword sdaf_prepare_private_key function name

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -65,7 +65,7 @@ Since SUT VMs have no public IPs, this is also serving as a jump-host to reach t
 
 our @EXPORT = qw(
   az_login
-  sdaf_prepare_private_key
+  sdaf_get_deployer_ssh_key
   serial_console_diag_banner
   set_common_sdaf_os_env
   prepare_sdaf_project
@@ -335,9 +335,9 @@ sub load_os_env_variables {
     assert_script_run('source ' . env_variable_file());
 }
 
-=head2 sdaf_prepare_private_key
+=head2 sdaf_get_deployer_ssh_key
 
-    sdaf_prepare_private_key(key_vault=>$key_vault);
+    sdaf_get_deployer_ssh_key(key_vault=>$key_vault);
 
 Retrieves public and private ssh key from specified keyvault and sets up permissions.
 
@@ -348,7 +348,7 @@ Retrieves public and private ssh key from specified keyvault and sets up permiss
 =back
 =cut
 
-sub sdaf_prepare_private_key {
+sub sdaf_get_deployer_ssh_key {
     my (%args) = @_;
     croak 'Missing mandatory argument $args{key_vault}' unless $args{key_vault};
     my $home = homedir();

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -114,7 +114,7 @@ subtest '[serial_console_diag_banner] ' => sub {
     dies_ok { serial_console_diag_banner('exeCuTing deploYment' x 6) } 'Fail with string exceeds max number of characters';
 };
 
-subtest '[sdaf_prepare_private_key]' => sub {
+subtest '[sdaf_get_deployer_ssh_key]' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     my $get_ssh_command;
     my %private_key;
@@ -135,16 +135,16 @@ LAB-SECE-DEP05-ssh
             %pubkey = @_ if grep /sshkey-pub$/, @_;
     });
 
-    sdaf_prepare_private_key(key_vault => 'LABSECEDEP05userDDF');
+    sdaf_get_deployer_ssh_key(key_vault => 'LABSECEDEP05userDDF');
     is $get_ssh_command, 'az keyvault secret list --vault-name LABSECEDEP05userDDF --query [].name --output tsv | grep sshkey',
       'Return correct command for retrieving private key';
     is $pubkey{ssh_key_name}, 'LAB-SECE-DEP05-sshkey-pub', 'Public key';
     is $private_key{ssh_key_name}, 'LAB-SECE-DEP05-sshkey', 'Private key';
 
-    dies_ok { sdaf_prepare_private_key() } 'Fail with missing "key_vault" argument';
+    dies_ok { sdaf_get_deployer_ssh_key() } 'Fail with missing "key_vault" argument';
 
     $ms_sdaf->redefine(script_output => sub { return 1 });
-    dies_ok { sdaf_prepare_private_key(key_vault => 'LABSECEDEP05userDDF') } 'Fail with not keyfile being found';
+    dies_ok { sdaf_get_deployer_ssh_key(key_vault => 'LABSECEDEP05userDDF') } 'Fail with not keyfile being found';
 };
 
 subtest '[set_common_sdaf_os_env]' => sub {

--- a/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
@@ -10,7 +10,7 @@ use strict;
 use warnings;
 use testapi;
 use sles4sap::sap_deployment_automation_framework::deployment
-  qw(serial_console_diag_banner az_login sdaf_prepare_private_key);
+  qw(serial_console_diag_banner az_login sdaf_get_deployer_ssh_key);
 use sles4sap::sap_deployment_automation_framework::deployment_connector
   qw(get_deployer_vm_name get_deployer_ip find_deployment_id);
 use serial_terminal qw(select_serial_terminal);
@@ -33,7 +33,7 @@ sub run {
     # This will allow using connect_target_to_serial() without specifying user/host to deployer every time.
     set_var('REDIRECT_DESTINATION_USER', get_var('PUBLIC_CLOUD_USER', 'azureadm'));
     set_var('REDIRECT_DESTINATION_IP', $deployer_ip);    # IP addr to redirect console to
-    sdaf_prepare_private_key(key_vault => get_required_var('SDAF_DEPLYOER_KEY_VAULT'));
+    sdaf_get_deployer_ssh_key(key_vault => get_required_var('SDAF_DEPLYOER_KEY_VAULT'));
     serial_console_diag_banner('Module sdaf_redirect_console_to_deployer.pm : end');
 }
 


### PR DESCRIPTION
This PR renames function `sdaf_prepare_private_key` to 
`sdaf_get_deployer_ssh_key`. Title is more descriptive and won't collide with 
another function which handles private key for SUT. This PR does no functional 
changes besice name replacement.

- Verification run: https://openqaworker15.qa.suse.cz/tests/301910
