### PR TITLE
containers: Support BUILDAH_STORAGE_DRIVER

### DIFF
--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -27,11 +27,14 @@ sub run_tests {
     my $tmp_dir = script_output "mktemp -d -p /var/tmp test.XXXXXX";
     selinux_hack $tmp_dir;
 
+    my $storage_driver = get_var("BUILDAH_STORAGE_DRIVER", script_output("buildah info --format '{{ .store.GraphDriverName }}'"));
+    record_info("storage driver", $storage_driver);
+
     my %_env = (
         BUILDAH_BINARY => "/usr/bin/buildah",
         BUILDAH_RUNTIME => $oci_runtime,
         CI_DESIRED_RUNTIME => $oci_runtime,
-        STORAGE_DRIVER => "overlay",
+        STORAGE_DRIVER => $storage_driver,
         BATS_TMPDIR => $tmp_dir,
         TMPDIR => $tmp_dir,
     );

--- a/variables.md
+++ b/variables.md
@@ -40,6 +40,7 @@ BCI_OS_VERSION | string | | Set the environment variable OS_VERSION to this valu
 BOOTLOADER | string | grub2 | Which bootloader is used by the image (and in the future also: will be selected during installation)
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.
+BUILDAH_STORAGE_DRIVER | string | | Storage driver used for buildah: vfs or overlay.
 CASEDIR | string | | Path to the directory which contains tests.
 CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test module.
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.


### PR DESCRIPTION
Support BUILDAH_STORAGE_DRIVER variable.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1239082
- Verification runs:
  - SLES 16.0: https://openqa.suse.de/tests/17215161 (`BUILDAH_STORAGE_DRIVER=vfs`)
  - TW: https://openqa.opensuse.org/tests/4961739