### PR TITLE
Remove unnecessary needles from ipxe install for virt tests

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -294,19 +294,7 @@ sub run {
     if (get_var('VIRT_AUTOTEST')) {
         #it is static menu and choose the TW entry to start installation
         enter_o3_ipxe_boot_entry if get_var('IPXE_STATIC');
-        check_screen([qw(load-linux-kernel load-initrd)], 240);
-        # Loading initrd spend much time(fg. 10-15 minutes to Beijing SUT)
-        # Downloading from O3 became much more quick, some needles may not be caught.
-        check_screen([qw(start-tw-install start-sle-install network-config-created autoyast-installation)], 60);
-        if (match_has_tag('start-tw-install')) {
-            record_info("Install TW", "Start installing Tumbleweed...");
-        }
-        elsif (match_has_tag('start-sle-install')) {
-            record_info("Install SLE", "Start installing SLE...");
-        }
-        else {
-            record_info("Installing", "Pls check if the expected product is being installed.");
-        }
+        check_screen([qw(load-linux-kernel load-initrd)], 80);
         assert_screen([qw(network-config-created loading-installation-system sshd-server-started autoyast-installation)], 300);
         return if get_var('AUTOYAST');
         wait_still_screen(stilltime => 12, similarity_level => 60, timeout => 30) unless check_screen('sshd-server-started', timeout => 60);


### PR DESCRIPTION
- Remove unnecessary needles from ipxe install for virt tests



- Related ticket: https://progress.opensuse.org/issues/169774
- Verification run: 
[quinn](https://10.145.10.207/tests/16183230)
[ph052](http://10.200.140.2/tests/580)
[fibonacci](https://10.145.10.207/tests/16183391)
[12sp5_xen_on_shichahai](https://10.145.10.207/tests/16190389)
[bare-metal2](https://10.145.10.207/tests/16190392)
[bare-metal1](https://10.145.10.207/tests/16190394)
[12sp5_kvm_on_blackbauhinia](https://10.145.10.207/tests/16190396)
[Leon's_sle12sp5_xen_ob_on_fabonacci](https://10.145.10.207/tests/16202395)
[Leon's_sle12sp5_kvm_job_on_shichahai](https://10.145.10.207/tests/16202396)
