### PR TITLE
Move qesapdeployment library

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -9,7 +9,7 @@ package sles4sap::ipaddr2;
 use strict;
 use warnings FATAL => 'all';
 use testapi;
-use qesapdeployment qw (qesap_calculate_address_range qesap_az_vnet_peering qesap_az_vnet_peering_delete qesap_az_clean_old_peerings);
+use sles4sap::qesap::qesapdeployment qw (qesap_calculate_address_range qesap_az_vnet_peering qesap_az_vnet_peering_delete qesap_az_clean_old_peerings);
 use Carp qw( croak );
 use Exporter qw(import);
 use Mojo::JSON qw( decode_json );

--- a/lib/sles4sap/qesap/qesapdeployment.pm
+++ b/lib/sles4sap/qesap/qesapdeployment.pm
@@ -25,7 +25,7 @@
 
 =cut
 
-package qesapdeployment;
+package sles4sap::qesap::qesapdeployment;
 
 use strict;
 use warnings;

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -26,7 +26,7 @@ use utils qw(file_content_replace);
 use serial_terminal qw(serial_term_prompt);
 use version_utils qw(check_version is_sle);
 use hacluster;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use publiccloud::utils;
 use publiccloud::provider;
 use publiccloud::ssh_interactive qw(select_host_console);

