### PR TITLE
Cleanup configration of bootloader for autoyast profiles

### DIFF
--- a/data/yam/autoyast/autoupgrade_with_maintenance_unreleased_updates.xml.ep
+++ b/data/yam/autoyast/autoupgrade_with_maintenance_unreleased_updates.xml.ep
@@ -3,11 +3,6 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <bootloader>
     <global>
-      <activate>false</activate>
-      <boot_extended>false</boot_extended>
-      <boot_mbr>true</boot_mbr>
-      <boot_root>true</boot_root>
-      <generic_mbr>false</generic_mbr>
       <timeout config:type="integer">5</timeout>
     </global>
     <loader_type></loader_type>

--- a/data/yam/autoyast/bug-877438_ix64ph1029.xml
+++ b/data/yam/autoyast/bug-877438_ix64ph1029.xml
@@ -40,18 +40,6 @@
       </device_map_entry>
     </device_map>
     <global>
-      <activate>true</activate>
-      <append> splash=silent quiet showopts</append>
-      <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
-      <boot_boot>false</boot_boot>
-      <boot_extended>false</boot_extended>
-      <boot_mbr>true</boot_mbr>
-      <boot_root>true</boot_root>
-      <default>0</default>
-      <generic_mbr>true</generic_mbr>
-      <gfxmode>auto</gfxmode>
-      <gfxtheme/>
-      <os_prober>true</os_prober>
       <timeout config:type="integer">-1</timeout>
       <vgamode/>
     </global>

--- a/data/yam/autoyast/bug-879147_autoinst.xml
+++ b/data/yam/autoyast/bug-879147_autoinst.xml
@@ -35,18 +35,6 @@
       </device_map_entry>
     </device_map>
     <global>
-      <activate>true</activate>
-      <append> splash=silent quiet showopts</append>
-      <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
-      <boot_boot>false</boot_boot>
-      <boot_extended>false</boot_extended>
-      <boot_mbr>false</boot_mbr>
-      <boot_root>true</boot_root>
-      <default>0</default>
-      <generic_mbr>true</generic_mbr>
-      <gfxmode>auto</gfxmode>
-      <os_prober>true</os_prober>
-      <terminal>gfxterm</terminal>
       <timeout config:type="integer">-1</timeout>
       <vgamode/>
     </global>

--- a/data/yam/autoyast/multipath.xml
+++ b/data/yam/autoyast/multipath.xml
@@ -83,12 +83,6 @@ pre init scripts feature. See poo#20818.
 
   <bootloader>
     <global>
-      <activate>true</activate>
-      <append>mce=dont_log_ce edd=off consoleblank=0 rd.lvm.vg=system biosdevname=0 elevator=deadline</append>
-      <boot_mbr>true</boot_mbr>
-      <secure_boot>false</secure_boot>
-      <os_prober>false</os_prober>
-      <terminal>console</terminal>
       <timeout config:type="integer">-1</timeout>
     </global>
     <loader_type>grub2</loader_type>

--- a/data/yam/autoyast/support_images/autoyast_scc_up_maintenance.xml.ep
+++ b/data/yam/autoyast/support_images/autoyast_scc_up_maintenance.xml.ep
@@ -3,11 +3,6 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <bootloader>
     <global>
-      <activate>false</activate>
-      <boot_extended>false</boot_extended>
-      <boot_mbr>true</boot_mbr>
-      <boot_root>true</boot_root>
-      <generic_mbr>false</generic_mbr>
       <timeout config:type="integer">5</timeout>
     </global>
     <loader_type>{{LOADER_TYPE}}</loader_type>

--- a/data/yam/autoyast/support_images/autoyast_sles12sp5_media_def_patterns_minimal_x86_64.xml
+++ b/data/yam/autoyast/support_images/autoyast_sles12sp5_media_def_patterns_minimal_x86_64.xml
@@ -6,22 +6,7 @@
   </add-on>
   <bootloader>
     <global>
-      <activate>true</activate>
-      <append>mitigations=auto showopts crashkernel=173M,high</append>
-      <boot_boot>false</boot_boot>
-      <boot_extended>false</boot_extended>
-      <boot_mbr>false</boot_mbr>
-      <boot_root>true</boot_root>
-      <cpu_mitigations>auto</cpu_mitigations>
-      <generic_mbr>true</generic_mbr>
-      <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
-      <os_prober>false</os_prober>
-      <terminal>gfxterm</terminal>
       <timeout config:type="integer">8</timeout>
-      <trusted_grub>false</trusted_grub>
-      <xen_append>crashkernel=173M,high</xen_append>
-      <xen_kernel_append>vga=gfx-1024x768x16 crashkernel=173M\&lt;4G</xen_kernel_append>
     </global>
     <loader_type>grub2</loader_type>
   </bootloader>


### PR DESCRIPTION
There are some bootloader configurations in autoyast profiles are outdated, make a cleanup for these autoyast profiles.

- Related ticket: https://progress.opensuse.org/issues/169303
- Needles: n/a
- Verification run: 
- [autoyast/autoupgrade_with_maintenance_unreleased_updates.xml.ep](https://openqa.suse.de/tests/16296562#)
- [autoyast/autoupgrade_with_maintenance_unreleased_updates.xml.ep](https://openqa.suse.de/tests/16296564#)
- [autoyast/bug-877438_ix64ph1029.xml](https://openqa.suse.de/tests/16296557#)
- [autoyast/bug-879147_autoinst.xml](https://openqa.suse.de/tests/16296558#)
- [autoyast/multipath.xml](https://openqa.suse.de/tests/16296559#)
- [autoyast/support_images/autoyast_scc_up_maintenance.xml.ep](https://openqa.suse.de/tests/16296600#)
- [autoyast/support_images/autoyast_sles12sp5_media_def_patterns_minimal_x86_64.xml](https://openqa.suse.de/tests/16296565#); [its migration job](https://openqa.suse.de/tests/16299849#)
- autoyast/autoyast_scc_up.xml: (This profile was already be cleanup in [[this PR]](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20545))
