### PR TITLE
Poo#174577 add aarch64 full-qu schedule

### DIFF
--- a/schedule/yast/sle/flows/default_aarch64_flavor_full.yaml
+++ b/schedule/yast/sle/flows/default_aarch64_flavor_full.yaml
@@ -1,0 +1,58 @@
+---
+# Default ordered sequence of steps to be optionally overwritten for this product
+bootloader:
+  - installation/bootloader_start
+setup_libyui:
+  - installation/setup_libyui
+access_beta:
+  - installation/access_beta_distribution
+product_selection: []
+license_agreement:
+  - installation/licensing/accept_license
+disk_activation: []
+registration:
+  - installation/registration/skip_registration
+extension_module_selection:
+  - installation/module_selection/skip_module_selection
+add_on_product:
+  - installation/add_on_product_installation/accept_add_on_installation
+additional_products: []
+system_probing: []
+add_on_product_installation: []
+system_role:
+  - installation/system_role/accept_selected_role_text_mode
+guided_partitioning: []
+guided_open: []
+guided_hard_disks: []
+guided_scheme: []
+guided_filesystem: []
+expert_partitioning: []
+suggested_partitioning:
+  - installation/partitioning/accept_proposed_layout
+clock_and_timezone:
+  - installation/clock_and_timezone/accept_timezone_configuration
+local_user:
+  - installation/authentication/use_same_password_for_root
+  - installation/authentication/default_user_simple_pwd
+software: []
+booting:
+  - installation/bootloader_settings/disable_boot_menu_timeout
+security: []
+security_configuration: []
+default_systemd_target: []
+installation_settings:
+  - installation/launch_installation
+installation:
+  - installation/confirm_installation
+  - installation/performing_installation/perform_installation
+installation_logs:
+  - installation/logs_from_installation_system
+confirm_reboot:
+  - installation/performing_installation/confirm_reboot
+grub:
+  - installation/grub_test
+disk_passphrase: []
+first_login:
+  - installation/first_boot
+system_preparation: []
+system_validation: []


### PR DESCRIPTION
Add offline schedule skipping registration for flavor full, QU security tests for aarch64.

- Related ticket: https://progress.opensuse.org/issues/174577
- Verification run: https://openqa.suse.de/tests/16252667