### PR TITLE
Add kdump issue on slem 5.5 for bug_ref

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -411,7 +411,7 @@
     "bsc#1195060": {
         "description": "Failed to start Load kdump kernel early on startup",
         "products": {
-            "sle-micro": ["5.1", "5.2", "5.3"]
+            "sle-micro": ["5.1", "5.2", "5.3", "5.5"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
Failed jobs: https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle-micro&version=5.5&build=20250415-1&groupid=535

- Related ticket: N/A
- Needles: N/A
- Verification run:  https://openqa.suse.de/tests/17359532#step/journal_check/10