### PR TITLE
containers: Install iptables in podman upstream tests

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -52,7 +52,7 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns catatonit git-core gpg2 jq make netavark openssl podman python3-PyYAML sudo systemd-container);
+    my @pkgs = qw(aardvark-dns catatonit git-core gpg2 iptables jq make netavark openssl podman python3-PyYAML sudo systemd-container);
     push @pkgs, qw(apache2-utils buildah glibc-devel-static go libcriu2 libgpgme-devel libseccomp-devel podman-remote socat skopeo);
     # passt requires podman 5.0
     push @pkgs, qw(criu passt) if (is_tumbleweed);


### PR DESCRIPTION
criu still uses iptables as dependency.

- Related ticket: https://progress.opensuse.org/issues/173362
- Verification run: https://openqa.opensuse.org/tests/4681397
