### PR TITLE
web_browser: allow Strict-Transport-Security in a case insensitive way

### DIFF
--- a/lib/web_browser.pm
+++ b/lib/web_browser.pm
@@ -78,7 +78,7 @@ sub run_web_browser_text_based {
         enter_cmd "clear";
 
         if ($browser ne "links") {
-            validate_script_output("$browser $options $https_url{$p}", sub { m/.*200 OK.*Strict-Transport-Security.*/s });
+            validate_script_output("$browser $options $https_url{$p}", sub { m/.*200 OK.*(?i)Strict-Transport-Security.*/s });
         } else {
             my $output_file = "webpage.txt";
             assert_script_run "$browser $options $https_url{$p} > $output_file";


### PR DESCRIPTION
Allow also lower case strict-transport-security due to build.opensuse.org changes.

- Related ticket: https://progress.opensuse.org/issues/178081
- Verification run: 15-SP6: https://openqa.suse.de/tests/16921224
