### PR TITLE
containers: Remove assert on iptables rule add

### DIFF
--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -84,7 +84,7 @@ sub run {
     # - https://fedoraproject.org/wiki/Changes/NetavarkNftablesDefault#Known_Issue_with_docker
     # - https://docs.docker.com/engine/network/packet-filtering-firewalls/#docker-on-a-router
     if (is_tumbleweed && $runtime eq "podman" && get_var("CONTAINER_RUNTIMES") =~ /docker/) {
-        assert_script_run "iptables -I DOCKER-USER -j ACCEPT";
+        script_run "iptables -I DOCKER-USER -j ACCEPT";
     }
 
     # We may test either one specific image VERSION or comma-separated CONTAINER_IMAGE_VERSIONS


### PR DESCRIPTION
Remove assertion when inserting iptables rule.

- Related ticket: https://progress.opensuse.org/issues/173362
- Failing test: https://openqa.opensuse.org/tests/4756699#step/image_podman/43
- Verification run: not needed