### PR TITLE
Support install_url with split repodata per architecture 

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -630,6 +630,13 @@ sub bootmenu_default_params {
         if (get_var('REPO_0')) {
             my $host = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
             my $repo = get_var('REPO_0');
+
+            # Split repodata functionality in Leap 16.0
+            # https://code.opensuse.org/leap/features/issue/193
+            if (get_var('SPLIT_REPODATA')) {
+                $repo .= "/\$basearch";
+            }
+
             # inst.install_url supports comma separated list if more repos are needed ...
             push @params, "inst.install_url=$host/assets/repo/$repo";
         }
@@ -893,6 +900,9 @@ sub specific_bootmenu_params {
     }
 
     if (my $agama_install_url = get_var('AGAMA_INSTALL_URL')) {
+        if (get_var('SPLIT_REPODATA')) {
+            $agama_install_url .= "/\$basearch";
+        }
         push @params, "inst.install_url=$agama_install_url";
     }
 

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -103,6 +103,11 @@ sub run {
     my $nr = 1;
     foreach my $r (split(/,/, get_var('ZDUPREPOS', $defaultrepo))) {
         $r =~ s/^\s+|\s+$//g;
+        # Split repodata functionality in Leap 16.0
+        # https://code.opensuse.org/leap/features/issue/193
+        if (get_var('SPLIT_REPODATA')) {
+            $r .= "/\$basearch";
+        }
         zypper_call("--no-gpg-checks ar \"$r\" repo$nr");
         $nr++;
     }


### PR DESCRIPTION
product-composer now supports generating repodata directorty per $basearch
Leap 16.0 is already using this feature code-o-o#leap/features#193

This PR adds appends $basearch to the REPO_0 path in case that SPLIT_REPODATA=1 is set. 

- Related ticket: https://code.opensuse.org/leap/features/issue/193
- Verification run for install_url: https://openqa.opensuse.org/tests/4907751#live
- Verification run for zdup: https://openqa.opensuse.org/tests/4907752#live