### PR TITLE
Rename ipaddr2 reg APIs

### DIFF
--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -764,40 +764,40 @@ subtest '[ipaddr2_configure_web_server] external_repo' => sub {
     ok((any { /zypper in.*nginx/ } @calls), 'Install nginx using zypper');
 };
 
-subtest '[ipaddr2_registeration_check] all registered' => sub {
+subtest '[ipaddr2_scc_check] all registered' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
     my @calls;
     $ipaddr2->redefine(script_output => sub {
             push @calls, $_[0];
-            # due to the itnernal implementation of the
+            # due to the internal implementation of the
             # function under test, this status is equivalent to `Registered`
             return '[{"status":"Bialetti"}]'; });
 
-    my $ret = ipaddr2_registeration_check(id => 42);
+    my $ret = ipaddr2_scc_check(id => 42);
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /SUSEConnect -s/ } @calls), 'SUSEConnect to check what is registered');
     ok(($ret eq 1), "Is registered ret:$ret");
 };
 
-subtest '[ipaddr2_registeration_check] one not registered' => sub {
+subtest '[ipaddr2_scc_check] one not registered' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
     my @calls;
     $ipaddr2->redefine(script_output => sub {
             push @calls, $_[0];
-            # due to the itnernal implementation of the
+            # due to the internal implementation of the
             # function under test, this status is equivalent to `Registered`
             return '[{"status":"Bialetti"}, {"status":"Not Registered"}]'; });
 
-    my $ret = ipaddr2_registeration_check(id => 42);
+    my $ret = ipaddr2_scc_check(id => 42);
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(($ret eq 0), "Is not registered ret:$ret");
 };
 
-subtest '[ipaddr2_registeration_set]' => sub {
+subtest '[ipaddr2_scc_register]' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
     my @calls;
@@ -808,7 +808,7 @@ subtest '[ipaddr2_registeration_set]' => sub {
             return;
     });
 
-    ipaddr2_registeration_set(id => 42, scc_code => '1234567890');
+    ipaddr2_scc_register(id => 42, scc_code => '1234567890');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /registercloudguest.*clean/ } @calls), 'registercloudguest clean');

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -15,8 +15,9 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_cloudinit_logs
   ipaddr2_network_peering_clean
   ipaddr2_infra_destroy
-  ipaddr2_registration
-  ipaddr2_register_addons
+  ipaddr2_scc_addons
+  ipaddr2_refresh_repo
+  ipaddr2_ssh_internal
   ipaddr2_bastion_pubip
 );
 
@@ -26,8 +27,22 @@ sub run {
     select_serial_terminal;
 
     my $bastion_pubip = ipaddr2_bastion_pubip();
-    ipaddr2_registration(bastion_pubip => $bastion_pubip);
-    ipaddr2_register_addons(bastion_pubip => $bastion_pubip);
+
+    # Addons registration not needed at the moment
+    #ipaddr2_scc_addons(bastion_pubip => $bastion_pubip);
+    foreach my $id (1 .. 2) {
+        # refresh repo
+        ipaddr2_refresh_repo(id => $id, bastion_pubip => $bastion_pubip);
+
+        # record repo lr
+        ipaddr2_ssh_internal(id => $id,
+            cmd => "sudo zypper lr",
+            bastion_ip => $bastion_pubip);
+        # record repo ls
+        ipaddr2_ssh_internal(id => $id,
+            cmd => "sudo zypper ls",
+            bastion_ip => $bastion_pubip);
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Rename some ipaddr2 API about registration. Remove API named ipaddr2_registration as it was not performing any registration. Move repo sync out from ipaddr2_scc_addons API.


- Related ticket: https://jira.suse.com/browse/TEAM-9962

# Verification run:

## No maintenance

 sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless
 -  http://openqaworker15.qa.suse.cz/tests/310707 :green_circle: 
 - http://openqaworker15.qa.suse.cz/tests/310809 :green_circle: 

sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test
 - http://openqaworker15.qa.suse.cz/tests/310708 :red_circle: TEAM-9967
 -  http://openqaworker15.qa.suse.cz/tests/310711 :green_circle: 

 sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test_cloud_init
 -  http://openqaworker15.qa.suse.cz/tests/310709 :green_circle: 

## Maintenance
IS_MAINTENANCE=1 IBSM_IPRANGE  IBSM_IP IBSM_RG INCIDENT_REPO

sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test
 -  http://openqaworker15.qa.suse.cz/tests/310841 :green_circle: 

sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test
 - http://openqaworker15.qa.suse.cz/tests/310824/ :green_circle: 
