### PR TITLE
Bump timeout for refreshing repos in Agama unattended

### DIFF
--- a/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
+++ b/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
@@ -21,7 +21,7 @@ sub new {
               agama-configuring-the-product
               agama-installing
               agama-sle-overview)],
-        timeout_expect_is_shown => $args->{timeout_expect_is_shown} // 120
+        timeout_expect_is_shown => $args->{timeout_expect_is_shown} // 240
     }, $class;
 }
 


### PR DESCRIPTION
- Fix sporadic issue: https://openqa.suse.de/tests/16209278#
- Verification runs: [20 x sles_default_unattended](https://openqa.suse.de/tests/overview?version=agama-10.0&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23bump-timeout2)
