### PR TITLE
Fix JeOS-Firstboot for SLES16

### DIFF
--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -50,7 +50,7 @@ sub run {
         eject_cd() unless $no_cd;
         microos_login;
     } elsif (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
-        wait_serial('The initial configuration takes', 180) or die "jeos-firstboot has not been reached";
+        wait_serial('The initial configuration', 180) or die "jeos-firstboot has not been reached";
         eject_cd() unless ($no_cd || is_usb_boot);
         return 1;
     } else {


### PR DESCRIPTION
On SLES16 there is a line break, so the wait_serial token must be cropped to the one line being present.

- Related failure: https://openqa.suse.de/tests/17218992#step/selfinstall/3
- Verification run:  https://openqa.suse.de/tests/17227947 and https://openqa.opensuse.org/tests/4962461 (pass `selfinstall` or `firstrun`)