### PR TITLE
Fix ibus failure on TW

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1048,9 +1048,10 @@ sub add_input_resource {
     }
 
     assert_and_click 'ibus-input-source-add';
-    assert_and_click 'ibus-input-language-list';
+    send_key_until_needlematch("more-input-source", "tab", 22, 6);
+    assert_and_click 'more-input-source';
+    assert_screen 'ibus-input-language-list';
     type_string_slow $tag;
-
     assert_and_click "ibus-input-$tag";
     if ($tag eq "japanese") {
         assert_and_dclick 'ibus-input-japanese-kkc';


### PR DESCRIPTION
See ticket poo#168064

- Related ticket: https://progress.opensuse.org/issues/168064
- Needles: already added when debugging on o3 and osd
- Verification run: 

> TW https://openqa.opensuse.org/tests/4711035#
> SLE15SP7 X11 https://openqa.suse.de/tests/16234988#
> SLE15SP7 Wayland https://openqa.suse.de/tests/16234870# 