### PR TITLE
Added wsl --distribution command for installation from MSStore

### DIFF
--- a/tests/wsl/install_wsl.pm
+++ b/tests/wsl/install_wsl.pm
@@ -82,6 +82,13 @@ sub run {
         # Install required SUSE distro from the MS Store
         $self->run_in_powershell(
             cmd => "wsl --install --distribution $WSL_version",
+            timeout => 300,
+        );
+        check_screen("welcome_to_wsl", timeout => 60);
+        send_key "alt-f4" if match_has_tag "welcome_to_wsl";
+
+        $self->run_in_powershell(
+            cmd => "wsl.exe --distribution $WSL_version",
             code => sub {
                 assert_screen("yast2-wsl-firstboot-welcome", timeout => 300);
             }


### PR DESCRIPTION
After installing from the MS Store with wsl --install --distribution <distro_name>, the firstboot YaST screen is not being launched automatically. Added wsl --d command to proceed to firstboot.



- Related ticket: https://progress.opensuse.org/issues/177769

- Verification run: 
https://openqa.suse.de/tests/16938233
https://openqa.suse.de/tests/16938231

These test are failing due to new issue further down the line. https://bugzilla.suse.com/show_bug.cgi?id=1237756
However, the problem related to the original ticket is solved, as firstboot YaST is launched correctly after installation. 


