### PR TITLE
Public Cloud: Increase robustness

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -263,8 +263,7 @@ If the file doesn't exists on the instance, B<no> error is thrown.
 
 sub upload_log {
     my ($self, $remote_file, %args) = @_;
-
-    my $tmpdir = script_output('mktemp -d');
+    my $tmpdir = script_output_retry('mktemp -d');
     my $dest = $tmpdir . '/' . basename($remote_file);
     my $ret = $self->scp('remote:' . $remote_file, $dest);
     upload_logs($dest, %args) if (defined($ret) && $ret == 0);

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -20,6 +20,8 @@ use utils;
 use publiccloud::utils;
 use publiccloud::ssh_interactive 'select_host_console';
 
+our $run_count = 0;
+
 my $path = is_sle('=15-SP2') ? '/usr/sbin/' : '';    # 15-SP2 is the oldest version that needs fullpaths
 my $regcode_param = (is_byos()) ? "-r " . get_required_var('SCC_REGCODE') : '';
 
@@ -27,6 +29,8 @@ sub run {
     my ($self, $args) = @_;
     my ($provider, $instance);
     select_host_console();
+
+    $run_count++;
 
     if (get_var('PUBLIC_CLOUD_QAM', 0)) {
         $instance = $self->{my_instance} = $args->{my_instance};
@@ -221,6 +225,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
+    return {fatal => 1, publiccloud_multi_module => 0} if $run_count > 1;
     return {fatal => 0, publiccloud_multi_module => 1};
 }
 

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -187,7 +187,7 @@ sub test_container_runtimes {
         }
         $instance->ssh_script_run('sudo chmod 644 /etc/containers/registries.conf');
     }
-    $instance->ssh_assert_script_run("sudo zypper install -y podman");
+    $instance->ssh_assert_script_run("sudo zypper install -y podman", timeout => 240);
     $instance->ssh_script_retry("podman --debug pull $image", retry => 3, delay => 60, timeout => 600);
     return 0;
 }
@@ -210,7 +210,8 @@ sub force_new_registration {
 sub post_fail_hook {
     my ($self) = @_;
     if (exists($self->{my_instance})) {
-        $self->{my_instance}->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log');
+        $self->{my_instance}->ssh_script_run("sudo chmod a+r /var/log/cloudregister", timeout => 0, quiet => 1);
+        $self->{my_instance}->upload_log('/var/log/cloudregister', log_name => $autotest::current_test->{name} . '-cloudregister.log.txt');
     }
     if (is_azure()) {
         record_info('azuremetadata', $self->{my_instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));


### PR DESCRIPTION
Currently, both [failing](https://openqa.suse.de/tests/16882874) and [passing](https://openqa.suse.de/tests/16882884) registration test jobs are not destroying the cloud instances. Fix by adding `test_flags => {fatal => 1}` to the second run of publiccloud/check_registercloudguest.

Make sure that /var/log/cloudregister file is readable before uploading it.

Increase timeout for podman installation.

Improve robustness of log uploading by using script_output_retry in publiccloud/instance::upload_log.

- Related ticket: https://progress.opensuse.org/issues/177814
- Verification run:
https://openqa.suse.de/tests/16888779#step/check_registercloudguest#1/365 (Instance destroyed)
