### PR TITLE
Add CI/CD check to avoid uses of plain password on data directory

### DIFF
--- a/t/01_style.t
+++ b/t/01_style.t
@@ -12,4 +12,6 @@ ok system(qq{git grep -I -l '[#/ ]*SPDX-License-Identifier ' ':!t/01_style.t'}) 
 $out = qx{git grep -ne "check_var('ARCH',.*)" -e "check_var('BACKEND',.*)" ':!lib/Utils/Architectures.pm' ':!lib/Utils/Backends.pm' 'lib' 'tests'};
 ok $? != 0 && $out eq '', 'No check_var function to verify ARCH/BACKEND types' or diag $out;
 ok system(qq{git grep -I -l \\( -e "egrep" -e "fgrep" \\) ':!t/01_style.t' ':!CONTRIBUTING.md'}) != 0, 'No usage of the deprecated egrep and fgrep commands';
+$out = qx{git grep -I -l 'nots3cr3t' ':!data/wsl/Autounattend_*.xml' 'data' | xargs grep -L 'luks.*password.*nots3cr3t'};
+ok $? != 0 && $out eq '', 'No plain password on data directory' or diag $out;
 done_testing;


### PR DESCRIPTION
Add CI/CD check to avoid uses of plain password on data directory in pull requests

- Related ticket: https://progress.opensuse.org/issues/160334