### PR TITLE
Fix ClamAV Test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1734,7 +1734,7 @@ sub load_extra_tests_console {
     loadtest "console/salt" if (is_jeos || is_opensuse);
     loadtest "console/gpg";
     loadtest "console/rsync";
-    loadtest "console/clamav";
+    loadtest "console/clamav" unless is_arm;
     loadtest "console/shells";
     loadtest 'console/sudo';
     # dstat is not in sle12sp1


### PR DESCRIPTION
Don't run on 32-bit ARM, replace vim with urand

- Related ticket: https://progress.opensuse.org/issues/165135
- Verification run: [https://openqa.opensuse.org/tests/4642784](https://openqa.opensuse.org/tests/4642784)