### PR TITLE
Add verbose and timer to unit-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tidy-full: tools/tidy
 
 .PHONY: unit-test
 unit-test:
-	prove -l -Ios-autoinst/ t/
+	prove --verbose --timer -l -Ios-autoinst/ t/
 
 .PHONY: test-compile
 test-compile: check-links


### PR DESCRIPTION
Introduce `--verbose` and `--timer` options to `prove` command line for enhanced debugging and performance analysis.
verbose is useful to get note to be printed out
timeout can give a glimpse on test implemented without using Test::Mock::Time

- Verification run: 