### PR TITLE
Assert if get_terraform_output is used in SAP test

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -735,6 +735,7 @@ To get the complete output structure, the call is:
 
 sub get_terraform_output {
     my ($self, $jq_query) = @_;
+    die "terraform output not supported in tests using qe-sap-deployment" if get_var('PUBLIC_CLOUD_SLES4SAP');
     my $res = script_output("terraform output -no-color -json | jq -r '$jq_query' 2>/dev/null", proceed_on_failure => 1);
     # jq 'null' shall return empty
     return $res unless ($res =~ /^null$/);


### PR DESCRIPTION
get_terraform_out is calling 'terraform output' in the current directory. This is something is not going to produce valid results in tests using qe-sap-deployment.


- Verification run: