### PR TITLE
Reduce ssh verbosity

### DIFF
--- a/data/publiccloud/ssh_config_sap
+++ b/data/publiccloud/ssh_config_sap
@@ -3,5 +3,4 @@ PasswordAuthentication no
 UserKnownHostsFile /dev/null
 IdentityFile %SSH_KEY%
 HostKeyAlgorithms +ssh-rsa
-LogLevel DEBUG3
 


### PR DESCRIPTION
Remove setting `LogLevel=DEBUG3` from SAP ssh config file for PC tests.


- Related ticket: https://jira.suse.com/browse/TEAM-9658

# Verification run: