### PR TITLE
Fix timeout parameter

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -48,7 +48,7 @@ Afterwards a screenshot will be created if C<$screenshot> is set.
 
 sub save_and_upload_log {
     my ($cmd, $file, $args) = @_;
-    script_run("$cmd | tee $file", $args->{timeout});
+    script_run("$cmd | tee $file", timeout => $args->{timeout});
     my $lname = $args->{logname} ? $args->{logname} : '';
     upload_logs($file, failok => 1, log_name => $lname) unless $args->{noupload};
     save_screenshot if $args->{screenshot};


### PR DESCRIPTION
The timeout parameter was not passed correctly.

- Related failure: https://openqa.suse.de/tests/16405172#step/bci_test_podman/187
- Verification run: https://openqa.suse.de/tests/16425368 (failure expected)