### PR TITLE
Reset virtio console in case output can't show in serial terminal

### DIFF
--- a/tests/console/krb5.pm
+++ b/tests/console/krb5.pm
@@ -28,7 +28,9 @@ sub logout_and_verify_shell_availability {
     wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
     # re-connect serial console on aarch64, see poo#157960
     if (is_aarch64) {
-        sleep 3;
+        select_console 'root-console';
+        systemctl 'restart serial-getty@hvc0.service';
+        reset_consoles;
         select_serial_terminal;
     }
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/178720

- Verification run:  [30 iterations](https://openqa.suse.de/tests/overview?build=rfan0313_1&version=15-SP6&distri=sle)