### PR TITLE
install_ltp: Install kernel-rt-devel for non-livepatch tests

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -157,11 +157,13 @@ sub install_build_dependencies {
       make
     );
 
-    if (is_rt) {
-        push @deps, 'kernel-rt-devel';
-    }
-    elsif (!get_var('KGRAFT')) {
-        push @deps, 'kernel-default-devel';
+    unless (get_var('KGRAFT')) {
+        if (is_rt) {
+            push @deps, 'kernel-rt-devel';
+        }
+        else {
+            push @deps, 'kernel-default-devel';
+        }
     }
 
     zypper_call('-t in ' . join(' ', @deps));


### PR DESCRIPTION
In livepatch tests, kernel-rt-devel will be installed and locked by update_kernel. Trying to install it again in install_ltp for LTP source build will cause job failure.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/16582866