### PR TITLE
Add ltss to all sles15sp5 support image testsuites' autoyast profiles

### DIFF
--- a/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_aarch64.xml
@@ -114,6 +114,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_s390x.xml
@@ -131,6 +131,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_gnome_all_patterns_x86_64.xml
@@ -112,6 +112,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_gnome_default_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_gnome_default_patterns_aarch64.xml
@@ -165,6 +165,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_gnome_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_gnome_default_patterns_s390x.xml
@@ -196,6 +196,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_gnome_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_gnome_default_patterns_x86_64.xml
@@ -164,6 +164,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_minimal_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_minimal_default_patterns_s390x.xml
@@ -148,6 +148,12 @@
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_minimal_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_minimal_default_patterns_x86_64.xml
@@ -123,6 +123,12 @@
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_aarch64.xml
@@ -92,7 +92,7 @@ exit 0
     </products>
   </software>
   <suse_register t="map">
-      <addons t="list">
+    <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
@@ -107,6 +107,12 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_s390x.xml
@@ -124,6 +124,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_all_patterns_x86_64.xml
@@ -90,7 +90,7 @@ exit 0
     </products>
   </software>
   <suse_register t="map">
-      <addons t="list">
+    <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
@@ -105,6 +105,12 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_default_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_default_patterns_aarch64.xml
@@ -153,6 +153,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp5_install_textmode_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp5_install_textmode_default_patterns_s390x.xml
@@ -179,6 +179,12 @@ exit 0
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>SLES-LTSS</name>
+        <version>{{VERSION}}</version>
+        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
+      </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>

--- a/data/yam/autoyast/support_images/sles15sp6_install_gnome_default_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_gnome_default_patterns_aarch64.xml
@@ -3,7 +3,7 @@
     <global t="map">
       <timeout t="integer">-1</timeout>
     </global>
-    <loader_type>grub2</loader_type>
+    <loader_type>grub2-efi</loader_type>
   </bootloader>
   <firewall t="map">
     <enable_firewall t="boolean">true</enable_firewall>
@@ -32,7 +32,6 @@
       <interface t="map">
         <bootproto>dhcp</bootproto>
         <device>eth0</device>
-        <dhclient_set_default_route>yes</dhclient_set_default_route>
         <startmode>auto</startmode>
       </interface>
     </interfaces>
@@ -96,13 +95,14 @@ exit 0
     </post-scripts>
   </scripts>
   <services-manager t="map">
-    <default_target>multi-user</default_target>
+    <default_target>graphical</default_target>
     <services t="map">
       <disable t="list"/>
       <enable t="list">
         <service>firewalld</service>
         <service>wicked</service>
-        <service>sshd</service>
+	<service>sshd</service>
+        <service>systemd-remount-fs</service>
       </enable>
     </services>
   </services-manager>
@@ -110,10 +110,12 @@ exit 0
     <packages t="list">
       <package>sle-module-server-applications-release</package>
       <package>sle-module-python3-release</package>
+      <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
+      <package>shim</package>
       <package>openssh</package>
       <package>kexec-tools</package>
-      <package>grub2</package>
+      <package>grub2-arm64-efi</package>
       <package>glibc</package>
       <package>firewalld</package>
       <package>e2fsprogs</package>
@@ -123,12 +125,19 @@ exit 0
     <patterns t="list">
       <pattern>apparmor</pattern>
       <pattern>base</pattern>
+      <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
       <pattern>enhanced_base</pattern>
+      <pattern>fonts</pattern>
+      <pattern>gnome_basic</pattern>
+      <pattern>gnome_basis</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
+      <pattern>x11_enhanced</pattern>
       <pattern>x11_yast</pattern>
       <pattern>yast2_basis</pattern>
+      <pattern>yast2_desktop</pattern>
+      <pattern>yast2_server</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>
@@ -138,8 +147,13 @@ exit 0
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
-	<version>{{VERSION}}</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
@@ -150,12 +164,6 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp6_install_gnome_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_gnome_default_patterns_s390x.xml
@@ -6,8 +6,30 @@
     <loader_type>grub2</loader_type>
   </bootloader>
   <firewall t="map">
