### PR TITLE
xfstests/partition.pm: add section name when configuring nfsmount.conf file

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -379,13 +379,15 @@ sub setup_nfs_server {
     if ($nfsversion == '3') {
         assert_script_run("echo 'MOUNT_NFS_V3=\"yes\"' >> /etc/sysconfig/nfs");
         assert_script_run("echo 'MOUNT_NFS_DEFAULT_PROTOCOL=3' >> /etc/sysconfig/autofs && echo 'OPTIONS=\"-O vers=3\"' >> /etc/sysconfig/autofs");
-        assert_script_run("echo 'Defaultvers=3' >> /etc/nfsmount.conf && echo 'Nfsvers=3' >> /etc/nfsmount.conf");
+        assert_script_run("echo '[NFSMount_Global_Options]' >> /etc/nfsmount.conf && echo 'Defaultvers=3' >> /etc/nfsmount.conf && echo 'Nfsvers=3' >> /etc/nfsmount.conf");
     }
     else {
         assert_script_run("sed -i 's/NFSV4LEASETIME=\"\"/NFSV4LEASETIME=\"$nfsgrace\"/' /etc/sysconfig/nfs");
         assert_script_run("echo -e '[nfsd]\\ngrace-time=$nfsgrace\\nlease-time=$nfsgrace' > /etc/nfs.conf.local");
     }
     assert_script_run('exportfs -a && systemctl restart rpcbind && systemctl enable nfs-server.service && systemctl restart nfs-server');
+
+    record_info('nfsmount.conf file', script_output("cat /etc/nfsmount.conf"));
 
     # There's a graceful time we need to wait before using the NFS server
     my $gracetime = script_output('cat /proc/fs/nfsd/nfsv4gracetime;');


### PR DESCRIPTION
several xfstests in o3/xfstests_nfs3-generic has been failing with 
```
+mount.nfs: config error at /etc/nfsmount.conf:1: ignoring line not in a section 
+mount.nfs: config error at /etc/nfsmount.conf:2: ignoring line not in a section 
```
so, adding the section name in nfsmount config file

- Related ticket: https://progress.opensuse.org/issues/168559
- Verification run: https://openqa.opensuse.org/tests/4627363#step/generic-029/19
