### PR TITLE
Control SDAF version to use latest -1

### DIFF
--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -44,6 +44,7 @@ subtest '[prepare_sdaf_project]' => sub {
     $ms_sdaf->redefine(git_clone => sub { return; });
     $ms_sdaf->redefine(get_workload_vnet_code => sub { return 'SAP04'; });
     $ms_sdaf->redefine(log_dir => sub { return '/tmp/openqa_logs'; });
+    $ms_sdaf->redefine(script_output => sub { return "v4\nv5"; });
     $ms_sdaf->redefine(assert_script_run => sub {
             push(@git_commands, join('', $_[0])) if grep(/git/, $_[0]);
             return 1; });
@@ -55,6 +56,7 @@ subtest '[prepare_sdaf_project]' => sub {
             return '/some/useless/path'; });
     set_var('SDAF_GIT_AUTOMATION_REPO', 'https://github.com/Azure/sap-automation.git');
     set_var('SDAF_GIT_TEMPLATES_REPO', 'https://github.com/Azure/sap-automation-samples.git');
+    set_var('SDAF_GIT_AUTOMATION_BRANCH', 'latest');
 
     prepare_sdaf_project(%arguments);
 
@@ -84,6 +86,7 @@ subtest '[prepare_sdaf_project] Check directory creation' => sub {
     $ms_sdaf->redefine(record_soft_failure => sub { return; });
 
     $ms_sdaf->redefine(record_info => sub { return; });
+    $ms_sdaf->redefine(script_output => sub { return "v4\nv5"; });
     $ms_sdaf->redefine(assert_script_run => sub { push(@mkdir_commands, $_[0]) if grep(/mkdir/, @_); return 1; });
     $ms_sdaf->redefine(deployment_dir => sub { return '/tmp/SDAF'; });
     $ms_sdaf->redefine(get_tfvars_path => sub { return $tfvars_file; });
@@ -93,6 +96,7 @@ subtest '[prepare_sdaf_project] Check directory creation' => sub {
 
     set_var('SDAF_GIT_AUTOMATION_REPO', 'https://github.com/Azure/sap-automation/tree/main');
     set_var('SDAF_GIT_TEMPLATES_REPO', 'https://github.com/Azure/SAP-automation-samples/tree/main');
+    set_var('SDAF_GIT_AUTOMATION_BRANCH', 'latest');
 
     prepare_sdaf_project(%arguments);
     is $mkdir_commands[0], 'mkdir -p /tmp/openqa_logs', 'Create logging directory';


### PR DESCRIPTION
Control SDAF version to use latest -1
- support SDAF_GIT_AUTOMATION_BRANCH="latest"
- support SDAF_GIT_AUTOMATION_BRANCH="$any-version-listed-in-releases" 
- support SDAF_GIT_AUTOMATION_BRANCH="", version latest-1 will be used if this version is bigger than "v3.11.0.3"
  
Related ticket: [TEAM-9683](https://jira.suse.com/browse/TEAM-9683)
[SDAF][research] Mechanism to control SDAF version
 
Note: 
1. Versions <= "v3.11.0.3" miss feautre so test cases will report failure.
2. Atm Version_latest="v3.13.0.1"; Version_latest-1="v3.13.0.0" this version has issue, see VRs.
   
Verification runs:

SDAF_GIT_AUTOMATION_BRANCH="" (then latest-1="v3.13.0.0")
  https://openqaworker15.qa.suse.cz/tests/304777#step/deploy_workload_zone/231 (failed)
  https://openqaworker15.qa.suse.cz/tests/304778#step/deploy_workload_zone/232 (failed)
  (This version is problematic)

SDAF_GIT_AUTOMATION_BRANCH="" and make latest-1="v3.11.0.3" on purpose  
  https://openqaworker15.qa.suse.cz/tests/304597#step/configure_deployer/177 (failed as expected)  

SDAF_GIT_AUTOMATION_BRANCH="" and make latest-1="v3.11.0.1" (< "v3.11.0.3") on purpose  
  https://openqaworker15.qa.suse.cz/tests/304598#step/configure_deployer/177 (failed as expected)  

SDAF_GIT_AUTOMATION_BRANCH="v3.11.0.3"  
  http://openqaworker15.qa.suse.cz/tests/304591 (v3.11.0.3 is the missing future version. Test case dies as expected)
  (failed on "SDAF deployment execution failed with RC: 2" and the cleanup done successfully)  

SDAF_GIT_AUTOMATION_BRANCH="v3.9.3.0"  
  http://openqaworker15.qa.suse.cz/tests/304592 (v3.9.3.0 < v3.11.0.3 is a very old version . Test case dies as expected)  
  (failed on "SDAF deployment execution failed with RC: 2" and the cleanup done successfully)  
  
SDAF_GIT_AUTOMATION_BRANCH="v3.13.0.1" (v3.13.0.1 is the latest version)
  http://openqaworker15.qa.suse.cz/tests/304593 (passed)  
  
SDAF_GIT_AUTOMATION_BRANCH="latest" (latest version v3.13.0.1 is used)
  https://openqaworker15.qa.suse.cz/tests/304776#step/configure_deployer/176 (passed)
