### PR TITLE
Revert "lib/bootloader_setup: Add check for SLE16 in add_custom_grub_entries"

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -134,9 +134,6 @@ sub add_custom_grub_entries {
     elsif (check_var('SLE_PRODUCT', 'slert')) {
         $distro = "SLE_RT" . ' \\?' . get_required_var('VERSION');
     }
-    elsif (is_sle("16+")) {
-        $distro = "SUSE Linux" . ' \\?' . get_required_var('VERSION');
-    }
     elsif (is_sle()) {
         $distro = "SLES" . ' \\?' . get_required_var('VERSION');
     }


### PR DESCRIPTION
This reverts commit 374543fa07c6b6143449f1d72621f6eb17ea0016.

SLE 16 changed content of /etc/os-release to previous state and we
need to revert to original setup.

- Related fail: https://openqa.suse.de/tests/17430835#step/install_ltp/215
- Related ticket: none
- Needles: none
- Verification run: 
SLE16: https://openqa.suse.de/tests/17434976
TW:  https://openqa.opensuse.org/tests/5015867
SLE15-SP7: https://openqa.suse.de/tests/17434989
