### PR TITLE
Fix getting server ip variable failure

### DIFF
--- a/schedule/virt_autotest/kubevirt-tests.yaml
+++ b/schedule/virt_autotest/kubevirt-tests.yaml
@@ -2,7 +2,8 @@ name:           kubevirt-tests
 description:    >
     Maintainer: Nan Zhang <nan.zhang@suse.com> qe-virt@suse.de
     Kubevirt server & agent node installation and test modules
-vars: {}
+vars:
+    MAX_JOB_TIME: 72000
 schedule:
     - '{{barrier_setup}}'
     - '{{bootup_and_install}}'

--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -573,7 +573,7 @@ EOF
 
             if ($section eq 'migration_test') {
                 assert_script_run("kubectl delete net-attach-def migration-cni -n kubevirt") if (!script_run("kubectl get net-attach-def -A | grep migration-cni"));
-                $server_ip = get_required_var('SERVER_IP');
+                $server_ip = script_output("nslookup " . get_required_var('SUT_IP') . "|sed -n '5,1p'|awk -F' ' '{print \$2}'");
                 $nic_name = script_output("ip addr | grep $server_ip | awk -F' ' '{print \$NF}'");
                 $extra_opt = "-migration-network-nic=$nic_name";
             }


### PR DESCRIPTION
The variable "SERVER_IP" should be deprecated and removed.
https://openqa.suse.de/tests/16214194#step/kubevirt_tests_server/464

- Related ticket: https://progress.opensuse.org/issues/174514
- Verification run: https://openqa.suse.de/tests/16264066
