### PR TITLE
Fix test module vg md5sum cmd timed out issue

### DIFF
--- a/tests/ha/vg.pm
+++ b/tests/ha/vg.pm
@@ -158,7 +158,7 @@ sub run {
     barrier_wait("VG_RW_CHECKED_${barrier_tag}_$cluster_name");
 
     # Wait until files integrity are checked
-    assert_script_run "md5sum /dev/$vg_name/$lv_name" if ($resource ne 'drbd_passive');
+    assert_script_run "md5sum /dev/$vg_name/$lv_name", timeout => 300 if ($resource ne 'drbd_passive');
     barrier_wait("VG_MD5SUM_${barrier_tag}_$cluster_name");
 }
 


### PR DESCRIPTION
Fix test module vg md5sum cmd timed out issue



- Related ticket:  [TEAM-10088 - [15 SP7][HA] "ha_zalpha_node" sporadically fails on test module "vg": command 'md5sum /dev/vg_cluster_md/lv_openqa' timed out](https://jira.suse.com/browse/TEAM-10088)
- Verification run:
https://openqa.suse.de/tests/16816855/logfile?filename=autoinst-log.txt
`md5sum` took 3*60+30=210 seconds it verified the code change works.
```
[2025-02-18T11:47:44.672367Z] [debug] [pid:27894] <<< testapi::type_string(string="md5sum /dev/vg_cluster_md/lv_openqa", max_interval=250, wait_screen_change=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2025-02-18T11:47:45.905865Z] [debug] [pid:27894] tests/ha/vg.pm:161 called testapi::assert_script_run
[2025-02-18T11:47:45.906089Z] [debug] [pid:27894] <<< testapi::type_string(string="; echo vk6DG-\$?- > /dev/ttysclp0\n", max_interval=250, wait_screen_change=0, wait_still_screen=0, timeout=30, similarity_level=47)
[2025-02-18T11:47:47.106084Z] [debug] [pid:27894] tests/ha/vg.pm:161 called testapi::assert_script_run
[2025-02-18T11:47:47.106439Z] [debug] [pid:27894] <<< testapi::wait_serial(record_output=undef, quiet=undef, buffer_size=undef, timeout=180, no_regex=0, regexp=qr/vk6DG-\d+-/u, expect_not_found=0)
vk6DG-0-
[2025-02-18T11:51:16.278751Z] [debug] [pid:27894] >>> testapi::wait_serial: (?^u:vk6DG-\d+-): ok
```

