### PR TITLE
New script for updating Windows.

### DIFF
--- a/data/wsl/UpdateInstall.ps1
+++ b/data/wsl/UpdateInstall.ps1
@@ -1,0 +1,91 @@
+# Define a function to log messages with timestamps
+function LogMessage {
+    param (
+        [string]$Message,
+        [string]$Color = "White"
+    )
+    $Timestamp = (Get-Date).ToString("yyyy-MM-dd HH:mm:ss")
+    Write-Host "$Timestamp - $Message" -ForegroundColor $Color
+}
+
+# Validate COM port status at script start
+if (-not $port -or -not ($port -is [System.IO.Ports.SerialPort]) -or -not $port.IsOpen) {
+    LogMessage "COM port is not initialized or closed. Exiting." -Color "Red"
+    exit 1
+}
+
+# Start logging
+LogMessage "Starting Windows Update process..."
+
+# Create Update Session
+$Session = New-Object -ComObject Microsoft.Update.Session
+$Searcher = $Session.CreateUpdateSearcher()
+
+# Search for Updates
+LogMessage "Searching for updates..."
+$SearchResult = $Searcher.Search("IsInstalled=0")
+
+# Check if updates are available
+if ($SearchResult.Updates.Count -eq 0) {
+    LogMessage "System already up-to-date" -Color "Green"
+    $port.WriteLine('0')
+    exit 0
+}
+
+# Display updates found
+LogMessage "$($SearchResult.Updates.Count) update(s) found."
+$UpdatesToInstall = New-Object -ComObject Microsoft.Update.UpdateColl
+foreach ($Update in $SearchResult.Updates) {
+    LogMessage "Update found: $($Update.Title)"
+    $UpdatesToInstall.Add($Update) | Out-Null
+}
+
+# Process updates one by one (download + install)
+foreach ($Update in $SearchResult.Updates) {
+    LogMessage "Processing: $($Update.Title)" -Color "Cyan"
+
+    # Download the update
+    try {
+        LogMessage "Downloading $($Update.Title)..."
+        $Downloader = $Session.CreateUpdateDownloader()
+        $SingleUpdateColl = New-Object -ComObject Microsoft.Update.UpdateColl
+        $SingleUpdateColl.Add($Update) | Out-Null
+        $Downloader.Updates = $SingleUpdateColl
+        $DownloadResult = $Downloader.Download()
+
+        if ($DownloadResult.ResultCode -ne 2) {
+            LogMessage "Download failed (Result code: $($DownloadResult.ResultCode))"
+            $port.WriteLine('1')
+            exit 1
+        }
+        LogMessage "Downloaded successfully." -Color "Green"
+    } catch {
+        LogMessage "ERROR downloading $($Update.Title): $_" -Color "Red"
+        $port.WriteLine('1')
+        exit 1
+    }
+
+    # Install the update
+    try {
+        LogMessage "Installing $($Update.Title)..."
+        $Installer = $Session.CreateUpdateInstaller()
+        $Installer.Updates = $SingleUpdateColl
+        $InstallResult = $Installer.Install()
+
+        if ($InstallResult.ResultCode -ne 2) {
+            LogMessage "Installation failed (Result code: $($InstallResult.ResultCode))"
+            $port.WriteLine('1')
+            exit 1
+        }
+        LogMessage "Installed successfully." -Color "Green"
+    } catch {
+        LogMessage "ERROR installing $($Update.Title): $_" -Color "Red"
+        $port.WriteLine('1')
+        exit 1
+    }
+}
+
+# Completion message
+LogMessage "Windows Update process completed."
+$port.WriteLine('0')
+exit 0

--- a/schedule/wsl/install/create_windows_image.yaml
+++ b/schedule/wsl/install/create_windows_image.yaml
@@ -14,4 +14,4 @@ conditional_schedule:
 schedule:
   - wsl/install/ms_win_installation
   - '{{unattended_install}}'
-  - wsl/update_windows
+  - wsl/install/update_windows

--- a/tests/wsl/install/update_windows.pm
+++ b/tests/wsl/install/update_windows.pm
@@ -12,14 +12,15 @@ use testapi;
 sub run {
     my $self = shift;
 
-    my $vbs_url = data_url("wsl/UpdateInstall.vbs");
+    my $vbs_url = data_url("wsl/UpdateInstall.ps1");
     $self->open_powershell_as_admin;
-    $self->run_in_powershell(cmd => "Invoke-WebRequest -Uri \"$vbs_url\" -OutFile \"C:\\UpdateInstall.vbs\"");
+    $self->run_in_powershell(cmd => "Invoke-WebRequest -Uri \"$vbs_url\" -OutFile \"\$env:TEMP\\UpdateInstall.ps1\"");
+    $self->run_in_powershell(cmd => "Set-ExecutionPolicy Bypass -Scope CurrentUser -Force");
     $self->run_in_powershell(
-        cmd => 'cd \\; $port.WriteLine($(cscript .\\UpdateInstall.vbs /Automate))',
+        cmd => "cd \$env:TEMP; .\\UpdateInstall.ps1",
         code => sub {
             die("Update script finished unespectedly or timed out...")
-              unless wait_serial("The update process finished with value 1", timeout => 3600);
+              unless wait_serial('0', timeout => 3600);
         }
     );
     save_screenshot;


### PR DESCRIPTION
The existing Windows Update script is failing to run on Windows 24H2 due to deprecation within the Windows Update Agent API. This necessitates the development of a new script compatible with the updated API.

- Related ticket: https://progress.opensuse.org/issues/176097
- Needles:
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/boot_windows-windows-screensaver-20250129.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-edge-welcome-20250127.png
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/blob/master/windows-setup-browser-20250131.png
- Verification runs:
  - https://openqa.suse.de/tests/16615654#
  - https://openqa.suse.de/tests/16624541
  - https://openqa.suse.de/tests/16624538
