### PR TITLE
Pub. cloud instance-flavor-check log regexp updated

### DIFF
--- a/tests/publiccloud/flavor_check.pm
+++ b/tests/publiccloud/flavor_check.pm
@@ -26,11 +26,11 @@ sub run {
     if (is_byos()) {
         validate_script_output('instance-flavor-check || true', sub { m/^BYOS$/m }, fail_message => "The command did not return 'BYOS'.");
         die('The command should return code 11 for BYOS flavor!') if (script_run('instance-flavor-check') != 11);
-        validate_script_output("cat $log_path", sub { m/^BYOS$/m }, fail_message => "The log file did not contain 'BYOS'.");
+        validate_script_output("cat $log_path", sub { m/BYOS$/m }, fail_message => "The log file did not contain 'BYOS'.");
     } elsif (is_ondemand()) {
         validate_script_output('instance-flavor-check || true', sub { m/^PAYG$/m }, fail_message => "The command did not return 'PAYG'.");
         die('The command should return code 10 for PAYG flavor!') if (script_run('instance-flavor-check') != 10);
-        validate_script_output("cat $log_path", sub { m/^PAYG$/m }, fail_message => "The log file did not contain 'PAYG'.");
+        validate_script_output("cat $log_path", sub { m/PAYG$/m }, fail_message => "The log file did not contain 'PAYG'.");
     } else {
         # Check the return code for unknown flavor but fail anyways because we so far have only BYOS or PAYG.
         die('The command should return code 12 for unknown flavor!') if (script_run('instance-flavor-check') != 12);


### PR DESCRIPTION
The file-log entry in previous tests was a simple string. But since [last re-runs](https://openqa.suse.de/tests/16670825#step/flavor_check/20) that log resulted to contain  time informations too on the left so that the comparison expression _no more matching the line beginning_(`^`), but end only(`$`). Therefore regexp has been updated and same consideration applied to both flavor types.

- Related ticket: https://progress.opensuse.org/issues/176718

- Verification run: https://openqa.suse.de/tests/16686283
