### PR TITLE
DRAFT: SLE-M: introduced the ownership filter

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -32,6 +32,10 @@ sub is_dvd {
     return get_required_var('FLAVOR') =~ /dvd/i;
 }
 
+sub is_qec_test_run {
+    return check_var('QEC_SLEM_TESTS_FILTER', '1');
+}
+
 sub is_regproxy_required {
     # For now only the Kubic kubeadm test needs a registry proxy.
     # docker_image and podman_image pull with the full path themselves.
@@ -205,7 +209,7 @@ sub load_common_tests {
     loadtest 'microos/one_line_checks';
     loadtest 'microos/services_enabled';
     # MicroOS -old images use wicked, but cockpit-wicked is no longer supported in TW
-    loadtest 'microos/cockpit_service' unless (is_microos('Tumbleweed') && is_staging) || (is_microos('Tumbleweed') && get_var('HDD_1', '') =~ /-old/) || !get_var('SCC_REGISTER');
+    loadtest 'microos/cockpit_service' unless (is_microos('Tumbleweed') && is_staging) || (is_microos('Tumbleweed') && get_var('HDD_1', '') =~ /-old/) || !get_var('SCC_REGISTER') || is_qec_test_run;
     loadtest 'console/perl_bootloader' unless (is_bootloader_sdboot);
     # Staging has no access to repos and the MicroOS-DVD does not contain ansible
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
@@ -224,10 +228,10 @@ sub load_transactional_tests {
     loadtest 'transactional/disable_timers';
     loadtest 'transactional/filesystem_ro';
     loadtest 'transactional/trup_smoke';
-    loadtest 'microos/patterns' if is_sle_micro;
-    loadtest 'transactional/transactional_update';
-    loadtest 'transactional/rebootmgr';
-    loadtest 'transactional/health_check' if is_bootloader_grub2;    # health-checker needs GRUB2 (poo#129748)
+    loadtest 'microos/patterns' if is_sle_micro && !is_qec_test_run;
+    loadtest 'transactional/transactional_update' unless is_qec_test_run;
+    loadtest 'transactional/rebootmgr' unless is_qec_test_run;
+    loadtest 'transactional/health_check' if is_bootloader_grub2 && !is_qec_test_run;    # health-checker needs GRUB2 (poo#129748)
 }
 
 

--- a/variables.md
+++ b/variables.md
@@ -176,6 +176,7 @@ PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
 PXE_BOOT_TIME | integer | 120 | Approximate time that IPMI worker needs to load and execute PXE boot payload. Should be set in the IPMI worker configuration.
 QA_TESTSUITE | string | | Comma or semicolon separated a list of the automation cases' name, and these cases will be installed and triggered if you call "start_testrun" function from qa_run.pm
 QAM_MINIMAL | string | "full" or "small" | Full is adding patterns x11, gnome-basic, base, apparmor in minimal/install_patterns test. Small is just base.
+QEC_SLEM_TESTS_FILTER | boolean | undef | 1: SLE-micro tests flow limited to the 'qe-c owned' modules only; undef/else: no limitation. 
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
 REBOOT_TIMEOUT | integer | 0 | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
 REGISTRY | string | docker.io | Registry to pull third-party container images from


### PR DESCRIPTION
Introduced, for SLE-Micro test code flow, the `QEC_SLEM_TESTS_FILTER` parameter: 
when =1, the ownership is triggered, based on poo#161150 and coverage table, so that Not _qe-c owned_ test modules are Skipped.

- Related ticket: https://progress.opensuse.org/issues/161150

- Verification run, set ~~QEC_TEST_FILTER=1~~: 
  https://openqa.suse.de/tests/16185796 VR1
  https://openqa.suse.de/tests/16185818 non regression
  See newer runs below with `QEC_SLEM_TESTS_FILTER`.