### PR TITLE
libreoffice_mainmenu_favorites: Remove bsc#1195836 softfail

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_favorites.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_favorites.pm
@@ -30,11 +30,6 @@ sub run {
         assert_screen('menu-favorites-libreoffice');
     }
 
-    unless (check_screen('favorites-list-libreoffice')) {
-        record_soft_failure 'bsc#1195836';
-        type_string 'libre';
-        wait_still_screen(1);
-    }
     # find the LibreOffice
     assert_and_click('favorites-list-libreoffice');
     assert_screen('welcome-to-libreoffice', 90);


### PR DESCRIPTION
Removed the soft-fail for fixed bug.

- Related ticket: https://progress.opensuse.org/issues/174988
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/0a934bf3acfec6a0b5318eea16ea6ea5bb856fec
- Verification run: https://openqa.suse.de/tests/16562003#step/libreoffice_mainmenu_favorites/2