### PR TITLE
Skip podmansh on MicroOS

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -148,7 +148,7 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.2") || is_leap_micro("<6.2"));
+        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.2") || is_leap_micro("<6.2") || is_microos); # Temporarily skipped on MicroOS due to poo#181316
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
Temporarily skip the podmansh tests on MicroOS due to ongoing issues, see https://progress.opensuse.org/issues/181316.

### Verification run

- [MicroOS](https://openqa.opensuse.org/tests/5029055) (not scheduled)
- [Tumbleweed](https://openqa.opensuse.org/tests/5029066) (`podmansh` being scheduled)
