### PR TITLE
Move one ipaddr2 dependency on qesap

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -9,7 +9,7 @@ package sles4sap::ipaddr2;
 use strict;
 use warnings FATAL => 'all';
 use testapi;
-use sles4sap::qesap::qesapdeployment qw (qesap_calculate_address_range qesap_az_vnet_peering qesap_az_vnet_peering_delete qesap_az_clean_old_peerings);
+use sles4sap::qesap::qesapdeployment qw (qesap_calculate_address_range qesap_az_vnet_peering qesap_az_clean_old_peerings);
 use Carp qw( croak );
 use Exporter qw(import);
 use Mojo::JSON qw( decode_json );
@@ -55,7 +55,6 @@ our @EXPORT = qw(
   ipaddr2_bastion_ssh_addr
   ipaddr2_get_internal_vm_private_ip
   ipaddr2_network_peering_create
-  ipaddr2_network_peering_clean
   ipaddr2_patch_system
   ipaddr2_add_server_repos_to_hosts
 );
@@ -1961,26 +1960,6 @@ sub ipaddr2_test_other_vm {
             bastion_ip => $args{bastion_ip});
         die "Resource $resource is running on $vm and should not" if ($res =~ m/is running on: $vm/);
     }
-}
-
-=head2 ipaddr2_network_peering_clean
-
-    ipaddr2_network_peering_clean(ibsm_rg => );
-
-Cleanup the network peering if needed.
-
-=over
-
-=item B<ibsm_rg> - Resource group of the IBSm
-
-=back
-
-=cut
-
-sub ipaddr2_network_peering_clean {
-    my (%args) = @_;
-    croak 'Missing mandatory argument < ibsm_rg >' unless $args{'ibsm_rg'};
-    qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $args{'ibsm_rg'});
 }
 
 =head2 ipaddr2_network_peering_create

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -981,21 +981,6 @@ subtest '[get_private_ip_range]' => sub {
     set_var('WORKER_ID', undef);
 };
 
-subtest 'ipaddr2_network_peering_clean' => sub {
-    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
-    $ipaddr2->redefine(ipaddr2_azure_resource_group => sub { return 'test'; });
-
-    my $peering_string;
-
-    $ipaddr2->redefine(qesap_az_vnet_peering_delete => sub {
-            my (%args) = @_;
-            $peering_string = "source_group is $args{source_group}, target_group is $args{target_group}";
-            return;
-    });
-    ipaddr2_network_peering_clean(ibsm_rg => 'ibsm');
-    is $peering_string, "source_group is test, target_group is ibsm", "Clean network peering successfully";
-};
-
 subtest '[ipaddr2_network_peering_create]' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(az_network_vnet_get => sub { return 'DavidCuartielles'; });

--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -9,13 +9,14 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_cluster_create
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_network_peering_clean
+  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -41,7 +42,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -9,6 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_key_accept
   ipaddr2_bastion_pubip
@@ -22,7 +23,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_scc_check
   ipaddr2_scc_register
   ipaddr2_refresh_repo
-  ipaddr2_network_peering_clean
+  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -98,7 +99,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -9,11 +9,12 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_network_peering_clean
+  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -25,7 +26,7 @@ sub run {
     select_serial_terminal;
 
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
 }
@@ -39,7 +40,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs();
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -9,13 +9,14 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_cloudinit_logs
-  ipaddr2_network_peering_clean
   ipaddr2_infra_destroy
   ipaddr2_network_peering_create
   ipaddr2_add_server_repos_to_hosts
+  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -38,7 +39,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/patch_system.pm
+++ b/tests/sles4sap/ipaddr2/patch_system.pm
@@ -9,10 +9,11 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_cloudinit_logs
-  ipaddr2_network_peering_clean
+  ipaddr2_azure_resource_group
   ipaddr2_infra_destroy
   ipaddr2_patch_system
 );
@@ -34,7 +35,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -10,15 +10,16 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use publiccloud::utils;
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_cloudinit_logs
-  ipaddr2_network_peering_clean
   ipaddr2_infra_destroy
   ipaddr2_scc_addons
   ipaddr2_refresh_repo
   ipaddr2_ssh_internal
   ipaddr2_bastion_pubip
+  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -54,7 +55,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -14,13 +14,14 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_cluster_sanity
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-  ipaddr2_network_peering_clean
+  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -44,7 +45,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/sanity_os.pm
+++ b/tests/sles4sap/ipaddr2/sanity_os.pm
@@ -9,6 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_cluster_sanity
@@ -16,7 +17,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
   ipaddr2_os_sanity
-  ipaddr2_network_peering_clean
+  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -46,7 +47,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -9,6 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_crm_clear
@@ -20,7 +21,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_test_master_vm
   ipaddr2_test_other_vm
   ipaddr2_wait_for_takeover
-  ipaddr2_network_peering_clean
+  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -92,7 +93,7 @@ sub post_fail_hook {
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        ipaddr2_network_peering_clean(ibsm_rg => $ibsm_rg);
+        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;


### PR DESCRIPTION
Move the function call about the IBSm network peering delete from the library up to each test module.


- Related ticket: https://jira.suse.com/browse/TEAM-10277


# Verification run:
sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless
- http://openqaworker15.qa.suse.cz/tests/321937 :green_circle: 

sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless  with wrong CLUSTER_OS_VER=paperino
- http://openqaworker15.qa.suse.cz/tests/321938 :green_circle: job fails as expected in [deploy](https://openqaworker15.qa.suse.cz/tests/321938/modules/deploy/steps/1/src) and post_fail_hook runs

- sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test -> http://openqaworker15.qa.suse.cz/tests/321939


- sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-ipaddr2_azure_test with wrong SCC_REGCODE_SLES4SAP=paperino -> http://openqaworker15.qa.suse.cz/tests/321940 :green_circle: post_fail_hook after a failure

