### PR TITLE
Enable netavark upstream tests on SLE 15-SP5+

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -309,7 +309,7 @@ sub load_container_tests {
             loadtest 'containers/runc_integration' if (is_tumbleweed || is_sle || is_leap);
         }
         if (!check_var('NETAVARK_BATS_SKIP', 'all')) {
-            loadtest 'containers/netavark_integration' if (is_tumbleweed);
+            loadtest 'containers/netavark_integration' if (is_tumbleweed || is_sle('>15-SP4') || is_leap);
         }
         return;
     }

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -10,7 +10,7 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(script_retry systemctl);
+use utils qw(script_retry);
 use containers::common;
 use containers::bats;
 use version_utils qw(is_sle is_tumbleweed is_microos);
@@ -54,7 +54,7 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns cargo dnsmasq firewalld iproute2 iptables jq make protobuf-devel netavark);
+    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 iptables jq make protobuf-devel netavark);
     if (is_tumbleweed || is_microos) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {
@@ -62,8 +62,6 @@ sub run {
     }
     install_packages(@pkgs);
     install_ncat;
-
-    systemctl "enable --now dnsmasq";
 
     $self->bats_setup;
 


### PR DESCRIPTION
Enable netavark upstream tests on SLE.

Also drop dnsmasq as unneeded in this test.

- Verification runs:
  - TW: https://openqa.opensuse.org/tests/4910054
  - 15-SP5: https://openqa.suse.de/tests/16994873
  - 15-SP7: https://openqa.suse.de/tests/16994874
  - 16.0: https://openqa.suse.de/tests/16994875
 
Subtest failures are skipped with `NETAVARK_BATS_SKIP` in:
Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2109