### PR TITLE
Fix Elemental container image test

### DIFF
--- a/tests/elemental/container_validation.pm
+++ b/tests/elemental/container_validation.pm
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 SUSE LLC
+# Copyright 2023-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Test Elemental container image
@@ -43,6 +43,9 @@ sub run {
     my $cnt_name = 'elemental_image';
     my $img_filename = "elemental-$build-$arch";
     my $shared = '/var/shared';
+
+    # Set SELinux in permissive mode, as there is an issue with Enforcing mode and Elemental doesn't support it
+    assert_script_run("setenforce Permissive");
 
     # Create shared directory
     assert_script_run("mkdir -p $shared");

--- a/tests/elemental/installation.pm
+++ b/tests/elemental/installation.pm
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 SUSE LLC
+# Copyright 2023-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Test installation and boot of Elemental ISO

--- a/tests/elemental/shutdown.pm
+++ b/tests/elemental/shutdown.pm
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 SUSE LLC
+# Copyright 2023-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Power off Elemental OS server


### PR DESCRIPTION
Set SELinux in permissive mode, as there is an issue with Enforcing mode and Elemental doesn't support it.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17241170 (also tested on my local openQA server)