### PR TITLE
containers: Use CONTAINER_IMAGE_TO_TEST for Tumbleweed image

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -25,10 +25,10 @@ use Utils::Backends qw(is_svirt);
 sub run_tests {
     my $runtime = shift;
 
-    my $image = "registry.opensuse.org/opensuse/tumbleweed:latest";
+    my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
     record_info('Test', "Pull image $image");
     assert_script_run("buildah pull $image", timeout => 300);
-    validate_script_output('buildah images', sub { /registry.opensuse.org\/opensuse\/tumbleweed/ });
+    validate_script_output('buildah images', sub { /\/tumbleweed/ });
 
     record_info('Test', "Create container from $image");
     my $container = script_output("buildah from $image");

--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -54,7 +54,7 @@ sub basic_container_tests {
     my %args = @_;
     my $runtime = $args{runtime};
     die "Undefined container runtime" unless $runtime;
-    my $image = "registry.opensuse.org/opensuse/tumbleweed";
+    my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
 
     ## Test search feature
     validate_script_output("$runtime search --no-trunc --format 'table {{.Name}} {{.Description}}' tumbleweed", sub { m/Official openSUSE Tumbleweed images/ }, timeout => 300);

--- a/tests/containers/podman_quadlet.pm
+++ b/tests/containers/podman_quadlet.pm
@@ -21,7 +21,7 @@ my $quadlet_dir = '/etc/containers/systemd';
 my $unit_name = 'quadlet-test';
 
 my $build_imagetag = "localhost/nginx";
-my $src_image = "registry.opensuse.org/opensuse/tumbleweed";
+my $src_image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
 my @systemd_build = ("$quadlet_dir/$unit_name.build", <<_EOF_);
 [Build]
 ImageTag=$build_imagetag

--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -26,7 +26,7 @@ sub run {
     $self->{runtime} = $engine;
     reset_container_network_if_needed($runtime);
 
-    my $image = is_opensuse ? "registry.opensuse.org/opensuse/tumbleweed:latest" : "registry.suse.com/bci/bci-base:latest";
+    my $image = get_var("CONTAINER_IMAGE_TO_TEST", is_opensuse ? "registry.opensuse.org/opensuse/tumbleweed:latest" : "registry.suse.com/bci/bci-base:latest");
     script_retry("$runtime pull $image", timeout => 300, delay => 120, retry => 3);
 
     record_info('Test', 'Launch a container with privileged mode');

--- a/tests/containers/realtime.pm
+++ b/tests/containers/realtime.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2024 SUSE LLC
+# Copyright 2024,2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: podman, docker
@@ -49,7 +49,7 @@ sub run {
 
     my $runtime = $args->{runtime};
     my $container = 'rt-test';
-    my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
+    my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
 
     $self->{runtime} = $self->containers_factory($runtime);
     script_retry("$runtime pull $image", timeout => 300, delay => 120, retry => 3);

--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -36,7 +36,7 @@ sub run {
     my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
     install_packages("$pkg_name-rootless-extras");
 
-    my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
+    my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
 
     my $subuid_start = get_user_subuid($user);
     if ($subuid_start eq '') {

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -66,11 +66,10 @@ sub run {
 
     # Check for bsc#1192051
     # Test needs to pass, if seccomp filtering is off
-    assert_script_run('podman run --security-opt=seccomp=unconfined --rm -it registry.opensuse.org/opensuse/tumbleweed:latest bash -c "test -x /bin/sh"');
+    my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
+    assert_script_run("podman run --security-opt=seccomp=unconfined --rm -it $image bash -c 'test -x /bin/sh'");
     # And this one is the actual check for bsc#1192051, with seccomp filtering on
-    assert_script_run('podman run --rm -it registry.opensuse.org/opensuse/tumbleweed:latest bash -c "test -x /bin/sh"', fail_message => "bsc#1192051 - Permission denied for faccessat2");
-
-    my $image = 'registry.opensuse.org/opensuse/tumbleweed:latest';
+    assert_script_run("podman run --rm -it $image bash -c 'test -x /bin/sh'", fail_message => "bsc#1192051 - Permission denied for faccessat2");
 
     # Some products don't have bernhard pre-defined (e.g. SLE Micro)
     if (script_run("grep $user /etc/passwd") != 0) {

--- a/tests/containers/seccomp.pm
+++ b/tests/containers/seccomp.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2024 SUSE LLC
+# Copyright 2024,2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: seccomp
@@ -29,7 +29,7 @@ sub run {
     # busybox ls doesn't handle readdir failure, so use something with coreutils inside.
     # Note that there can also be a kind of false negative: with runc, the seccomp policy
     # breaks runc even before it reaches ls.
-    my $image = "registry.opensuse.org/opensuse/tumbleweed";
+    my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
     my $policy = "policy.json";
 
     assert_script_run('curl ' . data_url("containers/$runtime-seccomp.json") . " -o $policy");


### PR DESCRIPTION
Use CONTAINER_IMAGE_TO_TEST for Tumbleweed image to allow testing unreleased OCI image.

- Related ticket: https://progress.opensuse.org/issues/178645
- o3 schedule: https://github.com/os-autoinst/opensuse-jobgroups/pull/625
- Verification run with `CONTAINER_IMAGE_TO_TEST=registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed:latest`:
  - TW: https://openqa.opensuse.org/tests/4945949
