### PR TITLE
klp: Don't install livepatch package on SL Micro for livepatch updates

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -64,7 +64,7 @@ sub install_klp_product {
         assert_script_run 'sed -i "/^multiversion =.*/c\\multiversion = provides:multiversion(kernel)" /etc/zypp/zypp.conf';
         assert_script_run 'sed -i "/^multiversion\.kernels =.*/c\\multiversion.kernels = latest" /etc/zypp/zypp.conf';
         assert_script_run 'echo "LIVEPATCH_KERNEL=\'always\'" >> /etc/sysconfig/livepatching';
-        install_package($livepatch_pack, trup_continue => 1, trup_reboot => 1);
+        install_package($livepatch_pack, trup_continue => 1, trup_reboot => 1) unless get_var('KGRAFT');
     } else {
         zypper_call("in -l -t product $lp_product", exitcode => [0, 102, 103]);
         zypper_call("mr -e kgraft-update") unless $livepatch_repo;


### PR DESCRIPTION
Installation of livepatch package pulls latest available kernel with livepatch, because SL Micro has livepatches in main repository (that's difference to SLE which has separate repository, which can be disabled). We need to skip installation of livepatch package to be be able to install only needed patch from update repository.

Related failure: https://openqa.suse.de/tests/17194414#step/update_kernel/374

- Related ticket: none
- Needles: none
- Verification run:  

kernel-rt: https://openqa.suse.de/tests/17195488
kernel-default: https://openqa.suse.de/tests/17195482
