### PR TITLE
Revert "verify_efi_mok: Fix unexpected SecureBoot state check"

### DIFF
--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -74,7 +74,7 @@ sub check_efi_state {
     diag "Found efi guid=$efi_guid_global";
     diag('Expected state of SecureBoot: ' . (get_var('DISABLE_SECUREBOOT', 0) ? 'Disabled' : 'Enabled'));
 
-    if (script_run("efivar -dn $efi_guid_global-SecureBoot") == get_var('DISABLE_SECUREBOOT', 0)) {
+    if (script_run("efivar -dn $efi_guid_global-SecureBoot") == !get_var('DISABLE_SECUREBOOT', 0)) {
         push @errors, 'System\'s SecureBoot state is unexpected according to efivar';
     }
 


### PR DESCRIPTION
This reverts commit 9e4c2938bbe7c82ada5eb98d493c2335be9a301b.

Reverting because of multiple failures, see e.g. https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20568#issuecomment-2469904599 and https://openqa.suse.de/tests/15918435#step/verify_efi_mok/101