### PR TITLE
Excluding LTP test defintion fix

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -132,10 +132,15 @@ sub run {
         my @skipped = $whitelist->list_skipped_tests($ltp_env, $ltp_command);
         if (@skipped) {
             $skip_tests = '^(' . join("|", @skipped) . ')$';
+            $skip_tests .= '|' . $ltp_exclude if $ltp_exclude;
         }
+        record_info("Exclude", "Excluding tests: $skip_tests");
+    } elsif ($ltp_exclude) {
+        $skip_tests = $ltp_exclude;
+        record_info("Exclude", "Excluding only 'LTP_COMMAND_EXCLUDE' tests: $skip_tests");
+    } else {
+        record_info("Exclude", "None");
     }
-    $skip_tests .= '|' . $ltp_exclude if $ltp_exclude;
-    record_info("Exclude", "Excluding tests: $skip_tests");
 
     my $kirk_repo = get_var("LTP_RUN_NG_REPO", "https://github.com/linux-test-project/kirk.git");
     my $kirk_branch = get_var("LTP_RUN_NG_BRANCH", "master");


### PR DESCRIPTION
LTP tests can be excluded from the pre-define whitelist, using LTP_COMMAND_EXCLUDE or from merged definition of both.

If the whitelist is empty and an user defines LTP_COMMAND_EXCLUDE, the generated skip list is broken.

```
--run-suite cve --skip-tests
'|cve-2016-7042|cve-2016-10044|cve-2017-2618'
```

See:
https://openqa.suse.de/tests/16478633/logfile?filename=serial_terminal.txt

- Verification run: http://kepler.suse.cz/tests/24220#
