### PR TITLE
Render autoinst url from openQA url

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -1882,17 +1882,17 @@ sub config_guest_installation_media {
         }
     }
     elsif ($self->{guest_installation_media} =~ /^.*\.(raw|raw\.xz|qcow2)$/i) {
-        if (script_output("curl --silent -I $self->{guest_installation_media} | grep -E \"^HTTP\" | awk -F \" \" \'{print \$2}\'") == "200") {
+        if (script_output("curl --silent -I " . render_autoinst_url(url => $self->{guest_installation_media}) . " | grep -E \"^HTTP\" | awk -F \" \" \'{print \$2}\'") == "200") {
             if ($self->{guest_installation_media} =~ /^.*\.raw\.xz$/i) {
-                assert_script_run("curl -s -o $self->{guest_storage_backing_path}.xz $self->{guest_installation_media}", timeout => 1200);
+                assert_script_run("curl -s -o $self->{guest_storage_backing_path}.xz " . render_autoinst_url(url => $self->{guest_installation_media}), timeout => 1200);
                 assert_script_run("xz -d $self->{guest_storage_backing_path}.xz", timeout => 120);
             }
             else {
-                assert_script_run("curl -s -o $self->{guest_storage_backing_path} $self->{guest_installation_media}", timeout => 3600);
+                assert_script_run("curl -s -o $self->{guest_storage_backing_path} " . render_autoinst_url(url => $self->{guest_installation_media}), timeout => 3600);
             }
         }
         else {
-            record_info("Installation media $self->{guest_installation_media} does not exist", script_output("curl -I $self->{guest_installation_media}", proceed_on_failure => 1), result => 'fail');
+            record_info("Installation media $self->{guest_installation_media} does not exist", script_output("curl -I " . render_autoinst_url(url => $self->{guest_installation_media}), proceed_on_failure => 1), result => 'fail');
             $self->record_guest_installation_result('FAILED');
         }
     }


### PR DESCRIPTION
* **New** subroutine ```render_autoinst_url``` in ```lib/utils.pm``` to render autoinst url from running openQA, in order to avoid direct downloading from openQA instance.

* **Replace** direct openQA address with rendered autoinst url in ```lib/guest_installation_and_configuration_base.pm```.

* **Verification Runs:** 
  * [sles15sp7 on sles15sp7](https://openqa.suse.de/tests/16935921)
  * [sles12sp5 on sles15sp7](https://openqa.suse.de/tests/16935922)
  * [sl micro 6.2 on sl micro 6.2](https://openqa.suse.de/tests/16935919)
  * [sles15sp6 on sl micro 6.2](https://openqa.suse.de/tests/16935920)
  * [Build5.3 sl micro 6.2 on sl micro 6.2](https://openqa.suse.de/tests/16947412)
  * [Build5.3 sles15sp6 on sl micro 6.2](https://openqa.suse.de/tests/16947887)