### PR TITLE
[Virtualization][MU] Fix login, finish,virtmanager_offon module and 12sp5 host installation unstability

### DIFF
--- a/data/virtualization/autoyast/host_12.xml.ep
+++ b/data/virtualization/autoyast/host_12.xml.ep
@@ -130,7 +130,7 @@
   </networking>
   <partitioning config:type="list">
     <drive>
-  % my $wwn = {'lipa' => 'wwn-0x5002538c4002f8bd', briza => 'wwn-0x5000c5004f0e566d'};
+  % my $wwn = {'lipa' => 'wwn-0x5002538c4002f8bd', briza => 'wwn-0x5000c5004f0e566d', quinn => 'wwn-0x5000c50099db2117'};
   % my $hostname = (split(/\./, $get_var->("SUT_IP")))[0];
   % my $device_id = defined($wwn->{$hostname}) ? '/dev/disk/by-id/' . $wwn->{$hostname} : '';
       <device><%= $device_id %></device>

--- a/tests/console/login.pm
+++ b/tests/console/login.pm
@@ -14,10 +14,12 @@ use warnings;
 use testapi;
 use lib 'sle/tests/virt_autotest';
 use lib 'os-autoinst-distri-opensuse/tests/virt_autotest';
+use virt_autotest::utils qw(reconnect_console_if_not_good);
 
 sub run {
     my $self = shift;
     select_console 'root-ssh';
-    record_info("console logined");
+
+    reconnect_console_if_not_good;
 }
 1;

--- a/tests/virtualization/universal/finish.pm
+++ b/tests/virtualization/universal/finish.pm
@@ -22,6 +22,7 @@ sub run {
     # See https://progress.opensuse.org/issues/93204
     select_console('root-console');
     select_serial_terminal;
+    reconnect_console_if_not_good('root-serial-ssh');
 
     # Show all guests
     assert_script_run 'virsh list --all';

--- a/tests/virtualization/universal/virtmanager_offon.pm
+++ b/tests/virtualization/universal/virtmanager_offon.pm
@@ -12,6 +12,7 @@ use warnings;
 use testapi;
 use utils;
 use virtmanager;
+use virt_autotest::utils qw(reconnect_console_if_not_good);
 
 sub run_test {
     my ($self) = @_;
@@ -36,6 +37,11 @@ sub run_test {
     }
 
     wait_screen_change { send_key 'ctrl-q'; };
+
+    # Wait a while untill the ssh console fully reacts after closing the X window of virt-manager
+    sleep 5;
+    # Reconnect if the text console does not respond well after long time no use
+    reconnect_console_if_not_good;
 }
 
 sub test_flags {


### PR DESCRIPTION
This PR is to 
- fix the unstable failures on login, finish and virtmanger_offon module when running MU SLES jobs on OSD workers, from multiple jobs, the issues do not happen any more
- revert the [earlier virtual network fix by Leon for name](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20938)d, which fails MU jobs like [this](https://openqa.suse.de/tests/16836568#step/libvirt_nated_virtual_network/17) // this has been fixed by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21288, so remove the commit
- 12sp5 host installation failure on machine quinn is fixed


Related ticket: https://progress.opensuse.org/issues/175554

Verification run: 
  - OSD workers
    - xen sriov: https://openqa.suse.de/tests/16895954#
    - xen feature test: https://openqa.suse.de/tests/16893628
    - kvm feature test: https://openqa.suse.de/tests/16896124
  - regression test on PRG1 remote workers
    - xen feature test: https://openqa.suse.de/tests/16893633
    - kvm feature test: https://openqa.suse.de/tests/16895953#
  - quinn fix: https://openqa.suse.de/tests/16947414
