### PR TITLE
Use new path on SLEM 6.2

### DIFF
--- a/tests/microos/verify_setup.pm
+++ b/tests/microos/verify_setup.pm
@@ -317,7 +317,8 @@ sub run {
     }
 
     if (get_var('QEMUTPM', '')) {
-        validate_script_output('cryptsetup status /dev/mapper/cr_root', qr/cr_root is active and is in use./);
+        my $device = (is_sle(">=16") || is_sle_micro(">=6.2")) ? "/dev/mapper/luks" : "/dev/mapper/cr_root";
+        validate_script_output("cryptsetup status $device", qr/is active and is in use./);
     }
 
     $self->result('failure') if $fail;


### PR DESCRIPTION
On SLEM 6.2 the cryptsetup path is luks not cr_root.

- Related failure: https://openqa.suse.de/tests/17219182#step/verify_setup/138
- Verification run: https://openqa.suse.de/tests/17232640#step/verify_setup/137
