### PR TITLE
Setup SLES 16 Tests for HA

### DIFF
--- a/schedule/ha/bv/agama_install_sles_ha.yaml
+++ b/schedule/ha/bv/agama_install_sles_ha.yaml
@@ -1,0 +1,20 @@
+---
+name: agama_install_sles_ha
+description: >
+  Agama installation tests for plain SLES HA.
+  Can be used to generate a qcow2 image.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/first_boot
+  - console/system_prepare
+  - '{{generate_image}}'
+conditional_schedule:
+  generate_image:
+    GENERATE_IMAGE:
+      1:
+        - console/hostname
+        - console/force_scheduled_tasks
+        - shutdown/grub_set_bootargs
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown


### PR DESCRIPTION
Setup SLES 16 Tests for HA: create_hdd_ha_textmode

TEAM-9960 - Setup SLES 16 Tests for HA

- Related ticket: [TEAM-9960](https://jira.suse.com/browse/TEAM-9960)
Setup SLES 16 Tests for HA
- Related job group: https://openqa.suse.de/admin/job_templates/579?
- Verification run:  https://openqa.suse.de/tests/16542765 (passed)

New VR: after revised code according comments: https://openqa.suse.de/tests/16552154#step/system_prepare/32 (passed)
