### PR TITLE
mdadm: Fix failing mdadm.sh

### DIFF
--- a/data/qam/mdadm.sh
+++ b/data/qam/mdadm.sh
@@ -26,7 +26,7 @@ tempmnt=$tempdir/mnt
 function run
 {
   echo "# $@"
-  $@ || exit 1
+  "$@" || exit 1
 }
 
 # echo command to log, check for pattern in output and exit on error or pattern not found
@@ -211,7 +211,7 @@ run losetup $DEV_3 disk3.img
 
 run losetup -l
 
-run yes | mdadm --create --verbose $MD_DEVICE --level=1 --raid-devices=3 --size=522240 $DEV_1 $DEV_2 $DEV_3
+run expect -c "spawn mdadm --create --verbose $MD_DEVICE --level=1 --raid-devices=3 --size=522240 --bitmap=internal $DEV_1 $DEV_2 $DEV_3; expect \"Continue creating array\"; send y\\r; interact"
 
 sleep 1
 rungrep "active raid1" cat /proc/mdstat
@@ -356,7 +356,7 @@ run losetup $DEV_3 disk3.img
 
 run losetup -l
 
-run mdadm --create --verbose $MD_DEVICE --level=5 --raid-devices=3 --size=522240 $DEV_1 $DEV_2 $DEV_3
+run mdadm --create --verbose $MD_DEVICE --level=5 --raid-devices=3 --size=522240 --bitmap=internal $DEV_1 $DEV_2 $DEV_3
 
 sleep 1
 rungrep "active raid5" cat /proc/mdstat

--- a/tests/console/mdadm.pm
+++ b/tests/console/mdadm.pm
@@ -22,7 +22,7 @@ use warnings;
 sub run {
     select_serial_terminal;
 
-    zypper_call('in mdadm');
+    zypper_call('in mdadm expect');
 
     record_info("mdadm build", script_output("rpm -q --qf '%{version}-%{release}' mdadm"));
 


### PR DESCRIPTION
```
- use expect to handle 'Continue creating array?'
- add --bitmap=internal to skip question
  To optimalize recovery speed, it is recommended to enable write-indent bitmap,
  do you want to enable it now? [y/N]? y
- put $@ into quotes otherwise more complex commands will be broken
```
- Related ticket: https://progress.opensuse.org/issues/174751
- Verification run:
http://openqa.suse.de/tests/overview?distri=sle&build=jpupava_mdadm osd
https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=jpupava_mdadm o3