### PR TITLE
SDAF - OpenQA API directly on SUT

### DIFF
--- a/lib/sles4sap/console_redirection.pm
+++ b/lib/sles4sap/console_redirection.pm
@@ -94,6 +94,9 @@ B<ssh_user>: SSH login user for B<destination_ip> - default value is defined by 
 
 B<destination_ip>: Destination host IP - default value is defined by OpenQA parameter REDIRECT_DESTINATION_IP
 
+B<switch_root>: Switch to root after login with unprivileged user with 'sudo su -'.
+    User B<MUST> have passwordless sudo permission.
+
 B<fail_ok>: Do not die, return 0 instead. Good for verifying if redirection works.
 
 Establishes ssh connection to destination host and redirects serial output to serial console on worker VM.
@@ -126,7 +129,11 @@ sub connect_target_to_serial {
     my $redirect_port = get_required_var("QEMUPORT") + 1;
     my $redirect_ip = get_var('QEMU_HOST_IP', '10.0.2.2');
     my $redirect_opts = "-R $redirect_port:$redirect_ip:$redirect_port";
-    enter_cmd "ssh $ssh_opt $redirect_opts $args{ssh_user}\@$args{destination_ip} 2>&1 | tee -a /dev/$serialdev";
+    my $switch_root_cmd = $args{switch_root} ? 'sudo su -' : '';
+    my $ssh_cmd = join(' ', 'ssh -t', $ssh_opt, $redirect_opts, "$args{ssh_user}\@$args{destination_ip}",
+        $switch_root_cmd, "2>&1 | tee -a /dev/$serialdev"
+    );
+    enter_cmd $ssh_cmd;
     handle_login_prompt($args{ssh_user});
 
     my $redirection_active = check_serial_redirection();

--- a/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
@@ -14,7 +14,6 @@ use Exporter qw(import);
 use Carp qw(croak);
 use sles4sap::sap_deployment_automation_framework::naming_conventions
   qw($deployer_private_key_path $sut_private_key_path);
-use sles4sap::console_redirection;
 
 =head1 SYNOPSIS
 
@@ -61,6 +60,7 @@ our @EXPORT = qw(
   read_inventory_file
   prepare_ssh_config
   verify_ssh_proxy_connection
+  create_redirection_data
 );
 
 =head2 read_inventory_file
@@ -230,4 +230,69 @@ sub verify_ssh_proxy_connection {
             record_info('SSH check', "SSH proxy connection to $hostname: OK");
         }
     }
+}
+
+=head2 create_redirection_data
+
+    create_redirection_data(inventory_data=>HASHREF);
+
+Reads parsed and referenced SDAF inventory data, creates data structure required for redirection based tests.
+Returns HASHREF. For more information about returned format check `/tests/sles4sap/redirection_tests/README.md`.
+
+=over
+
+=item * B<inventory_data> SDAF inventory content in referenced perl data structure.
+
+=item * B<sap_sid> SAP system ID. Default 'SAP_SID' OpenQA parameter.
+
+=back
+=cut
+
+sub create_redirection_data {
+    my (%args) = @_;
+    my %infrastructure;
+    $args{sap_sid} //= get_required_var('SAP_SID');
+    # Map instance type name in SDAF inventory file to name expected in redirection data structure
+    my %instance_type_keys = (
+        "$args{sap_sid}_DB" => 'db_hana',
+        "$args{sap_sid}_PAS" => 'nw_pas',
+        "$args{sap_sid}_APP" => 'nw_aas',
+        "$args{sap_sid}_SCS" => 'nw_ascs',
+        "$args{sap_sid}_ERS" => 'nw_ers',
+        "$args{sap_sid}_ISCSI" => 'nw_iscsi',
+        "$args{sap_sid}_OBSERVER_DB" => 'nw_observer_db',
+        "$args{sap_sid}_WEB" => 'nw_web'
+    );
+
+    for my $instance_type (keys(%{$args{inventory_data}})) {
+        my $hosts = $args{inventory_data}->{$instance_type}{hosts};
+        if ($instance_type_keys{$instance_type}) {
+            $infrastructure{$instance_type_keys{$instance_type}} = {translate_hosts_data(%$hosts)};
+        }
+    }
+    return \%infrastructure;
+}
+
+=head2 translate_hosts_data
+
+    translate_hosts_data(%hosts_data);
+
+Reads 'hosts' SDAF inventory section and returns structure translated to hash of hosts
+required for console redirection tests.
+
+=over
+
+=item * B<hosts_data> SDAF inventory content in referenced perl data structure.
+
+=back
+=cut
+
+sub translate_hosts_data {
+    my (%hosts_data) = @_;
+    return unless %hosts_data;
+    my %result = map { $_ => {
+            ip_address => $hosts_data{$_}{ansible_host},
+            ssh_user => $hosts_data{$_}{ansible_user}
+    } } keys(%hosts_data);
+    return %result;
 }

