### PR TITLE
Add a schedule to test basic NetWeaver cluster in pvm_hmc

### DIFF
--- a/schedule/sles4sap/pvm_nw_cluster_node.yaml
+++ b/schedule/sles4sap/pvm_nw_cluster_node.yaml
@@ -1,0 +1,138 @@
+---
+name: pvm_nw_cluster_node
+description: >
+  Basic NetWeaver Cluster Test for pvm_hmc. Use this schedule for all nodes.
+
+  Some settings are required in the job group or test suite for this schedule to work.
+  HA_CLUSTER_INIT must be defined for all jobs. In one of the jobs, it must be defined
+  to 'yes', while in the rest to 'no'. This will only control the conditional scheduling
+  of ha_cluster_init or ha_cluster_join.
+
+  The other settings required in the job group are.
+
+  CLUSTER_INFOS must be defined in the parent job to the name of the cluster, number
+  of nodes and number of LUNs. Example 'netweaver:2:3'
+  CLUSTER_NAME must be defined for all jobs as a string.
+  HA_CLUSTER_JOIN must be defined for the rest of the jobs, and it must contain the
+  hostname of the job where HA_CLUSTER_INIT is defined to yes
+  NW must be defined pointing to the location of the NetWeaver installation masters
+  HOSTNAME must be defined to different hostnames for each node.
+  INSTANCE_ID must be defined to different IDs for each node.
+  INSTANCE_IP_CIDR must be defined to different IP addresses for each node, in CIDR
+  format, and must use addresses that can be reached from the workers. For example, if
+  pvm_hmc workers get addresses via DHCP on the 10.0.1/24 network, then the values for
+  both nodes can be for example '10.0.1.200/24' in node 1 and '10.0.1.201/24' in node 2.
+  Note that this is different than in jobs with support server, where the local network
+  is always 10.0.2/24.
+  INSTANCE_TYPE should also be set, ideally to ASCS in one node and to ERS in the other.
+  ISCSI_LUN_INDEX must be defined in the parent job pointing to an available LUN
+  index in the iSCSI server
+  ISCSI_SERVER must be defined in all jobs pointing to an iSCSI server
+  MAX_JOB_TIME is recommended to be defined as well to a high value (ex. 20000)
+  NFS_SUPPORT_SHARE must be defined in all jobs pointing to a NFS share used by
+  the cluster nodes to share configuration files
+  All jobs with the exception of the parent job must include a PARALLEL_WITH setting
+  referencing the parent job.
+  SLE_PRODUCT must be defined and set to sles4sap.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  DESKTOP: 'textmode'
+  HA_CLUSTER: '1'
+  INSTANCE_SID: HA1
+  MULTIPATH_CONFIRM: 'yes'
+schedule:
+  - '{{barrier_init}}'
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/scc_registration
+  - '{{multipath}}'
+  - '{{sles4sap12_product}}'
+  - installation/addon_products_sle
+  - '{{sles4sap15_product}}'
+  - installation/partitioning
+  - installation/partitioning_smalldisk_storageng
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - '{{sles4sap12_desktop}}'
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/handle_reboot
+  - installation/first_boot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/setup_hosts_and_luns
+  - ha/watchdog
+  - sles4sap/patterns
+  - '{{cluster_setup}}'
+  - sles4sap/netweaver_network
+  - sles4sap/netweaver_filesystems
+  - sles4sap/netweaver_install
+  - sles4sap/netweaver_cluster
+  - sles4sap/monitoring_services
+  - '{{cluster_connector}}'
+  - ha/fencing
+  - '{{boot_to_desktop}}'
+  - ha/check_after_reboot
+  - ha/check_logs
+  - shutdown/shutdown
+conditional_schedule:
+  multipath:
+    MULTIPATH:
+      1:
+        - installation/multipath
+  barrier_init:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/barrier_init
+  cluster_setup:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/ha_cluster_init
+      no:
+        - ha/ha_cluster_join
+  cluster_connector:
+    HA_CLUSTER_INIT:
+      yes:
+        - sles4sap/sap_suse_cluster_connector
+  boot_to_desktop:
+    HA_CLUSTER_INIT:
+      yes:
+        - installation/handle_reboot
+        - installation/first_boot
+  sles4sap12_product:
+    VERSION:
+      12-SP5:
+        - installation/sles4sap_product_installation_mode
+  sles4sap15_product:
+    VERSION:
+      15-SP3:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP4:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP5:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP6:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+      15-SP7:
+        - installation/system_role
+        - installation/sles4sap_product_installation_mode
+  sles4sap12_desktop:
+    VERSION:
+      12-SP5:
+        - installation/change_desktop
+        - installation/resolve_dependency_issues

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -33,7 +33,9 @@ sub run {
 
         # BARRIER_HA_ needs to also wait the support-server
         if (is_not_supportserver_scenario) {
-            mutex_create 'iscsi';    # Mutex is already created in supportserver, no need to create it before
+            # These 2 mutexes are usually created in the supportserver, but since some HA/SAP test
+            # modules use them, we create them here as well for the scenarios without supportserver
+            mutex_create($_) foreach ('iscsi', 'support_server_ready');
             barrier_create("BARRIER_HA_$cluster_name", $num_nodes);
             barrier_create("BARRIER_HA_NFS_SUPPORT_DIR_SETUP_$cluster_name", $num_nodes);
             barrier_create("BARRIER_HA_HOSTS_FILES_READY_$cluster_name", $num_nodes);

--- a/tests/sles4sap/netweaver_cluster.pm
+++ b/tests/sles4sap/netweaver_cluster.pm
@@ -61,7 +61,7 @@ sub run {
     if ($type eq 'ERS') {
         assert_script_run "rm -rf /usr/sap/$sid/${type}${instance_id}/profile";
         assert_script_run "ln -s /sapmnt/$sid/profile /usr/sap/$sid/${type}${instance_id}/profile";
-        assert_script_run "chown -h ha1adm:sapsys /usr/sap/$sid/${type}${instance_id}/profile";
+        assert_script_run "chown -h $sapadm:sapsys /usr/sap/$sid/${type}${instance_id}/profile";
     }
 
     # Create the resource configuration

--- a/tests/sles4sap/netweaver_filesystems.pm
+++ b/tests/sles4sap/netweaver_filesystems.pm
@@ -45,7 +45,8 @@ sub run {
         assert_script_run "mkdir -p $mountpoint && mount $mountpoint";
 
         # NFS mounts need to be cleared before the NW installation
-        assert_script_run "rm -rf $mountpoint/*";
+        # Do this only in node 1
+        assert_script_run "rm -rf $mountpoint/*" if (is_node(1));
     }
 }
 


### PR DESCRIPTION
This commit introduces a new schedule for cluster nodes, to test a basic NetWeaver cluster on the pvm_hmc backend. It is based on the HANA schedule `schedule/sles4sap/pvm_hana_cluster_node.yaml` located on `schedule/sles4sap/hana/`.

- Related ticket: https://jira.suse.com/browse/TEAM-10160
- Needles: N/A
- Verification run on pvm_hmc: [node 1](https://openqa.suse.de/tests/17105012)  :green_circle: , [node 2](https://openqa.suse.de/tests/17105013)  :green_circle: 
- Verification run on qemu (regression): [support server](https://openqa.suse.de/tests/17092946)  :green_circle: , [node 1](https://openqa.suse.de/tests/17092945)  :green_circle:  & [node 2](https://openqa.suse.de/tests/17092947) :green_circle: 

New Verification Runs after latest changes:

- pvm_hmc: [node 1](https://openqa.suse.de/tests/17110013) :green_circle: , [node 2](https://openqa.suse.de/tests/17110014) :green_circle: 
- qemu (regression): [support server](https://openqa.suse.de/tests/17110018) :green_circle: , [node 1](https://openqa.suse.de/tests/17110017) :green_circle:  & [node 2](https://openqa.suse.de/tests/17110019) :green_circle: 
