### PR TITLE
HPC: Disable proxySCC in WW4 test

### DIFF
--- a/tests/hpc/ww4.pm
+++ b/tests/hpc/ww4.pm
@@ -3,7 +3,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Configure and run a warewulf4 controller
+# Summary: Configure and run a warewulf4 controller.
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 use Mojo::Base qw(hpcbase hpc::utils), -signatures;
@@ -53,6 +53,11 @@ sub run ($self) {
         record_info('authentication', 'container authentication is enabled');
     }
     my $hpc_container = get_required_var('HPC_WAREWULF_CONTAINER');
+
+    # Disable url to use default SCC for repositories inside the warewulf-container
+    # See: progress.opensuse.org/issues/168028
+    script_run(qq{sed -i 's/url/#url/g' /etc/SUSEConnect});
+
     $rt = (assert_script_run "wwctl container import $hpc_container warewulf-container --setdefault", timeout => 320) ? 1 : 0;
     test_case('Container pull', 'ww4', $rt);
     $rt = (assert_script_run "wwctl profile set -y -C warewulf-container") ? 1 : 0;


### PR DESCRIPTION
Workaround for the ww4 tests: disabling the proxySCC to pull the latest ww4 container from recent repository

- Related ticket: https://progress.opensuse.org/issues/168028
- Verification run: https://openqa.suse.de/tests/15874176
https://openqa.suse.de/tests/15874177
https://openqa.suse.de/tests/15874178

also without the SCC file:
https://openqa.suse.de/tests/15763450#step/ww4/110
