### PR TITLE
Add ulp live patch testing for sle16

### DIFF
--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -68,7 +68,7 @@ sub setup_ulp {
     my $packname = 'openposix-livepatches';
     my $repo_args = '';
 
-    install_klp_product unless is_sle('16+');
+    install_klp_product if is_sle('<16');
     zypper_call('in libpulp0 libpulp-tools libpulp-load-default');
 
     if (get_var('INCIDENT_REPO')) {


### PR DESCRIPTION
Add ulp live patch testing for sle16

- Related ticket: https://progress.opensuse.org/issues/179083
- Verification run: https://openqa.suse.de/tests/17442349
