### PR TITLE
autofs_server: Remove soft-fail bsc#1215649

### DIFF
--- a/tests/network/autofs_server.pm
+++ b/tests/network/autofs_server.pm
@@ -76,7 +76,7 @@ sub run {
     # check for bsc#1215649
     # https://progress.opensuse.org/issues/136004
     if (script_output("systemctl --no-pager status nfs-server") =~ m/status=1\/FAILURE/) {
-        record_soft_failure 'bsc#1215649';
+        record_info("bsc#1215649", "NFS server service is not able to bind port");
         systemctl 'stop nfs-server';
         systemctl 'start nfs-server';
     }


### PR DESCRIPTION
Removing soft_failure and recording info instead as the bug only happens in openQA.

https://bugzilla.suse.com/show_bug.cgi?id=1215649

VR: https://openqa.suse.de/tests/16694450
Related ticket: https://progress.opensuse.org/issues/174988

