### PR TITLE
Re-add vendor affirmation specific openjdk schedule

### DIFF
--- a/schedule/security/vendor_affirmation_validation_openjdk.yaml
+++ b/schedule/security/vendor_affirmation_validation_openjdk.yaml
@@ -1,0 +1,19 @@
+name: fips_crypt_openjdk
+description:    >
+    This is for the crypt_openjdk fips tests.
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - fips/openjdk/prepare_env
+    - fips/openjdk/openjdk_fips
+conditional_schedule:
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup


### PR DESCRIPTION
Add vendor affirmation specific openjdk testing schedule, that does not get refactored away.

- Related ticket: https://progress.opensuse.org/issues/175147
- Verification runs:
SLES: https://openqa.suse.de/tests/16446754
SLED: https://openqa.suse.de/tests/16446824
