### PR TITLE
Avoid false positive for Ansible failure

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -70,7 +70,6 @@ our @EXPORT = qw(
   qesap_ansible_script_output
   qesap_ansible_fetch_file
   qesap_ansible_reg_module
-  qesap_ansible_error_detection
   qesap_create_ansible_section
   qesap_remote_hana_public_ips
   qesap_wait_for_ssh
@@ -2427,9 +2426,13 @@ sub qesap_az_diagnostic_log {
     qesap_terrafom_ansible_deploy_retry( error_log=>$error_log )
         error_log - ansible error log file name
 
-    Retry to deploy terraform + ansible
-    Return 0: we manage the failure properly
-    Return 1: something went wrong or we do not know what to do with the failure
+    Retry to deploy terraform + ansible. This function is only expected to be called if a previous `qesap.py`
+    execution returns a non zero exit code. If this function is called after a successful execution,
+    the qesap_ansible_error_detection will not find anything wrong in the log, wrongly concluding that
+    an unknown error is in the log and skipping the retry and this function will return 1.
+.
+    Return 0: this function manage the failure properly, perform a retry and retry was a successful deployment
+    Return 1: something went wrong or this function does not know what to do with the failure
 
 =over
 
@@ -2445,6 +2448,7 @@ sub qesap_terrafom_ansible_deploy_retry {
     foreach (qw(error_log provider)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
 
     my $detected_error = qesap_ansible_error_detection(error_log => $args{error_log});
+    record_info('qesap_terrafom_ansible_deploy_retry', "detected error:$detected_error");
     my @ret;
     # 3: no sudo password
     if ($detected_error eq 3) {
@@ -2505,6 +2509,13 @@ sub qesap_terrafom_ansible_deploy_retry {
         record_info('ANSIBLE RETRY PASS');
         $detected_error = 0;
     }
+    else {
+        # qesap_ansible_error_detection return:
+        # - 0 (unknown error),
+        # - 1 (generic fatal, not something we can solve by retry) or something else...
+        # Mark both as a failure in the retry, allowing error to be propagated.
+        $detected_error = 1;
+    }
     return $detected_error;
 }
 
@@ -2515,8 +2526,8 @@ sub qesap_terrafom_ansible_deploy_retry {
     Inspect the provided Ansible log and search for known issue in the log
     Also provide a nice record_info to summarize the error
     Return:
-     - 0: no errors
-     - 1: unknown generic error
+     - 0: unable to detect errors
+     - 1: generic fatal error
      - 2: reboot timeout
      - 3: no sudo password
 
@@ -2561,7 +2572,7 @@ sub qesap_ansible_error_detection {
   qesap_test_postfail()
 
   Post fail tasks suitable for post_fail_hook of the test modules.
-  This API is mainly designed for qesap regresstion test modules.
+  This API is mainly designed for qesap regression test modules.
 
 =over
 

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -47,6 +47,7 @@ sub run {
         logname => 'qesap_exec_ansible.log.txt',
         verbose => 1,
         timeout => 3600);
+    record_info('ANSIBLE RESULT', "ret0:$ret[0] ret1:$ret[1]");
     my $find_cmd = join(' ',
         'find',
         '/tmp/results/',
@@ -57,7 +58,7 @@ sub run {
         #enter_cmd("rm $log");
     }
     if ($ret[0]) {
-        # Retry to deploy terraform + ansible
+        record_info("Retry to deploy terraform + ansible");
         if (qesap_terrafom_ansible_deploy_retry(error_log => $ret[1], provider => $provider)) {
             die "Retry failed, original ansible return: $ret[0]";
         }
@@ -70,6 +71,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    record_info('POST FAIL HOOK');
     qesap_cluster_logs();
     qesap_upload_logs();
     my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -71,7 +71,6 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    record_info('POST FAIL HOOK');
     qesap_cluster_logs();
     qesap_upload_logs();
     my $inventory = qesap_get_inventory(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));


### PR DESCRIPTION
Issue is about Ansible deployment stage for jobs using
qe-sap-deployment.
Avoid that Ansible error that are not `Failure:` or `Fatal:` result in
false positive. Propagate error to test module.


- Related ticket: 

# Verification run:

## qesap regression
sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6_PAYG-qesap_gcp_sapconf_test
 - http://openqaworker15.qa.suse.cz/tests/313419 :green_circle: 

sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test_spn
- http://openqaworker15.qa.suse.cz/tests/313420 :green_circle: 

## HanaSR
sle-15-SP6-HanaSr-Aws-Payg-x86_64-Build15-SP6_2025-02-12T03:03:18Z-hanasr_aws_test_fencing_native_crash ec2_r4.8xlarge
- http://openqaworker15.qa.suse.cz/tests/313421

sle-12-SP5-HanaSr-Gcp-Byos-x86_64-Build12-SP5_2025-02-12T03:03:18Z-hanasr_gcp_test_fencing_native_ltss_es gce_n1_highmem_8
- http://openqaworker15.qa.suse.cz/tests/313422
