### PR TITLE
Backport soft-fails from SL Micro 6.1 to Leap Micro

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -525,7 +525,7 @@
         "description": "plugin /usr/sbin/sedispatch terminated unexpectedly",
         "products": {
             "sle-micro": ["5.4" , "5.5", "6.0", "6.1"],
-            "leap-micro": [ "5.5" ]
+            "leap-micro": [ "5.5", "6.0", "6.1"]
         },
         "type": "bug"
     },

--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -35,7 +35,7 @@ sub run {
     my $left_sectors = 0;
     if ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow|SelfInstall/) {
         $left_sectors = 2048;
-    } elsif (is_sle_micro("6.0+") && is_aarch64) {
+    } elsif ((is_sle_micro("6.0+") or is_leap_micro("6.0+")) && is_aarch64) {
         $left_sectors = 0 if (get_var("HDD_1") =~ /qcow2/);
         $left_sectors = 4062 if (get_var("ISO") =~ /SelfInstall/);
         record_soft_failure "bsc#1220722: no unpartitioned space left on aarch64";


### PR DESCRIPTION
Ensure that Leap Micro 6.1 follows same soft fails as SLE Micro 6.1

* bsc#1215377: sedispatch terminated unexpectedly
* bsc#1220722: no unpartitioned space left on aarch64

Test run for image checks soft-fail bsc#1220722: https://openqa.opensuse.org/tests/4667692
Test run for sedispatch soft-fail bsc#1215377: https://openqa.opensuse.org/tests/4667694