### PR TITLE
Update 15sp7 autoyast profiles to open sshd service in mini installation

### DIFF
--- a/data/autoyast_sle15/mini_s390x.xml
+++ b/data/autoyast_sle15/mini_s390x.xml
@@ -33,6 +33,32 @@
     <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>
+    <firewall config:type="map">
+        <default_zone>public</default_zone>
+        <enable_firewall config:type="boolean">true</enable_firewall>
+        <log_denied_packets>off</log_denied_packets>
+        <start_firewall config:type="boolean">true</start_firewall>
+        <zones config:type="list">
+            <zone config:type="map">
+                <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+                <interfaces config:type="list">
+                    <interface>eth0</interface>
+                </interfaces>
+                <masquerade config:type="boolean">false</masquerade>
+                <name>public</name>
+                <ports config:type="list"/>
+                <protocols config:type="list"/>
+                <services config:type="list">
+                    <service>dhcpv6-client</service>
+                    <service>ssh</service>
+                    <service>tigervnc</service>
+                    <service>tigervnc-https</service>
+                </services>
+                <short>Public</short>
+                <target>default</target>
+            </zone>
+        </zones>
+    </firewall>
     <software>
         <products config:type="list">
             <product>SLES</product>
@@ -41,6 +67,13 @@
             <package>openssh</package>
         </packages>
     </software>
+    <services-manager>
+        <services>
+            <enable config:type="list">
+                <service>sshd</service>
+            </enable>
+        </services>
+    </services-manager>
     <users config:type="list">
         <user>
             <fullname>Bernhard M. Wiedemann</fullname>

--- a/data/yam/autoyast/create_hdd_textmode_powervm.xml
+++ b/data/yam/autoyast/create_hdd_textmode_powervm.xml
@@ -109,9 +109,7 @@
       </addon>
       <addon t="map">
         <arch>{{ARCH}}</arch>
-        <name>sle-module-python3</name>
-        <reg_code/>
-        <release_type>nil</release_type>
+        <name>sle-module-systems-management</name>
         <version>{{VERSION}}</version>
       </addon>
     </addons>

--- a/data/yam/autoyast/mini_desktop_remote.xml
+++ b/data/yam/autoyast/mini_desktop_remote.xml
@@ -14,6 +14,21 @@
                 <version>{{VERSION}}</version>
                 <arch>{{ARCH}}</arch>
             </addon>
+            <addon>
+                <name>sle-module-server-applications</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+            <addon>
+                <name>sle-module-python3</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+            <addon>
+                <name>sle-module-systems-management</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
         </addons>
     </suse_register>
     <bootloader>

--- a/schedule/yast/autoyast/autoyast_mini_spvm.yaml
+++ b/schedule/yast/autoyast/autoyast_mini_spvm.yaml
@@ -4,7 +4,6 @@ description: >
   Test verifies installation with minimal autoyast profile.
   Same as autoyast_mini_product but with product defined in the profile.
 vars:
-  AUTOYAST: yam/autoyast/mini_remote.xml
   AUTOYAST_CONFIRM: 1
   DESKTOP: textmode
   KEEP_DISKS: 1


### PR DESCRIPTION
Update 15sp7 autoyast profiles to open sshd service in minimal installation, based on [bsc#1241954](https://bugzilla.suse.com/show_bug.cgi?id=1241954#c12), update the mini autoyast profiles;
Add an autoyast profile for testsuite autoyast_create_hdd_gnome on power, the testsuite is using a minimal installation profile, add a new one for it which includes desktop applications module selected; 
And correct a profile of create_hdd_textmode_powervm.xml which has a duplicated addon of python3 module by changing one of them to sle-module-systems-management which is a new default selected module on SLES15SP7.

- Related failures: [autoyast_mini@ppc64le-spvm](https://openqa.suse.de/tests/17452919#step/console/1) ; [autoyast_mini@s390x-kvm](https://openqa.suse.de/tests/17452720#step/console/1); [autoyast_create_hdd_gnome](https://openqa.suse.de/tests/17452908#step/console/1)
- Verification run: [autoyast_mini@ppc64le-spvm](https://openqa.suse.de/tests/17473828#step/console/1) ; [autoyast_mini@s390x-kvm](https://openqa.suse.de/tests/17473857#step/console/1); [autoyast_create_hdd_gnome](https://openqa.suse.de/tests/17473812#step/console/1)
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/428