### PR TITLE
Inital hanaperf bare-metal test workflow on sles16

### DIFF
--- a/data/autoyast_hanaperf/agama-config.jsonnet
+++ b/data/autoyast_hanaperf/agama-config.jsonnet
@@ -8,6 +8,7 @@
   root: {
     password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
     hashedPassword: true,
+    sshPublicKey: 'enable ssh',
   },
   software: {
     patterns: ['sles_sap_HADB', 'sles_sap_HAAPP', 'sles_sap_DB', 'sles_sap_APP'],
@@ -64,8 +65,6 @@
         body: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
-          # Workaround for sshd service deactivated bsc#1238590
-          systemctl enable sshd
           # Workaround for NetworkManager to make sure the expected NIC up only
           rm -f /etc/NetworkManager/system-connections/default_connection.nmconnection
           echo -e "[main]\nno-auto-default=type:ethernet" > /etc/NetworkManager/conf.d/disable_auto.conf

--- a/schedule/hanaperf/agama_install.yaml
+++ b/schedule/hanaperf/agama_install.yaml
@@ -2,6 +2,20 @@ name: SLE16-HANA-PERF-BM-Installation
 description:
     SLE16 Agama Installation for HANA perf bare-metal x86_64 and ppc64le
 schedule:
-    - installation/ipxe_install
+    - '{{pxe_bootloader}}'
     - installation/agama_reboot
     - support_server/login
+    - kernel_performance/hanaperf_postinstall
+    - '{{full_run}}'
+conditional_schedule:
+    pxe_bootloader:
+        ARCH:
+            x86_64:
+                - installation/ipxe_install
+            ppc64le:
+                - installation/bootloader
+    full_run:
+        HANA_PERF_FULL_RUN:
+            1:
+                - autoyast/console
+                - kernel_performance/full_run

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -204,6 +204,11 @@ sub set_bootscript_agama_cmdline_extra {
         my $sol_console = (split(/,/, $ipxe_console))[0];
         $cmdline_extra .= "console=$ipxe_console linuxrc.log=/dev/$sol_console linuxrc.core=/dev/$sol_console linuxrc.debug=4,trace ";
     }
+
+    # Support passing EXTRA_PXE_CMDLINE and EXTRABOOTPARAMS to bootscripts (inherited from set_bootscript_cmdline_extra)
+    $cmdline_extra .= get_var('EXTRA_PXE_CMDLINE', '');
+    $cmdline_extra .= get_var('EXTRABOOTPARAMS', '');
+
     return $cmdline_extra;
 }
 

