### PR TITLE
Adapt cloud-init tests to work with IBSm

### DIFF
--- a/schedule/sles4sap/cloud-components/ipaddr2.yml
+++ b/schedule/sles4sap/cloud-components/ipaddr2.yml
@@ -6,9 +6,23 @@ vars:
     TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
     - boot/boot_to_desktop
+    - '{{validate_repos}}'
     - sles4sap/ipaddr2/deploy
     - sles4sap/ipaddr2/configure
+    - '{{patch_system}}'
+    - sles4sap/ipaddr2/cluster_create
     - sles4sap/ipaddr2/sanity_os
     - sles4sap/ipaddr2/sanity_cluster
     - sles4sap/ipaddr2/test_move_resource
     - sles4sap/ipaddr2/destroy
+conditional_schedule:
+    validate_repos:
+        IS_MAINTENANCE:
+            1:
+                - publiccloud/validate_repos
+    patch_system:
+        IS_MAINTENANCE:
+            1:
+                - sles4sap/ipaddr2/network_peering
+                - sles4sap/ipaddr2/registration
+                - sles4sap/ipaddr2/patch_system

--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Summary: Check that deployed resource in the cloud are as expected
+# Summary: Create cluster
 # Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
 
 use strict;
@@ -11,11 +11,10 @@ use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
-  ipaddr2_cluster_sanity
+  ipaddr2_cluster_create
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_os_sanity
   ipaddr2_clean_network_peering
 );
 
