### PR TITLE
Replace body with content for virt test on sle16

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -44,7 +44,7 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
@@ -58,7 +58,7 @@
       {
         name: "config_sshd",
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
@@ -67,14 +67,14 @@
       },
       {
         name: "enable_persistent_journal_logging",
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo -e "[Journal]\nStorage=persistent" > /etc/systemd/journald.conf.d/01-virt-test.conf
         |||
       },
       {
         name: "Configure_ssh_client",
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           ssh_config_file="/etc/ssh/ssh_config.d/01-virt-test.conf"
           echo -e "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null" > $ssh_config_file
@@ -83,7 +83,7 @@
      {
         name: "Setup_root_ssh_keys",
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           mkdir -p -m 700 /root/.ssh
           echo '{{_SECRET_RSA_PRIV_KEY}}' > /root/.ssh/id_rsa


### PR DESCRIPTION
`body` was replaced with `content` in sle16.

- Verification run: https://openqa.suse.de/tests/17223273
