### PR TITLE
containers: Remove assert from mkdir

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -213,7 +213,7 @@ sub bats_post_hook {
     select_serial_terminal;
 
     my $log_dir = "/tmp/logs/";
-    assert_script_run "mkdir $log_dir";
+    assert_script_run "mkdir -p $log_dir";
     assert_script_run "cd $log_dir";
 
     script_run "rm -rf $test_dir";


### PR DESCRIPTION
Remove assert from mkdir as it may fail if another BATS module created it.

- Failed test: https://openqa.suse.de/tests/16900477#step/runc_integration/224
- Verification run: https://openqa.suse.de/tests/16904638