### PR TITLE
Drop bluetooth service in aws ay profile

### DIFF
--- a/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_aarch64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_aarch64.xml
@@ -273,7 +273,6 @@
     <default_target>multi-user</default_target>
     <services t="map">
       <enable t="list">
-        <service>bluetooth</service>
         <service>firewalld</service>
         <service>wickedd-auto4</service>
         <service>wickedd-dhcp4</service>

--- a/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_ppc64le.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_ppc64le.xml
@@ -304,7 +304,6 @@
     <default_target>multi-user</default_target>
     <services t="map">
       <enable t="list">
-        <service>bluetooth</service>
         <service>firewalld</service>
         <service>wickedd-auto4</service>
         <service>wickedd-dhcp4</service>

--- a/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_s390x.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_s390x.xml
@@ -315,7 +315,6 @@
     <default_target>multi-user</default_target>
     <services t="map">
       <enable t="list">
-        <service>bluetooth</service>
         <service>firewalld</service>
         <service>wickedd-auto4</service>
         <service>wickedd-dhcp4</service>

--- a/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_x86_64.xml
+++ b/data/autoyast_sle15/create_hdd/create_hdd_pcm_aws_x86_64.xml
@@ -266,7 +266,6 @@
     <default_target>multi-user</default_target>
     <services t="map">
       <enable t="list">
-        <service>bluetooth</service>
         <service>firewalld</service>
         <service>wickedd-auto4</service>
         <service>wickedd-dhcp4</service>


### PR DESCRIPTION
Service is not defined to be installed and I don't see reason to expect/need
of this service
Warning pop-up is blocking s390x screen to match expected needle for reboot

![image](https://github.com/user-attachments/assets/3164a206-1c2f-455b-9a1a-7767e463b49f)

- Fail: https://openqa.suse.de/tests/16203444
- Verification run: https://openqa.suse.de/tests/16203541#step/installation/7