### PR TITLE
containers: Install desired OCI runtime in buildah upstream tests

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -90,11 +90,7 @@ sub run {
     install_packages(@pkgs);
     install_ncat;
 
-    $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
-    install_packages($oci_runtime);
-    script_run "mkdir /etc/containers/containers.conf.d";
-    assert_script_run "echo -e '[engine]\nruntime=\"$oci_runtime\"' >> /etc/containers/containers.conf.d/engine.conf";
-    record_info("OCI runtime", $oci_runtime);
+    $oci_runtime = install_oci_runtime;
 
     $self->bats_setup;
 


### PR DESCRIPTION
Install desired OCI runtime in buildah upstream tests to help determine if buildah subtests failures are related to the OCI runtime.

- Verification runs:
  - Tumbleweed: https://openqa.opensuse.org/tests/4860718 (`OCI_RUNTIME=runc`). Fails for unknown reason.
  - SLES 15-SP6: https://openqa.suse.de/tests/16805847 (`OCI_RUNTIME=crun`). 
