### PR TITLE
Fix 12sp5 sporadical fail: upload_logs timed out

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -629,7 +629,9 @@ sub ha_export_logs {
     script_run "crm report $report_opt -E $bootstrap_log $crm_log", 300;
     upload_logs("$bootstrap_log", failok => 1);
 
-    my $crm_log_name = script_output("ls $crm_log* | tail -1");
+    my $crm_log_name = script_output("echo \"FILE=\|\$(ls $crm_log* | tail -1)\|\"");
+    $crm_log_name =~ /FILE=\|([^\|]+)\|/;
+    $crm_log_name = $1;
     upload_logs("$crm_log_name", failok => 1);
 
     script_run "crm configure show > /tmp/crm.txt";


### PR DESCRIPTION
Fix 12sp5 qam-SAPHanaSR_ScaleUp_PerfOpt_node sporadically failed on check_logs: upload_logs timed out  
  
TEAM-10094 - [On Prem][12sp5] qam-SAPHanaSR_ScaleUp_PerfOpt_node sporadically failed on check_logs: upload_logs timed out

- Related ticket: https://jira.suse.com/browse/TEAM-10094
- Verification run: 
http://openqa.suse.de/tests/16999564#step/check_logs/12
The fix works when there are extra characters in this test step 
```
FILE=|/var/log/crm_report.tar.bz2|
[  566.472793] su[27877]: pam_unix(su-l:session): session closed for user ha1adm
SCRIPT_FINISHEDhrtK_-0-
```
