### PR TITLE
xfstests: Create /etc/nfs.conf before sed

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -395,7 +395,7 @@ sub setup_nfs_server {
     }
     else {
         assert_script_run("sed -i 's/NFSV4LEASETIME=\"\"/NFSV4LEASETIME=\"$nfsgrace\"/' /etc/sysconfig/nfs");
-        assert_script_run("echo -e '[nfsd]\\ngrace-time=$nfsgrace\\nlease-time=$nfsgrace' > /etc/nfs.conf.local");
+        assert_script_run("echo -e '[nfsd]\\ngrace-time=$nfsgrace\\nlease-time=$nfsgrace' > /etc/nfs.conf");
         if ($nfsversion =~ 'pnfs') {
             assert_script_run('mkdir -p /srv/pnfs_data && chown nobody:nogroup /srv/pnfs_data && echo \'/srv/pnfs_data *(rw,pnfs,no_subtree_check,no_root_squash,fsid=10)\' >> /etc/exports');
             assert_script_run('sed -i \'/^\[nfsd\\]$/a pnfs_dlm_device = localhost:/srv/pnfs_data\' /etc/nfs.conf');


### PR DESCRIPTION
In SLE16 it will fail in sed /etc/nfs.conf. I changed to create gracetime to /etc/nfs.conf, the step before sed. So it will make sure /etc/nfs.conf exists.

- Related ticket: https://progress.opensuse.org/issues/181241
- Verification run: https://openqa.suse.de/tests/17435720
