### PR TITLE
lib/serial_terminal.pm: Make check for entered username more reliable

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -173,7 +173,7 @@ sub login {
     die 'Failed to wait for login prompt' unless wait_serial(qr/login:\s*$/i);
     enter_cmd("$user");
 
-    my $re = qr/$user/i;
+    my $re = qr/$user[\r\n]/i;
     if (!wait_serial($re, timeout => 3)) {
         record_info('RELOGIN', 'Need to retry login to workaround virtio console race', result => 'softfail');
         enter_cmd("$user");


### PR DESCRIPTION
Also include the finishing newline to avoid matching "Note: Cockpit disallows root login by default.".

- Related ticket: https://openqa.suse.de/tests/17135040
- Verification run: http://10.168.5.231/tests/1782
