### PR TITLE
install_klp_product: Force livepatch version to match kernel

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -22,6 +22,7 @@ our @EXPORT = qw(
 );
 
 sub install_klp_product {
+    my $kver = shift;
     my $arch = get_required_var('ARCH');
     my $version = get_required_var('VERSION');
     my $livepatch_repo = get_var('REPO_SLE_MODULE_LIVE_PATCHING');
@@ -60,6 +61,7 @@ sub install_klp_product {
             $livepatch_pack = 'kernel-rt-livepatch';
         }
 
+        $livepatch_pack .= "-$kver" if defined($kver);
         assert_script_run 'cp /etc/zypp/zypp.conf /etc/zypp/zypp.conf.orig';
         assert_script_run 'sed -i "/^multiversion =.*/c\\multiversion = provides:multiversion(kernel)" /etc/zypp/zypp.conf';
         assert_script_run 'sed -i "/^multiversion\.kernels =.*/c\\multiversion.kernels = latest" /etc/zypp/zypp.conf';

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -297,7 +297,7 @@ sub prepare_kgraft {
     install_lock_kernel($kernel_version, $src_version);
     zypper_call("mr -d kgraft-test-repo-0") if get_var('FLAVOR') =~ /-Updates-Staging/;
 
-    install_klp_product;
+    install_klp_product($kernel_version);
 
     if (check_var('REMOVE_KGRAFT', '1') && @all_pkgs) {
         my $pversion = join(' ', map { $$_{name} } @all_pkgs);


### PR DESCRIPTION
The `kernel-default-livepatch` and `kernel-rt-livepatch` meta packages must be installed with specific version during livepatch testing, otherwise they'll try to install the latest kernel and fail on kernel version conflict.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SL Micro livepatches: https://openqa.suse.de/tests/17209707#step/update_kernel/183
  - SLES kernel update: https://openqa.suse.de/tests/17211046
