### PR TITLE
Add multipath profile for prod group

### DIFF
--- a/data/yam/agama/auto/sle_multipath_scc_plain_password.jsonnet
+++ b/data/yam/agama/auto/sle_multipath_scc_plain_password.jsonnet
@@ -1,0 +1,28 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: 'nots3cr3t',
+    userName: 'bernhard'
+  },
+  root: {
+    password: 'nots3cr3t'
+  },
+  scripts: {
+     pre: [
+       {
+         name: 'activate multipath',
+         body: |||
+           #!/bin/bash
+           if ! systemctl status multpathd ; then
+             echo 'Activating multipath'
+             systemctl start multipathd.socket
+             systemctl start multipathd
+           fi
+         |||
+      }
+    ]
+  }
+}


### PR DESCRIPTION
##
### Add multipath profile for prod group

- Related ticket: https://progress.opensuse.org/issues/173659
- Needles: N/A
- Verification run: 
  - [prod_multipath](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=hjluo_agama_regcode) 
  
##
