### PR TITLE
agama: product select is visible only at the bottom page

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -97,11 +97,11 @@ sub run {
 
     if (is_leap('>=16.0')) {
         assert_and_click('agama-product-leap16');
-        assert_and_click('agama-product-select');
     } else {    # Default to TW
         assert_and_click('agama-product-tumbleweed');
-        assert_and_click('agama-product-select');
     }
+    send_key "ctrl-down";    # ensure we see the product select button
+    assert_and_click('agama-product-select');
 
     # can take few minutes to get here
     assert_screen('agama-overview-screen');


### PR DESCRIPTION
- Adding slowroll caused that product selection button is no longer visible
- Ensure we're at the bottom before trying to click product select button
Test run: https://openqa.opensuse.org/tests/4637710#live