### PR TITLE
A new 'Welcome to WSL' screen breaks the tests

### DIFF
--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -15,8 +15,14 @@ use wsl qw(is_fake_scc_url_needed);
 sub run {
     my $self = shift;
 
-    assert_screen(['windows-desktop', 'powershell-as-admin-window']);
-    $self->open_powershell_as_admin if match_has_tag('windows-desktop');
+    assert_screen(['windows-desktop', 'powershell-as-admin-window', 'welcome_to_wsl']);
+    if (match_has_tag('windows-desktop')) {
+        $self->open_powershell_as_admin;
+    } elsif (match_has_tag('welcome_to_wsl')) {
+        click_lastmatch;
+        send_key 'alt-f4';
+        $self->open_powershell_as_admin;
+    }
 
     # Check that systemd is not enabled by default.
     $self->run_in_powershell(

--- a/tests/wsl/wsl_cmd_check.pm
+++ b/tests/wsl/wsl_cmd_check.pm
@@ -19,8 +19,15 @@ my %expected = (
 sub run {
     my $self = shift;
 
-    assert_screen(['windows-desktop', 'powershell-as-admin-window']);
-    $self->open_powershell_as_admin if match_has_tag('windows-desktop');
+    assert_screen(['windows-desktop', 'powershell-as-admin-window', 'welcome_to_wsl']);
+    if (match_has_tag('windows-desktop')) {
+        $self->open_powershell_as_admin;
+    }
+    elsif (match_has_tag('welcome_to_wsl')) {
+        click_lastmatch;
+        send_key 'alt-f4';
+        $self->open_powershell_as_admin;
+    }
     $self->run_in_powershell(cmd => 'wsl --list --verbose', timeout => 60);
     $self->run_in_powershell(cmd => "wsl mount | Select-String -Pattern $expected{mount}", timeout => 60);
     $self->run_in_powershell(cmd => qq{wsl ls $expected{mount}}, timeout => 60);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/176676
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/blob/master/welcome-to-wsl-20250219.png
- Verification runs:
  - https://openqa.suse.de/tests/16829323 :green_circle:
  - https://openqa.suse.de/tests/16829308 :green_circle: (test fails for different reason)
