### PR TITLE
Check if sap-parameters.yaml was created by SDAF

### DIFF
--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
@@ -105,10 +105,13 @@ sub run {
     az_login();
     sdaf_execute_deployment(deployment_type => 'sap_system', timeout => 3600);
 
-    # Check if inventory file was created by SDAF
-    my $inventory_path = get_sdaf_inventory_path(sap_sid => $sap_sid, config_root_path => $config_root_path);
-    record_info('File check', "Check if file '$inventory_path' was created by SDAF");
-    assert_script_run("test -f $inventory_path");
+    my @check_files = (
+        "$config_root_path/sap-parameters.yaml",
+        get_sdaf_inventory_path(sap_sid => $sap_sid, config_root_path => $config_root_path));
+    for my $file (@check_files) {
+        record_info('File check', "Check if file '$file' was created by SDAF");
+        assert_script_run("test -f $file");
+    }
 
     # diconnect the console
     disconnect_target_from_serial();


### PR DESCRIPTION
Check if sap-parameters.yaml was created by SDAF

- Related ticket: https://github.com/sdaf-suse/sap-automation/issues/4
- Verification run: 
( 15SP5 SDAF_GIT_AUTOMATION_BRANCH=development) https://openqaworker15.qa.suse.cz/tests/316786#step/deploy_sap_systems/192 (`test -f /xxx/sap-parameters.yam` failed due to issue#4)
( 15SP5 SDAF_GIT_AUTOMATION_BRANCH=v3.13.0.1)   http://openqaworker15.qa.suse.cz/tests/316755#step/deploy_sap_systems/199 (`test -f /xxx/sap-parameters.yam` passed)