### PR TITLE
Support OCI_RUNTIME in podman upstream tests

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -31,17 +31,24 @@ sub run_tests {
     $args .= " --remote" if ($remote);
 
     my $quadlet = script_output "rpm -ql podman | grep podman/quadlet";
-
-    my @skip_tests = split(/\s+/, get_required_var('PODMAN_BATS_SKIP') . " " . $skip_tests);
+    my %_env = (
+        BATS_TMPDIR => "/var/tmp",
+        PODMAN => "/usr/bin/podman",
+        QUADLET => $quadlet,
+    );
+    my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 
     assert_script_run "echo $log_file .. > $log_file";
     background_script_run "podman system service --timeout=0" if ($remote);
-    my $ret = script_run "env BATS_TMPDIR=/var/tmp PODMAN=/usr/bin/podman QUADLET=$quadlet hack/bats $args | tee -a $log_file", 8000;
-    patch_logfile($log_file, @skip_tests);
-    parse_extra_log(TAP => $log_file);
+    my $ret = script_run "env $env hack/bats $args | tee -a $log_file", 8000;
     script_run 'kill %1' if ($remote);
 
+    my @skip_tests = split(/\s+/, get_required_var('PODMAN_BATS_SKIP') . " " . $skip_tests);
+    patch_logfile($log_file, @skip_tests);
+    parse_extra_log(TAP => $log_file);
+
     assert_script_run "podman system reset -f";
+
     return ($ret);
 }
 

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -30,6 +30,9 @@ sub run_tests {
     my $args = ($rootless ? "--rootless" : "--root");
     $args .= " --remote" if ($remote);
 
+    my $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
+    assert_script_run "sed -i 's/^PODMAN_RUNTIME=/&$oci_runtime/' test/system/helpers.bash";
+
     my $quadlet = script_output "rpm -ql podman | grep podman/quadlet";
     my %_env = (
         BATS_TMPDIR => "/var/tmp",


### PR DESCRIPTION
This PR:
  - Adds support for OCI_RUNTIME in podman upstream tests
  - Minor readability fixes.

---

- Verification runs:
  - runc / skopeo: https://openqa.opensuse.org/tests/4839173
  - buildah: https://openqa.opensuse.org/tests/4839148
  - podman: https://openqa.opensuse.org/tests/4839219
