### PR TITLE
Decouple cleanup module for SDAF scenarios

### DIFF
--- a/schedule/sles4sap/sap_deployment_automation_framework/ensa2_scenarios.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/ensa2_scenarios.yml
@@ -14,7 +14,6 @@ schedule:
   - sles4sap/redirection_tests/redirection_check
   - '{{hana_cluster_check}}'
   - sles4sap/redirection_tests/ensa2_hanadb_sapcontrol_move_ascs
-  - sles4sap/sap_deployment_automation_framework/cleanup
 conditional_schedule:
   hana_cluster_check:
     HANA_CLUSTER_CHECK:

--- a/t/26_deployment_connector.t
+++ b/t/26_deployment_connector.t
@@ -51,12 +51,16 @@ subtest '[find_deployment_id]' => sub {
     $mock_function->redefine(get_current_job_id => sub { return '0079'; });
     $mock_function->redefine(get_parent_ids => sub { return ['0083', '0087']; });
     $mock_function->redefine(get_deployer_vm_name => sub { return '0079' if grep(/0079/, @_); });
+    $mock_function->redefine(record_info => sub { return; });
+    set_var('OPENQA_URL', 'openqa.suse.de');
 
     is find_deployment_id(deployer_resource_group => 'Char'), '0079', 'Current job ID belongs to VM';
 
+    set_var('SDAF_GRANDPARENT_ID', '');
     $mock_function->redefine(get_current_job_id => sub { return; });
     is find_deployment_id(deployer_resource_group => 'Char'), undef, 'Return undef if no ID found';
 
+    set_var('SDAF_GRANDPARENT_ID', '');
     $mock_function->redefine(get_deployer_vm_name => sub { return '0083' if grep(/0083/, @_); });
     is find_deployment_id(deployer_resource_group => 'Char'), '0083', 'Parent job ID belongs to VM';
 };

--- a/tests/sles4sap/redirection_tests/hanasr_schedule_tests.pm
+++ b/tests/sles4sap/redirection_tests/hanasr_schedule_tests.pm
@@ -104,9 +104,6 @@ sub run {
         Primary site $failover_db will stay intact.");
     }
 
-    loadtest('sles4sap/sap_deployment_automation_framework/cleanup', name => "SDAF cleanup", run_args => $run_args, @_);
-    record_info('Load test', 'Scheduling SDAF cleanup');
-
     $run_args->{scenarios} = \%scenarios;
 }
 


### PR DESCRIPTION
TEAM-10245 - [SDAF] Decouple cleanup module for HanaSR scenarios

Related MR: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/962
( :bell:  PR and MR should be merged at the same time)  

- Related ticket: https://jira.suse.com/browse/TEAM-10245
- Verification run:
SDAF_PRD_cleanup_ensa2: https://openqaworker15.qa.suse.cz/tests/320831#dependencies (all passed)
SDAF_PRD_cleanup_HanaSR: https://openqaworker15.qa.suse.cz/tests/320834#dependencies (all passed)
