### PR TITLE
Add dnsmasq testing

### DIFF
--- a/data/console/dnsmasq.conf
+++ b/data/console/dnsmasq.conf
@@ -1,0 +1,10 @@
+listen-address=127.0.0.1
+
+server=1.1.1.1
+server=8.8.8.8
+
+# Manual overrides
+address=/openqa.domain.none/11.22.33.44
+
+# block (NXDOMAIN) existing domain
+address=/suse.de/

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -6,6 +6,7 @@ schedule:
   - boot/boot_to_desktop
   - console/prepare_test_data
   - console/consoletest_setup
+  - console/dnsmasq
   - console/curl_ipv6
   - console/wget_ipv6
   - console/ca_certificates_mozilla

--- a/tests/console/dnsmasq.pm
+++ b/tests/console/dnsmasq.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: dnsmasq
+# Summary: Check basic dnsmasq resolving functionality
+#          both with staticly configured queries and with
+#          normal recursion.
+#
+# Maintainer: Ondřej Pithart <ondrej.pithart@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+use utils qw(zypper_call systemctl);
+
+sub run {
+    select_serial_terminal();
+    zypper_call('in dnsmasq bind-utils');
+
+    assert_script_run 'curl ' . data_url('console/dnsmasq.conf') . ' -o /etc/dnsmasq.conf';
+    systemctl('enable --now dnsmasq');
+
+    # Keys are DNS queries, values are regexes to be matched
+    # against output of `dig $query`.
+    my %records = (
+        'openqa.domain.none' => 'A\s+11.22.33.44',
+        'suse.de' => 'NXDOMAIN',
+        # The root servers can change their IP addresses, but only in case of
+        # great technical need. A change might occur once in 15+ years.
+        # https://itp.cdn.icann.org/en/files/root-server-system-advisory-committee-rssac-publications/rssac-023-04nov16-en.pdf
+        # Also the A root server has not changed once in it's existence
+        # and is propagated from multiples sites using anycast propagation.
+        'a.root-servers.net' => 'A\s+198.41.0.4',
+        '-t PTR 4.0.41.198.in-addr.arpa' => 'PTR\s+a.root-servers.net',
+
+        # only expect NOERROR because answers are changing
+        'scc.suse.com' => 'status: NOERROR'
+    );
+
+    while (my ($query, $output) = each %records) {
+        my $dig = script_output("dig \@127.0.0.1 $query");
+        if ($dig !~ m/$output/) {
+            die "expected output not foud. query: $query, expected match: $output";
+        }
+    }
+}
+
+sub cleanup {
+    systemctl('disable --now dnsmasq');
+    zypper_call('rm dnsmasq');
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    cleanup();
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = shift;
+    cleanup();
+    $self->SUPER::post_run_hook;
+}
+
+1;


### PR DESCRIPTION
Check basic `dnsmasq` resolving functionality both with statically configured queries and with normal recursion.

- Related ticket: https://progress.opensuse.org/issues/177474
- Verification runs:
  - [15-SP6](http://10.100.51.152/tests/147) [also s390x](https://openqa.suse.de/tests/17011964#step/dnsmasq/66)
  - [15-SP5](http://10.100.51.152/tests/148)
  - [15-SP4](http://10.100.51.152/tests/149)
  - [15-SP3](http://10.100.51.152/tests/150)
  - [15-SP2](http://10.100.51.152/tests/151)
  - [12-SP5](http://10.100.51.152/tests/152)
