### PR TITLE
Add inst.finish in kernel boot parameters for ovmdrv test

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -49,6 +49,9 @@ sub prepare_boot_params {
     }
     push @params, 'inst.register_url=' . get_var('SCC_URL') if get_var('FLAVOR') eq 'Online';
 
+    # disk label with OEMDRV will automatically pick the profile from disk without setting inst.auto
+    push @params, 'inst.finish=stop' if (get_var('HDD_2') =~ /oemdrv/);
+
     # add extra boot params along with the default ones
     push @params, split ' ', trim(get_var('EXTRABOOTPARAMS', ''));
 


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/176832
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17248194#details
