### PR TITLE
Fix long name in TAP logs

### DIFF
--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -26,11 +26,11 @@ sub run {
     my $test = get_required_var('AGAMA_TEST');
     my $test_options = get_required_var('AGAMA_TEST_OPTIONS');
     my $reboot_page = $testapi::distri->get_reboot();
-    my $spec = "$test.spec.txt";
-    my $tap = "$test.tap.txt";
+    my $spec = "spec.txt";
+    my $tap = "tap.txt";
     my $reporters = "--test-reporter=spec --test-reporter=tap --test-reporter-destination=/tmp/$spec --test-reporter-destination=/tmp/$tap";
     my $node_cmd = "node --enable-source-maps $reporters /usr/share/agama/system-tests/${test}.js $test_options";
-    record_info("node command", $node_cmd);
+    record_info("node cmd", $node_cmd);
 
     script_run("dmesg --console-off");
     my $ret = script_run($node_cmd, timeout => 2400);


### PR DESCRIPTION
- Verification run: [tumbleweed_default_TAP](https://openqa.opensuse.org/tests/overview?build=fix-long-name)
