### PR TITLE
Workaround for bsc#1238581 to use agama.auto

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -888,7 +888,8 @@ sub specific_bootmenu_params {
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $url = autoyast::expand_agama_profile($agama_auto);
         $url = shorten_url($url) if (is_backend_s390x && !is_opensuse);
-        push @params, "inst.auto=$url inst.finish=stop";
+        # Workaround for bsc#1238581, will remove it once the bug is fixed
+        push @params, "agama.auto=$url agama.finish=stop";
     }
 
     if (my $agama_install_url = get_var('AGAMA_INSTALL_URL')) {

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -185,7 +185,8 @@ sub set_bootscript_agama_cmdline_extra {
     my $cmdline_extra = " ";
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $agama_auto_url = autoyast::expand_agama_profile($agama_auto);
-        $cmdline_extra .= "inst.auto=$agama_auto_url inst.finish=stop ";
+        # Workaround for bsc#1238581, will remove it once the bug is fixed
+        $cmdline_extra .= "agama.auto=$agama_auto_url agama.finish=stop ";
     }
     # Agama Installation repository URL
     # By default Agama installs the packages from the repositories specified in the product configuration.


### PR DESCRIPTION
Current openQA codes uses inst.auto, but it is not supported by recent SLE16 build like 49.1 53.2 53.3
and slack discussion: https://suse.slack.com/archives/C082VE1U2F5/p1741020780699299
And workaround for https://bugzilla.suse.com/show_bug.cgi?id=1238581 to unblock bare-metal installation

- Related ticket: https://progress.opensuse.org/issues/178255
- Needles: N/A
- Verification run: 
 http://openqa.qa2.suse.asia/tests/82909
