### PR TITLE
Add installation/grub_test before the first_boot

### DIFF
--- a/schedule/ha/bv/agama_install_sles_ha.yaml
+++ b/schedule/ha/bv/agama_install_sles_ha.yaml
@@ -6,6 +6,7 @@ description: >
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_auto
+  - installation/grub_test
   - installation/first_boot
   - console/system_prepare
   - '{{generate_image}}'

--- a/schedule/sles4sap/installation/agama_install_sles4sap.yaml
+++ b/schedule/sles4sap/installation/agama_install_sles4sap.yaml
@@ -8,6 +8,7 @@ description: >
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_auto
+  - installation/grub_test
   - installation/first_boot
   - console/system_prepare
   - '{{test_sles4sap}}'

--- a/schedule/sles4sap/installation/agama_install_sles4sap_saptune.yaml
+++ b/schedule/sles4sap/installation/agama_install_sles4sap_saptune.yaml
@@ -7,6 +7,7 @@ description: >
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_auto
+  - installation/grub_test
   - installation/first_boot
   - console/system_prepare
   - sles4sap/patterns


### PR DESCRIPTION
Need to include the module installation/grub_test before the first_boot for SLE16

- Verification run:
https://openqa.suse.de/tests/16960738#step/grub_test/1 (installation/grub_test passed)