### PR TITLE
Make various security test failures non-fatal

### DIFF
--- a/tests/fips/openssl/dirmngr_setup.pm
+++ b/tests/fips/openssl/dirmngr_setup.pm
@@ -101,7 +101,7 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/fips/openssl/openssl_fips_dhparam.pm
+++ b/tests/fips/openssl/openssl_fips_dhparam.pm
@@ -64,7 +64,7 @@ sub test_flags {
     return {
         #poo160197 workaround since rollback seems not working with swTPM
         no_rollback => is_transactional ? 1 : 0,
-        fatal => 1
+        fatal => 0
     };
 }
 

--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -73,7 +73,7 @@ sub test_flags {
     return {
         #poo160197 workaround since rollback seems not working with swTPM
         no_rollback => is_transactional ? 1 : 0,
-        fatal => 1
+        fatal => 0
     };
 }
 

--- a/tests/security/vsftpd/vsftpd.pm
+++ b/tests/security/vsftpd/vsftpd.pm
@@ -45,4 +45,8 @@ sub run {
     enter_cmd('cd && clear');
 }
 
+sub test_flags {
+    return {milestone => 1, fatal => 0};
+}
+
 1;

--- a/tests/security/vsftpd/vsftpd_setup.pm
+++ b/tests/security/vsftpd/vsftpd_setup.pm
@@ -72,7 +72,7 @@ expect {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 1};
+    return {milestone => 1, fatal => 0};
 }
 
 1;


### PR DESCRIPTION
They still fail the test, but allow subsequent tests to continue.

- Related ticket: https://progress.opensuse.org/issues/179837
- Verification runs:
core: https://openqa.suse.de/tests/17241073#
    newer core run: https://openqa.suse.de/tests/17241765
extra: https://openqa.suse.de/tests/17241072#