### PR TITLE
Tidy helm rmt test module

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -16,6 +16,7 @@ use utils;
 use version_utils qw(check_os_release get_os_release is_sle is_sle_micro);
 use containers::common;
 use containers::utils qw(reset_container_network_if_needed);
+use containers::k8s qw(install_k3s);
 
 sub run {
     select_serial_terminal;
@@ -59,12 +60,12 @@ sub run {
     # Install engines in case they are not installed
     install_docker_when_needed() if ($engine =~ 'docker');
     install_podman_when_needed() if ($engine =~ 'podman');
+    install_k3s() if ($engine =~ 'k3s');
     reset_container_network_if_needed($engine);
 
     # Record podman|docker version
-    foreach my $eng (split(',\s*', $engine)) {
-        record_info($eng, script_output("$eng info"));
-    }
+    record_info("docker info", script_output("docker info")) if ($engine =~ 'docker');
+    record_info("podman info", script_output("podman info")) if ($engine =~ 'podman');
 }
 
 sub test_flags {

--- a/variables.md
+++ b/variables.md
@@ -52,6 +52,8 @@ CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` 
 CONTAINERS_CRICTL_VERSION | string | v1.23.0 | The version of CriCtl tool.
 CONTAINERS_NERDCTL_VERSION | string | 0.16.1 | The version of NerdCTL tool.
 CONTAINERS_DOCKER_FLAVOUR | string | | Flavour of docker to install. Valid options are `stable` or undefined (for standard docker package)
+HELM_CHART | string | | Helm chart under test |
+HELM_CONFIG | string | | Additional configuration file for helm |
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.


### PR DESCRIPTION
Make the helm chart configuration obligatory and compact some of the test calls in the module.
Also allow usage of arbitrary helm charts provided via a `oci://` link.

Merge together with https://gitlab.suse.de/qac/container-release-bot/-/merge_requests/397

- Related ticket: https://progress.opensuse.org/issues/177940
- Related PRs: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16313 https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17714
- Verification run: https://openqa.suse.de/tests/16906187#step/helm_rmt/59
