### PR TITLE
Add openqa-agent to Windows

### DIFF
--- a/data/wsl/Autounattend_UEFI.xml
+++ b/data/wsl/Autounattend_UEFI.xml
@@ -376,6 +376,23 @@
           <Order>63</Order>
           <Path>%windir%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\PersonalizationCSP" /v DesktopImageStatus /t REG_DWORD /d 1 /f</Path>
         </RunSynchronousCommand>
+        <!-- openqa-agent installation and config -->
+        <RunSynchronousCommand wcm:action="add">
+          <Order>64</Order>
+          <Path>powershell.exe -NoProfile -Command "Invoke-WebRequest -Uri https://github.com/grisu48/openqa-agent/releases/download/v1.1.2/agent-Windows-amd64 -OutFile 'C:\Program Files\openqa-agent.exe'"</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>65</Order>
+          <Path>powershell.exe -NoProfile -Command "Set-MpPreference -ExclusionPath 'C:\Program Files\openqa-agent.exe'"</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>66</Order>
+          <Path>powershell.exe -NoProfile -Command "New-NetFirewallRule -DisplayName 'Allow openqa-agent' -Direction Inbound -Action Allow -Protocol TCP -LocalPort 8421"</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>67</Order>
+          <Path>powershell.exe -NoProfile -Command "sc.exe create "openqa-agent" type= own start= auto binPath= 'C:\Program Files\openqa-agent.exe'"</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
   </settings>

--- a/lib/windowsbasetest.pm
+++ b/lib/windowsbasetest.pm
@@ -21,6 +21,11 @@ sub windows_run {
 
 
 sub _setup_serial_device {
+    # Prevent that openqa-agent blocks the serial port, if present
+    type_string "Stop-Service openqa-agent";
+    wait_screen_change(sub { send_key 'ret' }, 10);
+    sleep 60;
+
     if (is_aarch64) {
         type_string '$port = new-Object System.IO.Ports.SerialPort COM3,9600,None,8,one', max_interval => 125;
     } else {


### PR DESCRIPTION
Adds installation of openqa-agent to Windows in the Unattended Installation. This agent is pre-installed from now on but will not affect current test runs without further modifications.

- Related ticket: https://progress.opensuse.org/issues/178837
- Verification run: https://openqa.opensuse.org/tests/4952400
