### PR TITLE
Wait more time at grub phase for svirt-vmware70 machine

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -71,7 +71,7 @@ sub handle_first_grub {
         assert_screen_change { send_key('ret') };
         # Run ppc64le VMs on x86_64 setups is slow since no kvm support,
         # Wait one more minute to make sure system leaves grub
-        wait_still_screen 60 if check_var('MACHINE', 'ppc64le-emu');
+        wait_still_screen 60 if (check_var('MACHINE', 'ppc64le-emu') || check_var('MACHINE', 'svirt-vmware70'));
         save_screenshot;
     }
 }


### PR DESCRIPTION
Wait more time at grub phase for svirt-vmware70 machine

- Related ticket: https://progress.opensuse.org/issues/169447
- Verification run: https://openqa.suse.de/tests/15874212#
