### PR TITLE
Add ruby test

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -189,6 +189,7 @@ schedule:
     - '{{tumbleweed_tests}}'
     - console/journalctl
     - console/tar
+    - console/ruby
     - console/coredump_collect
     - console/valgrind
     - console/sssd_389ds_functional

--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -37,6 +37,7 @@ schedule:
   - console/sysstat
   - console/cpio
   - console/tar
+  - console/ruby
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:

--- a/tests/console/ruby.pm
+++ b/tests/console/ruby.pm
@@ -1,0 +1,43 @@
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Package: ruby
+# Summary: -  Install ruby package
+#          -  run a simple ruby program
+# Maintainer: QE Core <qe-core@suse.de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+
+sub run {
+    select_serial_terminal;
+    my $ruby = script_output("zypper se -s ruby | awk -F '|' '{ print \$2 }' | grep -o '\\bruby[0-9]\\+\\(\\.[0-9]\\+\\)\\?\\b' | uniq | sort -V");
+    record_info("ruby version in system", $ruby);
+    if (!defined $ruby || $ruby eq "") {
+        die "Could find out the ruby package" . script_output('zypper se ruby');
+    }
+    # Prepare test file
+    my $test_string = "Hello, World";
+    my $test_script = "test_ruby";
+    assert_script_run("echo 'puts \"$test_string\"' > $test_script");
+
+    # Test ruby
+    foreach my $r (split('\n', $ruby)) {
+        record_info("Test $r");
+        # Install ruby
+        zypper_call("in $r");
+
+        # Find our ruby command
+        my $ruby_shell = script_output("ruby-find-versioned | grep $r");
+        record_info("$ruby_shell");
+
+        validate_script_output "$ruby_shell $test_script", sub { m/$test_string/ };
+    }
+    script_run("rm -f $test_script");
+}
+
+1;


### PR DESCRIPTION
Related: https://progress.opensuse.org/issues/177805

VRs:
test module `ruby` passed all in following verification run.

15-SP7:  [job on x86](https://openqa.suse.de/tests/17184381#)       [all arches](https://openqa.suse.de/tests/overview?version=15-SP7&build=Amrysliu%2Fos-autoinst-distri-opensuse%23poo_177805&distri=sle)

15-SP6: [job on s390x](https://openqa.suse.de/tests/17184617)       [all arches](https://openqa.suse.de/tests/overview?build=Amrysliu%2Fos-autoinst-distri-opensuse%23poo_177805&version=15-SP6&distri=sle)

15-SP5:  [job on aarch64](https://openqa.suse.de/tests/17184619)       [all arches](https://openqa.suse.de/tests/overview?distri=sle&build=Amrysliu%2Fos-autoinst-distri-opensuse%23poo_177805&version=15-SP5)

15-SP4: [job on x86](https://openqa.suse.de/tests/17184624)       [all arches](https://openqa.suse.de/tests/overview?distri=sle&build=Amrysliu%2Fos-autoinst-distri-opensuse%23poo_177805&version=15-SP4)

15-SP3:  [job on s390x](https://openqa.suse.de/tests/17184627)       [all arches](https://openqa.suse.de/tests/overview?distri=sle&build=Amrysliu%2Fos-autoinst-distri-opensuse%23poo_177805&version=15-SP3)

15-SP2:  https://openqa.suse.de/tests/17184628

12-SP5: [ltss](https://openqa.suse.de/tests/17184629)      [all](https://openqa.suse.de/tests/overview?version=12-SP5&build=Amrysliu%2Fos-autoinst-distri-opensuse%23poo_177805&distri=sle)

12-SP3:  https://openqa.suse.de/tests/17184630

TW: https://openqa.opensuse.org/tests/4955193#

opensuse 15.6:  https://openqa.opensuse.org/tests/4955192#