### PR TITLE
Add SLES+HA agama auto jsonnet files

### DIFF
--- a/data/ha/agama/sles_ha_default.jsonnet
+++ b/data/ha/agama/sles_ha_default.jsonnet
@@ -1,0 +1,36 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}',
+    addons: [
+      {
+        id: 'sle-ha',
+        registrationCode: '{{SCC_REGCODE_HA}}'
+      }
+    ]
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    sshPublicKey: 'enable ssh',
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable sshd',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          systemctl enable sshd
+        |||
+      }
+    ]
+  }
+}

--- a/data/ha/agama/sles_ha_default_pvm.jsonnet
+++ b/data/ha/agama/sles_ha_default_pvm.jsonnet
@@ -1,0 +1,49 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}',
+    addons: [
+      {
+        id: 'sle-ha',
+        registrationCode: '{{SCC_REGCODE_HA}}'
+      }
+    ]
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        content: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              parted -s /dev/$i mklabel gpt
+              sync
+          done
+        |||
+      }
+    ],
+    post: [
+      {
+        name: 'enable root login sshd',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          systemctl enable sshd
+        |||
+      }
+    ]
+  }
+}

--- a/data/ha/agama/sles_ha_default_s390x_kvm.jsonnet
+++ b/data/ha/agama/sles_ha_default_s390x_kvm.jsonnet
@@ -1,7 +1,16 @@
 {
   product: {
     id: '{{AGAMA_PRODUCT_ID}}',
-    registrationCode: '{{SCC_REGCODE}}'
+    registrationCode: '{{SCC_REGCODE}}',
+    addons: [
+      {
+        id: 'sle-ha',
+        registrationCode: '{{SCC_REGCODE_HA}}'
+      }
+    ]
+  },
+  bootloader: {
+    stopOnBootMenu: true,
   },
   user: {
     fullName: 'Bernhard M. Wiedemann',
@@ -11,13 +20,12 @@
   },
   root: {
     password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
-    hashedPassword: true,
-    sshPublicKey: 'enable ssh',
+    hashedPassword: true
   },
   scripts: {
     post: [
       {
-        name: 'enable sshd',
+        name: 'enable root login sshd',
         chroot: true,
         content: |||
           #!/usr/bin/env bash


### PR DESCRIPTION
This commit adds to the x86_64 & aarch64 qemu jsonnet file for SLES+HA the configuration required so the HA Extension is activated during installation.

Additionally new SLES+HA jsonnet files have been created for s390x on svirt and for ppc64le on pvm, also including the activation of the HA Extension during installation.

- Related ticket: https://jira.suse.com/browse/TEAM-10163
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=VR4PR21919&version=16.0
