### PR TITLE
Fix WE module variable in scheduling

### DIFF
--- a/schedule/security/fips/fips_ker_mode_gnome.yaml
+++ b/schedule/security/fips/fips_ker_mode_gnome.yaml
@@ -22,7 +22,7 @@ conditional_schedule:
             x86_64:
                 - fips/xca
     we_tests:
-        WE_REQUIRED:
+        RUN_WE_MODULE_TESTS:
             1:
                 - x11/seahorse_sshkey
                 - x11/hexchat_ssl


### PR DESCRIPTION
`schedule/security/fips/fips_ker_mode_gnome.yaml` contains `WE_REQUIRED` instead of `RUN_WE_MODULE_TESTS`, therefore we are not executing some specific tests.

- Related ticket: https://progress.opensuse.org/issues/177135
- Verification run: https://openqa.suse.de/tests/16751918