### PR TITLE
Fix podman scp upstream test

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -312,6 +312,7 @@ sub bats_tests {
         my $args = ($log_file =~ /root/) ? "--root" : "--rootless";
         $args .= " --remote" if ($log_file =~ /remote/);
         $cmd = "hack/bats $args";
+        $tests =~ s/\.bats//g;
         $cmd .= " $tests" if ($tests ne $tests_dir{podman});
     }
 

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -28,6 +28,7 @@ sub run_tests {
     my $quadlet = script_output "rpm -ql podman | grep podman/quadlet";
 
     my %env = (
+        PODMAN_ROOTLESS_USER => $testapi::username,
         PODMAN => "/usr/bin/podman",
         QUADLET => $quadlet,
     );


### PR DESCRIPTION
Currently we're "skipping" (ignoring the failure of) `120-load`.  This will allows us to remove `120-load` from the BATS_SKIP variables.

Also fix an issue when calling `hack/bats` with `.bats` extensions.

- Verification run: https://openqa.opensuse.org/tests/5014237#external
