### PR TITLE
containers: Apply SELinux fix for haproxy

### DIFF
--- a/data/containers/docker-compose.yml
+++ b/data/containers/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     depends_on:
       - nginx
     restart: on-failure
+    security_opt:
+      - label=disable
 
 networks:
   frontend:

--- a/tests/containers/compose.pm
+++ b/tests/containers/compose.pm
@@ -46,6 +46,8 @@ sub basic_test {
     assert_script_run "$runtime compose ps";
     assert_script_run "$runtime compose top";
 
+    assert_script_run "$runtime compose logs";
+
     # Send HTTP request to haproxy - it should be proxied to nginx
     assert_script_run 'curl -s http://127.0.0.1:8080/ | grep "Welcome to nginx!"';
 


### PR DESCRIPTION
Apply SELinux fix for haproxy

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1241126
- Failing test: https://openqa.opensuse.org/tests/4991738#step/podman_compose/68
- Verification run: https://openqa.opensuse.org/tests/4993328
