### PR TITLE
Enable offline (install media) repos on full-QR installation

### DIFF
--- a/schedule/security/create_hdd_cc_libyui/aarch64/cc_qr_15sp6.yaml
+++ b/schedule/security/create_hdd_cc_libyui/aarch64/cc_qr_15sp6.yaml
@@ -22,6 +22,7 @@ schedule:
     - console/system_prepare
     - console/force_scheduled_tasks
     - security/cc/ensure_crypto_checks_enabled
+    - security/installation/enable_repos
     - shutdown/grub_set_bootargs
     - shutdown/cleanup_before_shutdown
     - shutdown/shutdown


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/175644
- Needles: nope
- Verification runs:
  - https://openqa.suse.de/tests/16625406
  - https://openqa.suse.de/tests/16625550
  - https://openqa.suse.de/tests/16625777
  (fails for another reason addressed in separate ticket)
