### PR TITLE
Enable SLES4SAP PVM_HMC installation with HANA and NetWeaver test

### DIFF
--- a/data/yam/agama/auto/sles_sap_default_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_sap_default_ppc64le.jsonnet
@@ -12,7 +12,19 @@
   root: {
     password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
     hashedPassword: true,
+    sshPublicKey: 'enable ssh',
   },
+  storage: {
+    drives: [
+      {
+        search: '/dev/sda',
+        partitions: [
+          { search: '*', delete: true },
+          { generate: 'default' },
+        ],
+      },
+    ],
+  },  
   scripts: {
     pre: [
       {

--- a/schedule/sles4sap/sles4sap_agama_auto_install_pvm_test.yaml
+++ b/schedule/sles4sap/sles4sap_agama_auto_install_pvm_test.yaml
@@ -1,0 +1,21 @@
+---
+name: sles4sap_agama_auto_install_pvm_test
+description: >
+  SLES4SAP Agama Auto Installation on pvm_hmc
+  Run HANA or NetWeaver installation and test by conditional
+schedule:
+  - yam/agama/boot_agama
+  - installation/agama_reboot
+  - installation/first_boot
+  - console/system_prepare
+  - sles4sap/patterns
+  - '{{single_node_testcase}}'
+conditional_schedule:
+  single_node_testcase:
+    SINGLE_NODE_TESTCASE:
+      single_node_hana_cli:
+        - sles4sap/hana_install
+        - sles4sap/hana_test
+      single_node_netweaver:
+        - sles4sap/netweaver_install
+        - sles4sap/netweaver_test_instance


### PR DESCRIPTION
Add Fake sshPublicKey to workaround https://bugzilla.suse.com/show_bug.cgi?id=1238590
Add single YAML file for PVM_HMC installation with conditional HANA and NetWeaver single node testing
Job group change in https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/918

- Related ticket: https://jira.suse.com/browse/TEAM-10116, https://jira.suse.com/browse/TEAM-10115
- Needles: N/A
- Verification run: 
_install on pvm_hmc + HANA install_ https://openqa.suse.de/tests/17024479
_install on pvm_hmc + NetWeaver install_ https://openqa.suse.de/tests/17024480
