### PR TITLE
Fix wsl_systemd conflict

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -270,6 +270,10 @@ sub select_all_patterns_by_menu {
     wait_screen_change { send_key 'ret'; };
     mouse_hide;
     save_screenshot;
+    if (check_screen('wsl_systemd_conflict', 5)) {
+        send_key 'alt-2';
+        send_key 'alt-o';
+    }
     send_key 'alt-o';
     $self->accept3rdparty();
     assert_screen 'inst-overview';


### PR DESCRIPTION
wsl-systemd has conflict with other DMs [1]
We have to handle this conflict and not install wsl-systemd

- Related ticket: https://progress.opensuse.org/issues/169666
- Verification run: https://openqa.suse.de/tests/15919604
