### PR TITLE
Do not pass $self to Utils::Logging::upload_coredumps on virt_autotest

### DIFF
--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use File::Basename;
 use base "opensusebasetest";
+use Utils::Logging qw(upload_coredumps);
 use testapi;
 use Data::Dumper;
 use XML::Writer;
@@ -286,7 +287,7 @@ sub post_fail_hook {
     }
     save_screenshot;
 
-    $self->upload_coredumps;
+    upload_coredumps;
     save_screenshot;
 }
 1;


### PR DESCRIPTION
`Utils::Logging::upload_coredumps` expects a perl hash input `%args` as parameters, when calling it with `$self` the blessed reference of the test is sent as the first parameter instead.

Fixes `tests/virt_autotest/guest_upgrade_run.pm` executions when a coredump needs to be uploaded.

Log extract of the failure:
```
[2024-11-04T01:04:16.701293+08:00] [debug] [pid:15183] >>> testapi::wait_serial: (?^u:Q7oA_-\d+-): ok
Reference found where even-sized list expected at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/lib/Utils/Logging.pm line 167.
	Utils::Logging::upload_coredumps(guest_upgrade_run=HASH(0x55b668fd1d20)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 289
	virt_autotest_base::post_fail_hook(guest_upgrade_run=HASH(0x55b668fd1d20)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/guest_upgrade_run.pm line 152
	guest_upgrade_run::post_fail_hook(guest_upgrade_run=HASH(0x55b668fd1d20)) called at /usr/lib/os-autoinst/basetest.pm line 315
	eval {...} called at /usr/lib/os-autoinst/basetest.pm line 315
	basetest::run_post_fail(guest_upgrade_run=HASH(0x55b668fd1d20), "test guest_upgrade_run died") called at /usr/lib/os-autoinst/basetest.pm line 391
	basetest::runtest(guest_upgrade_run=HASH(0x55b668fd1d20)) called at /usr/lib/os-autoinst/autotest.pm line 415
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 415
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 272
	eval {...} called at /usr/lib/os-autoinst/autotest.pm line 272
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 323
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x55b6697fcf30)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	eval {...} called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 326
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x55b6697fcf30), CODE(0x55b668da8088)) called at /usr/lib/perl5/vendor_perl/5.26.1/Mojo/IOLoop/ReadWriteProcess.pm line 489
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x55b6697fcf30)) called at /usr/lib/os-autoinst/autotest.pm line 325
	autotest::start_process() called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Runner.pm line 94
	OpenQA::Isotovideo::Runner::start_autotest(OpenQA::Isotovideo::Runner=HASH(0x55b661349280)) called at /usr/bin/isotovideo line 192
	eval {...} called at /usr/bin/isotovideo line 181
```

- Related ticket: N/A
- Needles: No needles needed
- Verification run: http://openqa.qa2.suse.asia/tests/79124/logfile?filename=autoinst-log.txt
