### PR TITLE
xfstests: workaround pynfs all fails in NFS4.1 with DELEG

### DIFF
--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -53,7 +53,9 @@ sub install_testsuite {
         $rel = "-b $rel" if ($rel);
 
         install_dependencies_pynfs;
-        assert_script_run("git clone -q --depth 1 $url $rel && cd ./pynfs");
+        assert_script_run("git clone $url $rel && cd ./pynfs");
+        # workaround poo#178288 all pynfs fails in DELEG2
+        assert_script_run('git checkout 81a4693305abb42ffd16e77a4808a1a607693476~');
         assert_script_run('./setup.py build && ./setup.py build_ext --inplace');
     }
     elsif (get_var("CTHON04")) {


### PR DESCRIPTION
to workaround the upstream commit to add v4.1+ st_delegation and st_xattr tests to "all" group. Meanwhile, to file a bug to see if it's an issue https://bugzilla.suse.com/show_bug.cgi?id=1238588

- Related ticket: https://progress.opensuse.org/issues/178288
- Verification run: https://openqa.opensuse.org/tests/4901382
