### PR TITLE
Skip podman parts on 12-SP5

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -42,7 +42,6 @@ sub check_k3s {
     assert_script_run('k3s kubectl config view --raw');
     validate_script_output_retry("k3s kubectl get nodes", qr/ Ready.*control-plane,master /, retry => 6, delay => 15, timeout => 90);
     validate_script_output_retry("k3s kubectl get namespaces", qr/default.*Active/, timeout => 120, delay => 60, retry => 3);
-    validate_script_output_retry('k3s kubectl get events -A', qr/Started container local-path-provisioner/, retry => 10, delay => 60, timeout => 300);
 
     # the default service account should be ready by now
     script_retry("k3s kubectl get serviceaccount default -o name", retry => 10, delay => 60, timeout => 300);

--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -118,7 +118,7 @@ sub install_k3s {
         script_retry("curl -sfL https://get.k3s.io  -o install_k3s.sh", timeout => 180, delay => 60, retry => 3);
         assert_script_run("sh install_k3s.sh $disables", timeout => 300);
         script_run("rm -f install_k3s.sh");
-        zypper_call('in apparmor-parser') if is_sle('<15-SP4');
+        zypper_call('in apparmor-parser') if is_sle('<15-SP4', get_var('HOST_VERSION', get_required_var('VERSION')));
         setup_and_check_k3s;
         return;
     }

--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -13,6 +13,7 @@
 
 use Mojo::Base qw(consoletest);
 use utils qw(zypper_call script_retry);
+use version_utils;
 use containers::common;
 use testapi;
 use serial_terminal 'select_serial_terminal';
@@ -34,6 +35,7 @@ sub run {
     my $engine;
     if ($engines =~ /podman|k3s/) {
         $engine = 'podman';
+        return if is_sle("=12-SP5", get_var("HOST_VERSION", get_required_var("VERSION")));    # podman is not available on 12-SP5.
     } elsif ($engines =~ /docker/) {
         $engine = 'docker';
     } else {

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -59,7 +59,7 @@ sub run {
 
     # Install engines in case they are not installed
     install_docker_when_needed() if ($engine =~ 'docker');
-    install_podman_when_needed() if ($engine =~ 'podman|k3s');
+    install_podman_when_needed() if ($engine =~ 'podman|k3s' && !is_sle("=12-SP5", get_required_var('HOST_VERSION')));
     install_k3s() if ($engine =~ 'k3s');
     reset_container_network_if_needed($engine);
 


### PR DESCRIPTION
Podman is not available on 12-SP5 so we need to skip the parts that depend on it.

- Related failure: e.g. https://openqa.suse.de/tests/17026803
- Verification run: https://openqa.suse.de/tests/17039294
