### PR TITLE
Increase timeout for php_postgresql case

### DIFF
--- a/tests/console/php_postgresql.pm
+++ b/tests/console/php_postgresql.pm
@@ -37,6 +37,7 @@ use serial_terminal 'select_serial_terminal';
 use utils 'zypper_call';
 use apachetest qw(setup_apache2 setup_pgsqldb test_pgsql destroy_pgsqldb postgresql_cleanup);
 use Utils::Systemd 'systemctl';
+use Utils::Architectures 'is_aarch64';
 use version_utils qw(is_leap is_sle php_version);
 
 sub run {
@@ -56,9 +57,14 @@ sub run {
     # setup database
     setup_pgsqldb;
 
+    # For aarch64, sometimes serial terminal will stuck which causes failure.
+    # So use root-console for aarch64. See poo#178639
+    select_console 'root-console' if (is_aarch64);
+
     # test itself
     test_pgsql;
 
+    select_serial_terminal if (is_aarch64);
     # destroy database
     destroy_pgsqldb;
 


### PR DESCRIPTION
On aarch64, sometimes test will fail due to serial console stuck, using
`root-console` for part of test due to:
1. when the sessoin stuck, we couldn't restart serial-getty service and
reconnect to it, because the `pushd` `popd` records will lost which
cause failure.
2. If the whole test module uses `root-console`, the module running time
will increase to more than 6m from 2m. So use it for a part of the
module.

Related: https://progress.opensuse.org/issues/178639

VR: https://openqa.suse.de/tests/17047354

For more VRs see [this page](https://openqa.suse.de/tests/overview?build=Amrysliu%2Fos-autoinst-distri-opensuse%23postgresql&version=16.0&distri=sle)
