### PR TITLE
SLEM 6.2 known issues updated 

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -57,7 +57,7 @@
     "bsc#1126272": {
         "description": "Failed unmounting \/\\S+\\.|-- Reboot --|pam_systemd.*Failed to release session",
         "products": {
-            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" , "5.4" , "5.5", "6.0"],
+            "sle-micro": [ "5.0", "5.1", "5.2", "5.3" , "5.4" , "5.5", "6.0", "6.2"],
             "leap-micro": [ "5.2", "5.3", "5.4", "5.5" ],
             "microos":  ["Tumbleweed"]
         },
@@ -641,7 +641,7 @@
     "bsc#1230472": {
         "description": "Failed to start selfinstallbootloader.service",
         "products": {
-            "sle-micro": ["6.1"],
+            "sle-micro": ["6.1", "6.2"],
             "leap-micro": ["6.1"]
         },
         "type": "bug"


### PR DESCRIPTION
SLEM 6.2 known issues: 2 rec.s updated with 6.2 version, for journal checks validation

- Related ticket: https://progress.opensuse.org/issues/179732
- Needles: no.
- Verification run: t.b.d.
