### PR TITLE
Substite LTSS-ES channel name

### DIFF
--- a/lib/maintenance_smelt.pm
+++ b/lib/maintenance_smelt.pm
@@ -10,6 +10,7 @@ use warnings;
 use testapi;
 use List::Util qw(first);
 use Mojo::UserAgent;
+use version_utils qw(is_sle);
 
 use base "Exporter";
 use Exporter;
@@ -49,6 +50,9 @@ sub get_packagebins_in_modules {
     # in different modules.
     my ($self) = @_;
     my ($package_name, $module_ref) = ($self->{package_name}, $self->{modules});
+    # substitute LTSS-ES, channel name in smelt is all upper case
+    # https://suse.slack.com/archives/C02CLB8TZP1/p1730783709126159
+    foreach (@{$module_ref}) { $_ =~ s/12-SP5-LTSS-Extended-Security/12-SP5-LTSS-EXTENDED-SECURITY/ if is_sle('=12-sp5'); }
     my $response = Mojo::UserAgent->new->get("$smelt_url/api/v1/basic/maintained/$package_name/")->result->body;
     my $graph = JSON->new->utf8->decode($response);
     # Get the modules to which this package provides binaries.


### PR DESCRIPTION
We are working with lower case which is correct, but channel name in smelt is all upper case, this should be workaround until it's fixed, one day.

- Related ticket: https://suse.slack.com/archives/C02CLB8TZP1/p1730783709126159
- Verification run: https://openqa.suse.de/tests/15890092#step/update_install/68
