### PR TITLE
Avoid failure in GCE IBSm network peering

### DIFF
--- a/tests/sles4sap/publiccloud/network_peering.pm
+++ b/tests/sles4sap/publiccloud/network_peering.pm
@@ -21,21 +21,18 @@ sub run {
     # Needed to have peering and ansible state propagated in post_fail_hook
     $self->import_context($run_args);
 
-    if (get_var('IBSM_VNET')) {
+    if (is_azure() && get_var('IBSM_VNET')) {
         record_info('PEERING MANAGED', 'Peering should already be created by terraform');
+        return;
     }
-    else {
-        die 'Network peering already in place' if ($self->{network_peering_present});
-        my $ibs_mirror_resource_group = get_required_var('IBSM_RG');
-        if (is_azure) {
-            my $rg = qesap_az_get_resource_group();
-            qesap_az_vnet_peering(source_group => $rg, target_group => $ibs_mirror_resource_group);
-        } elsif (is_ec2) {
-            my $vpc_id = qesap_aws_get_vpc_id(resource_group => $self->deployment_name() . '*');
-            die "No vpc_id in this deployment" if $vpc_id eq 'None';
-            my $ibs_mirror_target_ip = get_required_var('IBSM_IPRANGE');    # '10.254.254.240/28'
-            die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id, mirror_tag => get_var('IBSM_PRJ_TAG', 'IBS Mirror'));
-        }
+    die 'Network peering already in place' if ($self->{network_peering_present});
+    if (is_azure()) {
+        qesap_az_vnet_peering(source_group => qesap_az_get_resource_group(), target_group => get_required_var('IBSM_RG'));
+    } elsif (is_ec2()) {
+        my $vpc_id = qesap_aws_get_vpc_id(resource_group => $self->deployment_name() . '*');
+        die "No vpc_id in this deployment" if i($vpc_id eq 'None');
+        my $ibs_mirror_target_ip = get_required_var('IBSM_IPRANGE');    # '10.254.254.240/28'
+        die 'Error in network peering setup.' if (!qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id, mirror_tag => get_var('IBSM_PRJ_TAG', 'IBS Mirror')));
     }
     $run_args->{network_peering_present} = $self->{network_peering_present} = 1;
 }


### PR DESCRIPTION
Do not check variables about IBSM that only belong to Azure when running a deploymewnt on a different CSP.

Follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21601


- Related ticket: https://jira.suse.com/browse/TEAM-10231

## Verification run: 

BYOS https://openqaworker15.qa.suse.cz/tests/321730
PAYG https://openqaworker15.qa.suse.cz/tests/321731  https://openqaworker15.qa.suse.cz/tests/321732