### PR TITLE
Remove IPXE_HTTPSERVER from test schedule to support more complex setups

### DIFF
--- a/schedule/kernel/ibtest-master-autoyast.yaml
+++ b/schedule/kernel/ibtest-master-autoyast.yaml
@@ -11,7 +11,6 @@ vars:
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     SCC_ADDONS: sdk
     VIDEOMODE: ssh-x
 schedule:

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -9,7 +9,6 @@ vars:
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
     KERNEL_GIT_TREE: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
     KERNEL_GIT_BRANCH: for-next

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -9,7 +9,6 @@ vars:
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
     MLX_PROTOCOL: 2
     PATTERNS: base,minimal

--- a/schedule/kernel/ibtest-slave-autoyast.yaml
+++ b/schedule/kernel/ibtest-slave-autoyast.yaml
@@ -12,7 +12,6 @@ vars:
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     PARALLEL_WITH: ibtest-master
     SCC_ADDONS: sdk
 schedule:

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -9,7 +9,6 @@ vars:
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
     KERNEL_GIT_TREE: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
     KERNEL_GIT_BRANCH: for-next

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -9,7 +9,6 @@ vars:
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
     MLX_PROTOCOL: 2
     PARALLEL_WITH: ibtest-master

--- a/schedule/kernel/install_ltp_uefi_baremetal.yaml
+++ b/schedule/kernel/install_ltp_uefi_baremetal.yaml
@@ -5,7 +5,6 @@ vars:
     DESKTOP: textmode
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_UEFI: 1
     SCC_ADDONS: sdk
     LTP_BAREMETAL: 1

--- a/schedule/kernel/sles4sap/install_sles4sap_baremetal.yaml
+++ b/schedule/kernel/sles4sap/install_sles4sap_baremetal.yaml
@@ -8,7 +8,6 @@ vars:
   DESKTOP: textmode
   GRUB_TIMEOUT: 300
   IPXE: 1
-  IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
   HANA: nfs://10.162.31.119/srv/nfs/sap/HANA2/SPS04rev46/x86_64
   INSTANCE_SID: NDB
   INSTANCE_ID: '00'


### PR DESCRIPTION
This variable depends on the worker and its according network structure and should be set as a worker setting.
https://gitlab.suse.de/openqa/salt-pillars-openqa/-/merge_requests/970 is an example how this should be set. For o3 and other infrastructure this chance should make no difference as the previous value was not accessible outside of SUSE.

- Related ticket: https://progress.opensuse.org/issues/174298

Example: https://openqa.suse.de/tests/16831215#settings has the wrong values `IPXE_HTTPSERVER`-variable set despite the correct one [being present since 3 weeks](https://gitlab.suse.de/openqa/salt-pillars-openqa/-/commit/be37192f3c1e428882c5f873627a592c985ae373). With the correct setting, the same job completes: https://openqa.suse.de/tests/16905259#
