### PR TITLE
Assign default value to $qdevice_opt

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -59,7 +59,7 @@ sub run {
     my $unicast_opt = get_var("HA_UNICAST") ? '-u' : '';
     my $quorum_policy = 'stop';
     my $fencing_opt = "-s \"$sbd_device\"";
-    my $qdevice_opt;
+    my $qdevice_opt = '';
 
     # HA test modules use packages from ClusterTools2. Attempt to install it here and in
     # ha_cluster_join, but continue if it's not possible (retval 104)


### PR DESCRIPTION
The variable `$qdevice_opt` is not initialized in the test module `ha/ha_cluster_init` causing warnings such as this to be printed in autoinst-log.txt:

```
Use of uninitialized value $qdevice_opt in concatenation (.) or string at sle/tests/ha/ha_cluster_init.pm line 32.
	ha_cluster_init::cluster_init("crm-cluster-init", "-s \"/dev/disk/by-path/ip-10.0.2.1:3260-iscsi-iqn.2016-02.de.o"..., "", undef) called at sle/tests/ha/ha_cluster_init.pm line 81
	ha_cluster_init::run(ha_cluster_init=HASH(0x55688987ff58)) called at /usr/lib/os-autoinst/basetest.pm line 346
```

This fixes it.

- Failure: https://openqa.suse.de/tests/17456274/logfile?filename=autoinst-log.txt#line-2872
- Related ticket: N/A
- Needles: N/A
- Verification run: N/A. `undef` is already evaluated as the empty string.
