### PR TITLE
handle oomath tip screen

### DIFF
--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -29,6 +29,10 @@ sub run {
     # See https://progress.opensuse.org/issues/156628
     assert_and_click "oomath-textfield-ready";
 
+    if (check_screen "test-oomath-tip") {
+        assert_and_click "test-oomath-tip";
+    }
+
     # be more resilient during the automatic evaluation of formulas to prevent
     # mistyping with slow typing and retrying.
     my $retries = 7;


### PR DESCRIPTION
oomath has a new tip screen, close it when it appears so test can continue as usual


- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/5d3d37fbf2e5514c769829175e267375d2d18121
- Verification run: [openqa.mypersonalinstance.de/tests/xyz#step/module/x](https://openqa.opensuse.org/tests/4669804)
