### PR TITLE
Add network peering terraform variables to GCP

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
@@ -19,6 +19,11 @@ terraform:
     public_key: '%SLES4SAP_PUBSSHKEY%'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
 
+    # IBSm network peering
+    ibsm_vpc_name: '%IBSM_VPC_NAME%'
+    ibsm_subnet_name: '%IBSM_SUBNET_NAME%'
+    ibsm_subnet_region: '%IBSM_SUBNET_REGION%'
+
     # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'


### PR DESCRIPTION
Add terraform variables about the IBSm network peering to the qe-sap-deployment conf.yaml file used in HanaSR tests.

- Related ticket: https://jira.suse.com/browse/TEAM-10231

# Verification run:

https://openqaworker15.qa.suse.cz/tests/321712 :green_circle: the PR code is fine, the variables are visible in the .tfvars. Job fails as the deployment is created in a region different to the one of IBSm
https://openqaworker15.qa.suse.cz/tests/321713 :green_circle: collision
https://openqaworker15.qa.suse.cz/tests/321714