### PR TITLE
Enable docker testing in sle12sp5 LTSS in aarch64

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -17,6 +17,8 @@ use bootloader_setup 'add_grub_cmdline_settings';
 use serial_terminal 'select_serial_terminal';
 use power_action_utils 'power_action';
 use Mojo::JSON;
+use version_utils qw(is_sle);
+use Utils::Architectures qw(is_aarch64);
 
 our @EXPORT = qw(is_unreleased_sle install_podman_when_needed install_docker_when_needed install_containerd_when_needed
   test_container_runtime test_container_image
@@ -108,7 +110,7 @@ sub install_docker_when_needed {
         } else {
             if ($host_os =~ 'sle') {
                 # We may run openSUSE with DISTRI=sle and openSUSE does not have SUSEConnect
-                activate_containers_module;
+                activate_containers_module unless is_sle('=12-SP5') && is_aarch64;
 
                 # Temporarly enable LTSS product on LTSS systems where it is not present
                 if (get_var('SCC_REGCODE_LTSS') && script_run('test -f /etc/products.d/SLES-LTSS.prod') != 0 && !main_common::is_updates_tests) {

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -194,7 +194,7 @@ sub test_opensuse_based_image {
         test_zypper_on_container($runtime, $image);
         build_and_run_image(base => $image, runtime => $runtime);
         # zypper-docker package has been excluded from sle starting with 15-SP6
-        if (is_sle('<15-SP6') && $runtime->runtime eq 'docker') {
+        if (is_sle('<15-SP6') && $runtime->runtime eq 'docker' && script_run('zypper -q se zypper-docker') == 0) {
             build_with_zypper_docker(image => $image, runtime => $runtime, version => $version);
         }
     }

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -189,7 +189,7 @@ sub load_host_tests_docker {
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
     # Expected to work anywhere except of real HW backends, PC and Micro
-    unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro) {
+    unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {
         loadtest 'containers/validate_btrfs';
     }
 }


### PR DESCRIPTION
The container module for aarch64 12SP5 is not going to be enabled hence
the container packages will land in LTSS. We need to skip enabling
container repo.

The PR is skipping `validate_btrfs.pm` as the module is dependent on
`/var` subvolume that is not present in aarch64 sle12sp5 installations

Package `zypper-docker` is not yet present and it is unclear whether it
will be added in the near future.

```
devtmpfs        974M     0  974M   0% /dev
tmpfs           992M     0  992M   0% /dev/shm
tmpfs           992M   23M  970M   3% /run
tmpfs           992M     0  992M   0% /sys/fs/cgroup
/dev/vdb2        38G  2.9G   34G   8% /
/dev/vdb2        38G  2.9G   34G   8% /.snapshots
/dev/vdb1       305M  216K  305M   1% /boot/efi
tmpfs           199M     0  199M   0% /run/user/0
```

- ticket: [[Containers] Prepare docker tests on 12-SP5 arm](https://progress.opensuse.org/issues/170251)
- Verification run: 
  - sle-12-SP5-Server-DVD-Updates-aarch64-Buildmloviska_containers-docker_tests@aarch64-virtio -> https://openqa.suse.de/tests/16172562
