### PR TITLE
schedule/jeos12sp5-main: Add bootloader_uefi to uefi-virtio-vga machine

### DIFF
--- a/schedule/jeos/sle/jeos12sp5-main.yaml
+++ b/schedule/jeos/sle/jeos12sp5-main.yaml
@@ -19,6 +19,8 @@ conditional_schedule:
             'svirt-vmware70':
                 - installation/bootloader_svirt
                 - installation/bootloader_uefi
+            'uefi-virtio-vga':
+                - installation/bootloader_uefi
     efi:
         UEFI:
             '1':


### PR DESCRIPTION
The test jeos-nosb needs this in order to disable Secure Boot in the firmware before executing the test modules.

- Related ticket: https://progress.opensuse.org/issues/95434
