### PR TITLE
Support vmware tests on sles16

### DIFF
--- a/lib/Yam/Agama/Pom/RebootPage.pm
+++ b/lib/Yam/Agama/Pom/RebootPage.pm
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 
 use testapi;
+use version_utils qw(is_vmware);
 
 sub new {
     my ($class, $args) = @_;
@@ -35,8 +36,17 @@ sub expect_is_shown {
 
 sub reboot {
     my ($self) = @_;
-    select_console('installation');
-    assert_and_click($self->{tag_reboot_button});
+    if (is_vmware) {
+        if (current_console() =~ /root/) {
+            enter_cmd 'reboot';
+        } else {
+            select_console('root-console');
+            enter_cmd 'reboot';
+        }
+    } else {
+        select_console('installation');
+        assert_and_click($self->{tag_reboot_button});
+    }
 }
 
 1;

--- a/schedule/virt_autotest/sle16_default_svirt.yaml
+++ b/schedule/virt_autotest/sle16_default_svirt.yaml
@@ -2,10 +2,23 @@
 description: 'Main hyperv and vmware test suite. Maintainer: qa-virt@suse.de.'
 name: 'svirt hyperv and vmware'
 schedule:
-    - installation/bootloader_hyperv
+    - '{{bootloader}}'
     - yam/agama/boot_agama
-    - yam/agama/agama_auto_without_log
+    - '{{agama_auto}}'
     - installation/grub_test
     - installation/first_boot
     - yam/validate/validate_base_product
     - yam/validate/validate_first_user
+conditional_schedule:
+    bootloader:
+        VIRSH_VMM_FAMILY:
+            vmware:
+                - installation/bootloader_svirt
+            hyperv:
+                - installation/bootloader_hyperv
+    agama_auto:
+        VIRSH_VMM_FAMILY:
+            vmware:
+                - yam/agama/agama_auto
+            hyperv:
+                - yam/agama/agama_auto_without_log


### PR DESCRIPTION
Add support for sles16 installation tests on vmware.

- Related ticket: https://progress.opensuse.org/issues/163661
- Verification run: https://openqa.suse.de/tests/17280029
