### PR TITLE
ulp_openposix: Redirect some output to offload test

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -109,21 +109,15 @@ sub log_versions {
     }
 
     if ($kernel_config) {
-        my $cmd = "echo '# $kernel_config'; echo; ";
-
         upload_logs($kernel_config, failok => 1);
 
         if ($kernel_config eq '/proc/config.gz') {
             record_soft_failure 'boo#1189879 missing kernel config in kernel package, use /proc/config.gz' if $report_missing_config;
-            $cmd .= "zcat $kernel_config";
         } else {
             if ($report_missing_config && $kernel_config !~ /^\/boot\/config-/) {
                 record_soft_failure 'boo#1189879 missing symlink to /boot, use config in /usr/lib/modules/';
             }
-            $cmd .= "cat $kernel_config";
         }
-
-        record_info('KERNEL CONFIG', script_output("$cmd"));
     } elsif ($report_missing_config) {
         record_soft_failure 'boo#1189879 missing kernel config';
     }

--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -124,7 +124,8 @@ sub run {
     schedule_tests('openposix', "_glibc-$libver");
     loadtest_kernel('ulp_threads', name => "ulp_threads_glibc-$libver",
         run_args => $tinfo);
-    zypper_call("in " . $tinfo->{packname});
+    zypper_call("in " . $tinfo->{packname} . " >& /tmp/zypper_openposix-livepatches.log", timeout => 1000);
+    upload_logs("/tmp/zypper_openposix-livepatches.log");
 
     # Run tests again with the next untested glibc version
     if ($tinfo->{run_id} < $#{$tinfo->{glibc_versions}}) {
@@ -137,6 +138,11 @@ sub run {
     else {
         shutdown_ltp;
     }
+}
+
+sub post_fail_hook {
+    select_console 'log-console';
+    upload_logs("/tmp/zypper_openposix-livepatches.log");
 }
 
 sub test_flags {


### PR DESCRIPTION
Redirect zypper output into log to ofload huge amount of zypper in openposix log
Also just upload kernel config instad of printing it in serial log
At the end serial log gets from 200000+ lines to 30000+ and test is more stable

- Related ticket: https://progress.opensuse.org/issues/169207
- Verification run: https://openqa.suse.de/tests/overview?build=jpupava_lp&distri=sle