### PR TITLE
Fix update scenario from older JeOS version

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -992,7 +992,7 @@ Returns true if the distro has SELinux as default MAC
 =cut
 
 sub has_selinux_by_default {
-    return is_tumbleweed || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos || is_sle('16+');
+    return (is_tumbleweed && !check_var("ZDUP", 1)) || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos || is_sle('16+');
 }
 
 sub has_selinux {

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -147,6 +147,8 @@ subtest 'has_selinux_by_default' => sub {
     set_var('DISTRI', 'opensuse');
     set_var('VERSION', 'Tumbleweed');
     ok has_selinux_by_default, "check has_selinux_by_default for Tumbleweed";
+    set_var('ZDUP', '1');
+    ok !has_selinux_by_default, "check has_selinux_by_default for older Tumbleweed images";
 };
 
 subtest 'has_selinux' => sub {
@@ -164,6 +166,7 @@ subtest 'has_selinux' => sub {
     # Test Tumbleweed (default enabled)
     set_var('DISTRI', 'opensuse');
     set_var('VERSION', 'Tumbleweed');
+    set_var('ZDUP', '0');
     ok has_selinux, "check has_selinux for Tumbleweed without SELINUX=1 environment";
     set_var('SELINUX', '1');
     ok has_selinux, "check has_selinux for Tumbleweed with SELINUX=1";


### PR DESCRIPTION
Don't assume SELinux is installed by default on the update from older MinimalVM scenario.

- Related failure: https://openqa.opensuse.org/tests/4848174#step/firstrun/79

## Verification runs

- [twjeos2twnex](https://openqa.opensuse.org/tests/4848789)
- [Tumbleweed-JeOS-for-kvm-and-xen](https://openqa.opensuse.org/tests/4848790)
