### PR TITLE
Add validation to check that installed repos are the ones expected and enabled

### DIFF
--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -8,6 +8,7 @@ schedule:
   - yam/agama/agama
   - installation/grub_test
   - installation/first_boot
+  - console/validate_repos
   - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname

--- a/schedule/yam/agama_auto.yaml
+++ b/schedule/yam/agama_auto.yaml
@@ -7,6 +7,7 @@ schedule:
   - yam/agama/agama_auto
   - installation/grub_test
   - installation/first_boot
+  - console/validate_repos
   - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname

--- a/test_data/yam/agama_sle.yaml
+++ b/test_data/yam/agama_sle.yaml
@@ -1,2 +1,15 @@
 ---
 os_release_name: SLES
+repos:
+  - name: SLE-Product-SLES-%VERSION%
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%
+    enabled: 'Yes'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%-Debug
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%-Debug
+    enabled: 'No'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%-Source
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%-Source
+    enabled: 'No'
+    filter: name


### PR DESCRIPTION
We added a way to validate repos set by Agama after installation.

- Related ticket: https://progress.opensuse.org/issues/180956
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17503061
