### PR TITLE
Revert "containers: Remove soft-failure for bsc#1232522"

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -101,10 +101,14 @@ sub run {
 
     # Run tests as user
     if ($runtime eq "podman") {
-        select_user_serial_terminal;
-        record_info('Test as user');
-        run_tests($runtime) if ($runtime eq "podman");
-        select_serial_terminal;
+        if (is_sle('<15-SP5')) {
+            record_soft_failure("bsc#1232522 - buildah security update changes default network mode from slirp4netns to passt for rootless containers");
+        } else {
+            select_user_serial_terminal;
+            record_info('Test as user');
+            run_tests($runtime) if ($runtime eq "podman");
+            select_serial_terminal;
+        }
     }
 }
 


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20619 was merged before the update for buildah hit the repos.

- Related ticket: https://progress.opensuse.org/issues/169888
- Verification run: not needed 