### PR TITLE
Ensure only one agama.auto in bootloader parameters

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -880,6 +880,10 @@ sub specific_bootmenu_params {
 
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $url = autoyast::expand_profile_url($agama_auto);
+        if (is_backend_s390x) {
+            $url = shorten_url($url) unless (is_opensuse);
+            set_var('AGAMA_AUTO', $url);
+        }
         push @params, "agama.auto=$url";
     }
 

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -120,12 +120,6 @@ sub prepare_parmfile {
         $params .= " autoyast=" . $url;
         set_var('AUTOYAST', $url);
     }
-    if (get_var('AGAMA_AUTO')) {
-        my $url = expand_profile_url(get_var('AGAMA_AUTO'));
-        $url = shorten_url($url) unless (is_opensuse);
-        $params .= " agama.auto=" . $url;
-        set_var('AGAMA_AUTO', $url);
-    }
     return split_lines($params);
 }
 

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -45,11 +45,6 @@ sub set_svirt_domain_elements {
         if (get_var('AUTOYAST')) {
             $cmdline .= ' ' . join(' ', autoyast_boot_params);
         }
-        if (get_var('AGAMA_AUTO')) {
-            my $url = expand_profile_url(get_var('AGAMA_AUTO'));
-            $cmdline .= " agama.auto=" . $url;
-            set_var('AGAMA_AUTO', $url);
-        }
 
         $cmdline .= ' ' . get_var("EXTRABOOTPARAMS") if get_var("EXTRABOOTPARAMS");
         $cmdline .= specific_bootmenu_params;


### PR DESCRIPTION


- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23ensure-one-agama-auto-parameter&distri=sle&version=agama-10.0