### PR TITLE
Exclude libvorbis on SLES16+

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1709,7 +1709,7 @@ sub load_extra_tests_console {
             loadtest "console/wavpack";
         }
     }
-    loadtest "console/libvorbis";
+    loadtest "console/libvorbis" unless (is_sle("16+"));
     loadtest "console/command_not_found";
     if (is_sle('12-sp2+')) {
         loadtest 'console/openssl_alpn';

--- a/schedule/jeos/sle/minimalvm-toolchains.yaml
+++ b/schedule/jeos/sle/minimalvm-toolchains.yaml
@@ -1,0 +1,44 @@
+description: 'Test suite verifies functionality and integration of Development-Tools (sdk)'
+name: 'minimalvm-toolchains'
+conditional_schedule:
+    bootloader:
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+            'svirt-hyperv-uefi':
+                - installation/bootloader_hyperv
+            'svirt-hyperv':
+                - installation/bootloader_hyperv
+                - installation/bootloader_uefi
+            'svirt-vmware70':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+schedule:
+    - '{{bootloader}}'
+    - jeos/firstrun
+    - jeos/record_machine_id
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - jeos/grub2_gfxmode
+    - jeos/diskusage
+    - jeos/build_key
+    - console/suseconnect_scc
+    - console/consoletest_setup
+    - console/textinfo
+    - jeos/kiwi_templates
+    - console/zypper_ref
+    - console/command_not_found
+    - console/git
+    - console/java
+    - console/ant
+    - console/gdb
+    - console/perf
+    - console/update_alternatives
+    - toolchain/install
+    - toolchain/gcc_compilation
+    - toolchain/gcc_fortran_compilation
+    - console/orphaned_packages_check
+    - console/consoletest_finish


### PR DESCRIPTION
vorbis will not be part of SLES16 so there is no need to test it.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1236444

## Verification runs

* [MinimalVM 16](https://openqa.suse.de/tests/16820744) (libvorbis not scheduled)
* [SLES 15-SP7](https://openqa.suse.de/tests/16820737) (libvorbis scheduled)
* [Tumbleweed](https://openqa.opensuse.org/tests/4864738) (libvorbis scheduled)