### PR TITLE
Make helm a container basetest

### DIFF
--- a/tests/containers/helm_rmt.pm
+++ b/tests/containers/helm_rmt.pm
@@ -12,7 +12,7 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
-use Mojo::Base 'publiccloud::basetest';
+use Mojo::Base 'containers::basetest';
 use File::Basename qw(dirname);
 use testapi;
 use utils;


### PR DESCRIPTION
helm-rmt should not be a publiccloud basetest.

- Related ticket: https://progress.opensuse.org/issues/177940
- Related failure: https://openqa.suse.de/tests/16938298#step/helm_rmt/63
- Verification run: https://openqa.suse.de/tests/16938312#step/helm_rmt/62
