### PR TITLE
Remove Welcome-to-WSL pop-up

### DIFF
--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -72,16 +72,20 @@ sub run {
         $self->close_powershell;
         $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
         assert_and_click 'wsl-suse-startup-search';
-        assert_and_click("welcome_to_wsl", timeout => 120);
-        send_key "alt-f4";
+        if (check_var('DISTRI', 'sle')) {
+            assert_and_click("welcome_to_wsl", timeout => 120);
+            send_key "alt-f4";
+        }
     } elsif ($install_from eq 'msstore') {
         # Install required SUSE distro from the MS Store
         $self->run_in_powershell(
             cmd => "wsl --install --distribution $WSL_version",
             timeout => 300,
         );
-        assert_and_click("welcome_to_wsl", timeout => 60);
-        send_key "alt-f4";
+        if (check_var('DISTRI', 'sle')) {
+            assert_and_click("welcome_to_wsl", timeout => 120);
+            send_key "alt-f4";
+        }
 
         $self->run_in_powershell(
             cmd => "wsl.exe --distribution $WSL_version",


### PR DESCRIPTION
Attempt to prevent welcome-to-wsl pop-up from breaking WSL tests in TW/Leap/SLE

- Related ticket: https://progress.opensuse.org/issues/176676

- Verification run:

SLE: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=_chubykalo-welcome-to-wsl-poo176676
Leap: https://openqa.opensuse.org/tests/overview?version=15.6&build=_chubykalo-welcome-to-wsl-poo176676&distri=opensuse
TW: https://openqa.opensuse.org/tests/overview?distri=opensuse&build=_chubykalo-welcome-to-wsl-poo176676&version=Tumbleweed

None of the errors are related to Welcome to WSL pop-up anymore.