+    <default_zone>public</default_zone>
     <enable_firewall t="boolean">true</enable_firewall>
+    <log_denied_packets>off</log_denied_packets>
     <start_firewall t="boolean">true</start_firewall>
+    <zones t="list">
+      <zone t="map">
+        <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+        <interfaces t="list">
+          <interface>eth0</interface>
+        </interfaces>
+        <masquerade t="boolean">false</masquerade>
+        <name>public</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>dhcpv6-client</service>
+          <service>ssh</service>
+          <service>tigervnc</service>
+          <service>tigervnc-https</service>
+        </services>
+        <short>Public</short>
+        <target>default</target>
+      </zone>
+    </zones>
   </firewall>
   <general t="map">
     <mode t="map">
@@ -96,23 +118,34 @@ exit 0
     </post-scripts>
   </scripts>
   <services-manager t="map">
-    <default_target>multi-user</default_target>
+    <default_target>graphical</default_target>
     <services t="map">
       <disable t="list"/>
       <enable t="list">
         <service>firewalld</service>
-        <service>wicked</service>
+	<service>wicked</service>
+        <service>kdump</service>
+	<service>kdump-early</service>
+        <service>systemd-remount-fs</service>
         <service>sshd</service>
       </enable>
     </services>
   </services-manager>
   <software t="map">
     <packages t="list">
+      <package>yast2-x11</package>
+      <package>xorg-x11-server</package>
+      <package>xorg-x11-fonts</package>
+      <package>xorg-x11-Xvnc</package>
+      <package>xfsprogs</package>
       <package>sle-module-server-applications-release</package>
       <package>sle-module-python3-release</package>
+      <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
       <package>openssh</package>
       <package>kexec-tools</package>
+      <package>kdump</package>
+      <package>icewm</package>
       <package>grub2</package>
       <package>glibc</package>
       <package>firewalld</package>
@@ -123,12 +156,19 @@ exit 0
     <patterns t="list">
       <pattern>apparmor</pattern>
       <pattern>base</pattern>
+      <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
       <pattern>enhanced_base</pattern>
+      <pattern>fonts</pattern>
+      <pattern>gnome_basic</pattern>
+      <pattern>gnome_basis</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
+      <pattern>x11_enhanced</pattern>
       <pattern>x11_yast</pattern>
       <pattern>yast2_basis</pattern>
+      <pattern>yast2_desktop</pattern>
+      <pattern>yast2_server</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>
@@ -138,8 +178,13 @@ exit 0
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-python3</name>
+        <name>sle-module-desktop-applications</name>
 	<version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>sle-module-python3</name>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
@@ -150,12 +195,6 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp6_install_gnome_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_gnome_default_patterns_x86_64.xml
@@ -96,7 +96,7 @@ exit 0
     </post-scripts>
   </scripts>
   <services-manager t="map">
-    <default_target>multi-user</default_target>
+    <default_target>graphical</default_target>
     <services t="map">
       <disable t="list"/>
       <enable t="list">
@@ -110,6 +110,7 @@ exit 0
     <packages t="list">
       <package>sle-module-server-applications-release</package>
       <package>sle-module-python3-release</package>
+      <package>sle-module-desktop-applications-release</package>
       <package>sle-module-basesystem-release</package>
       <package>openssh</package>
       <package>kexec-tools</package>
@@ -123,12 +124,19 @@ exit 0
     <patterns t="list">
       <pattern>apparmor</pattern>
       <pattern>base</pattern>
+      <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
       <pattern>enhanced_base</pattern>
+      <pattern>fonts</pattern>
+      <pattern>gnome_basic</pattern>
+      <pattern>gnome_basis</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
+      <pattern>x11_enhanced</pattern>
       <pattern>x11_yast</pattern>
       <pattern>yast2_basis</pattern>
+      <pattern>yast2_desktop</pattern>
+      <pattern>yast2_server</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>
@@ -138,24 +146,23 @@ exit 0
     <addons t="list">
       <addon t="map">
         <arch>{{ARCH}}</arch>
