### PR TITLE
Increase timeout for network operations

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -60,9 +60,9 @@ sub set_svirt_domain_elements {
 
         # show this on screen and make sure that kernel and initrd are actually saved
         enter_cmd "wget $repo/boot/s390x/initrd -O $zkvm_img_path/$name.initrd";
-        assert_screen "initrd-saved";
+        assert_screen("initrd-saved", timeout => 300);
         enter_cmd "wget $repo/boot/s390x/linux -O $zkvm_img_path/$name.kernel";
-        assert_screen "kernel-saved";
+        assert_screen("kernel-saved", timeout => 300);
     }
     # after installation we need to redefine the domain, so just shutdown
     # on zdup and online migration we need to redefine in between


### PR DESCRIPTION
Increase the timeout for fetching the initrd and kernel binaries because on slow days, fetching those resources might take more than 30 seconds.

- Related failure: e.g. https://openqa.suse.de/tests/17083003#step/bootloader_start/25
- Verification run: https://openqa.suse.de/tests/17083206#step/bootloader_start/46
