### PR TITLE
Introduce variable allowing to keep image after test end

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -517,7 +517,7 @@ sub on_terraform_apply_timeout {
 
     eval { $self->upload_boot_diagnostics('resource_group' => $resgroup) }
       or record_info('Bootlog upl error', 'Failed to upload bootlog');
-    assert_script_run("az group delete --yes --no-wait --name $resgroup") unless get_var('PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE');
+    assert_script_run("az group delete --yes --no-wait --name $resgroup") unless get_var('PUBLIC_CLOUD_NO_CLEANUP');
 }
 
 sub get_resource_group_from_terraform_show {

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -118,8 +118,8 @@ sub _cleanup {
     diag('Public Cloud _cleanup: $self->{run_args}->{my_instance}=' . $self->{run_args}->{my_instance}) if ($self->{run_args} && $self->{run_args}->{my_instance});
 
     # currently we have two cases when cleanup of image will be skipped:
-    # 1. Job should have 'PUBLIC_CLOUD_NO_CLEANUP' variable and result == 'fail'
-    if (get_var('PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE') && $self->{result} && $self->{result} eq 'fail') {
+    # 1. Job should have 'PUBLIC_CLOUD_NO_CLEANUP' variable
+    if (get_var('PUBLIC_CLOUD_NO_CLEANUP')) {
         upload_logs('/var/tmp/ssh_sut.log', failok => 1, log_name => 'ssh_sut_log.txt');
         upload_asset(script_output('ls ~/.ssh/id* | grep -v pub | head -n1'));
         return;

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -22,7 +22,7 @@ use publiccloud::utils;
 use File::Basename;
 
 our $target_version = get_required_var('TARGET_VERSION');
-our $not_clean_vm = get_var('PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE');
+our $not_clean_vm = get_var('PUBLIC_CLOUD_NO_CLEANUP');
 
 sub run {
     my ($self, $args) = @_;

--- a/variables.md
+++ b/variables.md
@@ -359,7 +359,7 @@ PUBLIC_CLOUD_LTP | boolean | false | If set, the run_ltp test module is added to
 PUBLIC_CLOUD_MAX_INSTANCES | integer | 1 | Allows the test to call "create_instance" subroutine within lib/publiccloud/provider.md a limited amount of times. If set to 0 or undef, it allows an unlimited amount of calls.
 PUBLIC_CLOUD_NAMESPACE | string | "" | The Public Cloud Namespace name that will be used to compose the full credentials URL together with `PUBLIC_CLOUD_CREDENTIALS_URL`.
 PUBLIC_CLOUD_NEW_INSTANCE_TYPE | string | "t3a.large" | Specify the new instance type to check bsc#1205002 in EC2
-PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE | boolean | false | Do not remove the instance when the test fails.
+PUBLIC_CLOUD_NO_CLEANUP | boolean | false | Do not remove the instance after test finished running.
 PUBLIC_CLOUD_NVIDIA | boolean | 0 | If enabled, nvidia module would be scheduled. This variable should be enabled only sle15SP4 and above.
 PUBLIC_CLOUD_PERF_COLLECT | boolean | 1 | To enable `boottime` measures collection, at end of `create_instance` routine.
 PUBLIC_CLOUD_PERF_DB | string | "perf_2" | defines the bucket in which the performance metrics are stored on PUBLIC_CLOUD_PERF_DB_URI


### PR DESCRIPTION
Before we had variable PUBLIC_CLOUD_NO_CLEANUP_ON_FAILURE,
which was ignoring cleanup only when test failing.
But sometimes we need to investigate something even for test
which pass. So this PR will rename variable to
PUBLIC_CLOUD_NO_CLEANUP and drop condition that test failing

VR: http://openqa.suse.de/tests/16393923