### PR TITLE
Minor fixes for BATS tests

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -23,6 +23,7 @@ use Utils::Architectures 'is_aarch64';
 use Utils::Logging 'save_and_upload_log';
 use bootloader_setup 'add_grub_cmdline_settings';
 use power_action_utils 'power_action';
+use List::MoreUtils qw(uniq);
 
 our @EXPORT = qw(
   bats_post_hook
@@ -126,6 +127,8 @@ sub enable_modules {
 
 sub patch_logfile {
     my ($log_file, @skip_tests) = @_;
+
+    @skip_tests = uniq sort @skip_tests;
 
     foreach my $test (@skip_tests) {
         next if ($test eq "none");

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -78,8 +78,8 @@ sub run {
     script_retry("curl -sL https://github.com/containers/buildah/archive/refs/tags/v$buildah_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "cd $test_dir/buildah-$buildah_version/";
 
-    # Patch mkdir function to always use -p
-    assert_script_run "sed -i 's/run_unshared mkdir/& -p/' tests/helpers.bash";
+    # Patch mkdir to always use -p
+    assert_script_run "sed -i 's/ mkdir /& -p /' tests/*.bats tests/helpers.bash";
 
     # Compile helpers used by the tests
     my $helpers = script_output 'echo $(grep ^all: Makefile | grep -o "bin/[a-z]*" | grep -v bin/buildah)';

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -49,6 +49,16 @@ sub run_tests {
     script_run 'kill %1' if ($remote);
 
     my @skip_tests = split(/\s+/, get_required_var('PODMAN_BATS_SKIP') . " " . $skip_tests);
+
+    # Unconditionally ignore these flaky subtests
+    my @must_skip = (
+        # this test depends on the openQA worker's scheduler
+        "180-blkio",
+        # this test will fail if there's not "enough" free space
+        "320-system-df",
+    );
+    push @skip_tests, @must_skip;
+
     patch_logfile($log_file, @skip_tests);
     parse_extra_log(TAP => $log_file);
 


### PR DESCRIPTION
Minor fixes for BATS tests
  - Patch `mkdir` in buildah upstream tests to always use `mkdir -p`
  - Unconditionally ignore some flaky subtests in podman upstream tests

Related ticket: https://progress.opensuse.org/issues/176190

---

- Verification runs:
  - buildah 15-SP6: https://openqa.suse.de/tests/16771595
  - podman 15-SP6: https://openqa.suse.de/tests/16771596
  - buildah 15-SP5: https://openqa.suse.de/tests/16776853
  - buildah 15-SP4: https://openqa.suse.de/tests/16776855

Note: Any failure will be fixed with the relevant BATS_SKIP option.