### PR TITLE
Fix arguments download_hana_assets_from_server

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -144,7 +144,7 @@ server
 =cut
 
 sub download_hana_assets_from_server {
-    my %params = @_;
+    my ($self, %params) = @_;
     my $target = $params{target} // '/sapinst';
     my $nettout = $params{nettout} // 2700;
     # Each HANA asset is about 16GB. A ten minute timeout assumes a generous

--- a/t/17_sles4sap.t
+++ b/t/17_sles4sap.t
@@ -4,6 +4,7 @@ use Test::More;
 use Test::Exception;
 use Test::Warnings;
 use Test::MockModule;
+use List::Util qw(any none);
 use testapi;
 use sles4sap;
 
@@ -17,7 +18,8 @@ sub undef_vars {
       INSTANCE_SID
       _SECRET_SAP_MASTER_PASSWORD
       ASCS_PRODUCT_ID
-      INSTANCE_ID);
+      INSTANCE_ID
+      ASSET_0);
 }
 
 subtest '[prepare_swpm]' => sub {
@@ -181,6 +183,7 @@ subtest '[share_hosts_entry] All args defined' => sub {
     set_var('INSTANCE_TYPE', 'Astrid');
     $mockObject->share_hosts_entry(virtual_hostname => 'Olivia', virtual_ip => '192.168.1.1', shared_directory_root => '/Peter/Walter');
 
+    note("\n  -->  " . join("\n  -->  ", @calls));
     is $calls[1], 'mkdir -p /Peter/Walter/hosts', "Test 'mkdir' command";
     is $calls[2], "echo '192.168.1.1 Olivia' >> /Peter/Walter/hosts/Astrid", "Test 'hosts' file entry";
 
@@ -199,6 +202,7 @@ subtest '[share_hosts_entry] Test default values' => sub {
 
     $mockObject->share_hosts_entry();
 
+    note("\n  -->  " . join("\n  -->  ", @calls));
     is $calls[1], 'mkdir -p /sapmnt/hosts', "Test 'mkdir' command";
     is $calls[2], "echo '192.168.1.1 Olivia' >> /sapmnt/hosts/Astrid", "Test 'hosts' file entry";
     undef_vars();
@@ -257,5 +261,39 @@ subtest '[get_instance_profile_path]' => sub {
     is $mockObject->get_instance_profile_path(instance_id => '00', instance_type => 'ASCS'), '/sapmnt/EN2/profile/EN2_ASCS00_sapen2as', 'Return correct ASCS profile path.';
     undef_vars();
 };
+
+subtest '[fix_path] unsupported protocols' => sub {
+    my $mockObject = sles4sap->new();
+    foreach my $protocol (qw(something http ftp)) {
+        dies_ok { $mockObject->fix_path($protocol . '://somethingelse') } "Die for unsupported protocol $protocol";
+    }
+};
+
+subtest '[fix_path] supported protocols' => sub {
+    my $mockObject = sles4sap->new();
+    foreach my $protocol (qw(smb smbfs nfs)) {
+        my @ret = $mockObject->fix_path($protocol . '://somethingelse/else/other/somefile.someextension');
+        note("proto:$ret[0] path:$ret[1]");
+        ok($ret[0] eq 'cifs' or $ret[0] eq 'nfs');
+    }
+};
+
+subtest '[download_hana_assets_from_server]' => sub {
+    my $mockObject = sles4sap->new();
+    my $sles4sap = Test::MockModule->new('sles4sap', no_auto => 1);
+    my @calls;
+    # Return 1 to simulate no asset lock
+    $sles4sap->redefine(script_run => sub { push @calls, @_; return 1; });
+    $sles4sap->redefine(assert_script_run => sub { push @calls, @_; return; });
+    $sles4sap->redefine(data_url => sub { return 'MY_DOWNLOAD_URL'; });
+
+    set_var('ASSET_0', 'Zanzibar');
+    $mockObject->download_hana_assets_from_server();
+    undef_vars();
+    note("\n  -->  " . join("\n  -->  ", @calls));
+
+    ok((any { /wget.*MY_DOWNLOAD_URL/ } @calls), 'wget call');
+};
+
 
 done_testing;

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -102,14 +102,19 @@ sub run {
     my $RAM = $self->get_total_mem();
     die "RAM=$RAM. The SUT needs at least 24G of RAM" if $RAM < 24000;
 
-    # Check for SAPHanaSR-angi package going to be used
-    if (get_var('USE_SAP_HANA_SR_ANGI')) {
-        script_run('[ $(rpm -q SAPHanaSR-doc) ] && rpm -e --nodeps SAPHanaSR-doc');
-        script_run('[ $(rpm -q SAPHanaSR) ] && rpm -e --nodeps SAPHanaSR');
-        zypper_call('install SAPHanaSR-angi supportutils-plugin-ha-sap ClusterTools2') if get_var('HA_CLUSTER');
-    }
-    else {
-        zypper_call('install SAPHanaSR SAPHanaSR-doc ClusterTools2') if get_var('HA_CLUSTER');
+    if (get_var('HA_CLUSTER')) {
+        my @zypper_in = ('install');
+        # Check for SAPHanaSR-angi package going to be used
+        if (get_var('USE_SAP_HANA_SR_ANGI')) {
+            script_run('[ $(rpm -q SAPHanaSR-doc) ] && rpm -e --nodeps SAPHanaSR-doc');
+            script_run('[ $(rpm -q SAPHanaSR) ] && rpm -e --nodeps SAPHanaSR');
+            push @zypper_in, 'SAPHanaSR-angi', 'supportutils-plugin-ha-sap';
+        }
+        else {
+            push @zypper_in, 'SAPHanaSR', 'SAPHanaSR-doc';
+        }
+        push @zypper_in, 'ClusterTools2';
+        zypper_call(join(' ', @zypper_in));
     }
 
     # Add host's IP to /etc/hosts


### PR DESCRIPTION
Fix how arguments are passed to download_hana_assets_from_server. Improve package management in hana_installer.


- Related ticket: https://jira.suse.com/browse/TEAM-10126


# Verification run:

## PPC64LE
 - sle-15-SP7-Online-ppc64le-Build66.1-SAPHanaSR_ScaleUp_PerfOpt_node01@ppc64le-hmc-sap -> http://openqa.suse.de/tests/16888320 :green_circle: 
 - sle-15-SP7-Online-ppc64le-Build66.1-SAPHanaSR_ScaleUp_PerfOpt_node02@ppc64le-hmc-sap -> http://openqa.suse.de/tests/16888321 :green_circle: 

## ANGI
- sle-15-SP7-Online-x86_64-Build66.1-create_hdd_sles4sap_gnome@64bit-4gbram -> http://openqa.suse.de/tests/16896663 :green_circle:  here the `zypper in` https://openqa.suse.de/tests/16799153#step/hana_install/16
 - sle-15-SP7-Online-x86_64-Build66.1-SAPHanaSR_angi_ScaleUp_PerfOpt_supportserver@64bit-2gbram -> http://openqa.suse.de/tests/16896662
 - sle-15-SP7-Online-x86_64-Build66.1-SAPHanaSR_angi_ScaleUp_PerfOpt_WMP_node01@64bit-sap -> http://openqa.suse.de/tests/16896664
