### PR TITLE
Add pre/post scripts and remove workaround for agama auto install

### DIFF
--- a/data/agama_auto/sle_default.jsonnet
+++ b/data/agama_auto/sle_default.jsonnet
@@ -1,0 +1,16 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  }
+}

--- a/data/agama_auto/sle_default_ipmi.jsonnet
+++ b/data/agama_auto/sle_default_ipmi.jsonnet
@@ -1,0 +1,41 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        body: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||
+      }
+    ],
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||
+      }
+    ]
+  }
+}

--- a/data/agama_auto/sle_default_pvm.jsonnet
+++ b/data/agama_auto/sle_default_pvm.jsonnet
@@ -1,0 +1,41 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        body: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||
+      }
+    ],
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||
+      }
+    ]
+  }
+}

--- a/data/agama_auto/sle_default_s390x_kvm.jsonnet
+++ b/data/agama_auto/sle_default_s390x_kvm.jsonnet
@@ -1,0 +1,28 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||
+      }
+    ]
+  }
+}

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -182,10 +182,9 @@ sub enter_o3_ipxe_boot_entry {
 
 sub set_bootscript_agama_cmdline_extra {
     my $cmdline_extra = " ";
-    if (get_var('AGAMA_AUTO')) {
-        my $agama_auto = data_url(get_var('AGAMA_AUTO'));
-        $agama_auto =~ s/^\s+|\s+$//g;
-        $cmdline_extra .= "agama.auto=$agama_auto ";
+    if (my $agama_auto = get_var('AGAMA_AUTO')) {
+        my $agama_auto_url = autoyast::expand_agama_profile($agama_auto);
+        $cmdline_extra .= "agama.auto=$agama_auto_url ";
     }
     # Agama Installation repository URL
     # By default Agama installs the packages from the repositories specified in the product configuration.


### PR DESCRIPTION
1. Add pre scripts to initialize the disks
2. Handle variables in agama profile

VR:
[pvm](http://openqa.suse.de/tests/16424869)
[ipmi](https://openqa.suse.de/tests/16425016)