### PR TITLE
btrfs-progs: Fix issue with test result retrieval

### DIFF
--- a/tests/btrfs-progs/run.pm
+++ b/tests/btrfs-progs/run.pm
@@ -66,6 +66,12 @@ sub test_run {
     script_run("./clean-tests.sh");
     my $ret = script_output("TEST=$num\\* ./$category-tests.sh | tee output.log", 1800, proceed_on_failure => 1);
 
+    # determine whether a log file exists
+    if (script_run("test -f $logfile") != 0) {
+        $status = 'FAILED';
+        return $status;
+    }
+
     if ($ret =~ /test\s+failed\s+for\s+case/i) {
         $status = 'FAILED';
     }


### PR DESCRIPTION
The test result should be failed if no result file

- Related ticket: https://progress.opensuse.org/issues/179482
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/17163058 (passed)
https://openqa.suse.de/tests/17163057 (failed due to no result file)