--- a/tests/kernel_performance/hanaperf_postinstall.pm
+++ b/tests/kernel_performance/hanaperf_postinstall.pm
@@ -1,0 +1,150 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Post installation for HANA perf SLE16 testing
+# Inherit from install_qatestset.pm
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+package hanaperf_postinstall;
+use base 'y2_installbase';
+use power_action_utils 'power_action';
+use strict;
+use warnings;
+use utils;
+use testapi;
+use Utils::Architectures;
+use repo_tools 'add_qa_head_repo';
+use mmapi 'wait_for_children';
+use version_utils qw(is_sle);
+use ipmi_backend_utils;
+
+sub install_sleperf {
+    my $sleperf_source = get_var('SLE_SOURCE');
+    my $ver_path = '/root';
+
+    # Download SLEperf package, extract and install
+    assert_script_run("wget --quiet -O $ver_path/sleperf.tar $sleperf_source 2>&1");
+    assert_script_run('tar xf /root/sleperf.tar -C /root');
+    assert_script_run('cd /root/sleperf/SLEPerf; ./installer.sh scheduler-service');
+    assert_script_run('cd /root/sleperf/SLEPerf; ./installer.sh common-infra');
+}
+
+sub extract_settings_qaset_config {
+    my $values = shift;
+    my @fields = split(/;/, $values);
+    if (@fields > 0) {
+        foreach my $a_value (@fields) {
+            record_info(${a_value});
+            assert_script_run("echo '${a_value}' >> /root/qaset/config");
+        }
+    }
+}
+
+sub setup_environment {
+    my $qaset_role = get_var('QASET_ROLE', 'HANA');
+    my $mitigation_switch = get_var('MITIGATION_SWITCH', 'mitigations=auto');
+    my $qaset_kernel_tag = get_var('QASET_KERNEL_TAG', '');
+    my $ver_cfg = get_var('VER_CFG');
+
+    # Fill $ver_cfg by default value if it is undefined
+    unless ($ver_cfg) {
+        my $mybuild = check_var('BUILD', 'GM') ? 'GM' : 'Build' . get_var('BUILD', '');
+        $ver_cfg = 'PRODUCT_RELEASE=SLES-' . get_required_var('VERSION') . ";PRODUCT_BUILD=$mybuild";
+        record_info($ver_cfg);
+    }
+
+    # Disable service
+    assert_script_run('systemctl disable qaperf.service chronyd.service firewalld.service');
+
+    # sync time
+    assert_script_run("chronyd -q 'server 0.europe.pool.ntp.org iburst'");
+
+    # set static hostname
+    assert_script_run('hostnamectl hostname `hostname -s`');
+
+    # create basic /root/qaset/config
+    assert_script_run('mkdir -p /root/qaset/');
+    my $qaset_config_file = <<'EOF';
+_QASET_ROLE=HANA
+SQ_TEST_RUN_SET=performance
+SQ_MSG_QUEUE_ENALBE=y
+_QASET_SOFTWARE_TAG=baremetal
+_QASET_SOFTWARE_SUB_TAG=default
+EOF
+    assert_script_run("echo -n '$qaset_config_file' > /root/qaset/config");
+    assert_script_run("echo '_QASET_KERNEL_TAG=$qaset_kernel_tag' >> /root/qaset/config") if $qaset_kernel_tag ne '';
+
+    # The qaset/config need not be updated when role is HANA and ABAP
+    return if (get_var('PROJECT_M_ROLE', '') =~ /PROJECT_M_HANA|PROJECT_M_ABAP/);
+
+    # Extract the openQA parameter: QASET_CONFIG and VER_CFG
+    # Historical reasons that the different settings splitted into two parameters.
+    # VER_CFG="PRODUCT_RELEASE=SLES-15-SP3;PRODUCT_BUILD=202109"
+    extract_settings_qaset_config(get_var('QASET_CONFIG', ''));
+    extract_settings_qaset_config($ver_cfg);
+}
+
+sub os_update {
+    my $update_repo_url = shift;
+    my $zypper_repo_path = '/etc/zypp/repos.d';
+
+    assert_script_run("wget -N -P $zypper_repo_path $update_repo_url 2>&1");
+    zypper_call('--gpg-auto-import-keys ref');
+    zypper_call('dup', timeout => 1800);
+}
+
+sub handle_repo_and_package {
+    # Add QA:HEAD repo
+    add_qa_head_repo;
+
+    # Install mandatory packages for SLE16
+    zypper_call('install qa_lib_ctcs2 wget bc bzip2 screen cpupower pciutils lsscsi ' .
+          'smartmontools netcat-openbsd libltdl7 unzip lvm hana_insserv_compat');
+    zypper_call('rm snapper-zypp-plugin');
+}
+
+sub run {
+    my $self = shift;
+
+    my $project_m_role = get_var('PROJECT_M_ROLE', '');
+
+    select_console 'root-console';
+
+    # Add repo, remove and install packages
+    handle_repo_and_package;
+
+    # Update OS for MU testing
+    if (my $hana_perf_os_update = get_var('HANA_PERF_OS_UPDATE')) {
+        os_update($hana_perf_os_update);
+    }
+
+    # Install SLEperf test framework
+    install_sleperf;
+
+    # Setup environment
+    setup_environment;
+
+    # Hold and wait other job finish if role is driver
+    wait_for_children if ($project_m_role eq 'PROJECT_M_DRIVER');
+
+    # Reboot system
+    power_action('reboot', textmode => 1);
+    if (is_x86_64) {
+        # Handle x86_64 bare-metal reboot
+        switch_from_ssh_to_sol_console(reset_console_flag => 'on');
+        sleep 30;
+        assert_screen('linux-login', 2400);
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
The PR implements x86_64 and ppc64le bare-metal installation by agama auto profile online method.
Implement a new post install script to remove old releases support and implement functions instead of deploy_hana_perf.sh.
Added EXTRA_PXE_CMDLINE and EXTRABOOTPARAMS for agama ipxe boot which is inherited from autoyast ipxe install.

- Related ticket: https://jira.suse.com/browse/TEAM-10119
- Needles: N/A
- Verification run: 
ppc64le -> https://openqa.suse.de/tests/17026798
x86_64 -> http://openqa.qa2.suse.asia/tests/82975
