### PR TITLE
Automate guest installation using agama iso

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_kvm_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_kvm_hvm_x86_64.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT/</guest_installation_media>
     <guest_boot_settings/>
     <guest_secure_boot/>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_hvm_x86_64.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT/</guest_installation_media>
     <guest_boot_settings/>
     <guest_secure_boot/>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_pv_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/opensuse_tumbleweed_64_xen_pv_x86_64.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=hvc0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.opensuse.org/assets/repo/openSUSE-Tumbleweed-oss-x86_64-CURRENT/</guest_installation_media>
     <guest_boot_settings/>
     <guest_secure_boot/>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/oracle_linux_7_9_graphical_server_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/oracle_linux_7_9_graphical_server_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>OracleLinux-R7-U9-Server-x86_64-dvd.iso</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings/>
     <guest_secure_boot/>
     <guest_os_variant>ol7.9</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/oracle_linux_8_10_graphical_server_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/oracle_linux_8_10_graphical_server_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>OracleLinux-R8-U10-x86_64-dvd.iso</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings/>
     <guest_secure_boot/>
     <guest_os_variant>ol8.5</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/oracle_linux_9_4_graphical_server_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/oracle_linux_9_4_graphical_server_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>OracleLinux-R9-U4-x86_64-dvd.iso</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings/>
     <guest_secure_boot/>
     <guest_os_variant>ol9.3</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/slem_5_5_64_kvm_hvm_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/slem_5_5_64_kvm_hvm_x86_64.xml
@@ -25,7 +25,6 @@
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-5.5-Micro-POOL-x86_64-Build12345-Media1/</guest_installation_media>
-    <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings></guest_boot_settings>
     <guest_secure_boot></guest_secure_boot>
     <guest_os_variant>slem5.4</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_kvm_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_kvm_hvm_uefi_with_power_management_x86_64.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,loader.readonly=yes,loader.type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_12_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://dist.suse.de/install/SLP/SLE-12-SP5-Server-LATEST/x86_64/DVD1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp3_64_kvm_hvm_uefi_without_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp3_64_kvm_hvm_uefi_without_power_management_x86_64.xml
@@ -24,8 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP3-Full-x86_64-GM-Media1</guest_installation_media>
-    <guest_installation_fine_grained></guest_installation_fine_grained>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP3-Full-x86_64-GM-Media1/</guest_installation_media>
     <guest_boot_settings>uefi</guest_boot_settings>
     <guest_secure_boot>false</guest_secure_boot>
     <guest_os_variant></guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp3_64_xen_hvm_uefi_without_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp3_64_xen_hvm_uefi_without_power_management_x86_64.xml
@@ -24,8 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP3-Full-x86_64-GM-Media1</guest_installation_media>
-    <guest_installation_fine_grained></guest_installation_fine_grained>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP3-Full-x86_64-GM-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant></guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_nonuefi_x86_64_vnet.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_nonuefi_x86_64_vnet.xml
@@ -25,7 +25,6 @@
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_os_variant></guest_os_variant>
     <guest_storage_path></guest_storage_path>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_sev_es_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_sev_es_x86_64.xml
@@ -25,7 +25,6 @@
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/ovmf-x86_64-vars.bin</guest_boot_settings>
     <guest_secure_boot>false</guest_secure_boot>
     <guest_os_variant></guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64.xml
@@ -25,7 +25,6 @@
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant></guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64_vnet.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_kvm_hvm_uefi_with_power_management_x86_64_vnet.xml
@@ -28,7 +28,6 @@
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_installation_fine_grained></guest_installation_fine_grained>
     <guest_os_variant></guest_os_variant>
     <guest_storage_path></guest_storage_path>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp4_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -24,8 +24,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait></guest_installation_wait>
     <guest_installation_method_others></guest_installation_method_others>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1</guest_installation_media>
-    <guest_installation_fine_grained></guest_installation_fine_grained>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP4-Full-x86_64-GM-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant></guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_kvm_hvm_sev_es_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_kvm_hvm_sev_es_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP5-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/ovmf-x86_64-vars.bin</guest_boot_settings>
     <guest_secure_boot>false</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_kvm_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_kvm_hvm_uefi_with_power_management_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP5-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP5-Full-x86_64-Build12345-Media1</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP5-Full-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP5-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_xen_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp5_64_xen_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug#display=3#ipv4only=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP5-Full-x86_64-Build12345-Media1</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP5-Full-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms.bin,loader_type=pflash,loader_ro=yes</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_sev_es_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_sev_es_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-sev.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,loader.stateless=yes</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_without_power_management_aarch64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_without_power_management_aarch64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/aarch64/DVD1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>uefi</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_xen_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp6_64_xen_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -26,7 +26,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms.bin,loader_type=pflash,loader_ro=yes</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_sev_es_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_sev_es_x86_64.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-sev.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,loader.stateless=yes</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_uefi_with_power_management_x86_64.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,loader.readonly=yes,loader.type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_xen_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_xen_hvm_uefi_with_power_management_x86_64.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-xen-4m.bin,loader_type=pflash</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_xen_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_xen_hvm_uefi_without_power_management_x86_64_using_virtmanagerlt3.0.0.xml
