### PR TITLE
Fix micro target version check

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -157,8 +157,11 @@ sub check_reboot_changes {
 sub check_target_version {
     my $release = script_output "cat /etc/os-release";
     my $expected_version = get_var("TARGET_VERSION", get_required_var("VERSION"));
+    my $selector = is_micro(">=6.2") ?
+      "VARIANT=\"Micro ?$expected_version\"?" :
+      "VERSION=\"?$expected_version\"?";
 
-    die "Target version not found! Expected: $expected_version" if ($release !~ "VERSION=\"?$expected_version\"?");
+    die "Target version not found! Expected: $expected_version" if ($release !~ $selector);
 }
 
 =head2 record_kernel_audit_messages

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -777,7 +777,8 @@ sub check_os_release {
 
 Returns 1 (true) if os release version matches the one passed as arguement.
 If no arguements are given, the function will compare the os release version
-in /etc/os-release file with "VERSION" var.
+in /etc/os-release file with "VERSION" or "VARIANT" var.
+VARIANT contains the version on SL Micro/Microos from 6.2.
 
 =cut
 
@@ -785,7 +786,7 @@ sub verify_os_version {
     my ($version, $os_release_file) = @_;
     $version //= get_var("VERSION");
     $os_release_file //= '/etc/os-release';
-    return script_output("grep VERSION= $os_release_file | grep $version");
+    return script_output("grep 'VERSION=\\|VARIANT=' $os_release_file | grep $version");
 }
 
 =head2 is_public_cloud


### PR DESCRIPTION
Fixed verification of SL Micro version, we have to switch from `VERSION=`to `VARIANT=` in `/etc/os-release`

- Related ticket: N/A
- Needles: N/A
- Verification run: 
  - 6.1->6.2: https://openqa.suse.de/tests/17298095
  - 6.0->6.1: https://openqa.suse.de/tests/17298096
  - 5.5->6.0: https://openqa.suse.de/tests/17298097
