### PR TITLE
Add dummy.xml file

### DIFF
--- a/data/yam/autoyast/dummy.xml
+++ b/data/yam/autoyast/dummy.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile
+  xmlns="http://www.suse.com/1.0/yast2ns"
+  xmlns:config="http://www.suse.com/1.0/configns">
+  <!--
+    The purpose of this file is to have a static file,
+    with fixed content, to use as download URL in
+    data/yam/agama/auto/autoyast_supported.xml
+    with a fixed checksum value
+  -->
+</profile>


### PR DESCRIPTION
- Related ticket: [poo#180125](https://progress.opensuse.org/issues/180125)
- Related [PR#21736](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21736)
> The purpose of this file is to have a static file,
    with fixed content, to use as download URL in
    `data/yam/agama/auto/autoyast_supported.xml`
    with a fixed checksum value