### PR TITLE
Fix buildx and rootless for docker-stable on Tumbleweed

### DIFF
--- a/tests/containers/buildx.pm
+++ b/tests/containers/buildx.pm
@@ -24,7 +24,9 @@ sub run {
     select_serial_terminal;
 
     install_docker_when_needed();
-    install_packages('docker-buildx');
+
+    my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
+    install_packages("$pkg_name-buildx");
 
     my $docker_info = script_output("docker info");
     record_info('Docker info post-install', $docker_info);

--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -33,7 +33,8 @@ sub run {
 
     my $docker = containers::docker->new();
 
-    install_packages('docker-rootless-extras');
+    my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
+    install_packages("$pkg_name-rootless-extras");
 
     my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/176550
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4863351