### PR TITLE
Skip locale check except for community and 12sp5 images

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -14,7 +14,8 @@ use strict;
 use warnings;
 use lockapi qw(mutex_create mutex_wait);
 use testapi;
-use version_utils qw(is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro is_leap_micro is_vmware is_bootloader_sdboot is_bootloader_grub2_bls has_selinux_by_default);
+use version_utils qw(is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro
+  is_leap_micro is_vmware is_bootloader_sdboot is_bootloader_grub2_bls has_selinux_by_default is_community_jeos);
 use Utils::Architectures;
 use Utils::Backends;
 use jeos qw(expect_mount_by_uuid);
@@ -221,15 +222,9 @@ sub run {
         send_key 'ret';
     }
 
-    # kiwi-templates-JeOS images (sle, opensuse x86_64 only) are build w/o translations
+    # kiwi-templates-JeOS images except of 12sp5 and community jeos are build w/o translations
     # jeos-firstboot >= 0.0+git20200827.e920a15 locale warning dialog has been removed
-    # TO BE REMOVED *soon*; keep only else part
-    if ((is_sle('15+') && is_sle('<15-sp3')) || (is_leap('<15.3') && is_x86_64)) {
-        assert_screen 'jeos-lang-notice', 300;
-        # Without this 'ret' sometimes won't get to the dialog
-        wait_still_screen;
-        send_key 'ret';
-    } elsif ((is_opensuse && !is_microos && !is_x86_64) || is_sle('=12-sp5')) {
+    if (is_community_jeos || is_sle('=12-sp5')) {
         assert_screen 'jeos-locale', 300;
         send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 51;
         send_key 'ret';


### PR DESCRIPTION
The locale setup option is not present in our images any more since jeos-firstboot version 0.0+git20200827.e920a15. As we test only `12sp5` images, and it breaks Cloud@aarch64 image test, we need to update this condition.

- ticket: https://progress.opensuse.org/issues/117412

#### Verification runs

 - opensuse-Tumbleweed-JeOS-for-OpenStack-Cloud-aarch64-Build20250304-jeos-wizard@aarch64 -> https://openqa.opensuse.org/tests/4901962
 - sle-15-SP3-JeOS-for-kvm-and-xen-Updates-x86_64-Build20250304-1-jeos-main@uefi-virtio-vga -> https://openqa.suse.de/tests/16960783
 - sle-12-SP5-JeOS-for-kvm-and-xen-Updates-x86_64-Build20250221-1-jeos-main@64bit-virtio-vga -> https://openqa.suse.de/tests/16960784
 - opensuse-Tumbleweed-JeOS-for-AArch64-aarch64-Build20250303-jeos-container_host@aarch64-HD20G -> https://openqa.opensuse.org/tests/4901963