### PR TITLE
containers: Rebuild SELinux policies without the dontaudit rules

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -192,6 +192,10 @@ sub bats_setup {
         record_info("Disabling SELinux");
         assert_script_run "sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config";
         assert_script_run "setenforce 0";
+    } else {
+        # Rebuild SELinux policies without the so-called "dontaudit" rules
+        # https://en.opensuse.org/Portal:SELinux/Troubleshooting
+        script_run "semodule -DB || true";
     }
 
     # Remove mounts.conf


### PR DESCRIPTION
There are some SELinux policies that are not audited by default.  To ease debugging, we must _rebuild the policy without the so-called "dontaudit" rule_ as suggested by https://en.opensuse.org/Portal:SELinux/Troubleshooting

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1238136
- Verification run: https://openqa.opensuse.org/tests/5001800/file/audit.txt