### PR TITLE
Remove grub_test module from SLES+HA 16 installation schedule

### DIFF
--- a/schedule/ha/bv/agama_install_sles_ha.yaml
+++ b/schedule/ha/bv/agama_install_sles_ha.yaml
@@ -19,7 +19,6 @@ conditional_schedule:
       qemu:
         - yam/agama/boot_agama
         - yam/agama/agama_auto
-        - installation/grub_test
       pvm_hmc:
         - installation/bootloader
         - installation/agama_reboot


### PR DESCRIPTION
With the latest SLES 16 build, jobs in aarch64 architecture on qemu backend fail on the `installation/grub_test` test module, but reach the login prompt successfully.

Removing the module from the SLES+HA installation schedule for 16 on qemu backend produces jobs which pass on both x86_64 and aarch64 architectures, so this commit removes the module from the schedule.

- Related ticket: https://jira.suse.com/browse/TEAM-9407
- Needles: 
- Verification run: [aarch64](http://mango.qe.nue2.suse.org/tests/6307) :green_circle: , [x86_64](http://mango.qe.nue2.suse.org/tests/6304) :green_circle: 