+        <name>sle-module-desktop-applications</name>
+	<version>{{VERSION}}</version>
+      </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
 	<version>{{VERSION}}</version>
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-server-applications</name>
-        <version>{{VERSION}}</version>
+	<version>{{VERSION}}</version>
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp6_install_minimal_default_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_minimal_default_patterns_s390x.xml
@@ -6,8 +6,30 @@
     <loader_type>grub2</loader_type>
   </bootloader>
   <firewall t="map">
+    <default_zone>public</default_zone>
     <enable_firewall t="boolean">true</enable_firewall>
+    <log_denied_packets>off</log_denied_packets>
     <start_firewall t="boolean">true</start_firewall>
+    <zones t="list">
+      <zone t="map">
+        <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+        <interfaces t="list">
+          <interface>eth0</interface>
+        </interfaces>
+        <masquerade t="boolean">false</masquerade>
+        <name>public</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>dhcpv6-client</service>
+          <service>ssh</service>
+          <service>tigervnc</service>
+          <service>tigervnc-https</service>
+        </services>
+        <short>Public</short>
+        <target>default</target>
+      </zone>
+    </zones>
   </firewall>
   <general t="map">
     <mode t="map">
@@ -69,45 +91,25 @@
       <timeout t="integer">0</timeout>
     </yesno_messages>
   </report>
-  <scripts t="map">
-    <post-scripts t="list">
-      <script t="map">
-        <filename>post.sh</filename>
-        <interpreter>shell</interpreter>
-        <source><![CDATA[
-#!/bin/sh
-# zypper process is locked by some ruby process, modify the repo file
-cd /etc/zypp/repos.d
-sed -i 's/enabled=1/enabled=0/' $(ls|grep -i nvidia)
-zypper lr
-
-    # Regarding rpm lock see Q9@ https://documentation.suse.com/de-de/sles/15-SP1/html/SLES-all/app-ay-faq.html
-    # quote : "during the post-script phase, YaST still has an exclusive lock on the RPM database."
-    # the package cannot be installed the autoyast way, because of the changing package name (eg libyui-rest-api15)
-    # only zypper allows to install "by capability".
-    mv /var/run/zypp.pid /var/run/zypp.sav
-    zypper -n in libyui-rest-api
-    mv /var/run/zypp.sav /var/run/zypp.pid
-
-exit 0
-
-]]></source>
-      </script>
-    </post-scripts>
-  </scripts>
   <services-manager t="map">
     <default_target>multi-user</default_target>
     <services t="map">
       <disable t="list"/>
       <enable t="list">
         <service>firewalld</service>
-        <service>wicked</service>
+	<service>wicked</service>
+        <service>kdump</service>
+	<service>kdump-early</service>
+        <service>systemd-remount-fs</service>
         <service>sshd</service>
       </enable>
     </services>
   </services-manager>
   <software t="map">
     <packages t="list">
+      <package>xfsprogs</package>
+      <package>wicked</package>
+      <package>snapper</package>
       <package>sle-module-server-applications-release</package>
       <package>sle-module-python3-release</package>
       <package>sle-module-basesystem-release</package>
@@ -123,12 +125,7 @@ exit 0
     <patterns t="list">
       <pattern>apparmor</pattern>
       <pattern>base</pattern>
-      <pattern>basic_desktop</pattern>
-      <pattern>enhanced_base</pattern>
       <pattern>minimal_base</pattern>
-      <pattern>x11</pattern>
-      <pattern>x11_yast</pattern>
-      <pattern>yast2_basis</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>
@@ -139,7 +136,7 @@ exit 0
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
-	<version>{{VERSION}}</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
@@ -150,12 +147,6 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp6_install_minimal_default_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_minimal_default_patterns_x86_64.xml
@@ -69,32 +69,6 @@
       <timeout t="integer">0</timeout>
     </yesno_messages>
   </report>
