### PR TITLE
Fix SDAF Post fail hook not executed when timeout

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -104,8 +104,10 @@ sub post_fail_hook {
         #   For playbook please do not use '> ' (or $testapi::distri->{serial_term_prompt})
         #   as there are lots of '> ' in the output of playbook.
         #   For playbook/script 'qr/-\d+-/' is usually the last output from playbook/script execution
+        #   For playbook if command contains -v (verbosity) the output may contain 'qr/-\d+-/',
+        #   so here uses 'qr/-\d+-Comment/' for regex as 'script_run(xxx, output => xxx)' is used to run playbook
         my $match_re = $testapi::distri->{serial_term_prompt};
-        $match_re = qr/-\d+-/ if ($serial_regexp_playbook);
+        $match_re = qr/-\d+-Comment/ if ($serial_regexp_playbook);
         unless (wait_serial($match_re)) {
             type_string('', terminate_with => 'ETX');
             # Wait for process returns


### PR DESCRIPTION
Fix SDAF Post fail hook not executed when timeout

When set `SDAF_ANSIBLE_VERBOSITY_LEVEL=4` (for example) and the playbook execution timed out then the outputs of playbook contains `-$numbers-` liked string(s) it make test code thinks the console/serial is **ready** (but it is not). So the post fail hook clean up failed.
For example: http://openqaworker15.qa.suse.cz/tests/305204#step/deploy_hanasr/209 (clean up was not done)
`ansible-tmp-xxx-21813-xxx/AnsiballZ_command.py` (the outputs of playbook with `SDAF_ANSIBLE_VERBOSITY_LEVEL=4`)

- Related ticket: [TEAM-9790](https://jira.suse.com/browse/TEAM-9790) - [SDAF][BUG] Post fail hook not executed in case of playbook timeout
- Verification run: http://openqaworker15.qa.suse.cz/tests/305233#step/deploy_hanasr/210
When timed out happened the all resources were destroyed via post fail hook