### PR TITLE
containers: Install iptables-backend-nft along with Docker on Tumbleweed

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -120,7 +120,12 @@ sub install_docker_when_needed {
             }
 
             # docker package can be installed
-            zypper_call('in docker', timeout => 300);
+            my @pkgs = qw(docker);
+            if (is_tumbleweed) {
+                push @pkgs, "iptables-backend-nft";
+                assert_script_run "sed -i 's/^FlushAllOnReload=no/FlushAllOnReload=yes/' /etc/firewalld/firewalld.conf";
+            }
+            zypper_call("in @pkgs", timeout => 300);
 
             # Restart firewalld if enabled before. Ensure docker can properly interact (boo#1196801)
             if (script_run('systemctl is-active firewalld') == 0) {


### PR DESCRIPTION
Docker seems to be better integrated with iptables-nft in latest Debian, Ubuntu & Fedora as I can see DOCKER chains in the output of `iptables-nft -L -vn`, with `iptables` being a symbolic link to `xtables-nft-multi`.  This is a workaround until either we fix that or Docker migrates to nftables for good.

- Related ticket: https://progress.opensuse.org/issues/173362
- Verification run: https://openqa.opensuse.org/tests/4754739