### PR TITLE
Download script when openqa-bootstrap runs in Leap

### DIFF
--- a/tests/openqa/install/openqa_bootstrap.pm
+++ b/tests/openqa/install/openqa_bootstrap.pm
@@ -11,7 +11,7 @@ use warnings;
 use base "consoletest";
 use testapi;
 use utils;
-use version_utils qw(has_selinux);
+use version_utils qw(has_selinux is_leap);
 
 sub run {
     select_console 'root-console';
@@ -24,7 +24,14 @@ sub run {
     if (has_selinux) {
         script_run('setsebool -P httpd_can_network_connect 1');
     }
-    zypper_call('in openQA-bootstrap');
+    if (is_leap) {
+        # https://progress.opensuse.org/issues/180905
+        assert_script_run('mkdir -p /usr/share/openqa/script/');
+        assert_script_run('curl -L https://raw.githubusercontent.com/os-autoinst/openQA/refs/heads/master/script/openqa-bootstrap > /usr/share/openqa/script/openqa-bootstrap');
+        assert_script_run('test -e /usr/share/openqa/script/openqa-bootstrap && chmod +x /usr/share/openqa/script/openqa-bootstrap');
+    }
+    else { zypper_call('in openQA-bootstrap'); }
+
     my $proxy_var = get_var('OPENQA_WEB_PROXY') ? 'setup_web_proxy=' . get_var('OPENQA_WEB_PROXY') . ' ' : '';
     assert_script_run($proxy_var . "/usr/share/openqa/script/openqa-bootstrap", 4000);
 }


### PR DESCRIPTION
Use always the latest bootstrap script from the repo as the rpm is not always the latest one. This will fix
https://progress.opensuse.org/issues/180905 where the openQA config files have been moved around but the bootstrap script is not up to date. As for now there is not automatic submission on Leap and this is the easiest approach to fix the test module.

- Related ticket: https://progress.opensuse.org/issues/180905
- Needles: n/a
- Verification run: https://openqa.opensuse.org/tests/5011869#details