### PR TITLE
Softfail prevalidation for 12sp5

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -33,6 +33,7 @@ use publiccloud::ssh_interactive 'select_host_console';
 use publiccloud::instance;
 use sles4sap;
 use saputils;
+use version_utils 'is_sle';
 
 our @EXPORT = qw(
   run_cmd
@@ -1274,6 +1275,11 @@ sub wait_for_cluster {
         if ($args{max_retries} <= 0) {
             record_info('NOT OK', "Cluster or DB data synchronization issue detected after retrying.");
             $self->display_full_status();
+            # softfail because of bsc#1233026 - if fixed remove the 'if' condition AND the 'use version_utils' from this file
+            if (is_sle('=12-SP5') && $crm_output =~ /TimeoutError/) {
+                record_soft_failure("bsc#1233026 - Error occurred, see previous output: Proceeding despite failure.");
+                return;
+            }
             die "Cluster is not ready after specified retries.";
         }
         sleep($args{wait_time});


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20469 made the test module qesap_prevalidate abort tests earlier when there are failed resources actions in the cluster monitoring output.

This has uncovered a bug in 12-SP5 which is tracked in https://bugzilla.suse.com/show_bug.cgi?id=1233026.

This pr softfails 12sp5 cases, since the error is non-fatal and the bug is going to probably be low-prio, so that it doesn't block our tests.

- Related ticket: https://jira.suse.com/browse/TEAM-9820
- Verification run: 
12sp5, softfail: https://openqa.suse.de/tests/15932702
15, PASS: https://openqa.suse.de/tests/15932703