### PR TITLE
Un-schedule ‘apache-nss’ test from tumbleweed and sle16

### DIFF
--- a/schedule/qam/common/mau-webserver.yaml
+++ b/schedule/qam/common/mau-webserver.yaml
@@ -10,7 +10,6 @@ schedule:
   - console/dns_srv
   - console/apache
   - console/apache_ssl
-  - console/apache_nss
   - console/postgresql_server
   - console/mariadb_srv
   - console/sqlite3
@@ -20,47 +19,43 @@ schedule:
 conditional_schedule:
   version_specific:
     VERSION:
-      12-SP2:
-        - console/shibboleth
       12-SP3:
-        - console/shibboleth
-      12-SP4:
+        - console/apache_nss
         - console/shibboleth
       12-SP5:
+        - console/apache_nss
         - console/shibboleth
-      15:
-        - console/shibboleth
-        - console/django
-        - console/nginx
-      15-SP1:
-        - console/shibboleth
-        - console/django
-        - console/nginx
       15-SP2:
+        - console/apache_nss
         - console/shibboleth
         - console/django
         - console/nginx
       15-SP3:
+        - console/apache_nss
         - console/shibboleth
         - console/django
         - console/nginx
       15-SP4:
+        - console/apache_nss
         - console/django
         - console/nginx
       15-SP5:
+        - console/apache_nss
         - console/django
         - console/nginx
       15-SP6:
+        - console/apache_nss
+        - console/django
+        - console/nginx
+      15-SP7:
+        - console/apache_nss
         - console/django
         - console/nginx
       tumbleweed:
         - console/django
         - console/rails
         - console/nginx
-      15.3:
-        - console/shibboleth
-        - console/django
-        - console/nginx
-      15.4:
+      15.6:
+        - console/apache_nss
         - console/django
         - console/nginx


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1236295
https://progress.opensuse.org/issues/178366
https://progress.opensuse.org/issues/175371

- Verification run: 
[sle](https://openqa.suse.de/tests/overview?build=rfan0312&distri=sle)
[tw](https://openqa.opensuse.org/tests/4915974)

**At the same time, remove old sle versions which are not tested in openQA**