### PR TITLE
containers: Fix check_bsc1200623

### DIFF
--- a/tests/containers/skopeo.pm
+++ b/tests/containers/skopeo.pm
@@ -128,7 +128,6 @@ sub run {
 }
 
 sub cleanup {
-    my $runtime = shift;
     record_info('Cleanup', 'Delete copied image directories');
     script_run "rm -rf $workdir";
 
@@ -138,13 +137,11 @@ sub cleanup {
 }
 
 sub post_run_hook {
-    my ($self) = @_;
-    cleanup($self->{runtime});
+    cleanup;
 }
 
 sub post_fail_hook {
-    my ($self) = @_;
-    cleanup($self->{runtime});
+    cleanup;
 }
 
 1;


### PR DESCRIPTION
This PR:
  - Fixes `check_bsc1200623` to better handle extra lines.
  - Fixes skopeo failing cleanup routine that led to extra lines in the log.

Notes:
  - A better fix in the s390x backend is needed so logs are not visible in `script_output`.

---

- Failing test: https://openqa.suse.de/tests/17076635#step/rootless_podman/205
- Verification run: https://openqa.suse.de/tests/17077653