### PR TITLE
vsftpd: Remove soft-fail bsc#1176813

### DIFF
--- a/tests/console/vsftpd.pm
+++ b/tests/console/vsftpd.pm
@@ -46,10 +46,8 @@ sub run {
     assert_script_run 'cd /tmp';
     assert_script_run 'wget ' . data_url('qam/vsftpd.tar.gz');
     assert_script_run 'tar xzfv vsftpd.tar.gz';
-    # The run_s390x.sh excludes the cases with anonymous user, which fail in s390x because of bsc#1176813
-    # To remove the condition and the run_s390x.sh when the bsc#1176813 is solved and keep only --> assert_script_run 'bash run.sh |& tee run.log', 300;
     if (is_s390x) {
-        record_soft_failure 'bsc#1176813 - vsftpd: security: one_process_model needs a better OS for the anonymous user scenarios';
+        record_info("bsc#1176813", "vsftpd: security: one_process_model needs a better OS for the anonymous user scenarios");
         assert_script_run 'bash run_s390x.sh |& tee run.log', 300;
     } else {
         assert_script_run 'bash run.sh |& tee run.log', 300;


### PR DESCRIPTION
[Bug ticket](https://bugzilla.suse.com/show_bug.cgi?id=1176813) is closed, maybe it makes sense to stop tracking the soft-failure.

- Related ticket: https://progress.opensuse.org/issues/174988
