### PR TITLE
Remove no longer used qesap_test_postfail

### DIFF
--- a/lib/qesapdeployment.pm
+++ b/lib/qesapdeployment.pm
@@ -106,7 +106,6 @@ our @EXPORT = qw(
   qesap_az_list_container_files
   qesap_az_diagnostic_log
   qesap_terrafom_ansible_deploy_retry
-  qesap_test_postfail
 );
 
 =head1 DESCRIPTION
@@ -2655,58 +2654,6 @@ sub qesap_ansible_error_detection {
     }
     record_info('ANSIBLE ISSUE', $error_message) unless $ret_code eq 0;
     return $ret_code;
-}
-
-=head2 qesap_test_postfail
-
-  qesap_test_postfail()
-
-  Post fail tasks suitable for post_fail_hook of the test modules.
-  This API is mainly designed for qesap regression test modules.
-
-=over
-
-=item B<PROVIDER> - cloud provider name as from PUBLIC_CLOUD_PROVIDER setting
-
-=item B<NET_PEERING_ID> - ID of the network peering, for Azure it has to be the name 
-                          of the Resource Group of the mirror, for AWS it has to be the
-                          something different from an empty string, for example
-                          the setting about the IP RANGE.
-
-=back
-=cut
-
-sub qesap_test_postfail {
-    my (%args) = @_;
-    croak 'Missing mandatory provider argument' unless $args{provider};
-    $args{net_peering_id} //= '';
-
-    qesap_cluster_logs();
-    qesap_upload_logs();
-    if ($args{provider} eq 'AZURE') {
-        if ($args{net_peering_id} ne '') {
-            my $rg = qesap_az_get_resource_group();
-            qesap_az_vnet_peering_delete(source_group => $rg, target_group => $args{net_peering_id});
-        }
-    }
-    elsif ($args{provider} eq 'EC2') {
-        if ($args{net_peering_id} ne '') {
-            qesap_aws_delete_transit_gateway_vpc_attachment(name => qesap_calculate_deployment_name('qesapval') . '*');
-        }
-    }
-    # TODO : GCP is not supported yet.
-    qesap_execute(
-        cmd => 'ansible',
-        cmd_options => '-d',
-        logname => 'qesap_exec_ansible_destroy.log.txt',
-        verbose => 1,
-        timeout => 300);
-    qesap_execute(
-        cmd => 'terraform',
-        cmd_options => '-d',
-        logname => 'qesap_exec_terraform_destroy.log.txt',
-        verbose => 1,
-        timeout => 1200);
 }
 
 1;

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -1392,26 +1392,6 @@ subtest '[qesap_terrafom_ansible_deploy_retry] reboot timeout Ansible failures' 
     ok $qesap_execute_calls eq 3, "qesap_execute() never called (qesap_execute_calls: $qesap_execute_calls expected 3)";
 };
 
-subtest '[qesap_test_postfail]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
-
-    $qesap->redefine(qesap_cluster_logs => sub { return; });
-    $qesap->redefine(qesap_upload_logs => sub { return; });
-    my @calls;
-    $qesap->redefine(qesap_execute => sub {
-            my (%args) = @_;
-            push @calls, $args{cmd}; });
-
-    qesap_test_postfail(provider => 'NEMO');
-
-    note("\n  I-->  " . join("\n  I-->  ", @calls));
-
-    my $cmd_chk = pop @calls;
-    ok $cmd_chk eq 'terraform', "Postfail calls $cmd_chk : is expected to be terraform ati very last";
-    $cmd_chk = pop @calls;
-    ok $cmd_chk eq 'ansible', "Postfail calls $cmd_chk : is expected to be ansible before terraform";
-};
-
 subtest '[qesap_calculate_address_range]' => sub {
     my %result_1 = qesap_calculate_address_range(slot => 1);
     my %result_2 = qesap_calculate_address_range(slot => 2);

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -130,8 +130,6 @@ sub run {
         $variables{REPOS} = join(',', get_test_repos());
     }
 
-
-
     qesap_prepare_env(
         openqa_variables => \%variables,
         provider => get_required_var('PUBLIC_CLOUD_PROVIDER')

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -43,9 +43,8 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    # This test module does not have both
-    # fatal flag and qesap_test_postfail, so that in case of failure
-    # the next test_ module is executed too.
+    # This test module does not have the fatal flag.
+    # In case of failure, the next test_ module is executed too.
     # Deployment destroy is delegated to the destroy test module
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/qesapdeployment/test_crash.pm
+++ b/tests/sles4sap/qesapdeployment/test_crash.pm
@@ -26,9 +26,8 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    # This test module does not have both
-    # fatal flag and qesap_test_postfail, so that in case of failure
-    # the next test_ module is executed too.
+    # This test module does not have the fatal flag.
+    # In case of failure, the next test_ module is executed too.
     # Deployment destroy is delegated to the destroy test module
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -38,9 +38,8 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    # This test module does not have both
-    # fatal flag and qesap_test_postfail, so that in case of failure
-    # the next test_ module is executed too.
+    # This test module does not have the fatal flag.
+    # In case of failure, the next test_ module is executed too.
     # Deployment destroy is delegated to the destroy test module
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/qesapdeployment/test_system.pm
+++ b/tests/sles4sap/qesapdeployment/test_system.pm
@@ -33,9 +33,8 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
-    # This test module does not have both
-    # fatal flag and qesap_test_postfail, so that in case of failure
-    # the next test_ module is executed too.
+    # This test module does not have the fatal flag.
+    # In case of failure, the next test_ module is executed too.
     # Deployment destroy is delegated to the destroy test module
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Remove no more used library function for the cleanup. This function cannot be resued in the `run` body of the destroy.pm testmodule neither in the post_fail_hook of the deploy.pm test module.


This function was created as part of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20156/  but then no more used from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20242/

Related ticket: https://jira.suse.com/browse/TEAM-9654

# Verification run:


## qesap regression 
 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_angi_test@64bit -> http://openqaworker15.qa.suse.cz/tests/321648

## HAnasr regression
 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-04-15T02:03:23Z-hanasr_azure_test_msi  az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/321626
