### PR TITLE
QU - single yaml for Full and Online s390x and aarch64

### DIFF
--- a/schedule/security/create_hdd_cc_libyui/aarch64/cc_qr.yaml
+++ b/schedule/security/create_hdd_cc_libyui/aarch64/cc_qr.yaml
@@ -7,6 +7,12 @@ schedule:
   access_beta: []
   product_selection:
     - installation/product_selection/install_SLES
+  registration:
+    - security/installation/registration
+  extension_module_selection:
+    - security/installation/module_selection
+  add_on_product:
+    - security/installation/add_on_selection
   system_role:
     - installation/system_role/select_common_criteria_role
     - installation/common_criteria_configuration/common_criteria_configuration

--- a/schedule/security/create_hdd_cc_libyui/aarch64/cc_qr_15sp6.yaml
+++ b/schedule/security/create_hdd_cc_libyui/aarch64/cc_qr_15sp6.yaml
@@ -5,6 +5,12 @@ description: >
   encryption on QR SLES.
 schedule:
   access_beta: []
+  registration:
+    - security/installation/registration
+  extension_module_selection:
+    - security/installation/module_selection
+  add_on_product:
+    - security/installation/add_on_selection
   system_role:
     - installation/system_role/select_common_criteria_role
     - installation/common_criteria_configuration/common_criteria_configuration

--- a/schedule/security/create_hdd_cc_libyui/s390x/cc_qr.yaml
+++ b/schedule/security/create_hdd_cc_libyui/s390x/cc_qr.yaml
@@ -5,6 +5,12 @@ description: >
   encryption on QR SLES.
 schedule:
   access_beta: []
+  registration:
+    - security/installation/registration
+  extension_module_selection:
+    - security/installation/module_selection
+  add_on_product:
+    - security/installation/add_on_selection
   system_role:
     - installation/system_role/select_common_criteria_role
     - installation/common_criteria_configuration/common_criteria_configuration


### PR DESCRIPTION
Modifying the security YAML to work with Full and Online flavor.

- Related ticket: https://progress.opensuse.org/issues/167755
- Verification run: 
  - https://openqa.suse.de/tests/16393933
  - https://openqa.suse.de/tests/16381385
  - https://openqa.suse.de/tests/16393995