### PR TITLE
Schedule samba AD tests also in FIPS mode

### DIFF
--- a/schedule/security/fips/fips_ker_mode_textmode_extra.yaml
+++ b/schedule/security/fips/fips_ker_mode_textmode_extra.yaml
@@ -16,6 +16,7 @@ schedule:
     - security/ntpd
     - console/ntp_client
     - console/cups
+    - network/samba/samba_adcli
     - console/syslog
     - x11/evolution/evolution_prepare_servers
     - console/mutt

--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -134,6 +134,12 @@ sub run {
         record_info("Not available", "this test run is not available for SLES version older than 12-SP3.");
         return;
     }
+    # when run in FIPS mode, bail out on < 15-SP6 due to lack of proper support for crypto-policies
+    # https://jira.suse.com/browse/PED-12018
+    if (get_var('FIPS_ENABLED') && is_sle('<15-SP6')) {
+        record_info('TEST SKIPPED', 'missing crypto-policies support for legacy AD auth');
+        return;
+    }
     select_serial_terminal;
 
     # Ensure the required variables are set


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/169954
- Needles: no
- Verification runs:
  - https://openqa.suse.de/tests/16724388
  - https://openqa.suse.de/tests/16724389
  - https://openqa.suse.de/tests/16724390
  - https://openqa.suse.de/tests/16724391

As of 2025-01-30, krb5 + crypto-policies-scripts updates are in our testing already as S:M:37150:359688 (15-SP6). 
Fail 15-SP7 is expected since update has not yet been released.

The variables needed AD_DOMAIN, AD_HOSTNAME, AD_HOST_IP, AD_WORKGROUP are specified at the jobgroup level.


 