### PR TITLE
Fix SMT autoyast profile for 15sp7 spvm

### DIFF
--- a/data/yam/autoyast/create_hdd_migration_ppc64le.xml.ep
+++ b/data/yam/autoyast/create_hdd_migration_ppc64le.xml.ep
@@ -4,6 +4,9 @@
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
     <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+    % if ($check_var->('SCC_URL', 'none') or $check_var->('SCC_URL', "")) {
+        <reg_server><%= $get_var->('SMT_URL') %></reg_server>
+    % }
     <install_updates config:type="boolean">true</install_updates>
     % if (keys %$addons) {
     <addons config:type="list">

--- a/tests/migration/online_migration/yast2_migration.pm
+++ b/tests/migration/online_migration/yast2_migration.pm
@@ -218,7 +218,14 @@ sub run {
         # gpg keys; Same with leap to sle migration, need to trust packagehub gpg key.
         if (get_var('SMT_URL') =~ /smt/) {
             assert_screen 'import-untrusted-gpg-key', 180;
-            send_key 'alt-t';
+            # for 15-SP7 yast2 migration with smt, we need to choose Again and Yes.
+            if (is_sle('15-SP7+')) {
+                send_key 'alt-a';
+                send_key 'alt-y';
+            }
+            else {
+                send_key 'alt-t';
+            }
             if ((is_x86_64) && (!(is_leap_migration)) || (is_aarch64)) {
                 assert_screen 'import-untrusted-gpg-key-nvidia', 300;
                 send_key 'alt-t';


### PR DESCRIPTION
##
### Fix SMT autoyast profile for 15sp7 spvm

We need to add SMT_URL for smt milestone case and choose "Yes" for yast2 migration with smt.

- Error screen:
   -  https://openqa.suse.de/tests/16124624#step/yast2_migration/7
- Related ticket: 
  - https://progress.opensuse.org/issues/169789
  - https://progress.opensuse.org/issues/169624
- Needles: 
  - N/A 
- Verification run: 
  -  https://openqa.suse.de/tests/16141815

##