### PR TITLE
ltp: Add support for SLE 16

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -258,7 +258,7 @@ sub setup_network {
     # boo#1017616: missing link to ping6 in iputils >= s20150815
     assert_script_run('which ping6 >/dev/null 2>&1 || ln -s `which ping` /usr/local/bin/ping6');
 
-    unless (is_transactional) {
+    unless (is_transactional || is_sle('16+')) {
         # dhcpd
         assert_script_run('touch /var/lib/dhcp/db/dhcpd.leases');
         script_run('touch /var/lib/dhcp6/db/dhcpd6.leases');


### PR DESCRIPTION
SLE 16 support in similar way like for transactional systems.
```
Test died: command 'touch /var/lib/dhcp/db/dhcpd.leases' failed at /usr/lib/os-autoinst/testapi.pm line 932.
	testapi::assert_script_run("touch /var/lib/dhcp/db/dhcpd.leases") called at sle/tests/kernel/install_ltp.pm line 263
	install_ltp::setup_network() called at sle/tests/kernel/install_ltp.pm line 390
```

- Related fail: https://openqa.suse.de/tests/16115637#step/install_ltp/291
- Needles: none
- Verification run: 
SLE16: https://openqa.suse.de/tests/16115676


**Maybe it is wrong solution, but it makes POC for SLE 16  pass and we should install dhcpcd as dependency which is available**