### PR TITLE
containers: Remove soft-failure for bsc#1232522

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021-2023 SUSE LLC
+# Copyright 2021-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: buildah
@@ -102,14 +102,10 @@ sub run {
 
     # Run tests as user
     if ($runtime eq "podman" && !is_public_cloud && !is_sle('<15-SP3') && !is_svirt) {
-        if (is_sle('<15-SP4')) {
-            record_soft_failure("bsc#1232522 - buildah security update changes default network mode from slirp4netns to passt for rootless containers");
-        } else {
-            select_user_serial_terminal;
-            record_info('Test as user');
-            run_tests($runtime) if ($runtime eq "podman");
-            select_serial_terminal;
-        }
+        select_user_serial_terminal;
+        record_info('Test as user');
+        run_tests($runtime);
+        select_serial_terminal;
     }
 }
 


### PR DESCRIPTION
Remove soft-failure for bsc#1232522

- Related ticket: https://progress.opensuse.org/issues/169075
- Verification runs:
  - 15-SP3: https://openqa.suse.de/tests/16202768
  - 15-SP4: https://openqa.suse.de/tests/15997537
