### PR TITLE
Adjust password length according to vnc RFC

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -35,9 +35,9 @@ my $timeout = (is_aarch64 && is_sle) ? 120 : 30;
 my $display = ':37';
 
 # Passwords for VNC access
-my @options = ({pw => "readonly_pw", change => 0}, {pw => "readwrite_pw", change => 1});
+my @options = ({pw => "ropasswd", change => 0}, {pw => "rwpasswd", change => 1});
 # A wrong password to check if the access is denied
-my $wrong_password = "password123";
+my $wrong_password = "badpass";
 
 my $test_xauth;
 my $tigervnc_vers;


### PR DESCRIPTION
The 8 char password max is a protocol limitation, rather than an implementation issue.
See [1]:

"The client encrypts the challenge with DES, using a password supplied by the user as
the key. To form the key, the password is truncated to eight characters, or padded
with null bytes on the right."

[1] https://www.rfc-editor.org/rfc/rfc6143#section-7.2.2

- Related ticket: https://progress.opensuse.org/issues/181235
- Verification run:  https://openqa.opensuse.org/tests/5011250#step/vnc_two_passwords/82

Failure is https://bugzilla.opensuse.org/show_bug.cgi?id=1241518
