### PR TITLE
rasdaemon: Add missing console selection

### DIFF
--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -54,6 +54,8 @@ sub subtestcase_output ($out, $regex, $description) {
 }
 
 sub run {
+    select_serial_terminal();
+
     # load kernel module
     assert_script_run('modprobe mce-inject') if is_x86_64;
 


### PR DESCRIPTION
Fix poo#180167: Some tests were removed from extra_tests_kernel, which used to run before rasdaemon and handled the console selection. As a result, rasdaemon started failing due to the missing console setup.

- Related ticket: https://progress.opensuse.org/issues/180167
- Needles: none
- Verification run: https://openqa.suse.de/tests/17285616
