### PR TITLE
Add variable for the AWS IBSm project

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1661,12 +1661,19 @@ sub qesap_aws_filter_query {
 
     Return the Transient Gateway ID of the IBS Mirror
 
+=over
+
+=item B<MIRROR_TAG> - Value of Project tag applied to the IBS Mirror
+
+=back
 =cut
 
 sub qesap_aws_get_mirror_tg {
+    my (%args) = @_;
+    croak "Missing mandatory $_ argument" unless $args{mirror_tag};
     return qesap_aws_filter_query(
         cmd => 'describe-transit-gateways',
-        filter => '"Name=tag-key,Values=Project" "Name=tag-value,Values=IBS Mirror"',
+        filter => '"Name=tag-key,Values=Project" "Name=tag-value,Values=' . $args{mirror_tag} . '"',
         query => '"TransitGateways[].TransitGatewayId"'
     );
 }
@@ -1730,14 +1737,16 @@ sub qesap_aws_get_routing {
 
 =item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
 
+=item B<MIRROR_TAG> - Value of Project tag applied to the IBS Mirror
+
 =back
 =cut
 
 sub qesap_aws_vnet_peering {
     my (%args) = @_;
-    foreach (qw(target_ip vpc_id)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+    foreach (qw(target_ip vpc_id mirror_tag)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
 
-    my $trans_gw_id = qesap_aws_get_mirror_tg();
+    my $trans_gw_id = qesap_aws_get_mirror_tg(mirror_tag => $args{mirror_tag});
     unless ($trans_gw_id) {
         record_info('AWS PEERING', 'Empty trans_gw_id');
         return 0;

--- a/tests/sles4sap/publiccloud/network_peering.pm
+++ b/tests/sles4sap/publiccloud/network_peering.pm
@@ -30,7 +30,7 @@ sub run {
         my $vpc_id = qesap_aws_get_vpc_id(resource_group => $self->deployment_name() . '*');
         die "No vpc_id in this deployment" if $vpc_id eq 'None';
         my $ibs_mirror_target_ip = get_required_var('IBSM_IPRANGE');    # '10.254.254.240/28'
-        die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
+        die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id, mirror_tag => get_var('IBSM_PRJ_TAG', 'IBS Mirror'));
     }
     $run_args->{network_peering_present} = $self->{network_peering_present} = 1;
 }

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -30,7 +30,7 @@ sub run {
             my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name);
             die "No vpc_id in this deployment" if $vpc_id eq 'None';
             my $ibs_mirror_target_ip = get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE');    # '10.254.254.240/28'
-            die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id);
+            die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id, mirror_tag => get_var('QESAPDEPLOY_IBSM_PRJ_TAG', 'IBS Mirror'));
             qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));
             die 'Error in network peering delete.' if !qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
         }


### PR DESCRIPTION
In one of the command to create network peering the the IBSm in AWS, the value of a tag Project is needed. Value is the one used during the IBSm deployment. Create a variable to be able to provide it from the external. Variable is named IBSM_PRJ_TAG. Temporary provide a valid default value for it. As soon as all JobGroup will have the variable it needs to be changed to get_required_var without default.

This change fix problem introduced here https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17202/files#r1922537983

This is exactly what we are already doing in Azure with variable IBSM_RG.

# Verification run:

## qesap regression
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test@64bit -> http://openqaworker15.qa.suse.cz/tests/311311 :green_circle:  http://openqaworker15.qa.suse.cz/tests/311311#step/test_mirror/12

## HanaSR
 - sle-15-SP5-EC2-SAP-BYOS-Incidents-x86_64-Build:37072:rpmlint-SAPHanaSR-ScaleUp-PerfOpt-native-stop-kill@ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/311312 :green_circle: http://openqaworker15.qa.suse.cz/tests/311312#step/network_peering/13