### PR TITLE
Add ssh public keys to enable sshd on sle16

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -11,7 +11,8 @@
   },
   root: {
     password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
-    hashedPassword: true
+    hashedPassword: true,
+    sshPublicKey: '{{_SECRET_RSA_PUB_KEY}}'
   },
   storage: {
     drives: [
@@ -89,7 +90,6 @@
           sed -i 's/CR/\n/g' /root/.ssh/id_rsa
           chmod 600 /root/.ssh/id_rsa
           echo '{{_SECRET_RSA_PUB_KEY}}' > /root/.ssh/id_rsa.pub
-          echo '{{_SECRET_RSA_PUB_KEY}}' >> /root/.ssh/authorized_keys
         |||
      }
     ]

--- a/schedule/virt_autotest/sle16_guest_installation.yaml
+++ b/schedule/virt_autotest/sle16_guest_installation.yaml
@@ -5,5 +5,5 @@ schedule:
     - installation/ipxe_install
     - installation/agama_reboot
     - virt_autotest/login_console
-    - virt_autotest/prepare_non_transactional_server
+    # - virt_autotest/prepare_non_transactional_server
     # - virt_autotest/unified_guest_installation


### PR DESCRIPTION
There was a new change to latest build #61.3 and test failed with sshd is disabled, https://openqa.suse.de/tests/17063970

Two commits in the PR:

- Copy ssh public key and enable sshd after sle16 installation
- Stop prepare_non_transactional_server as it failed

Verification run: https://openqa.suse.de/tests/17082235
