### PR TITLE
Set selinuxtest as base class for selinux_setup

### DIFF
--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -5,7 +5,7 @@
 # Maintainer: QE Security <none@suse.de>
 # Tags: poo#40358, poo#105202, tc#1769801
 
-use base 'opensusebasetest';
+use base 'selinuxtest';
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/175647
- Needles: n/a
- Verification runs:
  - https://openqa.suse.de/tests/16536143
  - https://openqa.suse.de/tests/16536144
  - https://openqa.opensuse.org/tests/4798116
  - http://10.168.5.231/tests/1668 (thanks to @Vogtinator for the SELinux-Tumbleweed VR)
