### PR TITLE
The image check unpartitioned space is 2048 for flavor Base-qcow-Updates

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -33,7 +33,7 @@ sub run {
 
     # Verify that there is no unpartitioned space left
     my $left_sectors = 0;
-    if ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow|SelfInstall/) {
+    if ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && (get_var('FLAVOR', '') !~ m/qcow|SelfInstall/ || check_var('TARGET_VERSION', '6.0'))) {
         $left_sectors = 2048;
     } elsif (is_sle_micro("6.0+") && is_aarch64) {
         $left_sectors = 0 if (get_var("HDD_1") =~ /qcow2/);


### PR DESCRIPTION
Failed job: https://openqa.suse.de/tests/15892037#step/image_checks/11

- Related ticket: https://progress.opensuse.org/issues/168676
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/15909250#step/image_checks/10  Migration test VR
  https://openqa.suse.de/tests/15909251#step/image_checks/11   Installation test to avoid regression  
