### PR TITLE
Minor BATS tests enhancements

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -148,7 +148,7 @@ sub patch_logfile {
     foreach my $test (@skip_tests) {
         next if ($test eq "none");
         if (script_run("grep -q 'in test file.*/$test.bats' $log_file") != 0) {
-            record_info("BATS: Test $test passed!");
+            record_info("PASS", $test);
         }
     }
     assert_script_run "bats_skip_notok $log_file " . join(' ', @skip_tests) if (@skip_tests);
@@ -338,7 +338,7 @@ sub bats_patches {
 
     foreach my $patch (split(/\s+/, get_var("BATS_PATCHES", ""))) {
         my $url = "https://github.com/$github_org/$package/pull/$patch.diff";
-        record_info("Applying patch $url");
+        record_info("patch", $url);
         assert_script_run "curl -sL $url | patch -p1 --merge";
     }
 }

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -313,7 +313,7 @@ sub bats_tests {
     if ($package eq "podman") {
         my $args = ($log_file =~ /root/) ? "--root" : "--rootless";
         $args .= " --remote" if ($log_file =~ /remote/);
-        $cmd = "hack/bats $args";
+        $cmd = "hack/bats -t $args";
         $cmd .= " $tests" if ($tests ne $tests_dir{podman});
     }
 

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -159,19 +159,21 @@ NOTES
 | test | reason |
 | --- | --- |
 | [080-pause] | https://github.com/opencontainers/runc/pull/4709 |
-| [195-run-namespaces] | https://github.com/opencontainers/runc/issues/4732 |
+| [252-quadlet] | unknown |
 | [505-networking-pasta] | https://bugs.passt.top/show_bug.cgi?id=49 |
 
 [080-pause]: https://github.com/containers/podman/blob/main/test/system/080-pause.bats
-[195-run-namespaces]: https://github.com/containers/podman/blob/main/test/system/195-run-namespaces.bats
+[252-quadlet]: https://github.com/containers/podman/blob/main/test/system/252-quadlet.bats
 [505-networking-pasta]: https://github.com/containers/podman/blob/main/test/system/505-networking-pasta.bats
 
 ### runc
 
 | test | reason |
 | --- | --- |
+| [cgroups] | `io.bfq.weight: operation not supported` |
 | [checkpoint] | https://github.com/checkpoint-restore/criu/issues/2650 |
 
+[cgroups]: https://github.com/opencontainers/runc/blob/main/tests/integration/cgroups.bats
 [checkpoint]: https://github.com/opencontainers/runc/blob/main/tests/integration/checkpoint.bats
 
 ## Tools

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -82,13 +82,12 @@ sub run {
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "cd $test_dir";
     script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    assert_script_run "curl -sLo hack/bats https://raw.githubusercontent.com/containers/podman/refs/heads/main/hack/bats";
     bats_patches;
 
     $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
 
     # Patch tests
-    assert_script_run "curl -sLo hack/bats https://raw.githubusercontent.com/containers/podman/refs/heads/main/hack/bats";
-    assert_script_run "sed -i 's/bats_opts=()/bats_opts=(--tap)/' hack/bats";
     assert_script_run "sed -i 's/^PODMAN_RUNTIME=/&$oci_runtime/' test/system/helpers.bash";
     assert_script_run "rm -f contrib/systemd/system/podman-kube@.service.in";
     # This test is flaky and will fail if system is "full"


### PR DESCRIPTION
Minor BATS tests enhancements
- Update README
- Improve record_info so it's visible with click
- No need to patch `hack/bats` anymore since https://github.com/containers/podman/pull/25960

Verification runs:
- SLE 16.0: https://openqa.suse.de/tests/17445100 `BATS_TESTS=410-selinux BATS_PATCHES=25133`
