### PR TITLE
Enhance to filter out the correct ethernet adapter

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -575,7 +575,7 @@ EOF
             if ($section eq 'migration_test') {
                 assert_script_run("kubectl delete net-attach-def migration-cni -n kubevirt") if (!script_run("kubectl get net-attach-def -A | grep migration-cni"));
                 $server_ip = script_output("nslookup " . get_required_var('SUT_IP') . "|sed -n '5,1p'|awk -F' ' '{print \$2}'");
-                $nic_name = script_output("ip addr | grep $server_ip | awk -F' ' '{print \$NF}'");
+                $nic_name = script_output("ip addr | grep $server_ip/ | awk -F' ' '{print \$NF}'");
                 $extra_opt = "-migration-network-nic=$nic_name";
             }
 


### PR DESCRIPTION
If the similar ip address appears in the same host, it cannot filter out the unique ethernet adapter, refer to the following example. So to fix it, just appending an end character to avoid such case.
```
# ip addr | grep 10.145.10.18 
inet 10.145.10.18/24 brd 10.145.10.255 scope global dynamic noprefixroute eth0
inet 10.145.10.181/24 brd 10.145.10.255 scope global dynamic noprefixroute eth1
```

- Related ticket: https://progress.opensuse.org/issues/177006
- Verification run: https://openqa.suse.de/tests/16741955
