### PR TITLE
Add new Business One installer

### DIFF
--- a/data/sles4sap/b1.settings
+++ b/data/sles4sap/b1.settings
@@ -13,11 +13,11 @@ AUTHENTICATION_SERVICE_MANAGEMENT_HTTP_PORT=40021
 # Set AutoStart for SAMBA service?
 B1S_SAMBA_AUTOSTART=true
 # Overwrite the existing B1 Shared folder?
-B1S_SHARED_FOLDER_OVERWRITE=true
+B1S_SHARED_FOLDER_OVERWRITE=false
 # Password for B1 tech user.
 B1S_TECHUSER_PASSWORD=
 # Compress backups
-BCKP_BACKUP_COMPRESS=true
+BCKP_BACKUP_COMPRESS=false
 # N/A
 BCKP_HANA_SERVERS=<servers><server><system address="%SERVER%"/><database instance="%INSTANCE%" port="30013" tenant-db="%TENANT_DB%" user="" password=""/></server></servers>
 # Log files location
@@ -40,6 +40,8 @@ CENTRAL_LOG_PASSWORD=
 CENTRAL_LOG_PATH=/usr/sap/SAPBusinessOne/ServerTools/SLD/CentralLogFolder
 # Central log repository username under which is shared.
 CENTRAL_LOG_USER=b1LogUser
+# Certificate verification when connecting to applications and websites
+CONNECTION_SSL_CERTIFICATE_VERIFICATION=false
 # Delete Shared Folder during uninstall
 DELETE_B1_SHR=false
 # Port used by Electronic Document Service dashboard
@@ -105,7 +107,7 @@ SLD_WINDOWS_DOMAIN_ACTION=skip
 # Service Layer load balancer member(s)
 SL_LB_MEMBERS=127.0.0.1:50001,127.0.0.1:50002,127.0.0.1:50003,127.0.0.1:50004
 # Install Service Layer load balancer member(s) only
-SL_LB_MEMBER_ONLY=false
+SL_LB_MEMBER_ONLY=true
 # Service Layer load balancer port number
 SL_LB_PORT=50000
 # Maximum threads per Service Layer load balancer member

--- a/data/sles4sap/bone.cfg
+++ b/data/sles4sap/bone.cfg
@@ -19,6 +19,8 @@ SL_LB_MEMBER_ONLY=false
 SL_LB_PORT=50000
 SL_THREAD_PER_SERVER=24
 WEBCLIENT_PORT=8443
+# Certificate verification when connecting to applications and websites
+CONNECTION_SSL_CERTIFICATE_VERIFICATION=false
 #### flexible part ###
 BCKP_HANA_SERVERS=<servers><server><system address="%SERVER%"/><database instance="%INSTANCE%" port="30013" tenant-db="%TENANT_DB%" user="SYSTEM" password="%PASSWORD%"/></server></servers>
 HANA_DATABASE_ADMIN_ID=%ADMIN_ID%

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -1040,8 +1040,8 @@ Package and upload HANA installation logs from SUT.
 =cut
 
 sub upload_hana_install_log {
-    my @hana_logs = qw(/var/adm/autoinstall/logs /var/tmp/hdb*);
-    push(@hana_logs, "/var/log/SAPBusinessOne/B1Installer*") if get_var('BONE');
+    my @hana_logs = qw("/var/adm/autoinstall/logs" "/var/tmp/hdb");
+    push(@hana_logs, "/var/log/SAPBusinessOne") if get_var('BONE');
     script_run 'tar -Jcf /tmp/hana_install.log.tar.xz ' . join(' ', map { "'$_'" } @hana_logs);
     upload_logs '/tmp/hana_install.log.tar.xz';
 }


### PR DESCRIPTION
Adds necessary changes to support 2411 SAP Business One Installer.

Fixes:
TEAM-10112 (Update Business One Installer to 2411)

VR

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
