### PR TITLE
Simplify HanaSR at AZURE_FENCE_AGENT_CONFIGURATION

### DIFF
--- a/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
+++ b/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
@@ -7,7 +7,7 @@
 # Settings:
 #   FENCING_MECHANISM - needs to be set  to 'native'
 #   PUBLIC_CLOUD_PROVIDER - needs to be set to 'AZURE'
-#   AZURE_FENCE_AGENT_CONFIGURATION - set to 'msi' or 'spn' (default value: msi)
+#   AZURE_FENCE_AGENT_CONFIGURATION - set to 'msi' or 'spn'
 #   SPN related settings:
 #       _SECRET_AZURE_SPN_APPLICATION_ID - application ID for fencing agent
 #       _SECRET_AZURE_SPN_APP_PASSWORD - application password used by fencing agent
@@ -34,38 +34,49 @@ sub run {
 
     my $instances = $self->{instances} = $run_args->{instances};
     my $provider_client = $run_args->{instances}[0]{provider}{provider_client};
-    my $fence_agent_configuration = get_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi');
+    # This test module has only to be scheduled when:
+    # - test is on Azure
+    # -  fencing mechanism is native
+    # In this combination, AZURE_FENCE_AGENT_CONFIGURATION is required
+    my $fence_agent_configuration = get_required_var('AZURE_FENCE_AGENT_CONFIGURATION');
     my $resource_group = qesap_az_get_resource_group();
     my $subscription_id = $provider_client->{subscription};
-    my $tenant_id = check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn') ? qesap_az_get_tenant_id($subscription_id) : '';
-    my $spn_application_id = get_var('AZURE_SPN_APPLICATION_ID', get_required_var('_SECRET_AZURE_SPN_APPLICATION_ID'));
-    my $spn_application_password = get_var('AZURE_SPN_APP_PASSWORD', get_required_var('_SECRET_AZURE_SPN_APP_PASSWORD'));
     my @cluster_nodes = @{$self->list_cluster_nodes()};
 
     die 'Resoruce group not found' unless $resource_group;
-    die 'Tenant ID is required in case of Azure SPN fencing' if check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn') and !$tenant_id;
-    # Setting up credentials as variables so they do not show up in openQA outputs in plaintext
-    my $bashrc_vars = "export SUBSCRIPTION_ID=$subscription_id
-        export TENANT_ID=$tenant_id
-        export SPN_APPLICATION_ID=$spn_application_id
-        export SPN_APP_PASSWORD=$spn_application_password";
 
-    my $fence_agent_cmd = join(' ',
+    my @fence_agent_cmd_list = (
         'fence_azure_arm',
         "-C \'\'",
         '--action=list',
         "--resourceGroup=$resource_group",
         '--subscriptionId=$SUBSCRIPTION_ID');
 
-    $fence_agent_cmd = join(' ', $fence_agent_cmd, "--$fence_agent_configuration",) if $fence_agent_configuration eq 'msi';
-    $fence_agent_cmd = join(' ', $fence_agent_cmd,
-        '--username=$SPN_APPLICATION_ID',
-        '--password=$SPN_APP_PASSWORD',
-        '--tenantId=$TENANT_ID') if $fence_agent_configuration eq 'spn';
+    # Setting up credentials as variables so they do not show up in openQA outputs in plaintext
+    my @bashrc_vars = ("export SUBSCRIPTION_ID=$subscription_id");
+
+    if ($fence_agent_configuration eq 'spn') {
+        my $spn_application_id = get_var('AZURE_SPN_APPLICATION_ID', get_required_var('_SECRET_AZURE_SPN_APPLICATION_ID'));
+        my $spn_application_password = get_var('AZURE_SPN_APP_PASSWORD', get_required_var('_SECRET_AZURE_SPN_APP_PASSWORD'));
+
+        push @bashrc_vars, "export SPN_APPLICATION_ID=$spn_application_id";
+        push @bashrc_vars, "export SPN_APP_PASSWORD=$spn_application_password";
+
+        my $tenant_id = qesap_az_get_tenant_id($subscription_id);
+        die 'Tenant ID is required in case of Azure SPN fencing' unless $tenant_id;
+        push @bashrc_vars, "export TENANT_ID=$tenant_id";
+
+        push @fence_agent_cmd_list,
+          '--username=$SPN_APPLICATION_ID',
+          '--password=$SPN_APP_PASSWORD',
+          '--tenantId=$TENANT_ID';
+    }
+
+    push @fence_agent_cmd_list, "--$fence_agent_configuration" if $fence_agent_configuration eq 'msi';
 
     select_serial_terminal;
     # prepare bashrc file - this way credentials are not presented in outputs
-    save_tmp_file('bashrc', $bashrc_vars);
+    save_tmp_file('bashrc', join("\n", @bashrc_vars));
     assert_script_run('curl ' . autoinst_url . '/files/bashrc -o /tmp/bashrc');
 
     foreach my $instance (@$instances) {
@@ -82,7 +93,7 @@ sub run {
         assert_script_run($scp_cmd);
 
         record_info('Test start', "Running test from $instance->{instance_id}.");
-        my @nodes_ready = split(/[\n\s]/, $self->run_cmd(cmd => $fence_agent_cmd));
+        my @nodes_ready = split(/[\n\s]/, $self->run_cmd(cmd => join(' ', @fence_agent_cmd_list)));
 
         foreach (@cluster_nodes) {
             die "VM '$_' " . uc($fence_agent_configuration) . ' is not configured correctly.'

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -12,6 +12,7 @@ use warnings FATAL => 'all';
 use base 'sles4sap_publiccloud_basetest';
 use testapi;
 use main_common 'loadtest';
+use publiccloud::utils 'is_azure';
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
@@ -42,9 +43,9 @@ sub run {
         loadtest('sles4sap/publiccloud/qesap_ansible', name => 'deploy_qesap_ansible', run_args => $run_args, @_);
         loadtest('sles4sap/publiccloud/qesap_prevalidate', name => 'qesap_prevalidate', run_args => $run_args, @_);
     }
-    if (check_var('FENCING_MECHANISM', 'native') and check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+    if (check_var('FENCING_MECHANISM', 'native') and is_azure) {
         # MSI is preferred method not requiring additional password so it is set to default.
-        my $fence_agent_setup_type = uc(get_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi'));
+        my $fence_agent_setup_type = uc(get_required_var('AZURE_FENCE_AGENT_CONFIGURATION'));
         my $test_name = "Verify_azure_fence_agent_$fence_agent_setup_type";
         loadtest('sles4sap/publiccloud/azure_fence_agents_test', name => $test_name, run_args => $run_args, @_);
     }

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -83,7 +83,7 @@ sub run {
             my $instances = create_instance_data(provider => $provider_instance);
             foreach my $instance (@$instances) {
                 record_info 'New Instance', join(' ', 'IP: ', $instance->public_ip, 'Name: ', $instance->instance_id);
-                if (get_var('FENCING_MECHANISM') eq 'native' && $provider eq 'AZURE' && !check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn')) {
+                if (get_var('FENCING_MECHANISM') eq 'native' && is_azure && check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi')) {
                     qesap_az_setup_native_fencing_permissions(
                         vm_name => $instance->instance_id,
                         resource_group => qesap_az_get_resource_group());

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -170,7 +170,7 @@ sub run {
         $playbook_configs{ptf_account} = get_required_var('PTF_ACCOUNT');
     }
     if ($playbook_configs{fencing} eq 'native' and is_azure) {
-        $playbook_configs{fence_type} = get_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi');
+        $playbook_configs{fence_type} = get_required_var('AZURE_FENCE_AGENT_CONFIGURATION');
         if ($playbook_configs{fence_type} eq 'spn') {
             $playbook_configs{spn_application_id} = get_var('AZURE_SPN_APPLICATION_ID', get_required_var('_SECRET_AZURE_SPN_APPLICATION_ID'));
             $playbook_configs{spn_application_password} = get_var('AZURE_SPN_APP_PASSWORD', get_required_var('_SECRET_AZURE_SPN_APP_PASSWORD'));
@@ -226,7 +226,7 @@ sub run {
         # We expect hostnames reported by terraform to match the actual hostnames in Azure and GCE
         die "Expected hostname $expected_hostname is different than actual hostname [$real_hostname]"
           if ((is_azure() || is_gce()) && ($expected_hostname ne $real_hostname));
-        if (get_var('FENCING_MECHANISM') eq 'native' && get_var('PUBLIC_CLOUD_PROVIDER') eq 'AZURE' && !check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn')) {
+        if (get_var('FENCING_MECHANISM') eq 'native' && is_azure() && check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi')) {
             qesap_az_setup_native_fencing_permissions(
                 vm_name => $instance->instance_id,
                 resource_group => qesap_az_get_resource_group());

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -24,8 +24,8 @@ sub run {
     my $inventory = qesap_get_inventory(provider => $provider);
     upload_logs($inventory, failok => 1);
 
-    # Set up azure native fencing
-    if (get_var('QESAPDEPLOY_FENCING') eq 'native' && $provider eq 'AZURE' && !check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'spn')) {
+    # Set up azure native fencing for MSI
+    if (get_var('QESAPDEPLOY_FENCING') eq 'native' && $provider eq 'AZURE' && check_var('AZURE_FENCE_AGENT_CONFIGURATION', 'msi')) {
         my @nodes = qesap_get_nodes_names(provider => $provider);
         foreach my $host_name (@nodes) {
             if ($host_name =~ /hana/) {


### PR DESCRIPTION
Simplify code by making AZURE_FENCE_AGENT_CONFIGURATION mandatory when using native fencing with the Azure cloud provider. This removes the need to manage default value consistency across multiple test modules and libraries.


- Related ticket: https://jira.suse.com/browse/TEAM-9764

# Verification run:

## MSI

- sle-15-SP5-HanaSr-Azure-Payg-x86_64-Build15-SP5_2024-12-17T03:03:23Z-hanasr_azure_test_msi@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/307710 :green_circle: here where the `fence_azure_arm` command is composed http://openqaworker15.qa.suse.cz/tests/307710#step/Verify_azure_fence_agent_MSI/88

 - sle-15-SP3-HanaSr-Azure-Payg-x86_64-Build15-SP3_2024-12-17T03:03:23Z-hanasr_azure_test_msi@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/307711 :green_circle:  command composition is in http://openqaworker15.qa.suse.cz/tests/307711#step/Verify_azure_fence_agent_MSI/181

## SPN
 - sle-15-SP3-HanaSr-Azure-Payg-x86_64-Build15-SP3_2024-12-17T03:03:23Z-hanasr_azure_test_spn@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/307712 :green_circle: here where command is composed http://openqaworker15.qa.suse.cz/tests/307712#step/Verify_azure_fence_agent_SPN/96
