### PR TITLE
Containers SLE15-SP5 added for LTSS

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -31,7 +31,7 @@
         % }
         <arch>{{ARCH}}</arch>
       </addon>
-      % if ($get_var->('VERSION') =~ /15-SP[1-3]/) {
+      % if ($get_var->('VERSION') =~ /15-SP[1-5]/) {
       <addon>
         <name>SLES-LTSS</name>
         <arch>{{ARCH}}</arch>


### PR DESCRIPTION
Containers: SLE15-SP5 added for LTSS in autoyast. 
15-SP4 included too,in SP range.

- Related ticket: https://progress.opensuse.org/issues/174100
- Needles: none
- Verification run: t.b.d., see PR posts.
