### PR TITLE
Make tools/check_yaml return failure again if YAML validation fails

### DIFF
--- a/schedule/migration/migration_autoyast.yaml
+++ b/schedule/migration/migration_autoyast.yaml
@@ -1,4 +1,5 @@
 ---
+name: migration_autoyast
 schedule:
   - boot/boot_to_desktop
   - migration/record_disk_info

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -46,7 +46,7 @@ conditional_schedule:
         - console/nginx
         - '{{arch_specific}}'
         - console/valgrind
-        - '{{arch_specific15_sp5+}}'
+        - '{{arch_specific15_sp5plus}}'
       15-SP5:
         - console/osinfo_db
         - console/ovn
@@ -57,7 +57,7 @@ conditional_schedule:
         - console/nginx
         - '{{arch_specific}}'
         - console/valgrind
-        - '{{arch_specific15_sp5+}}'
+        - '{{arch_specific15_sp5plus}}'
       15-SP4:
         - console/osinfo_db
         - console/ovn
@@ -131,7 +131,7 @@ conditional_schedule:
         - console/journald_fss
       aarch64:
         - console/journald_fss
-  arch_specific15_sp5+:
+  arch_specific15_sp5plus:
     ARCH:
       x86_64:
         - console/year_2038_detection

--- a/schedule/virt_autotest/sle16_guest_installation.yaml
+++ b/schedule/virt_autotest/sle16_guest_installation.yaml
@@ -1,7 +1,6 @@
 name:          sle16-virt-guest-installation
 description:    >
     Virtualization guest installation tests including extended feature tests schedule with agama and IPXE
-vars:
 schedule:
     - installation/ipxe_install
     - installation/agama_reboot

--- a/tools/check_yaml
+++ b/tools/check_yaml
@@ -4,7 +4,7 @@ success=1
 YAMLS=$(git ls-files schedule/ test_data/ | grep '.ya\?ml$' | xargs echo)
 
 if test -n "$YAMLS"; then
-    export PERL5LIB=${PERL5LIB_} ; echo "$YAMLS" | xargs tools/test_yaml_valid | grep -Ev "has valid yaml syntax|has valid schema";
+    export PERL5LIB=${PERL5LIB_} ; echo "$YAMLS" | xargs tools/test_yaml_valid >/dev/null
     which yamllint >/dev/null 2>&1 || (echo "Command 'yamllint' not found, can not execute YAML syntax checks" && exit 1) || success=0;
     echo "$YAMLS" | xargs yamllint -c .yamllint || exit 1 || success=0;
 else


### PR DESCRIPTION
A previous commit added a "| grep -v" to strip verbose output, but this
broke exit code propagation. Replace the grep with stdout redirection.