### PR TITLE
Add unattended installation with localization changed

### DIFF
--- a/data/yam/agama/auto/sles_change_localization.jsonnet
+++ b/data/yam/agama/auto/sles_change_localization.jsonnet
@@ -1,0 +1,35 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}',
+  },
+  bootloader: {
+    stopOnBootMenu: true,
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+  },
+  localization: {
+    language: 'cs_CZ.UTF-8',
+    keyboard: 'cz',
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||,
+      },
+    ],
+  },
+}

--- a/schedule/yam/agama_change_localization_unattended.yaml
+++ b/schedule/yam/agama_change_localization_unattended.yaml
@@ -1,0 +1,10 @@
+---
+name: agama_change_localization_unattended
+description: >
+  Perform unattended installation with Agama, with localization changed.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - locale/keymap_or_locale


### PR DESCRIPTION
Add unattended installation with localization changed.

- Related ticket: https://progress.opensuse.org/issues/178600
- Needles: n/a
- Verification run: [vr_on_x86_64](https://openqa.suse.de/tests/17025170#step/keymap_or_locale/3); [vr_on_aarch64](https://openqa.suse.de/tests/17025171#step/keymap_or_locale/3)
