### PR TITLE
Fix helm docker.io rate limit issues

### DIFF
--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -24,10 +24,6 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 use containers::k8s;
 use publiccloud::utils qw(gcloud_install);
 
-my $chart_repo_url = "https://helm.nginx.com/stable";
-my $chart_repo = "nginx-stable";
-my $chart_name = "nginx-ingress";
-
 sub run {
     my ($self, $run_args) = @_;
     my $job_id = get_current_job_id();
@@ -41,8 +37,9 @@ sub run {
     $self->{is_k3s} = $is_k3s;
 
     select_serial_terminal;
+    my $chart = "nginx-stable/nginx-ingress";
 
-    record_info("Chart name", "$chart_repo/$chart_name @ $chart_repo_url");
+    record_info("Chart name", $chart);
 
     if ($is_k3s) {
         install_k3s();
@@ -123,10 +120,10 @@ sub run {
 
     # Add repo, search and show values
     assert_script_run(
-        "helm repo add $chart_repo $chart_repo_url", 180);
+        "helm repo add nginx-stable https://helm.nginx.com/stable", 180);
     assert_script_run("helm repo update", 180);
-    assert_script_run("helm search repo $chart_name");
-    assert_script_run("helm show all $chart_repo/$chart_name");
+    assert_script_run("helm search repo nginx-ingress");
+    assert_script_run("helm show all $chart");
 
     uninstall_k3s() if $is_k3s;
 }

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -147,4 +147,8 @@ sub test_flags {
     return {milestone => 1};
 }
 
+sub _cleanup {
+    # Skip baseclass _cleanup subroutine as it's not applicable in this test module.
+}
+
 1;

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -6,8 +6,8 @@
 # Summary: Test deploy a helm chart in a k3s
 # - install k3s, kubectl and helm
 # - test helm repo add, update, search and show all
-# - add bitnami repo
-# - test helm install with apache helm chart
+# - add nginx repo
+# - test helm install with nginx helm chart
 # - test helm list
 # - check the correct deployment of the helm chart
 # - cleanup system (helm and k3s)
@@ -24,6 +24,10 @@ use registration qw(add_suseconnect_product get_addon_fullname);
 use containers::k8s;
 use publiccloud::utils qw(gcloud_install);
 
+my $chart_repo_url = "https://helm.nginx.com/stable";
+my $chart_repo = "nginx-stable";
+my $chart_name = "nginx-ingress";
+
 sub run {
     my ($self, $run_args) = @_;
     my $job_id = get_current_job_id();
@@ -37,9 +41,8 @@ sub run {
     $self->{is_k3s} = $is_k3s;
 
     select_serial_terminal;
-    my $chart = "bitnami/apache";
 
-    record_info("Chart name", $chart);
+    record_info("Chart name", "$chart_repo/$chart_name @ $chart_repo_url");
 
     if ($is_k3s) {
         install_k3s();
@@ -120,10 +123,10 @@ sub run {
 
     # Add repo, search and show values
     assert_script_run(
-        "helm repo add bitnami https://charts.bitnami.com/bitnami", 180);
+        "helm repo add $chart_repo $chart_repo_url", 180);
     assert_script_run("helm repo update", 180);
-    assert_script_run("helm search repo apache");
-    assert_script_run("helm show all $chart");
+    assert_script_run("helm search repo $chart_name");
+    assert_script_run("helm show all $chart_repo/$chart_name");
 
     uninstall_k3s() if $is_k3s;
 }


### PR DESCRIPTION
Fix docker.io rate limit issues by replacing bitnami/apache chart with nginx-ingress which doesn't have any dependencies on dockerhub.

- Related ticket: https://progress.opensuse.org/issues/180101
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17289697