### PR TITLE
WIP: Fix lslic incorrect parameter

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -236,7 +236,7 @@ sub boot_hmc_pvm {
 
     # Print the machine details before anything else, Firmware name might be useful when reporting bugs
     record_info("HMC machine details", "See the next screen to get details on $hmc_machine_name");
-    enter_cmd "lslic -m $hmc_machine_name -t syspower | sed 's/,/\\n/g'";
+    enter_cmd "lslic -m $hmc_machine_name -t sys | sed 's/,/\\n/g'";
 
     # Fail the job when a lpar is not available
     die 'The managed system is not available' if check_screen('lpar_manage_status_unavailable', 3);


### PR DESCRIPTION
-t syspower cannot work in the latest HMC version, especially for POWER10, it is not mentioned in manual or help of lslic and got the failure information, so suggest using `-t sys` replacing `-t syspower`

- Related ticket: https://progress.opensuse.org/issues/170455
- Needles: N/A
- Verification run: N/A
