### PR TITLE
containers: Enable BCI tests on CentOS 10

### DIFF
--- a/tests/containers/update_host.pm
+++ b/tests/containers/update_host.pm
@@ -40,7 +40,8 @@ sub run {
         # https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1950314
         script_retry("yes yes | DEBIAN_FRONTEND=noninteractive apt-get upgrade -y", timeout => $update_timeout);
     } elsif ($host_distri eq 'centos') {
-        assert_script_run("dhclient -v");
+        # dhclient is no longer available in CentOS 10
+        script_run("dhclient -v");
         script_retry("dnf update -y --nobest", timeout => $update_timeout);
     } elsif ($host_distri eq 'rhel') {
         script_retry("dnf update -y", timeout => $update_timeout);


### PR DESCRIPTION
Code to enable BCI tests on CentOS 10:
  - Remove the `assert` to run `dhclient` as it was removed on CentOS 10 per [documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10-beta/html/10.0_beta_release_notes/removed-features#removed-features-networking)

- Related ticket: https://progress.opensuse.org/issues/174433
- Verification run: https://openqa.suse.de/tests/16341267#