### PR TITLE
Fix record_info in saputils

### DIFF
--- a/lib/saputils.pm
+++ b/lib/saputils.pm
@@ -220,7 +220,7 @@ sub check_hana_topology {
         # If something is missing the topology is considered invalid.
         foreach (qw(lss srPoll)) {
             unless (defined($topology->{Site}->{$site}->{$_})) {
-                record_info('check_hana_topology', ' [ERROR] ', "Missing '$_' field in topology output for site $site");
+                record_info('check_hana_topology', "[ERROR] Missing '$_' field in topology output for site $site");
                 return 0;
             }
         }


### PR DESCRIPTION
record_info only expect two arguments not three

Fix issue
```
# Test died: Odd name/value argument for subroutine 'testapi::record_info' at /var/lib/openqa/pool/38/os-autoinst-distri-opensuse/lib/saputils.pm line 223.
	testapi::record_info("check_hana_topology", " [ERROR] ", "Missing 'lss' field in topology output for site a") called at /var/lib/openqa/pool/38/os-autoinst-distri-opensuse/lib/saputils.pm line 223
```

Related ticket: https://jira.suse.com/browse/TEAM-10079

# Verification runs:
sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-03-25T03:03:21Z-hanasr_azure_test_angi az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/318166 :green_circle: test keep failing but exception now is no more about `Odd name/value argument for subroutine` 
```
[2025-03-25T17:27:50.103262+01:00] [info] [pid:76606] ::: basetest::runtest: # Test died: wait_for_sync [ERROR] Replication SYNC did not finish within defined timeout. (900 sec). at /var/lib/openqa/pool/38/os-autoinst-distri-opensuse/lib/sles4sap_publiccloud.pm line 689.
  	sles4sap_publiccloud::wait_for_sync(qesap_prevalidate=HASH(0x55f2d4728498)) called at /var/lib/openqa/pool/38/os-autoinst-distri-opensuse/tests/sles4sap/publiccloud/qesap_prevalidate.pm line 44
  	qesap_prevalidate::run(qesap_prevalidate=HASH(0x55f2d4728498), OpenQA::Test::RunArgs=HASH(0x55f2d3121950)) called at /usr/lib/os-autoinst/basetest.pm line 348
```
- http://openqaworker15.qa.suse.cz/tests/318167
