### PR TITLE
Swap qesap_az_get_vnet  with az_network_vnet_get

### DIFF
--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -37,6 +37,7 @@ use Carp;
 use utils qw(script_retry random_string);
 use testapi;
 use qesapdeployment;
+use sles4sap::azure_cli;
 
 use Exporter 'import';
 
@@ -930,9 +931,9 @@ sub cluster_trento_net_peering {
     my $cmd = join(' ',
         $basedir . '/00.050-trento_net_peering_tserver-sap_group.sh',
         '-s', $trento_rg,
-        '-n', qesap_az_get_vnet($trento_rg),
+        '-n', az_network_vnet_get(resource_group => $trento_rg, query => "[0].name"),
         '-t', $cluster_rg,
-        '-a', qesap_az_get_vnet($cluster_rg));
+        '-a', az_network_vnet_get(resource_group => $cluster_rg, query => "[0].name"));
     record_info('NET PEERING');
     assert_script_run($cmd, 360);
 }

--- a/t/08_trento.t
+++ b/t/08_trento.t
@@ -100,10 +100,11 @@ subtest '[cluster_trento_net_peering] cluster_trento_net_peering has to compose 
     my $expected_net_name = 'PIZZANET';
     $trento->redefine(get_resource_group => sub { return 'VALLUTATA'; });
     $trento->redefine(qesap_az_get_resource_group => sub { return 'ZUPPA'; });
-    $trento->redefine(qesap_az_get_vnet => sub {
-            push @calls, $_[0];
-            return "PIATTO_DI_VALLUTATA" if ($_[0] =~ /VALLUTATA/);
-            return "PIATTO_DI_ZUPPA" if ($_[0] =~ /ZUPPA/);
+    $trento->redefine(az_network_vnet_get => sub {
+            my (%args) = @_;
+            push @calls, $args{resource_group};
+            return "PIATTO_DI_VALLUTATA" if ($args{resource_group} =~ /VALLUTATA/);
+            return "PIATTO_DI_ZUPPA" if ($args{resource_group} =~ /ZUPPA/);
     });
 
     $trento->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });

--- a/tests/sles4sap/publiccloud/clean_leftover_peerings.pm
+++ b/tests/sles4sap/publiccloud/clean_leftover_peerings.pm
@@ -10,6 +10,7 @@ use base 'sles4sap_publiccloud_basetest';
 use testapi;
 use qesapdeployment;
 use publiccloud::utils qw(is_azure is_ec2);
+use sles4sap::azure_cli;
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};
@@ -23,8 +24,7 @@ sub run {
             return 0;
         }
         my $group = get_var('IBSM_RG');
-        my $vnet_name = qesap_az_get_vnet($group);
-        qesap_az_clean_old_peerings(rg => $group, vnet => $vnet_name);
+        qesap_az_clean_old_peerings(rg => $group, vnet => az_network_vnet_get(resource_group => $group, query => "[0].name"));
     }
 }
 


### PR DESCRIPTION
Remove qesap_az_get_vnet and replace it with equivalent az_network_vnet_get.

Extend concept from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20946/files#diff-c25cf94dbded12cf8e346fd7f8799ab0f03f3440381ebae21ecca66ae9f79028R1994

# Verification run:

 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test@64bit -> http://openqaworker15.qa.suse.cz/tests/311326 :green_circle: 

 - sle-15-SP5-EC2-SAP-BYOS-Incidents-x86_64-Build:37072:rpmlint-SAPHanaSR-ScaleUp-PerfOpt-native-stop-kill@ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/311408 :green_circle: test is failing but code using changed code is ok (`clean_left_over`, `post_fail_hooks`)

 - sle-15-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:37072:rpmlint-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/311419 :green_circle: 
