### PR TITLE
Add bootloader_zkvm to io_uring schedule

### DIFF
--- a/schedule/kernel/io_uring.yaml
+++ b/schedule/kernel/io_uring.yaml
@@ -12,3 +12,6 @@ conditional_schedule:
         BACKEND:
             spvm:
                 - installation/bootloader
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm


### PR DESCRIPTION
Fix poo#173680: We need to run io_uring on s390x architecture and we need to include bootloader_zkvm into schedule.

- Related ticket: https://progress.opensuse.org/issues/173680
- Needles: none
- Verification run: https://openqa.suse.de/tests/16083391
