### PR TITLE
Add workaround for hana and netweaver install to support sles16

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -71,6 +71,7 @@ our @EXPORT = qw(
   get_instance_profile_path
   load_ase_env
   upload_ase_logs
+  modify_selinux_setenforce
 );
 
 =head1 SYNOPSIS
@@ -157,6 +158,10 @@ sub download_hana_assets_from_server {
     my $asset_lock = "/tmp/asset_0";
     my $asset_lock_found = script_run "test -e $asset_lock";    # 0 if asset is already downloaded
     if ($asset_lock_found) {
+        # Install wget package if its command not found
+        if (script_run "which wget") {
+            zypper_call "in wget";
+        }
         assert_script_run "wget -O - $hana_location | tar -xf -", timeout => $nettout;
         assert_script_run "touch $asset_lock";
         # Skip checksum check if DISABLE_CHECKSUM is set, or if checksum file is not
@@ -1426,6 +1431,24 @@ sub upload_ase_logs {
     return unless $self->ASE_RESPONSE_FILE;
     $self->load_ase_env;
     save_and_upload_log('tar -zcf ase_logs.tar.gz $SYBASE/log $SYBASE/$SYBASE_ASE/install/*.log', 'ase_logs.tar.gz');
+}
+
+=head2 modify_selinux_setenforce
+
+  $self->modify_selinux_setenforce
+
+Modify SELinux mode to Enforcing or Permissive.
+
+=cut
+
+sub modify_selinux_setenforce {
+    my ($self, %args) = @_;
+    my $selinux_mode = $args{selinux_mode} // get_var('SLES4SAP_SELINUX_SETENFORCE', 'Enforcing');
+    script_run("sestatus");
+    if (script_output("getenforce") !~ m/$selinux_mode/) {
+        assert_script_run("setenforce " . $selinux_mode);
+        validate_script_output("getenforce", sub { m/$selinux_mode/ });
+    }
 }
 
 sub post_run_hook {

--- a/t/17_sles4sap.t
+++ b/t/17_sles4sap.t
@@ -286,6 +286,7 @@ subtest '[download_hana_assets_from_server]' => sub {
     $sles4sap->redefine(script_run => sub { push @calls, @_; return 1; });
     $sles4sap->redefine(assert_script_run => sub { push @calls, @_; return; });
     $sles4sap->redefine(data_url => sub { return 'MY_DOWNLOAD_URL'; });
+    $sles4sap->redefine(zypper_call => sub { push @calls, @_; return 1; });
 
     set_var('ASSET_0', 'Zanzibar');
     $mockObject->download_hana_assets_from_server();

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -52,6 +52,24 @@ sub run {
     # Mount media
     $self->mount_media($proto, $path, '/sapinst');
 
+    # Workaround for SLE16 if variable WORKAROUND_BSC1234806 set
+    if (get_var("WORKAROUND_BSC1236235")) {
+        record_soft_failure("bsc#1236235: workaround by installing libnsl package from NFS");
+        assert_script_run "rpm -Uvh /mnt/libnsl1-2.38-160000.4.4." . get_var("ARCH") . ".rpm";
+    }
+
+    # Workaround for SLE16 for bsc#1236372
+    if (get_var("WORKAROUND_BSC1236372")) {
+        record_soft_failure("bsc#1236372: workaround by creating a soft link for /etc/services");
+        assert_script_run "ln -s /usr/etc/services /etc/services";
+    }
+
+    # Modify SELinux mode
+    if (get_var("WORKAROUND_BSC1239148")) {
+        record_soft_failure("bsc#1239148: workaround by changing mode to Permissive");
+        $self->modify_selinux_setenforce('selinux_mode' => 'Permissive');
+    }
+
     # Define a valid hostname/IP address in /etc/hosts, but not in HA
     $self->add_hostname_to_hosts if (!get_var('HA_CLUSTER'));
 


### PR DESCRIPTION
Tickets: https://jira.suse.com/browse/TEAM-10116, https://jira.suse.com/browse/TEAM-10115

Add single node HANA and NetWeaver install for SLE16.0 with kinds of workaround:

HANA installation

`WORKAROUND_BSC1234806: '1'` for insserv-compat support during HANA installation, install package hana_insserv_compat from QA:HEAD

`WORKAROUND_BSC1239148: '1'` to change SELinux mode to permissive during HANA installation for bsc#1239148

NetWeaver installation

`WORKAROUND_BSC1236235: '1' `for mssing libnsl library during NetWeaver installation, package is stored at NFS qesap-nfs:/srv/nfs/sap/NW*/

`WORKAROUND_BSC1236372: '1' `for missing /etc/services during NetWeaver installation

`WORKAROUND_BSC1239148: '1'` to change SELinux mode to permissive during HANA installation for bsc#1239148

VR: 
https://openqa.suse.de/tests/16999744

https://openqa.suse.de/tests/16999747

https://openqa.suse.de/tests/16999745

https://openqa.suse.de/tests/16999746