### PR TITLE
Run terraform destroy before retrying terraform apply

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -601,6 +601,17 @@ sub qesap_execute_conditional_retry {
         if ($ret[0]) {
             if (qesap_file_find_string(file => $ret[1], search_string => $args{error_string})) {
                 record_info('DETECTED ' . uc($args{cmd}) . ' ERROR', $args{error_string});
+
+                # Executing terraform destroy before retrying terraform apply
+                if ($args{destroy_terraform}) {
+                    qesap_execute(
+                        cmd => 'terraform',
+                        cmd_options => '-d',
+                        logname => "qesap_exec_terraform_destroy_before_retry$args{retries}.log.txt",
+                        verbose => 1,
+                        timeout => 1200);
+                }
+
                 @ret = qesap_execute(cmd => $args{cmd},
                     logname => 'qesap_' . $args{cmd} . '_retry_' . $args{retries} . '.log.txt',
                     timeout => $args{timeout});

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -210,7 +210,8 @@ sub run {
         verbose => 1,
         timeout => 3600,
         retries => 2,
-        error_string => 'An internal execution error occurred. Please retry later');
+        error_string => 'An internal execution error occurred. Please retry later',
+        destroy_terraform => 1);
     die 'Terraform deployment FAILED. Check "qesap*" logs for details.' if ($ret[0]);
 
     $provider->terraform_applied(1);


### PR DESCRIPTION
When retrying the terraform appaly command, the second error related to the resource already existing. So we could run destory befor retrying to avoid this error.

Related: https://jira.suse.com/browse/TEAM-9788

VR: https://openqa.suse.de/tests/16171500#step/qesap_terraform/368 
Using `QESAP_SIM_RC=45 QESAP_SIM_MSG='An internal execution error occurred. Please retry later'` to trigger a simulated failure.