### PR TITLE
Increase timeout for finding rpmnew files

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -237,7 +237,7 @@ sub problem_detection {
     clear_console;
 
     # Unapplied configuration files
-    save_and_upload_log("find /* -name '*.rpmnew'", "unapplied-configuration-files.txt", {screenshot => 1, noupload => 1});
+    save_and_upload_log("find /* -name '*.rpmnew'", "unapplied-configuration-files.txt", {screenshot => 1, noupload => 1, timeout => 300});
     clear_console;
 
     # Errors, warnings, exceptions, and crashes mentioned in dmesg


### PR DESCRIPTION
Collection of rpmnew files searches the whole root filesystem for matching files. This can take time. This commit increases the timeout for this step from the default of 30 seconds to 5 minutes to avoid openQA jobs failing while collecting logs.

- Related failure: https://openqa.suse.de/tests/16209580#step/bci_test_podman/200
- Verification run: https://openqa.suse.de/tests/16211560 (expected to fail, but log collection works properly)