### PR TITLE
Replace agama.auto with inst.auto for sle16 installation and fix a regression logic issue

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -895,8 +895,7 @@ sub specific_bootmenu_params {
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $url = autoyast::expand_agama_profile($agama_auto);
         $url = shorten_url($url) if (is_backend_s390x && !is_opensuse);
-        # Workaround for bsc#1238581, will remove it once the bug is fixed
-        push @params, "agama.auto=$url agama.finish=stop";
+        push @params, "inst.auto=$url inst.finish=stop";
     }
 
     if (my $agama_install_url = get_var('AGAMA_INSTALL_URL')) {

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -2417,7 +2417,7 @@ sub config_guest_unattended_installation {
             $self->{guest_installation_automation_options} = "--extra-args \"ks=$self->{guest_installation_automation_file}\"" if (($self->{guest_os_name} =~ /oraclelinux/im) and ($self->{guest_version_major} lt 7));
         }
         elsif ($self->{guest_installation_automation_method} eq 'autoagama') {
-            $self->{guest_installation_fine_grained_kernel_args} .= ' agama.auto=' . $self->{guest_installation_automation_file} . ' agama.finish=stop' if ($self->{guest_installation_method} eq 'directkernel');
+            $self->{guest_installation_fine_grained_kernel_args} .= ' inst.auto=' . $self->{guest_installation_automation_file} . ' inst.finish=stop' if ($self->{guest_installation_method} eq 'directkernel');
         }
         if (script_retry("curl -sSf $self->{guest_installation_automation_file} > /dev/null") ne 0) {
             record_info("Guest $self->{guest_name} unattended installation file hosted on local host can not be reached", "Mark guest installation as FAILED. The unattended installation file url is $self->{guest_installation_automation_file}", result => 'fail');

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -32,7 +32,7 @@ sub set_svirt_domain_elements {
 
         my $ntlm_p = get_var('NTLM_AUTH_INSTALL') ? $ntlm_auth::ntlm_proxy : '';
         my $cmdline = get_var('VIRSH_CMDLINE') . $ntlm_p . " ";
-        if (get_var('AGAMA')) {
+        if (is_agama) {
             $cmdline .= " root=live:http://" . get_var('OPENQA_HOSTNAME') .
               ((get_var('FLAVOR') eq "Full") ?
                   "/assets/repo/" . get_required_var('REPO_0') . "/LiveOS/squashfs.img" :

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -185,8 +185,7 @@ sub set_bootscript_agama_cmdline_extra {
     my $cmdline_extra = " ";
     if (my $agama_auto = get_var('AGAMA_AUTO')) {
         my $agama_auto_url = autoyast::expand_agama_profile($agama_auto);
-        # Workaround for bsc#1238581, will remove it once the bug is fixed
-        $cmdline_extra .= "agama.auto=$agama_auto_url agama.finish=stop ";
+        $cmdline_extra .= "inst.auto=$agama_auto_url inst.finish=stop ";
     }
     # Agama Installation repository URL
     # By default Agama installs the packages from the repositories specified in the product configuration.

--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -59,7 +59,7 @@ sub run {
           generate_json_profile() :
           expand_agama_profile($agama_auto);
         set_var('AGAMA_AUTO', $profile_url);
-        set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '') . " agama.auto=\"$profile_url\"");
+        set_var('EXTRABOOTPARAMS', get_var('EXTRABOOTPARAMS', '') . " inst.auto=\"$profile_url\"");
     }
     my @params = split ' ', trim(get_var('EXTRABOOTPARAMS', ''));
 

--- a/variables.md
+++ b/variables.md
@@ -495,6 +495,6 @@ Following variables are relevant for agama installation
 Variable        | Type      | Default value | Details
 ---             | ---       | ---           | ---
 AGAMA | boolean | 0 | Agama installation support
-AGAMA_AUTO | string | | The auto-installation is started by passing `agama.auto=<url>` on the kernel's command line
+AGAMA_AUTO | string | | The auto-installation is started by passing `inst.auto=<url>` on the kernel's command line
 AGAMA_LIVE_ISO_URL | string | | The url of agama live iso to pass as kernel's command-line parameter. Example of usage "root=live:http://agama.iso"
 AGAMA_INSTALL_URL | string | | This will support using 'agama.install_url' boot parameter for overriding the default installation repositories. You can use multiple URLs separated by comma: agama.install_url=https://example.com/1,https://example.com/2


### PR DESCRIPTION
Remove the workaround for https://bugzilla.suse.com/show_bug.cgi?id=1238581

And fix a regression issue http://openqa.suse.de/tests/17168139#step/bootloader_zkvm/42

VR:[all arches](https://openqa.suse.de/tests/overview?build=rfan0327&distri=sle&version=16.0)
