### PR TITLE
On SLED is gnome-terminal default_gui_terminal

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -619,7 +619,7 @@ Returns the default console to be used by test modules, defaults to xterm
 =cut
 
 sub default_gui_terminal {
-    return "gnome-terminal" if check_var('DESKTOP', 'gnome') && (is_leap("<16"));
+    return "gnome-terminal" if check_var('DESKTOP', 'gnome') && (is_leap("<16")) || check_var('SLE_PRODUCT', 'sled');
     # Let SLE decide if they want to change to new behavior
     return "xterm" if check_var('DESKTOP', 'gnome') && (is_sle("<16"));
     return "kgx" if check_var('DESKTOP', 'gnome');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/169162
- Verification run: https://dzedro.suse.cz/tests/2532#step/change_password/71
