### PR TITLE
Drop of not required parameter which causing issues

### DIFF
--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -144,10 +144,6 @@ resource "google_compute_instance" "openqa" {
     }
   }
 
-  scheduling {
-    on_host_maintenance = "TERMINATE"
-  }
-
   metadata = merge({
     sshKeys             = "susetest:${file("${var.ssh_public_key}")}"
     openqa_created_by   = var.name


### PR DESCRIPTION
This parameter causing `Error creating instance: googleapi: Error 400: e2 instances do not support onHostMaintenance=TERMINATE unless they are preemptible., badRequest` . On other hand confidential VMs can be succesfully created w/o it ( see VR : https://openqa.suse.de/tests/17514300 ) 