### PR TITLE
Minor fixes to BATS tests

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -66,7 +66,7 @@ sub install_ncat {
 sub install_bats {
     return if (script_run("which bats") == 0);
 
-    my $bats_version = get_var("BATS_VERSION", "1.11.0");
+    my $bats_version = get_var("BATS_VERSION", "1.11.1");
 
     script_retry("curl -sL https://github.com/bats-core/bats-core/archive/refs/tags/v$bats_version.tar.gz | tar -zxf -", retry => 5, delay => 60, timeout => 300);
     assert_script_run "bash bats-core-$bats_version/install.sh /usr/local";

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -205,7 +205,7 @@ sub selinux_hack {
 
     # Use the same labeling in /var/lib/containers for $dir
     # https://github.com/containers/podman/blob/main/troubleshooting.md#11-changing-the-location-of-the-graphroot-leads-to-permission-denied
-    script_run "sudo semanage fcontext -a -e /var/lib/containers $dir";
+    script_run "sudo semanage fcontext -a -e /var/lib/containers $dir", timeout => 120;
     script_run "sudo restorecon -R -v $dir";
 }
 

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -75,6 +75,8 @@ sub run {
 
     switch_to_user;
 
+    record_info("buildah rootless", script_output("buildah info"));
+
     # Download buildah sources
     my $buildah_version = script_output "buildah --version | awk '{ print \$3 }'";
     my $url = get_var("BUILDAH_BATS_URL", "https://github.com/containers/buildah/archive/refs/tags/v$buildah_version.tar.gz");

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -102,6 +102,8 @@ sub run {
 
     switch_to_user;
 
+    record_info("podman rootless", script_output("podman info"));
+
     # Download podman sources
     my $podman_version = get_podman_version();
     my $url = get_var("PODMAN_BATS_URL", "https://github.com/containers/podman/archive/refs/tags/v$podman_version.tar.gz");


### PR DESCRIPTION
Minor fixes to BATS tests:
  - Show output of `info` command for buildah & podman in rootless mode
  - Increase timeout for `semanage`
  - Update to BATS 1.11.1

---

- Verification run: https://openqa.opensuse.org/tests/4914945