### PR TITLE
Revert Do not expect GRUB on VMware

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -12,7 +12,7 @@ use Utils::Architectures;
 use Utils::Backends qw(is_qemu);
 use serial_terminal 'select_serial_terminal';
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key quit_packagekit script_retry script_output_retry wait_for_purge_kernels);
-use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro is_hpc is_jeos is_transactional is_staging is_agama is_vmware);
+use version_utils qw(is_sle is_sles4sap is_upgrade is_leap_migration is_sle_micro is_hpc is_jeos is_transactional is_staging is_agama);
 use transactional qw(trup_call process_reboot);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
@@ -1079,8 +1079,7 @@ sub runtime_registration {
         trup_call('register' . $cmd);
         trup_call('--continue run zypper --gpg-auto-import-keys refresh') if is_staging;
         if (is_sle_micro('>=6.0') && is_sle_micro('<=6.1')) {
-            my $expected_grub = !is_vmware;    # On VMware GRUB is not needed and often is missed by openQA
-            process_reboot(trigger => 1, expected_grub => $expected_grub);
+            process_reboot(trigger => 1);
             add_suseconnect_product('SL-Micro-Extras');
         }
         process_reboot(trigger => 1);


### PR DESCRIPTION
We're going to stop using KEEP_GRUB_TIMEOUT to avoid the issues with missed GRUB screens.

- Related failure: e.g. https://openqa.suse.de/tests/17241892#step/health_check/23
- Reverts https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21663

Merge together with https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2162

### Verification runs

All of them fail at `rebootmgr`, that's a different issue.

* https://openqa.suse.de/tests/17242635
* https://openqa.suse.de/tests/17242636
* https://openqa.suse.de/tests/17242637
* https://openqa.suse.de/tests/17242638
