### PR TITLE
Enable rsync_full_access if selinux is present and ensure rsync installed

### DIFF
--- a/tests/console/rsync_client.pm
+++ b/tests/console/rsync_client.pm
@@ -17,8 +17,13 @@ use strict;
 use warnings;
 use testapi;
 use lockapi;
+use utils qw(zypper_call);
 
 sub run {
+    select_console 'root-console';
+    zypper_call('in rsync');
+    assert_script_run('setsebool -P rsync_full_access 1') if has_selinux;
+
     select_console 'user-console';
 
     #waiting for configuration of rsync server

--- a/tests/console/rsync_server.pm
+++ b/tests/console/rsync_server.pm
@@ -18,13 +18,16 @@ use warnings;
 use testapi;
 use lockapi;
 use version_utils;
-
+use utils qw(zypper_call);
 
 sub run {
+    select_console 'root-console';
+    zypper_call('in rsync');
+    assert_script_run('setsebool -P rsync_full_access 1') if has_selinux;
+
     barrier_create('rsync_setup', 2);
     barrier_create('rsync_finished', 2);
     mutex_create 'barrier_setup_done';
-    select_console 'root-console';
 
     #preparation of rsync config files
     assert_script_run('curl -v -o /etc/rsyncd.conf ' . data_url('console/rsyncd.conf'));


### PR DESCRIPTION
Related to SLE16 test, as it comes with SELinux rsync_full_access should be enabled and rsync should be installed. Right now test blocked by outdated policy, waiting for https://build.suse.de/request/show/358742 to be accepted, then a new VR can be run and this PR can be undrafted, reviewed and merged. 

- Related ticket: https://progress.opensuse.org/issues/175785
- Verification run: https://openqa.suse.de/tests/16547908 (**NOT ACCEPTABLE** because SELinux either disabled or permissive must be set for rsync)
