### PR TITLE
Minor BATS tests enhancements

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -259,5 +259,6 @@ sub bats_post_hook {
         upload_logs($log_dir . $log);
     }
 
+    upload_logs('/proc/config.gz');
     upload_logs('/var/log/audit/audit.log', log_name => "audit.txt");
 }

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -313,8 +313,8 @@ sub load_container_tests {
         return;
     }
 
-    if (get_var('BATS_PACKAGE') =~ /(aardvark|buildah|netavark|podman|runc|skopeo)/) {
-        loadtest "containers/bats/$1";
+    if (my $bats_package = get_var('BATS_PACKAGE', '')) {
+        loadtest "containers/bats/$bats_package";
         return;
     }
 

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -21,14 +21,14 @@ The tests rely on some variables:
 | `ENABLE_SELINUX` | Set to `0` to put SELinux in permissive mode |
 | `OCI_RUNTIME` | OCI runtime to use: `runc` or `crun` |
 
-## aardvark / netavark
+### aardvark / netavark
 
 | variable | description |
 | --- | --- |
 | `BATS_TESTS` | Run only the specified tests, otherwise: |
 | `BATS_SKIP` | Skip subtests |
 
-## buildah / runc / skopeo
+### buildah / runc / skopeo
 
 | variable | description |
 | --- | --- |
@@ -37,7 +37,7 @@ The tests rely on some variables:
 | `BATS_SKIP_ROOT` | Skip subtests for root user |
 | `BATS_SKIP_USER` | Skip subtests for non-root user |
 
-## podman
+### podman
 
 | variable | description |
 | --- | --- |
@@ -52,7 +52,7 @@ NOTES
  - The special value `all` may be used to skip all tests.
  - The special value `none` should be used to avoid skipping any subtests.
 
-## Summary of the `BATS_SKIP` variables
+### Summary of the `BATS_SKIP` variables
 
 | variable | aardvark | buildah | netavark | podman | runc | skopeo |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -71,6 +71,11 @@ NOTES
 - To debug buildah issues you may clone a job with `BUILDAH_STORAGE_DRIVER=vfs`
 - To debug individual tests you may clone a job with `BATS_TESTS`
 - You can also use `BATS_URL` to use the latest version from the `main` branch like `BATS_URL=https://github.com/containers/netavark/archive/refs/heads/main.tar.gz`
+
+## Warning
+
+- If you want to run `bats` tests manually, do so in a fresh VM, otherwise you risk losing all your volumes, images & containers.
+Please add this warning on each bug report you open when adding instructions on how to reproduce an issue.
 
 ## openQA schedules
 
@@ -140,6 +145,33 @@ NOTES
 [sp3_r]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP3&arch=x86_64&test=runc_testsuite
 [sp3_s]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP3&arch=x86_64&test=skopeo_testsuite
 
+## Skipped tests
+
+### buildah
+
+| test | reason |
+| --- | --- |
+| lots of them | https://github.com/containers/buildah/issues/6071 |
+
+### podman
+
+| test | reason |
+| --- | --- |
+| [080-pause] | https://github.com/opencontainers/runc/pull/4709 |
+| [195-run-namespaces] | https://github.com/opencontainers/runc/issues/4732 |
+| [505-networking-pasta] | https://bugs.passt.top/show_bug.cgi?id=49 |
+
+[080-pause]: https://github.com/containers/podman/blob/main/test/system/080-pause.bats
+[195-run-namespaces]: https://github.com/containers/podman/blob/main/test/system/195-run-namespaces.bats
+[505-networking-pasta]: https://github.com/containers/podman/blob/main/test/system/505-networking-pasta.bats
+
+### runc
+
+| test | reason |
+| --- | --- |
+| [checkpoint] | https://github.com/checkpoint-restore/criu/issues/2650 |
+
+[checkpoint]: https://github.com/opencontainers/runc/blob/main/tests/integration/checkpoint.bats
 
 ## Tools
 

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -57,7 +57,7 @@ sub run {
     select_serial_terminal;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns firewalld iproute2 iptables jq netavark podman);
+    my @pkgs = qw(aardvark-dns firewalld iproute2 jq netavark podman);
     if (is_tumbleweed || is_sle('>=16.0')) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -17,7 +17,6 @@ use version_utils qw(is_sle is_tumbleweed);
 
 my $test_dir = "/var/tmp/netavark-tests";
 my $netavark;
-my $firewalld_backend;
 
 sub run_tests {
     my $tmp_dir = script_output "mktemp -d -p /var/tmp test.XXXXXX";
@@ -43,10 +42,6 @@ sub run_tests {
 
     unless (@tests) {
         my @skip_tests = split(/\s+/, get_var('BATS_SKIP', ''));
-        # Unconditionally ignore these flaky subtests
-        my @must_skip = ();
-        push @must_skip, "100-bridge-iptables" if ($firewalld_backend ne "iptables");
-        push @skip_tests, @must_skip;
         patch_logfile($log_file, @skip_tests);
     }
 
@@ -82,11 +77,12 @@ sub run {
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
 
-    $firewalld_backend = script_output "awk -F= '\$1 == \"FirewallBackend\" { print \$2 }' < /etc/firewalld/firewalld.conf";
+    my $firewalld_backend = script_output "awk -F= '\$1 == \"FirewallBackend\" { print \$2 }' < /etc/firewalld/firewalld.conf";
     record_info("Firewalld backend", $firewalld_backend);
 
     # Compile helpers & patch tests
     assert_script_run "make examples", timeout => 600;
+    assert_script_run "rm -f test/100-bridge-iptables.bats" if ($firewalld_backend ne "iptables");
 
     my $errors = run_tests;
     die "netavark tests failed" if ($errors);

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -60,7 +60,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 iptables jq make protobuf-devel netavark);
+    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 jq make protobuf-devel netavark);
     if (is_tumbleweed || is_sle('>=16.0')) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -82,7 +82,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(aardvark-dns apache2-utils buildah catatonit git-core glibc-devel-static go gpg2 iptables jq libcriu2 libgpgme-devel
+    my @pkgs = qw(aardvark-dns apache2-utils buildah catatonit git-core glibc-devel-static go gpg2 jq libcriu2 libgpgme-devel
       libseccomp-devel make netavark openssl podman podman-remote python3-PyYAML skopeo socat sudo systemd-container);
     push @pkgs, qw(criu) if is_tumbleweed;
     # Needed for podman machine

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -58,14 +58,6 @@ sub run_tests {
 
     unless (@tests) {
         my @skip_tests = split(/\s+/, get_required_var('BATS_SKIP') . " " . $skip_tests);
-        # Unconditionally ignore these flaky subtests
-        my @must_skip = (
-            # this test depends on the openQA worker's scheduler
-            "180-blkio",
-            # this test will fail if there's not "enough" free space
-            "320-system-df",
-        );
-        push @skip_tests, @must_skip;
         patch_logfile($log_file, @skip_tests);
     }
 
@@ -120,6 +112,8 @@ sub run {
     assert_script_run "sed -i 's/bats_opts=()/bats_opts=(--tap)/' hack/bats";
     assert_script_run "sed -i 's/^PODMAN_RUNTIME=/&$oci_runtime/' test/system/helpers.bash";
     assert_script_run "rm -f contrib/systemd/system/podman-kube@.service.in";
+    # This test is flaky and will fail if system is "full"
+    assert_script_run "rm -f test/system/320-system-df.bats";
 
     # Compile helpers used by the tests
     script_run "make podman-testing", timeout => 600;

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -26,7 +26,6 @@ sub run_tests {
 
     return if ($skip_tests eq "all");
 
-    my $log_file = "bats-" . ($rootless ? "user" : "root") . "-" . ($remote ? "remote" : "local") . ".tap";
     my $args = ($rootless ? "--rootless" : "--root");
     $args .= " --remote" if ($remote);
 
@@ -43,7 +42,9 @@ sub run_tests {
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 
+    my $log_file = "bats-" . ($rootless ? "user" : "root") . "-" . ($remote ? "remote" : "local") . ".tap";
     assert_script_run "echo $log_file .. > $log_file";
+
     background_script_run "podman system service --timeout=0" if ($remote);
 
     my @tests;

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -61,7 +61,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(git-core glibc-devel-static go iptables jq libseccomp-devel make runc);
+    my @pkgs = qw(git-core glibc-devel-static go jq libseccomp-devel make runc);
     push @pkgs, "criu" if is_tumbleweed;
 
     $self->bats_setup(@pkgs);

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -22,8 +22,6 @@ sub run_tests {
 
     return if ($skip_tests eq "all");
 
-    my $log_file = "runc-" . ($rootless ? "user" : "root") . ".tap";
-
     my $tmp_dir = script_output "mktemp -d -p /var/tmp test.XXXXXX";
 
     my %_env = (
@@ -34,6 +32,7 @@ sub run_tests {
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 
+    my $log_file = "runc-" . ($rootless ? "user" : "root") . ".tap";
     assert_script_run "echo $log_file .. > $log_file";
 
     my @tests;

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -26,10 +26,6 @@ sub run_tests {
 
     my $log_file = "skopeo-" . ($rootless ? "user" : "root") . ".tap";
 
-    # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
-    my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";
-    assert_script_run "sed -i 's/arch=.*/arch=$goarch/' systemtest/010-inspect.bats";
-
     # Default quay.io/libpod/registry:2 image used by the test only has amd64 image
     my $registry = is_x86_64 ? "" : "docker.io/library/registry:2";
 
@@ -84,6 +80,10 @@ sub run {
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+
+    # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
+    my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";
+    assert_script_run "sed -i 's/arch=.*/arch=$goarch/' systemtest/010-inspect.bats";
 
     my $errors = run_tests(rootless => 1, skip_tests => get_var('BATS_SKIP_USER', ''));
 

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -24,8 +24,6 @@ sub run_tests {
 
     return if ($skip_tests eq "all");
 
-    my $log_file = "skopeo-" . ($rootless ? "user" : "root") . ".tap";
-
     # Default quay.io/libpod/registry:2 image used by the test only has amd64 image
     my $registry = is_x86_64 ? "" : "docker.io/library/registry:2";
 
@@ -39,6 +37,7 @@ sub run_tests {
     );
     my $env = join " ", map { "$_=$_env{$_}" } sort keys %_env;
 
+    my $log_file = "skopeo-" . ($rootless ? "user" : "root") . ".tap";
     assert_script_run "echo $log_file .. > $log_file";
 
     my @tests;


### PR DESCRIPTION
Minor BATS tests enhancements:
- Simplify scheduling
- Upload kernel configuration in post hook
- Drop iptables dependency as packages are supposed to pull them in
- netavark: Remove iptables test if it's not a firewalld backend
- podman: Allow 180-blkio & remove 320-system-df
- Document skipped tests in Tumbleweed.

Verification runs:
  - aardvark: https://openqa.opensuse.org/tests/5009538
  - buildah: https://openqa.opensuse.org/tests/5009539
  - netavark: https://openqa.opensuse.org/tests/5009549
  - podman: https://openqa.opensuse.org/tests/5009541
  - runc: https://openqa.opensuse.org/tests/5010365
  - skopeo: https://openqa.opensuse.org/tests/5009543