### PR TITLE
lib/version_utils.pm: Support short is_leap("16+") without ".0"

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -374,7 +374,7 @@ sub is_leap {
     $version =~ s/:(Core|S)[:\w]*//i;
     $version =~ s/^Jump://i;
 
-    return check_version($query, $version, qr/\d{2,}\.\d/);
+    return check_version($query, $version, qr/\d{2,}(?:\.\d)?/);
 }
 
 =head2 is_opensuse

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -50,12 +50,12 @@ subtest 'is_leap' => sub {
 
     set_var('VERSION', '42.3');
     ok is_leap, "check is_leap";
-    ok is_leap($_), "check $_" for qw(=42.3 <=15.0 >42.1 >=42.3);
-    ok !is_leap($_), "check $_" for qw(=15.0 >42.3 <42.3 <13.0);
-    dies_ok { is_leap $_ } "check $_" for (qw(13+ <=15 =42 42+ 42.1:S:A+ =42.3:S:A));
+    ok is_leap($_), "check $_" for qw(=42.3 <=15.0 >42.1 >=42.3 12+);
+    ok !is_leap($_), "check $_" for qw(=15.0 >42.3 <42.3 <13.0 15+);
+    dies_ok { is_leap $_ } "check $_" for (qw(42.1:S:A+ =42.3:S:A 12 15- =12+ >1 <15+));
 
     set_var('VERSION', '42.3:S:A');
-    ok is_leap($_), "check $_" for qw(=42.3 <=15.0);
+    ok is_leap($_), "check $_" for qw(=42.3 <=15.0 <15);
 };
 
 subtest 'is_sle' => sub {


### PR DESCRIPTION
is_sle("16+") is supported, but is_leap requires 16.0 as version, which has led to multiple breakages in the past. Make the expected input consistent.

Related: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21066

No VR, covered by unit tests.