### PR TITLE
Make sles4sap saptune single incidents tests to support LTSS and LTSS-ES

### DIFF
--- a/data/autoyast_sle12/autoyast_sles4sap_saptune.xml.ep
+++ b/data/autoyast_sle12/autoyast_sles4sap_saptune.xml.ep
@@ -2,9 +2,29 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
-  <do_registration config:type="boolean">true</do_registration>
-  <reg_code><%= $get_var->('SCC_REGCODE_SLES4SAP') %></reg_code>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_code><%= $get_var->('SCC_REGCODE_SLES4SAP') %></reg_code>
     <install_updates config:type="boolean">true</install_updates>
+    <addons config:type="list">
+      % if ($get_var->('SCC_REGCODE_LTSS')) {
+      <addon>
+        <!-- SUSE Linux Enterprise Server LTSS -->
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+      </addon>
+      %}
+      % if ($get_var->('SCC_REGCODE_LTSS_ES')) {
+      <addon>
+        <!-- SUSE Linux Enterprise Server LTSS Extended Security -->
+        <name>SLES-LTSS-Extended-Security</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+        <reg_code><%= $get_var->('SCC_REGCODE_LTSS_ES') %></reg_code>
+      </addon>
+      %}
+    </addons>
   </suse_register>
   <add-on>
     <add_on_products config:type="list">


### PR DESCRIPTION
Make sles4sap saptune single incidents tests to support LTSS and LTSS-ES

- Related ticket: https://jira.suse.com/browse/TEAM-9783
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/15865226#dependencies
    https://openqa.suse.de/tests/15866681 (only SCC_REGCODE_LTSS)
    https://openqa.suse.de/tests/15866701 (no SCC_REGCODE_LTSS and SCC_REGCODE_LTSS_ES)