### PR TITLE
containers/bats: Load null_blk module for podman tests

### DIFF
--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -62,6 +62,7 @@ sub run {
 
     run_command "podman system reset -f";
     run_command "modprobe ip6_tables";
+    run_command "modprobe null_blk nr_devices=1 || true";
 
     record_info("podman version", script_output("podman version"));
     record_info("podman info", script_output("podman info"));


### PR DESCRIPTION
Load null_blk module for podman tests.

> Since /dev/zero is not a block device, it's unsuitable for testing cgroup controls designed for block devices.

From https://github.com/containers/podman/pull/26022#issuecomment-2842186141
