### PR TITLE
Proof of Concept Use singletons for publiccloud provider and instance

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -25,12 +25,12 @@ sub load_maintenance_publiccloud_tests {
     loadtest "publiccloud/download_repos";
     loadtest "publiccloud/prepare_instance", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
-        loadtest("publiccloud/check_registercloudguest", run_args => $args);
+        loadtest("publiccloud/check_registercloudguest");
     } else {
-        loadtest("publiccloud/registration", run_args => $args);
+        loadtest("publiccloud/registration");
     }
-    loadtest "publiccloud/transfer_repos", run_args => $args;
-    loadtest "publiccloud/patch_and_reboot", run_args => $args;
+    loadtest "publiccloud/transfer_repos";
+    loadtest "publiccloud/patch_and_reboot";
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
         loadtest "publiccloud/check_services", run_args => $args;
         loadtest("publiccloud/img_proof", run_args => $args);

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -96,6 +96,20 @@ sub provider_factory {
     return $provider;
 }
 
+# singletons
+my $_provider;
+sub provider {
+    my ($self, $provider) = @_;
+    $_provider = $provider if @_ > 1;
+    return $_provider;
+}
+my $_instance;
+sub instance {
+    my ($self, $instance) = @_;
+    $_instance = $instance if @_ > 1;
+    return $_instance;
+}
+
 sub cleanup {
     # to be overridden by tests
     return 1;

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -19,40 +19,40 @@ use publiccloud::ssh_interactive qw(select_host_console);
 use version_utils qw(is_sle_micro);
 
 sub run {
-    my ($self, $args) = @_;
+    my ($self) = @_;
     select_host_console();    # select console on the host, not the PC instance
 
     my $cmd_time = time();
     my $ref_timeout = check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE') ? 3600 : 240;
-    my $remote = $args->{my_instance}->username . '@' . $args->{my_instance}->public_ip;
+    my $remote = $self->instance->username . '@' . $self->instance->public_ip;
     # pkcon not present on SLE-micro
-    kill_packagekit($args->{my_instance}) unless (is_sle_micro);
+    kill_packagekit($self->instance) unless (is_sle_micro);
 
     # Record package list before fully patch system
     if (get_var('SAVE_LIST_OF_PACKAGES')) {
-        $args->{my_instance}->ssh_script_run(cmd => 'rpm -qa > /tmp/rpm-qa-before-patch-system.txt');
-        $args->{my_instance}->upload_log('/tmp/rpm-qa-before-patch-system.txt');
+        $self->instance->ssh_script_run(cmd => 'rpm -qa > /tmp/rpm-qa-before-patch-system.txt');
+        $self->instance->upload_log('/tmp/rpm-qa-before-patch-system.txt');
     }
 
-    $args->{my_instance}->ssh_script_retry("sudo zypper -n --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
+    $self->instance->ssh_script_retry("sudo zypper -n --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
     record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');
     record_soft_failure('bsc#1195382 - Considerable decrease of zypper performance and increase of registration times') if ((time() - $cmd_time) > 240);
     if (is_sle_micro) {
-        ssh_update_transactional_system($args->{my_instance});
+        ssh_update_transactional_system($self->instance);
     } else {
         ssh_fully_patch_system($remote);
     }
-    record_info('UNAME', $args->{my_instance}->ssh_script_output(cmd => 'uname -a'));
-    $args->{my_instance}->ssh_assert_script_run(cmd => 'rpm -qa > /tmp/rpm-qa.txt');
-    $args->{my_instance}->upload_log('/tmp/rpm-qa.txt');
+    record_info('UNAME', $self->instance->ssh_script_output(cmd => 'uname -a'));
+    $self->instance->ssh_assert_script_run(cmd => 'rpm -qa > /tmp/rpm-qa.txt');
+    $self->instance->upload_log('/tmp/rpm-qa.txt');
 
     if (is_cloudinit_supported) {
-        $args->{my_instance}->cleanup_cloudinit();
-        $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600), scan_ssh_host_key => 1);
-        $args->{my_instance}->check_cloudinit();
-        permit_root_login($args->{my_instance});
+        $self->instance->cleanup_cloudinit();
+        $self->instance->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600), scan_ssh_host_key => 1);
+        $self->instance->check_cloudinit();
+        permit_root_login($self->instance);
     } else {
-        $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
+        $self->instance->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
     }
 }
 

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -37,10 +37,9 @@ sub run {
     my %instance_args;
     $instance_args{check_connectivity} = 1;
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
-    $args->{my_provider} = $self->provider_factory();
-    $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
-    my $provider = $args->{my_provider};
-    my $instance = $args->{my_instance};
+    $self->provider($self->provider_factory);
+    $self->instance($self->provider->create_instance(%instance_args));
+    my $instance = $self->instance;
 
     $instance->network_speed_test();
     $instance->check_cloudinit() if (is_cloudinit_supported);

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -21,22 +21,22 @@ use publiccloud::ssh_interactive "select_host_console";
 use File::Basename 'basename';
 
 sub run {
-    my ($self, $args) = @_;
+    my ($self) = @_;
 
     select_host_console();    # select console on the host, not the PC instance
 
-    registercloudguest($args->{my_instance}) if (is_byos() || get_var('PUBLIC_CLOUD_FORCE_REGISTRATION'));
-    register_addons_in_pc($args->{my_instance});
+    registercloudguest($self->instance) if (is_byos() || get_var('PUBLIC_CLOUD_FORCE_REGISTRATION'));
+    register_addons_in_pc($self->instance);
     # Since SLE 15 SP6 CHOST images don't have curl and we need it for testing
     if (is_sle('>15-SP5') && is_container_host()) {
-        $args->{my_instance}->ssh_assert_script_run('sudo zypper -n in --force-resolution -y curl');
+        $self->instance->ssh_assert_script_run('sudo zypper -n in --force-resolution -y curl');
     }
 }
 
 sub cleanup {
     my ($self) = @_;
     if (is_azure()) {
-        record_info('azuremetadata', $self->{run_args}->{my_instance}->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
+        record_info('azuremetadata', $self->instance->run_ssh_command(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
     }
     1;
 }

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -19,11 +19,11 @@ use maintenance_smelt qw(is_embargo_update);
 use version_utils qw(is_sle_micro);
 
 sub run {
-    my ($self, $args) = @_;
+    my ($self) = @_;
     select_host_console();    # select console on the host, not the PC instance
 
-    my $instance = $args->{my_instance};
-    my $remote = $instance->username . '@' . $args->{my_instance}->public_ip;
+    my $instance = $self->instance;
+    my $remote = $instance->username . '@' . $self->instance->public_ip;
     my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);
     my $repodir = "/opt/repos/";
     # Trigger to skip the download to speed up verification runs


### PR DESCRIPTION
This is a proof of concept how to avoid having to use `run_args` to share variables between test modules.
One could use global variables directly, but that makes later changes harder. an API function hides the implementation, and it is traceable if necessary.

You can use `$self->provider($new_object)` to set the singleton and later just retrieve it with `$self->provider`. Same for `instance`.

I did a couple of modules to show how it would look like. Haven't tested it!
