### PR TITLE
containers: Fix BATS tests on SELinux

### DIFF
--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -26,8 +26,10 @@ sub run_tests {
 
     my $log_file = "runc-" . ($rootless ? "user" : "root") . ".tap";
 
+    my $tmp_dir = script_output "mktemp -d -p $test_dir test.XXXXXX";
+
     my %_env = (
-        BATS_TMPDIR => "/var/tmp",
+        BATS_TMPDIR => $tmp_dir,
         RUNC_USE_SYSTEMD => "1",
         RUNC => "/usr/bin/runc",
     );
@@ -39,6 +41,8 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('RUNC_BATS_SKIP', '') . " " . $skip_tests);
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
+
+    script_run "rm -rf $tmp_dir";
 
     return ($ret);
 }

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -34,8 +34,10 @@ sub run_tests {
     # Default quay.io/libpod/registry:2 image used by the test only has amd64 image
     my $registry = is_x86_64 ? "" : "docker.io/library/registry:2";
 
+    my $tmp_dir = script_output "mktemp -d -p $test_dir test.XXXXXX";
+
     my %_env = (
-        BATS_TMPDIR => "/var/tmp",
+        BATS_TMPDIR => $tmp_dir,
         SKOPEO_BINARY => "/usr/bin/skopeo",
         SKOPEO_TEST_REGISTRY_FQIN => $registry,
     );
@@ -47,6 +49,8 @@ sub run_tests {
     my @skip_tests = split(/\s+/, get_var('SKOPEO_BATS_SKIP', '') . " " . $skip_tests);
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
+
+    script_run "rm -rf $tmp_dir";
 
     return ($ret);
 }


### PR DESCRIPTION
Fix BATS tests on SELinux.

Apply workaround suggested in [podman documentation](https://github.com/containers/podman/blob/main/troubleshooting.md#11-changing-the-location-of-the-graphroot-leads-to-permission-denied)

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1236924
- Failed tests:
  - buildah: https://openqa.opensuse.org/tests/4851942#external
  - podman: https://openqa.opensuse.org/tests/4851946#external
- Verification runs:
  - buildah: https://openqa.opensuse.org/tests/4854743
  - podman: https://openqa.opensuse.org/tests/4854744
  - runc / skopeo: https://openqa.opensuse.org/tests/4854694

Notes:
  - The buildah & podman failed VR's are addressed here:
https://github.com/os-autoinst/opensuse-jobgroups/pull/599
  - More work is needed on individual subtests to unskip them.