### PR TITLE
containers: Increase timeout and use -b with journalctl

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -156,6 +156,6 @@ sub bats_post_hook {
     select_serial_terminal;
     save_and_upload_log('dmesg', 'dmesg.txt');
     save_and_upload_log('rpm -qa | sort', 'rpm-qa.txt');
-    save_and_upload_log('journalctl', 'journalctl.txt');
+    save_and_upload_log('journalctl -b', 'journalctl-b.txt', {timeout => 120});
     upload_logs('/var/log/audit/audit.log', log_name => "audit.txt");
 }


### PR DESCRIPTION
Increase timeout and use -b with journalctl to get only the journal from the current boot.

- Failed test: https://openqa.opensuse.org/tests/4847468#step/podman_integration/321
- Verification run: not needed.