### PR TITLE
containers: Avoid patching BATS tests if BATS_URL is specified

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -333,6 +333,8 @@ sub bats_tests {
 }
 
 sub bats_patches {
+    return if get_var("BATS_URL");
+
     my $package = get_required_var("BATS_PACKAGE");
     my $github_org = ($package eq "runc") ? "opencontainers" : "containers";
 


### PR DESCRIPTION
Avoid patching BATS tests if `BATS_URL` is specified.  When cloning with `BATS_URL`, patching is not desired as the branch contains the patches.

VR not needed as currently we don't have any jobs with both `BATS_URL` & `BATS_PATCHES` specified.