### PR TITLE
Update FLAVOR for partition table check in JeOS

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -112,7 +112,7 @@ sub verify_partition_label {
     # The RPi firmware needs MBR. s390x images also use MBR.
     # Note: JeOS-for-RaspberryPi means "kiwi-templates-Minimal" and JeOS-for-RPi means "community JeOS".
     # In sle-micro the raw aarch64 images are used for RPi, hence they have contain `dos`
-    if (is_s390x || check_var('FLAVOR', 'JeOS-for-RaspberryPi') || check_var('FLAVOR', 'JeOS-for-RPi') || (is_sle_micro && is_aarch64 && get_var('FLAVOR', '') =~ /(^Base$|^Default$)/)) {
+    if (is_s390x || get_var('FLAVOR', '') =~ /JeOS-for-RaspberryPi/ || check_var('FLAVOR', 'JeOS-for-RPi') || (is_sle_micro && is_aarch64 && get_var('FLAVOR', '') =~ /(^Base$|^Default$)/)) {
         $label = 'dos';
     }
 


### PR DESCRIPTION
The QR flavor for RPi was omitted therefore incorrect partition table type was being asserted.

#### Verification runs

* [15-sp7](https://openqa.suse.de/tests/16158755#)
* [15-sp6 qr](https://openqa.suse.de/tests/16158754#step/firstrun/71)
