### PR TITLE
New schedule without hostname validation for arch ppc64le

### DIFF
--- a/schedule/yam/agama_ppc64le.yaml
+++ b/schedule/yam/agama_ppc64le.yaml
@@ -1,0 +1,12 @@
+---
+name: agama_ppc64le
+description: >
+  Perform interactive installation with agama.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_product
+  - yam/validate/validate_first_user


### PR DESCRIPTION
New schedule without hostname validation for arch ppc64le.
- Verification run: [fix_hostname_ppc64le](https://openqa.suse.de/tests/overview?build=fix_hostname_ppc64le)
