### PR TITLE
Make podman_ipv6 test more stable

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -134,6 +134,7 @@ sub register_addon {
         ssh_add_suseconnect_product($remote, get_addon_fullname($addon), program => $program, version => '${VERSION_ID}', arch => $arch, params => "-r " . get_required_var('SCC_REGCODE_LTSS'), timeout => $timeout, retries => $retries, delay => $delay);
     } elsif (is_ondemand) {
         record_info($addon, 'This is on demand image, we will not register this addon.');
+        return;
     } elsif (is_sle('<15') && $addon =~ /tcm|wsm|contm|asmm|pcm/) {
         ssh_add_suseconnect_product($remote, get_addon_fullname($addon), program => 'SUSEConnect', version => '`echo ${VERSION} | cut -d- -f1`', arch => $arch, params => '', timeout => $timeout, retries => $retries, delay => $delay);
     } elsif (is_sle('<15') && $addon =~ /sdk|we/) {


### PR DESCRIPTION
- Related ticket: [poo#175165](https://progress.opensuse.org/issues/175165)
- Verification run: 
[Build20250130-1](https://pdostal-server.suse.cz/tests/overview?build=20250130-1&distri=sle&version=15-SP6) of sle-15-SP6-Azure-Standard-Updates.x86_64	[publiccloud_containers@64bit](https://pdostal-server.suse.cz/tests/8111)	[29](https://pdostal-server.suse.cz/tests/8111)
[Build20250130-1](https://pdostal-server.suse.cz/tests/overview?build=20250130-1&distri=sle&version=15-SP6) of sle-15-SP6-EC2-Updates.aarch64	[publiccloud_containers@64bit](https://pdostal-server.suse.cz/tests/8110)	[29 1](https://pdostal-server.suse.cz/tests/8110)
[Build20250130-1](https://pdostal-server.suse.cz/tests/overview?build=20250130-1&distri=sle&version=15-SP6) of sle-15-SP6-GCE-Updates.aarch64	[publiccloud_containers@64bit](https://pdostal-server.suse.cz/tests/8109)	[29 1](https://pdostal-server.suse.cz/tests/8109)