### PR TITLE
Simplify BATS tests

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -313,28 +313,8 @@ sub load_container_tests {
         return;
     }
 
-    if (get_var('SKOPEO_BATS_SKIP') || get_var('RUNC_BATS_SKIP') || get_var('NETAVARK_BATS_SKIP')) {
-        if (!check_var('SKOPEO_BATS_SKIP', 'all')) {
-            loadtest 'containers/bats/skopeo' if (is_tumbleweed || is_microos || is_sle || is_leap || is_sle_micro('>=5.5'));
-        }
-        if (!check_var('RUNC_BATS_SKIP', 'all')) {
-            loadtest 'containers/bats/runc' if (is_tumbleweed || is_sle || is_leap);
-        }
-        if (!check_var('NETAVARK_BATS_SKIP', 'all')) {
-            loadtest 'containers/bats/netavark' if (is_tumbleweed || is_sle('>15-SP4') || is_leap);
-        }
-        return;
-    }
-
-    if (get_var('PODMAN_BATS_SKIP')) {
-        if (!check_var('PODMAN_BATS_SKIP', 'all')) {
-            loadtest 'containers/bats/podman';
-        }
-        return;
-    }
-
-    if (get_var('BUILDAH_BATS_SKIP')) {
-        loadtest 'containers/bats/buildah';
+    if (get_var('BATS_PACKAGE') =~ /(buildah|netavark|podman|runc|skopeo)/) {
+        loadtest "containers/bats/$1";
         return;
     }
 

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -27,55 +27,69 @@ The tests rely on some variables:
 | variable | description |
 | --- | --- |
 | `BUILDAH_STORAGE_DRIVER` | Storage driver used for buildah: `vfs` or `overlay` |
-| `BUILDAH_BATS_URL` | URL to get the tests from |
-| `BUILDAH_BATS_TESTS` | Run only the specified tests, otherwise: |
-| `BUILDAH_BATS_SKIP` | Skip subtests on ALL scenarios below: |
-| `BUILDAH_BATS_SKIP_ROOT` | Skip subtests for root user |
-| `BUILDAH_BATS_SKIP_USER` | Skip subtests for non-root user |
+| `BATS_URL` | URL to get the tests from |
+| `BATS_TESTS` | Run only the specified tests, otherwise: |
+| `BATS_SKIP` | Skip subtests on ALL scenarios below: |
+| `BATS_SKIP_ROOT` | Skip subtests for root user |
+| `BATS_SKIP_USER` | Skip subtests for non-root user |
 
 ## netavark
 
 | variable | description |
 | --- | --- |
-| `NETAVARK_BATS_URL` | URL to get the tests from |
-| `NETAVARK_BATS_TESTS` | Run only the specified tests, otherwise: |
-| `NETAVARK_BATS_SKIP` | Skip tests on ALL scenarios |
+| `BATS_URL` | URL to get the tests from |
+| `BATS_TESTS` | Run only the specified tests, otherwise: |
+| `BATS_SKIP` | Skip tests on ALL scenarios |
 
 ## podman
 
 | variable | description |
 | --- | --- |
-| `PODMAN_BATS_URL` | URL to get the tests from |
-| `PODMAN_BATS_TESTS` | Run only the specified tests, otherwise: |
-| `PODMAN_BATS_SKIP` | Skip subtests on ALL scenarios below: |
-| `PODMAN_BATS_SKIP_ROOT_LOCAL` | Skip subtests for root / local |
-| `PODMAN_BATS_SKIP_ROOT_REMOTE` | Skip subtests root / remote |
-| `PODMAN_BATS_SKIP_USER_LOCAL` | Skip subtests for rootless / local |
-| `PODMAN_BATS_SKIP_USER_REMOTE` | Skip subtests for rootless / remote |
+| `BATS_URL` | URL to get the tests from |
+| `BATS_TESTS` | Run only the specified tests, otherwise: |
+| `BATS_SKIP` | Skip subtests on ALL scenarios below: |
+| `BATS_SKIP_ROOT_LOCAL` | Skip subtests for root / local |
+| `BATS_SKIP_ROOT_REMOTE` | Skip subtests root / remote |
+| `BATS_SKIP_USER_LOCAL` | Skip subtests for rootless / local |
+| `BATS_SKIP_USER_REMOTE` | Skip subtests for rootless / remote |
 
 ## runc
 
 | variable | description |
 | --- | --- |
-| `RUNC_BATS_URL` | URL to get the tests from |
-| `RUNC_BATS_TESTS` | Run only the specified tests, otherwise: |
-| `RUNC_BATS_SKIP` | Skip subtests on ALL scenarios below: |
-| `RUNC_BATS_SKIP_ROOT` | Skip subtests for root user |
-| `RUNC_BATS_SKIP_USER` | Skip subtests for non-root user |
+| `BATS_URL` | URL to get the tests from |
+| `BATS_TESTS` | Run only the specified tests, otherwise: |
+| `BATS_SKIP` | Skip subtests on ALL scenarios below: |
+| `BATS_SKIP_ROOT` | Skip subtests for root user |
+| `BATS_SKIP_USER` | Skip subtests for non-root user |
 
 ## skopeo
 
 | variable | description |
 | --- | --- |
-| `SKOPEO_BATS_URL` | URL to get the tests from |
-| `SKOPEO_BATS_TESTS` | Run only the specified tests, otherwise: |
-| `SKOPEO_BATS_SKIP` | Skip subtests on ALL scenarios below: |
-| `SKOPEO_BATS_SKIP_ROOT` | Skip subtests for root user |
-| `SKOPEO_BATS_SKIP_USER` | Skip subtests for non-root |
+| `BATS_URL` | URL to get the tests from |
+| `BATS_TESTS` | Run only the specified tests, otherwise: |
+| `BATS_SKIP` | Skip subtests on ALL scenarios below: |
+| `BATS_SKIP_ROOT` | Skip subtests for root user |
+| `BATS_SKIP_USER` | Skip subtests for non-root |
 
 NOTES
  - The special value `all` may be used to skip all tests.
  - The special value `none` should be used to avoid skipping any subtests.
+
+## Summary of variables
+
+| variable | buildah | netavark | podman | runc | skopeo |
+|---|:---:|:---:|:---:|:---:|:---:|
+| `BATS_URL` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `BATS_TESTS` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `BATS_SKIP` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `BATS_SKIP_ROOT` | ✅ | | | ✅ | ✅ |
+| `BATS_SKIP_USER` | ✅ | | | ✅ | ✅ |
+| `BATS_SKIP_ROOT_LOCAL` | | | ✅ | | |
+| `BATS_SKIP_ROOT_REMOTE` | | | ✅ | | |
+| `BATS_SKIP_USER_LOCAL` | | | ✅ | | |
+| `BATS_SKIP_USER_REMOTE` | | | ✅ | | |
 
 ## openQA schedules
 
@@ -111,7 +125,8 @@ NOTES
 
 ## Workflow
 
-- To debug possible SELinux issues you may check the audit log & clone a job with `ENABLE_SELINUX=0`
+- To debug SELinux issues you may check the audit log & clone a job with `ENABLE_SELINUX=0`
+- To debug runtime issues you may clone a job with `OCI_RUNTIME=crun`.  The default OCI runtime is `runc` on all openSUSE & SUSE products except SLEM 6.0 & 6.1
 
 ## Tools
 

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -18,6 +18,7 @@ The tests rely on some variables:
 
 | variable | description |
 | --- | --- |
+| `BATS_PACKAGE` | `buildah` `netavark` `podman` `runc` `skopeo` |
 | `BATS_VERSION` | Version of [bats](https://github.com/bats-core/bats-core) to use |
 | `ENABLE_SELINUX` | Set to `0` to put SELinux in permissive mode |
 | `OCI_RUNTIME` | OCI runtime to use: `runc` or `crun` |
@@ -97,31 +98,6 @@ NOTES
 - [Latest SLE 16](https://gitlab.suse.de/qac/qac-openqa-yaml/-/blob/master/containers/latest_host_sle16.yaml)
 - [Latest SLES 15](https://gitlab.suse.de/qac/qac-openqa-yaml/-/blob/master/containers/latest_host.yaml)
 - [SLES 15-SP3+](https://gitlab.suse.de/qac/qac-openqa-yaml/-/blob/master/containers/updates.yaml)
-
-## openQA jobs
-
-| product | packages |
-| --- | ---|
-| opensuse Tumbleweed	| [runc skopeo netavark](https://openqa.opensuse.org/tests/latest?distri=opensuse&flavor=DVD&version=Tumbleweed&arch=x86_64&test=container_host_bats_testsuite) |
-| | [buildah](https://openqa.opensuse.org/tests/latest?distri=opensuse&flavor=DVD&version=Tumbleweed&arch=x86_64&test=container_host_buildah_testsuite) |
-| | [podman](https://openqa.opensuse.org/tests/latest?distri=opensuse&flavor=DVD&version=Tumbleweed&arch=x86_64&test=container_host_podman_testsuite) |
-| Latest SLE 16 | [runc skopeo netavark](https://openqa.suse.de/tests/latest?distri=sle&flavor=Online&version=16.0&arch=x86_64&test=bats_testsuite) |
-| | [buildah](https://openqa.suse.de/tests/latest?distri=sle&flavor=Online&version=16.0&arch=x86_64&test=buildah_testsuite) |
-| | [podman](https://openqa.suse.de/tests/latest?distri=sle&flavor=Online&version=16.0&arch=x86_64&test=podman_testsuite) |
-| Latest SLE 15 | [runc skopeo netavark](https://openqa.suse.de/tests/latest?distri=sle&flavor=Online&version=15-SP7&arch=x86_64&test=bats_testsuite) |
-| |	[buildah](https://openqa.suse.de/tests/latest?distri=sle&flavor=Online&version=15-SP7&arch=x86_64&test=buildah_testsuite) |
-| |	[podman](https://openqa.suse.de/tests/latest?distri=sle&flavor=Online&version=15-SP7&arch=x86_64&test=podman_testsuite) |
-| SLE 15-SP7 | [runc skopeo netavark](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=x86_64&test=bats_testsuite) |
-| | [buildah](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=x86_64&test=buildah_testsuite) |
-| | [podman](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=x86_64&test=podman_testsuite) |
-| SLE 15-SP6 | [runc skopeo netavark](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=x86_64&test=bats_testsuite) |
-| | [buildah](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=x86_64&test=buildah_testsuite)
-| | [podman](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=x86_64&test=podman_testsuite)
-| SLE 15-SP5 | [runc skopeo netavark](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP5&arch=x86_64&test=bats_testsuite) |
-| | [buildah](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP5&arch=x86_64&test=buildah_testsuite)
-| SLE 15-SP4 | [runc skopeo netavark](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP4&arch=x86_64&test=bats_testsuite) |
-| | [buildah](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP4&arch=x86_64&test=buildah_testsuite) |
-| SLE 15-SP3 | [runc skopeo netavark](https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP3&arch=x86_64&test=bats_testsuite) |
 
 ## Workflow
 

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -60,20 +60,16 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    install_bats;
-    enable_modules if is_sle;
-
-    # Install tests dependencies
     my @pkgs = qw(aardvark-dns cargo firewalld iproute2 iptables jq make protobuf-devel netavark);
     if (is_tumbleweed || is_sle('>=16.0')) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {
         push @pkgs, qw(dbus-1);
     }
-    install_packages(@pkgs);
-    install_ncat;
 
-    $self->bats_setup;
+    $self->bats_setup(@pkgs);
+
+    install_ncat;
 
     $netavark = script_output "rpm -ql netavark | grep podman/netavark";
     record_info("netavark version", script_output("$netavark --version"));

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -33,7 +33,7 @@ sub run_tests {
     assert_script_run "echo $log_file .. > $log_file";
 
     my @tests;
-    foreach my $test (split(/\s+/, get_var("NETAVARK_BATS_TESTS", ""))) {
+    foreach my $test (split(/\s+/, get_var("BATS_TESTS", ""))) {
         $test .= ".bats" unless $test =~ /\.bats$/;
         push @tests, "test/$test";
     }
@@ -42,7 +42,7 @@ sub run_tests {
     my $ret = script_run "env $env bats --tap $tests | tee -a $log_file", 1200;
 
     unless (@tests) {
-        my @skip_tests = split(/\s+/, get_var('NETAVARK_BATS_SKIP', ''));
+        my @skip_tests = split(/\s+/, get_var('BATS_SKIP', ''));
         # Unconditionally ignore these flaky subtests
         my @must_skip = ();
         push @must_skip, "100-bridge-iptables" if ($firewalld_backend ne "iptables");
@@ -81,7 +81,7 @@ sub run {
 
     # Download netavark sources
     my $netavark_version = script_output "$netavark --version | awk '{ print \$2 }'";
-    my $url = get_var("NETAVARK_BATS_URL", "https://github.com/containers/netavark/archive/refs/tags/v$netavark_version.tar.gz");
+    my $url = get_var("BATS_URL", "https://github.com/containers/netavark/archive/refs/tags/v$netavark_version.tar.gz");
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
@@ -97,15 +97,11 @@ sub run {
 }
 
 sub post_fail_hook {
-    my ($self) = @_;
     bats_post_hook $test_dir;
-    $self->SUPER::post_fail_hook;
 }
 
 sub post_run_hook {
-    my ($self) = @_;
     bats_post_hook $test_dir;
-    $self->SUPER::post_run_hook;
 }
 
 1;

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -11,9 +11,8 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils qw(script_retry);
-use containers::common;
 use containers::bats;
-use version_utils qw(is_sle is_tumbleweed);
+use version_utils qw(is_tumbleweed);
 
 my $test_dir = "/var/tmp/runc-tests";
 
@@ -62,15 +61,10 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    install_bats;
-    enable_modules if is_sle;
-
-    # Install tests dependencies
     my @pkgs = qw(git-core glibc-devel-static go iptables jq libseccomp-devel make runc);
     push @pkgs, "criu" if is_tumbleweed;
-    install_packages(@pkgs);
 
-    $self->bats_setup;
+    $self->bats_setup(@pkgs);
 
     record_info("runc version", script_output("runc --version"));
     record_info("runc features", script_output("runc features"));

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -14,7 +14,7 @@ use utils qw(script_retry);
 use containers::common;
 use Utils::Architectures qw(is_x86_64);
 use containers::bats;
-use version_utils qw(is_sle is_sle_micro);
+use version_utils qw(is_sle);
 
 my $test_dir = "/var/tmp/skopeo-tests";
 
@@ -70,15 +70,10 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    install_bats;
-    enable_modules if is_sle;
-
-    # Install tests dependencies
     my @pkgs = qw(apache2-utils jq openssl podman squashfs skopeo);
     push @pkgs, "fakeroot" unless is_sle('>=16.0');
-    install_packages(@pkgs);
 
-    $self->bats_setup;
+    $self->bats_setup(@pkgs);
 
     record_info("skopeo version", script_output("skopeo --version"));
     record_info("skopeo package version", script_output("rpm -q skopeo"));


### PR DESCRIPTION
Simplify BATS tests:
  - Run each package's tests on its job.
  - The above allows us to have generic BATS_* variable names and cut the number from 25 to 10.
  - Simplify BATS setup in one function.

---

- Verification runs:
  - Tumbleweed:
    - buildah: https://openqa.opensuse.org/tests/4993175 (failed subtest will be skipped)
    - netavark: https://openqa.opensuse.org/tests/4992891 
    - podman: https://openqa.opensuse.org/tests/4993046 (transient network error)
    - runc: https://openqa.opensuse.org/tests/4992893
    - skopeo: https://openqa.opensuse.org/tests/4992894

