### PR TITLE
Add aggregate repos to ibsm modules

### DIFF
--- a/t/17_sles4sap.t
+++ b/t/17_sles4sap.t
@@ -296,5 +296,4 @@ subtest '[download_hana_assets_from_server]' => sub {
     ok((any { /wget.*MY_DOWNLOAD_URL/ } @calls), 'wget call');
 };
 
-
 done_testing;

--- a/t/33_qam.t
+++ b/t/33_qam.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Warnings;
+use Test::MockModule;
+use List::Util qw(any none);
+use testapi;
+use qam;
+
+sub undef_vars {
+    set_var($_, undef) for qw(
+      BALAMB_TEST_REPOS
+      WINHILL_TEST_REPOS
+    );
+}
+
+subtest '[get_test_repos]' => sub {
+    set_var('BALAMB_TEST_REPOS', 'Squall,Seifer');
+    set_var('WINHILL_TEST_REPOS', 'Quistis,Rinoa');
+
+    my $qam_mock = Test::MockModule->new('qam', no_auto => 1);
+    $qam_mock->redefine('set_var', sub { return; });
+
+    my @repos = get_test_repos();
+
+    undef_vars();
+
+    ok((any { /Squall/ } @repos), 'Got "Squall" from BALAMB_TEST_REPOS');
+    ok((any { /Seifer/ } @repos), 'Got "Seifer" from BALAMB_TEST_REPOS');
+    ok((any { /Quistis/ } @repos), 'Got "Quistis" from WINHILL_TEST_REPOS');
+    ok((any { /Rinoa/ } @repos), 'Got "Rinoa" from WINHILL_TEST_REPOS');
+};
+
+done_testing;

--- a/tests/publiccloud/validate_repos.pm
+++ b/tests/publiccloud/validate_repos.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use strict;
 use utils;
+use qam;
 use publiccloud::ssh_interactive "select_host_console";
 use publiccloud::utils "validate_repo";
 
@@ -25,10 +26,7 @@ sub run {
         record_info('Skip validation', 'Skipping maintenance update validation (triggered by setting)');
         return;
     } else {
-        # In Incidents there is INCIDENT_REPO instead of MAINT_TEST_REPO
-        # Those two variables contain list of repositories separated by comma
-        set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) unless get_var('MAINT_TEST_REPO');
-        my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
+        my @repos = get_test_repos();
         # Failsafe: Fail if there are no test repositories, otherwise we have the wrong template link
         my $count = scalar @repos;
         my $check_empty_repos = get_var('PUBLIC_CLOUD_IGNORE_EMPTY_REPO', 0) == 0;

--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -8,6 +8,7 @@ use strict;
 use warnings;
 use base 'sles4sap_publiccloud_basetest';
 use sles4sap_publiccloud;
+use qam;
 use testapi;
 
 sub test_flags {
@@ -17,9 +18,7 @@ sub test_flags {
 sub run {
     my ($self, $run_args) = @_;
     $self->import_context($run_args);
-
-    set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) if get_var('INCIDENT_REPO');
-    my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
+    my @repos = get_test_repos();
     my $count = 0;
     my @zypper_cmd;
 


### PR DESCRIPTION
Now that we want to enable aggregate tests for IBSM jobs, `cluster_add_repos.pm` and `validate_repos.pm` need to be adjusted to also look for repos in the openqa variables that hold aggregate test repos.

- Related ticket: https://jira.suse.com/browse/TEAM-9981
- Verification run: 
Aggregate test: http://openqaworker15.qa.suse.cz/tests/319972 (All good - only fails because timeout needs to be changed in settings)
Single Incident test: https://openqa.suse.de/tests/17281449 (PASS)
