### PR TITLE
Adapt minimum size warning for boot on installer

### DIFF
--- a/test_data/yast/opensuse/btrfs/btrfs+warnings_aarch64.yaml
+++ b/test_data/yast/opensuse/btrfs/btrfs+warnings_aarch64.yaml
@@ -25,4 +25,4 @@ errors:
 warnings:
   <<: !include test_data/yast/btrfs/common/btrfs+warnings_warnings.yaml
   rootfs_small: Missing device for / with size equal or bigger than 5 GiB and filesystem ext2, ext3, ext4, btrfs, xfs
-  missing_boot: Missing device for /boot/efi with size equal or bigger than 128 MiB and filesystem vfat
+  missing_boot: Missing device for /boot/efi with size equal or bigger than .* and filesystem vfat


### PR DESCRIPTION
It seems that the minimum size for /boot/efi changed in the meantime to > 0.5GB

Ticket: https://progress.opensuse.org/issues/176601
VR https://openqa.opensuse.org/tests/5026151
