### PR TITLE
Copy agama jsonnets for SLES for SAP to data/sles4sap/agama

### DIFF
--- a/data/sles4sap/agama/sles_sap_default.jsonnet
+++ b/data/sles4sap/agama/sles_sap_default.jsonnet
@@ -1,0 +1,23 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE_SLES4SAP}}',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    sshPublicKey: 'enable ssh',
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||,
+      },
+    ],
+  },
+}

--- a/data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet
+++ b/data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet
@@ -1,0 +1,47 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE_SLES4SAP}}',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    sshPublicKey: 'enable ssh',
+  },
+  storage: {
+    drives: [
+      {
+        search: '/dev/sda',
+        partitions: [
+          { search: '*', delete: true },
+          { generate: 'default' },
+        ],
+      },
+    ],
+  },  
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        body: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||,
+      },
+    ],    
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||,
+      },
+    ],
+  },
+}


### PR DESCRIPTION
The jsonnet files under `data/yam/agama/auto` are expected to be under constant modification and recommendation from YAM squad is to instead use the files there as a template for dedicated copies to be used by other squads. This commit creates/copies the jsonnet files for SLES for SAP on qemu and pvm_hmc.

- Related ticket: https://jira.suse.com/browse/TEAM-10160
- Needles: N/A
- Verification run: [ppc64le](https://openqa.suse.de/tests/17084126) :green_circle:  , [x86_64](https://openqa.suse.de/tests/17084122) :green_circle: 
