### PR TITLE
update_kernel: Reconnect console after installing kernel for livepatching

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -305,6 +305,7 @@ sub prepare_kgraft {
     }
 
     power_action('reboot', textmode => 1);
+    reconnect_mgmt_console if is_pvm || get_var('LTP_BAREMETAL');
 
     return $incident_klp_pkg;
 }


### PR DESCRIPTION
Baremetal and PowerVM backends need to reconnect boot console after reboot, otherwise the test will time out waiting for GRUB menu.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/16070701