### PR TITLE
Allow controlling install_execution_mode

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -1043,26 +1043,25 @@ sub get_hana_site_names {
 
 =head2 create_hana_vars_section
 
-    Detects HANA/HA scenario from openQA variables and creates "terraform: variables:" section in config.yaml file.
+    Detects HANA/HA scenario from openQA variables and creates
+    data later used for "ansible: hana_vars:" section in config.yaml file.
 
 =cut
 
 sub create_hana_vars_section {
-    my ($ha_enabled) = @_;
     # Cluster related setup
     my %hana_vars;
-    if ($ha_enabled == 1) {
-        my @hana_sites = get_hana_site_names();
-        $hana_vars{sap_hana_install_software_directory} = get_required_var('HANA_MEDIA');
-        $hana_vars{sap_hana_install_master_password} = get_required_var('_HANA_MASTER_PW');
-        $hana_vars{sap_hana_install_sid} = get_required_var('INSTANCE_SID');
-        $hana_vars{sap_hana_install_instance_number} = get_required_var('INSTANCE_ID');
-        $hana_vars{sap_domain} = get_var('SAP_DOMAIN', 'qesap.example.com');
-        $hana_vars{use_sap_hana_sr_angi} = get_var('USE_SAP_HANA_SR_ANGI', 'false');
-        $hana_vars{primary_site} = $hana_sites[0];
-        $hana_vars{secondary_site} = $hana_sites[1];
-        set_var('SAP_SIDADM', lc(get_var('INSTANCE_SID') . 'adm'));
-    }
+    $hana_vars{sap_hana_install_install_execution_mode} = get_var('HANA_INSTALL_MODE') if get_var('HANA_INSTALL_MODE');
+    $hana_vars{sap_hana_install_software_directory} = get_required_var('HANA_MEDIA');
+    $hana_vars{sap_hana_install_master_password} = get_required_var('_HANA_MASTER_PW');
+    $hana_vars{sap_hana_install_sid} = get_required_var('INSTANCE_SID');
+    $hana_vars{sap_hana_install_instance_number} = get_required_var('INSTANCE_ID');
+    $hana_vars{sap_domain} = get_var('SAP_DOMAIN', 'qesap.example.com');
+    $hana_vars{use_sap_hana_sr_angi} = get_var('USE_SAP_HANA_SR_ANGI', 'false');
+    my @hana_sites = get_hana_site_names();
+    $hana_vars{primary_site} = $hana_sites[0];
+    $hana_vars{secondary_site} = $hana_sites[1];
+    set_var('SAP_SIDADM', lc(get_var('INSTANCE_SID') . 'adm'));
     return (\%hana_vars);
 }
 

--- a/t/12_sles4sap_publicccloud.t
+++ b/t/12_sles4sap_publicccloud.t
@@ -102,7 +102,8 @@ subtest "[sles4sap_cleanup] terraform to be called even if ansible fails" => sub
                 return (1, 0);
             } else {
                 return (0, 0);
-    } });
+            }
+    });
     my $self = sles4sap_publiccloud->new();
 
     my $ret = $self->sles4sap_cleanup(ansible_present => 1);
@@ -1043,6 +1044,22 @@ subtest '[saphanasr_showAttr_version]' => sub {
 
     my $ret = $self->saphanasr_showAttr_version();
     ok $ret eq '1.2.3.4';
+};
+
+subtest '[create_hana_vars_section]' => sub {
+    set_var('HANA_MEDIA', '>>>HANA_MEDIA---VALUE<<<');
+    set_var('_HANA_MASTER_PW', '>>>_HANA_MASTER_PW---VALUE<<<');
+    set_var('INSTANCE_SID', '>>>INSTANCE_SID---VALUE<<<');
+    set_var('INSTANCE_ID', '>>>INSTANCE_ID---VALUE<<<');
+
+    my $ret = create_hana_vars_section();
+
+    set_var('HANA_MEDIA', undef);
+    set_var('_HANA_MASTER_PW', undef);
+    set_var('INSTANCE_SID', undef);
+    set_var('INSTANCE_ID', undef);
+
+    ok %$ret{sap_hana_install_sid} eq '>>>INSTANCE_SID---VALUE<<<';
 };
 
 done_testing;

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -194,12 +194,12 @@ sub run {
     }
     $ansible_playbooks = create_playbook_section_list(%playbook_configs);
 
-    my $ansible_hana_vars = create_hana_vars_section($ha_enabled);
-
     # Prepare QESAP deployment
     qesap_prepare_env(provider => $provider_setting);
     qesap_create_ansible_section(ansible_section => 'create', section_content => $ansible_playbooks) if @$ansible_playbooks;
-    qesap_create_ansible_section(ansible_section => 'hana_vars', section_content => $ansible_hana_vars) if %$ansible_hana_vars;
+    qesap_create_ansible_section(
+        ansible_section => 'hana_vars',
+        section_content => create_hana_vars_section()) if $ha_enabled;
 
     # Regenerate config files (This workaround will be replaced with full yaml generator)
     qesap_prepare_env(provider => $provider_setting, only_configure => 1);


### PR DESCRIPTION
Allow controlling hana_var variable `sap_hana_install_install_execution_mode` from an openQA variable.
Simplify API for create_hana_vars_section and add UT.


- Related ticket: TEAM-10053

# Verification run:

## 15sp6
sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-02-19T03:03:23Z-hanasr_azure_test_msi az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/314759 :green_heart: no `HANA_INSTALL_MODE`. Generated `hana_vars` http://openqaworker15.qa.suse.cz/tests/314759/file/deploy_qesap_terraform-hana_vars.yaml has no `sap_hana_install_install_execution_mode`.

sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-02-19T03:03:23Z-hanasr_azure_test_msi az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/314760 `HANA_INSTALL_MODE=optimized` but still use HANA 7rev79. http://openqaworker15.qa.suse.cz/tests/314761/file/deploy_qesap_terraform-hana_vars.yaml has `sap_hana_install_install_execution_mode=optimized`, that is ok also to be used when using HANA sps7

sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-02-19T03:03:23Z-hanasr_azure_test_msi az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/314761 `HANA_INSTALL_MODE=optimized` but still use HANA 8rev82

## 12sp5
sle-12-SP5-HanaSr-Aws-Payg-x86_64-Build12-SP5_2025-02-19T03:03:23Z-hanasr_aws_test_fencing_native_ltss ec2_r4.8xlarge
- http://openqaworker15.qa.suse.cz/tests/314762