### PR TITLE
Fix intermittent stall failure on slem

### DIFF
--- a/lib/virt_autotest/kubevirt_utils.pm
+++ b/lib/virt_autotest/kubevirt_utils.pm
@@ -16,10 +16,23 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils qw(is_transactional);
+use bootloader_setup qw(change_grub_config);
 
 our @EXPORT = qw(
+  set_grub_timeout
   install_cni_plugins
 );
+
+sub set_grub_timeout {
+    my $grub_timeout = shift // 30;
+
+    if (is_transactional) {
+        change_grub_config('=.*', '=' . $grub_timeout, 'GRUB_TIMEOUT');
+        record_info('GRUB', script_output('cat /etc/default/grub'));
+        assert_script_run('transactional-update grub.cfg');
+    }
+}
 
 sub install_cni_plugins {
     # Setup cnv-bridge containernetworking plugin: one of the tests requires

--- a/tests/virt_autotest/kubevirt_tests_agent.pm
+++ b/tests/virt_autotest/kubevirt_tests_agent.pm
@@ -25,6 +25,7 @@ sub run {
 
     if (check_var('RUN_TEST_ONLY', 0)) {
         use_ssh_serial_console;
+        $self->set_grub_timeout();
 
         # Synchronize the server & agent node before setup
         barrier_wait('kubevirt_test_setup');

--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -72,6 +72,7 @@ sub run {
 
     if (check_var('RUN_TEST_ONLY', 0)) {
         use_ssh_serial_console;
+        $self->set_grub_timeout();
 
         # Synchronize the server & agent node before setup
         barrier_wait('kubevirt_test_setup');


### PR DESCRIPTION
Stall failure was occured intermittently while login console after sle-micro rebooting. Increasing grub timeout will solve the issue.
https://openqa.suse.de/tests/16288024#step/kubevirt_tests_server/104

- Related ticket: https://progress.opensuse.org/issues/168622
- Verification run: https://openqa.suse.de/tests/16296594, https://openqa.suse.de/tests/16296603
