### PR TITLE
Add support for vhd disks in cloudnetconfig test

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -39,6 +39,7 @@ our @EXPORT = qw(
   az_network_lb_probe_create
   az_network_lb_rule_create
   az_vm_as_create
+  az_img_from_vhd_create
   az_vm_create
   az_vm_list
   az_vm_openport
@@ -662,6 +663,35 @@ sub az_vm_as_create {
         '-l', $args{region},
         $fc_cmd);
     assert_script_run($az_cmd);
+}
+
+=head2 az_img_from_vhd_create
+
+    az_img_from_vhd_create(resource_group => $rg, name => $name, source => $uploaded_vhd_url);
+
+Create an image out of a .vhd disk in Azure storage.
+
+=over
+
+=item B<resource_group> - existing resource group
+
+=item B<name> - NAME of the created image
+
+=item B<source> - URI of the vhd disk from which the image will be created
+
+=back
+=cut
+
+sub az_img_from_vhd_create {
+    my (%args) = @_;
+    foreach (qw(resource_group name source)) {
+        croak("Argument < $_ > missing") unless $args{$_}; }
+    my $az_cmd = join(' ', 'az image create',
+        '--resource-group', $args{resource_group},
+        '-n', $args{name},
+        '--os-type', 'linux',
+        '--source', $args{source});
+    assert_script_run($az_cmd, timeout => 600);
 }
 
 =head2 az_vm_create

--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -236,6 +236,16 @@ sub ipaddr2_infra_deploy {
         name => $rg,
         region => $args{region});
 
+    # If image provided is a blob storage link, create image out of it
+    if ($args{os} =~ /\.vhd$/) {
+        my $img_name = $rg . 'img';
+        az_img_from_vhd_create(
+            resource_group => $rg,
+            name => $img_name,
+            source => $args{os});
+        $args{os} = $img_name;
+    }
+
     # Create a VNET only needed later when creating the VM
     # Use $rg instead of DEPLOY_PREFIX to try to prevent
     # some deployment failures like:

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -9,6 +9,26 @@ use List::Util qw(any none);
 
 use sles4sap::azure_cli;
 
+subtest '[az_img_from_vhd_create]' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+
+    az_img_from_vhd_create(resource_group => 'Mycenaeans', name => 'Agamemnon', source => 'TrojanHorse.vhd');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /az image create/ } @calls), 'command creates image');
+    ok((any { /--resource-group Mycenaeans/ } @calls), 'RG is correctly used');
+    ok((any { /-n Agamemnon/ } @calls), 'name is correctly used');
+    ok((any { /--source TrojanHorse.vhd/ } @calls), 'source is correctly used');
+};
+
+subtest '[az_group_create] missing args' => sub {
+    dies_ok { az_img_from_vhd_create(name => 'Agamemnon', source => 'TrojanHorse.vhd'); } 'Die for missing argument resource_group';
+    dies_ok { az_img_from_vhd_create(recource_group => 'Mycenaeans', source => 'TrojanHorse.vhd') } 'Die for missing argument name';
+    dies_ok { az_img_from_vhd_create(recource_group => 'Mycenaeans', name => 'Agamemnon') } 'Die for missing argument source';
+};
+
 subtest '[az_group_create]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;


### PR DESCRIPTION
This ticket creates an image out of uploaded vhd disks, in order to create VMs in the case of non-catalog images.

- Related ticket: https://jira.suse.com/browse/TEAM-10095
- Verification run: https://openqaworker15.qa.suse.cz/tests/315392
