### PR TITLE
virt_autotest: Extend timeout of s390x lpar_cmd()

### DIFF
--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -199,7 +199,7 @@ sub run_test {
     my $test_cmd = $self->get_script_run();
     #FOR S390X LPAR
     if (is_s390x) {
-        virt_utils::lpar_cmd("$test_cmd");
+        virt_utils::lpar_cmd("$test_cmd", {timeout => $timeout});
         return;
     }
 

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -306,17 +306,12 @@ sub clean_up_red_disks {
 
 sub lpar_cmd {
     my ($cmd, $args) = @_;
+    my $timeout = $args->{timeout} // 300;
     die 'Command not provided' unless $cmd;
-
     $args->{ignore_return_code} ||= 0;
-    my $ret = console('svirt')->run_cmd($cmd);
-    if ($ret == 0) {
-        record_info('INFO', "Command $cmd run on S390X LPAR: SUCESS");
-    }
-    unless ($args->{ignore_return_code} || !$ret) {
-        record_info('INFO', "Command $cmd run on S390X LPAR: FAIL");
-        die 'Find new failure, please check manually';
-    }
+    my $ret = console('svirt')->run_cmd($cmd, timeout => $timeout);
+    record_info('INFO', "Command $cmd run on S390X LPAR: SUCESS") if ($ret == 0);
+    die 'Find new failure, please check manually' unless ($args->{ignore_return_code} || !$ret);
 }
 
 # Guest xml will be uploaded with name format [generated_name_by_this_func].xml


### PR DESCRIPTION
Refer to [poo#178324](https://progress.opensuse.org/issues/178324), there was new changed to call svirt backend. Now, the **timeout** for running commands via ssh is actually enforced. Add **timeout** to `call console('svirt')->run_cmd($cmd)` as extend timeout of s390x` lpar_cmd() `

- Related ticket: https://progress.opensuse.org/issues/177342
- Verification run: 
s390x
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/16995374#) PASS
[gi-guest_sles15sp6-on-host_developing-kvm](https://openqa.suse.de/tests/16995469#) PASS
[gi-guest_sles12sp5-on-host_developing-kvm](https://openqa.suse.de/tests/16995462#) PASS
[gi-guest_developing-on-host_sles15sp6-kvm](https://openqa.suse.de/tests/16993407#) PASS
[gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.suse.de/tests/16995735#) PASS
[prj4_guest_upgrade_sles15sp6_on_sles15sp6-kvm](https://openqa.suse.de/tests/16993411#) PASS
[prj4_guest_upgrade_sles12sp5_on_sles12sp5-kvm](https://openqa.suse.de/tests/16993412#) PASS
x86_64
[gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/16993413#) PASS

