### PR TITLE
Automate support extension in the interactive installation (HA)

### DIFF
--- a/schedule/yam/agama_extensions_and_patterns.yaml
+++ b/schedule/yam/agama_extensions_and_patterns.yaml
@@ -1,0 +1,12 @@
+---
+name: agama_extensions_and_patterns
+description: >
+  Perform interactive installation with extensions and software pattern selection.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_registered_addons
+  - yam/validate/validate_installed_patterns


### PR DESCRIPTION
We have added the required schedule to run this test.

- Related ticket: https://progress.opensuse.org/issues/180134
- Related PR: https://github.com/jknphy/agama-integration-test-webpack/pull/101
- Needles: N/A
- Verification run: Not available in OpenQA check integration test verification
