### PR TITLE
containers: Remove assert when disabling docker secret

### DIFF
--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -52,7 +52,7 @@ sub run {
 
     # Avoid this error as rootless:
     # "docker: Error response from daemon: SUSE:secrets :: failed to read through tar reader: unexpected EOF."
-    assert_script_run "echo 0 > /etc/docker/suse-secrets-enable";
+    script_run "echo 0 > /etc/docker/suse-secrets-enable";
 
     my %ip_addr;
     for my $ip_version (4, 6) {


### PR DESCRIPTION
The `assert_script_run` will fail when docker is not installed.

- Faling test: https://openqa.suse.de/tests/17091164#step/podman_isolation/259
- Verification run: not needed.