### PR TITLE
Workaround missing disk_boot@ppc container update hosts tests

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -48,7 +48,7 @@ sub load_config_tests {
 }
 
 sub load_boot_from_disk_tests {
-    return if is_ppc64le && get_var('MACHINE') !~ /ppc64le-emu/i;
+    return if is_ppc64le && get_var('MACHINE') !~ /ppc64le-emu/i && !(is_sle_micro('=5.5') && check_var('FLAVOR', 'Container-Image-Updates'));
     # add additional image handling module for svirt workers
     if (is_s390x()) {
         loadtest 'installation/bootloader_start';


### PR DESCRIPTION
Only sle-micro 5.5 is currently supported on power8 and requires
emulated workers. A workaround has to be introduced as we implicitly count
that ppc64le images are tested on emulated machines in case of container
testing.

- image bug: [missing toolbox package in ppc64le slem
  5.5](https://bugzilla.suse.com/show_bug.cgi?id=1240332)
- toolbox container bug:
  https://bugzilla.suse.com/show_bug.cgi?id=1239591
##### Verification runs

- https://openqa.suse.de/tests/17188921#
- host update job: https://openqa.suse.de/tests/17187968#
