### PR TITLE
Just testing vmware

### DIFF
--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -83,7 +83,8 @@ sub check_efi_state {
     diag "Found efi guid=$efi_guid_global";
     diag('Expected state of SecureBoot: ' . (get_var('DISABLE_SECUREBOOT', 0) ? 'Disabled' : 'Enabled'));
 
-    my $sb_state = script_output("efivar -dn $efi_guid_global-SecureBoot");
+    # it is not expected to find these efivars in vmware and so on
+    my $sb_state = script_output("efivar -dn $efi_guid_global-SecureBoot", proceed_on_failure => 1) || 0;
     my $sb_desired_state = !get_var('DISABLE_SECUREBOOT', 0);
     record_info("SecureBoot states", "Actual (efivar): $sb_state :: Expected (!DISABLE_SECUREBOOT): $sb_desired_state");
     if ($sb_state != $sb_desired_state) {


### PR DESCRIPTION
If the secureboot efivars are not found, set the expected marker to a
false value.

- Verification run: https://openqa.suse.de/tests/17210088#step/verify_efi_mok/1
