### PR TITLE
Manage the HANA install path

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -106,8 +106,9 @@ sub run {
         my @zypper_in = ('install');
         # Check for SAPHanaSR-angi package going to be used
         if (get_var('USE_SAP_HANA_SR_ANGI')) {
-            script_run('[ $(rpm -q SAPHanaSR-doc) ] && rpm -e --nodeps SAPHanaSR-doc');
-            script_run('[ $(rpm -q SAPHanaSR) ] && rpm -e --nodeps SAPHanaSR');
+            foreach ('SAPHanaSR-doc', 'SAPHanaSR') {
+                assert_script_run("rpm -e --nodeps $_") if (script_run("rpm -q $_") == 0);
+            }
             push @zypper_in, 'SAPHanaSR-angi', 'supportutils-plugin-ha-sap';
         }
         else {
@@ -241,8 +242,13 @@ sub run {
     }
     assert_script_run "df -h";
 
-    # hdblcm is used for installation, verify if it exists
-    my $hdblcm = '/sapinst/' . get_var('HANA_HDBLCM', "DATA_UNITS/HDB_SERVER_LINUX_" . uc(get_required_var('ARCH')) . "/hdblcm");
+    # hdblcm is used for installation, verify if it exists.
+    # hdblcm can be provided from the external with HANA_HDBLCM
+    # variable, that is a relative path to /sapinst
+    my $hdblcm = join('/', $target,
+        get_var(
+            'HANA_HDBLCM',
+            "DATA_UNITS/HDB_SERVER_LINUX_" . uc(get_required_var('ARCH')) . '/hdblcm'));
     die "hdblcm is not in [$hdblcm]. Set HANA_HDBLCM to the appropiate relative path. Example: DATA_UNITS/HDB_SERVER_LINUX_X86_64/hdblcm"
       if (script_run "ls $hdblcm");
 
@@ -265,7 +271,7 @@ sub run {
       "--logpath=$mountpts{hanalog}->{mountpt}/$sid",
       "--sapmnt=$mountpts{hanashared}->{mountpt}";
     push @hdblcm_args, "--pmempath=$pmempath", "--use_pmem" if get_var('NVDIMM');
-    push @hdblcm_args, "--component_dirs=/sapinst/" . get_var('HDB_CLIENT_LINUX') if get_var('HDB_CLIENT_LINUX');
+    push @hdblcm_args, "--component_dirs=$target/" . get_var('HDB_CLIENT_LINUX') if get_var('HDB_CLIENT_LINUX');
 
     my $cmd = join(' ', $hdblcm, @hdblcm_args);
     record_info 'hdblcm command', $cmd;


### PR DESCRIPTION
Manage the install path, everywhere within hana_install, with the same variable.
Change the conditional bash command to remove the packages not needed for ANGI.

Related ticket: https://jira.suse.com/browse/TEAM-10126

# Verification run:

## ppc64le

sle-15-SP7-Online-ppc64le-Build66.1-SAPHanaSR_ScaleUp_PerfOpt_node01 ppc64le-hmc-sap
- http://openqa.suse.de/tests/16939023 :green_circle: 
- http://openqa.suse.de/tests/17013127


sle-15-SP7-Online-ppc64le-Build66.1-SAPHanaSR_ScaleUp_PerfOpt_node02 ppc64le-hmc-sap
- http://openqa.suse.de/tests/16939022 :green_circle: 
- http://openqa.suse.de/tests/17027402

## x86_64

sle-15-SP7-Online-x86_64-Build66.1-sles4sap_scc_gnome_hana_cli
 - http://openqa.suse.de/tests/16939040   :green_circle: 
 - http://openqa.suse.de/tests/17013140  :green_circle:  


sle-15-SP3-Server-DVD-SAP-Incidents-x86_64:
- qam-create_hdd_sles4sap_gnome -> http://openqa.suse.de/tests/17025775  :green_circle: 
- qam-SAPHanaSR_ScaleUp_PerfOpt_supportserver -> http://openqa.suse.de/tests/17025777  :green_circle: 
- qam-SAPHanaSR_ScaleUp_PerfOpt_WMP_node01 -> http://openqa.suse.de/tests/17025774  :green_circle: 
- qam-SAPHanaSR_ScaleUp_PerfOpt_WMP_node02 -> http://openqa.suse.de/tests/17025776  :green_circle: 

sle-15-SP7-Online-x86_64-Build66.1-sles4sap_scc_gnome_hana_cli with USE_SAP_HANA_SR_ANGI=true
 - https://openqa.suse.de/tests/16948733  :green_circle:  
 - http://openqa.suse.de/tests/17013137  :green_circle: 


sle-15-SP6-Server-DVD-SAP-Incidents-x86_64  with USE_SAP_HANA_SR_ANGI=1
 - supportserver -> http://openqa.suse.de/tests/17039285
 - qam-SAPHanaSR_angi_ScaleUp_PerfOpt_WMP_node01 -> http://openqa.suse.de/tests/17039286
 - qam-SAPHanaSR_angi_ScaleUp_PerfOpt_WMP_node02 -> http://openqa.suse.de/tests/17039287