### PR TITLE
P.C. Aitl tests timeout management added

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -311,6 +311,7 @@ PUBLIC_CLOUD | boolean | false | All Public Cloud tests have this variable set t
 PUBLIC_CLOUD_ACCNET | boolean | false | If set, az_accelerated_net test module is added to the job.
 PUBLIC_CLOUD_ACCOUNT | string | "" | For GCE will set account via `gcloud config set account ' . $self->account`.
 PUBLIC_CLOUD_AHB_LT | string | "SLES_BYOS" | For Azure, it specifies the license type to change to (and test).
+PUBLIC_CLOUD_AITL_TIMEOUT | int | 5400 | Azure AITL tests max time to run in sec.
 PUBLIC_CLOUD_ARCH | string | "x86_64" | The architecture of created VM.
 PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION | string | "" | Defines the image definition for uploading Arm64 images to the image gallery.
 PUBLIC_CLOUD_AZURE_K8S_RESOURCE_GROUP | string | "" | Name for the resource group which is subscribed the kubernetes cluster.


### PR DESCRIPTION
An infinite loop `while(1)` generally is preferable to be avoided, here in partcular for publiccloud, due to expensive nature of resources, therefore adding a timeout management.

- Related ticket: [179623](https://progress.opensuse.org/issues/179623)
- Needles: no.
- Verification run: TBD
