### PR TITLE
Speed up hacluster UT execution

### DIFF
--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use Test::Exception;
 use Test::MockModule;
+use Test::Mock::Time;
 use hacluster;
 use testapi;
 use Scalar::Util qw(looks_like_number);


### PR DESCRIPTION
Add Time mock to avoid 10sec sleep during each test execution

BEFORE:
```
[11:47:42] t/11_hacluster.t ................  ok    11581 ms ( 0.03 usr  0.00 sys +  0.51 cusr  0.07 csys =  0.61 CPU)
```

AFTER
```
[18:08:24] t/11_hacluster.t ................  ok      582 ms ( 0.01 usr  0.00 sys +  0.51 cusr  0.07 csys =  0.59 CPU)
```

- Verification run: 