### PR TITLE
BCI: Softfail skipped testcase only when there is pytest.xfail type

### DIFF
--- a/tests/containers/bci_logs.pm
+++ b/tests/containers/bci_logs.pm
@@ -55,7 +55,8 @@ sub run {
                 my $skippedNode = $tc->findnodes('./skipped[1]');
                 next unless (scalar $skippedNode);
                 my $node = $skippedNode->[0];
-                record_info('SKIP', $node->{message});
+                record_info('TYPE', $node->{type});
+                next unless ($node->{type} eq 'pytest.xfail');
                 my $message = $node->{type} . ': ' . $node->{message};
                 my $softfailure = $dom->createElement('softfailure');
                 $softfailure->setAttribute('message', $message);


### PR DESCRIPTION
- Related ticket: [poo#177321](https://progress.opensuse.org/issues/177321)
- Previous tickets: #6264
- Verification run: [pdostal-server.suse.cz/t8654](https://pdostal-server.suse.cz/tests/8654)
