### PR TITLE
containers: Run rshared mount command if /tmp is a partition

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -181,7 +181,7 @@ sub bats_setup {
 
     select_serial_terminal;
 
-    assert_script_run "mount --make-rshared /tmp";
+    assert_script_run "mount --make-rshared /tmp" if (script_run("findmnt -no FSTYPE /tmp") == 0);
 }
 
 sub selinux_hack {


### PR DESCRIPTION
Run rshared mount command if /tmp is a partition.  Fixes 15-SP7 weirdness where `/tmp` is not a different partition.  Likely a bug.

Failed test: https://openqa.suse.de/tests/16767504#step/skopeo_integration/104
VR: Not needed.  Hotfix.
