### PR TITLE
ltp: Add reconnect_mgmt_console to prepare_kernel_base

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -80,6 +80,7 @@ sub prepare_kernel_base {
     zypper_call("in -l kernel-default-base", exitcode => [0, 100, 101, 102, 103], timeout => 700);
     check_kernel_package('kernel-default-base');
     power_action('reboot', textmode => 1);
+    reconnect_mgmt_console if is_pvm;
     boot_to_console($self);
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/169942
- Needles: 
- Verification run:  https://openqa.suse.de/tests/15942681#step/update_kernel/30 (console is reconnected, failure is not related)
