### PR TITLE
Simplify AutoYaST profiles for sles12sp5 support image

### DIFF
--- a/data/autoyast_sle12/create_hdd/create_hdd_sap_sles.xml.ep
+++ b/data/autoyast_sle12/create_hdd/create_hdd_sap_sles.xml.ep
@@ -7,21 +7,9 @@
     <install_updates config:type="boolean">true</install_updates>
   </suse_register>
   <bootloader>
-    <device_map config:type="list">
-      <device_map_entry>
-        <firmware>hd0</firmware>
-        <linux>/dev/vda</linux>
-      </device_map_entry>
-    </device_map>
     <global>
-      <timeout config:type="integer">1</timeout>
-      <activate>true</activate>
       <timeout config:type="integer">-1</timeout>
-      <boot_boot>false</boot_boot>
-      <xen_append>fadump= crashkernel=201M</xen_append>
-      <xen_kernel_append><![CDATA[vga=gfx-1024x768x16 vga=gfx-1024x768x16 crashkernel=201M<4G]]></xen_kernel_append>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>

--- a/data/yam/autoyast/sles12sp5_create_hdd_gnome_unregistered_no_self_update_s390x.xml.ep
+++ b/data/yam/autoyast/sles12sp5_create_hdd_gnome_unregistered_no_self_update_s390x.xml.ep
@@ -6,10 +6,8 @@
   </suse_register>
   <bootloader>
     <global>
-      <terminal>console</terminal>
       <timeout config:type="integer">-1</timeout>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
   <general>
     <ask-list config:type="list"/>

--- a/data/yam/autoyast/support_images/autoyast_sles12sp5_media_def_patterns_minimal_x86_64.xml
+++ b/data/yam/autoyast/support_images/autoyast_sles12sp5_media_def_patterns_minimal_x86_64.xml
@@ -6,9 +6,8 @@
   </add-on>
   <bootloader>
     <global>
-      <timeout config:type="integer">8</timeout>
+      <timeout config:type="integer">-1</timeout>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>

