### PR TITLE
Use autoyast for qam jobs

### DIFF
--- a/schedule/qam/12-SP3/qam-regression-installation.yaml
+++ b/schedule/qam/12-SP3/qam-regression-installation.yaml
@@ -2,26 +2,10 @@
 name: qam-regression-installation-SLES
 description: installation for qam-regression-firefox
 schedule:
+- autoyast/prepare_profile
 - installation/isosize
 - installation/bootloader
-- installation/welcome
-- installation/scc_registration
-- installation/add_update_test_repo
-- installation/addon_products_sle
-- installation/system_role
-- installation/partitioning
-- installation/partitioning_finish
-- installation/installer_timezone
-- installation/user_settings
-- installation/user_settings_root
-- installation/resolve_dependency_issues
-- installation/installation_overview
-- installation/disable_grub_timeout
-- installation/start_install
-- installation/await_install
-- installation/logs_from_installation_system
-- installation/reboot_after_installation
-- installation/grub_test
+- autoyast/installation
 - installation/first_boot
 - x11/x11_setup
 - qa_automation/patch_and_reboot

--- a/schedule/qam/12-SP5/qam-regression-installation.yaml
+++ b/schedule/qam/12-SP5/qam-regression-installation.yaml
@@ -2,26 +2,10 @@
 name: qam-regression-installation-SLES
 description: installation for qam-regression-firefox
 schedule:
+- autoyast/prepare_profile
 - installation/isosize
 - installation/bootloader
-- installation/welcome
-- installation/scc_registration
-- installation/add_update_test_repo
-- installation/addon_products_sle
-- installation/system_role
-- installation/partitioning
-- installation/partitioning_finish
-- installation/installer_timezone
-- installation/user_settings
-- installation/user_settings_root
-- installation/resolve_dependency_issues
-- installation/installation_overview
-- installation/disable_grub_timeout
-- installation/start_install
-- installation/await_install
-- installation/logs_from_installation_system
-- installation/reboot_after_installation
-- installation/grub_test
+- autoyast/installation
 - installation/first_boot
 - x11/x11_setup
 - qa_automation/patch_and_reboot

--- a/schedule/qam/15-SP2/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP2/qam-regression-installation.yaml
@@ -2,25 +2,10 @@
 name: qam-regression-installation
 description: installation for qam-regression-firefox
 schedule:
+- autoyast/prepare_profile
+- installation/isosize
 - installation/bootloader
-- installation/welcome
-- installation/scc_registration
-- installation/add_update_test_repo
-- installation/addon_products_sle
-- installation/system_role
-- installation/partitioning
-- installation/partitioning_finish
-- installation/installer_timezone
-- installation/user_settings
-- installation/user_settings_root
-- installation/resolve_dependency_issues
-- installation/installation_overview
-- installation/disable_grub_timeout
-- installation/start_install
-- installation/await_install
-- installation/logs_from_installation_system
-- installation/reboot_after_installation
-- installation/grub_test
+- autoyast/installation
 - installation/first_boot
 - x11/x11_setup
 - qa_automation/patch_and_reboot

--- a/schedule/qam/15-SP2/qam-textmode.yaml
+++ b/schedule/qam/15-SP2/qam-textmode.yaml
@@ -1,26 +1,10 @@
 ---
 name: qam-textmode
 schedule:
+- autoyast/prepare_profile
 - installation/isosize
 - installation/bootloader
-- installation/welcome
-- installation/scc_registration
-- installation/add_update_test_repo
-- installation/addon_products_sle
-- installation/system_role
-- installation/partitioning
-- installation/partitioning_finish
-- installation/installer_timezone
-- installation/user_settings
-- installation/user_settings_root
-- installation/resolve_dependency_issues
-- installation/installation_overview
-- installation/disable_grub_timeout
-- installation/start_install
-- installation/await_install
-- installation/logs_from_installation_system
-- installation/reboot_after_installation
-- installation/grub_test
+- autoyast/installation
 - installation/first_boot
 - qa_automation/patch_and_reboot
 - locale/keymap_or_locale

--- a/schedule/qam/15-SP3/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP3/qam-regression-installation.yaml
@@ -2,25 +2,10 @@
 name: qam-regression-installation
 description: installation for qam-regression-firefox
 schedule:
+- autoyast/prepare_profile
+- installation/isosize
 - installation/bootloader
