### PR TITLE
Quickfix: Fix checks for Leap 16

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1238,7 +1238,7 @@ sub load_consoletests {
     }
     loadtest 'console/systemd_wo_udev' if (is_sle('15-sp4+') || is_leap('15.4+') || is_tumbleweed);
     loadtest "console/ncurses" if is_leap;
-    loadtest "console/yast2_lan" unless ((is_sle("16+") || is_leap("16+")) || is_bridged_networking);
+    loadtest "console/yast2_lan" unless ((is_sle("16+") || is_leap("16.0+")) || is_bridged_networking);
     # no local certificate store
     if (!is_krypton_argon) {
         loadtest "console/curl_https";
@@ -1264,8 +1264,8 @@ sub load_consoletests {
     loadtest "console/zypper_in";
     loadtest "console/zypper_log";
     if (!get_var("LIVETEST")) {
-        loadtest "console/yast2_i" unless (is_sle("16+") || is_leap("16+"));
-        loadtest "console/yast2_bootloader" unless ((is_sle("16+") || is_leap("16+")) || is_bootloader_sdboot);
+        loadtest "console/yast2_i" unless (is_sle("16+") || is_leap("16.0+"));
+        loadtest "console/yast2_bootloader" unless ((is_sle("16+") || is_leap("16.0+")) || is_bootloader_sdboot);
     }
     loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
 # textmode install comes without firewall by default atm on openSUSE. For virtualization server xen and kvm is disabled by default: https://fate.suse.com/324207


### PR DESCRIPTION
is_leap requires a minor version as well. Add the minor versions to the is_leap checks where required.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related failure: https://openqa.suse.de/tests/16592562
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21063
- Verification run: https://openqa.suse.de/tests/16594214
