### PR TITLE
Handle CC testing on s390x when ssh root login is disabled

### DIFF
--- a/lib/selinuxtest.pm
+++ b/lib/selinuxtest.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2020-2024 SUSE LLC
+# Copyright 2020-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Base module for SELinux test cases
@@ -18,6 +18,7 @@ use version_utils qw(has_selinux);
 use Utils::Backends 'is_pvm';
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
 use power_action_utils 'power_action';
+use Utils::Architectures 'is_s390x';
 
 use base "opensusebasetest";
 
@@ -121,7 +122,9 @@ sub reboot_and_reconnect {
 sub set_sestatus {
     my ($self, $mode, $type) = @_;
     my $selinux_config_file = '/etc/selinux/config';
-    select_serial_terminal;
+
+    # In CC testing, the root login will be disabled, so we need to use select_console
+    is_s390x() ? select_console 'root-console' : select_serial_terminal;
 
     # workaround for 'selinux-auto-relabel' in case: auto relabel then trigger reboot
     my $results = script_run("zypper --non-interactive se selinux-autorelabel");
@@ -145,7 +148,7 @@ sub set_sestatus {
 
     # reboot the vm and reconnect the console
     $self->reboot_and_reconnect(textmode => 1);
-    select_serial_terminal;
+    is_s390x() ? select_console 'root-console' : select_serial_terminal;
 
     validate_script_output(
         'sestatus',

--- a/schedule/security/cc_audit_tests_part2.yaml
+++ b/schedule/security/cc_audit_tests_part2.yaml
@@ -6,12 +6,12 @@ schedule:
     - security/boot_disk
     - security/cc/cc_audit_test_setup
     - '{{trustedprograms}}'
-    - '{{disable_root_ssh}}'
+    - security/selinux/selinux_setup
     - security/cc/filter
     - security/cc/syscalls
     - security/cc/polkit_tests
     - security/cc/audit_trail_protection
-    - security/selinux/selinux_setup
+    - '{{disable_root_ssh}}'
     - security/cc/libpam
 conditional_schedule:
     bootloader_zkvm:

--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 SUSE LLC
+# Copyright 2018-2025 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Setup environment for selinux tests.


### PR DESCRIPTION
`selinux_setup` needs special handling for root console on s390x

- Related ticket: https://progress.opensuse.org/issues/176088
- Needles: nope
- Verification runs:
   - https://openqa.suse.de/tests/16771623
   - https://openqa.suse.de/tests/16771625
   - https://openqa.suse.de/tests/16771628
   - https://openqa.suse.de/tests/16771630
   - https://openqa.suse.de/tests/16771631

