### PR TITLE
Fix helm_rmt tests

### DIFF
--- a/tests/containers/helm_rmt.pm
+++ b/tests/containers/helm_rmt.pm
@@ -16,6 +16,7 @@ use Mojo::Base 'publiccloud::basetest';
 use File::Basename qw(dirname);
 use testapi;
 use utils;
+use version_utils qw(get_os_release is_sle);
 use serial_terminal qw(select_serial_terminal);
 use Utils::Architectures qw(is_ppc64le);
 use containers::k8s;
@@ -24,8 +25,9 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    # Skip HELM tests on PPC, where k3s is not available
-    return if (is_ppc64le || check_var('CONTAINER_RUNTIMES', 'k8s'));
+    my ($version, $sp, $host_distri) = get_os_release;
+    # Skip HELM tests on SLES <15-SP3 and on PPC, where k3s is not available
+    return if (!($host_distri == "sles" && $version == 15 && $sp >= 3) || is_ppc64le || check_var('CONTAINER_RUNTIMES', 'k8s'));
 
     systemctl 'stop firewalld';
     ensure_ca_certificates_suse_installed();

--- a/tests/containers/helm_rmt.pm
+++ b/tests/containers/helm_rmt.pm
@@ -59,7 +59,7 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    assert_script_run('tar -capf /tmp/containers-logs.tar.xz /var/log/pods $(find /var/lib/rancher/k3s -name \*.log -name \*.toml)');
+    script_run('tar -capf /tmp/containers-logs.tar.xz /var/log/pods $(find /var/lib/rancher/k3s -name \*.log -name \*.toml)');
     upload_logs("/tmp/containers-logs.tar.xz");
     script_run("helm delete rmt");
     uninstall_k3s() if $self->{is_k3s};


### PR DESCRIPTION
This PR:
  - Fixes bug introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20908/commits/5eecb8cf26cd965b1edd487610469ae9dbd99019#diff-e1f7c3621759a0e97dbdfb051c73f42f2feb8540c8768b67ba8072d05900c9e9
  - Fixes fail hook

---

- Related ticket: https://progress.opensuse.org/issues/175479
- Verification run: https://openqa.suse.de/tests/16455624
