### PR TITLE
Upload sshd_config file to check the content

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -92,6 +92,7 @@ sub test_cryptographic_policies() {
     }
 
     record_info("Restart sshd", "Restart sshd.service");
+    upload_logs("/etc/ssh/sshd_config");
     systemctl("restart sshd");
 
     # Add all the ssh public key hashes as known hosts


### PR DESCRIPTION
https://progress.opensuse.org/issues/178879

**Even I could not reproduce the issue, I suppose  it has something with performance on hyper-v:**
1. Serial terminal can't be used in hyper-v setups
2. There are lots of characters input before restarting the sshd service

So let me upload the sshd config file to check if any format issue :)

- Verification run: [vr](https://openqa.suse.de/tests/overview?version=15-SP7&build=rfan0314_2&distri=sle)