### PR TITLE
xfstests/partition.pm: move record_info nfsmount.conf to correct place

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -380,6 +380,7 @@ sub setup_nfs_server {
         assert_script_run("echo 'MOUNT_NFS_V3=\"yes\"' >> /etc/sysconfig/nfs");
         assert_script_run("echo 'MOUNT_NFS_DEFAULT_PROTOCOL=3' >> /etc/sysconfig/autofs && echo 'OPTIONS=\"-O vers=3\"' >> /etc/sysconfig/autofs");
         assert_script_run("echo '[NFSMount_Global_Options]' >> /etc/nfsmount.conf && echo 'Defaultvers=3' >> /etc/nfsmount.conf && echo 'Nfsvers=3' >> /etc/nfsmount.conf");
+        record_info('nfsmount.conf file', script_output("cat /etc/nfsmount.conf"));
     }
     else {
         assert_script_run("sed -i 's/NFSV4LEASETIME=\"\"/NFSV4LEASETIME=\"$nfsgrace\"/' /etc/sysconfig/nfs");
@@ -387,7 +388,6 @@ sub setup_nfs_server {
     }
     assert_script_run('exportfs -a && systemctl restart rpcbind && systemctl enable nfs-server.service && systemctl restart nfs-server');
 
-    record_info('nfsmount.conf file', script_output("cat /etc/nfsmount.conf"));
 
     # There's a graceful time we need to wait before using the NFS server
     my $gracetime = script_output('cat /proc/fs/nfsd/nfsv4gracetime;');


### PR DESCRIPTION
Fixes: 66c797f525 (xfstests/partition.pm: add section name when configuring nfsmount.conf)

- Related ticket: https://progress.opensuse.org/issues/168559
