### PR TITLE
ulp_openposix: Don't install livepatching product on SLE-16

### DIFF
--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -16,6 +16,7 @@ use klp;
 use qam;
 use LTP::utils;
 use OpenQA::Test::RunArgs;
+use version_utils;
 
 sub parse_incident_repo {
     my $incident_id = get_required_var('INCIDENT_ID');
@@ -67,7 +68,7 @@ sub setup_ulp {
     my $packname = 'openposix-livepatches';
     my $repo_args = '';
 
-    install_klp_product;
+    install_klp_product unless is_sle('16+');
     zypper_call('in libpulp0 libpulp-tools libpulp-load-default');
 
     if (get_var('INCIDENT_REPO')) {


### PR DESCRIPTION
Installing KLP product is not needed for ULP testing.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17174441
