### PR TITLE
Enable JeOS-for-kvm-and-xen-sdboot flavor

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -646,7 +646,7 @@ sub load_jeos_tests {
     loadtest "jeos/record_machine_id";
     loadtest "console/force_scheduled_tasks";
     # this test case also disables grub timeout
-    loadtest "jeos/grub2_gfxmode";
+    loadtest "jeos/grub2_gfxmode" unless is_bootloader_sdboot;
     unless (get_var('INSTALL_LTP') || get_var('SYSTEMD_TESTSUITE')) {
         # jeos/diskusage as of now works only with BTRFS
         loadtest "jeos/diskusage" if get_var('FILESYSTEM', 'btrfs') =~ /btrfs/;
@@ -1265,7 +1265,7 @@ sub load_consoletests {
     loadtest "console/zypper_log";
     if (!get_var("LIVETEST")) {
         loadtest "console/yast2_i";
-        loadtest "console/yast2_bootloader";
+        loadtest "console/yast2_bootloader" unless is_bootloader_sdboot;
     }
     loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
 # textmode install comes without firewall by default atm on openSUSE. For virtualization server xen and kvm is disabled by default: https://fate.suse.com/324207

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -72,6 +72,11 @@ sub run {
         }
     }
 
+    if (is_jeos && get_required_var('FLAVOR') =~ /sdboot/) {
+        assert_screen("bootloader-sdboot");
+        return;
+    }
+
     if (get_var("IPXE") && !is_usb_boot) {
         sleep 60;
         return;


### PR DESCRIPTION
This PR contains some small fixes required to run the new Tumbleweed JeOS-for-kvm-and-xen-sdboot flavor.

- Related ticket: https://progress.opensuse.org/issues/169354
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/823
- OBS trigger: https://github.com/os-autoinst/openqa-trigger-from-obs/pull/282
- Schedule: https://github.com/os-autoinst/opensuse-jobgroups/pull/572
- Verification run: https://rmarliere-openqa.qe.prg2.suse.org/tests/1098
