### PR TITLE
Send_key home each time when deselect patterns

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -332,7 +332,10 @@ sub deselect_pattern {
     @patterns{split(/,/, get_var('EXCLUDE_PATTERNS'))} = ();
     $self->go_to_patterns();
     for my $p (keys %patterns) {
-        my $count = $p =~ 'wsl' ? '40' : '20';
+        # send Home key to avoid some pattern can't be found
+        # on the sequence of exclude patterns
+        send_key 'home';
+        my $count = $p =~ 'wsl|fips' ? '40' : '20';
         send_key_until_needlematch "$p-selected", 'down', $count;
         send_key ' ';    #deselect pattern
         assert_screen 'on-pattern';


### PR DESCRIPTION
##
### Send key home each time when deselect patterns

- Related ticket: https://progress.opensuse.org/issues/164934
- Needles:
    - on-pattern-wsl_base-20241115
    - on-pattern-wsl_gui-20241115
    - on-pattern-wsl_systemd-20241115
    - on-pattern-fips-20241115
    - select_patterns-fips-selected-20241115
    - select_patterns-wsl_base-20241115
    -  select_patterns-wsl_gui-20241115
    -  select_patterns-wsl_systemd-20241115   
    -  select_patterns-fips-20241115
  
- Verification run: 
  -  https://openqa.suse.de/tests/15947315
  - https://openqa.suse.de/tests/15947320
##
