### PR TITLE
Minor fixes to BATS tests

### DIFF
--- a/tests/containers/buildah_integration.pm
+++ b/tests/containers/buildah_integration.pm
@@ -37,6 +37,7 @@ sub run_tests {
         STORAGE_DRIVER => $storage_driver,
         BATS_TMPDIR => $tmp_dir,
         TMPDIR => $tmp_dir,
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 

--- a/tests/containers/netavark_integration.pm
+++ b/tests/containers/netavark_integration.pm
@@ -25,12 +25,13 @@ sub run_tests {
     my %_env = (
         NETAVARK => $netavark,
         BATS_TMPDIR => $tmp_dir,
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 
     my $log_file = "netavark.tap";
     assert_script_run "echo $log_file .. > $log_file";
-    my $ret = script_run "env $env PATH=/usr/local/bin:\$PATH bats --tap test | tee -a $log_file", 1200;
+    my $ret = script_run "env $env bats --tap test | tee -a $log_file", 1200;
 
     my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', ''));
 

--- a/tests/containers/podman_integration.pm
+++ b/tests/containers/podman_integration.pm
@@ -39,6 +39,7 @@ sub run_tests {
         BATS_TMPDIR => $tmp_dir,
         PODMAN => "/usr/bin/podman",
         QUADLET => $quadlet,
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 

--- a/tests/containers/runc_integration.pm
+++ b/tests/containers/runc_integration.pm
@@ -31,6 +31,7 @@ sub run_tests {
         BATS_TMPDIR => $tmp_dir,
         RUNC_USE_SYSTEMD => "1",
         RUNC => "/usr/bin/runc",
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -62,7 +62,7 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(apache2-utils jq openssl podman skopeo);
+    my @pkgs = qw(apache2-utils fakeroot jq openssl podman squashfs skopeo);
     install_packages(@pkgs);
 
     $self->bats_setup;

--- a/tests/containers/skopeo_integration.pm
+++ b/tests/containers/skopeo_integration.pm
@@ -39,6 +39,7 @@ sub run_tests {
         BATS_TMPDIR => $tmp_dir,
         SKOPEO_BINARY => "/usr/bin/skopeo",
         SKOPEO_TEST_REGISTRY_FQIN => $registry,
+        PATH => '/usr/local/bin:$PATH:/usr/sbin:/sbin',
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 


### PR DESCRIPTION
Minor fixes to BATS tests:
  - fakeroot package not available
  - Fix PATH to fix `selinuxenabled command not found in $PATH`

These weren't noticed before as the affected subtests were silently skipped rather than failed.

- Verification runs:
  - buildah: https://openqa.opensuse.org/tests/4962248 (failing for transient 502).
  - runc/skopeo/netavark: https://openqa.opensuse.org/tests/4961860
  - podman: https://openqa.opensuse.org/tests/4962252
