### PR TITLE
Storage: Make blktests config not mandatory

### DIFF
--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -35,7 +35,7 @@ sub run {
     my $tests = get_required_var('BLK_TESTS');
     my $quick = get_required_var('BLK_QUICK');
     my $exclude = get_required_var('BLK_EXCLUDE');
-    my $config = get_required_var('BLK_CONFIG');
+    my $config = get_var('BLK_CONFIG');
     my $devices = get_required_var('BLK_DEVICE_ONLY');
 
     record_info('KERNEL', script_output('rpm -qi kernel-default'));


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/181649
- Verification run: https://openqa.suse.de/tests/17527953

In the VR we can see the value isn't causing the test to fail however we still have some other issues with the blktests
