### PR TITLE
Prevent to bring DASD down in Agama

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -293,12 +293,15 @@ sub format_dasd {
         die "dasdfmt died with exit code $r" unless (defined($r) && $r == 0);
     }
 
-    # bring DASD down again to test the activation during the installation
-    if (script_run("timeout --preserve-status 20 bash -x /sbin/dasd_configure $dasd_path 0") != 0) {
-        record_soft_failure('bsc#1151436');
-        script_run('dasd_reload');
-        assert_script_run('dmesg');
-        assert_script_run("bash -x /sbin/dasd_configure -f $dasd_path 0");
+    # until Agama get better UI for DASD, activation will be done via parmfile (bsc#1238891#c9)
+    unless (is_agama) {
+        # bring DASD down again to test the activation during the installation
+        if (script_run("timeout --preserve-status 20 bash -x /sbin/dasd_configure $dasd_path 0") != 0) {
+            record_soft_failure('bsc#1151436');
+            script_run('dasd_reload');
+            assert_script_run('dmesg');
+            assert_script_run("bash -x /sbin/dasd_configure -f $dasd_path 0");
+        }
     }
 }
 


### PR DESCRIPTION
See for further info:
https://bugzilla.suse.com/show_bug.cgi?id=1238891#c9

- Related ticket: https://progress.opensuse.org/issues/178396
- Related PR: tbd
- Verification run: [dasd and dasd+zfcp](https://openqa.suse.de/tests/overview?version=16.0&distri=sle&build=jknphy%2Fos-autoinst-distri-opensuse%23dasd-down)
