### PR TITLE
Fix mr_test Ansible for LTSS

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -190,7 +190,7 @@ sub run {
         if ($name) {
             record_info($name, "Register '$name' with code '$ADDONS_REGCODE{$name}'");
             $playbook_configs{ltss} = join(',', join('/', $name, scc_version(), 'x86_64'), $ADDONS_REGCODE{$name});
-            $playbook_configs{registration} = 'suseconnect' if ($os_image_name =~ 'byos');
+            $playbook_configs{registration} = 'suseconnect' if ($os_image_name =~ 'byos' && $reg_mode !~ 'noreg');
         }
     }
     $ansible_playbooks = create_playbook_section_list(%playbook_configs);


### PR DESCRIPTION
Fix playbook list composition for LTSS, mr_test has not to have any Ansible section in the qe-sap-deployment conf.yaml, also when test is configured with SCC_ADDONS=ltss
Fix issue introduced with  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20642

- Related ticket: https://jira.suse.com/browse/TEAM-9839

- Verification run:
sle-12-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-BuildjgwangVR-sles4sap_gnome_saptune_notes@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/305880