-  <scripts t="map">
-    <post-scripts t="list">
-      <script t="map">
-        <filename>post.sh</filename>
-        <interpreter>shell</interpreter>
-        <source><![CDATA[
-#!/bin/sh
-# zypper process is locked by some ruby process, modify the repo file
-cd /etc/zypp/repos.d
-sed -i 's/enabled=1/enabled=0/' $(ls|grep -i nvidia)
-zypper lr
-
-    # Regarding rpm lock see Q9@ https://documentation.suse.com/de-de/sles/15-SP1/html/SLES-all/app-ay-faq.html
-    # quote : "during the post-script phase, YaST still has an exclusive lock on the RPM database."
-    # the package cannot be installed the autoyast way, because of the changing package name (eg libyui-rest-api15)
-    # only zypper allows to install "by capability".
-    mv /var/run/zypp.pid /var/run/zypp.sav
-    zypper -n in libyui-rest-api
-    mv /var/run/zypp.sav /var/run/zypp.pid
-
-exit 0
-
-]]></source>
-      </script>
-    </post-scripts>
-  </scripts>
   <services-manager t="map">
     <default_target>multi-user</default_target>
     <services t="map">
@@ -108,6 +82,9 @@ exit 0
   </services-manager>
   <software t="map">
     <packages t="list">
+      <package>xfsprogs</package>
+      <package>wicked</package>
+      <package>snapper</package>
       <package>sle-module-server-applications-release</package>
       <package>sle-module-python3-release</package>
       <package>sle-module-basesystem-release</package>
@@ -123,12 +100,7 @@ exit 0
     <patterns t="list">
       <pattern>apparmor</pattern>
       <pattern>base</pattern>
-      <pattern>basic_desktop</pattern>
-      <pattern>enhanced_base</pattern>
       <pattern>minimal_base</pattern>
-      <pattern>x11</pattern>
-      <pattern>x11_yast</pattern>
-      <pattern>yast2_basis</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>
@@ -150,12 +122,6 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp6_install_textmode_all_patterns_aarch64.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_textmode_all_patterns_aarch64.xml
@@ -3,72 +3,12 @@
     <global t="map">
       <timeout t="integer">-1</timeout>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
-  <firewall t="map">
-    <enable_firewall t="boolean">true</enable_firewall>
-    <start_firewall t="boolean">true</start_firewall>
-  </firewall>
   <general t="map">
     <mode t="map">
       <confirm t="boolean">false</confirm>
     </mode>
   </general>
-  <keyboard t="map">
-    <keyboard_values t="map">
-      <delay/>
-      <discaps t="boolean">false</discaps>
-      <numlock>bios</numlock>
-      <rate/>
-    </keyboard_values>
-    <keymap>english-us</keymap>
-  </keyboard>
-  <language t="map">
-    <language>en_US</language>
-    <languages/>
-  </language>
-  <networking t="map">
-    <interfaces t="list">
-      <interface t="map">
-        <bootproto>dhcp</bootproto>
-        <device>eth0</device>
-        <dhclient_set_default_route>yes</dhclient_set_default_route>
-        <startmode>auto</startmode>
-      </interface>
-    </interfaces>
-    <keep_install_network t="boolean">true</keep_install_network>
-  </networking>
-  <ntp-client t="map">
-    <ntp_policy>auto</ntp_policy>
-  </ntp-client>
-  <partitioning t="list">
-    <drive t="map">
-      <initialize t="boolean">true</initialize>
-      <use>all</use>
-    </drive>
-  </partitioning>
-  <report t="map">
-    <errors t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </errors>
-    <messages t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </messages>
-    <warnings t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </warnings>
-    <yesno_messages t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </yesno_messages>
-  </report>
   <scripts t="map">
     <post-scripts t="list">
       <script t="map">
@@ -103,32 +43,49 @@ exit 0
         <service>firewalld</service>
         <service>wicked</service>
         <service>sshd</service>
+        <service>systemd-remount-fs</service>
       </enable>
     </services>
   </services-manager>
   <software t="map">
