### PR TITLE
multipath: Make sure multipath-tools are installed

### DIFF
--- a/tests/kernel/multipath_iscsi.pm
+++ b/tests/kernel/multipath_iscsi.pm
@@ -29,7 +29,7 @@ sub run {
     # Install iscsi and make sure multipath-tools are installed
     zypper_call("in open-iscsi multipath-tools");
 
-    # Start isci amd multipath services
+    # Start isci and multipath services
     systemctl 'start iscsid';
     systemctl 'start multipathd';
     systemctl 'status multipathd';

--- a/tests/kernel/multipath_iscsi.pm
+++ b/tests/kernel/multipath_iscsi.pm
@@ -26,8 +26,8 @@ sub run {
     # Check connectivity to target inside multimachine network (supportserver)
     ping_size_check($target);
 
-    # Install iscsi
-    zypper_call("in open-iscsi");
+    # Install iscsi and make sure multipath-tools are installed
+    zypper_call("in open-iscsi multipath-tools");
 
     # Start isci amd multipath services
     systemctl 'start iscsid';


### PR DESCRIPTION
- Related fail: https://openqa.suse.de/tests/16097455#step/multipath_iscsi/42 :red_circle: 
- Needles: none
- Verification run:
15-SP7 KOTD (image doesn't  have multipath-tools installed):  https://openqa.suse.de/tests/16098454 :green_circle: 
12-SP5: https://openqa.suse.de/tests/16098448 :green_circle: 
15-SP6: https://openqa.suse.de/tests/16098451 :green_circle: 