### PR TITLE
Adapt `import_agama_profile` test step to use dynamic generated JSON profiles

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -795,8 +795,9 @@ sub expand_agama_profile {
 =cut
 
 sub generate_json_profile {
+    my ($profile) = @_;
     my $profile_name = "generated_profile.json";
-    my $profile_path = get_required_var('CASEDIR') . "/data/" . get_required_var('INST_AUTO');
+    my $profile_path = get_required_var('CASEDIR') . "/data/" . $profile;
 
     my @profile_options = map { " --tla-" . (/true|false/ ? "code" : "str") . " $_" }
       split(' ', trim(get_var('AGAMA_PROFILE_OPTIONS')));

--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -40,10 +40,10 @@ sub prepare_boot_params {
     }
 
     # add default boot params
-    if (my $agama_auto = get_var('INST_AUTO')) {
-        my $profile_url = ($agama_auto =~ /\.libsonnet/) ?
-          generate_json_profile() :
-          expand_agama_profile($agama_auto);
+    if (my $inst_auto = get_var('INST_AUTO')) {
+        my $profile_url = ($inst_auto =~ /\.libsonnet/) ?
+          generate_json_profile($inst_auto) :
+          expand_agama_profile($inst_auto);
         set_var('INST_AUTO', $profile_url);
         push @params, "inst.auto=\"$profile_url\"", "inst.finish=stop";
     }

--- a/tests/yam/agama/import_agama_profile.pm
+++ b/tests/yam/agama/import_agama_profile.pm
@@ -8,12 +8,16 @@ use base Yam::Agama::patch_agama_base;
 use strict;
 use warnings;
 use testapi qw(assert_script_run data_url get_required_var select_console script_run);
-use autoyast qw(expand_agama_profile);
+use autoyast qw(expand_agama_profile generate_json_profile);
 
 sub run {
-    my $profile = expand_agama_profile(get_required_var('AGAMA_PROFILE'));
+    my $profile = get_required_var('AGAMA_PROFILE');
+    my $profile_url = ($profile =~ /\.libsonnet/) ?
+      generate_json_profile($profile) :
+      expand_agama_profile($profile);
+
     select_console 'root-console';
-    assert_script_run("agama profile import $profile", timeout => 300);
+    assert_script_run("agama profile import $profile_url", timeout => 300);
 }
 
 1;


### PR DESCRIPTION
We have added minor changes to include dynamic profile generation also in import agama profile step.

- Related ticket: https://progress.opensuse.org/issues/179173
- Needles: N/A
- Verification run:
  - sles_encrypted: https://openqa.suse.de/tests/17322677
  - sles_encrypted (No generated profile) https://openqa.suse.de/tests/17324572
  - sles_lvm_unattended: https://openqa.suse.de/tests/17324578
  - sles_lvm: https://openqa.suse.de/tests/17324582#
  - sles_lvm (No generated profile): https://openqa.suse.de/tests/17324583#
