### PR TITLE
installation/configure_sdboot.pm: No longer expect the experimental dialog

### DIFF
--- a/tests/installation/configure_sdboot.pm
+++ b/tests/installation/configure_sdboot.pm
@@ -37,7 +37,6 @@ sub run {
     send_key 'spc', wait_screen_change => 1;
     send_key_until_needlematch 'inst-bootloader-systemd-boot-selected', 'down';
     send_key 'ret', wait_screen_change => 1;    # Select the option
-    send_key 'ret', wait_screen_change => 1;    # Acknowledge the warning that this is WIP
 
     unless (get_var('KEEP_GRUB_TIMEOUT')) {
         assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);


### PR DESCRIPTION
This dialog got removed recently.

- Related ticket: https://progress.opensuse.org/issues/175530
- Verification run: https://openqa.opensuse.org/tests/4813560
