### PR TITLE
Add softfailure for bsc#1239303

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -112,7 +112,14 @@ sub basic_container_tests {
     assert_script_run("$runtime image rm example.com/tw-commit_test");
 
     ## Test connectivity inside the container
-    script_retry("$runtime container exec basic_test_container curl -sfIL http://conncheck.opensuse.org", retry => 3, delay => 60, fail_message => "cannot reach conncheck.opensuse.org");
+    if (script_run("$runtime container exec basic_test_container curl -sfIL http://conncheck.opensuse.org") != 0) {
+        if (is_sle("12-SP5")) {
+            record_soft_failure("bsc#1239303");
+        } else {
+            sleep(60);    # wait 1 delay time before retrying
+            script_retry("$runtime container exec basic_test_container curl -sfIL http://conncheck.opensuse.org", retry => 2, delay => 60, fail_message => "cannot reach conncheck.opensuse.org");
+        }
+    }
 
     ## Test `--init` option, i.e. the container process won't be PID 1 (to avoid zombie processes)
     # Ensure PID 1 has either the $runtime-init (e.g. podman-init) OR /init (e.g. `/dev/init) suffix


### PR DESCRIPTION
On SLES12-SP5 (s390x) sys_sendmmsg is blocked with EPERM instead of ENOSYS. Add a softfailure for this issue (bsc#1239303) to allow other updates to proceed.

- Related failure: https://openqa.suse.de/tests/17088836#step/docker/210
- Related bugzilla ticket: https://bugzilla.suse.com/show_bug.cgi?id=1239303#c2
- Verification runs: TBD