### PR TITLE
containers: Temporarily mute podmansh

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -148,7 +148,8 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.2") || is_leap_micro("<6.2"));
+        # NOTE: Temporarily mute podmansh
+        # loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.2") || is_leap_micro("<6.2"));
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
This module is failing on SLE 16.0.  I suggest moving to a separate job or make it run last so we can test other modules as this one is fatal to the whole job.

https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=78.2&groupid=630