### PR TITLE
Change powerVM autoyast boot timeout to -1

### DIFF
--- a/data/yam/autoyast/create_hdd_migration_ppc64le.xml.ep
+++ b/data/yam/autoyast/create_hdd_migration_ppc64le.xml.ep
@@ -50,7 +50,7 @@
   </add-on>
   <bootloader>
     <global>
-      <timeout config:type="integer">45</timeout>
+      <timeout config:type="integer">-1</timeout>
     </global>
   </bootloader>
   <general>


### PR DESCRIPTION
##
###  Change powerVM autoyast boot timeout to -1

- Error screen:
  -  https://openqa.suse.de/tests/16141905#step/online_migration_setup/1
- Related ticket: 
   - https://progress.opensuse.org/issues/169789
- Needles: 
  - N/A 
- Verification run:
  -  https://openqa.suse.de/tests/16142016#step/online_migration_setup/2
  
##
