### PR TITLE
Use BCI images as base on SLES

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -28,6 +28,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils;
 use containers::common;
 use containers::utils;
 use containers::container_images;
@@ -155,8 +156,10 @@ sub run {
     check_containers_connectivity($engine);
 
     basic_container_tests(runtime => $self->{runtime});
+
     # Build an image from Dockerfile and run it
-    build_and_run_image(runtime => $engine, dockerfile => 'Dockerfile.python3', base => 'registry.opensuse.org/opensuse/bci/python:latest');
+    my $base = (is_opensuse ? 'registry.opensuse.org/opensuse/bci/python:latest' : 'registry.suse.com/bci/python:3.11');
+    build_and_run_image(runtime => $engine, dockerfile => 'Dockerfile.python3', base => $base);
 
     # Once more test the basic functionality
     runtime_smoke_tests(runtime => $engine);


### PR DESCRIPTION
On SLES we use the SLES BCI images as a base for the container build.

- Related failure: https://openqa.suse.de/tests/17009640#step/podman/274
- Verification run: https://openqa.suse.de/tests/17013076#step/podman/366
