### PR TITLE
Update agama jsonnet for SLES16 guest

### DIFF
--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
@@ -71,7 +71,7 @@
     post: [
       {
         name: "persistent_hostname",
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo -e "##Host-Name##.##Domain-Name##" > /etc/hostname
         |||
@@ -79,21 +79,21 @@
       {
         name: "sshd_config",
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes\nPermitEmptyPasswords no\nTCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > /etc/ssh/sshd_config.d/01-qe-virtualization-functional.conf
         |||
       },
       {
         name: "ssh_config",
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo -e "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null" > /etc/ssh/ssh_config.d/01-qe-virtualization-functional.conf
         |||
       },
       {
         name: "persistent_journal_logging",
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo -e "[Journal]\\nStorage=persistent" > /etc/systemd/journald.conf.d/01-qe-virtualization-functional.conf
         |||


### PR DESCRIPTION
* **Use** ```content``` instead of ```body``` when defining scripts in agama jsonnet for SLES16 guest.

* **Verification Runs:**
  * [Build71.1 online iso](http://10.200.140.9/tests/450)
  * [Build71.1 full iso](http://10.200.140.9/tests/452)
  * [Build71.1 online and full iso](http://10.200.140.9/tests/453)


