### PR TITLE
Increase TIMEOUT_SCALE to 3 in basic cluster node schedule

### DIFF
--- a/schedule/ha/bv/basic_cluster_node.yaml
+++ b/schedule/ha/bv/basic_cluster_node.yaml
@@ -36,7 +36,7 @@ vars:
   HDD_SCC_REGISTERED: '1'
   # Disable qemu snapshots to avoid unexpected fences in HA tests
   QEMU_DISABLE_SNAPSHOTS: '1'
-  TIMEOUT_SCALE: '2'
+  TIMEOUT_SCALE: '3'
   USE_SUPPORT_SERVER: '1'
   VIRTIO_CONSOLE: '1'
   # Below have to be entered in the OpenQA UI because it doesn't read this YAML


### PR DESCRIPTION
Some Aggregated ctdb tests in 15-SP5 and 15-SP6 started failing with `TIMEOUT_SCALE=2`. This increases the timeout scaling to 3 which is working for Single Incidents ctdb tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/15910561, https://openqa.suse.de/tests/15910567
