### PR TITLE
allow to control install_execution_mode

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -28,7 +28,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
@@ -31,7 +31,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -27,7 +27,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -26,7 +26,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -29,7 +29,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -29,7 +29,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
@@ -26,7 +26,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -24,7 +24,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
@@ -23,7 +23,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -24,7 +24,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -29,7 +29,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
@@ -31,7 +31,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -29,7 +29,8 @@ ansible:
     - '%HANA_CLIENT_SAR%'
     - '%HANA_SAPCAR%'
   hana_vars:
-    sap_hana_install_software_directory: /hana/shared/install
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
     sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
     sap_hana_install_sid: 'HQ0'
     sap_hana_install_instance_number: '00'

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -105,6 +105,7 @@ sub run {
     }
 
     $variables{ANSIBLE_ROLES} = qesap_get_ansible_roles_dir();
+    $variables{HANA_INSTALL_MODE} = get_var('QESAPDEPLOY_HANA_INSTALL_MODE', 'standard');
 
     qesap_prepare_env(
         openqa_variables => \%variables,


### PR DESCRIPTION
Allow to control it in qesap regression test suing an openQA variable Default value is 'default', but the variable allow to use 'optimized' when using HANA SPS8rev82.

- Related ticket: TEAM-10053

# Verification run:

## GCP

### qesap_gcp_sapconf.yaml

#### 15sp6
sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6_PAYG-qesap_gcp_sapconf_test
- http://openqaworker15.qa.suse.cz/tests/314625 :green_circle:  not set QESAPDEPLOY_HANA_INSTALL_MODE and use HANA installer SPS7
- http://openqaworker15.qa.suse.cz/tests/314626  :green_circle:  set QESAPDEPLOY_HANA_INSTALL_MODE=optimized and use HANA installer SPS8

### qesap_gcp.yaml

#### 12sp5
sle-12-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE12_5_PAYG-qesap_gcp_saptune_ltss_test
- http://openqaworker15.qa.suse.cz/tests/314633 :green_circle: failure is known issue in RA

## AWS

### qesap_aws.yaml

#### 12sp5
 sle-12-SP5-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE12_5_PAYG-qesap_aws_saptune_ltss_test
 - http://openqaworker15.qa.suse.cz/tests/314634
 
## AZURE

### qesap_azure.yaml

#### 15sp6
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test
- http://openqaworker15.qa.suse.cz/tests/314628 :green_circle: not set QESAPDEPLOY_HANA_INSTALL_MODE and use HANA installer SPS7
- http://openqaworker15.qa.suse.cz/tests/314627  :green_circle:  set QESAPDEPLOY_HANA_INSTALL_MODE=optimized and use HANA installer SPS8 (failure is later in destroy)

### qesap_azure_fencing_msi.yaml

#### 15sp6
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test_msi
 - http://openqaworker15.qa.suse.cz/tests/314629 :green_circle: not set QESAPDEPLOY_HANA_INSTALL_MODE and use HANA installer SPS7
 - http://openqaworker15.qa.suse.cz/tests/314630  :green_circle:   set QESAPDEPLOY_HANA_INSTALL_MODE=optimized and use HANA installer SPS8