### PR TITLE
Support SLE16 virt test on host installation

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -1,0 +1,110 @@
+{
+  product: {
+    id: 'SLES'
+  },
+  user: {
+    userName: 'bernhard',
+    fullName: "Bernhard M. Wiedemann",
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  legacyAutoyastStorage: [
+      {
+         "device": "/dev/sda",
+         "disklabel": "gpt",
+         "enable_snapshots": false,
+         "initialize": true,
+         "partitions": [
+            {
+               "create": true,
+               "filesystem": "vfat",
+               "format": true,
+               "mount": "/boot/efi",
+               "mountby": "uuid",
+               "partition_id": 259,
+               "size": "512M"
+            },
+            {
+               "create": true,
+               "create_subvolumes": true,
+               "filesystem": "btrfs",
+               "format": true,
+               "mount": "/",
+               "mountby": "uuid",
+               "partition_id": 131,
+               "size": "120G"
+            },
+            {
+               "create": true,
+               "filesystem": "xfs",
+               "format": true,
+               "mount": "/var/lib/libvirt/images/",
+               "mountby": "uuid",
+               "partition_id": 131,
+               "resize": false
+            },
+            {
+               "create": true,
+               "filesystem": "swap",
+               "format": true,
+               "mountby": "uuid",
+               "size": "4G"
+            }
+         ],
+         type: "CT_DISK",
+         use: "all"
+      }
+  ],
+  software: {
+      patterns: [
+         'base',
+         'kvm_host'
+      ]
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        body: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||
+      }
+    ],
+    post: [
+      {
+        name: "config_sshd",
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
+          echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > $sshd_config_file
+        |||
+      },
+      {
+        name: "enable_persistent_journal_logging",
+        body: |||
+          #!/usr/bin/env bash
+          echo -e "[Journal]\\nStorage=persistent" > /etc/systemd/journald.conf.d/01-virt-test.conf
+        |||
+      },
+      {
+        name: "Configure_ssh_client",
+        body: |||
+          #!/usr/bin/env bash
+          ssh_config_file="/etc/ssh/ssh_config.d/01-virt-test.conf"
+          echo -e "\StrictHostKeyChecking no\nUserKnownHostsFile /dev/null" > $ssh_config_file
+        |||
+      }
+    ]
+  }
+}

--- a/schedule/virt_autotest/sle16_guest_installation.yaml
+++ b/schedule/virt_autotest/sle16_guest_installation.yaml
@@ -1,0 +1,8 @@
+name:          sle16-virt-guest-installation
+description:    >
+    Virtualization guest installation tests including extended feature tests schedule with agama and IPXE
+vars:
+schedule:
+    - installation/ipxe_install
+    - installation/agama_reboot
+    - virt_autotest/login_console

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -19,6 +19,7 @@ use version_utils qw(is_upgrade is_tumbleweed is_sle is_leap is_sle_micro is_aga
 use bootloader_setup 'prepare_disks';
 use Utils::Architectures;
 use Utils::Backends qw(is_ipmi is_qemu);
+use autoyast qw(expand_agama_profile);
 use virt_autotest::utils qw(is_kvm_host is_xen_host);
 use HTTP::Tiny;
 use IPC::Run;


### PR DESCRIPTION
A sle16 virt test is created in https://openqa.suse.de/group_overview/213. It can help install a sle16 kvm host by running the test. 

This is the first PR. Enhancement is on the way.

What have been done for our virt test:

- Install SLE16 on an ipmi backend baremetal host and wipefs all disks.
- Install kvm patterns on the host with a seperate partition for /var/lib/libvirt/images.
- Config sshd and ssh client on the host.
- persistent journal logging.

What have not been done: 
- ssh keys
- br0
- install system on a specified hard disk
- installed on `quinn`, `fozzie` and `bare-metal5` successfully, but failed on `bare-metal1/3`.

Related ticket: https://progress.opensuse.org/issues/169900
Verification run: 
[a_test_on_OSD](https://openqa.suse.de/tests/16425434)
[a_test_on_BJ](http://10.200.140.2/tests/676)
