### PR TITLE
Move fwupd and tuned tests from kernel squad to core

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2620,8 +2620,6 @@ sub load_extra_tests_syscontainer {
 }
 
 sub load_extra_tests_kernel {
-    loadtest "kernel/tuned";
-    loadtest "kernel/fwupd" if is_sle('15+');
     loadtest "hpc/rasdaemon" if ((is_sle('15+') && (!is_ppc64le)) || is_tumbleweed);
 
     # keep it on the latest place as it taints kernel

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -154,6 +154,8 @@ schedule:
     - console/sqlite3
     - console/sysctl
     - console/sysstat
+    - console/tuned
+    - console/fwupd
     - '{{snmp}}'
     - console/curl_ipv6
     - console/wget_ipv6

--- a/schedule/functional/extra_tests_textmode_sle16.yaml
+++ b/schedule/functional/extra_tests_textmode_sle16.yaml
@@ -100,6 +100,8 @@ schedule:
     - console/sqlite3
     - console/sysctl
     - console/sysstat
+    - console/tuned
+    - console/fwupd
     - '{{snmp}}'
     - console/curl_ipv6
     - console/wget_ipv6

--- a/tests/console/fwupd.pm
+++ b/tests/console/fwupd.pm
@@ -1,11 +1,11 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright 2021-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: fwupd
 # Summary: fwupd smoke test
-# Maintainer: Kernel QE <kernel-qa@suse.de>
+# Maintainer: QE Core <qe-core@suse.de>
 
 use base 'opensusebasetest';
 use strict;

--- a/tests/console/tuned.pm
+++ b/tests/console/tuned.pm
@@ -1,11 +1,11 @@
 # SUSE's openQA tests
 #
-# Copyright 2019 SUSE LLC
+# Copyright 2019-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: tuned
 # Summary: Regression test for tuned daemon
-# Maintainer: Petr Cervinka <pcervinka@suse.com>
+# Maintainer: QE Core <qe-core@suse.de>
 # Tags: https://jira.suse.com/browse/SLE-6514
 
 use base 'consoletest';


### PR DESCRIPTION
https://progress.opensuse.org/issues/179840

- Verification run:
[sle](http://openqa.suse.de/tests/overview?distri=sle&build=rfan0407)
[tw](https://openqa.opensuse.org/tests/4976182#)

**Please ignore the failed modules, they are known issues**