### PR TITLE
Fix typo in ssh log

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -188,7 +188,7 @@ sub sles4sap_cleanup {
 
     qesap_cluster_logs();
     qesap_upload_logs();
-    upload_logs('/var/tmp/ssh_sut.log', failok => 1, log_name => 'ssh_sut_log.txt');
+    upload_logs('/var/tmp/ssh_sut.log', failok => 1, log_name => 'ssh_sut.log.txt');
     if ($args{network_peering_present}) {
         delete_network_peering();
     }


### PR DESCRIPTION
Atypo while uploading the sshlog on cleanup has been fixed with this pr, so that it overwrites previously uploaded file instead of having 2 files.

- Related ticket: https://jira.suse.com/browse/TEAM-10125
- Verification run: https://openqa.suse.de/tests/17096775 (search for 'ssh' in the logs - there should be a single file, compared to the cloned job, https://openqa.suse.de/tests/17084892, that has 2)
