### PR TITLE
GFX settings: move only 2 lines down

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -498,6 +498,8 @@ sub uefi_bootmenu_params {
         my $gfx = 2;
         if (is_leap_micro || is_microos || is_sle_micro) {
             $gfx += 5;
+        } elsif (is_sle('=12-SP5')) {
+            ;
         } else {
             $gfx++;
         }


### PR DESCRIPTION
In sle12sp5, the gfx parameter is on the third line and not the forth. Move only 2 lines down from the current position of the cursor.

- ticket: https://progress.opensuse.org/issues/177453
- Verification run: [sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20250218-1-jeos-kdump@64bit-virtio-vga](https://openqa.suse.de/tests/16827375#step/bootloader_uefi/3)
