### PR TITLE
Use ovmf sev firmware for SEV/ES guest

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_sev_es_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_sev_es_x86_64.xml
@@ -27,7 +27,7 @@
     <guest_installation_method_others/>
     <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
     <guest_installation_fine_grained/>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/ovmf-x86_64-vars.bin</guest_boot_settings>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-sev.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,loader.stateless=yes</guest_boot_settings>
     <guest_secure_boot>false</guest_secure_boot>
     <guest_os_variant/>
     <guest_storage_path/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_sev_es_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_sev_es_x86_64.xml
@@ -27,7 +27,7 @@
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1</guest_installation_media>
     <guest_installation_fine_grained/>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/ovmf-x86_64-vars.bin</guest_boot_settings>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-sev.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,loader.stateless=yes</guest_boot_settings>
     <guest_secure_boot>false</guest_secure_boot>
     <guest_os_variant/>
     <guest_storage_path/>


### PR DESCRIPTION
* **Use** ovmf sev firmware ovmf-x86_64-sev.bin for SEV/ES guest.

* **Verification Runs:**
  * [ovmf sev firmware works with 15sp6 guest](https://openqa.suse.de/tests/15939406)
  * [ovmf sev firmware works with 15sp7 guest](https://openqa.suse.de/tests/15939407)