### PR TITLE
Skip check for running services on Azure 12-SP5

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -14,6 +14,7 @@ use Term::ANSIColor 2.01 'colorstrip';
 use testapi qw(is_serial_terminal :DEFAULT);
 use mmapi 'get_current_job_id';
 use utils qw(script_retry script_output_retry);
+use version_utils qw(is_sle);
 use publiccloud::azure_client;
 use publiccloud::ssh_interactive 'select_host_console';
 use Data::Dumper;
@@ -489,6 +490,7 @@ sub img_proof {
     $args{instance_type} //= 'Standard_A2';
     $args{user} //= 'azureuser';
     $args{provider} //= 'azure';
+    $args{exclude} //= 'test_sles_azure_running_services' if (is_sle("=12-SP5"));
 
     if (my $parsed_id = $self->parse_instance_id($args{instance})) {
         $args{running_instance_id} = $parsed_id->{vm_name};


### PR DESCRIPTION
Skip tests because of ongoing [bsc#1240385](https://bugzilla.suse.com/show_bug.cgi?id=1240385). Revival of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21789

- Related ticket: https://progress.opensuse.org/issues/180950
- Related failure: e.g. https://openqa.suse.de/tests/17367697
- Verification run: https://openqa.suse.de/tests/17373918
