### PR TITLE
Tidy podman_network_cni scheduling

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -132,8 +132,9 @@ sub load_host_tests_podman {
     load_container_engine_privileged_mode($run_args);
     loadtest 'containers/podman_bci_systemd';
     loadtest 'containers/podman_pods';
-    # fresh install of sle-micro comes with netavark
-    loadtest('containers/podman_network_cni') unless (is_sle_micro('6.0+') || (is_sle_micro('=5.5') && is_public_cloud) || (check_var('FLAVOR', 'DVD-Updates') && is_sle_micro));
+    # CNI is the default network backend on SLEM<6 and SLES<15-SP6. It is still available on later products as a dependency for docker.
+    # podman+CNI is not supported on SLEM6+ and SLES-15-SP6+.
+    loadtest('containers/podman_network_cni') if (is_sle_micro('<6.0') || is_sle("<15-SP6"));
     # Firewall is not installed in JeOS OpenStack, MicroOS and Public Cloud images
     load_firewall_test($run_args);
     # IPv6 is not available on Azure


### PR DESCRIPTION
Simplify the scheduling conditions of podman_network_cni, which appers to have grown out of proportions.

- Related ticket: https://progress.opensuse.org/issues/166589

## Verification runs

* [MicroOS container-host](https://openqa.opensuse.org/tests/4622477)
* [Tumbleweed containers_host_podman](https://openqa.opensuse.org/tests/4622478)
* [SLES 15-SP6](https://openqa.suse.de/tests/15866398)
* [SLES 15-SP6 aarch64](https://openqa.suse.de/tests/15866399)
* [SLES 15-SP5](https://openqa.suse.de/tests/15866400)
* [SLES 15-SP4](https://openqa.suse.de/tests/15866387)
* [SLES 15-SP3](https://openqa.suse.de/tests/15866388)
* [SLES 15-SP2](https://openqa.suse.de/tests/15866389)
* [SLEM 5.5](https://openqa.suse.de/tests/15866390)
* [SLEM 5.4](https://openqa.suse.de/tests/15866391)
* [SLEM 5.3](https://openqa.suse.de/tests/15866392)
* [SLEM 5.2](https://openqa.suse.de/tests/15867675)
* [SLEM 5.1](https://openqa.suse.de/tests/15866380)
* [SLEM 5.5 GCE](https://openqa.suse.de/tests/15866381)
* [SLEM 5.4 GCE](https://openqa.suse.de/tests/15866382)
* [SLEM 5.3 GCE](https://openqa.suse.de/tests/15866383)