### PR TITLE
Add register to proxy scc support for Agama

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -125,7 +125,7 @@ sub enter_netboot_parameters {
     my $ntlm_p = get_var('NTLM_AUTH_INSTALL') ? $ntlm_auth::ntlm_proxy : '';
     if (is_agama) {
         type_string_slow "linux $mntpoint/linux root=live:http://" . get_var('OPENQA_HOSTNAME') . "/assets/iso/" . get_var('ISO') . " live.password=$testapi::password";
-        # agama.auto and agama.install_url are defined in below function
+        # inst.auto and inst.install_url are defined in below function
         specific_bootmenu_params;
         type_string_slow " " . get_var('EXTRABOOTPARAMS') if (get_var('EXTRABOOTPARAMS'));
     }
@@ -137,10 +137,10 @@ sub enter_netboot_parameters {
         bootmenu_default_params;
         bootmenu_network_source;
         specific_bootmenu_params;
-        registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED) unless get_var('NTLM_AUTH_INSTALL');
         type_string_slow remote_install_bootmenu_params;
     }
 
+    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED) unless get_var('NTLM_AUTH_INSTALL');
     type_string_slow " fips=1" if (get_var('FIPS_INSTALLATION'));
     type_string_slow " UPGRADE=1" if (get_var('UPGRADE'));
 

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -630,8 +630,8 @@ sub bootmenu_default_params {
         if (get_var('REPO_0')) {
             my $host = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
             my $repo = get_var('REPO_0');
-            # agama.install_url supports comma separated list if more repos are needed ...
-            push @params, "agama.install_url=$host/assets/repo/$repo";
+            # inst.install_url supports comma separated list if more repos are needed ...
+            push @params, "inst.install_url=$host/assets/repo/$repo";
         }
         push @params, "live.password=$testapi::password";
     }
@@ -888,11 +888,11 @@ sub specific_bootmenu_params {
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $url = autoyast::expand_agama_profile($agama_auto);
         $url = shorten_url($url) if (is_backend_s390x && !is_opensuse);
-        push @params, "agama.auto=$url";
+        push @params, "inst.auto=$url inst.finish=stop";
     }
 
     if (my $agama_install_url = get_var('AGAMA_INSTALL_URL')) {
-        push @params, "agama.install_url=$agama_install_url";
+        push @params, "inst.install_url=$agama_install_url";
     }
 
     # Boot the system with the debug options if shutdown takes suspiciously long time.

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -12,7 +12,7 @@ use Utils::Architectures;
 use Utils::Backends qw(is_qemu);
 use serial_terminal 'select_serial_terminal';
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key quit_packagekit script_retry script_output_retry wait_for_purge_kernels);
-use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro is_hpc is_jeos is_transactional is_staging);
+use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro is_hpc is_jeos is_transactional is_staging is_agama);
 use transactional qw(trup_call process_reboot);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
