### PR TITLE
Install podman for k3s test runs

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -59,7 +59,7 @@ sub run {
 
     # Install engines in case they are not installed
     install_docker_when_needed() if ($engine =~ 'docker');
-    install_podman_when_needed() if ($engine =~ 'podman');
+    install_podman_when_needed() if ($engine =~ 'podman|k3s');
     install_k3s() if ($engine =~ 'k3s');
     reset_container_network_if_needed($engine);
 


### PR DESCRIPTION
Some test modules still rely on podman being installed, even is k3s is used.

- Related failure: https://openqa.suse.de/tests/17026737
- Verification run: https://openqa.suse.de/tests/17026781#
