### PR TITLE
Add workaround for bsc#1238152

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -341,6 +341,13 @@ sub wait_hana_node_up {
             timeout => 5,
             proceed_on_failure => 1);
         return if ($out =~ m/running/);
+        if ($out =~ m/degraded/) {
+            my $failed_service = $instance->run_ssh_command(cmd => 'sudo systemctl --failed', timeout => 600, proceed_on_failure => 1);
+            if ($out =~ /degraded/ && $failed_service =~ /guestregister/) {
+                record_soft_failure('bsc#1238152 - Restart guestregister service');
+                $instance->run_ssh_command(cmd => "sudo systemctl restart guestregister.service", timeout => 600, proceed_on_failure => 1);
+            }
+        }
         record_info("WAIT_FOR_SYSTEM", "System state: $out");
         sleep 10;
     }


### PR DESCRIPTION
Restarts guestregister.service in case of `degraded` system status. Related bug is https://bugzilla.suse.com/show_bug.cgi?id=1238152

- Related ticket: https://jira.suse.com/browse/TEAM-10083
- Verification run: https://openqa.suse.de/tests/16922867#step/Crash_site_b-primary/472
