### PR TITLE
Ensure match reboot for autoyast test on  yast X86_64

### DIFF
--- a/data/yam/autoyast/resize_luks2.xml
+++ b/data/yam/autoyast/resize_luks2.xml
@@ -30,6 +30,7 @@
     <general>
       <mode>
         <confirm config:type="boolean">false</confirm>
+        <final_reboot config:type="boolean">true</final_reboot>
       </mode>
     </general>
     <networking>


### PR DESCRIPTION
##
### Ensure match reboot for autoyast test on yast X86_64

- Related ticket: https://progress.opensuse.org/issues/174736
- Needles: N/A
- Verification run: 
  - [**VR**](https://openqa.suse.de/tests/overview?version=15-SP7&build=hjluo_ay_yast_reboot&distri=sle)

##
