### PR TITLE
Disable cleanup for AITL tests

### DIFF
--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -162,4 +162,9 @@ sub json_to_xml {
     $dom->toFile(hashed_string('aitl_results.xml'), 1);
 }
 
+sub _cleanup {
+    # because it is AITL where we don't create actual instance no point to call _cleanup
+}
+
+
 1;

--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -32,7 +32,7 @@ sub run {
     my $resource_group = "openqa-aitl-$job_id";
     my $subscription_id = $provider->provider_client->subscription;
 
-    my $aitl_client_version = "20241118.1";
+    my $aitl_client_version = get_required_var("PUBLIC_CLOUD_AZURE_AITL_VER");
     my $aitl_image_gallery = "test_image_gallery";
     my $aitl_image_version = "latest";
     my $aitl_job_name = "openqa-aitl-$job_id";

--- a/variables.md
+++ b/variables.md
@@ -318,6 +318,7 @@ PUBLIC_CLOUD_AZURE_OFFER | string | "" | Specific to Azure. Allow to query for i
 PUBLIC_CLOUD_AZURE_PUBLISHER | string | "SUSE" | Specific to Azure. Allows to define the used publisher, if it should not be "SUSE"
 PUBLIC_CLOUD_AZURE_SKU | string | "" | Specific to Azure.
 PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID | string | "" | Used to create the service account file together with `PUBLIC_CLOUD_AZURE_TENANT_ID`.
+PUBLIC_CLOUD_AZURE_AITL_VER | string | undef | Define version of Azure Image Testing for Linux (AITL) used in testing
 PUBLIC_CLOUD_AZ_API | string | "http://169.254.169.254/metadata/instance/compute" | For Azure, it is the metadata API endpoint.
 PUBLIC_CLOUD_AZ_API_VERSION | string | "2021-02-01" | For Azure, it is the API version used whe querying metadata API.
 PUBLIC_CLOUD_BUILD | string | "" | The image build number. Used only when we use custom built image.


### PR DESCRIPTION
- create a variable to control AITL version which we are using 
- mute cleanup logic for AITL because we not controlling any VMs in that case 

VR: https://openqa.suse.de/tests/17353959