### PR TITLE
containers: Check default OCI runtime on buildah

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -77,6 +77,11 @@ sub run_tests {
     assert_script_run("buildah rm $container");
     assert_script_run("buildah rmi newimage $image");
     assert_script_run("rm -f /tmp/script.sh");
+
+    if (!get_var("OCI_RUNTIME")) {
+        my $runtime = script_output("buildah info --format '{{ .host.OCIRuntime }}'");
+        die "Unexpected OCI runtime: $runtime" if ($runtime ne "runc");
+    }
 }
 
 sub run {


### PR DESCRIPTION
Check default OCI runtime on buildah.

- Verification runs:
  - Tumbleweed: https://openqa.opensuse.org/tests/4964710
  - SLE 16.0: https://openqa.suse.de/tests/17240040
  - SLE 15-SP7: https://openqa.suse.de/tests/17240042
  - SLE 15-SP3: https://openqa.suse.de/tests/17240078

Note: SLEM lacks buildah :)