### PR TITLE
Allow k3s in bci_version_check

### DIFF
--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -32,7 +32,7 @@ sub run {
     # If multiple engines are defined (e.g. CONTAINER_RUNTIMES=podman,docker), we use just one. podman is preferred.
     my $engines = get_required_var('CONTAINER_RUNTIMES');
     my $engine;
-    if ($engines =~ /podman/) {
+    if ($engines =~ /podman|k3s/) {
         $engine = 'podman';
     } elsif ($engines =~ /docker/) {
         $engine = 'docker';


### PR DESCRIPTION
Helm tests run on k3s but we should still check the image under test for the correct version. This commit allows k3s in the bci_version_check module and will use podman internally to perform this check.

- Related failures: https://openqa.suse.de/tests/17023157
- Verification run: [k3s](https://openqa.suse.de/tests/17025132) | [podman](https://openqa.suse.de/tests/17025134)
