### PR TITLE
Also set ssh_opts in mrtest

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -218,7 +218,7 @@ sub run {
     foreach my $instance (@$instances) {
         record_info 'Instance', join(' ', 'IP: ', $instance->public_ip, 'Name: ', $instance->instance_id);
         $self->{my_instance} = $instance;
-        $self->set_cli_ssh_opts unless (get_var('MR_TEST', 0));    # Set CLI SSH opts in HanaSR test, not in saptune/mr_test tests
+        $self->set_cli_ssh_opts;
         my $expected_hostname = $instance->{instance_id};
         $instance->wait_for_ssh();
 


### PR DESCRIPTION
Enable call of set_cli_ssh_opts in MR_TEST too.

- Related ticket: https://jira.suse.com/browse/TEAM-10109

# Verification run:
 sle-15-SP3-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:37380:dtb-aarch64-sles4sap_gnome_saptune_delete_rename az_Standard_E4s_v3
 - http://openqaworker15.qa.suse.cz/tests/315092 :green_circle: 

sle-15-SP5-HanaSr-Azure-Payg-x86_64-Build15-SP5_2025-02-21T03:03:20Z-hanasr_azure_test_msi az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/315093 :green_circle: 

sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:37545:crmsh-SAPHanaSR-ScaleUp-PerfOpt az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/315094 :green_circle: 
