### PR TITLE
Refactor firewalld

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1271,8 +1271,8 @@ sub load_consoletests {
     loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
     # textmode install comes without firewall by default atm on openSUSE.
     # For virtualization server xen and kvm is disabled by default: https://fate.suse.com/324207
-    # Cloud images come without firewalld by default
-    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server && get_var('FLAVOR', '') !~ /JeOS-for-OpenStack-Cloud.*/ && get_var('FLAVOR', '') !~ /Minimal-VM-Cloud/) {
+    # Cloud and VMware images come without firewalld by default
+    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server && !is_vmware && get_var('FLAVOR', '') !~ /JeOS-for-OpenStack-Cloud.*/ && get_var('FLAVOR', '') !~ /Minimal-VM-Cloud/) {
         loadtest "console/firewall_enabled";
     }
     if (is_jeos) {

--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -16,30 +16,22 @@ use strict;
 use warnings;
 use testapi;
 use version_utils qw(is_upgrade is_jeos is_sle is_vmware is_leap is_tumbleweed);
+use serial_terminal 'select_serial_terminal';
 use Utils::Architectures;
 
 sub run {
     my ($self) = @_;
     if ($self->firewall eq 'firewalld') {
-        my $timeout = 30;
-        $timeout = 60 if is_ppc64le;
-        my $ret = script_run('firewall-cmd --state', timeout => $timeout);
-        if ($ret && is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/) {
-            # In case of upgrades from SFW2-based distros (Leap < 15.0 to TW) we end up without
-            # any firewall
-            record_soft_failure "boo#1144543 - Migration from SFW2 to firewalld: no firewall enabled";
-            $ret = 0;
+        assert_script_run("firewall-cmd --version", fail_message => "firewall-cmd is not present");
+        if (script_output('firewall-cmd --state', timeout => 60, proceed_on_failure => 1) !~ /running/) {
+            if (is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/) {
+                # In case of upgrades from SFW2-based distros (Leap < 15.0 to TW) we end up without any firewall
+                record_soft_failure "boo#1144543 - Migration from SFW2 to firewalld: no firewall enabled";
+                return;
+            }
+            die "firewall-cmd is not running";
         }
-        if ($ret == 0) {
-            $self->result('ok');
-        } elsif (is_jeos && is_vmware && (is_tumbleweed || is_sle('15-SP4+') || is_leap('15.4+'))) {
-            record_info('Expected', 'Starting with sle15sp4\'s QR1 JeOS vmware image, firewalld is disabled by default');
-        }
-        else {
-            $self->result('fail');
-        }
-    }
-    else {
+    } else {
         assert_script_run('SuSEfirewall2 status');
     }
 }


### PR DESCRIPTION
Simplify the code flow for firewalld and make test failures better visible by running a 'die' instead of just marking the module as failed.

- Related failure: https://openqa.suse.de/tests/16663333#step/firewall_enabled/1

## Verification runs

- [Tumbleweed](https://openqa.opensuse.org/tests/4836535)
- [MinimalVM SLES16](https://openqa.suse.de/tests/16684331) (unrealted failure)
- [SLES15-SP6](https://openqa.suse.de/tests/16684333)
- [SLES15-SP5](https://openqa.suse.de/tests/16684335)
- [SLES15-SP2](https://openqa.suse.de/tests/16684336)
- [SLES12-SP3](https://openqa.suse.de/tests/16684334)
