### PR TITLE
containers: Do not fail on findmnt

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -162,7 +162,7 @@ sub bats_setup {
     script_run "rm -vf /etc/containers/mounts.conf /usr/share/containers/mounts.conf";
 
     # Disable tmpfs from next boot
-    if (script_output("findmnt -no FSTYPE /tmp") =~ /tmpfs/) {
+    if (script_output("findmnt -no FSTYPE /tmp", proceed_on_failure => 1) =~ /tmpfs/) {
         # Bind mount /tmp to /var/tmp
         fix_tmp;
         $reboot_needed = 1;


### PR DESCRIPTION
Do not fail if `findmnt` fails due to `/tmp` not being a different partition.

Failing test: https://openqa.suse.de/tests/16764527#step/buildah_integration/98
