### PR TITLE
containers: Increase delay for zypper ref

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -216,7 +216,7 @@ sub test_zypper_on_container {
     }
     validate_script_output_retry("$runtime run -i --entrypoint '' $image zypper lr -s", sub { m/.*Alias.*Name.*Enabled.*GPG.*Refresh.*Service/ }, timeout => 180);
     assert_script_run("$runtime run -t -d --name 'refreshed' --entrypoint '' $image bash", timeout => 300);
-    script_retry("$runtime exec refreshed zypper -nv --gpg-auto-import-keys ref", timeout => 600, retry => 3, delay => 60);
+    script_retry("$runtime exec refreshed zypper -nv --gpg-auto-import-keys ref", timeout => 600, retry => 3, delay => 120);
     assert_script_run("$runtime commit refreshed refreshed-image", timeout => 120);
     assert_script_run("$runtime rm -f refreshed");
     script_retry("$runtime run -i --rm --entrypoint '' refreshed-image zypper -nv ref", timeout => 300, retry => 3, delay => 60);


### PR DESCRIPTION
 Increase delay for `zypper ref`

- Related ticket: https://progress.opensuse.org/issues/176871
- Verification run:https://openqa.opensuse.org/tests/4845634