### PR TITLE
Use add_on_products to enable modules without registration

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_12.xml.ep
@@ -34,6 +34,17 @@
     </addons>
     %}
   </suse_register>
+  <add-on>
+    <add_on_products config:type="list">
+      % my $n =0;
+      % for my $repo (@$repos) {
+      <listentry>
+	<media_url><%= $repo %></media_url>
+	<alias>TEST_<%= $n++ %></alias>
+      </listentry>
+      % }
+    </add_on_products>
+  </add-on>
   <bootloader>
     <global>
       <activate>true</activate>

--- a/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
+++ b/data/virt_autotest/host_unattended_installation_files/autoyast/dev_host_15.xml.ep
@@ -35,17 +35,17 @@
     </addons>
     %}
   </suse_register>
-  <!--add-on>
+  <add-on>
     <add_on_products config:type="list">
       % my $n =0;
       % for my $repo (@$repos) {
       <listentry>
         <media_url><%= $repo %></media_url>
-        <alias>TEST_<%= $n++ %></alias>
+	<alias>TEST_<%= $n++ %></alias>
       </listentry>
       % }
     </add_on_products>
-  </add-on-->
+  </add-on>
   <bootloader>
     <global>
       <activate>true</activate>

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -26,11 +26,71 @@ use Utils::Architectures;
 use IO::Socket::INET;
 use Carp;
 
