### PR TITLE
Fix Salt installation for missing modules

### DIFF
--- a/data/yam/autoyast/salt.xml
+++ b/data/yam/autoyast/salt.xml
@@ -22,6 +22,16 @@
           <version>{{VERSION}}</version>
           <arch>{{ARCH}}</arch>
         </addon>
+        <addon>
+          <name>sle-module-systems-management</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+        <addon>
+          <name>sle-module-python3</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
       </addons>
     </suse_register>
     <bootloader>


### PR DESCRIPTION
Fix issue [Build74.1-autoyast_salt@64bit](https://openqa.suse.de/tests/17036051)
- Verification run: [autoyast_salt__FIX__](https://openqa.suse.de/tests/overview?build=fix-salt-install)