### PR TITLE
year_2038: Remove soft-fail poo#127343

### DIFF
--- a/tests/console/year_2038_detection.pm
+++ b/tests/console/year_2038_detection.pm
@@ -83,7 +83,7 @@ sub run {
     script_retry('journalctl -u chronyd | grep -e "System clock wrong" -e "Received KoD RATE"', delay => 60, retry => 3, die => 0);
     assert_script_run('chronyc makestep');
     unless (script_retry('date +"%Y-%m-%d" | grep -v 2038', delay => 5, retry => 5, die => 0) == 0) {
-        record_soft_failure('poo#127343, Time sync with NTP server failed');
+        record_info("poo#127343", "Time sync with NTP server failed");
         systemctl('stop chronyd.service');
         # Set time stamp when we start the test
         assert_script_run("timedatectl set-time \"$date\"");


### PR DESCRIPTION
Might make sense to remove as well soft-fail which points to resolved [poo#127343](https://progress.opensuse.org/issues/127343)

- Related ticket: https://progress.opensuse.org/issues/174988
