### PR TITLE
Add Minimalvm extra schedule for SLES16

### DIFF
--- a/schedule/jeos/sle/minimalvm-extratest.yaml
+++ b/schedule/jeos/sle/minimalvm-extratest.yaml
@@ -1,0 +1,63 @@
+---
+description: 'Extratest MinimalVM test suite for SLES16+. Maintainer: qac'
+name: 'jeos-extratest'
+conditional_schedule:
+    bootloader:
+        MACHINE:
+            'svirt-xen-pv':
+                - installation/bootloader_svirt
+            'svirt-xen-hvm':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+            'svirt-hyperv-uefi':
+                - installation/bootloader_hyperv
+            'svirt-hyperv':
+                - installation/bootloader_hyperv
+                - installation/bootloader_uefi
+            'svirt-vmware70':
+                - installation/bootloader_svirt
+                - installation/bootloader_uefi
+            's390x-kvm':
+                - installation/bootloader_start
+    maintenance:
+        FLAVOR:
+            'JeOS-for-kvm-and-xen-Updates':
+                - qa_automation/patch_and_reboot
+schedule:
+    - '{{bootloader}}'
+    - jeos/firstrun
+    - console/consoletest_setup
+    - jeos/record_machine_id
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - jeos/grub2_gfxmode
+    - jeos/diskusage
+    - jeos/build_key
+    - console/suseconnect_scc
+    - '{{maintenance}}'
+    - console/zypper_lr_validate
+    - console/zypper_ref
+    - console/validate_packages_and_patterns
+    - console/zypper_extend
+    - console/check_os_release
+    - console/timezone
+    - console/ntp_client
+    - console/sshd
+    - console/rpm
+    - console/openssl_alpn
+    - console/check_default_network_manager
+    - console/cups
+    - console/sysctl
+    - console/sysstat
+    - console/curl_ipv6
+    - console/wget_ipv6
+    - console/ca_certificates_mozilla
+    - console/ansible
+    - x11/evolution/evolution_prepare_servers
+    - console/unzip
+    - console/salt
+    - console/gpg
+    - console/rsync
+    - console/shells
+    - console/journalctl
+    - console/procps

--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -71,7 +71,6 @@ schedule:
     - console/postgresql_server
     - console/shibboleth
     - console/apache_ssl
-    - console/apache_nss
     - console/hostname
     - console/installation_snapshots
     - console/zypper_lr


### PR DESCRIPTION
Create a new YAML schedule for SLES16 for extratests and remove not needed tests for SLES16.

- Verification run: https://openqa.suse.de/tests/16973053 (schedule works)
