### PR TITLE
Increase timeout for nmcli device disconnect

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1197,9 +1197,8 @@ sub set_hostname {
                 next if ($dev eq 'lo');
                 next if !($line =~ /connected/);
 
-                # Default timeout (10 seconds) may be too short with qemu NO kvm, so increase to 20s - poo#131366
-                my $nmcli = get_var('QEMU_NO_KVM') ? 'nmcli -w 20' : 'nmcli';
-                assert_script_run "$nmcli device disconnect $dev";
+                # poo#169726
+                assert_script_run("nmcli -w 60 device disconnect $dev");
                 assert_script_run 'nmcli device connect ' . $dev;
             }
 


### PR DESCRIPTION
 Increased timeout for nmcli device disconnect $dev 

- Related ticket: https://progress.opensuse.org/issues/169726
- Verification run: https://openqa.suse.de/tests/overview/?build=cedvid%2Fos-autoinst-distri-opensuse%2320634
