### PR TITLE
Fix qam-minimal+base schdule on 12-SP5

### DIFF
--- a/schedule/qam/12-SP5/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-base.yaml
@@ -27,7 +27,7 @@ schedule:
   - console/yast2_bootloader
   - console/yast2_i
   - console/yast2_lan
-  - console/yast2_nfs_server
+  - '{{yast2_nfs_server}}'
   - console/mtab
   - console/mariadb_srv
   - console/rsync
@@ -46,4 +46,8 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/glibc_sanity
+  yast2_nfs_server:
+    BACKEND:
+      qemu:
+        - console/yast2_nfs_server
 ...


### PR DESCRIPTION
yast2_nfs_server is not running on s390x the setup does expect qemu backend

- Related ticket: https://progress.opensuse.org/issues/179452
- Verification run: https://openqa.suse.de/tests/17307498