### PR TITLE
Kselftests: openqa runner

### DIFF
--- a/schedule/kernel/run_kselftests.yaml
+++ b/schedule/kernel/run_kselftests.yaml
@@ -1,0 +1,19 @@
+name:          kselftests
+description:    >
+    Generic scheduler for Linux kselftests
+schedule:
+    - '{{boot}}'
+    - boot/boot_to_desktop
+    - kernel/run_kselftests
+    - shutdown/shutdown
+
+conditional_schedule:
+    boot:
+        BACKEND:
+            spvm:
+                - installation/bootloader
+            pvm_hmc:
+                - installation/bootloader
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm

--- a/tests/kernel/kselftests.pm
+++ b/tests/kernel/kselftests.pm
@@ -5,6 +5,8 @@
 #
 # Summary: Executes kselftests
 # Maintainer: Kernel QE <kernel-qa@suse.de>
+#
+# Tags: deprecated
 
 use base 'opensusebasetest';
 

--- a/tests/kernel/run_kselftests.pm
+++ b/tests/kernel/run_kselftests.pm
@@ -1,0 +1,92 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Executes kselftests.
+# This module introduces simplistic openqa runner for kernel selftests. The test
+# module allows running tests kernel selftests from either git repository which should be
+# defined in the test setting: KERNEL_GIT_TREE or from OBS/IBS repository using packaged
+# and build rpm. As of May-2025 this runner is meant exclusively for cgroup tests.
+# Running from git supports checking out specific git tag version of the kernel, so if required
+# the tests can checkout the older version, corresponding with the kernel under tests, and run
+# such tests
+#
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+use base 'opensusebasetest';
+
+use strict;
+use warnings;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use registration;
+use utils;
+
+sub prepare_kselftests_from_git
+{
+    my ($root) = @_;
+
+    my $git_tree = get_var('KERNEL_GIT_TREE', 'https://github.com/torvalds/linux.git');
+    my $git_tag = get_var('KERNEL_GIT_TAG', '');
+    zypper_call('in bc git-core ncurses-devel gcc flex bison libelf-devel libopenssl-devel');
+    assert_script_run("git clone --depth 1 --single-branch --branch master $git_tree linux", 7200);
+
+    if ($git_tag ne '') {
+        assert_script_run("git checkout $git_tag");
+    }
+
+    assert_script_run("cd ./linux");
+    assert_script_run("make headers");
+    assert_script_run("make -j `nproc` -C tools/testing/selftests install", 7200);
+    assert_script_run("cd ./tools/testing/selftests/kselftest_install");
+    assert_script_run("./run_kselftest.sh -l");
+}
+
+sub prepare_kselftests_from_ibs
+{
+    my ($root) = @_;
+
+    my $repo = get_var('KSELFTESTS_REPO', '');
+    zypper_call("ar -f $repo kselftests");
+    zypper_call("--gpg-auto-import-keys ref");
+
+    my $kselftests_suite = get_var('KSELFTESTS_SUITE');
+    my @kselftests_suite = split(',', $kselftests_suite);
+
+    foreach my $i (@kselftests_suite) {
+        zypper_call("install -y kselftests-$i");
+    }
+}
+
+sub run
+{
+    select_serial_terminal;
+
+    my $kselftest_git = get_var('KSELFTEST_FROM_GIT', 0);
+    my $kselftests_suite = get_required_var('KSELFTESTS_SUITE');
+    my @kselftests_suite = split(',', $kselftests_suite);
+
+    if (get_var('KSELFTEST_FROM_GIT')) {
+        prepare_kselftests_from_git();
+
+        foreach my $i (@kselftests_suite) {
+            #required by the TAP openQA parser
+            assert_script_run("echo t/$i.t .. > $i.tap");
+            assert_script_run("./run_kselftest.sh -c $i >> $i.tap", 7200);
+            parse_extra_log(TAP => "$i.tap");
+        }
+
+    } else {
+        prepare_kselftests_from_ibs("/usr/share/kselftests");
+
+        foreach my $i (@kselftests_suite) {
+            assert_script_run("echo t/$i.t .. > $i.tap");
+            assert_script_run("/usr/share/kselftests/run_kselftest.sh -c $i >> $i.tap", 7200);
+            parse_extra_log(TAP => "$i.tap");
+        }
+
+    }
+}
+
+1;


### PR DESCRIPTION
As of now the kselftests tests are run using kirk: https://github.com/linux-test-project/kirk as well as selftests.pm module.

The LTP upstream project decided to drop kselftest support in kirk. For this reason there is a need to run kselftests using  "native" openqa runner. 

This PR is barely marking kselftests kirk runner deprecated to indicate this pm module will be removed soon.

New, simplistic kselftests runner is introduced.
The main idea for the new runner is to allow:
 - running kselftests build from defined git repository, so that the most recent upstream kselftests could be used. This approach is good for instance for cgroup tests as discussed with MichalK.
 - running using kselftests rpm prepared and build in IBS

Also initial patch is using native shell script to run kselftests: run_kselftest.sh. Kernel selftests are using TAP test protocol/format to collect the results and thus this runner is using that to report tests in the openQA UI.

Further steps:
 - kselftests modify TAP and introduce KTAP. KTAP parser shall be introduced in the openQA: https://progress.opensuse.org/issues/182360
 - with such KTAP parser whitelisting of known issues will be introduced: https://progress.opensuse.org/issues/182363
 - decision to be made: if and how to build rpms with the kselftests: https://progress.opensuse.org/issues/182366


Related ticket: https://progress.opensuse.org/issues/180284

Verification run:
(1) VR with kselftests rpm installed and used for running cgroup tests:
https://openqa.suse.de/tests/17687051

(2) VR with kselftests build from linux git tree. Only cgroup:
https://openqa.suse.de/tests/17687030

(3) VR with kselftests build from linux tree. cgroup and kvm tests:
https://openqa.suse.de/tests/17687052
