### PR TITLE
Add a default value to IBS GCE variables

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -88,6 +88,10 @@ sub run {
         # for both jobs that creates the peering with terraform or the az cli
         set_var('IBSM_RG', '') unless (get_var('IBSM_RG'));
         set_var('IBSM_VNET', '') unless (get_var('IBSM_VNET'));
+    } elsif (is_gce()) {
+        set_var('IBSM_VPC_NAME', '') unless (get_var('IBSM_VPC_NAME'));
+        set_var('IBSM_SUBNET_NAME', '') unless (get_var('IBSM_SUBNET_NAME'));
+        set_var('IBSM_SUBNET_REGION', '') unless (get_var('IBSM_SUBNET_REGION'));
     }
 
     my $deployment_name = deployment_name();


### PR DESCRIPTION
Define with empty variables IBSM_VPC_NAME, IBSM_SUBNET_NAME and IBSM_SUBNET_REGION.


- Related ticket: https://jira.suse.com/browse/TEAM-10231

#  Verification run:

## Single incident
https://openqaworker15.qa.suse.cz/tests/321941

## HanaSR regression

### Without any IBS variables
 sle-12-SP5-HanaSr-Gcp-Byos-x86_64-Build12-SP5_2025-04-18T02:03:17Z-hanasr_gcp_test_fencing_native_ltss_es gce_n1_highmem_8
 - http://openqaworker15.qa.suse.cz/tests/321933 :green_circle: 

### With all the  IBS variables
 sle-15-SP6-HanaSr-Gcp-Byos-x86_64-Build15-SP6_2025-04-18T02:03:17Z-hanasr_gcp_test_peering gce_n1_highmem_8
- http://openqaworker15.qa.suse.cz/tests/321934 :green_circle: 