### PR TITLE
Add agama jsonnet file for SLES+HA on qemu

### DIFF
--- a/data/sles4sap/agama/sles_ha_default.jsonnet
+++ b/data/sles4sap/agama/sles_ha_default.jsonnet
@@ -1,0 +1,30 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}'
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    sshPublicKey: 'enable ssh',
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable sshd',
+        chroot: true,
+        body: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          systemctl enable sshd
+        |||
+      }
+    ]
+  }
+}


### PR DESCRIPTION
SLES+HA jobs for SLES 16 have used in the past the `data/agama_auto/sle_default.jsonnet` on qemu backends, as it is not possible to activate the HA extension during installation. This allows the installation of a SLES where the HA extension can be activated later.

However, the `data/agama_auto/sle_default.jsonnet` file does not enable ssh root login (as the pvm and s390x jsonnet files do), which means that HA tests attempting to configure clusters using ssh connections to root will fail.

This commit copies `agama_auto/sle_default.jsonnet` to `data/sles4sap/agama/sles_ha_default.jsonnet` and adds a post script to enable root login via ssh.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qe.nue2.suse.org/tests/6407
