### PR TITLE
containers: Use toolbox image on s390x

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -157,7 +157,8 @@ sub run {
         subnet => '10.64.0.0/16',
     };
     my $ctr2 = {
-        image => 'registry.opensuse.org/opensuse/busybox',
+        # s390x is using an older BusyBox image with https://bugzilla.suse.com/show_bug.cgi?id=1239176
+        image => is_s390x ? 'docker.io/library/alpine' : 'registry.opensuse.org/opensuse/busybox',
         name => 'busybox_ctr',
         ip => '10.64.0.8',
         mac => '92:aa:33:44:55:66',


### PR DESCRIPTION
Use toolbox image on s390x until image is updated.

```
$ skopeo inspect --override-arch s390x docker://registry.opensuse.org/opensuse/busybox:latest | grep busybox.version
        "org.opensuse.tumbleweed.busybox.version": "1.36.1-18.45"
$ skopeo inspect --override-arch amd64 docker://registry.opensuse.org/opensuse/busybox:latest | grep busybox.version
        "org.opensuse.tumbleweed.busybox.version": "1.37.0-17.57"
```

- Related ticket: https://progress.opensuse.org/issues/179167
- Verification run: https://openqa.suse.de/tests/17090532