### PR TITLE
Revert "change_password: Drop unused likely outdated needle"

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -80,7 +80,9 @@ sub add_user {
         type_string $newUser;
     }
     assert_and_click "set-password-option";
-    assert_screen 'adduser-password-window';
+    if (!check_screen('adduser-password-window', 2)) {
+        assert_and_click "adduser-next";
+    }
     assert_and_click "set-newuser-password";
     type_string $pwd4newUser;
     assert_and_click "confirm-newuser-password";


### PR DESCRIPTION
This reverts commit 1b3e8dfa2ae77e0ae080360060f8b178e9cedb56.

- Verification run: 
https://openqa.suse.de/tests/17271142 15-SP6
https://openqa.opensuse.org/tests/4970653 TW