--- a/lib/sles4sap_publiccloud_basetest.pm
+++ b/lib/sles4sap_publiccloud_basetest.pm
@@ -14,7 +14,7 @@ use warnings FATAL => 'all';
 use Exporter 'import';
 use Carp qw(croak);
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use sles4sap_publiccloud;
 use publiccloud::utils qw(get_ssh_private_key_path);
 

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -36,7 +36,7 @@ use YAML::PP;
 use Carp;
 use utils qw(script_retry random_string);
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use sles4sap::azure_cli;
 
 use Exporter 'import';

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -9,11 +9,12 @@ use Test::Mock::Time;
 use List::Util qw(any none);
 
 use testapi 'set_var';
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
+
 set_var('QESAP_CONFIG_FILE', 'MARLIN');
 
 subtest '[qesap_get_inventory] upper case' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     $qesap->redefine(qesap_get_file_paths => sub {
             my %paths;
             $paths{terraform_dir} = '/BRUCE';
@@ -27,7 +28,7 @@ subtest '[qesap_get_inventory] upper case' => sub {
 };
 
 subtest '[qesap_get_inventory] lower case' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     $qesap->redefine(qesap_get_file_paths => sub {
             my %paths;
             $paths{terraform_dir} = '/BRUCE';
@@ -41,7 +42,7 @@ subtest '[qesap_get_inventory] lower case' => sub {
 };
 
 subtest '[qesap_get_deployment_code] from default github' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -60,7 +61,7 @@ subtest '[qesap_get_deployment_code] from default github' => sub {
 };
 
 subtest '[qesap_get_deployment_code] symlinks' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -82,7 +83,7 @@ subtest '[qesap_get_deployment_code] symlinks' => sub {
 };
 
 subtest '[qesap_get_deployment_code] from fork' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -105,7 +106,7 @@ subtest '[qesap_get_deployment_code] from fork' => sub {
 };
 
 subtest '[qesap_get_deployment_code] from branch' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -128,7 +129,7 @@ subtest '[qesap_get_deployment_code] from branch' => sub {
 };
 
 subtest '[qesap_get_deployment_code] from a specific release' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -153,7 +154,7 @@ subtest '[qesap_get_deployment_code] from a specific release' => sub {
 };
 
 subtest '[qesap_get_deployment_code] from the latest release' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -179,7 +180,7 @@ subtest '[qesap_get_deployment_code] from the latest release' => sub {
 };
 
 subtest '[qesap_get_roles_code] from default github' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -197,7 +198,7 @@ subtest '[qesap_get_roles_code] from default github' => sub {
 };
 
 subtest '[qesap_get_roles_code] from fork' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -217,7 +218,7 @@ subtest '[qesap_get_roles_code] from fork' => sub {
 };
 
 subtest '[qesap_get_roles_code] from branch' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
@@ -238,7 +239,7 @@ subtest '[qesap_get_roles_code] from branch' => sub {
 
 subtest '[qesap_execute] simple call integrate qesap_venv_cmd_exec' => sub {
     # Call qesap_execute without to mock qesap_venv_cmd_exec
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @logs = ();
     my $expected_res = 0;
@@ -278,7 +279,7 @@ subtest '[qesap_execute] simple call integrate qesap_venv_cmd_exec' => sub {
 };
 
 subtest '[qesap_execute] simplest call' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @logs = ();
     my $expected_res = 0;
@@ -305,7 +306,7 @@ subtest '[qesap_execute] simplest call' => sub {
 };
 
 subtest '[qesap_execute] positive timeout' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @logs = ();
     my $cmd = 'GILL';
@@ -328,7 +329,7 @@ subtest '[qesap_execute] positive timeout' => sub {
 };
 
 subtest '[qesap_execute] invalid timeout' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $cmd = 'GILL';
     $qesap->redefine(record_info => sub { note(join(' # ', 'RECORD_INFO -->', @_)); });
@@ -351,7 +352,7 @@ subtest '[qesap_execute] invalid timeout' => sub {
 };
 
 subtest '[qesap_execute] cmd_options' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @logs = ();
     my $expected_res = 0;
@@ -381,7 +382,7 @@ subtest '[qesap_execute] cmd_options' => sub {
 };
 
 subtest '[qesap_execute] failure' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @logs = ();
     my $expected_res = 1;
@@ -408,7 +409,7 @@ subtest '[qesap_execute] failure' => sub {
 };
 
 subtest '[qesap_execute] check_logs' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @logs = ();
     my $expected_res = 1;
@@ -444,7 +445,7 @@ END
 };
 
 subtest '[qesap_terraform_conditional_retry] pass at first' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
 
     $qesap->redefine(record_info => sub {
@@ -467,7 +468,7 @@ subtest '[qesap_terraform_conditional_retry] pass at first' => sub {
 };
 
 subtest '[qesap_terraform_conditional_retry] retry after fail with expected error message' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
 
     $qesap->redefine(record_info => sub {
@@ -501,7 +502,7 @@ subtest '[qesap_terraform_conditional_retry] retry after fail with expected erro
 };
 
 subtest '[qesap_terraform_conditional_retry] retry with destroy terraform' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @return_list = (0, 0, 1, 0, 1);
     # Simulate sequence of return codes for qesap_execute,
@@ -538,7 +539,7 @@ subtest '[qesap_terraform_conditional_retry] retry with destroy terraform' => su
 };
 
 subtest '[qesap_terraform_conditional_retry] retry with destroy terraform and fail during destruction' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @return_list = (42, 1);
 
@@ -566,7 +567,7 @@ subtest '[qesap_terraform_conditional_retry] retry with destroy terraform and fa
 };
 
 subtest '[qesap_terraform_conditional_retry] dies if expected error message is not found' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     $qesap->redefine(record_info => sub {
             note(join(' # ', 'RECORD_INFO -->', @_)); });
     my @calls;
@@ -588,7 +589,7 @@ subtest '[qesap_terraform_conditional_retry] dies if expected error message is n
 };
 
 subtest '[qesap_terraform_conditional_retry] test qesap_file_find_strings' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
 
     $qesap->redefine(record_info => sub {
@@ -625,7 +626,7 @@ subtest '[qesap_terraform_conditional_retry] test qesap_file_find_strings' => su
 };
 
 subtest '[qesap_get_nodes_number]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $str = <<END;
 all:
@@ -658,7 +659,7 @@ END
 };
 
 subtest '[qesap_remote_hana_public_ips]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
     $qesap->redefine(qesap_get_terraform_dir => sub { return '/path/to/qesap/terraform/dir'; });
@@ -674,7 +675,7 @@ subtest '[qesap_remote_hana_public_ips]' => sub {
 };
 
 subtest '[qesap_wait_for_ssh]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
 
@@ -686,7 +687,7 @@ subtest '[qesap_wait_for_ssh]' => sub {
 };
 
 subtest '[qesap_wait_for_ssh] custom port' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
 
@@ -697,7 +698,7 @@ subtest '[qesap_wait_for_ssh] custom port' => sub {
 };
 
 subtest '[qesap_wait_for_ssh] some failures' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @return_list = ();
     push @return_list, 0;
@@ -713,7 +714,7 @@ subtest '[qesap_wait_for_ssh] some failures' => sub {
 };
 
 subtest '[qesap_wait_for_ssh] timeout' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @return_list = ();
     # each loop sleep 5, and we call the function with a timeout of 1sec.
@@ -728,7 +729,7 @@ subtest '[qesap_wait_for_ssh] timeout' => sub {
 };
 
 subtest '[qesap_cluster_logs]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @ansible_calls;
     my @crm_report_calls;
     my @save_file_calls;
@@ -763,7 +764,7 @@ subtest '[qesap_cluster_logs]' => sub {
 };
 
 subtest '[qesap_cluster_logs] multi log command' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @ansible_calls;
     my @logfile_calls;
     $qesap->redefine(qesap_ansible_script_output_file => sub {
@@ -797,7 +798,7 @@ subtest '[qesap_upload_crm_report] die for missing mandatory arguments' => sub {
 };
 
 subtest '[qesap_upload_crm_report]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
 
     $qesap->redefine(is_sle => sub { return 0; });
@@ -816,7 +817,7 @@ subtest '[qesap_upload_crm_report]' => sub {
 };
 
 subtest '[qesap_upload_crm_report] ansible host query' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @fetch_filename;
 
@@ -840,7 +841,7 @@ subtest '[qesap_upload_crm_report] ansible host query' => sub {
 };
 
 subtest '[qesap_supportconfig_logs]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $upload_log_called = 0;
 
@@ -863,7 +864,7 @@ subtest '[qesap_supportconfig_logs]' => sub {
 };
 
 subtest '[qesap_calculate_deployment_name]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     $qesap->redefine(get_current_job_id => sub { return 42; });
 
     my $result = qesap_calculate_deployment_name();
@@ -872,7 +873,7 @@ subtest '[qesap_calculate_deployment_name]' => sub {
 };
 
 subtest '[qesap_calculate_deployment_name] with postfix' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     $qesap->redefine(get_current_job_id => sub { return 42; });
 
     my $result = qesap_calculate_deployment_name('AUSTRALIA');
@@ -886,7 +887,7 @@ subtest '[qesap_prepare_env] die for missing argument' => sub {
 
 subtest '[qesap_prepare_env] integration test' => sub {
     # As less mock as possible
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
 
     $qesap->redefine(qesap_get_file_paths => sub {
             my %paths;
@@ -919,7 +920,7 @@ subtest '[qesap_prepare_env] integration test' => sub {
 sub create_qesap_prepare_env_mocks_noret {
     my $called_functions = shift;
     my $mock_func = shift;
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
 
     # First mock functions returning nothing
     foreach (@{$mock_func}) {
@@ -932,7 +933,7 @@ sub create_qesap_prepare_env_mocks_noret {
 
 sub create_qesap_prepare_env_mocks_with_calls {
     my $called_functions = shift;
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
 
     # then mock functions with some more complex return value
     $called_functions->{qesap_get_file_paths} = 0;
@@ -1101,7 +1102,7 @@ subtest '[qesap_prepare_env] qesap_create_folder_tree/qesap_get_file_paths user 
 };
 
 sub create_qesap_prepare_env_mocks() {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     $qesap->redefine(qesap_get_file_paths => sub {
             my %paths;
             $paths{qesap_conf_src} = '/REEF';
@@ -1241,7 +1242,7 @@ subtest '[qesap_prepare_env] qesap_create_aws_config not solved template and var
 };
 
 subtest '[qesap_is_job_finished]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @results = ();
     $qesap->redefine(script_output => sub {
             if ($_[0] =~ /100000/) { return "not json"; }
@@ -1263,7 +1264,7 @@ subtest '[qesap_is_job_finished]' => sub {
 };
 
 subtest '[qesap_get_nodes_names]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $str = <<END;
 all:
@@ -1296,7 +1297,7 @@ END
 };
 
 subtest '[qesap_add_server_to_hosts]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_ansible_cmd => sub { my (%args) = @_; push @calls, $args{cmd}; });
     set_var('PUBLIC_CLOUD_PROVIDER', 'NEMO');
@@ -1315,7 +1316,7 @@ subtest '[qesap_terrafom_ansible_deploy_retry] no or unknown Ansible failures, n
     # error_detection does not find and known error in the log. It is something could
     # happen if this function is called after a failure of some kind error_detection
     # does not know, or if calling this function after a successful deployment.
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my $qesap_execute_calls = 0;
 
     # 0: unable to detect errors
@@ -1331,7 +1332,7 @@ subtest '[qesap_terrafom_ansible_deploy_retry] no or unknown Ansible failures, n
 
 subtest '[qesap_terrafom_ansible_deploy_retry] no or unknown Ansible failures, no retry, error. More layers' => sub {
     # Like previous test but only mock testapi
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my $qesap_execute_calls = 0;
     my @calls;
 
@@ -1354,7 +1355,7 @@ subtest '[qesap_terrafom_ansible_deploy_retry] no or unknown Ansible failures, n
 };
 
 subtest '[qesap_terrafom_ansible_deploy_retry] generic Ansible failures, no retry' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my $qesap_execute_calls = 0;
 
     # 1 means a generic Ansible error
@@ -1369,7 +1370,7 @@ subtest '[qesap_terrafom_ansible_deploy_retry] generic Ansible failures, no retr
 };
 
 subtest '[qesap_terrafom_ansible_deploy_retry] no sudo password Ansible failures' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my $qesap_execute_calls = 0;
 
     # 3 means "no sudo password" error
@@ -1389,7 +1390,7 @@ subtest '[qesap_terrafom_ansible_deploy_retry] no sudo password Ansible failures
 };
 
 subtest '[qesap_terrafom_ansible_deploy_retry] reboot timeout Ansible failures' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my $qesap_execute_calls = 0;
 
     # 2 means "reboot timeout" error

--- a/t/14_qesap_ansible.t
+++ b/t/14_qesap_ansible.t
@@ -9,7 +9,7 @@ use Test::Mock::Time;
 use List::Util qw(any none);
 
 use testapi 'set_var';
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 set_var('QESAP_CONFIG_FILE', 'MARLIN');
 
 subtest '[qesap_ansible_cmd] no cmd' => sub {
@@ -17,7 +17,7 @@ subtest '[qesap_ansible_cmd] no cmd' => sub {
 };
 
 subtest '[qesap_ansible_cmd]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_venv_cmd_exec => sub {
@@ -36,7 +36,7 @@ subtest '[qesap_ansible_cmd]' => sub {
 };
 
 subtest '[qesap_ansible_cmd] fail' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_venv_cmd_exec => sub {
@@ -52,7 +52,7 @@ subtest '[qesap_ansible_cmd] fail' => sub {
 
 subtest '[qesap_ansible_cmd] integration' => sub {
     # mock as less methods as possible
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_run => sub {
@@ -69,7 +69,7 @@ subtest '[qesap_ansible_cmd] integration' => sub {
 };
 
 subtest '[qesap_ansible_cmd] verbose' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_venv_cmd_exec => sub {
@@ -87,7 +87,7 @@ subtest '[qesap_ansible_cmd] verbose' => sub {
 subtest '[qesap_ansible_cmd] failok and pass' => sub {
     # failok is enabled but internal command just exit 0,
     # test the logic when failok is active but it should not do anything
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_venv_cmd_exec => sub {
@@ -105,7 +105,7 @@ subtest '[qesap_ansible_cmd] failok and pass' => sub {
 subtest '[qesap_ansible_cmd] failok and fail' => sub {
     # failok is enabled and internal command exit 1,
     # test the logic when failok is active and prevent the die in case of internal error
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_venv_cmd_exec => sub {
@@ -121,7 +121,7 @@ subtest '[qesap_ansible_cmd] failok and fail' => sub {
 };
 
 subtest '[qesap_ansible_cmd] filter and user' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_get_inventory => sub { return '/SIDNEY'; });
@@ -138,7 +138,7 @@ subtest '[qesap_ansible_cmd] filter and user' => sub {
 };
 
 subtest '[qesap_ansible_script_output]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0];
             return 'ANEMONE' if ($_[0] =~ /cat.*/); });
@@ -161,7 +161,7 @@ subtest '[qesap_ansible_script_output]' => sub {
 };
 
 subtest '[qesap_ansible_script_output] integration' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
@@ -181,7 +181,7 @@ subtest '[qesap_ansible_script_output] integration' => sub {
 subtest '[qesap_ansible_script_output_file]' => sub {
     # Call qesap_ansible_script_output_file with the bare minimal set of arguments
     # and mock all the dependency.
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $fetch_remote_path;
     my $fetch_out_path;
@@ -218,7 +218,7 @@ subtest '[qesap_ansible_script_output_file]' => sub {
 };
 
 subtest '[qesap_ansible_script_output_file] fail' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $fetch_called = 0;
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
@@ -246,7 +246,7 @@ subtest '[qesap_ansible_script_output_file] fail' => sub {
 subtest '[qesap_ansible_script_output_file] call with all arguments' => sub {
     # Call qesap_ansible_script_output_file with all possible arguments
     # and mock all the dependency.
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $fetch_remote_path;
     my $fetch_out_path;
@@ -295,7 +295,7 @@ subtest '[qesap_ansible_script_output_file] call with all arguments' => sub {
 
 subtest '[qesap_ansible_script_output_file] integrate with qesap_venv_cmd_exec and qesap_ansible_get_playbook' => sub {
     # This test does not mock qesap_venv_cmd_exec so also test it implicitly
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
@@ -321,7 +321,7 @@ subtest '[qesap_ansible_script_output_file] integrate with qesap_venv_cmd_exec a
 subtest '[qesap_ansible_script_output_file] no curl if test true' => sub {
     # Call qesap_ansible_script_output_file with the bare minimal set of arguments
     # and mock all the dependency.
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $test_e_result;
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
@@ -363,7 +363,7 @@ subtest '[qesap_ansible_script_output_file] no curl if test true' => sub {
 };
 
 subtest '[qesap_ansible_script_output_file] failok' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $fetch_failok;
 
@@ -397,7 +397,7 @@ subtest '[qesap_ansible_script_output_file] failok' => sub {
 subtest '[qesap_ansible_script_output_file] cmd with spaces' => sub {
     # Call qesap_ansible_script_output_file with the bare minimal set of arguments
     # and mock all the dependency.
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
@@ -423,7 +423,7 @@ subtest '[qesap_ansible_script_output_file] cmd with spaces' => sub {
 };
 
 subtest '[qesap_ansible_script_output_file] custom user integrate with qesap_venv_cmd_exec' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
 
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
@@ -440,7 +440,7 @@ subtest '[qesap_ansible_script_output_file] custom user integrate with qesap_ven
 };
 
 subtest '[qesap_ansible_script_output_file] root integrate with qesap_venv_cmd_exec' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
 
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
@@ -469,7 +469,7 @@ subtest '[qesap_ansible_fetch_file] mandatory arguments' => sub {
 };
 
 subtest '[qesap_ansible_fetch_file]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_get_inventory => sub { return '/SIDNEY'; });
     $qesap->redefine(qesap_ansible_get_playbook => sub { push @calls, $_[0]; });
@@ -487,7 +487,7 @@ subtest '[qesap_ansible_fetch_file]' => sub {
 };
 
 subtest '[qesap_ansible_fetch_file] fail' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_get_inventory => sub { return '/SIDNEY'; });
     $qesap->redefine(qesap_ansible_get_playbook => sub { push @calls, $_[0]; });
@@ -503,7 +503,7 @@ subtest '[qesap_ansible_fetch_file] fail' => sub {
 };
 
 subtest '[qesap_ansible_fetch_file] integration' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_get_inventory => sub { return '/SIDNEY'; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -9,12 +9,12 @@ use Test::Mock::Time;
 use List::Util qw(any none);
 
 use testapi qw(set_var);
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 set_var('QESAP_CONFIG_FILE', 'MARLIN');
 
 
 subtest '[qesap_az_get_resource_group]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'BOAT' });
     $qesap->redefine(get_current_job_id => sub { return 'CRAB'; });
@@ -35,7 +35,7 @@ subtest '[qesap_az_vnet_peering] missing group arguments' => sub {
 };
 
 subtest '[qesap_az_vnet_peering]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(az_network_vnet_get => sub {
             my (%args) = @_;
@@ -69,7 +69,7 @@ subtest '[qesap_az_get_peering_name] missing resource_group arguments' => sub {
 };
 
 subtest '[qesap_az_vnet_peering_delete]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(get_current_job_id => sub { return 42; });
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'NEMO'; });
@@ -90,7 +90,7 @@ subtest '[qesap_az_vnet_peering_delete]' => sub {
 };
 
 subtest '[qesap_az_vnet_peering_delete] delete failure' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @soft_failure;
     $qesap->redefine(get_current_job_id => sub { return 42; });
@@ -118,7 +118,7 @@ subtest '[qesap_az_vnet_peering_delete] delete failure' => sub {
 subtest '[qesap_az_setup_native_fencing_permissions]' => sub {
     my $command;
     my $vm_id = 'c0ffeeee-c0ff-eeee-1234-123456abcdef';
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     $qesap->redefine(script_output => sub { return $vm_id; });
     $qesap->redefine(assert_script_run => sub { $command = shift; return 1; });
 
@@ -139,7 +139,7 @@ subtest '[qesap_az_setup_native_fencing_permissions]' => sub {
 };
 
 subtest '[qesap_az_get_tenant_id]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     dies_ok { qesap_az_get_tenant_id() } 'Expected failure: missing mandatory arg';
 
     my $valid_uuid = 'c0ffeeee-c0ff-eeee-1234-123456abcdef';
@@ -149,7 +149,7 @@ subtest '[qesap_az_get_tenant_id]' => sub {
 };
 
 subtest '[qesap_az_get_active_peerings] die for missing mandatory arguments' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
 
     # Test missing arguments
     dies_ok { qesap_az_get_active_peerings(); } "Expected die if called without arguments";
@@ -158,7 +158,7 @@ subtest '[qesap_az_get_active_peerings] die for missing mandatory arguments' => 
 };
 
 subtest '[qesap_az_get_active_peerings] test correct ID extraction' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my %results;
 
     $qesap->redefine(script_output => sub {
@@ -179,7 +179,7 @@ subtest '[qesap_az_get_active_peerings] test correct ID extraction' => sub {
 };
 
 subtest '[qesap_az_get_active_peerings] test for incorrect job ID' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my %results;
 
     $qesap->redefine(script_output => sub {
@@ -192,7 +192,7 @@ subtest '[qesap_az_get_active_peerings] test for incorrect job ID' => sub {
 };
 
 subtest '[qesap_az_clean_old_peerings]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @delete_calls;
 
     $qesap->redefine(qesap_az_get_active_peerings => sub {
@@ -229,7 +229,7 @@ subtest '[qesap_az_create_sas_token] mandatory arguments' => sub {
 };
 
 subtest '[qesap_az_create_sas_token]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'BOAT' });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
@@ -249,7 +249,7 @@ subtest '[qesap_az_create_sas_token]' => sub {
 };
 
 subtest '[qesap_az_create_sas_token] with custom timeout' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'BOAT' });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
@@ -261,7 +261,7 @@ subtest '[qesap_az_create_sas_token] with custom timeout' => sub {
 };
 
 subtest '[qesap_az_create_sas_token] with custom permissions' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'BOAT' });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
@@ -280,7 +280,7 @@ subtest '[qesap_az_create_sas_token] with custom permissions' => sub {
 };
 
 subtest '[qesap_az_list_container_files] missing arguments' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     dies_ok { qesap_az_list_container_files(storage => 'TAD', token => 'SAS', prefix => 'GURGLE') } 'Missing container argument';
     dies_ok { qesap_az_list_container_files(container => 'BLOAT', token => 'SAS', prefix => 'GURGLE') } 'Missing storage argument';
     dies_ok { qesap_az_list_container_files(container => 'BLOAT', storage => 'TAD', prefix => 'GURGLE') } 'Missing token argument';
@@ -288,7 +288,7 @@ subtest '[qesap_az_list_container_files] missing arguments' => sub {
 };
 
 subtest '[qesap_az_list_container_files] bad output' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my $so_ret = '';
     $qesap->redefine(script_output => sub { return $so_ret; });
@@ -298,7 +298,7 @@ subtest '[qesap_az_list_container_files] bad output' => sub {
 };
 
 subtest '[qesap_az_list_container_files] command composition' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'GURGLE/ifrit.rpm\nGURGLE/shiva.src.rpm' });
     qesap_az_list_container_files(container => 'BLOAT', storage => 'TAD', token => 'SAS', prefix => 'GURGLE');
@@ -310,7 +310,7 @@ subtest '[qesap_az_list_container_files] command composition' => sub {
 };
 
 subtest '[qesap_az_diagnostic_log] no VMs' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_az_get_resource_group => sub { return 'DENTIST'; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
@@ -328,7 +328,7 @@ subtest '[qesap_az_diagnostic_log] no VMs' => sub {
 };
 
 subtest '[qesap_az_diagnostic_log] one VMs' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(qesap_az_get_resource_group => sub { return 'DENTIST'; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });

--- a/t/16_qesap_aws.t
+++ b/t/16_qesap_aws.t
@@ -10,11 +10,11 @@ use List::Util qw(any none);
 use Data::Dumper;
 
 use testapi 'set_var';
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 set_var('QESAP_CONFIG_FILE', 'MARLIN');
 
 subtest '[qesap_aws_get_vpc_id]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @soft_failure;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'FISHERMAN'; });
@@ -37,7 +37,7 @@ subtest '[qesap_aws_vnet_peering] died args' => sub {
 };
 
 subtest '[qesap_aws_get_region_subnets]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     my @outputs;
     my @result;
@@ -105,7 +105,7 @@ subtest '[qesap_aws_get_region_subnets]' => sub {
 };
 
 subtest '[qesap_aws_create_transit_gateway_vpc_attachment]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
@@ -140,7 +140,7 @@ subtest '[qesap_aws_create_transit_gateway_vpc_attachment]' => sub {
 };
 
 subtest '[qesap_aws_create_transit_gateway_vpc_attachment] timeout' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
@@ -175,7 +175,7 @@ subtest '[qesap_aws_create_transit_gateway_vpc_attachment] timeout' => sub {
 };
 
 subtest '[qesap_aws_delete_transit_gateway_vpc_attachment]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
@@ -192,7 +192,7 @@ subtest '[qesap_aws_delete_transit_gateway_vpc_attachment]' => sub {
 };
 
 subtest '[qesap_aws_delete_transit_gateway_vpc_attachment] timeout' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
@@ -209,7 +209,7 @@ subtest '[qesap_aws_delete_transit_gateway_vpc_attachment] timeout' => sub {
 };
 
 subtest '[qesap_aws_get_transit_gateway_vpc_attachment] no filters' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_output => sub { push @calls, $_[0];
@@ -224,7 +224,7 @@ subtest '[qesap_aws_get_transit_gateway_vpc_attachment] no filters' => sub {
 };
 
 subtest '[qesap_aws_get_transit_gateway_vpc_attachment] return multiple tga' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_output => sub { push @calls, $_[0];
@@ -242,7 +242,7 @@ subtest '[qesap_aws_get_transit_gateway_vpc_attachment] return multiple tga' => 
 };
 
 subtest '[qesap_aws_get_transit_gateway_vpc_attachment] transit_gateway_attach_id filter' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_output => sub { push @calls, $_[0];
@@ -270,7 +270,7 @@ subtest '[qesap_aws_get_transit_gateway_vpc_attachment] transit_gateway_attach_i
 };
 
 subtest '[qesap_aws_get_transit_gateway_vpc_attachment] name filter' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_output => sub { push @calls, $_[0];
@@ -299,7 +299,7 @@ subtest '[qesap_aws_get_transit_gateway_vpc_attachment] name filter' => sub {
 };
 
 subtest '[qesap_aws_add_route_to_tgw]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_run => sub { push @calls, $_[0]; });
 
@@ -316,7 +316,7 @@ subtest '[qesap_aws_add_route_to_tgw]' => sub {
 };
 
 subtest '[qesap_aws_get_mirror_tg]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'tgw-00deadbeef00'; });
 
@@ -328,7 +328,7 @@ subtest '[qesap_aws_get_mirror_tg]' => sub {
 };
 
 subtest '[qesap_aws_get_vpc_workspace]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'VPC_TAG_NAME'; });
 
@@ -340,7 +340,7 @@ subtest '[qesap_aws_get_vpc_workspace]' => sub {
 };
 
 subtest '[qesap_aws_get_routing]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'rtb-00deadbeef00'; });
 
@@ -352,7 +352,7 @@ subtest '[qesap_aws_get_routing]' => sub {
 };
 
 subtest '[qesap_aws_vnet_peering]' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_aws_get_mirror_tg => sub { return 'tgw-00deadbeef00'; });
@@ -369,7 +369,7 @@ subtest '[qesap_aws_vnet_peering]' => sub {
 };
 
 subtest '[qesap_aws_vnet_peering] died when aws does not return expected output' => sub {
-    my $qesap = Test::MockModule->new('qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my $tgw_return;

--- a/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
+++ b/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
@@ -19,7 +19,7 @@ use base 'sles4sap_publiccloud_basetest';
 use serial_terminal 'select_serial_terminal';
 use testapi;
 use sles4sap_publiccloud;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use Data::Dumper;
 
 sub test_flags {

--- a/tests/sles4sap/publiccloud/clean_leftover_peerings.pm
+++ b/tests/sles4sap/publiccloud/clean_leftover_peerings.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use base 'sles4sap_publiccloud_basetest';
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use publiccloud::utils qw(is_azure is_ec2);
 use sles4sap::azure_cli;
 

--- a/tests/sles4sap/publiccloud/network_peering.pm
+++ b/tests/sles4sap/publiccloud/network_peering.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use base 'sles4sap_publiccloud_basetest';
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use publiccloud::utils qw(is_azure is_ec2);
 
 sub test_flags {

--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -12,7 +12,7 @@ use base 'sles4sap_publiccloud_basetest';
 use testapi;
 use publiccloud::utils;
 use sles4sap_publiccloud;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use serial_terminal 'select_serial_terminal';
 
 sub test_flags {

--- a/tests/sles4sap/publiccloud/qesap_reuse_infra.pm
+++ b/tests/sles4sap/publiccloud/qesap_reuse_infra.pm
@@ -13,7 +13,7 @@ use testapi;
 use publiccloud::ssh_interactive 'select_host_console';
 use serial_terminal 'select_serial_terminal';
 use sles4sap_publiccloud;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 
 sub test_flags {
     return {fatal => 1, publiccloud_multi_module => 1};

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -32,7 +32,7 @@ use publiccloud::instance;
 use publiccloud::instances;
 use publiccloud::utils qw(is_azure is_gce is_ec2 get_ssh_private_key_path is_byos);
 use sles4sap_publiccloud;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use serial_terminal 'select_serial_terminal';
 use registration qw(get_addon_fullname scc_version %ADDONS_REGCODE);
 

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -13,7 +13,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use registration qw(get_addon_fullname scc_version %ADDONS_REGCODE);
 use qam 'get_test_repos';
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 
 sub run {
     my ($self) = @_;

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 
 sub run {
     my ($self) = @_;

--- a/tests/sles4sap/qesapdeployment/destroy.pm
+++ b/tests/sles4sap/qesapdeployment/destroy.pm
@@ -9,7 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 
 sub run {
     select_serial_terminal;

--- a/tests/sles4sap/qesapdeployment/test_cluster.pm
+++ b/tests/sles4sap/qesapdeployment/test_cluster.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
 
 sub run {

--- a/tests/sles4sap/qesapdeployment/test_crash.pm
+++ b/tests/sles4sap/qesapdeployment/test_crash.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
 
 sub run {

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
 
 sub run {

--- a/tests/sles4sap/qesapdeployment/test_system.pm
+++ b/tests/sles4sap/qesapdeployment/test_system.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
 
 sub run {

--- a/tests/sles4sap/trento/cluster_configure.pm
+++ b/tests/sles4sap/trento/cluster_configure.pm
@@ -9,7 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use qesapdeployment 'qesap_upload_logs';
+use sles4sap::qesap::qesapdeployment 'qesap_upload_logs';
 use trento 'cluster_config';
 
 sub run {

--- a/tests/sles4sap/trento/cluster_deploy.pm
+++ b/tests/sles4sap/trento/cluster_deploy.pm
@@ -9,7 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use qesapdeployment qw(qesap_upload_logs qesap_ansible_cmd);
+use sles4sap::qesap::qesapdeployment qw(qesap_upload_logs qesap_ansible_cmd);
 use trento;
 
 sub run {

--- a/tests/sles4sap/trento/destroy.pm
+++ b/tests/sles4sap/trento/destroy.pm
@@ -9,7 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use qesapdeployment 'qesap_upload_logs';
+use sles4sap::qesap::qesapdeployment 'qesap_upload_logs';
 use trento;
 
 sub run {

--- a/tests/sles4sap/trento/install_agents.pm
+++ b/tests/sles4sap/trento/install_agents.pm
@@ -9,7 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use qesapdeployment 'qesap_upload_logs';
+use sles4sap::qesap::qesapdeployment 'qesap_upload_logs';
 use trento;
 
 sub run {

--- a/tests/sles4sap/trento/test_hana_restore_stopped.pm
+++ b/tests/sles4sap/trento/test_hana_restore_stopped.pm
@@ -11,7 +11,7 @@ use base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'script_retry';
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use trento;
 
 sub run {

--- a/tests/sles4sap/trento/test_hana_stop.pm
+++ b/tests/sles4sap/trento/test_hana_stop.pm
@@ -11,7 +11,7 @@ use base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'script_retry';
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use trento;
 
 sub run {

--- a/tests/sles4sap/trento/test_hana_unregister_node.pm
+++ b/tests/sles4sap/trento/test_hana_unregister_node.pm
@@ -10,7 +10,7 @@ use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use qesapdeployment;
+use sles4sap::qesap::qesapdeployment;
 use trento;
 
 sub run {

--- a/tests/sles4sap/trento/test_trento_deploy.pm
+++ b/tests/sles4sap/trento/test_trento_deploy.pm
@@ -11,7 +11,7 @@ use base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'script_retry';
-use qesapdeployment 'qesap_upload_logs';
+use sles4sap::qesap::qesapdeployment 'qesap_upload_logs';
 use trento;
 
 

--- a/tests/sles4sap/trento/test_trento_web.pm
+++ b/tests/sles4sap/trento/test_trento_web.pm
@@ -10,7 +10,7 @@ use Mojo::Base 'publiccloud::basetest';
 use base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use qesapdeployment 'qesap_upload_logs';
+use sles4sap::qesap::qesapdeployment 'qesap_upload_logs';
 use trento;
 
 


### PR DESCRIPTION
Move the library in a subfolder of sles4sap

- Related ticket: https://jira.suse.com/browse/TEAM-8439

# Verification run:

## qesap regression

 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_angi_test@64bit -> http://openqaworker15.qa.suse.cz/tests/321852 :green_circle: 

## hanasr regression 

 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-04-17T02:03:16Z-hanasr_azure_test_angi@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/321853

## ipaddr2
sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless
 - http://openqaworker15.qa.suse.cz/tests/321854 :green_circle: 