### PR TITLE
Append disable_ddw=1 in sle-micro 6.2

### DIFF
--- a/tests/transactional/host_config.pm
+++ b/tests/transactional/host_config.pm
@@ -16,7 +16,7 @@ use testapi;
 use transactional qw(process_reboot);
 use bootloader_setup qw(change_grub_config);
 use utils qw(ensure_ca_certificates_suse_installed zypper_call ensure_serialdev_permissions);
-use version_utils qw(is_bootloader_grub2 is_bootloader_sdboot is_bootloader_grub2_bls);
+use version_utils qw(is_bootloader_grub2 is_bootloader_sdboot is_bootloader_grub2_bls is_sle is_sle_micro);
 use serial_terminal qw(select_serial_terminal prepare_serial_console);
 use Utils::Architectures 'is_ppc64le';
 
@@ -32,6 +32,14 @@ sub run {
     my $keep_grub_timeout = get_var('KEEP_GRUB_TIMEOUT');
 
     if (is_bootloader_grub2) {
+        if (is_ppc64le && (is_sle_micro('6.2+') || is_sle('15-SP7+'))) {
+            # selfinstall jobs performs kexec before this module is scheduled
+            # the paramater has to be defined in EXTRABOOTPARAMS as well
+            if (!defined($extrabootparams) || $extrabootparams !~ /disable_ddw=1/) {
+                $extrabootparams .= ' disable_ddw=1';
+            }
+            record_soft_failure('bsc#1239691 - 15-SP7 KOTD kernel crashes qemu during reboot on ppc64le when virtual machine has a PCI device');
+        }
         change_grub_config('=\"[^\"]*', "& $extrabootparams", 'GRUB_CMDLINE_LINUX_DEFAULT') if $extrabootparams;
         $keep_grub_timeout or change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT');
 


### PR DESCRIPTION
We already have a workaround implemented in container hdds, no we need to handle the same problem in sle-micro with the kernel that contains the problematic patch


- Related ticket: https://progress.opensuse.org/issues/179702

#### Verification runs: 
 - sle-micro-6.2-Default-ppc-4096-SelfInstall-ppc64le-Build6.20-combustion@ppc64le-emu -> https://openqa.suse.de/tests/17222155
 - sle-micro-6.2-Default-ppc-4096-ppc64le-Build6.20-default@ppc64le-emu -> https://openqa.suse.de/tests/17223221