### PR TITLE
Refactor ssh retrieval from keyvault

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
@@ -13,8 +13,8 @@ use warnings;
 use testapi;
 use Exporter qw(import);
 use Carp qw(croak);
-use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployment_id);
 use mmapi qw(get_current_job_id);
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployment_id);
 
 =head1 SYNOPSIS
 
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   convert_region_to_short
   generate_deployer_name
   get_workload_vnet_code
+  get_sdaf_inventory_path
 );
 
 =head2 %sdaf_region_matrix

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -114,39 +114,6 @@ subtest '[serial_console_diag_banner] ' => sub {
     dies_ok { serial_console_diag_banner('exeCuTing deploYment' x 6) } 'Fail with string exceeds max number of characters';
 };
 
-subtest '[sdaf_get_deployer_ssh_key]' => sub {
-    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
-    my $get_ssh_command;
-    my %private_key;
-    my %pubkey;
-    $ms_sdaf->redefine(script_run => sub { return 0; });
-    $ms_sdaf->redefine(homedir => sub { return '/home/dir/'; });
-    $ms_sdaf->redefine(assert_script_run => sub { return 0; });
-    $ms_sdaf->redefine(script_output => sub {
-            $get_ssh_command = $_[0] if grep /keyvault/, @_;
-            return "
-LAB-SECE-DEP05-sshkey
-LAB-SECE-DEP05-sshkey-pub
-LAB-SECE-DEP05-ssh
-"
-    });
-    $ms_sdaf->redefine(az_get_ssh_key => sub {
-            %private_key = @_ if grep /sshkey$/, @_;
-            %pubkey = @_ if grep /sshkey-pub$/, @_;
-    });
-
-    sdaf_get_deployer_ssh_key(key_vault => 'LABSECEDEP05userDDF');
-    is $get_ssh_command, 'az keyvault secret list --vault-name LABSECEDEP05userDDF --query [].name --output tsv | grep sshkey',
-      'Return correct command for retrieving private key';
-    is $pubkey{ssh_key_name}, 'LAB-SECE-DEP05-sshkey-pub', 'Public key';
-    is $private_key{ssh_key_name}, 'LAB-SECE-DEP05-sshkey', 'Private key';
-
-    dies_ok { sdaf_get_deployer_ssh_key() } 'Fail with missing "key_vault" argument';
-
-    $ms_sdaf->redefine(script_output => sub { return 1 });
-    dies_ok { sdaf_get_deployer_ssh_key(key_vault => 'LABSECEDEP05userDDF') } 'Fail with not keyfile being found';
-};
-
 subtest '[set_common_sdaf_os_env]' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     my %arguments = (
@@ -458,7 +425,52 @@ subtest '[ansible_hanasr_show_status]' => sub {
 
     note("SAPHanaSR-showAttr command:\n\t $calls{saphanasr_showattr}");
     ok(grep(/--args="sudo SAPHanaSR-showAttr"/, $calls{saphanasr_showattr}), 'Check for executed "SAPHanaSR-showAttr" command');
+};
 
+subtest '[sdaf_ssh_key_from_keyvault] Test exceptions' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
+    $ms_sdaf->redefine(homedir => sub { return '/home/Amuro'; });
+    my $croak_message;
+    $ms_sdaf->redefine(croak => sub { $croak_message = $_[0]; note("\n  -->  $_[0]"); die; });
+    $ms_sdaf->redefine(assert_script_run => sub { return; });
+    $ms_sdaf->redefine(script_run => sub { return 1; });
+    $ms_sdaf->redefine(record_info => sub { return });
+    $ms_sdaf->redefine(az_keyvault_secret_show => sub { return 'lol'; });
+
+    # Exception is handled by 'az_keyvault_secret_list'
+    dies_ok { sdaf_ssh_key_from_keyvault() } 'Croak with missing $args{key_vault}';
+    ok($croak_message =~ /key_vault/, 'Check if croak message is correct');
+
+    $ms_sdaf->redefine(az_keyvault_secret_list => sub { return ['Amuro', 'Ray']; });
+    dies_ok { sdaf_ssh_key_from_keyvault(key_vault => 'SCV-70 White Base') } 'Croak with az cli returning multiple key vaults';
+    ok($croak_message =~ /Multiple/, 'Check if croak message is correct');
+
+    $ms_sdaf->redefine(az_keyvault_secret_list => sub { return ['Amuro']; });
+
+    dies_ok { sdaf_ssh_key_from_keyvault(key_vault => 'SCV-70 White Base') } 'Croak with invalid private key returned';
+    ok($croak_message =~ /Failed/, 'Check if croak message is correct');
+};
+
+subtest '[sdaf_ssh_key_from_keyvault] Verify executed commands' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
+    my @assert_script_run;
+    my @script_run;
+    $ms_sdaf->redefine(homedir => sub { return '/home/Amuro'; });
+    $ms_sdaf->redefine(az_keyvault_secret_list => sub { return ['Amuro']; });
+    $ms_sdaf->redefine(az_keyvault_secret_show => sub { return; });
+    $ms_sdaf->redefine(assert_script_run => sub { push @assert_script_run, $_[0]; return; });
+    $ms_sdaf->redefine(script_run => sub { push @script_run, $_[0]; return; });
+    $ms_sdaf->redefine(record_info => sub { return });
+
+    sdaf_ssh_key_from_keyvault(key_vault => 'SCV-70 White Base');
+    note("\n --> " . join("\n --> ", @assert_script_run));
+    ok(grep(/mkdir -p/, @assert_script_run), 'Create ssh directory');
+    ok(grep(/touch/, @assert_script_run), 'Create ssh file');
+    ok(grep(/chmod 700/, @assert_script_run), 'Set ssh directory permissions');
+    ok(grep(/chmod 600/, @assert_script_run), 'Set public key permissions');
+
+    note("\n --> " . join("\n --> ", @script_run));
+    ok(grep(//, @assert_script_run), 'Validate ssh key');
 };
 
 done_testing;

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -903,4 +903,102 @@ subtest '[az_storage_blob_update]' => sub {
     ok(grep(/--lease-id 12345/, @calls), 'Check for argument "--lease-id"');
 };
 
+subtest '[az_keyvault_list]' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["Arlecchino", "Pantalone"]'; });
+
+    my $return_value = az_keyvault_list(
+        resource_group => 'Arlecchino',
+        query => '[].Pantalone',
+    );
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az keyvault list/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
+    ok(grep(/--resource_group Arlecchino/, @calls), 'Check for argument "--resource_group"');
+    ok(grep(/--query \[\].Pantalone/, @calls), 'Check for argument "--query"');
+    ok(grep(/--output json/, @calls), 'Return output in "json" format');
+    is(join(' ', @$return_value), 'Arlecchino Pantalone', 'Return correct value');
+};
+
+subtest '[az_keyvault_list] Test exception' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(croak => sub { @calls = $_[0]; die; });
+
+    dies_ok { az_keyvault_list() } 'Fail with missing "resource_group" argument';
+    ok(grep(/resource_group/, @calls), 'Check if test fails for correct reason - Missing resource group argument');
+};
+
+subtest '[az_keyvault_secret_list]' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["Arlecchino", "Pantalone"]'; });
+
+    my $return_value = az_keyvault_secret_list(
+        vault_name => 'Arlecchino',
+        query => '[].Pantalone',
+    );
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az keyvault secret list/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
+    ok(grep(/--vault-name Arlecchino/, @calls), 'Check for argument "--vault-name"');
+    ok(grep(/--query \[\].Pantalone/, @calls), 'Check for argument "--query"');
+    ok(grep(/--output json/, @calls), 'Return output in "json" format');
+    is(join(' ', @$return_value), 'Arlecchino Pantalone', 'Return correct value');
+};
+
+subtest '[az_keyvault_secret_list] Test exception' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(croak => sub { @calls = $_[0]; die; });
+
+    dies_ok { az_keyvault_secret_list() } 'Fail with missing "resource_group" argument';
+    ok(grep(/vault_name/, @calls), 'Check if test fails for correct reason - Missing vault name argument');
+};
+
+subtest '[az_keyvault_secret_show] Test exception' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    $azcli->redefine(croak => sub { note("\n --> " . join("\n --> ", $_[0])); die; });
+    dies_ok { az_keyvault_secret_show(id => '123', vault_name => 'Arlecchino', name => 'Colombina') }
+    'Fail with mutually exclusive arguments defined';
+    dies_ok { az_keyvault_secret_show(vault_name => 'Pantalone') } 'Fail with missing "name" argument';
+    dies_ok { az_keyvault_secret_show(name => 'Colombina') } 'Fail with missing "vault_name" argument';
+    dies_ok { az_keyvault_secret_show() } 'Fail with missing "id" argument';
+};
+
+subtest '[az_keyvault_secret_show] Calling with "id" argument' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return 'SUper$ecretStuffAnD_even_m0re_secret$tuFF'; });
+
+    az_keyvault_secret_show(id => 'Arlecchino');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az keyvault secret show/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
+    ok(grep(/--id Arlecchino/, @calls), 'Check for argument "--id"');
+    ok(grep(/--query value/, @calls), 'Check for argument "--query"');
+    ok(grep(/--output tsv/, @calls), 'Return output in "tsv" format');
+};
+
+subtest '[az_keyvault_secret_show] Calling with "name" and "vault_name" arguments' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '"SUper$ecretStuffAnD_even_m0re_secret$tuFF"'; });
+
+    my $result = az_keyvault_secret_show(name => 'Arlecchino', vault_name => 'Pantalone', output => 'json');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az keyvault secret show/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
+    ok(grep(/--name Arlecchino/, @calls), 'Check for argument "--name"');
+    ok(grep(/--vault-name Pantalone/, @calls), 'Check for argument "--vault-name"');
+    ok(grep(/--query value/, @calls), 'Check for argument "--query"');
+    ok(grep(/--output json/, @calls), 'Return output in "json" format');
+    is $result, 'SUper$ecretStuffAnD_even_m0re_secret$tuFF', 'Decode JSON output';
+};
+
 done_testing;

