### PR TITLE
containers: Introduce the *_BATS_URL variables

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -208,7 +208,12 @@ sub selinux_hack {
 }
 
 sub bats_post_hook {
+    my $test_dir = shift;
+
     select_serial_terminal;
+
+    assert_script_run "cd /";
+    script_run "rm -rf $test_dir";
 
     script_run('findmnt > /tmp/findmnt.txt');
     upload_logs('/tmp/findmnt.txt');


### PR DESCRIPTION
Introduce the BATS_URL variables to specify the URL to download the upstream tests.  

This allow us to test PR's against our repos like in https://github.com/SUSE/podman/pull/8

- Verification runs:
  - SLE 15-SP7 podman: https://openqa.suse.de/tests/16832284 (cloned with `PODMAN_BATS_URL=https://github.com/SUSE/podman/archive/refs/heads/backport-testfix-v4.9.5.tar.gz`)
  - Tumbleweed runc / skopeo: https://openqa.opensuse.org/tests/4868045
  - Tumbleweed buildah: https://openqa.opensuse.org/tests/4868630

Notes:
  - We're using full URL instead of split REPO / BRANCH variables because we need to support _both_ tags & branches.
  - The URL must not be a `.zip` because it doesn't preserve executable permissions.
  - For SLE, we'll eventually use the SUSE repos for podman, buildah, skopeo & runc as default URL.