### PR TITLE
disk_boot: Don't wait grub2 also on UEFI

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -14,6 +14,7 @@ use version_utils qw(is_sle_micro);
 use Utils::Architectures qw(is_aarch64);
 use microos "microos_login";
 use transactional "record_kernel_audit_messages";
+use utils qw(is_uefi_boot);
 
 sub run {
 
@@ -22,7 +23,7 @@ sub run {
     # this leads to test failures because openQA does not assert grub2 properly
     # KEEP_GRUB_TIMEOUT=0 will force the grub needle to match, useful when booting
     # pre-configured images with disabled timeout. See opensusebasetest::handle_grub
-    if ((is_aarch64 || is_sle_micro('>=6.0')) && get_var('KEEP_GRUB_TIMEOUT', '1') && !main_micro_alp::is_dvd()) {
+    if ((is_uefi_boot || is_aarch64 || is_sle_micro('>=6.0')) && get_var('KEEP_GRUB_TIMEOUT', '1') && !main_micro_alp::is_dvd()) {
         shift->wait_boot_past_bootloader(textmode => 1);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
The issue is not happening on 6.0 and never, but on UEFI generally, same as aarch64 or ppc64le which are slower and miss the short grub2 timeout IMO same is done here for ppc64le
https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/lib/opensusebasetest.pm#L440

- Related ticket: https://progress.opensuse.org/issues/175884 [6.1 few months ago](https://openqa.suse.de/tests/15296462#step/disk_boot/1) [5.3](https://openqa.suse.de/tests/16646624#next_previous) [5.4](https://openqa.suse.de/tests/16644049#next_previous)
- Verification run: https://openqa.suse.de/tests/overview?distri=sle-micro&build=jpupava_uefi