### PR TITLE
[Virtualization][MU]: Support running SLES MU tests on OSD SUTs

### DIFF
--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -286,6 +286,28 @@
     </user>
   </users>
   <scripts>
+    <pre-scripts config:type="list">
+      <script>
+        <filename>pre_erase_all_disks.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+disks=$(lsblk -n -l -o NAME -d -e 7,11,254);
+for disk in $disks;do
+    echo "Wiping /dev/$disk..."
+    wipefs -af /dev/$disk
+    sync
+    parted -s /dev/$disk mklabel gpt
+    sync
+done
+echo "All disks are wiped out."
+lsblk
+]]>
+        </source>
+        <feedback config:type="boolean">false</feedback>
+        <notification>Please wait while pre-script is running...</notification>
+      </script>
+    </pre-scripts>
     <post-scripts config:type="list">
       <script>
         <filename>debug_libvirtd.sh</filename>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -293,6 +293,28 @@
     </user>
   </users>
   <scripts>
+    <pre-scripts config:type="list">
+      <script>
+        <filename>pre_erase_all_disks.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+disks=$(lsblk -n -l -o NAME -d -e 7,11,254);
+for disk in $disks;do
+    echo "Wiping /dev/$disk..."
+    wipefs -af /dev/$disk
+    sync
+    parted -s /dev/$disk mklabel gpt
+    sync
+done
+echo "All disks are wiped out."
+lsblk
+]]>
+        </source>
+        <feedback config:type="boolean">false</feedback>
+        <notification>Please wait while pre-script is running...</notification>
+      </script>
+    </pre-scripts>
     <post-scripts config:type="list">
       % if ($check_var->('SYSTEM_ROLE', 'xen') && $get_var->('VERSION') gt '15-SP5') {
       <script>

--- a/lib/parallel_guest_migration_base.pm
+++ b/lib/parallel_guest_migration_base.pm
@@ -630,8 +630,7 @@ iptables -P OUTPUT ACCEPT;
 iptables -t nat -F;
 iptables -F;
 sysctl -w net.ipv4.ip_forward=1;
-sysctl -w net.ipv4.conf.all.forwarding=1;
-sysctl -w net.ipv6.conf.all.forwarding=1"
+sysctl -w net.ipv4.conf.all.forwarding=1"
     );
     save_screenshot;
     setup_common_ssh_config;

--- a/lib/parallel_guest_migration_base.pm
+++ b/lib/parallel_guest_migration_base.pm
@@ -279,7 +279,7 @@ sub do_local_initialization {
     my $_localfqdn = '';
     set_var('LOCAL_IPADDR', $_localip);
     set_var('LOCAL_FQDN', $_localfqdn);
-    $_localip = script_output("hostname -i", type_command => 1) if (script_retry("hostname -i", option => '--kill-after=1 --signal=9', delay => 1, retry => 60) == 0);
+    $_localip = script_output("hostname -i | cut -d' ' -f 2", type_command => 1) if (script_retry("hostname -i", option => '--kill-after=1 --signal=9', delay => 1, retry => 60) == 0);
     (($_localip eq '' or $_localip eq '127.0.0.1' or $_localip eq '::1 127.0.0.1') and (is_sle('15+') or !is_sle)) ? set_var('LOCAL_IPADDR', (split(/ /, script_output("hostname -I", type_command => 1)))[0]) : set_var('LOCAL_IPADDR', $_localip);
     $_localfqdn = script_output("hostname -f", type_command => 1) if (script_retry("hostname -f", option => '--kill-after=1 --signal=9', delay => 1, retry => 60) == 0);
     (($_localfqdn eq '' or $_localfqdn eq 'localhost') and (is_sle('15+') or !is_sle)) ? set_var('LOCAL_FQDN', (split(/ /, script_output("hostname -A", type_command => 1)))[0]) : set_var('LOCAL_FQDN', $_localfqdn);


### PR DESCRIPTION
This PR allows SLES MU VT tests to be able to run on both OSD SUTs in OSD test, as well as on PRG1 lab SUTs in openqa.qam.suse.cz.

To be detailed, this PR mainly does below
- Differentiate pxe/ipxe installation based on SUT configuration for that
    - if IPXE configured(OSD case), ipxe_install is used
    - if no IPXE configured (openqa.qam.suse.cz case), boot_from_pxe is used
    Unless customized installation repository is given, it will generate the required repo for installation.
- Erase all disks before installation via host autoyast pre-script
- Fix guest migration issues with OSD SUT which has ipv6 and ipv4 configured


Related ticket: https://progress.opensuse.org/issues/174469
Verification run:
  - OSD SUT 15sp6 feature test: https://openqa.suse.de/tests/16291411
  - OSD SUT 15sp4 test: 
    https://openqa.suse.de/tests/16296325# (feature tests), 
    https://openqa.suse.de/tests/16296498# (migration)
  - OSD SUT 12sp5 xen sriov test: https://openqa.suse.de/tests/16296246
  - openqa.qam.suse.cz PRG1 SUT 15SP4 regression test : 
       - http://openqa.qam.suse.cz/tests/82680# (feature)
       - http://openqa.qam.suse.cz/tests/82686  (migration)
