### PR TITLE
Add installation/enable_apparmor module and run it if SELINUX=0

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1107,7 +1107,8 @@ sub load_inst_tests {
             loadtest "installation/disable_grub_graphics";
         }
         # Do not run enable_selinux in systems that have SELinux by default (bsc#1230118)
-        loadtest "installation/enable_selinux" if get_var('SELINUX') && !has_selinux_by_default;
+        loadtest "installation/enable_selinux" if check_var('SELINUX', '1') && !has_selinux_by_default;
+        loadtest "installation/enable_apparmor" if check_var('SELINUX', '0') && has_selinux_by_default;
 
         if (check_var("UPGRADE", "LOW_SPACE")) {
             loadtest "installation/disk_space_release";

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -181,6 +181,29 @@ sub go_to_search_packages {
     }
 }
 
+=head2 go_to_security_settings
+
+    go_to_security_settings();
+
+From the installation overview screen, open the security settings.
+=cut
+
+sub go_to_security_settings {
+    my ($self) = @_;
+    assert_screen "installation-settings-overview-loaded";
+    if (check_var('VIDEOMODE', 'text')) {
+        send_key $cmd{change};
+        assert_screen 'inst-overview-options';
+        send_key 'alt-e';
+    }
+    else {
+        send_key_until_needlematch 'security-section-selected', 'tab', 31, 2;
+        send_key 'ret';
+    }
+
+    wait_still_screen stilltime => 9, timeout => 45;
+}
+
 =head2 move_down
 
     move_down();

--- a/tests/installation/enable_apparmor.pm
+++ b/tests/installation/enable_apparmor.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enable AppArmor during installation
+# Maintainer: Fabian Vogt <fvogt@suse.de>
+
+use strict;
+use warnings;
+use base 'y2_installbase';
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    my $textmode = check_var('VIDEOMODE', 'text');
+
+    $self->go_to_security_settings();
+
+    send_key 'alt-s';
+    send_key_until_needlematch 'security-module-apparmor', 'down';
+    send_key 'ret' if $textmode;
+
+    send_key $cmd{ok};
+
+    # Make sure the overview is fully loaded and not being recalculated
+    wait_still_screen(3);
+    assert_screen 'installation-settings-overview-loaded';
+}
+
+1;

--- a/tests/installation/enable_selinux.pm
+++ b/tests/installation/enable_selinux.pm
@@ -13,21 +13,10 @@ use testapi;
 use version_utils qw(is_sle_micro is_leap_micro);
 
 sub run {
+    my ($self) = @_;
     my $textmode = check_var('VIDEOMODE', 'text');
-    # Verify Installation Settings overview is displayed as starting point
-    assert_screen "installation-settings-overview-loaded";
 
-    if ($textmode) {
-        # Select section booting on Installation Settings overview on text mode
-        send_key $cmd{change};
-        assert_screen 'inst-overview-options';
-        send_key 'alt-e';
-    }
-    else {
-        # Select section booting on Installation Settings overview (video mode)
-        send_key_until_needlematch 'security-section-selected', 'tab', 31, 2;
-        send_key 'ret';
-    }
+    $self->go_to_security_settings();
 
     if (is_sle_micro('<5.3') || is_leap_micro('<5.3')) {
         # Combobox for SELinux specifically


### PR DESCRIPTION
On distros which default to SELinux during installation, provide a way to switch to AppArmor.

- Related ticket: https://progress.opensuse.org/issues/166613
- Needles: Already added (https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/4d6833394b396c981c7a860721473dc6778b05b9)
- Verification runs:
TW with SELinux by default (Staging:D): http://10.168.5.231/tests/1732 (KDE) http://10.168.5.231/tests/1742 (textmode)
TW with AppArmor by default (current snapshot in QA): http://10.168.5.231/tests/1733
