### PR TITLE
containers: Add test for podman artifact

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -130,6 +130,8 @@ sub load_host_tests_podman {
     load_3rd_party_image_test($run_args) unless is_staging;
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
+    # podman artifact needs podman 5.4.0
+    loadtest 'containers/podman_artifact' if is_tumbleweed;
     loadtest 'containers/podman_bci_systemd';
     loadtest 'containers/podman_pods';
     # CNI is the default network backend on SLEM<6 and SLES<15-SP6. It is still available on later products as a dependency for docker.

--- a/tests/containers/podman_artifact.pm
+++ b/tests/containers/podman_artifact.pm
@@ -1,0 +1,61 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: podman artifact
+# Summary: Test podman artifact
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use version_utils;
+
+my $test_dir = "/tmp/test_artifact";
+
+sub run {
+    select_serial_terminal;
+
+    my $test_file = "$test_dir/test_file";
+    my $artifact = "test-artifact";
+
+    assert_script_run "mkdir -p $test_dir";
+    assert_script_run "touch $test_file";
+
+    # Test add
+    assert_script_run "podman artifact add $artifact $test_file";
+    assert_script_run "! podman artifact add $artifact $test_file";
+
+    # Test inspect
+    validate_script_output "podman artifact inspect $artifact", qr/"Name": "$artifact"/;
+    assert_script_run "! podman artifact inspect noexist";
+
+    # Test ls
+    validate_script_output "podman artifact ls", qr/$artifact/;
+
+    # Test rm
+    assert_script_run "podman artifact rm $artifact";
+    assert_script_run "! podman artifact rm $artifact";
+
+    assert_script_run "rm -rf $test_dir";
+}
+
+1;
+
+sub cleanup() {
+    script_run 'podman artifact ls -n --format "{{.Repository}}" | while read artifact ; do podman artifact rm $artifact ; done';
+    script_run "rm -rf $test_dir";
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    cleanup;
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    cleanup;
+    $self->SUPER::post_run_hook;
+}

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -56,6 +56,16 @@ sub registry_push_pull {
     # Pull $image from the local registry
     assert_script_run $engine->runtime . " pull localhost:5000/$image", 90;
     assert_script_run $engine->runtime . " images | grep 'localhost:5000/$image'", 60;
+
+    # podman artifact needs podman 5.4.0
+    if ($engine->runtime eq "podman" && is_tumbleweed) {
+        my $artifact = "localhost:5000/testing-artifact";
+        assert_script_run "podman artifact add $artifact /etc/passwd";
+        assert_script_run "podman artifact push $artifact";
+        assert_script_run "podman artifact rm $artifact";
+        assert_script_run "podman artifact pull $artifact";
+        assert_script_run "podman artifact rm $artifact";
+    }
 }
 
 sub run {


### PR DESCRIPTION
Add test for `podman artifact`

- Related ticket: https://progress.opensuse.org/issues/176586
- Verification runs:
  - podman: https://openqa.opensuse.org/tests/4903666
  - podman push/pull: https://openqa.opensuse.org/tests/4903674#step/registry/223
 
Notes:
  - The test for `podman artifact pull` & `push` is done in the registry module.  For some reason this is scheduled in docker tests but it also runs podman.

