### PR TITLE
Install device-mapper package in dm_crypt test

### DIFF
--- a/tests/security/check_kernel_config/dm_crypt.pm
+++ b/tests/security/check_kernel_config/dm_crypt.pm
@@ -23,7 +23,7 @@ sub run {
     select_serial_terminal;
 
     # Install runtime dependencies
-    zypper_call("in sudo");
+    zypper_call("in sudo device-mapper");
 
     # Simulate a ram device
     assert_script_run("modprobe brd rd_nr=1 rd_size=512000");


### PR DESCRIPTION
Ensure device-mapper is installed before test.

- Related ticket: https://progress.opensuse.org/issues/177030
- Verification run: 
  - SLE16.0: https://openqa.suse.de/tests/16739005
  - SLE15.7: https://openqa.suse.de/tests/16739201
  - SLE15.6: https://openqa.suse.de/tests/16739270
  - SLE15.3: https://openqa.suse.de/tests/16739271
