### PR TITLE
hpc: Change remote execution from mrsh to rsh on 15-SP7+

### DIFF
--- a/tests/hpc/pdsh_slave.pm
+++ b/tests/hpc/pdsh_slave.pm
@@ -14,6 +14,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;
 use utils;
+use version_utils 'is_sle';
 
 our $file = 'tmpresults.xml';
 
@@ -39,8 +40,9 @@ sub run ($self) {
 
     $self->switch_user('nobody');
     my $genders_plugin = get_var('PDSH_GENDER_TEST') ? '-g type=genders-test' : '';
-    $rt = (assert_script_run("pdsh -R mrsh $genders_plugin -w $server_hostname ls / &> /tmp/pdsh.log")) ? 1 : 0;
-    test_case('Run remotelly mrsh module on the server', 'pdsh remote invocation', $rt);
+    my $sh = is_sle('15-sp7+') ? 'ssh' : 'mrsh';
+    $rt = (assert_script_run("pdsh -R $sh $genders_plugin -w $server_hostname ls / &> /tmp/pdsh.log")) ? 1 : 0;
+    test_case("Run remotelly over $sh", 'pdsh remote invocation', $rt);
     assert_script_run("test -s /tmp/pdsh.log");
     upload_logs '/tmp/pdsh.log';
     barrier_wait("PDSH_SLAVE_DONE");

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -229,12 +229,13 @@ sub t09_basic() {
 }
 
 sub t10_basic() {
-    my $name = 'pdsh-slurm over mrsh';
-    my $description = 'Basic check of pdsh-slurm over mrsh';
+    my $sh = is_sle('15-sp7+') ? 'ssh' : 'mrsh';
+    my $name = "pdsh-slurm over $sh";
+    my $description = "Basic check of pdsh-slurm over $sh";
     my $result = 0;
 
     my $sinfo_nodeaddr = script_output('sinfo -a --Format=nodeaddr -h');
-    my $pdsh_nodes = script_output("runuser -l nobody -c 'pdsh -R mrsh -P minor /usr/bin/hostname'");
+    my $pdsh_nodes = script_output("runuser -l nobody -c 'pdsh -R $sh -P minor /usr/bin/hostname'");
     my @sinfo_nodeaddr = (split ' ', $sinfo_nodeaddr);
 
     foreach my $i (@sinfo_nodeaddr) {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/175863
- Needles: none
- Verification run:  slurm & pdsh clusters
 https://openqa.suse.de/tests/overview?build=czerw%2Fos-autoinst-distri-opensuse%2321003&distri=sle&version=15-SP7
