### PR TITLE
[SDAF] Sanity check for files being created by SDAF

### DIFF
--- a/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars
+++ b/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars
@@ -340,7 +340,7 @@ dns_label="openqa.net"
 # Boolean value indicating if storage accounts and key vaults should be registered to the corresponding dns zones
 register_storage_accounts_keyvaults_with_dns = false
 
-# If defined provides the lsit of DNS servers to attach to the Virtual NEtwork
+# If defined provides the list of DNS servers to attach to the Virtual Network
 #dns_server_list = []
 
 #########################################################################################

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -49,6 +49,7 @@ our @EXPORT = qw(
   ansible_show_status
   playbook_settings
   $output_log_file
+  sdaf_register_byos
 );
 
 our $output_log_file = '';
@@ -974,6 +975,42 @@ sub playbook_settings {
     }
 
     return (\@playbooks);
+}
+
+=head2 sdaf_register_byos
+
+    sdaf_register_byos(sdaf_config_root_dir=>'/stairway/to_heaven', scc_reg_code=>'CODE-XYZ', sap_sid='PRD');
+
+Performs SCC registration on BYOS image using B<registercloudguest> method.
+
+=over
+
+=item * B<sdaf_config_root_dir>: SDAF root configuration directory
+
+=item * B<scc_reg_code>: SCC registration code
+
+=item * B<sap_sid>: SAP system ID
+
+=back
+=cut
+
+sub sdaf_register_byos {
+    my (%args) = @_;
+    my @mandatory_args = qw(sdaf_config_root_dir scc_reg_code sap_sid);
+
+    for my $arg (@mandatory_args) {
+        croak "Missing mandatory argument \$args($arg)", unless $args{$arg};
+    }
+
+    record_info('Register SUTs');
+    assert_script_run("cd $args{sdaf_config_root_dir}");
+    ansible_execute_command(
+        command => "sudo registercloudguest -r $args{scc_reg_code}",
+        host_group => "$args{sap_sid}_DB",
+        sdaf_config_root_dir => $args{sdaf_config_root_dir},
+        sap_sid => $args{sap_sid},
+        verbose => 1
+    );
 }
 
 1;

--- a/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
@@ -43,6 +43,7 @@ our @EXPORT = qw(
   generate_deployer_name
   get_workload_vnet_code
   get_sdaf_inventory_path
+  get_sut_sshkey_path
 );
 
 =head2 %sdaf_region_matrix