--- a/schedule/sles4sap/sap_deployment_automation_framework/hanasr_redirected.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/hanasr_redirected.yml
@@ -1,0 +1,15 @@
+---
+name: sap_deployment_automation_framework
+description: |
+  Hana SR test scenario executed on deployment created by 'SAP Deployment automation framework'.
+  Test variant connects to SUT directly through ssh proxy jump, which allows direct use of OpenQA API calls.
+  This should allow to use standard sles4sap/HA libraries.
+vars:
+  TEST_CONTEXT: 'OpenQA::Test::RunArgs'
+schedule:
+  - boot/boot_to_desktop
+  - sles4sap/sap_deployment_automation_framework/connect_to_deployer
+  - sles4sap/sap_deployment_automation_framework/prepare_ssh_config
+  - sles4sap/redirection_tests/redirection_check
+  - sles4sap/redirection_tests/hana_cluster_check
+  - sles4sap/sap_deployment_automation_framework/cleanup

--- a/tests/sles4sap/redirection_tests/README.md
+++ b/tests/sles4sap/redirection_tests/README.md
@@ -1,0 +1,175 @@
+# Redirection test modules
+
+## Overview
+
+Test modules in this directory are intended for testing scenarios with remote SUT (System under test).  
+This means worker VM is serving only as an SSH jumphost to SUT.
+
+```| OpenQA instance| --> | QEMU Worker | --> Open SSH terminal --> | System under test|```   
+
+This is achieved using console redirection located in `lib/sles4sap/console_redirection.pm`.  
+
+Test modules are independent of a particular deployment solution and do not contain code related to it. 
+Technically, you should be able to run test with two (or more)
+local workers where one worker serves as an SSH gateway and test coordinator to the others.
+
+One exception is base test with post-fail/post-run hooks as there is no solution yet to separate those from test code.
+
+### Practical goal
+
+At the moment, there are multiple projects in SLES4SAP/HA that use different deployment solutions,
+and the test code is tied to it to some degree.
+This means that each test scenario requires separate test modules for each platform/project.
+The goal is to decrease redundant work done while increasing the coverage. 
+
+**Specifically, projects below:**
+- Cloud tests deployed using [qe-sap-deployment](https://github.com/SUSE/qe-sap-deployment)
+- Azure tests deployed using [SAP deployment automation framework](https://github.com/Azure/sap-automation)
+- Tests with SUT running directly on OpenQA worker - using one of the workers as an SSH Jump host
+- Remote VMWare deployments
+
+### Ideal goal
+
+One test to rule them all!
+Completely independent test modules which will work on any deployment solution if test start criteria are met.
+They should solve a problem with poverty, invent panacea, end all conflicts and achieve world peace.
+
+## Rules
+
+- `K`eep `I`t `S`imple `S`tupid
+- Do not base test modules on specific deployment type but on use of console redirection principle:
+  - worker serves as SSH jumphost to SUT
+  - standard OpenQA API calls are executed transparently on remote host the console is redirected to (in most cases SUT) 
+- Ideally test module should work regardless of deployment if required start conditions are met (input variables, SUT state, etc...)
+- Always document test module requirements, input parameters in `SYNOPSIS` or create an .md file
+- Keep documentation up to date
+- Sadly, there will be projects that won't be able to benefit from this concept, please don't make compromises and shortcuts for the sake of one project. 
+
+## Requirements
+
+- working passwordless SSH connection from worker VM to SUT  
+
+## Redirection data structure
+
+There is a standard required data that has to be provided to test module using `$run_args->{redirection_data}`.
+Redirection data contains a list of hosts which belong to the tested infrastructure and SSH connection data.
+
+```
+$run_args->{redirection_data} = {
+    host_group_type => {
+        'hostname' => {
+            ip_address => '',
+            ssh_user   => ''
+        }
+    }
+};
+```
+
+Example:
+```
+$run_args->{redirection_data} = {
+    ha_node => {
+        cluster_01 => {
+            ip_address => '192.168.1.3',
+            ssh_user   => 'hanaadmin'
+        },
+        cluster_02 => {
+            ip_address => '192.168.1.4',
+            ssh_user   => 'hanaadmin'
+        },
+        cluster_03 => {
+            ip_address => '192.168.1.3',
+            ssh_user   => 'hanaadmin'
+        },        
+    },
+    db_hana => {
+        hanadb_a => {
+            ip_address => '192.168.1.3',
+            ssh_user   => 'hanaadmin'
+        },
+        hanadb_b => {
+            ip_address => '192.168.1.4',
+            ssh_user   => 'hanaadmin'
+        }
+    },
+    db_ase => {
+        asedb => {
+            ip_address => '192.168.1.5',
+            ssh_user   => 'hanaadmin'
+        }
+    },    
+    nw_pas   => {
+        nw_pas => {
+            ip_address => '192.168.1.6',
+            ssh_user   => 'hanaadmin'
+        }
+    },
+    nw_aas   => {
+        nw_aas_01 => {
+            ip_address => '192.168.1.7',
+            ssh_user   => 'hanaadmin'
+        },
+        nw_aas_02 => {
+            ip_address => '192.168.1.8',
+            ssh_user   => 'hanaadmin'
+        }
+    },
+    nw_ascs  => {
+        nw_ascs => {
+            ip_address => '192.168.1.9',
+            ssh_user   => 'hanaadmin'
+        }
+    },
+    nw_ers   => {
+        nw_ers => {
+            ip_address => '192.168.1.10',
+            ssh_user   => 'hanaadmin'
+        }
+    }
+};
+```
+
+Please keep information in the data structure only relevant to console redirection.  
+If a test module needs additional information (data about sap instances),
+create a new required structure and document it.
+Try to make this structure generic, not based on a specific document outputted from a specific deployment solution like
+a tfvars file.
+
+For data to be passed between test modules, it is required to include variable `TEST_CONTEXT: OpenQA::Test::RunArgs`
+into YAML schedule:
+
+```
+vars:
+  TEST_CONTEXT: 'OpenQA::Test::RunArgs'
+```
+
+# Test module example
+
+Below is an example of a basic test module which loops over all hosts and tests common API calls:
+
+```
+sub run {
+    my ($self, $run_args) = @_;
+    my %redirection_data = %{ $run_args->{redirection_data} };
+    
+    for my $instance_type (keys(%redirection_data)) {
+        my $hosts = redirection_data{$instance_type};
+        for my $hostname (keys %$hosts) {
+            my $ip_addr = $hosts->{$hostname}{ip_address};
+            my $user = $hosts->{$hostname}{user};
+            
+            # Redirect console to SUT
+            connect_target_to_serial(destination_ip=>$ip_addr, ssh_user=>$user);
+            
+            # Do your things on SUT
+            record_info(script_output('sudo crm status'));
+            my $hostname_real = script_output('hostname');
+            assert_script_run("echo \$(hostname) > /tmp/hostname_$hostname_real");
+            upload_logs("/tmp/hostname_$hostname_real");
+            
+            # Disconnect serial from SUT <- never forget to do that. 
+            disconnect_target_from_serial();
+        }
+    }
+}
+```

--- a/tests/sles4sap/redirection_tests/hana_cluster_check.pm
+++ b/tests/sles4sap/redirection_tests/hana_cluster_check.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Test module serves as a demonstration of executing simple HA/SLES4SAP on-premise libraries on remote host
+#   using console redirection.
+#   It loops over all hosts defined in `$run_args->{redirection_data}` and executes selected functions on each host.
+#   For more information read 'README.md'
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+use warnings;
+use strict;
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::console_redirection;
+use hacluster qw(check_cluster_state wait_until_resources_started wait_for_idle_cluster);
+use saputils;
+use Data::Dumper;
+
+sub run {
+    my ($self, $run_args) = @_;
+    my %redirection_data = %{$run_args->{redirection_data}};
+
+    for my $instance_type (keys(%redirection_data)) {
+
+        for my $hostname (keys(%{$redirection_data{$instance_type}})) {
+            my %host_data = %{$redirection_data{$instance_type}{$hostname}};
+            connect_target_to_serial(
+                destination_ip => $host_data{ip_address}, ssh_user => $host_data{ssh_user}, switch_root => '1');
+            # hacluster lib
+            record_info('HA wait', 'Waiting for resources to start');
+            wait_until_resources_started();
+            wait_for_idle_cluster();
+            record_info('HA check', 'Checking state of HA cluster resources');
+            check_cluster_state();
+
+            # saputils lib
+            my $topology = calculate_hana_topology(input => script_output('SAPHanaSR-showAttr --format=script'));
+            record_info('Topology', Dumper($topology));
+
+            my $crm_out = check_crm_output(input => script_output('crm_mon -R -r -n -N -1'));
+            record_info('CRM check', Dumper($crm_out));
+
+            disconnect_target_from_serial();
+        }
+    }
+}
+
+1;

--- a/tests/sles4sap/redirection_tests/redirection_check.pm
+++ b/tests/sles4sap/redirection_tests/redirection_check.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Test module serves as a simple check for redirection to be working.
+#   It loops over all hosts defined in `$run_args->{redirection_data}` and attempts few common OpenQA api calls.
+#   For more information read 'README.md'
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+use warnings;
+use strict;
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::console_redirection;
+
+sub run {
+    my ($self, $run_args) = @_;
+    my %redirection_data = %{$run_args->{redirection_data}};
+
+    for my $instance_type (keys(%redirection_data)) {
+
+        for my $hostname (keys(%{$redirection_data{$instance_type}})) {
+            my %host_data = %{$redirection_data{$instance_type}{$hostname}};
+            record_info("Host: $hostname");
+            connect_target_to_serial(
+                destination_ip => $host_data{ip_address}, ssh_user => $host_data{ssh_user});
+
+            # Check if hostnames matches with what is expected
+            # Check API calls: script_output, assert_script_run
+            my $hostname_real = script_output('hostname');
+            assert_script_run("echo \$(hostname) > /tmp/hostname_$hostname_real");
+            die "Expected hostname '$hostname' does not match hostname returned '$hostname_real'"
+              unless $hostname_real eq $hostname;
+            record_info('API check', "script_output: PASS\nassert_script_run: PASS\nhostname match: PASS");
+
+            # Check if connection between SUT and OpenQA instance works
+            # Check API calls: save_tmp_file, upload_logs
+            upload_logs("/tmp/hostname_$hostname_real");
+            save_tmp_file('hostname.txt', $hostname);
+            assert_script_run('curl -s ' . autoinst_url . "/files/hostname.txt| grep $hostname");
+            record_info('API check', "upload_logs: PASS\nsave_tmp_file: PASS\nOpenQA connection: PASS");
+
+            disconnect_target_from_serial();
+        }
+    }
+}
+
+1;

--- a/tests/sles4sap/sap_deployment_automation_framework/prepare_ssh_config.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/prepare_ssh_config.pm
@@ -23,10 +23,6 @@ use sles4sap::sap_deployment_automation_framework::naming_conventions
   $sut_private_key_path
   generate_resource_group_name);
 
-sub test_flags {
-    return {fatal => 1, publiccloud_multi_module => 1};
-}
-
 sub run {
     my ($self, $run_args) = @_;
     select_serial_terminal;
@@ -48,7 +44,9 @@ sub run {
     disconnect_target_from_serial();
 
     # Share inventory data between all tests
-    $self->{sdaf_inventory} = $inventory_data;
+    $run_args->{sdaf_inventory} = $inventory_data;
+    # Create console redirection data
+    $run_args->{redirection_data} = create_redirection_data(inventory_data => $inventory_data);
 
     my @workload_key_vault = @{az_keyvault_list(
             resource_group => generate_resource_group_name(deployment_type => 'workload_zone'))};


### PR DESCRIPTION
This PR adds functionality to execute standard API call directly on SUT behind 
firewall using SSH proxy jump host. Currently adds support to SDAF based tests 
by translating ansible inventory file to data structure required by redirection 
tests. PR introduces two test modules which showcase couple of API calls and 
existing library functions working out of the box.

- Related ticket: https://jira.suse.com/browse/TEAM-9866
- Verification run: https://mordor.suse.cz/tests/878#
