### PR TITLE
[WIP] Add Agama automation test in Headless mode

### DIFF
--- a/data/yam/agama/auto/scripts.jsonnet
+++ b/data/yam/agama/auto/scripts.jsonnet
@@ -1,4 +1,7 @@
 {
+  root: {
+    sshPublicKey: 'fake public key to enable sshd and open firewall',
+  },
   scripts: {
     pre: [
       {

--- a/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
+++ b/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
@@ -22,7 +22,8 @@ sub new {
               agama-unsupported-autoyast-elements
               agama-installing
               agama-sle-overview
-              agama-multipath)],
+              agama-multipath
+              agama-headless-mode-ready)],
         timeout_expect_is_shown => $args->{timeout_expect_is_shown} // 240
     }, $class;
 }

--- a/schedule/yam/agama_headless_mode.yaml
+++ b/schedule/yam/agama_headless_mode.yaml
@@ -1,0 +1,13 @@
+---
+name: agama_headless_mode
+description: >
+  Perform interactive installation with agama in headless mode.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_base_product
+  - yam/validate/validate_first_user
+  - yam/validate/validate_systemd_target

--- a/schedule/yam/agama_headless_mode_ppc64le.yaml
+++ b/schedule/yam/agama_headless_mode_ppc64le.yaml
@@ -1,0 +1,14 @@
+---
+name: agama_headless_mode_ppc64le
+description: >
+  Perform interactive installation with agama in headless mode.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_base_product
+  - yam/validate/validate_first_user
+  - yam/validate/validate_systemd_target

--- a/schedule/yam/agama_headless_mode_s390x.yaml
+++ b/schedule/yam/agama_headless_mode_s390x.yaml
@@ -1,0 +1,14 @@
+---
+name: agama_headless_mode_s390x
+description: >
+  Perform interactive installation with agama for s390x worker in headless mode.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_base_product
+  - yam/validate/validate_first_user
+  - yam/validate/validate_systemd_target

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -58,7 +58,7 @@ sub run {
         my $svirt = console('svirt')->change_domain_element(os => boot => {dev => 'hd'});
     }
 
-    (is_s390x() || is_ppc64le()) ?
+    (is_s390x() || is_ppc64le() || (get_var('EXTRABOOTPARAMS') =~ /systemd\.unit=multi-user\.target/)) ?
       # reboot via console
       power_action('reboot', keepconsole => 1, first_reboot => 1) :
       # graphical reboot

--- a/tests/yam/validate/validate_systemd_target.pm
+++ b/tests/yam/validate/validate_systemd_target.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The test module is to validate whether the installation is in headless mode.
+# systemctl status graphical.target and systemctl status x11-autologin.service are
+# different between a normal installation and a headless one. And validate the X11/Wayland
+# is not used and firefox is not lauched.
+#
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+
+     my $multi_user_target_status = script_run('systemctl is-active multi-user.target');
+     die "multi-user.target is not active, but it is expected to be" if $multi_user_target_status != 0;
+
+    my $graphical_target_status = script_run('systemctl is-active graphical.target');
+    die "graphical.target is active, but it should not be" if $graphical_target_status == 0;
+
+    my $is_x11_wayland_running = script_run('pgrep -x X || pgrep -x wayland');
+    die "X11 or Wayland is running, but it should not be" if $is_x11_wayland_running == 0;
+
+    my $is_firefox_running = script_run('pgrep -x firefox');
+    die "Firefox is running, but it should not be" if $is_firefox_running == 0;
+}
+
+1;


### PR DESCRIPTION
Add Agama automation test in Headless mode, and validate the X11/Wayland is not used and firefox is not lauched.

- Related ticket: https://progress.opensuse.org/issues/180914
- Needles: n/a
- Verification run: [vrs](https://openqa.suse.de/tests/overview?version=agama-10.0&build=chcao_180914&distri=sle)