### PR TITLE
Fix Azure AITL success

### DIFF
--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -162,6 +162,10 @@ sub json_to_xml {
     $dom->toFile(hashed_string('aitl_results.xml'), 1);
 }
 
+sub _upload_logs {
+    return 1;
+}
+
 sub _cleanup {
     # because it is AITL where we don't create actual instance no point to call _cleanup
 }


### PR DESCRIPTION
Fix for `$self->_upload_logs() failed -- Can't call method "ssh_script_run" on an undefined value at sle/lib/publiccloud/basetest.pm line 169.`

- Related ticket: https://progress.opensuse.org/issues/179620
- Verification run: http://sandman.qe.prg2.suse.org/tests/307#