### PR TITLE
Fix x509 tls certificate failure

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_agent.pm
+++ b/tests/virt_autotest/kubevirt_tests_agent.pm
@@ -63,7 +63,7 @@ sub rke2_agent_setup {
     transactional::process_reboot(trigger => 1) if (is_transactional);
     record_info('Installed certificates packages', script_output('rpm -qa | grep certificates'));
     # Set kernel hostname to avoid x509 server connection issue
-    assert_script_run('hostnamectl set-hostname $(uname -n)');
+    assert_script_run('hostnamectl set-hostname $(hostname -f)');
 
     # Install kubevirt packages complete
     barrier_wait('kubevirt_packages_install_complete');

--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -113,7 +113,7 @@ sub rke2_server_setup {
     transactional::process_reboot(trigger => 1) if (is_transactional);
     record_info('Installed certificates packages', script_output('rpm -qa | grep certificates'));
     # Set kernel hostname to avoid x509 server connection issue
-    assert_script_run('hostnamectl set-hostname $(uname -n)');
+    assert_script_run('hostnamectl set-hostname $(hostname -f)');
 
     $self->install_kubevirt_packages();
 


### PR DESCRIPTION
Fix the following failure during connecting kubevirt nodes.

> E1206 06:37:50.095586   15055 memcache.go:265] couldn't get current server API group list: Get "https://bare-metal1.oqa.prg2.suse.org:6443/api?timeout=32s": tls: failed to verify certificate: x509: certificate is valid for kubernetes, kubernetes.default, kubernetes.default.svc, kubernetes.default.svc.cluster.local, localhost, bare-metal1, not bare-metal1.oqa.prg2.suse.org

- Related ticket: https://progress.opensuse.org/issues/173710
- Verification run: https://openqa.suse.de/tests/16127509
