### PR TITLE
xfstests: Fix problem when can't find fs_stat log

### DIFF
--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -492,7 +492,7 @@ umount \$TEST_DEV &> /dev/null
 [ -n "\$SCRATCH_DEV" ] && umount \$SCRATCH_DEV &> /dev/null
 END_CMD
     enter_cmd("$cmd");
-    record_info('fs_stat log', script_output("cat $LOG_DIR/$category/$num.fs_stat"));
+    record_info('fs_stat log', script_output("find $LOG_DIR/$category/ -name $num.fs_stat -type f -exec cat {} +"));
 }
 
 =head2 copy_all_log


### PR DESCRIPTION
Check before cat the fs_stat log.

- Related ticket: https://progress.opensuse.org/issues/173707
- Verification run: https://openqa.suse.de/tests/16094717
