### PR TITLE
Safe defaults for virt_utils::generateXML_from_data

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -495,25 +495,25 @@ sub generateXML_from_data {
         'testsuites',
         id => "0",
         error => "n/a",
-        failures => $xmldata{"fail_nums"},
-        softfailures => $xmldata{"softfail_nums"},
-        name => $xmldata{"product_name"},
-        skipped => $xmldata{"skip_nums"},
+        failures => $xmldata{"fail_nums"} // 0,
+        softfailures => $xmldata{"softfail_nums"} // 0,
+        name => $xmldata{"product_name"} // 'No product_name found',
+        skipped => $xmldata{"skip_nums"} // 0,
         tests => "$count",
-        time => $xmldata{"test_time"}
+        time => $xmldata{"test_time"} // 0
     );
     $writer->startTag(
         'testsuite',
         id => "0",
         error => "n/a",
-        failures => $xmldata{"fail_nums"},
-        softfailures => $xmldata{"softfail_nums"},
+        failures => $xmldata{"fail_nums"} // 0,
+        softfailures => $xmldata{"softfail_nums"} // 0,
         hostname => hostname(),
-        name => $xmldata{"product_tested_on"},
-        package => $xmldata{"package_name"},
-        skipped => $xmldata{"skip_nums"},
+        name => $xmldata{"product_tested_on"} // 'No product_tested_on found',
+        package => $xmldata{"package_name"} // 'No package_name found',
+        skipped => $xmldata{"skip_nums"} // 0,
         tests => $count,
-        time => $xmldata{"test_time"},
+        time => $xmldata{"test_time"} // 0,
         timestamp => $timestamp
     );
 


### PR DESCRIPTION
Keys of `$data` (which is then converted to `%xmldata`) may be missing and thus produce "Use of uninitialized value" errors on `XML::Writer`


Log extract:
```
Use of uninitialized value $_[0] in pattern match (m//) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 829.
	XML::Writer::_croakUnlessDefinedCharacters(undef) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 797
	XML::Writer::_checkAttributes(ARRAY(0x55b668e662a0), CODE(0x55b668ce2390)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 271
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuites", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 503
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $data in pattern match (m//) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 807.
	XML::Writer::_escapeLiteral(undef) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 94
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuites", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 503
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $value in substitution (s///) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 95.
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuites", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 503
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $value in substitution (s///) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 96.
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuites", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 503
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $value in substitution (s///) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 97.
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuites", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 503
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $value in concatenation (.) or string at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 99.
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuites", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 503
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $_[0] in pattern match (m//) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 829.
	XML::Writer::_croakUnlessDefinedCharacters(undef) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 797
	XML::Writer::_checkAttributes(ARRAY(0x55b668e662a0), CODE(0x55b668ce2390)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 271
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuite", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 516
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $data in pattern match (m//) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 807.
	XML::Writer::_escapeLiteral(undef) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 94
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuite", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 516
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $value in substitution (s///) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 95.
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuite", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 516
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $value in substitution (s///) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 96.
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuite", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 516
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $value in substitution (s///) at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 97.
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuite", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 516
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
# [...]

Use of uninitialized value $value in concatenation (.) or string at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 99.
	XML::Writer::__ANON__(ARRAY(0x55b668e662a0)) called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 255
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 284
	XML::Writer::__ANON__ called at /usr/lib/perl5/vendor_perl/5.26.1/XML/Writer.pm line 604
	XML::Writer::startTag(undef, "testsuite", "id", 0, "error", "n/a", "failures", 1, ...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_utils.pm line 516
	virt_utils::generateXML_from_data(HASH(0x55b6691388f0), HASH(0x55b668e80ad8)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 87
	virt_autotest_base::generateXML(guest_upgrade_run=HASH(0x55b668fd1d20), HASH(0x55b6691388f0)) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 218
	virt_autotest_base::add_junit_log(guest_upgrade_run=HASH(0x55b668fd1d20), "Overall guest upgrade result is:\x{a}         Guest Name         "...) called at /var/lib/openqa/pool/69/os-autoinst-distri-opensuse/tests/virt_autotest/virt_autotest_base.pm line 150
```

- Related ticket: N/A
- Needles: No needles needed
- Verification run: Pending
