### PR TITLE
Update sle16 minimal-vm tests

### DIFF
--- a/data/jeos/g_cloudinit.cfg
+++ b/data/jeos/g_cloudinit.cfg
@@ -4,6 +4,9 @@
 # examples are documented here https://documentation.suse.com/sles/15-SP4/html/SLES-all/article-minimal-vm.html#sec-cloud-init-config-examples
 hostname: cucaracha
 timezone: Europe/Prague
+locale: en_US.UTF-8
+keyboard:
+  layout: us
 users:
   - default
   - name: root

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -400,15 +400,15 @@ sub load_boot_tests {
     if (get_var("ISO_MAXSIZE") && (!is_remote_backend() || is_svirt_except_s390x())) {
         loadtest "installation/isosize";
     }
-    if ((get_var("UEFI") || is_jeos()) && !is_svirt) {
+    if ((get_var("UEFI") || is_jeos()) && !is_svirt && !get_var('NO_CLOUD')) {
         loadtest "installation/data_integrity" if data_integrity_is_applicable;
         loadtest "installation/bootloader_uefi";
     }
-    elsif (is_svirt_except_s390x()) {
-        load_svirt_vm_setup_tests;
-    }
     elsif (is_s390x && is_jeos) {
         loadtest "installation/bootloader_start";
+    }
+    elsif (is_svirt_except_s390x()) {
+        load_svirt_vm_setup_tests;
     }
     elsif (uses_qa_net_hardware() || get_var("PXEBOOT")) {
         loadtest "boot/boot_from_pxe";
@@ -628,7 +628,7 @@ sub load_jeos_tests {
         loadtest "jeos/prepare_firstboot";
     }
 
-    load_boot_tests() unless get_var('NO_CLOUD');
+    load_boot_tests();
     if (check_var('FIRST_BOOT_CONFIG', 'combustion')) {
         loadtest 'microos/verify_setup';
         loadtest 'microos/image_checks';

--- a/schedule/jeos/sle/minimalvm-extratest.yaml
+++ b/schedule/jeos/sle/minimalvm-extratest.yaml
@@ -54,6 +54,7 @@ schedule:
     - console/ca_certificates_mozilla
     - console/ansible
     - x11/evolution/evolution_prepare_servers
+    - console/console_reboot
     - console/unzip
     - console/gpg
     - console/rsync

--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2018-2020 SUSE LLC
+# Copyright 2018-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: systemd
@@ -37,7 +37,7 @@ use constant {
 
 # Tumbleweed uses a persistent journal, Leap 15.3+ (except 15.3 AArch64 JeOS) inherits SLE's default
 sub has_default_persistent_journal {
-    return is_tumbleweed || (is_leap('=15.3') && check_var('FLAVOR', 'JeOS-for-AArch64'));
+    return is_tumbleweed || is_sle('16.0+') || (is_leap('=15.3') && check_var('FLAVOR', 'JeOS-for-AArch64'));
 }
 
 # If the daemon is stopped uncleanly, or if the files are found to be corrupted, they are renamed using the ".journal~" suffix
@@ -176,7 +176,7 @@ sub run {
     # To enable persistent logging in opensuse, we use systemd-logger.rpm that creates */var/log/journal/* directory
     get_current_boot_id \@boots;
     if (has_default_persistent_journal) {
-        if (is_tumbleweed) {
+        if (is_tumbleweed || is_sle('16.0+')) {
             script_output(sprintf("test -d %s && ls --almost-all %s", PERSISTENT_LOG_DIR, PERSISTENT_LOG_DIR));
         } else {
             assert_script_run 'rpm -q systemd-logger';

--- a/tests/console/slp.pm
+++ b/tests/console/slp.pm
@@ -1,6 +1,6 @@
 # SUSE's openSLP regression test
 #
-# Copyright 2019-2020 SUSE LLC
+# Copyright 2019-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: openslp-server
@@ -21,7 +21,7 @@ use warnings;
 use utils qw(zypper_call systemctl script_retry);
 use Utils::Systemd 'disable_and_stop_service';
 use Utils::Logging 'save_and_upload_log';
-use version_utils qw(is_tumbleweed);
+use version_utils qw(is_tumbleweed is_sle);
 
 sub run {
     my ($self) = @_;
@@ -41,7 +41,7 @@ sub run {
     assert_script_run 'slptool -v';
     assert_script_run 'slptool findsrvs service:service-agent | grep service-agent';
 
-    unless (is_tumbleweed) {
+    unless (is_tumbleweed || is_sle('16.0+')) {
         assert_script_run 'slptool findsrvs service:ssh | grep "ssh://\|:22,"';
 
         # List all available services

--- a/tests/jeos/verify_cloudinit.pm
+++ b/tests/jeos/verify_cloudinit.pm
@@ -13,6 +13,7 @@ use Utils::Logging qw(save_and_upload_log);
 use publiccloud::ssh_interactive qw(select_host_console);
 use utils qw(ensure_serialdev_permissions);
 use version_utils qw(is_openstack is_public_cloud is_opensuse);
+use serial_terminal;
 
 my @errors = ();
 
@@ -29,7 +30,7 @@ sub run {
         }
     };
 
-    select_console('root-console');
+    select_serial_terminal;
     record_info('VERSION', script_output('cloud-init -v'));
     record_info('STATUS', script_output('cloud-init status --wait --long', proceed_on_failure => 1));
     record_info('ANALYZE', script_output('cloud-init analyze show'));


### PR DESCRIPTION
1. Adapt existing tests for sle16
2. Introduce s390x cloud image testing, configured by cloud-init and jeos-firstboot

#### Verification runs

 - [sle-16.0-Minimal-VM-Cloud-s390x-Build11.10-minimalvm-cloud-init@s390x-kvm](https://openqa.suse.de/tests/17171276)
 - [sle-16.0-Minimal-VM-Cloud-s390x-Build11.10-minimalvm-wizard@s390x-kvm](https://openqa.suse.de/tests/17171008)
 - [sle16 with reboot](https://openqa.suse.de/tests/17172269#)
