### PR TITLE
Fix SDAF fencing mechanism

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/configure_tfvars.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/configure_tfvars.pm
@@ -216,6 +216,7 @@ sub set_fencing_parameters {
     # Fencing mechanism AFA (Azure fencing agent - MSI), ASD (Azure shared disk - SBD), ISCSI (iSCSI based SBD fencing)
     # Default value: 'msi' - AFA - Azure fencing agent (MSI)
     my $fencing_type = get_var('SDAF_FENCING_MECHANISM', 'msi');
+    record_info("FENCING: $fencing_type", "Fencing mechanism set to '$fencing_type'");
 
     # Ensures consistent OpenQA setting names across all types deployment solutions.
     # msi = MSI based fencing
@@ -225,7 +226,7 @@ sub set_fencing_parameters {
     die "Fencing type '$fencing_type' is not supported" unless grep /^$fencing_type$/, keys(%supported_fencing_values);
 
     # This is dumb and will be improved in TEAM-10145
-    set_var('SDAF_FENCING_TYPE', $supported_fencing_values{get_var('SDAF_FENCING_MECHANISM')});
+    set_var('SDAF_FENCING_TYPE', $supported_fencing_values{$fencing_type});
     # Setup ISCSI deployment
     if (get_var('SDAF_FENCING_TYPE') =~ /ISCSI/) {
         # Set default value for iSCSI device count

--- a/t/27_sdaf_configure_tfvars.t
+++ b/t/27_sdaf_configure_tfvars.t
@@ -209,6 +209,7 @@ subtest '[set_fencing_parameters] Unsupported fencing types' => sub {
 
 subtest '[set_fencing_parameters] Check value translation' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::configure_tfvars', no_auto => 1);
+    $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $ms_sdaf->redefine(assert_script_run => sub { return 1; });
     $ms_sdaf->redefine(upload_logs => sub { return 1; });
     $ms_sdaf->redefine(replace_tfvars_variables => sub { return 1; });


### PR DESCRIPTION
Tests seem to ignore default value `msi` for fencing mechanism. This PR fixes the problem

- Related ticket: https://jira.suse.com/browse/TEAM-10087
- Verification run: 

SBD: https://openqaworker15.qa.suse.cz/tests/317722#step/deploy_workload_zone/97
Default MSI: https://openqaworker15.qa.suse.cz/tests/317720#step/deploy_workload_zone/97
