### PR TITLE
quickfix: unused $prompt on select_serial_terminal

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -365,7 +365,6 @@ use root-ssh console directly.
 
 sub select_serial_terminal {
     my $root = shift // 1;
-    my $prompt = shift // ($root ? '# ' : '> ');
 
     my $backend = get_required_var('BACKEND');
     my $console;


### PR DESCRIPTION
Remove unused `$prompt` var in `serial_terminal::select_serial_terminal`.

- Related ticket: N/A
- Needles: No need for needles, it's functionally exact.
- Verification run: No need for VR, it's functionally exact.
