### PR TITLE
Adapt krb5 tests for SLE16

### DIFF
--- a/lib/mm_tests.pm
+++ b/lib/mm_tests.pm
@@ -27,8 +27,8 @@ our @EXPORT = qw(
 sub configure_static_network {
     my $ip = shift;
 
-    configure_default_gateway;
     configure_static_ip(ip => $ip);
+    configure_default_gateway;
     configure_static_dns(get_host_resolv_conf());
     restart_networking();
     assert_script_run "ping -c 1 10.0.2.2 || journalctl -b --no-pager -o short-precise >/dev/$serialdev";

--- a/tests/security/krb5/krb5_crypt_prepare.pm
+++ b/tests/security/krb5/krb5_crypt_prepare.pm
@@ -29,7 +29,6 @@ sub krb5_network_config {
     # Append to /etc/hosts
     assert_script_run("sed -i \"s/\\($ip.*\$\\)/\\1 $hostname/g\" /etc/hosts");
     assert_script_run("cat /etc/hosts");
-
     configure_static_network("$ip/24");
 }
 
@@ -79,11 +78,15 @@ EOF
 
         mutex_create "KRB5_CLIENT_NETWORK_READY";
     }
-    else {    # Avoid misconfigration in lib/main_comman.pm
+    else {    # Avoid misconfiguration in lib/main_common.pm
         die "Unrecognized value of SECURITY_TEST";
     }
 
-    (is_sle('<15')) ? systemctl('stop SuSEfirewall2') : systemctl('stop firewalld');
+    if (is_sle '<15') {
+        systemctl('stop SuSEfirewall2');
+    } elsif (is_sle '<16') {
+        systemctl('stop firewalld');
+    }    # on SLE16 firewalld is not installed by default
 
     # Prepare krb5 application and config files
     zypper_call('ref');
@@ -102,7 +105,7 @@ EOF
     dns_canonicalize_hostname = false
     rdns = false
     default_realm = EXAMPLE.COM
-    allow_week_crypto = false
+    allow_weak_crypto = false
     default_tgs_enctypes = $algo
     default_tkt_enctypes = $algo
     permitted_enctypes = $algo


### PR DESCRIPTION
This PR is intended to have the needed code in place to run the test on SLE16.

- Related ticket: https://progress.opensuse.org/issues/176385
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/16739157

(VR itself is failing for a known bug, bsc#1237064)