### PR TITLE
Install eog as it is not installed by default

### DIFF
--- a/tests/x11/exiv2.pm
+++ b/tests/x11/exiv2.pm
@@ -78,7 +78,7 @@ sub run {
     #prepare
     become_root;
     quit_packagekit;
-    zypper_call "in exiv2";
+    zypper_call "in exiv2 eog";
 
     #Get assets to local directory
     assert_script_run "wget --quiet " . data_url('exiv2/test.jpg') . " -O test.jpg";


### PR DESCRIPTION
Install eog as it cannot be installed by default

- Related ticket: https://progress.opensuse.org/issues/181349
- Verification run: https://openqa.opensuse.org/tests/5027185#step/exiv2/10
