### PR TITLE
LTP: Remove LTP packages before installing one from repo

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -496,6 +496,10 @@ sub install_from_repo {
     # Lock kernel-default to don't pull it as LTP dependency
     zypper_call 'al kernel-default' if get_kernel_flavor eq 'kernel-64kb';
 
+    # Remove packages if they are installed - useful for testing to resolve
+    # conflicts when 'ltp-stable' is installed and 'ltp' to be installed.
+    zypper_call('rm ltp ltp-32bit ltp-stable ltp-stable-32bit qa_test_ltp', exitcode => [0, 104]);
+
     my @pkgs = split(/\s* \s*/, get_var('LTP_PKG', get_default_pkg));
 
     if (is_transactional) {


### PR DESCRIPTION
Remove packages if they are installed - useful for testing to resolve conflicts when 'ltp-stable' is installed and 'ltp' to be installed.

Example of the failure:
http://quasar.suse.cz/tests/331#step/install_ltp/63
`SATResolver.cc(problems):1378 the installed ltp-stable-20240930-qa.87.5.x86_64 conflicts with 'ltp' provided by the to be installed ltp-20250217.459b3cdf-qa.2072.1.x86_64`

Verification run:
* http://quasar.suse.cz/tests/333
* http://quasar.suse.cz/tests/326
* http://quasar.suse.cz/tests/348
