### PR TITLE
Fix podmansh on RISC-V runs

### DIFF
--- a/tests/containers/podmansh.pm
+++ b/tests/containers/podmansh.pm
@@ -15,7 +15,7 @@ use Utils::Systemd qw(systemctl);
 use utils;
 use containers::common;
 
-my $src_image = "registry.opensuse.org/opensuse/leap";
+my $src_image = "registry.opensuse.org/opensuse/tumbleweed";
 my $quadlet_container = <<_EOF_;
 [Unit]
 Description=Podman shell container
@@ -129,7 +129,7 @@ sub execute_tests {
     validate_script_output("$cmd id", sub { /^uid=1000\(bernhard\) gid=1000\(bernhard\) groups=1000\(bernhard\)$/ });
 
     # verifies if correct image variant
-    validate_script_output("$cmd 'cat /etc/os-release'", sub { /^ID=\"opensuse-leap\"$/m });
+    validate_script_output("$cmd 'cat /etc/os-release'", sub { /^ID=\"opensuse-tumbleweed\"$/m });
 }
 
 sub prepare_user_account {


### PR DESCRIPTION
Fixes podmansh test on RISC-V build by using Tumbleweed instead of Leap container images, because Leap doesn't have a riscv64 variant.

- Related ticket: https://progress.opensuse.org/issues/181265
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/5011641#step/podmansh/1