### PR TITLE
Public Cloud: Use record_info in basetest::_cleanup()

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -106,7 +106,7 @@ sub _cleanup {
     die("Cleanup called twice!") if ($self->{cleanup_called});
     $self->{cleanup_called} = 1;
 
-    eval { $self->cleanup(); } or bmwqemu::fctwarn("self::cleanup() failed -- $@");
+    eval { $self->cleanup(); } or record_info('FAILED', "\$self->cleanup() failed -- $@", result => 'fail');
 
     my $flags = $self->test_flags();
 
@@ -144,7 +144,7 @@ sub _cleanup {
     # We need $self->{run_args} and $self->{run_args}->{my_provider}
     if ($self->{run_args} && $self->{run_args}->{my_provider}) {
         diag('Public Cloud _cleanup: Ready for provider cleanup.');
-        eval { $self->{run_args}->{my_provider}->cleanup(); } or bmwqemu::fctwarn("\$self->provider::cleanup() failed -- $@");
+        eval { $self->{run_args}->{my_provider}->cleanup() } or record_info('FAILED', "\$self->run_args->my_provider::cleanup() failed -- $@", result => 'fail');
         diag('Public Cloud _cleanup: The provider cleanup finished.');
     } else {
         diag('Public Cloud _cleanup: Not ready for provider cleanup.');


### PR DESCRIPTION
Also, wrap _upload_logs() calls in 'eval' so it doesn't break any job and leave the instance hanging.

- Related ticket: https://progress.opensuse.org/issues/177814
- Original problem: https://openqa.suse.de/tests/16904656/logfile?filename=autoinst-log.txt#line-1244
- Verification run: https://openqa.suse.de/tests/16905559