### PR TITLE
Move ansible test out of package hub for 15-SP7

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1252,6 +1252,7 @@ sub load_consoletests {
     # SLES but not SLED. Don't run it on live media, not really useful there.
     if (!get_var("LIVETEST") && is_opensuse || (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && !is_desktop)) {
         loadtest "console/salt";
+        loadtest "console/ansible" if (is_sle('=15-SP7'));
     }
     if (!is_staging && (is_x86_64
             || is_i686

--- a/schedule/functional/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/extra_tests_textmode_phub.yaml
@@ -6,7 +6,6 @@ schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
     - console/add_phub_extension
-    - console/ansible
     - console/vmstat
     - console/libjpeg_turbo
     - console/libgit2

--- a/tests/console/ansible.pm
+++ b/tests/console/ansible.pm
@@ -32,7 +32,7 @@ sub run {
 
     # 1. System setup
 
-    unless (is_opensuse || (main_common::is_updates_tests && !(get_var('FIPS_ENABLED') || is_jeos)) || is_sle("16+")) {
+    unless (is_opensuse || (main_common::is_updates_tests && !(get_var('FIPS_ENABLED') || is_jeos)) || is_sle("16+") || is_sle('=15-SP7')) {
         # The Desktop module is required by the Development Tools module
         add_suseconnect_product(get_addon_fullname('desktop'));
         # Package 'ansible-test' needs python3-virtualenv from Development Tools module

--- a/tests/console/libjpeg_turbo.pm
+++ b/tests/console/libjpeg_turbo.pm
@@ -17,6 +17,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use version_utils;
 use utils qw(zypper_call upload_y2logs);
+use registration qw(add_suseconnect_product get_addon_fullname);
 use registration qw(add_suseconnect_product is_phub_ready);
 
 sub run {
@@ -24,6 +25,9 @@ sub run {
 
     # Package 'libjpeg-turbo' requires PackageHub is available
     return if (!is_phub_ready() && is_sle);
+
+    # Package ImageMagick requires Desktop-Applications is available
+    add_suseconnect_product(get_addon_fullname('desktop')) if is_sle('=15-SP7');
 
     # Install libjpeg-turbo package
     zypper_call("install libjpeg-turbo");


### PR DESCRIPTION
For 15-SP7 ansible and salt are from systems-management repo, so we need to move ansible out of packageHub testing

Related: https://progress.opensuse.org/issues/177528

VR:
15-SP7: 
ansible : https://openqa.suse.de/tests/17136883  (Passed)
PackageHub: https://openqa.suse.de/tests/17147473 (Passed)

15-SP6: https://openqa.suse.de/tests/17147477# (Passed)

TW:  https://openqa.suse.de/tests/17147477# (Passed)

See more VRs in https://openqa.suse.de/tests/overview?version=15-SP7&build=Amrysliu%2Fos-autoinst-distri-opensuse%23move_ansible&distri=sle
