### PR TITLE
x11/evolution: evolution test should not be fatal

### DIFF
--- a/tests/console/journal_check.pm
+++ b/tests/console/journal_check.pm
@@ -89,8 +89,8 @@ sub run {
     }
 
     # Write full journal output for reference and upload it into Uploaded Logs section in test webUI
-    script_run("journalctl --no-pager -o short-precise > /tmp/full_journal.log");
-    upload_logs "/tmp/full_journal.log";
+    script_run("journalctl --no-pager -o short-precise > /tmp/full_journal.txt");
+    upload_logs "/tmp/full_journal.txt";
 
     # Check for failed systemd services and examine them
     # script_run("pkill -SEGV dbus-daemon"); # comment out for a test

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -102,7 +102,7 @@ sub run() {
 }
 
 sub test_flags() {
-    return is_public_cloud() ? {milestone => 0, fatal => 1, no_rollback => 1} : {milestone => 1, fatal => 1};
+    return is_public_cloud() ? {milestone => 0, fatal => 1, no_rollback => 1} : {milestone => 1, fatal => 0};
 }
 
 sub post_fail_hook {

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -102,7 +102,7 @@ sub run() {
 }
 
 sub test_flags() {
-    return is_public_cloud() ? {milestone => 0, fatal => 1, no_rollback => 1} : {milestone => 1, fatal => 0};
+    return {milestone => 1, fatal => 0};
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
This PR:
  - Removes fatality from evolution test
  - Renames .log extension to .txt to make it browser-friendly

It makes the next module (mutt, the mail client) fail because the dovecot mail server is failing right now.

---

- Related ticket: https://progress.opensuse.org/issues/176379
- Failing test: https://openqa.opensuse.org/tests/4819957 (the fatality doesn't allow the rest of the tests run)
- Verification run: https://openqa.opensuse.org/tests/4820078 (failing due to https://progress.opensuse.org/issues/176379).