### PR TITLE
pynfs: Don't use xdrlib3

### DIFF
--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -53,7 +53,9 @@ sub install_testsuite {
         $rel = "-b $rel" if ($rel);
 
         install_dependencies_pynfs;
-        assert_script_run("git clone -q --depth 1 $url $rel && cd ./pynfs");
+        assert_script_run("git clone $url $rel && cd ./pynfs");
+        #workaround poo#176907, don't use xdrlib3
+        assert_script_run('git checkout dfb0b07eb5c0579d34f321d27a9d3434f75be38a~');
         assert_script_run('./setup.py build && ./setup.py build_ext --inplace');
     }
     elsif (get_var("CTHON04")) {


### PR DESCRIPTION
The latest commit in pynfs change xdrlib to using xdrlib3 and which we don't have both in SLE and openSUSE. Workaround it to git revert this commit before building.

- Related ticket: https://progress.opensuse.org/issues/176907
- Verification run: https://openqa.suse.de/tests/16726916
