### PR TITLE
Change mode to non-interactive for zypper commands

### DIFF
--- a/tests/sles4sap/qesapdeployment/test_system.pm
+++ b/tests/sles4sap/qesapdeployment/test_system.pm
@@ -24,9 +24,9 @@ sub run {
         'pwd', 'uname -a',
         'cat /etc/os-release',
         'sudo SUSEConnect --status-text',
-        'zypper ref', 'zypper lr',
-        'zypper in -f -y vim',
-        'zypper -n in ClusterTools2'
+        'zypper -n ref -s -f', 'zypper -n lr',
+        'zypper -n in -f -y vim',
+        'zypper -n in -y ClusterTools2'
     );
     qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 300) for @remote_cmd;
 }


### PR DESCRIPTION
- Related ticket: https://jira.suse.com/browse/TEAM-9766

# Verification run:


## 15sp4
sle-15-SP4-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_4_BYOS-qesap_aws_saptune_test
- http://openqaworker15.qa.suse.cz/tests/312216

## 12sp5
sle-12-SP5-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE12_5_PAYG-qesap_aws_saptune_ltss_test
- http://openqaworker15.qa.suse.cz/tests/312217 :green_circle:  job fails exactly in the same stage, but now the cause is more explicit http://openqaworker15.qa.suse.cz/tests/312217#step/test_system/50

sle-12-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE12_5_PAYG-qesap_gcp_saptune_ltss_test
- http://openqaworker15.qa.suse.cz/tests/312234 :green_circle: http://openqaworker15.qa.suse.cz/tests/312234#step/test_system/50