### PR TITLE
Install SLES for SAP for agama testing

### DIFF
--- a/data/yam/agama/auto/default_sap.json
+++ b/data/yam/agama/auto/default_sap.json
@@ -1,0 +1,16 @@
+{
+  "product": {
+    "id": "SLES_SAP_16.0",
+    "registrationCode": "{{SCC_REGCODE_SLES4SAP}}"
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true,
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true
+  }
+}

--- a/data/yam/agama/auto/default_sap_no_scc.json
+++ b/data/yam/agama/auto/default_sap_no_scc.json
@@ -1,0 +1,15 @@
+{
+  "product": {
+    "id": "SLES_SAP_16.0"
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true,
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true
+  }
+}

--- a/test_data/yam/agama_sap.yaml
+++ b/test_data/yam/agama_sap.yaml
@@ -1,0 +1,2 @@
+---
+os_release_name: SLES_SAP


### PR DESCRIPTION
Install SLES for SAP for agama testing. Add an auto profile for sap
installation and a data file to verify sap product.

- Related ticket: https://progress.opensuse.org/issues/173806
- Needles: n/a
- Verification run: [vrs](https://openqa.suse.de/tests/overview?build=chcao_agama&distri=sle&version=agama-10.0)
