### PR TITLE
Make crypto_policies test independet of killall/psmisc

### DIFF
--- a/data/security/crypto_policies/test_nss_client.sh
+++ b/data/security/crypto_policies/test_nss_client.sh
@@ -20,4 +20,4 @@ SERVER_PID=$!
 sleep 3
 # stop the server and the background client
 kill $SERVER_PID
-killall tstclnt
+kill $(pidof tstclnt)


### PR DESCRIPTION
Use kill pidof instead of killall which is not installed by default in SLE16 

- Related ticket: https://progress.opensuse.org/issues/176967
- Verification run: 
 - SLE16.0: https://openqa.suse.de/tests/16727374
 - SLE15SP7: https://openqa.suse.de/tests/16728026