### PR TITLE
containers: Limit bsc#1232522 soft-failure to 15-SP3

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -102,7 +102,7 @@ sub run {
 
     # Run tests as user
     if ($runtime eq "podman" && !is_public_cloud && !is_sle('<15-SP3') && !is_svirt) {
-        if (is_sle('<15-SP5')) {
+        if (is_sle('<15-SP4')) {
             record_soft_failure("bsc#1232522 - buildah security update changes default network mode from slirp4netns to passt for rootless containers");
         } else {
             select_user_serial_terminal;


### PR DESCRIPTION
 Limit bsc#1232522 soft-failure to 15-SP3

- Related ticket: https://progress.opensuse.org/issues/169075
- Verification run: https://openqa.suse.de/tests/15997537 for another PR.