### PR TITLE
Quickfix double redirection in upload_agama_logs

### DIFF
--- a/lib/Yam/Agama/agama_base.pm
+++ b/lib/Yam/Agama/agama_base.pm
@@ -18,9 +18,9 @@ sub post_fail_hook {
 
 sub upload_agama_logs {
     select_console 'root-console';
-    save_and_upload_log('agama config show > /tmp/agama-config.json', "/tmp/agama-config.json");
-    save_and_upload_log('agama logs store', "/tmp/agama-logs.tar.gz");
-    save_and_upload_log('journalctl -b > /tmp/journal.log', "/tmp/journal.log");
+    save_and_upload_log('agama config show', "/tmp/agama-config.json", {timeout => 60});
+    save_and_upload_log('agama logs store', "/tmp/agama-logs.tar.gz", {timeout => 60});
+    save_and_upload_log('journalctl -b', "/tmp/journal.log", {timeout => 60});
 }
 
 sub upload_browser_automation_dumps {


### PR DESCRIPTION
- Removed the output redirection, because this is already done by giving the filename for the tee command.
- Increased timeout for the commands because sometimes the post_fail method timed out.

VR: https://openqa.suse.de/tests/16161920



