### PR TITLE
Add Agama unattended installation for encrypted LVM

### DIFF
--- a/data/yam/agama/auto/lvm_encrypted.jsonnet
+++ b/data/yam/agama/auto/lvm_encrypted.jsonnet
@@ -1,0 +1,54 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  storage: {
+    drives: [
+      {
+        alias: 'pvs-disk',
+	partitions: [ 
+	  { search: "*", delete: true }
+	]
+      }
+    ],
+    volumeGroups: [
+      {
+        name: 'system',
+        physicalVolumes: [
+          { generate: {
+             targetDevices: ['pvs-disk'],
+	     encryption: {
+	        luks2: { password: "nots3cr3t" }
+             } 	
+           }
+         }
+        ],
+        logicalVolumes: [
+          { generate: 'default' }
+        ]
+      }
+    ]
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||
+      }
+    ]
+  }
+}

--- a/schedule/yam/agama_lvm_encrypted_unattended.yaml
+++ b/schedule/yam/agama_lvm_encrypted_unattended.yaml
@@ -1,0 +1,15 @@
+---
+name: Agama unattended lvm with encryption
+description: >
+  Perform Agama unattended installation with encryption on LVM.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm
+  - console/validate_encrypt
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  <<: !include test_data/yast/encryption/default_enc_luks2.yaml

--- a/schedule/yam/agama_lvm_encrypted_unattended_ppc64le.yaml
+++ b/schedule/yam/agama_lvm_encrypted_unattended_ppc64le.yaml
@@ -1,0 +1,16 @@
+---
+name: Agama unattended lvm
+description: >
+  Perform Agama unattended installation with encryptedLVM on ppc64le.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm
+  - console/validate_encrypt
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  <<: !include test_data/yast/encryption/default_enc_luks2.yaml

--- a/schedule/yam/agama_lvm_encrypted_unattended_s390x.yaml
+++ b/schedule/yam/agama_lvm_encrypted_unattended_s390x.yaml
@@ -1,0 +1,17 @@
+---
+name: Agama unattended lvm with encryption
+description: >
+  Perform Agama unattended installation with an encrypted LVM on s390x.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/validate_lvm
+  - console/validate_encrypt
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  <<: !include test_data/yast/encryption/default_enc_luks2.yaml


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/175416

[Verification runs](https://openqa.suse.de/tests/overview?distri=sle&build=rakoenig%2Fos-autoinst-distri-opensuse%23poo175416&version=16.0) :
- still need adaption for `s390x` and `ppc64le` and the VRs for that.