--- a/data/yam/autoyast/support_images/create_hdd_ha_sles.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_ha_sles.xml.ep
@@ -181,7 +181,7 @@
     % unless ($check_var->('ARCH', 's390x')) {
     <bootloader>
       <global>
-        <timeout config:type="integer">45</timeout>
+        <timeout config:type="integer">-1</timeout>
       </global>
     </bootloader>
     <general>

--- a/data/yam/autoyast/support_images/create_hdd_sap_textmode_sles.xml.ep
+++ b/data/yam/autoyast/support_images/create_hdd_sap_textmode_sles.xml.ep
@@ -7,21 +7,9 @@
     <install_updates config:type="boolean">true</install_updates>
   </suse_register>
   <bootloader>
-    <device_map config:type="list">
-      <device_map_entry>
-        <firmware>hd0</firmware>
-        <linux>/dev/vda</linux>
-      </device_map_entry>
-    </device_map>
     <global>
-      <timeout config:type="integer">1</timeout>
-      <activate>true</activate>
       <timeout config:type="integer">-1</timeout>
-      <boot_boot>false</boot_boot>
-      <xen_append>fadump= crashkernel=201M</xen_append>
-      <xen_kernel_append><![CDATA[vga=gfx-1024x768x16 vga=gfx-1024x768x16 crashkernel=201M<4G]]></xen_kernel_append>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
@@ -100,16 +88,6 @@
     <languages/>
   </language>
   <networking>
-    <dhcp_options>
-      <dhclient_client_id/>
-      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
-    </dhcp_options>
-    <dns>
-      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
-      <hostname>susetest</hostname>
-      <resolv_conf_policy>auto</resolv_conf_policy>
-      <write_hostname config:type="boolean">false</write_hostname>
-    </dns>
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>
@@ -117,32 +95,7 @@
         <dhclient_set_default_route>yes</dhclient_set_default_route>
         <startmode>auto</startmode>
       </interface>
-      <interface>
-        <bootproto>static</bootproto>
-        <device>lo</device>
-        <firewall>no</firewall>
-        <ipaddr>127.0.0.1</ipaddr>
-        <netmask>255.0.0.0</netmask>
-        <network>127.0.0.0</network>
-        <prefixlen>8</prefixlen>
-        <startmode>nfsroot</startmode>
-        <usercontrol>no</usercontrol>
-      </interface>
     </interfaces>
-    <ipv6 config:type="boolean">true</ipv6>
-    <keep_install_network config:type="boolean">true</keep_install_network>
-    <managed config:type="boolean">false</managed>
-    <net-udev config:type="list">
-      <rule>
-        <name>eth0</name>
-        <rule>KERNELS</rule>
-        <value>0000:01:00.0</value>
-      </rule>
-    </net-udev>
-    <routing>
-      <ipv4_forward config:type="boolean">false</ipv4_forward>
-      <ipv6_forward config:type="boolean">false</ipv6_forward>
-    </routing>
   </networking>
   <partitioning config:type="list">
     <drive>

--- a/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_all_patterns_s390x.xml
@@ -8,17 +8,8 @@
   </suse_register>
   <bootloader>
     <global>
-      <append>hvc_iucv=8 TERM=dumb resume=/dev/disk/by-path/ccw-0.0.0000-part3 crashkernel=163M</append>
-      <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
-      <os_prober>false</os_prober>
-      <terminal>console</terminal>
       <timeout config:type="integer">-1</timeout>
-      <trusted_grub>false</trusted_grub>
-      <xen_append>crashkernel=163M</xen_append>
-      <xen_kernel_append>crashkernel=163M\&lt;4G</xen_kernel_append>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
   <dasd>
     <devices config:type="list"/>
@@ -49,71 +40,14 @@
     <start_firewall config:type="boolean">true</start_firewall>
   </firewall>
   <networking>
-    <dhcp_options>
-      <dhclient_client_id/>
-      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
-    </dhcp_options>
-    <dns>
-      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
-      <hostname>susetest</hostname>
-      <nameservers config:type="list">
-        <nameserver>10.144.53.53</nameserver>
-      </nameservers>
-      <resolv_conf_policy>auto</resolv_conf_policy>
-      <searchlist config:type="list">
-        <search>suse.de</search>
-      </searchlist>
-      <write_hostname config:type="boolean">false</write_hostname>
-    </dns>
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>
-        <name>eth0</name>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
         <startmode>auto</startmode>
-        <zone>public</zone>
-      </interface>
-      <interface>
-        <bootproto>static</bootproto>
-        <device>lo</device>
-        <firewall>no</firewall>
-        <ipaddr>127.0.0.1</ipaddr>
-        <netmask>255.0.0.0</netmask>
-        <network>127.0.0.0</network>
-        <prefixlen>8</prefixlen>
-        <startmode>nfsroot</startmode>
-        <usercontrol>no</usercontrol>
       </interface>
     </interfaces>
-    <ipv6 config:type="boolean">true</ipv6>
-    <keep_install_network config:type="boolean">true</keep_install_network>
-    <managed config:type="boolean">false</managed>
-    <routing>
-      <ipv4_forward config:type="boolean">false</ipv4_forward>
-      <ipv6_forward config:type="boolean">false</ipv6_forward>
-      <routes config:type="list">
-        <route>
-          <destination>default</destination>
-          <device>eth0</device>
-          % if ( $get_var->('WORKER_HOSTNAME') =~ /prg2/ ) {
-          <gateway>10.145.10.254</gateway>
-          % }
-          % if ( $get_var->('WORKER_HOSTNAME') =~ /nue2/ ) {
-          <gateway>10.161.159.254</gateway>
-          % }
-          <netmask>-</netmask>
-        </route>
-      </routes>
-    </routing>
-    <s390-devices config:type="list">
-      <listentry>
-        <chanids>   </chanids>
-        <type/>
-      </listentry>
-      <listentry>
-        <chanids>   </chanids>
-        <type/>
-      </listentry>
-    </s390-devices>
   </networking>
   <report>
     <errors>

--- a/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles12sp5_install_default_patterns_s390x.xml
@@ -8,17 +8,8 @@
   </suse_register>
   <bootloader>
     <global>
-      <append>hvc_iucv=8 TERM=dumb resume=/dev/disk/by-path/ccw-0.0.0000-part3 crashkernel=163M</append>
-      <gfxmode>auto</gfxmode>
-      <hiddenmenu>false</hiddenmenu>
-      <os_prober>false</os_prober>
-      <terminal>console</terminal>
       <timeout config:type="integer">-1</timeout>
-      <trusted_grub>false</trusted_grub>
-      <xen_append>crashkernel=163M</xen_append>
-      <xen_kernel_append>crashkernel=163M\&lt;4G</xen_kernel_append>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
   <dasd>
     <devices config:type="list"/>

--- a/data/yam/autoyast/support_images/sles15sp6_install_textmode_hpc_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_textmode_hpc_x86_64.xml
@@ -14,19 +14,6 @@
       <confirm t="boolean">false</confirm>
     </mode>
   </general>
-  <keyboard t="map">
-    <keyboard_values t="map">
-      <delay/>
-      <discaps t="boolean">false</discaps>
-      <numlock>bios</numlock>
-      <rate/>
-    </keyboard_values>
-    <keymap>english-us</keymap>
-  </keyboard>
-  <language t="map">
-    <language>en_US</language>
-    <languages/>
-  </language>
   <networking t="map">
     <interfaces t="list">
       <interface t="map">


### PR DESCRIPTION
##
### Simplify AutoYaST profiles for sles12sp5 support image

- Related ticket:  https://progress.opensuse.org/issues/169681
- Needles: N/A
- Verification run: 
  -  [12sp5_supp](https://openqa.suse.de/tests/overview?build=hjluo_ay_tidy&distri=sle&version=12-SP5)

##
