### PR TITLE
Force to start wsl commandline as root to prevent failures

### DIFF
--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -33,19 +33,13 @@ sub run {
         }
     );
     $self->run_in_powershell(
-        cmd => q(wsl),
+        cmd => q(wsl --user root),
         code => sub {
-            # become_root is now preferred and expected behavior:
-            # https://bugzilla.suse.com/show_bug.cgi?id=1225075
-            become_root;
             enter_cmd("zypper in -y -t pattern wsl_systemd");
             wait_still_screen stilltime => 3, timeout => 10, similarity_level => 43;
             save_screenshot;
             enter_cmd("exit");
             wait_still_screen stilltime => 3, timeout => 10, similarity_level => 43;
-            # There's need to exit twice, one from the root and another
-            # one from the WSL
-            enter_cmd("exit");
         }
     );
     # Hopefully temporary workaround for https://github.com/microsoft/WSL/issues/11857


### PR DESCRIPTION
The WSL command line sometimes starts as root and sometimes as `<user>`. I've added a `--user root` flag to prevent this inconsistency.

- Related ticket: https://progress.opensuse.org/issues/177621
- Verification run: https://openqa.suse.de/tests/16905234
