### PR TITLE
Ignore failure on optional copy operation

### DIFF
--- a/tests/security/tpm2/keylime/keylime.pm
+++ b/tests/security/tpm2/keylime/keylime.pm
@@ -26,7 +26,7 @@ sub run {
     if (is_sle "<=15-SP6") {
         # Copy the keylime configuration file to /etc if not there
         $agent_cfg_path = "/etc/keylime.conf";
-        assert_script_run("cp -n /usr$agent_cfg_path $agent_cfg_path");
+        script_run("cp -n /usr$agent_cfg_path $agent_cfg_path");
     } else {
         script_run("mkdir -p /etc/keylime && test -d /usr/etc/keylime && cp -n /usr/etc/keylime/*.conf /etc/keylime");
         assert_script_run qq{test -f /etc/keylime/agent.conf || cp `rpm -ql keylime-config` /etc/keylime/agent.conf};


### PR DESCRIPTION
a quick fix to address previous https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20705

- Related ticket: https://progress.opensuse.org/issues/170512
- Needles: 
- Verification runs:
  - 15SP7 https://openqa.suse.de/tests/16049978
  - 15SP6 https://openqa.suse.de/tests/16049979
