### PR TITLE
kdump: Use http instead of ftp for debug repository

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -48,10 +48,11 @@ sub install_kernel_debuginfo {
 }
 
 sub get_repo_url_for_kdump_sle {
-    return join('/', $utils::OPENQA_FTP_URL, get_var('REPO_SLE_MODULE_BASESYSTEM_DEBUG'))
+    my $openqa_url = 'http://' . get_var('OPENQA_HOSTNAME', 'openqa.suse.de') . '/assets/repo';
+    return join('/', $openqa_url, get_var('REPO_SLE_MODULE_BASESYSTEM_DEBUG'))
       if get_var('REPO_SLE_MODULE_BASESYSTEM_DEBUG')
       and is_sle('15+');
-    return join('/', $utils::OPENQA_FTP_URL, get_var('REPO_SLES_DEBUG')) if get_var('REPO_SLES_DEBUG');
+    return join('/', $openqa_url, get_var('REPO_SLES_DEBUG')) if get_var('REPO_SLES_DEBUG');
 }
 
 sub prepare_for_kdump_sle {


### PR DESCRIPTION
Fix poo#170422: FTP service on openqa.suse.de is not available due to
recent security changes and is better to use http for debug
repository.

- Related ticket: https://progress.opensuse.org/issues/174370
- Needles: none
##### Verification runs:
###### 15-SP7 product validation
The only place where debug repository was added via ftp.
- ppc64le this one needed a fix - https://openqa.suse.de/tests/16191310
- aarch64: https://openqa.suse.de/tests/16192074
- x86_64: https://openqa.suse.de/tests/16192073

###### Maintenance  + KOTD
ftp is not used in these scenarions, it is just generic verification.

15-SP7 KOTD:  https://openqa.suse.de/tests/16190249
15-SP6: https://openqa.suse.de/tests/16192077
12-SP5: https://openqa.suse.de/tests/16188747


