### PR TITLE
Remove duplicate skipped testcases from XML result files

### DIFF
--- a/data/virt_autotest/kubevirt_tests/junit-noframes.xsl
+++ b/data/virt_autotest/kubevirt_tests/junit-noframes.xsl
@@ -1,0 +1,523 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+        xmlns:lxslt="http://xml.apache.org/xslt"
+        xmlns:string="xalan://java.lang.String">
+<xsl:output method="html" indent="yes" encoding="UTF-8"
+  doctype-public="-//W3C//DTD HTML 4.01 Transitional//EN" />
+<xsl:decimal-format decimal-separator="." grouping-separator="," />
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ -->
+
+<xsl:param name="TITLE">Unit Test Results.</xsl:param>
+
+<!--
+
+ Sample stylesheet to be used with Ant JUnitReport output.
+
+ It creates a non-framed report that can be useful to send via
+ e-mail or such.
+
+-->
+<xsl:template match="testsuites">
+    <html>
+        <head>
+            <title><xsl:value-of select="$TITLE"/></title>
+    <style type="text/css">
+      body {
+        font:normal 68% verdana,arial,helvetica;
+        color:#000000;
+      }
+      table tr td, table tr th {
+          font-size: 68%;
+      }
+      table.details tr th{
+        font-weight: bold;
+        text-align:left;
+        background:#a6caf0;
+      }
+      table.details tr td{
+        background:#eeeee0;
+      }
+
+      p {
+        line-height:1.5em;
+        margin-top:0.5em; margin-bottom:1.0em;
+      }
+      h1 {
+        margin: 0px 0px 5px; font: 165% verdana,arial,helvetica
+      }
+      h2 {
+        margin-top: 1em; margin-bottom: 0.5em; font: bold 125% verdana,arial,helvetica
+      }
+      h3 {
+        margin-bottom: 0.5em; font: bold 115% verdana,arial,helvetica
+      }
+      h4 {
+        margin-bottom: 0.5em; font: bold 100% verdana,arial,helvetica
+      }
+      h5 {
+        margin-bottom: 0.5em; font: bold 100% verdana,arial,helvetica
+      }
+      h6 {
+        margin-bottom: 0.5em; font: bold 100% verdana,arial,helvetica
+      }
+      .Error {
+        font-weight:bold; color:red;
+      }
+      .Failure {
+        font-weight:bold; color:purple;
+      }
+      .Properties {
+        text-align:right;
+      }
+      </style>
+      <script type="text/javascript" language="JavaScript">
+        var TestCases = new Array();
+        var cur;
+        <xsl:for-each select="./testsuite">
+            <xsl:apply-templates select="properties"/>
+        </xsl:for-each>
+
+       </script>
+       <script type="text/javascript" language="JavaScript"><![CDATA[
+        function displayProperties (name) {
+          var win = window.open('','JUnitSystemProperties','scrollbars=1,resizable=1');
+          var doc = win.document;
+          doc.open();
+          doc.write("<html><head><title>Properties of " + name + "</title>");
+          doc.write("<style>")
+          doc.write("body {font:normal 68% verdana,arial,helvetica; color:#000000; }");
+          doc.write("table tr td, table tr th { font-size: 68%; }");
+          doc.write("table.properties { border-collapse:collapse; border-left:solid 1 #cccccc; border-top:solid 1 #cccccc; padding:5px; }");
+          doc.write("table.properties th { text-align:left; border-right:solid 1 #cccccc; border-bottom:solid 1 #cccccc; background-color:#eeeeee; }");
+          doc.write("table.properties td { font:normal; text-align:left; border-right:solid 1 #cccccc; border-bottom:solid 1 #cccccc; background-color:#fffffff; }");
+          doc.write("h3 { margin-bottom: 0.5em; font: bold 115% verdana,arial,helvetica }");
+          doc.write("</style>");
+          doc.write("</head><body>");
+          doc.write("<h3>Properties of " + name + "</h3>");
+          doc.write("<div align=\"right\"><a href=\"javascript:window.close();\">Close</a></div>");
+          doc.write("<table class='properties'>");
+          doc.write("<tr><th>Name</th><th>Value</th></tr>");
+          for (prop in TestCases[name]) {
+            doc.write("<tr><th>" + prop + "</th><td>" + TestCases[name][prop] + "</td></tr>");
+          }
+          doc.write("</table>");
+          doc.write("</body></html>");
+          doc.close();
+          win.focus();
+        }
+      ]]>
+      </script>
+        </head>
+        <body>
+            <a name="top"></a>
+            <xsl:call-template name="pageHeader"/>
+
+            <!-- Summary part -->
+            <xsl:call-template name="summary"/>
+            <hr size="1" width="100%" align="left"/>
+
+            <!-- Package List part -->
+            <!--
+            <xsl:call-template name="packagelist"/>
+            <hr size="1" width="100%" align="left"/>
+            -->
+
+            <!-- For each package create its part -->
+            <xsl:call-template name="packages"/>
+            <hr size="1" width="100%" align="left"/>
+
+            <!-- For each class create the part -->
+            <xsl:call-template name="classes"/>
+
+        </body>
+    </html>
+</xsl:template>
+
+
+
+    <!-- ================================================================== -->
+    <!-- Write a list of all packages with an hyperlink to the anchor of    -->
+    <!-- of the package name.                                               -->
+    <!-- ================================================================== -->
+    <xsl:template name="packagelist">
+        <h2>TestSuites</h2>
+        Note: package statistics are not computed recursively, they only sum up all of its testsuites numbers.
+        <table class="details" border="0" cellpadding="5" cellspacing="2" width="100%">
+            <xsl:call-template name="testsuite.test.header"/>
+            <!-- list all packages recursively -->
+            <xsl:for-each select="./testsuite[not(./@package = preceding-sibling::testsuite/@package)]">
+                <xsl:sort select="@package"/>
+                <xsl:variable name="testsuites-in-package" select="/testsuites/testsuite[./@package = current()/@package]"/>
+                <xsl:variable name="testCount" select="sum($testsuites-in-package/@tests)"/>
+                <xsl:variable name="errorCount" select="sum($testsuites-in-package/@errors)"/>
+                <xsl:variable name="failureCount" select="sum($testsuites-in-package/@failures)"/>
+                <xsl:variable name="skippedCount" select="sum($testsuites-in-package/@skipped)"/>
+                <xsl:variable name="timeCount" select="sum($testsuites-in-package/@time)"/>
+                <xsl:variable name="successCount" select="$testCount - $failureCount - $errorCount - $skippedCount"/>
+
+                <!-- write a summary for the package -->
+                <tr valign="top">
+                    <!-- set a nice color depending if there is an error/failure -->
+                    <xsl:attribute name="class">
+                        <xsl:choose>
+                            <xsl:when test="$failureCount &gt; 0">Failure</xsl:when>
+                            <xsl:when test="$errorCount &gt; 0">Error</xsl:when>
+                        </xsl:choose>
+                    </xsl:attribute>
+                    <td><a href="#{@package}"><xsl:value-of select="@package"/></a></td>
+                    <td><xsl:value-of select="$testCount"/></td>
+                    <td><xsl:value-of select="$successCount"/></td>
+                    <td><xsl:value-of select="$errorCount"/></td>
+                    <td><xsl:value-of select="$failureCount"/></td>
+                    <td><xsl:value-of select="$skippedCount" /></td>
+                    <td>
+                    <xsl:call-template name="display-time">
+                        <xsl:with-param name="value" select="$timeCount"/>
+                    </xsl:call-template>
+                    </td>
+                </tr>
+            </xsl:for-each>
+        </table>
+    </xsl:template>
+
+
+    <!-- ================================================================== -->
+    <!-- Write a package level report                                       -->
+    <!-- It creates a table with values from the document:                  -->
+    <!-- Name | Tests | Errors | Failures | Time                            -->
+    <!-- ================================================================== -->
+    <xsl:template name="packages">
+        <!-- create an anchor to this package name -->
+        <xsl:for-each select="/testsuites/testsuite[not(./@package = preceding-sibling::testsuite/@package)]">
+            <xsl:sort select="@package"/>
+                <a name="{@package}"></a>
+                <h3>TestSuites <xsl:value-of select="@package"/></h3>
+
+                <table class="details" border="0" cellpadding="5" cellspacing="2" width="100%">
+                    <xsl:call-template name="testsuite.test.header"/>
+
+                    <!-- match the testsuites of this package -->
+                    <xsl:apply-templates select="/testsuites/testsuite[./@package = current()/@package]" mode="print.test"/>
+                </table>
+                <!-- <a href="#top">Back to top</a> -->
+                <p/>
+                <p/>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="classes">
+        <xsl:for-each select="testsuite">
+            <xsl:sort select="@name"/>
+            <!-- create an anchor to this class name -->
+            <a name="{@name}"></a>
+            <h3>TestCase <xsl:value-of select="@name"/></h3>
+
+            <table class="details" border="0" cellpadding="5" cellspacing="2" width="100%">
+              <xsl:call-template name="testcase.test.header"/>
+              <!--
+              test can even not be started at all (failure to load the class)
+              so report the error directly
+              -->
+                <xsl:if test="./error">
+                    <tr class="Error">
+                        <td colspan="4"><xsl:apply-templates select="./error"/></td>
+                    </tr>
+                </xsl:if>
+                <xsl:apply-templates select="./testcase" mode="print.test"/>
+            </table>
+	        <!--
+            <div class="Properties">
+                <a>
+                    <xsl:attribute name="href">javascript:displayProperties('<xsl:value-of select="@package"/>.<xsl:value-of select="@name"/>');</xsl:attribute>
+                    Properties &#187;
+                </a>
+            </div>
+	        -->
+            <p/>
+
+            <a href="#top">Back to top</a>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="summary">
+        <h2>Summary</h2>
+        <xsl:variable name="testCount" select="sum(testsuite/@tests)"/>
+        <!-- <xsl:variable name="errorCount" select="sum(testsuite/@errors)"/> -->
+        <xsl:variable name="failureCount" select="sum(testsuite/@failures)"/>
+        <xsl:variable name="skippedCount" select="sum(testsuite/@skipped)"/>
+        <xsl:variable name="timeCount" select="sum(testsuite/@time)"/>
+        <xsl:variable name="successCount" select="$testCount - $failureCount - $skippedCount"/>
+        <!-- <xsl:variable name="successRate" select="($testCount - $failureCount - $errorCount) div $testCount"/> -->
+        <xsl:variable name="successRate" select="$successCount div ($testCount - $skippedCount)"/>
+        <table class="details" border="0" cellpadding="5" cellspacing="2" width="100%">
+        <tr valign="top">
+            <th>Tests</th>
+            <th>Passed</th>
+            <th>Failures</th>
+            <!-- <th>Errors</th> -->
+            <th>Skipped</th>
+            <th>Success rate</th>
+            <th>Time</th>
+        </tr>
+        <tr valign="top">
+            <xsl:attribute name="class">
+                <xsl:choose>
+                    <xsl:when test="$failureCount &gt; 0">Failure</xsl:when>
+                    <!-- <xsl:when test="$errorCount &gt; 0">Error</xsl:when> -->
+                </xsl:choose>
+            </xsl:attribute>
+            <td><xsl:value-of select="$testCount"/></td>
+            <td><xsl:value-of select="$successCount"/></td>
+            <td><xsl:value-of select="$failureCount"/></td>
+            <!-- <td><xsl:value-of select="$errorCount"/></td> -->
+            <td><xsl:value-of select="$skippedCount"/></td>
+            <td>
+                <xsl:call-template name="display-percent">
+                    <xsl:with-param name="value" select="$successRate"/>
+                </xsl:call-template>
+            </td>
+            <td>
+                <xsl:call-template name="display-time">
+                    <xsl:with-param name="value" select="$timeCount"/>
+                </xsl:call-template>
+            </td>
+
+        </tr>
+        </table>
+        <table border="0" width="95%">
+        <tr>
+        <td style="text-align: justify;">
+        <!-- Note: <i>failures</i> are anticipated and checked for with assertions while <i>errors</i> are unanticipated. -->
+        </td>
+        </tr>
+        </table>
+    </xsl:template>
+
+  <!--
+   Write properties into a JavaScript data structure.
+   This is based on the original idea by Erik Hatcher (ehatcher@apache.org)
+   -->
+  <xsl:template match="properties">
+    cur = TestCases['<xsl:value-of select="../@package"/>.<xsl:value-of select="../@name"/>'] = new Array();
+    <xsl:for-each select="property">
+    <xsl:sort select="@name"/>
+        cur['<xsl:value-of select="@name"/>'] = '<xsl:call-template name="JS-escape"><xsl:with-param name="string" select="@value"/></xsl:call-template>';
+    </xsl:for-each>
+  </xsl:template>
+
+<!-- Page HEADER -->
+<xsl:template name="pageHeader">
+    <h1><xsl:value-of select="$TITLE"/></h1>
+    <table width="100%">
+    <tr>
+        <td align="left"></td>
+	<!-- <td align="right">Designed for use with <a href='https://www.junit.org'>JUnit</a> and <a href='https://ant.apache.org/ant'>Ant</a>.</td> -->
+    </tr>
+    </table>
+    <hr size="1"/>
+</xsl:template>
+
+<xsl:template match="testsuite" mode="header">
+    <tr valign="top">
+        <th width="80%">Name</th>
+        <th>Tests</th>
+        <th>Passed</th>
+        <th>Errors</th>
+        <th>Failures</th>
+        <th nowrap="nowrap">Time(s)</th>
+    </tr>
+</xsl:template>
+
+<!-- class header -->
+<xsl:template name="testsuite.test.header">
+    <tr valign="top">
+        <th width="80%">Name</th>
+        <th>Tests</th>
+        <th>Passed</th>
+        <!-- <th>Errors</th> -->
+        <th>Failures</th>
+        <th nowrap="nowrap">Time(s)</th>
+    </tr>
+</xsl:template>
+
+<!-- method header -->
+<xsl:template name="testcase.test.header">
+    <tr valign="top">
+        <th>Name</th>
+        <th>Status</th>
+        <th width="60%">Type</th>
+        <th nowrap="nowrap">Time(s)</th>
+    </tr>
+</xsl:template>
+
+
+<!-- class information -->
+<xsl:template match="testsuite" mode="print.test">
+    <tr valign="top">
+        <!-- set a nice color depending if there is an error/failure -->
+        <xsl:attribute name="class">
+            <xsl:choose>
+                <xsl:when test="@failures[.&gt; 0]">Failure</xsl:when>
+                <xsl:when test="@errors[.&gt; 0]">Error</xsl:when>
+            </xsl:choose>
+        </xsl:attribute>
+
+        <xsl:variable name="testCount" select="sum(@tests)"/>
+        <!-- <xsl:variable name="errorCount" select="sum(@errors)"/> -->
+        <xsl:variable name="failureCount" select="sum(@failures)"/>
+        <xsl:variable name="skippedCount" select="sum(@skipped)"/>
+        <xsl:variable name="successCount" select="$testCount - $failureCount - $skippedCount"/>
+
+        <!-- print testsuite information -->
+        <td><a href="#{@name}"><xsl:value-of select="@name"/></a></td>
+        <td><xsl:value-of select="@tests"/></td>
+        <td><xsl:value-of select="$successCount"/></td>
+        <!-- <td><xsl:value-of select="@errors"/></td> -->
+        <td><xsl:value-of select="@failures"/></td>
+        <td>
+            <xsl:call-template name="display-time">
+                <xsl:with-param name="value" select="@time"/>
+            </xsl:call-template>
+        </td>
+    </tr>
+</xsl:template>
+
+<xsl:template match="testcase" mode="print.test">
+    <tr valign="top">
+        <xsl:attribute name="class">
+            <xsl:choose>
+                <xsl:when test="failure | error">Error</xsl:when>
+            </xsl:choose>
+        </xsl:attribute>
+        <td><xsl:value-of select="@name"/></td>
+        <xsl:choose>
+            <xsl:when test="failure">
+                <td>Failure</td>
+                <td><xsl:apply-templates select="failure"/></td>
+            </xsl:when>
+            <xsl:when test="error">
+                <td>Error</td>
+                <td><xsl:apply-templates select="error"/></td>
+            </xsl:when>
+            <xsl:when test="skipped">
+            	<td>Skipped</td>
+            	<td><xsl:apply-templates select="skipped"/></td>
+            </xsl:when>
+            <xsl:otherwise>
+                <td>Success</td>
+                <td></td>
+            </xsl:otherwise>
+        </xsl:choose>
+        <td>
+            <xsl:call-template name="display-time">
+                <xsl:with-param name="value" select="@time"/>
+            </xsl:call-template>
+        </td>
+    </tr>
+</xsl:template>
+
+
+<xsl:template match="failure">
+    <xsl:call-template name="display-failures"/>
+</xsl:template>
+
+<xsl:template match="error">
+    <xsl:call-template name="display-failures"/>
+</xsl:template>
+
+<xsl:template match="skipped">
+    <xsl:call-template name="display-failures"/>
+</xsl:template>
+
+<!-- Style for the error, failure and skipped in the testcase template -->
+<xsl:template name="display-failures">
+    <xsl:choose>
+        <xsl:when test="not(@message)">N/A</xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="@message"/>
+        </xsl:otherwise>
+    </xsl:choose>
+    <!-- display the stacktrace -->
+    <code>
+        <br/><br/>
+        <xsl:call-template name="br-replace">
+            <xsl:with-param name="word" select="."/>
+        </xsl:call-template>
+    </code>
+    <!-- the later is better but might be problematic for non-21" monitors... -->
+    <!--pre><xsl:value-of select="."/></pre-->
+</xsl:template>
+
+<xsl:template name="JS-escape">
+    <xsl:param name="string"/>
+    <xsl:param name="tmp1" select="string:replaceAll(string:new(string($string)),'\\','\\\\')"/>
+    <xsl:param name="tmp2" select="string:replaceAll(string:new(string($tmp1)),&quot;'&quot;,&quot;\\&apos;&quot;)"/>
+    <xsl:param name="tmp3" select="string:replaceAll(string:new(string($tmp2)),&quot;&#10;&quot;,'\\n')"/>
+    <xsl:param name="tmp4" select="string:replaceAll(string:new(string($tmp3)),&quot;&#13;&quot;,'\\r')"/>
+    <xsl:value-of select="$tmp4"/>
+</xsl:template>
+
+
+<!--
+    template that will convert a carriage return into a br tag
+    @param word the text from which to convert CR to BR tag
+-->
+<xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:param name="splitlimit">32</xsl:param>
+    <xsl:variable name="secondhalfstartindex" select="(string-length($word)+(string-length($word) mod 2)) div 2"/>
+    <xsl:variable name="secondhalfword" select="substring($word, $secondhalfstartindex)"/>
+    <!-- When word is very big, a recursive replace is very heap/stack expensive, so subdivide on line break after middle of string -->
+    <xsl:choose>
+      <xsl:when test="(string-length($word) > $splitlimit) and (contains($secondhalfword, '&#xa;'))">
+        <xsl:variable name="secondhalfend" select="substring-after($secondhalfword, '&#xa;')"/>
+        <xsl:variable name="firsthalflen" select="string-length($word) - string-length($secondhalfword)"/>
+        <xsl:variable name="firsthalfword" select="substring($word, 1, $firsthalflen)"/>
+        <xsl:variable name="firsthalfend" select="substring-before($secondhalfword, '&#xa;')"/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="concat($firsthalfword,$firsthalfend)"/>
+        </xsl:call-template>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="$secondhalfend"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains($word, '&#xa;')">
+        <xsl:value-of select="substring-before($word, '&#xa;')"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word, '&#xa;')"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:template name="display-time">
+    <xsl:param name="value"/>
+    <xsl:value-of select="format-number($value,'0.000')"/>
+</xsl:template>
+
+<xsl:template name="display-percent">
+    <xsl:param name="value"/>
+    <xsl:value-of select="format-number($value,'0.00%')"/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/data/virt_autotest/kubevirt_tests/remove_dup_skipped_tests.py
+++ b/data/virt_autotest/kubevirt_tests/remove_dup_skipped_tests.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+
+def traverse_folder(root_dir):
+    # Iterate through all XML files in a path
+    root_list = []
+    for file in os.listdir(root_dir):
+        if file.endswith(".xml"):
+            file_path = os.path.join(root_dir, file)
+            print(f"Reading XML file: {file_path}")
+            # Parsing XML files
+            tree = ET.parse(file_path)
+            root = tree.getroot()
+            root_list.append(root)
+    return root_list
+
+def group_all_test_cases(root_list):
+    # Grouping testcase
+    skipped_testcases = []
+    non_skipped_testcases = []
+
+    for root in root_list:
+        for testsuite in root.iter('testsuite'):
+            for testcase in testsuite.iter('testcase'):
+                if testcase.find('skipped') is not None:
+                    skipped_testcases.append(testcase)
+                else:
+                    non_skipped_testcases.append(testcase)
+
+    # Delete duplicate testcases that appear in non-skipped testcase groups
+    non_skipped_names = [testcase.attrib['name'] for testcase in non_skipped_testcases]
+    tmp_skipped_testcases = [testcase for testcase in skipped_testcases if testcase.attrib['name'] not in non_skipped_names]
+
+    # Remove duplicate skipped testcases by name
+    unique_skipped_testcases = []
+    skipped_names = set()
+
+    for testcase in tmp_skipped_testcases:
+        name = testcase.attrib['name']
+        if name not in skipped_names:
+            unique_skipped_testcases.append(testcase)
+            skipped_names.add(name)
+
+    return unique_skipped_testcases, non_skipped_testcases
+
+def remove_skipped_case_in_files(root_dir):
+    # Iterate through all XML files in a path
+    for file in os.listdir(root_dir):
+        if file.endswith(".xml"):
+            file_path = os.path.join(root_dir, file)
+            print(f"Processing XML file: {file_path}")
+            # Parsing XML files
+            tree = ET.parse(file_path)
+            root = tree.getroot()
+            # Iterate over all <testcase> elements and remove those with the <skipped /> tag
+            for testsuite in root.iter('testsuite'):
+                for testcase in list(testsuite.iter('testcase')):
+                    if testcase.find('skipped') is not None:
+                        testsuite.remove(testcase)
+            # Overwrite the original file
+            tree.write(file_path, encoding='utf-8', xml_declaration=True)
+
+def create_new_skipped_file(filename, unique_skipped_testcases):
+    # Create a new XML
+    new_root = ET.Element("testsuite", attrib={"errors": "0",
+                                               "failures": "0",
+                                               "name": "SKIPPED_TEST",
+                                               "tests": str(len(unique_skipped_testcases)),
+                                               "skipped": str(len(unique_skipped_testcases)),
+                                               "time": "0"})
+
+    for testcase in unique_skipped_testcases:
+        testcase.set('classname', 'SKIPPED_TEST')
+        new_root.append(testcase)
+
+    # Generate XML file
+    new_tree = ET.ElementTree(new_root)
+    new_tree.write(filename, encoding="UTF-8", xml_declaration=True)
+
+
+if __name__ == '__main__':
+    RESULT_DIR = sys.argv[1]
+    SKIPPED_FILENAME = os.path.join(RESULT_DIR, 'skipped_test.xml')
+    root_list = traverse_folder(RESULT_DIR)
+    unique_skipped_testcases, _ = group_all_test_cases(root_list)
+    remove_skipped_case_in_files(RESULT_DIR)
+    create_new_skipped_file(SKIPPED_FILENAME, unique_skipped_testcases)
+


### PR DESCRIPTION
For kubevirt test in final html report (http://openqa.suse.de/tests/15823784/file/index.html), each skipped test id is counted multiple times. In summary page, test results should show PASS+FAIL test cases only, without skipped tests duplication.

- Related ticket: https://progress.opensuse.org/issues/113558
- Verification run: https://openqa.suse.de/tests/16161108 (html report: https://openqa.suse.de/tests/16161108/file/junit-noframes.html)
