### PR TITLE
filesystem: Add xfstests to yaml scheduler

### DIFF
--- a/schedule/filesystem/xfstests_create_hdd_micro_ppc.yaml
+++ b/schedule/filesystem/xfstests_create_hdd_micro_ppc.yaml
@@ -1,0 +1,12 @@
+---
+name: 'xfstests_create_hdd@sle_micro_ppc'
+description:    >
+  Maintainer: An Long <lan@suse.com>
+  xfstests_create_hdd test suite for SLE-Micro on ppc
+schedule:
+    - installation/bootloader
+    - microos/install_image
+    - transactional/host_config
+    - console/suseconnect_scc
+    - xfstests/install
+    - shutdown/shutdown

--- a/schedule/filesystem/xfstests_micro_ppc.yaml
+++ b/schedule/filesystem/xfstests_micro_ppc.yaml
@@ -1,0 +1,9 @@
+---
+name: 'xfstests@sle_micro_ppc'
+description:    >
+  Maintainer: An Long <lan@suse.com>
+  xfstests test suite for SLE-Micro on ppc
+schedule:
+    - installation/bootloader
+    - xfstests/partition
+    - xfstests/run


### PR DESCRIPTION
Add xfstests to yaml scheduler for microos on ppc
1. Add xfstests_create_hdd
2. Add xfstests

- Related ticket: https://progress.opensuse.org/issues/173953
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/16262132
