### PR TITLE
SLES 16 Container create hdd s390x-kvm jsonnet fixed

### DIFF
--- a/data/containers/agama/sle_default_s390x_kvm.jsonnet
+++ b/data/containers/agama/sle_default_s390x_kvm.jsonnet
@@ -16,11 +16,12 @@
   scripts: {
     post: [
       {
-        name: 'enable root login',
+        name: 'enable root login sshd',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          systemctl enable sshd
         |||
       }
     ]


### PR DESCRIPTION
SLES 16 Container create hdd s390x-kvm jsonnet update:
config. `containers/agama/sle_default_s390x_kvm.jsonnet` needed in post-install to enable ssh.

Fixing the test: https://openqa.suse.de/tests/17228284

- Related ticket: https://progress.opensuse.org/issues/175950
- Needles: No.
- Verification run: https://openqa.suse.de/tests/17240564
