### PR TITLE
PC: Do not fail on ec2 when no console log

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -212,7 +212,7 @@ sub upload_boot_diagnostics {
     my $time = $dt->hms;
     $time =~ s/:/-/g;
     my $asset_path = "/tmp/console-$time.txt";
-    assert_script_run("aws ec2 get-console-output --latest --color=on --no-paginate --output text --instance-id $instance_id &> $asset_path");
+    script_run("aws ec2 get-console-output --latest --color=off --no-paginate --output text --instance-id $instance_id &> $asset_path", proceed_on_failure => 1);
     if (script_output("du $asset_path | cut -f1") < 8) {
         record_soft_failure('poo#155116 - The console log is empty.');
     } else {


### PR DESCRIPTION
- Fixing: #21149
- Related ticket: [poo#155116](https://progress.opensuse.org/issues/155116)
- Verification run:
[Build:37348:dtb-armv7l](https://pdostal-server.suse.cz/tests/overview?build=%3A37348%3Adtb-armv7l&distri=sle&version=15-SP6) of sle-15-SP6-EC2-Incidents.x86_64	  [publiccloud_smoketests@ec2_i3.large](https://pdostal-server.suse.cz/tests/8248)
[Build20250204-1](https://pdostal-server.suse.cz/tests/overview?build=20250204-1&distri=sle&version=15-SP6) of sle-15-SP6-GCE-Updates.aarch64	  [publiccloud_consoletests@64bit](https://pdostal-server.suse.cz/tests/8247)
[Build20250204-1](https://pdostal-server.suse.cz/tests/overview?build=20250204-1&distri=sle&version=15-SP6) of sle-15-SP6-GCE-Updates.x86_64	  [publiccloud_consoletests@64bit](https://pdostal-server.suse.cz/tests/8246)