### PR TITLE
SDAF fix cleanup az query

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -365,7 +365,7 @@ sub destroy_orphaned_resources {
     # Result will show only resources created by OpenQA tests and only those which are allowed to be cleaned up.
     my $all_resources = az_resource_list(
         resource_group => get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP'),
-        query => '[?tags.deployment_id && tags.' . no_cleanup_tag() . '].{resource_id:id, creation_time:createdTime}'
+        query => '[?tags.deployment_id && tags.' . no_cleanup_tag() . ' == null ].{resource_id:id, creation_time:createdTime}'
     );
     my @orphaned_resources;
 


### PR DESCRIPTION
Az query for filtering 'no clenaup' resources is currently broken. This PR fixes the query.

- Related ticket: https://jira.suse.com/browse/TEAM-10222
- Verification run: 

`SDAF_RETAIN_DEPLOYMENT='yes'` 
https://mordor.suse.cz/tests/1549#

Test without `pcw_cleanup` tag (will be cleaned up)
https://mordor.suse.cz/tests/1546#

Cleanup job with retention 30sec  `SDAF_DEPLOYER_VM_RETENTION_SEC=30`
https://mordor.suse.cz/tests/1551#step/cleanup/342

Resources  *1546 destroyed, *1549 kept intact


