### PR TITLE
Agama proxy scc workaround for sle16 beta1 install

### DIFF
--- a/data/agama_auto/sle_default_ipmi_no_reg.jsonnet
+++ b/data/agama_auto/sle_default_ipmi_no_reg.jsonnet
@@ -1,0 +1,40 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        body: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||
+      }
+    ],
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||
+      }
+    ]
+  }
+}

--- a/data/agama_auto/sle_default_no_reg.jsonnet
+++ b/data/agama_auto/sle_default_no_reg.jsonnet
@@ -1,0 +1,15 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  }
+}

--- a/data/agama_auto/sle_default_pvm_no_reg.jsonnet
+++ b/data/agama_auto/sle_default_pvm_no_reg.jsonnet
@@ -1,0 +1,40 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        body: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||
+      }
+    ],
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||
+      }
+    ]
+  }
+}

--- a/data/agama_auto/sle_default_s390x_kvm_no_reg.jsonnet
+++ b/data/agama_auto/sle_default_s390x_kvm_no_reg.jsonnet
@@ -1,0 +1,27 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||
+      }
+    ]
+  }
+}

--- a/schedule/functional/sle16/agama-create-hdd-textmode_pvm.yaml
+++ b/schedule/functional/sle16/agama-create-hdd-textmode_pvm.yaml
@@ -6,3 +6,4 @@ schedule:
     - installation/bootloader
     - installation/agama_reboot
     - installation/first_boot
+    - console/system_prepare

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -16,7 +16,7 @@ use base 'consoletest';
 use testapi;
 use utils;
 use zypper;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_agama);
 use serial_terminal 'prepare_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use registration;
@@ -121,6 +121,19 @@ sub run {
 
     # stop and disable PackageKit
     quit_packagekit;
+    ########
+    # Workaround to install sle16 in beta1
+    # Don't register the system during the installation and use daily build as install url
+    # Register the system once installation done
+    if (is_agama && is_sle) {
+        zypper_call('in suseconnect-ng');
+        record_info "agama pscc register";
+        my $regcode = (get_var('AGAMA_PRODUCT_ID') =~ /SAP/) ? get_var('SCC_REGCODE_SLES4SAP') : get_var('SCC_REGCODE');
+        my $regurl = get_var('SCC_URL');
+        assert_script_run("suseconnect -r $regcode --url $regurl");
+    }
+    ########
+
 }
 
 sub test_flags {


### PR DESCRIPTION
We can not support register the system to proxy scc for now,  so the workaround is:

1. do not register the system during the installation phase
2. use suseconnet command to register the system after the system boots up

VR: 
[x86_64](https://openqa.suse.de/tests/16542094)
[x86_64 uefi](https://openqa.suse.de/tests/16542131)
[aarch64](https://openqa.suse.de/tests/16542142)
[powervm](https://openqa.suse.de/tests/16542321)