### PR TITLE
SLE16: several packages are dropped

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1250,7 +1250,7 @@ sub load_consoletests {
     }
     # salt in SLE is only available for SLE12 ASMM or SLES15 and variants of
     # SLES but not SLED. Don't run it on live media, not really useful there.
-    if (!get_var("LIVETEST") && is_opensuse || (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && !is_desktop)) {
+    if (!get_var("LIVETEST") && is_opensuse || (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && is_sle('<16.0') && !is_desktop)) {
         loadtest "console/salt";
     }
     if (!is_staging && (is_x86_64
@@ -1737,7 +1737,7 @@ sub load_extra_tests_console {
     loadtest "console/wget_ipv6";
     loadtest "console/ca_certificates_mozilla";
     loadtest "console/unzip";
-    loadtest "console/salt" if (is_jeos || is_opensuse);
+    loadtest "console/salt" if ((is_jeos && is_sle('<16.0')) || is_opensuse);
     loadtest "console/gpg";
     loadtest "console/rsync";
     loadtest "console/clamav" unless is_arm;

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -47,7 +47,7 @@ sub run {
     # except of sle, where it is provided by *sysvinit-tools* rpm
     # since sle(15-SP3+) *sysvinit-tools* is not preinstalled on JeOS
     # as systemd's dependency with *sysvinit-tools* was dropped
-    $test_deps .= ' sysvinit-tools' if (is_sle('>15-sp2') || is_leap('>15.2'));
+    $test_deps .= ' sysvinit-tools' if ((is_sle('<16.0') && is_sle('>15-sp2')) || is_leap('>15.2'));
     zypper_call("in $test_deps");
     # disable debuginfod
     assert_script_run('unset DEBUGINFOD_URLS');

--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -13,6 +13,7 @@ use Utils::Architectures;
 use utils;
 use power_action_utils qw(power_action);
 use Utils::Systemd qw(systemctl);
+use version_utils qw(is_sle);
 
 sub check_package
 {
@@ -60,11 +61,15 @@ sub rollback_and_reboot {
 
 sub run {
     my ($self) = @_;
+    my %checks = (
+        zsh => '/usr/share/zsh/functions',
+        tcpdump => '/usr/sbin/tcpdump'
+    );
 
     select_console('root-console');
     my $file = '/etc/openQA_snapper_test';
-    my $pkgname = 'zsh';
-    my $check_path = '/usr/share/zsh/functions';
+    my $pkgname = is_sle('16.0+') ? 'tcpdump' : 'zsh';
+    my $check_path = $checks{$pkgname};
     my $openqainit = script_output("snapper create -p -d openqainit");
 
     assert_script_run("head -c 10000 < /dev/urandom > $file");


### PR DESCRIPTION
We need to adapt several tests, as some packages are not going to land in sle16

#### Verification runs

* [404 salt](http://kepler.suse.cz/tests/24511)
* [404 sysvinit](http://kepler.suse.cz/tests/24512#step/gdb/1)
* [404 zsh](http://kepler.suse.cz/tests/24513#step/snapper_jeos_cli/16)
