### PR TITLE
Add support for transactional systems to kernel livepatching infrastructure tests

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -76,7 +76,7 @@ sub is_klp_pkg {
     my $base = qr/(?:kgraft-|kernel-live)patch/;
 
     if ($$pkg{name} =~ m/^${base}-\d+/) {
-        if ($$pkg{name} =~ m/^${base}-(\d+_\d+_\d+-\d+(?:_stage|_*\d*)_\d*)-([a-z][a-z0-9]*)$/) {
+        if ($$pkg{name} =~ m/^${base}-(\d+_\d+_\d+-\d+(?:_stage_\d+|(?:_\d+){1,2})?)-([a-z][a-z0-9]*)$/) {
             my $kver = $1;
             my $kflavor = $2;
             $kver =~ s/_(?!stage)/./g;


### PR DESCRIPTION
SLE Micro 6.0+ has livepatches included in the base product. Update livepatching infrastructure tests to support transactional systems and fix package versioning quirks.

- Related ticket: https://progress.opensuse.org/issues/176406
- Needles: N/A
- Verification runs:
  - SLE-Micro 6.0 x86_64: https://openqa.suse.de/tests/16671249
  - SLE-Micro 6.0 s390x: https://openqa.suse.de/tests/16684419
  - SLE-12SP5 x86_64 KOTD: https://openqa.suse.de/tests/16694678
  - SLE-15SP6 x86_64: https://openqa.suse.de/tests/16694673
  - SLE-15SP6 PPC64LE: https://openqa.suse.de/tests/16694671
  - SLE-15SP6 s390x: https://openqa.suse.de/tests/16694672
