### PR TITLE
Revert "pynfs: Don't use xdrlib3"

### DIFF
--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -53,9 +53,7 @@ sub install_testsuite {
         $rel = "-b $rel" if ($rel);
 
         install_dependencies_pynfs;
-        assert_script_run("git clone $url $rel && cd ./pynfs");
-        #workaround poo#176907, don't use xdrlib3
-        assert_script_run('git checkout dfb0b07eb5c0579d34f321d27a9d3434f75be38a~');
+        assert_script_run("git clone -q --depth 1 $url $rel && cd ./pynfs");
         assert_script_run('./setup.py build && ./setup.py build_ext --inplace');
     }
     elsif (get_var("CTHON04")) {


### PR DESCRIPTION
This reverts commit 55073f5bd5a3f2addfc77a01b93f8d9b3ac2b2e3.

Problem was fixed upstream:
https://git.linux-nfs.org/?p=cdmackay/pynfs.git;a=commit;h=d80769a2160ca80362aef8f53e41c6d33dc76637

Fixes: https://progress.opensuse.org/issues/176907

Verification run: (still running)
- https://openqa.suse.de/tests/overview?build=revert-pynfs-workaround
- https://openqa.opensuse.org/tests/overview?build=revert-pynfs-workaround
