### PR TITLE
console/procps: Fix regex for top

### DIFF
--- a/tests/console/procps.pm
+++ b/tests/console/procps.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: procps
@@ -43,7 +43,7 @@ sub run {
     validate_script_output("ps -p 1",
         qr/PID\sTTY\s+TIME\sCMD\s+1\s\?\s+\d+:\d+:\d+\s(systemd|init)/);
     validate_script_output("top -b -n 1",
-qr/top - \d+:\d+:\d+ up\s+((\d+:\d+)|(\d+ \w+)|(\d+ \w+,\s+\d+:\d+)),\s+\d+ \w+,\s+load average: \d+.\d+, \d+.\d+, \d+.\d+\s+Tasks:\s+\d+\s+total,\s+\d+\s+running,\s+\d+\s+sleeping.*top/s);
+qr/top - \d+:\d+:\d+ up\s+((\d+:\d+)|(\d+ \w+)|(\d+ \w+,\s+\d+:\d+)),\s+\d+ \w+,\s+load average: \d+.\d+, \d+.\d+, \d+.\d+\s+Tasks:\s+\d+\s+total,\s+\d+\s+running,\s+\d+\s+sleep.*top/s);
 }
 
 1;


### PR DESCRIPTION
Fix regex for top

- Related ticket: https://progress.opensuse.org/issues/174664
- Failing test: https://openqa.opensuse.org/tests/4723309#step/procps/15
- Verification run: https://openqa.opensuse.org/tests/4819879 (failing due to [poo#174667](https://progress.opensuse.org/issues/174667))