### PR TITLE
Add option for additional kernel parameters

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -37,7 +37,8 @@ sub get_script_run {
     my $guest_pattern = get_var('GUEST_PATTERN', 'sles-12-sp2-64-[p|f]v-def-net');
     my $parallel_num = get_var("PARALLEL_NUM", "2");
     my ($regcode, $regcode_ltss) = get_guest_regcode(separator => '|');
-    $pre_test_cmd .= " -f \"" . $guest_pattern . "\" -n " . $parallel_num . " -r " . " -e \"" . $regcode . "\" -E \"" . $regcode_ltss . "\"";
+    my $kernel_params = get_guest_settings(settings => 'GUEST_EXT_KERNEL_PARAMS', separator => '|');
+    $pre_test_cmd .= " -f \"" . $guest_pattern . "\" -n " . $parallel_num . " -r " . " -e \"" . $regcode . "\" -E \"" . $regcode_ltss . "\" -k \"" . $kernel_params->{'GUEST_EXT_KERNEL_PARAMS'} . "\"";
     $pre_test_cmd .= " 2>&1 | tee /tmp/s390x_guest_install_test.log" if (is_s390x);
 
     return $pre_test_cmd;

--- a/tests/virt_autotest/host_upgrade_generate_run_file.pm
+++ b/tests/virt_autotest/host_upgrade_generate_run_file.pm
@@ -33,6 +33,8 @@ sub get_script_run {
     my $do_registration = (check_var('SCC_REGISTER', 'installation') || check_var('REGISTER', 'installation') || get_var('AUTOYAST', '')) ? "true" : "false";
     my $registration_server = get_var('SCC_URL', 'https://scc.suse.com');
     my $registration_code = get_var('SCC_REGCODE', 'INVALID_REGCODE');
+    my $host_kernel_params = get_var('HOST_EXT_KERNEL_PARAMS', 'NA');
+    my $guest_kernel_params = get_guest_settings(settings => 'GUEST_EXT_KERNEL_PARAMS', separator => '|');
 
     $pre_test_cmd = "/usr/share/qa/tools/_generate_vh-update_tests.sh";
     $pre_test_cmd .= " -m $mode";
@@ -46,6 +48,8 @@ sub get_script_run {
     $pre_test_cmd .= " -e $do_registration";
     $pre_test_cmd .= " -s $registration_server";
     $pre_test_cmd .= " -c $registration_code";
+    $pre_test_cmd .= " -K \"$host_kernel_params\"";
+    $pre_test_cmd .= " -k \"$guest_kernel_params->{GUEST_EXT_KERNEL_PARAMS}\"";
 
     return "$pre_test_cmd";
 }


### PR DESCRIPTION
* **bsc#1231522** makes one point clear that we are looking into feature request to have some point before reboot to collect logs for further analysis and using something that already exists created exactly for this purpose which has the timeout value configurable on the linuxrc command line:
  * https://github.com/yast/yast-yast2/pull/977
  * https://github.com/yast/yast-installation/pull/823
  * https://github.com/openSUSE/installation-images/pull/344 It's even briefly documented at https://en.opensuse.org/SDB:Linuxrc. 
  
* **In** order to generalize this change and also make things much easier, using "extra kernel params" can help pass any desired parameters to kernel instead of just ```reboot_timeout```.

* **Add** subroutine ```get_guest_settings``` to replicate desired settings to all guests involved.

* **Pass** extra kernel parameters in ```guest_installation_run``` and ```host_upgrade_generate_run_file```.

* **By** the way, ```tests/installation/ipxe_install.pm``` already supports ```EXTRABOOTPARAMS```.

* **Example**, ```HOST_EXT_KERNEL_PARAMS="var1=val1 var2=val2"``` and ```GUEST_EXT_KERNEL_PARAMS="var3=val3 var4=val4"```.

* **Multiple** guests can have ```GUEST_EXT_KERNEL_PARAMS="var3=val3 var4=val4|var5=val5 var6"``` for two guests. 

* **If** there is only one set of parameters, for example, ```GUEST_EXT_KERNEL_PARAMS="var3=val3 var4=val4"```, but two guests to be installed, then these two guests will have the same ```GUEST_EXT_KERNEL_PARAMS="var3=val3 var4=val4"```, unless ```GUEST_EXT_KERNEL_PARAMS="var3=val3 var4=val4|"``` or ```GUEST_EXT_KERNEL_PARAMS="|var3=val3 var4=val4"```.

* **This** pull request should be merged together with https://github.com/SUSE/qa-automation/pull/856 and https://github.com/SUSE/qa-testsuites/pull/1112.

* **Verification Runs:**
  * [guest installation kvm](https://openqa.suse.de/tests/17090082)
  * [guest installation xen](https://openqa.suse.de/tests/17035288)
  * [online host upgrade kvm](https://openqa.suse.de/tests/17090080)
  * [online host upgrade xen](https://openqa.suse.de/tests/17090077)
  * [offline host upgrade kvm](https://openqa.suse.de/tests/17034476)
  * [offline host upgrade xen](https://openqa.suse.de/tests/17090094)
  * [offline guest upgrade kvm](https://openqa.suse.de/tests/17082254)
  * [online guest upgrade xen](https://openqa.suse.de/tests/17090088)
  * [aarch64 64kpg guest installation](https://openqa.suse.de/tests/17090089)
  * [aarch64 offline host upgrade](https://openqa.suse.de/tests/17091937)
  * [guest installation with GUEST_EXT_KERNEL_PARAMS="earlyprintk=ttyS0,115200 ignore_loglevel"](https://openqa.suse.de/tests/17089733)
  * [offline host upgrade with HOST_EXT_KERNEL_PARAMS="reboot_timeout=0 ignore_loglevel and GUEST_EXT_KERNEL_PARAMS="earlyprintk=ttyS0,115200 ignore_loglevel"](https://openqa.suse.de/tests/17089732)
  * [offline host upgrade with HOST_EXT_KERNEL_PARAMS="reboot_timeout=0 ignore_loglevel" and GUEST_EXT_KERNEL_PARAMS="earlyprintk=ttyS0,115200 ignore_loglevel|debug earlyprintk=ttyS0,115200"](https://openqa.suse.de/tests/17102226)
  * [guest installation with GUEST_EXT_KERNEL_PARAMS="earlyprintk=ttyS0,115200 ignore_loglevel|debug earlyprintk=ttyS0,115200"](https://openqa.suse.de/tests/17101983)
  * [offline host upgrade with HOST_EXT_KERNEL_PARAMS="earlyprintk=ttyS1,115200 ignore_loglevel" and GUEST_EXT_KERNEL_PARAMS="earlyprintk=ttyS0,115200 ignore_loglevel|debug earlyprintk=ttyS0,115200"](https://openqa.suse.de/tests/17101387)