### PR TITLE
Make container engine test fatal and milestone

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -178,5 +178,9 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
 1;
 


### PR DESCRIPTION
Container engine tests are crucial for the whole test runs, as they install the container engines. If they fail it does not make any sense to continue.

Also create a milestone, as otherwise a snapshot would revert to a state before the container engines are installed.

- Related failure: https://openqa.suse.de/tests/16954887#step/docker_runc/43 (because of https://openqa.suse.de/tests/16954887#step/docker_runc/1)
- Verification run: https://openqa.suse.de/tests/16954903
