### PR TITLE
non-interactive zypper in  Ansible test commands

### DIFF
--- a/tests/sles4sap/qesapdeployment/test_system.pm
+++ b/tests/sles4sap/qesapdeployment/test_system.pm
@@ -28,7 +28,7 @@ sub run {
         'zypper in -f -y vim',
         'zypper -n in ClusterTools2'
     );
-    qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 300) for @remote_cmd;
+    qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 600) for @remote_cmd;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Double timeout for Ansible test commands in qesap regression test_system. This is needed to avoid failure in `zypper ref` when LTSS modules are enabled.

- Related ticket: https://jira.suse.com/browse/TEAM-9766

# Verification run:


## sle-15-SP4-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_4_BYOS-qesap_aws_saptune_test
- http://openqaworker15.qa.suse.cz/tests/312215

 ## sle-12-SP5-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE12_5_PAYG-qesap_aws_saptune_ltss_test
- http://openqaworker15.qa.suse.cz/tests/312214
