### PR TITLE
Remove root password for scripts_ssh_pub_key.jsonnet

### DIFF
--- a/data/yam/agama/auto/scripts_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/scripts_ssh_pub_key.jsonnet
@@ -1,7 +1,5 @@
 {
   root: {
-    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
-    hashedPassword: true,
     sshPublicKey: 'fake public key',
   },
   scripts: {


### PR DESCRIPTION
The extra root password will confuse current puppeteer test.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17014159#step/validate_first_user/1
