### PR TITLE
Create unattended installation for lvm multipath encrypted

### DIFF
--- a/data/yam/agama/auto/lvm_multipath_encrypted.jsonnet
+++ b/data/yam/agama/auto/lvm_multipath_encrypted.jsonnet
@@ -1,0 +1,62 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}',
+  },
+  bootloader: {
+    stopOnBootMenu: true,
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+  },
+  storage: {
+    drives: [
+      {
+        alias: 'pvs-disk',
+        partitions: [
+          { search: '*', delete: true },
+        ],
+      },
+    ],
+    volumeGroups: [
+      {
+        name: 'system',
+        physicalVolumes: [
+          {
+            generate: {
+              targetDevices: ['pvs-disk'],
+              encryption: {
+                luks2: { password: 'nots3cr3t' },
+              },
+            },
+          },
+        ],
+        logicalVolumes: [
+          { generate: 'default' },
+        ],
+      },
+    ],
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'activate multipath',
+        body: |||
+          #!/bin/bash
+          if ! systemctl status multpathd ; then
+            echo 'Activating multipath'
+            systemctl start multipathd.socket
+            systemctl start multipathd
+          fi
+        |||,
+      },
+    ]
+  },
+}

--- a/schedule/yam/agama_lvm_multipath_encrypted_unattended.yaml
+++ b/schedule/yam/agama_lvm_multipath_encrypted_unattended.yaml
@@ -1,0 +1,12 @@
+---
+name: Agama unattended lvm with encryption
+description: >
+  Perform Agama unattended installation with encryption on LVM.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm
+  - console/validate_encrypt
+  - console/validate_multipath

--- a/test_data/yam/agama_lvm_multipath_encrypted.yaml
+++ b/test_data/yam/agama_lvm_multipath_encrypted.yaml
@@ -1,0 +1,5 @@
+---
+crypttab:
+  num_devices_encrypted: 1
+<<: !include test_data/yast/encryption/default_enc_luks2.yaml
+<<: !include test_data/yast/multipath.yaml


### PR DESCRIPTION
We have added the profile templates to perform lvm multipath encrypted tests

- Related ticket: https://progress.opensuse.org/issues/176460
- Needles: N/A
- Verification run: 
  - x86_64: https://openqa.suse.de/tests/16938239#
  - aarch64: https://openqa.suse.de/tests/16938237
