### PR TITLE
containers/bats: Skip PASS for empty test

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -168,6 +168,7 @@ sub patch_logfile {
     @skip_tests = uniq sort @skip_tests;
 
     foreach my $test (@skip_tests) {
+        next if (!$test);
         if (script_run("grep -q 'in test file.*/$test.bats' $log_file") != 0) {
             record_info("PASS", $test);
         }


### PR DESCRIPTION
Skip PASS `record_info` for empty test.

https://openqa.opensuse.org/tests/5028317#step/runc/251