### PR TITLE
Use xterm instead of gnome-terminal for some gnome tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1346,8 +1346,11 @@ sub load_x11tests {
         loadtest "x11/gnome_control_center";
         # TODO test on SLE https://progress.opensuse.org/issues/31972
         loadtest "x11/gnome_tweak_tool" if is_opensuse;
-        loadtest "x11/gnome_console" unless (is_leap("<16") || is_sle("<16"));
-        loadtest "x11/gnome_terminal";
+        if (is_leap("<16") || is_sle("<16")) {
+            loadtest "x11/gnome_terminal";
+        } else {
+            loadtest "x11/gnome_console";
+        }
         loadtest "x11/gedit";
     }
     # Need remove firefox tests in our migration tests from old Leap releases, keep them only in 15.2 and newer.

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -120,7 +120,7 @@ sub switch_users {
 
 # restore password to original value
 sub restore_passwd {
-    x11_start_program(x11_default_test_terminal());
+    x11_start_program(default_gui_terminal());
     enter_cmd "su";
     assert_screen "pwd4root-terminal";
     type_password "$password\n";

--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -120,7 +120,7 @@ sub switch_users {
 
 # restore password to original value
 sub restore_passwd {
-    x11_start_program('gnome-terminal');
+    x11_start_program(x11_default_test_terminal());
     enter_cmd "su";
     assert_screen "pwd4root-terminal";
     type_password "$password\n";

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   untick_welcome_on_next_startup
   start_root_shell_in_xterm
   x11_start_program_xterm
+  x11_default_test_terminal
   handle_gnome_activities
 );
 
@@ -607,6 +608,19 @@ sub x11_start_program_xterm {
         click_lastmatch;
         assert_screen 'xterm';
     }
+}
+
+=head2 x11_default_test_terminal {
+
+    x11_default_test_terminal()
+
+Returns the default console to be used by test modules, defaults to xterm
+
+=cut
+
+sub x11_default_test_terminal {
+    return "gnome-terminal" if is_sle("<16") || is_leap("<16");
+    return "xterm";
 }
 
 =head2 handle_gnome_activities

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -619,7 +619,7 @@ Returns the default console to be used by test modules, defaults to xterm
 =cut
 
 sub x11_default_test_terminal {
-    return "gnome-terminal" if is_sle("<16") || is_leap("<16");
+    return "gnome-terminal" if (check_var('DESKTOP', 'gnome') && (is_sle("<16") || is_leap("<16")));
     return "xterm";
 }
 

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -37,7 +37,7 @@ our @EXPORT = qw(
   untick_welcome_on_next_startup
   start_root_shell_in_xterm
   x11_start_program_xterm
-  x11_default_test_terminal
+  default_gui_terminal
   handle_gnome_activities
 );
 
@@ -610,15 +610,15 @@ sub x11_start_program_xterm {
     }
 }
 
-=head2 x11_default_test_terminal {
+=head2 default_gui_terminal {
 
-    x11_default_test_terminal()
+    default_gui_terminal()
 
 Returns the default console to be used by test modules, defaults to xterm
 
 =cut
 
-sub x11_default_test_terminal {
+sub default_gui_terminal {
     return "gnome-terminal" if (check_var('DESKTOP', 'gnome') && (is_sle("<16") || is_leap("<16")));
     return "xterm";
 }

--- a/tests/x11/gnome_terminal.pm
+++ b/tests/x11/gnome_terminal.pm
@@ -16,6 +16,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use version_utils qw(is_sle is_leap);
 
 sub run {
     my ($self) = @_;

--- a/tests/x11/gnome_terminal.pm
+++ b/tests/x11/gnome_terminal.pm
@@ -20,6 +20,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     mouse_hide(1);
+    ensure_installed('gnome-terminal') unless (is_leap("<16") || is_sle("<16"));
     x11_start_program('gnome-terminal');
     send_key "ctrl-shift-t";
     if (!check_screen "gnome-terminal-second-tab", 30) {

--- a/tests/x11/ibus/ibus_installation.pm
+++ b/tests/x11/ibus/ibus_installation.pm
@@ -15,7 +15,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils 'is_tumbleweed';
-use x11utils qw(x11_default_test_terminal handle_relogin);
+use x11utils qw(default_gui_terminal handle_relogin);
 
 sub install_ibus {
     x11_start_program("xterm");
@@ -30,7 +30,7 @@ sub install_ibus {
 }
 
 sub override_i18n {
-    x11_start_program(x11_default_test_terminal());
+    x11_start_program(default_gui_terminal());
     enter_cmd "echo 'export INPUT_METHOD=ibus' > .i18n ";
     enter_cmd "cat .i18n ";
     assert_screen 'ibus_i18n_overrided';
@@ -38,7 +38,7 @@ sub override_i18n {
 }
 
 sub ibus_daemon_started {
-    x11_start_program(x11_default_test_terminal());
+    x11_start_program(default_gui_terminal());
     wait_still_screen;
 
     enter_cmd_slow "env | grep ibus ";

--- a/tests/x11/ibus/ibus_installation.pm
+++ b/tests/x11/ibus/ibus_installation.pm
@@ -15,7 +15,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils 'is_tumbleweed';
-use x11utils 'handle_relogin';
+use x11utils qw(x11_default_test_terminal handle_relogin);
 
 sub install_ibus {
     x11_start_program("xterm");
@@ -30,7 +30,7 @@ sub install_ibus {
 }
 
 sub override_i18n {
-    x11_start_program('gnome-terminal');
+    x11_start_program(x11_default_test_terminal());
     enter_cmd "echo 'export INPUT_METHOD=ibus' > .i18n ";
     enter_cmd "cat .i18n ";
     assert_screen 'ibus_i18n_overrided';
@@ -38,7 +38,7 @@ sub override_i18n {
 }
 
 sub ibus_daemon_started {
-    x11_start_program('gnome-terminal');
+    x11_start_program(x11_default_test_terminal());
     wait_still_screen;
 
     enter_cmd_slow "env | grep ibus ";


### PR DESCRIPTION
This is a follow up to os-autoinst/os-autoinst-distri-opensuse/pull/21557

This PR does two things: 
- ensures that for new codestreams there's no dependency on gnome-terminal
- Ensures that for new codestreams gnome_terminal test installs gnome-terminal

VR:
- [Staging test](https://openqa.opensuse.org/tests/4948403)
- [default gnome scenario on TW](https://openqa.opensuse.org/tests/4948286#live)
- [Leap 15.6 update gnome](https://openqa.opensuse.org/tests/4948264#step/gnome_terminal/4)
- [Change password](https://openqa.opensuse.org/tests/4947361#step/change_password/91)
- [ibus installation](https://openqa.opensuse.org/tests/4947362#step/ibus_installation/32)


goes together with: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/828
