### PR TITLE
Don't patch openssl_nodejs test in 15SP4

### DIFF
--- a/tests/console/openssl_nodejs.pm
+++ b/tests/console/openssl_nodejs.pm
@@ -32,7 +32,7 @@ sub run {
         $source_repo = script_output(q{zypper lr | grep Source-Pool | awk -F '|' '/Web_and_Scripting_Module/ {print $2}'});
         zypper_call("mr -e $source_repo", exitcode => [0, 3]);
     }
-    assert_script_run 'wget --quiet ' . data_url('qam/crypto_rsa_dsa.patch') unless get_var('FLAVOR') =~ /TERADATA/ || is_sle('=12-sp5');
+    assert_script_run 'wget --quiet ' . data_url('qam/crypto_rsa_dsa.patch') unless get_var('FLAVOR') =~ /TERADATA/ || is_sle('=12-sp5') || is_sle('=15-sp4');
     assert_script_run 'wget --quiet ' . data_url('console/test_openssl_nodejs.sh');
     assert_script_run 'chmod +x test_openssl_nodejs.sh';
     assert_script_run "./test_openssl_nodejs.sh $os_version", 900;


### PR DESCRIPTION
because the patch is already available in the package now


- Related ticket: https://progress.opensuse.org/issues/176112

- Verification run: https://openqa.suse.de/tests/16561942#details
- https://openqa.suse.de/tests/16561943#details
