### PR TITLE
Add missing variables to allow execution

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -100,7 +100,9 @@ my $should_use_runargs = sub {
       PUBLIC_CLOUD_SMOKETEST
       PUBLIC_CLOUD_AZURE_NFS_TEST
       PUBLIC_CLOUD_NVIDIA
-      PUBLIC_CLOUD_NETCONFIG);
+      PUBLIC_CLOUD_NETCONFIG
+      PUBLIC_CLOUD_AHB
+      PUBLIC_CLOUD_NEW_INSTANCE_TYPE);
     return grep { exists $bmwqemu::vars{$_} } @public_cloud_variables;
 };
 


### PR DESCRIPTION

should_use_runargs function was missing variables of some tests
which were actually within apropriate check so tests were not executable

VRs : 
http://openqa.suse.de/tests/16405503  ( vs failed on current master https://openqa.suse.de/tests/16365063 ) 
http://openqa.suse.de/tests/16405519 ( vs failed on current master https://openqa.suse.de/tests/16365035 ) 
