### PR TITLE
Fix 12SP5 crm_report logs extension "tar.gz" issue

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -1277,6 +1277,7 @@ sub qesap_upload_crm_report {
     $log_filename =~ s/[\[\]"]//g;
 
     my $crm_log = "/var/log/$log_filename";
+    my $crm_log_postfix = is_sle('15+') ? 'tar.gz' : 'tar.bz2';
     my $report_opt = !is_sle('12-sp4+') ? '-f0' : '';
     qesap_ansible_cmd(cmd => "crm report $report_opt -E /var/log/ha-cluster-bootstrap.log $crm_log",
         provider => $args{provider},
@@ -1291,7 +1292,7 @@ sub qesap_upload_crm_report {
         root => 1,
         remote_path => '/var/log/',
         out_path => '/tmp/ansible_script_output/',
-        file => "$log_filename.tar.gz",
+        file => "$log_filename" . '.' . "$crm_log_postfix",
         verbose => 1);
     upload_logs($local_path, failok => 1);
 }

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -777,7 +777,7 @@ subtest '[qesap_upload_crm_report] ansible host query' => sub {
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  FETCH_FILENAME-->  " . join("\n  FETCH_FILENAME-->  ", @fetch_filename));
     ok((any { /.*\/var\/log\/vmhana01\-crm_report/ } @calls), 'crm report file has the node name in it');
-    ok((any { /vmhana01\-crm_report\.tar\.gz/ } @fetch_filename), 'crm report fetch file is properly formatted');
+    ok((any { /vmhana01\-crm_report\.tar/ } @fetch_filename), 'crm report fetch file is properly formatted');
 };
 
 subtest '[qesap_calculate_deployment_name]' => sub {


### PR DESCRIPTION
Fix 12 SP5 qesap_upload_crm_report failed upload the logs as the extension ".tar.bz2" not ".tar.gz" 

[TEAM-10084](https://jira.suse.com/browse/TEAM-10084) - [12 SP5] qesap_upload_crm_report failed upload the logs as the extension‌ is ".tar.bz2" not ".tar.gz"

- Related ticket: https://jira.suse.com/browse/TEAM-10084
- Verification run: 
-- 12SP5 http://openqa.suse.de/tests/17013142 (when passed: `deploy_qesap_ansible-vmhana*-crm_report.tar.bz2` files were uploaded)
-- 15SP3 http://openqa.suse.de/tests/17014087 (when failed: `Crash_site_b-primary-vmhana*-crm_report.tar.gz` files were uploaded)
-- 15SP3 https://openqa.suse.de/tests/17024416 (when passed: `deploy_qesap_ansible-vmhana*-crm_report.tar.gz` files were uploaded)