### PR TITLE
Switch EC2 default instance type to t3a

### DIFF
--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -28,7 +28,7 @@ variable "name" {
 }
 
 variable "type" {
-  default = "t2.large"
+  default = "t3a.large"
 }
 
 variable "image_id" {

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -199,7 +199,7 @@ sub terraform_apply {
 sub img_proof {
     my ($self, %args) = @_;
 
-    $args{instance_type} //= 't2.large';
+    $args{instance_type} //= 't3a.large';
     $args{user} //= 'ec2-user';
     $args{provider} //= 'ec2';
     $args{ssh_private_key_file} //= SSH_KEY_PEM;

--- a/tests/publiccloud/bsc_1205002.pm
+++ b/tests/publiccloud/bsc_1205002.pm
@@ -30,7 +30,7 @@ sub run {
 
     $provider->stop_instance($instance);
 
-    my $instance_type = get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE', 't2.large');
+    my $instance_type = get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE', 't3a.large');
     $provider->change_instance_type($instance, $instance_type);
 
     $provider->start_instance($instance);

--- a/variables.md
+++ b/variables.md
@@ -351,13 +351,13 @@ PUBLIC_CLOUD_INFRA | boolean | false | Would trigger special flow in [check_regi
 PUBLIC_CLOUD_INFRA_RMT_V4 | string | "" | Defines IPv4 registration server in test infra. Must be used together with PUBLIC_CLOUD_INFRA. (DO NOT use the variable if you don't know what is about)
 PUBLIC_CLOUD_INFRA_RMT_V6 | string | "" | Defines IPv6 registration server in test infra. Must be used together with PUBLIC_CLOUD_INFRA. (DO NOT use the variable if you don't know what is about)
 PUBLIC_CLOUD_INSTANCE_IP | string | "" | If defined, no instance will be created and this IP will be used to connect to
-PUBLIC_CLOUD_INSTANCE_TYPE | string | "" | Specify the instance type. Which instance types exists depends on the CSP. (default-azure: Standard_A2, default-ec2: t2.large )
+PUBLIC_CLOUD_INSTANCE_TYPE | string | "" | Specify the instance type. Which instance types exists depends on the CSP. (default-azure: Standard_A2, default-ec2: t3a.large )
 PUBLIC_CLOUD_K8S_CLUSTER | string | "" | Name for the kubernetes cluster.
 PUBLIC_CLOUD_KEEP_IMG | boolean | false | If set, the uploaded image will be tagged with `pcw_ignore=1`
 PUBLIC_CLOUD_LTP | boolean | false | If set, the run_ltp test module is added to the job.
 PUBLIC_CLOUD_MAX_INSTANCES | integer | 1 | Allows the test to call "create_instance" subroutine within lib/publiccloud/provider.md a limited amount of times. If set to 0 or undef, it allows an unlimited amount of calls.
 PUBLIC_CLOUD_NAMESPACE | string | "" | The Public Cloud Namespace name that will be used to compose the full credentials URL together with `PUBLIC_CLOUD_CREDENTIALS_URL`.
-PUBLIC_CLOUD_NEW_INSTANCE_TYPE | string | "t2.large" | Specify the new instance type to check bsc#1205002 in EC2
+PUBLIC_CLOUD_NEW_INSTANCE_TYPE | string | "t3a.large" | Specify the new instance type to check bsc#1205002 in EC2
 PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE | boolean | false | Do not remove the instance when the test fails.
 PUBLIC_CLOUD_NVIDIA | boolean | 0 | If enabled, nvidia module would be scheduled. This variable should be enabled only sle15SP4 and above.
 PUBLIC_CLOUD_PERF_COLLECT | boolean | 1 | To enable `boottime` measures collection, at end of `create_instance` routine.


### PR DESCRIPTION
The new generation t3a instances deliver up to 10% cost savings over comparable instance types.

- Related ticket: https://progress.opensuse.org/issues/169405
