### PR TITLE
publiccloud: Increase timeout when installing docker

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2022 SUSE LLC
+# Copyright 2022-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: cloud-regionsrv-client
@@ -161,7 +161,7 @@ sub test_container_runtimes {
 
     record_info('Test docker');
     $instance->ssh_assert_script_run("sudo rm -f /root/.docker/config.json");    # workaround for https://bugzilla.suse.com/show_bug.cgi?id=1231185
-    $instance->ssh_assert_script_run("sudo zypper install -y docker");
+    $instance->ssh_assert_script_run("sudo zypper install -y docker", timeout => 300);
     $instance->ssh_assert_script_run("sudo systemctl start docker.service");
     record_info("systemctl status docker.service", $instance->ssh_script_output("systemctl status docker.service"));
     $instance->ssh_assert_script_run("sudo docker pull $image");


### PR DESCRIPTION
Increase timeout when installing docker

- Related ticket: https://progress.opensuse.org/issues/176052
- Verification run: https://openqa.suse.de/tests/16553788
