### PR TITLE
Skip podmansh on SLEM 6.1

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -148,7 +148,7 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.1") || is_leap_micro("<6.1"));
+        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.2") || is_leap_micro("<6.2"));
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
On SLEM 6.1 there is no podmansh package available.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related failure: https://openqa.suse.de/tests/17436204
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1241694 (requests `podmansh` for SLEM 6.2)
- Verification run: https://openqa.suse.de/tests/17442332 (`podmansh` not scheduled)
