### PR TITLE
Avoid to set SCC_URL in bootloader for Agama Full medium testings

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -784,7 +784,7 @@ sub registration_bootloader_params {
     my ($max_interval) = @_;    # see 'type_string'
     $max_interval //= 13;
     my @params;
-    if (get_var('SCC_URL') ne 'none') {
+    if (!(is_agama && get_var('FLAVOR', 'Full'))) {
         push @params, split ' ', registration_bootloader_cmdline;
     }
     type_string "@params", $max_interval;

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -22,7 +22,7 @@ use English;
 use bootloader_setup;
 use registration;
 use utils 'shorten_url';
-use version_utils qw(is_sle is_tumbleweed is_opensuse);
+use version_utils qw(is_agama is_sle is_tumbleweed is_opensuse);
 
 # try to find the 2 longest lines that are below beyond the limit
 # collapsing the lines - we have a limit of 10 lines
@@ -106,7 +106,7 @@ sub prepare_parmfile {
 
     $params .= specific_bootmenu_params;
     unless (get_var("AGAMA")) {
-        if (get_var('SCC_URL') ne 'none') {
+        if (!(is_agama && get_var('FLAVOR', 'Full'))) {
             $params .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
         }
     }

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -52,7 +52,7 @@ sub set_svirt_domain_elements {
         $cmdline .= ' ' . get_var("EXTRABOOTPARAMS") if get_var("EXTRABOOTPARAMS");
         # inst.auto and inst.install_url are defined in 'specific_bootmenu_params'
         $cmdline .= specific_bootmenu_params;
-        if (get_var('SCC_URL') ne 'none') {
+        if (!(is_agama && get_var('FLAVOR', 'Full'))) {
             $cmdline .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation') && !get_var('NTLM_AUTH_INSTALL');
         }
 


### PR DESCRIPTION
Avoid to set SCC_URL in grub for Agama Full medium testing when the SCC_URL is not none. Change the checking to Agama flavor.

- Related failure: [failed_job](https://openqa.suse.de/tests/17160334#step/post_registration/1) 
- Verification run: [vrs_link](https://openqa.suse.de/tests/overview?version=16.0&build=chcao_skip_url&distri=sle)
- Related pr: [pr_21363](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21363/files)
