### PR TITLE
Don't remove system default python when doing cleanup

### DIFF
--- a/schedule/functional/stack_tests_python_sle16.yaml
+++ b/schedule/functional/stack_tests_python_sle16.yaml
@@ -3,7 +3,6 @@ name: stack_tests_python_sle16+
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - console/python_scientific
   - console/python3_new_version_check
   - console/python3_setuptools
   - console/python3_pipx
@@ -13,14 +12,4 @@ schedule:
   - console/python3_websocket_client
   - console/python_flake8
   - console/python_pycairo
-  - console/django
-  - '{{python_liblouis}}'
-  - console/rabbitmq
   - console/python_scientific
-conditional_schedule:
-  python_liblouis:
-    ARCH:
-      'x86_64':
-        - console/python_liblouis
-      'aarch64':
-        - console/python_liblouis

--- a/tests/console/python3_pipx.pm
+++ b/tests/console/python3_pipx.pm
@@ -57,9 +57,7 @@ sub run_tests ($python3_spec_release) {
 
 sub cleanup {
     if (is_sle() || is_leap('>15.5')) {
-        foreach my $python_version (get_available_python_versions()) {
-            zypper_call("rm $python_version-base", exitcode => [0, 104]);
-        }
+        remove_installed_pythons();
     }
     assert_script_run("cd ..");
     script_run("rm -r data");

--- a/tests/console/python3_pynacl.pm
+++ b/tests/console/python3_pynacl.pm
@@ -25,6 +25,12 @@ sub run_test {
     my ($python_package) = @_;
     my $pkg = "$python_package-PyNaCl";
 
+    if ($python_package eq 'python311' && is_sle('>=16.0')) {
+        # python311-setuptools is not available on sle16
+        record_info("Skip python311", 'Skip python311-PyNaCl test on SLE 16.0');
+        return;
+    }
+
     zypper_call("se $pkg");
 
     if (is_transactional) {

--- a/tests/console/python3_setuptools.pm
+++ b/tests/console/python3_setuptools.pm
@@ -45,6 +45,12 @@ sub run_tests ($python3_spec_release) {
         record_info("Skip python39", 'https://jira.suse.com/browse/PED-8196');
         return;
     }
+    if ($python3_spec_release eq 'python311' && is_sle('>=16.0')) {
+        # python311-setuptools is not available on sle16
+        record_info("Skip python311", 'Skip python311-setuptools test on SLE 16.0');
+        return;
+    }
+
     zypper_call("install $python3_spec_release $python3_spec_release-setuptools");
     record_info("pip3 version:", script_output("rpm -q $python3_spec_release-pip"));
     record_info("python3-setuptools:", script_output("rpm -q $python3_spec_release-setuptools"));

--- a/tests/console/python3_websocket_client.pm
+++ b/tests/console/python3_websocket_client.pm
@@ -49,7 +49,7 @@ sub run_test ($python_package) {
 
 sub run {
     my $self = shift;
-    add_suseconnect_product(get_addon_fullname('python3')) if is_sle();
+    add_suseconnect_product(get_addon_fullname('python3')) if is_sle('<16.0');
     my $server_pid = test_setup();
     my @python3_versions = get_available_python_versions();
     unshift @python3_versions, "python3";    # append the system default one

--- a/tests/console/python_scientific.pm
+++ b/tests/console/python_scientific.pm
@@ -41,7 +41,7 @@ sub run {
     # Package 'python3-scipy' requires PackageHub is available
     return unless is_phub_ready();
 
-    my $scipy = is_sle('<15-sp1') ? '' : 'python3-scipy';
+    my $scipy = is_sle('<15-sp1') || is_sle('>=16.0') ? '' : 'python3-scipy';
     zypper_call "in python3 python3-numpy $scipy";
     # Run python scripts
     run_python_script('python3-numpy-test.py');

--- a/tests/console/python_virtualenv.pm
+++ b/tests/console/python_virtualenv.pm
@@ -80,9 +80,7 @@ sub uninstall_package ($version_number) {
 
 sub cleanup {
     if (is_sle()) {
-        foreach my $python_version (get_available_python_versions()) {
-            zypper_call("rm $python_version-base", exitcode => [0, 104]);
-        }
+        remove_installed_pythons();
     }
     assert_script_run("cd ..");
     script_run("rm -r data");


### PR DESCRIPTION
For sle16, we need to do following changes:
1. Don't remove system default installed python package: python313
2. Skip not available packages tests on sle16

Related: https://progress.opensuse.org/issues/180161

VRs:
16.0:  https://openqa.suse.de/tests/17311552  (passed)
15.7:  https://openqa.suse.de/tests/17311462   (passed)
TW: https://openqa.opensuse.org/tests/4986501# (softfail)