### PR TITLE
Reduce the time for checking boot from cd

### DIFF
--- a/tests/wsl/install/ms_win_installation.pm
+++ b/tests/wsl/install/ms_win_installation.pm
@@ -30,7 +30,7 @@ sub run {
     my $self = shift;
 
     if (get_var('UEFI')) {
-        while (check_screen('windows-boot', timeout => 5)) {
+        while (check_screen('windows-boot', timeout => 1)) {
             send_key 'spc';
             record_info('SPC', 'Space key pressed');
         }    # boot from CD or DVD


### PR DESCRIPTION
Seems like 5s is not enough refresh rate for pressing spc key in the 'Press any key to boot from CD...' Windows screen.