### PR TITLE
Poo#174574 add s390x full-qu schedule

### DIFF
--- a/schedule/yast/sle/flows/default_s390x_kvm_flavor_full.yaml
+++ b/schedule/yast/sle/flows/default_s390x_kvm_flavor_full.yaml
@@ -1,0 +1,56 @@
+---
+# Default ordered sequence of steps to be optionally overwritten for this product
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+access_beta:
+  - installation/access_beta_distribution
+license_agreement:
+  - installation/licensing/accept_license
+registration:
+  - installation/registration/skip_registration
+extension_module_selection:
+  - installation/module_selection/skip_module_selection
+add_on_product:
+  - installation/add_on_product_installation/accept_add_on_installation
+add_on_product_installation: []
+system_role:
+  - installation/system_role/accept_selected_role_text_mode
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+guided_partitioning: []
+expert_partitioning: []
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+security: []
+default_systemd_target: []
+installation_settings:
+  - installation/launch_installation
+installation:
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+stop_timeout_system_reboot:
+  - installation/performing_installation/stop_timeout_system_reboot_now
+installation_logs:
+  - installation/logs_from_installation_system
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+reconnect_svirt:
+  - installation/performing_installation/reconnect_after_reboot
+disk_passphrase: []
+grub:
+  - installation/handle_reboot
+first_login:
+  - installation/first_boot
+system_preparation:
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+system_validation: []


### PR DESCRIPTION
Add offline schedule skipping registration for flavor full, QU security tests for s390x.

- Related ticket: https://progress.opensuse.org/issues/174574
- Verification run: https://openqa.suse.de/tests/16247365