### PR TITLE
Expand variables in Agama profile on remote worker

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -886,6 +886,10 @@ sub specific_bootmenu_params {
         }
         push @params, "agama.auto=$url";
     }
+    if (my $agama_profile = get_var('AGAMA_PROFILE')) {
+        my $path = autoyast::expand_agama_profile($agama_profile);
+        set_var('AGAMA_PROFILE', $path);
+    }
 
     if (my $agama_install_url = get_var('AGAMA_INSTALL_URL')) {
         push @params, "agama.install_url=$agama_install_url";


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/174943
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=lemon-suse%2Fos-autoinst-distri-opensuse%23expend-variable-in-profile-on-remote-worker&version=agama-10.0
