### PR TITLE
Add perf hardware info

### DIFF
--- a/tests/console/perf.pm
+++ b/tests/console/perf.pm
@@ -20,6 +20,8 @@ sub run {
     # test 1
     # Installing and testing options -a -d -p
     zypper_call('in perf', exitcode => [0, 102, 103, 106]) if (script_run("which perf") != 0);
+    record_info("list hw", script_output("perf list hw"));
+    record_info("list pmu", script_output("perf list pmu"));
     assert_script_run('perf stat -a -d -p 1 sleep 5');
     # test 2
     # Counting with perf stat


### PR DESCRIPTION
Adds output of hardware and PMU availability to the test run.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1238885#c2
- Verification run: https://openqa.suse.de/tests/17002647#step/perf/9
