### PR TITLE
Rename grub2-bls check to be more specific

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -646,7 +646,7 @@ sub load_jeos_tests {
     loadtest "jeos/record_machine_id";
     loadtest "console/force_scheduled_tasks";
     # this test case also disables grub timeout
-    loadtest "jeos/grub2_gfxmode" unless (is_bootloader_sdboot || is_bootloader_bls);
+    loadtest "jeos/grub2_gfxmode" unless (is_bootloader_sdboot || is_bootloader_grub2_bls);
     unless (get_var('INSTALL_LTP') || get_var('SYSTEMD_TESTSUITE')) {
         # jeos/diskusage as of now works only with BTRFS
         loadtest "jeos/diskusage" if get_var('FILESYSTEM', 'btrfs') =~ /btrfs/;
@@ -1266,7 +1266,7 @@ sub load_consoletests {
     loadtest "console/zypper_log";
     if (!get_var("LIVETEST")) {
         loadtest "console/yast2_i" unless (is_sle("16+") || is_leap("16.0+"));
-        loadtest "console/yast2_bootloader" unless ((is_sle("16+") || is_leap("16.0+")) || is_bootloader_sdboot || is_bootloader_bls);
+        loadtest "console/yast2_bootloader" unless ((is_sle("16+") || is_leap("16.0+")) || is_bootloader_sdboot || is_bootloader_grub2_bls);
     }
     loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
     # textmode install comes without firewall by default atm on openSUSE.
@@ -1781,7 +1781,7 @@ sub load_extra_tests_console {
     loadtest 'console/wpa_supplicant' unless (!is_x86_64 || is_sle('<15') || is_leap('<15.1') || is_jeos || is_public_cloud);
     loadtest 'console/python_scientific' unless (is_sle("<15"));
     loadtest "console/parsec" if is_tumbleweed;
-    loadtest "console/perl_bootloader" unless (is_public_cloud() || is_bootloader_sdboot || is_bootloader_bls);
+    loadtest "console/perl_bootloader" unless (is_public_cloud() || is_bootloader_sdboot || is_bootloader_grub2_bls);
 }
 
 sub load_extra_tests_sdk {

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -206,7 +206,7 @@ sub load_common_tests {
     loadtest 'microos/services_enabled';
     # MicroOS -old images use wicked, but cockpit-wicked is no longer supported in TW
     loadtest 'microos/cockpit_service' unless (is_microos('Tumbleweed') && is_staging) || (is_microos('Tumbleweed') && get_var('HDD_1', '') =~ /-old/) || !get_var('SCC_REGISTER');
-    loadtest 'console/perl_bootloader' unless (is_bootloader_sdboot || is_bootloader_bls);
+    loadtest 'console/perl_bootloader' unless (is_bootloader_sdboot || is_bootloader_grub2_bls);
     # Staging has no access to repos and the MicroOS-DVD does not contain ansible
     # Ansible test needs Packagehub in SLE and it can't be enabled in SLEM
     loadtest 'console/ansible' unless (is_staging || is_sle_micro || is_leap_micro);

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -914,7 +914,7 @@ sub wait_boot {
         assert_screen 'systemd-boot', 300;
         save_screenshot;    # Show what's selected for booting
         send_key('ret');
-    } elsif (is_bootloader_bls) {
+    } elsif (is_bootloader_grub2_bls) {
         save_screenshot;
     } else {
         die 'Unknown bootloader';

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -52,7 +52,7 @@ use constant {
           is_tunneled
           is_bootloader_grub2
           is_bootloader_sdboot
-          is_bootloader_bls
+          is_bootloader_grub2_bls
           is_plasma6
           requires_role_selection
           check_version
@@ -843,13 +843,13 @@ sub is_bootloader_sdboot {
     return get_var('BOOTLOADER', 'grub2') eq 'systemd-boot';
 }
 
-=head2 is_bootloader_bls
+=head2 is_bootloader_grub2_bls
 
 Returns true if the SUT uses GRUB2-BLS as bootloader
 =cut
 
-sub is_bootloader_bls {
-    return get_var('BOOTLOADER', 'grub2') eq 'bls';
+sub is_bootloader_grub2_bls {
+    return get_var('BOOTLOADER', 'grub2') eq 'grub2-bls';
 }
 
 =head2 is_plasma6

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -43,7 +43,7 @@ use lockapi 'mutex_wait';
 use bootloader_setup;
 use registration;
 use utils;
-use version_utils qw(is_jeos is_microos is_opensuse is_sle is_selfinstall is_sle_micro is_leap_micro is_bootloader_sdboot is_bootloader_bls);
+use version_utils qw(is_jeos is_microos is_opensuse is_sle is_selfinstall is_sle_micro is_leap_micro is_bootloader_sdboot is_bootloader_grub2_bls);
 use Utils::Backends qw(is_ipmi);
 
 # hint: press shift-f10 trice for highest debug level
@@ -126,7 +126,7 @@ sub run {
         return if is_bootloader_sdboot;
     }
 
-    if (match_has_tag('bootloader-grub2') && is_bootloader_bls) {
+    if (match_has_tag('bootloader-grub2') && is_bootloader_grub2_bls) {
         return;
     }
 

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 use lockapi qw(mutex_create mutex_wait);
 use testapi;
-use version_utils qw(is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro is_leap_micro is_vmware is_bootloader_sdboot is_bootloader_bls has_selinux_by_default);
+use version_utils qw(is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro is_leap_micro is_vmware is_bootloader_sdboot is_bootloader_grub2_bls has_selinux_by_default);
 use Utils::Architectures;
 use Utils::Backends;
 use jeos qw(expect_mount_by_uuid);
@@ -262,7 +262,7 @@ sub run {
     # Enter password & Confirm
     enter_root_passwd;
 
-    if (is_bootloader_sdboot || is_bootloader_bls) {
+    if (is_bootloader_sdboot || is_bootloader_grub2_bls) {
         send_key_until_needlematch 'jeos-fde-option-enroll-recovery-key', 'down' unless check_screen('jeos-fde-option-enroll-recovery-key', 1);
         send_key 'ret';
 
@@ -341,7 +341,7 @@ sub run {
     }
 
 
-    if (is_bootloader_sdboot || is_bootloader_bls) {
+    if (is_bootloader_sdboot || is_bootloader_grub2_bls) {
         # Verify that /etc/issue shows the recovery key
         wait_serial(qr/^Recovery key:\s+(([a-z]+-)+[a-z]+)/m) or die 'The encryption recovery key is missing';
     }

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -16,7 +16,7 @@ use testapi;
 use transactional qw(process_reboot);
 use bootloader_setup qw(change_grub_config);
 use utils qw(ensure_ca_certificates_suse_installed zypper_call ensure_serialdev_permissions);
-use version_utils qw(is_bootloader_grub2 is_bootloader_sdboot is_bootloader_bls);
+use version_utils qw(is_bootloader_grub2 is_bootloader_sdboot is_bootloader_grub2_bls);
 use serial_terminal qw(select_serial_terminal prepare_serial_console);
 use Utils::Architectures 'is_ppc64le';
 
@@ -41,7 +41,7 @@ sub run {
             ensure_ca_certificates_suse_installed if get_var('HOST_VERSION');
             process_reboot(trigger => 1);
         }
-    } elsif (is_bootloader_sdboot || is_bootloader_bls) {
+    } elsif (is_bootloader_sdboot || is_bootloader_grub2_bls) {
         die 'EXTRABOOTPARAMS not implemented for this bootloader' if $extrabootparams;
         assert_script_run('bootctl set-timeout menu-force') unless $keep_grub_timeout;
     } else {

--- a/tests/transactional/trup_smoke.pm
+++ b/tests/transactional/trup_smoke.pm
@@ -13,7 +13,7 @@ use warnings;
 use testapi;
 use transactional;
 use Utils::Architectures qw(is_s390x);
-use version_utils qw(is_bootloader_sdboot is_sle_micro is_bootloader_bls);
+use version_utils qw(is_bootloader_sdboot is_sle_micro is_bootloader_grub2_bls);
 use serial_terminal;
 
 sub action {
@@ -21,7 +21,7 @@ sub action {
     $reboot //= 1;
     record_info('TEST', $text);
     trup_call($target);
-    if ($reboot && $target =~ /bootloader|grub\.cfg|initrd/ && (is_bootloader_sdboot || is_bootloader_bls)) {
+    if ($reboot && $target =~ /bootloader|grub\.cfg|initrd/ && (is_bootloader_sdboot || is_bootloader_grub2_bls)) {
         # With sdbootutil, the snapshot is not changed. Verify that and test rebooting.
         check_reboot_changes(0);
         process_reboot(trigger => 1);
@@ -44,7 +44,7 @@ sub run {
     }
     action('grub.cfg', 'Regenerate grub.cfg');
     action('initrd', 'Regenerate initrd');
-    if (is_bootloader_sdboot || is_bootloader_bls) {
+    if (is_bootloader_sdboot || is_bootloader_grub2_bls) {
         record_soft_failure("boo#1226676: kdump not yet implemented with sdbootutil");
     }
     else {


### PR DESCRIPTION
Bootloader specification is implemented by both `grub2-bls` and `systemd-boot`
