### PR TITLE
Add network-bonding-target job for sle16

### DIFF
--- a/tests/network/network_bonding_setup.pm
+++ b/tests/network/network_bonding_setup.pm
@@ -202,7 +202,7 @@ sub setup_server {
 
     set_resolv(nameservers => \@scc_dns) if scalar(@scc_dns) > 0;
     runtime_registration() if $requires_scc_registration;
-    add_suseconnect_product("sle-module-containers") if is_sle;
+    add_suseconnect_product("sle-module-containers") if is_sle('<16');
 
     install_pkgs($self, "podman", "ethtool", "dnsmasq");
 


### PR DESCRIPTION
Add network-bonding-target job for sle16

- Related ticket: https://progress.opensuse.org/issues/179855
- Verification run: https://openqa.suse.de/tests/17285466
  https://openqa.suse.de/tests/17285465