### PR TITLE
Check LTSS status from SUSEConnect -l

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -139,11 +139,7 @@ sub run {
     return if (get_var('HELM_CONFIG') && !($host_distri == "sles" && $version == 15 && $sp >= 3));
 
     # Ensure LTSS subscription is active when testing LTSS containers.
-    my $ltss_command = qq(SUSEConnect -s | jq -Mr '.[] | select(.identifier == "SLES-LTSS") | .subscription_status');
-    if (get_var('CONTAINER_IMAGE_TO_TEST') =~ /ltss/i) {
-        assert_script_run("SUSEConnect --status-text");
-        validate_script_output($ltss_command, qr/ACTIVE/, fail_message => "Host requires LTSS subscription for LTSS container");
-    }
+    validate_script_output("SUSEConnect -l", qr/.*LTSS.*Activated/, fail_message => "Host requires LTSS subscription for LTSS container") if (get_var('CONTAINER_IMAGE_TO_TEST') =~ /ltss/i);
 
     # For BCI tests using podman, buildah package is also needed
     install_buildah_when_needed($host_distri) if ($engines =~ /podman/);


### PR DESCRIPTION
On 12-SP5 the LTSS subscription [is not printed in the json output](https://bugzilla.suse.com/show_bug.cgi?id=1237089). This commit switches the check to `SUSEConnect -l` where LTSS is present.

- Related ticket: https://progress.opensuse.org/issues/176700

## Verification runs

* https://openqa.suse.de/tests/16740717#step/bci_prepare/43
* https://openqa.suse.de/tests/16740719#step/bci_prepare/40
