### PR TITLE
Add test cases for x11 related containers' testing with podman

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2142,6 +2142,12 @@ sub load_x11_remote {
         loadtest 'x11/remote_desktop/windows_network_setup';
         loadtest 'x11/remote_desktop/windows_server_setup';
     }
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_server')) {
+        loadtest 'microos/workloads/x11-container/x11_server';
+    }
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_client')) {
+        loadtest 'microos/workloads/x11-container/x11_client';
+    }
 }
 
 
@@ -2175,6 +2181,8 @@ sub load_common_x11 {
     elsif (check_var('REGRESSION', 'remote')) {
         if (check_var("REMOTE_DESKTOP_TYPE", "win_client") || check_var('REMOTE_DESKTOP_TYPE', "win_server")) {
             loadtest "x11/remote_desktop/windows_client_boot";
+        } elsif (check_var("REMOTE_DESKTOP_TYPE", "x11_server")) {
+            loadtest 'microos/disk_boot';
         }
         else {
             loadtest 'boot/boot_to_desktop';

--- a/tests/microos/workloads/x11-container/x11_client.pm
+++ b/tests/microos/workloads/x11-container/x11_client.pm
@@ -1,0 +1,92 @@
+# SUSE"s openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: podman x11-container
+# Summary: install and verify x11 container.
+# Maintainer: Grace Wang <grace.wang@suse.com>
+
+use warnings;
+use strict;
+use testapi;
+use lockapi;
+use base 'x11test';
+use mmapi;
+use mm_tests;
+use x11utils 'turn_off_gnome_screensaver';
+
+# MM network check: try to ping the gateway, and the server
+sub ensure_server_reachable {
+    assert_script_run('ping -c 1 10.0.2.2');
+    assert_script_run('ping -c 1 10.0.2.101');
+}
+
+sub run {
+
+    my $self = shift;
+
+    # Setup static NETWORK
+    $self->configure_static_ip_nm('10.0.2.102/24');
+
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver;
+
+    mutex_wait("x11_container_ready");
+    ensure_server_reachable();
+
+    # ssh login to the x11 server
+    enter_cmd('ssh root@10.0.2.101');
+    assert_screen 'ssh-login', 60;
+    enter_cmd "yes";
+    assert_screen 'password-prompt', 60;
+    type_password();
+    send_key "ret";
+    assert_screen 'ssh-login-ok';
+
+    my $opts = "-e DISPLAY=:0 -e XAUTHORITY=/home/user/xauthority/.xauth -e PULSE_SERVER=/var/run/pulse/native -v xauthority:/home/user/xauthority:rw -v pasocket:/var/run/pulse/ -v xsocket:/tmp/.X11-unix:rw";
+    # pulseaudio image url and firefox kiosk url are joined together by a space
+    # split the string by space
+    my ($pacontainerpath, $ffcontainerpath) = split(/\s+/, get_var("CONTAINER_IMAGE_TO_TEST", 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/pulseaudio:17 registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk-firefox-esr:128.8'));
+    # start pulseaudio container
+    enter_cmd("podman pull $pacontainerpath --tls-verify=false", 300);
+    assert_screen("podman-pa-pull-done");
+    enter_cmd("podman run -d --pod wallboard-pod $opts -v /run/udev/data:/run/udev/data:rw --name pulseaudio-container --privileged $pacontainerpath bash -c 'chown root:audio /dev/snd/*; /usr/bin/pulseaudio -vvv --log-target=stderr'");
+    assert_screen("podman-pa-run");
+
+    # start firefox container
+    enter_cmd("podman pull $ffcontainerpath --tls-verify=false", 300);
+    assert_screen("podman-ff-pull-done");
+    # URL https://freesound.org/people/kevp888/sounds/796468/ can be used for testing
+    # Since it doesn't have ads and require login before playing audio
+    enter_cmd("podman run -d --pod wallboard-pod -e URL=https://freesound.org/people/kevp888/sounds/796468/ $opts --user 1000 --name wallboard-container --security-opt=no-new-privileges $ffcontainerpath");
+    assert_screen("podman-firefox-run");
+
+    # check if pulseaudio service is running
+    enter_cmd("podman exec pulseaudio-container ps aux | grep pulseaudio");
+    assert_screen("pa-service-running");
+
+    # wait for the server side to play audio from firefox
+    sleep 60;
+    # check the audio can be played fine from the code level
+    enter_cmd("podman exec pulseaudio-container pactl list sink-inputs");
+    assert_screen("firefox-container-playing-audio");
+
+    # stop container
+    enter_cmd("podman stop wallboard-container");
+    assert_screen("wallboard-container-stopped");
+    enter_cmd("podman stop pulseaudio-container");
+    assert_screen("pa-container-stopped");
+    enter_cmd("podman stop x11-init-container");
+    assert_screen("x11-container-stopped");
+
+    # stop ssh
+    enter_cmd "exit";
+
+    # exit xterm
+    send_key "alt-f4";
+    assert_screen 'generic-desktop';
+}
+
+1;
+

--- a/tests/microos/workloads/x11-container/x11_server.pm
+++ b/tests/microos/workloads/x11-container/x11_server.pm
@@ -1,0 +1,73 @@
+# SUSE"s openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: podman x11-container
+# Summary: install and verify x11 container.
+# Maintainer: Grace Wang <grace.wang@suse.com>
+
+use base 'consoletest';
+use warnings;
+use strict;
+use testapi;
+use lockapi;
+use mmapi;
+use utils qw(set_hostname permit_root_ssh);
+use mm_network 'setup_static_mm_network';
+
+# MM network check: try to ping the gateway, the client and the internet
+sub ensure_client_reachable {
+    assert_script_run('ping -c 1 10.0.2.2');
+    assert_script_run('ping -c 1 10.0.2.102');
+    assert_script_run('curl conncheck.opensuse.org');
+}
+
+sub x11_preparation {
+
+    # create volume
+    assert_script_run("podman volume create xauthority");
+    assert_script_run("podman volume create xsocket");
+    assert_script_run("podman volume create pasocket");
+
+    # create a pod
+    assert_script_run("podman pod create --name wallboard-pod");
+}
+
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'root-console';
+    set_hostname(get_var('HOSTNAME') // 'server');
+    setup_static_mm_network('10.0.2.101/24');
+    ensure_client_reachable();
+
+    # Permit ssh login as root
+    assert_script_run("echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf");
+    assert_script_run("systemctl restart sshd");
+
+    assert_script_run "chmod a+rw /dev/snd/*";
+
+    # preparations
+    x11_preparation();
+
+    # start X11 container
+    my $containerpath = get_var('CONTAINER_IMAGE_TO_TEST', 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/xorg:latest');
+    assert_script_run("podman pull $containerpath --tls-verify=false", 300);
+    assert_script_run("podman run --privileged -d --pod wallboard-pod -e XAUTHORITY=/home/user/xauthority/.xauth -v xauthority:/home/user/xauthority:rw -v xsocket:/tmp/.X11-unix:rw -v /run/udev/data:/run/udev/data:rw --name x11-init-container --security-opt=no-new-privileges $containerpath");
+    # verify the x11 server container started
+    assert_screen "icewm_wallboard";
+
+    # Notify that the server is ready
+    mutex_create("x11_container_ready");
+
+    # verify the firefox kiosk container started
+    assert_screen("firefox_kiosk", 300);
+    assert_and_click "firefox_play_audio";
+
+    wait_for_children();
+}
+
+1;
+


### PR DESCRIPTION
Only covered deploy the below containers with podman: 
x11 container, pulseaudio container and firefox kiosk container

- Related ticket: https://progress.opensuse.org/issues/174418
- Needles: already added when debugging on osd
- Test suites settings can be found https://openqa.suse.de/admin/test_suites

**(Grace updated below info on Apr 25)**: 
- Verification run：
x11_client https://openqa.suse.de/tests/17452967#
x11_server https://openqa.suse.de/tests/17452966#

The `my ($pacontainerpath, $ffcontainerpath) = split(/\s+/, get_var("CONTAINER_IMAGE_TO_TEST", PA-IMAGEURL FF-IMAGEURL));` works as expected.
Tests failed since there are some issues exist (such as https://suse.slack.com/archives/C06S6BAGCPR/p1745416155523529)
The fix is on the way. 

The VR for registry.opensuse.org image URLs:
> x11_server https://openqa.suse.de/tests/17295257#
> x11_client https://openqa.suse.de/tests/17295258#
