### PR TITLE
console/firewalld: Skip backend test if iptables command not present

### DIFF
--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright 2019-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: firewalld
@@ -339,6 +339,7 @@ sub test_firewall_offline_cmd {
 # Test #10 - Verify default backend on 15+ (SLES and Leap)
 #            Factory derived products, should have nf_tables too
 sub test_default_backend {
+    return if (script_run("command -v iptables") != 0);
     validate_script_output('iptables --version', sub {
             # This could have been done using capture groups too
             # removing the need for repeating regexes and nesting ifs


### PR DESCRIPTION
Skip backend test if iptables command not present

- Related ticket: https://progress.opensuse.org/issues/174667
- Failed test: https://openqa.opensuse.org/tests/4723309#step/firewalld/341
- Verification run: https://openqa.opensuse.org/tests/4819957 (failing due to [poo#174664](https://progress.opensuse.org/issues/174664))