### PR TITLE
Switch to HTTP if mount fails during hyperv testing

### DIFF
--- a/lib/virt_autotest/hyperv_utils.pm
+++ b/lib/virt_autotest/hyperv_utils.pm
@@ -50,7 +50,7 @@ sub hyperv_cmd_with_retry {
     for my $retry (1 .. $attempts) {
         my ($ret, $stdout, $stderr) = console('svirt')->run_cmd($cmd, wantarray => 1);
         # return when powershell returns 0 (SUCCESS)
-        return if $ret == 0;
+        return {success => 1} if $ret == 0;
 
         diag "Attempt $retry/$attempts: Command failed";
         my $msg_found = 0;
@@ -71,9 +71,9 @@ sub hyperv_cmd_with_retry {
             }
         }
         # Error we don't know if we should attempt to recover from
-        die 'Command failed with unhandled error' unless $msg_found;
+        return {success => 0, error => "Command failed with unhandled error"} unless $msg_found;
     }
-    die 'Run out of attempts';
+    return {success => 0, error => "Run out of attempts"};
 }
 
 1;


### PR DESCRIPTION
For hyperv testing:
OSD CC machines(prg2) will use "mount \\openqa.suse.de\var\lib\openqa\share\factory N:" to download file
OSD non-CC machines(nue2) will use HTTP protocol to download file.

- Related ticket: https://progress.opensuse.org/issues/176514
- Needles: N/A
- Verification run: 
NUE2 VR ISO:  https://openqa.oqa.prg2.suse.org/tests/17089927
NUE2 VR HDD: https://openqa.oqa.prg2.suse.org/tests/17089928
NUE2 VR HDD(sle16): https://openqa.oqa.prg2.suse.org/tests/17089929
PRG2 VR ISO: https://openqa.oqa.prg2.suse.org/tests/17089930
PRG2 VR HDD: https://openqa.oqa.prg2.suse.org/tests/17089931
PRG2 VR HDD(sle16): https://openqa.oqa.prg2.suse.org/tests/17089932


