### PR TITLE
Ensure `wsl --update` is run before `wsl --install --no-distribution`

### DIFF
--- a/tests/wsl/prepare_wsl.pm
+++ b/tests/wsl/prepare_wsl.pm
@@ -26,7 +26,7 @@ sub run {
     $self->open_powershell_as_admin;
     # WSL must be in the latest version, otherwise the `--no-distribution`
     # option is not available.
-    $self->run_in_powershell(cmd => 'wsl --update --verbose', timeout => 300);
+    $self->run_in_powershell(cmd => 'wsl --update', timeout => 300);
 
     if (get_var('WSL2')) {
         # WSL2 platform must be enabled from the MSstore from now on

--- a/tests/wsl/prepare_wsl.pm
+++ b/tests/wsl/prepare_wsl.pm
@@ -24,6 +24,9 @@ sub run {
     my ($self) = @_;
 
     $self->open_powershell_as_admin;
+    # WSL must be in the latest version, otherwise the `--no-distribution`
+    # option is not available.
+    $self->run_in_powershell(cmd => 'wsl --shutdown; wsl --update', timeout => 300);
 
     if (get_var('WSL2')) {
         # WSL2 platform must be enabled from the MSstore from now on
@@ -50,11 +53,6 @@ sub run {
             cmd => 'Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart',
             timeout => 300
         );
-        # Some versions immediately want to install updates on the first wsl.exe run, do that now
-        $self->run_in_powershell(
-            cmd => 'wsl.exe --update',
-            timeout => 300
-        ) if get_var('HDD_1') =~ /24H2/;
     }
 
     $self->reboot_or_shutdown(is_reboot => 1);

--- a/tests/wsl/prepare_wsl.pm
+++ b/tests/wsl/prepare_wsl.pm
@@ -26,7 +26,7 @@ sub run {
     $self->open_powershell_as_admin;
     # WSL must be in the latest version, otherwise the `--no-distribution`
     # option is not available.
-    $self->run_in_powershell(cmd => 'wsl --shutdown; wsl --update', timeout => 300);
+    $self->run_in_powershell(cmd => 'wsl --update --verbose', timeout => 300);
 
     if (get_var('WSL2')) {
         # WSL2 platform must be enabled from the MSstore from now on


### PR DESCRIPTION
The `wsl --install --no-distribution` command requires the latest WSL version. Move the `wsl --update` command outside of conditional blocks to ensure it's always executed.

- Related ticket: https://progress.opensuse.org/issues/179338
- Verification run: https://openqa.suse.de/tests/17116620 :construction:
