### PR TITLE
Replica failover tests

### DIFF
--- a/lib/sles4sap/database_hana.pm
+++ b/lib/sles4sap/database_hana.pm
@@ -20,6 +20,7 @@ our @EXPORT = qw(
   wait_for_takeover
   register_replica
   get_node_roles
+  check_node_roles
   find_hana_resource_name
 );
 
@@ -172,6 +173,36 @@ sub get_node_roles {
         primary_node => get_primary_node(topology_data => $topology),
         failover_node => get_failover_node(topology_data => $topology));
     return (\%result);
+}
+
+=head2 check_node_roles
+
+    check_node_roles(expected_primary=>'Albus', expected_failover=>'Dumbledore');
+
+Checks if expected node roles match current node order. Returns if roles match, otherwise test dies.
+
+=over
+
+=item * B<expected_primary> hostname of expected primary node
+
+=item * B<expected_failover> hostname of expected failover node
+
+=back
+
+=cut
+
+sub check_node_roles {
+    my (%args) = @_;
+    croak 'Missing mandatory argument: expected_primary' unless $args{expected_primary};
+    croak 'Missing mandatory argument: expected_failover' unless $args{expected_failover};
+
+    my $node_roles = get_node_roles();
+    # Check if cluster node state is correct
+    die "Incorrect cluster state\nExpected primary: '$args{expected_primary}'\nCurrent primary: '$node_roles->{primary_node}'" if
+      $args{expected_primary} ne $node_roles->{primary_node};
+    die "Incorrect cluster state\nExpected failover: '$args{expected_failover}'\nCurrent failover: '$node_roles->{failover_node}'" if
+      $args{expected_failover} ne $node_roles->{failover_node};
+    return;
 }
 
 =head2 find_hana_resource_name

