### PR TITLE
Enhance terraform_retry for gcp errors

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -203,13 +203,19 @@ sub run {
 
     # Regenerate config files (This workaround will be replaced with full yaml generator)
     qesap_prepare_env(provider => $provider_setting, only_configure => 1);
+
+    # Retrying terraform more times in case of GCP, to handle concurrent peering attempts
+    my $retries = is_gce() ? 5 : 2;
     my @ret = qesap_execute_conditional_retry(
         cmd => 'terraform',
         logname => 'qesap_exec_terraform.log.txt',
         verbose => 1,
         timeout => 3600,
-        retries => 2,
-        error_string => 'An internal execution error occurred. Please retry later',
+        retries => $retries,
+        error_list => [
+            'An internal execution error occurred. Please retry later',
+            'There is a peering operation in progress'
+        ],
         destroy_terraform => 1);
     die 'Terraform deployment FAILED. Check "qesap*" logs for details.' if ($ret[0]);
 

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -19,7 +19,7 @@ sub run {
         verbose => 1,
         timeout => 1800,
         retries => 1,
-        error_string => 'An internal execution error occurred. Please retry later');
+        error_list => ['An internal execution error occurred. Please retry later']);
 
     my $inventory = qesap_get_inventory(provider => $provider);
     upload_logs($inventory, failok => 1);


### PR DESCRIPTION
Primary ticket: https://jira.suse.com/browse/TEAM-10133 
Secondary fix for https://jira.suse.com/browse/TEAM-10144

This pr allows terraform retry to accept an array of error messages to look for, and adds the gcp-concurrent-peering error string to the list of used strings.

The error appears because GCP networks do not allow multiple peering operations at the same time. See https://cloud.google.com/vpc/docs/using-vpc-peering#creating_a_peering_configuration

- Related ticket: https://jira.suse.com/browse/TEAM-10133
- Verification run: https://openqa.suse.de/tests/17042479, https://openqa.suse.de/tests/17067646
