### PR TITLE
Handle HA 12-SP4 LTSS to 12-SP5 LTSS Extended Security migration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -487,6 +487,12 @@ sub process_scc_register_addons {
         my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
         # remove empty elements
         @scc_addons = grep { $_ ne '' } @scc_addons;
+        # For HA LTSS_TO_LTSS_ES migration if the original version is 12-SP4 then it only has LTSS
+        if ((grep { $_ == 'ltss_es' } @scc_addons) && get_var('LTSS_TO_LTSS_ES') && is_sle('=12-SP4')) {
+            foreach my $addon (@scc_addons) {
+                $addon =~ s/ltss_es/ltss/g;
+            }
+        }
 
         for my $addon (@scc_addons) {
             next if (skip_package_hub_if_necessary($addon));

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node01_sle12.yaml
@@ -54,3 +54,6 @@ conditional_schedule:
     LTSS_TO_LTSS:
       1:
         - migration/online_migration/register_ltss
+    LTSS_TO_LTSS_ES:
+      1:
+        - migration/online_migration/register_ltss

--- a/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
+++ b/schedule/ha/qam/common/qam_ha_rolling_upgrade_migration_node02_sle12.yaml
@@ -54,3 +54,6 @@ conditional_schedule:
     LTSS_TO_LTSS:
       1:
         - migration/online_migration/register_ltss
+    LTSS_TO_LTSS_ES:
+      1:
+        - migration/online_migration/register_ltss

--- a/tests/migration/online_migration/register_ltss.pm
+++ b/tests/migration/online_migration/register_ltss.pm
@@ -27,6 +27,9 @@ sub run {
         $os_sp_version =~ s/-/_/g;
         add_suseconnect_product("SLES-LTSS", undef, undef, "-r " . get_var("SCC_REGCODE_LTSS_$os_sp_version"), 300, 0);
     }
+    elsif (grep $_ eq 'ltss_es', @scc_addons) {
+        add_suseconnect_product("SLES-LTSS-Extended-Security", undef, undef, "-r " . get_var("SCC_REGCODE_LTSS_ES"), 300, 0);
+    }
 }
 
 1;

--- a/tests/migration/online_migration/register_without_ltss.pm
+++ b/tests/migration/online_migration/register_without_ltss.pm
@@ -21,17 +21,21 @@ sub run {
 
     # Re-register system without LTSS with resetting SCC_ADDONS variable without ltss
     my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
-    @scc_addons = grep { $_ ne 'ltss' } @scc_addons;
+    @scc_addons = grep { $_ ne 'ltss' && $_ ne 'ltss_es' } @scc_addons;
     set_var('SCC_ADDONS', join(',', @scc_addons));
 
     register_system_in_textmode;
 
     # Sometimes in HA scenario, we need to test rolling upgrade migration from
-    # a LTSS version to another one LTSS version.
-    # In this case, we need to add ltss again to SCC_ADDONS and set HDDVERSION to
+    # a LTSS version to another one LTSS/LTSS-ES version.
+    # In this case, we need to add ltss/ltss_es again to SCC_ADDONS and set HDDVERSION to
     # the targeted OS version for getting the good LTSS regcode.
     if (get_var('LTSS_TO_LTSS')) {
         set_var('SCC_ADDONS', join(',', @scc_addons, 'ltss'));
+        set_var('HDDVERSION', get_var('UPGRADE_TARGET_VERSION', get_var('VERSION')));
+    }
+    if (get_var('LTSS_TO_LTSS_ES')) {
+        set_var('SCC_ADDONS', join(',', @scc_addons, 'ltss_es'));
         set_var('HDDVERSION', get_var('UPGRADE_TARGET_VERSION', get_var('VERSION')));
     }
 }


### PR DESCRIPTION
Handle HA 12-SP4 LTSS to 12-SP5 LTSS Extended Security migration
TEAM-9709 - 12-SP5 LTSS & LTSS Extended Security Setup - SLES+HA

Aggregate Flavor `Server-DVD-HA-Updates-LTSS-ES` Settings: see https://openqa.suse.de/admin/products

- Related ticket: https://jira.suse.com/browse/TEAM-9709
- Verification run (LTSS-ES): 
   https://openqa.suse.de/tests/15860001#step/register_system/39 (passed :green_circle: )(`qam_ha_rolling_update_node01`, `ltss_es`)
   https://openqa.suse.de/tests/15859995#step/scc_registration/35 (passed :green_circle: )(`qam_create_hdd_ha_textmode`, `ltss_es`)
   https://openqa.suse.de/tests/15860007#dependencies (passed :green_circle: )(`qam_alpha_cluster_01`, `ltss_es`)
   https://openqa.suse.de/tests/15860005#dependencies (passed :green_circle: )(`ha_ctdb_node01`, `ltss_es`)
   `qam_ha_rolling_upgrade_migration_node01`:  
   https://openqa.suse.de/tests/15865088#step/register_system/36 (passed :green_apple: )(register `12SP4` with `ltss`)
   https://openqa.suse.de/tests/15865088#step/register_without_ltss/29 (passed :green_circle: ) (register `12SP4` `without` `ltss`)
   https://openqa.suse.de/tests/15865088#step/register_ltss/13 (passed :green_circle: )(register `12SP5` with `ltss_es`)

- Verification run (LTSS): 
  http://openqa.suse.de/tests/15865120#step/scc_registration/33 (passed :green_circle: )(`qam_create_hdd_ha_textmode`)
  w http://openqa.suse.de/tests/15865119#dependencies (passed :green_circle: )(`qam_ha_rolling_upgrade_migration_node02`)