### PR TITLE
containers: Add isolation module to test internal networks

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -130,6 +130,7 @@ sub load_host_tests_podman {
     load_3rd_party_image_test($run_args) unless is_staging;
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
+    loadtest 'containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation";
     # podman artifact needs podman 5.4.0
     loadtest 'containers/podman_artifact' if is_tumbleweed;
     loadtest 'containers/podman_bci_systemd';
@@ -166,6 +167,7 @@ sub load_host_tests_docker {
     load_3rd_party_image_test($run_args);
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
+    loadtest 'containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation";
     # Firewall is not installed in Public Cloud, JeOS OpenStack and MicroOS but it is in SLE Micro
     load_firewall_test($run_args);
     unless (is_sle("<=15") && is_aarch64) {

--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -1,0 +1,108 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: isolation
+# Summary: Test container network isolation
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
+use containers::common qw(install_packages);
+use utils qw(script_retry systemctl);
+use version_utils qw(is_transactional);
+
+my $runtime;
+my $network = "test_isolated_network";
+
+sub test_ip_version {
+    my ($ip_version, $ip_addr) = @_;
+
+    # We use alpine as registry.opensuse.org/opensuse/busybox has a buggy ping that needs setuid root
+    # https://bugzilla.suse.com/show_bug.cgi?id=1239176
+    my $image = "registry.opensuse.org/opensuse/toolbox";
+    script_retry("$runtime pull $image", timeout => 300, delay => 60, retry => 3);
+
+    # Test that containers can't access the host
+    assert_script_run "! $runtime run --rm --network $network $image ping -$ip_version -c 1 $ip_addr";
+
+    # Test that containers can't access the Internet
+    # Google DNS servers
+    my $external_ip = ($ip_version == 6) ? "2001:4860:4860::8888" : "8.8.8.8";
+    assert_script_run "! $runtime run --rm --network $network $image ping -$ip_version -c 1 $external_ip";
+
+    # Test that containers can't modify IP routes
+    assert_script_run "! $runtime run --rm --privileged --cap-add=CAP_NET_ADMIN --network $network $image ip -$ip_version route add default via $ip_addr";
+}
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_serial_terminal;
+
+    $runtime = $self->containers_factory($args->{runtime});
+    install_packages('jq');
+
+    my %ip_addr;
+    for my $ip_version (4, 6) {
+        my $iface = script_output "ip -$ip_version --json route list match default | jq -r '.[0].dev'";
+        $ip_addr{$ip_version} = script_output "ip -$ip_version --json addr show $iface | jq -r '.[0].addr_info[0].local'";
+    }
+
+    assert_script_run "$runtime network create --ipv6 --internal $network";
+    for my $ip_version (4, 6) {
+        record_info("Test IPv$ip_version");
+        test_ip_version $ip_version, $ip_addr{$ip_version};
+    }
+    assert_script_run "$runtime network rm $network";
+
+    select_user_serial_terminal;
+
+    # https://docs.docker.com/engine/security/rootless/
+    if ($args->{runtime} eq "docker") {
+        # rootless docker is not available on MicroOS & SLEM
+        return if is_transactional;
+        assert_script_run "dockerd-rootless-setuptool.sh install";
+        systemctl "--user enable --now docker";
+    }
+
+    assert_script_run "$runtime network create --ipv6 --internal $network";
+    for my $ip_version (4, 6) {
+        record_info("Test IPv$ip_version rootless");
+        test_ip_version $ip_version, $ip_addr{$ip_version};
+    }
+    assert_script_run "$runtime network rm $network";
+
+    select_serial_terminal;
+}
+
+1;
+
+sub cleanup() {
+    # rootless docker is not available on MicroOS & SLEM
+    if ($runtime->{runtime} eq "podman" || !is_transactional) {
+        select_user_serial_terminal;
+        script_run "$runtime network rm $network";
+        $runtime->cleanup_system_host();
+        script_run "dockerd-rootless-setuptool.sh uninstall";
+        script_run "rootlesskit rm -rf ~/.local/share/docker ~/.config/docker";
+    }
+
+    select_serial_terminal;
+    script_run "$runtime network rm $network";
+    $runtime->cleanup_system_host();
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    cleanup;
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    cleanup;
+    $self->SUPER::post_run_hook;
+}


### PR DESCRIPTION
Add isolation module to test internal networks

- Related ticket: https://progress.opensuse.org/issues/176850
- Verification runs:
   - TW podman: https://openqa.opensuse.org/tests/4918119
   - TW docker: https://openqa.opensuse.org/tests/4918117
   - SLES 15-SP6 podman: https://openqa.suse.de/tests/17033587
   - SLES 15-SP6 docker: https://openqa.suse.de/tests/17033588
   - SLEM 5.5 podman: https://openqa.suse.de/tests/17039643
   - SLEM 5.5 docker: https://openqa.suse.de/tests/17040376
