### PR TITLE
Update openqa-agent to Version 1.1.3

### DIFF
--- a/data/wsl/Autounattend_UEFI.xml
+++ b/data/wsl/Autounattend_UEFI.xml
@@ -379,7 +379,7 @@
         <!-- openqa-agent installation and config -->
         <RunSynchronousCommand wcm:action="add">
           <Order>64</Order>
-          <Path>powershell.exe -NoProfile -Command "Invoke-WebRequest -Uri https://github.com/grisu48/openqa-agent/releases/download/v1.1.2/agent-Windows-amd64 -OutFile 'C:\Program Files\openqa-agent.exe'"</Path>
+          <Path>powershell.exe -NoProfile -Command "Invoke-WebRequest -Uri https://github.com/grisu48/openqa-agent/releases/download/v1.1.3/agent-Windows-amd64 -OutFile 'C:\Program Files\openqa-agent.exe'"</Path>
         </RunSynchronousCommand>
         <RunSynchronousCommand wcm:action="add">
           <Order>65</Order>


### PR DESCRIPTION
Add recent bugfixes by bumping the openqa-agent version in the unattended installation.

- Related ticket: https://progress.opensuse.org/issues/178837
- Verification run: https://openqa.opensuse.org/tests/4978205#live
