### PR TITLE
Added welcome_to_wsl check for WSL build images.

### DIFF
--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -74,14 +74,16 @@ sub run {
         $self->close_powershell;
         $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
         assert_and_click 'wsl-suse-startup-search';
+        assert_and_click("welcome_to_wsl", timeout => 120);
+        send_key "alt-f4";
     } elsif ($install_from eq 'msstore') {
         # Install required SUSE distro from the MS Store
         $self->run_in_powershell(
             cmd => "wsl --install --distribution $WSL_version",
             timeout => 300,
         );
-        check_screen("welcome_to_wsl", timeout => 60);
-        send_key "alt-f4" if match_has_tag "welcome_to_wsl";
+        assert_and_click("welcome_to_wsl", timeout => 60);
+        send_key "alt-f4";
 
         $self->run_in_powershell(
             cmd => "wsl.exe --distribution $WSL_version",


### PR DESCRIPTION
Accounting for all welcome_to_wsl pop-up cases.

- Related ticket: https://progress.opensuse.org/issues/176676
- Verification run: 

15sp5 win10 UEFI 
https://openqa.suse.de/tests/17173076 ✅
https://openqa.suse.de/tests/17173077 ✅ unrelated failure
https://openqa.suse.de/tests/17173078 ✅ unrelated failure
https://openqa.suse.de/tests/17173079 ✅

15sp6 win10 UEFI: 
https://openqa.suse.de/tests/17173080 ✅

15sp7 win10 UEFI: 
https://openqa.suse.de/tests/17173081 ✅
