### PR TITLE
Ignore known error of Spectre-V2-LFENCE for slem 5.1

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -808,7 +808,7 @@
     "Spectre-V2-LFENCE": {
         "description": "kernel: Spectre V2 : Spectre mitigation: LFENCE not serializing, switching to generic retpoline",
         "products": {
-            "sle-micro": ["5.2"]
+            "sle-micro": ["5.1", "5.2"]
         },
         "type": "ignore"
     }


### PR DESCRIPTION
Ignore known error for slem 5.1: kernel: Spectre V2 : Spectre mitigation: LFENCE not serializing, switching to generic retpoline

- Related ticket: [quick pr for this failure](https://openqa.suse.de/tests/16313846#step/journal_check/12)
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/16314045#
