### PR TITLE
Fix check_target_version

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -158,7 +158,7 @@ sub check_target_version {
     my $release = script_output "cat /etc/os-release";
     my $expected_version = get_var("TARGET_VERSION", get_required_var("VERSION"));
     my $selector = is_micro(">=6.2") ?
-      "VARIANT=\"Micro ?$expected_version\"?" :
+      qq|SUSE_SUPPORT_PRODUCT_VERSION="$expected_version"| :
       "VERSION=\"?$expected_version\"?";
 
     die "Target version not found! Expected: $expected_version" if ($release !~ $selector);


### PR DESCRIPTION
- Verification run: [slem_migration_6.1_to_6.2__TEST__](https://openqa.suse.de/tests/overview?build=leo-test-fix-check-version)

> there are some changes in `/etc/os-release` on SL-Micro 6.2
`VERSION="16.0 Beta4"`

See [/etc/os-release](https://openqa.suse.de/tests/17429188#step/zypper_migration/34) content.

See [confluence document](https://confluence.suse.com/display/~okir/Another+attempt+at+os-release).