### PR TITLE
Add variable to control terraform parallel

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -204,23 +204,23 @@ sub run {
     # Regenerate config files (This workaround will be replaced with full yaml generator)
     qesap_prepare_env(provider => $provider_setting, only_configure => 1);
 
-    # Retrying terraform more times in case of GCP, to handle concurrent peering attempts
-    my $retries = is_gce() ? 5 : 2;
-    my @ret = qesap_execute_conditional_retry(
-        cmd => 'terraform',
+    my %retry_args = (
         logname => 'qesap_exec_terraform.log.txt',
         verbose => 1,
         timeout => 3600,
-        retries => $retries,
         error_list => [
             'An internal execution error occurred. Please retry later',
             'There is a peering operation in progress'
         ],
-        destroy_terraform => 1);
+        destroy => 1);
+    # Retrying terraform more times in case of GCP, to handle concurrent peering attempts
+    $retry_args{retries} = is_gce() ? 5 : 2;
+    $retry_args{cmd_options} = '--parallel ' . get_var('HANASR_TERRAFORM_PARALLEL') if get_var('HANASR_TERRAFORM_PARALLEL');
+    my @ret = qesap_terraform_conditional_retry(%retry_args);
     die 'Terraform deployment FAILED. Check "qesap*" logs for details.' if ($ret[0]);
 
     # Sleep $N for fixing ansible "Missing sudo password" issue on GCP
-    if ($provider_setting eq 'GCE') {
+    if (is_gce()) {
         sleep 60;
         record_info('Workaround: "sleep 60" for fixing ansible "Missing sudo password" issue on GCP');
     }

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -219,6 +219,12 @@ sub run {
         destroy_terraform => 1);
     die 'Terraform deployment FAILED. Check "qesap*" logs for details.' if ($ret[0]);
 
+    # Sleep $N for fixing ansible "Missing sudo password" issue on GCP
+    if ($provider_setting eq 'GCE') {
+        sleep 60;
+        record_info('Workaround: "sleep 60" for fixing ansible "Missing sudo password" issue on GCP');
+    }
+
     $provider->terraform_applied(1);
     my $instances = create_instance_data(provider => $provider);
     foreach my $instance (@$instances) {


### PR DESCRIPTION
Add variable HANASR_TERRAFORM_PARALLEL to control terraform parallelism.

Ticket https://jira.suse.com/browse/TEAM-10214

# Verifications:

## qesap regression
 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_angi_test@64bit -> http://openqaworker15.qa.suse.cz/tests/321529

## HanaSR
 - sle-15-SP6-HanaSr-Aws-Payg-x86_64-Build15-SP6_2025-04-15T02:03:23Z-hanasr_aws_test_fencing_native_baremetal ec2_r5b.metal -> http://openqaworker15.qa.suse.cz/tests/321530 :green_circle:  here the call to Terraform using the changed code https://openqaworker15.qa.suse.cz/tests/321530#step/deploy_qesap_terraform/474

 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-04-15T02:03:23Z-hanasr_azure_test_msi az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/321531 :green_circle: 


 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-04-15T02:03:23Z-hanasr_azure_test_msi az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/321532 :green_circle:  this one introduce an artificial failure in Terraform by providing an invalid value to `PUBLIC_CLOUD_IMAGE_ID` . Here the retry code searching for known errors https://openqaworker15.qa.suse.cz/tests/321532#step/deploy_qesap_terraform/393


- sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-04-15T02:03:23Z-hanasr_azure_test_msi@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/321625 :green_apple:  using `HANASR_TERRAFORM_PARALLEL=3` here `--parallel 3` in the command line https://openqaworker15.qa.suse.cz/tests/321625#step/deploy_qesap_terraform/364