### PR TITLE
Stop installing ClusterTools2 multiple times

### DIFF
--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -37,7 +37,6 @@ sub run {
     $self->{my_instance} = $target_site;
 
     # Check initial cluster status
-    $self->run_cmd(cmd => 'zypper -n in ClusterTools2', timeout => 300);
     $self->wait_for_idle(timeout => 240);
     my $cluster_status = $self->run_cmd(cmd => 'crm status');
     record_info('Cluster status', $cluster_status);


### PR DESCRIPTION
HanaSR test needs some tools provided by ClusterTools2 during the test execution, after the end of the deployment.
There's a `zypper in ClusterTools2` that is executed at the beginning of each test stage. Remove it as tool installation is performed by qe-sap-deployment.

- Related ticket: https://jira.suse.com/browse/TEAM-7830

# Verification run:
 - sle-15-SP5-HanaSr-Azure-Payg-x86_64-Build15-SP5_2025-03-06T03:03:21Z-hanasr_azure_test_msi@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/316122