### PR TITLE
Add post script in single jsonnet

### DIFF
--- a/data/yam/agama/auto/post_script.jsonnet
+++ b/data/yam/agama/auto/post_script.jsonnet
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "post": [
+      {
+        "name": "enable root login",
+        "chroot": true,
+        "body": |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||
+      }
+    ]
+  }
+}

--- a/schedule/yam/agama_remote.yaml
+++ b/schedule/yam/agama_remote.yaml
@@ -1,0 +1,13 @@
+---
+name: agama
+description: >
+  Perform interactive installation with agama for remote worker.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_product
+  - yam/validate/validate_first_user


### PR DESCRIPTION
We need import the post script in single jsonnet to ensure root login after installation for interactive installation test.
Failed job: https://openqa.suse.de/tests/16340313#step/validate_product/1

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/16340485#step/validate_product/2