### PR TITLE
Add 'none' Condition for Convenient Testing in Package Update Logic

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2387,10 +2387,12 @@ sub set_mu_virt_vars {
     $BUILD =~ /^:(\d+):([^:]+)$/im;
 
     die "BUILD value is $BUILD, but does not match required format." if (!$2);
-
     my $_pkg = $2;
     my $_update_package = '';
-    if ($_pkg =~ /qemu|xen|virt-manager|libguestfs|libslirp|open-vm-tools/) {
+    # If $_pkg contains none, it is for ease of functional testing when no incidents are coming.
+    if ($_pkg =~ /none/) {
+        $_update_package = '';
+    } elsif ($_pkg =~ /qemu|xen|virt-manager|libguestfs|libslirp|open-vm-tools/) {
         $_update_package = $_pkg;
     } elsif ($_pkg =~ /libvirt/) {
         $_update_package = 'libvirt-client';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/169999
- Needles: N/A
- Verification run: [Package is none](http://openqa.qam.suse.cz/tests/81639)
                               [ another VR test when package is none](http://openqa.qam.suse.cz/tests/81569#step/kernel/1) please ignore failure afterwards.
