### PR TITLE
containers: Comment localhost entry for ::1 on CentOS 10

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -49,7 +49,12 @@ sub run {
             script_retry("apt-get update -qq -y", timeout => $update_timeout);
         } elsif ($host_distri eq 'centos') {
             # dhclient is no longer available in CentOS 10
-            script_run("dhclient -v");
+            if (script_run("dhclient") == 0) {
+                script_run("dhclient -v");
+            } else {
+                # Comment localhost entry for ::1
+                script_run(q(sed -ri '/^::1\s+/s/localhost localhost.localdomain//' /etc/hosts));
+            }
             script_retry("dnf update -q -y --nobest", timeout => $update_timeout);
         } elsif ($host_distri eq 'rhel') {
             script_retry("dnf update -q -y", timeout => $update_timeout);


### PR DESCRIPTION
For some reason the name resolution on CentOS 10 uses IPv6 on Python when resolving localhost. This is quick fix for the BCI tests.  Further investigation is needed to fix this issue.

- Failing test: https://openqa.suse.de/tests/16401240#step/_root_BCI-tests_nginx_/1
- Related ticket: https://progress.opensuse.org/issues/174433
- Verification run: https://openqa.suse.de/tests/16437165
