### PR TITLE
Add schedule for fips_ker_mode_openjdk

### DIFF
--- a/schedule/security/fips/fips_crypt_openjdk.yaml
+++ b/schedule/security/fips/fips_crypt_openjdk.yaml
@@ -1,0 +1,19 @@
+name: fips_crypt_openjdk
+description:    >
+    This is for the crypt_openjdk fips tests.
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - '{{repo_setup}}'
+    - fips/fips_setup
+    - fips/openjdk/prepare_env
+    - fips/openjdk/openjdk_fips
+conditional_schedule:
+    repo_setup:
+        BETA:
+            1:
+                - security/test_repo_setup
+        FLAVOR:
+            Online-QR:
+                - security/test_repo_setup


### PR DESCRIPTION
Add missing schedule after refactoring

- Related ticket: https://progress.opensuse.org/issues/177180
- Verification run: https://openqa.suse.de/tests/16804697