-our @EXPORT = qw(is_vmware_virtualization is_hyperv_virtualization is_fv_guest is_pv_guest is_sev_es_guest guest_is_sle is_guest_ballooned is_xen_host is_kvm_host
-  is_monolithic_libvirtd turn_on_libvirt_debugging_log restart_libvirtd check_libvirtd restart_modular_libvirt_daemons check_modular_libvirt_daemons
-  reset_log_cursor check_failures_in_journal check_host_health check_guest_health print_cmd_output_to_file collect_virt_system_logs setup_rsyslog_host download_script download_script_and_execute upload_virt_logs enable_nm_debug upload_nm_debug_log
-  ssh_setup setup_common_ssh_config add_alias_in_ssh_config install_default_packages parse_subnet_address_ipv4 backup_file manage_system_service check_port_state is_registered_sles is_registered_system do_system_registration check_system_registration subscribe_extensions_and_modules check_activate_network_interface wait_for_host_reboot
-  create_guest import_guest ssh_copy_id add_guest_to_hosts ensure_default_net_is_active ensure_guest_started remove_additional_disks remove_additional_nic start_guests is_guest_online ensure_online wait_guest_online restore_downloaded_guests save_original_guest_xmls restore_original_guests save_guests_xml_for_change restore_xml_changed_guests shutdown_guests wait_guests_shutdown remove_vm recreate_guests download_vm_import_disks get_guest_regcode
+our @EXPORT = qw(
+  is_vmware_virtualization
+  is_hyperv_virtualization
+  is_fv_guest
+  is_pv_guest
+  is_sev_es_guest
+  guest_is_sle
+  is_guest_ballooned
+  is_xen_host
+  is_kvm_host
+  is_monolithic_libvirtd
+  turn_on_libvirt_debugging_log
+  restart_libvirtd
+  check_libvirtd
+  restart_modular_libvirt_daemons
+  check_modular_libvirt_daemons
+  reset_log_cursor
+  check_failures_in_journal
+  check_host_health
+  check_guest_health
+  print_cmd_output_to_file
+  collect_virt_system_logs
+  setup_rsyslog_host
+  download_script
+  download_script_and_execute
+  upload_virt_logs
+  enable_nm_debug
+  upload_nm_debug_log
+  ssh_setup
+  setup_common_ssh_config
+  add_alias_in_ssh_config
+  install_default_packages
+  parse_subnet_address_ipv4
+  backup_file
+  manage_system_service
+  check_port_state
+  is_registered_sles
+  is_registered_system
+  do_system_registration
+  check_system_registration
+  subscribe_extensions_and_modules
+  check_activate_network_interface
+  wait_for_host_reboot
+  create_guest
+  import_guest
+  ssh_copy_id
+  add_guest_to_hosts
+  ensure_default_net_is_active
+  ensure_guest_started
+  remove_additional_disks
+  remove_additional_nic
+  start_guests
+  is_guest_online
+  ensure_online wait_guest_online
+  restore_downloaded_guests
+  save_original_guest_xmls
+  restore_original_guests
+  save_guests_xml_for_change
+  restore_xml_changed_guests
+  shutdown_guests
+  wait_guests_shutdown
+  remove_vm
+  recreate_guests
+  download_vm_import_disks
+  get_guest_regcode
 );
 
 my %log_cursors;
@@ -914,7 +974,7 @@ sub check_port_state {
 
 #Detect whether SUT host is installed with scc registration
 sub is_registered_sles {
-    if (!get_var('SCC_REGISTER') || check_var('SCC_REGISTER', 'none') || check_var('SCC_REGISTER', '')) {
+    if ((!get_var('SCC_REGISTER') or check_var('SCC_REGISTER', 'none')) and (!get_var('REGISTER') or check_var('REGISTER', 'none'))) {
         return 0;
     }
     else {

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -24,8 +24,35 @@ use LWP::Simple 'head';
 use virt_autotest::utils;
 use version_utils qw(is_sle is_alp get_os_release);
 
-our @EXPORT
-  = qw(enable_debug_logging update_guest_configurations_with_daily_build locate_sourcefile get_repo_0_prefix repl_repo_in_sourcefile repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk get_guest_list download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data check_guest_disk_type perform_guest_restart collect_host_and_guest_logs cleanup_host_and_guest_logs monitor_guest_console start_monitor_guest_console stop_monitor_guest_console is_developing_sles);
+our @EXPORT = qw(
+  enable_debug_logging
+  update_guest_configurations_with_daily_build
+  locate_sourcefile
+  get_repo_0_prefix
+  repl_repo_in_sourcefile
+  repl_addon_with_daily_build_module_in_files
+  repl_module_in_sourcefile
+  handle_sp_in_settings
+  handle_sp_in_settings_with_fcs
+  handle_sp_in_settings_with_sp0
+  clean_up_red_disks
+  lpar_cmd
+  generate_guest_asset_name
+  get_guest_disk_name_from_guest_xml
+  compress_single_qcow2_disk
+  get_guest_list
+  download_guest_assets
+  is_installed_equal_upgrade_major_release
+  generateXML_from_data
+  check_guest_disk_type
+  perform_guest_restart
+  collect_host_and_guest_logs
+  cleanup_host_and_guest_logs
+  monitor_guest_console
+  start_monitor_guest_console
+  stop_monitor_guest_console
+  is_developing_sles
+);
 
 sub enable_debug_logging {
 


### PR DESCRIPTION
* **For** test scenarios that do not do registration, using add_on_products can help enable modules and install packages without registration.

* **The** functionality is already implemented by using ```MAINT_TEST_REPO``` settings.

* **Improve** ```is_registered_sles``` in ```lib/virt_autotest/utils.pm``` to include ```REGISTER``` setting.

* **Clean** up lists of exported subroutines in ```lib/virt_autotest/utils.pm``` and ```tests/virt_autotest/virt_utils.pm```.

* **Verification Runs:**
  * [verification run with full media without registration](http://10.200.140.9/tests/112) 
  * [15sp7 with online media with registration](https://openqa.suse.de/tests/15874362)
  * [15sp6 with full media and modules without registration](https://openqa.suse.de/tests/15874259)
  * [15sp7 with full media and modules without registration](https://openqa.suse.de/tests/15874164)
  * [15sp7 with full media without module with registration](https://openqa.suse.de/tests/15865151)
  * [12sp5 with registration](https://openqa.suse.de/tests/15997447)
  * [12sp5 without registration with udpate/LTSS repo](https://openqa.suse.de/tests/15997453)
