### PR TITLE
Do not automatically restart NM after static configuration

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -228,7 +228,10 @@ sub setup_static_mm_network {
     configure_static_ip(ip => $ip, is_nm => $is_nm);
     configure_default_gateway(is_nm => $is_nm);
     configure_static_dns(get_host_resolv_conf(), is_nm => $is_nm);
-    restart_networking(is_nm => $is_nm);
+    # Previous functions apply NM settings at runtime and no restart is required to apply them.
+    # Tracking if a restart is required troughout these functions would be cleaner but given their current implementation
+    # we can get away with not restarting if using NM.
+    restart_networking(is_nm => $is_nm) unless $is_nm;
 }
 
 sub restart_networking {


### PR DESCRIPTION
NM changes happen at runtime and automatically restarting it just wastes time and introduces more options to fail without providing any benefit.

Related issue: https://progress.opensuse.org/issues/169531
Verification run:
  - https://openqa.opensuse.org/tests/4635229
  - https://openqa.opensuse.org/tests/4635230