### PR TITLE
User serial terminal for test 'mtab'

### DIFF
--- a/tests/console/mtab.pm
+++ b/tests/console/mtab.pm
@@ -15,12 +15,12 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use serial_terminal qw(select_user_serial_terminal);
 
 sub run {
-    select_console 'user-console';
+    select_user_serial_terminal;
     assert_script_run 'test -L /etc/mtab';
-    script_run('cat /etc/mtab');
-    save_screenshot;
+    record_info('/etc/mtab', script_output('cat /etc/mtab'));
 }
 
 1;


### PR DESCRIPTION
[poo#179759](https://progress.opensuse.org/issues/179759)

We can see sporadic performance issue on ppc64le and aarch64 after switch to user console, so use serial terminal instead.

- Verification run: 
[20+ iterations on ppc](http://openqa.suse.de/tests/overview?distri=sle&build=rfan0411&version=15-SP7)
[other platform](http://openqa.suse.de/tests/overview?build=rfan0411_nonppc&distri=sle&version=15-SP7)
[tw](https://openqa.opensuse.org/tests/4987900)