### PR TITLE
Increase timeout for podman pull

### DIFF
--- a/tests/containers/bci_collect_stats.pm
+++ b/tests/containers/bci_collect_stats.pm
@@ -25,7 +25,7 @@ sub run {
     my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
     return unless ($engines =~ /podman/);
 
-    script_retry("podman pull -q $image", retry => 3, delay => 120);
+    script_retry("podman pull -q $image", timeout => 300, retry => 3, delay => 120);
     my $size_mb = script_output("podman inspect --format \"{{.VirtualSize}}\" $image") / 1000000;
     my %args;
     $args{arch} = get_required_var('ARCH');


### PR DESCRIPTION
Pulling can take some time, so let's increase the timeout.

- Related failure: https://openqa.suse.de/tests/16214104#step/bci_collect_stats/8
- Verification run: Can't schedule because I'm hitting a Rate limit error
