### PR TITLE
containers/bats: No need for special value none anymore

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -176,7 +176,6 @@ sub patch_logfile {
     @skip_tests = uniq sort @skip_tests;
 
     foreach my $test (@skip_tests) {
-        next if ($test eq "none");
         if (script_run("grep -q 'in test file.*/$test.bats' $log_file") != 0) {
             record_info("PASS", $test);
         }

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -55,7 +55,6 @@ NOTES
 
 NOTES
  - The special value `all` may be used to skip all tests.
- - The special value `none` should be used to avoid skipping any subtests.
 
 ### Summary of the `BATS_SKIP` variables
 


### PR DESCRIPTION
Since we have `BATS_PACKAGE` to schedule the tests, we don't overload `BATS_SKIP` anymore so we can drop the special value `none` and use an empty string instead.

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2210
Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/656