-    <packages t="list">
-      <package>sle-module-server-applications-release</package>
-      <package>sle-module-python3-release</package>
-      <package>sle-module-basesystem-release</package>
-      <package>openssh</package>
-      <package>kexec-tools</package>
-      <package>grub2</package>
-      <package>glibc</package>
-      <package>firewalld</package>
-      <package>e2fsprogs</package>
-      <package>btrfsprogs</package>
-      <package>autoyast2</package>
-    </packages>
     <patterns t="list">
+      <pattern>32bit</pattern>
       <pattern>apparmor</pattern>
+      <pattern>apparmor-32bit</pattern>
       <pattern>base</pattern>
+      <pattern>base-32bit</pattern>
+      <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
+      <pattern>dhcp_dns_server</pattern>
+      <pattern>directory_server</pattern>
+      <pattern>documentation</pattern>
       <pattern>enhanced_base</pattern>
+      <pattern>enhanced_base-32bit</pattern>
+      <pattern>file_server</pattern>
+      <pattern>fonts</pattern>
+      <pattern>gateway_server</pattern>
+      <pattern>kvm_server</pattern>
+      <pattern>kvm_tools</pattern>
+      <pattern>lamp_server</pattern>
+      <pattern>mail_server</pattern>
       <pattern>minimal_base</pattern>
+      <pattern>minimal_base-32bit</pattern>
+      <pattern>ofed</pattern>
+      <pattern>oracle_server</pattern>
+      <pattern>print_server</pattern>
+      <pattern>sap_server</pattern>
+      <pattern>sw_management</pattern>
+      <pattern>sw_management-32bit</pattern>
       <pattern>x11</pattern>
+      <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>
+      <pattern>xen_server</pattern>
+      <pattern>xen_tools</pattern>
       <pattern>yast2_basis</pattern>
+      <pattern>yast2_desktop</pattern>
+      <pattern>gnome_basic</pattern>
+      <pattern>x11_raspberrypi</pattern>
+      <pattern>yast2_server</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>
@@ -139,7 +96,7 @@ exit 0
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
-	<version>{{VERSION}}</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
@@ -150,12 +107,6 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp6_install_textmode_all_patterns_s390x.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_textmode_all_patterns_s390x.xml
@@ -3,72 +3,38 @@
     <global t="map">
       <timeout t="integer">-1</timeout>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
-  <firewall t="map">
+    <firewall t="map">
+    <default_zone>public</default_zone>
     <enable_firewall t="boolean">true</enable_firewall>
+    <log_denied_packets>off</log_denied_packets>
     <start_firewall t="boolean">true</start_firewall>
+    <zones t="list">
+      <zone t="map">
+        <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+        <interfaces t="list">
+          <interface>eth0</interface>
+        </interfaces>
+        <masquerade t="boolean">false</masquerade>
+        <name>public</name>
+        <ports t="list"/>
+        <protocols t="list"/>
+        <services t="list">
+          <service>dhcpv6-client</service>
+          <service>ssh</service>
+          <service>tigervnc</service>
+          <service>tigervnc-https</service>
+        </services>
+        <short>Public</short>
+        <target>default</target>
+      </zone>
+    </zones>
   </firewall>
   <general t="map">
     <mode t="map">
       <confirm t="boolean">false</confirm>
     </mode>
   </general>
-  <keyboard t="map">
-    <keyboard_values t="map">
-      <delay/>
-      <discaps t="boolean">false</discaps>
-      <numlock>bios</numlock>
-      <rate/>
-    </keyboard_values>
-    <keymap>english-us</keymap>
-  </keyboard>
-  <language t="map">
-    <language>en_US</language>
-    <languages/>
-  </language>
-  <networking t="map">
-    <interfaces t="list">
-      <interface t="map">
-        <bootproto>dhcp</bootproto>
-        <device>eth0</device>
-        <dhclient_set_default_route>yes</dhclient_set_default_route>
-        <startmode>auto</startmode>
-      </interface>
-    </interfaces>
-    <keep_install_network t="boolean">true</keep_install_network>
-  </networking>
-  <ntp-client t="map">
-    <ntp_policy>auto</ntp_policy>
-  </ntp-client>
-  <partitioning t="list">
-    <drive t="map">
-      <initialize t="boolean">true</initialize>
-      <use>all</use>
-    </drive>
-  </partitioning>
-  <report t="map">
-    <errors t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </errors>
-    <messages t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </messages>
-    <warnings t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </warnings>
-    <yesno_messages t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </yesno_messages>
-  </report>
   <scripts t="map">
     <post-scripts t="list">
       <script t="map">
