### PR TITLE
Revert "containers: Temporarily mute podmansh"

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -148,8 +148,7 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        # NOTE: Temporarily mute podmansh
-        # loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.2") || is_leap_micro("<6.2"));
+        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.2") || is_leap_micro("<6.2"));
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#21877 as this change was made hastily. We should fix the test module instead.