### PR TITLE
Fix netavark upstream tests on SLE 16.0

### DIFF
--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -13,7 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
 use containers::common;
 use containers::bats;
-use version_utils qw(is_sle is_tumbleweed is_microos);
+use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp/netavark-tests";
 my $netavark;
@@ -55,7 +55,7 @@ sub run {
 
     # Install tests dependencies
     my @pkgs = qw(aardvark-dns cargo firewalld iproute2 iptables jq make protobuf-devel netavark);
-    if (is_tumbleweed || is_microos) {
+    if (is_tumbleweed || is_sle('>=16.0')) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {
         push @pkgs, qw(dbus-1);


### PR DESCRIPTION
SLE 16.0 uses the `dbus-1-daemon` package instead of `dbus` for `dbus-daemon`.

`dbus-daemon: No such file or directory`

- Failed test: https://openqa.suse.de/tests/17141219/file/netavark_integration-netavark.tap
- Verification run: https://openqa.suse.de/tests/17147589