### PR TITLE
Reenable and fix podmansh for Tumbleweed, MicroOS and JeOS 

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -148,8 +148,8 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
+        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.1") || is_leap_micro("<6.1"));
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
-        # loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.1") || is_leap_micro("<6.1"));
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects
     load_buildah_tests($run_args) unless (is_sle('<15') || is_sle_micro || is_microos || is_leap_micro || is_staging);


### PR DESCRIPTION
Fixes issues with running on Tumbleweed, MicroOS and JeOS from [here](https://openqa.opensuse.org/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&arch=&flavor=&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=164015&distri=microos&distri=opensuse&version=Tumbleweed&build=20250409&groupid=1#).

- Related ticket: https://progress.opensuse.org/issues/164015
- Needles: N/A
- VRs:
    TW: https://openqa.opensuse.org/tests/4999392#step/podmansh/1
    MicroOS: https://openqa.opensuse.org/tests/4999393#step/podmansh/1
    JeOS: https://openqa.opensuse.org/tests/4999394#step/podmansh/1

~Note: The `rootless_podman` test doesn't properly restore the user environment and leaves the user session unclean, hence breaking Tumbleweed and JeOS runs if executed before `podmansh`. MicroOS runs were not affected because of the transactional update mechanism rebooting the system.~

EDIT: All issues fixed. Now makes sure the serial console is clean and ready on entry and exit of the test.