### PR TITLE
containers: Disable tmpfs on all BATS tests

### DIFF
--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats patch_logfile switch_to_user delegate_controllers enable_modules remove_mounts_conf bats_post_hook);
+use containers::bats;
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -61,11 +61,7 @@ sub run {
     push @pkgs, qw(crun) if is_tumbleweed;
     install_packages(@pkgs);
 
-    delegate_controllers;
-
-    remove_mounts_conf;
-
-    switch_cgroup_version($self, 2);
+    $self->bats_setup;
 
     record_info("buildah version", script_output("buildah --version"));
     record_info("buildah info", script_output("buildah info"));

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -15,7 +15,7 @@ use utils qw(script_retry);
 use version_utils qw(is_sle is_tumbleweed);
 use containers::common;
 use Utils::Architectures qw(is_x86_64 is_aarch64);
-use containers::bats qw(install_bats install_ncat patch_logfile remove_mounts_conf switch_to_user delegate_controllers enable_modules bats_post_hook);
+use containers::bats;
 
 my $test_dir = "/var/tmp";
 my $podman_version = "";
@@ -82,14 +82,10 @@ sub run {
     assert_script_run "echo -e '[engine]\nruntime=\"$oci_runtime\"' >> /etc/containers/containers.conf.d/engine.conf";
     record_info("OCI runtime", $oci_runtime);
 
-    delegate_controllers;
+    $self->bats_setup;
 
     assert_script_run "podman system reset -f";
     assert_script_run "modprobe ip6_tables";
-
-    remove_mounts_conf;
-
-    switch_cgroup_version($self, 2);
 
     record_info("podman version", script_output("podman version"));
     record_info("podman info", script_output("podman info"));

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
-use containers::bats qw(install_bats patch_logfile switch_to_user delegate_controllers enable_modules bats_post_hook);
+use containers::bats;
 use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp";
@@ -55,9 +55,7 @@ sub run {
     push @pkgs, "criu" if is_tumbleweed;
     install_packages(@pkgs);
 
-    delegate_controllers;
-
-    switch_cgroup_version($self, 2);
+    $self->bats_setup;
 
     record_info("runc version", script_output("runc --version"));
     record_info("runc features", script_output("runc features"));

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -13,7 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use Utils::Architectures qw(is_x86_64);
-use containers::bats qw(install_bats patch_logfile remove_mounts_conf switch_to_user enable_modules bats_post_hook);
+use containers::bats;
 use version_utils qw(is_sle is_sle_micro);
 
 my $test_dir = "/var/tmp";
@@ -62,12 +62,10 @@ sub run {
     my @pkgs = qw(apache2-utils jq openssl podman skopeo);
     install_packages(@pkgs);
 
+    $self->bats_setup;
+
     record_info("skopeo version", script_output("skopeo --version"));
     record_info("skopeo package version", script_output("rpm -q skopeo"));
-
-    remove_mounts_conf;
-
-    switch_to_user;
 
     assert_script_run "cd $test_dir";
 


### PR DESCRIPTION
Disable tmpfs on all BATS tests as some subtests seem to ignore the `BATS_TMPDIR` & `TMPDIR` environment variables and tmpfs doesn't support SELinux labels.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1236924

- Verification runs:
  - buildah: https://openqa.opensuse.org/tests/4849871
  - podman: https://openqa.opensuse.org/tests/4849872
  - runc / skopeo: https://openqa.opensuse.org/tests/4849873
