### PR TITLE
containers: Remove soft-failure for bsc#1232522

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -101,14 +101,10 @@ sub run {
 
     # Run tests as user
     if ($runtime eq "podman") {
-        if (is_sle('<15-SP5')) {
-            record_soft_failure("bsc#1232522 - buildah security update changes default network mode from slirp4netns to passt for rootless containers");
-        } else {
-            select_user_serial_terminal;
-            record_info('Test as user');
-            run_tests($runtime) if ($runtime eq "podman");
-            select_serial_terminal;
-        }
+        select_user_serial_terminal;
+        record_info('Test as user');
+        run_tests($runtime) if ($runtime eq "podman");
+        select_serial_terminal;
     }
 }
 


### PR DESCRIPTION
Remove soft-failure for bsc#1232522

Do NOT merge til buildah update is shipped to 15-SP3.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1232522
- Verification runs:
  - 15-SP4: https://openqa.suse.de/tests/15930515
  - 15-SP3: TBD