### PR TITLE
Allow set up SSH key during Agama installation

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -102,9 +102,22 @@
         body: |||
           #!/usr/bin/env bash
           ssh_config_file="/etc/ssh/ssh_config.d/01-virt-test.conf"
-          echo -e "\StrictHostKeyChecking no\nUserKnownHostsFile /dev/null" > $ssh_config_file
+          echo -e "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null" > $ssh_config_file
         |||
-      }
+     },
+     {
+        name: "Setup_root_ssh_keys",
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          mkdir -p -m 700 /root/.ssh
+          echo '{{_SECRET_RSA_PRIV_KEY}}' > /root/.ssh/id_rsa
+          sed -i 's/CR/\n/g' /root/.ssh/id_rsa
+          chmod 600 /root/.ssh/id_rsa
+          echo '{{_SECRET_RSA_PUB_KEY}}' > /root/.ssh/id_rsa.pub
+          echo '{{_SECRET_RSA_PUB_KEY}}' >> /root/.ssh/authorized_keys
+        |||
+     }
     ]
   }
 }

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -680,7 +680,7 @@ sub expand_version {
 
 sub expand_agama_variables {
     my ($profile) = @_;
-    my @vars = qw(SCC_REGCODE SCC_REGCODE_SLES4SAP AGAMA_PRODUCT_ID);
+    my @vars = qw(SCC_REGCODE SCC_REGCODE_SLES4SAP AGAMA_PRODUCT_ID _SECRET_RSA_PRIV_KEY _SECRET_RSA_PUB_KEY);
     for my $var (@vars) {
         next unless my ($value) = get_var($var);
         $profile =~ s/\{\{$var\}\}/$value/g;


### PR DESCRIPTION
- Set up SSH key with two openqa settings `_SECRET_RSA_PUB_KEY` and `_SECRET_RSA_PRIV_KEY`.
- Fix a typo, see https://progress.opensuse.org/issues/176073


Verification run: 
[on_ph052 in BJ](http://10.200.140.2/tests/707)
[on OSD](https://openqa.suse.de/tests/16561646)

@xlai @waynechen55 @guoxuguang @RoyCai7 @martinsmarcelo @nanzhg @tbaev and others, welcome review!