@@ -103,32 +69,39 @@ exit 0
         <service>firewalld</service>
         <service>wicked</service>
         <service>sshd</service>
+        <service>systemd-remount-fs</service>
       </enable>
     </services>
   </services-manager>
   <software t="map">
-    <packages t="list">
-      <package>sle-module-server-applications-release</package>
-      <package>sle-module-python3-release</package>
-      <package>sle-module-basesystem-release</package>
-      <package>openssh</package>
-      <package>kexec-tools</package>
-      <package>grub2</package>
-      <package>glibc</package>
-      <package>firewalld</package>
-      <package>e2fsprogs</package>
-      <package>btrfsprogs</package>
-      <package>autoyast2</package>
-    </packages>
     <patterns t="list">
       <pattern>apparmor</pattern>
       <pattern>base</pattern>
+      <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
+      <pattern>dhcp_dns_server</pattern>
+      <pattern>directory_server</pattern>
+      <pattern>documentation</pattern>
       <pattern>enhanced_base</pattern>
+      <pattern>file_server</pattern>
+      <pattern>fonts</pattern>
+      <pattern>gateway_server</pattern>
+      <pattern>hwcrypto</pattern>
+      <pattern>kvm_server</pattern>
+      <pattern>kvm_tools</pattern>
+      <pattern>lamp_server</pattern>
+      <pattern>mail_server</pattern>
       <pattern>minimal_base</pattern>
+      <pattern>ofed</pattern>
+      <pattern>oracle_server</pattern>
+      <pattern>print_server</pattern>
+      <pattern>sap_server</pattern>
+      <pattern>sw_management</pattern>
       <pattern>x11</pattern>
       <pattern>x11_yast</pattern>
       <pattern>yast2_basis</pattern>
+      <pattern>yast2_desktop</pattern>
+      <pattern>yast2_server</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>
@@ -139,7 +112,7 @@ exit 0
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
-	<version>{{VERSION}}</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
@@ -150,12 +123,6 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>

--- a/data/yam/autoyast/support_images/sles15sp6_install_textmode_all_patterns_x86_64.xml
+++ b/data/yam/autoyast/support_images/sles15sp6_install_textmode_all_patterns_x86_64.xml
@@ -3,72 +3,12 @@
     <global t="map">
       <timeout t="integer">-1</timeout>
     </global>
-    <loader_type>grub2</loader_type>
   </bootloader>
-  <firewall t="map">
-    <enable_firewall t="boolean">true</enable_firewall>
-    <start_firewall t="boolean">true</start_firewall>
-  </firewall>
   <general t="map">
     <mode t="map">
       <confirm t="boolean">false</confirm>
     </mode>
   </general>
-  <keyboard t="map">
-    <keyboard_values t="map">
-      <delay/>
-      <discaps t="boolean">false</discaps>
-      <numlock>bios</numlock>
-      <rate/>
-    </keyboard_values>
-    <keymap>english-us</keymap>
-  </keyboard>
-  <language t="map">
-    <language>en_US</language>
-    <languages/>
-  </language>
-  <networking t="map">
-    <interfaces t="list">
-      <interface t="map">
-        <bootproto>dhcp</bootproto>
-        <device>eth0</device>
-        <dhclient_set_default_route>yes</dhclient_set_default_route>
-        <startmode>auto</startmode>
-      </interface>
-    </interfaces>
-    <keep_install_network t="boolean">true</keep_install_network>
-  </networking>
-  <ntp-client t="map">
-    <ntp_policy>auto</ntp_policy>
-  </ntp-client>
-  <partitioning t="list">
-    <drive t="map">
-      <initialize t="boolean">true</initialize>
-      <use>all</use>
-    </drive>
-  </partitioning>
-  <report t="map">
-    <errors t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </errors>
-    <messages t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </messages>
-    <warnings t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </warnings>
-    <yesno_messages t="map">
-      <log t="boolean">true</log>
-      <show t="boolean">true</show>
-      <timeout t="integer">0</timeout>
-    </yesno_messages>
-  </report>
   <scripts t="map">
     <post-scripts t="list">
       <script t="map">
