### PR TITLE
fix: agama boot module fails when EXTRABOOTPRAMS is not set

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -38,7 +38,7 @@ sub run {
     # prepare kernel parameters
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $path = data_url($agama_auto);
-        set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS') . " agama.auto=\"$path\"");
+        set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '') . " agama.auto=\"$path\"");
     }
     my @params = split ' ', trim(get_var('EXTRABOOTPARAMS', ''));
 


### PR DESCRIPTION
When scheduling the `boot_agama.pm` module without the `EXTRABOOTPARAMS` var, the test hangs forever.

The worker log shows:

```
[2024-11-07T03:50:37.837899+08:00] [debug] [pid:14113] ||| starting boot_agama tests/yam/agama/boot_agama.pm
Use of uninitialized value in concatenation (.) or string at sle/tests/yam/agama/boot_agama.pm line 41.
	boot_agama::run(boot_agama=HASH(0x55f5c1931950)) called at /usr/lib/os-autoinst/basetest.pm line 352
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 346
	basetest::runtest(boot_agama=HASH(0x55f5c1931950)) called at /usr/lib/os-autoinst/autotest.pm line 415
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 415
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 272
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 272
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 323
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x55f5c1755708)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x55f5c1755708), CODE(0x55f5c2c09880)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 489
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x55f5c1755708)) called at /usr/lib/os-autoinst/autotest.pm line 325
	autotest::start_process() called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Runner.pm line 94
	OpenQA::Isotovideo::Runner::start_autotest(OpenQA::Isotovideo::Runner=HASH(0x55f5ba3e4388)) called at /usr/bin/isotovideo line 192
	eval {...} called at /usr/bin/isotovideo line 181
```

Passing a default value (just like two lines below) fixes the issue.

- Related ticket: N/A
- Needles: No need for needles
- Verification run: No need for VR.
