### PR TITLE
Ignore RETBleed warning on SLEM 6.2

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -804,7 +804,8 @@
     "vmware-RETBleed": {
         "description": "kernel: RETBleed: WARNING: Spectre v2 mitigation leaves CPU vulnerable to RETBleed attacks, data leaks possible!",
         "products": {
-            "sle": ["15-SP6", "15-SP7", "16.0"]
+            "sle": ["15-SP6", "15-SP7", "16.0"],
+            "sle-micro": ["6.2"]
         },
         "type": "ignore"
     },


### PR DESCRIPTION
Known issue for SLES 16, so also known for SLEM 6.2

* Related failure: https://openqa.suse.de/tests/17241892#step/journal_check/6
