### PR TITLE
Automate to set the hostname during Agama installation

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -798,9 +798,10 @@ sub generate_json_profile {
     my $profile_name = "generated_profile.json";
     my $profile_path = get_required_var('CASEDIR') . "/data/" . get_required_var('INST_AUTO');
 
-    my @profile_options = map { " --tla-" . (/true|false/ ? "code" : "str") . " $_" }
+    my @profile_options = map { "--tla-" . (/true|false/ ? "code" : "str") . " $_ " }
       split(' ', trim(get_var('AGAMA_PROFILE_OPTIONS')));
     diag "jsonnet @profile_options $profile_path";
+    record_info("JSONNET Command", "jsonnet @profile_options $profile_path");
     my $profile_content = `jsonnet @profile_options $profile_path`;
     record_info("Profile", $profile_content);
 

--- a/schedule/yam/agama_extended.yaml
+++ b/schedule/yam/agama_extended.yaml
@@ -1,7 +1,9 @@
 ---
 name: agama_extended
 description: >
-  Perform interactive installation with agama.
+  Perform interactive installation with the following additional test:
+    - Set static hostname via UI.
+    - Install packages gvim,rpm-build via profile.
 schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests

--- a/schedule/yam/agama_extended_unattended.yaml
+++ b/schedule/yam/agama_extended_unattended.yaml
@@ -1,0 +1,11 @@
+---
+name: agama_extended_unattended
+description: >
+  Perform unattended installation with agama setting a custom hostname via kernel parameters and individual packages installed.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_hostname
+  - yam/validate/validate_packages

--- a/test_data/yam/agama_sle_extended.yaml
+++ b/test_data/yam/agama_sle_extended.yaml
@@ -1,2 +1,2 @@
 ---
-hostname_from_kernel_cmdline: suselinux
+hostname: suselinux

--- a/tests/yam/validate/validate_hostname.pm
+++ b/tests/yam/validate/validate_hostname.pm
@@ -17,7 +17,7 @@ use Test::Assert ':assert';
 
 sub run {
     select_console 'root-console';
-    my $expected_install_hostname = get_test_suite_data()->{hostname_from_kernel_cmdline} // 'localhost';
+    my $expected_install_hostname = get_test_suite_data()->{hostname} // 'localhost';
     my $hostname = script_output('hostnamectl hostname');
     assert_str_equals($expected_install_hostname, $hostname, "Wrong hostname. Expected: '$expected_install_hostname', got '$hostname'");
 }


### PR DESCRIPTION
We have added the required modifications to manage setting the hostname in Agama.

- Related ticket: https://progress.opensuse.org/issues/179293
- Related PR: https://github.com/jknphy/agama-integration-test-webpack/pull/100
- Needles: N/A
- Verification run:
  - sles_extended: https://openqa.suse.de/tests/17322678 (FAILED due to external reasons, tested locally)
  - sles_extended_unattended: https://openqa.suse.de/tests/17322482