### PR TITLE
redis: Redis7 is available since 15-SP5

### DIFF
--- a/tests/console/redis.pm
+++ b/tests/console/redis.pm
@@ -19,8 +19,10 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils qw(zypper_call script_retry validate_script_output_retry);
 use registration qw(add_suseconnect_product get_addon_fullname);
+use version_utils qw(is_sle);
 
-my @redis_versions = ("redis", "redis7");
+my @redis_versions = ("redis");
+push(@redis_versions, 'redis7') unless is_sle('<=15-sp4');
 my %ROLES = (
     MASTER => 'MASTER',
     REPLICA => 'REPLICA',


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/175377
- Verification run:
https://openqa.suse.de/tests/16560442
https://openqa.suse.de/tests/16560443
https://openqa.suse.de/tests/16560445
https://openqa.suse.de/tests/16560447
