### PR TITLE
Drop hexchat and chromium from Leap upgrade tests

### DIFF
--- a/schedule/functional/extra_tests_leap_update_gnome.yaml
+++ b/schedule/functional/extra_tests_leap_update_gnome.yaml
@@ -50,7 +50,6 @@ schedule:
     - x11/gedit
     - x11/firefox
     - x11/firefox_audio
-    - x11/chromium
     - x11/graphicsMagick
     - x11/ooffice
     - x11/oomath
@@ -62,7 +61,6 @@ schedule:
     - x11/desktop_mainmenu
     - x11/inkscape
     - x11/gimp
-    - x11/hexchat
     - x11/vlc
     - x11/reboot_gnome
     - console/zypper_log_packages

--- a/schedule/functional/extra_tests_leap_update_kde.yaml
+++ b/schedule/functional/extra_tests_leap_update_kde.yaml
@@ -46,7 +46,6 @@ schedule:
     - x11/sshxterm
     - x11/firefox
     - x11/firefox_audio
-    - x11/chromium
     - x11/ooffice
     - x11/oomath
     - x11/oocalc
@@ -58,7 +57,6 @@ schedule:
     - x11/desktop_mainmenu
     - x11/inkscape
     - x11/gimp
-    - x11/hexchat
     - x11/vlc
     - x11/kate
     - x11/amarok


### PR DESCRIPTION
* Leap 16.0 doesn't have chromium yet
* We dropped hexchat  code-o-o#leap/features#188