### PR TITLE
xfstests: Fix fs_stat log path contain dir issue

### DIFF
--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -472,26 +472,16 @@ sub collect_fs_status {
     }
     if ($fstype eq 'xfs') {
         $cmd = <<END_CMD;
-echo "==> /sys/fs/$fstype/stats/stats <==" > $LOG_DIR/$category/$num.fs_stat
-cat /sys/fs/$fstype/stats/stats >> $LOG_DIR/$category/$num.fs_stat
-tail -n +1 /sys/fs/$fstype/*/log/* >> $LOG_DIR/$category/$num.fs_stat
-tail -n +1 /sys/fs/$fstype/*/stats/stats >> $LOG_DIR/$category/$num.fs_stat
-xfs_info $TEST_FOLDER > $LOG_DIR/$category/$num.xfsinfo
+find /sys/fs/$fstype/ -type f -exec tail -n +1 {} + >> $LOG_DIR/$category/$num.fs_stat
+xfs_info $TEST_FOLDER >> $LOG_DIR/$category/$num.xfsinfo
 xfs_info $SCRATCH_FOLDER >> $LOG_DIR/$category/$num.xfsinfo
 END_CMD
     }
     elsif ($fstype eq 'btrfs') {
-        $cmd = <<END_CMD;
-tail -n +1 /sys/fs/$fstype/*/allocation/data/[bdft]* >> $LOG_DIR/$category/$num.fs_stat
-tail -n +1 /sys/fs/$fstype/*/allocation/metadata/[bdft]* >> $LOG_DIR/$category/$num.fs_stat
-tail -n +1 /sys/fs/$fstype/*/allocation/metadata/dup/* >> $LOG_DIR/$category/$num.fs_stat
-tail -n +1 /sys/fs/$fstype/*/allocation/*/single/* >> $LOG_DIR/$category/$num.fs_stat
-END_CMD
+        $cmd = "find /sys/fs/$fstype/*/allocation/ -type f -exec tail -n +1 {} + >> $LOG_DIR/$category/$num.fs_stat";
     }
     elsif ($fstype eq 'ext4') {
-        $cmd = <<END_CMD;
-tail -n +1 /sys/fs/$fstype/*/* >> $LOG_DIR/$category/$num.fs_stat
-END_CMD
+        $cmd = "find /sys/fs/$fstype/ -type f -exec tail -n +1 {} + >> $LOG_DIR/$category/$num.fs_stat";
     }
     elsif ($fstype eq 'nfs') {
         enter_cmd("$cmd");
@@ -502,6 +492,7 @@ umount \$TEST_DEV &> /dev/null
 [ -n "\$SCRATCH_DEV" ] && umount \$SCRATCH_DEV &> /dev/null
 END_CMD
     enter_cmd("$cmd");
+    record_info('fs_stat log', script_output("cat $LOG_DIR/$category/$num.fs_stat"));
 }
 
 =head2 copy_all_log


### PR DESCRIPTION
Use tail to read fs_stat log may meet the issue that the path also contain dir. Use find could avoid this issue.

- Related ticket: https://progress.opensuse.org/issues/166736
- Verification run: 
Before: it has the red fail block  https://openqa.suse.de/tests/16033573#step/generic-091/32
After: it will not fails in tail log part  https://openqa.suse.de/tests/16079982#step/generic-075/38