### PR TITLE
Skip apache_nss on SLES 16

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1154,7 +1154,7 @@ sub load_console_server_tests {
     # TODO test on openSUSE https://progress.opensuse.org/issues/31972
     loadtest "console/apache_ssl" if is_sle;
     # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-    loadtest "console/apache_nss" if is_sle;
+    loadtest "console/apache_nss" if is_sle("<16");
 }
 
 sub load_consoletests {


### PR DESCRIPTION
`apache_nss` will not be part of SLES 16.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1236295#c3
- Verification run: https://openqa.suse.de/tests/17443316 (no `apache_nss` scheduled)
