### PR TITLE
Fix SSH systemctl is-system-running probe issue

### DIFF
--- a/data/publiccloud/ssh_config
+++ b/data/publiccloud/ssh_config
@@ -1,8 +1,8 @@
+BatchMode yes
 ControlMaster auto
 ControlPath /tmp/ssh_%r_%h_%p
+ControlPersist 86400
 HostKeyAlgorithms +ssh-rsa
 IdentityFile %SSH_KEY%
-ControlPersist 86400
-PasswordAuthentication no
 LogLevel VERBOSE
-
+PasswordAuthentication no

--- a/data/publiccloud/ssh_config_sap
+++ b/data/publiccloud/ssh_config_sap
@@ -1,7 +1,7 @@
-StrictHostKeyChecking no
-PasswordAuthentication no
-UserKnownHostsFile /dev/null
-IdentityFile %SSH_KEY%
+BatchMode yes
 HostKeyAlgorithms +ssh-rsa
+IdentityFile %SSH_KEY%
 LogLevel DEBUG3
-
+PasswordAuthentication no
+StrictHostKeyChecking no
+UserKnownHostsFile /dev/null

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -473,7 +473,11 @@ sub wait_for_ssh {
         }
 
         # Finally make sure that SSH works
-        $self->ssh_script_retry(cmd => "true", username => $args{username}, timeout => 90, retry => 5, delay => 3);
+        while (($duration = time() - $start_time) < $args{timeout}) {
+            $exit_code = $self->ssh_script_run(cmd => "true", username => $args{username}, timeout => $args{timeout} - $duration);
+            last if isok($exit_code);
+            sleep $delay;
+        }
 
         # Log upload
         if (!get_var('PUBLIC_CLOUD_SLES4SAP') and $args{logs}) {


### PR DESCRIPTION
The issue was discovered [in here](https://openqa.suse.de/tests/16994929)
- Verification run:
  - *GCE:*
    - *x86_64:*
      - sle-15-SP7-GCE-x86_64-Build0625-publiccloud_consoletests@gce_n1_standard_2 -> https://openqa.suse.de/tests/17050140#step/prepare_instance/159
    - *aarch64:* 
      - sle-15-SP7-GCE-aarch64-Build0625-publiccloud_consoletests@64bit -> https://openqa.suse.de/tests/17050138#step/prepare_instance/151 
  - *EC2:*
    - *x86_64:*
      - sle-15-SP7-EC2-x86_64-Build0668-publiccloud_consoletests@ec2_t3a.large -> https://openqa.suse.de/tests/17050134#step/prepare_instance/302
    - *aarch64:*
      - sle-15-SP7-EC2-aarch64-Build0668-publiccloud_consoletests@ec2_a1.large -> https://openqa.suse.de/tests/17050133#step/prepare_instance/246 
  - *Azure BYOS:*
    - *x86_64:*
      - sle-15-SP7-Azure-BYOS-x86_64-Build0660-publiccloud_containers@az_Standard_B2s -> https://openqa.suse.de/tests/17050114  
    - *aarch64:* 
      - sle-15-SP7-Azure-BYOS-aarch64-Build0660-publiccloud_consoletests@64bit -> https://openqa.suse.de/tests/17050112
  - *SAP Azure BYOS:*
    - *x86_64:* 
      - sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:37831:aaa_base-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E4s_v3 -> https://openqa.suse.de/tests/17050103
      - sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:37831:aaa_base-SAPHanaSR-ScaleUp-PerfOpt-msi@az_Standard_E4s_v3 -> https://openqa.suse.de/tests/17050106
      - sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:37831:aaa_base-SAPHanaSR-ScaleUp-PerfOpt-spn@az_Standard_E4s_v3 -> https://openqa.suse.de/tests/17050104
       - sle-15-SP6-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:37831:aaa_base-sles4sap_gnome_saptune_delete_rename@az_Standard_E4s_v3 -> https://openqa.suse.de/tests/17050109
      - sle-15-SP6-EC2-SAP-BYOS-Incidents-x86_64-Build:37831:aaa_base-SAPHanaSR-ScaleUp-PerfOpt-native-stop-kill@ec2_r4.8xlarge -> https://openqa.suse.de/tests/17050105
  - *SAP EC2:*
    - *x86_64:* 
      - sle-15-SP6-EC2-SAP-BYOS-Incidents-x86_64-Build:37831:aaa_base-SAPHanaSR-ScaleUp-PerfOpt-native-stop-kill@ec2_r4.8xlarge -> https://openqa.suse.de/tests/17050110
      - **Flaky:**
        - sle-15-SP6-EC2-SAP-BYOS-Incidents-x86_64-Build:37831:aaa_base-SAPHanaSR-ScaleUp-PerfOpt-native-stop-kill@ec2_r4.8xlarge with `HANASR_PRIMARY_ACTIONS=crash` `HANASR_SECONDARY_ACTIONS=crash` ->
          - https://openqa.suse.de/tests/17050111 - **SIMILAR FAILURE**: http://openqaworker15.qa.suse.cz/tests/316839#step/Crash_site_b-primary/398
          - https://openqa.suse.de/tests/17051062