### PR TITLE
LTP: Allow to reboot after each test (LTP_REBOOT_AFTER_TEST=1)

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -521,6 +521,10 @@ will be used.
 
 Overrides the official LTP GitHub repository URL.
 
+=head2 LTP_INSTALL_REBOOT
+
+Reboot SUT after LTP installation.
+
 =head2 GRUB_PARAM
 
 Append custom group entries with appended group param via


### PR DESCRIPTION
Add LTP_REBOOT_AFTER_TEST=1 variable to allow to reboot after each test (needed for certain tests, e.g. IMA).

Related ticket: https://progress.opensuse.org/issues/159045

Verification run: 
* https://openqa.suse.de/tests/overview?build=pevik%2Fos-autoinst-distri-opensuse%23LTP_REBOOT_AFTER_TEST 
   (NOTE: `ltp_ima_reboot` and `ltp_ima_selinux` fail on sle micro due missing support for installing LTP from git)
* https://openqa.opensuse.org/tests/overview?build=pevik%2Fos-autoinst-distri-opensuse%23LTP_REBOOT_AFTER_TEST