### PR TITLE
PC: slem_basic: Don't clutter AVC messages with SSH messages

### DIFF
--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -30,11 +30,11 @@ sub check_avc {
 
     my $instance = $self->{my_instance};
     # Read the Access Vector Cache to check for SELinux denials
-    my $avc = $instance->ssh_script_output(cmd => 'sudo ausearch -ts boot -m avc --format raw', proceed_on_failure => 1, ssh_opts => '-t');
+    my $avc = $instance->ssh_script_output(cmd => 'sudo ausearch -ts boot -m avc --format raw', proceed_on_failure => 1, ssh_opts => '-t -o ControlPath=none');
     record_info("AVC at boot", $avc);
 
     ## Gain better formatted logs and upload them for further investigation
-    $instance->ssh_script_run(cmd => 'sudo ausearch -ts boot -m avc > ausearch.txt', ssh_opts => '-t');    # ausearch fails if there are no matches
+    $instance->ssh_script_run(cmd => 'sudo ausearch -ts boot -m avc > ausearch.txt', ssh_opts => '-t -o ControlPath=none'); # ausearch fails if there are no matches
     assert_script_run("scp " . $instance->username() . "@" . $instance->public_ip . ":ausearch.txt ausearch.txt");
     upload_logs("ausearch.txt");
 


### PR DESCRIPTION
The AVC checkers fail because of `Shared connection to closed` messages but those messsages are not hidable because of pseudo terminal `ssh -t` required by the `ausearch` utility.

- Verification run: https://pdostal-server.suse.cz/tests/7768#step/slem_basic/31
