### PR TITLE
Skip modules on SLES16

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -129,6 +129,8 @@ sub delegate_controllers {
 }
 
 sub enable_modules {
+    return if is_sle("16+");    # no modules on SLES16+
+
     add_suseconnect_product(get_addon_fullname('desktop'));
     add_suseconnect_product(get_addon_fullname('sdk'));
     add_suseconnect_product(get_addon_fullname('python3')) if is_sle('>=15-SP4');


### PR DESCRIPTION
On SLES16 there are no modules.

- Related failure: https://openqa.suse.de/tests/16954839
- Verification run: https://openqa.suse.de/tests/16954891 (different failure)
