### PR TITLE
Exclude syscall_thrasher from encrypted s390x

### DIFF
--- a/tests/security/eal4/syscall_thrasher.pm
+++ b/tests/security/eal4/syscall_thrasher.pm
@@ -12,11 +12,19 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Architectures 'is_s390x';
 
 my $log_file = '/tmp/syscalls_output.log';
 
 sub run {
     my ($self) = shift;
+
+    # Skip on s390x with encrypted disk due to timeouts
+    # poo#176454
+    if (check_var('ENCRYPT', '1') && is_s390x) {
+        record_info('SKIPPING TEST', "Skipping on encrypted s390x, poo#176454");
+        return;
+    }
 
     select_console 'root-console';
 


### PR DESCRIPTION
Test module `syscall_thrasher` is very unstable on s390x in terms of timeouts. This excludes `syscall_thrasher` from the s390x schedule.

- Related ticket: https://progress.opensuse.org/issues/176454
- Verification run: https://openqa.suse.de/tests/17115437
