### PR TITLE
containers: Only SLEM 6.0 & 6.1 use crun

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -144,10 +144,10 @@ sub basic_container_tests {
 
     # Check for https://bugzilla.suse.com/show_bug.cgi?id=1239088
     if (!get_var("OCI_RUNTIME")) {
-        # Default OCI runtime should be runc on all products, SUSE & openSUSE
         my $template = ($runtime eq "podman") ? "{{ .Host.OCIRuntime.Name }}" : "{{ .DefaultRuntime }}";
         my $runtime = script_output("$runtime info -f '$template'");
-        my $expected = is_sle_micro('=6.1') ? "crun" : "runc";
+        # Only SLEM 6.0 & SLEM 6.1 use crun
+        my $expected = (is_sle_micro('>=6.0') && is_sle_micro('<=6.1')) ? "crun" : "runc";
         die "Unexpected OCI runtime: $runtime != $expected" if ($runtime ne $expected);
     }
 


### PR DESCRIPTION
Only SLEM 6.0 & 6.1 use crun: https://bugzilla.suse.com/show_bug.cgi?id=1239088#c13
