### PR TITLE
Improve regexp for IPV4 CIDR match

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -189,8 +189,20 @@ sub az_network_vnet_create {
     }
     foreach (qw(address_prefixes subnet_prefixes)) {
         if ($args{$_}) {
+            # Check if both address_prefixes and subnet_prefixes are
+            # valid ipv4 address ranges for the az network vnet command
+            #
+            # Regexp has 5 block:
+            #  1. [1-9]{1}[0-9]{0,2} 1 to 3 digit number, not starting by 0. Separated from next block by a dot.
+            #  2. ([0-9]|[1-9][0-9]|[1-2][0-9]{2}) could be 1 to 3 digits:
+            #     if 1 digit it could be from 0 to 9,
+            #     if 2 digits it could be from 10 to 99,
+            #     if 3 digit it could be from 100 to 299 (yes nothing above 256 is valid but regexp ignore it)
+            #     Separation dot
+            #  3. and 4. are like 2
+            #  5. net mask \/[0-9]+ at the end
             croak "Invalid IP range $args{$_} in $_"
-              unless ($args{$_} =~ /^[1-9]{1}[0-9]{0,2}\.(0|[1-9]{1,3})\.(0|[1-9]{1,3})\.(0|[1-9]{1,3})\/[0-9]+$/);
+              unless ($args{$_} =~ /^[1-9]{1}[0-9]{0,2}\.([0-9]|[1-9][0-9]|[1-2][0-9]{2})\.([0-9]|[1-9][0-9]|[1-2][0-9]{2})\.([0-9]|[1-9][0-9]|[1-2][0-9]{2})\/[0-9]+$/);
         }
     }
 

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -99,7 +99,7 @@ subtest '[az_network_vnet_create] die on invalid IP' => sub {
             ok scalar @calls == 0, "No call to assert_script_run, croak before to run the command for invalid IP $test_pattern as argument $arg";
             @calls = ();
         }
-        foreach my $test_pattern (qw(192.168.0.0/16 192.0.0.0/16 2.168.0.0/16)) {
+        foreach my $test_pattern (qw(192.168.0.0/16 192.0.0.0/16 2.168.0.0/16 10.4.104.0/21)) {
             az_network_vnet_create(
                 resource_group => 'Arlecchino',
                 region => 'Pulcinella',


### PR DESCRIPTION
Improve regexp used to validate ip ranges used as `az vnet create` argument.

    Related ticket: https://jira.suse.com/browse/TEAM-9967

# Verification run:

sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test

-  http://openqaworker15.qa.suse.cz/tests/315035
-  http://openqaworker15.qa.suse.cz/tests/315036
-  http://openqaworker15.qa.suse.cz/tests/315037
-  http://openqaworker15.qa.suse.cz/tests/315038