### PR TITLE
SDAF deployment retention fixes

### DIFF
--- a/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars
+++ b/data/sles4sap/sap_deployment_automation_framework/SAP_SYSTEM.tfvars
@@ -868,4 +868,5 @@ bom_name = "%SDAF_BOM_NAME%"
 # These tags will be applied to all resources
 tags = {
   "DeployedBy" = "OpenQA-SDAF-automation",
+  %SDAF_NO_CLEANUP%
 }

--- a/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars
+++ b/data/sles4sap/sap_deployment_automation_framework/WORKLOAD_ZONE.tfvars
@@ -536,4 +536,5 @@ utility_vm_useDHCP = true
 # These tags will be applied to all resources
 tags = {
   "DeployedBy" = "OpenQA-SDAF-automation",
+  %SDAF_NO_CLEANUP%
 }

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -34,6 +34,7 @@ use sles4sap::sap_deployment_automation_framework::naming_conventions qw(
 );
 
 our @EXPORT = qw(
+  $output_log_file
   az_login
   sdaf_ssh_key_from_keyvault
   serial_console_diag_banner
@@ -48,9 +49,9 @@ our @EXPORT = qw(
   ansible_execute_command
   ansible_show_status
   playbook_settings
-  $output_log_file
   sdaf_register_byos
   get_sdaf_instance_id
+  sdaf_deployment_reused
 );
 
 our $output_log_file = '';
@@ -1072,6 +1073,33 @@ sub sdaf_register_byos {
         sap_sid => $args{sap_sid},
         verbose => 1
     );
+}
+
+=head2 sdaf_deployment_reused
+
+    sdaf_deployment_reused(quiet=>'BeQuiet!');
+
+If an existing deployment is being reused according to openQA setting `SDAF_DEPLOYMENT_ID`, function will display
+`record_info` message with details and returns deployment ID. Otherwise returns nothing/false.
+Argument B<quiet> can be used to disable `record_info` message.
+
+=over
+
+=item * B<quiet>: Hide 'record_info' message. Default: undef
+
+=back
+=cut
+
+sub sdaf_deployment_reused {
+    my (%args) = @_;
+    my $deployment_id = get_var('SDAF_DEPLOYMENT_ID');
+    return unless $deployment_id;
+
+    record_info(
+        'Deploy skip', "OpenQA setting 'SDAF_DEPLOYMENT_ID' defined.\nExisting deployment '$deployment_id' will be used.")
+      if !$args{quiet};
+
+    return $deployment_id;
 }
 
 1;

--- a/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm
@@ -41,6 +41,8 @@ sub check_required_vars {
 }
 
 sub run {
+    # Skip module if existing deployment is being re-used
+    return if sdaf_deployment_reused();
     serial_console_diag_banner('Module sdaf_deployer_setup.pm : start');
     select_serial_terminal();
 

--- a/tests/sles4sap/sap_deployment_automation_framework/execute_playbooks.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/execute_playbooks.pm
@@ -62,6 +62,9 @@ sub test_flags {
 }
 
 sub run {
+    # Skip module if existing deployment is being re-used
+    return if sdaf_deployment_reused();
+
     serial_console_diag_banner('Module sdaf_deploy_hanasr.pm : start');
     my $sap_sid = get_required_var('SAP_SID');
     my $sdaf_config_root_dir = get_sdaf_config_path(


### PR DESCRIPTION
Deployment retention does not currently work as intended and deployer 
resources are still being cleaned up even with 'SDAF_RETAIN_DEPLOYMENT' 
being set. This PR applies fixes and introduces feature which tags all 
resources that should be ignored by cleanup mechanism. Tag name can be 
customized using openQA setting `SDAF_NO_CLEANUP_TAG` with default value 
'sdaf_no_cleanup'. Tag is applied on all resources created including 
sap_systems and workload_zone.

- Related ticket: https://jira.suse.com/browse/TEAM-10222
- Verification runs: 

Retain deployment: 
```SDAF_RETAIN_DEPLOYMENT='yeah' SDAF_NO_CLEANUP_TAG='pcw_ignore'```
https://openqaworker15.qa.suse.cz/tests/320288#step/SDAF%20cleanup/1

Reuse deployment:
```SDAF_DEPLOYMENT_ID=320287 SDAF_RETAIN_DEPLOYMENT='yeah'```
Deployment modules skipped: https://openqaworker15.qa.suse.cz/tests/320298#
Old deployment used in tests: https://openqaworker15.qa.suse.cz/tests/320299#

