### PR TITLE
Fix escaping for $basearch

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -634,7 +634,7 @@ sub bootmenu_default_params {
             # Split repodata functionality in Leap 16.0
             # https://code.opensuse.org/leap/features/issue/193
             if (get_var('SPLIT_REPODATA')) {
-                $repo .= "/\$basearch";
+                $repo .= "/\\\$basearch";
             }
 
             # inst.install_url supports comma separated list if more repos are needed ...
@@ -901,7 +901,7 @@ sub specific_bootmenu_params {
 
     if (my $agama_install_url = get_var('AGAMA_INSTALL_URL')) {
         if (get_var('SPLIT_REPODATA')) {
-            $agama_install_url .= "/\$basearch";
+            $agama_install_url .= "/\\\$basearch";
         }
         push @params, "inst.install_url=$agama_install_url";
     }

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -106,7 +106,7 @@ sub run {
         # Split repodata functionality in Leap 16.0
         # https://code.opensuse.org/leap/features/issue/193
         if (get_var('SPLIT_REPODATA')) {
-            $r .= "/\$basearch";
+            $r .= "/\\\$basearch";
         }
         zypper_call("--no-gpg-checks ar \"$r\" repo$nr");
         $nr++;


### PR DESCRIPTION
Fixes escaping of variables in $bash

- we need double escape for both bash and grub

- Verification run for agama: https://openqa.opensuse.org/tests/4910636#live
- Verification run for zdup: https://openqa.opensuse.org/tests/4910637#live

