### PR TITLE
Use ensure_install instead of duplicated code in ibus_installation

### DIFF
--- a/tests/x11/ibus/ibus_installation.pm
+++ b/tests/x11/ibus/ibus_installation.pm
@@ -18,15 +18,8 @@ use version_utils 'is_tumbleweed';
 use x11utils qw(default_gui_terminal handle_relogin);
 
 sub install_ibus {
-    x11_start_program("xterm");
-    become_root;
-    quit_packagekit;
-    wait_still_screen 1;
     my $ibus_pinyin = is_tumbleweed() ? "ibus-libpinyin" : "ibus-pinyin";
-    zypper_call("in ibus $ibus_pinyin ibus-kkc ibus-hangul");
-    assert_screen 'ibus_installed';
-    send_key 'ctrl-d';
-    send_key 'ctrl-d';
+    ensure_installed("ibus $ibus_pinyin ibus-kkc ibus-hangul");
 }
 
 sub override_i18n {


### PR DESCRIPTION
#21592 changed the default terminal in `default_gui_terminal` and logically there's some fallout where it is being used

VR: http://10.149.209.202/tests/118#step/ibus_installation/13 - failure is unrelated to the change
VR: http://10.149.209.202/tests/119#step/change_password/92 - needles related to change_password
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/832
