### PR TITLE
Replace 'body' with 'content' for HANAperf SLE16 agama.json

### DIFF
--- a/data/autoyast_hanaperf/agama-config.jsonnet
+++ b/data/autoyast_hanaperf/agama-config.jsonnet
@@ -47,7 +47,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -61,7 +61,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           # Workaround for sshd service deactivated bsc#1238590


### PR DESCRIPTION
https://github.com/agama-project/agama/blob/master/rust/agama-lib/src/scripts/model.rs#L79

refer to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21631, https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21616

VR: n/a

