### PR TITLE
Change is_byos to case insensitive

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -54,7 +54,7 @@ our @EXPORT = qw(
 
 # Check if we are a BYOS test run
 sub is_byos() {
-    return is_public_cloud && get_var('FLAVOR') =~ 'BYOS';
+    return is_public_cloud && get_var('FLAVOR') =~ /byos/i;
 }
 
 # Check if we are a OnDemand test run


### PR DESCRIPTION
is_byos is a PC utils lib checking content of FLAVOR against a regexp. Change this test to be case in-sensitive.

Related ticket: https://jira.suse.com/browse/TEAM-9933

# Verification run:

 - sle-15-SP5-HanaSr-Aws-Byos-x86_64-Build15-SP5_2025-01-31T03:03:19Z-hanasr_aws_test_fencing_native -> http://openqaworker15.qa.suse.cz/tests/312343 :green_circle: `qesap_ansible` test module is pass and registration playbook is correctly configured in http://openqaworker15.qa.suse.cz/tests/312343/file/deploy_qesap_terraform-sles4sap_aws_generic.yaml