### PR TITLE
wsl/prepare_wsl.pm: Run wsl.exe --update on Win 11 24H2 only

### DIFF
--- a/tests/wsl/prepare_wsl.pm
+++ b/tests/wsl/prepare_wsl.pm
@@ -54,7 +54,7 @@ sub run {
         $self->run_in_powershell(
             cmd => 'wsl.exe --update',
             timeout => 300
-        ) if check_var('WIN_VERSION', '11');
+        ) if get_var('HDD_1') =~ /24H2/;
     }
 
     $self->reboot_or_shutdown(is_reboot => 1);


### PR DESCRIPTION
Despite the documentation claiming that it exists even on win 10, it's not even available on 23H2!

VRs:
x86 23H2: https://openqa.opensuse.org/tests/4695166
aarch64: 24H2: https://openqa.opensuse.org/tests/4695167

CC @Chubykalo