### PR TITLE
Failure downloading ASSET_1 in Win11

### DIFF
--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -53,13 +53,11 @@ sub run {
     my $install_from = get_required_var('WSL_INSTALL_FROM');
     if ($install_from eq 'build') {
         my $wsl_appx_filename = (split /\//, get_required_var('ASSET_1'))[-1];
-        my $wsl_appx_uri = "\\\\10.0.2.4\\qemu\\$wsl_appx_filename";
+        my $wsl_appx_uri = data_url('ASSET_1');
         # Enable the 'developer mode' in Windows
         $self->run_in_powershell(
             cmd => 'New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -Name AllowDevelopmentWithoutDevLicense -PropertyType DWORD -Value 1'
         );
-        # On Win 11 for Arm Build 25931, smb transfers don't work (poo#126083)
-        $wsl_appx_uri = data_url('ASSET_1') if is_aarch64;
         $self->run_in_powershell(
             cmd => "Start-BitsTransfer -Source $wsl_appx_uri -Destination C:\\\\$wsl_appx_filename",
             timeout => 60


### PR DESCRIPTION
We have suddenly found that when trying to download the .appx file stated in the ASSET_1 var, the Windows 11 distros are throwing out a failure. As @vogtinator suggests, let's try this approach to see if it's a SMB deprecation failure

- Related ticket: https://progress.opensuse.org/issues/179611
- Verification runs:
  - [Win10]()
  - [Win11]()
