### PR TITLE
Add migration_test for kubevirt core tests

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -63,7 +63,8 @@ my @core_tests = (
     'console_test',
     'vnc_test',
     'expose_test',
-    'replicaset_test'
+    'replicaset_test',
+    'migration_test'
 );
 
 sub run {


### PR DESCRIPTION
Missing test suite 'migration_test' for kubevirt core tests.

- Related ticket: https://progress.opensuse.org/issues/174514
- Verification run: https://openqa.suse.de/tests/16264066