### PR TITLE
Ipaddr2 network peering az functions.

### DIFF
--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -15,7 +15,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
 );
 
 sub run {
@@ -41,7 +41,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -22,7 +22,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_registeration_check
   ipaddr2_registeration_set
   ipaddr2_refresh_repo
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
 );
 
 sub run {
@@ -87,7 +87,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -13,7 +13,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
 );
 
 sub run {
@@ -25,7 +25,7 @@ sub run {
     select_serial_terminal;
 
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
 }
@@ -39,9 +39,8 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs();
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
-    ipaddr2_clean_network_peering();
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -12,9 +12,9 @@ use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_cloudinit_logs
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
   ipaddr2_infra_destroy
-  ipaddr2_network_peering
+  ipaddr2_network_peering_create
   ipaddr2_add_server_repos_to_hosts
 );
 
@@ -24,7 +24,7 @@ sub run {
     select_serial_terminal;
 
     # Create network peering
-    ipaddr2_network_peering(ibsm_rg => get_required_var('IBSM_RG'));
+    ipaddr2_network_peering_create(ibsm_rg => get_required_var('IBSM_RG'));
 
     ipaddr2_add_server_repos_to_hosts(ibsm_ip => get_required_var('IBSM_IP'), incident_repo => get_var('INCIDENT_REPO', ''));
 }
@@ -38,7 +38,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/patch_system.pm
+++ b/tests/sles4sap/ipaddr2/patch_system.pm
@@ -12,7 +12,7 @@ use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_cloudinit_logs
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
   ipaddr2_infra_destroy
   ipaddr2_patch_system
 );
@@ -34,7 +34,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -13,7 +13,7 @@ use publiccloud::utils;
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_cloudinit_logs
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
   ipaddr2_infra_destroy
   ipaddr2_registration
   ipaddr2_register_addons
@@ -39,7 +39,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -20,7 +20,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
 );
 
 sub run {
@@ -44,7 +44,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/sanity_os.pm
+++ b/tests/sles4sap/ipaddr2/sanity_os.pm
@@ -16,7 +16,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
   ipaddr2_os_sanity
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
 );
 
 sub run {
@@ -46,7 +46,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -20,7 +20,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_test_master_vm
   ipaddr2_test_other_vm
   ipaddr2_wait_for_takeover
-  ipaddr2_clean_network_peering
+  ipaddr2_network_peering_clean
 );
 
 sub run {
@@ -92,7 +92,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_clean_network_peering(ibsm_rg => $ibsm_rg);
+        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;


### PR DESCRIPTION
Move get_vnet from qesap to az library. Rename both create and clean function name. Add argument documentation. Add UT.

- Related ticket: https://jira.suse.com/browse/TEAM-9962

# Verification run:

 - sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless
  http://openqaworker15.qa.suse.cz/tests/310445

 - sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless with IS_MAINTENANCE=1 IBSM_RG=dsdm0we
http://openqaworker15.qa.suse.cz/tests/310388 :green_circle: 

