### PR TITLE
Skip dhcp configuration for sle 16.0

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -258,7 +258,7 @@ sub setup_network {
     # boo#1017616: missing link to ping6 in iputils >= s20150815
     assert_script_run('which ping6 >/dev/null 2>&1 || ln -s `which ping` /usr/local/bin/ping6');
 
-    unless (is_transactional) {
+    unless (is_transactional || is_sle('16.0+')) {
         # dhcpd
         assert_script_run('touch /var/lib/dhcp/db/dhcpd.leases');
         script_run('touch /var/lib/dhcp6/db/dhcpd6.leases');


### PR DESCRIPTION
LTP tests fail to create a lease file as the directory tree is missing. https://openqa.suse.de/tests/16605553#step/install_ltp/159

Package `kea` is the new implementation of dhcp

### Verification run

* [sle 16.0](https://openqa.suse.de/tests/16649109#live)
