### PR TITLE
journal: Spectre LFENCE message in bug-ref added

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -784,7 +784,7 @@
     },
     "boo#1227081": {
         "description": "Activation request for 'org\\.freedesktop\\.nm_dispatcher' failed\\.",
-	"products": {
+        "products": {
             "opensuse": ["Tumbleweed"],
             "microos":  ["Tumbleweed"]
         },
@@ -804,5 +804,12 @@
             "leap-micro": ["6.1"]
         },
         "type": "bug"
+    },
+    "Spectre-V2-LFENCE": {
+        "description": "kernel: Spectre V2 : Spectre mitigation: LFENCE not serializing, switching to generic retpoline",
+        "products": {
+            "sle-micro": ["5.2"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
Journal: Spectre LFENCE message in bug-ref.json for sle-micro 5.2 added.
Found this issue in a test impacting a delivery.

After added the new log message to the bugs_ref.json, the issue disappeared in test rerun VR.

- Verification run: https://openqa.suse.de/tests/16264387
- 