### PR TITLE
yast: Do not test apparmor module on selinux enabled system

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1490,7 +1490,7 @@ sub load_extra_tests_y2uitest_ncurses {
         loadtest "console/yast2_nis" if is_sle;
         loadtest "console/yast2_http";
         loadtest "console/yast2_ftp";
-        loadtest "console/yast2_apparmor";
+        loadtest "console/yast2_apparmor" unless has_selinux;
         loadtest "console/yast2_lan";
         loadtest "console/yast2_lan_device_settings";
     }

--- a/schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+++ b/schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
@@ -18,7 +18,6 @@ schedule:
   - console/yast2_proxy
   - console/yast2_vnc
   - console/yast2_ftp
-  - console/yast2_apparmor
   - console/yast2_lan
   - console/yast2_lan_device_settings
   - console/yast2_lan_hostname/dhcp_no


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/166613
- Needles: N/A
- Verification run: N/A
