### PR TITLE
Update guest SLES 16.0 media

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_full_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_full_iso.xml
@@ -26,8 +26,8 @@
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-x86_64-Build12345.install.iso</guest_installation_media>
-    <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-x86_64-Build12345.install/</guest_installation_fine_grained_media>
+    <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-Full-x86_64-Build12345.install.iso</guest_installation_media>
+    <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-Full-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
     <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -26,8 +26,8 @@
     <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-Online-16.0-x86_64-Build12345.install.iso</guest_installation_media>
-    <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-Online-16.0-x86_64-Build12345.install/</guest_installation_fine_grained_media>
+    <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build12345.install.iso</guest_installation_media>
+    <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
     <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>

--- a/schedule/virt_autotest/sle16_guest_installation.yaml
+++ b/schedule/virt_autotest/sle16_guest_installation.yaml
@@ -5,5 +5,5 @@ schedule:
     - installation/ipxe_install
     - installation/agama_reboot
     - virt_autotest/login_console
-    # - virt_autotest/prepare_non_transactional_server
-    # - virt_autotest/unified_guest_installation
+    - virt_autotest/prepare_non_transactional_server
+    - virt_autotest/unified_guest_installation


### PR DESCRIPTION
* **Update** guest SLES 16.0 media which take new format, including ```data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_full_iso.xml``` and ```data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml```.

* **Update** schedule file ```schedule/virt_autotest/sle16_guest_installation.yaml``` to include guest installation part.

* **openQA** yaml config is [here](https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/268). 

* **Verification Runs:**
  * [online iso guest installation](https://openqa.suse.de/tests/17285629)
  * [full iso guest installation](https://progress.opensuse.org/issues/180164)



