### PR TITLE
Allow HanaSR test to support both peering methods

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -81,6 +81,15 @@ sub run {
     set_var('FENCING_MECHANISM', 'native') unless ($ha_enabled);
     set_var_output('ANSIBLE_REMOTE_PYTHON', '/usr/bin/python3');
 
+    if (is_azure()) {
+        # Within the qe-sap-deployment terraform code,
+        # an empty string means no peering.
+        # This "trick" is needed to only have one conf.yaml
+        # for both jobs that creates the peering with terraform or the az cli
+        set_var('IBSM_RG', '') unless (get_var('IBSM_RG'));
+        set_var('IBSM_VNET', '') unless (get_var('IBSM_VNET'));
+    }
+
     my $deployment_name = deployment_name();
     # Create a QESAP_DEPLOYMENT_NAME variable so it includes the random
     # string appended to the PUBLIC_CLOUD_RESOURCE_GROUP


### PR DESCRIPTION
Add some code to allow supporting both the methods to create the network peering to the IBSm in Azure: using the az cli (legacy) and using terraform (new). The problem is to be able to support both with the same conf.yaml. This commit is to avoid failure in qesap_terraform about missing IBSM_VNET and IBSM_RG openQA variables.


Follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21601

- Related ticket: https://jira.suse.com/browse/TEAM-10216

# Verification run: 
sle-12-SP5-Azure-SAP-BYOS-Updates-x86_64-Build20250416-1-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E4s_v3

Without this PR  http://openqaworker15.qa.suse.cz/tests/321740

With the code in this PR http://openqaworker15.qa.suse.cz/tests/321741
