### PR TITLE
Fix snapshot ID capture in snapper_zypp test

### DIFF
--- a/tests/console/snapper_zypp.pm
+++ b/tests/console/snapper_zypp.pm
@@ -20,8 +20,11 @@ use version_utils 'is_sle';
 use Test::Assert 'assert_equals';
 
 sub get_snapshot_id {
-    my $snapshot_id = is_sle("<=12-SP5") ? '$3' : '$1';
-    return script_output("snapper ls | awk 'END {print $snapshot_id}'");
+    # Temporarily silence messages on the console to avoid unwanted output
+    script_run("dmesg --console-off");
+    my $snapshot_id = is_sle("<=12-SP5") ? script_output("snapper ls | awk 'END {print \$3}'") : script_output("snapper ls --disable-used-space --columns number | tail -n1");
+    script_run("dmesg --console-on");
+    return $snapshot_id;
 }
 
 sub run_zypper_cmd {


### PR DESCRIPTION
Fixed the capture of snapshot ID. The test was failing in [svirt-xen-hvm](https://openqa.suse.de/tests/16614248#step/snapper_zypp/12) environment because the output of `snapper ls` included unwanted BTRFS info.

- Related ticket: https://progress.opensuse.org/issues/176199
- Verification runs: 
  - SLE https://openqa.suse.de/tests/overview?build=cedvid%2Fos-autoinst-distri-opensuse%2321075
  - openSUSE https://openqa.opensuse.org/tests/overview?build=cedvid%2Fos-autoinst-distri-opensuse%2321075
