### PR TITLE
containers: Fix docker rootless cleanup

### DIFF
--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -94,7 +94,6 @@ sub cleanup() {
         script_run "$runtime network rm $network";
         $runtime->cleanup_system_host();
         script_run "dockerd-rootless-setuptool.sh uninstall";
-        script_run "rootlesskit rm -rf ~/.local/share/docker ~/.config/docker";
     }
 
     select_serial_terminal;

--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -20,9 +20,7 @@ my $network = "test_isolated_network";
 sub test_ip_version {
     my ($ip_version, $ip_addr) = @_;
 
-    # We use alpine as registry.opensuse.org/opensuse/busybox has a buggy ping that needs setuid root
-    # https://bugzilla.suse.com/show_bug.cgi?id=1239176
-    my $image = "registry.opensuse.org/opensuse/toolbox";
+    my $image = "registry.opensuse.org/opensuse/busybox";
     script_retry("$runtime pull $image", timeout => 300, delay => 60, retry => 3);
 
     # Test that containers can't access the host

--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -74,7 +74,7 @@ sub get_user_subuid {
 
 sub cleanup {
     script_run "docker system prune -f";
-    script_run "rootlesskit rm -rf ~/.local/share/docker";
+    script_run "dockerd-rootless-setuptool.sh uninstall";
 }
 
 sub post_run_hook {


### PR DESCRIPTION
Fix docker rootless cleanup so isolation module can work.

Also use our busybox image since https://bugzilla.suse.com/show_bug.cgi?id=1239176 is fixed.

- Related ticket: https://progress.opensuse.org/issues/176850
- Failing test: https://openqa.opensuse.org/tests/4921949#step/docker_isolation/146
- Verification run: https://openqa.opensuse.org/tests/4922215