### PR TITLE
BCI_prepare registration status showed for debug improvement

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -139,9 +139,11 @@ sub run {
     return if (get_var('HELM_CONFIG') && !($host_distri == "sles" && $version == 15 && $sp >= 3));
 
     # Ensure LTSS subscription is active when testing LTSS containers.
-    my $ltss_command = q(SUSEConnect -s | jq -Mr '.[] | select(.identifier == "SLES-LTSS") | .subscription_status');
-    validate_script_output($ltss_command, qr/ACTIVE/, fail_message => "Host requires LTSS subscription for LTSS container")
-      if (get_var('CONTAINER_IMAGE_TO_TEST') =~ /ltss/i);
+    my $ltss_command = qq(SUSEConnect -s | jq -Mr '.[] | select(.identifier == "SLES-LTSS") | .subscription_status');
+    if (get_var('CONTAINER_IMAGE_TO_TEST') =~ /ltss/i) {
+        assert_script_run("SUSEConnect --status-text");
+        validate_script_output($ltss_command, qr/ACTIVE/, fail_message => "Host requires LTSS subscription for LTSS container");
+    }
 
     # For BCI tests using podman, buildah package is also needed
     install_buildah_when_needed($host_distri) if ($engines =~ /podman/);


### PR DESCRIPTION
In BCI test preparation, for LTSS versions printed the suseconnect status to improve eventual debugging.

- Related ticket: https://progress.opensuse.org/issues/175938

- Verification run: https://openqa.suse.de/tests/16680578#step/bci_prepare/45
