### PR TITLE
    journal_check: sshd frequenly reports errors to journal

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -821,5 +821,13 @@
             "sle-micro": ["6.0", "6.1", "6.2"]
         },
         "type": "ignore"
+    },
+    "sshd-mm-reap": {
+        "description": "sshd-session[.*]: error: (mm_reap: preauth child terminated|mm_request_receive: read: Broken pipe)",
+        "products": {
+            "opensuse": ["Tumbleweed"],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
    These two usually show up together:
    sshd-session[1636]: error: mm_request_receive: read: Broken pipe
    sshd-session[1636]: error: mm_reap: preauth child terminated by signal 15
    
    They are mostly observed on machine reboots. Even though they are not nice.
    they have not shown up in any real issues


- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1229935
- Needles: N/A
- Verification run: N/A
