### PR TITLE
MinimalVM base on sle16 comes with selinux

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -992,7 +992,7 @@ Returns true if the distro has SELinux as default MAC
 =cut
 
 sub has_selinux_by_default {
-    return (is_tumbleweed && check_var("VERSION", "Staging:D")) || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos;
+    return (is_tumbleweed && check_var("VERSION", "Staging:D")) || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos || is_sle('16+');
 }
 
 sub has_selinux {


### PR DESCRIPTION
SElinux has been enabled by default in new MinimalVM images.

- Verification run: https://openqa.suse.de/tests/16364292#step/firstrun/82
