### PR TITLE
Isolation test:jq  monochrome opt.add to skip extrachars

### DIFF
--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -53,8 +53,8 @@ sub run {
 
     my %ip_addr;
     for my $ip_version (4, 6) {
-        my $iface = script_output "ip -$ip_version --json route list match default | jq -r '.[0].dev'";
-        $ip_addr{$ip_version} = script_output "ip -$ip_version --json addr show $iface | jq -r '.[0].addr_info[0].local'";
+        my $iface = script_output "ip -$ip_version --json route list match default | jq -Mr '.[0].dev'";
+        $ip_addr{$ip_version} = script_output "ip -$ip_version --json addr show $iface | jq -Mr '.[0].addr_info[0].local'";
     }
 
     my $ipv6_opts = ($args->{runtime} eq "docker") ? "--subnet 2001:db8::/64" : "";


### PR DESCRIPTION
Issue noted in https://openqa.suse.de/tests/17043603#step/podman_isolation/69
the error
```
Device "30mnullm" does not exist.
SCRIPT_FINISHEDDg39P-1-
```
due to non-ptrintable extrachars.
The `-M` jq option should filter those out.