### PR TITLE
Change native fencing IAM role

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -2280,11 +2280,12 @@ sub qesap_az_setup_native_fencing_permissions {
 
     # Assign role
     my $subscription_id = script_output('az account show --query "id" -o tsv');
+    my $role_id = script_output('az role definition list --name "Linux Fence Agent Role" --query "[].id" --output tsv');
     my $az_cmd = join(' ', 'az role assignment',
         'create --only-show-errors',
         "--assignee-object-id $vm_id",
         '--assignee-principal-type ServicePrincipal',
-        "--role 'Virtual Machine Contributor'",
+        "--role '$role_id'",
         "--scope '/subscriptions/$subscription_id/resourceGroups/$args{resource_group}'");
     assert_script_run($az_cmd);
 }


### PR DESCRIPTION
Replaces the built-in, generously privileged IAM role we used for Azure Native Fencing with a less privileged custom role we have defined.

Custom role for Azure native fencing is described here: https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#1-create-a-custom-role-for-the-fence-agent

- Related ticket: https://jira.suse.com/browse/TEAM-9698
- Verification run: 

MSI:
https://openqa.suse.de/tests/16203411
https://openqa.suse.de/tests/16203481
https://openqa.suse.de/tests/16203482
https://openqa.suse.de/tests/16203483
https://openqa.suse.de/tests/16203484
https://openqa.suse.de/tests/16203485
https://openqa.suse.de/tests/16203486
https://openqa.suse.de/tests/16203528
https://openqa.suse.de/tests/16203529
https://openqa.suse.de/tests/16203530 - FAIL
https://openqa.suse.de/tests/16203531
https://openqa.suse.de/tests/16203532
https://openqa.suse.de/tests/16203533
https://openqa.suse.de/tests/16203534
https://openqa.suse.de/tests/16203535 - FAIL

FAILS for MSI: 2/15

SPN:
https://openqa.suse.de/tests/16210135#
https://openqa.suse.de/tests/16210136#details
https://openqa.suse.de/tests/16210137#details
https://openqa.suse.de/tests/16210138#
https://openqa.suse.de/tests/16210139#details
https://openqa.suse.de/tests/16210140#details
https://openqa.suse.de/tests/16210141#details

FAILS for SPN: 0/6