### PR TITLE
Enable the listen-on option in named.conf on SLES15SP6+

### DIFF
--- a/tests/virt_autotest/libvirt_isolated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_isolated_virtual_network.pm
@@ -27,14 +27,14 @@ sub run_test {
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_isolated_cfg_name);
 
     #Stop named.service, refer to poo#175287
-    systemctl("stop named.service") if (is_sle('15+'));
+    systemctl("stop named.service") if (is_sle('>=15-SP6') && check_var('VIRT_AUTOTEST', 1));
     #Create ISOLATED NETWORK
     assert_script_run("virsh net-create vnet_isolated.xml");
     save_screenshot;
     upload_logs "vnet_isolated.xml";
     assert_script_run("rm -rf vnet_isolated.xml");
     #Resume named.service, refer to poo#175287
-    systemctl("start named.service") if (is_sle('15+'));
+    systemctl("start named.service") if (is_sle('>=15-SP6') && check_var('VIRT_AUTOTEST', 1));
 
     my ($mac, $model, $affecter, $exclusive, $skip_type);
     my $gate = '192.168.127.1';    # This host exists but should not work as a gate in the ISOLATED NETWORK

--- a/tests/virt_autotest/libvirt_routed_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_routed_virtual_network.pm
@@ -29,8 +29,8 @@ sub run_test {
     my $vnet_routed_clone_cfg_name = "vnet_routed_clone.xml";
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_routed_clone_cfg_name);
 
-    #Stop named.service ,refer to poo#175287
-    systemctl("stop named.service") if (is_sle('15+'));
+    #Stop named.service, refer to poo#175287
+    systemctl("stop named.service") if (is_sle('>=15-SP6') && check_var('VIRT_AUTOTEST', 1));
     #Create ROUTED NETWORK
     assert_script_run("virsh net-create vnet_routed.xml");
     assert_script_run("virsh net-create vnet_routed_clone.xml");
@@ -38,8 +38,8 @@ sub run_test {
     upload_logs "vnet_routed.xml";
     upload_logs "vnet_routed_clone.xml";
     assert_script_run("rm -rf vnet_routed.xml vnet_routed_clone.xml");
-    #Resume named.service ,refer to poo#175287
-    systemctl("start named.service") if (is_sle('15+'));
+    #Resume named.service, refer to poo#175287
+    systemctl("start named.service") if (is_sle('>=15-SP6') && check_var('VIRT_AUTOTEST', 1));
 
     my ($mac1, $mac2, $model1, $model2, $affecter, $exclusive);
     my $target1 = '192.168.130.1';


### PR DESCRIPTION
Enable the listen-on option in named.conf for dnsmasq new behavior on SLES15SP6+ with UEFI and SEV-ES guest systems. refer to [bsc#1235809](https://bugzilla.suse.com/show_bug.cgi?id=1235809) for more details.

- Related ticket: https://progress.opensuse.org/issues/177354
- Verification run: 
[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/16919483#) PASS
[uefi-gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/16922184#) PASS
[sev-es-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/16922179#) PASS
[sev-es-gi-guest_developing-on-host_sles15sp6-kvm](https://openqa.suse.de/tests/16922180#) PASS
[sev-es-gi-guest_sles15sp6-on-host_developing-kvm](https://openqa.suse.de/tests/16922181#) PASS
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/16919479#) PASS
[gi-guest_developing-on-host_developing-xen](https://openqa.suse.de/tests/16922162#) PASS
[gi-guest_developing-on-host_sles15sp6-kvm](https://openqa.suse.de/tests/16922166#) PASS