### PR TITLE
Use vnc instead of upstream dead spice graphics for virtual machine

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
+++ b/data/virt_autotest/guest_params_xml_files/slm_6_2_64_kvm_hvm_x86_64_default_encrypted_ignition+combustion.xml
@@ -44,12 +44,12 @@
     <guest_ipaddr/>
     <guest_ipaddr_static>false</guest_ipaddr_static>
     <guest_macaddr/>
-    <guest_graphics>spice</guest_graphics>
+    <guest_graphics>vnc</guest_graphics>
     <guest_controller/>
     <guest_input/>
     <guest_serial>pty,target.type=isa-serial</guest_serial>
     <guest_parallel/>
-    <guest_channel>type=unix#spicevmc</guest_channel>
+    <guest_channel>type=unix</guest_channel>
     <guest_console>pty,target.type=serial</guest_console>
     <guest_hostdev/>
     <guest_filesystem/>


### PR DESCRIPTION
* **spice** is not supported anymore and using it leads to error reported by virt-install.

* **Failed** test run because of spice is [here](https://openqa.suse.de/tests/17168067#step/unified_guest_installation/701).

* **Use** vnc as graphics for virtual machines. 

* **Verification Runs:**
  * [slmicro 6.2 on slmicro 6.2](https://openqa.suse.de/tests/17172421)