### PR TITLE
Substitue SLES_SAP for LTSS repo

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -206,6 +206,10 @@ sub run {
     # Extract module name from repo url.
     my @modules = split(/,/, $repos);
     foreach (@modules) {
+        # substitue SLES_SAP for LTSS repo at this point is SAP ESPOS
+        # workaround only availabe for 15-SP2
+        $_ =~ s/SAP_(\d+(-SP\d)?)/$1-LTSS/ if is_sle('=15-SP2');
+
         next if s{http.*SUSE_Updates_(.*)/?}{$1};
         die 'Modules regex failed. Modules could not be extracted from repos variable.';
     }


### PR DESCRIPTION
substitue SLES_SAP for LTSS repo because SLE-Product-SLES_SAP_15-SP2 channel is empty when checking rpm binaries.

- Related ticket: https://jira.suse.com/browse/TEAM-9909
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/16209467 (docker on x86_64, PASSED)
    https://openqa.suse.de/tests/16210080 (docker on ppc64le, PASSED)
    https://openqa.suse.de/tests/16210132 (libsoup, PASSED)