### PR TITLE
lib: version_utils: handle SELinux default for SLES 16+

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -992,7 +992,7 @@ Returns true if the distro has SELinux as default MAC
 =cut
 
 sub has_selinux_by_default {
-    return (is_tumbleweed && check_var("VERSION", "Staging:D")) || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos;
+    return (is_tumbleweed && check_var("VERSION", "Staging:D")) || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos || is_sle('16+');
 }
 
 sub has_selinux {

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -138,6 +138,15 @@ subtest 'has_selinux_by_default' => sub {
     set_var('VERSION', '5.4');
     ok has_selinux_by_default, "check has_selinux_by_default for sle-micro 5.4";
 
+    # Test SLE < 16 (SELinux not enabled by default)
+    set_var('DISTRI', 'sle');
+    set_var('VERSION', '15-SP6');
+    ok !has_selinux_by_default, "check !has_selinux_by_default for sle 15-SP6";
+
+    # Test SLES 16 (SELinux enabled by default)
+    set_var('VERSION', '16.0');
+    ok has_selinux_by_default, "check has_selinux_by_default for sle 16.0";
+
     # Test Tumbleweed (SELinux enabled by default only in Staging:D)
     set_var('DISTRI', 'opensuse');
     set_var('VERSION', 'Tumbleweed');
@@ -158,6 +167,15 @@ subtest 'has_selinux' => sub {
     # Test SLE Micro 5.3 (not enabled by default)
     set_var('VERSION', '5.3');
     ok !has_selinux, "check !has_selinux with default settings (sle-micro 5.3)";
+
+    # Test SLE < 16 (not enabled by default)
+    set_var('DISTRI', 'sle');
+    set_var('VERSION', '15-SP6');
+    ok !has_selinux, "check !has_selinux with default settings (sle 15-SP6)";
+
+    # Test SLES 16 (enabled by default)
+    set_var('VERSION', '16.0');
+    ok has_selinux, "check !has_selinux with default settings (sle 16.0)";
 
     # Test Tumbleweed (default enabled in Staging:D)
     set_var('DISTRI', 'opensuse');


### PR DESCRIPTION
SLES 16+ defaults to SELinux, so `has_selinux_by_default` should return true in this case.

Related to jsc#PED-11619.

Example failure: https://openqa.suse.de/tests/16316286#step/firstrun/86

- Related ticket: https://progress.opensuse.org/issues/174892
- Verification run: https://openqa.suse.de/tests/16316371
