### PR TITLE
Do not use b.o.o on <= 15-SP5 bsc#1239835

### DIFF
--- a/lib/web_browser.pm
+++ b/lib/web_browser.pm
@@ -74,6 +74,9 @@ sub run_web_browser_text_based {
         OBS => "https://build.opensuse.org/",
     );
 
+    # <= 15-SP5 has problems under FIPS with new b.o.o configuration bsc#1239835
+    delete $https_url{OBS} if (is_sle('<=15-SP5'));
+
     for my $p (keys %https_url) {
         enter_cmd "clear";
 


### PR DESCRIPTION
Seems FIPS is the only user.

- Related ticket: https://progress.opensuse.org/issues/178048
- Verification runs:

15-SP2: http://openqa.suse.de/tests/17108016
15-SP3: http://openqa.suse.de/tests/17108017
15-SP4: http://openqa.suse.de/tests/17108018
15-SP5: http://openqa.suse.de/tests/17108019
15-SP6: http://openqa.suse.de/tests/17108020

