### PR TITLE
Set kube job termination and cleanup

### DIFF
--- a/tests/containers/run_container_in_k8s.pm
+++ b/tests/containers/run_container_in_k8s.pm
@@ -49,6 +49,8 @@ spec:
             memory: 128Mi
       restartPolicy: Never
   backoffLimit: 4
+  ttlSecondsAfterFinished: 30
+  activeDeadlineSeconds: 1700
 EOT
 
     record_info('Manifest', "Applying manifest:\n$manifest");


### PR DESCRIPTION
According to
https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup there are option to the manifest which ensures cleanup and termination of jobs. This can help us avoid hanging jobs in the cluster as the number of tests are increasing, especially with regard to BCI runs.

- ticket: https://progress.opensuse.org/issues/177420