-- installation/welcome
-- installation/scc_registration
-- installation/add_update_test_repo
-- installation/addon_products_sle
-- installation/system_role
-- installation/partitioning
-- installation/partitioning_finish
-- installation/installer_timezone
-- installation/user_settings
-- installation/user_settings_root
-- installation/resolve_dependency_issues
-- installation/installation_overview
-- installation/disable_grub_timeout
-- installation/start_install
-- installation/await_install
-- installation/logs_from_installation_system
-- installation/reboot_after_installation
-- installation/grub_test
+- autoyast/installation
 - installation/first_boot
 - x11/x11_setup
 - qa_automation/patch_and_reboot

--- a/schedule/qam/15-SP4/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP4/qam-regression-installation.yaml
@@ -1,26 +1,10 @@
 ---
 name: qam-regression-installation
-description: installation for qam-regression-firefox
 schedule:
+- autoyast/prepare_profile
+- installation/isosize
 - installation/bootloader
-- installation/welcome
-- installation/scc_registration
-- installation/add_update_test_repo
-- installation/addon_products_sle
-- installation/system_role
-- installation/partitioning
-- installation/partitioning_finish
-- installation/installer_timezone
-- installation/user_settings
-- installation/user_settings_root
-- installation/resolve_dependency_issues
-- installation/installation_overview
-- installation/disable_grub_timeout
-- installation/start_install
-- installation/await_install
-- installation/logs_from_installation_system
-- installation/reboot_after_installation
-- installation/grub_test
+- autoyast/installation
 - installation/first_boot
 - x11/x11_setup
 - qa_automation/patch_and_reboot

--- a/schedule/qam/15-SP5/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP5/qam-regression-installation.yaml
@@ -2,32 +2,17 @@
 name: qam-regression-installation
 description: installation for qam-regression-firefox
 schedule:
-- installation/bootloader
-- installation/welcome
-- installation/scc_registration
-- installation/add_update_test_repo
-- installation/addon_products_sle
-- installation/system_role
-- installation/partitioning
-- installation/partitioning_finish
-- installation/installer_timezone
-- installation/user_settings
-- installation/user_settings_root
-- installation/resolve_dependency_issues
-- installation/installation_overview
-- installation/disable_grub_timeout
-- installation/start_install
-- installation/await_install
-- installation/logs_from_installation_system
-- installation/reboot_after_installation
-- installation/grub_test
-- installation/first_boot
-- x11/x11_setup
-- qa_automation/patch_and_reboot
-- console/system_prepare
-- console/hostname
-- console/force_scheduled_tasks
-- shutdown/grub_set_bootargs
-- shutdown/cleanup_before_shutdown
-- shutdown/shutdown
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader
+  - autoyast/installation
+  - installation/first_boot
+  - x11/x11_setup
+  - qa_automation/patch_and_reboot
+  - console/system_prepare
+  - console/hostname
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
 ...

--- a/schedule/qam/15-SP6/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP6/qam-regression-installation.yaml
@@ -2,25 +2,10 @@
 name: qam-regression-installation
 description: installation for qam-regression-firefox
 schedule:
+- autoyast/prepare_profile
+- installation/isosize
 - installation/bootloader
-- installation/welcome
-- installation/scc_registration
-- installation/add_update_test_repo
-- installation/addon_products_sle
-- installation/system_role
-- installation/partitioning
-- installation/partitioning_finish
-- installation/installer_timezone
-- installation/user_settings
-- installation/user_settings_root
-- installation/resolve_dependency_issues
-- installation/installation_overview
-- installation/disable_grub_timeout
-- installation/start_install
-- installation/await_install
-- installation/logs_from_installation_system
-- installation/reboot_after_installation
-- installation/grub_test
+- autoyast/installation
 - installation/first_boot
 - x11/x11_setup
 - qa_automation/patch_and_reboot


### PR DESCRIPTION
Use autoyast for qam jobs

- Related ticket: https://progress.opensuse.org/issues/108836
- Verification run: 15-SP5：
qam-regression-installation-SLES
https://openqa.suse.de/tests/17160394#
mru-install-desktop-with-addons
https://openqa.suse.de/tests/17168073#
qam-textmode+sle15：
https://openqa.suse.de/tests/17170995
mru-install-desktop-with-addons@s390x-kvm
http://openqa.suse.de/tests/17184020
mru-install-desktop-with-addons@aarch64-virtio
http://openqa.suse.de/tests/17184021
15-SP4：
qam-textmode+sle15：
https://openqa.suse.de/tests/17170995
15-SP3：
qam-textmode+sle15：
https://openqa.suse.de/tests/17171004

12-SP5：
https://openqa.suse.de/tests/17171006
qam-yast_self_update
http://openqa.suse.de/tests/17171032

15-SP6：
qam-regression-installation-SLED
https://openqa.suse.de/tests/17172160
  * Related MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/826
