### PR TITLE
install_ltp: don't install exfatprogs for LTP git in TW

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -80,7 +80,6 @@ sub install_runtime_dependencies {
       e2fsprogs
       evmctl
       exfat-utils
-      exfatprogs
       fuse-exfat
       ibmtss
       lvm2
@@ -103,6 +102,9 @@ sub install_runtime_dependencies {
     # modules then fail on SLE-12 because the required driver is available but
     # modprobe refuses to load it.
     push @maybe_deps, 'kernel-default-extra' unless is_sle('<15');
+
+    # exfatprogs create a conflict with exfat-utils on Tumbleweed.
+    push @maybe_deps, 'exfatprogs' unless is_tumbleweed();
 
     zypper_install_available(@maybe_deps);
 }


### PR DESCRIPTION
exfatprogs is conflicting with exfat-utils in TW as following:

exfatprogs-1.2.8-1.1.x86_64 conflicts with 'exfat-utils'
provided by the installed exfat-utils-1.4.0-2.4.x86_64

* Related ticket: N/A
* Needles: N/A
* Verification run: https://openqa.opensuse.org/tests/4951326

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>
