### PR TITLE
Enable MinimalVM x86_64 with SecureBoot disabled test scenario

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1072,13 +1072,11 @@ sub tianocore_enter_menu {
 }
 
 sub tianocore_disable_secureboot {
-
     my ($basetest, $revert) = @_;
 
     my $neelle_sb_conf_attempt = $revert ? 'tianocore-devicemanager-sb-conf-disabled' : 'tianocore-devicemanager-sb-conf-attempt-sb';
     my $neelle_sb_change_state = $revert ? 'tianocore-devicemanager-sb-conf-enabled' : 'tianocore-devicemanager-sb-conf-attempt-sb';
     my $neelle_sb_config_state = $revert ? 'tianocore-secureboot-enabled' : 'tianocore-secureboot-not-enabled';
-    my $timeout = is_aarch64 ? '30' : '20';
 
     assert_screen 'grub2';
     send_key 'c';
@@ -1101,7 +1099,6 @@ sub tianocore_disable_secureboot {
     send_key_until_needlematch 'tianocore-devicemanager', 'esc';
     send_key_until_needlematch 'tianocore-mainmenu-reset', 'down';
     send_key 'ret';
-    send_key 'ret' if (!is_aarch64() && check_screen($neelle_sb_config_state, $timeout));
     $basetest->wait_grub;
 }
 

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -382,7 +382,7 @@ sub wait_grub {
     my $bootloader_time = $args{bootloader_time} // 100;
     my $in_grub = $args{in_grub} // 0;
     my @tags;
-    push @tags, 'bootloader-shim-import-prompt' if get_var('UEFI');
+    push @tags, 'bootloader-shim-import-prompt' if get_var('UEFI') && !get_var('DISABLE_SECUREBOOT');
     push @tags, 'grub2';
     push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');    # LIVETEST won't to do installation and no grub2 menu show up
     push @tags, 'bootloader' if get_var('OFW');

--- a/schedule/jeos/sle/jeos12sp5-main.yaml
+++ b/schedule/jeos/sle/jeos12sp5-main.yaml
@@ -4,6 +4,8 @@ name: 'jeos-main@64bit-virtio-vga ( qemu )'
 conditional_schedule:
     bootloader:
         MACHINE:
+            '64bit-virtio-vga':
+                - installation/bootloader_uefi
             'svirt-xen-pv':
                 - installation/bootloader_svirt
             'svirt-xen-hvm':

--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -74,7 +74,7 @@ sub check_efi_state {
     diag "Found efi guid=$efi_guid_global";
     diag('Expected state of SecureBoot: ' . (get_var('DISABLE_SECUREBOOT', 0) ? 'Disabled' : 'Enabled'));
 
-    if (script_run("efivar -dn $efi_guid_global-SecureBoot") == !get_var('DISABLE_SECUREBOOT', 0)) {
+    if (script_run("efivar -dn $efi_guid_global-SecureBoot") == get_var('DISABLE_SECUREBOOT', 0)) {
         push @errors, 'System\'s SecureBoot state is unexpected according to efivar';
     }
 

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -90,7 +90,7 @@ sub run {
     }
 
     # aarch64 firmware 'tianocore' can take longer to load
-    my $bootloader_timeout = is_aarch64 ? 90 : 15;
+    my $bootloader_timeout = is_aarch64 ? 90 : 25;
     $bootloader_timeout += 90 if get_var('FLAVOR', '') =~ /encrypted/i;
     if (get_var('UEFI_HTTP_BOOT') || get_var('UEFI_HTTPS_BOOT')) {
         tianocore_http_boot;


### PR DESCRIPTION
These are the required modifications in order to add the jeos-nosb test scenario, defined as:

DISTRI=opensuse
VERSION=Tumbleweed
FLAVOR=JeOS-for-kvm-and-xen
ARCH=x86_64 
BOOT_HDD_IMAGE=1
CHECK_MOK_IMPORT=1
DESKTOP=textmode
DISABLE_SECUREBOOT=1
UEFI=1

Please check individual commit messages for more info.

- Related ticket: https://progress.opensuse.org/issues/95434
- Verification runs:
[Tumbleweed](https://openqa.opensuse.org/tests/4624423)
[Leap 15.5](https://openqa.opensuse.org/tests/4627194)
[Leap 15.6](https://openqa.opensuse.org/tests/4627193)
[12 SP5](https://openqa.suse.de/tests/15880206)
[15 SP2](https://openqa.suse.de/tests/15878392)
[15 SP3](https://openqa.suse.de/tests/15878393)
[15 SP4](https://openqa.suse.de/tests/15879453)
[15 SP5](https://openqa.suse.de/tests/15878396)
[15 SP6](https://openqa.suse.de/tests/15878401)
[15 SP6 HyperV](https://openqa.suse.de/tests/15882230)
[15 SP7](https://openqa.suse.de/tests/15877517)