@@ -29,12 +28,8 @@ sub run {
 
     my $bastion_ip = ipaddr2_bastion_pubip();
 
-    # Default for ipaddr2_os_sanity is cloudadmin.
-    # It has to know about it to decide which ssh are expected in internal VMs
-    my %sanity_args = (bastion_ip => $bastion_ip);
-    $sanity_args{user} = 'root' unless check_var('IPADDR2_ROOTLESS', '1');
-    ipaddr2_os_sanity(%sanity_args);
-    ipaddr2_cluster_sanity(bastion_ip => $bastion_ip);
+    record_info("TEST STAGE", "Init and configure the Pacemaker cluster");
+    ipaddr2_cluster_create(bastion_ip => $bastion_ip, rootless => get_var('IPADDR2_ROOTLESS', '0'));
 }
 
 sub test_flags {

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -13,6 +13,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
+  ipaddr2_clean_network_peering
 );
 
 sub run {
@@ -23,6 +24,9 @@ sub run {
 
     select_serial_terminal;
 
+    if (my $ibsm_rg = get_var('IBSM_RG')) {
+        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+    }
     ipaddr2_infra_destroy();
 }
 
@@ -34,6 +38,10 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs();
+    if (my $ibsm_rg = get_var('IBSM_RG')) {
+        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+    }
+    ipaddr2_clean_network_peering();
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -1,8 +1,8 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Summary: Check that deployed resource in the cloud are as expected
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Summary: Create network peering with IBSm
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use strict;
 use warnings;
@@ -10,31 +10,23 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
-  ipaddr2_bastion_pubip
-  ipaddr2_cluster_sanity
   ipaddr2_deployment_logs
-  ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_os_sanity
   ipaddr2_clean_network_peering
+  ipaddr2_infra_destroy
+  ipaddr2_network_peering
+  ipaddr2_add_server_repos_to_hosts
 );
 
 sub run {
     my ($self) = @_;
 
-    die('Azure is the only CSP supported for the moment')
-      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-
     select_serial_terminal;
 
-    my $bastion_ip = ipaddr2_bastion_pubip();
+    # Create network peering
+    ipaddr2_network_peering(ibsm_rg => get_required_var('IBSM_RG'));
 
-    # Default for ipaddr2_os_sanity is cloudadmin.
-    # It has to know about it to decide which ssh are expected in internal VMs
-    my %sanity_args = (bastion_ip => $bastion_ip);
-    $sanity_args{user} = 'root' unless check_var('IPADDR2_ROOTLESS', '1');
-    ipaddr2_os_sanity(%sanity_args);
-    ipaddr2_cluster_sanity(bastion_ip => $bastion_ip);
+    ipaddr2_add_server_repos_to_hosts(ibsm_ip => get_required_var('IBSM_IP'), incident_repo => get_var('INCIDENT_REPO', ''));
 }
 
 sub test_flags {

--- a/tests/sles4sap/ipaddr2/patch_system.pm
+++ b/tests/sles4sap/ipaddr2/patch_system.pm
@@ -1,8 +1,8 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Summary: Check that deployed resource in the cloud are as expected
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Summary: zypper patch and reboot
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use strict;
 use warnings;
@@ -10,31 +10,19 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
-  ipaddr2_bastion_pubip
-  ipaddr2_cluster_sanity
   ipaddr2_deployment_logs
-  ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_os_sanity
   ipaddr2_clean_network_peering
+  ipaddr2_infra_destroy
+  ipaddr2_patch_system
 );
 
 sub run {
     my ($self) = @_;
 
-    die('Azure is the only CSP supported for the moment')
-      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-
     select_serial_terminal;
 
-    my $bastion_ip = ipaddr2_bastion_pubip();
-
-    # Default for ipaddr2_os_sanity is cloudadmin.
-    # It has to know about it to decide which ssh are expected in internal VMs
-    my %sanity_args = (bastion_ip => $bastion_ip);
-    $sanity_args{user} = 'root' unless check_var('IPADDR2_ROOTLESS', '1');
-    ipaddr2_os_sanity(%sanity_args);
-    ipaddr2_cluster_sanity(bastion_ip => $bastion_ip);
+    ipaddr2_patch_system();
 }
 
 sub test_flags {

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -1,40 +1,33 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Summary: Check that deployed resource in the cloud are as expected
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Summary: Registration SUT
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use publiccloud::utils;
 use sles4sap::ipaddr2 qw(
-  ipaddr2_bastion_pubip
-  ipaddr2_cluster_sanity
   ipaddr2_deployment_logs
-  ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_os_sanity
   ipaddr2_clean_network_peering
+  ipaddr2_infra_destroy
+  ipaddr2_registration
+  ipaddr2_register_addons
+  ipaddr2_bastion_pubip
 );
 
 sub run {
     my ($self) = @_;
 
-    die('Azure is the only CSP supported for the moment')
-      unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-
     select_serial_terminal;
 
-    my $bastion_ip = ipaddr2_bastion_pubip();
-
-    # Default for ipaddr2_os_sanity is cloudadmin.
-    # It has to know about it to decide which ssh are expected in internal VMs
-    my %sanity_args = (bastion_ip => $bastion_ip);
-    $sanity_args{user} = 'root' unless check_var('IPADDR2_ROOTLESS', '1');
-    ipaddr2_os_sanity(%sanity_args);
-    ipaddr2_cluster_sanity(bastion_ip => $bastion_ip);
+    my $bastion_pubip = ipaddr2_bastion_pubip();
+    ipaddr2_registration(bastion_pubip => $bastion_pubip);
+    ipaddr2_register_addons(bastion_pubip => $bastion_pubip);
 }
 
 sub test_flags {

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -20,6 +20,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
+  ipaddr2_clean_network_peering
 );
 
 sub run {
@@ -42,6 +43,9 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    if (my $ibsm_rg = get_var('IBSM_RG')) {
+        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+    }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -20,6 +20,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_test_master_vm
   ipaddr2_test_other_vm
   ipaddr2_wait_for_takeover
+  ipaddr2_clean_network_peering
 );
 
 sub run {
@@ -90,6 +91,9 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    if (my $ibsm_rg = get_var('IBSM_RG')) {
+        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+    }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
When runing maintenance testing, doing network peering with IBSM and patch system with incident repo.

Related: https://jira.suse.com/browse/TEAM-9864

VR: 
15-SP5-SapCloud-Azure-Byos-cloud-init: https://openqaworker15.qa.suse.cz/tests/309577#
15-SP6-SapCloud-Azure-Payg-ipaddr2_azure_test_rootless:  http://openqaworker15.qa.suse.cz/tests/309939#
12-SP5-SapCloud-Azure-Payg-ipaddr2_azure_test:  https://openqaworker15.qa.suse.cz/tests/309942#
15-SP3: https://openqaworker15.qa.suse.cz/tests/310054#
