### PR TITLE
Set PAGER=more for serial console

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -188,7 +188,7 @@ sub login {
     die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \s*$/x);
 
     # Some (older) versions of bash don't take changes to the terminal during runtime into account. Re-exec it.
-    enter_cmd('export TERM=dumb; stty cols 2048; exec $SHELL');
+    enter_cmd('export PAGER=more TERM=dumb; stty cols 2048; exec $SHELL');
     die 'Failed to confirm that shell re-exec was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \s*$/x);
     set_serial_prompt($prompt);
     # TODO: Send 'tput rmam' instead/also


### PR DESCRIPTION
According to https://bugzilla.suse.com/show_bug.cgi?id=1240570#c1, we should set PAGER=more instead of using PAGER=less when dumb terminal is used. Otherwise, we can hit an issue in sle16

```
$ zypper lifecycle --help; echo 5YDH1-$?-
WARNING: terminal is not fully functional
Press RETURN to continue
```


- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1240570
### Verification runs: 
 * [sle16](http://kepler.suse.cz/tests/24661#step/zypper_lifecycle/1) 
 * [sp7](http://kepler.suse.cz/tests/24660#step/zypper_lifecycle/1)
 * [sle-15-SP7@s390x-kvm ](https://openqa.suse.de/tests/17377504)
