### PR TITLE
Get java test source from data_url instead of github

### DIFF
--- a/data/security/openjdk/JCEProviderInfo.java
+++ b/data/security/openjdk/JCEProviderInfo.java
@@ -1,0 +1,45 @@
+// from https://github.com/ecki/JavaCryptoTest/blob/main/src/main/java/net/eckenfels/test/jce/JCEProviderInfo.java
+// package net.eckenfels.test.jce;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.Provider.Service;
+import java.security.Security;
+
+public class JCEProviderInfo
+{
+    public static void main(String[] args) throws NoSuchAlgorithmException, NoSuchProviderException
+    {
+        System.out.printf("JCE Provider Info: %s %s/%s on %s %s%n", System.getProperty("java.vm.name"),
+                          System.getProperty("java.runtime.version"),
+                          System.getProperty("java.vm.version"),
+                          System.getProperty("os.name"),
+                          System.getProperty("os.version"));
+
+        Provider[] ps;
+        if (args.length > 0)
+        {
+            System.out.printf("Searching for JCA Security Providers with filter=\"%s\"%n", args[0]);
+            ps = Security.getProviders(args[0]);
+
+        } else {
+            System.out.printf("Listing all JCA Security Providers.%n");
+            ps = (args.length>0)?Security.getProviders(args[0]):Security.getProviders();
+        }
+        if (ps == null || ps.length == 0)
+        {
+            System.out.printf("No Results.%n");
+            return;
+        }
+        for(Provider p : ps)
+        {
+            System.out.printf("--- Provider %s %s%n    info %s%n", p.getName(), p.getVersion(), p.getInfo());
+            for(Service s : p.getServices())
+            {
+                    System.out.printf(" + %s.%s : %s (%s)%n  tostring=%s%n", s.getType(), s.getAlgorithm(), s.getClassName(), s.getProvider().getName(), s.toString());
+            }
+        }
+    }
+
+}

--- a/lib/openjdktest.pm
+++ b/lib/openjdktest.pm
@@ -52,10 +52,9 @@ sub configure_java_version {
 sub run_crypto_test {
     my ($version) = @_;
 
-    assert_script_run("cd ~; test -d JavaCryptoTest || git clone -q https://github.com/ecki/JavaCryptoTest");
-    script_run("cd ~/JavaCryptoTest/src/main/java/");
-    script_run("javac net/eckenfels/test/jce/JCEProviderInfo.java");
-    my $crypto = script_output("java -cp ~/JavaCryptoTest/src/main/java/ net.eckenfels.test.jce.JCEProviderInfo");
+    assert_script_run 'curl -O ' . data_url('security/openjdk/JCEProviderInfo.java');
+    script_run("javac JCEProviderInfo.java");
+    my $crypto = script_output("java JCEProviderInfo");
     record_info("FAIL", "Cannot list all crypto providers", result => 'fail') if ($crypto !~ /Listing all JCA Security Providers/);
 
     my $JDK_TCHECK = get_var("JDK_TCHECK", "https://gitlab.suse.de/qe-security/testing/-/raw/main/data/openjdk/Tcheck.java");


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/175150
- Needles: n/a
- Verification runs:
  - https://openqa.suse.de/tests/16425408
  - https://openqa.suse.de/tests/16425409
  - https://openqa.suse.de/tests/16425410
  - https://openqa.suse.de/tests/16425411
