### PR TITLE
Temporarily disable podmansh test

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -149,7 +149,7 @@ sub load_host_tests_podman {
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
-        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.1") || is_leap_micro("<6.1"));
+        # loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.1") || is_leap_micro("<6.1"));
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects
     load_buildah_tests($run_args) unless (is_sle('<15') || is_sle_micro || is_microos || is_leap_micro || is_staging);


### PR DESCRIPTION
Temporarily disables #21297 before a permanent fix gets implemented.

- Related ticket: https://progress.opensuse.org/issues/164015
- Needles: N/A
- Verification run: N/A