### PR TITLE
Create ssh config on worker VM

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -1688,7 +1688,7 @@ sub az_keyvault_list {
 
     my @az_cmd = ('az keyvault list',
         '--only-show-errors',
-        '--resource_group', $args{resource_group},
+        '--resource-group', $args{resource_group},
         '--query', "$args{query}",
         '--output json'
     );

--- a/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
@@ -1,0 +1,233 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+package sles4sap::sap_deployment_automation_framework::inventory_tools;
+
+use warnings;
+use strict;
+use YAML::PP;
+use testapi;
+use Exporter qw(import);
+use Carp qw(croak);
+use sles4sap::sap_deployment_automation_framework::naming_conventions
+  qw($deployer_private_key_path $sut_private_key_path);
+use sles4sap::console_redirection;
+
+=head1 SYNOPSIS
+
+Library contains functions that handle SDAF inventory file.
+
+SDAF inventory yaml file example:
+QES_DB:
+  hosts:
+    dbhost01:
+      ansible_host        : 192.168.1.2
+      ansible_user        : someuser
+      ansible_connection  : ssh
+      connection_type     : key
+      virtual_host        : virtualhostname01
+      become_user         : root
+      os_type             : linux
+      vm_name             : somevmname01
+    dbhost02:
+      ansible_host        : 192.168.1.3
+      ansible_user        : someuser
+      ansible_connection  : ssh
+      connection_type     : key
+      virtual_host        : virtualhostname02
+      become_user         : root
+      os_type             : linux
+      vm_name             : somevmname02
+  vars:
+    node_tier             : hana
+    supported_tiers       : [hana, scs, pas]
+QES_SCS:
+  hosts:
+  vars:
+    node_tier             : scs
+    supported_tiers       : [scs, pas]
+QES_ERS:
+  hosts:
+  vars:
+    node_tier             : ers
+    supported_tiers       : [ers]
+
+=cut
+
+our @EXPORT = qw(
+  read_inventory_file
+  prepare_ssh_config
+  verify_ssh_proxy_connection
+);
+
+=head2 read_inventory_file
+
+    read_inventory_file($sap_inventory_file_path);
+
+Returns SDAF inventory file content in perl HASHREF format.
+
+=over
+
+=item * B<inventory_file_path> Full file path pointing to SDAF inventory file
+
+=back
+=cut
+
+sub read_inventory_file {
+    my ($inventory_file_path) = @_;
+    my $ypp = YAML::PP->new;
+    return $ypp->load_string(script_output("cat $inventory_file_path"));
+}
+
+=head2 ssh_config_entry_add
+
+    ssh_config_entry_add(entry_name=>'jump_host', hostname=>'SuperMario'
+        [, identity_file=>'/path/to/private/key',
+        identities_only=>1,
+        user=>'luigi'
+        proxy_jump=>'192.168.1.100',
+        strict_host_key_checking=>0,
+        batch_mode=>1]);
+
+Produce ~/.ssh/config host entry like:
+
+-----
+Host Mario_host
+  HostName 192.2.150.85 some_hostname
+  IdentitiesOnly yes
+  BatchMode yes
+  User mario_plumber
+  IdentityFile ~/.ssh/id_rsa
+-----
+
+=over
+
+=item * B<entry_name> Config entry name. This name can be used instead of host/IP in ssh command. Example: ssh root@<entry_name>
+
+=item * B<user> Define ssh username
+
+=item * B<hostname> Target hostname or IP addr
+
+=item * B<identity_file> Full path to SSH private key
+
+=item * B<identities_only> If true, SSH will only attempt passwordless login
+
+=item * B<batch_mode> If true, all SSH interactive features will be disabled. Test won't have to wait for timeouts.
+
+=item * B<proxy_jump> Jump host hostname, IP addr or point to another entry in config file
+
+=item * B<strict_host_key_checking> Turn off host key check
+
+=back
+=cut
+
+sub ssh_config_entry_add {
+    my (%args) = @_;
+    my $config_path = '~/.ssh/config';
+    my @mandatory_args = qw(entry_name hostname);
+    foreach (@mandatory_args) {
+        croak "Missing mandatory argument: $_" unless $args{$_};
+    }
+
+    # passwordless, non-interactive ssh by default
+    $args{batch_mode} //= 'yes';
+    $args{identities_only} //= 'yes';
+
+    my @file_contents = (
+        "Host $args{entry_name}",
+        "  HostName $args{hostname}",
+        "  IdentitiesOnly $args{identities_only}",
+        "  BatchMode $args{batch_mode}"
+    );
+    push(@file_contents, "  User $args{user}") if $args{user};
+    push(@file_contents, "  IdentityFile $args{identity_file}") if $args{identity_file};
+    push(@file_contents, "  ProxyJump $args{proxy_jump}") if $args{proxy_jump};
+    push(@file_contents, "  StrictHostKeyChecking $args{strict_host_key_checking}") if $args{strict_host_key_checking};
+    assert_script_run("echo \"$_\" >> $config_path", quiet => 1) foreach @file_contents;
+}
+
+=head2 prepare_ssh_config
+
+    prepare_ssh_config(inventory_data=>HASHREF, jump_host=>10.10.10.10, jump_host_user=>'azureadm');
+
+Reads referenced SDAF inventory data and composes F<~/.ssh/config> entry for each host.
+In case of SDAF you need to specify B<jump_host> if you want to set this up on worker VM and access SUT via SSH proxy.
+For an example of an SDAF inventory data structure check B<SYNOPSIS> part of this module.
+
+=over
+
+=item * B<inventory_data> SDAF inventory content in referenced perl data structure.
+
+=item * B<jump_host_ip> hostname, IP address or F<~/.ssh/config> entry pointing to jumphost. Keyless SSH must be working.
+
+=item * B<jump_host_user> SSH login user.
+
+=back
+=cut
+
+sub prepare_ssh_config {
+    my (%args) = @_;
+    foreach ('inventory_data', 'jump_host_ip', 'jump_host_user') {
+        croak "Missing mandatory argument '\$args{$_}'" unless $args{$_};
+    }
+
+    # Add Jumphost first
+    ssh_config_entry_add(
+        entry_name => "deployer_jump $args{jump_host_ip}",
+        user => $args{jump_host_user},
+        hostname => $args{jump_host_ip},
+        identities_only => 'yes',
+        identity_file => $deployer_private_key_path
+    );
+
+    # Add all SUT systems defined in inventory file
+    for my $instance_type (keys(%{$args{inventory_data}})) {
+        my $hosts = $args{inventory_data}->{$instance_type}{hosts};
+        for my $hostname (keys %$hosts) {
+            my $host_data = $hosts->{$hostname};
+            ssh_config_entry_add(
+                entry_name => "$hostname $host_data->{ansible_host}",    # This allows both hostname and IP login
+                user => $host_data->{ansible_user},
+                hostname => $host_data->{ansible_host},
+                identity_file => $sut_private_key_path,
+                identities_only => 'yes',
+                proxy_jump => 'deployer_jump',
+                strict_host_key_checking => 'no'
+            );
+        }
+    }
+    record_info('SSH config', "SSH proxy setup added into '~/.ssh/config':\n" .
+          script_output('cat ~/.ssh/config', quiet => 1));
+}
+
+=head2 verify_ssh_proxy_connection
+
+    verify_ssh_proxy_connection(inventory_data=>HASHREF);
+
+Reads parsed and referenced SDAF inventory data and executes simple C<hostname> command on each SUT to verify the
+connection is working. A check is performed if C<hostname> output is the same as target from inventory file.
+For an example of an SDAF inventory data structure check B<SYNOPSIS> part of this module.
+
+=over
+
+=item * B<inventory_data> SDAF inventory content in referenced perl data structure.
+
+=back
+=cut
+
+sub verify_ssh_proxy_connection {
+    my (%args) = @_;
+    for my $instance_type (keys(%{$args{inventory_data}})) {
+        my $hosts = $args{inventory_data}->{$instance_type}{hosts};
+        for my $hostname (keys %$hosts) {
+            # run simple 'hostname' command on each host
+            my $hostname_output = script_output("ssh $hostname hostname", quiet => 1);
+            die "Hostname returned does not match target host.\nExpected: $hostname\nGot: $hostname_output"
+              unless $hostname_output =~ $hostname;
+            record_info('SSH check', "SSH proxy connection to $hostname: OK");
+        }
+    }
+}

--- a/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
@@ -24,7 +24,12 @@ Please try not to add here complex functions that do much beyond returning a str
 
 =cut
 
+our $deployer_private_key_path = '~/.ssh/id_rsa';
+our $sut_private_key_path = '~/.ssh/sut_id_rsa';
+
 our @EXPORT = qw(
+  $deployer_private_key_path
+  $sut_private_key_path
   homedir
   deployment_dir
   log_dir
@@ -369,4 +374,39 @@ sub get_workload_vnet_code {
     # deployer-vnet_to_workload-vnet
     # if it is too long you might hit name length limit and test ID gets clipped.
     return ($args{job_id});
+}
+
+=head2 get_sdaf_inventory_path
+
+    get_sdaf_inventory_path();
+
+Returns full Ansible inventory filepath respective to deployment type.
+
+=over
+
+=item * B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
+
+=item * B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
+
+=item * B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
+
+=item * B<sap_sid>: SDAF parameter for sap system ID.
+
+=back
+=cut
+
+sub get_sdaf_inventory_path {
+    my (%args) = @_;
+
+    # Argument (%args) validation is done by 'get_sdaf_config_path()'
+    my $config_root_path = get_sdaf_config_path(
+        deployment_type => 'sap_system',
+        sap_sid => $args{sap_sid},
+        env_code => $args{env_code},
+        vnet_code => $args{vnet_code},
+        sdaf_region_code => $args{sdaf_region_code}
+    );
+
+    # file name is hard coded in SDAF
+    return "$config_root_path/$args{sap_sid}_hosts.yaml";
 }

--- a/schedule/sles4sap/sap_deployment_automation_framework/test_hana_sr.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/test_hana_sr.yml
@@ -5,4 +5,5 @@ description: |
 schedule:
   - boot/boot_to_desktop
   - sles4sap/sap_deployment_automation_framework/connect_to_deployer
+  - sles4sap/sap_deployment_automation_framework/prepare_ssh_config
   - sles4sap/sap_deployment_automation_framework/cleanup

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -916,7 +916,7 @@ subtest '[az_keyvault_list]' => sub {
     note("\n --> " . join("\n --> ", @calls));
     ok((any { /az keyvault list/ } @calls), 'Correct composition of the main command');
     ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
-    ok(grep(/--resource_group Arlecchino/, @calls), 'Check for argument "--resource_group"');
+    ok(grep(/--resource-group Arlecchino/, @calls), 'Check for argument "--resource_group"');
     ok(grep(/--query \[\].Pantalone/, @calls), 'Check for argument "--query"');
     ok(grep(/--output json/, @calls), 'Return output in "json" format');
     is(join(' ', @$return_value), 'Arlecchino Pantalone', 'Return correct value');

--- a/t/24_sdaf_naming_convention.t
+++ b/t/24_sdaf_naming_convention.t
@@ -135,4 +135,14 @@ subtest '[get_workload_vnet_code] ' => sub {
     is get_workload_vnet_code(job_id => '0087'), '0087', 'Return correct VNET code defined by named argument';
 };
 
+subtest '[get_tfvars_path] Test passing scenarios' => sub {
+    my $mock_lib = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::naming_conventions', no_auto => 1);
+
+    $mock_lib->redefine(get_sdaf_config_path => sub { return '/ProjectZeta'; });
+
+    is get_sdaf_inventory_path(sap_sid => 'ZETA', env_code => 'AnaheimElectronics', sdaf_region_code => 'AEUG'),
+      '/ProjectZeta/ZETA_hosts.yaml', 'Return correct inventory path.';
+};
+
+
 done_testing;

--- a/t/29_sdaf_inventory_tools.t
+++ b/t/29_sdaf_inventory_tools.t
@@ -1,0 +1,109 @@
+use strict;
+use warnings;
+use Test::Mock::Time;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use testapi;
+use sles4sap::sap_deployment_automation_framework::inventory_tools;
+use Data::Dumper;
+
+
+subtest '[prepare_ssh_config] ' => sub {
+    my $mock = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::inventory_tools', no_auto => 1);
+    my $croak_message;
+    $mock->redefine(croak => sub { $croak_message = $_[0]; die; });
+    $mock->redefine(record_info => sub { return; });
+    my %mandatory_args = (
+        inventory_data => 'Radio GaGa',
+        jump_host_ip => '8.8.8.8',
+        jump_host_user => 'Freddie',
+    );
+    foreach (keys(%mandatory_args)) {
+        my $original_value = $mandatory_args{$_};
+        $mandatory_args{$_} = undef;
+        dies_ok { prepare_ssh_config(%mandatory_args) } "Croak with mandatory argument '$_' undefined";
+        ok($croak_message =~ /$_/, "Verify croak message: $croak_message");
+        $mandatory_args{$_} = $original_value;
+    }
+};
+
+subtest '[prepare_ssh_config] ' => sub {
+    my $mock = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::inventory_tools', no_auto => 1);
+    my $jump_config_content;
+    my $db_host_A_content;
+    my $db_host_B_content;
+
+    $mock->redefine(record_info => sub { return; });
+    $mock->redefine(script_output => sub { return 'I`ve got to break free'; });
+    $mock->redefine(ssh_config_entry_add => sub {
+            $jump_config_content = join(' ', @_) if join(' ', @_) =~ /entry_name deployer_jump/;
+            $db_host_A_content = join(' ', @_) if join(' ', @_) =~ /entry_name John/;
+            $db_host_B_content = join(' ', @_) if join(' ', @_) =~ /entry_name Freddie/;
+            return; });
+
+    my $mock_inventory_data = {
+        'QES_PAS' => {
+            'hosts' => {
+                'Freddie' => {
+                    'ansible_connection' => 'ssh',
+                    'connection_type' => 'key',
+                    'virtual_host' => 'Mercury',
+                    'ansible_user' => 'freddie',
+                    'vm_name' => 'FreddieMercury',
+                    'become_user' => 'root',
+                    'ansible_host' => '10.10.10.2',
+                    'os_type' => 'linux'
+                }
+            },
+            'vars' => undef
+        },
+        'QES_DB' => {
+            'vars' => undef,
+            'hosts' => {
+                'John' => {
+                    'ansible_connection' => 'ssh',
+                    'connection_type' => 'key',
+                    'virtual_host' => 'Deacon',
+                    'ansible_user' => 'john',
+                    'vm_name' => 'JohnDeacon',
+                    'become_user' => 'john',
+                    'ansible_host' => '10.10.10.3',
+                    'os_type' => 'linux'
+                }
+            }
+        }
+    };
+
+    prepare_ssh_config(inventory_data => $mock_inventory_data, jump_host_ip => '127.0.0.1', jump_host_user => 'Freddie');
+    note("\n --> $jump_config_content");
+    ok($jump_config_content =~ /entry_name deployer_jump/, 'Jump host: entry_name');
+    ok($jump_config_content =~ /user Freddie/, 'Jump host: user');
+    ok($jump_config_content =~ /hostname 127.0.0.1/, 'Jump host: hostname');
+    ok($jump_config_content =~ /identities_only yes/, 'Jump host: identities_only');
+    ok($jump_config_content =~ /identity_file/, 'Jump host: identity_file');
+
+    note("\n --> $db_host_A_content");
+    ok($db_host_A_content =~ /entry_name John/, 'DB host A: entry_name');
+    ok($db_host_A_content =~ /user john/, 'DB host A: user');
+    ok($db_host_A_content =~ /hostname 10.10.10.3/, 'DB host A: hostname');
+    ok($db_host_A_content =~ /identities_only yes/, 'DB host A: identities_only');
+    ok($db_host_A_content =~ /identity_file/, 'DB host A: identity_file');
+    ok($db_host_A_content =~ /proxy_jump deployer_jump/, 'DB host A: proxy_jump');
+    ok($db_host_A_content =~ /strict_host_key_checking no/, 'DB host A: strict_host_key_checking');
+
+    note("\n --> $db_host_B_content");
+    ok($db_host_B_content =~ /entry_name Freddie/, 'DB host A: entry_name');
+    ok($db_host_B_content =~ /user freddie/, 'DB host A: user');
+    ok($db_host_B_content =~ /hostname 10.10.10.2/, 'DB host A: hostname');
+    ok($db_host_B_content =~ /identities_only yes/, 'DB host A: identities_only');
+    ok($db_host_B_content =~ /identity_file/, 'DB host A: identity_file');
+    ok($db_host_B_content =~ /proxy_jump deployer_jump/, 'DB host A: proxy_jump');
+    ok($db_host_B_content =~ /strict_host_key_checking no/, 'DB host A: strict_host_key_checking');
+
+
+};
+
+
+done_testing;

--- a/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/connect_to_deployer.pm
@@ -13,6 +13,7 @@ use sles4sap::sap_deployment_automation_framework::deployment
   qw(serial_console_diag_banner az_login sdaf_ssh_key_from_keyvault);
 use sles4sap::sap_deployment_automation_framework::deployment_connector
   qw(get_deployer_vm_name get_deployer_ip find_deployment_id);
+use sles4sap::sap_deployment_automation_framework::naming_conventions qw($deployer_private_key_path);
 use serial_terminal qw(select_serial_terminal);
 
 sub test_flags {
@@ -33,7 +34,8 @@ sub run {
     # This will allow using connect_target_to_serial() without specifying user/host to deployer every time.
     set_var('REDIRECT_DESTINATION_USER', get_var('PUBLIC_CLOUD_USER', 'azureadm'));
     set_var('REDIRECT_DESTINATION_IP', $deployer_ip);    # IP addr to redirect console to
-    sdaf_ssh_key_from_keyvault(key_vault => get_required_var('SDAF_DEPLYOER_KEY_VAULT'));
+    sdaf_ssh_key_from_keyvault(
+        key_vault => get_required_var('SDAF_DEPLYOER_KEY_VAULT'), target_file => $deployer_private_key_path);
     serial_console_diag_banner('Module sdaf_redirect_console_to_deployer.pm : end');
 }
 

--- a/tests/sles4sap/sap_deployment_automation_framework/prepare_ssh_config.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/prepare_ssh_config.pm
@@ -1,0 +1,69 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary:  Executes setup of HanaSR scenario using SDAF ansible playbooks according to:
+#           https://learn.microsoft.com/en-us/azure/sap/automation/tutorial#sap-application-installation
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+use warnings;
+use strict;
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::console_redirection;
+use sles4sap::azure_cli qw(az_keyvault_list);
+use sles4sap::sap_deployment_automation_framework::inventory_tools;
+use sles4sap::sap_deployment_automation_framework::deployment qw(sdaf_ssh_key_from_keyvault);
+use sles4sap::sap_deployment_automation_framework::naming_conventions
+  qw( get_sdaf_inventory_path
+  convert_region_to_short
+  get_workload_vnet_code
+  $sut_private_key_path
+  generate_resource_group_name);
+
+sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    select_serial_terminal;
+
+    # Connect serial to Deployer VM to get inventory file
+    connect_target_to_serial();
+
+    my $jump_host_user = get_required_var('REDIRECT_DESTINATION_USER');
+    my $jump_host_ip = get_required_var('REDIRECT_DESTINATION_IP');
+
+    my $inventory_path = get_sdaf_inventory_path(
+        env_code => get_required_var('SDAF_ENV_CODE'),
+        sdaf_region_code => convert_region_to_short(get_required_var('PUBLIC_CLOUD_REGION')),
+        vnet_code => get_workload_vnet_code(),
+        sap_sid => get_required_var('SAP_SID')
+    );
+    my $inventory_data = read_inventory_file($inventory_path);
+    # From now on all commands will be executed on worker VM
+    disconnect_target_from_serial();
+
+    # Share inventory data between all tests
+    $self->{sdaf_inventory} = $inventory_data;
+
+    my @workload_key_vault = @{az_keyvault_list(
+            resource_group => generate_resource_group_name(deployment_type => 'workload_zone'))};
+    die "There needs to be exactly 1 workload key vault present. Value returned:\n" . join("\n", @workload_key_vault)
+      unless @workload_key_vault == 1;
+
+    sdaf_ssh_key_from_keyvault(key_vault => $workload_key_vault[0], target_file => $sut_private_key_path);
+
+    prepare_ssh_config(
+        inventory_data => $inventory_data,
+        jump_host_ip => $jump_host_ip,
+        jump_host_user => $jump_host_user
+    );
+    # checks SSH connection to each host executing simple command
+    verify_ssh_proxy_connection(inventory_data => $inventory_data);
+}
+
+1;


### PR DESCRIPTION
This PR adds feature for existing SDAF test to create SSH config file on worker 
VM. Deployer VM is set as proxy jump host and this will allow SSH connection 
between worker VM and SUT by executin only one SSH command. It is a first step 
to use `lib/publiccloud` library without `lib/sles4sap/console_redirection.pm`.

- Related ticket: https://jira.suse.com/browse/TEAM-9793
- Verification run: https://openqaworker15.qa.suse.cz/tests/302700#step/prepare_ssh_config/113
