### PR TITLE
containers/bats: Use mktemp output to create directory

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -318,7 +318,8 @@ sub bats_tests {
 
     my $package = get_required_var("BATS_PACKAGE");
 
-    my $tmp_dir = script_output "mktemp -d -p /var/tmp test.XXXXXX";
+    my $tmp_dir = script_output "mktemp -du -p /var/tmp test.XXXXXX";
+    run_command "mkdir -p $tmp_dir";
     selinux_hack $tmp_dir if ($package =~ /buildah|podman/);
 
     $env{BATS_TMPDIR} = $tmp_dir;


### PR DESCRIPTION
Use mktemp output to manually create directory so it appears in commands.txt

- Verification run: not needed
