### PR TITLE
Remove salt from schedule

### DIFF
--- a/schedule/jeos/sle/minimalvm-extratest.yaml
+++ b/schedule/jeos/sle/minimalvm-extratest.yaml
@@ -55,7 +55,6 @@ schedule:
     - console/ansible
     - x11/evolution/evolution_prepare_servers
     - console/unzip
-    - console/salt
     - console/gpg
     - console/rsync
     - console/shells

--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -77,7 +77,6 @@ schedule:
     - console/zypper_ref
     - console/ncurses
     - console/curl_https
-    - console/salt
     - console/glibc_sanity
     - update/zypper_up
     - console/console_reboot


### PR DESCRIPTION
There's no salt on SLES16. See https://bugzilla.suse.com/show_bug.cgi?id=1236501#c6