### PR TITLE
Adds PUBLIC_CLOUD_AVAILABILITY_ZONE variable

### DIFF
--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -19,7 +19,7 @@ provider "google" {
   credentials = var.cred_file
   project     = var.project
   region      = var.region #sets global default region for all resources
-  zone        = local.availability_zone #sets the global default zone for all zonal resources
+  zone        = local.zone #sets the global default zone for all zonal resources
 }
 
 data "external" "gce_cred" {
@@ -28,7 +28,7 @@ data "external" "gce_cred" {
 }
 
 locals {
-  availability_zone = "${var.region}-b"
+  zone = "${var.region}-${var.availability_zone}"
 }
 
 variable "cred_file" {
@@ -47,8 +47,15 @@ variable "type" {
   default = "n1-standard-2"
 }
 
+# https://cloud.google.com/compute/docs/regions-zones
 variable "region" {
+  description = "The region where the objects will be deployed to."
   default = "europe-west1"
+}
+
+variable "availability_zone" {
+  description = "The availability zone of the specified region. Used by zone-specific resources like DBs and disks."
+  default = "b"
 }
 
 variable "image_id" {
@@ -214,5 +221,5 @@ output "region" {
 }
 
 output "availability_zone" {
-  value = local.availability_zone
+  value = local.zone
 }

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -15,14 +15,6 @@ terraform {
   }
 }
 
-locals {
-  availability_zone = "${var.region}-b"
-}
-
-variable "cred_file" {
-  default = "/root/google_credentials.json"
-}
-
 provider "google" {
   credentials = var.cred_file
   project     = var.project
@@ -33,6 +25,14 @@ provider "google" {
 data "external" "gce_cred" {
   program = ["cat", var.cred_file]
   query   = {}
+}
+
+locals {
+  availability_zone = "${var.region}-b"
+}
+
+variable "cred_file" {
+  default = "/root/google_credentials.json"
 }
 
 variable "instance_count" {

--- a/variables.md
+++ b/variables.md
@@ -311,6 +311,7 @@ PUBLIC_CLOUD_ACCNET | boolean | false | If set, az_accelerated_net test module i
 PUBLIC_CLOUD_ACCOUNT | string | "" | For GCE will set account via `gcloud config set account ' . $self->account`.
 PUBLIC_CLOUD_AHB_LT | string | "SLES_BYOS" | For Azure, it specifies the license type to change to (and test).
 PUBLIC_CLOUD_ARCH | string | "x86_64" | The architecture of created VM.
+PUBLIC_CLOUD_AVAILABILITY_ZONE | string | "" | The availability zone to use. Depends on `PUBLIC_CLOUD_REGION`.
 PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION | string | "" | Defines the image definition for uploading Arm64 images to the image gallery.
 PUBLIC_CLOUD_AZURE_K8S_RESOURCE_GROUP | string | "" | Name for the resource group which is subscribed the kubernetes cluster.
 PUBLIC_CLOUD_AZURE_OFFER | string | "" | Specific to Azure. Allow to query for image based on offer and sku. Should be used together with PUBLIC_CLOUD_AZURE_SKU.


### PR DESCRIPTION
Our current approach is that we have a variable `PUBLIC_CLOUD_REGION` which was in fact the Availability Zone (e.g. `europe-west4-a`). I believe this is misleading and the wrong use. We literally have `zone = var.region` in the code.

This MR adds the variable `availability_zone` which is appended to the variable `region` for GCP specifically. This is necessary because in GCP, some resources are ZONAL (e.g. Disks, DBs) but he Terraform provider does not select a zone for you automatically and you have to specify it. 

This PR needs to get merged together with this MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2166 

- Related ticket: https://progress.opensuse.org/issues/176925
- Needles: N/A
- Verification run: SOON TM
- Extra Info:
  * https://cloud.google.com/compute/docs/regions-zones 
  * https://github.com/hashicorp/terraform-provider-google/issues/4603 
  * https://cloud.google.com/compute/docs/gpus/gpu-regions-zones