### PR TITLE
Ignore sle15sp2 sriov test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2575,8 +2575,9 @@ sub load_hypervisor_tests {
         my $feature = $virt_features{$test};
         my $modules = $feature->{modules};
         my $hypervisor = $feature->{hypervisor};
+        # The LTSS for SUSE 15-SP1 has ended. Due to a bug (bsc#1230913), also skip 15-SP2.
         if ($test eq 'ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH') {
-            next unless is_sle('>15');
+            next unless is_sle('>=15-sp3');
         }
         check_and_load_mu_virt_features($test, $modules, $hypervisor);
     }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/167018
- Needles: N/A
- Verification run:  
[15sp2](http://openqa.qam.suse.cz/tests/86101)
[15sp5](http://openqa.qam.suse.cz/tests/86102#)
