### PR TITLE
Adapt console_reboot testing for pvm

### DIFF
--- a/tests/console/console_reboot.pm
+++ b/tests/console/console_reboot.pm
@@ -11,6 +11,7 @@
 use base "consoletest";
 use testapi;
 use Utils::Architectures;
+use Utils::Backends 'is_pvm';
 use utils;
 use power_action_utils 'power_action';
 use strict;
@@ -23,6 +24,7 @@ sub run {
         $self->wait_boot(bootloader_time => 300);
     }
     else {
+        reconnect_mgmt_console if is_pvm;
         $self->wait_boot;
     }
     select_console 'root-console';


### PR DESCRIPTION
##
### Adapt console_reboot testing for pvm

- Related ticket: 
   - https://progress.opensuse.org/issues/167581
- Needles: 
  - N/A 
- Verification run: 
  -  https://openqa.suse.de/tests/15865111
