### PR TITLE
[WIP]   [Virtualization][MU]: Set default xen boot and ssh alive time

### DIFF
--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -321,7 +321,25 @@ lsblk
         <notification>Please wait while pre-script is running...</notification>
       </script>
     </pre-scripts>
+    <chroot-scripts config:type="list">
+      <script>
+        <!--  Keep ssh connection alive for long-time run test  -->
+        <chrooted t="boolean">true</chrooted>
+        <filename>configure_sshd.sh</filename>
+        <interpreter>/bin/bash -x</interpreter>
+        <source>
+          <![CDATA[ sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf" echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > $sshd_config_file ]]>
+        </source>
+      </script>
+    </chroot-scripts>
     <post-scripts config:type="list">
+      <script>
+        <filename>default_xen_boot.sh</filename>
+        <interpreter>/bin/bash -x</interpreter>
+        <source>
+          <![CDATA[ grub2-set-default 2 ]]>
+        </source>
+      </script>
       % if ($check_var->('SYSTEM_ROLE', 'xen') && $get_var->('VERSION') gt '15-SP5') {
       <script>
         <filename>configure_xen_modular_libvirt_log.sh</filename>


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: 
    - xen migration test on OSD SUT: https://openqa.suse.de/tests/16472487#dependencies
    - xen feature test on OSD sut: https://openqa.suse.de/tests/16473982#live, wip
    - regression test on remote worker,  wip
        - xen sriov, https://openqa.suse.de/tests/16475346#live
        - kvm feature test, https://openqa.suse.de/tests/16475341#live
        - xen feature test, http://openqa.suse.de/tests/16475363