### PR TITLE
containers: Fix has_build check for podman_quadlet

### DIFF
--- a/tests/containers/podman_quadlet.pm
+++ b/tests/containers/podman_quadlet.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2023-2024 SUSE LLC
+# Copyright 2023-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: podman
@@ -139,7 +139,7 @@ sub run {
     systemctl("disable --now $unit_name.service");
     systemctl("stop $unit_name-volume.service");
     systemctl("stop $unit_name-network.service");
-    systemctl("stop $unit_name-build.service") unless ($has_build);
+    systemctl("stop $unit_name-build.service") if ($has_build);
     for my $unit (@units) {
         systemctl("is-active $unit", expect_false => 1);
     }


### PR DESCRIPTION
Fix has_build check for podman_quadlet

- Failing test: https://openqa.suse.de/tests/16458386#step/podman_quadlet/158
- Verification run: https://openqa.suse.de/tests/16463254