### PR TITLE
Skip firewalld on Cloud image

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1269,8 +1269,10 @@ sub load_consoletests {
         loadtest "console/yast2_bootloader" unless ((is_sle("16+") || is_leap("16.0+")) || is_bootloader_sdboot);
     }
     loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
-# textmode install comes without firewall by default atm on openSUSE. For virtualization server xen and kvm is disabled by default: https://fate.suse.com/324207
-    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server && get_var('FLAVOR', '') !~ /JeOS-for-OpenStack-Cloud.*/) {
+    # textmode install comes without firewall by default atm on openSUSE.
+    # For virtualization server xen and kvm is disabled by default: https://fate.suse.com/324207
+    # Cloud images come without firewalld by default
+    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server && get_var('FLAVOR', '') !~ /JeOS-for-OpenStack-Cloud.*/ && get_var('FLAVOR', '') !~ /Minimal-VM-Cloud/) {
         loadtest "console/firewall_enabled";
     }
     if (is_jeos) {


### PR DESCRIPTION
MinimalVM Cloud images come without firewalld so we need to skip the firewall enabled test there.

- Related: https://suse.slack.com/archives/C02CAFDT3MY/p1738838353392139

# Verification runs

* [SLES16 MinimalVM-Cloud](https://openqa.suse.de/tests/16681198#) (no `firewall-enabled` test)
* [SLES16 MinimalVM-kvm-and-xen](https://openqa.suse.de/tests/16681200#details) (`firewall-enabled` test present)
