### PR TITLE
Use desktop environment's default terminal in ensure_installed

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -337,14 +337,22 @@ sub ensure_installed {
     my $pkglist = ref $pkgs eq 'ARRAY' ? join ' ', @$pkgs : $pkgs;
     $args{timeout} //= 90;
 
-    x11_start_program(default_gui_terminal());
+    # In this context we want to call the x11_start_program from the distribution directly
+    $self->x11_start_program(default_gui_terminal());
 
     $self->become_root;
     ensure_serialdev_permissions;
     quit_packagekit;
     zypper_call "in $pkglist";
     wait_still_screen 1;
-    send_key("alt-f4");    # close xterm
+    send_key("alt-f4");    # close terminal
+
+    if (check_screen 'terminal-close-window', timeout => 30) {
+        wait_screen_change {
+            testapi::assert_and_click('terminal-close-window');
+        };
+    }
+
     assert_screen 'generic-desktop' if is_opensuse;
 }
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -17,7 +17,7 @@ use utils qw(
   zypper_call
 );
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_opensuse is_hyperv is_plasma6 is_public_cloud);
-use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop x11_start_program_xterm);
+use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop x11_start_program_xterm default_gui_terminal);
 use Utils::Backends;
 
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_USER_TERMINAL_DEFAULT_DEVICE SERIAL_USER_TERMINAL_DEFAULT_PORT);
@@ -337,7 +337,8 @@ sub ensure_installed {
     my $pkglist = ref $pkgs eq 'ARRAY' ? join ' ', @$pkgs : $pkgs;
     $args{timeout} //= 90;
 
-    x11_start_program_xterm;
+    x11_start_program(default_gui_terminal());
+
     $self->become_root;
     ensure_serialdev_permissions;
     quit_packagekit;

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -622,9 +622,9 @@ sub default_gui_terminal {
     return "gnome-terminal" if check_var('DESKTOP', 'gnome') && (is_leap("<16"));
     # Let SLE decide if they want to change to new behavior
     return "xterm" if check_var('DESKTOP', 'gnome') && (is_sle("<16"));
-    return "konsole" if check_var('DESKTOP', 'kde');
-    return "xfce4-terminal" if check_var('DESKTOP', 'xfce');
     return "kgx" if check_var('DESKTOP', 'gnome');
+    # return "konsole" if check_var('DESKTOP', 'kde');
+    # return "xfce4-terminal" if check_var('DESKTOP', 'xfce');
     return "xterm";
 }
 

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -623,7 +623,7 @@ sub default_gui_terminal {
     # Let SLE decide if they want to change to new behavior
     return "xterm" if check_var('DESKTOP', 'gnome') && (is_sle("<16"));
     return "kgx" if check_var('DESKTOP', 'gnome');
-    # return "konsole" if check_var('DESKTOP', 'kde');
+    return "konsole" if check_var('DESKTOP', 'kde');
     # return "xfce4-terminal" if check_var('DESKTOP', 'xfce');
     return "xterm";
 }

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -624,7 +624,7 @@ sub default_gui_terminal {
     return "xterm" if check_var('DESKTOP', 'gnome') && (is_sle("<16"));
     return "kgx" if check_var('DESKTOP', 'gnome');
     return "konsole" if check_var('DESKTOP', 'kde');
-    # return "xfce4-terminal" if check_var('DESKTOP', 'xfce');
+    return "xfce4-terminal" if check_var('DESKTOP', 'xfce');
     return "xterm";
 }
 

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -619,7 +619,12 @@ Returns the default console to be used by test modules, defaults to xterm
 =cut
 
 sub default_gui_terminal {
-    return "gnome-terminal" if (check_var('DESKTOP', 'gnome') && (is_sle("<16") || is_leap("<16")));
+    return "gnome-terminal" if check_var('DESKTOP', 'gnome') && (is_leap("<16"));
+    # Let SLE decide if they want to change to new behavior
+    return "xterm" if check_var('DESKTOP', 'gnome') && (is_sle("<16"));
+    return "konsole" if check_var('DESKTOP', 'kde');
+    return "xfce4-terminal" if check_var('DESKTOP', 'xfce');
+    return "kgx" if check_var('DESKTOP', 'gnome');
     return "xterm";
 }
 

--- a/t/01_x11utils.t
+++ b/t/01_x11utils.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use testapi qw(set_var);
+use version_utils qw(is_sle is_leap);
+
+
+subtest 'Expected_terminals' => sub {
+    use x11utils 'default_gui_terminal';
+
+    set_var('DISTRI', 'microos');
+    ok default_gui_terminal eq 'xterm', "Defaults to xterm in unknown distri";
+
+    set_var('DESKTOP', 'gnome');
+    set_var('DISTRI', 'sle');
+    set_var('VERSION', '16-SP1');
+    ok default_gui_terminal eq 'kgx', "Defaults to kgx for SLE 16";
+
+    set_var('DESKTOP', 'gnome');
+    set_var('DISTRI', 'sle');
+    set_var('VERSION', '15-sp7');
+    ok default_gui_terminal eq 'xterm', "15-sp7 returns xterm";
+
+    set_var('DESKTOP', 'gnome');
+    set_var('DISTRI', 'opensuse');
+    set_var('VERSION', 'Tumbleweed');
+    ok default_gui_terminal eq 'kgx', "Tumbleweed defaults to gnome-console";
+
+    set_var('DESKTOP', 'gnome');
+    set_var('DISTRI', 'opensuse');
+    set_var('VERSION', '16.1');
+    ok default_gui_terminal eq 'kgx', "Leap 16+ defaults to gnome-console";
+
+    set_var('DESKTOP', 'gnome');
+    set_var('DISTRI', 'opensuse');
+    set_var('VERSION', '15.6');
+    ok default_gui_terminal eq 'gnome-terminal', "Leap 15 returns gnome-terminal";
+
+};
+
+done_testing;

--- a/t/01_x11utils.t
+++ b/t/01_x11utils.t
@@ -5,10 +5,10 @@ use Test::Exception;
 use Test::Warnings;
 use testapi qw(set_var);
 use version_utils qw(is_sle is_leap);
-
+use x11utils 'default_gui_terminal';
 
 subtest 'Expected_terminals' => sub {
-    use x11utils 'default_gui_terminal';
+
 
     set_var('DISTRI', 'microos');
     ok default_gui_terminal eq 'xterm', "Defaults to xterm in unknown distri";


### PR DESCRIPTION
Currently the `ensure_installed` routine uses xterm by default, regardless of the desktop environment
with these changes the behavior now changes, except for SLE where the default would still be xterm.

This is particularily important when considering that nowdays we're using Wayland as default except for
some specific scenarios where the system is installed with X11


[poo#169162](https://progress.opensuse.org/issues/169162)

Verification runs:

- SLES https://openqa.suse.de/tests/17162523#step/gedit/3
- gnome @ tumbleweed https://openqa.opensuse.org/tests/4951531#step/gimp/14
- kde @ tumbleweed https://openqa.opensuse.org/tests/4951595#step/hexchat/12
- xfce @ tumbleweed https://openqa.opensuse.org/tests/4951668#step/chromium/17
- gnome @ leap https://openqa.opensuse.org/tests/4951743#step/inkscape/15
- kde @ leap https://openqa.opensuse.org/tests/4951746#step/glxgears/12

Corresponding needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/829