### PR TITLE
sles4sap/publiccloud: avoid extra 'wait_for_ssh' in 'stop_hana'

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -353,7 +353,7 @@ sub wait_hana_node_up {
     Stops HANA database using default or specified method.
     "stop" - stops database using "HDB stop" command.
     "kill" - kills database processes using "HDB -kill" command.
-    "crash" - crashes entire os using "/proc-sysrq-trigger" method.
+    "crash" - crashes entire OS using "/proc/sysrq-trigger" method.
 
 =over
 
@@ -434,6 +434,7 @@ sub stop_hana {
     else {
         my $sapadmin = lc(get_required_var('INSTANCE_SID')) . 'adm';
         $self->run_cmd(cmd => $cmd, runas => $sapadmin, timeout => $timeout);
+        $self->{my_instance}->wait_for_ssh(username => 'cloudadmin', scan_ssh_host_key => 1);
     }
 }
 

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -177,6 +177,9 @@ subtest "[stop_hana]" => sub {
             return; }
     );
     my $self = sles4sap_publiccloud->new();
+    my $mock_pc = Test::MockObject->new();
+    $mock_pc->set_true('wait_for_ssh');
+    $self->{my_instance} = $mock_pc;
 
     set_var('INSTANCE_SID', 'INSTANCE_SIDTEST');
     $self->stop_hana();

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -60,7 +60,6 @@ sub run {
 
     # Stop/kill/crash HANA DB and wait till SSH is again available with pacemaker running.
     $self->stop_hana(method => $takeover_action);
-    $self->{my_instance}->wait_for_ssh(username => 'cloudadmin', scan_ssh_host_key => 1);
 
     # SBD delay is active only after reboot
     if ($takeover_action eq 'crash' || $takeover_action eq 'stop') {

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -64,7 +64,6 @@ sub run {
     $sbd_delay = $self->sbd_delay_formula if $db_action eq 'crash';
 
     $self->stop_hana(method => $db_action);
-    $self->{my_instance}->wait_for_ssh(username => 'cloudadmin', scan_ssh_host_key => 1);
 
     # SBD delay is active only after reboot
     if ($db_action eq 'crash' || $db_action eq 'stop') {


### PR DESCRIPTION
In 'stop_hana', for the 'crash' test scenario, there's no need to run 'wait_for_ssh' because we already have 'wait_hana_node_up'.

This is a follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20539.

- Related ticket: https://jira.suse.com/browse/TEAM-9823
- Needles: none
- Verification run:
msi:
https://openqaworker15.qa.suse.cz/tests/302517 (fail at different place)
https://openqaworker15.qa.suse.cz/tests/302518
https://openqaworker15.qa.suse.cz/tests/302519
https://openqaworker15.qa.suse.cz/tests/302520
sbd:
https://openqaworker15.qa.suse.cz/tests/302587 (fail at different place)
https://openqaworker15.qa.suse.cz/tests/302588
https://openqaworker15.qa.suse.cz/tests/302589
https://openqaworker15.qa.suse.cz/tests/302590
spn:
https://openqaworker15.qa.suse.cz/tests/302591
https://openqaworker15.qa.suse.cz/tests/302592
https://openqaworker15.qa.suse.cz/tests/302593
https://openqaworker15.qa.suse.cz/tests/302594