### PR TITLE
redis: Don't add redis7 on 15-SP7

### DIFF
--- a/tests/console/redis.pm
+++ b/tests/console/redis.pm
@@ -22,7 +22,7 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 use version_utils qw(is_sle);
 
 my @redis_versions = ("redis");
-push(@redis_versions, 'redis7') unless is_sle('<=15-sp4');
+push(@redis_versions, 'redis7') unless is_sle('<=15-sp4') || is_sle('>15-sp6');
 my %ROLES = (
     MASTER => 'MASTER',
     REPLICA => 'REPLICA',


### PR DESCRIPTION
redis is redis7 version on 15-SP7

- Related ticket: https://openqa.suse.de/tests/16624355#step/redis/1
- Verification run: https://openqa.suse.de/tests/16640122#step/redis/4
