### PR TITLE
Modify the selinux policy for apache

### DIFF
--- a/tests/console/php_postgresql.pm
+++ b/tests/console/php_postgresql.pm
@@ -61,6 +61,10 @@ sub run {
     # So use root-console for aarch64. See poo#178639
     select_console 'root-console' if (is_aarch64);
 
+    if (is_sle('=16.0')) {
+        assert_script_run("setsebool -P httpd_can_network_connect_db 1");
+    }
+
     # test itself
     test_pgsql;
 


### PR DESCRIPTION
On sle16 enforcing is on by default, so we need to modify the selinux policy
to allow apache access database. 

Related: https://progress.opensuse.org/issues/179771

VR: 
sle 16.0
https://openqa.suse.de/tests/17287611 (x86 passed on php_postgresql)
https://openqa.suse.de/tests/17287609 (aarch64 passed on php_postgresql)

**The failed module is tracked by https://bugzilla.suse.com/show_bug.cgi?id=1240949**