### PR TITLE
smartcard: Don't expect pcsc-pcgem on Tumbleweed

### DIFF
--- a/tests/security/smartcard/version_check.pm
+++ b/tests/security/smartcard/version_check.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils qw(zypper_call systemctl package_upgrade_check);
 use registration 'add_suseconnect_product';
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_tumbleweed);
 
 sub run {
     select_serial_terminal;
@@ -30,6 +30,7 @@ sub run {
         'libp11-3' => '0.4.11',
         'pcsc-tools' => '1.5.8',
     };
+    delete $pkg_list->{'pcsc-gempc'} if is_tumbleweed;
     zypper_call("in " . join(' ', keys %$pkg_list));
     package_upgrade_check($pkg_list);
 


### PR DESCRIPTION
The package has been removed On Jan 5 2025
r28 | anag+factory | 2025-01-05 14:27:45 | 3c3c012dd26f056d70907349aafe924a | 1.0.8 | rq1231114

[botdel] Package has had build problems for >= 6 weeks

- Related ticket: https://progress.opensuse.org/issues/175015
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4860725
