### PR TITLE
containers: Run isolation test earlier

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -130,6 +130,8 @@ sub load_host_tests_podman {
     load_3rd_party_image_test($run_args) unless is_staging;
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
+    # FIXME: Transactional doesn't like user serial console
+    loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless is_transactional;
     # podman artifact needs podman 5.4.0
     loadtest 'containers/podman_artifact' if is_tumbleweed;
     loadtest 'containers/podman_bci_systemd';
@@ -156,8 +158,6 @@ sub load_host_tests_podman {
     load_volume_tests($run_args);
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
-    # FIXME: Transactional doesn't like user serial console
-    loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless is_transactional;
 }
 
 sub load_host_tests_docker {
@@ -168,6 +168,9 @@ sub load_host_tests_docker {
     load_3rd_party_image_test($run_args);
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
+    # Skip this test on docker-stable due to https://bugzilla.opensuse.org/show_bug.cgi?id=1239596
+    # FIXME: Transactional doesn't like user serial console
+    loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_transactional || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable"));
     # Firewall is not installed in Public Cloud, JeOS OpenStack and MicroOS but it is in SLE Micro
     load_firewall_test($run_args);
     unless (is_sle("<=15") && is_aarch64) {
@@ -195,9 +198,6 @@ sub load_host_tests_docker {
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {
         loadtest 'containers/validate_btrfs';
     }
-    # Skip this test on docker-stable due to https://bugzilla.opensuse.org/show_bug.cgi?id=1239596
-    # FIXME: Transactional doesn't like user serial console
-    loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_transactional || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable"));
 }
 
 sub load_host_tests_containerd_crictl {

--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -57,9 +57,7 @@ sub run {
         $ip_addr{$ip_version} = script_output "ip -$ip_version --json addr show $iface | jq -r '.[0].addr_info[0].local'";
     }
 
-    # For some reason, Docker v24 doesn't create a subnet by default
-    my $ipv6_opts = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "--subnet 2001:db8::/64" : "";
-
+    my $ipv6_opts = ($args->{runtime} eq "docker") ? "--subnet 2001:db8::/64" : "";
     assert_script_run "$runtime network create --ipv6 $ipv6_opts --internal $network";
     for my $ip_version (4, 6) {
         record_info("Test IPv$ip_version");


### PR DESCRIPTION
Urgent hotfix.

Fix isolation test:
  - Run isolation test earlier.
  - Unconditionally create subnet for Docker
 
---

- Related ticket: https://progress.opensuse.org/issues/176850
- Failing test: https://openqa.opensuse.org/tests/4920427#step/docker_isolation/148
- Verification run: https://openqa.opensuse.org/tests/4920584

TODO:
  - Fix stupid failure in user console on transactional systems.