### PR TITLE
Need to switch to 'repo to be tested for next snapshot'

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -158,6 +158,7 @@ sub load_selfinstall_boot_tests {
     if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
         loadtest 'jeos/firstrun';
     }
+    replace_opensuse_repos_tests if is_repo_replacement_required;
 }
 
 sub load_remote_target_tests {


### PR DESCRIPTION
Need to use published repos

- Related ticket: https://progress.opensuse.org/issues/170158
- Verification run: https://openqa.opensuse.org/tests/4682873#
- Need update trigger command: related PR: https://github.com/os-autoinst/openqa-trigger-from-obs/pull/280
