### PR TITLE
containers: Introduce OCI_RUNTIME

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -42,6 +42,29 @@ sub activate_containers_module {
     record_info('SUSEConnect', script_output_retry('SUSEConnect --status-text', timeout => 240, retry => 3, delay => 60));
 }
 
+sub install_oci_runtime {
+    my $runtime = shift;
+
+    my $oci_runtime = get_var("OCI_RUNTIME");
+    return if (!$oci_runtime);
+
+    my $template = ($runtime eq "podman") ? "{{ .Host.OCIRuntime.Name }}" : "{{ .DefaultRuntime }}";
+    my $use_runtime = script_output("$runtime info -f '$template'");
+
+    if ($oci_runtime ne $use_runtime) {
+        record_info("OCI runtime", "$use_runtime -> $oci_runtime");
+        zypper_call "in $oci_runtime" if (script_run("which $oci_runtime") != 0);
+        if ($runtime eq "podman") {
+            script_run "mkdir /etc/containers/containers.conf.d";
+            assert_script_run "echo -e '[engine]\nruntime=\"$oci_runtime\"' >> /etc/containers/containers.conf.d/engine.conf";
+        } else {
+            assert_script_run "sed -i 's%^{%&\"default-runtime\":\"$oci_runtime\",\"runtimes\":{\"$oci_runtime\":{\"path\":\"/usr/bin/$oci_runtime\"}},%' /etc/docker/daemon.json";
+            systemctl('restart docker', timeout => 180);
+        }
+        $use_runtime = script_output("$runtime info -f '$template'");
+        die "Could not change OCI runtime to $oci_runtime" if ($oci_runtime ne $use_runtime);
+    }
+}
 
 sub install_podman_when_needed {
     my $host_os = shift;
@@ -55,8 +78,8 @@ sub install_podman_when_needed {
             # We may run openSUSE with DISTRI=sle and opensuse doesn't have SUSEConnect
             activate_containers_module if $host_os =~ 'sle';
             push(@pkgs, 'podman-cni-config') if is_jeos() && is_sle('<=15-SP2');    # 1217509#c8
-            push(@pkgs, 'apparmor-parser') if is_leap("=15.1");    # bsc#1123387
             zypper_call "in @pkgs";
+            install_oci_runtime("podman");
         }
     }
     record_info('podman', script_output('podman info'));
@@ -117,6 +140,7 @@ sub install_docker_when_needed {
     systemctl('start docker', timeout => 180);
     systemctl('is-active docker');
     systemctl('status docker', timeout => 120);
+    install_oci_runtime("docker") if ($host_os =~ /sle|opensuse/);
     record_info('docker', script_output('docker info'));
 }
 

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -27,10 +27,8 @@ sub configure_insecure_registries {
     # The debug output is messing with terminal in migration tests
     my $debug = (get_var('UPGRADE')) ? 'false' : 'true';
     # Allow our internal 'insecure' registry only if REGISTRY variable is set
-    my $str = '{ \"debug\": ' . $debug;
-    $str .= get_var('REGISTRY') ? ', \"insecure-registries\" : [\"' . $registry . '\"] }' : '}';
-    my $config = script_output("echo $str | tee /etc/docker/daemon.json");
-    record_info('daemon.json', $config);
+    assert_script_run "sed -i 's%^{%&\"debug\":$debug,\"insecure-registries\":[\"$registry\"],%' /etc/docker/daemon.json";
+    record_info('daemon.json', script_output("cat /etc/docker/daemon.json"));
     systemctl('restart docker');
 }
 

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -51,7 +51,7 @@ sub _sanity_test_btrfs {
             die "Expected storage driver for this docker version is 'overlay2', got '$storage'";
         }
         assert_script_run('docker system prune -af');
-        assert_script_run(q[sed -i 's/{/{ "storage-driver": "btrfs",/' /etc/docker/daemon.json]);
+        assert_script_run(q[sed -i 's/^{/{ "storage-driver": "btrfs",/' /etc/docker/daemon.json]);
         systemctl('restart docker');
     } else {
         if ($storage ne 'btrfs') {

--- a/variables.md
+++ b/variables.md
@@ -163,6 +163,7 @@ NOAUTOLOGIN | boolean | false | Indicates disabled auto login.
 NOIMAGES |||
 NOLOGS | boolean | false | Do not collect logs if set to true. Handy during development.
 NVIDIA_REPO | string | '' | Define the external repo for nvidia driver. Used by `nvidia.pm` module.
+OCI_RUNTIME | string | '' | Define the OCI runtime to use in container tests, if set.
 OPENSHIFT_CONFIG_REPO | string | '' | Git repo of the OpenShift configuration and packages needed by tests/containers/openshift_setup.pm. 
 OPT_KERNEL_PARAMS | string | Specify optional kernel command line parameters on bootloader settings page of the installer.
 PHUB_READY | boolean | true | Indicates PackageHub is available, it may be not ready in early development phase[Before Beta].


### PR DESCRIPTION
Introduce OCI_RUNTIME to test different OCI runtimes.

- Related ticket: https://progress.opensuse.org/issues/169639
- Verification runs:
  - TW: podman w/ `OCI_RUNTIME=runc` https://openqa.opensuse.org/tests/4664555
  - TW: docker w/ `OCI_RUNTIME=crun` https://openqa.opensuse.org/tests/4664653