### PR TITLE
Rename Public Cloud cleanups

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1041,11 +1041,7 @@ sub post_fail_hook {
 
         # Destroy the public cloud instance in case of fatal test failure
         my $flags = $self->test_flags();
-        $self->{run_args}->{my_provider}->cleanup() if ($flags->{fatal});
-
-        # When tunnel-console is used we upload the log
-        my $ssh_sut = '/var/tmp/ssh_sut.log';
-        upload_logs($ssh_sut) unless (script_run("test -f $ssh_sut") != 0);
+        $self->{run_args}->{my_provider}->finalize() if ($flags->{fatal});
     }
 }
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -748,13 +748,13 @@ sub escape_single_quote {
     return $s;
 }
 
-=head2 cleanup
+=head2 teardown
 
-This method is called called after each test on failure or success.
+This method is calling the terraform_destroy() subroutine.
 
 =cut
 
-sub cleanup {
+sub teardown {
     my ($self) = @_;
     $self->terraform_destroy();
     assert_script_run "cd";

--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -135,7 +135,7 @@ sub post_fail_hook {
             $run_args->{network_peering_present} = $self->{network_peering_present} = 0;
         }
         $run_args->{my_provider} = $self->{provider};
-        $run_args->{my_provider}->cleanup($run_args);
+        $run_args->{my_provider}->finalize($run_args);
         return;
     }
     $self->SUPER::post_fail_hook;

--- a/variables.md
+++ b/variables.md
@@ -365,7 +365,7 @@ PUBLIC_CLOUD_LTP | boolean | false | If set, the run_ltp test module is added to
 PUBLIC_CLOUD_MAX_INSTANCES | integer | 1 | Allows the test to call "create_instance" subroutine within lib/publiccloud/provider.md a limited amount of times. If set to 0 or undef, it allows an unlimited amount of calls.
 PUBLIC_CLOUD_NAMESPACE | string | "" | The Public Cloud Namespace name that will be used to compose the full credentials URL together with `PUBLIC_CLOUD_CREDENTIALS_URL`.
 PUBLIC_CLOUD_NEW_INSTANCE_TYPE | string | "t3a.large" | Specify the new instance type to check bsc#1205002 in EC2
-PUBLIC_CLOUD_NO_CLEANUP | boolean | false | Do not remove the instance after test finished running.
+PUBLIC_CLOUD_NO_TEARDOWN | boolean | false | Do not tear the instance down.
 PUBLIC_CLOUD_NVIDIA | boolean | 0 | If enabled, nvidia module would be scheduled. This variable should be enabled only sle15SP4 and above.
 PUBLIC_CLOUD_PERF_COLLECT | boolean | 1 | To enable `boottime` measures collection, at end of `create_instance` routine.
 PUBLIC_CLOUD_PERF_DB | string | "perf_2" | defines the bucket in which the performance metrics are stored on PUBLIC_CLOUD_PERF_DB_URI


### PR DESCRIPTION
Instead of `publiccloud::basetest::_cleanup` we now have `publiccloud::basetest::finalActions`.
Instead of `publiccloud::provider::cleanup` we now have `publiccloud::provider::tearDown`.
I left the `<test_module>::cleanup` methods the same as that would be way more work.
The point is that there will not be multiple `cleanup` subroutines.

- Related ticket: [poo#180038](https://progress.opensuse.org/issues/180038)
- Verification run: 
   * [Build0594](https://pdostal-server.suse.cz/tests/overview?build=0594&distri=sle&version=15-SP7) of sle-15-SP7-Azure-SAP-BYOS.x86_64	  [sles4sap_gnome_saptune_delete_rename@az_Standard_E8s_v3](https://pdostal-server.suse.cz/tests/8801)
   * [Build0594](https://pdostal-server.suse.cz/tests/overview?build=0594&distri=sle&version=15-SP7) of sle-15-SP7-GCE-SAP-BYOS.x86_64	  [sles4sap_gnome_saptune_delete_rename@gce_n1_highmem_8](https://pdostal-server.suse.cz/tests/8800)
   * [Build20250413-1](https://pdostal-server.suse.cz/tests/overview?build=20250413-1&distri=sle&version=15-SP6) of sle-15-SP6-EC2-BYOS-Updates.x86_64	  [publiccloud_consoletests@64bit](https://pdostal-server.suse.cz/tests/8793)
   * [Build20250413-1](https://pdostal-server.suse.cz/tests/overview?build=20250413-1&distri=sle&version=15-SP6) of sle-15-SP6-Azure-BYOS-Updates.aarch64	  [publiccloud_img_proof@64bit](https://pdostal-server.suse.cz/tests/8792)
   * [Build20250413-1](https://pdostal-server.suse.cz/tests/overview?build=20250413-1&distri=sle&version=12-SP5) of sle-12-SP5-Azure-Standard-Updates.x86_64	  [publiccloud_img_proof@64bit](https://pdostal-server.suse.cz/tests/8789)
   * [Build:38189:dtb-armv7l](https://pdostal-server.suse.cz/tests/overview?build=%3A38189%3Adtb-armv7l&distri=sle&version=15-SP5) of sle-15-SP5-EC2-SAP-PAYG-Incidents-saptune.x86_64	  [sles4sap_gnome_saptune_notes@ec2_r4.8xlarge](https://pdostal-server.suse.cz/tests/8776)
   * [Build0594](https://pdostal-server.suse.cz/tests/overview?build=0594&distri=sle&version=15-SP7) of sle-15-SP7-EC2-SAP-BYOS.x86_64	  [sles4sap_gnome_saptune_notes@ec2_r4.8xlarge](https://pdostal-server.suse.cz/tests/8773)
   * [Build:38189:dtb-armv7l](https://pdostal-server.suse.cz/tests/overview?build=%3A38189%3Adtb-armv7l&distri=sle&version=15-SP5) of sle-15-SP5-Azure-SAP-BYOS-Incidents-saptune.x86_64	  [sles4sap_gnome_saptune_delete_rename@az_Standard_E4s_v3](https://pdostal-server.suse.cz/tests/8775)
   * [Build:38189:dtb-armv7l](https://pdostal-server.suse.cz/tests/overview?build=%3A38189%3Adtb-armv7l&distri=sle&version=15-SP5) of sle-15-SP5-GCE-SAP-PAYG-Incidents-saptune.x86_64	  [sles4sap_gnome_saptune_delete_rename@gce_n1_highmem_8](https://pdostal-server.suse.cz/tests/8777)