### PR TITLE
containers: Set PODMAN_ROOTLESS_USER for podman upstream tests

### DIFF
--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -36,6 +36,7 @@ sub run_tests {
     selinux_hack $tmp_dir;
 
     my %_env = (
+        PODMAN_ROOTLESS_USER => $testapi::username,
         BATS_TMPDIR => $tmp_dir,
         PODMAN => "/usr/bin/podman",
         QUADLET => $quadlet,


### PR DESCRIPTION
Set `PODMAN_ROOTLESS_USER` to make `podman image scp transfer` subtest in [120-load.bats](https://github.com/containers/podman/blob/main/test/system/120-load.bats#L84) work.

- Verification run: https://openqa.opensuse.org/tests/4889989

TODO:
- Fix `PODMAN_BATS_SKIP_ROOT_LOCAL` in o3.
- Ditto above for osd.