### PR TITLE
Fix the separator issue, support multi guest test

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -1270,7 +1270,7 @@ sub get_guest_regcode {
     my $count = ($args{separator} eq '|' ? scalar(split("\\$args{separator}", $guest)) : scalar(split("$args{separator}", $guest)));
     $regcode = join("$args{separator}", (get_var("SCC_REGCODE", "")) x $count) if (!$regcode);
     if (!$regcode_ltss) {
-        my @guest_parts = split($args{separator}, $guest);
+        my @guest_parts = $args{separator} eq '|' ? split("\\$args{separator}", $guest) : split("$args{separator}", $guest);
         my @regcode_ltss_parts;
         for my $part (@guest_parts) {
             push @regcode_ltss_parts, ($part =~ /12/ ? get_var("SCC_REGCODE_LTSS_12", "") : $part =~ /15/ ? get_var("SCC_REGCODE_LTSS_15", "") : "");


### PR DESCRIPTION
Issue Description:
When attempting to install a guest, the LTSS (Long Term Service Support) registration code cannot be get. Instead, it displays an incorrect or empty string '-E "|||||||||||||"'.


- Related ticket: https://progress.opensuse.org/issues/169678
- Needles: N/A
- Verification run: 
       - [multi-guest test](http://openqa.qa2.suse.asia/tests/80419) with '|'
       - [multi-guest test](http://openqa.qa2.suse.asia/tests/80465) with ','
       - [one guest test](http://openqa.qa2.suse.asia/tests/80466)
