### PR TITLE
ay: Use only major version on sle12 pcm

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -136,7 +136,7 @@ sub expand_patterns {
     return [split(/,/, get_var('PATTERNS') =~ s/\bminimal\b/Minimal/r)];
 }
 
-my @unversioned_products = qw(asmm contm lgm tcm wsm);
+my @unversioned_products = qw(asmm contm lgm tcm wsm pcm);
 
 =head2 get_product_version
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/178693
- Verification run: https://openqa.suse.de/tests/overview?build=jpupava_pcm&distri=sle