### PR TITLE
amarok: fix syntax for ternary operation

### DIFF
--- a/tests/x11/amarok.pm
+++ b/tests/x11/amarok.pm
@@ -22,7 +22,7 @@ sub run {
     # and don't put this after opening oga file, per video
     # the window pop-up meanwhile x11_start_progran typeing,
     # and 40 sec to wait that window pop-up should enough
-    send_key match_has_tag 'test-amarok-new-1' ? 'alt-u' : 'alt-y';
+    send_key(match_has_tag('test-amarok-new-1') ? 'alt-u' : 'alt-y');
     assert_screen([qw(librivox-authentication test-amarok-2)]);
     if (match_has_tag('librivox-authentication')) {
         send_key "alt-c";    # cancel librivox certificate


### PR DESCRIPTION
send_key tag_has_match('foo') ? 'variant1' : 'variant2';
results in the condition 'sendkey tag_has_match' - and its true/false result
would trigger 'variant1' or 'variant2' as 'command'. In perl though, a 'string' on
Its own is simply a true statement:

Wrap the ternary operation properly in parentheses to ensure the result of that
operation is passed down to send_key.

- Related ticket: NONE
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4780021