@@ -25,8 +25,7 @@
     <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1#rd.debug#rd.memdebug=4#rd.udev.debug#display=3#ipv4only=1</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1</guest_installation_media>
-    <guest_installation_fine_grained/>
+    <guest_installation_media>http://openqa.suse.de/assets/repo/SLE-15-SP7-Full-x86_64-Build12345-Media1/</guest_installation_media>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms.bin,loader_type=pflash,loader_ro=yes</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_full_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_full_iso.xml
@@ -1,42 +1,46 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>sles</guest_os_name>
-    <guest_version>15-sp6</guest_version>
-    <guest_version_major>15</guest_version_major>
-    <guest_version_minor>6</guest_version_minor>
+    <guest_version>16.0</guest_version>
+    <guest_version_major>16</guest_version_major>
+    <guest_version_minor>0</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build>gm</guest_build>
+    <guest_build/>
     <host_hypervisor_uri/>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
-    <guest_machine_type/>
+    <guest_machine_type>q35</guest_machine_type>
     <guest_arch>x86_64</guest_arch>
     <guest_name/>
     <guest_domain_name/>
-    <guest_memory>2048,maxmemory=4096</guest_memory>
-    <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel/>
+    <guest_memory>16384</guest_memory>
+    <guest_vcpus>2</guest_vcpus>
+    <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata/>
-    <guest_xpath>./os/boot[@dev='hd']/@order=1#./os/boot[@dev='network']/@order=2</guest_xpath>
-    <guest_installation_automation_method>autoyast</guest_installation_automation_method>
-    <guest_installation_automation_platform/>
-    <guest_installation_automation_file>sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml</guest_installation_automation_file>
-    <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-vars.bin,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
+    <guest_xpath/>
+    <guest_installation_automation_method>autoagama</guest_installation_automation_method>
+    <guest_installation_automation_platform></guest_installation_automation_platform>
+    <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet</guest_installation_automation_file>
+    <guest_installation_method>directkernel</guest_installation_method>
+    <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,loader.readonly=yes,loader.type=pflash</guest_boot_settings>
-    <guest_secure_boot>true</guest_secure_boot>
-    <guest_os_variant/>
+    <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-x86_64-Build12345.install.iso</guest_installation_media>
+    <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-x86_64-Build12345.install/</guest_installation_fine_grained_media>
+    <guest_installation_fine_grained_repos/>
+    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args_overwrite/>
+    <guest_installation_fine_grained_others/>
+    <guest_os_variant>sle15sp7</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>
     <guest_storage_label>gpt</guest_storage_label>
-    <guest_storage_size/>
+    <guest_storage_size>40</guest_storage_size>
     <guest_storage_backing_path/>
     <guest_storage_backing_format/>
-    <guest_storage_others/>
+    <guest_storage_others>driver.name=qemu,target.dev=vda,target.bus=virtio,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>bridge</guest_network_type>
     <guest_network_mode>bridge</guest_network_mode>
     <guest_network_device/>
@@ -88,9 +92,9 @@
     <guest_noautoconsole>false</guest_noautoconsole>
     <guest_noreboot/>
     <guest_default_target>graphical</guest_default_target>
-    <guest_do_registration>true</guest_do_registration>
+    <guest_do_registration>false</guest_do_registration>
     <guest_registration_server/>
-    <guest_registration_username>www@suse.com</guest_registration_username>
+    <guest_registration_username/>
     <guest_registration_password/>
-    <guest_registration_extensions>sle-module-legacy#sle-module-basesystem#sle-module-server-applications#sle-module-desktop-applications#sle-module-web-scripting</guest_registration_extensions>
+    <guest_registration_extensions/>
 </guest>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -1,42 +1,46 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>sles</guest_os_name>
-    <guest_version>15-sp6</guest_version>
-    <guest_version_major>15</guest_version_major>
-    <guest_version_minor>6</guest_version_minor>
+    <guest_version>16.0</guest_version>
+    <guest_version_major>16</guest_version_major>
+    <guest_version_minor>0</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
-    <guest_build>gm</guest_build>
+    <guest_build/>
     <host_hypervisor_uri/>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
