### PR TITLE
Using autoyast install for kubevirt tests

### DIFF
--- a/schedule/virt_autotest/kubevirt-tests-sles.yaml
+++ b/schedule/virt_autotest/kubevirt-tests-sles.yaml
@@ -1,0 +1,28 @@
+name:           kubevirt-tests
+description:    >
+    Maintainer: Nan Zhang <nan.zhang@suse.com> qe-virt@suse.de
+    Kubevirt server & agent node installation and test modules
+vars:
+    MAX_JOB_TIME: 72000
+schedule:
+    - '{{barrier_setup}}'
+    - '{{bootup_and_install}}'
+    - '{{kubevirt_tests}}'
+conditional_schedule:
+    barrier_setup:
+        SERVICE:
+            rke2-server:
+                - virt_autotest/kubevirt_barriers
+    bootup_and_install:
+        RUN_TEST_ONLY:
+            0:
+                - autoyast/prepare_profile
+                - installation/ipxe_install
+                - autoyast/installation
+                - virt_autotest/login_console
+    kubevirt_tests:
+        SERVICE:
+            rke2-server:
+                - virt_autotest/kubevirt_tests_server
+            rke2-agent:
+                - virt_autotest/kubevirt_tests_agent


### PR DESCRIPTION
For SLES installation, autoyast will be used for kubevirt tests.

- Related ticket: https://progress.opensuse.org/issues/163682
- Verification run: https://openqa.suse.de/tests/16321193, https://openqa.suse.de/tests/16332281
