### PR TITLE
Improve the code when deregister ltss module

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -110,8 +110,8 @@ sub deregister_dropped_modules {
     return unless ((get_var('DROPPED_MODULES')) || ((get_var('SCC_ADDONS', '') =~ /ltss/) && (get_var('SCC_ADDONS', '') !~ /ltss_es/)));
 
     my $droplist = get_var('DROPPED_MODULES', '');
-    $droplist .= ',ltss' if (get_var('SCC_ADDONS', '') =~ /ltss/);
     my @all_addons = grep($_, split(/,/, get_var('SCC_ADDONS', '')));
+    $droplist .= ',ltss' if (grep { $_ eq 'ltss' } @all_addons);
     for my $name (grep($_, split(/,/, $droplist))) {
         record_info "deregister $name", "deregister $name module and remove it from SCC_ADDONS";
         if ($name eq 'ltss') {


### PR DESCRIPTION
When `SCC_ADDONS` include `ltss_es`, it matches the regex `/ltss/`, but we should not deregister it because there is no LTSS module added. It will cause the job fails. So change the code, only `SCC_ADDONS` includes 'ltss', then do deregister.

Related: https://jira.suse.com/browse/TEAM-9865

VRs:
   LTSS:
       offline-scc: : https://openqa.suse.de/tests/16036668#step/patch_sle/45  (Passed)
       offline-dvd:  https://openqa.suse.de/tests/16036665#step/patch_sle/45  (Passed)
   LTSS-ES:
       offline-scc: https://openqa.suse.de/tests/16036671#step/patch_sle/42   (Passed)
       offline-dvd: https://openqa.suse.de/tests/16036672#step/patch_sle/42 (Passed)
        