### PR TITLE
Fix snapper diff in console/snapper_zypp and use it in boot_to_snapshot

### DIFF
--- a/scenario-definitions.yaml
+++ b/scenario-definitions.yaml
@@ -13,7 +13,6 @@ machines:
       HDDSIZEGB: "20"
       QEMUCPU: host
       VIRTIO_CONSOLE: "1"
-      OFFLINE_SUT: "1"
       WORKER_CLASS: qemu_x86_64
 
 .common: &common

--- a/schedule/boot_to_snapshot.yaml
+++ b/schedule/boot_to_snapshot.yaml
@@ -5,4 +5,5 @@ vars:
     BOOT_TO_SNAPSHOT: 1
 schedule:
     - boot/boot_to_desktop
+    - console/snapper_zypp
     - installation/boot_into_snapshot

--- a/tests/console/snapper_zypp.pm
+++ b/tests/console/snapper_zypp.pm
@@ -26,13 +26,13 @@ sub get_snapshot_id {
 
 sub run_zypper_cmd {
     my ($zypper_cmd, $package) = @_;
-    my $before_snapshot_id = get_snapshot_id();
+    my $pre_snapshot_id = get_snapshot_id() + 1;
     zypper_call($zypper_cmd);
-    my $after_snapshot_id = get_snapshot_id();
-    record_info("Snapshot IDs", "Before: $before_snapshot_id, After: $after_snapshot_id");
-    assert_equals($after_snapshot_id, $before_snapshot_id + 2, "Snapshot ID did not increment as expected");
-    my $grep_pattern = "snapshot.*$before_snapshot_id.*$package.*$after_snapshot_id.*differ";
-    assert_script_run("snapper diff $before_snapshot_id..$after_snapshot_id | grep '$grep_pattern'", fail_message => "No changes between snapshots for $package");
+    my $post_snapshot_id = get_snapshot_id();
+    record_info("Snapshot IDs", "Pre: $pre_snapshot_id, Post: $post_snapshot_id");
+    assert_equals($post_snapshot_id, $pre_snapshot_id + 1, "Snapshot ID did not increment as expected");
+    my $grep_pattern = "snapshot.*$pre_snapshot_id.*$package.*$post_snapshot_id.*differ";
+    assert_script_run("snapper diff $pre_snapshot_id..$post_snapshot_id | grep '$grep_pattern'", fail_message => "No changes between snapshots for $package");
 }
 
 sub run {


### PR DESCRIPTION
Instead of booting into the initial snapshot from installation, run the snapper_zypp module to create some new snapshots which are more relevant in practice. The snapper_zypp module needs a fix to run diff between the correct snapshots.

- Related ticket: https://progress.opensuse.org/issues/175497
- Verification runs:
Tumbleweed with SELinux, poo#175497 fixed: http://10.168.5.231/tests/1653 (older snapshot, needed custom schedule for repo replacement)
Plain Tumbleweed: http://10.168.5.231/tests/1654