### PR TITLE
ipsecbase.pm: Update correct parameter for systemctl

### DIFF
--- a/lib/ipsecbase.pm
+++ b/lib/ipsecbase.pm
@@ -113,7 +113,7 @@ sub pre_run_hook {
 }
 
 sub ensure_apparmor_disabled () {
-    unless (systemctl "is-active apparmor", proceed_on_failure => 1) {    # 0 if active, unless to revert
+    unless (systemctl "is-active apparmor", ignore_failure => 1) {    # 0 if active, unless to revert
         systemctl "disable --now apparmor";
         record_info "apparmor", "disabled";
     }


### PR DESCRIPTION
ipsecbase.pm: Update correct parameter for systemctl

- Related ticket: https://progress.opensuse.org/issues/173746
- Needles: na 
- Verification run: https://openqa.suse.de/tests/16108605#step/ipsec3hosts/18
