### PR TITLE
Quick fix for iscsi_client on SP6 (final version)

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -42,7 +42,7 @@ sub initiator_service_tab {
                 after_reboot => {start_on_boot => 'alt-b'}
             );
         } else {
-            if (is_sle(`=15-SP6`)) {
+            if (is_sle('=15-SP6')) {
                 change_service_configuration(
                     after_writing => {start => 'alt-t'},
                     after_reboot => {start_on_demand => 'alt-a'}
@@ -69,7 +69,7 @@ sub initiator_discovered_targets_tab {
     }
     assert_screen 'iscsi-discovered-targets', 120;
     # press discovery button
-    if (is_sle(`=15-SP6`)) {
+    if (is_sle('=15-SP6')) {
         send_key "alt-i";
     } else {
         send_key "alt-d";


### PR DESCRIPTION
- related ticket: https://progress.opensuse.org/issues/169840

- Needles: Created 2 new needles so that the changed hotkeys match
- Verification run: )
  - [SP6 MU that now passes](https://openqa.suse.de/tests/15952937)
  - [SP5 MU that should not get broken by the changes](https://openqa.suse.de/tests/15952938)

New PR because [the first PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20654) still had some typos. 