### PR TITLE
Remove openvswitch_ssl from Tumbleweed schedule

### DIFF
--- a/schedule/functional/extra_tests_misc.yaml
+++ b/schedule/functional/extra_tests_misc.yaml
@@ -8,7 +8,6 @@ conditional_schedule:
         DISTRI:
             opensuse:
                 - console/ndctl
-                - console/openvswitch_ssl
                 - x11/ghostscript
 schedule:
     - installation/bootloader_start


### PR DESCRIPTION
See discussion in https://progress.opensuse.org/issues/178657

TL;DR is that the test depends on pox and that is unmantained (no updates in past 5 years)

> The reason is a call of ssl.wrap_socket() [1] which was deprecated[2] by python 3.7 and is removed in python 3.13.
> Using SSLContext or stick to python3.11 are fixing the problem.
> The quick fix could be this pr[3]
>
> [1] https://github.com/noxrepo/pox/blob/gar-experimental/pox/openflow/of_01.py#L1110
> [2] https://github.com/python/cpython/commit/00464bbed66e5f64bdad7f930b315a88d5afccae
> [3] https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21412

Since Python3.11 will eventually leave TW too it makes little sense to keep executing it there
