### PR TITLE
Collect logs from sssd on failure

### DIFF
--- a/tests/security/389ds/tls_389ds_sssd_client.pm
+++ b/tests/security/389ds/tls_389ds_sssd_client.pm
@@ -14,6 +14,7 @@ use warnings;
 use utils;
 use lockapi;
 use services::389ds_sssd_client;
+use Utils::Logging 'tar_and_upload_log';
 
 sub run {
     select_console("root-console");
@@ -29,8 +30,13 @@ sub run {
 }
 
 sub post_fail_hook {
-    upload_logs("/var/log/messages");
+    tar_and_upload_log("/var/log/sssd", "sssd.tar.bz2");
+    script_run("journalctl -o short-precise -u sssd.service > /tmp/journal.log");
     upload_logs("/etc/sssd/sssd.conf");
+    upload_logs("/etc/openldap/ldap.conf");
+    upload_logs('/tmp/journal.log', failok => 1);
+    upload_logs("/var/log/messages", failok => 1);
+
 }
 
 1;


### PR DESCRIPTION
To help debugging https://progress.opensuse.org/issues/175434 collect sssd logs upon failure on the client

VR (expected to fail): https://openqa.opensuse.org/tests/4922041#step/tls_389ds_sssd_client/38