### PR TITLE
Fix link protocol for infiniband tests

### DIFF
--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -11,7 +11,7 @@ vars:
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
-    MLX_PROTOCOL: 2
+    MLX_PROTOCOL: 1
     PATTERNS: base,minimal
     SCC_ADDONS: sdk
 schedule:

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -11,7 +11,7 @@ vars:
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
-    MLX_PROTOCOL: 2
+    MLX_PROTOCOL: 1
     PARALLEL_WITH: ibtest-master
     PATTERNS: base,minimal
     SCC_ADDONS: sdk


### PR DESCRIPTION
The interfaces were configured as Ethernet, but we need them to be InfiniBand.