### PR TITLE
Public Cloud: When searching for EC2 AMI verify OwnerID

### DIFF
--- a/tests/publiccloud/aws_cli.pm
+++ b/tests/publiccloud/aws_cli.pm
@@ -32,7 +32,8 @@ sub run {
 
     my $provider = $self->provider_factory();
 
-    my $image_id = script_output("aws ec2 describe-images --filters 'Name=name,Values=suse-sles-15-sp5-v*-x86_64' 'Name=state,Values=available' --query 'Images[?Name != `ecs`]|[0].ImageId' --output=text", 240);
+    my $ownerId = get_var('PUBLIC_CLOUD_EC2_ACCOUNT_ID', script_output('aws sts get-caller-identity --query "Account" --output text'));
+    my $image_id = script_output("aws ec2 describe-images --filters 'Name=name,Values=suse-sles-15-sp5-v*-x86_64' 'Name=state,Values=available' --owners '$ownerId' --query 'Images[?Name != `ecs`]|[0].ImageId' --output=text", 240);
     record_info("EC2 AMI", "EC2 AMI query: " . $image_id);
 
     my $ssh_key = "openqa-cli-test-key-$job_id";

--- a/variables.md
+++ b/variables.md
@@ -329,6 +329,7 @@ PUBLIC_CLOUD_CREDENTIALS_URL | string | "" | Base URL where to get the credentia
 PUBLIC_CLOUD_DOWNLOAD_TESTREPO | boolean | false | If set, it schedules `publiccloud/download_repos` job.
 PUBLIC_CLOUD_EC2_BOOT_MODE | string | "uefi-preferred" | The `--boot-mode` parameter for `ec2uploadimg` script. Available values: `legacy-bios`, `uefi`, `uefi-preferred` Currently unused variable. Use `git blame` to get context.
 PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT | string | 0 | How many IPv6 addresses should the instance have
+PUBLIC_CLOUD_EC2_ACCOUNT_ID | string | `aws sts get-caller-identity --query "Account" --output text` | The account ID (AMI OwnerId property) See poo#177387.
 PUBLIC_CLOUD_EC2_UPLOAD_AMI | string | "" | Needed to decide which image will be used for helper VM for upload some image. When not specified some predefined value will be used. Overwrite the value for `ec2uploadimg --ec2-ami`.
 PUBLIC_CLOUD_EC2_UPLOAD_SECGROUP | string | "" | Allow to instruct ec2uploadimg script to use some existing security group instead of creating new one. If given, the parameter `--security-group-ids` is passed to `ec2uploadimg`.
 PUBLIC_CLOUD_EC2_UPLOAD_VPCSUBNET | string | "" | Allow to instruct ec2uploadimg script to use some existing VPC instead of creating new one.


### PR DESCRIPTION
- Related ticket: [poo#177387](https://progress.opensuse.org/issues/177387)
- Verification run:
[Build0649](https://pdostal-server.suse.cz/tests/overview?build=0649&distri=sle&version=15-SP7) of sle-15-SP7-EC2.aarch64	  [publiccloud_smoketests@ec2_a1.medium](https://pdostal-server.suse.cz/tests/8457)
[Build0649](https://pdostal-server.suse.cz/tests/overview?build=0649&distri=sle&version=15-SP7) of sle-15-SP7-EC2.x86_64	  [publiccloud_smoketests@ec2_m5.large](https://pdostal-server.suse.cz/tests/8458)
[Build0649](https://pdostal-server.suse.cz/tests/overview?build=0649&distri=sle&version=15-SP7) of sle-15-SP7-EC2.x86_64	  [publiccloud_upload_img@64bit](https://pdostal-server.suse.cz/tests/8456)
[Build0649](https://pdostal-server.suse.cz/tests/overview?build=0649&distri=sle&version=15-SP7) of sle-15-SP7-EC2.aarch64	  [publiccloud_upload_img@64bit](https://pdostal-server.suse.cz/tests/8455)