### PR TITLE
Use Tumbleweed as test image for quadlet

### DIFF
--- a/tests/containers/podman_quadlet.pm
+++ b/tests/containers/podman_quadlet.pm
@@ -23,7 +23,7 @@ my $quadlet_dir = '/etc/containers/systemd';
 my $unit_name = 'quadlet-test';
 
 my $build_imagetag = "localhost/nginx";
-my $src_image = "registry.opensuse.org/opensuse/leap";
+my $src_image = "registry.opensuse.org/opensuse/tumbleweed";
 my @systemd_build = ("$quadlet_dir/$unit_name.build", <<_EOF_);
 [Build]
 ImageTag=$build_imagetag


### PR DESCRIPTION
Use Tumbleweed as the test image because Leap is not available on RISC-V.

- Related ticket: https://progress.opensuse.org/issues/166589
- Related failure: https://openqa.opensuse.org/tests/4685094#step/podman_quadlet/142
- Verification run: https://openqa.opensuse.org/tests/4685231#
