### PR TITLE
Fix fips_tests_crypt_krb5_client and fips_tests_crypt_krb5_server

### DIFF
--- a/data/agama_auto/sle_default.jsonnet
+++ b/data/agama_auto/sle_default.jsonnet
@@ -18,7 +18,7 @@
       {
         name: 'enable sshd',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           systemctl enable sshd
         |||

--- a/data/agama_auto/sle_default_ipmi_no_reg.jsonnet
+++ b/data/agama_auto/sle_default_ipmi_no_reg.jsonnet
@@ -16,7 +16,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -30,7 +30,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||

--- a/data/agama_auto/sle_default_pvm.jsonnet
+++ b/data/agama_auto/sle_default_pvm.jsonnet
@@ -17,7 +17,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -31,7 +31,7 @@
       {
         name: 'enable root login sshd',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           systemctl enable sshd

--- a/data/agama_auto/sle_default_pvm_no_reg.jsonnet
+++ b/data/agama_auto/sle_default_pvm_no_reg.jsonnet
@@ -16,7 +16,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -30,7 +30,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||

--- a/data/agama_auto/sle_default_s390x_kvm.jsonnet
+++ b/data/agama_auto/sle_default_s390x_kvm.jsonnet
@@ -18,7 +18,7 @@
       {
         name: 'enable root login sshd',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           systemctl enable sshd

--- a/data/agama_auto/sle_default_s390x_kvm_no_reg.jsonnet
+++ b/data/agama_auto/sle_default_s390x_kvm_no_reg.jsonnet
@@ -17,7 +17,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||

--- a/data/autoyast_hanaperf/agama-config.jsonnet
+++ b/data/autoyast_hanaperf/agama-config.jsonnet
@@ -48,7 +48,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -62,7 +62,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           # Workaround for NetworkManager to make sure the expected NIC up only

--- a/data/sles4sap/agama/sles_ha_default.jsonnet
+++ b/data/sles4sap/agama/sles_ha_default.jsonnet
@@ -19,7 +19,7 @@
       {
         name: 'enable sshd',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           systemctl enable sshd

--- a/data/sles4sap/agama/sles_sap_default.jsonnet
+++ b/data/sles4sap/agama/sles_sap_default.jsonnet
@@ -13,7 +13,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet
+++ b/data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet
@@ -23,7 +23,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -37,7 +37,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -44,7 +44,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -58,7 +58,7 @@
       {
         name: "config_sshd",
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
@@ -67,14 +67,14 @@
       },
       {
         name: "enable_persistent_journal_logging",
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo -e "[Journal]\nStorage=persistent" > /etc/systemd/journald.conf.d/01-virt-test.conf
         |||
       },
       {
         name: "Configure_ssh_client",
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           ssh_config_file="/etc/ssh/ssh_config.d/01-virt-test.conf"
           echo -e "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null" > $ssh_config_file
@@ -83,7 +83,7 @@
      {
         name: "Setup_root_ssh_keys",
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           mkdir -p -m 700 /root/.ssh
           echo '{{_SECRET_RSA_PRIV_KEY}}' > /root/.ssh/id_rsa

--- a/data/yam/agama/auto/lib/scripts_post.libsonnet
+++ b/data/yam/agama/auto/lib/scripts_post.libsonnet
@@ -2,7 +2,7 @@
   enable_root_login: {
     name: 'enable root login',
     chroot: true,
-    body: |||
+    content: |||
       #!/usr/bin/env bash
       echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
     |||

--- a/data/yam/agama/auto/lib/scripts_pre.libsonnet
+++ b/data/yam/agama/auto/lib/scripts_pre.libsonnet
@@ -1,7 +1,7 @@
 {
   activate_multipath: {
     name: 'activate multipath',
-    body: |||
+    content: |||
       #!/bin/bash
       if ! systemctl status multpathd ; then
         echo 'Activating multipath'
@@ -12,7 +12,7 @@
   },
   wipe_filesystem: {
     name: 'wipefs',
-    body: |||
+    content: |||
       #!/usr/bin/env bash
       for i in `lsblk -n -l -o NAME -d -e 7,11,254`
           do wipefs -af /dev/$i

--- a/data/yam/agama/auto/lvm_encrypted_ppc64le.jsonnet
+++ b/data/yam/agama/auto/lvm_encrypted_ppc64le.jsonnet
@@ -48,7 +48,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -62,7 +62,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/lvm_encrypted_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/lvm_encrypted_ssh_pub_key.jsonnet
@@ -50,7 +50,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/lvm_encrypted_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/lvm_encrypted_ssh_pub_key_ppc64le.jsonnet
@@ -49,7 +49,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -63,7 +63,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/scripts.jsonnet
+++ b/data/yam/agama/auto/scripts.jsonnet
@@ -3,7 +3,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -17,7 +17,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||

--- a/data/yam/agama/auto/scripts_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/scripts_ssh_pub_key.jsonnet
@@ -6,7 +6,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -20,7 +20,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||

--- a/data/yam/agama/auto/sles_change_localization.jsonnet
+++ b/data/yam/agama/auto/sles_change_localization.jsonnet
@@ -25,7 +25,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_default.jsonnet
+++ b/data/yam/agama/auto/sles_default.jsonnet
@@ -21,7 +21,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_default_no_registration.jsonnet
+++ b/data/yam/agama/auto/sles_default_no_registration.jsonnet
@@ -20,7 +20,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_default_no_registration_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_default_no_registration_ppc64le.jsonnet
@@ -19,7 +19,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -33,7 +33,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_default_no_registration_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/sles_default_no_registration_ssh_pub_key.jsonnet
@@ -21,7 +21,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_default_no_registration_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_default_no_registration_ssh_pub_key_ppc64le.jsonnet
@@ -20,7 +20,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -34,7 +34,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_default_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_default_ppc64le.jsonnet
@@ -20,7 +20,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -34,7 +34,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_default_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/sles_default_ssh_pub_key.jsonnet
@@ -22,7 +22,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_default_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_default_ssh_pub_key_ppc64le.jsonnet
@@ -21,7 +21,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -35,7 +35,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_lvm.jsonnet
+++ b/data/yam/agama/auto/sles_lvm.jsonnet
@@ -39,7 +39,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_lvm_no_reg.jsonnet
+++ b/data/yam/agama/auto/sles_lvm_no_reg.jsonnet
@@ -38,7 +38,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_lvm_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_lvm_ppc64le.jsonnet
@@ -38,7 +38,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -52,7 +52,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_lvm_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/sles_lvm_ssh_pub_key.jsonnet
@@ -40,7 +40,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_lvm_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_lvm_ssh_pub_key_ppc64le.jsonnet
@@ -39,7 +39,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -53,7 +53,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_multipath.jsonnet
+++ b/data/yam/agama/auto/sles_multipath.jsonnet
@@ -17,7 +17,7 @@
     pre: [
       {
         name: 'activate multipath',
-        body: |||
+        content: |||
           #!/bin/bash
           if ! systemctl status multpathd ; then
             echo 'Activating multipath'

--- a/data/yam/agama/auto/sles_multipath_no_reg.jsonnet
+++ b/data/yam/agama/auto/sles_multipath_no_reg.jsonnet
@@ -16,7 +16,7 @@
     pre: [
       {
         name: 'activate multipath',
-        body: |||
+        content: |||
           #!/bin/bash
           if ! systemctl status multpathd ; then
             echo 'Activating multipath'

--- a/data/yam/agama/auto/sles_root_filesystem_ext4.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_ext4.jsonnet
@@ -29,7 +29,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_ext4_no_reg.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_ext4_no_reg.jsonnet
@@ -28,7 +28,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_ext4_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_ext4_ppc64le.jsonnet
@@ -28,7 +28,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -42,7 +42,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_ext4_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_ext4_ssh_pub_key.jsonnet
@@ -30,7 +30,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_ext4_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_ext4_ssh_pub_key_ppc64le.jsonnet
@@ -29,7 +29,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -43,7 +43,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_xfs.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_xfs.jsonnet
@@ -29,7 +29,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_xfs_no_reg.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_xfs_no_reg.jsonnet
@@ -28,7 +28,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_xfs_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_xfs_ppc64le.jsonnet
@@ -28,7 +28,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -42,7 +42,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_xfs_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_xfs_ssh_pub_key.jsonnet
@@ -30,7 +30,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_root_filesystem_xfs_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_xfs_ssh_pub_key_ppc64le.jsonnet
@@ -29,7 +29,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -43,7 +43,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_sap_default_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_sap_default_ppc64le.jsonnet
@@ -29,7 +29,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -43,7 +43,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/sles_sap_default_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/sles_sap_default_ssh_pub_key.jsonnet
@@ -18,7 +18,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -32,7 +32,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/yam/agama/auto/tumbleweed_default.jsonnet
+++ b/data/yam/agama/auto/tumbleweed_default.jsonnet
@@ -20,7 +20,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||

--- a/data/yam/agama/auto/tumbleweed_gnome.jsonnet
+++ b/data/yam/agama/auto/tumbleweed_gnome.jsonnet
@@ -22,7 +22,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -134,6 +134,9 @@ sub add_custom_grub_entries {
     elsif (check_var('SLE_PRODUCT', 'slert')) {
         $distro = "SLE_RT" . ' \\?' . get_required_var('VERSION');
     }
+    elsif (is_sle("16+")) {
+        $distro = "SUSE Linux" . ' \\?' . get_required_var('VERSION');
+    }
     elsif (is_sle()) {
         $distro = "SLES" . ' \\?' . get_required_var('VERSION');
     }

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -1817,7 +1817,7 @@ sub config_guest_installation_method {
 
     $self->config_guest_installation_media;
     my $_guest_installation_media = render_autoinst_url(url => $self->{guest_installation_media});
-    if (script_output("curl --silent -I $_guest_installation_media | grep -E \"^HTTP\" | awk -F \" \" \'{print \$2}\'") != "200") {
+    if ($_guest_installation_media =~ /^http\:\/\//im and script_output("curl --silent -I $_guest_installation_media | grep -E \"^HTTP\" | awk -F \" \" \'{print \$2}\'") != "200") {
         record_info("Installation media $_guest_installation_media does not exist", script_output("curl -I $_guest_installation_media", proceed_on_failure => 1), result => 'fail');
         $self->record_guest_installation_result('FAILED');
     }

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -106,6 +106,7 @@ sub _cleanup {
     die("Cleanup called twice!") if ($self->{cleanup_called});
     $self->{cleanup_called} = 1;
 
+    # Call cleanup() defined in test modules - not the provider cleanup()
     eval { $self->cleanup(); } or record_info('FAILED', "\$self->cleanup() failed -- $@", result => 'fail');
 
     my $flags = $self->test_flags();
@@ -151,6 +152,7 @@ sub _cleanup {
     # We need $self->{run_args} and $self->{run_args}->{my_provider}
     if ($self->{run_args} && $self->{run_args}->{my_provider}) {
         diag('Public Cloud _cleanup: Ready for provider cleanup.');
+        # Call the provider cleanup
         eval { $self->{run_args}->{my_provider}->cleanup() } or record_info('FAILED', "\$self->run_args->my_provider::cleanup() failed -- $@", result => 'fail');
         diag('Public Cloud _cleanup: The provider cleanup finished.');
     } else {

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -164,13 +164,10 @@ sub _upload_logs {
     my ($self) = @_;
     my $ssh_sut_log = '/var/tmp/ssh_sut.log';
 
-    if ($self->{run_args}) {
-        diag('Public Cloud _upload_logs: $self->{run_args}=' . $self->{run_args});
-        return;
-    }
-    if ($self->{run_args}->{my_instance}) {
-        diag('Public Cloud _upload_logs: $self->{run_args}->{my_instance}=' . $self->{run_args}->{my_instance});
-        return;
+    diag('Public Cloud _upload_logs: $self->{run_args}=' . $self->{run_args}) if ($self->{run_args});
+    diag('Public Cloud _upload_logs: $self->{run_args}->{my_instance}=' . $self->{run_args}->{my_instance}) if ($self->{run_args}->{my_instance});
+    unless ($self->{run_args} && $self->{run_args}->{my_instance}) {
+        die('Public Cloud _upload_logs: Either $self->{run_args} or $self->{run_args}->{my_instance} is not available. Maybe the test died before the instance has been created?');
     }
 
     script_run("sudo chmod a+r " . $ssh_sut_log);

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -163,6 +163,16 @@ sub _cleanup {
 sub _upload_logs {
     my ($self) = @_;
     my $ssh_sut_log = '/var/tmp/ssh_sut.log';
+
+    if ($self->{run_args}) {
+        diag('Public Cloud _upload_logs: $self->{run_args}=' . $self->{run_args});
+        return;
+    }
+    if ($self->{run_args}->{my_instance}) {
+        diag('Public Cloud _upload_logs: $self->{run_args}->{my_instance}=' . $self->{run_args}->{my_instance});
+        return;
+    }
+
     script_run("sudo chmod a+r " . $ssh_sut_log);
     upload_logs($ssh_sut_log, failok => 1, log_name => $ssh_sut_log . ".txt");
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -758,6 +758,7 @@ sub cleanup {
     my ($self) = @_;
     $self->terraform_destroy();
     assert_script_run "cd";
+    return 1;
 }
 
 =head2 stop_instance

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -784,7 +784,7 @@ sub registration_bootloader_params {
     my ($max_interval) = @_;    # see 'type_string'
     $max_interval //= 13;
     my @params;
-    if (!(is_agama && get_var('FLAVOR', 'Full'))) {
+    if (!(is_agama && check_var('FLAVOR', 'Full'))) {
         push @params, split ' ', registration_bootloader_cmdline;
     }
     type_string "@params", $max_interval;

--- a/schedule/yam/agama_ppc64le.yaml
+++ b/schedule/yam/agama_ppc64le.yaml
@@ -8,5 +8,5 @@ schedule:
   - yam/agama/agama
   - installation/grub_test
   - installation/first_boot
-  - yam/validate/validate_product
+  - yam/validate/validate_base_product
   - yam/validate/validate_first_user

--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -41,7 +41,7 @@ sub run {
         $checker{PRETTY_NAME} =~ s/Server/Desktop/ if is_desktop;
         $checker{PRETTY_NAME} =~ s/Server/Real Time/ if is_rt;
         $checker{PRETTY_NAME} =~ s/Server/High Performance Computing/ if is_hpc;
-        $checker{ID} = lc($checker{NAME});
+        $checker{ID} = is_sle('<16.0') ? lc($checker{NAME}) : 'sles';
         $checker{CPE_NAME} = is_sle('<16.0') ? "cpe:/o:suse:$product:$checker{VERSION}" : "cpe:/o:suse:$product:16:$checker{VERSION}";
 
         $checker{CPE_NAME} =~ s/\-SP/:sp/;

--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -33,15 +33,17 @@ sub run {
         $product = 'sles' if (is_sles4sap and check_var('SCC_REGCODE_SLES4SAP', 'invalid_key') and is_sle('=12-SP5'));
         $checker{NAME} = uc($product);
         $checker{NAME} = 'SLES' if ($product =~ /^sles/);
+        $checker{NAME} = 'SUSE Linux' if is_sle('16.0+');
         $checker{VERSION_ID} =~ s/\-SP/./;
-        $checker{PRETTY_NAME} = "SUSE Linux Enterprise Server $checker{VERSION}";
+        $checker{PRETTY_NAME} = is_sle('<16.0') ? "SUSE Linux Enterprise Server $checker{VERSION}" : "SUSE Linux $checker{VERSION}";
         $checker{PRETTY_NAME} =~ s/\-SP/ SP/;
         $checker{PRETTY_NAME} =~ s/Server/Server for SAP Applications/ if (is_sles4sap and is_sle('<=12-SP2'));
         $checker{PRETTY_NAME} =~ s/Server/Desktop/ if is_desktop;
         $checker{PRETTY_NAME} =~ s/Server/Real Time/ if is_rt;
         $checker{PRETTY_NAME} =~ s/Server/High Performance Computing/ if is_hpc;
         $checker{ID} = lc($checker{NAME});
-        $checker{CPE_NAME} = "cpe:/o:suse:$product:$checker{VERSION}";
+        $checker{CPE_NAME} = is_sle('<16.0') ? "cpe:/o:suse:$product:$checker{VERSION}" : "cpe:/o:suse:$product:16:$checker{VERSION}";
+
         $checker{CPE_NAME} =~ s/\-SP/:sp/;
     }
     if (is_leap) {

--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -37,6 +37,7 @@ sub run_tests {
         STORAGE_DRIVER => $storage_driver,
         BATS_TMPDIR => $tmp_dir,
         TMPDIR => $tmp_dir,
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 

--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -147,7 +147,11 @@ sub basic_container_tests {
         # Default OCI runtime should be runc on all products, SUSE & openSUSE
         my $template = ($runtime eq "podman") ? "{{ .Host.OCIRuntime.Name }}" : "{{ .DefaultRuntime }}";
         my $runtime = script_output("$runtime info -f '$template'");
-        die "Invalid default OCI runtime: $runtime" if ($runtime ne "runc");
+        if (is_sle_micro('>=6.0')) {
+            record_soft_failure('bsc#1239088 - podman 5.2 uses crun instead of runc');
+        } else {
+            die "Invalid default OCI runtime: $runtime" if ($runtime ne "runc");
+        }
     }
 
     ## Note: Leave the tumbleweed container to save some bandwidth. It is used in other test modules as well.

--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -147,11 +147,8 @@ sub basic_container_tests {
         # Default OCI runtime should be runc on all products, SUSE & openSUSE
         my $template = ($runtime eq "podman") ? "{{ .Host.OCIRuntime.Name }}" : "{{ .DefaultRuntime }}";
         my $runtime = script_output("$runtime info -f '$template'");
-        if (is_sle_micro('>=6.0')) {
-            record_soft_failure('bsc#1239088 - podman 5.2 uses crun instead of runc');
-        } else {
-            die "Invalid default OCI runtime: $runtime" if ($runtime ne "runc");
-        }
+        my $expected = is_sle_micro('>=6.0') ? "crun" : "runc";
+        die "Unexpected OCI runtime: $runtime != $expected" if ($runtime ne $expected);
     }
 
     ## Note: Leave the tumbleweed container to save some bandwidth. It is used in other test modules as well.

--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -142,6 +142,14 @@ sub basic_container_tests {
     assert_script_run("$runtime container rm basic_test_container");
     validate_script_output("$runtime container ls --all", sub { $_ !~ m/basic_test_container/ });
 
+    # Check for https://bugzilla.suse.com/show_bug.cgi?id=1239088
+    if (!get_var("OCI_RUNTIME")) {
+        # Default OCI runtime should be runc on all products, SUSE & openSUSE
+        my $template = ($runtime eq "podman") ? "{{ .Host.OCIRuntime.Name }}" : "{{ .DefaultRuntime }}";
+        my $runtime = script_output("$runtime info -f '$template'");
+        die "Invalid default OCI runtime: $runtime" if ($runtime ne "runc");
+    }
+
     ## Note: Leave the tumbleweed container to save some bandwidth. It is used in other test modules as well.
 }
 

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -25,12 +25,13 @@ sub run_tests {
     my %_env = (
         NETAVARK => $netavark,
         BATS_TMPDIR => $tmp_dir,
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 
     my $log_file = "netavark.tap";
     assert_script_run "echo $log_file .. > $log_file";
-    my $ret = script_run "env $env PATH=/usr/local/bin:\$PATH bats --tap test | tee -a $log_file", 1200;
+    my $ret = script_run "env $env bats --tap test | tee -a $log_file", 1200;
 
     my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', ''));
 

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -39,6 +39,7 @@ sub run_tests {
         BATS_TMPDIR => $tmp_dir,
         PODMAN => "/usr/bin/podman",
         QUADLET => $quadlet,
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -31,6 +31,7 @@ sub run_tests {
         BATS_TMPDIR => $tmp_dir,
         RUNC_USE_SYSTEMD => "1",
         RUNC => "/usr/bin/runc",
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -62,7 +62,7 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(apache2-utils jq openssl podman skopeo);
+    my @pkgs = qw(apache2-utils fakeroot jq openssl podman squashfs skopeo);
     install_packages(@pkgs);
 
     $self->bats_setup;

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -39,6 +39,7 @@ sub run_tests {
         BATS_TMPDIR => $tmp_dir,
         SKOPEO_BINARY => "/usr/bin/skopeo",
         SKOPEO_TEST_REGISTRY_FQIN => $registry,
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -106,9 +106,7 @@ sub prepare_parmfile {
 
     $params .= specific_bootmenu_params;
     unless (get_var("AGAMA")) {
-        if (!(is_agama && get_var('FLAVOR', 'Full'))) {
-            $params .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
-        }
+        $params .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
     }
 
     # Pass autoyast parameter for s390x, shorten the url because of 72 columns limit in x3270 xedit

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -53,7 +53,7 @@ sub set_svirt_domain_elements {
         $cmdline .= ' ' . get_var("EXTRABOOTPARAMS") if get_var("EXTRABOOTPARAMS");
         # inst.auto and inst.install_url are defined in 'specific_bootmenu_params'
         $cmdline .= specific_bootmenu_params;
-        if (!(is_agama && get_var('FLAVOR', 'Full'))) {
+        if (!(is_agama && check_var('FLAVOR', 'Full'))) {
             $cmdline .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation') && !get_var('NTLM_AUTH_INSTALL');
         }
 

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -33,6 +33,7 @@ sub run {
         export_to_json($tinfo->test_result_export);
     }
 
+    script_run('cat /proc/stat');
     script_run('df -h');
     check_kernel_taint($self, has_published_assets() ? 1 : 0);
 
@@ -45,6 +46,11 @@ sub run {
     upload_system_logs();
 
     power_action('poweroff');
+}
+
+sub post_fail_hook {
+    select_console('root-console');
+    script_run('cat /proc/stat');
 }
 
 sub test_flags {

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -50,7 +50,7 @@ sub run {
         eject_cd() unless $no_cd;
         microos_login;
     } elsif (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
-        wait_serial('The initial configuration takes', 180) or die "jeos-firstboot has not been reached";
+        wait_serial('The initial configuration', 180) or die "jeos-firstboot has not been reached";
         eject_cd() unless ($no_cd || is_usb_boot);
         return 1;
     } else {

--- a/tests/microos/verify_setup.pm
+++ b/tests/microos/verify_setup.pm
@@ -317,7 +317,8 @@ sub run {
     }
 
     if (get_var('QEMUTPM', '')) {
-        validate_script_output('cryptsetup status /dev/mapper/cr_root', qr/cr_root is active and is in use./);
+        my $device = (is_sle(">=16") || is_sle_micro(">=6.2")) ? "/dev/mapper/luks" : "/dev/mapper/cr_root";
+        validate_script_output("cryptsetup status $device", qr/is active and is in use./);
     }
 
     $self->result('failure') if $fail;

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -228,10 +228,14 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    # If we are in multi module scenario and this is not the first run of this test module we wanna run basetest cleanup
-    return {fatal => 1, publiccloud_multi_module => 1} if ($run_count > 1 && check_var('PUBLIC_CLOUD_QAM', 1));
-    # If we are in multi module scenario and this is the first run of the test module we wanna not fail the whole run
-    return {fatal => 0, publiccloud_multi_module => 1} if ($run_count < 2 && check_var('PUBLIC_CLOUD_QAM', 1));
+    if (check_var('PUBLIC_CLOUD_QAM', 1)) {
+        if ($run_count == 1) {
+            # If we are in multi module scenario and this is the first run of the test module we wanna not fail the whole run
+            return {fatal => 0, publiccloud_multi_module => 1};
+        }
+        # If we are in multi module scenario and this is not the first run of this test module we wanna fail the whole run
+        return {fatal => 1, publiccloud_multi_module => 1};
+    }
     # If we are not in multi module scenario it is always the first run and we wanna run basetest cleanup
     return {fatal => 1, publiccloud_multi_module => 0};
 }

--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2024 SUSE LLC
+# Copyright 2024 - 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Check public cloud specific services
@@ -21,8 +21,7 @@ sub run {
     my ($self, $args) = @_;
     select_host_console();
 
-    my $instance = $self->{my_instance} = $args->{my_instance};
-    my $provider = $self->{provider} = $args->{my_provider};    # required for cleanup
+    my $instance = $args->{my_instance};
 
     # Debug
     $instance->ssh_script_run('systemctl --no-pager list-units');

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -91,17 +91,14 @@ sub run {
     $self->{ltp_command} = $ltp_command;
     my $ltp_exclude = get_var('LTP_COMMAND_EXCLUDE', '');
 
-    my $provider;
-    my $instance;
-
     select_host_console();
 
     unless ($args->{my_provider} && $args->{my_instance}) {
         $args->{my_provider} = $self->provider_factory();
         $args->{my_instance} = $args->{my_provider}->create_instance(check_guestregister => is_openstack ? 0 : 1);
     }
-    $instance = $args->{my_instance};
-    $provider = $args->{my_provider};
+    my $instance = $args->{my_instance};
+    my $provider = $args->{my_provider};
 
     assert_script_run("cd $root_dir");
     assert_script_run('curl ' . data_url('publiccloud/restart_instance.sh') . ' -o restart_instance.sh');
@@ -188,13 +185,13 @@ sub run {
 }
 
 sub cleanup {
-    my ($self, $args) = @_;
+    my ($self) = @_;
 
     # Ensure that the ltp script gets killed
     type_string('', terminate_with => 'ETX');
     $self->upload_ltp_logs();
 
-    if ($self->{my_instance} && script_run("test -f $root_dir/log_instance.sh") == 0) {
+    if ($self->{run_args}->{my_instance} && script_run("test -f $root_dir/log_instance.sh") == 0) {
         script_run($root_dir . '/log_instance.sh stop ' . instance_log_args($self->{run_args}->{my_provider}, $self->{run_args}->{my_instance}));
         script_run("(cd /tmp/log_instance && tar -zcf $root_dir/instance_log.tar.gz *)");
         upload_logs("$root_dir/instance_log.tar.gz", failok => 1);

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -191,7 +191,11 @@ sub cleanup {
     type_string('', terminate_with => 'ETX');
     $self->upload_ltp_logs();
 
-    if ($self->{run_args}->{my_instance} && script_run("test -f $root_dir/log_instance.sh") == 0) {
+    unless ($self->{run_args} && $self->{run_args}->{my_instance}) {
+        die('cleanup: Either $self->{run_args} or $self->{run_args}->{my_instance} is not available. Maybe the test died before the instance has been created?');
+    }
+
+    if (script_run("test -f $root_dir/log_instance.sh") == 0) {
         script_run($root_dir . '/log_instance.sh stop ' . instance_log_args($self->{run_args}->{my_provider}, $self->{run_args}->{my_instance}));
         script_run("(cd /tmp/log_instance && tar -zcf $root_dir/instance_log.tar.gz *)");
         upload_logs("$root_dir/instance_log.tar.gz", failok => 1);

--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2021 - 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Basic test of SLE Micro in public cloud
@@ -51,12 +51,9 @@ sub check_avc {
 
 sub run {
     my ($self, $args) = @_;
-    my $provider;
-    my $instance;
     select_serial_terminal();
 
-    $instance = $self->{my_instance} = $args->{my_instance};
-    $provider = $self->{provider} = $args->{my_provider};
+    my $instance = $self->{my_instance} = $args->{my_instance};
 
     # On SLEM 5.2+ check that we don't have any SELinux denials. This needs to happen before anything else is ongoing
     $self->check_avc() unless (is_sle_micro('=5.1'));

--- a/tests/security/ima/ima_kernel_cmdline_hash.pm
+++ b/tests/security/ima/ima_kernel_cmdline_hash.pm
@@ -31,13 +31,22 @@ sub run {
         {algo => "tgr192", len => 48},
     );
 
-    my %fips_approved = map { $_ => 1 } qw(sha256 sha512);
-    if (check_var('FIPS_ENABLED', '1')) {
-        @algo_list = grep { $fips_approved{$_->{algo}} } @algo_list;
-    }
-
     # Add kernel modules to enable some algorithms
-    my $algo_modlist = "sha256 sha512";
+    my $algo_modlist = "rmd160 wp512 tgr192";
+
+    # On newer kernel, tgr192 algorithms may be removed due to
+    # upsteam commit, then we need skip it, refer to bsc#1191521
+    my $results = script_run("zcat /proc/config.gz | grep CONFIG_CRYPTO_TGR192");
+    if ($results) {
+        for (my $i = 0; $i < scalar(@algo_list); $i++) {
+
+            splice @algo_list, $i, 1 if ($algo_list[$i]->{algo} eq 'tgr192');
+
+        }
+        $algo_modlist =~ s/ tgr192//;
+    }
+    $algo_modlist .= " sha512" if (!is_sle && !is_leap);
+
     assert_script_run "echo -e $algo_modlist | sed 's/ /\\n/g' > /etc/modules-load.d/hash.conf";
     assert_script_run "echo 'force_drivers+=\"$algo_modlist\"' >/etc/dracut.conf.d/10.hashs.conf";
     assert_script_run "dracut -f";

--- a/tests/security/krb5/krb5_crypt_ssh_client.pm
+++ b/tests/security/krb5/krb5_crypt_ssh_client.pm
@@ -1,4 +1,4 @@
-# Copyright 2019 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Test ssh with krb5 authentication - client
@@ -17,8 +17,14 @@ use krb5crypt;    # Import public variables
 sub run {
     select_console 'root-console';
 
+    my $ssh_config_file = "/usr/etc/ssh/ssh_config";
+
+    # Test if ssh config exists
+    assert_script_run "grep GSSAPIAuthentication $ssh_config_file";
+
+    # Enable necessary options
     foreach my $i ('GSSAPIAuthentication', 'GSSAPIDelegateCredentials') {
-        assert_script_run "sed -i 's/^.*$i .*\$/$i yes/' /etc/ssh/ssh_config";
+        assert_script_run "sed -i 's/^.*$i.*\$/$i yes/' $ssh_config_file";
     }
 
     mutex_wait('CONFIG_READY_SSH_SERVER');

--- a/tests/security/krb5/krb5_crypt_ssh_server.pm
+++ b/tests/security/krb5/krb5_crypt_ssh_server.pm
@@ -1,4 +1,4 @@
-# Copyright 2019 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Test ssh with krb5 authentication - server
@@ -20,9 +20,11 @@ sub run {
     assert_script_run "kadmin -p $adm -w $pass_a -q 'addprinc -pw $pass_t $tst'";
     assert_script_run "useradd -m $tst";
 
+    my $sshd_config_file = "/usr/etc/ssh/sshd_config";
+
     # Config sshd
     foreach my $i ('GSSAPIAuthentication', 'GSSAPICleanupCredentials') {
-        assert_script_run "sed -i 's/^#$i .*\$/$i yes/' /etc/ssh/sshd_config";
+        assert_script_run "sed -i 's/^#$i.*\$/$i yes/' $sshd_config_file";
     }
     systemctl("restart sshd");
 

--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -16,7 +16,7 @@ use testapi;
 use transactional qw(process_reboot);
 use bootloader_setup qw(change_grub_config);
 use utils qw(ensure_ca_certificates_suse_installed zypper_call ensure_serialdev_permissions);
-use version_utils qw(is_bootloader_grub2 is_bootloader_sdboot is_bootloader_grub2_bls);
+use version_utils qw(is_bootloader_grub2 is_bootloader_sdboot is_bootloader_grub2_bls is_sle is_sle_micro);
 use serial_terminal qw(select_serial_terminal prepare_serial_console);
 use Utils::Architectures 'is_ppc64le';
 
@@ -32,6 +32,14 @@ sub run {
     my $keep_grub_timeout = get_var('KEEP_GRUB_TIMEOUT');
 
     if (is_bootloader_grub2) {
+        if (is_ppc64le && (is_sle_micro('6.2+') || is_sle('15-SP7+'))) {
+            # selfinstall jobs performs kexec before this module is scheduled
+            # the paramater has to be defined in EXTRABOOTPARAMS as well
+            if (!defined($extrabootparams) || $extrabootparams !~ /disable_ddw=1/) {
+                $extrabootparams .= ' disable_ddw=1';
+            }
+            record_soft_failure('bsc#1239691 - 15-SP7 KOTD kernel crashes qemu during reboot on ppc64le when virtual machine has a PCI device');
+        }
         change_grub_config('=\"[^\"]*', "& $extrabootparams", 'GRUB_CMDLINE_LINUX_DEFAULT') if $extrabootparams;
         $keep_grub_timeout or change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT');
 

--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -37,7 +37,8 @@ sub get_script_run {
     my $guest_pattern = get_var('GUEST_PATTERN', 'sles-12-sp2-64-[p|f]v-def-net');
     my $parallel_num = get_var("PARALLEL_NUM", "2");
     my ($regcode, $regcode_ltss) = get_guest_regcode(separator => '|');
-    $pre_test_cmd .= " -f \"" . $guest_pattern . "\" -n " . $parallel_num . " -r " . " -e \"" . $regcode . "\" -E \"" . $regcode_ltss . "\"";
+    my $kernel_params = get_guest_settings(settings => 'GUEST_EXT_KERNEL_PARAMS', separator => '|');
+    $pre_test_cmd .= " -f \"" . $guest_pattern . "\" -n " . $parallel_num . " -r " . " -e \"" . $regcode . "\" -E \"" . $regcode_ltss . "\" -k \"" . $kernel_params->{'GUEST_EXT_KERNEL_PARAMS'} . "\"";
     $pre_test_cmd .= " 2>&1 | tee /tmp/s390x_guest_install_test.log" if (is_s390x);
 
     return $pre_test_cmd;

--- a/tests/virt_autotest/host_upgrade_generate_run_file.pm
+++ b/tests/virt_autotest/host_upgrade_generate_run_file.pm
@@ -33,6 +33,8 @@ sub get_script_run {
     my $do_registration = (check_var('SCC_REGISTER', 'installation') || check_var('REGISTER', 'installation') || get_var('AUTOYAST', '')) ? "true" : "false";
     my $registration_server = get_var('SCC_URL', 'https://scc.suse.com');
     my $registration_code = get_var('SCC_REGCODE', 'INVALID_REGCODE');
+    my $host_kernel_params = get_var('HOST_EXT_KERNEL_PARAMS', 'NA');
+    my $guest_kernel_params = get_guest_settings(settings => 'GUEST_EXT_KERNEL_PARAMS', separator => '|');
 
     $pre_test_cmd = "/usr/share/qa/tools/_generate_vh-update_tests.sh";
     $pre_test_cmd .= " -m $mode";
@@ -46,6 +48,8 @@ sub get_script_run {
     $pre_test_cmd .= " -e $do_registration";
     $pre_test_cmd .= " -s $registration_server";
     $pre_test_cmd .= " -c $registration_code";
+    $pre_test_cmd .= " -K \"$host_kernel_params\"";
+    $pre_test_cmd .= " -k \"$guest_kernel_params->{GUEST_EXT_KERNEL_PARAMS}\"";
 
     return "$pre_test_cmd";
 }


### PR DESCRIPTION
Bail out before the actual reconfiguration if the ssh config file does not exist on SUT.

Slight modification in the sed regexp.

- Related ticket: https://progress.opensuse.org/issues/179194
