### PR TITLE
Fix locale parameters

### DIFF
--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -204,7 +204,7 @@ sub run {
     return if (is_sle('<15'));
 
     ## Revert locales to default and verify
-    my $rc_lc_reverted = change_locale($lang_booted_short, $rc_lc_changed);
+    my $rc_lc_reverted = change_locale($lc_data{$lang_booted_short}, $rc_lc_changed);
     my $reverted_glibc_string = test_users_locale($rc_lc_reverted, $test_data_lang{$lang_ref});
     power_action('reboot', textmode => 1);
     record_info('Rebooting', "Expected locale set=$rc_lc_reverted->{RC_LANG}");


### PR DESCRIPTION
During revert of locale changes done by `glibc_locale`, the encoding
`UTF-8` was omitted which results in ansible
[failure](https://openqa.suse.de/tests/17304472#step/ansible/61)

- Verification run: https://openqa.suse.de/tests/17308475#step/ansible/1
