### PR TITLE
Skip update maintenance repo on base system

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -39,7 +39,7 @@ sub run {
     # Now we add the incident repositories and do a zypper patch
     add_test_repositories;
     record_info('Updates', script_output('zypper lu'));
-    my $ret = trup_call('up', timeout => 300, proceed_on_failure => 1);
+    trup_call('up', timeout => 300, proceed_on_failure => 1) unless get_var('DISABLE_UPDATE_WITH_PATCH');
 
     # after update, clean the audit log to make sure there aren't any leftovers that were already fixed
     # see poo#169090


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/168676
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23fix-slem-6.0-repo&distri=sle-micro&version=6.0
 The failure for un-partitioned sector issue on aarch64 is not related with this PR, I filed another PR for that https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20583

Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/365