### PR TITLE
Increase timeout for nmcli device disconnect

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1203,8 +1203,11 @@ sub set_hostname {
                 next if ($dev eq 'lo');
                 next if !($line =~ /connected/);
 
-                # poo#169726
-                assert_script_run("nmcli -w 60 device disconnect $dev");
+                # poo#169726 Increasing timeout to 120s and adding DEBUG logs for future investigation
+                script_run("nmcli general logging level DEBUG");
+                assert_script_run("nmcli -w 120 device disconnect $dev");
+                script_run("journalctl -u NetworkManager -b >> /var/log/nmcli_logs");
+                record_info("Logs", script_output("cat /var/log/nmcli_logs"));
                 assert_script_run 'nmcli device connect ' . $dev;
             }
 


### PR DESCRIPTION
I am increasing the timeout due to timeout issues on certain workers.
Also added DEBUG logs from NetworkManager for future investigation.

- Related ticket: https://progress.opensuse.org/issues/169726
- Verification run: https://openqa.suse.de/tests/overview?build=cedvid%2Fos-autoinst-distri-opensuse%2320671