-    <guest_machine_type/>
+    <guest_machine_type>q35</guest_machine_type>
     <guest_arch>x86_64</guest_arch>
     <guest_name/>
     <guest_domain_name/>
     <guest_memory>2048,maxmemory=4096</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel/>
+    <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata/>
-    <guest_xpath>./os/boot[@dev='hd']/@order=1#./os/boot[@dev='network']/@order=2</guest_xpath>
-    <guest_installation_automation_method>autoyast</guest_installation_automation_method>
-    <guest_installation_automation_platform/>
-    <guest_installation_automation_file>sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml</guest_installation_automation_file>
-    <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-vars.bin,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
+    <guest_xpath/>
+    <guest_installation_automation_method>autoagama</guest_installation_automation_method>
+    <guest_installation_automation_platform></guest_installation_automation_platform>
+    <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet</guest_installation_automation_file>
+    <guest_installation_method>directkernel</guest_installation_method>
+    <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://dist.suse.de/install/SLP/SLE-15-SP6-Full-GM/x86_64/DVD1/</guest_installation_media>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,loader.readonly=yes,loader.type=pflash</guest_boot_settings>
-    <guest_secure_boot>true</guest_secure_boot>
-    <guest_os_variant/>
+    <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-Online-16.0-x86_64-Build12345.install.iso</guest_installation_media>
+    <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-Online-16.0-x86_64-Build12345.install/</guest_installation_fine_grained_media>
+    <guest_installation_fine_grained_repos/>
+    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args_overwrite/>
+    <guest_installation_fine_grained_others/>
+    <guest_os_variant>sle15sp7</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>
     <guest_storage_label>gpt</guest_storage_label>
-    <guest_storage_size/>
+    <guest_storage_size>40</guest_storage_size>
     <guest_storage_backing_path/>
     <guest_storage_backing_format/>
-    <guest_storage_others/>
+    <guest_storage_others>driver.name=qemu,target.dev=vda,target.bus=virtio,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>bridge</guest_network_type>
     <guest_network_mode>bridge</guest_network_mode>
     <guest_network_device/>
@@ -90,7 +94,7 @@
     <guest_default_target>graphical</guest_default_target>
     <guest_do_registration>true</guest_do_registration>
     <guest_registration_server/>
-    <guest_registration_username>www@suse.com</guest_registration_username>
+    <guest_registration_username/>
     <guest_registration_password/>
-    <guest_registration_extensions>sle-module-legacy#sle-module-basesystem#sle-module-server-applications#sle-module-desktop-applications#sle-module-web-scripting</guest_registration_extensions>
+    <guest_registration_extensions/>
 </guest>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_qcow_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_qcow_ignition+combustion.xml
@@ -27,7 +27,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SLES16-Minimal-VM.x86_64-kvm-and-xen-Build12345.qcow2</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>sle15sp7</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_aarch64_default_qcow_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_aarch64_default_qcow_ignition+combustion.xml
@@ -28,7 +28,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.aarch64-6.1-Default-qcow-Build12345.qcow2</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_aarch64_default_raw_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_aarch64_default_raw_ignition+combustion.xml
@@ -27,7 +27,6 @@
   <guest_installation_extra_args/>
   <guest_installation_wait/>
   <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.aarch64-6.1-Default-Build12345.raw.xz</guest_installation_media>
-  <guest_installation_fine_grained/>
   <guest_os_variant>slm6.0</guest_os_variant>
   <guest_storage_path/>
   <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
@@ -28,7 +28,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw.xz</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_encrypted_ignition.xml
@@ -28,7 +28,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-encrypted-Build12345.raw.xz</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
@@ -28,7 +28,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-qcow-Build12345.qcow2</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_qcow_ignition.xml
@@ -28,7 +28,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-qcow-Build12345.qcow2</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>slm6.0</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
@@ -27,7 +27,6 @@
   <guest_installation_extra_args/>
   <guest_installation_wait/>
   <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-Build12345.raw.xz</guest_installation_media>
-  <guest_installation_fine_grained/>
   <guest_os_variant>slm6.0</guest_os_variant>
   <guest_storage_path/>
   <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_1_64_kvm_hvm_x86_64_default_raw_ignition.xml
@@ -27,7 +27,6 @@
   <guest_installation_extra_args/>
   <guest_installation_wait/>
   <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.1-Default-Build12345.raw.xz</guest_installation_media>
-  <guest_installation_fine_grained/>
   <guest_os_variant>slm6.0</guest_os_variant>
   <guest_storage_path/>
   <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_aarch64_default_qcow_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_aarch64_default_qcow_ignition+combustion.xml
