### PR TITLE
containers/bats: Introduce run_command wrapper

### DIFF
--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -22,6 +22,10 @@ The tests rely on some variables:
 | `ENABLE_SELINUX` | Set to `0` to put SELinux in permissive mode |
 | `OCI_RUNTIME` | OCI runtime to use: `runc` or `crun` |
 
+NOTES
+- `BATS_URL` can be a full URL to the tarball in github, `SUSE#branch` or a tag `v1.2.3`
+- `BATS_PATCHES` can be a full URL like `https://github.com/containers/podman/pull/25918.diff`
+
 ### aardvark / netavark
 
 | variable | description |
@@ -71,7 +75,9 @@ NOTES
 - To debug runtime issues you may clone a job with `OCI_RUNTIME=crun`.  The default OCI runtime is `runc` on all openSUSE & SUSE products except SLEM 6.0 & 6.1
 - To debug buildah issues you may clone a job with `BUILDAH_STORAGE_DRIVER=vfs`
 - To debug individual tests you may clone a job with `BATS_TESTS`
-- You can also use `BATS_URL` to use the latest version from the `main` branch like `BATS_URL=https://github.com/containers/netavark/archive/refs/heads/main.tar.gz`
+- You can also test individual tests from the latest version in the `main` branch with `BATS_URL=main`
+- The BATS output is in the log files with `.tap` extension
+- The commands are collected in a log file ending with `-commands.txt`
 
 ## Warning
 

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -35,9 +35,9 @@ sub run_tests {
 
     my $ret = bats_tests($log_file, \%env, $skip_tests);
 
-    script_run 'podman rm -vf $(podman ps -aq --external)';
-    assert_script_run "podman system reset -f";
-    assert_script_run "buildah prune -a -f";
+    run_command 'podman rm -vf $(podman ps -aq --external) || true';
+    run_command "podman system reset -f";
+    run_command "buildah prune -a -f";
 
     return ($ret);
 }
@@ -64,11 +64,11 @@ sub run {
     bats_patches;
 
     # Patch mkdir to always use -p
-    assert_script_run "sed -i 's/ mkdir /& -p /' tests/*.bats tests/helpers.bash";
+    run_command "sed -i 's/ mkdir /& -p /' tests/*.bats tests/helpers.bash";
 
     # Compile helpers used by the tests
     my $helpers = script_output 'echo $(grep ^all: Makefile | grep -o "bin/[a-z]*" | grep -v bin/buildah)';
-    assert_script_run "make $helpers", timeout => 600;
+    run_command "make $helpers", timeout => 600;
 
     my $errors = run_tests(rootless => 1, skip_tests => get_var('BATS_SKIP_USER', ''));
 

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -51,8 +51,8 @@ sub run {
     record_info("Firewalld backend", $firewalld_backend);
 
     # Compile helpers & patch tests
-    assert_script_run "make examples", timeout => 600;
-    assert_script_run "rm -f test/100-bridge-iptables.bats" if ($firewalld_backend ne "iptables");
+    run_command "make examples", timeout => 600;
+    run_command "rm -f test/100-bridge-iptables.bats" if ($firewalld_backend ne "iptables");
 
     my $errors = run_tests;
     die "netavark tests failed" if ($errors);

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -52,7 +52,7 @@ sub run {
 
     # Compile helpers used by the tests
     my $cmds = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d -printf '%f ' || true";
-    script_run "make $cmds";
+    run_command "make $cmds || true";
 
     my $errors = run_tests(rootless => 1, skip_tests => get_var('BATS_SKIP_USER', ''));
 

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -53,7 +53,7 @@ sub run {
 
     # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
     my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";
-    assert_script_run "sed -i 's/arch=.*/arch=$goarch/' systemtest/010-inspect.bats";
+    run_command "sed -i 's/arch=.*/arch=$goarch/' systemtest/010-inspect.bats";
 
     my $errors = run_tests(rootless => 1, skip_tests => get_var('BATS_SKIP_USER', ''));
 


### PR DESCRIPTION
Introduce `run_command` wrapper for `assert_script_run` to create a reproducer shell script for BATS tests which may be used to manually reproduce an issue.  This may be put in Bugzilla, Github issues, etc.

Verification runs:
- aardvark-dns: https://openqa.opensuse.org/tests/5026286/logfile?filename=aardvark-commands.txt
- buildah: https://openqa.opensuse.org/tests/5026387/logfile?filename=buildah-commands.txt
- netavark: https://openqa.opensuse.org/tests/5026216/logfile?filename=netavark-commands.txt
- podman: https://openqa.opensuse.org/tests/5026217/logfile?filename=podman-commands.txt
- runc: https://openqa.opensuse.org/tests/5026218/logfile?filename=runc-commands.txt
- skopeo: https://openqa.opensuse.org/tests/5026219/logfile?filename=skopeo-commands.txt
