### PR TITLE
Add LTSS repo to SLES 15-SP2 teradata

### DIFF
--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -51,6 +51,12 @@
   </suse_register>
   <add-on>
     <add_on_products config:type="list">
+      % if ($check_var->('VERSION', '15-SP2')) {
+      <listentry>
+        <media_url>http://updates.nue.suse.com/download/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS-TERADATA/x86_64/update/</media_url>
+        <alias>SLES15-SP2-LTSS-TERADATA</alias>
+      </listentry>
+      % }
       <listentry>
         <media_url>http://download.suse.de/ibs/SUSE:/CA/{{CA_STR}}/</media_url>
       </listentry>

--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -35,6 +35,12 @@
     % unless ($check_var->('PATCH_WITH_ZYPPER', '1')) {
   <add-on>
     <add_on_products config:type="list">
+      % if ($check_var->('VERSION', '15-SP2')) {
+      <listentry>
+        <media_url>http://updates.nue.suse.com/download/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS-TERADATA/x86_64/update/</media_url>
+	<alias>SLES15-SP2-LTSS-TERADATA</alias>
+      </listentry>
+      % }
       % my $n =0;
       % for my $repo (@$repos) {
       <listentry>


### PR DESCRIPTION
Test adaption for 15sp2 ltss extended for TERADATA, add repo as add-on
 
Related ticket: https://progress.opensuse.org/issues/168535
Verification run:
http://openqa.qam.suse.cz/tests/82756
http://openqa.qam.suse.cz/tests/82755
* Error not affect this commit or tests.

Check repo as ad-on, on hots 15-SP2:

 ```
lipa:~ # zypper lr | grep LTSS
17 | SLES15-SP2-LTSS-TERADATA                                                                          | SLES15-SP2-LTSS-TERADATA                                | Yes     | (r ) Yes  | Yes
23 | SUSE_Linux_Enterprise_Server_LTSS_15_SP2_x86_64:SLE-Product-SLES15-SP2-Debuginfo-LTSS-Updates     | SLE-Product-SLES15-SP2-Debuginfo-LTSS-Updates           | No      | ----      | ----
24 | SUSE_Linux_Enterprise_Server_LTSS_15_SP2_x86_64:SLE-Product-SLES15-SP2-LTSS-Updates               | SLE-Product-SLES15-SP2-LTSS-Updates                     | Yes     | (r ) Yes  | Yes
```

on guest 

```
lipa:~ # ssh root@sles15sp2 zypper lr |  grep LTSS
Warning: Permanently added 'sles15sp2,10.100.198.75' (RSA) to the list of known hosts.
17 | SLES15-SP2-LTSS-TERADATA                                                                          | SLES15-SP2-LTSS-TERADATA                 
                 | Yes     | (r ) Yes  | Yes
23 | SUSE_Linux_Enterprise_Server_LTSS_15_SP2_x86_64:SLE-Product-SLES15-SP2-Debuginfo-LTSS-Updates     | SLE-Product-SLES15-SP2-Debuginfo-LTSS-Upd
ates             | No      | ----      | ----
24 | SUSE_Linux_Enterprise_Server_LTSS_15_SP2_x86_64:SLE-Product-SLES15-SP2-LTSS-Updates               | SLE-Product-SLES15-SP2-LTSS-Updates      
                 | Yes     | (r ) Yes  | Yes
```




