### PR TITLE
hostname_inst: Remove bsc#1166778 soft fail

### DIFF
--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -35,7 +35,7 @@ sub run {
     # Before SLE15-SP2, yast didn't take during installation the hostname by DHCP
     # See fate#319639
     if (is_sle('<15-SP2') && (script_run(qq{test "\$(hostname)" == "linux"}) == 0)) {
-        record_soft_failure('bsc#1166778 - Default hostname in SLE15-SP1 is not "install"');
+        record_info('bsc#1166778', 'bsc#1166778 - Default hostname in SLE15-SP1 is not "install"');
     } else {
         assert_script_run(qq{test "\$(hostname)" == "$expected_install_hostname"});
     }


### PR DESCRIPTION
Hostname not install is expected on 15-SP1 and older

- Related ticket: https://progress.opensuse.org/issues/174373 https://bugzilla.suse.com/show_bug.cgi?id=1166778#c8
- VR: https://openqa.suse.de/tests/overview?distri=sle&build=jpupava_hostname