### PR TITLE
Do not enable addons for sle15sp4 TERADATA

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -38,7 +38,7 @@ sub activate_containers_module {
             last;
         }
     }
-    add_suseconnect_product('sle-module-containers') unless ($registered);
+    add_suseconnect_product('sle-module-containers') unless (($registered) || check_var('SCC_REGISTER', 'skip'));
     record_info('SUSEConnect', script_output_retry('SUSEConnect --status-text', timeout => 240, retry => 3, delay => 60));
 }
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/169339

[VR](http://openqa.suse.de/tests/overview?arch=&flavor=Server-DVD-Updates-TERADATA&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=&distri=sle&version=15-SP4&build=rfan1105#)

https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/801 The code change is to fix the issue caused by wicked tests product changes.