### PR TITLE
xfstests/partition.pm: print autofs and nfs config files

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -380,12 +380,14 @@ sub setup_nfs_server {
         assert_script_run("echo 'MOUNT_NFS_V3=\"yes\"' >> /etc/sysconfig/nfs");
         assert_script_run("echo 'MOUNT_NFS_DEFAULT_PROTOCOL=3' >> /etc/sysconfig/autofs && echo 'OPTIONS=\"-O vers=3\"' >> /etc/sysconfig/autofs");
         assert_script_run("echo '[NFSMount_Global_Options]' >> /etc/nfsmount.conf && echo 'Defaultvers=3' >> /etc/nfsmount.conf && echo 'Nfsvers=3' >> /etc/nfsmount.conf");
+        record_info('autofs config', script_output("cat /etc/sysconfig/autofs"));
         record_info('nfsmount.conf file', script_output("cat /etc/nfsmount.conf"));
     }
     else {
         assert_script_run("sed -i 's/NFSV4LEASETIME=\"\"/NFSV4LEASETIME=\"$nfsgrace\"/' /etc/sysconfig/nfs");
         assert_script_run("echo -e '[nfsd]\\ngrace-time=$nfsgrace\\nlease-time=$nfsgrace' > /etc/nfs.conf.local");
     }
+    record_info('nfs config', script_output("cat /etc/sysconfig/nfs"));
     assert_script_run('exportfs -a && systemctl restart rpcbind && systemctl enable nfs-server.service && systemctl restart nfs-server');
 
 


### PR DESCRIPTION
Just to print `/etc/sysconfig/autofs` and `/etc/sysconfig/nfs` while configuring nfs server.

- Related ticket: https://progress.opensuse.org/issues/168559
- Verification runs: https://openqa.opensuse.org/tests/4637832 and https://openqa.opensuse.org/tests/4637842
