### PR TITLE
containers: Use go1.24 for runc upstream tests

### DIFF
--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -36,7 +36,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(git-core glibc-devel-static go jq libseccomp-devel make runc);
+    my @pkgs = qw(git-core glibc-devel-static go1.24 jq libseccomp-devel make runc);
     push @pkgs, "criu" if is_tumbleweed;
 
     $self->bats_setup(@pkgs);


### PR DESCRIPTION
Use go1.24 for runc upstream tests.

The new update from runc 1.1.x to runc 1.2.x in 15-SP3 & 15-SP4 needs a newer Go version >= 1.21.  Let's use the latest as it's available on SLES 15-SP3+

```
$ susepkg -p any go1.24 | grep SLES/
SLES/15.3 go1.24 1.24.0-150000.1.9.1
SLES/15.4 go1.24 1.24.0-150000.1.9.1
SLES/15.5 go1.24 1.24.0-150000.1.9.1
SLES/15.6 go1.24 1.24.2-150000.1.17.1
SLES/15.7 go1.24 1.24.1-150000.1.12.1
SLES/16.0 go1.24 1.24.1-160000.1.3
```

- Failing test: https://openqa.suse.de/tests/17449303/logfile?filename=serial_terminal_user.txt

```
$ make memfd-bind fs-idmap pidfd-kill recvtty remap-rootfs sd-helper seccompagent; echo u7TUW-$?-
52	fatal: not a git repository (or any parent up to mount point /)
53	Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
54	go build -trimpath "-buildmode=pie"  -tags "seccomp urfave_cli_no_docs " -ldflags "-X main.gitCommit= -X main.version=1.2.6 " -o contrib/cmd/memfd-bind/memfd-bind ./contrib/cmd/memfd-bind
55	go: go.mod requires go >= 1.22 (running go 1.21.13; GOTOOLCHAIN=local)
```