### PR TITLE
Add CI check for jsonnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         apt-get -y update
         apt-get -y install libdbus-1-dev libssh2-1-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip
-        pip3 install yamllint
+        pip3 install yamllint jsonnet
     - name: Setup perl
       env:
         INLINE_PYTHON_EXECUTABLE: /usr/bin/python3

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ test-yaml-valid:
 test-modules-in-yaml-schedule:
 	export PERL5LIB=${PERL5LIB_} ; tools/detect_nonexistent_modules_in_yaml_schedule `git diff --diff-filter=d --name-only --exit-code origin/master | grep '^schedule/*'`
 
+.PHONY: test-jsonnet-valid
+test-jsonnet-valid:
+	tools/check_jsonnet
+
 .PHONY: test-metadata
 test-metadata:
 	tools/check_metadata $$(git ls-files "tests/**.pm")
@@ -106,7 +110,7 @@ test-spec:
 	tools/update_spec --check
 
 .PHONY: test-static
-test-static: tidy-check test-yaml-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax test-code-style test-metadata test_pod_whitespace_rule test_pod_errors
+test-static: tidy-check test-yaml-valid test-jsonnet-valid test-modules-in-yaml-schedule test-merge test-dry test-no-wait_idle test-deleted-renamed-referenced-files test-unused-modules-changed test-soft_failure-no-reference test-spec test-invalid-syntax test-code-style test-metadata test_pod_whitespace_rule test_pod_errors
 
 .PHONY: test
 ifeq ($(TESTS),compile)

--- a/tools/check_jsonnet
+++ b/tools/check_jsonnet
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+success=1
+JSONNET_FILES=$(git ls-files data/ | grep -E '.jsonnet$|.json$|.libsonnet$' | grep -v 'bug_refs.json' | xargs echo)
+
+if test -n "$JSONNET_FILES"; then
+    for file in $JSONNET_FILES; do
+        if ! python3 -c "import _jsonnet; _jsonnet.evaluate_file('$file'); print('OK: $file')"; then
+            success=0
+        fi
+    done
+else
+    echo "No jsonnet/libsonnet files modified.";
+fi
+[ $success = 1 ] && echo "check_jsonnet SUCCESS" && exit 0
+exit 1


### PR DESCRIPTION
We have two options to do this CI check for jsonnet:
1. Install jsonnet package, use the binary to do the check, but unfortunately jsonnet pkg only can be found on bookworm version while currently we used buster version, anyway, we can install jsonnet separately on bookworm, https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21168 This method will cause more images for container and complex condition.
2. On current container, install jsonnet for python, I updated code to apply the check for python in this option 2 PR. So tester need use the format tool(jsonnet) installing go locally if see that the format doesn't match.
3. Created a [ticket](https://progress.opensuse.org/issues/179383) to follow up formatting and style.

- Related ticket: https://progress.opensuse.org/issues/175111
- Needles: N/A
- Verification run: N/A

Some wrong format check for jsonnet profiles as VRs: https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/13963972477/job/39090281935?pr=21496
