### PR TITLE
Make NetworkManager the default on SLES16

### DIFF
--- a/tests/console/check_default_network_manager.pm
+++ b/tests/console/check_default_network_manager.pm
@@ -38,7 +38,11 @@ sub run {
     my $unexpected = 'wicked';
     my $reason = 'networking';
 
-    if (is_jeos && (is_sle || is_leap)) {
+    if (is_sle("16+") || is_leap("16+")) {
+        $expected = 'NetworkManager';
+        $unexpected = 'wicked';
+        $reason = 'networking';
+    } elsif (is_jeos && (is_sle || is_leap)) {
         $expected = 'wicked';
         $unexpected = 'NetworkManager';
         $reason = 'JeOS';


### PR DESCRIPTION
On SLES16+ NetworkManager is the default network manager.

- Related failure: https://openqa.suse.de/tests/16969170#step/check_default_network_manager/15
- Verification run: https://openqa.suse.de/tests/16973054#step/check_default_network_manager/13
