### PR TITLE
clamav: Use repo/fixed to avoid cleanup

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -60,7 +60,7 @@ sub run {
     # Initialize and download ClamAV database
     # First from local mirror, it's much faster, then from official clamav db
     my $host = is_sle ? 'openqa.oqa.prg2.suse.org' : 'openqa.opensuse.org';
-    assert_script_run("sed -i '/mirror1/i PrivateMirror $host/assets/repo/cvd' /etc/freshclam.conf");
+    assert_script_run("sed -i '/mirror1/i PrivateMirror $host/assets/repo/fixed/cvd' /etc/freshclam.conf");
     assert_script_run('freshclam', timeout => 300);
 
     # clamd takes a lot of memory at startup so a swap partition is needed on JeOS


### PR DESCRIPTION
- Related ticket: https://openqa.suse.de/tests/16679589#step/clamav/39
- Verification run: 
https://openqa.opensuse.org/tests/4835193#step/clamav/23 o3
https://openqa.suse.de/tests/16680257#step/clamav/35 osd