### PR TITLE
firefox_audio: Remove bsc#1048271 soft fail

### DIFF
--- a/tests/x11/firefox_audio.pm
+++ b/tests/x11/firefox_audio.pm
@@ -35,10 +35,8 @@ sub run {
     }
     sleep 1;    # at least a second of silence
 
-    # firefox_audio is unstable due to bsc#1048271, we don't want to invest
-    # time in rerunning it, if it fails, so instead of assert, simply soft-fail
     unless (check_recorded_sound 'DTMF-159D') {
-        record_soft_failure 'bsc#1048271';
+        record_info("bsc#1048271", "WONTFIX - Tones are sporadically played with lower frequencies");
     }
     send_key 'alt-f4';
     assert_screen([qw(firefox-save-and-quit generic-desktop)]);


### PR DESCRIPTION
Bug bsc#1048271 has status 'RESOLVED WONTFIX'. 
Adapted the test to pass instead of keeping track of the issue with soft-fail.

- Related ticket: https://progress.opensuse.org/issues/174988
- Verification run: https://openqa.suse.de/tests/16536015#step/firefox_audio/9
