### PR TITLE
Add POC qesap regression test with IBSm

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_azure_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_peering.yaml
@@ -1,0 +1,54 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'azure'
+apiver: 3
+terraform:
+  variables:
+    az_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    public_key: '%SLES4SAP_PUBSSHKEY%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    vnet_address_range: '%MAIN_ADDRESS_RANGE%'
+    subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
+    ibsm_rg: '%IBSM_RG%'
+    ibsm_vnet_name: '%IBSM_VNET%'
+ansible:
+  roles_path: '%ANSIBLE_ROLES%'
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_key_name: '%HANA_KEYNAME%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  hana_vars:
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HQ0'
+    sap_hana_install_instance_number: '00'
+    sap_domain: 'qe-test.example.com'
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+    use_sap_hana_sr_angi: '%USE_SR_ANGI%'
+  create:
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+    - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'
+    - fully-patch-system.yaml
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+    - cluster_sbd_prep.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml
+  destroy:
+    - deregister.yaml

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -107,6 +107,17 @@ sub run {
     $variables{ANSIBLE_ROLES} = qesap_get_ansible_roles_dir();
     $variables{HANA_INSTALL_MODE} = get_var('QESAPDEPLOY_HANA_INSTALL_MODE', 'standard');
 
+    # Default to empty string is intentional:
+    # empty value is used in terraform not to create the deployment
+    $variables{IBSM_VNET} = get_var('QESAPDEPLOY_IBSM_VNET', '');
+    $variables{IBSM_RG} = get_var('QESAPDEPLOY_IBSM_RG', '');
+    if (get_var('QESAPDEPLOY_IBSM_VNET') && get_var('QESAPDEPLOY_IBSM_RG')) {
+        $variables{IBSM_IP} = get_required_var('QESAPDEPLOY_IBSM_IP');
+        $variables{DOWNLOAD_HOSTNAME} = get_required_var('QESAPDEPLOY_DOWNLOAD_HOSTNAME');
+        # To be replaced with get_test_repos
+        $variables{REPOS} = get_required_var('QESAPDEPLOY_REPOS');
+    }
+
     qesap_prepare_env(
         openqa_variables => \%variables,
         provider => get_required_var('PUBLIC_CLOUD_PROVIDER')

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -16,12 +16,12 @@ sub run {
     my $provider_setting = get_required_var('PUBLIC_CLOUD_PROVIDER');
 
     if ($provider_setting eq 'AZURE') {
-        if (get_var("QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP")) {
-            my $rg = qesap_az_get_resource_group();
-            my $ibs_mirror_rg = get_var('QESAPDEPLOY_IBSMIRROR_RESOURCE_GROUP');
-            qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_rg);
-            qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSMIRROR_IP"));
-            qesap_az_vnet_peering_delete(source_group => $rg, target_group => $ibs_mirror_rg);
+        if (get_var('QESAPDEPLOY_IBSM_VNET') && get_var('QESAPDEPLOY_IBSM_RG')) {
+            my @remote_cmd = (
+                'ping -c3 ' . get_required_var('QESAPDEPLOY_DOWNLOAD_HOSTNAME'),
+                'zypper -n ref -s -f',
+                'zypper -n lr');
+            qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 300) for @remote_cmd;
         }
     }
     elsif ($provider_setting eq 'EC2') {


### PR DESCRIPTION
Prepare qesap regression code to add a proof of concept Azure variant of the test schedule doing:
- network peering to the IBSm via Terraform
- TEST repo added by Ansible
- remove test code to create the peering using az cli
- Add some validation commands


# Related ticket: 
https://jira.suse.com/browse/TEAM-10216

# Verification run:

YAML schedule running existing test module about peering. Uses new conf.yaml and with settings about peering
http://openqaworker15.qa.suse.cz/tests/320076

Without setting about peering and without scheduling test module about peering
http://openqaworker15.qa.suse.cz/tests/320078
