### PR TITLE
Move wait_still_screen to the start of the loop

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -103,6 +103,7 @@ sub run {
     send_key $cmd{next};
 
     while (1) {
+        wait_still_screen 1;    # Slow down the loop
         assert_screen [qw(sap-wizard-disk-selection-warning sap-wizard-disk-selection sap-wizard-partition-issues sap-wizard-continue-installation sap-product-installation)], no_wait => 1;
         last if match_has_tag 'sap-product-installation';
         send_key $cmd{next} if match_has_tag 'sap-wizard-disk-selection-warning';    # A warning can be shown
@@ -112,7 +113,6 @@ sub run {
         }
         send_key 'alt-o' if match_has_tag 'sap-wizard-partition-issues';
         send_key 'alt-y' if match_has_tag 'sap-wizard-continue-installation';
-        wait_still_screen 1;    # Slow down the loop
     }
 
     if (check_var('DESKTOP', 'textmode')) {


### PR DESCRIPTION
There is a loop in the `sles4sap/wizard_hana_install` test module, which cycles until the `sap-product-installation` needle matches. On SUTs with only one disk, this is a good solution as it allows the test to continue faster, but on SUTs with more disks, it's possible that the dialog prompting the user to select the disk where HANA is going to be installed takes a few seconds to appear, which can cause the module to wrongly match with `sap-product-installation` which is the window behind the disk selection dialog.

This commit moves the `wait_still_screen` call from the end of the loop to the start of the same loop. Idea is that module will wait until screen settles before attempting to match either the disk selection dialog or the `sap-product-installation` needle, giving it more time to wait for the disk selection dialog to be shown.

- Failed Job: https://openqa.suse.de/tests/15963698#step/wizard_hana_install/47
- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/a2adc6350ebb6abfeb6fefae495fe802b1888ab3

# Verification runs

- 15-SP7 on ipmi-nvdimm: https://openqa.suse.de/tests/15976699 :green_circle: 
- 15-SP7 gnome on qemu_x86-64: http://openqa.suse.de/tests/15981215 :green_circle: 
- 15-SP7 textmode on qemu_x86_64: http://openqa.suse.de/tests/15981216 :green_circle: 
- 15-SP6 QR gnome: http://openqa.suse.de/tests/15981237 :green_circle: 
- 15-SP6 QR textmode: http://openqa.suse.de/tests/15981239 :green_circle: 
- 15-SP6 QAM: http://openqa.suse.de/tests/15981235 :green_circle: 
- 15-SP5 QAM: http://openqa.suse.de/tests/15981233 :green_circle: 
- 15-SP4 QAM: http://openqa.suse.de/tests/15981228 :green_circle: 
- 15-SP3 QAM: http://openqa.suse.de/tests/15981225 :green_circle: 
- 15-SP2 QAM: http://openqa.suse.de/tests/15981223 :green_circle: 
- 12-SP5 QAM: https://openqa.suse.de/tests/15981221 :green_circle: 