--- a/lib/sles4sap/sapcontrol.pm
+++ b/lib/sles4sap/sapcontrol.pm
@@ -192,6 +192,7 @@ sub sapcontrol_process_check {
 
     while ($rc ne $state_to_rc{$expected_state}) {
         last unless $wait_for_state;
+        record_info('Status wait', "Sapcontrol waiting until expected process state: $expected_state");
         $rc = sapcontrol(instance_id => $instance_id, webmethod => 'GetProcessList');
         croak "Timeout while waiting for expected state: $expected_state" if (time - $start_time > $timeout);
         sleep $loop_sleep;

--- a/tests/sles4sap/redirection_tests/hana_sr_replica_failover.pm
+++ b/tests/sles4sap/redirection_tests/hana_sr_replica_failover.pm
@@ -1,0 +1,88 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Test module performs variants of HANA secondary site takeover scenario
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+use warnings;
+use strict;
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::console_redirection;
+use sles4sap::database_hana;
+use sles4sap::sap_host_agent qw(saphostctrl_list_databases parse_instance_name);
+use sles4sap::sapcontrol qw(sapcontrol_process_check sap_show_status_info);
+use hacluster qw(wait_for_idle_cluster wait_until_resources_started);
+use Data::Dumper;
+use Carp qw(croak);
+
+=head1 SYNOPSIS
+
+Module executes variants of 'SAP HANA Secondary site takeover' scenario on Performance-optimized setup.
+Variants of the tests are described here: https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#cha.s4s.test-cluster
+Currently supported variants include Stopping database using 'HDB stop' command and killing DB processes with 'HDB kill -x'.
+It is not possible to use this module as standalone but rather scheduling it via 'loadtest' API
+
+=cut
+
+sub run {
+    my ($self, $run_args) = @_;
+    my @supported_scenarios = ('stop', 'kill');
+    my %scenario = %{$run_args->{scenarios}{$self->{name}}};
+    my $expected_primary_db = $scenario{primary_db};
+    my $expected_failover_db = $scenario{failover_db};
+    my $failover_method = $scenario{failover_method};
+
+    croak "Failover type $failover_method not supported" unless grep /$failover_method/, @supported_scenarios;
+    record_info('Test INFO', "Performing replica DB failover scenario: $failover_method\n
+    Failover database '$expected_failover_db' will be disrupted\n
+    Primary database '$expected_primary_db' will stay intact. No failover is expected.");
+
+    my %databases = %{$run_args->{redirection_data}{db_hana}};
+    my %target_node_data = %{$databases{$expected_failover_db}};
+
+    connect_target_to_serial(
+        destination_ip => $target_node_data{ip_address}, ssh_user => $target_node_data{ssh_user}, switch_root => 1);
+
+    check_node_roles(expected_primary => $expected_primary_db, expected_failover => $expected_failover_db);
+
+    # Perform failover on primary
+    my $node_roles = get_node_roles();
+
+    # Retrieve database information: DB SID and instance ID
+    my @db_data = @{(saphostctrl_list_databases())};
+    record_info('DB data', Dumper(@db_data));
+    die('Multiple databases on one host not supported') if @db_data > 1;
+    my ($db_sid, $db_id) = @{parse_instance_name($db_data[0]->{instance_name})};
+
+    # Perform failover on replica
+    record_info('Failover', "Performing failover method '$failover_method' on database '$expected_failover_db'");
+    sap_show_status_info(cluster => 1, netweaver => 1, instance_id => $db_id);
+    wait_until_resources_started();
+    wait_for_idle_cluster();
+    hdb_stop(instance_id => $db_id, switch_user => lc($db_sid) . 'adm', command => $failover_method);
+
+    # Wait for replica to get back up again.
+    wait_for_failed_resources();
+    record_info('DB wait', "Waiting for database node '$node_roles->{failover_node}' to start");
+    sapcontrol_process_check(
+        instance_id => $db_id, expected_state => 'started', wait_for_state => 'yes', timeout => 600, loop_sleep => 30);
+    record_info('DB started', "All database node '$node_roles->{failover_node}' processes are 'GREEN'");
+    assert_script_run('crm resource cleanup');
+
+    # Wait for cluster to become ready
+    record_info('Cluster wait', 'Waiting for idle cluster');
+    wait_until_resources_started();
+    wait_for_idle_cluster();
+    # check node roles again - They must be same as at the beginning of the test
+    check_node_roles(expected_primary => $expected_primary_db, expected_failover => $expected_failover_db);
+    record_info('Cluster OK', 'Cluster resources up and running');
+    sap_show_status_info(cluster => 1, netweaver => 1, instance_id => $db_id);
+    record_info('TEST END', 'Test module finished successfully.');
+    disconnect_target_from_serial();
+}
+
+1;

--- a/tests/sles4sap/redirection_tests/hanasr_schedule_tests.pm
+++ b/tests/sles4sap/redirection_tests/hanasr_schedule_tests.pm
@@ -65,7 +65,7 @@ sub run {
     my %scenarios;
     my @failover_actions = split(",", get_var("HANASR_FAILOVER_SCENARIOS", 'stop,kill'));
     for my $method (@failover_actions) {
-        my $test_name = ucfirst($method) . "_DB-$primary_site-$primary_db";
+        my $test_name = ucfirst($method) . "_primary_DB-$primary_site";
         $scenarios{$test_name} = {
             primary_db => $primary_db,
             failover_db => $failover_db,
@@ -78,7 +78,7 @@ sub run {
         Failover site $failover_db will take over.");
 
         # Reverse roles and put cluster into original state using same failover method
-        $test_name = ucfirst($method) . "_DB-$failover_site-$failover_db";
+        $test_name = ucfirst($method) . "_primary_DB-$failover_site";
         $scenarios{$test_name} = {
             primary_db => $failover_db,
             failover_db => $primary_db,
@@ -89,6 +89,19 @@ sub run {
         Test name: $test_name\n
         Primary site $failover_db will be stopped.\n
         Failover site $primary_db will take over.");
+
+        # Failover test for replica database
+        $test_name = ucfirst($method) . "_failover_DB-$failover_site";
+        $scenarios{$test_name} = {
+            primary_db => $primary_db,
+            failover_db => $failover_db,
+            failover_method => $method
+        };
+        loadtest('sles4sap/redirection_tests/hana_sr_replica_failover', name => $test_name, run_args => $run_args, @_);
+        record_info('Load test', "Scheduling failover DB failover using '$method' method.\n
+        Test name: $test_name\n
+        Failover site $primary_db will be restarted.\n
+        Primary site $failover_db will stay intact.");
     }
 
     loadtest('sles4sap/sap_deployment_automation_framework/cleanup', name => "SDAF cleanup", run_args => $run_args, @_);


### PR DESCRIPTION
PR is adding test modules and function to enable HanaSR failover test on replication site. Currently supported methods are using 'HDB stop' and 'HDB kill' commands.

- Related ticket: https://jira.suse.com/browse/TEAM-9983
- Verification run: https://openqaworker15.qa.suse.cz/tests/312236