### PR TITLE
gnuhealth: Fix mygnuhealth relying on clean desktop

### DIFF
--- a/tests/gnuhealth/gnuhealth_client_first_time.pm
+++ b/tests/gnuhealth/gnuhealth_client_first_time.pm
@@ -51,14 +51,12 @@ sub run {
         send_key 'alt-o';
     }
     assert_screen "$gnuhealth-admin_view", 300;
+    send_key 'alt-f4';
+    assert_and_click "$gnuhealth-admin-confirm_close";
 }
 
 sub test_flags {
     return {fatal => 1};
-}
-
-# overwrite the base class check for a clean desktop
-sub post_run_hook {
 }
 
 1;


### PR DESCRIPTION
Followup to
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19626

```
openqa-clone-custom-git-refspec https://github.com/okurz/os-autoinst-distri-opensuse/tree/fix/gnuhealth https://openqa.opensuse.org/tests/4888103
```

- https://openqa.opensuse.org/tests/4888237