### PR TITLE
Public Cloud: Refactor SUPER post_fail_hook

### DIFF
--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -35,11 +35,6 @@ sub run {
 
 sub cleanup {
     my ($self) = @_;
-    my @logs = ('/var/log/cloudregister', '/etc/hosts', '/var/log/zypper.log', '/etc/zypp/credentials.d/SCCcredentials');
-    $self->{run_args}->{my_instance}->ssh_script_run("sudo chmod a+r " . join(' ', @logs));
-    for my $file (@logs) {
-        $self->{run_args}->{my_instance}->upload_log($file, log_name => $autotest::current_test->{name} . '-' . basename($file) . '.txt');
-    }
     if (is_azure()) {
         record_info('azuremetadata', $self->{run_args}->{my_instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
     }

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -23,27 +23,25 @@ use File::Basename 'basename';
 sub run {
     my ($self, $args) = @_;
 
-    $self->{instance} = $args->{my_instance};
-
     select_host_console();    # select console on the host, not the PC instance
 
     registercloudguest($args->{my_instance}) if (is_byos() || get_var('PUBLIC_CLOUD_FORCE_REGISTRATION'));
     register_addons_in_pc($args->{my_instance});
     # Since SLE 15 SP6 CHOST images don't have curl and we need it for testing
     if (is_sle('>15-SP5') && is_container_host()) {
-        $self->{instance}->ssh_assert_script_run('sudo zypper -n in --force-resolution -y curl');
+        $args->{my_instance}->ssh_assert_script_run('sudo zypper -n in --force-resolution -y curl');
     }
 }
 
 sub cleanup {
     my ($self) = @_;
     my @logs = ('/var/log/cloudregister', '/etc/hosts', '/var/log/zypper.log', '/etc/zypp/credentials.d/SCCcredentials');
-    $self->{instance}->ssh_script_run("sudo chmod a+r " . join(' ', @logs));
+    $self->{run_args}->{my_instance}->ssh_script_run("sudo chmod a+r " . join(' ', @logs));
     for my $file (@logs) {
-        $self->{instance}->upload_log($file, log_name => $autotest::current_test->{name} . '-' . basename($file) . '.txt');
+        $self->{run_args}->{my_instance}->upload_log($file, log_name => $autotest::current_test->{name} . '-' . basename($file) . '.txt');
     }
     if (is_azure()) {
-        record_info('azuremetadata', $self->{instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
+        record_info('azuremetadata', $self->{run_args}->{my_instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
     }
 }
 


### PR DESCRIPTION
The goal of this PR is to always upload the same logs in any Public Cloud test.

Related ticket: https://progress.opensuse.org/issues/176898

Verification runs:

https://openqa.suse.de/tests/16748065 (with https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21197/commits/c2cb1f7ecaca22f2b3e587820e2e58f745ad9408 to force a failure)
https://openqa.suse.de/tests/16754159 (QE-SAP)
https://openqa.suse.de/tests/16754192#step/registration/33 (Azure with wrong REGCODE to force a failure in registration.pm)