### PR TITLE
console/ping: Use command instead of which to get full pathname

### DIFF
--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -29,7 +29,7 @@ sub run {
     $ping_group_range = script_output('sysctl net.ipv4.ping_group_range');
 
     zypper_call('in iputils libcap-progs sudo');
-    $capability = script_output('getcap $(which ping)', proceed_on_failure => 1);
+    $capability = script_output('getcap $(command -v ping)', proceed_on_failure => 1);
 
     record_info('KERNEL VERSION', script_output('uname -a'));
     record_info('net.ipv4.ping_group_range', $ping_group_range);


### PR DESCRIPTION
Use `command -v` instead of `which` to get pathname to executable.  `command` is [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html).  Checked in openSUSE (bash & Bash `sh` mode), Debian (Dash), Alpine (sh), FreeBSD (sh & ksh), NetBSD (sh & ksh), OpenBSD (sh & ksh), DragonflyBSD (sh) & OpenIndiana (sh & ksh).

- Related ticket: https://progress.opensuse.org/issues/168961
- Verification run: https://openqa.opensuse.org/tests/4696577 (failing for other reason)