@@ -378,17 +379,14 @@ sub get_workload_vnet_code {
 
 =head2 get_sdaf_inventory_path
 
-    get_sdaf_inventory_path();
+    get_sdaf_inventory_path(config_root_path=>'/config/path', sap_sid=>'QAS');
 
 Returns full Ansible inventory filepath respective to deployment type.
+B<config_root_path> can be obtained from function B<get_sdaf_config_path>.
 
 =over
 
-=item * B<env_code>:  SDAF parameter for environment code (for our purpose we can use 'LAB')
-
-=item * B<sdaf_region_code>: SDAF parameter to choose PC region. Note SDAF is using internal abbreviations (SECE = swedencentral)
-
-=item * B<vnet_code>: SDAF parameter for virtual network code. Library and deployer use different vnet than SUT env
+=item * B<config_root_path>: SDAF config root path
 
 =item * B<sap_sid>: SDAF parameter for sap system ID.
 
@@ -397,16 +395,32 @@ Returns full Ansible inventory filepath respective to deployment type.
 
 sub get_sdaf_inventory_path {
     my (%args) = @_;
-
-    # Argument (%args) validation is done by 'get_sdaf_config_path()'
-    my $config_root_path = get_sdaf_config_path(
-        deployment_type => 'sap_system',
-        sap_sid => $args{sap_sid},
-        env_code => $args{env_code},
-        vnet_code => $args{vnet_code},
-        sdaf_region_code => $args{sdaf_region_code}
-    );
+    for my $argument (qw(sap_sid config_root_path)) {
+        croak "Missing mandatory argument '$argument'" unless $args{$argument};
+    }
 
     # file name is hard coded in SDAF
-    return "$config_root_path/$args{sap_sid}_hosts.yaml";
+    return "$args{config_root_path}/$args{sap_sid}_hosts.yaml";
+}
+
+=head2 get_sut_sshkey_path
+
+    get_sut_sshkey_path(config_root_path=>'/config/path');
+
+Returns full SUT private sshkey filepath located on deployer VM after deployment.
+B<config_root_path> can be obtained from function B<get_sdaf_config_path>.
+
+=over
+
+=item * B<config_root_path>: SDAF config root path
+
+=back
+=cut
+
+sub get_sut_sshkey_path {
+    my (%args) = @_;
+    croak 'Missing mandatory argument $args{config_root_path}' unless $args{config_root_path};
+
+    # file name is hard coded in SDAF
+    return "$args{config_root_path}/sshkey";
 }

--- a/t/24_sdaf_naming_convention.t
+++ b/t/24_sdaf_naming_convention.t
@@ -136,13 +136,15 @@ subtest '[get_workload_vnet_code] ' => sub {
 };
 
 subtest '[get_tfvars_path] Test passing scenarios' => sub {
-    my $mock_lib = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::naming_conventions', no_auto => 1);
-
-    $mock_lib->redefine(get_sdaf_config_path => sub { return '/ProjectZeta'; });
-
-    is get_sdaf_inventory_path(sap_sid => 'ZETA', env_code => 'AnaheimElectronics', sdaf_region_code => 'AEUG'),
-      '/ProjectZeta/ZETA_hosts.yaml', 'Return correct inventory path.';
+    is get_sdaf_inventory_path(sap_sid => 'ZETA', config_root_path => '/Project/Zeta'),
+      '/Project/Zeta/ZETA_hosts.yaml', 'Return correct inventory path.';
+    dies_ok { get_sdaf_inventory_path(sap_sid => 'ZETA') } 'Fail with missing config root path argument';
+    dies_ok { get_sdaf_inventory_path(config_root_path => '/Project/Zeta') } 'Fail with missing SAP sid argument';
 };
 
+subtest '[get_sut_sshkey_path]' => sub {
+    is get_sut_sshkey_path(config_root_path => '/Project/Zeta'), '/Project/Zeta/sshkey', 'Return correct ssh key path.';
+    dies_ok { get_sut_sshkey_path() } 'Fail with missing config root path argument';
+};
 
 done_testing;

--- a/tests/sles4sap/sap_deployment_automation_framework/execute_playbooks.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/execute_playbooks.pm
@@ -11,7 +11,7 @@ use parent 'sles4sap::sap_deployment_automation_framework::basetest';
 use strict;
 use warnings;
 use sles4sap::sap_deployment_automation_framework::deployment;
-use sles4sap::sap_deployment_automation_framework::naming_conventions qw(get_sdaf_config_path convert_region_to_short get_workload_vnet_code);
+use sles4sap::sap_deployment_automation_framework::naming_conventions;
 use sles4sap::console_redirection qw(connect_target_to_serial disconnect_target_from_serial);
 use sles4sap::sap_deployment_automation_framework::configure_tfvars qw(validate_components);
 use serial_terminal qw(select_serial_terminal);
@@ -63,12 +63,14 @@ sub test_flags {
 
 sub run {
     serial_console_diag_banner('Module sdaf_deploy_hanasr.pm : start');
+    my $sap_sid = get_required_var('SAP_SID');
     my $sdaf_config_root_dir = get_sdaf_config_path(
         deployment_type => 'sap_system',
         vnet_code => get_workload_vnet_code(),
         env_code => get_required_var('SDAF_ENV_CODE'),
         sdaf_region_code => convert_region_to_short(get_required_var('PUBLIC_CLOUD_REGION')),
-        sap_sid => get_required_var('SAP_SID'));
+        sap_sid => $sap_sid);
+    my $sut_private_key_path = get_sut_sshkey_path(config_root_path => $sdaf_config_root_dir);
     # setup = combination of all components chosen for installation
     my @setup = split(/,/, get_required_var('SDAF_DEPLOYMENT_SCENARIO'));
     validate_components(components => \@setup);
@@ -85,31 +87,25 @@ sub run {
     # Some playbooks use azure cli
     az_login();
 
-    # Register SUTs before executing playbooks
-    if (is_byos() || get_var('PUBLIC_CLOUD_FORCE_REGISTRATION')) {
-        # Execute playbook 'pb_get-sshkey.yaml' for sshkey
-        $sles4sap::sap_deployment_automation_framework::basetest::serial_regexp_playbook = 1;
-        sdaf_execute_playbook(playbook_filename => 'pb_get-sshkey.yaml', timeout => 90, sdaf_config_root_dir => $sdaf_config_root_dir);
-        $sles4sap::sap_deployment_automation_framework::basetest::serial_regexp_playbook = 0;
-
-        # Register SUTs
-        my $sap_sid = get_required_var('SAP_SID');
-        my $scc_reg_code = get_required_var('SCC_REGCODE_SLES4SAP');
-        assert_script_run("cd $sdaf_config_root_dir");
-        record_info('Register SUTs');
-        ansible_execute_command(
-            command => "sudo registercloudguest -r $scc_reg_code",
-            host_group => "${sap_sid}_DB",
-            sdaf_config_root_dir => "$sdaf_config_root_dir",
-            sap_sid => "$sap_sid",
-            verbose => 1
-        );
-    }
-
     for my $playbook_options (@execute_playbooks) {
         $sles4sap::sap_deployment_automation_framework::basetest::serial_regexp_playbook = 1;
         sdaf_execute_playbook(%{$playbook_options}, sdaf_config_root_dir => $sdaf_config_root_dir);
         $sles4sap::sap_deployment_automation_framework::basetest::serial_regexp_playbook = 0;
+
+        # tasks needed to be run after playbook 'pb_get-sshkey.yaml'
+        if ($playbook_options->{playbook_filename} =~ /pb_get-sshkey/) {
+            # Check if SSH key was created by playbook
+            record_info('File check', "Check if SSH key '$sut_private_key_path' was created by SDAF");
+            assert_script_run("test -f $sut_private_key_path");
+
+            # BYOS image registration must happen before executing any other playbooks
+            sdaf_register_byos(
+                sap_sid => $sap_sid,
+                sdaf_config_root_dir => $sdaf_config_root_dir,
+                scc_reg_code => get_required_var('SCC_REGCODE_SLES4SAP'))
+              if is_byos() || get_var('PUBLIC_CLOUD_FORCE_REGISTRATION');
+        }
+
     }
 
     # Display deployment information

--- a/tests/sles4sap/sap_deployment_automation_framework/prepare_ssh_config.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/prepare_ssh_config.pm
@@ -16,9 +16,7 @@ use sles4sap::console_redirection;
 use sles4sap::azure_cli qw(az_keyvault_list);
 use sles4sap::sap_deployment_automation_framework::inventory_tools;
 use sles4sap::sap_deployment_automation_framework::deployment qw(sdaf_ssh_key_from_keyvault);
-use sles4sap::sap_deployment_automation_framework::naming_conventions
-  qw( get_sdaf_inventory_path get_sdaf_config_path convert_region_to_short get_workload_vnet_code $sut_private_key_path
-  generate_resource_group_name);
+use sles4sap::sap_deployment_automation_framework::naming_conventions;
 
 sub run {
     my ($self, $run_args) = @_;
@@ -30,10 +28,10 @@ sub run {
 
     my $jump_host_user = get_required_var('REDIRECT_DESTINATION_USER');
     my $jump_host_ip = get_required_var('REDIRECT_DESTINATION_IP');
-    my $inventory_path = get_sdaf_inventory_path(env_code => $env_code, sdaf_region_code => $sdaf_region_code,
-        vnet_code => $workload_vnet_code, sap_sid => $sap_sid);
-    my $private_key_src_path = get_sdaf_config_path(deployment_type => 'sap_system', env_code => $env_code,
-        sdaf_region_code => $sdaf_region_code, sap_sid => $sap_sid, vnet_code => $workload_vnet_code) . '/sshkey';
+    my $config_root_path = get_sdaf_config_path(deployment_type => 'sap_system', env_code => $env_code,
+        sdaf_region_code => $sdaf_region_code, sap_sid => $sap_sid, vnet_code => $workload_vnet_code);
+    my $inventory_path = get_sdaf_inventory_path(sap_sid => $sap_sid, config_root_path => $config_root_path);
+    my $private_key_src_path = get_sut_sshkey_path(config_root_path => $config_root_path);
 
     # Connect serial to Deployer VM to get inventory file
     connect_target_to_serial();

--- a/tests/sles4sap/sap_deployment_automation_framework/setup_publiccloud_instances.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/setup_publiccloud_instances.pm
@@ -13,8 +13,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use sles4sap::console_redirection qw(connect_target_to_serial disconnect_target_from_serial);
 use sles4sap::sap_deployment_automation_framework::inventory_tools qw(read_inventory_file sdaf_create_instances);
-use sles4sap::sap_deployment_automation_framework::naming_conventions
-  qw(get_sdaf_inventory_path convert_region_to_short get_sdaf_config_path get_workload_vnet_code);
+use sles4sap::sap_deployment_automation_framework::naming_conventions;
 
 sub run {
     my ($self, $run_args) = @_;
@@ -24,19 +23,15 @@ sub run {
     my $sdaf_region_short = convert_region_to_short(get_required_var('PUBLIC_CLOUD_REGION'));
     my $sdaf_env_code = get_required_var('SDAF_ENV_CODE');
 
-    my $inventory_path = get_sdaf_inventory_path(
-        env_code => $sdaf_env_code,
-        sdaf_region_code => $sdaf_region_short,
-        vnet_code => $workload_vnet_code,
-        sap_sid => $sap_sid
-    );
-
-    my $sut_ssh_private_key = get_sdaf_config_path(
+    my $config_root_path = get_sdaf_config_path(
         deployment_type => 'sap_system',
         env_code => $sdaf_env_code,
         sdaf_region_code => $sdaf_region_short,
         vnet_code => $workload_vnet_code,
-        sap_sid => $sap_sid) . '/sshkey';
+        sap_sid => $sap_sid);
+
+    my $inventory_path = get_sdaf_inventory_path(config_root_path => $config_root_path, sap_sid => $sap_sid);
+    my $sut_ssh_private_key = get_sut_sshkey_path(config_root_path => $config_root_path);
 
     # Redirect serial to deployer VM. Deployer VM takes same role as worker VM.
     # Normally PC test runs under root user


### PR DESCRIPTION
SDAF test code is missing sanity checks afte 'sap_systems' deployment wchich 
would help troubleshooting SDAF failures. This PR adds checks for important 
files that should be created by SDAF - 'SUT ssh key' and 'ansible inventory 
file'

- Related ticket: https://github.com/sdaf-suse/sap-automation/issues/3
- Verification runs:

BYOS 15SP7: https://openqa.suse.de/tests/17025069#step/execute_playbooks/120 :red_circle:  (Known issue on BYOS deployment)
PAYG 15SP5: https://openqaworker15.qa.suse.cz/tests/316589#step/execute_playbooks/80 :green_circle: 
