### PR TITLE
install_ltp: Install exfatprogs for LTP git

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -80,6 +80,7 @@ sub install_runtime_dependencies {
       e2fsprogs
       evmctl
       exfat-utils
+      exfatprogs
       fuse-exfat
       ibmtss
       lvm2


### PR DESCRIPTION
There is not `exfat-utils` package on SLE-15SP6. Install `exfatprogs` instead.

- Related ticket: N/A
- Needles: N/A
- Verification run: Pending
