### PR TITLE
Add support for testing SL-Micro livepatches

### DIFF
--- a/lib/klp.pm
+++ b/lib/klp.pm
@@ -66,7 +66,8 @@ sub install_klp_product {
         assert_script_run 'sed -i "/^multiversion =.*/c\\multiversion = provides:multiversion(kernel)" /etc/zypp/zypp.conf';
         assert_script_run 'sed -i "/^multiversion\.kernels =.*/c\\multiversion.kernels = latest" /etc/zypp/zypp.conf';
         assert_script_run 'echo "LIVEPATCH_KERNEL=\'always\'" >> /etc/sysconfig/livepatching';
-        install_package($livepatch_pack, trup_continue => 1, trup_reboot => 1);
+        install_package($livepatch_pack, trup_continue => 1, trup_reboot => 1)
+          unless is_sle_micro('=6.0') && $livepatch_pack eq 'kernel-rt-livepatch-6.4.0-10.1';
     } else {
         zypper_call("in -l -t product $lp_product", exitcode => [0, 102, 103]);
         zypper_call("mr -e kgraft-update") unless $livepatch_repo;

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -29,11 +29,13 @@ sub check_kernel_package {
     my $kernel_name = shift;
 
     enter_trup_shell(global_options => '-c') if is_transactional;
-    script_run('ls -1 /boot/vmlinu[xz]*');
+    script_run('shopt -s nullglob');
+    script_run('ls -1 /boot/vmlinu[xz]* /boot/[Ii]mage*');
+    script_run('shopt -u nullglob');
     # Only check versioned kernels in livepatch tests. Some old kernel
     # packages install /boot/vmlinux symlink but don't set package ownership.
     my $glob = get_var('KGRAFT', 0) ? '-*' : '*';
-    my $cmd = 'rpm -qf --qf "%{NAME}\n" /boot/vmlinu[xz]' . $glob;
+    my $cmd = 'shopt -s nullglob; rpm -qf --qf "%{NAME}\n" /boot/vmlinu[xz]' . $glob . ' /boot/[Ii]mage' . $glob;
     my $packs = script_output($cmd);
     exit_trup_shell if is_transactional;
 

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -227,13 +227,11 @@ sub install_lock_kernel {
         'kernel-source-rt' => $src_version
     );
 
-    unless (is_sle_micro) {
-        if (check_var('SLE_PRODUCT', 'slert')) {
-            push @packages, "kernel-devel-rt";
-        }
-        else {
-            push @packages, "kernel-devel";
-        }
+    if (check_var('SLE_PRODUCT', 'slert')) {
+        push @packages, "kernel-devel-rt";
+    }
+    else {
+        push @packages, "kernel-devel";
     }
 
     # add explicit version to each package


### PR DESCRIPTION
SL-Micro livepatch installation requires special handling. Add support for selecting the correct package to test.

- Related ticket: https://progress.opensuse.org/issues/181508
- Needles: N/A
- Verification runs:
  - SLE kernel-default: https://openqa.suse.de/tests/17516432
  - SLE kernel-livepatch: https://openqa.suse.de/tests/17516433
  - kernel-default-base: https://openqa.suse.de/tests/17516434
  - kernel-azure (GM kernel): https://openqa.suse.de/tests/17516435
  - kernel-azure (update): https://openqa.suse.de/tests/17516436
  - SL-Micro kernel-livepatch: https://openqa.suse.de/tests/17516437
  - SL-Micro 6.0 kernel-rt-6.4.0-10 livepatch: https://openqa.suse.de/tests/17516438

Note: Most verification runs will fail because the update repositories don't exist. There are no updates in the queue at the moment.
