### PR TITLE
Update a slem autoyast profile to get update repo from scc only

### DIFF
--- a/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
+++ b/data/autoyast_sle15/autoyast_sle-micro_updates.xml.ep
@@ -6,15 +6,6 @@
     <reg_code>{{SCC_REGCODE}}</reg_code>
     <install_updates config:type="boolean">true</install_updates>
   </suse_register>
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <name>SUSE-MicroOS-<%= $get_var->('VERSION') %>-Updates</name>
-        <alias>SUSE-MicroOS-<%= $get_var->('VERSION') %>-Updates</alias>
-        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Updates/SUSE-MicroOS/<%= $get_var->('VERSION') %>/<%= $get_var->('ARCH') %>/update/]]></media_url>
-      </listentry>
-    </add_on_products>
-  </add-on>
   <bootloader>
     <global>
       <timeout config:type="integer">-1</timeout>


### PR DESCRIPTION
Update a slem autoyast profile to get the update repo from scc only.
From the profile, it has the registration, so the update repo could be
picked from scc, no need to add an update repo from disk.suse.de.

- Related ticket: n/a
- To fix this failure: https://openqa.suse.de/tests/16079638
- Verification run: [x86_64](https://openqa.suse.de/tests/16080005#), [s390x](https://openqa.suse.de/tests/16080019#), [aarch64](https://openqa.suse.de/tests/16080018#)
