### PR TITLE
containers/podman_quadlet.pm: Fix on TW and avoid serial timeouts

### DIFF
--- a/tests/containers/podman_quadlet.pm
+++ b/tests/containers/podman_quadlet.pm
@@ -115,7 +115,6 @@ sub run {
         script_retry("podman pull $src_image", retry => 3, delay => 60, timeout => 180);
         systemctl("start $unit_name-build.service", timeout => 180);
         record_info('Build output', script_output("journalctl --no-pager -u $unit_name-build"));
-        systemctl("is-active $unit_name-build.service");    # Service Type=oneshot stays up after finishing
         validate_script_output('podman images -n', qr/$build_imagetag/);
     }
 

--- a/tests/containers/podman_quadlet.pm
+++ b/tests/containers/podman_quadlet.pm
@@ -94,7 +94,8 @@ sub run {
     assert_script_run("$quadlet -version");
     for my $file (@files) {
         my ($path, $content) = @$file;
-        assert_script_run("printf '$content' > $path");
+        $content =~ s/\n/\\n/g;
+        assert_script_run("echo -e '$content' > $path");
     }
     record_info('Unit', script_output("$quadlet -v -dryrun"));
 


### PR DESCRIPTION
Depending on the version of quadlet, the -build unit has RemainAfterExit=yes. Instead of adding some version checks, just remove this test. The next line validates that the build succeeded anyway.

Also fix newline escaping.

- Related ticket: https://progress.opensuse.org/issues/178381
- Verification runs:
  * TW: http://10.168.5.231/tests/1765
  * SLM 6.2: http://10.168.5.231/tests/1766

https://progress.opensuse.org/issues/178381