### PR TITLE
Skip module installation on SLES16

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -360,7 +360,7 @@ sub configure_service {
     my $self = y2_module_consoletest->new();
     if ($args{test_type} eq 'function') {
         # preparation for crash test
-        if (is_sle '15+') {
+        if (is_sle('15+') && is_sle('<16')) {
             add_suseconnect_product('sle-module-desktop-applications');
             add_suseconnect_product('sle-module-development-tools');
         }


### PR DESCRIPTION
On SLES16 there are no modules available.

- Related failure: https://openqa.suse.de/tests/16969193#step/kdump_and_crash/19
- Verification run: https://openqa.suse.de/tests/16974329
