### PR TITLE
containers: Remove soft-failure on bsc#1239088

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -147,11 +147,8 @@ sub basic_container_tests {
         # Default OCI runtime should be runc on all products, SUSE & openSUSE
         my $template = ($runtime eq "podman") ? "{{ .Host.OCIRuntime.Name }}" : "{{ .DefaultRuntime }}";
         my $runtime = script_output("$runtime info -f '$template'");
-        if (is_sle_micro('>=6.0')) {
-            record_soft_failure('bsc#1239088 - podman 5.2 uses crun instead of runc');
-        } else {
-            die "Invalid default OCI runtime: $runtime" if ($runtime ne "runc");
-        }
+        my $expected = is_sle_micro('>=6.0') ? "crun" : "runc";
+        die "Unexpected OCI runtime: $runtime != $expected" if ($runtime ne $expected);
     }
 
     ## Note: Leave the tumbleweed container to save some bandwidth. It is used in other test modules as well.


### PR DESCRIPTION
crun will be the default OCI runtime on SLEM 6.0+ for the time being.

