### PR TITLE
Add ssh public key in autoyast profile

### DIFF
--- a/data/yam/agama/auto/autoyast_supported.xml
+++ b/data/yam/agama/auto/autoyast_supported.xml
@@ -69,6 +69,9 @@
             <encrypted config:type="boolean">true</encrypted>
             <user_password>$6$Viz.6zkOLg.HGiYS$uwvqo4HVVn9/n7UByRDCwf/3h7.jVunrhugXfuxQve7db8kS0Q0flCXajdB/8Odh5tbwfnWf.cT1K8QgWlsci1</user_password>
             <username>root</username>
+	    <authorized_keys config:type="list">
+                <listentry>fake public key to enable sshd and open firewall</listentry>
+            </authorized_keys>
         </user>
     </users>
     <scripts>


### PR DESCRIPTION
Quick PR, add ssh public key in autoyast profile to fix ssh not activated issue after installation via autoyast on remote worker. Refer to bsc#https://bugzilla.suse.com/show_bug.cgi?id=1238590

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=lemon-suse%2Fos-autoinst-distri-opensuse%23add-ssh-pub-key-for-autoyast_supported
