### PR TITLE
Add check for a set-root-password dialog in agama.pm

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -37,20 +37,6 @@ sub agama_set_root_password_diag {
     send_key 'ret';
 }
 
-# A More complex screen for root auth
-sub agama_set_root_password_screen {
-    wait_still_screen 5;
-
-    type_password();
-    send_key 'tab';    # show password btn
-    send_key 'tab';
-    wait_still_screen 5;
-    type_password();
-    send_key 'tab';
-    send_key 'tab';    # show password btn
-    send_key 'ret';
-}
-
 sub agama_define_user_screen {
     wait_still_screen 5;
 
@@ -133,9 +119,6 @@ sub run {
     assert_and_click('agama-show-tabs');
 
     assert_and_click('agama-users-tab');
-    #    assert_and_click('agama-set-root-password');
-    #    agama_set_root_password_screen();
-
 
     # Define user and set autologin on
     assert_and_click('agama-define-user-button');

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -103,7 +103,7 @@ sub run {
     send_key "ctrl-down";    # ensure we see the product select button
     assert_and_click('agama-product-select');
 
-	# A newly introduced set root password dialog
+    # A newly introduced set root password dialog
     assert_screen('agama-set-root-password-diag');
 
     # can take few minutes to get here

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -24,11 +24,11 @@ use x11utils 'ensure_unlocked_desktop';
 
 # Unlike passwod_screen diag has just a single input box
 sub agama_set_root_password_diag {
-    wait_still_screen 2;
+    wait_still_screen 5;
     send_key 'tab';    # The little arrow on the top
-    wait_still_screen 2;
+    wait_still_screen 5;
     send_key 'tab';    # Activate password input box
-    wait_still_screen;
+    wait_still_screen 5;
     type_password();
     send_key 'tab';    # Show password button
     wait_still_screen 2;

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -103,6 +103,9 @@ sub run {
     send_key "ctrl-down";    # ensure we see the product select button
     assert_and_click('agama-product-select');
 
+	# A newly introduced set root password dialog
+    assert_screen('agama-set-root-password-diag');
+
     # can take few minutes to get here
     assert_screen('agama-overview-screen');
 

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -125,8 +125,8 @@ sub run {
     assert_and_click('agama-show-tabs');
 
     assert_and_click('agama-users-tab');
-    assert_and_click('agama-set-root-password');
-    agama_set_root_password_screen();
+#    assert_and_click('agama-set-root-password');
+#    agama_set_root_password_screen();
 
 
     # Define user and set autologin on

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -22,7 +22,15 @@ use utils;
 use Utils::Logging qw(export_healthcheck_basic);
 use x11utils 'ensure_unlocked_desktop';
 
-sub agama_set_root_password_dialog {
+# Unlike passwod_screen diag has just a single input box
+sub agama_set_root_password_diag {
+    wait_still_screen 5;
+    type_password();
+    send_key 'ret';
+}
+
+# A More complex screen for root auth
+sub agama_set_root_password_screen {
     wait_still_screen 5;
 
     type_password();
@@ -105,6 +113,7 @@ sub run {
 
     # A newly introduced set root password dialog
     assert_screen('agama-set-root-password-diag');
+    agama_set_root_password_diag();
 
     # can take few minutes to get here
     assert_screen('agama-overview-screen');
@@ -117,7 +126,7 @@ sub run {
 
     assert_and_click('agama-users-tab');
     assert_and_click('agama-set-root-password');
-    agama_set_root_password_dialog();
+    agama_set_root_password_screen();
 
 
     # Define user and set autologin on

--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -24,8 +24,16 @@ use x11utils 'ensure_unlocked_desktop';
 
 # Unlike passwod_screen diag has just a single input box
 sub agama_set_root_password_diag {
-    wait_still_screen 5;
+    wait_still_screen 2;
+    send_key 'tab';    # The little arrow on the top
+    wait_still_screen 2;
+    send_key 'tab';    # Activate password input box
+    wait_still_screen;
     type_password();
+    send_key 'tab';    # Show password button
+    wait_still_screen 2;
+    send_key 'tab';    # Accept button
+    wait_still_screen 2;
     send_key 'ret';
 }
 
@@ -125,8 +133,8 @@ sub run {
     assert_and_click('agama-show-tabs');
 
     assert_and_click('agama-users-tab');
-#    assert_and_click('agama-set-root-password');
-#    agama_set_root_password_screen();
+    #    assert_and_click('agama-set-root-password');
+    #    agama_set_root_password_screen();
 
 
     # Define user and set autologin on


### PR DESCRIPTION
Handle newly added  Agama dialog to set root password as a firs step after choosing product.

Test run: https://openqa.opensuse.org/tests/4800403#live (passes the problematic part)