### PR TITLE
Quickfix for upload_agama_logs

### DIFF
--- a/lib/Yam/Agama/agama_base.pm
+++ b/lib/Yam/Agama/agama_base.pm
@@ -18,9 +18,10 @@ sub post_fail_hook {
 
 sub upload_agama_logs {
     select_console 'root-console';
-    save_and_upload_log('agama config show', "/tmp/agama-config.json", {timeout => 60});
-    save_and_upload_log('agama logs store', "/tmp/agama-logs.tar.gz", {timeout => 60});
-    save_and_upload_log('journalctl -b', "/tmp/journal.log", {timeout => 60});
+    save_and_upload_log('agama config show > /tmp/agama-config.json', "/tmp/agama-config.json", {timeout => 60});
+    script_run("agama logs store -d /tmp/agama-logs", {timeout => 60});
+    upload_logs("/tmp/agama-logs.tar.gz", failok => 1);
+    save_and_upload_log('journalctl -b > /tmp/journal.log', "/tmp/journal.log", {timeout => 60});
 }
 
 sub upload_browser_automation_dumps {


### PR DESCRIPTION
- Fixed the upload from `agama logs store` command
- Put back the output redirection to avoid screen clutter
- Verification run: https://openqa.suse.de/tests/16183350