### PR TITLE
Change name for the qesap variable about Angi

### DIFF
--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -44,7 +44,7 @@ sub run {
     $variables{OS_OWNER} = get_var('QESAPDEPLOY_CLUSTER_OS_OWNER', 'amazon') if check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
 
     $variables{USE_SAPCONF} = get_var('QESAPDEPLOY_USE_SAPCONF', 'false');
-    $variables{USE_SR_ANGI} = get_var('USE_SAP_HANA_SR_ANGI', 'false');
+    $variables{USE_SR_ANGI} = get_var('QESAPDEPLOY_USE_SAP_HANA_SR_ANGI', 'false');
     $variables{SLES4SAP_PUBSSHKEY} = get_ssh_private_key_path() . '.pub';
     $variables{REGISTRATION_PLAYBOOK} = get_var('QESAPDEPLOY_REGISTRATION_PLAYBOOK', 'registration');
     $variables{REGISTRATION_PLAYBOOK} =~ s/\.yaml$//;


### PR DESCRIPTION
Rename USE_SAP_HANA_SR_ANGI to QESAPDEPLOY_USE_SAP_HANA_SR_ANGI. All the variables in this test module are followith this naming convention. The name is still comparable to the one used in HanaSR test modules.

- Related ticket: https://jira.suse.com/browse/TEAM-9426

# Verification run:

sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test
 -  http://openqaworker15.qa.suse.cz/tests/315839
