### PR TITLE
openssh-server, firewalld are back, openssl missing in SLE 16

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -34,7 +34,6 @@ sub run {
     my $user = $testapi::username;
     select_serial_terminal;
 
-    zypper_call('in openssh-server') if is_sle('>=16');
     systemctl('start sshd');
 
     # generate ssh key and use same key for root and bernhard

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -37,6 +37,8 @@ sub enable_fips {
     my $self = shift;
 
     if (is_sle('>=15-SP4') || is_jeos || is_tumbleweed) {
+        # bsc#1239509
+        zypper_call('in openssl-3') if is_sle('>=16');
         assert_script_run("fips-mode-setup --enable");
         $self->reboot_and_select_serial_term;
     } else {

--- a/tests/security/krb5/krb5_crypt_prepare.pm
+++ b/tests/security/krb5/krb5_crypt_prepare.pm
@@ -84,9 +84,9 @@ EOF
 
     if (is_sle '<15') {
         systemctl('stop SuSEfirewall2');
-    } elsif (is_sle '<16') {
+    } else {
         systemctl('stop firewalld');
-    }    # on SLE16 firewalld is not installed by default
+    }
 
     # Prepare krb5 application and config files
     zypper_call('ref');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/178456
- Verification run: https://openqa.suse.de/tests/17092923

(fails earlier without these changes)