### PR TITLE
Make guest installation media configurable

### DIFF
--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -68,6 +68,7 @@ sub instantiate_guests_and_profiles {
         my $_res = $_ua->request($_req);
         my $_guest_profile = (XML::Simple->new)->XMLin($_res->content, SuppressEmpty => '');
         $_guest_profile->{guest_name} = $_element;
+        $_guest_profile->{guest_installation_media} = $_store_of_guests{$_element}{INSTALL_MEDIA} if ($_store_of_guests{$_element}{INSTALL_MEDIA} ne '');
         $_guest_profile->{guest_registration_code} = $_store_of_guests{$_element}{REG_CODE};
         $_guest_profile->{guest_registration_extensions_codes} = $_store_of_guests{$_element}{REG_EXTS_CODES};
         $guest_instances_profiles{$_element} = $_guest_profile;

--- a/tests/virt_autotest/unified_guest_installation.pm
+++ b/tests/virt_autotest/unified_guest_installation.pm
@@ -66,11 +66,13 @@ sub run {
     my @guest_profiles = split(/,/, get_required_var('UNIFIED_GUEST_PROFILES'));
     croak("Guest names and profiles must be given to create, configure and install guests.") if ((scalar(@guest_names) eq 0) or (scalar(@guest_profiles) eq 0));
     my %store_of_guests;
-    my @guest_registration_codes = my @guest_registration_extensions_codes = ('') x scalar @guest_names;
+    my @guest_installation_media = my @guest_registration_codes = my @guest_registration_extensions_codes = ('') x scalar @guest_names;
+    @guest_installation_media = split(/,/, get_var('UNIFIED_GUEST_INSTALLATION_MEDIA', '')) if (get_var('UNIFIED_GUEST_INSTALLATION_MEDIA', '') ne '');
     @guest_registration_codes = split(/,/, get_var('UNIFIED_GUEST_REG_CODES', '')) if (get_var('UNIFIED_GUEST_REG_CODES', '') ne '');
     @guest_registration_extensions_codes = split(/,/, get_var('UNIFIED_GUEST_REG_EXTS_CODES', '')) if (get_var('UNIFIED_GUEST_REG_EXTS_CODES', '') ne '');
     while (my ($index, $element) = each @guest_names) {
         $store_of_guests{$element}{PROFILE} = $guest_profiles[$index];
+        $store_of_guests{$element}{INSTALL_MEDIA} = $guest_installation_media[$index];
         $store_of_guests{$element}{REG_CODE} = $guest_registration_codes[$index];
         $store_of_guests{$element}{REG_EXTS_CODES} = $guest_registration_extensions_codes[$index];
     }


### PR DESCRIPTION
* **Use** openQA setting UNIFIED_GUEST_INSTALLATION_MEDIA to make guest installation media configurable, so media can be specified on the fly without limitation. This brings convenience especially taking non-/CC areas into consideration. 

* **Old** way of using parameter guest_installation_media in guest profile is still supported, so only when value in UNIFIED_GUEST_INSTALLATION_MEDIA is not empty, guest_installation_media will take value from it. Otherwise, the guest_installation_media still takes value from guest profile.

* **Ticket** [poo#173698](https://progress.opensuse.org/issues/173698) to request missing medium. 

* **Verification Runs:**
  * [Two sl micro guests using UNIFIED_GUEST_INSTALLATION_MEDIA](http://openqa.qa2.suse.asia/tests/80565)
  * [One of two sl micro guests using  UNIFIED_GUEST_INSTALLATION_MEDIA](http://openqa.qa2.suse.asia/tests/80567)
  * [sles12sp5 guest does not use UNIFIED_GUEST_INSTALLATION_MEDIA](https://openqa.suse.de/tests/16111854)
  * [sles15sp6 guest uses UNIFIED_GUEST_INSTALLATION_MEDIA](https://openqa.suse.de/tests/16111855)