### PR TITLE
Enable Agama auto install on Bare Metal server

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -24,6 +24,7 @@ use constant {
           is_sle_micro
           is_micro
           is_alp
+          is_agama
           is_selfinstall
           is_gnome_next
           is_jeos
@@ -986,4 +987,13 @@ sub has_selinux_by_default {
 
 sub has_selinux {
     return get_var('SELINUX', has_selinux_by_default);
+}
+
+=head2 is_agama
+
+Check if agama installation is being used
+=cut
+
+sub is_agama {
+    return (get_var('AGAMA') || get_var('AGAMA_AUTO'));
 }

--- a/tests/installation/agama_reboot.pm
+++ b/tests/installation/agama_reboot.pm
@@ -3,10 +3,10 @@
 # Copyright 2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Installation of Leap or Tumbleweed with Agama
+# Summary: Installation of Sle/Leap or Tumbleweed with Agama
 # https://github.com/openSUSE/agama/
 
-# Exepcted to be executed right after agama.pm
+# Exepcted to be executed right after agama.pm or agama auto install
 # This test handles actions that happen once we see the reboot button after install
 # 1) Switch from installer to console to Upload logs
 # 2) Switch back to X11/Wayland and reset_console s
@@ -14,6 +14,8 @@
 # 3) workaround for no ability to disable grub timeout in agama
 #    https://github.com/openSUSE/agama/issues/1594
 #    grub_test() is too slow to catch boot screen for us
+# 4) for ipmi backend, vnc access during the installation is not available now,
+#    we need to access to live root system to monitor installation process
 # Maintainer: Lubos Kocman <lubos.kocman@suse.com>,
 
 use strict;
@@ -24,12 +26,14 @@ use version_utils qw(is_leap is_sle);
 use utils;
 use Utils::Logging qw(export_healthcheck_basic);
 use x11utils 'ensure_unlocked_desktop';
+use Utils::Backends qw(is_ipmi);
+use Utils::Architectures qw(is_aarch64);
 
 sub upload_agama_logs {
     return if (get_var('NOLOGS'));
     select_console("root-console");
     # stores logs in /tmp/agma-logs.tar.gz
-    script_run('agama logs store');
+    script_run('agama logs store -d /tmp');
     upload_logs('/tmp/agama-logs.tar.gz');
 }
 
@@ -38,8 +42,67 @@ sub get_agama_install_console_tty {
     return 7;
 }
 
+sub verify_agama_auto_install_done_cmdline {
+    # for some remote workers, there is no vnc access to the install console,
+    # so we need to make sure the installation has completed from command line.
+    my $timeout = 300;
+    while ($timeout > 0) {
+        if (script_run("journalctl -u agama | grep 'Install phase done'") == 0) {
+            record_info("agama install phase done");
+            return;
+        }
+        sleep 20;
+        $timeout = $timeout - 20;
+    }
+    die "Install phase is not done, please check agama logs";
+}
+
+sub agama_system_prepare_ipmi {
+    # Mount the root disk after installation, and do some prepare tasks:
+    # Configure serial console, enable root ssh access, etc
+
+    # Get the root disk name
+    my $device = script_output qq(agama config show | grep -oP '(?<="disk": ")[^"]+');
+    # Use partition prefix for nvme devices
+    my $prefix = $device =~ /nvme/ ? "p" : "";
+    my $root_partition_id = 2;
+    my $root_partition = "${device}" . $prefix . $root_partition_id;
+    record_info("Device information", "Device: ${device}\nRoot partition: ${root_partition}");
+    assert_script_run("mount ${root_partition} /mnt");
+    # Set correct serial console to be able to see login in first boot
+    record_info("Set serial console");
+    my $sol_console = (is_aarch64) ? get_var('SERIALCONSOLE', 'ttyAMA0') : get_var('SERIALCONSOLE', 'ttyS1');
+    assert_script_run("sed -i 's/quiet/console=$sol_console,115200/g' /mnt/boot/grub2/grub.cfg");
+    # Upload original grub configuration
+    upload_logs("/mnt/etc/default/grub", failok => 1);
+    upload_logs("/mnt/boot/grub2/grub.cfg", failok => 1);
+    # Set permanent grub configuration
+    assert_script_run("sed -i 's/quiet/console=$sol_console,115200/g' /mnt/etc/default/grub");
+    # Enable root ssh access
+    record_info("Enable root ssh login");
+    assert_script_run("echo 'PermitRootLogin yes' > /mnt/etc/ssh/sshd_config.d/root.conf");
+    assert_script_run("umount /mnt");
+}
+
 sub run {
     my ($self) = @_;
+
+    if (is_ipmi && get_var('AGAMA_AUTO')) {
+        select_console('root-console');
+        record_info 'Wait for installation phase done';
+        verify_agama_auto_install_done_cmdline();
+        script_run('agama logs store -d /tmp');
+        upload_logs('/tmp/agama-logs.tar.gz');
+        record_info 'Prepare system before rebooting';
+        agama_system_prepare_ipmi();
+        record_info 'Reboot system to disk boot';
+        enter_cmd 'reboot';
+        # Swith back to sol console, then user can monitor the boot log
+        select_console 'sol', await_console => 0;
+        wait_still_screen 10;
+        save_screenshot;
+        return;
+    }
 
     assert_screen('agama-congratulations');
     console('installation')->set_tty(get_agama_install_console_tty());

--- a/variables.md
+++ b/variables.md
@@ -482,3 +482,14 @@ Variable        | Type      | Default value | Details
 ---             | ---       | ---           | ---
 SCC_RECGODE_LTSS | string | | This will hold the registration code for activating the product SLES-LTSS
 SCC_RECGODE_LTSS_ES | string | | This will hold the registration code for activating the product SLES-LTSS-Extended-Security
+
+### Agama specific variables
+
+Following variables are relevant for agama installation
+
+Variable        | Type      | Default value | Details
+---             | ---       | ---           | ---
+AGAMA | boolean | 0 | Agama installation support
+AGAMA_AUTO | string | | The auto-installation is started by passing `agama.auto=<url>` on the kernel's command line
+AGAMA_LIVE_ISO_URL | string | | The url of agama live iso to pass as kernel's command-line parameter. Example of usage "root=live:http://agama.iso"
+AGAMA_INSTALL_URL | string | | This will support using 'agama.install_url' boot parameter for overriding the default installation repositories. You can use multiple URLs separated by comma: agama.install_url=https://example.com/1,https://example.com/2


### PR DESCRIPTION
https://progress.opensuse.org/issues/173758

- Verification run: 

aarch64: http://10.200.129.6/tests/81288
x86_64: 
[root disk: sda](https://openqa.suse.de/tests/16210187)
[root disk: nvme0n1](https://openqa.suse.de/tests/16210189)

**Now vnc console access during the installation has some problems, see https://progress.opensuse.org/issues/170434**

So adding some workarounds to configure the serial console and root ssh login before rebooting the host from harddisk after installation

**Currently, we are still in early phase of agama, so some new changes are expected in next few weeks**