### PR TITLE
Fix the function of set_grub_timeout

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_agent.pm
+++ b/tests/virt_autotest/kubevirt_tests_agent.pm
@@ -25,7 +25,7 @@ sub run {
 
     if (check_var('RUN_TEST_ONLY', 0)) {
         use_ssh_serial_console;
-        $self->set_grub_timeout();
+        set_grub_timeout;
 
         # Synchronize the server & agent node before setup
         barrier_wait('kubevirt_test_setup');

--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -72,7 +72,7 @@ sub run {
 
     if (check_var('RUN_TEST_ONLY', 0)) {
         use_ssh_serial_console;
-        $self->set_grub_timeout();
+        set_grub_timeout;
 
         # Synchronize the server & agent node before setup
         barrier_wait('kubevirt_test_setup');


### PR DESCRIPTION
Solve the problem of varibale getting a wrong value.
https://openqa.suse.de/tests/16299964#step/kubevirt_tests_server/1

- Related ticket: https://progress.opensuse.org/issues/168622
- Verification run: https://openqa.suse.de/tests/16300055
