### PR TITLE
Remove pipefail from wireguard test and improve test run time (poo#168589)

### DIFF
--- a/tests/network/wireguard.pm
+++ b/tests/network/wireguard.pm
@@ -111,7 +111,6 @@ sub run {
     assert_script_run 'ip link delete dev wg0';
 
     ## Test wg-quick
-    assert_script_run('set -eo pipefail');
     assert_script_run('cd /etc/wireguard');
     if (get_var('IS_MM_SERVER')) {
         # Prepare new keys

--- a/tests/network/wireguard.pm
+++ b/tests/network/wireguard.pm
@@ -135,14 +135,14 @@ sub run {
         barrier_wait('WG_QUICK_READY');
         # client2
         assert_script_run('echo -e "[Interface]\nPrivateKey = `cat /etc/wireguard/client2`\nAddress = 192.168.2.3\n" > /etc/wireguard/wg2.conf');
-        assert_script_run('echo -e "[Peer]\nPublicKey = `cat /etc/wireguard/server.pub`\nEndpoint=' . "$remote:51820\n" . '\nAllowedIPs = 192.168.2.0/24" >> /etc/wireguard/wg2.conf');
+        assert_script_run('echo -e "[Peer]\nPublicKey = `cat /etc/wireguard/server.pub`\nEndpoint=' . "$remote:51820" . '\n\nAllowedIPs = 192.168.2.0/24" >> /etc/wireguard/wg2.conf');
         script_run('cat /etc/wireguard/wg2.conf');
         start_wgquick("wg2");
         script_retry("ping -c10 $vpn_remote", delay => 3, retry => 10);
         assert_script_run('systemctl stop wg-quick@wg2');
         # client1 - the server expects client1 to be online after WG_QUICK_ENABLED
         assert_script_run('echo -e "[Interface]\nPrivateKey = `cat /etc/wireguard/client1`\nAddress = 192.168.2.2\n" > /etc/wireguard/wg1.conf');
-        assert_script_run('echo -e "[Peer]\nPublicKey = `cat /etc/wireguard/server.pub`\nEndpoint=' . "$remote:51820\n" . '\nAllowedIPs = 192.168.2.0/24" >> /etc/wireguard/wg1.conf');
+        assert_script_run('echo -e "[Peer]\nPublicKey = `cat /etc/wireguard/server.pub`\nEndpoint=' . "$remote:51820" . '\n\nAllowedIPs = 192.168.2.0/24" >> /etc/wireguard/wg1.conf');
         script_run('cat /etc/wireguard/wg1.conf');
         start_wgquick("wg1");
         barrier_wait('WG_QUICK_ENABLED');


### PR DESCRIPTION
Whilst testing with SELinux in enforcing mode in tumbleweed for bsc#1230118, we found that the wireguard test hangs at `ausearch -m avc -r` and exits the serial terminal.
This is because in case `ausearch -m avc -r` does not find any avcs, the return value is 1 and then the whole test fails and exits due to the pipefail.

This removes the pipefail call that caused the issue and also moves one newline around for an improvement in runtime.

- Related ticket: https://progress.opensuse.org/issues/168589
- Needles: N/A
- Verification run:
  - https://openqa.opensuse.org/tests/4624374
  - https://openqa.opensuse.org/tests/4624375

cc @rfan1 
thanks @Vogtinator for the help :)