### PR TITLE
Fix serial console settings for agama install

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -195,8 +195,9 @@ sub set_bootscript_agama_cmdline_extra {
         $cmdline_extra .= "agama.install_url=$agama_install_url ";
     }
     if (is_ipmi) {
-        my $sol_console = get_required_var('IPXE_CONSOLE');
-        $cmdline_extra .= "console=$sol_console linuxrc.log=/dev/$sol_console linuxrc.core=/dev/$sol_console linuxrc.debug=4,trace ";
+        my $ipxe_console = get_required_var('IPXE_CONSOLE');
+        my $sol_console = (split(/,/, $ipxe_console))[0];
+        $cmdline_extra .= "console=$ipxe_console linuxrc.log=/dev/$sol_console linuxrc.core=/dev/$sol_console linuxrc.debug=4,trace ";
     }
     return $cmdline_extra;
 }


### PR DESCRIPTION
Quick fix for PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20777

The serial console settings are not correct even no function impact found so far:
`console=ttyS1,115200 linuxrc.log=/dev/ttyS1,115200 linuxrc.core=/dev/ttyS1,115200` 

Correct one should be:
`console=ttyS1,115200 linuxrc.log=/dev/ttyS1 linuxrc.core=/dev/ttyS1`


- Verification run: https://openqa.suse.de/tests/16246503