### PR TITLE
Allow ipaddr2 test to use alternative vars for image source

### DIFF
--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -33,14 +33,6 @@ sub run {
     # before to start.
     die('Azure is the only CSP supported for the moment')
       unless check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-    my $os = get_required_var('CLUSTER_OS_VER');
-    my %cloudinit_args;
-    $cloudinit_args{scc_code} = get_required_var('SCC_REGCODE_SLES4SAP') if ($os =~ /byos/i);
-    $cloudinit_args{external_repo} = get_var('IPADDR2_NGINX_EXTREPO') if get_var('IPADDR2_NGINX_EXTREPO');
-    my %deployment = (
-        os => $os,
-        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0));
-    $deployment{trusted_launch} = 0 if (check_var('IPADDR2_TRUSTEDLAUNCH', 0));
 
     select_serial_terminal;
 
@@ -51,6 +43,24 @@ sub run {
     # in particular it has setting about verbosity that
     # break test steps that relay to remote ssh comman output
     assert_script_run('rm ~/.ssh/config');
+
+    my $os;
+    if (get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) {
+        # This section is only needed by Azure tests using images uploaded
+        # with publiccloud_upload_img. This is because qe-sap-deployment
+        # is still not able to use images from Azure Gallery
+        $os = $self->{provider}->get_blob_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
+    } else {
+        $os = get_required_var('CLUSTER_OS_VER');
+    }
+
+    my %cloudinit_args;
+    $cloudinit_args{scc_code} = get_required_var('SCC_REGCODE_SLES4SAP') if ($os =~ /byos/i);
+    $cloudinit_args{external_repo} = get_var('IPADDR2_NGINX_EXTREPO') if get_var('IPADDR2_NGINX_EXTREPO');
+    my %deployment = (
+        os => $os,
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0));
+    $deployment{trusted_launch} = 0 if (check_var('IPADDR2_TRUSTEDLAUNCH', 0));
 
     $deployment{region} = $provider->provider_client->region;
     # If required (by default cloud-init is active), both:


### PR DESCRIPTION
This pr enables the ipaddr2 test to alternatively use `PUBLIC_CLOUD_IMAGE_LOCATION` instead of `CLUSTER_OS_VER` as the image source.

- Related ticket: https://jira.suse.com/browse/TEAM-9863
- Verification run: https://openqaworker15.qa.suse.cz/tests/315838

For the VR I just cloned a 15sp6 job and set the PUBLIC_CLOUD_IMAGE_LOCATION and PUBLIC_CLOUD_STORAGE_ACCOUNT in the clone command
