### PR TITLE
Add test for gnome-console (kgx)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1346,6 +1346,7 @@ sub load_x11tests {
         loadtest "x11/gnome_control_center";
         # TODO test on SLE https://progress.opensuse.org/issues/31972
         loadtest "x11/gnome_tweak_tool" if is_opensuse;
+        loadtest "x11/gnome_console" unless (is_leap("<16") || is_sle("<16"));
         loadtest "x11/gnome_terminal";
         loadtest "x11/gedit";
     }

--- a/tests/x11/gnome_console.pm
+++ b/tests/x11/gnome_console.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: gnome-console
+# Summary: Basic functionality of gnome console
+# - Launch "gnome-console" and confirm it is running
+# - Open a second tab
+# - Type "If you can see this text gnome-console is working."
+# - Close gnome-console
+# Maintainer: Santiago Zarate <santiago.zarate@suse.com>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    mouse_hide(1);
+    x11_start_program('kgx');
+    send_key "ctrl-shift-t";
+    assert_screen "gnome-console-second-tab";
+    $self->enter_test_text('gnome-console', cmd => 1);
+    assert_screen 'test-gnome_console-1';
+    send_key 'alt-f4';
+}
+
+1;


### PR DESCRIPTION
Gnome terminal is being replaced with gnome-console (kgx) this PR prepares the groundwork for that change

Progress ticket: https://progress.opensuse.org/issues/169162
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/827
VR: 
  - (test only) http://10.149.209.202/tests/97
  - (default gnome schedule) https://openqa.opensuse.org/tests/4946137#step/gnome_console/5

