### PR TITLE
Run firewalld checker in vmware and cloud

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1272,8 +1272,7 @@ sub load_consoletests {
     loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
     # textmode install comes without firewall by default atm on openSUSE.
     # For virtualization server xen and kvm is disabled by default: https://fate.suse.com/324207
-    # Cloud and VMware images come without firewalld by default
-    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server && !is_vmware && get_var('FLAVOR', '') !~ /JeOS-for-OpenStack-Cloud.*/ && get_var('FLAVOR', '') !~ /Minimal-VM-Cloud/) {
+    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_krypton_argon && !is_virtualization_server && !is_vmware) {
         loadtest "console/firewall_enabled";
     }
     if (is_jeos) {

--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -22,14 +22,21 @@ use Utils::Architectures;
 sub run {
     my ($self) = @_;
     if ($self->firewall eq 'firewalld') {
+        if (is_jeos && get_var('FLAVOR', '') =~ /cloud/i) {
+            script_run('rpm -q firewalld') or die "Firewalld is pre-installed on Minimal-VM cloud images";
+            return;
+        }
         assert_script_run("firewall-cmd --version", fail_message => "firewall-cmd is not present");
         if (script_output('firewall-cmd --state', timeout => 60, proceed_on_failure => 1) !~ /running/) {
             if (is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/) {
                 # In case of upgrades from SFW2-based distros (Leap < 15.0 to TW) we end up without any firewall
                 record_soft_failure "boo#1144543 - Migration from SFW2 to firewalld: no firewall enabled";
                 return;
+            } elsif (is_jeos && is_vmware) {
+                record_info('No FW', 'MinimalVM\'s VMWare image has firewalld disabled');
+            } else {
+                die "firewall-cmd is not running";
             }
-            die "firewall-cmd is not running";
         }
     } else {
         assert_script_run('SuSEfirewall2 status');


### PR DESCRIPTION
MimimalVM images might not have pre-installed firewalld (cloud) or it is not enabled by default(vmware).
Original failure https://openqa.suse.de/tests/17480423#step/firewall_enabled/1

- Verification runs
  * [sp6](http://kepler.suse.cz/tests/24689#step/firewall_enabled/1)
  * [sle16](http://kepler.suse.cz/tests/24688#step/firewall_enabled/1)

