### PR TITLE
Fix duplicated agama profile path issue

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -880,15 +880,8 @@ sub specific_bootmenu_params {
 
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $url = autoyast::expand_agama_profile($agama_auto);
-        if (is_backend_s390x) {
-            $url = shorten_url($url) unless (is_opensuse);
-            set_var('AGAMA_AUTO', $url);
-        }
+        $url = shorten_url($url) if (is_backend_s390x && !is_opensuse);
         push @params, "agama.auto=$url";
-    }
-    if (my $agama_profile = get_var('AGAMA_PROFILE')) {
-        my $path = autoyast::expand_agama_profile($agama_profile);
-        set_var('AGAMA_PROFILE', $path);
     }
 
     if (my $agama_install_url = get_var('AGAMA_INSTALL_URL')) {

--- a/tests/yam/agama/import_agama_profile.pm
+++ b/tests/yam/agama/import_agama_profile.pm
@@ -8,10 +8,11 @@ use base Yam::Agama::patch_agama_base;
 use strict;
 use warnings;
 use testapi qw(assert_script_run data_url get_required_var select_console script_run);
+use autoyast qw(expand_agama_profile);
 
 sub run {
+    my $profile = expand_agama_profile(get_required_var('AGAMA_PROFILE'));
     select_console 'root-console';
-    my $profile = get_required_var('AGAMA_PROFILE');
     script_run("dmesg --console-off");
     assert_script_run("agama profile import $profile", timeout => 300);
     script_run("dmesg --console-on");


### PR DESCRIPTION
Failed job: https://openqa.suse.de/tests/16486891#step/import_agama_profile/5

- Related ticket: qucik PR
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=lemon-suse%2Fos-autoinst-distri-opensuse%23fix-agama-profile-path-duplicated-issue
