### PR TITLE
Selinux is enabled by default on Leap 16.0

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -1002,7 +1002,7 @@ Returns true if the distro has SELinux as default MAC
 =cut
 
 sub has_selinux_by_default {
-    return is_tumbleweed || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos || is_sle('16+');
+    return is_tumbleweed || is_sle_micro('5.4+') || is_leap_micro('5.4+') || is_microos || is_sle('16+') || is_leap('16.0+');
 }
 
 sub has_selinux {


### PR DESCRIPTION

![Screenshot from 2025-02-21 16-15-09](https://github.com/user-attachments/assets/61594c83-bfbb-4a43-ba55-ff73a8271556)
https://progress.opensuse.org/issues/177456

- Verification run: n/a, please see attachment in ticket above