### PR TITLE
Add new algorithms to the list in fips for openSSL 3.5

### DIFF
--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -46,7 +46,7 @@ sub check_pk_algos {
     my ($openssl_binary) = @_;
 
     my @valid_algos = qw(RSA rsa DSA dsa EC DH HMAC CMAC);
-    push(@valid_algos, 'ED') unless is_sle('<16');
+    push(@valid_algos, 'ED', 'ML') unless is_sle('<16');
     push(@valid_algos, 'HKDF', 'TLS1-PRF') if has_default_openssl3;
     my %pattern = (
         fips => '\@ fips',

--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -46,6 +46,7 @@ sub check_pk_algos {
     my ($openssl_binary) = @_;
 
     my @valid_algos = qw(RSA rsa DSA dsa EC DH HMAC CMAC);
+    push(@valid_algos, 'ED') unless is_sle('<16');
     push(@valid_algos, 'HKDF', 'TLS1-PRF') if has_default_openssl3;
     my %pattern = (
         fips => '\@ fips',

--- a/tests/fips/openssl/openssl_pubkey_rsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_rsa.pm
@@ -48,8 +48,8 @@ sub run_fips_rsa_tests {
             my $encrypt_cmd = "$openssl_binary pkeyutl -encrypt -in $file_raw -inkey $rsa_pubkey -pubin -out $file_enc";
             my $decrypt_cmd = "$openssl_binary pkeyutl -decrypt -in $file_enc -inkey $rsa_prikey -out $file_dec";
             # should fail without oaep padding and pass with oeap padding
-            validate_script_output "$encrypt_cmd 2>&1", sub { m/illegal or unsupported padding mode/ }, proceed_on_failure => 1;    # Encrypt with public key
-            validate_script_output "$decrypt_cmd 2>&1", sub { m/illegal or unsupported padding mode/ }, proceed_on_failure => 1;    # Decrypt with private key
+            validate_script_output "$encrypt_cmd 2>&1", sub { m/(illegal or unsupported|invalid) padding mode/ }, proceed_on_failure => 1; # Encrypt with public key
+            validate_script_output "$decrypt_cmd 2>&1", sub { m/(illegal or unsupported|invalid) padding mode/ }, proceed_on_failure => 1; # Decrypt with private key
             my $oaep_options = " -pkeyopt rsa_padding_mode:oaep";
             assert_script_run $encrypt_cmd . $oaep_options;    # Encrypt with public key
             assert_script_run $decrypt_cmd . $oaep_options;    # Decrypt with private key


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1242046

Algorithm List test is now passing: https://openqa.opensuse.org/tests/5032250#step/openssl_fips_alglist/53

Subsequent failures reported at https://bugzilla.suse.com/show_bug.cgi?id=1242046#c5

- **Add ED curves as permitted algorithm**
- **Add ML as permitted algorithm**
- [Update regex to match openssl 3.4+ rsa message](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21927/commits/66cc2950eddce9668a4110d2f4fd730b9a00892f)
