### PR TITLE
ltp: Remove cockpit login message during installation

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -321,6 +321,9 @@ sub run {
     select_serial_terminal;
     export_ltp_env;
 
+    # cockpit login message sporadically breaks login in boot_ltp
+    script_run '[ -f /etc/issue.d/cockpit.issue ] && rm /etc/issue.d/cockpit.issue';
+
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
         script_run('echo 1 > /sys/module/printk/parameters/time');
         $grub_param .= ' printk.time=1';


### PR DESCRIPTION
Fix poo#175141: Remove Cockpit login message to prevent sporadic login failures in `boot_ltp`.

- Related ticket: https://progress.opensuse.org/issues/175141
- Needles: none
- Verification run:
SL Micro: https://openqa.suse.de/tests/overview?build=czerw%2Fos-autoinst-distri-opensuse%2320911&distri=sle-micro
SLE: https://openqa.suse.de/tests/overview?version=15-SP6&build=czerw%2Fos-autoinst-distri-opensuse%2320911&distri=sle