### PR TITLE
Add testing for docker-stable

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -95,11 +95,7 @@ sub install_docker_when_needed {
     record_info("get_os_release", "'$running_version', '$sp', '$host_os'");
     if (script_run("which docker") != 0) {
         my $ltss_needed = 0;
-        if (is_transactional) {
-            select_console 'root-console';
-            trup_call("pkg install docker");
-            check_reboot_changes;
-        } elsif ($host_os eq 'centos') {
+        if ($host_os eq 'centos') {
             assert_script_run "dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo";
             # if podman installed use flag "--allowerasing" to solve conflicts
             assert_script_run "dnf -y install docker-ce --nobest --allowerasing", timeout => 300;
@@ -108,26 +104,34 @@ sub install_docker_when_needed {
             assert_script_run "apt-cache policy docker-ce";
             script_retry("apt-get -y install docker-ce", timeout => 300);
         } else {
-            if ($host_os =~ 'sle') {
-                # We may run openSUSE with DISTRI=sle and openSUSE does not have SUSEConnect
-                activate_containers_module if ($running_version =~ "15");
+            my $pkg_name = check_var("DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
 
-                # Temporarly enable LTSS product on LTSS systems where it is not present
-                if (get_var('SCC_REGCODE_LTSS') && script_run('test -f /etc/products.d/SLES-LTSS.prod') != 0 && !main_common::is_updates_tests) {
-                    add_suseconnect_product('SLES-LTSS', undef, undef, '-r ' . get_var('SCC_REGCODE_LTSS'), 150);
-                    $ltss_needed = 1;
+            if (is_transactional) {
+                select_console 'root-console';
+                trup_call("pkg install $pkg_name");
+                check_reboot_changes;
+            } else {
+                if ($host_os =~ 'sle') {
+                    # We may run openSUSE with DISTRI=sle and openSUSE does not have SUSEConnect
+                    activate_containers_module if ($running_version =~ "15");
+
+                    # Temporarly enable LTSS product on LTSS systems where it is not present
+                    if (get_var('SCC_REGCODE_LTSS') && script_run('test -f /etc/products.d/SLES-LTSS.prod') != 0 && !main_common::is_updates_tests) {
+                        add_suseconnect_product('SLES-LTSS', undef, undef, '-r ' . get_var('SCC_REGCODE_LTSS'), 150);
+                        $ltss_needed = 1;
+                    }
                 }
+
+                # docker package can be installed
+                zypper_call("in $pkg_name", timeout => 300);
+
+                # Restart firewalld if enabled before. Ensure docker can properly interact (boo#1196801)
+                if (script_run('systemctl is-active firewalld') == 0) {
+                    systemctl 'try-restart firewalld';
+                }
+
+                remove_suseconnect_product('SLES-LTSS') if $ltss_needed && !main_common::is_updates_tests;
             }
-
-            # docker package can be installed
-            zypper_call('in docker', timeout => 300);
-
-            # Restart firewalld if enabled before. Ensure docker can properly interact (boo#1196801)
-            if (script_run('systemctl is-active firewalld') == 0) {
-                systemctl 'try-restart firewalld';
-            }
-
-            remove_suseconnect_product('SLES-LTSS') if $ltss_needed && !main_common::is_updates_tests;
         }
     }
 

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -90,49 +90,56 @@ sub install_podman_when_needed {
     systemctl("stop firewalld") if ($host_os =~ 'tumbleweed');
 }
 
+sub install_docker_multiplatform {
+    my ($running_version, $sp, $host_os) = get_os_release;
+    my $ltss_needed = 0;
+    if ($host_os eq 'centos') {
+        assert_script_run "dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo";
+        # if podman installed use flag "--allowerasing" to solve conflicts
+        assert_script_run "dnf -y install docker-ce --nobest --allowerasing", timeout => 300;
+        return;
+    }
+    if ($host_os eq 'ubuntu') {
+        # Make sure you are about to install from the Docker repo instead of the default Ubuntu repo
+        assert_script_run "apt-cache policy docker-ce";
+        script_retry("apt-get -y install docker-ce", timeout => 300);
+        return;
+    }
+
+    my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
+    if (is_transactional) {
+        select_console 'root-console';
+        trup_call("pkg install $pkg_name");
+        check_reboot_changes;
+    } else {
+        if ($host_os =~ 'sle') {
+            # We may run openSUSE with DISTRI=sle and openSUSE does not have SUSEConnect
+            activate_containers_module if ($running_version =~ "15");
+
+            # Temporarly enable LTSS product on LTSS systems where it is not present
+            if (get_var('SCC_REGCODE_LTSS') && script_run('test -f /etc/products.d/SLES-LTSS.prod') != 0 && !main_common::is_updates_tests) {
+                add_suseconnect_product('SLES-LTSS', undef, undef, '-r ' . get_var('SCC_REGCODE_LTSS'), 150);
+                $ltss_needed = 1;
+            }
+        }
+
+        # docker package can be installed
+        zypper_call("in $pkg_name", timeout => 300);
+
+        # Restart firewalld if enabled before. Ensure docker can properly interact (boo#1196801)
+        if (script_run('systemctl is-active firewalld') == 0) {
+            systemctl 'try-restart firewalld';
+        }
+
+        remove_suseconnect_product('SLES-LTSS') if $ltss_needed && !main_common::is_updates_tests;
+    }
+}
+
 sub install_docker_when_needed {
     my ($running_version, $sp, $host_os) = get_os_release;
     record_info("get_os_release", "'$running_version', '$sp', '$host_os'");
     if (script_run("which docker") != 0) {
-        my $ltss_needed = 0;
-        if ($host_os eq 'centos') {
-            assert_script_run "dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo";
-            # if podman installed use flag "--allowerasing" to solve conflicts
-            assert_script_run "dnf -y install docker-ce --nobest --allowerasing", timeout => 300;
-        } elsif ($host_os eq 'ubuntu') {
-            # Make sure you are about to install from the Docker repo instead of the default Ubuntu repo
-            assert_script_run "apt-cache policy docker-ce";
-            script_retry("apt-get -y install docker-ce", timeout => 300);
-        } else {
-            my $pkg_name = check_var("DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
-
-            if (is_transactional) {
-                select_console 'root-console';
-                trup_call("pkg install $pkg_name");
-                check_reboot_changes;
-            } else {
-                if ($host_os =~ 'sle') {
-                    # We may run openSUSE with DISTRI=sle and openSUSE does not have SUSEConnect
-                    activate_containers_module if ($running_version =~ "15");
-
-                    # Temporarly enable LTSS product on LTSS systems where it is not present
-                    if (get_var('SCC_REGCODE_LTSS') && script_run('test -f /etc/products.d/SLES-LTSS.prod') != 0 && !main_common::is_updates_tests) {
-                        add_suseconnect_product('SLES-LTSS', undef, undef, '-r ' . get_var('SCC_REGCODE_LTSS'), 150);
-                        $ltss_needed = 1;
-                    }
-                }
-
-                # docker package can be installed
-                zypper_call("in $pkg_name", timeout => 300);
-
-                # Restart firewalld if enabled before. Ensure docker can properly interact (boo#1196801)
-                if (script_run('systemctl is-active firewalld') == 0) {
-                    systemctl 'try-restart firewalld';
-                }
-
-                remove_suseconnect_product('SLES-LTSS') if $ltss_needed && !main_common::is_updates_tests;
-            }
-        }
+        install_docker_multiplatform;
     }
 
     # Disable docker's own rate-limit in the service file (3 restarts in 60s)

--- a/variables.md
+++ b/variables.md
@@ -51,6 +51,7 @@ CONTAINERS_NO_SUSE_OS | boolean | false | Used by main_containers to see if the 
 CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.
 CONTAINERS_CRICTL_VERSION | string | v1.23.0 | The version of CriCtl tool.
 CONTAINERS_NERDCTL_VERSION | string | 0.16.1 | The version of NerdCTL tool.
+CONTAINERS_DOCKER_FLAVOUR | string | | Flavour of docker to install. Valid options are `stable` or undefined (for standard docker package)
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.


### PR DESCRIPTION
Establishes test runs for docker-stable on standard and transactional OpenSUSE-based systems

- Related ticket: [https://progress.opensuse.org/issues/176550](https://progress.opensuse.org/issues/176550)
- Needles: N/A
- Verification run: [https://openqa.suse.de/tests/16741950#step/docker/44](https://openqa.suse.de/tests/16741950#step/docker/44)

Enablement for all SLES versions: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2067