### PR TITLE
containers: Introduce BATS_PATCHES

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -314,7 +314,6 @@ sub bats_tests {
         my $args = ($log_file =~ /root/) ? "--root" : "--rootless";
         $args .= " --remote" if ($log_file =~ /remote/);
         $cmd = "hack/bats $args";
-        $tests =~ s/\.bats//g;
         $cmd .= " $tests" if ($tests ne $tests_dir{podman});
     }
 

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -15,6 +15,7 @@ The tests rely on some variables:
 | variable | description |
 | --- | --- |
 | `BATS_PACKAGE` | `aardvark` `buildah` `netavark` `podman` `runc` `skopeo` |
+| `BATS_PATCHES` | List of github PR id's containing upstream test patches |
 | `BATS_URL` | URL to get the tests from. The default depends on the package version |
 | `BATS_VERSION` | Version of [bats](https://github.com/bats-core/bats-core) to use |
 | `BUILDAH_STORAGE_DRIVER` | Storage driver used for buildah: `vfs` or `overlay` |

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -57,6 +57,7 @@ sub run {
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_patches;
 
     my $errors = run_tests;
     die "ardvark-dns tests failed" if ($errors);

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -69,6 +69,7 @@ sub run {
     selinux_hack "/tmp";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_patches;
 
     # Patch mkdir to always use -p
     assert_script_run "sed -i 's/ mkdir /& -p /' tests/*.bats tests/helpers.bash";

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -53,6 +53,7 @@ sub run {
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_patches;
 
     my $firewalld_backend = script_output "awk -F= '\$1 == \"FirewallBackend\" { print \$2 }' < /etc/firewalld/firewalld.conf";
     record_info("Firewalld backend", $firewalld_backend);

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -87,6 +87,7 @@ sub run {
     $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
 
     # Patch tests
+    assert_script_run "curl -sLo hack/bats https://raw.githubusercontent.com/containers/podman/refs/heads/main/hack/bats";
     assert_script_run "sed -i 's/bats_opts=()/bats_opts=(--tap)/' hack/bats";
     assert_script_run "sed -i 's/^PODMAN_RUNTIME=/&$oci_runtime/' test/system/helpers.bash";
     assert_script_run "rm -f contrib/systemd/system/podman-kube@.service.in";

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -82,6 +82,7 @@ sub run {
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_patches;
 
     $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -53,6 +53,7 @@ sub run {
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_patches;
 
     # Compile helpers used by the tests
     my $cmds = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d -printf '%f ' || true";

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -55,6 +55,7 @@ sub run {
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_patches;
 
     # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
     my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";


### PR DESCRIPTION
Introduce the BATS_PATCHES variable.

This will help us to dramatically reduce the number of ignored tests via the `BATS_SKIP_*` variables.

- Verification run: https://openqa.opensuse.org/tests/5014486#external (`BATS_PATCHES="25918 25955"`)

In the [original test](https://openqa.opensuse.org/tests/5013185) we ignore `195-run-namespace`.  The above VR downloads the test patches specified by BATS_PATCHES so we can stop ignoring most tests.
