### PR TITLE
SLE16 Container host tests preparation with Agama

### DIFF
--- a/schedule/containers/create_hdd_agama.yaml
+++ b/schedule/containers/create_hdd_agama.yaml
@@ -1,0 +1,36 @@
+---
+name: create_hdd_autoyast
+description:    >
+    Maintainer: qa-c@suse.de.
+    HDD creation for container tests in product QA
+conditional_schedule:
+    grub_set_bootargs:
+        ARCH:
+            's390x':
+                - shutdown/grub_set_bootargs
+    svirt_upload_assets:
+        ARCH:
+            's390x':
+                - shutdown/svirt_upload_assets
+    fips:
+        FIPS:
+            '1':
+                - fips/fips_setup
+    bci_prepare:
+        BCI_PREPARE:
+            '1':
+                - containers/bci_prepare
+
+schedule:
+    - yam/agama/boot_agama
+    - yam/agama/agama_auto
+    - installation/first_boot
+    - autoyast/console.pm
+    - '{{grub_set_bootargs}}'
+    - containers/install_updates
+    - console/system_prepare
+    - '{{fips}}'
+    - '{{bci_prepare}}'
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown
+    - '{{svirt_upload_assets}}'


### PR DESCRIPTION
SLE16 Container host tests preparation with Agama, publish HDD from 
new schedule yaml schedule/containers/create_hdd_agama.yaml
New hdd published from agama-installer.x86_64-*.iso

- Related ticket: https://progress.opensuse.org/issues/175950

- Verification run: https://openqa.suse.de/tests/16870758
