### PR TITLE
bpftools.yaml: Add support for s390x

### DIFF
--- a/schedule/kernel/bpftools.yaml
+++ b/schedule/kernel/bpftools.yaml
@@ -13,3 +13,6 @@ conditional_schedule:
         BACKEND:
             spvm:
                 - installation/bootloader
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm


### PR DESCRIPTION
NOTE: CI fails due another problem, see https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20726
