### PR TITLE
Add test for selecting grub2-bls during install

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -127,7 +127,7 @@ sub load_installation_tests {
         loadtest 'installation/installation_overview';
     }
     loadtest 'installation/disable_grub_timeout' if is_bootloader_grub2;
-    loadtest 'installation/configure_sdboot' if is_bootloader_sdboot;
+    loadtest 'installation/configure_bls' if is_bootloader_sdboot || is_bootloader_grub2_bls;
     loadtest 'installation/enable_selinux' if get_var('ENABLE_SELINUX');
     loadtest 'installation/start_install';
     loadtest 'installation/await_install';

--- a/tests/installation/configure_bls.pm
+++ b/tests/installation/configure_bls.pm
@@ -11,6 +11,7 @@ use warnings;
 use base 'y2_installbase';
 use testapi;
 use utils;
+use version_utils qw(is_bootloader_sdboot is_bootloader_grub2_bls);
 
 sub run {
     my ($self) = shift;
@@ -35,7 +36,8 @@ sub run {
     # Select systemd-boot as bootloader
     send_key 'alt-b', wait_screen_change => 1;
     send_key 'spc', wait_screen_change => 1;
-    send_key_until_needlematch 'inst-bootloader-systemd-boot-selected', 'down';
+    send_key_until_needlematch 'inst-bootloader-systemd-boot-selected', 'down' if is_bootloader_sdboot;
+    send_key_until_needlematch 'inst-bootloader-grub2-bls-selected', 'down' if is_bootloader_grub2_bls;
     send_key 'ret', wait_screen_change => 1;    # Select the option
 
     unless (get_var('KEEP_GRUB_TIMEOUT')) {

--- a/variables.md
+++ b/variables.md
@@ -37,7 +37,7 @@ BCI_SKIP | boolean | false | Switch to disable BCI test runs. Necessary for fine
 BCI_PREPARE | boolean | false | Launch the bci_prepare step again. Useful to re-initialize the BCI-Test repo when using a different BCI_TESTS_REPO
 BCI_VIRTUALENV | boolean | false | Use a virtualenv for pip dependencies in BCI tests
 BCI_OS_VERSION | string | | Set the environment variable OS_VERSION to this value, if present
-BOOTLOADER | string | grub2 | Which bootloader is used by the image (and in the future also: will be selected during installation)
+BOOTLOADER | string | grub2 | Which bootloader is used by the image or will be selected during installation, e.g. `grub2`, `grub2-bls`, `systemd-boot`
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.
 BUILDAH_STORAGE_DRIVER | string | | Storage driver used for buildah: vfs or overlay.


### PR DESCRIPTION
This module selects grub2-bls during the installation. As of right now, the test run will fail afterwards due to a bug in the current MicroOS image, which causes `mkdumprd` to be called _before_ `sdbootutil add-all-kernels` during the installation when grub2-bls has been selected.

- Related ticket:
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/833
- Verification run: http://192.168.43.19/tests/13
