### PR TITLE
Softfail: Spectre mitigation: LFENCE not serializing

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -808,7 +808,8 @@
     "Spectre-V2-LFENCE": {
         "description": "kernel: Spectre V2 : Spectre mitigation: LFENCE not serializing, switching to generic retpoline",
         "products": {
-            "sle-micro": ["5.1", "5.2"]
+            "sle-micro": ["5.1", "5.2"],
+            "sle": ["15-SP3"]
         },
         "type": "ignore"
     }


### PR DESCRIPTION
Softfail in sle15sp3 testing
https://openqa.suse.de/tests/16349728#step/journal_check/2

- Verification run: not needed
