### PR TITLE
Align all the Azure HanaSR conf.yaml

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -11,11 +11,17 @@ apiver: 3
 terraform:
   variables:
     # GENERAL VARIABLES #
+    vnet_address_range: "%MAIN_ADDRESS_RANGE%"
+    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '%SLES4SAP_PUBSSHKEY%'
     os_image: '%SLES4SAP_OS_IMAGE_NAME%'
+
+    # IBSM PEERING VARIABLES
+    ibsm_rg: '%IBSM_RG%'
+    ibsm_vnet_name: '%IBSM_VNET%'
 
     # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -11,11 +11,17 @@ apiver: 3
 terraform:
   variables:
     # GENERAL VARIABLES #
+    vnet_address_range: "%MAIN_ADDRESS_RANGE%"
+    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
     public_key: '%SLES4SAP_PUBSSHKEY%'
     os_image_uri: '%SLES4SAP_OS_IMAGE_NAME%'
+
+    # IBSM PEERING VARIABLES
+    ibsm_rg: '%IBSM_RG%'
+    ibsm_vnet_name: '%IBSM_VNET%'
 
     # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
@@ -30,7 +36,6 @@ terraform:
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
 
 ansible:
-  roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
   az_container_name:  '%HANA_CONTAINER%'
   az_key_name: '%HANA_KEYNAME%'


### PR DESCRIPTION
Align them about variables for IBSm and network_ranges

- Related ticket: https://jira.suse.com/browse/TEAM-10232


# Verification run:

## HanaSR regression :

https://openqaworker15.qa.suse.cz/tests/321830 :green_circle: New terraform vars are in the https://openqaworker15.qa.suse.cz/tests/321830/file/deploy_qesap_terraform-sles4sap_azure_generic.yaml , peering is created in Terraform https://openqaworker15.qa.suse.cz/tests/321830/logfile?filename=deploy_qesap_terraform-terraform.apply.log.txt#line-31

## Aggregates  :

https://openqaworker15.qa.suse.cz/tests/321840 :green_circle:  this one is with old JobGroup, peering not created in Terraform but using az cli. https://openqaworker15.qa.suse.cz/tests/321840/file/deploy_qesap_terraform-sles4sap_azure_generic_maintenance.yaml  `ibsm_vnet_name: ''` has an empty value and it result in the terraform code not to create the peering. The pering is created by the  OSADO test module https://openqaworker15.qa.suse.cz/tests/321840#step/network_peering/46

http://openqaworker15.qa.suse.cz/tests/321851 same as before but with new settings introduced by MR openqa_ha_sap/971 `IBSM_IP`, `IBSM_VNET` , `IBSM_RG`

## SingleIncident : 

http://openqaworker15.qa.suse.cz/tests/321844

## Image from IBS :
http://openqaworker15.qa.suse.cz/tests/321842

