### PR TITLE
year_2038: Remove soft failure bsc#1188626

### DIFF
--- a/tests/console/year_2038_detection.pm
+++ b/tests/console/year_2038_detection.pm
@@ -68,7 +68,7 @@ sub run {
     my $wtmp_output = script_output('last -F');
     if ($utmp_output !~ m/2038/sx || $wtmp_output !~ m/2038/sx) {
         if (is_sle('<16') || is_leap('<16.0') || is_sle_micro || is_leap_micro) {
-            record_soft_failure('bsc#1188626 SLE <= 15 not Y2038 compatible');
+            record_info("bsc#1188626", "SLE <= 15 not Y2038 compatible");
         }
         else {
             die('Not Y2038 compatible');


### PR DESCRIPTION
[Bug](https://bugzilla.suse.com/show_bug.cgi?id=1188626) status is WONTFIX, removing the soft-failure.

- Related ticket: https://progress.opensuse.org/issues/174988
