### PR TITLE
Create summary screens for different deployment

### DIFF
--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -478,6 +478,7 @@ subtest '[ansible_show_status] HanaSR status commands' => sub {
     my @commands;
     $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', $_[0], ':', $_[1])); });
     $ms_sdaf->redefine(ansible_execute_command => sub { push @commands, @_; return $_[1] });
+    $ms_sdaf->redefine(get_sdaf_instance_id => sub { return '00'; });
     ansible_show_status(sdaf_config_root_dir => '/config/dir', sap_sid => 'abc', scenarios => ['db_install', 'db_ha']);
 
     ok(grep(/cat \/etc\/os-release/, @commands), 'Execute os-release command');
@@ -490,6 +491,7 @@ subtest '[ansible_show_status] ENSA2 status commands' => sub {
     my @commands;
     $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', $_[0], ':', $_[1])); });
     $ms_sdaf->redefine(ansible_execute_command => sub { push @commands, @_; return $_[1] });
+    $ms_sdaf->redefine(get_sdaf_instance_id => sub { return '00'; });
     ansible_show_status(sdaf_config_root_dir => '/config/dir', sap_sid => 'abc', scenarios => ['db_install', 'db_ha', 'nw_pas', 'nw_aas', 'nw_ensa']);
 
     ok(grep(/cat \/etc\/os-release/, @commands), 'Execute os-release command');

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
@@ -114,7 +114,7 @@ sub run {
         get_sdaf_inventory_path(sap_sid => $sap_sid, config_root_path => $config_root_path));
     for my $file (@check_files) {
         record_info('File check', "Check if file '$file' was created by SDAF");
-        assert_script_run("test -f $file");
+        assert_script_run("cat $file");
     }
 
     # diconnect the console


### PR DESCRIPTION
Create summary screens for different SDAF deployment scenarios TEAM-10085 - [SDAF] Create summary screens for different deployment scenarios

[TEAM-10085](https://jira.suse.com/browse/TEAM-10085) - [SDAF] Create summary screens for different deployment scenarios

- Related ticket: https://jira.suse.com/browse/TEAM-10085
- Verification run: 
-- SDAF_PRD_deploy_ENSA2 (`SDAF_DEPLOYMENT_SCENARIO=db_install,db_ha,nw_pas,nw_aas,nw_ensa`):
  https://openqaworker15.qa.suse.cz/tests/317719#step/execute_playbooks/389 (passed: summary screens are started from this test step)
-- SDAF_PRD_deploy_HanaSR (`SDAF_DEPLOYMENT_SCENARIO=db_install,db_ha`):
   http://openqaworker15.qa.suse.cz/tests/317727#step/execute_playbooks/290 (passed)
-- SDAF_PRD_deploy_HanaSR (`SDAF_DEPLOYMENT_SCENARIO=db_install`):
   http://openqaworker15.qa.suse.cz/tests/317728#step/execute_playbooks/245 (passed)
