### PR TITLE
Don't rely on HOST_VERSION to be set

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -59,7 +59,7 @@ sub run {
 
     # Install engines in case they are not installed
     install_docker_when_needed() if ($engine =~ 'docker');
-    install_podman_when_needed() if ($engine =~ 'podman|k3s' && !is_sle("=12-SP5", get_required_var('HOST_VERSION')));
+    install_podman_when_needed() if ($engine =~ 'podman|k3s' && !is_sle("=12-SP5", get_var('HOST_VERSION', get_required_var('VERSION'))));
     install_k3s() if ($engine =~ 'k3s');
     reset_container_network_if_needed($engine);
 


### PR DESCRIPTION
On Tumbleweed we don't set HOST_VERSION, but rely on the VERSION setting instead.

- Related failure: https://openqa.opensuse.org/tests/4919284#step/host_configuration/96
- Verification run: [Tumbleweed](https://openqa.opensuse.org/tests/4919889) | [SLES](https://openqa.suse.de/tests/17041632)
