### PR TITLE
containers: Add more logs to bats_post_hook

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -154,6 +154,8 @@ sub patch_logfile {
 
 sub bats_post_hook {
     select_serial_terminal;
+    save_and_upload_log('dmesg', 'dmesg.txt');
+    save_and_upload_log('rpm -qa | sort', 'rpm-qa.txt');
     save_and_upload_log('journalctl', 'journalctl.txt');
     upload_logs('/var/log/audit/audit.log', log_name => "audit.txt");
 }


### PR DESCRIPTION
Add more logs to bats_post_hook useful for debugging.

- Verification run: https://openqa.opensuse.org/tests/4849071 (will fail due to https://bugzilla.opensuse.org/show_bug.cgi?id=1236924 but logs should be visible).
