### PR TITLE
agama: Add support for multipath confirmation during installation

### DIFF
--- a/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
+++ b/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
@@ -20,7 +20,8 @@ sub new {
             qw(agama-product-selection
               agama-configuring-the-product
               agama-installing
-              agama-sle-overview)],
+              agama-sle-overview
+              agama-multipath)],
         timeout_expect_is_shown => $args->{timeout_expect_is_shown} // 240
     }, $class;
 }

--- a/schedule/kernel/agama_create_hdd_multipath_textmode.yaml
+++ b/schedule/kernel/agama_create_hdd_multipath_textmode.yaml
@@ -1,0 +1,12 @@
+name: agama-create-hdd-multipath-textmode
+
+description:  >
+    Prepare image with multipath enabled using agama for kernel testing.
+
+schedule:
+  - yam/agama/boot_agama
+  - installation/agama_multipath
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - shutdown/shutdown

--- a/tests/installation/agama_multipath.pm
+++ b/tests/installation/agama_multipath.pm
@@ -1,0 +1,17 @@
+## Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Confirm multipath during installation.
+# Maintainer: QE Kernel <kernel-qa@suse.de>
+
+use base "installbasetest";
+use strict;
+use warnings;
+
+use testapi;
+
+sub run {
+    assert_and_click('agama-multipath');
+}
+
+1;


### PR DESCRIPTION
- Related ticket: none
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1681
- Verification run: 
multipath: http://10.100.12.105/tests/516
normal installation: http://10.100.12.105/tests/512
