### PR TITLE
Add softfailure for bsc#1229228

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -785,6 +785,13 @@
         },
         "type": "bug"
     },
+    "bsc#1229228": {
+        "description": "agetty\\[\\d+\\]: failed to open credentials directory",
+        "products": {
+            "sle": ["15-SP7"]
+        },
+        "type": "bug"
+    },
     "wicked-warning": {
         "description": "wicked.*: Interface wait time \\(30s\\) reached",
         "products": {


### PR DESCRIPTION
Make the known [bug#1229228](https://bugzilla.suse.com/show_bug.cgi?id=1229228) a softfailure.

- Related failure: https://openqa.suse.de/tests/16797290#step/journal_check/1
- Related bugzilla ticket: https://bugzilla.suse.com/show_bug.cgi?id=1229228
- Verification run: https://openqa.suse.de/tests/16816443#step/journal_check/1