@@ -750,7 +750,7 @@ sub registration_bootloader_cmdline {
     set_var('SCC_URL', 'https://scc.suse.com') unless get_var('SCC_URL');
     my $cmdline = '';
     if (my $url = get_var('SMT_URL') || get_var('SCC_URL')) {
-        $cmdline .= " regurl=$url";
+        $cmdline .= is_agama ? " inst.register_url=$url" : " regurl=$url";
         $cmdline .= " regcert=$url" if get_var('SCC_CERT');
     }
     return $cmdline;

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -123,30 +123,6 @@ sub run {
 
     # stop and disable PackageKit
     quit_packagekit;
-    ########
-    # Workaround to install sle16 in beta1
-    # Don't register the system during the installation and use daily build as install url
-    # Register the system once installation done
-    if (is_agama && is_sle) {
-        zypper_call('in suseconnect-ng');
-        record_info "agama pscc register";
-        my $regcode = (get_var('AGAMA_PRODUCT_ID') =~ /SAP/) ? get_var('SCC_REGCODE_SLES4SAP') : get_var('SCC_REGCODE');
-        my $regurl = get_var('SCC_URL');
-        assert_script_run("suseconnect -r $regcode --url $regurl");
-
-        # Register HA extension and output some debug info for reference
-        if (get_var('SCC_ADDONS', '') eq 'ha') {
-            record_info('Register HA extension');
-            command_register(get_required_var('VERSION'), 'ha', get_required_var('SCC_REGCODE_HA'));
-            # Just for debug purpose
-            zypper_call('up', timeout => 600);
-            record_info('REPOS', script_output('zypper lr -u'));
-            record_info('PKGs', script_output('zypper se ha | grep -i high'));
-            record_info('PATTERNS', script_output('zypper patterns'));
-        }
-    }
-    ########
-
 }
 
 sub test_flags {

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -48,9 +48,9 @@ sub set_svirt_domain_elements {
         }
 
         $cmdline .= ' ' . get_var("EXTRABOOTPARAMS") if get_var("EXTRABOOTPARAMS");
-        # agama.auto and agama.install_url are defined in 'specific_bootmenu_params'
+        # inst.auto and inst.install_url are defined in 'specific_bootmenu_params'
         $cmdline .= specific_bootmenu_params;
-        $cmdline .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation') && !get_var('NTLM_AUTH_INSTALL') && !(is_agama);
+        $cmdline .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation') && !get_var('NTLM_AUTH_INSTALL');
 
         $svirt->change_domain_element(os => initrd => "$zkvm_img_path/$name.initrd");
         $svirt->change_domain_element(os => kernel => "$zkvm_img_path/$name.kernel");

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -185,14 +185,18 @@ sub set_bootscript_agama_cmdline_extra {
     my $cmdline_extra = " ";
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $agama_auto_url = autoyast::expand_agama_profile($agama_auto);
-        $cmdline_extra .= "agama.auto=$agama_auto_url ";
+        $cmdline_extra .= "inst.auto=$agama_auto_url inst.finish=stop ";
     }
     # Agama Installation repository URL
     # By default Agama installs the packages from the repositories specified in the product configuration.
-    # From now Agama supports using the agama.install_url boot parameter for overriding the default installation repositories.
+    # From now Agama supports using the inst.install_url boot parameter for overriding the default installation repositories.
     if (my $agama_install_url = get_var('AGAMA_INSTALL_URL')) {
         $agama_install_url =~ s/^\s+|\s+$//g;
-        $cmdline_extra .= "agama.install_url=$agama_install_url ";
+        $cmdline_extra .= "inst.install_url=$agama_install_url ";
+    }
+    # Add register URL
+    if (my $register_url = get_var('SCC_URL')) {
+        $cmdline_extra .= "inst.register_url=$register_url ";
     }
     if (is_ipmi) {
         my $ipxe_console = get_required_var('IPXE_CONSOLE');


### PR DESCRIPTION
https://progress.opensuse.org/issues/177729

- Verification run: 
[x86_64-BM](https://openqa.suse.de/tests/16874375)
[powerVM](https://openqa.suse.de/tests/16874374)

```
bare-metal5:~ # suseconnect -s
[{"name":"SUSE Employee subscription for SUSE Linux Enterprise Server x86_64","identifier":"SLES","version":"16.0","arch":"x86_64","status":"Registered","regcode":"xxxxxxxxxxxxx","starts_at":"2024-12-16 12:48:17 UTC","expires_at":"2025-12-16 12:48:17 UTC","subscription_status":"ACTIVE","type":"internal"}]
bare-metal5:~ # zypper lr -u
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias                                                                 | Name                         | Enabled | GPG Check | Refresh | URI
--+-----------------------------------------------------------------------+------------------------------+---------+-----------+---------+-----------------------------------------------------------------------------
1 | SUSE_Linux_Enterprise_Server_16.0_x86_64:SLE-Product-SLES-16.0        | SLE-Product-SLES-16.0        | Yes     | (r ) Yes  | Yes     | http://openqa.suse.de/assets/repo/SLES-Packages-16.0-x86_64-Build5.1/
2 | SUSE_Linux_Enterprise_Server_16.0_x86_64:SLE-Product-SLES-16.0-Debug  | SLE-Product-SLES-16.0-Debug  | No      | ----      | ----    | http://openqa.suse.de/assets/repo/SLES-Packages-16.0-x86_64-Debug-Build5.1/
3 | SUSE_Linux_Enterprise_Server_16.0_x86_64:SLE-Product-SLES-16.0-Source | SLE-Product-SLES-16.0-Source | No      | ----      | ----    | http://openqa.suse.de/assets/repo/SLES-Packages-16.0-x86_64-Source-Build5.1/

```