### PR TITLE
Add live.password for Full medium testing on s390x

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -36,7 +36,8 @@ sub set_svirt_domain_elements {
             $cmdline .= " root=live:http://" . get_var('OPENQA_HOSTNAME') .
               ((get_var('FLAVOR') eq "Full") ?
                   "/assets/repo/" . get_required_var('REPO_0') . "/LiveOS/squashfs.img" :
-                  "/assets/iso/" . get_required_var('ISO') . " live.password=$testapi::password");
+                  "/assets/iso/" . get_required_var('ISO'));
+            $cmdline .= " live.password=$testapi::password";
         } else {
             $cmdline .= "install=$repo";
             $cmdline .= remote_install_bootmenu_params;


### PR DESCRIPTION
The live.password is not added for s390x Full medium testing, add it in this PR.

- Related failure: [s390x_kvm](https://openqa.suse.de/tests/17172788#step/patch_agama_tests/3) ; [s390_zkvm](https://openqa.suse.de/tests/17172787#step/boot_agama/26)
- Verification run: [s390x_kvm_vr](https://openqa.suse.de/tests/17184357#step/patch_agama_tests/4); [s390x_zkvm_vr](https://openqa.suse.de/tests/17184356#live)
