### PR TITLE
containers: Introduce SECURITY_MAC to allow testing Apparmor & SELinux

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -363,6 +363,7 @@ sub load_container_tests {
         } else {
             # Container Host tests
             loadtest 'microos/toolbox' if (/podman/i && !is_staging && (is_sle_micro || is_microos || is_leap_micro));
+            loadtest 'console/enable_mac' if get_var("SECURITY_MAC");
             load_host_tests_podman($run_args) if (/podman/i);
             load_host_tests_docker($run_args) if (/docker/i);
             load_host_tests_multi_runtime($run_args) if (/multi_runtime/i);

--- a/tests/console/enable_mac.pm
+++ b/tests/console/enable_mac.pm
@@ -1,0 +1,78 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: containers
+# Summary: Enable SELinux or AppArmor
+#
+# Maintainer: QA-C team <qa-c@suse.de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use Utils::Systemd qw(systemctl);
+use Utils::Logging 'save_and_upload_log';
+use bootloader_setup qw(replace_grub_cmdline_settings);
+use power_action_utils qw(power_action);
+use utils qw(zypper_call);
+
+# Taken from tests/transactional/enable_selinux.pm
+sub check_enforcing {
+    assert_script_run('selinuxenabled');
+    validate_script_output("getenforce", sub { m/Enforcing/ });
+    validate_script_output("sestatus", sub { m/Current mode:.*enforcing/ });
+    validate_script_output("sestatus", sub { m/Mode from config file:.*enforcing/ });
+    record_info('SELinux', script_output('sestatus'));
+    record_info('Audit report', script_output('aureport'));
+    record_info('Audit denials', script_output('aureport -a', proceed_on_failure => 1));
+}
+
+sub run {
+    my ($self) = @_;
+
+    select_serial_terminal;
+
+    my $current_mac = script_output("grep -Eo '(selinux|apparmor)' /sys/kernel/security/lsm");
+    my $security_mac = get_required_var("SECURITY_MAC");
+    die "Invalid value for SECURITY_MAC: $security_mac" unless ($security_mac =~ /selinux|apparmor/);
+
+    if ($security_mac eq $current_mac) {
+        record_info "SECURITY_MAC", "SECURITY_MAC is already $security_mac";
+    } else {
+        record_info "SECURITY_MAC", "Switching from $current_mac to $security_mac";
+
+        zypper_call "rm --clean-deps -t pattern $current_mac" if ($current_mac);
+        zypper_call "in -t pattern $security_mac";
+
+        if ($security_mac eq "selinux") {
+            replace_grub_cmdline_settings('security=apparmor', 'security=selinux selinux=1', update_grub => 1);
+            assert_script_run "sed -i -e 's/^SELINUX=.*/SELINUX=enforcing/g' /etc/selinux/config";
+            assert_script_run "touch /.autorelabel";
+        } else {
+            replace_grub_cmdline_settings('security=selinux selinux=1', 'security=apparmor', update_grub => 1);
+        }
+
+        power_action('reboot', textmode => 1);
+        $self->wait_boot(bootloader_time => 300);
+        select_serial_terminal;
+    }
+
+    $current_mac = script_output("grep -Eo '(selinux|apparmor)' /sys/kernel/security/lsm");
+    die "$current_mac != $security_mac" if ($current_mac ne $security_mac);
+
+    if ($security_mac eq "selinux") {
+        systemctl 'is-enabled auditd';
+        check_enforcing;
+    } else {
+        validate_script_output("aa-status", sub { m/profiles are in enforce mode/ });
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -191,6 +191,7 @@ RESET_HOSTNAME| boolean | false | If set to true content of /etc/hostname file w
 SCC_DEBUG_SUSECONNECT | boolean | false | Set to pass debug flag to SUSEConnect
 SCC_ADDONS | string | | Comma separated list of modules to be enabled using SCC/RMT.
 SCC_DOCKER_IMAGE | string | | The content of /etc/zypp/credentials.d/SCCcredentials used by container-suseconnect-zypp zypper service in SLE base container images
+SECURITY_MAC | string | "apparmor", "selinux" | MAC LSM to use with container tests.
 SELECT_FIRST_DISK | boolean | false | Enables test module to select first disk for the installation. Is used for baremetal machine tests with multiple disks available, including cases when server still has previous installation.
 ENABLE_SELINUX | boolean | false | Explicitly enable SELinux in transactional server environments.
 SEPARATE_HOME | three-state | undef | Used for scheduling the test module where separate `/home` partition should be explicitly enabled (if `1` is set) or disabled (if `0` is set). If not specified, the test module is skipped.


### PR DESCRIPTION
Introduce SECURITY_MAC to allow tests Apparmor & SELinux

- Related ticket: https://progress.opensuse.org/issues/168682
- Verification runs:
  - Tumbleweed (podman w/ `SECURITY_MAC=selinux`): https://openqa.opensuse.org/tests/4706320
  - Tumbleweed (podman w/ `SECURITY_MAC=apparmor`): https://openqa.opensuse.org/tests/4706338
  - Tumbleweed (docker w/ `SECURITY_MAC=selinux`): https://openqa.opensuse.org/tests/4706453

Notes:
  - There's no test for the change from a product with SELinux enabled by default to AppArmor.
  - SELinux comes by default in MicroOS & SLEM 5.2+ so there's no point in testing AppArmor on transactional systems.  Also `transactional-update setup-apparmor` is not available, unlike `setup-selinux`.

TODO:
  - Create job schedules for Tumbleweed & MicroOS.