### PR TITLE
Increase robustness of publiccloud::basetest _cleanup subroutine

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -106,6 +106,7 @@ sub _cleanup {
     die("Cleanup called twice!") if ($self->{cleanup_called});
     $self->{cleanup_called} = 1;
 
+    # Call cleanup() defined in test modules - not the provider cleanup()
     eval { $self->cleanup(); } or record_info('FAILED', "\$self->cleanup() failed -- $@", result => 'fail');
 
     my $flags = $self->test_flags();
@@ -151,6 +152,7 @@ sub _cleanup {
     # We need $self->{run_args} and $self->{run_args}->{my_provider}
     if ($self->{run_args} && $self->{run_args}->{my_provider}) {
         diag('Public Cloud _cleanup: Ready for provider cleanup.');
+        # Call the provider cleanup
         eval { $self->{run_args}->{my_provider}->cleanup() } or record_info('FAILED', "\$self->run_args->my_provider::cleanup() failed -- $@", result => 'fail');
         diag('Public Cloud _cleanup: The provider cleanup finished.');
     } else {

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -164,13 +164,10 @@ sub _upload_logs {
     my ($self) = @_;
     my $ssh_sut_log = '/var/tmp/ssh_sut.log';
 
-    if ($self->{run_args}) {
-        diag('Public Cloud _upload_logs: $self->{run_args}=' . $self->{run_args});
-        return;
-    }
-    if ($self->{run_args}->{my_instance}) {
-        diag('Public Cloud _upload_logs: $self->{run_args}->{my_instance}=' . $self->{run_args}->{my_instance});
-        return;
+    diag('Public Cloud _upload_logs: $self->{run_args}=' . $self->{run_args}) if ($self->{run_args});
+    diag('Public Cloud _upload_logs: $self->{run_args}->{my_instance}=' . $self->{run_args}->{my_instance}) if ($self->{run_args}->{my_instance});
+    unless ($self->{run_args} && $self->{run_args}->{my_instance}) {
+        die('Public Cloud _upload_logs: Either $self->{run_args} or $self->{run_args}->{my_instance} is not available. Maybe the test died before the instance has been created?');
     }
 
     script_run("sudo chmod a+r " . $ssh_sut_log);

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -163,6 +163,16 @@ sub _cleanup {
 sub _upload_logs {
     my ($self) = @_;
     my $ssh_sut_log = '/var/tmp/ssh_sut.log';
+
+    if ($self->{run_args}) {
+        diag('Public Cloud _upload_logs: $self->{run_args}=' . $self->{run_args});
+        return;
+    }
+    if ($self->{run_args}->{my_instance}) {
+        diag('Public Cloud _upload_logs: $self->{run_args}->{my_instance}=' . $self->{run_args}->{my_instance});
+        return;
+    }
+
     script_run("sudo chmod a+r " . $ssh_sut_log);
     upload_logs($ssh_sut_log, failok => 1, log_name => $ssh_sut_log . ".txt");
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -758,6 +758,7 @@ sub cleanup {
     my ($self) = @_;
     $self->terraform_destroy();
     assert_script_run "cd";
+    return 1;
 }
 
 =head2 stop_instance

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -228,10 +228,14 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    # If we are in multi module scenario and this is not the first run of this test module we wanna run basetest cleanup
-    return {fatal => 1, publiccloud_multi_module => 1} if ($run_count > 1 && check_var('PUBLIC_CLOUD_QAM', 1));
-    # If we are in multi module scenario and this is the first run of the test module we wanna not fail the whole run
-    return {fatal => 0, publiccloud_multi_module => 1} if ($run_count < 2 && check_var('PUBLIC_CLOUD_QAM', 1));
+    if (check_var('PUBLIC_CLOUD_QAM', 1)) {
+        if ($run_count == 1) {
+            # If we are in multi module scenario and this is the first run of the test module we wanna not fail the whole run
+            return {fatal => 0, publiccloud_multi_module => 1};
+        }
+        # If we are in multi module scenario and this is not the first run of this test module we wanna fail the whole run
+        return {fatal => 1, publiccloud_multi_module => 1};
+    }
     # If we are not in multi module scenario it is always the first run and we wanna run basetest cleanup
     return {fatal => 1, publiccloud_multi_module => 0};
 }

--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2024 SUSE LLC
+# Copyright 2024 - 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Check public cloud specific services
@@ -21,8 +21,7 @@ sub run {
     my ($self, $args) = @_;
     select_host_console();
 
-    my $instance = $self->{my_instance} = $args->{my_instance};
-    my $provider = $self->{provider} = $args->{my_provider};    # required for cleanup
+    my $instance = $args->{my_instance};
 
     # Debug
     $instance->ssh_script_run('systemctl --no-pager list-units');

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -91,17 +91,14 @@ sub run {
     $self->{ltp_command} = $ltp_command;
     my $ltp_exclude = get_var('LTP_COMMAND_EXCLUDE', '');
 
-    my $provider;
-    my $instance;
-
     select_host_console();
 
     unless ($args->{my_provider} && $args->{my_instance}) {
         $args->{my_provider} = $self->provider_factory();
         $args->{my_instance} = $args->{my_provider}->create_instance(check_guestregister => is_openstack ? 0 : 1);
     }
-    $instance = $args->{my_instance};
-    $provider = $args->{my_provider};
+    my $instance = $args->{my_instance};
+    my $provider = $args->{my_provider};
 
     assert_script_run("cd $root_dir");
     assert_script_run('curl ' . data_url('publiccloud/restart_instance.sh') . ' -o restart_instance.sh');
@@ -188,13 +185,13 @@ sub run {
 }
 
 sub cleanup {
-    my ($self, $args) = @_;
+    my ($self) = @_;
 
     # Ensure that the ltp script gets killed
     type_string('', terminate_with => 'ETX');
     $self->upload_ltp_logs();
 
-    if ($self->{my_instance} && script_run("test -f $root_dir/log_instance.sh") == 0) {
+    if ($self->{run_args}->{my_instance} && script_run("test -f $root_dir/log_instance.sh") == 0) {
         script_run($root_dir . '/log_instance.sh stop ' . instance_log_args($self->{run_args}->{my_provider}, $self->{run_args}->{my_instance}));
         script_run("(cd /tmp/log_instance && tar -zcf $root_dir/instance_log.tar.gz *)");
         upload_logs("$root_dir/instance_log.tar.gz", failok => 1);

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -191,7 +191,11 @@ sub cleanup {
     type_string('', terminate_with => 'ETX');
     $self->upload_ltp_logs();
 
-    if ($self->{run_args}->{my_instance} && script_run("test -f $root_dir/log_instance.sh") == 0) {
+    unless ($self->{run_args} && $self->{run_args}->{my_instance}) {
+        die('cleanup: Either $self->{run_args} or $self->{run_args}->{my_instance} is not available. Maybe the test died before the instance has been created?');
+    }
+
+    if (script_run("test -f $root_dir/log_instance.sh") == 0) {
         script_run($root_dir . '/log_instance.sh stop ' . instance_log_args($self->{run_args}->{my_provider}, $self->{run_args}->{my_instance}));
         script_run("(cd /tmp/log_instance && tar -zcf $root_dir/instance_log.tar.gz *)");
         upload_logs("$root_dir/instance_log.tar.gz", failok => 1);

--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2021 - 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Basic test of SLE Micro in public cloud
@@ -51,12 +51,9 @@ sub check_avc {
 
 sub run {
     my ($self, $args) = @_;
-    my $provider;
-    my $instance;
     select_serial_terminal();
 
-    $instance = $self->{my_instance} = $args->{my_instance};
-    $provider = $self->{provider} = $args->{my_provider};
+    my $instance = $self->{my_instance} = $args->{my_instance};
 
     # On SLEM 5.2+ check that we don't have any SELinux denials. This needs to happen before anything else is ongoing
     $self->check_avc() unless (is_sle_micro('=5.1'));


### PR DESCRIPTION
### Changelog:
 - Make sure that `$self->{my_provider}` and `$self->{my_instance}` are available in test modules where `cleanup()` subroutine needs those.
 - Make sure that `$args->{my_provider}` `$args->{my_instance}` is available as it's used in `lib/publiccloud/basetest.pm` where it's available as `$self->{run_args}`.

---
- Related ticket: [poo#178099](https://progress.opensuse.org/issues/178099), [poo#179272](https://progress.opensuse.org/issues/179272)
- Part of work in this PR has been moved to: #21438
- Verification runs:
[Build:38063:corosync](https://pdostal-server.suse.cz/tests/overview?build=%3A38063%3Acorosync&distri=sle&version=15-SP5) of sle-15-SP5-Azure-SAP-BYOS-Incidents.x86_64	  [SAPHanaSR-ScaleUp-PerfOpt-msi@az_Standard_E4s_v3](https://pdostal-server.suse.cz/tests/8718)
[Build20250330-1](https://pdostal-server.suse.cz/tests/overview?build=20250330-1&distri=sle&version=12-SP5) of sle-12-SP5-EC2-Updates.x86_64	  [publiccloud_consoletests@64bit](https://pdostal-server.suse.cz/tests/8722)
[Build20250330-1](https://pdostal-server.suse.cz/tests/overview?build=20250330-1&distri=sle&version=12-SP5) of sle-12-SP5-GCE-Updates.x86_64	  [publiccloud_containers@64bit](https://pdostal-server.suse.cz/tests/8723)
[Build20250330-1](https://pdostal-server.suse.cz/tests/overview?build=20250330-1&distri=sle&version=12-SP5) of sle-12-SP5-Azure-BYOS-Updates.x86_64	  [publiccloud_img_proof@64bit](https://pdostal-server.suse.cz/tests/8721)
[Build20250325-1](https://pdostal-server.suse.cz/tests/overview?build=20250325-1&distri=sle&version=15-SP6) of sle-15-SP6-Azure-BYOS-Updates.x86_64	  [publiccloud_cloud_netconfig@64bit](https://pdostal-server.suse.cz/tests/8720)
[Build20250325-1](https://pdostal-server.suse.cz/tests/overview?build=20250325-1&distri=sle&version=15-SP6) of sle-15-SP6-EC2-Updates.aarch64	  [publiccloud_cloud_netconfig@64bit](https://pdostal-server.suse.cz/tests/8719)
[Build0644](https://pdostal-server.suse.cz/tests/overview?build=0644&distri=sle&version=15-SP7) of sle-15-SP7-GCE.aarch64	  [publiccloud_ltp_syscalls@64bit](https://pdostal-server.suse.cz/tests/8716)
[Build0691](https://pdostal-server.suse.cz/tests/overview?build=0691&distri=sle&version=15-SP7) of sle-15-SP7-EC2.aarch64	  [publiccloud_smoketests@ec2_a1.medium](https://pdostal-server.suse.cz/tests/8717)
[Build:37748:python-wheel](https://pdostal-server.suse.cz/tests/overview?build=%3A37748%3Apython-wheel&distri=sle&version=12-SP5) of sle-12-SP5-Azure-BYOS-Incidents-Ext.x86_64	  [publiccloud_img_proof@az_Standard_B2s](https://pdostal-server.suse.cz/tests/8711)
[Build20250327-1](https://pdostal-server.suse.cz/tests/overview?build=20250327-1&distri=sle-micro&version=5.3) of sle-micro-5.3-GCE-BYOS-Updates.aarch64	  [publiccloud_slem_containers@gce_t2a_standard_1](https://pdostal-server.suse.cz/tests/8707)
