### PR TITLE
containers: Run buildah tests also as user

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -16,28 +16,15 @@
 
 use Mojo::Base qw(consoletest);
 use testapi;
-use serial_terminal 'select_serial_terminal';
+use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
 use utils;
 use version_utils qw(get_os_release is_sle);
 use containers::common;
 
-sub run {
-    my ($self, $args) = @_;
-    select_serial_terminal;
-    my ($running_version, $sp, $host_distri) = get_os_release;
+sub run_tests {
+    my $runtime = shift;
 
-    my $runtime = $args->{runtime};
     my $image = "registry.opensuse.org/opensuse/tumbleweed:latest";
-
-    record_info('Test', "Install buildah along with $runtime");
-    install_buildah_when_needed($host_distri);
-    install_podman_when_needed($host_distri) if ($runtime eq 'podman');
-    if ($runtime eq 'docker') {
-        install_docker_when_needed($host_distri);
-        zypper_call('install skopeo');
-    }
-    record_info('Version', script_output('buildah --version'));
-
     record_info('Test', "Pull image $image");
     assert_script_run("buildah pull $image", timeout => 300);
     validate_script_output('buildah images', sub { /registry.opensuse.org\/opensuse\/tumbleweed/ });
@@ -88,6 +75,35 @@ sub run {
     record_info('Test', "Cleanup");
     assert_script_run("buildah rm $container");
     assert_script_run("buildah rmi newimage");
+    assert_script_run("rm -f /tmp/script.sh");
+}
+
+sub run {
+    my ($self, $args) = @_;
+    select_serial_terminal;
+    my ($running_version, $sp, $host_distri) = get_os_release;
+
+    my $runtime = $args->{runtime};
+
+    record_info('Test', "Install buildah along with $runtime");
+    install_buildah_when_needed($host_distri);
+    if ($runtime eq 'podman') {
+        install_podman_when_needed($host_distri);
+    } elsif ($runtime eq 'docker') {
+        install_docker_when_needed($host_distri);
+        zypper_call('install skopeo');
+    }
+    record_info('Version', script_output('buildah --version'));
+
+    # Run tests as root
+    run_tests($runtime);
+
+    # Run tests as user
+    if ($runtime eq "podman") {
+        select_user_serial_terminal;
+        run_tests($runtime) if ($runtime eq "podman");
+        select_serial_terminal;
+    }
 }
 
 1;


### PR DESCRIPTION
Run buildah tests also as rootless.

- Related ticket: https://progress.opensuse.org/issues/169075
- Verification runs:
  - opensuse-Tumbleweed-DVD-x86_64-Build20241109-containers_host_docker@64bit -> https://openqa.opensuse.org/tests/4635815
  - opensuse-Tumbleweed-DVD-x86_64-Build20241109-containers_host_podman@64bit -> https://openqa.opensuse.org/tests/4635795
