### PR TITLE
Enable Azure AITL tests for SLE-Micro

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -300,7 +300,9 @@ sub load_journal_check_tests {
 
 sub load_slem_on_pc_tests {
     my $args = OpenQA::Test::RunArgs->new();
-    if (get_var('PUBLIC_CLOUD_DOWNLOAD_TESTREPO')) {
+    if (get_var('PUBLIC_CLOUD_AZURE_AITL')) {
+        loadtest "publiccloud/azure_aitl", run_args => $args;
+    } elsif (get_var('PUBLIC_CLOUD_DOWNLOAD_TESTREPO')) {
         load_publiccloud_download_repos();
     } elsif (get_var('PUBLIC_CLOUD_UPLOAD_IMG')) {
         loadtest("boot/boot_to_desktop");


### PR DESCRIPTION
The last AITL PR enabled AITL for SLES and this PR also enables it for SLEM.



- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20649
- Verification run: http://dirtman.qe.prg2.suse.org/tests/243#
