### PR TITLE
containers: Use go1.24 for buildah & podman upstream tests

### DIFF
--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -49,7 +49,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(buildah docker git-core git-daemon glibc-devel-static go jq libgpgme-devel libseccomp-devel make openssl podman selinux-tools);
+    my @pkgs = qw(buildah docker git-core git-daemon glibc-devel-static go1.24 jq libgpgme-devel libseccomp-devel make openssl podman selinux-tools);
 
     $self->bats_setup(@pkgs);
 

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -51,7 +51,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(aardvark-dns apache2-utils buildah catatonit git-core glibc-devel-static go gpg2 jq libcriu2 libgpgme-devel
+    my @pkgs = qw(aardvark-dns apache2-utils buildah catatonit git-core glibc-devel-static go1.24 gpg2 jq libcriu2 libgpgme-devel
       libseccomp-devel make netavark openssl podman podman-remote python3-PyYAML skopeo socat sudo systemd-container);
     push @pkgs, qw(criu) if is_tumbleweed;
     # Needed for podman machine


### PR DESCRIPTION
Use go1.24 for buildah & podman upstream tests.

Verifications runs:
- buildah 15-SP4: https://openqa.suse.de/tests/17454207
- podman 15-SP6: https://openqa.suse.de/tests/17454209
