### PR TITLE
Implement conditional use of scheduling parameter

### DIFF
--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -144,6 +144,14 @@ resource "google_compute_instance" "openqa" {
     }
   }
 
+  # some instance types requires this parameter others fails with it so we need to use it based on instance type
+  dynamic "scheduling" {
+    for_each = contains(["c3-highcpu-192-metal"], var.type) ? [1] : []
+    content {
+      on_host_maintenance = "TERMINATE"
+    }
+  }
+
   metadata = merge({
     sshKeys             = "susetest:${file("${var.ssh_public_key}")}"
     openqa_created_by   = var.name


### PR DESCRIPTION
e2 instances do not support onHostMaintenance=TERMINATE but c3-highcpu-192-metal requires it.
Lets use dynamic to convince both

VRs : 
- https://openqa.suse.de/tests/17530832
- https://openqa.suse.de/tests/17530835
- https://openqa.suse.de/tests/17530836
