### PR TITLE
Autoyast firstboot: Use GNOME_X11 pattern

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot.xml
@@ -25,7 +25,7 @@
       </packages>
       <patterns config:type="list">
         <pattern>base</pattern>
-        <pattern>gnome</pattern>
+        <pattern>gnome_x11</pattern>
         <pattern>selinux</pattern>
       </patterns>
     </software>


### PR DESCRIPTION
The autoyast startup script relies on Xorg to start up the GUI session,
wheras the 'gnome' pattern no longer pulls in Xorg directly.

As autoyast is benig deprecated (in favor of Agama), there is no interest
in fixing the AY startup scripts.

When purely relying on GNOME (wayland), one can steps through the firts boot
wizard in ncurses mode

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1240855
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/4995826
