### PR TITLE
PC: Remove unused SCC_ADDONS variable from transfer_repos test module

### DIFF
--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -24,7 +24,6 @@ sub run {
 
     my $instance = $args->{my_instance};
     my $remote = $instance->username . '@' . $args->{my_instance}->public_ip;
-    my @addons = split(/,/, get_var('SCC_ADDONS', ''));
     my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);
     my $repodir = "/opt/repos/";
     # Trigger to skip the download to speed up verification runs


### PR DESCRIPTION
- Related ticket: [poo#175410](https://progress.opensuse.org/issues/175410)
- Verification run: 
