### PR TITLE
update_install: Add libica-openssl1_1-tools on s390x

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -81,6 +81,7 @@ my @conflicting_packages = (
     'nfsidmap-devel',
     'libglfw3',
     'openvpn-dco',
+    'libica-openssl1_1-tools',
     'cyrus-sasl-bdb-ntlm', 'cyrus-sasl-bdb-otp', 'cyrus-sasl-saslauthd-bdb', 'cyrus-sasl-otp',
     'cyrus-sasl-ntlm', 'cyrus-sasl-bdb-devel', 'cyrus-sasl-sqlauxprop',
     'kernel-firmware-nvidia-gspx-G06-cuda', 'nvidia-open-driver-G06-signed-cuda-kmp-default',


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/176928
- Verification run:
https://openqa.suse.de/tests/16727210
https://openqa.suse.de/tests/16727239