### PR TITLE
Fix isolation test on Xen backend

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -156,7 +156,7 @@ sub load_host_tests_podman {
     load_volume_tests($run_args);
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
-    loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_jeos || is_public_cloud || is_transactional);
+    loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_public_cloud || is_transactional);
 }
 
 sub load_host_tests_docker {
@@ -186,7 +186,7 @@ sub load_host_tests_docker {
         loadtest 'containers/rootless_docker';
     }
     # Skip this test on docker-stable due to https://bugzilla.opensuse.org/show_bug.cgi?id=1239596
-    unless (is_jeos || is_transactional || is_public_cloud || is_sle('<15-SP4') || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {
+    unless (is_transactional || is_public_cloud || is_sle('<15-SP4') || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {
         loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation");
     }
     loadtest('containers/skopeo', run_args => $run_args, name => $run_args->{runtime} . "_skopeo") unless (is_sle('<15') || is_sle_micro('<5.5'));

--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -25,15 +25,15 @@ sub test_ip_version {
     script_retry("$runtime pull $image", timeout => 300, delay => 60, retry => 3);
 
     # Test that containers can't access the host
-    validate_script_output "! $runtime run --rm --network $network $image ping -$ip_version -c 1 $ip_addr", qr/Network is unreachable/;
+    validate_script_output "! $runtime run --rm -t --network $network $image ping -$ip_version -c 1 $ip_addr", qr/Network is unreachable/;
 
     # Test that containers can't access the Internet
     # Google DNS servers
     my $external_ip = ($ip_version == 6) ? "2001:4860:4860::8888" : "8.8.8.8";
-    validate_script_output "! $runtime run --rm --network $network $image ping -$ip_version -c 1 $external_ip", qr/Network is unreachable/;
+    validate_script_output "! $runtime run --rm -t --network $network $image ping -$ip_version -c 1 $external_ip", qr/Network is unreachable/;
 
     # Test that containers can't modify IP routes
-    validate_script_output "! $runtime run --rm --privileged --cap-add=CAP_NET_ADMIN --network $network $image ip -$ip_version route add default via $ip_addr", qr/No route to host|Nexthop has invalid gateway|Network is unreachable/;
+    validate_script_output "! $runtime run --rm -t --privileged --cap-add=CAP_NET_ADMIN --network $network $image ip -$ip_version route add default via $ip_addr", qr/No route to host|Nexthop has invalid gateway|Network is unreachable/;
 }
 
 sub run {


### PR DESCRIPTION
Fix isolation test on Xen backend.

- Failing test: https://openqa.suse.de/tests/17097655#step/docker_isolation/56
- Verification runs (15-SP7):
  - docker@svirt-xen-hvm -> https://openqa.suse.de/tests/17106413
  - docker@svirt-xen-pv -> https://openqa.suse.de/tests/17106402
  - podman@svirt-xen-hvm -> https://openqa.suse.de/tests/17106403
  - podman@svirt-xen-pv -> https://openqa.suse.de/tests/17106404
  
