### PR TITLE
adds test for PrivateRegistry helm chart

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -99,7 +99,7 @@ sub install_k3s {
     # github.com/k3s-io/k3s#5946 - The kubectl delete namespace helm-ns-413 command freezes and does nothing
     my $disables = '--disable=metrics-server';
     $disables .= ' --disable-helm-controller' unless (get_var('K3S_ENABLE_HELM_CONTROLLER'));
-    $disables .= ' --disable=traefik';
+    $disables .= ' --disable=traefik' unless get_var('K3S_ENABLE_TRAEFIK');
     $disables .= ' --disable=coredns' unless get_var('K3S_ENABLE_COREDNS');
 
     while (my ($key, $value) = each %k3s_args) {

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -297,6 +297,7 @@ sub load_container_tests {
         if ($chart eq 'helm' || $chart =~ m/rmt-helm$/) {
             loadtest 'containers/charts/rmt';
         } elsif ($chart =~ m/private-registry/) {
+            set_var('K3S_ENABLE_TRAEFIK', 1);
             loadtest 'containers/charts/privateregistry';
         }   
           else {

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -296,7 +296,10 @@ sub load_container_tests {
 
         if ($chart eq 'helm' || $chart =~ m/rmt-helm$/) {
             loadtest 'containers/charts/rmt';
-        } else {
+        } elsif ($chart =~ m/private-registry/) {
+            loadtest 'containers/charts/privateregistry';
+        }   
+          else {
             die "Unsupported HELM_CHART value";
         }
         return;

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -299,8 +299,8 @@ sub load_container_tests {
         } elsif ($chart =~ m/private-registry/) {
             set_var('K3S_ENABLE_TRAEFIK', 1);
             loadtest 'containers/charts/privateregistry';
-        }   
-          else {
+        }
+        else {
             die "Unsupported HELM_CHART value";
         }
         return;

--- a/tests/containers/charts/privateregistry.pm
+++ b/tests/containers/charts/privateregistry.pm
@@ -57,25 +57,23 @@ sub run {
     script_retry("helm pull $helm_chart", timeout => 300, retry => 6, delay => 60) if ($helm_chart =~ m!^oci://!);
     assert_script_run("helm install $set_options $release_name $helm_chart $helm_options", timeout => 300);
     assert_script_run("helm list");
- 
+
     # Smoketest - is everything Ready?
     foreach my $component (@private_registry_components) {
-      validate_script_output_retry("kubectl get pods -l component=$component", qr/$component/, title => "$component status:" ,fail_message => "$release_name-$component didn't deploy");
-      #my @pods = split(' ', script_output("kubectl get pods --no-headers -l component=$component"));
-      #my $full_pod_name = $pods[0];
-      my $full_pod_name = script_output("kubectl get pods -l component=$component --no-headers -o custom-columns=':metadata.name'");
-      #assert_script_run("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", retry => 5, delay => 30, timeout => 120, fail_message => "$full_pod_name is not in the Ready state!");
-      validate_script_output_retry("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", qr/True/, title => "$component readiness", fail_message => "$full_pod_name is not in the Ready state!");
-      
+        validate_script_output_retry("kubectl get pods -l component=$component", qr/$component/, title => "$component status:", fail_message => "$release_name-$component didn't deploy");
+        my $full_pod_name = script_output("kubectl get pods -l component=$component --no-headers -o custom-columns=':metadata.name'");
+#assert_script_run("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", retry => 5, delay => 30, timeout => 120, fail_message => "$full_pod_name is not in the Ready state!");
+        validate_script_output_retry("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", qr/True/, title => "$component readiness", fail_message => "$full_pod_name is not in the Ready state!");
+
     }
-    
+
     #Install Traefik manually
     assert_script_run("helm install traefik oci://ghcr.io/traefik/helm/traefik --namespace kube-system");
 
     #script_run("sleep 120", timeout => 140);
     my $traefik_pod = script_output("kubectl get pods -n kube-system --no-headers -l app.kubernetes.io/name=traefik -o custom-columns=':metadata.name'");
     validate_script_output_retry("kubectl get pod $traefik_pod -n kube-system --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", qr/True/, title => "Traefik readiness");
-    
+
 
     # Get the webui credentials & ingress url
     my $registry_password = script_output("kubectl get secrets $release_name-harbor-core --template={{.data.HARBOR_ADMIN_PASSWORD}} | base64 -d -w 0");
@@ -96,8 +94,8 @@ sub run {
     # Push chart
     assert_script_run("helm create dummy_chart && tar -czvf dummy_chart.tar.gz -C dummy_chart .", timeout => 60);
     assert_script_run("helm push dummy_chart.tar.gz oci://$registry_ingress_url/library --insecure-skip-tls-verify", timeout => 60);
-    
-} 
+
+}
 
 sub post_fail_hook {
     my ($self) = @_;

--- a/tests/containers/charts/privateregistry.pm
+++ b/tests/containers/charts/privateregistry.pm
@@ -47,10 +47,11 @@ sub run {
     }
     my $helm_values = get_var('HELM_CONFIG');
     assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
-    my $set_options = "--set global.imageRegistry=registry.suse.de/suse/sle-15-sp6/update/products/privateregistry/containerfile";
+    my $full_registry_path = get_var('HELM_FULL_REGISTRY_PATH');
+    my $set_options = "--set global.imageRegistry=$full_registry_path";
     if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
         my ($repository, $tag) = split(':', $image, 2);
-        $set_options = "--set app.image.repository=$repository --set app.image.tag=$tag";
+        $set_options = "--set global.imageRegistry=$full_registry_path --set app.image.repository=$repository --set app.image.tag=$tag";
     }
     my $helm_options = "--debug";
     $helm_options = "-f myvalue.yaml $helm_options" if ($helm_values);

--- a/tests/containers/charts/privateregistry.pm
+++ b/tests/containers/charts/privateregistry.pm
@@ -1,0 +1,104 @@
+# SUSE's openQA tests
+#
+# Copyright 2022-2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Test deploy a helm chart in a k3s
+# - install k3s, kubectl and helm
+# - test helm install
+# - test helm list
+# - check the correct deployment of the helm chart
+# - cleanup system (helm and k3s)
+#
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use File::Basename qw(dirname);
+use testapi;
+use utils;
+use version_utils qw(get_os_release is_sle);
+use serial_terminal qw(select_serial_terminal);
+use Utils::Architectures qw(is_ppc64le);
+use containers::k8s;
+
+our $release_name = "privateregistry";
+
+sub run {
+    my ($self) = @_;
+    my @private_registry_components = qw(core jobservice portal registry database redis trivy);
+    my $test_image = "registry.suse.com/bci/bci-busybox:latest";
+    select_serial_terminal;
+
+    my ($version, $sp, $host_distri) = get_os_release;
+    # Skip HELM tests on SLES <15-SP3 and on PPC, where k3s is not available
+    return if (!($host_distri == "sles" && $version == 15 && $sp >= 3) || is_ppc64le);
+    die "helm tests only work on k3s" unless (check_var('CONTAINER_RUNTIMES', 'k3s'));
+
+    my $helm_chart = get_required_var('HELM_CHART');
+
+    install_kubectl();
+    install_helm();
+
+    # Pull helm chart, if it is a http file
+    if ($helm_chart =~ m!^http(s?)://!) {
+        my ($url, $path) = split(/#/, $helm_chart, 2);    # split extracted folder path, if present
+        assert_script_run("curl -sSL --retry 3 --retry-delay 30 $url | tar -zxf -");
+        $helm_chart = $path ? "./$path" : ".";
+    }
+    my $helm_values = get_var('HELM_CONFIG');
+    assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
+    my $set_options = "--set global.imageRegistry=registry.suse.de/suse/sle-15-sp6/update/products/privateregistry/containerfile";
+    if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
+        my ($repository, $tag) = split(':', $image, 2);
+        $set_options = "--set app.image.repository=$repository --set app.image.tag=$tag";
+    }
+    my $helm_options = "--debug";
+    $helm_options = "-f myvalue.yaml $helm_options" if ($helm_values);
+    script_retry("helm pull $helm_chart", timeout => 300, retry => 6, delay => 60) if ($helm_chart =~ m!^oci://!);
+    assert_script_run("helm install $set_options $release_name $helm_chart $helm_options", timeout => 300);
+    assert_script_run("helm list");
+ 
+    # Smoketest - is everything Ready?
+    foreach my $component (@private_registry_components) {
+      validate_script_output_retry("kubectl get pods -l component=$component", qr/$component/, retry => 3, delay => 30, timeout => 120, fail_message => "$release_name-$component didn't deploy");
+      my @pods = split(' ', script_output("kubectl get pods --no-headers -l component=$component"));
+      my $full_pod_name = $pods[0];
+      assert_script_run("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={..status.conditions[?(@.type==\"Ready\")].status}'", retry => 5, delay => 30, timeout => 60, fail_message => "$full_pod_name is not in the Ready state!");
+      record_info("$component is ready", "$full_pod_name is in the Ready state.");
+    }
+    
+    # Get the webui credentials & ingress url
+    my $registry_password = script_output("kubectl get secrets $release_name-harbor-core --template={{.data.HARBOR_ADMIN_PASSWORD}} | base64 -d -w 0");
+    my $registry_ingress_url = script_output("kubectl get ingress $release_name-harbor-ingress -o jsonpath='{.spec..host}'");
+    my $registry_ingress_ip = script_output("kubectl get nodes -o jsonpath='{..status.addresses[0].address}'");
+
+    # Add the k3s IP to /etc/hosts
+    assert_script_run("echo \"$registry_ingress_ip $registry_ingress_url\" | sudo tee -a /etc/hosts");
+
+    # Login 
+    script_run("sleep 1800", timeout => 1800);
+    assert_script_run("podman login $registry_ingress_url --username admin --password $registry_password --tls-verify=false", retry => 3, delay => 10);
+    assert_script_run("helm registry login $registry_ingress_url --username admin --password $registry_password --insecure", retry => 3, delay => 10);
+
+    # Push container
+    assert_script_run("podman pull $test_image:latest");
+    assert_script_run("podman push $test_image:latest $registry_ingress_url/library/main/$test_image:latest --tls-verify=false");
+
+    # Push chart
+    assert_script_run("helm create dummy_chart && tar -czvf dummy_chart.tar.gz -C dummy_chart .");
+    assert_script_run("helm push dummy_chart.tar.gz oci://$registry_ingress_url/library");
+    
+} 
+
+sub post_fail_hook {
+    my ($self) = @_;
+    script_run('tar -capf /tmp/containers-logs.tar.xz /var/log/pods $(find /var/lib/rancher/k3s -name \*.log -name \*.toml)');
+    upload_logs("/tmp/containers-logs.tar.xz");
+    script_run("helm delete $release_name");
+}
+
+sub test_flags {
+    return {milestone => 1};
+}
+
+1;

--- a/tests/containers/charts/privateregistry.pm
+++ b/tests/containers/charts/privateregistry.pm
@@ -60,17 +60,14 @@ sub run {
 
     # Smoketest - is everything Ready?
     foreach my $component (@private_registry_components) {
-        validate_script_output_retry("kubectl get pods -l component=$component", qr/$component/, title => "$component status:", fail_message => "$release_name-$component didn't deploy");
-        my $full_pod_name = script_output("kubectl get pods -l component=$component --no-headers -o custom-columns=':metadata.name'");
-#assert_script_run("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", retry => 5, delay => 30, timeout => 120, fail_message => "$full_pod_name is not in the Ready state!");
-        validate_script_output_retry("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", qr/True/, title => "$component readiness", fail_message => "$full_pod_name is not in the Ready state!");
-
+      validate_script_output_retry("kubectl get pods -l component=$component", qr/$component/, title => "$component status:" ,fail_message => "$release_name-$component didn't deploy");
+      my $full_pod_name = script_output("kubectl get pods -l component=$component --no-headers -o custom-columns=':metadata.name'");
+      validate_script_output_retry("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", qr/True/, title => "$component readiness", fail_message => "$full_pod_name is not in the Ready state!");
+      
     }
 
     #Install Traefik manually
     assert_script_run("helm install traefik oci://ghcr.io/traefik/helm/traefik --namespace kube-system");
-
-    #script_run("sleep 120", timeout => 140);
     my $traefik_pod = script_output("kubectl get pods -n kube-system --no-headers -l app.kubernetes.io/name=traefik -o custom-columns=':metadata.name'");
     validate_script_output_retry("kubectl get pod $traefik_pod -n kube-system --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", qr/True/, title => "Traefik readiness");
 

--- a/tests/containers/charts/privateregistry.pm
+++ b/tests/containers/charts/privateregistry.pm
@@ -60,16 +60,22 @@ sub run {
  
     # Smoketest - is everything Ready?
     foreach my $component (@private_registry_components) {
-      validate_script_output_retry("kubectl get pods -l component=$component", qr/$component/, retry => 3, delay => 30, timeout => 120, fail_message => "$release_name-$component didn't deploy");
-      my @pods = split(' ', script_output("kubectl get pods --no-headers -l component=$component"));
-      my $full_pod_name = $pods[0];
-      assert_script_run("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", retry => 5, delay => 30, timeout => 120, fail_message => "$full_pod_name is not in the Ready state!");
+      validate_script_output_retry("kubectl get pods -l component=$component", qr/$component/, title => "$component status:" ,fail_message => "$release_name-$component didn't deploy");
+      #my @pods = split(' ', script_output("kubectl get pods --no-headers -l component=$component"));
+      #my $full_pod_name = $pods[0];
+      my $full_pod_name = script_output("kubectl get pods -l component=$component --no-headers -o custom-columns=':metadata.name'");
+      #assert_script_run("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", retry => 5, delay => 30, timeout => 120, fail_message => "$full_pod_name is not in the Ready state!");
+      validate_script_output_retry("kubectl get pod $full_pod_name --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", qr/True/, title => "$component readiness", fail_message => "$full_pod_name is not in the Ready state!");
+      
     }
     
     #Install Traefik manually
     assert_script_run("helm install traefik oci://ghcr.io/traefik/helm/traefik --namespace kube-system");
-    script_run("sleep 120", timeout => 140);
-    script_output("kubectl get pods -n kube-system -l app.kubernetes.io/name=traefik");
+
+    #script_run("sleep 120", timeout => 140);
+    my $traefik_pod = script_output("kubectl get pods -n kube-system --no-headers -l app.kubernetes.io/name=traefik -o custom-columns=':metadata.name'");
+    validate_script_output_retry("kubectl get pod $traefik_pod -n kube-system --no-headers -o 'jsonpath={.status.conditions[?(@.type==\"Ready\")].status}'", qr/True/, title => "Traefik readiness");
+    
 
     # Get the webui credentials & ingress url
     my $registry_password = script_output("kubectl get secrets $release_name-harbor-core --template={{.data.HARBOR_ADMIN_PASSWORD}} | base64 -d -w 0");

--- a/variables.md
+++ b/variables.md
@@ -56,6 +56,7 @@ CONTAINERS_NERDCTL_VERSION | string | 0.16.1 | The version of NerdCTL tool.
 CONTAINERS_DOCKER_FLAVOUR | string | | Flavour of docker to install. Valid options are `stable` or undefined (for standard docker package)
 HELM_CHART | string | | Helm chart under test. See `main_containers.pm` for supported chart types |
 HELM_CONFIG | string | | Additional configuration file for helm |
+HELM_FULL_REGISTRY_PATH | string | Full path to the helm chart within the registry, without the chart name. e.g. `my.registry.com/myteam/secret_project` | 
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.

--- a/variables.md
+++ b/variables.md
@@ -100,7 +100,7 @@ HTTPPROXY  |||
 HPC_WAREWULF_CONTAINER | string | | Set the container meant for warewulf test suite.
 HPC_WAREWULF_CONTAINER_NAME | string | The OS name which is expected to run from HPC_WAREWULF_CONTAINER.
 HPC_WAREWULF_CONTAINER_USERNAME | string | Defining username enables authentication for containers, needs valid HPC subscription on SCC for containers from registry.suse.com. If you want use default HPC subscription, just set same value as in SCC_EMAIL
-_SECRET_HPC_WAREWULF_CONTAINER_PASSWORD | string | Password for container, needs valid HPC subscription on SCC for containers from registry.suse.com. If not specified it will use code from SCC_REGCODE_HPC 
+_SECRET_HPC_WAREWULF_CONTAINER_PASSWORD | string | Password for container, needs valid HPC subscription on SCC for containers from registry.suse.com. If not specified it will use code from SCC_REGCODE_HPC
 INSTALL_KEYBOARD_LAYOUT | string | | Specify one of the supported keyboard layout to switch to during installation or to be used in autoyast scenarios e.g.: cz, fr
 INSTALL_SOURCE | string | | Specify network protocol to be used as installation source e.g. MIRROR_HTTP
 INSTALLATION_VALIDATION | string | | Comma separated list of modules to be used for installed system validation, should be used in combination with INSTALLONLY, to schedule only relevant test modules.
@@ -118,6 +118,9 @@ IS_MM_CLIENT | boolean | | If set, run client-specific part of the multimachine 
 K3S_SYMLINK | string | | Can be 'skip' or 'force'. Skips the installation of k3s symlinks to tools like kubectl or forces the creation of symlinks
 K3S_BIN_DIR | string | | If defined, install k3s to this provided directory instead of `/usr/local/bin/`
 K3S_CHANNEL | string | | Set the release channel to pick the k3s version from. Options include "stable", "latest" and "testing"
+K3S_ENABLE_COREDNS | boolean | | During K3s installation, should CoreDNS be installed.
+K3S_ENABLE_TRAEFIK | boolean | | During K3s installation, should Traefik be installed.
+K3S_ENABLE_HELM_CONTROLLER | boolean | | During K3s installation, should Helm Controller be installed.
 KERNEL_FLAVOR | string | kernel-default | Set specific kernel flavor for test scenarios
 KUBECTL_CLUSTER | string | | Defines the cluster used to test `kubectl`. Currently only `k3s` is supported.
 KUBECTL_VERSION | string | v1.22.12 | Defines the kubectl version.


### PR DESCRIPTION
Adds a new test for SUSE Private Registry. The test does the following:

1. Sets up the environment (K3s, Helm, Podman).
2. Installs Traefik Ingress Controller.
3. Deploys the PrivateRegistry and waits until all components are in the Ready state.
4. Tests pushing images and charts to the registry.
5. Tests pulling images and charts from the registry.

- Related ticket: https://progress.opensuse.org/issues/181238
- Needles: N/A
- Verification run:
  - https://openqa.suse.de/tests/17750021