### PR TITLE
Restrict redundant grub2 edit moves for ppc64le

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -72,6 +72,7 @@ our @EXPORT = qw(
 );
 
 our $zkvm_img_path = "/var/lib/libvirt/images";
+my $in_grub_edit = 0;
 
 use constant GRUB_CFG_FILE => "/boot/grub2/grub.cfg";
 use constant GRUB_DEFAULT_FILE => "/etc/default/grub";
@@ -484,16 +485,24 @@ sub uefi_bootmenu_params {
     # Locate gfxpayload parameter and update it
     # The main branch should be used only for bootable pre-installed images that contain already full
     # grub2 configuration
+    my $linux = 0;
     if (get_var('BOOT_HDD_IMAGE') && (is_jeos || is_leap_micro || is_microos || is_sle_micro)) {
-        # skip healthchecker lines
+        # there is always a blank line
+        # sle 12-sp5 has no load_video
+        # if there is a healthchecker, skip it
+        my $gfx = 2;
         if (is_leap_micro || is_microos || is_sle_micro) {
-            send_key "down" for (1 .. 4);
+            $gfx += 5;
+        } else {
+            $gfx++;
         }
 
-        # navigate to gfxpayload=keep
-        if (!get_var('OFW')) {
-            my $gfx = is_sle('=12-SP5') ? 2 : 3;
-            send_key "down" for (1 .. $gfx);
+        # navigate to gfxpayload=keep and change its settings
+        # OFW images do not have any gfxpayload, so jump over load_video
+        send_key "down" for (1 .. $gfx);
+        if (get_var('OFW')) {
+            $linux = -1;
+        } else {
             wait_screen_change(sub { send_key "end"; }, 5);
             # delete "keep" word
             send_key "backspace" for (1 .. 4);
@@ -504,7 +513,7 @@ sub uefi_bootmenu_params {
 
         # navigate to the beginning of the line containing *linux* command
         wait_screen_change(sub { send_key "home"; }, 5);
-        my $linux = is_sle('=12-SP5') ? 2 : 6;
+        $linux += is_sle('=12-SP5') ? 2 : 6;
         # On Leap/SLE we need to move down (grub 2.04)
         # skip additional movement downwards in
         # sle15sp4+, leap15.4+ and TW (grub 2.06)
@@ -512,10 +521,9 @@ sub uefi_bootmenu_params {
         if (get_var('FLAVOR', '') =~ /encrypt/i) {
             $linux += is_sle_micro('6.1+') ? 11 : 10;
         }
-        $linux-- if get_var('OFW');
-        send_key "down" for (1 .. $linux);
     }
     else {
+        $linux = 4;
         for (1 .. 2) { send_key "down"; }
         send_key "end";
         # delete "keep" word
@@ -527,8 +535,15 @@ sub uefi_bootmenu_params {
         send_key "home";
         for (1 .. 2) { send_key "up"; }
         sleep 5;
-        for (1 .. 4) { send_key "down"; }
     }
+
+    # flag, in order to skip more movement in grub2 submenu in case of powerPC
+    $in_grub_edit = 1 if (get_var('OFW') && is_sle_micro);
+
+    # jump to linux kernel bootparams
+    wait_screen_change(sub {
+            send_key "down" for (1 .. $linux);
+    }, 3);
 
     send_key "end";
     save_screenshot();
@@ -581,14 +596,16 @@ sub bootmenu_default_params {
     my (%args) = @_;
     my @params;
     if (get_var('OFW')) {
-        # edit menu, wait until we get to grub edit
-        wait_screen_change { send_key "e" };
-        # go down to kernel entry
-        send_key "down";
-        send_key "down";
-        send_key "down";
-        wait_screen_change { send_key "end" };
-        wait_still_screen(1);
+        if (!$in_grub_edit) {
+            # edit menu, wait until we get to grub edit
+            wait_screen_change { send_key "e" };
+            # go down to kernel entry
+            send_key "down";
+            send_key "down";
+            send_key "down";
+            wait_screen_change { send_key "end" };
+            wait_still_screen(1);
+        }
         # load kernel manually with append
         if (check_var('VIDEOMODE', 'text')) {
             push @params, "textmode=1";

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -161,6 +161,7 @@ sub run {
     }
 
     bootmenu_default_params;
+    save_screenshot();
     unless (is_selfinstall) {
         bootmenu_remote_target;
         specific_bootmenu_params unless is_microos || is_jeos;


### PR DESCRIPTION
Appending kernel parameters has to be done in the line with [linux](https:]/kepler.suse.cz/tests/24159#step/bootloader_uefi/7) If OFW is set, there are 2 places in the code where this can occur.

Fixing: http://kepler.suse.cz/tests/24156#step/bootloader_uefi/7

ticket: https://progress.opensuse.org/issues/169243

#### Verification run

##### has health checker, but no gfxpayload
* [powerPC selfinstall iso](http://kepler.suse.cz/tests/24195#step/bootloader_uefi/7)
* [powerPC image](http://kepler.suse.cz/tests/24196#step/bootloader_uefi/5)

##### has load_video and gfxpayload, but no healthchecker
* [sle-15-SP2-JeOS-for-kvm-and-xen](https://openqa.suse.de/tests/16125405#step/bootloader_uefi/6)
* [sle-15-SP7-JeOS-for-kvm-and-xen](http://kepler.suse.cz/tests/24200#step/bootloader_uefi/6)
* [tw-jeos](http://kepler.suse.cz/tests/24189#step/bootloader_uefi/6)

##### has healthchecker, load_video, gfxpayload
* [microos-Tumbleweed-MicroOS-Image](http://kepler.suse.cz/tests/24190#step/bootloader_uefi/5)

##### installation grub2 configs
* [opensuse-Tumbleweed-NET](http://kepler.suse.cz/tests/24193#step/bootloader_uefi/8)
* [opensuse-Tumbleweed-DVD](http://kepler.suse.cz/tests/24185#step/bootloader_uefi/7)
* [microos-dvd](http://kepler.suse.cz/tests/24191#step/bootloader_uefi/6)
* [microos selfinstall](http://kepler.suse.cz/tests/24187#step/bootloader_uefi/7)

#### (Live|Rescue)-CD 
* [opensuse-Tumbleweed-Rescue-CD](http://kepler.suse.cz/tests/24192#step/bootloader_uefi/7)
* [opensuse-Tumbleweed-XFCE-Live](http://kepler.suse.cz/tests/24186#step/bootloader_uefi/6)
* [opensuse-Tumbleweed-KDE-Live](http://kepler.suse.cz/tests/24194#step/bootloader_uefi/7)
