### PR TITLE
Fix saptune failures on 16 due to changed initial conditions

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -367,6 +367,7 @@ sub prepare_profile {
 
     if ($has_saptune) {
         assert_script_run 'saptune service takeover';
+        assert_script_run 'saptune revert all' if is_sle('16+');
         assert_script_run "saptune solution apply $profile";
     }
     elsif (is_sle('15+')) {


### PR DESCRIPTION
Running `saptune sollution apply` fails on SLE16 because there is already a SAP basic solution applied. This removes the basic solution before applying the one defined in `$profile`

- Related Ticket: TEAM-10220
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=apappas_vr_saptune

Failures are unrelated to the PR but caused by product changes/bugs