### PR TITLE
Container host hdd  LTSS registration added for SLE12

### DIFF
--- a/data/containers/autoyast_containers.xml.ep
+++ b/data/containers/autoyast_containers.xml.ep
@@ -31,7 +31,7 @@
         % }
         <arch>{{ARCH}}</arch>
       </addon>
-      % if ($get_var->('VERSION') =~ /15-SP[1-5]/) {
+      % if ($get_var->('VERSION') =~ /12-SP[3-5]|15-SP[1-5]/) {
       <addon>
         <name>SLES-LTSS</name>
         <arch>{{ARCH}}</arch>


### PR DESCRIPTION
BCI containers LTSS registration missing for SLE12 added in autoyast yaml.

Also already added in OSD _Medium_ proper `SCC_REGCODE_LTSS` for `SLE 12-SP5 Container-Host`.

- Related ticket: https://progress.opensuse.org/issues/175938
- Verification run: TBD
