### PR TITLE
Add CI check for agama profiles which are at json/jsonnet format (option 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,13 @@ jobs:
       matrix:
         include:
           - test: static
-            perl-version: 5.32
+            perl-version: '5.32'
           - test: unit
             perl-version: 5.32
           - test: compile
             perl-version: 5.26
+          - test: jsonnet
+            perl-version: '5.38-bookworm'
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
     steps:
@@ -21,8 +23,13 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        apt-get -y install libdbus-1-dev libssh2-1-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip
-        pip3 install yamllint
+        if [[ "${{ matrix.test }}" == "jsonnet" ]]; then
+          apt-get -y install jsonnet
+        else
+          apt-get -y install libdbus-1-dev libssh2-1-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip
+          pip3 install yamllint
+        fi
+      shell: bash -e {0}
     - name: Setup perl
       env:
         INLINE_PYTHON_EXECUTABLE: /usr/bin/python3
@@ -32,7 +39,10 @@ jobs:
         echo " requires 'Date::Parse';" >> cpanfile
         echo " requires 'Regexp::Common';" >> cpanfile
         echo " requires 'Perl::Tidy', '== 20250214';" >> cpanfile
-        make prepare
+        if [[ "${{ matrix.test }}" != "jsonnet" ]]; then
+          make prepare
+        fi
+      shell: bash -e {0}
     - name: Run ${{ matrix.test }} tests
       env:
         TESTS: ${{ matrix.test }}

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ test-yaml-valid:
 test-modules-in-yaml-schedule:
 	export PERL5LIB=${PERL5LIB_} ; tools/detect_nonexistent_modules_in_yaml_schedule `git diff --diff-filter=d --name-only --exit-code origin/master | grep '^schedule/*'`
 
+.PHONY: test-jsonnet-valid
+test-jsonnet-valid:
+	tools/check_jsonnet
+
 .PHONY: test-metadata
 test-metadata:
 	tools/check_metadata $$(git ls-files "tests/**.pm")
@@ -115,6 +119,8 @@ else ifeq ($(TESTS),static)
 test: test-static
 else ifeq ($(TESTS),unit)
 test: unit-test perlcritic
+else ifeq ($(TESTS),jsonnet)
+test: test-jsonnet-valid
 else ifeq ($(TESTS),isotovideo)
 test: test-isotovideo
 else

--- a/tools/check_jsonnet
+++ b/tools/check_jsonnet
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+success=1
+JSONNET_FILES=$(git ls-files data/ | grep '.json\?net$' | xargs echo)
+
+if test -n "$JSONNET_FILES"; then
+    which jsonnet >/dev/null 2>&1 || (echo "Command 'jsonnet' not found, can not execute Jsonnet syntax checks" && exit 1) || success=0;
+    echo "jsonnet $JSONNET_FILES" || exit 1 || success=0;
+else
+    echo "No jsonnets modified.";
+fi
+[ $success = 1 ] && echo "check_jsonnet SUCCESS" && exit 0
+exit 1


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/175111
- Needles: N/A
- Verification run: N/A
I tried to setup jsonnet in 'static' on bookworm, got the python dependency issue https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/13918982242/job/38947578151?pr=21168
