### PR TITLE
Update autoyast profiles of textmode all patterns by removing fips

### DIFF
--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_aarch64.xml
@@ -62,7 +62,6 @@ exit 0
       <pattern>enhanced_base</pattern>
       <pattern>enhanced_base-32bit</pattern>
       <pattern>file_server</pattern>
-      <pattern>fips</pattern>
       <pattern>fonts</pattern>
       <pattern>gateway_server</pattern>
       <pattern>kvm_server</pattern>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_s390x.xml
@@ -84,7 +84,6 @@ exit 0
       <pattern>documentation</pattern>
       <pattern>enhanced_base</pattern>
       <pattern>file_server</pattern>
-      <pattern>fips</pattern>
       <pattern>fonts</pattern>
       <pattern>gateway_server</pattern>
       <pattern>hwcrypto</pattern>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_x86_64.xml
@@ -62,7 +62,6 @@ exit 0
       <pattern>enhanced_base</pattern>
       <pattern>enhanced_base-32bit</pattern>
       <pattern>file_server</pattern>
-      <pattern>fips</pattern>
       <pattern>fonts</pattern>
       <pattern>gateway_server</pattern>
       <pattern>kvm_server</pattern>
@@ -84,6 +83,7 @@ exit 0
       <pattern>xen_tools</pattern>
       <pattern>yast2_basis</pattern>
       <pattern>yast2_desktop</pattern>
+      <pattern>yast2_server</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>


### PR DESCRIPTION
Update autoyast profiles of textmode all patterns by removing fips, and add a missed pattern of yast2_server.

- Related ticket: https://progress.opensuse.org/issues/166274
- Needles: n/a
- Verification run: [support images](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=20241124-1&groupid=576); [migration jobs](https://openqa.suse.de/tests/overview?arch=x86_64%2Cs390x%2Caarch64&flavor=&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=&distri=sle&version=15-SP7&build=41.1&groupid=576#)
- Related mr: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/379#note_694883
