### PR TITLE
containers: Increase timeout for buildah testsuite

### DIFF
--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -32,7 +32,7 @@ sub run_tests {
     script_run "rm -rf $tmp_dir/buildah_tests.*";
 
     assert_script_run "echo $log_file .. > $log_file";
-    script_run "env BATS_TMPDIR=$tmp_dir TMPDIR=$tmp_dir BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 4200;
+    script_run "env BATS_TMPDIR=$tmp_dir TMPDIR=$tmp_dir BUILDAH_BINARY=/usr/bin/buildah STORAGE_DRIVER=overlay bats --tap tests | tee -a $log_file", 7000;
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 


### PR DESCRIPTION
Increase timeout for buildah_testsuite

- Failed test: https://openqa.suse.de/tests/15931784#step/buildah_integration/266
- Verification run: https://openqa.suse.de/tests/15932761