### PR TITLE
Adapt dstat test to use drop in replacement dool

### DIFF
--- a/tests/console/dstat.pm
+++ b/tests/console/dstat.pm
@@ -12,25 +12,26 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_leap);
 
 sub run {
     select_console 'root-console';
 
-    zypper_call('in dstat');
+    my $binary = (is_sle('<16') || is_leap('<16.0')) ? "dstat" : "dool";
+    zypper_call("in $binary");
 
-    assert_script_run('dstat --helloworld 1 5');
+    assert_script_run("$binary --helloworld 1 5");
     assert_screen 'dstat-hello-world';
     if (is_sle('=12-SP3')) {
         record_info("bsc#1085238", "12sp3 - dstat counts to 6 instead of 5");
     }
     clear_console;
 
-    assert_script_run('dstat --nocolor 1 2');
+    assert_script_run("$binary --nocolor 1 2");
     assert_screen 'dstat-nocolor';
     clear_console;
 
-    assert_script_run('dstat -cdn --output testfile 1 2');
+    assert_script_run("$binary -cdn --output testfile 1 2");
     assert_script_run('cat testfile');
     assert_screen 'dstat-fileoutput';
 }


### PR DESCRIPTION
There's already a SR to remove dstat from Factory - https://build.opensuse.org/request/show/1252085 so there's no point in keeping the test around for Tumbleweed

while we wait for [factory](https://build.opensuse.org/request/show/1252378): https://openqa.opensuse.org/tests/4917720#details