### PR TITLE
Refactor bci_collect_stats

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -278,7 +278,8 @@ sub load_container_tests {
         # Container Image tests common
         loadtest 'containers/host_configuration';
         if (get_var('BCI_TESTS') && !get_var('BCI_SKIP')) {
-            # bci_version_check required jq from bci_prepare.
+            loadtest 'containers/bci_collect_stats' if (get_var('IMAGE_STORE_DATA'));
+            # Note: bci_version_check requires jq.
             loadtest 'containers/bci_version_check' if (get_var('CONTAINER_IMAGE_TO_TEST') && get_var('CONTAINER_IMAGE_BUILD'));
         }
     }

--- a/tests/containers/bci_collect_stats.pm
+++ b/tests/containers/bci_collect_stats.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: bci-tests stats collection
+#
+#   This module collects basic container stats and sends them to the k2 database
+# Maintainer: QE-C team <qa-c@suse.de>
+
+
+use Mojo::Base qw(consoletest);
+use utils qw(script_retry);
+use db_utils qw(push_image_data_to_db);
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+
+    die "IMAGE_STORE_DATA is not set" unless get_var('IMAGE_STORE_DATA');    # Failsafe
+
+    # podman and docker collect the image size differently. To remain consistent we only collect the image size as reported by podman
+    my $engines = get_required_var('CONTAINER_RUNTIMES');
+    my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
+    return unless ($engines =~ /podman/);
+
+    script_retry("podman pull -q $image", retry => 3, delay => 120);
+    my $size_mb = script_output("podman inspect --format \"{{.VirtualSize}}\" $image") / 1000000;
+    my %args;
+    $args{arch} = get_required_var('ARCH');
+    $args{distri} = 'bci';
+    $args{flavor} = get_required_var('BCI_IMAGE_NAME');
+    $args{flavor} =~ s/^bci-//;    # Remove optional bci prefix from the image name because the distri already determines that this is bci.
+    $args{type} = 'VirtualSize';
+    $args{version} = get_required_var('VERSION');
+    $args{build} = get_required_var('BUILD');
+    push_image_data_to_db('containers', $image, $size_mb, %args);
+}
+
+1;


### PR DESCRIPTION
Extract a own test module bci_collect_stats to collect stats about the running containers.

This is useful as it displays errors with the container stats visibly within the job group instead of a generic test failure in "bci_version_check". Also it makes it more visible when and where the stats are collected and allows us to softfail those issues, if necessary.

## Verification runs

* [Tumbleweed - bci_init](https://openqa.opensuse.org/tests/4695353) - **not** supposed to collect stats
* [SLES 15-SP4 bci_minimal](https://openqa.suse.de/tests/16164052) - **not** supposed to collect stats
* [SLES 15-SP6 bci_minimal](https://openqa.suse.de/tests/16164053) - is supposed to collect stats
* [SLES 15-SP6 bci_minimal ppc64](https://openqa.suse.de/tests/16164054) is supposed to collect stats and to fail, but the test run should continue