### PR TITLE
Add Agama interactive installation for encrypted LVM

### DIFF
--- a/schedule/yam/agama_lvm_encrypted.yaml
+++ b/schedule/yam/agama_lvm_encrypted.yaml
@@ -1,0 +1,17 @@
+---
+name: agama_lvm_encrypted
+description: >
+  Installation with lvm encrypted
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm
+  - console/validate_encrypt
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  <<: !include test_data/yast/encryption/default_enc_luks2.yaml

--- a/schedule/yam/agama_lvm_encrypted_s390x.yaml
+++ b/schedule/yam/agama_lvm_encrypted_s390x.yaml
@@ -1,0 +1,18 @@
+---
+name: agama_lvm_encrypted
+description: >
+  Installation with lvm encrypted
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm
+  - console/validate_encrypt
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  <<: !include test_data/yast/encryption/default_enc_luks2.yaml


### PR DESCRIPTION
We have added two new schedules to manage encrypted LVM SLES installation with Agama
This PR need some job group update with specific variables.


- Related ticket: https://progress.opensuse.org/issues/175413
- Needles: N/A
- Related PR: https://github.com/jknphy/agama-integration-test-webpack/pull/75
- Verification run:
  - x86_64: https://openqa.suse.de/tests/16552790
  - aarch64: https://openqa.suse.de/tests/16552946
  - ppc64le: https://openqa.suse.de/tests/16552947
  - s390x: https://openqa.suse.de/tests/16552856 (Infra error)
