### PR TITLE
Replace body section with content in SLES for SAP & HA jsonnet files

### DIFF
--- a/data/sles4sap/agama/sles_ha_default.jsonnet
+++ b/data/sles4sap/agama/sles_ha_default.jsonnet
@@ -19,7 +19,7 @@
       {
         name: 'enable sshd',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           systemctl enable sshd

--- a/data/sles4sap/agama/sles_sap_default.jsonnet
+++ b/data/sles4sap/agama/sles_sap_default.jsonnet
@@ -13,7 +13,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,

--- a/data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet
+++ b/data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet
@@ -23,7 +23,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -37,7 +37,7 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
         |||,


### PR DESCRIPTION
Per
https://github.com/agama-project/agama/blob/master/rust/agama-lib/src/scripts/model.rs#L79 the `body:` sections of jsonnet files for agama auto have been replaced with `content:`. This commit updates jsonnet files used by SLES for SAP and SLES+HA tests accordingly.

See also the commits/PR:

1. 736682bc47d720a38e237ed390dde0ecc7fb7d52 / #21631 
2. e37c5b98a7ba1e5a016699d3002e6aeb9fec511e / #21616 

- Related ticket: https://jira.suse.com/browse/TEAM-9407
- Needles: N/A
- Verification run: N/A
