### PR TITLE
containers: fakeroot is not available on SLE 16.0

### DIFF
--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -74,7 +74,8 @@ sub run {
     enable_modules if is_sle;
 
     # Install tests dependencies
-    my @pkgs = qw(apache2-utils fakeroot jq openssl podman squashfs skopeo);
+    my @pkgs = qw(apache2-utils jq openssl podman squashfs skopeo);
+    push @pkgs, "fakeroot" unless is_sle('>=16.0');
     install_packages(@pkgs);
 
     $self->bats_setup;


### PR DESCRIPTION
fakeroot is not available on SLE 16.0 impacting skopeo upstream tests.

I notified about the missing package.  This will be reverted if the decision is made to eventually add it.

- Failing test: https://openqa.suse.de/tests/17279889#step/skopeo/61
- Verification run: https://openqa.suse.de/tests/17285908
