### PR TITLE
Pc cleanup subroutines

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -124,22 +124,29 @@ sub _cleanup {
     # currently we have two cases when cleanup of image will be skipped:
     # 1. Job should have 'PUBLIC_CLOUD_NO_CLEANUP' variable
     if (get_var('PUBLIC_CLOUD_NO_CLEANUP')) {
+        diag('Public Cloud _cleanup: The test has PUBLIC_CLOUD_NO_CLEANUP variable.');
         eval { $self->_upload_logs() } or record_info('FAILED', "\$self->_upload_logs() failed -- $@", result => 'fail');
         upload_asset(script_output('ls ~/.ssh/id* | grep -v pub | head -n1'));
         return;
     }
     diag('Public Cloud _cleanup: 1st check passed.');
 
-    # 2. Test module needs to have 'publiccloud_multi_module' and should not have 'fatal' flags and 'fail' result
+    # 2. Test module needs to have 'publiccloud_multi_module' flag and should not have 'fatal' flag and 'fail' result
+    #   * In case the test does not have 'publiccloud_multi_module' flag we don't expect anything else running after it.
+    #   * In case the test does have 'publiccloud_multi_module' flag:
     if ($flags->{publiccloud_multi_module}) {
+        # * We continue with cleanup if the test is failed and fatal.
+        # * We don't continue with cleaup if the test is not failed or not fatal
+        #   This is because we expect other test modules requirening the machine running after.
         diag('Public Cloud _cleanup: Test has `publiccloud_multi_module` flag.');
+        diag('Public Cloud _cleanup: We will end here unless this is `fatal` test finishing with `fail` result.');
         return unless ($flags->{fatal} && $self->{result} && $self->{result} eq 'fail');
     } else {
         diag('Public Cloud _cleanup: Test does not have `publiccloud_multi_module` flag.');
     }
     diag('Public Cloud _cleanup: 2nd check passed.');
 
-    eval { $self->_upload_logs() } or record_info('FAILED', "\$self->_upload_logs() failed -- $@", result => 'fail');
+    eval { $self->_upload_logs(); } or record_info('FAILED', "\$self->_upload_logs() failed -- $@", result => 'fail');
 
     # We need $self->{run_args} and $self->{run_args}->{my_provider}
     if ($self->{run_args} && $self->{run_args}->{my_provider}) {
@@ -153,17 +160,16 @@ sub _cleanup {
 
 sub _upload_logs {
     my ($self) = @_;
-
     my $ssh_sut_log = '/var/tmp/ssh_sut.log';
     script_run("sudo chmod a+r " . $ssh_sut_log);
     upload_logs($ssh_sut_log, failok => 1, log_name => $ssh_sut_log . ".txt");
-    return unless $self->{run_args} && $self->{run_args}->{my_instance};
 
     my @instance_logs = ('/var/log/cloudregister', '/etc/hosts', '/var/log/zypper.log', '/etc/zypp/credentials.d/SCCcredentials');
     for my $instance_log (@instance_logs) {
         $self->{run_args}->{my_instance}->ssh_script_run("sudo chmod a+r " . $instance_log, timeout => 0, quiet => 1);
         $self->{run_args}->{my_instance}->upload_log($instance_log, failok => 1, log_name => $instance_log . ".txt");
     }
+    return 1;
 }
 
 sub post_fail_hook {

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -265,7 +265,7 @@ sub upload_log {
     my ($self, $remote_file, %args) = @_;
     my $tmpdir = script_output_retry('mktemp -d');
     my $dest = $tmpdir . '/' . basename($remote_file);
-    my $ret = $self->scp('remote:' . $remote_file, $dest);
+    my $ret = $self->scp('remote:' . $remote_file, $dest, %args);
     upload_logs($dest, %args) if (defined($ret) && $ret == 0);
     assert_script_run("test -d '$tmpdir' && rm -rf '$tmpdir'");
 }
@@ -872,7 +872,7 @@ sub upload_supportconfig_log {
     my ($self, %args) = @_;
     $self->ssh_script_run(cmd => 'sudo supportconfig -R /var/tmp -B supportconfig -x AUDIT', timeout => 7200);
     $self->ssh_script_run(cmd => 'sudo chmod 755 /var/tmp/scc_supportconfig.txz', timeout => 3600);
-    $self->upload_log('/var/tmp/scc_supportconfig.txz', failok => 1);
+    $self->upload_log('/var/tmp/scc_supportconfig.txz', failok => 1, timeout => 600);
 }
 
 1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -735,8 +735,10 @@ To get the complete output structure, the call is:
 
 sub get_terraform_output {
     my ($self, $jq_query) = @_;
+    script_run("cd " . TERRAFORM_DIR);
     my $res = script_output("terraform output -no-color -json | jq -r '$jq_query' 2>/dev/null", proceed_on_failure => 1);
     # jq 'null' shall return empty
+    script_run('cd -');
     return $res unless ($res =~ /^null$/);
 }
 

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -38,6 +38,7 @@ sub cleanup {
     if (is_azure()) {
         record_info('azuremetadata', $self->{run_args}->{my_instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
     }
+    1;
 }
 
 sub test_flags {


### PR DESCRIPTION
### Changelog
- Make sure the subroutines called via `eval {}` return something as it otherwise fails.
- Implement `timeout` parameter for `scp()` (because of `supportconfig`)
- Make sure `get_terraform_output` changes directory to `TERRAFORM_DIR`

---

- Related ticket: [poo#178099](https://progress.opensuse.org/issues/178099)
- Verification run: [pdostal-server.suse.cz](https://pdostal-server.suse.cz)