### PR TITLE
Package tar is missing

### DIFF
--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -23,6 +23,10 @@ sub run {
     if ($host_distri =~ /sles|opensuse/) {
         zypper_call("--quiet up", timeout => $update_timeout);
         ensure_ca_certificates_suse_installed() if is_sle();
+        if (script_run('rpm -q tar') && $version =~ '16.0') {
+            record_soft_failure('bsc#1238784 - tar packet not installed by default');
+            zypper_call('in tar');
+        }
     } elsif ($host_distri eq 'ubuntu') {
         # Sometimes, the host doesn't get an IP automatically via dhcp, we need force it just in case
         assert_script_run("dhclient -v");


### PR DESCRIPTION
Package tar should be present on the system according to https://bugzilla.suse.com/show_bug.cgi?id=1238784. As of now, we need to workaround the missing binary

- Verification run: http://kepler.suse.cz/tests/24454#
