### PR TITLE
WIP: Disable IPv6 for x86_64 systems and control bnxt_en loading

### DIFF
--- a/data/autoyast_hanaperf/agama-config.jsonnet
+++ b/data/autoyast_hanaperf/agama-config.jsonnet
@@ -76,6 +76,11 @@
           sed -e "s/selinux=1 enforcing=1/ /g" -i /boot/grub2/grub.cfg
           sed -e "s/selinux=1 enforcing=1/ /g" -i /etc/default/grub
           sed -e "s/SELINUX=enforcing/SELINUX=permissive/g" -i /etc/selinux/config
+          # Disable IPv6 for x86_64 systems because their lab does not support IPv6
+          if [[ "$(uname -i)" == "x86_64" ]]; then
+               echo 'net.ipv6.conf.all.disable_ipv6 = 1' >> /etc/sysctl.d/disable_ipv6.conf
+               echo 'net.ipv6.conf.default.disable_ipv6 = 1' >> /etc/sysctl.d/disable_ipv6.conf
+          fi
         |||,
       },
     ],


### PR DESCRIPTION
Disable IPv6 for x86_64 systems because no IPv6 network in their labs
Control bnxt_en loading as similar SLE15 did before to avoid incorrect net link sequence

- Related ticket: https://jira.suse.com/browse/TEAM-10256
- Needles: N/A
- Verification run: TODO
