### PR TITLE
xfstests: to get the correct firewall service name

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -444,10 +444,7 @@ sub run {
         script_run("echo export UNIONMOUNT_TESTSUITE=/opt/unionmount-testsuite >> $CONFIG_FILE");
     }
     if (check_var('XFSTESTS', 'nfs')) {
-        # No firewalld on SLE-16
-        if (!is_sle('16+')) {
-            disable_and_stop_service('firewalld');
-        }
+        disable_and_stop_service(opensusebasetest::firewall, ignore_failure => 1);
         set_var('XFSTESTS_TEST_DEV', mountpoint_to_partition('/'));
         post_env_info(join(' ', get_partition_size('/')));
         if (get_var('XFSTESTS_NFS_SERVER')) {


### PR DESCRIPTION
Change to use opensusebasetest::firewall() to get the correct firewall service name.

- Related ticket: https://progress.opensuse.org/issues/177627#note-5
- Verification run: (only to make sure partition step works)
- 12SP5: https://openqa.suse.de/tests/16894478#step/partition/2
- 15SP7: https://openqa.suse.de/tests/16894490#step/partition/8
- 16: https://openqa.suse.de/tests/16894497