### PR TITLE
Fix pod initializing failure while deploying node-helper daemonset

### DIFF
--- a/data/virt_autotest/kubevirt_tests/node-helper-patch.yaml
+++ b/data/virt_autotest/kubevirt_tests/node-helper-patch.yaml
@@ -7,3 +7,18 @@ spec:
         options:
         - name: ndots
           value: "1"
+      initContainers:
+      - name: helper
+        command:
+          - /bin/sh
+          - -euxc
+          - |
+            test -z "${IMAGE1}" || ${CTR} i pull -k --local ${IMAGE1} > /dev/null
+            test -z "${TAG1}" || ${CTR} i tag --force ${IMAGE1} ${TAG1}
+            while mountpoint /tmp/hostImages/mount_hp; do
+              umount /tmp/hostImages/mount_hp
+            done
+            rm -rf /tmp/hostImages/*
+            for i in ${PRE_PULL}; do
+              ${CTR} i pull -k --local ${i} > /dev/null
+            done


### PR DESCRIPTION
This PR will fix the kubevirt "ctr" command failure on sle-micro 6.2.

Test failures:
```
# kubectl get pods -n kubevirt-ci
kubevirt-ci   node-helper-bj55v                                        0/1     Init:CrashLoopBackOff   14 (4m48s ago)   46m
kubevirt-ci   node-helper-ng7bw                                        0/1     Init:CrashLoopBackOff   14 (4m11s ago)   46m

# kubectl logs -n kubevirt-ci pod/node-helper-bj55v
Defaulted container "sleeper" out of: sleeper, helper (init)
Error from server (BadRequest): container "sleeper" in pod "node-helper-bj55v" is waiting to start: PodInitializing

  Warning  BackOff         2m37s (x24 over 7m35s)  kubelet            Back-off restarting failed container helper in pod node-helper-bj55v_kubevirt-ci(6f11dd69-5833-4944-99b0-5361382d99d4

# kubectl logs -n kubevirt-ci node-helper-bj55v -c helper
+ test -z quay.io/kubevirt/alpine-ext-kernel-boot-demo:v1.2.2
+ /var/lib/rancher/rke2/bin/ctr -a /run/k3s/containerd/containerd.sock -n k8s.io i pull -k quay.io/kubevirt/alpine-ext-kernel-boot-demo:v1.2.2
ctr: "--skip-verify" requires "--local" flag
```
- Related ticket: https://progress.opensuse.org/issues/178339
- Verification run: https://openqa.suse.de/tests/16970965
