### PR TITLE
Increase timeout for broken symlinks

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -266,7 +266,7 @@ sub problem_detection {
     save_and_upload_log(
 "find / -type d \\( -path /proc -o -path /run -o -path /.snapshots -o -path /var \\) -prune -o -xtype l -exec ls -l --color=always {} \\; -exec rpmquery -f {} \\;",
         "broken-symlinks.txt",
-        {screenshot => 1, noupload => 1, timeout => 60});
+        {screenshot => 1, noupload => 1, timeout => 300});
     clear_console;
 
     # Binaries with missing libraries


### PR DESCRIPTION
This occasionally times out, so let's increase the timeout.

- Related failure: https://openqa.suse.de/tests/16213839#step/bci_test_podman/225
- Verification run: https://openqa.suse.de/tests/16214959 (failure is expected, problem collection works as expected)