### PR TITLE
Drop chromium and hexchat from zdup from 15.6

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1355,7 +1355,7 @@ sub load_x11tests {
         loadtest "x11/firefox_audio";
     }
     if (chromiumstep_is_applicable() && !(is_staging() || is_livesystem)) {
-        loadtest "x11/chromium";
+        loadtest "x11/chromium" unless is_leap('>15.5');
     }
     if (xfcestep_is_applicable()) {
         # Midori got dropped from TW and Leap 15.6
@@ -1427,9 +1427,6 @@ sub load_x11tests {
         loadtest "x11/gimp";
     }
     if (is_opensuse && !is_livesystem) {
-        if (!is_staging) {
-            loadtest "x11/hexchat";
-        }
         loadtest "x11/vlc";
     }
     if (kdestep_is_applicable()) {


### PR DESCRIPTION
- Leap 16.0 does not contain hexchat code-o-o#leap/features#188
- Chromium is still WIP

- Verification run: https://openqa.opensuse.org/tests/4993310
