### PR TITLE
rsync: Install tar manually on SLE16

### DIFF
--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -28,6 +28,9 @@ sub run {
         zypper_call('-t in rsync', dumb_term => 1);
     }
 
+    # bsc#1238784 tar is not installed by default on BETA
+    zypper_call('in tar') if is_sle('>=16');
+
     # create the folders and files that will be synced
     assert_script_run('mkdir /tmp/rsync_test_folder_a');
     assert_script_run('mkdir /tmp/rsync_test_folder_b');


### PR DESCRIPTION
Workaround for https://bugzilla.suse.com/show_bug.cgi?id=1238784

`tar` is not installed by default on BETA and it's making rsync test fail.

- Related ticket: https://progress.opensuse.org/issues/178372
- Verification run: 
