### PR TITLE
Change schedule from HELM_CONFIG to HELM_CHART

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -283,7 +283,7 @@ sub load_container_tests {
         return;
     }
 
-    if (get_var('HELM_CONFIG')) {
+    if (get_var('HELM_CHART')) {
         set_var('K3S_ENABLE_COREDNS', 1);
         loadtest 'containers/helm_rmt';
         return;


### PR DESCRIPTION
HELM_CONFIG became an optional setting, HELM_CHART is now the obligatory setting for triggering helm test runs.

- Related ticket: https://progress.opensuse.org/issues/177940
- Related MR: https://gitlab.suse.de/qac/container-release-bot/-/merge_requests/397/diffs
