### PR TITLE
Increase timeout in transactional-update install

### DIFF
--- a/tests/microos/cockpit_service.pm
+++ b/tests/microos/cockpit_service.pm
@@ -51,7 +51,7 @@ sub run {
     if (@pkgs) {
         record_info('TEST', 'Installing Cockpit\'s Modules...');
 
-        my $results = script_output("transactional-update -n pkg install @pkgs", timeout => 480);
+        my $results = script_output("transactional-update -n pkg install @pkgs", timeout => 600);
         # No reboot needed if no package update
         check_reboot_changes if ($results !~ /zypper: nothing to update/);
     }

--- a/tests/microos/patterns.pm
+++ b/tests/microos/patterns.pm
@@ -28,7 +28,7 @@ sub run {
     @inst_patterns = grep (!/elemental_client/, @patterns) if is_sle_micro('>=6.0');
 
     # install new patterns
-    trup_call('pkg install -t pattern ' . join(" ", @inst_patterns), timeout => 720);
+    trup_call('pkg install -t pattern ' . join(" ", @inst_patterns), timeout => 900);
     process_reboot(trigger => 1);
 
     # expect empty list therefore ZYPPER_EXIT_INF_CAP_NOT_FOUND


### PR DESCRIPTION
Increase timeout due to timeout failures.

- Related ticket: https://progress.opensuse.org/issues/174181
- Verification run: https://openqa.suse.de/tests/16235380
