### PR TITLE
WIP: Double timeout when power emulated in Agama

### DIFF
--- a/lib/Yam/Agama/Pom/RebootPage.pm
+++ b/lib/Yam/Agama/Pom/RebootPage.pm
@@ -23,6 +23,7 @@ sub new {
 sub expect_is_shown {
     my $self = shift;
     my $timeout = 2400;
+    $timeout *= 2 if get_var("MACHINE") eq "ppc64le-emu";
 
     while ($timeout > 0) {
         my $ret = check_screen($self->{tag_installation_complete}, 30);


### PR DESCRIPTION
Additional fix for #20576 
2400 might not be enough in this slow machine: https://openqa.suse.de/tests/15874440#step/agama_auto/17

Verification run: [osd](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=jknphy%2Fos-autoinst-distri-opensuse%23reboot-auto)