@@ -28,7 +28,6 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.aarch64-6.2-Default-qcow-Build12345.qcow2</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>slem6.1</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_aarch64_default_raw_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_aarch64_default_raw_ignition+combustion.xml
@@ -27,7 +27,6 @@
   <guest_installation_extra_args/>
   <guest_installation_wait/>
   <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.aarch64-6.2-Default-Build12345.raw.xz</guest_installation_media>
-  <guest_installation_fine_grained/>
   <guest_os_variant>slem6.1</guest_os_variant>
   <guest_storage_path/>
   <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
@@ -23,12 +23,10 @@
     <guest_installation_automation_platform>metal</guest_installation_automation_platform>
     <guest_installation_automation_file>ignition_config_encrypted_image.ign#combustion_script</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
-    <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.2-Default-encrypted-Build12345.raw.xz</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>slem6.1</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_x86_64_default_qcow_ignition+combustion.xml
@@ -23,12 +23,10 @@
     <guest_installation_automation_platform>qemu</guest_installation_automation_platform>
     <guest_installation_automation_file>ignition_config_non_encrypted_image.ign#combustion_script</guest_installation_automation_file>
     <guest_installation_method>import</guest_installation_method>
-    <guest_installation_method_others/>
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.2-Default-qcow-Build12345.qcow2</guest_installation_media>
-    <guest_installation_fine_grained/>
     <guest_os_variant>slem6.1</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_x86_64_default_raw_ignition+combustion.xml
@@ -27,7 +27,6 @@
   <guest_installation_extra_args/>
   <guest_installation_wait/>
   <guest_installation_media>http://openqa.suse.de/assets/hdd/SL-Micro.x86_64-6.2-Default-Build12345.raw.xz</guest_installation_media>
-  <guest_installation_fine_grained/>
   <guest_os_variant>slem6.1</guest_os_variant>
   <guest_storage_path/>
   <guest_storage_type>disk</guest_storage_type>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
@@ -1,0 +1,103 @@
+{
+  "localization": {
+    "language": "en_US.UTF-8",
+    "keyboard": "us",
+    "timezone": "Europe/Berlin"
+  },
+  product: {
+    id: "SLES",
+    registrationCode: "##Registration-Code##", 
+    registrationEmail: "www@suse.com"
+  },
+  "bootloader": {
+    "stopOnBootMenu": false
+  },
+  "user": {
+    "fullName": "QE Virtualization Functional Test",
+    "userName": "qevirt",
+    "password": "$2a$10$v32/h9hPd9cATZgLI/a1AepB9eQuMbjvNBOxQIla19fmAMjznSczG",
+    "hashedPassword": true,
+    "autologin": false
+  },
+  "root": {
+    "password": "$2a$10$2qfKlKzzEp9tl3mde5CmhuxsEPd3DdlfJMQ.PNSI3rqXx4KztGYT6",
+    "hashedPassword": true,
+    "sshPublicKey": "##Authorized-Keys##"
+  },
+  legacyAutoyastStorage: [
+      {
+         "device": "/dev/vda",
+         "disklabel": "##Disk-Label##",
+         "enable_snapshots": true,
+         "initialize": true,
+         use: "all"
+      }
+  ],
+  "storage": {
+    "drives": [
+      {
+        "partitions": [
+          { "filesystem": { "path": "/" } },
+          { "filesystem": { "path": "/home" } },
+          { "filesystem": { "path": "swap" } }
+        ]
+      }
+    ]
+  },
+  "software": {
+      patterns: [
+         'base'
+      ]
+  },
+  "network": {
+    "connections": [
+      {
+        "id": "Wired Connection",
+        "method4": "auto",
+        "method6": "auto",
+        "ignoreAutoDns": false,
+        "status": "up",
+        "autoconnect": true,
+        "dns_searchlist": [
+          "##Domain-Name##",
+          "suse.de",
+          "suse.asia",
+          "opensuse.org"
+        ]
+      }
+    ]
+  },
+  scripts: {
+    post: [
+      {
+        name: "persistent_hostname",
+        body: |||
+          #!/usr/bin/env bash
+          echo -e "##Host-Name##.##Domain-Name##" > /etc/hostname
+        |||
+      },
+      {
+        name: "sshd_config",
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes\nPermitEmptyPasswords no\nTCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > /etc/ssh/sshd_config.d/01-qe-virtualization-functional.conf
+        |||
+      },
+      {
+        name: "ssh_config",
+        body: |||
+          #!/usr/bin/env bash
+          echo -e "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null" > /etc/ssh/ssh_config.d/01-qe-virtualization-functional.conf
+        |||
+      },
+      {
+        name: "persistent_journal_logging",
+        body: |||
+          #!/usr/bin/env bash
+          echo -e "[Journal]\\nStorage=persistent" > /etc/systemd/journald.conf.d/01-qe-virtualization-functional.conf
+        |||
+      }
+    ]
+  }
+}

