### PR TITLE
Reuse existing SDAF deployment

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -189,6 +189,10 @@ In case of multi-machine test this can be either parent test ID or current job i
 This function collects all OpenQA job IDs related to current test run and checks if any of them match an existing
 deployer VM tagged with this ID.
 
+Using OpenQA parameter B<SDAF_DEPLOYMENT_ID> it is possible to override this value. It is mostly intended for development
+purposes where it allows you to run test code on already existing deployment. Use it with caution and override
+the value only with ID of the infrastructure that belongs to you.
+
 B<Example>:
 Job: 123456 - deployment module - created deployer VM tagged with "deployment_id=123456",
 Job: 123457 (child of 123456) - some test module
@@ -203,6 +207,7 @@ Deployment ID returned from both jobs: 123456 - because it matches with existing
 
 sub find_deployment_id {
     my (%args) = @_;
+    return get_var('SDAF_DEPLOYMENT_ID') if get_var('SDAF_DEPLOYMENT_ID');
     $args{deployer_resource_group} //= get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
     my @check_list = (get_current_job_id(), @{get_parent_ids()});
 

--- a/t/26_deployment_connector.t
+++ b/t/26_deployment_connector.t
@@ -61,6 +61,12 @@ subtest '[find_deployment_id]' => sub {
     is find_deployment_id(deployer_resource_group => 'Char'), '0083', 'Parent job ID belongs to VM';
 };
 
+subtest '[find_deployment_id]' => sub {
+    set_var('SDAF_DEPLOYMENT_ID', '0079');
+    is find_deployment_id(deployer_resource_group => 'Char'), '0079', 'Override deployment id using "SDAF_DEPLOYMENT_ID"';
+    set_var('SDAF_DEPLOYMENT_ID', undef);
+};
+
 subtest '[find_deployer_resources] Check command composition' => sub {
     my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
     my @calls;


### PR DESCRIPTION
This PR adds a simple feature to override deployment id using OpenQA parameter 
`SDAF_DEPLOYMENT_ID`. Instead of creating a new deployment, test code will 
simply connect to an existing one. Feature is only intended for development 
purposes to avoid deploying whole infrastructure every time one needs to test 
the code.

- Related ticket: https://jira.suse.com/browse/TEAM-9795
- Verification run:

Executing only deployment job (TEST=SDAF_PRD_deploy_HanaSR): 
https://openqaworker15.qa.suse.cz/tests/302597#

Executing job 'SDAF_PRD_HanaSR'  with parameters: 
`TEST=SDAF_PRD_HanaSR START_AFTER_TEST="" SDAF_DEPLOYMENT_ID=302597`
https://openqaworker15.qa.suse.cz/tests/302603#step/connect_to_deployer/42
- test connected to existing infrastructure instead of creating new one. 

