### PR TITLE
lib/main_containers.pm: Omit podman_quadlet on Leap as well

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -141,7 +141,7 @@ sub load_host_tests_podman {
     loadtest 'containers/podman_ipv6' if (is_public_cloud && is_sle('>=15-SP5') && !is_azure);
     loadtest 'containers/podman_netavark' unless (is_staging || is_ppc64le);
     loadtest('containers/skopeo', run_args => $run_args, name => $run_args->{runtime} . "_skopeo") unless (is_sle('<15') || is_sle_micro('<5.5'));
-    loadtest 'containers/podman_quadlet' unless (is_staging || is_sle("<16") || is_sle_micro("<6.1"));
+    loadtest 'containers/podman_quadlet' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.1"));
     # https://github.com/containers/podman/issues/5732#issuecomment-610222293
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {


### PR DESCRIPTION
It's omitted on SLE < 16 already, omit it on Leap < 16 as well.

- Related ticket: https://progress.opensuse.org/issues/176298
- Verification run: http://10.168.5.231/tests/1737
