### PR TITLE
ltp: Add add Base-Kernel-RT flavors to ltp installation

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -341,7 +341,7 @@ sub run {
 
     # Lock kernel default on transactional system and RT flavors
     # This is workaround for poo#165036 to prevent kernel-default and kernel-default-base installation
-    zypper_call("al kernel-default kernel-default-base") if (is_transactional && (get_var('FLAVOR', '') =~ /Base-RT-Updates|Base-RT|Base-RT-encrypted/));
+    zypper_call("al kernel-default kernel-default-base") if (is_transactional && (get_var('FLAVOR', '') =~ /Base-RT-Updates|Base-RT|Base-RT-encrypted|Base-Kernel-RT/));
 
     if ($inst_ltp =~ /git/i) {
         install_build_dependencies;


### PR DESCRIPTION
- Related fail: https://openqa.suse.de/tests/15920107#step/install_ltp/171
- Needles: none
- Verification run:  https://openqa.suse.de/tests/overview?build=czerw%2Fos-autoinst-distri-opensuse%2320609&distri=sle-micro&version=6.0
