### PR TITLE
Increase timeout for vm create

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -774,7 +774,7 @@ sub az_vm_create {
         push @vm_create, '--authentication-type ssh --generate-ssh-keys';
     }
 
-    assert_script_run(join(' ', @vm_create), timeout => 600);
+    assert_script_run(join(' ', @vm_create), timeout => 900);
 }
 
 =head2 az_vm_list


### PR DESCRIPTION
Increase timeout of script_run in Azure vm create from 600 to 900.

It could eventually help some tests on 15sp7 

- Verification run:
 http://openqaworker15.qa.suse.cz/tests/320836