### PR TITLE
containers: Add more logs to BATS tests

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -248,11 +248,23 @@ sub bats_post_hook {
     script_run('dmesg > dmesg.txt');
     script_run('findmnt > findmnt.txt');
     script_run('rpm -qa | sort > rpm-qa.txt');
+    script_run('sysctl -a > sysctl.txt');
     script_run('systemctl > systemctl.txt');
     script_run('systemctl status > systemctl-status.txt');
     script_run('systemctl list-unit-files > systemctl_units.txt');
     script_run('journalctl -b > journalctl-b.txt', timeout => 120);
     script_run('tar zcf containers-conf.tgz $(find /etc/containers /usr/share/containers -type f)');
+
+    for my $ip_version (4, 6) {
+        script_run("ip -$ip_version addr > ip$ip_version-addr.txt");
+        script_run("ip -$ip_version route > ip$ip_version-route.txt");
+    }
+    script_run("iptables-save > iptables.txt");
+    script_run("ip6tables-save > ip6tables.txt");
+    script_run('nft list ruleset > nft.txt');
+
+    # Remove all empty logs
+    script_run "find $log_dir -type f -size 0 -exec rm -f {} +";
 
     my @logs = split /\s+/, script_output "ls";
     for my $log (@logs) {


### PR DESCRIPTION
Add more logs to BATS tests:
- sysctl's
- IP addresses & routes
- Dump of iptables/nftables rules

Needed to debug network tests.

- Verification run: https://openqa.opensuse.org/tests/5013839 (`BATS_TESTS=505-networking-pasta`)

VR fails for $reasons.
