### PR TITLE
Change to SLE <= 16 not Y2038 compatible

### DIFF
--- a/tests/console/year_2038_detection.pm
+++ b/tests/console/year_2038_detection.pm
@@ -67,8 +67,8 @@ sub run {
     my $utmp_output = script_output('LC_TIME=C.UTF-8 who');
     my $wtmp_output = script_output('last -F');
     if ($utmp_output !~ m/2038/sx || $wtmp_output !~ m/2038/sx) {
-        if (is_sle('<16') || is_leap('<16.0') || is_sle_micro || is_leap_micro) {
-            record_info("bsc#1188626", "SLE <= 15 not Y2038 compatible");
+        if (is_sle('<=16') || is_leap('<=16.0') || is_sle_micro || is_leap_micro) {
+            record_info("bsc#1188626", "SLE <= 16 not Y2038 compatible");
         }
         else {
             die('Not Y2038 compatible');


### PR DESCRIPTION
Change to SLE <= 16 not Y2038 compatible

- Related ticket: https://progress.opensuse.org/issues/179161
- Verification run: https://openqa.suse.de/tests/17089937#step/year_2038_detection/102