### PR TITLE
Adjust for new Welcome_to_WSL window pop-up.

### DIFF
--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -182,6 +182,9 @@ sub run {
     # https://github.com/microsoft/WSL/issues/4322
     if (get_var('WSL2')) {
         enter_cmd_slow "exit\n";
+        # Check for welcome_to_wsl pop-up and close it
+        check_screen("welcome_to_wsl", timeout => 60);
+        send_key "alt-f4" if match_has_tag "welcome_to_wsl";
         return;
     }
 

--- a/tests/wsl/firstrun.pm
+++ b/tests/wsl/firstrun.pm
@@ -189,6 +189,9 @@ sub run {
     assert_script_run 'cd ~';
     assert_script_run "zypper ps";
     enter_cmd_slow "exit\n";
+    # Check for welcome_to_wsl pop-up and close it
+    check_screen("welcome_to_wsl", timeout => 60);
+    send_key "alt-f4" if match_has_tag "welcome_to_wsl";
     sleep 3;
     save_screenshot;
     is_fake_scc_url_needed || enter_cmd_slow "exit\n";

--- a/tests/wsl/install_wsl.pm
+++ b/tests/wsl/install_wsl.pm
@@ -82,13 +82,23 @@ sub run {
         # Install required SUSE distro from the MS Store
         $self->run_in_powershell(
             cmd => "wsl --install --distribution $WSL_version",
+            timeout => 300,
+        );
+        check_screen("welcome_to_wsl", timeout => 60);
+        send_key "alt-f4" if match_has_tag "welcome_to_wsl";
+
+        $self->run_in_powershell(
+            cmd => "wsl.exe --distribution $WSL_version",
             code => sub {
                 assert_screen("yast2-wsl-firstboot-welcome", timeout => 300);
             }
         );
     } else {
         die("The value entered for WSL_INSTALL_FROM is not 'build' neither 'msstore'");
+
     }
+
+
 }
 
 1;


### PR DESCRIPTION
Added new welcome_to_wsl needle logic to account for new needle pop-up.


- Related ticket: https://progress.opensuse.org/issues/176676
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
