### PR TITLE
bootloader_svirt: Don't copy image from NFS datastore

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -71,9 +71,7 @@ sub run {
         $svirt->get_cmd_output("set -x; rm -f ${vmware_openqa_datastore}*${name}*", {domain => 'sshVMwareServer'});
     }
 
-    # Workaround before fix in svirt (https://github.com/os-autoinst/os-autoinst/pull/901) is deployed
     my $n = get_var('NUMDISKS', 1);
-    set_var('NUMDISKS', defined get_var('RAIDLEVEL') ? 4 : $n);
 
     my $xenconsole = "hvc0";
     if (!get_var('SP2ORLATER')) {

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -144,9 +144,7 @@ sub run {
                 $hddpath = "$vmware_openqa_datastore/$hdd" =~ s/vmdk\.xz/vmdk/r;
                 # do nothing if the image is already unpacked in datastore
                 if ($svirt->run_cmd("test -e $hddpath", domain => 'sshVMwareServer')) {
-                    my $ret = $svirt->run_cmd("cp $nfs_ro $vmware_openqa_datastore", domain => 'sshVMwareServer');
-                    die "Image copy to datastore failed!\n" if $ret;
-                    $ret = $svirt->run_cmd("xz --decompress --keep --verbose $vmware_openqa_datastore/$hdd", domain => 'sshVMwareServer');
+                    my $ret = $svirt->run_cmd("xz --decompress --keep --verbose $vmware_openqa_datastore/$hdd", domain => 'sshVMwareServer');
                     die "Image decompress in datastore failed!\n" if $ret;
                 }
             }


### PR DESCRIPTION
The svirt os-autoinst backend already takes care of copying the assets, therefore remove the unneeded code.

- Related ticket: https://progress.opensuse.org/issues/159579
- Verification run: https://openqa.suse.de/tests/16001344#step/bootloader_svirt/32 (failures are unrelated to PR)