### PR TITLE
lib/bootloader_setup: Add check for SLE16 in add_custom_grub_entries

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -134,6 +134,9 @@ sub add_custom_grub_entries {
     elsif (check_var('SLE_PRODUCT', 'slert')) {
         $distro = "SLE_RT" . ' \\?' . get_required_var('VERSION');
     }
+    elsif (is_sle("16+")) {
+        $distro = "SUSE Linux" . ' \\?' . get_required_var('VERSION');
+    }
     elsif (is_sle()) {
         $distro = "SLES" . ' \\?' . get_required_var('VERSION');
     }


### PR DESCRIPTION
The GRUB entry in SLE16 was changed to "SUSE Linux", add a condition to the add_custom_grub_entries subroutine to correctly parse it.

- Related ticket: https://progress.opensuse.org/issues/179756
- Verification run: https://openqa.suse.de/tests/17229254
