### PR TITLE
Add remote_python for HanaSR conf.yaml

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -20,6 +20,10 @@ terraform:
     os_owner: '%SLES4SAP_OS_OWNER%'
     vpc_address_range: '%MAIN_ADDRESS_RANGE%'
 
+    # REMOTE PYTHON
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+
     # HANA
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -16,6 +16,8 @@ terraform:
     admin_user: 'cloudadmin'
     public_key: '%SLES4SAP_PUBSSHKEY%'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
+
+    # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -18,6 +18,8 @@ terraform:
     admin_user: 'cloudadmin'
     public_key: '%SLES4SAP_PUBSSHKEY%'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
+
+    # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -17,6 +17,10 @@ terraform:
     public_key: '%SLES4SAP_PUBSSHKEY%'
     os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
 
+    # REMOTE PYTHON
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+
     # HANA
     hana_count: '%NODE_COUNT%'
     hana_ha_enabled: '%HA_CLUSTER%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
@@ -18,6 +18,8 @@ terraform:
     admin_user: 'cloudadmin'
     public_key: '%SLES4SAP_PUBSSHKEY%'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
+
+    # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
 
@@ -30,6 +32,7 @@ terraform:
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     hana_data_disk_type: 'pd-standard'
     hana_log_disk_type: 'pd-standard'
+
 ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'


### PR DESCRIPTION
Add terraform variable to be able to force a remote python version for Ansible in qe-sap-deployment  conf.yaml.


- Related ticket: TEAM-9910

# Verification run:

 - sle-12-SP5-EC2-SAP-BYOS-Incidents-x86_64-Build:37460:kernel-ec2-SAPHanaSR-ScaleUp-PerfOpt-native-ltsses-stop-kill@ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/314601