### PR TITLE
Change kvm_host pattern name to kvm_server and kvm_tools

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -35,7 +35,8 @@
   software: {
       patterns: [
          'base',
-         'kvm_host'
+         'kvm_server',
+         'kvm_tools'
       ]
   },
   scripts: {


### PR DESCRIPTION
The kvm pattern name was found changed to `kvm_server` and `kvm_tools` at build 57.3.

- Verification run: https://openqa.suse.de/tests/16970973
