### PR TITLE
Add systems-management for QR test

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -34,6 +34,10 @@ sub handle_all_packages_medium {
     unless (is_sle('15-SP2+')) {
         push @addons, $sle_prod if !grep(/^$sle_prod$/, @addons);
     }
+
+    # For sles 15-SP6 and SP7, systems-management is the default product should be installed.
+    push @addons, 'sysm' if (is_sle('>=15-SP6'));
+
     # Select Desktop-Applications module if gnome is wanted
     push @addons, 'desktop' if check_var('DESKTOP', 'gnome') && !grep(/^desktop$/, @addons);
 


### PR DESCRIPTION
Related: https://progress.opensuse.org/issues/181430

VRs:
x86: https://openqa.suse.de/tests/17473950#step/addon_products_sle/62 
aarch64:  https://openqa.suse.de/tests/17473974#step/addon_products_sle/52
ppc64le: https://openqa.suse.de/tests/17473972#step/addon_products_sle/52
s390x: https://openqa.suse.de/tests/17473970#step/addon_products_sle/50 

More VRs in: https://openqa.suse.de/tests/overview?build=Amrysliu%2Fos-autoinst-distri-opensuse%2321893&distri=sle&version=15-SP6