### PR TITLE
xfstests: install dependency packages on MicroOS

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -55,6 +55,9 @@ sub install_xfstests_from_repo {
         unless (is_sle_micro('>=6.0')) {
             trup_call('--continue pkg install fio');
         }
+        if (scalar @PACKAGES > 2) {
+            trup_call('--continue pkg install --replacefiles ' . join(' ', @PACKAGES[2 .. $#PACKAGES]));
+        }
         reboot_on_changes;
     }
     else {


### PR DESCRIPTION
XFSTESTS_PACKAGES doesn't work for MicroOS, thus enable it.

- Related ticket: https://progress.opensuse.org/issues/168457
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/15874255#step/install/55 (no XFSTESTS_PACKAGES)
https://openqa.suse.de/tests/15874348#step/install/59 (XFSTESTS_PACKAGES="btrfs-progs xfsprogs")
