### PR TITLE
apache: Ensure "semanage" is installed on JeOS when SELinux managed

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -38,6 +38,7 @@ sub run {
     # Install and start apache
     zypper_call "in $apache2";
     zypper_call "in apache2-utils" if is_jeos;
+    zypper_call "in policycoreutils-python-utils" if (is_jeos && has_selinux);
     systemctl 'enable apache2';    # Note: The systemd service is always apache2, not apache2-tls13.
     systemctl 'restart apache2';    # apache2 could be already running from previous test runs
     systemctl 'status apache2';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/178240
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4908950
