### PR TITLE
Improve restart of NetworkManager

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -241,7 +241,7 @@ sub restart_networking {
         # Wait until the connections are configured
         my $expected_nm_connectivity = get_var('EXPECTED_NM_CONNECTIVITY', 'full');
         if ($expected_nm_connectivity ne 'none') {
-            assert_script_run "until nmcli networking connectivity check | tee /dev/stderr | grep '$expected_nm_connectivity'; do sleep 10; done";
+            assert_script_run "timeout 90 bash -c \"until nmcli networking connectivity check | tee /dev/stderr | grep '$expected_nm_connectivity'; do sleep 10; done\"";
         }
     } else {
         assert_script_run 'rcnetwork restart';

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -241,7 +241,7 @@ sub restart_networking {
         # Wait until the connections are configured
         my $expected_nm_connectivity = get_var('EXPECTED_NM_CONNECTIVITY', 'full');
         if ($expected_nm_connectivity ne 'none') {
-            assert_script_run "timeout 90 bash -c \"until nmcli networking connectivity check | tee /dev/stderr | grep '$expected_nm_connectivity'; do sleep 10; done\"";
+            assert_script_run "timeout 90 bash -c \"until nmcli networking connectivity check | tee /dev/stderr | grep -E '$expected_nm_connectivity'; do sleep 10; done\"";
         }
     } else {
         assert_script_run 'rcnetwork restart';


### PR DESCRIPTION
Alternative approach to solve https://progress.opensuse.org/issues/169531 - we don't really *need* full (the default if `EXPECTED_NM_CONNECTIVITY` is not set) network connectivity in our test  but also don't care if we have it so we need to expand the test to be able to check multiple values.

The timeout was mainly added to avoid confusing additional output after the test already finished like e.g. visible in https://openqa.opensuse.org/tests/4625960#step/setup_multimachine/83

Validation runs:

**rsync-server**/**rsync-client**:
* https://openqa.opensuse.org/tests/4667626 🟢
* https://openqa.opensuse.org/tests/4667627 🟢

**ping_server**/**ping_client**:
* https://openqa.opensuse.org/tests/4667630 🟢
* https://openqa.opensuse.org/tests/4667629 🟢

**qam-mail-server-thunderbird**/**qam-mail-thunderbird**:
* https://openqa.suse.de/tests/16025414 🟢
* https://openqa.suse.de/tests/16025415 🟢

**yast2_nfs_v3_server**/**yast2_nfs_v3_client**:
* https://openqa.opensuse.org/tests/4667631 🟢
* https://openqa.opensuse.org/tests/4667632 🟢

**yast2_nfs_v4_server**/**yast2_nfs_v4_client**:
* https://openqa.opensuse.org/tests/4667633 🟢
* https://openqa.opensuse.org/tests/4667634 🟡