### PR TITLE
Fix s390x booting of Full medium

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -90,7 +90,10 @@ sub prepare_parmfile {
     }
     else {
         if (get_var('AGAMA')) {
-            $params .= " root=live:ftp://" . get_var('REPO_HOST', 'openqa') . '/' . get_var('REPO_999');
+            $params .= " root=live:ftp://" . get_var('REPO_HOST', 'openqa') . '/' .
+              (get_var('FLAVOR') eq "Full") ?
+              get_required_var('REPO_0') . "/LiveOS/squashfs.img" :
+              get_var('REPO_999');
         }
         else {
             $params .= " install=" . $instsrc . $repo . " ";

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -32,8 +32,11 @@ sub set_svirt_domain_elements {
 
         my $ntlm_p = get_var('NTLM_AUTH_INSTALL') ? $ntlm_auth::ntlm_proxy : '';
         my $cmdline = get_var('VIRSH_CMDLINE') . $ntlm_p . " ";
-        if (is_agama) {
-            $cmdline .= "root=live:http://" . get_var('OPENQA_HOSTNAME') . "/assets/iso/" . get_required_var('ISO') . " live.password=$testapi::password";
+        if (get_var('AGAMA')) {
+            $cmdline .= " root=live:http://" . get_var('OPENQA_HOSTNAME') .
+              (get_var('FLAVOR') eq "Full") ?
+              "/assets/repo/" . get_required_var('REPO_0') . "/LiveOS/squashfs.img" :
+              "/assets/iso/" . get_required_var('ISO') . " live.password=$testapi::password";
         } else {
             $cmdline .= "install=$repo";
             $cmdline .= remote_install_bootmenu_params;


### PR DESCRIPTION
We have added the required kernel parameters to load Offline ISO without download into memory.

- Related ticket: https://progress.opensuse.org/issues/179290
- Needles: N/A
- Verification run: 
  - s390x-kvm: https://openqa.suse.de/tests/17139239
  - s390x-zvm: https://openqa.suse.de/tests/17118733 (Created short path to configure)
