### PR TITLE
Drop check for Staging:D from has_selinux_by_default

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -992,7 +992,7 @@ Returns true if the distro has SELinux as default MAC
 =cut
 
 sub has_selinux_by_default {
-    return (is_tumbleweed && check_var("VERSION", "Staging:D")) || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos || is_sle('16+');
+    return is_tumbleweed || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos || is_sle('16+');
 }
 
 sub has_selinux {

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -143,13 +143,10 @@ subtest 'has_selinux_by_default' => sub {
     set_var('VERSION', '5.4');
     ok has_selinux_by_default, "check has_selinux_by_default for sle-micro 5.4";
 
-    # Test Tumbleweed (SELinux enabled by default only in Staging:D)
+    # Test Tumbleweed (SELinux enabled by default)
     set_var('DISTRI', 'opensuse');
     set_var('VERSION', 'Tumbleweed');
-    ok !has_selinux_by_default, "check !has_selinux_by_default for Tumbleweed";
-
-    set_var('VERSION', 'Staging:D');
-    ok has_selinux_by_default, "check has_selinux_by_default for Tumbleweed Staging:D";
+    ok has_selinux_by_default, "check has_selinux_by_default for Tumbleweed";
 };
 
 subtest 'has_selinux' => sub {
@@ -164,10 +161,10 @@ subtest 'has_selinux' => sub {
     set_var('VERSION', '5.3');
     ok !has_selinux, "check !has_selinux with default settings (sle-micro 5.3)";
 
-    # Test Tumbleweed (default enabled in Staging:D)
+    # Test Tumbleweed (default enabled)
     set_var('DISTRI', 'opensuse');
     set_var('VERSION', 'Tumbleweed');
-    ok !has_selinux, "check !has_selinux for Tumbleweed without SELINUX=1 environment";
+    ok has_selinux, "check has_selinux for Tumbleweed without SELINUX=1 environment";
     set_var('SELINUX', '1');
     ok has_selinux, "check has_selinux for Tumbleweed with SELINUX=1";
     set_var('SELINUX', '0');


### PR DESCRIPTION
Drop the check for Staging:D when SELinux is the default MAC in enforcing mode on tumbleweed

- Related ticket: https://progress.opensuse.org/issues/166613
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=20250204-SELinux&groupid=1

@Vogtinator 