### PR TITLE
evolution_prepare_servers: Remove workaound module

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -30,14 +30,12 @@ sub run() {
 
     if (check_var('SLE_PRODUCT', 'sled') || get_var('DOVECOT_REPO')) {
         my $dovecot_repo = get_required_var("DOVECOT_REPO");
-        my $version = get_var('VERSION');
         # Add dovecot repository and install dovecot
         zypper_call("ar -f ${dovecot_repo} dovecot_repo");
-        zypper_call("ar -f http://dist.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/$version/x86_64/update/ server_applications");
 
         zypper_call("--gpg-auto-import-keys ref");
         zypper_call("in dovecot 'openssl(cli)'", exitcode => [0, 102, 103]);
-        zypper_call("rr dovecot_repo server_applications");
+        zypper_call("rr dovecot_repo");
     } else {
         if (is_opensuse) {
             # exim is installed by default in openSUSE, but we need postfix


### PR DESCRIPTION
dovecot23 package is fixed in the dovecot repo
ce38026a36ffc43f8bebf03c8e81e5686c603fe6

- Related ticket: https://progress.opensuse.org/issues/170035
- Verification run: https://openqa.suse.de/tests/15987474