### PR TITLE
containers: Remove info method

### DIFF
--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -34,8 +34,7 @@ sub configure_insecure_registries {
 }
 
 sub get_storage_driver {
-    my $json = shift->info(json => 1);
-    my $storage = $json->{Driver};
+    my $storage = script_output("docker info -f '{{.Driver}}'");
     record_info 'Storage', "Detected storage driver=$storage";
 
     return $storage;

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -31,8 +31,7 @@ sub configure_insecure_registries {
 }
 
 sub get_storage_driver {
-    my $json = shift->info(json => 1);
-    my $storage = $json->{store}->{graphDriverName};
+    my $storage = script_output("podman info -f '{{.Store.GraphDriverName}}'");
     record_info 'Storage', "Detected storage driver=$storage";
 
     return $storage;

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -106,7 +106,7 @@ sub run {
     if ($storage ne 'overlay') {
         die "Unexpected storage driver -> $storage";
     }
-    $podman->info();
+    record_info("podman info", script_output("podman info"));
 
     test_container_image(image => $image, runtime => $podman);
     build_and_run_image(base => $image, runtime => $podman);


### PR DESCRIPTION
The `info` method is an over-engineered solution for getting simple information from container runtimes.  Ideally we should get rid of the OOP approach to testing container engines as part of the epic for refactoring these tests.

- Related ticket: https://progress.opensuse.org/issues/152590
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: https://openqa.opensuse.org/tests/4738395#step/rootless_podman/91 (job failing due to https://github.com/containers/podman/issues/24738)