### PR TITLE
Boot Agama in OSD in PowerVM

### DIFF
--- a/lib/Distribution/Opensuse/AgamaDevel.pm
+++ b/lib/Distribution/Opensuse/AgamaDevel.pm
@@ -16,6 +16,7 @@ use Yam::Agama::Pom::GrubMenuBasePage;
 use Yam::Agama::Pom::GrubMenuAgamaPage;
 use Yam::Agama::Pom::GrubMenuTumbleweedPage;
 use Yam::Agama::Pom::GrubEntryEditionPage;
+use Yam::Agama::Pom::GrubCmdPage;
 use Yam::Agama::Pom::AgamaUpAndRunningPage;
 use Yam::Agama::Pom::RebootPage;
 use Yam::Agama::Pom::RebootTextmodePage;
@@ -43,9 +44,8 @@ sub get_grub_menu_installed_system {
     });
 }
 
-sub get_grub_entry_edition {
-    return is_ppc64le() ? Yam::Agama::Pom::GrubEntryEditionPage->new({
-            max_interval => utils::VERY_SLOW_TYPING_SPEED})
+sub get_grub_editor {
+    return is_ppc64le() ? Yam::Agama::Pom::GrubCmdPage->new()
       : Yam::Agama::Pom::GrubEntryEditionPage->new();
 }
 
@@ -56,7 +56,7 @@ sub get_agama_up_an_running {
 }
 
 sub get_reboot {
-    return Yam::Agama::Pom::RebootTextmodePage->new() if is_s390x();
+    return Yam::Agama::Pom::RebootTextmodePage->new() if is_s390x() || is_ppc64le();
     return Yam::Agama::Pom::RebootPage->new();
 }
 

--- a/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
+++ b/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
@@ -20,7 +20,8 @@ sub new {
             qw(agama-product-selection
               agama-configuring-the-product
               agama-installing
-              agama-sle-overview)],
+              agama-sle-overview
+              agama-shell-logged)],
         timeout_expect_is_shown => $args->{timeout_expect_is_shown} // 120
     }, $class;
 }

--- a/lib/Yam/Agama/Pom/GrubCmdPage.pm
+++ b/lib/Yam/Agama/Pom/GrubCmdPage.pm
@@ -1,0 +1,76 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles GRUB cmd.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+package Yam::Agama::Pom::GrubCmdPage;
+use strict;
+use warnings;
+use utils qw(type_string_slow);
+
+use testapi;
+use bootloader_setup;
+
+sub new {
+    my ($class, $args) = @_;
+    return bless {
+        max_interval => $args->{max_interval},
+        key_return => 'ret'
+    }, $class;
+}
+
+sub type {
+    my ($self, $args) = @_;
+    type_string_slow("$args ", max_interval => $self->{max_interval});
+    wait_still_screen(1);
+    save_screenshot();
+}
+
+sub send_return_key {
+    my ($self) = @_;
+    send_key($self->{key_return});
+}
+
+sub add_boot_parameters {
+    my ($self) = @_;
+
+    my $iso = get_required_var('ISO');
+    my $repo = get_required_var('REPO_0');
+    my $mntpoint = "mnt/openqa/repo/$repo/boot/ppc64le";
+
+    if (my $ppc64le_grub_http = get_var('PPC64LE_GRUB_HTTP')) {
+        # Enable grub http protocol to load file from OSD: (http,10.145.10.207)/assets/repo/$repo/boot/ppc64le
+        $mntpoint = "$ppc64le_grub_http/assets/repo/$repo/boot/ppc64le";
+        record_info("Updated boot path for PPC64LE_GRUB_HTTP defined", $mntpoint);
+    }
+
+    $self->type("linux $mntpoint/linux");
+    $self->type("vga=normal");
+    $self->type("console=hvc0");
+    $self->type("kernel.softlockup_panic=1");
+    $self->type("Y2DEBUG=1");
+    if (my $extrabootparams = get_var('EXTRABOOTPARAMS')) {
+        $self->type($extrabootparams);
+    }
+    else {
+        $self->type("live.password=$testapi::password");
+    }
+    my $host = get_var('OPENQA_HOSTNAME', 'openqa.opensuse.org');
+    $self->type("root=live:http://$host/assets/iso/$iso");
+    $self->send_return_key();
+
+    $self->type("initrd $mntpoint/initrd");
+    $self->send_return_key();
+}
+
+sub boot {
+    my ($self) = @_;
+    enter_cmd("boot");
+    prepare_disks;
+    script_run("agamactl -s");
+}
+
+1;

--- a/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
@@ -31,4 +31,6 @@ sub boot_from_hd {
 
 sub edit_current_entry { shift->{grub_menu_base}->edit_current_entry() }
 
+sub cmd { shift->{grub_menu_base}->cmd() }
+
 1;

--- a/lib/Yam/Agama/Pom/GrubMenuBasePage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuBasePage.pm
@@ -14,13 +14,19 @@ use testapi;
 sub new {
     my ($class, $args) = @_;
     return bless {
-        key_edit_entry => 'e'
+        key_edit_entry => 'e',
+        key_cmd_entry => 'c'
     }, $class;
 }
 
 sub edit_current_entry {
     my ($self) = @_;
     wait_screen_change { send_key($self->{key_edit_entry}) };
+}
+
+sub cmd {
+    my ($self) = @_;
+    wait_screen_change { send_key($self->{key_cmd_entry}) };
 }
 
 sub select_first_entry {

--- a/lib/Yam/Agama/Pom/GrubMenuSlesPage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuSlesPage.pm
@@ -11,20 +11,29 @@ use strict;
 use warnings;
 use testapi;
 
+use Utils::Architectures;
+
 sub new {
     my ($class, $args) = @_;
     return bless {
         grub_menu_base => $args->{grub_menu_base},
         tag_first_entry_highlighted => 'grub-menu-sles16-highlighted',
+        tag_first_entry_highlighted_hmc_ppc64le => 'grub-menu-hmc_ppc64le-highlighted',
     }, $class;
 }
 
 sub expect_is_shown {
     my ($self) = @_;
-    assert_screen($self->{tag_first_entry_highlighted}, 60);
+    if (is_ppc64le()) {
+        assert_screen($self->{tag_first_entry_highlighted_hmc_ppc64le}, 60);
+    }
+    else {
+        assert_screen($self->{tag_first_entry_highlighted}, 60);
+    }
 }
 
 sub edit_current_entry { shift->{grub_menu_base}->edit_current_entry() }
 sub select_first_entry { shift->{grub_menu_base}->select_first_entry() }
+sub cmd { shift->{grub_menu_base}->cmd() }
 
 1;

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -284,7 +284,7 @@ sub boot_hmc_pvm {
         return;
     }
     get_into_net_boot;
-    prepare_pvm_installation;
+    prepare_pvm_installation unless get_var('AGAMA_TEST');
 }
 
 =head2 boot_spvm


### PR DESCRIPTION
We have swapped ppc64le machine from svirt to hmc, this includes some changes in the way to boot and manage parameters.

- Related ticket: https://progress.opensuse.org/issues/169480
- Related testing PR: https://github.com/jknphy/agama-integration-test-webpack/pull/47
- Needles: `grub-menu-hmc_ppc64le-highlighted`
- Verification run: https://openqa.suse.de/tests/16171456
