### PR TITLE
Add scenario for mediacheck of both installation mediums

### DIFF
--- a/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
@@ -29,6 +29,11 @@ sub boot_from_hd {
     send_key 'ret';
 }
 
+sub check_installation_medium {
+    my ($self) = @_;
+    send_key_until_needlematch('grub-menu-agama-mediacheck-highlighted', 'down');
+}
+
 sub edit_current_entry { shift->{grub_menu_base}->edit_current_entry() }
 
 1;

--- a/schedule/yam/agama_check_installation_medium.yaml
+++ b/schedule/yam/agama_check_installation_medium.yaml
@@ -1,0 +1,6 @@
+---
+name: agama_check_installation_medium
+description: >
+  Test suite triggers installation medium integrity check and verifies that is successful by checking logs.
+schedule:
+  - yam/agama/agama_check_installation_medium

--- a/tests/yam/agama/agama_check_installation_medium.pm
+++ b/tests/yam/agama/agama_check_installation_medium.pm
@@ -1,0 +1,31 @@
+## Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Select Check Installation Medium in Grub then perform boot log inspection to get mediacheck tool result.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "installbasetest";
+use strict;
+use warnings;
+use testapi;
+use Mojo::Util 'trim';
+
+sub run {
+    my $grub_menu = $testapi::distri->get_grub_menu_agama();
+    my $grub_entry_edition = $testapi::distri->get_grub_entry_edition();
+    my $agama_up_an_running = $testapi::distri->get_agama_up_an_running();
+    my @params = split ' ', trim(get_var('EXTRABOOTPARAMS', ''));
+
+    $grub_menu->expect_is_shown();
+    $grub_menu->check_installation_medium();
+    $grub_menu->edit_current_entry();
+    $grub_entry_edition->move_cursor_to_end_of_kernel_line();
+    $grub_entry_edition->type(\@params);
+    $grub_entry_edition->boot();
+    $agama_up_an_running->expect_is_shown();
+
+    select_console 'root-console';
+    assert_script_run("journalctl -b | grep \"Finished Installation medium integrity check.\"", timeout => 60);
+}
+
+1;


### PR DESCRIPTION
We have added the mediacheck schedule, needles and required code.

- Related ticket: https://progress.opensuse.org/issues/176781
- Needles: `mediacheck-bootloader-prompt-20250304` and `mediacheck-boot-agama-mediacheck-20250304`
- Verification run: 
  - x86_64: https://openqa.suse.de/tests/17172754
  - aarch64: https://openqa.suse.de/tests/17172755
