### PR TITLE
Fix az vm create about public-ip-address

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -722,7 +722,8 @@ sub az_vm_create {
     push @vm_create, '--resource-group', $args{resource_group};
     push @vm_create, '-n', $args{name};
     push @vm_create, '--image', $args{image};
-    push @vm_create, '--public-ip-address ""';
+    push @vm_create, '--public-ip-address';
+    push @vm_create, $args{public_ip} ? $args{public_ip} : '""';
 
     $args{size} //= 'Standard_B1s';
     push @vm_create, '--size', $args{size};
@@ -734,7 +735,6 @@ sub az_vm_create {
     push @vm_create, '--nsg', $args{nsg} if $args{nsg};
     push @vm_create, '--custom-data', $args{custom_data} if $args{custom_data};
     push @vm_create, '--nics', $args{nic} if $args{nic};
-    push @vm_create, '--public-ip-address', $args{public_ip} if $args{public_ip};
     push @vm_create, '--vnet-name', $args{vnet} if $args{vnet};
     push @vm_create, '--subnet', $args{snet} if $args{snet};
     push @vm_create, '--security-type', $args{security_type} if $args{security_type};

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -286,9 +286,30 @@ subtest '[az_vm_create] with public IP' => sub {
         public_ip => 'Fulgenzio');
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /--public-ip-address Fulgenzio/ } @calls), 'custom Public IP address');
+    ok((none { /--public-ip-address ""/ } @calls), 'not force empty Public IP address');
 };
 
 subtest '[az_vm_create] with no public IP' => sub {
+    # Here function call is same of the previous test '[az_vm_create]'
+    # What is different is that this test has a dedicated
+    # expectation check about --public-ip-address
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    az_vm_create(
+        resource_group => 'Arlecchino',
+        name => 'Truffaldino',
+        image => 'Mirandolina');
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /--public-ip-address ""/ } @calls), 'empty Public IP address');
+};
+
+
+subtest '[az_vm_create] with empty public IP' => sub {
+    # The user can in theory provide a public_ip
+    # with an empty string. It doesn't make much sense
+    # as the user can obtain the same result without using
+    # the public_ip argument at all (like covered by the previous test).
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
     $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });


### PR DESCRIPTION
Fix command line composition about argument --public-ip-address, avoid adding it more than one.


# Verification run:
sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless
- http://openqaworker15.qa.suse.cz/tests/315386