### PR TITLE
Un-schedule fwupd test for s390x on sle16

### DIFF
--- a/schedule/functional/extra_tests_textmode_sle16.yaml
+++ b/schedule/functional/extra_tests_textmode_sle16.yaml
@@ -1,8 +1,17 @@
-name:           extra_tests_textmode
-description:    >
+---
+name: extra_tests_textmode_sle16
+description: >
     Maintainer: qe-core
     Extra CLI tests
 conditional_schedule:
+    fwupd:
+        ARCH:
+            aarch64:
+                - console/fwupd
+            x86_64:
+                - console/fwupd
+            ppc64le:
+                - console/fwupd
     snmp:
         MACHINE:
             64bit:
@@ -101,7 +110,7 @@ schedule:
     - console/sysctl
     - console/sysstat
     - console/tuned
-    - console/fwupd
+    - '{{fwupd}}'
     - '{{snmp}}'
     - console/curl_ipv6
     - console/wget_ipv6


### PR DESCRIPTION
https://progress.opensuse.org/issues/180662

quick fix for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21759
