### PR TITLE
Enhance SAPHanaSR-showAttr version check

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -1240,9 +1240,10 @@ sub pacemaker_version {
 
 sub saphanasr_showAttr_version {
     my ($self) = @_;
-    my $version_cmd = 'SAPHanaSR-showAttr --version';
 
-    my $version_output = $self->run_cmd(cmd => $version_cmd, quiet => 1);
+    my $which_output = $self->run_cmd(cmd => 'which SAPHanaSR-showAttr', quiet => 1);
+    my $version_output = $self->run_cmd(cmd => "rpm -qf $which_output", quiet => 1);
+    record_info('SAPHanaSR INFO', "path=$which_output; version=$version_output");
 
     if ($version_output =~ /(\d+\.\d+(?:\.\d+)*)/) {
         return $1;

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -1035,4 +1035,14 @@ subtest '[wait_for_cluster]' => sub {
     ok((any { qr/online/ } @node_state_matches), 'Pacemaker older than 2.1.7 match with online');
 };
 
+subtest '[saphanasr_showAttr_version]' => sub {
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap_publiccloud', no_auto => 1);
+    $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $sles4sap_publiccloud->redefine(run_cmd => sub { return 'hello-world-1.2.3.4-12345.6.78.9.end'; });
+    my $self = sles4sap_publiccloud->new();
+
+    my $ret = $self->saphanasr_showAttr_version();
+    ok $ret eq '1.2.3.4';
+};
+
 done_testing;

--- a/tests/sles4sap/publiccloud/qesap_prevalidate.pm
+++ b/tests/sles4sap/publiccloud/qesap_prevalidate.pm
@@ -38,6 +38,9 @@ sub run {
         # Skip instances without HANA db or setup without cluster
         next if ($instance_id !~ m/vmhana/) or !$ha_enabled;
 
+        # Output the version of tool 'SAPHanaSR-showAttr'
+        record_info('SAPHanaSR version number', $self->saphanasr_showAttr_version());
+
         $self->wait_for_sync();
 
         # Define initial state for both sites


### PR DESCRIPTION
Enhance SAPHanaSR-showAttr version check


- Related ticket: [TEAM-10057](https://jira.suse.com/browse/TEAM-10057) - Latest SAPHanaSR-showAttr drop --version argument


- Verification run:
(USE_SAP_HANA_SR_ANGI=true) failed as expected see TEAM-9930 for details
http://openqaworker15.qa.suse.cz/tests/313061#step/qesap_prevalidate/27 (/usr/bin/SAPHanaSR-showAttr)
http://openqaworker15.qa.suse.cz/tests/313061#step/qesap_prevalidate/42 (/usr/bin/SAPHanaSR-showAttr version: 1.2.9)
(USE_SAP_HANA_SR_ANGI='') passed
http://openqaworker15.qa.suse.cz/tests/313062#step/qesap_prevalidate/27 (/usr/sbin/SAPHanaSR-showAttr)
http://openqaworker15.qa.suse.cz/tests/313062#step/qesap_prevalidate/42 (/usr/sbin/SAPHanaSR-showAttr version: 0.162.4)