### PR TITLE
Only collect supportconfig in case of error

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -187,6 +187,7 @@ sub sles4sap_cleanup {
     type_string('', terminate_with => 'ETX');
 
     qesap_cluster_logs();
+    qesap_supportconfig_logs(provider => get_required_var('PUBLIC_CLOUD_PROVIDER'));
     qesap_upload_logs();
     upload_logs('/var/tmp/ssh_sut.log', failok => 1, log_name => 'ssh_sut.log.txt');
     if ($args{network_peering_present}) {

--- a/t/12_sles4sap_publiccloud.t
+++ b/t/12_sles4sap_publiccloud.t
@@ -48,6 +48,7 @@ subtest "[sles4sap_cleanup] no args and all pass" => sub {
     $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
     $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
     $sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(qesap_supportconfig_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my @calls;
     $sles4sap_publiccloud->redefine(qesap_execute => sub {
@@ -55,9 +56,11 @@ subtest "[sles4sap_cleanup] no args and all pass" => sub {
             push @calls, $args{cmd};
             return (0, 0); });
     my $self = sles4sap_publiccloud->new();
+    set_var('PUBLIC_CLOUD_PROVIDER', 'FRUTTOLO');
 
     my $ret = $self->sles4sap_cleanup();
 
+    set_var('PUBLIC_CLOUD_PROVIDER', undef);
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(any { /terraform/ } @calls, "Check if terraform is called");
     ok(any { /ansible/ } @calls, "Check that ansible is not called");
@@ -72,6 +75,7 @@ subtest "[sles4sap_cleanup] ansible and all pass" => sub {
     $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
     $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
     $sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(qesap_supportconfig_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my @calls;
     $sles4sap_publiccloud->redefine(qesap_execute => sub {
@@ -79,9 +83,11 @@ subtest "[sles4sap_cleanup] ansible and all pass" => sub {
             push @calls, $args{cmd};
             return (0, 0); });
     my $self = sles4sap_publiccloud->new();
+    set_var('PUBLIC_CLOUD_PROVIDER', 'FRUTTOLO');
 
     my $ret = $self->sles4sap_cleanup(ansible_present => 1);
 
+    set_var('PUBLIC_CLOUD_PROVIDER', undef);
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(any { /terraform/ } @calls, "Check if terraform is called");
     ok(any { /ansible/ } @calls, "Check if ansible is called");
@@ -95,6 +101,7 @@ subtest "[sles4sap_cleanup] terraform to be called even if ansible fails" => sub
     $sles4sap_publiccloud->redefine(qesap_upload_logs => sub { return; });
     $sles4sap_publiccloud->redefine(upload_logs => sub { return; });
     $sles4sap_publiccloud->redefine(qesap_cluster_logs => sub { return; });
+    $sles4sap_publiccloud->redefine(qesap_supportconfig_logs => sub { return; });
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my @calls;
     $sles4sap_publiccloud->redefine(qesap_execute => sub {
@@ -107,9 +114,11 @@ subtest "[sles4sap_cleanup] terraform to be called even if ansible fails" => sub
             }
     });
     my $self = sles4sap_publiccloud->new();
+    set_var('PUBLIC_CLOUD_PROVIDER', 'FRUTTOLO');
 
     my $ret = $self->sles4sap_cleanup(ansible_present => 1);
 
+    set_var('PUBLIC_CLOUD_PROVIDER', undef);
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(any { /terraform/ } @calls, "Check if terraform is called");
     ok(any { /ansible/ } @calls, "Check if ansible is called");


### PR DESCRIPTION
Change sles4sap tests only to collect supportconfig in case of errors, only as part of post_fail_hook.


- Related ticket: https://jira.suse.com/browse/TEAM-10138

# Verification

 - sle-12-SP5-HanaSr-Aws-Payg-x86_64-Build12-SP5_2025-03-26T03:03:25Z-hanasr_aws_test_fencing_native_ltss ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/318307 :green_circle:  job fails and supportconfig is uploaded https://openqaworker15.qa.suse.cz/tests/318307/file/deploy_qesap_ansible-scc_vmhana01-supportconfig_log.txz


- sle-15-SP6-HanaSr-Aws-Payg-x86_64-Build15-SP6_2025-03-26T03:03:25Z-hanasr_aws_test_fencing_native_stop_kill ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/318343 :green_circle: supportconfig not collected in case of pass


 - sle-12-SP5-HanaSr-Gcp-Byos-x86_64-Build12-SP5_2025-03-26T03:03:25Z-hanasr_gcp_test_fencing_native_ltss_es gce_n1_highmem_8 -> http://openqaworker15.qa.suse.cz/tests/318344 :green_circle: supportconfig collected in case of failure

- sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-03-26T03:03:25Z-hanasr_azure_test_msi az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/318345

 - sle-12-SP5-Azure-SAP-PAYG-Incidents-x86_64-Build:37806:vim-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/318577