### PR TITLE
Enable back ntp-wait in journalctl test for SLE12

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -152,11 +152,10 @@ sub run {
         # SLES12 on Publiccloud has ntp enabled by default.
         if (!is_public_cloud) {
             # SLE 12 has no chrony by default but uses ntp
+            assert_script_run('echo "server 0.suse.pool.ntp.org" >> /etc/ntp.conf');
             assert_script_run("ntpdate -b 0.suse.pool.ntp.org", fail_message => "forced time sync failed");
             assert_script_run("systemctl enable --now ntpd");
-            # We're not enabling ntp-wait until bsc#1207042 is resolved
-            record_soft_failure("bsc#1207042 - Won't enable ntp-wait due to cron issues");
-            #assert_script_run("systemctl enable ntp-wait.service");
+            assert_script_run("systemctl enable ntp-wait.service");
         }
     } else {
         assert_script_run("systemctl start chronyd");


### PR DESCRIPTION
Enabling back ntp-wait service in `journalctl.pm`  for SLE12 and removing soft-failure for [bsc#1207042](https://bugzilla.suse.com/show_bug.cgi?id=1207042). 

Ensuring that ntp-wait has finished syncing before proceeding to cron testing, otherwise cron won't start.

- Related ticket: https://progress.opensuse.org/issues/175833
- Verification run: https://openqa.suse.de/tests/16696808
