### PR TITLE
Improve lftp test

### DIFF
--- a/tests/security/vsftpd/lftp.pm
+++ b/tests/security/vsftpd/lftp.pm
@@ -11,12 +11,10 @@ use warnings;
 use testapi;
 use utils;
 
-sub check_md5 {
-    if ($_[0] == $_[1]) {
-        record_info('Pass: ', 'md5 values matched');
-    } else {
-        record_info('Error: ', 'md5 values did not match');
-    }
+sub check_hash {
+    my ($expected_hash, $calculated_hash) = @_;
+    my $message = ($expected_hash eq $calculated_hash) ? "Pass: Hash values matched" : "Error: Hash values did not match. Expected: $expected_hash, Got: $calculated_hash";
+    record_info($message);
 }
 
 sub run {
@@ -48,18 +46,18 @@ sub run {
     # Check if file has been downloaded
     assert_script_run('ls | grep f1.txt');
 
-    # Check md5 of original file in ftp server and downloaded one
-    my $md5_orig = script_output("md5sum $ftp_users_path/$user/$ftp_served_dir/f1.txt");
-    my $md5_downloaded = script_output('md5sum f1.txt');
-    check_md5($md5_orig, $md5_downloaded);
+    # Compare file hashes
+    my $hash_orig = script_output("sha256sum $ftp_users_path/$user/$ftp_served_dir/f1.txt");
+    my $hash_downloaded = script_output('sha256sum f1.txt');
+    check_hash($hash_orig, $hash_downloaded);
 
     # Check if file has been uploaded
     assert_script_run("ls $ftp_users_path/$user/$ftp_received_dir | grep f2.txt");
 
-    # Check md5 for created file and uploaded one
-    my $md5_created = script_output('md5sum f2.txt');
-    my $md5_uploaded = script_output("md5sum $ftp_users_path/$user/$ftp_received_dir/f2.txt");
-    check_md5($md5_created, $md5_uploaded);
+    # Compare file hashes
+    my $hash_created = script_output('sha256sum f2.txt');
+    my $hash_uploaded = script_output("sha256sum $ftp_users_path/$user/$ftp_received_dir/f2.txt");
+    check_hash($hash_created, $hash_uploaded);
 }
 
 1;


### PR DESCRIPTION
Changes:
- Change hash comparison logic
- Replace md5 with sha256 for FIPS compliancy

Links:
- Related ticket: https://progress.opensuse.org/issues/176607
- Verification run: https://openqa.suse.de/tests/16671340
