### PR TITLE
virt_autotest: Set up the 2 new purchased machines in OSD as ipmi worker

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -359,7 +359,8 @@ sub set_grub_on_vh {
 sub ipmitool {
     my ($cmd) = @_;
 
-    my @cmd = ('ipmitool', '-I', 'lanplus', '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
+    my $ipmi_options = $bmwqemu::vars{IPMI_OPTIONS} // '-I lanplus';
+    my @cmd = ('ipmitool', split(' ', $ipmi_options), '-H', $bmwqemu::vars{IPMI_HOSTNAME}, '-U', $bmwqemu::vars{IPMI_USER}, '-P', $bmwqemu::vars{IPMI_PASSWORD});
     push(@cmd, split(/ /, $cmd));
 
     my ($stdin, $stdout, $stderr, $ret);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/167890
- Verification run: 
bare-metal5
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/15947566#) PASS
[prj2_host_upgrade_sles15sp6_to_developing_kvm](https://openqa.suse.de/tests/15953728#) PASS
[prj4_guest_upgrade_sles15sp6_on_sles15sp6-kvm](https://openqa.suse.de/tests/15962881#) PASS
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/15953727#) Fail by [bsc#1233225](https://bugzilla.suse.com/show_bug.cgi?id=1233225)
bare-metal6
[prj4_guest_upgrade_sles15sp6_on_sles15sp6-kvm](https://openqa.suse.de/tests/15962880#) PASS