### PR TITLE
Set PAGER=cat for serial console

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -188,7 +188,7 @@ sub login {
     die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \s*$/x);
 
     # Some (older) versions of bash don't take changes to the terminal during runtime into account. Re-exec it.
-    enter_cmd('export TERM=dumb; stty cols 2048; exec $SHELL');
+    enter_cmd('export PAGER=cat TERM=dumb; stty cols 2048; exec $SHELL');
     die 'Failed to confirm that shell re-exec was successful' unless wait_serial(qr/$escseq* \w+:~(\s\#|>) $escseq* \s*$/x);
     set_serial_prompt($prompt);
     # TODO: Send 'tput rmam' instead/also


### PR DESCRIPTION
This reverts commit 63d1eab39da758ee60fa00256a1408b2b58cfdb6.

The problem that was reported https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21832#issuecomment-2825542819 is in fact in the perf module https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21869
