### PR TITLE
Revert "Add inst.finish in kernel boot parameters for ovmdrv test"

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -49,9 +49,6 @@ sub prepare_boot_params {
     }
     push @params, 'inst.register_url=' . get_var('SCC_URL') if get_var('FLAVOR') eq 'Online';
 
-    # disk label with OEMDRV will automatically pick the profile from disk without setting inst.auto
-    push @params, 'inst.finish=stop' if (get_var('HDD_2') =~ /oemdrv/);
-
     # add extra boot params along with the default ones
     push @params, split ' ', trim(get_var('EXTRABOOTPARAMS', ''));
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#21662 We can use EXTRABOOTPARAMS to add inst.finish, so do not need this PR any more.