### PR TITLE
Remove ssh key scan for run method

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -115,7 +115,7 @@ sub run_cmd {
     delete($args{timeout});
     delete($args{runas});
 
-    $self->{my_instance}->wait_for_ssh(timeout => $timeout, scan_ssh_host_key => 1);
+    $self->{my_instance}->wait_for_ssh(timeout => $timeout);
     my $out = $self->{my_instance}->run_ssh_command(cmd => "sudo $cmd", timeout => $timeout, %args);
     record_info("$title output - $self->{my_instance}->{instance_id}", $out) unless ($timeout == 0 or $args{quiet} or $args{rc_only});
     return $out;


### PR DESCRIPTION
Removing ssh key scan for run method on public cloud library

- Related ticket: https://jira.suse.com/browse/TEAM-9782
- Needles: None
- Verification run: https://openqaworker15.qa.suse.cz/tests/308338#
- https://openqaworker15.qa.suse.cz/tests/308833#