--- a/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
@@ -10,7 +10,7 @@ use strict;
 use warnings;
 use testapi;
 use sles4sap::sap_deployment_automation_framework::deployment
-  qw(serial_console_diag_banner az_login sdaf_get_deployer_ssh_key);
+  qw(serial_console_diag_banner az_login sdaf_ssh_key_from_keyvault);
 use sles4sap::sap_deployment_automation_framework::deployment_connector
   qw(get_deployer_vm_name get_deployer_ip find_deployment_id);
 use serial_terminal qw(select_serial_terminal);
@@ -33,7 +33,7 @@ sub run {
     # This will allow using connect_target_to_serial() without specifying user/host to deployer every time.
     set_var('REDIRECT_DESTINATION_USER', get_var('PUBLIC_CLOUD_USER', 'azureadm'));
     set_var('REDIRECT_DESTINATION_IP', $deployer_ip);    # IP addr to redirect console to
-    sdaf_get_deployer_ssh_key(key_vault => get_required_var('SDAF_DEPLYOER_KEY_VAULT'));
+    sdaf_ssh_key_from_keyvault(key_vault => get_required_var('SDAF_DEPLYOER_KEY_VAULT'));
     serial_console_diag_banner('Module sdaf_redirect_console_to_deployer.pm : end');
 }
 


### PR DESCRIPTION
This PR refactors SDAF functions responsible for retrieving deployer SSH public 
keys from keyvault. Functions are now generalized so they can be used for 
generel secret and public key retrieval. Azure api calls are moved to 
`lib/sles4sap/azure_cli.pm`.

- Related ticket: https://jira.suse.com/browse/TEAM-9793
- Verification run: 
Key being validated: https://openqaworker15.qa.suse.cz/tests/302252#step/connect_to_deployer/78
Redirection to deployer VM working: https://openqaworker15.qa.suse.cz/tests/302252#step/configure_deployer/12
Cleanup test connecting to deployer fine: https://openqaworker15.qa.suse.cz/tests/302253#