### PR TITLE
Remove sapconf configuration for sle 16

### DIFF
--- a/schedule/sles4sap/installation/agama_install_sles4sap_saptune.yaml
+++ b/schedule/sles4sap/installation/agama_install_sles4sap_saptune.yaml
@@ -1,0 +1,18 @@
+---
+name: agama_install_sles4sap
+description: >
+  Agama installation tests for sles4sap
+
+  Can be used to generate a qcow2 image for saptune test.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/first_boot
+  - console/system_prepare
+  - sles4sap/patterns
+  - sles4sap/saptune
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -50,9 +50,11 @@ sub setup {
     quit_packagekit;
     # Install saptune
     zypper_call "in saptune";
-    zypper_call "in sapconf";
-    if (systemctl("-q is-active sapconf.service", ignore_failure => 1)) {
-        record_soft_failure("bsc#1190787 - sapconf is not started");
+    unless (is_sle('16+')) {
+        zypper_call "in sapconf";
+        if (systemctl("-q is-active sapconf.service", ignore_failure => 1)) {
+            record_soft_failure("bsc#1190787 - sapconf is not started");
+        }
     }
     # Install mr_test dependencies
     # 'zypper_call "-n in python3-rpm"' returns error message:
@@ -71,9 +73,11 @@ sub setup {
     }
 
     # Remove any configuration set by sapconf
-    assert_script_run "sed -i.bak '/^@/,\$d' /etc/security/limits.conf";
-    script_run "mv /etc/systemd/logind.conf.d/sap.conf{,.bak}" unless check_var('DESKTOP', 'textmode');
-    systemctl '--now disable sapconf';
+    unless (is_sle('16+')) {
+        assert_script_run "sed -i.bak '/^@/,\$d' /etc/security/limits.conf";
+        script_run "mv /etc/systemd/logind.conf.d/sap.conf{,.bak}" unless check_var('DESKTOP', 'textmode');
+        systemctl '--now disable sapconf';
+    }
     assert_script_run 'saptune service enablestart';
     if (is_qemu) {
         # Ignore disk_elevator on VM's


### PR DESCRIPTION
There is no 'sapconf' in sle16, so remove related operation.

Ticket https://jira.suse.com/browse/TEAM-9969

VRs: https://openqa.suse.de/tests/16561970# 
        https://openqa.suse.de/tests/16580407