### PR TITLE
Add legacy module as requirement for package libicu60_2

### DIFF
--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -75,6 +75,8 @@ sub run {
         # enable business one repositories
         add_suseconnect_product('sle-module-development-tools');
         add_suseconnect_product('sle-module-sap-business-one');
+        # also enable legacy module, due to bsc#1231763
+        add_suseconnect_product('sle-module-legacy');
         zypper_call('in patterns-sap-bone jq libidn11 rpm-build xmlstarlet glibc-i18ndata libicu60_2 nfs-kernel-server libcap-progs');
     }
 


### PR DESCRIPTION
This workaround is necessary because adding legacy module on SCC_ADDONS variable does not work on a reliable way.
VR:
https://openqaworker15.qa.suse.cz/tests/308156
https://openqaworker15.qa.suse.cz/tests/308140