### PR TITLE
KLP: Install livepatches without discarding latest snapshot

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -64,7 +64,7 @@ sub install_klp_product {
         assert_script_run 'sed -i "/^multiversion =.*/c\\multiversion = provides:multiversion(kernel)" /etc/zypp/zypp.conf';
         assert_script_run 'sed -i "/^multiversion\.kernels =.*/c\\multiversion.kernels = latest" /etc/zypp/zypp.conf';
         assert_script_run 'echo "LIVEPATCH_KERNEL=\'always\'" >> /etc/sysconfig/livepatching';
-        install_package($livepatch_pack, trup_reboot => 1);
+        install_package($livepatch_pack, trup_continue => 1, trup_reboot => 1);
     } else {
         zypper_call("in -l -t product $lp_product", exitcode => [0, 102, 103]);
         zypper_call("mr -e kgraft-update") unless $livepatch_repo;


### PR DESCRIPTION
The default behavior of transactional-update is to discard all changes and copy the currently mounted snapshot. Add the missing continue flag when installing kernel-default-livepatch so that the command doesn't revert to the previous kernel in update_kernel.

- Related ticket: https://progress.opensuse.org/issues/176406
- Needles: N/A
- Verification runs:
  - install_ltp: https://openqa.suse.de/tests/16752053
  - kernel-live-patching: https://openqa.suse.de/tests/16752054