### PR TITLE
Skip module installation on SLES16

### DIFF
--- a/tests/console/ansible.pm
+++ b/tests/console/ansible.pm
@@ -35,7 +35,7 @@ sub run {
 
     # 1. System setup
 
-    unless (is_opensuse || (main_common::is_updates_tests && !(get_var('FIPS_ENABLED') || is_jeos))) {
+    unless (is_opensuse || (main_common::is_updates_tests && !(get_var('FIPS_ENABLED') || is_jeos)) || is_sle("16+")) {
         # The Desktop module is required by the Development Tools module
         add_suseconnect_product(get_addon_fullname('desktop'));
         # Package 'ansible-test' needs python3-virtualenv from Development Tools module


### PR DESCRIPTION
On SLES16 there are no modules.

- Related failure: https://openqa.suse.de/tests/16973841#step/ansible/19
- Verification run: https://openqa.suse.de/tests/16977935#step/ansible/18 (Reported in https://bugzilla.suse.com/show_bug.cgi?id=1238921)
