### PR TITLE
Run SELinux testsuite in enforcing mode if distro has it as default

### DIFF
--- a/lib/selinuxtest.pm
+++ b/lib/selinuxtest.pm
@@ -14,7 +14,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use security_boot_utils;
-use version_utils qw(is_sle_micro);
+use version_utils qw(has_selinux);
 use Utils::Backends 'is_pvm';
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
 use power_action_utils 'power_action';
@@ -29,8 +29,8 @@ our @EXPORT = qw(
 );
 
 our $file_contexts_local;
-# On SLE Micro we want to use the default selinux targeted policy and do not have minimum installed which this checks
-if (is_sle_micro('>=6.0')) {
+# On distros with SELinux enabled we want to use the default selinux targeted policy and do not have minimum installed which this checks
+if (has_selinux) {
     $file_contexts_local = '/etc/selinux/targeted/contexts/files/file_contexts.local';
 } else {
     $file_contexts_local = '/etc/selinux/minimum/contexts/files/file_contexts.local';

--- a/tests/security/selinux/audit2allow.pm
+++ b/tests/security/selinux/audit2allow.pm
@@ -13,7 +13,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use power_action_utils 'power_action';
-use version_utils qw(is_sle_micro is_sle is_tumbleweed);
+use version_utils qw(has_selinux is_sle is_tumbleweed);
 use registration qw(add_suseconnect_product);
 
 sub run {
@@ -32,7 +32,7 @@ sub run {
     assert_script_run("systemctl restart $audit_service");
     assert_script_run("cp $original_audit $audit_log");
 
-    if (is_sle_micro('>=6.0')) {
+    if (has_selinux) {
         validate_script_output("audit2allow -a", sub { m/^\s*$/sx });
         record_info("Empty output", "Since there are no denies, audit2allow always returns an empty output.");
         return 0;

--- a/tests/security/selinux/enforcing_mode_setup.pm
+++ b/tests/security/selinux/enforcing_mode_setup.pm
@@ -13,11 +13,18 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils 'has_selinux';
 use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
     select_serial_terminal;
+
+    if (has_selinux) {
+        # make sure SELinux is in "enforcing" mode already
+        validate_script_output("sestatus", sub { m/.*Current\ mode:\ .*enforcing/sx });
+        return 1;
+    }
 
     # make sure SELinux in "permissive" mode
     validate_script_output("sestatus", sub { m/.*Current\ mode:\ .*permissive.*/sx });

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -76,6 +76,8 @@ sub run {
             $fail_msg = 'SELinux is disabled when it should be enabled';
         }
         validate_script_output('sestatus', sub { m/SELinux status: .*$expected_state/ }, fail_message => $fail_msg);
+
+        $self->set_sestatus('permissive', 'minimum') unless has_selinux();
     }
 }
 

--- a/tests/security/selinux/selinux_smoke.pm
+++ b/tests/security/selinux/selinux_smoke.pm
@@ -16,18 +16,13 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use registration qw(add_suseconnect_product register_product);
-use version_utils qw(is_sle is_tumbleweed);
+use version_utils qw(is_sle);
 
 sub run {
     select_serial_terminal;
 
     # make sure SELinux is "enabled"
     validate_script_output("sestatus", sub { m/SELinux\ status: .*enabled/sx });
-
-    if (is_tumbleweed && script_run('fixfiles check /etc/selinux/config |& grep "command not found"') == 0) {
-        record_soft_failure('boo#1190813');
-        assert_script_run("sed -i 's/ //' /etc/selinux/config");
-    }
 
     # https://progress.opensuse.org/issues/101481
     if (is_sle('<=15-sp2') && script_run('zypper lu|grep sle-we-release') == 0) {

--- a/tests/security/selinux/selinux_smoke.pm
+++ b/tests/security/selinux/selinux_smoke.pm
@@ -1,7 +1,7 @@
 # Copyright 2018-2020 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# Summary: Test with SELinux is "enabled" and in "permissive" mode system still
+# Summary: Test that with with SELinux "enabled" the system still
 #          works, can access files, directories, ports and processes, e.g.,
 #          no problem with refreshing and updating,
 #          packages should be installed and removed without any problems,
@@ -21,8 +21,8 @@ use version_utils qw(is_sle is_tumbleweed);
 sub run {
     select_serial_terminal;
 
-    # make sure SELinux is "enabled" and in "permissive" mode
-    validate_script_output("sestatus", sub { m/SELinux\ status: .*enabled.* Current\ mode: .*permissive/sx });
+    # make sure SELinux is "enabled"
+    validate_script_output("sestatus", sub { m/SELinux\ status: .*enabled/sx });
 
     if (is_tumbleweed && script_run('fixfiles check /etc/selinux/config |& grep "command not found"') == 0) {
         record_soft_failure('boo#1190813');

--- a/tests/security/selinux/semanage_boolean.pm
+++ b/tests/security/selinux/semanage_boolean.pm
@@ -13,7 +13,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_sle_micro);
+use version_utils qw(has_selinux);
 use Utils::Backends 'is_pvm';
 
 sub run {
@@ -44,7 +44,7 @@ sub run {
     validate_script_output("semanage boolean -l | grep $test_boolean", sub { m/${test_boolean}.*(on.*,.*on).*Allow.*to.*/ });
 
     # test option "-C": to list boolean local customizations
-    if (is_sle_micro('>=6.0')) {
+    if (has_selinux) {
         validate_script_output(
             "semanage boolean -l -C",
             sub {

--- a/tests/security/selinux/semanage_boolean.pm
+++ b/tests/security/selinux/semanage_boolean.pm
@@ -23,14 +23,10 @@ sub run {
     select_serial_terminal;
 
     # list and verify some (not all as it changes often) boolean(s)
-    validate_script_output(
-        "semanage boolean -l",
-        sub {
-            m/
-            authlogin_.*(off.*,.*off).*
-            daemons_.*(off.*,.*off).*
-            domain_.*(off.*,.*off).*/sx
-        });
+    my $booleans = script_output("semanage boolean -l");
+    for my $prefix (qw(authlogin_ daemons_ domain_)) {
+        die "Missing boolean ${prefix}*" unless $booleans =~ m/^${prefix}.*\(off.*,.*off\)/m;
+    }
 
     # test option "-m": to set boolean value "off/on"
     assert_script_run("semanage boolean -m --off $test_boolean");

--- a/tests/security/selinux/semodule.pm
+++ b/tests/security/selinux/semodule.pm
@@ -11,7 +11,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_sle_micro);
+use version_utils qw(has_selinux);
 
 sub run {
     my $test_module = "openvpn";
@@ -47,7 +47,7 @@ sub run {
     assert_script_run("semodule -lfull | grep -w $test_module", sub { m/100\ $test_module\ .*pp.*/sx });
 
     # test option "-l": list all modules and verify some of them (disabled + enabled)
-    if (is_sle_micro('>=6.0')) {
+    if (has_selinux) {
         validate_script_output(
             "semodule -lfull",
             sub {

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -14,15 +14,10 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_sle_micro);
 
 sub run {
     my ($self) = @_;
     select_serial_terminal;
-    # SLE Micro is already set to enforcing mode
-    if (!is_sle_micro('>=6.0')) {
-        $self->set_sestatus('permissive', 'minimum');
-    }
 
     # Check SELinux status: 'selinuxenabled' exits with status 0 if SELinux is enabled and 1 if it is not enabled
     assert_script_run('selinuxenabled');


### PR DESCRIPTION
Currently the SELinux testsuite assumes that the distro does not use SELinux by default and forcibly installs the minimum policy in permissive mode and breaks otherwise. Change it so that it can cope with and properly test distros which use the targeted policy in enforcing mode by default.

- Related ticket: https://progress.opensuse.org/issues/175320
- Verification run: http://10.168.5.231/tests/1663 (TW 20250108 with SELinux by default)

Any other requests for VRs?
