### PR TITLE
Expand SLES+HA installation schedule to svirt & pvm_hmc

### DIFF
--- a/schedule/ha/bv/agama_install_sles_ha.yaml
+++ b/schedule/ha/bv/agama_install_sles_ha.yaml
@@ -2,16 +2,30 @@
 name: agama_install_sles_ha
 description: >
   Agama installation tests for plain SLES HA.
-  Can be used to generate a qcow2 image.
+  Can be used to generate a qcow2 image on qemu and svirt.
+  Requires the settings AGAMA_PRODUCT_ID, AGAMA_AUTO,
+  EXTRABOOTPARAMS (only in qemu), SCC_ADDONS set to `ha`,
+  and AGAMA_PROFILE (on s390x)
+
 schedule:
-  - yam/agama/boot_agama
-  - yam/agama/agama_auto
-  - installation/grub_test
+  - '{{agama_install}}'
   - installation/first_boot
   - console/system_prepare
   - ha/check_hae_active.py
   - '{{generate_image}}'
 conditional_schedule:
+  agama_install:
+    BACKEND:
+      qemu:
+        - yam/agama/boot_agama
+        - yam/agama/agama_auto
+        - installation/grub_test
+      pvm_hmc:
+        - installation/bootloader
+        - installation/agama_reboot
+      svirt:
+        - installation/bootloader_zkvm
+        - installation/agama_reboot
   generate_image:
     GENERATE_IMAGE:
       1:
@@ -20,3 +34,8 @@ conditional_schedule:
         - shutdown/grub_set_bootargs
         - shutdown/cleanup_before_shutdown
         - shutdown/shutdown
+        - '{{svirt_upload_assets}}'
+  svirt_upload_assets:
+    BACKEND:
+      svirt:
+        - shutdown/svirt_upload_assets


### PR DESCRIPTION
Currently SLES+HA installation tests on s390x (backend: svirt) and on ppc64le_hmc (backend: pvm_hmc) are failing in the `yam/agama/agama_auto` test module in an error message indicating that the method `expect_is_shown` does not exist in the class
`Yam::Agama::Pom::RebootTextmodePage` which is the one selected for both backends `svirt` and `pvm_hmc`.

See:

- ppc64le: https://openqa.suse.de/tests/17056517#step/agama_auto/2
- s390x: https://openqa.suse.de/tests/17056480#step/agama_auto/2

This commit modifies the schedule adding conditionally alternative modules to use during the installation on both `svirt` and `pvm_hmc`.

- Related ticket: https://jira.suse.com/browse/TEAM-10160
- Needles: N/A

Verification runs

- aarch64/qemu: https://openqa.suse.de/tests/17076093 (fails later in `check_hae_active` due to missing HA regcode)
- ppc64le/pvm_hmc: https://openqa.suse.de/tests/17076686 (fails later in `check_hae_active` due to missing HA regcode)
- s390x/svirt: https://openqa.suse.de/tests/17077513 (fails later in `check_hae_active` due to missing HA regcode)
- x86_64/qemu: https://openqa.suse.de/tests/17076096 :green_circle: 
