### PR TITLE
Treat Connection reset by peer as a bug in journal checks

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -829,12 +829,12 @@
         },
         "type": "ignore"
     },
-    "sshd-mm-reap": {
-        "description": "sshd-session[.*]: error: (mm_reap: preauth child terminated|mm_request_receive: read: Broken pipe)",
+    "boo#1229935": {
+        "description": "sshd-session[.*]: error: (mm_reap: preauth child terminated|mm_request_receive: read: Broken pipe|mm_request_receive: read: Connection reset by peer)",
         "products": {
             "opensuse": ["Tumbleweed"],
             "microos":  ["Tumbleweed"]
         },
-        "type": "ignore"
+        "type": "bug"
     }
 }


### PR DESCRIPTION
poo: https://progress.opensuse.org/issues/179350
VR: https://openqa.opensuse.org/tests/4939332 and https://openqa.opensuse.org/tests/4945577
