### PR TITLE
Minor refactor of BATS tests

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -340,7 +340,7 @@ sub bats_patches {
     my $github_org = ($package eq "runc") ? "opencontainers" : "containers";
 
     foreach my $patch (split(/\s+/, get_var("BATS_PATCHES", ""))) {
-        my $url = "https://github.com/$github_org/$package/pull/$patch.diff";
+        my $url = ($patch =~ /^\d+$/) ? "https://github.com/$github_org/$package/pull/$patch.diff" : $patch;
         record_info("patch", $url);
         assert_script_run "curl -sL $url | patch -p1 --merge";
     }

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -32,7 +32,6 @@ our @EXPORT = qw(
   bats_setup
   bats_sources
   bats_tests
-  install_ncat
   switch_to_user
 );
 
@@ -187,6 +186,8 @@ sub bats_setup {
     install_packages(@pkgs);
 
     configure_oci_runtime $oci_runtime;
+
+    install_ncat if (get_required_var("BATS_PACKAGE") =~ /^aardvark|netavark|podman$/);
 
     delegate_controllers;
 

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -32,8 +32,11 @@ our @EXPORT = qw(
   bats_setup
   bats_sources
   bats_tests
+  switch_to_root
   switch_to_user
 );
+
+my $test_dir = "/var/tmp/bats-tests";
 
 sub install_ncat {
     return if (script_run("rpm -q ncat") == 0);
@@ -94,6 +97,11 @@ sub get_user_subuid {
     my ($user) = shift;
     my $start_range = script_output("awk -F':' '\$1 == \"$user\" {print \$2}' /etc/subuid", proceed_on_failure => 1);
     return $start_range;
+}
+
+sub switch_to_root {
+    select_serial_terminal;
+    assert_script_run "cd $test_dir";
 }
 
 sub switch_to_user {
@@ -237,8 +245,6 @@ sub selinux_hack {
 }
 
 sub bats_post_hook {
-    my $test_dir = shift;
-
     select_serial_terminal;
 
     my $log_dir = "/tmp/logs/";
@@ -354,7 +360,7 @@ sub bats_patches {
 }
 
 sub bats_sources {
-    my ($version, $test_dir) = @_;
+    my $version = shift;
 
     my $package = get_required_var("BATS_PACKAGE");
     $package = ($package eq "aardvark") ? "aardvark-dns" : $package;

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -318,7 +318,12 @@ sub bats_tests {
         $cmd .= " $tests" if ($tests ne $tests_dir{podman});
     }
 
+    $package = ($package eq "aardvark") ? "aardvark-dns" : $package;
+    my $version = script_output "rpm -q --queryformat '%{VERSION} %{RELEASE}' $package";
+    my $os_version = join(' ', get_var("DISTRI"), get_var("VERSION"), get_var("BUILD"), get_var("ARCH"));
+
     assert_script_run "echo $log_file .. > $log_file";
+    assert_script_run "echo '# $package $version $os_version' >> $log_file";
     my $ret = script_run "env $env $cmd | tee -a $log_file", 7000;
 
     unless (@tests) {

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -10,8 +10,6 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(script_retry);
-use containers::common;
 use containers::bats;
 use version_utils qw(is_sle is_tumbleweed);
 
@@ -53,10 +51,7 @@ sub run {
 
     # Download aardvark sources
     my $aardvark_version = script_output "$aardvark --version | awk '{ print \$2 }'";
-    my $url = get_var("BATS_URL", "https://github.com/containers/aardvark-dns/archive/refs/tags/v$aardvark_version.tar.gz");
-    assert_script_run "mkdir -p $test_dir";
-    assert_script_run "cd $test_dir";
-    script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_sources $aardvark_version, $test_dir;
     bats_patches;
 
     my $errors = run_tests;

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -13,7 +13,6 @@ use serial_terminal qw(select_serial_terminal);
 use containers::bats;
 use version_utils qw(is_sle is_tumbleweed);
 
-my $test_dir = "/var/tmp/aardvark-tests";
 my $aardvark = "";
 
 sub run_tests {
@@ -49,7 +48,7 @@ sub run {
 
     # Download aardvark sources
     my $aardvark_version = script_output "$aardvark --version | awk '{ print \$2 }'";
-    bats_sources $aardvark_version, $test_dir;
+    bats_sources $aardvark_version;
     bats_patches;
 
     my $errors = run_tests;
@@ -57,11 +56,11 @@ sub run {
 }
 
 sub post_fail_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 sub post_run_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 1;

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -43,8 +43,6 @@ sub run {
 
     $self->bats_setup(@pkgs);
 
-    install_ncat;
-
     $aardvark = script_output "rpm -ql aardvark-dns | grep podman/aardvark-dns";
     record_info("aardvark-dns version", script_output("$aardvark --version"));
     record_info("aardvark-dns package version", script_output("rpm -q aardvark-dns"));

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -12,7 +12,6 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use containers::bats;
 
-my $test_dir = "/var/tmp/buildah-tests";
 
 sub run_tests {
     my %params = @_;
@@ -61,7 +60,7 @@ sub run {
 
     # Download buildah sources
     my $buildah_version = script_output "buildah --version | awk '{ print \$3 }'";
-    bats_sources $buildah_version, $test_dir;
+    bats_sources $buildah_version;
     bats_patches;
 
     # Patch mkdir to always use -p
@@ -73,8 +72,7 @@ sub run {
 
     my $errors = run_tests(rootless => 1, skip_tests => get_var('BATS_SKIP_USER', ''));
 
-    select_serial_terminal;
-    assert_script_run "cd $test_dir";
+    switch_to_root;
 
     $errors += run_tests(rootless => 0, skip_tests => get_var('BATS_SKIP_ROOT', ''));
 
@@ -82,11 +80,11 @@ sub run {
 }
 
 sub post_fail_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 sub post_run_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 1;

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -10,8 +10,6 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(script_retry);
-use containers::common;
 use containers::bats;
 
 my $test_dir = "/var/tmp/buildah-tests";
@@ -63,12 +61,7 @@ sub run {
 
     # Download buildah sources
     my $buildah_version = script_output "buildah --version | awk '{ print \$3 }'";
-    my $url = get_var("BATS_URL", "https://github.com/containers/buildah/archive/refs/tags/v$buildah_version.tar.gz");
-    assert_script_run "mkdir -p $test_dir";
-    selinux_hack $test_dir;
-    selinux_hack "/tmp";
-    assert_script_run "cd $test_dir";
-    script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_sources $buildah_version, $test_dir;
     bats_patches;
 
     # Patch mkdir to always use -p

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -10,8 +10,6 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(script_retry);
-use containers::common;
 use containers::bats;
 use version_utils qw(is_sle is_tumbleweed);
 
@@ -49,10 +47,7 @@ sub run {
 
     # Download netavark sources
     my $netavark_version = script_output "$netavark --version | awk '{ print \$2 }'";
-    my $url = get_var("BATS_URL", "https://github.com/containers/netavark/archive/refs/tags/v$netavark_version.tar.gz");
-    assert_script_run "mkdir -p $test_dir";
-    assert_script_run "cd $test_dir";
-    script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_sources $netavark_version, $test_dir;
     bats_patches;
 
     my $firewalld_backend = script_output "awk -F= '\$1 == \"FirewallBackend\" { print \$2 }' < /etc/firewalld/firewalld.conf";

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -13,7 +13,6 @@ use serial_terminal qw(select_serial_terminal);
 use containers::bats;
 use version_utils qw(is_sle is_tumbleweed);
 
-my $test_dir = "/var/tmp/netavark-tests";
 my $netavark;
 
 sub run_tests {
@@ -45,7 +44,7 @@ sub run {
 
     # Download netavark sources
     my $netavark_version = script_output "$netavark --version | awk '{ print \$2 }'";
-    bats_sources $netavark_version, $test_dir;
+    bats_sources $netavark_version;
     bats_patches;
 
     my $firewalld_backend = script_output "awk -F= '\$1 == \"FirewallBackend\" { print \$2 }' < /etc/firewalld/firewalld.conf";
@@ -60,11 +59,11 @@ sub run {
 }
 
 sub post_fail_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 sub post_run_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 1;

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -39,8 +39,6 @@ sub run {
 
     $self->bats_setup(@pkgs);
 
-    install_ncat;
-
     $netavark = script_output "rpm -ql netavark | grep podman/netavark";
     record_info("netavark version", script_output("$netavark --version"));
     record_info("netavark package version", script_output("rpm -q netavark"));

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -61,8 +61,6 @@ sub run {
 
     $self->bats_setup(@pkgs);
 
-    install_ncat;
-
     assert_script_run "podman system reset -f";
     assert_script_run "modprobe ip6_tables";
 

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -14,7 +14,6 @@ use version_utils qw(is_tumbleweed);
 use Utils::Architectures qw(is_x86_64 is_aarch64);
 use containers::bats;
 
-my $test_dir = "/var/tmp/podman-tests";
 my $oci_runtime = "";
 
 sub run_tests {
@@ -74,7 +73,7 @@ sub run {
 
     # Download podman sources
     my $podman_version = script_output "podman --version | awk '{ print \$3 }'";
-    bats_sources $podman_version, $test_dir;
+    bats_sources $podman_version;
     bats_patches;
 
     $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
@@ -94,8 +93,7 @@ sub run {
     # user / remote
     $errors += run_tests(rootless => 1, remote => 1, skip_tests => get_var('BATS_SKIP_USER_REMOTE', ''));
 
-    select_serial_terminal;
-    assert_script_run "cd $test_dir";
+    switch_to_root;
 
     # root / local
     $errors += run_tests(rootless => 0, remote => 0, skip_tests => get_var('BATS_SKIP_ROOT_LOCAL', ''));
@@ -107,11 +105,11 @@ sub run {
 }
 
 sub post_fail_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 sub post_run_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 1;

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -10,9 +10,7 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(script_retry);
 use version_utils qw(is_tumbleweed);
-use containers::common;
 use Utils::Architectures qw(is_x86_64 is_aarch64);
 use containers::bats;
 
@@ -78,11 +76,7 @@ sub run {
 
     # Download podman sources
     my $podman_version = script_output "podman --version | awk '{ print \$3 }'";
-    my $url = get_var("BATS_URL", "https://github.com/containers/podman/archive/refs/tags/v$podman_version.tar.gz");
-    assert_script_run "mkdir -p $test_dir";
-    assert_script_run "cd $test_dir";
-    script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
-    assert_script_run "curl -sLo hack/bats https://raw.githubusercontent.com/containers/podman/refs/heads/main/hack/bats";
+    bats_sources $podman_version, $test_dir;
     bats_patches;
 
     $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -13,7 +13,6 @@ use serial_terminal qw(select_serial_terminal);
 use containers::bats;
 use version_utils qw(is_tumbleweed);
 
-my $test_dir = "/var/tmp/runc-tests";
 
 sub run_tests {
     my %params = @_;
@@ -48,7 +47,7 @@ sub run {
 
     # Download runc sources
     my $runc_version = script_output "runc --version  | awk '{ print \$3 }'";
-    bats_sources $runc_version, $test_dir;
+    bats_sources $runc_version;
     bats_patches;
 
     # Compile helpers used by the tests
@@ -57,8 +56,7 @@ sub run {
 
     my $errors = run_tests(rootless => 1, skip_tests => get_var('BATS_SKIP_USER', ''));
 
-    select_serial_terminal;
-    assert_script_run "cd $test_dir";
+    switch_to_root;
 
     $errors += run_tests(rootless => 0, skip_tests => get_var('BATS_SKIP_ROOT', ''));
 
@@ -66,11 +64,11 @@ sub run {
 }
 
 sub post_fail_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 sub post_run_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 1;

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -10,7 +10,6 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(script_retry);
 use containers::bats;
 use version_utils qw(is_tumbleweed);
 
@@ -49,10 +48,7 @@ sub run {
 
     # Download runc sources
     my $runc_version = script_output "runc --version  | awk '{ print \$3 }'";
-    my $url = get_var("BATS_URL", "https://github.com/opencontainers/runc/archive/refs/tags/v$runc_version.tar.gz");
-    assert_script_run "mkdir -p $test_dir";
-    assert_script_run "cd $test_dir";
-    script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_sources $runc_version, $test_dir;
     bats_patches;
 
     # Compile helpers used by the tests

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -10,8 +10,6 @@
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(script_retry);
-use containers::common;
 use Utils::Architectures qw(is_x86_64);
 use containers::bats;
 use version_utils qw(is_sle);
@@ -51,10 +49,7 @@ sub run {
 
     # Download skopeo sources
     my $skopeo_version = script_output "skopeo --version  | awk '{ print \$3 }'";
-    my $url = get_var("BATS_URL", "https://github.com/containers/skopeo/archive/refs/tags/v$skopeo_version.tar.gz");
-    assert_script_run "mkdir -p $test_dir";
-    assert_script_run "cd $test_dir";
-    script_retry("curl -sL $url | tar -zxf - --strip-components 1", retry => 5, delay => 60, timeout => 300);
+    bats_sources $skopeo_version, $test_dir;
     bats_patches;
 
     # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -14,7 +14,6 @@ use Utils::Architectures qw(is_x86_64);
 use containers::bats;
 use version_utils qw(is_sle);
 
-my $test_dir = "/var/tmp/skopeo-tests";
 
 sub run_tests {
     my %params = @_;
@@ -49,7 +48,7 @@ sub run {
 
     # Download skopeo sources
     my $skopeo_version = script_output "skopeo --version  | awk '{ print \$3 }'";
-    bats_sources $skopeo_version, $test_dir;
+    bats_sources $skopeo_version;
     bats_patches;
 
     # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
@@ -58,8 +57,7 @@ sub run {
 
     my $errors = run_tests(rootless => 1, skip_tests => get_var('BATS_SKIP_USER', ''));
 
-    select_serial_terminal;
-    assert_script_run "cd $test_dir";
+    switch_to_root;
 
     $errors += run_tests(rootless => 0, skip_tests => get_var('BATS_SKIP_ROOT', ''));
 
@@ -67,11 +65,11 @@ sub run {
 }
 
 sub post_fail_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 sub post_run_hook {
-    bats_post_hook $test_dir;
+    bats_post_hook;
 }
 
 1;


### PR DESCRIPTION
Minor refactor of BATS tests:
- Move sources download to library
- Install ncat in bats_setup
- `BATS_PATCHES` can also be an URL
- Allow flexible `BATS_URL`
- Log package/OS version in TAP file

Verification runs:
- aardvark: https://openqa.opensuse.org/tests/5024523 (`BATS_URL=main`)
- buildah: https://openqa.opensuse.org/tests/5024524 (`BATS_URL=containers#main`)
- netavark: https://openqa.suse.de/tests/17480749 (`BATS_URL=https://github.com/containers/netavark/archive/refs/heads/main.tar.gz`)
- podman: https://openqa.opensuse.org/tests/5024526 (`BATS_PATCHES=https://github.com/containers/podman/pull/25918.diff`)
- runc: https://openqa.opensuse.org/tests/5024527
- skopeo: https://openqa.opensuse.org/tests/5024528