@@ -103,32 +43,47 @@ exit 0
         <service>firewalld</service>
         <service>wicked</service>
         <service>sshd</service>
+        <service>systemd-remount-fs</service>
       </enable>
     </services>
   </services-manager>
   <software t="map">
-    <packages t="list">
-      <package>sle-module-server-applications-release</package>
-      <package>sle-module-python3-release</package>
-      <package>sle-module-basesystem-release</package>
-      <package>openssh</package>
-      <package>kexec-tools</package>
-      <package>grub2</package>
-      <package>glibc</package>
-      <package>firewalld</package>
-      <package>e2fsprogs</package>
-      <package>btrfsprogs</package>
-      <package>autoyast2</package>
-    </packages>
     <patterns t="list">
+      <pattern>32bit</pattern>
       <pattern>apparmor</pattern>
+      <pattern>apparmor-32bit</pattern>
       <pattern>base</pattern>
+      <pattern>base-32bit</pattern>
+      <pattern>basesystem</pattern>
       <pattern>basic_desktop</pattern>
+      <pattern>dhcp_dns_server</pattern>
+      <pattern>directory_server</pattern>
+      <pattern>documentation</pattern>
       <pattern>enhanced_base</pattern>
+      <pattern>enhanced_base-32bit</pattern>
+      <pattern>file_server</pattern>
+      <pattern>fonts</pattern>
+      <pattern>gateway_server</pattern>
+      <pattern>kvm_server</pattern>
+      <pattern>kvm_tools</pattern>
+      <pattern>lamp_server</pattern>
+      <pattern>mail_server</pattern>
       <pattern>minimal_base</pattern>
+      <pattern>minimal_base-32bit</pattern>
+      <pattern>ofed</pattern>
+      <pattern>oracle_server</pattern>
+      <pattern>print_server</pattern>
+      <pattern>sap_server</pattern>
+      <pattern>sw_management</pattern>
+      <pattern>sw_management-32bit</pattern>
       <pattern>x11</pattern>
+      <pattern>x11-32bit</pattern>
       <pattern>x11_yast</pattern>
+      <pattern>xen_server</pattern>
+      <pattern>xen_tools</pattern>
       <pattern>yast2_basis</pattern>
+      <pattern>yast2_desktop</pattern>
+      <pattern>yast2_server</pattern>
     </patterns>
     <products t="list">
       <product>SLES</product>
@@ -139,7 +94,7 @@ exit 0
       <addon t="map">
         <arch>{{ARCH}}</arch>
         <name>sle-module-python3</name>
-	<version>{{VERSION}}</version>
+        <version>{{VERSION}}</version>
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
@@ -150,12 +105,6 @@ exit 0
         <arch>{{ARCH}}</arch>
         <name>sle-module-basesystem</name>
         <version>{{VERSION}}</version>
-      </addon>
-      <addon t="map">
-        <arch>{{ARCH}}</arch>
-        <name>SLES-LTSS</name>
-        <version>{{VERSION}}</version>
-        <reg_code>{{SCC_REGCODE_LTSS}}</reg_code>
       </addon>
     </addons>
     <do_registration t="boolean">true</do_registration>


### PR DESCRIPTION
Add ltss to all sles15sp5 support image testsuites' autoyast profiles.

- Related ticket: https://progress.opensuse.org/issues/174910
- Needles: n/a
- Verification run: [sles15sp5](https://openqa.suse.de/tests/overview?version=15-SP5&build=chcao_poo_174910&distri=sle); [sles15sp6](https://openqa.suse.de/tests/overview?build=chcao_poo_174910&distri=sle&version=15-SP6)
- Related mr: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/413
