### PR TITLE
Initial hana performance bare-metal installation for sle16

### DIFF
--- a/data/autoyast_hanaperf/agama-config.jsonnet
+++ b/data/autoyast_hanaperf/agama-config.jsonnet
@@ -1,0 +1,95 @@
+{
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+  },
+  software: {
+    patterns: ['sles_sap_HADB', 'sles_sap_HAAPP', 'sles_sap_DB', 'sles_sap_APP'],
+  },
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE_SLES4SAP}}',
+  },
+  storage: {
+    drives: [
+      {
+        search: '/dev/disk/by-id/scsi-SATA_DELLBOSS_VD_b68e1f8449390010',
+        partitions: [
+          { search: '*', delete: true },
+          { generate: 'default' },
+        ],
+      },
+    ],
+  },
+  network: {
+    connections: [
+      {
+        id: 'Wired Connection',
+        method4: 'auto',
+        method6: 'auto',
+        ignoreAutoDns: false,
+        status: 'up',
+      },
+    ],
+  },
+  localization: {
+    language: 'en_US.UTF-8',
+    keyboard: 'us',
+    timezone: 'Asia/Shanghai',
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        body: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||,
+      },
+    ],
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          HOST_INFO_DB=(
+          "hana01","2c:ea:7f:ea:b0:24"
+          "hana02","2c:ea:7f:ea:ad:0c"
+          "hana03","2c:ea:7f:ea:bd:7c"
+          "hana04","5c:6f:69:14:14:12"
+          "hana05","5c:6f:69:13:f3:84"
+          )
+          for HOST_INFO in ${HOST_INFO_DB[@]}; do
+                IFS=',' read -r HOST_SHORT_NAME HOST_MAC <<< "${HOST_INFO}"
+                if ip link show | grep -qi "${HOST_MAC}";then
+                    break
+                fi
+          done
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          # Workaround for NetworkManager to make sure the expected NIC up only
+          rm -f /etc/NetworkManager/system-connections/default_connection.nmconnection
+          echo -e "[main]\nno-auto-default=type:ethernet" > /etc/NetworkManager/conf.d/disable_auto.conf
+          echo -e "[connection]\nid=nic0\nuuid=$(uuidgen)\ntype=ethernet\n[ethernet]\nmac-address=${HOST_MAC}\n[ipv4]\nmethod=auto\n" > /etc/NetworkManager/system-connections/nic0.nmconnection
+          chmod 0600 /etc/NetworkManager/system-connections/nic0.nmconnection
+          # Workaround to set SELinux as permissive
+          cp /boot/grub2/grub.cfg /boot/grub2/grub.cfg.orig
+          cp /etc/default/grub /etc/default/grub.orig
+          sed -e "s/selinux=1 enforcing=1/ /g" -i /boot/grub2/grub.cfg
+          sed -e "s/selinux=1 enforcing=1/ /g" -i /etc/default/grub
+          sed -e "s/SELINUX=enforcing/SELINUX=permissive/g" -i /etc/selinux/config
+        |||,
+      },
+    ],
+  },
+}

--- a/schedule/hanaperf/agama_install.yaml
+++ b/schedule/hanaperf/agama_install.yaml
@@ -1,0 +1,7 @@
+name: SLE16-HANA-PERF-BM-Installation
+description:
+    SLE16 Agama Installation for HANA perf bare-metal x86_64 and ppc64le
+schedule:
+    - installation/ipxe_install
+    - installation/agama_reboot
+    - support_server/login


### PR DESCRIPTION
This MR is used for OS installation, by adding jsonnet and yaml schedule to enable HANA perf bare-metal installation
Pending task:
1. Automatically update disk ID according to specific variables 
2. Support more boot parameters like `intel_idle.max_cstate=1`
3. Once https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21108 got merged, the jsonnet file need be updated for dynamic variables.

- Related ticket: https://jira.suse.com/browse/TEAM-10120
- Needles: N/A
- Verification run: http://openqa.qa2.suse.asia/tests/82812
