### PR TITLE
containers/bats: Add timing information to .tap files

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -336,12 +336,12 @@ sub bats_tests {
     }
     my $tests = @tests ? join(" ", @tests) : $tests_dir{$package};
 
-    my $cmd = "env $env bats --tap $tests";
+    my $cmd = "env $env bats --tap -T $tests";
     # With podman we must use its own hack/bats instead of calling bats directly
     if ($package eq "podman") {
         my $args = ($log_file =~ /root/) ? "--root" : "--rootless";
         $args .= " --remote" if ($log_file =~ /remote/);
-        $cmd = "env $env hack/bats -t $args";
+        $cmd = "env $env hack/bats -t -T $args";
         $cmd .= " $tests" if ($tests ne $tests_dir{podman});
     }
     $cmd .= " | tee -a $log_file";


### PR DESCRIPTION
Add timing information for each subtest to .tap files

Each test will now be shown as:

```
ok 1 [505] IPv4 default address assignment in 1403ms
ok 2 [505] IPv4 address assignment in 1220ms
ok 3 [505] No IPv4 in 1258ms
```

Manually tested.