### PR TITLE
Fix rm registercloudguest in serial console

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -934,7 +934,7 @@ sub scc_deregistration {
         # Remove registercloudguest when use suseconnect in a non public cloud environment.
         if (get_var('SCC_ADDONS', '') =~ /pcm/) {
             my $cloudguest_bin = "/usr/sbin/registercloudguest";
-            assert_script_run "test -f $cloudguest_bin && rm -f $cloudguest_bin";
+            script_run "[ -f $cloudguest_bin ] && rm -f $cloudguest_bin";
         }
         # We don't need to pass $debug_flag to SUSEConnect, because it's already set
         my $deregister_ret = script_run("SUSEConnect --de-register --debug > /tmp/SUSEConnect.debug 2>&1", 300);


### PR DESCRIPTION
##
### 
Fix rm registercloudguest in serial console
- Related ticket: https://openqa.suse.de/tests/17384648#step/scc_deregistration/26
- Needles: N/A
- Verification run: 
     - [select_serial_console]
         -  https://openqa.suse.de/tests/17419339#dependencies
     - [select_root_console]
         - https://openqa.suse.de/tests/17432755#dependencies

##