### PR TITLE
Remove SLE_IMAGE_OWNER from sles4sap_aws_generic

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -17,7 +17,6 @@ terraform:
     public_key: '%SLES4SAP_PUBSSHKEY%'
     aws_credentials: '/root/amazon_credentials'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
-    os_owner: '%SLE_IMAGE_OWNER%'
 
     # HANA
     hana_count: '%NODE_COUNT%'


### PR DESCRIPTION
Remove the need of SLE_IMAGE_OWNER variable from the qe-sap-deployment conf.yaml named sles4sap_aws_generic.yaml


- Related ticket: https://jira.suse.com/browse/TEAM-9910

# Verification run:

## 15sp5
sle-15-SP5-HanaSr-Aws-Byos-x86_64-Build15-SP5_2025-01-17T03:03:22Z-hanasr_aws_test_fencing_native ec2_r4.8xlarge
 -  http://openqaworker15.qa.suse.cz/tests/310881 :green_circle: terraform is ok

sle-12-SP5-HanaSr-Aws-Payg-x86_64-Build12-SP5_2025-01-17T03:03:22Z-hanasr_aws_test_fencing_native_ltss ec2_r4.8xlarge
 - http://openqaworker15.qa.suse.cz/tests/310882 :green_circle: terraform is ok
