### PR TITLE
EC2 Terraform: Switch from ebs_block_device to root_block_device

### DIFF
--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -117,8 +117,7 @@ resource "aws_instance" "openqa" {
     openqa_created_id   = element(random_id.service.*.hex, count.index)
   }, var.tags)
 
-  ebs_block_device {
-    device_name = "/dev/sda1"
+  root_block_device {
     volume_size = var.root-disk-size 
     volume_type = "gp3"
   }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/164604
- Verification run: https://pdostal-server.suse.cz/tests/7799
