### PR TITLE
Drop the useless code of substituting module name

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -56,7 +56,7 @@ use warnings;
 
 use utils;
 use power_action_utils qw(prepare_system_shutdown power_action);
-use List::Util qw(first pairmap uniq notall);
+use List::Util qw(first pairmap uniq);
 use qam;
 use maintenance_smelt qw(get_packagebins_in_modules get_incident_packages);
 use testapi;
@@ -206,9 +206,6 @@ sub run {
     # Extract module name from repo url.
     my @modules = split(/,/, $repos);
     foreach (@modules) {
-        # substitue SLES_SAP for LTSS repo at this point is SAP ESPOS
-        $_ =~ s/SAP_(\d+(-SP\d)?)/$1-LTSS/ if is_sle('15+');
-        $_ =~ s/SAP_(\d+(-SP\d)?)/SERVER_$1-LTSS/ if is_sle('=12-sp5') && !get_var('BUILD') =~ /saptune/;
         next if s{http.*SUSE_Updates_(.*)/?}{$1};
         die 'Modules regex failed. Modules could not be extracted from repos variable.';
     }


### PR DESCRIPTION
the name of saptune package update channel will be updated to `*_LTSS*` in `update_install.pm`, but saptune package is not in LTSS update channel, this results in the failure to find saptune rpm binary.
Now substituting the module name is useless, I drop the  related code to fix issue.

- Related ticket: https://jira.suse.com/browse/TEAM-9817
- Needles: None
- Verification run: 
    https://openqa.suse.de/tests/16110212#step/update_install/24 (saptune, NOT in LTSS)
    https://openqa.suse.de/tests/16110213#step/update_install/24 (webkit2gtk3, in LTSS)
    https://openqa.suse.de/tests/16110227#step/update_install/24 (ppc64le, in Public Cloud)
    https://openqa.suse.de/tests/16110231#step/update_install/24 (15-SP6)