### PR TITLE
Use ASSET_n to download guest assets for virt tests

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -185,7 +185,7 @@ sub is_hyperv_virtualization {
 
 # Return 1 if it is SLES MU virt test, otherwise return 0
 sub is_sles_mu_virt_test {
-    return is_sle && get_var('REGRESSION') =~ /xen|kvm|qemu|hyperv|vmware/ && !get_var("VIRT_AUTOTEST");
+    return is_sle && get_var('REGRESSION', '') =~ /xen|kvm|qemu|hyperv|vmware/ && !get_var("VIRT_AUTOTEST");
 }
 
 #return 1 if it is a fv guest judging by name


### PR DESCRIPTION
Downloading assets from OSD require authentication to achieve CC compliance, refer to https://app.slack.com/client/T02863RC2AC/C02CANHLANP

Related ticket: https://progress.opensuse.org/issues/176589

Solution:  Use ASSET_n to download guest assets.

Add `ASSET_n0` to indicate the path of vm xml file, and `ASSET_n1` for the vm disk file. fg. 
```
ASSET_10=guest_%GUEST_LIST%-fv-def-net_on-host_%DISTRI%-%VERSION%_build%BUILD%_%SYSTEM_ROLE%_%ARCH%.xml 

ASSET_11=guest_%GUEST_LIST%-fv-def-net_on-host_%DISTRI%-%VERSION%_build%BUILD%_%SYSTEM_ROLE%_%ARCH%.disk
```

Advantages:

- No authetication is required.
- It is a more typical use of downloading files from OSD repo. It is safer and faster.
- Don't start the test if there is no guest assets uploaded by its dependency tests.

Disadvantages:

- Need add 2 or 4 openqa settings "ASSET_n" to a few tests which need download guest assets.
- Don't start the test even if there are part of guest assets. ie. for a xen test, if there is only a pv asset, while missing a fv asset, the test would not start.
- In the case you would not like to use the default value of `GUEST_LIST` , fg. to test a pv test only, you would have to re-set `ASSET_10/11` accordingly.


Verification run: 
[a_chained_sriov_test](https://openqa.suse.de/tests/16710036)
[prj4_on_xen](https://openqa.suse.de/tests/16707620)    //pv & fv guest
[prj4_guest_upgrade_sles15sp6_on_developing-xen](https://openqa.suse.de/tests/16707346)  //pv guest only
[prj3](https://openqa.suse.de/tests/16724222)

@alice-suse @waynechen55 @guoxuguang @nanzhg  and others, welcome review!
