### PR TITLE
Quickfix for wiping filesystems before installing

### DIFF
--- a/data/yam/agama/auto/lvm_encrypted.jsonnet
+++ b/data/yam/agama/auto/lvm_encrypted.jsonnet
@@ -40,6 +40,19 @@
     ]
   },
   scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        body: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||
+      }
+    ],
     post: [
       {
         name: 'enable root login',


### PR DESCRIPTION
- needed on PowerVM because it might reuse previously encrypted partitions.

- Verification run: https://openqa.suse.de/tests/16639802