### PR TITLE
Disable IP_CHANGE detection for sles4sap

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -407,7 +407,8 @@ sub wait_for_ssh {
         last if (isok($exit_code) and not $args{wait_stop});    # ssh port open ok
         last if (not isok($exit_code) and $args{wait_stop});    # ssh port closed ok
 
-        if ($duration >= $args{timeout} - 30) {
+        # skip SLES4SAP as incompatible with get_public_ip
+        if (($duration >= $args{timeout} - 30) and (!get_var('PUBLIC_CLOUD_SLES4SAP'))) {
             my $public_ip_from_provider = $self->provider->get_public_ip();
             if ($args{public_ip} eq $public_ip_from_provider) {
                 record_info('IP CHANGED', printf("The address we know is %s but provider returns %s", $args{public_ip}, $public_ip_from_provider));


### PR DESCRIPTION
IP_CHANGE detection in wait_for_ssh, and in particular when executed in AWS or GCP, are suing terraform output to detect public IP change. This technique is not working when used with deployment created by qe-sap-deployment. Skip this code when used in sles4sap tests.
Refinement for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21141

- Related ticket: https://progress.opensuse.org/issues/155116

# Verification run:

sle-15-SP7-EC2-SAP-BYOS-x86_64-Build0565-ec2_sap_byos_hanasr ec2_r5.8xlarge
- http://openqa.suse.de/tests/16952679
