### PR TITLE
Remove unecessary patterns for ppc64le all patterns migration

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -274,6 +274,10 @@ sub select_all_patterns_by_menu {
         send_key 'alt-2';
         send_key 'alt-o';
     }
+    if (check_screen('fips_certified_conflict', 5)) {
+        send_key 'alt-1';
+        send_key 'alt-o';
+    }
     send_key 'alt-o';
     $self->accept3rdparty();
     assert_screen 'inst-overview';

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -29,6 +29,7 @@ use ipmi_backend_utils;
 
 sub run {
     my ($self) = @_;
+
     my $dasd_path = get_var('DASD_PATH', '0.0.0150');
     select_console 'install-shell';
 


### PR DESCRIPTION
##
### Drop unexpected patterns for migration where all patterns are selected

- Related ticket: 
   -  https://progress.opensuse.org/issues/164934
- Needles: 
  -  select_patterns-fips-certified-conflict-20241113
- Verification run: 
  - [**select_patterns**](https://openqa.suse.de/tests/overview?version=15-SP7&distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23remove_patterns)

##