### PR TITLE
Disable calls of upload_y2logs on SLE 16

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -636,7 +636,7 @@ sub ha_export_logs {
     upload_logs('/tmp/crm.txt');
 
     # Extract YaST logs and upload them
-    upload_y2logs(failok => 1);
+    upload_y2logs(failok => 1) if is_sle('<16');
 
     # Generate the packages list
     script_run "rpm -qa > $packages_list";

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -1445,7 +1445,7 @@ sub post_fail_hook {
     select_console('root-console');
 
     # YaST logs
-    upload_y2logs;
+    upload_y2logs if is_sle('<16');
 
     # HANA installation logs, if needed
     $self->upload_hana_install_log if get_var('HANA');


### PR DESCRIPTION
SLE 16 will not come with YaST, so our tests should not even attempt to collect y2logs when running in those versions.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
