### PR TITLE
Make sure nfs-client is installed as part of krb5 tests

### DIFF
--- a/tests/security/krb5/krb5_crypt_prepare.pm
+++ b/tests/security/krb5/krb5_crypt_prepare.pm
@@ -91,7 +91,7 @@ EOF
     # Prepare krb5 application and config files
     zypper_call('ref');
     zypper_call('lr -u');
-    zypper_call('in krb5 krb5-server krb5-client');
+    zypper_call('in krb5 krb5-server krb5-client nfs-client');
     assert_script_run("echo 'export KRB5CCNAME=/root/kcache' >> /etc/profile.d/krb5.sh");    # Make ticket permanent
     assert_script_run("source /etc/profile.d/krb5.sh");
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/180014
- Verification run: https://openqa.suse.de/tests/17265961#step/krb5_crypt_nfs_client/10 (that exact step now works), https://openqa.suse.de/tests/17265961#step/krb5_crypt_prepare/100 (it's installed here)
