### PR TITLE
Do not execute syscall_thrasher on s390x

### DIFF
--- a/schedule/security/atsec_tests.yaml
+++ b/schedule/security/atsec_tests.yaml
@@ -12,7 +12,7 @@ schedule:
     - security/atsec/dbus_services_exposure
     - security/atsec/check_undocumented_security_programs
     - security/atsec/dbus_fuzzer
-    - security/atsec/syscall_thrasher
+    - '{{syscall_thrasher}}'
     - security/atsec/netlink_message
     - security/atsec/chrony_pid_file
     - security/atsec/permission_settings
@@ -24,6 +24,12 @@ conditional_schedule:
                 - security/atsec/check_processor_vulnerability_mitigations
             aarch64:
                 - security/atsec/check_processor_vulnerability_mitigations
+    syscall_thrasher:
+        ARCH:
+            x86_64:
+                - security/atsec/syscall_thrasher
+            aarch64:
+                - security/atsec/syscall_thrasher
     disable_root_ssh:
         ARCH:
             s390x:


### PR DESCRIPTION
Disable running syscall_thrasher on s390x.

- Related ticket: https://progress.opensuse.org/issues/174079
- Verification runs:
  - aarcxh64: https://openqa.suse.de/tests/16170037
  - s390x: https://openqa.suse.de/tests/16170038
  - x86_64: https://openqa.suse.de/tests/16170039
