### PR TITLE
bootloader_uefi: Fix sdboot check

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -72,11 +72,6 @@ sub run {
         }
     }
 
-    if (is_bootloader_sdboot) {
-        assert_screen("bootloader-sdboot");
-        return;
-    }
-
     if (get_var("IPXE") && !is_usb_boot) {
         sleep 60;
         return;
@@ -111,12 +106,15 @@ sub run {
         assert_screen("bootloader-grub2-agama", $bootloader_timeout);
     }
     else {
-        assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2)], $bootloader_timeout);
+        assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2 bootloader-sdboot)], $bootloader_timeout);
     }
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";
         send_key "ret";
-        assert_screen "bootloader-grub2", $bootloader_timeout;
+        assert_screen([qw(bootloader-grub2 bootloader-sdboot)], $bootloader_timeout);
+    }
+    if (match_has_tag("bootloader-sdboot")) {
+        return if is_bootloader_sdboot;
     }
     if (get_var('DISABLE_SECUREBOOT') && (get_var('BACKEND') eq 'qemu')) {
         $self->tianocore_disable_secureboot;


### PR DESCRIPTION
Commit cf9b9db30571 ("bootloader_uefi: Fix sdboot check") made the check too generic and it broke Tumbleweed DVD flavor which starts with grub2 image and later change to systemd-boot. Fix it by adding bootloader-sdboot to the array along with other needles and later use match_has_tag to return early if is_bootloader_sdboot.

- Related ticket: https://progress.opensuse.org/issues/174541
- Verification runs:
- https://rmarliere-openqa.qe.prg2.suse.org/tests/1119# (microos-Tumbleweed-DVD-x86_64-Build20241218-microos-sdboot)
- https://rmarliere-openqa.qe.prg2.suse.org/tests/1118# (opensuse-Tumbleweed-JeOS-for-kvm-and-xen-sdboot-x86_64-Build20241218-jeos)
