### PR TITLE
SLE microos on powerVM  don't use FIRST_BOOT_CONFIG setting

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -52,7 +52,8 @@ sub run {
     my $varsize = script_output "findmnt -rnboSIZE -T/var";
     die "/var did not grow, got $varsize B" unless $varsize > (5 * 1024 * 1024 * 1024);
 
-    if (get_var("FIRST_BOOT_CONFIG", is_jeos ? "wizard" : "combustion+ignition") =~ /combustion/) {
+    # PowerVM jobs do not use FIRST_BOOT_CONFIG setting
+    if (get_var("FIRST_BOOT_CONFIG", is_jeos ? "wizard" : "combustion+ignition") =~ /combustion/ && !is_pvm) {
         # Verify that combustion ran
         validate_script_output('cat /usr/share/combustion-welcome', qr/Combustion was here/);
     }


### PR DESCRIPTION
sle microos on powerVM  dont use FIRST_BOOT_CONFIG setting

- Related ticket: https://progress.opensuse.org/issues/174205
- Verification run:  https://openqa.suse.de/tests/16191009#step/image_checks/11