### PR TITLE
[SDAF] Enable SBD fencing option

### DIFF
--- a/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars
+++ b/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars
@@ -118,10 +118,10 @@ use_private_endpoint = true
 #########################################################################################
 
 # scs_cluster_type defines cluster quorum type; AFA (Azure Fencing Agent), ASD (Azure Shared Disk), ISCSI
-scs_cluster_type = "AFA"
+scs_cluster_type = "%SDAF_FENCING_TYPE%"
 
 # database_cluster_type defines cluster quorum type; AFA (Azure Fencing Agent), ASD (Azure Shared Disk), ISCSI
-database_cluster_type = "AFA"
+database_cluster_type = "%SDAF_FENCING_TYPE%"
 
 # use_msi_for_clusters if defined will use managed service identity for the Pacemaker cluster fencing
 use_msi_for_clusters = true

--- a/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars
+++ b/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars
@@ -437,7 +437,7 @@ ANF_qos_type = "Manual"
 #iscsi_subnet_arm_id = ""
 
 # iscsi_subnet_address_prefix is a mandatory parameter if the subnets are not defined in the workload or if existing subnets are not used
-#iscsi_subnet_address_prefix = ""
+iscsi_subnet_address_prefix = "%ISCSI_SUBNET_ADDRESS_PREFIX%"
 
 # iscsi_subnet_nsg_arm_id is an optional parameter that if provided specifies Azure resource identifier for the existing nsg
 #iscsi_subnet_nsg_arm_id = ""
@@ -453,7 +453,7 @@ ANF_qos_type = "Manual"
 ###########################################################################
 
 # Number of iSCSI devices to be created
-iscsi_count = 0
+iscsi_count = "%SDAF_ISCSI_DEVICE_COUNT%"
 
 # Size of iSCSI Virtual Machines to be created
 iscsi_size = "Standard_D2s_v3"
@@ -474,7 +474,7 @@ iscsi_authentication_username = "azureadm"
 #iscsi_nic_ips = []
 
 # Defines the Availability zones for the iSCSI devices
-#iscsi_vm_zones = []
+iscsi_vm_zones = ["1", "2", "3"]
 
 # user_assigned_identity_id defines the user assigned identity to be assigned to the Virtual machines
 #user_assigned_identity_id = ""

--- a/tests/sles4sap/redirection_tests/hana_cluster_check.pm
+++ b/tests/sles4sap/redirection_tests/hana_cluster_check.pm
@@ -24,7 +24,7 @@ sub run {
     my %redirection_data = %{$run_args->{redirection_data}};
 
     for my $instance_type (keys(%redirection_data)) {
-
+        next() unless grep /$instance_type/, qw(ha_node db_hana nw_ascs nw_ers);
         for my $hostname (keys(%{$redirection_data{$instance_type}})) {
             my %host_data = %{$redirection_data{$instance_type}{$hostname}};
             connect_target_to_serial(

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
@@ -46,11 +46,15 @@ B<Available options are:>
 =item * B<nw_ensa> - Installs ERS and sets up ENSA2 scenario
 
 =back
-B<Required OpenQA variables:>
-    SDAF_DEPLOYMENT_SCENARIO See above
-    SDAF_ENV_CODE  Code for SDAF deployment env.
-    PUBLIC_CLOUD_REGION SDAF internal code for azure region.
-    SAP_SID SAP system ID.
+B<Required OpenQA settings:>
+    SDAF_DEPLOYMENT_SCENARIO - See above
+    SDAF_ENV_CODE - Code for SDAF deployment env.
+    PUBLIC_CLOUD_REGION - SDAF internal code for azure region.
+    SAP_SID - SAP system ID.
+B<Optional OpenQA settings:>
+    SDAF_FENCING_MECHANISM - Fencing mechanism. Default: MSI
+        Accepted values: 'msi' - MSI fencing agent, 'sbd' - iscsi based SBD device, 'asd' - Azure shared disk as SBD device
+    SDAF_ISCSI_DEVICE_COUNT - Number of iSCSI devices to be used for SBD. Default: 1
 =cut
 
 sub test_flags {


### PR DESCRIPTION
This PR adds options for SDAF test deploy SBD based fencing with multiple SBD 
devices. Changes include adjusting subnet IP distribution to be more efficient 
and adds iSCSI subnet.  

- Related ticket: https://jira.suse.com/browse/TEAM-10087
- Verification runs: 
HanaSR 1xSBD: https://openqaworker15.qa.suse.cz/tests/317472#step/execute_playbooks/272 :green_circle: 
HanaSR 3xSBD: https://openqaworker15.qa.suse.cz/tests/317474 :red_circle: 
   Failure related to: https://github.com/sdaf-suse/sap-automation/issues/5
HanaSR MSI: https://openqaworker15.qa.suse.cz/tests/317478


