### PR TITLE
Update the zgrep search log to agama_auto-agama-logs.tar.gz for ibft validation

### DIFF
--- a/tests/installation/validation/ibft.pm
+++ b/tests/installation/validation/ibft.pm
@@ -86,7 +86,7 @@ sub ibft_validation {
     }
     else {
         # SLE16 uses agama, so search the general logs of agama
-        assert_script_run 'zgrep -e rd.iscsi.ibft=1 -e rd.iscsi.firmware=1 /var/log/agama-installation/*';
+        assert_script_run "zgrep -a -e rd.iscsi.ibft=1 -e rd.iscsi.firmware=1 /var/log/agama-installation/logs.tar.gz";
     }
 
     # Scan for ibft interface


### PR DESCRIPTION
We have changed the way to check ibft in the agama logs.

- Related ticket: https://progress.opensuse.org/issues/181394
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17517795# (Failed in a further step)
