### PR TITLE
Fix use of unitialized value while splitting UPDATE_ADD_CONFLICT

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -48,7 +48,7 @@
 #     run install patch with --replacefiles, not enabled by default
 #     would hide unintended conflict
 #
-# Maintainer: Ondřej Súkup <osukup@suse.cz>, Anton Pappas <apappas@suse.com>
+# Maintainer: QE Core <qe-core@suse.de>, QE SAP <qe-sap@suse.de>
 
 use base "opensusebasetest";
 use strict;
@@ -248,9 +248,8 @@ sub run {
         my %patch_bins = %bins;
         my (@patch_l2, @patch_l3, @patch_unsupported, @update_conflicts);
         my @conflicts = is_sle('<=12-SP5') ? @conflicting_packages_sle12 : @conflicting_packages;
-        foreach (split(/,/, get_var('UPDATE_ADD_CONFLICT'))) {
-            push(@conflicts, $_);
-        }
+        push(@conflicts, split(/,/, get_var('UPDATE_ADD_CONFLICT'))) if (defined get_var('UPDATE_ADD_CONFLICT'));
+
         # Make sure on SLE 15+ zyppper 1.14+ with '--force-resolution --solver-focus Update' patched binaries are installed
         my $solver_focus = $zypper_version >= 14 ? '--force-resolution --solver-focus Update ' : '';
 


### PR DESCRIPTION
We get a "Use of uninitialized value in split" warning in while splitting the UPDATE_ADD_CONFLICT variable as this is most often not set. This is fixed by splitting only when the variable is defined.

Additionally the loop was removed as `push` gets lists as arguments and `split` returns the list in list context.

- Related Ticket: poo#170005
- Verification run: 
[15-SP6](https://openqaworker15.qa.suse.cz/tests/302993)  [15-SP5](http://openqaworker15.qa.suse.cz/tests/304468)[15-SP4](http://openqaworker15.qa.suse.cz/tests/304465) [15-SP2](http://openqaworker15.qa.suse.cz/tests/304464) [12-SP5](http://openqaworker15.qa.suse.cz/tests/304466)