### PR TITLE
Use independent .perltidyrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ os-autoinst
 tools/absolutize
 tools/lib
 tools/tidy
-.perltidyrc
 *.tdy
 .*.swp
 *~

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,15 @@
+# Workaround needed for handling non-ASCII in files.
+# # See <https://github.com/houseabsolute/perl-code-tidyall/issues/84>.
+--character-encoding=none
+--no-valign
+-l=160
+-fbl     # don't change blank lines
+-fnl     # don't remove new lines
+-nsfs    # no spaces before semicolons
+-baao    # space after operators
+-bbao    # space before operators
+-pt=2    # no spaces around ()
+-bt=2    # no spaces around []
+-sbt=2   # no spaces around {}
+-sct     # stack closing tokens )}
+--pack-operator-types='->' # allow chained method calls on one line

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ testing" && exit 2)
 
 tools/tidy: os-autoinst/
 	@test -e tools/tidy || ln -s ../os-autoinst/tools/tidy tools/
-	@test -e .perltidyrc || ln -s os-autoinst/.perltidyrc ./
 
 tools/lib/: os-autoinst/
 	@test -e tools/lib || ln -s ../os-autoinst/tools/lib tools/


### PR DESCRIPTION
There were complaints about a `.perltidyrc` change in os-autoinst.
Since os-autoinst is cloned in osado and `.perltidyrc` is just a symlink to the one in os-autoinst, changes there will have an immediate effect here.

With this osado maintainers can decide about their own perltidy rules.