### PR TITLE
Change to correct shutdown command

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -201,7 +201,7 @@ sub poweroff_x11 {
             assert_and_click 'authentication-required_cancel_btn';
         }
         # opens logout dialog
-        x11_start_program('shutdown', target_match => [qw(authentication-required authorization_failed lxqt_shutdowndialog)], match_timeout => 60);
+        x11_start_program('Shutdown', target_match => [qw(authentication-required authorization_failed lxqt_shutdowndialog)], match_timeout => 60);
         # we have typing issue because of poor performance, to record this if happens.
         # Double check for bsc#1137230
         if (match_has_tag 'authorization_failed' || 'authentication-required') {


### PR DESCRIPTION
"Shutdown" calls lxqt-leave --shutdown and gracefully exits the desktop enviroment and powers down the machine.  "shutdown" is calling /sbin/shutdown, and isn't in the $PATH of unprivileged users

See: https://bugzilla.opensuse.org/show_bug.cgi?id=1235763



- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: https://openqa.opensuse.org/tests/4779894
