### PR TITLE
xfstests: Add suseconnect_scc step in micro tests

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -348,6 +348,7 @@ sub load_xfstests_tests {
     if (check_var('XFSTESTS', 'installation')) {
         load_boot_from_disk_tests;
         loadtest 'transactional/host_config';
+        loadtest 'console/suseconnect_scc';
         loadtest 'xfstests/install';
         unless (check_var('NO_KDUMP', '1')) {
             loadtest 'xfstests/enable_kdump';

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -36,7 +36,7 @@ sub install_xfstests_from_repo {
         add_qa_head_repo(priority => 100);
         if (is_sle('16+')) {
             my $dep_url = get_var('DEPENDENCY_REPO', 'http://download.suse.de/ibs/home:/yosun:/branches:/SUSE:/Factory:/Head/standard/');
-            zypper_ar($dep_url, name => 'dependency-repo');
+            zypper_ar($dep_url, name => 'dependency-repo', priority => 101);
         }
     }
     elsif (is_tumbleweed) {
@@ -48,7 +48,7 @@ sub install_xfstests_from_repo {
         my $repo_url = get_var('XFSTESTS_REPO', 'http://download.suse.de/ibs/home:/yosun:/branches:/QA:/Head/SUSE_ALP_Products_Marble_6.0_standard/');
         my $dep_url = get_var('DEPENDENCY_REPO', 'http://download.suse.de/ibs/home:/yosun:/branches:/SUSE:/Factory:/Head/standard/');
         zypper_ar($repo_url, name => 'xfstests-repo');
-        zypper_ar($dep_url, name => 'dependency-repo');
+        zypper_ar($dep_url, name => 'dependency-repo', priority => 101);
     }
     record_info('repo info', script_output('zypper lr -U'));
     if (is_transactional) {


### PR DESCRIPTION
1. Add suseconnect_scc before installing xfstests when testing SLMicro products to avoid missing repo and package issues.
2. Meanwhile, lower the dependency repo(packages from SUSE:Factory:Head) priority to 101(the number 1 is the highest priority, the bigger the lower). Then it will lower than default 99 and QA:Head repo 100. If others repo don't have the package then it will start to use this repo.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1238583#c4
- Verification run: https://openqa.suse.de/tests/16971527
