### PR TITLE
Skip pcm module for sle16 in flask test

### DIFF
--- a/tests/console/flask.pm
+++ b/tests/console/flask.pm
@@ -19,7 +19,7 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 sub run {
     select_serial_terminal;
 
-    add_suseconnect_product(get_addon_fullname('pcm'), (is_sle('<15') ? '12' : undef)) if is_sle;
+    add_suseconnect_product(get_addon_fullname('pcm'), (is_sle('<15') ? '12' : undef)) if is_sle('<16');
 
     zypper_call "in python3-Flask";
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/178621

- Verification run: http://openqa.suse.de/tests/17013702#step/flask/2

**Please ignore the failed test module, it is not related to pcm module**