### PR TITLE
Add test module to validate the base product

### DIFF
--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -8,6 +8,6 @@ schedule:
   - yam/agama/agama
   - installation/grub_test
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname

--- a/schedule/yam/agama_auto.yaml
+++ b/schedule/yam/agama_auto.yaml
@@ -7,6 +7,6 @@ schedule:
   - yam/agama/agama_auto
   - installation/grub_test
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname

--- a/schedule/yam/agama_autoyast_supported_ppc64le.yaml
+++ b/schedule/yam/agama_autoyast_supported_ppc64le.yaml
@@ -8,6 +8,6 @@ schedule:
   - yam/agama/agama
   - installation/grub_test
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - console/verify_separate_home

--- a/schedule/yam/agama_autoyast_supported_qemu.yaml
+++ b/schedule/yam/agama_autoyast_supported_qemu.yaml
@@ -7,6 +7,6 @@ schedule:
   - yam/agama/agama_auto
   - installation/grub_test
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - console/verify_separate_home

--- a/schedule/yam/agama_autoyast_supported_s390x.yaml
+++ b/schedule/yam/agama_autoyast_supported_s390x.yaml
@@ -8,6 +8,6 @@ schedule:
   - yam/agama/agama
   - boot/reconnect_mgmt_console
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - console/verify_separate_home

--- a/schedule/yam/agama_from_usb.yaml
+++ b/schedule/yam/agama_from_usb.yaml
@@ -8,5 +8,5 @@ schedule:
   - yam/agama/agama
   - yam/agama/agama_boot_from_hdd
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user

--- a/schedule/yam/agama_remote_pvm.yaml
+++ b/schedule/yam/agama_remote_pvm.yaml
@@ -9,5 +9,5 @@ schedule:
   - yam/agama/agama
   - installation/grub_test
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user

--- a/schedule/yam/agama_remote_s390x.yaml
+++ b/schedule/yam/agama_remote_s390x.yaml
@@ -9,5 +9,5 @@ schedule:
   - yam/agama/agama
   - boot/reconnect_mgmt_console
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user

--- a/schedule/yam/agama_s390x.yaml
+++ b/schedule/yam/agama_s390x.yaml
@@ -8,5 +8,5 @@ schedule:
   - yam/agama/agama
   - boot/reconnect_mgmt_console
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user

--- a/tests/yam/validate/validate_base_product.pm
+++ b/tests/yam/validate/validate_base_product.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Validate the base product from /etc/products.d/baseproduct.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use Test::Assert ':assert';
+
+sub run {
+    select_console 'root-console';
+    my $expected_prod = get_required_var("AGAMA_PRODUCT_ID");
+    my $prod = script_output 'basename `readlink /etc/products.d/baseproduct ` .prod';
+    assert_equals($expected_prod, $prod, "Wrong product name in '/etc/products.d/baseproduct'");
+}
+
+1;


### PR DESCRIPTION
Product cannot be validate with cat /etc/os-release due it doesn't differentiate well between sles and sles sap. So add a new test module to validate the product by reading /etc/products.d/baseproduct.

- Related ticket: https://progress.opensuse.org/issues/178729
- Verification run: [vrs](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=chcao_178729)
