### PR TITLE
[qe-core]Add systemd_testkit_offline in functional on SLE16

### DIFF
--- a/tests/console/create_hdd_systemd_testkit.pm
+++ b/tests/console/create_hdd_systemd_testkit.pm
@@ -13,6 +13,7 @@ use File::Basename;
 use Mojo::JSON qw(encode_json);
 use base "consoletest";
 use testapi;
+use version_utils qw(is_sle);
 use serial_terminal 'select_serial_terminal';
 use utils;
 
@@ -24,6 +25,7 @@ sub run {
     assert_script_run("mkdir -p  $testdir");
     assert_script_run("wget --no-check-certificate $systemd_suse_url -O $testdir" . basename($systemd_suse_url));
     assert_script_run("ls -l $testdir");
+    zypper_call 'in polkit' if (is_sle('>=16'));
 }
 
 1;

--- a/tests/console/start_systemd_testkit_offline.pm
+++ b/tests/console/start_systemd_testkit_offline.pm
@@ -47,6 +47,15 @@ sub run {
     record_info("START", "Testsuite execution is starting");
     assert_script_run "cp systemd/*.sh .";
     assert_script_run 'sh -e ./systemd_prepare.sh';
+
+    # For sle16.0, selinux is enforcing mode, so we need to adjust the permission
+    if (is_sle('>=16')) {
+        assert_script_run("semanage fcontext -a -t bin_t '/systemd/bin/systemd_dummy_srv'");
+        assert_script_run("restorecon -v /systemd/bin/systemd_dummy_srv");
+        assert_script_run("semanage fcontext -a -t bin_t '/systemd/bin/semtest'");
+        assert_script_run("restorecon -v /systemd/bin/semtest");
+    }
+
     # Wait at least 180s for test to finish
     my $wait = 180;
     # Run the test and save the logs and results


### PR DESCRIPTION
Related: https://progress.opensuse.org/issues/177237

VR:  https://openqa.suse.de/tests/17240099#
