### PR TITLE
xfstests: ignore installation dependencies

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -24,6 +24,7 @@ use repo_tools 'add_qa_head_repo';
 use version_utils qw(is_sle is_leap is_tumbleweed is_sle_micro is_transactional);
 use File::Basename;
 use transactional;
+use Utils::Architectures 'is_ppc64le';
 
 my $STATUS_LOG = '/opt/status.log';
 my $VERSION_LOG = '/opt/version.log';
@@ -51,7 +52,21 @@ sub install_xfstests_from_repo {
         script_run('id fsgqa2 &> /dev/null || useradd -d /home/fsgqa2 -k /etc/skel -ms /bin/bash -U fsgqa2');
         script_run('getent group sys >/dev/null || groupadd -r sys');
         script_run('id daemon &> /dev/null || useradd daemon -g sys');
-        trup_call('pkg install xfstests');
+        if (is_ppc64le) {
+            script_run_interactive(
+                "transactional-update -n pkg install xfstests",
+                [
+                    {
+                        prompt => qr/Choose from above solutions by number or cancel/m,
+                        key => '2',
+                    },
+                ],
+                100
+            );
+        }
+        else {
+            trup_call('pkg install xfstests');
+        }
         unless (is_sle_micro('>=6.0')) {
             trup_call('--continue pkg install fio');
         }


### PR DESCRIPTION
Ignore installation dependencies of xfstests on ppc64le on microos

- Related ticket: https://progress.opensuse.org/issues/174640
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/16320350