### PR TITLE
containers: nerdctl must skip update test

### DIFF
--- a/lib/containers/utils.pm
+++ b/lib/containers/utils.pm
@@ -130,7 +130,7 @@ sub runtime_smoke_tests {
         assert_script_run("$runtime exec sleeper echo 'Hello'");
 
         # Test update command
-        test_update_cmd(runtime => $runtime, container => 'sleeper');
+        test_update_cmd(runtime => $runtime, container => 'sleeper') unless ($runtime eq "nerdctl");
 
         # Stop the container
         assert_script_run("$runtime stop sleeper");


### PR DESCRIPTION
Fix test issue introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/02624a4871ae88d5ad86dd44ec00226dfbf1dc7f

- Related ticket: https://progress.opensuse.org/issues/175245
- Failing test: https://openqa.opensuse.org/tests/4767146#step/containerd_nerdctl/70
- Verification run: https://openqa.opensuse.org/tests/4767171