--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -72,6 +72,8 @@ sub instantiate_guests_and_profiles {
         $_guest_profile->{guest_build} = $_store_of_guests{$_element}{INSTALL_BUILD} if ($_store_of_guests{$_element}{INSTALL_BUILD} ne '');
         $_guest_profile->{guest_registration_code} = $_store_of_guests{$_element}{REG_CODE};
         $_guest_profile->{guest_registration_extensions_codes} = $_store_of_guests{$_element}{REG_EXTS_CODES};
+        $_guest_profile->{guest_installation_fine_grained_media} = $_store_of_guests{$_element}{INSTALL_FINE_GRAINED_MEDIA} if ($_store_of_guests{$_element}{INSTALL_FINE_GRAINED_MEDIA} ne '');
+        $_guest_profile->{guest_installation_fine_grained_repos} = $_store_of_guests{$_element}{INSTALL_FINE_GRAINED_REPOS} if ($_store_of_guests{$_element}{INSTALL_FINE_GRAINED_REPOS} ne '');
         $guest_instances_profiles{$_element} = $_guest_profile;
         diag "Guest $_element is going to use profile" . Dumper($guest_instances_profiles{$_element});
     }
@@ -105,7 +107,7 @@ sub install_guest_instances {
         }
         $guest_instances{$_}->{guest_installation_attached} = 'true';
         save_screenshot;
