### PR TITLE
Fix up virt nat network issue on SLES15

### DIFF
--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -26,11 +26,15 @@ sub run_test {
     my $vnet_isolated_cfg_name = "vnet_isolated.xml";
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_isolated_cfg_name);
 
+    #Stop named.service, refer to poo#175287
+    systemctl("stop named.service") if (is_sle('15+'));
     #Create ISOLATED NETWORK
     assert_script_run("virsh net-create vnet_isolated.xml");
     save_screenshot;
     upload_logs "vnet_isolated.xml";
     assert_script_run("rm -rf vnet_isolated.xml");
+    #Resume named.service, refer to poo#175287
+    systemctl("start named.service") if (is_sle('15+'));
 
     my ($mac, $model, $affecter, $exclusive, $skip_type);
     my $gate = '192.168.127.1';    # This host exists but should not work as a gate in the ISOLATED NETWORK

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -30,11 +30,15 @@ sub run_test {
 
     die "The default(NAT BASED NETWORK) virtual network does not exist" if (script_run('virsh net-list --all | grep default') != 0 && !is_alp);
 
+    #Stop named.service, refer to poo#175287
+    systemctl("stop named.service") if (is_sle('15+'));
     #Create NAT BASED NETWORK
     assert_script_run("virsh net-create vnet_nated.xml");
     save_screenshot;
     upload_logs "vnet_nated.xml";
     assert_script_run("rm -rf vnet_nated.xml");
+    #Resume named.service, refer to poo#175287
+    systemctl("start named.service") if (is_sle('15+'));
 
     my ($mac, $model, $affecter, $exclusive, $skip_type);
     my $gate = '192.168.128.1';

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -29,12 +29,17 @@ sub run_test {
     my $vnet_routed_clone_cfg_name = "vnet_routed_clone.xml";
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_routed_clone_cfg_name);
 
+    #Stop named.service ,refer to poo#175287
+    systemctl("stop named.service") if (is_sle('15+'));
     #Create ROUTED NETWORK
     assert_script_run("virsh net-create vnet_routed.xml");
-    upload_logs "vnet_routed.xml";
     assert_script_run("virsh net-create vnet_routed_clone.xml");
+    save_screenshot;
+    upload_logs "vnet_routed.xml";
     upload_logs "vnet_routed_clone.xml";
     assert_script_run("rm -rf vnet_routed.xml vnet_routed_clone.xml");
+    #Resume named.service ,refer to poo#175287
+    systemctl("start named.service") if (is_sle('15+'));
 
     my ($mac1, $mac2, $model1, $model2, $affecter, $exclusive);
     my $target1 = '192.168.130.1';


### PR DESCRIPTION
Refer to https://bugzilla.suse.com/show_bug.cgi?id=1235809#c10,  found that the named service is running on our SLES15+ vm hosts and immediately starts listening on the network interfaces created by libvirt, which prevents dnsmasq from using them.  So, this problem block our OSD virtual network  - nat, round and isolated.  So far we don't have a clear idea of the exact cause of this problem and need to continue to follow bsc#1235809. 

Good news, we have figured out a workaround. Just only stop named.service before create virtual network  - nat, round and isolated. 

I know that this is not a good solution, but in order not to let this problem affect our current osd 15SP7 Virtualization Acceptance tests, we have to use this workaround for the time being and wait until we find the root cause of the problem in bsc#1235809. before deciding on a final solution.

- Related ticket: https://progress.opensuse.org/issues/175287
- Validation run:
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/16500624#) PASS
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/16500629#) PASS
[gi-guest_sles15sp6-on-host_developing-kvm](https://openqa.suse.de/tests/16500630#) PASS 
[gi-guest_sles15sp6-on-host_developing-xen](https://openqa.suse.de/tests/16500631#) PASS
[gi-guest_developing-on-host_sles15sp6-kvm](https://openqa.suse.de/tests/16500632#) PASS
[gi-guest_developing-on-host_sles15sp6-xen](https://openqa.suse.de/tests/16500633#) Fail by [bsc#1230956](https://bugzilla.suse.com/show_bug.cgi?id=1230956) 
[gi-guest_sles12sp5-on-host_developing-kvm](https://openqa.suse.de/tests/16500634#)  PASS
[gi-guest_sles12sp5-on-host_developing-xen](https://openqa.suse.de/tests/16500635#) PASS