### PR TITLE
Add setting about hana cli installer

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -266,9 +266,9 @@ sub run {
     die "hdblcm is not in [$hdblcm]. Set HANA_HDBLCM to the appropiate relative path. Example: DATA_UNITS/HDB_SERVER_LINUX_X86_64/hdblcm"
       if (script_run "ls $hdblcm");
 
-    # Install hana
-    # Prepare hdblcm args.
-    # Note: set "--components=server,client" as other test moudle (monitoring_services.pm) installs shared pkgs from dir 'hdbclient'
+    # Install hana: Prepare hdblcm args.
+    # Note: set "--components=server,client" as other test moudle (monitoring_services.pm)
+    # installs shared pkgs from dir 'hdbclient'
     my @hdblcm_args = qw(--autostart=n --shell=/bin/sh --workergroup=default --system_usage=custom --batch
       --hostname=$(hostname) --db_mode=multiple_containers --db_isolation=low --restrict_max_mem=n
       --userid=1001 --groupid=79 --use_master_password=n --skip_hostagent_calls=n --system_usage=production
@@ -286,6 +286,7 @@ sub run {
       "--sapmnt=$mountpts{hanashared}->{mountpt}";
     push @hdblcm_args, "--pmempath=$pmempath", "--use_pmem" if get_var('NVDIMM');
     push @hdblcm_args, "--component_dirs=$target/" . get_var('HDB_CLIENT_LINUX') if get_var('HDB_CLIENT_LINUX');
+    push @hdblcm_args, get_var('HDBLCM_EXTRA_ARGS') if get_var('HDBLCM_EXTRA_ARGS');
 
     my $cmd = join(' ', $hdblcm, @hdblcm_args);
     record_info 'hdblcm command', $cmd;


### PR DESCRIPTION
Add openQA setting HDBLCM_EXTRA_ARGS to add arguments on the installation command line.

- Related ticket: https://jira.suse.com/browse/TEAM-10126

# Verification run:

## sle-15-SP7-Online-x86_64-Buildmpagot_VR-SAPHanaSR_ScaleUp_PerfOpt_WMP_node01
https://openqa.suse.de/tests/17110581 called with setting `HDBLCM_EXTRA_ARGS` and value of it is visible in https://openqa.suse.de/tests/17110581#step/hana_install/229

## sle-15-SP6-Server-DVD-SAP-Incidents qam-SAPHanaSR_angi_ScaleUp_PerfOpt_WMP

- node01 http://openqaworker15.qa.suse.cz/tests/318051
- node02 http://openqaworker15.qa.suse.cz/tests/318053

This test is also using new ASSETS and `HDBLCM_COMPONENTS=all` instead of `HDBLCM_COMPONENTS=server`. But again it proves that string from the setting is added to the command line
- node01 http://openqaworker15.qa.suse.cz/tests/318046
- node02 http://openqaworker15.qa.suse.cz/tests/318045