-        if (!(check_screen([qw(guest-installation-yast2-started guest-installation-anaconda-started guest-firstboot-provision-finished)], timeout => 180 / get_var('TIMEOUT_SCALE', 1)))) {
+        if (!(check_screen([qw(agama-installer-live-root guest-installation-yast2-started guest-installation-anaconda-started guest-firstboot-provision-finished)], timeout => 180 / get_var('TIMEOUT_SCALE', 1)))) {
             record_info("Failed to detect or guest $guest_instances{$_}->{guest_name} does not have installation window opened", "This might be caused by improper console settings or reboot after installaton finishes. Will continue to monitor its installation progess, so this is not treated as fatal error at the moment.");
         }
         else {

--- a/lib/guest_installation_and_configuration_metadata.pm
+++ b/lib/guest_installation_and_configuration_metadata.pm
@@ -42,8 +42,8 @@ our %guest_params = (
     'guest_cpumodel' => '',    # virt-install --cpu [guest_cpumodel]
     'guest_metadata' => '',    # virt-install --metadata [guest_metadata]
     'guest_xpath' => '',    # virt-install --xml [guest_xpath].it can contain multiple items seperated by hash key
-    'guest_installation_automation_method' => '',    # This indicates whether guest uses autoyast, kickstart, ignition, combustion or
-                                                     # ignition+combustion for installation, not virt-install argument
+    'guest_installation_automation_method' => '',    # This indicates whether guest uses autoyast, kickstart, ignition, combustion,
+                                                     # ignition+combustion or autoagama for installation, not virt-install argument
     'guest_installation_automation_platform' => '',    # This indicates ignition/combustion platform, not virt-install argument. Please
                                                        # refer to https://coreos.github.io/ignition/supported-platforms
     'guest_installation_automation_file' => '',    # virt-install --extra-args "autoyast=[guest_installation_automation_file] or
@@ -59,7 +59,17 @@ our %guest_params = (
     'guest_installation_wait' => '',    # virt-install --wait [guest_installation_wait]
     'guest_installation_media' => '',    # virt-install --location [guest_installation_media] or --cdrom [guest_installation_media]
                                          # It can also specify the imported virtual disk image to be used for installation.
-    'guest_installation_fine_grained' => '',    # virt-install --install [guest_installation_fine_grained]
+    'guest_installation_fine_grained_media' => '',    # [guest_installation_media] will still be used as installation media. But matching
+                                                      # kernel/initrd files will be retrieved from [guest_installation_fine_grained_media].
+                                                      # virt-install --install kernel=x,initrd=y,root=live:[guest_installation_media]
+    'guest_installation_fine_grained_repos' => '',    # Additonal installation repositories can also be provided besides installation media.
+                                                      # Multiple repositories are separated by comma. Example command is as below:
+                                                      # virt-install --install agama.install_url=[guest_installation_fine_grained_repos]
+    'guest_installation_fine_grained_kernel_args' => '',    # virt-install --install kernel_args=[guest_installation_fine_grained_kernel_args]
+    'guest_installation_fine_grained_kernel_args_overwrite' => '',    # Set it to true, if provided kernel arguments will overwrite existing ones.
+                                                                      # virt-install --install kernel_args_overwrite=yes|no
+    'guest_installation_fine_grained_others' => '',    # virt-install --install [guest_installation_fine_grained_others], for example:
+                                                       # guest_installation_fine_grained_others can be os=x,bootdev=y,no_install=yes|no,zzzzz
     'guest_boot_settings' => '',    # virt-install --boot [guest_boot_settings]
     'guest_secure_boot' => '',    # This indicates whether uefi secure boot is enabled(true, false or empty) during
                                   # installation in unattended installation file, not virt-install argument

--- a/tests/virt_autotest/prepare_non_transactional_server.pm
+++ b/tests/virt_autotest/prepare_non_transactional_server.pm
@@ -53,9 +53,13 @@ sub prepare_extensions {
 sub prepare_packages {
     my $self = shift;
 
-    # spice needs to be installed in advance if virtual machine uses it. spice is not installed by default.
-    my $zypper_install_package = "install --no-allow-downgrade --no-allow-name-change --no-allow-vendor-change libspice-server1 qemu-audio-spice qemu-chardev-spice qemu-spice qemu-ui-spice-core spice-vdagent";
-    zypper_call("$zypper_install_package");
+    # install additional packages from product repositories
+    zypper_call("--gpg-auto-import-keys refresh");
+    if (get_var('INSTALL_PRODUCT_PACKAGES', '')) {
+        my $cmd = "install --no-allow-downgrade --no-allow-name-change --no-allow-vendor-change";
+        $cmd = $cmd . " $_" foreach (split(/,/, get_var('INSTALL_PRODUCT_PACKAGES', '')));
+        zypper_call($cmd);
+    }
     # install auxiliary packages from additional repositories to facilitate automation, for example screen and etc.
     install_extra_packages;
 }
@@ -73,9 +77,8 @@ sub prepare_bootloader {
 sub prepare_services {
     my $self = shift;
 
-    #Disable rebootmgr service to prevent scheduled maitenance reboot.
-    disable_and_stop_service('rebootmgr.service');
-    systemctl('status rebootmgr.service', ignore_failure => 1);
+    # prepare services to facilitate test run
+    # no services to be handled at the moment
 }
 
 sub prepare_reboot {

--- a/tests/virt_autotest/unified_guest_installation.pm
+++ b/tests/virt_autotest/unified_guest_installation.pm
@@ -62,21 +62,26 @@ sub run {
     use_ssh_serial_console;
 
     $self->reveal_myself;
-    my @guest_names = split(/,/, get_required_var('UNIFIED_GUEST_LIST'));
-    my @guest_profiles = split(/,/, get_required_var('UNIFIED_GUEST_PROFILES'));
+    my @guest_names = split(/\|/, get_required_var('UNIFIED_GUEST_LIST'));
+    my @guest_profiles = split(/\|/, get_required_var('UNIFIED_GUEST_PROFILES'));
     croak("Guest names and profiles must be given to create, configure and install guests.") if ((scalar(@guest_names) eq 0) or (scalar(@guest_profiles) eq 0));
     my %store_of_guests;
     my @guest_installation_media = my @guest_installation_builds = my @guest_registration_codes = my @guest_registration_extensions_codes = ('') x scalar @guest_names;
-    @guest_installation_media = split(/,/, get_var('UNIFIED_GUEST_INSTALLATION_MEDIA', '')) if (get_var('UNIFIED_GUEST_INSTALLATION_MEDIA', '') ne '');
-    @guest_installation_builds = split(/,/, get_var('UNIFIED_GUEST_INSTALLATION_BUILDS', '')) if (get_var('UNIFIED_GUEST_INSTALLATION_BUILDS', '') ne '');
-    @guest_registration_codes = split(/,/, get_var('UNIFIED_GUEST_REG_CODES', '')) if (get_var('UNIFIED_GUEST_REG_CODES', '') ne '');
-    @guest_registration_extensions_codes = split(/,/, get_var('UNIFIED_GUEST_REG_EXTS_CODES', '')) if (get_var('UNIFIED_GUEST_REG_EXTS_CODES', '') ne '');
+    my @guest_installation_fine_grained_media = my @guest_installation_fine_grained_repos = ('') x scalar @guest_names;
+    @guest_installation_media = split(/\|/, get_var('UNIFIED_GUEST_INSTALLATION_MEDIA', '')) if (get_var('UNIFIED_GUEST_INSTALLATION_MEDIA', '') ne '');
+    @guest_installation_builds = split(/\|/, get_var('UNIFIED_GUEST_INSTALLATION_BUILDS', '')) if (get_var('UNIFIED_GUEST_INSTALLATION_BUILDS', '') ne '');
+    @guest_registration_codes = split(/\|/, get_var('UNIFIED_GUEST_REG_CODES', '')) if (get_var('UNIFIED_GUEST_REG_CODES', '') ne '');
+    @guest_registration_extensions_codes = split(/\|/, get_var('UNIFIED_GUEST_REG_EXTS_CODES', '')) if (get_var('UNIFIED_GUEST_REG_EXTS_CODES', '') ne '');
+    @guest_installation_fine_grained_media = split(/\|/, get_var('UNIFIED_GUEST_INSTALLATION_FINE_GRAINED_MEDIA', '')) if (get_var('UNIFIED_GUEST_INSTALLATION_FINE_GRAINED_MEDIA', '') ne '');
+    @guest_installation_fine_grained_repos = split(/\|/, get_var('UNIFIED_GUEST_INSTALLATION_FINE_GRAINED_REPOS', '')) if (get_var('UNIFIED_GUEST_INSTALLATION_FINE_GRAINED_REPOS', '') ne '');
     while (my ($index, $element) = each @guest_names) {
         $store_of_guests{$element}{PROFILE} = $guest_profiles[$index];
         $store_of_guests{$element}{INSTALL_MEDIA} = $guest_installation_media[$index];
         $store_of_guests{$element}{INSTALL_BUILD} = $guest_installation_builds[$index];
         $store_of_guests{$element}{REG_CODE} = $guest_registration_codes[$index];
         $store_of_guests{$element}{REG_EXTS_CODES} = $guest_registration_extensions_codes[$index];
+        $store_of_guests{$element}{INSTALL_FINE_GRAINED_MEDIA} = $guest_installation_fine_grained_media[$index];
+        $store_of_guests{$element}{INSTALL_FINE_GRAINED_REPOS} = $guest_installation_fine_grained_repos[$index];
     }
 
     $self->concurrent_guest_installations_run(\%store_of_guests);

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -641,12 +641,14 @@ sub collect_host_and_guest_logs {
     script_output("chmod +x ~/virt_logs_collector.sh && ~/virt_logs_collector.sh -l \"$host_extra_logs\" -g \"$guest_wanted\" -e \"$guest_extra_logs\"", 3600 / get_var('TIMEOUT_SCALE', 1), type_command => 1, proceed_on_failure => 1);
     save_screenshot;
 
+    send_key("ret");
     my $logs_fetching_script_url = data_url("virt_autotest/fetch_logs_from_guest.sh");
     script_output("curl -s -o ~/fetch_logs_from_guest.sh $logs_fetching_script_url", 180, type_command => 0, proceed_on_failure => 0);
     save_screenshot;
     script_output("chmod +x ~/fetch_logs_from_guest.sh && ~/fetch_logs_from_guest.sh -g \"$guest_wanted\" -e \"$guest_extra_logs\"", 1800, type_command => 1, proceed_on_failure => 1);
     save_screenshot;
 
+    send_key("ret");
     upload_logs("/tmp/virt_logs_all.tar.gz", log_name => "virt_logs_all$log_token.tar.gz", timeout => 600);
     upload_logs("/var/log/virt_logs_collector.log", log_name => "virt_logs_collector$log_token.log");
     upload_logs("/var/log/fetch_logs_from_guest.log", log_name => "fetch_logs_from_guest$log_token.log");


### PR DESCRIPTION
* **Enhance** installation method using ```virt-install --install``` which is named ```directkernel``` because it needs loading downloaded kernel/initrd and specify fine-grained kernel arguments directly to perform guest installation which is required by automated Agama installer. Example command looks like ```virt-install --install kernel=/path/to/kernel,initrd=/path/to/initrd,kernel_args=xxxxx,kernel_args_overwrite=yes|no```. Please refer to [virt-install manpage](https://manpages.opensuse.org/Tumbleweed/virt-install/virt-install.1.en.html).


* **Introduce** new automation method ```autoagama``` which uses unattended installation file in jsonnet format for Agama installer.
 
* **Introduce** guest parameters, including 
  * ```guest_installation_fine_grained_media```, 
  * ```guest_installation_fine_grained_repos```, 
  * ```guest_installation_fine_grained_kernel_args``` and 
  * ```guest_installation_fine_grained_kernel_args_overwrite``` 

  to facilitate ```directkernel``` installation method. 


* **The** already existing guest parameter ```guest_installation_media``` still specifies the installation media to be used with guest installation. ```guest_installation_fine_grained_media``` will be used with ```directkernel``` installation method which needs to specify the location from where kernel/initrd files will be retrieved. ```guest_installation_fine_grained_repos``` will specify any repositories to be used with ```directkernel``` installation method (besides ```guest_installation_media```) and multiple repositories (separated by comma) are allowed for a guest. **Example** command looks like:
  ```virt-install --install kernel=[from guest_installation_fine_grained_media],initrd=[from guest_installation_fine_grained_media],kernel_args="root=live:[guest_installation_media],agama.install_url=[guest_installation_fine_grained_repos],agama.auto=xxxxx,inst.register_url=yyyyy,zzzzz",[other guest_installation_fine_grained_others]```.


* **Corresponding** test suite level settings ```UNIFIED_GUEST_INSTALLATION_FINE_GRAINED_MEDIA``` and ```UNIFIED_GUEST_INSTALLATION_FINE_GRAINED_REPOS``` are introduced to help set customized media and repos to be used with ```directkernel``` installation method.


* **Update** ```lib/guest_installation_and_configuration_metadata.pm``` to cover new guest parameters and their explanations.


* **Introduce** several new subroutines in module file ```lib/guest_installation_and_configuration_base.pm```, including
  * ```monitor_guest_agama_installation```, 
  * ```setup_guest_agama_installation_shell```, 
  * ```verify_guest_agama_installation_done``` and 
  * ```save_guest_agama_installation_logs```

  to facilitate guest installation using Agama installer. Agama installation logs will always be saved regardless of     successful or failed installation.


* **Introduce** new subroutine ```is_agama_guest``` in ```lib/utils.pm```.


* **Introudce** new guest profiles and unattended installation files, including 
  * ```data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_full_iso.xml```, 
  * ```data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml``` and 
  * ```data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet```. 

  These two guest profiles use different installation media (online with registration by default or offline without registration by default) but the same installation method. User can choose either to use based on sensible choice.


* **Use** pipe symbol to split passed in settings in test module ```tests/virt_autotest/unified_guest_installation.pm```, because certain setting like ```GUEST_INSTALLATION_FINE_GRAINED_REPOS``` can be given multiple repositories separated by comma for a single guest.


* **Adapt** ```tests/virt_autotest/prepare_non_transactional_server.pm``` to new changes which include spice dropping and rebootmgr service removing. Use test suite level setting ```INSTALL_PRODUCT_PACKAGES``` to indicate packages to be installed from product repositories.


* **Remove** obsolete guest parameter ```guest_installation_fine_grained``` from all guest profiles.


* **Update** ```guest_installation_media``` for all guest profiles in order to have repositories URLs end with forward slash '/'. Otherwise availability detection by using ```curl``` will fail. 

* **Update** subroutine ```render_autoinst_url``` in ```lib/utils.pm``` to keep trailing split character if the original URL has it and skip rendering repo assets because openQA only syncs iso and hdd assets.


* **Send** return keys in ```collect_host_and_guest_logs``` subroutine in ```tests/virt_autotest/virt_utils.pm``` to avoid garbled input session left by previous command.

 
* **This** pull request should be merged together with [Update symbol to be used for split for unified guest installation](https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/261).


* **Verification Runs:**
  * [slmicro 6.2 on slmicro 6.2](https://openqa.suse.de/tests/16972974)
  * [sles on slemicro](https://openqa.suse.de/tests/16971161)
  * [oracle linux](https://openqa.suse.de/tests/16971162)
  * [sles15sp7 on sles15sp7](https://openqa.suse.de/tests/16971163)
  * [sles12sp5 on sles15sp7](https://openqa.suse.de/tests/16971164)
  * [Guest using SLES 16.0 Agama Online ISO Build57.3](http://10.200.140.9/tests/339)
  * [Guest using SLES 16.0 Agama Full ISO Build57.3](http://10.200.140.9/tests/341)
  * [Guests using SLES 16.0 Agama Full and Online ISO Build57.3](http://10.200.140.9/tests/347)
  * [Guest using Online ISO with registration](http://10.200.140.9/tests/365)
  * [Guest using Full ISO with registration](http://10.200.140.9/tests/366)
  * [Failed guest installation due to failed passwordless ssh to agama installer](http://10.200.140.9/tests/359)
  * [Failed guest installation due to failed registration](http://10.200.140.9/tests/367)
  * [All above guest scenarios are still valid on Beta2 Build57.3 host, for example, Guest Online ISO Build57.3](http://10.200.140.9/tests/388) and [Guest Full ISO Build57.3](http://10.200.140.9/tests/390)