### PR TITLE
Revert "Use REPO_MIRROR_HOST as OPENQA_FTP_URL"

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -150,7 +150,7 @@ use constant SLOW_TYPING_SPEED => 13;
 use constant VERY_SLOW_TYPING_SPEED => 4;
 
 # openQA internal ftp server url
-our $OPENQA_FTP_URL = "ftp://" . get_var("REPO_MIRROR_HOST", "openqa.suse.de");
+our $OPENQA_FTP_URL = "ftp://openqa.suse.de";
 
 # set flag IN_ZYPPER_CALL in zypper_call and unset when leaving
 our $IN_ZYPPER_CALL = 0;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#20698
s390x is only in PRG, it's not needed and we need this variable on all workers.
https://gitlab.suse.de/openqa/salt-pillars-openqa/-/merge_requests/958