### PR TITLE
containers: De-schedule podman on SLEM & Leap Micro

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -148,7 +148,7 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.2") || is_leap_micro("<6.2") || is_microos); # Temporarily skipped on MicroOS due to poo#181316
+        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro || is_leap_micro || is_microos); # Temporarily skipped on MicroOS due to poo#181316
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
De-schedule podman on SLEM & Leap Micro.

```
$ susepkg -p any podmansh
SLES/15.5 podmansh 4.9.5-150500.3.40.1
SLES/15.6 podmansh 4.9.5-150500.3.40.1
SLES/15.7 podmansh 4.9.5-150500.3.40.1
SLES/16.0 podmansh 5.2.5-160000.4.2
SLE-Micro/5.5 podmansh 4.9.5-150500.3.40.1
openSUSE_Leap/15.6 podmansh 4.9.5-150500.3.40.1
openSUSE_Tumbleweed podmansh 5.4.2-1.1
```


- Failing tests: https://openqa.suse.de/tests/overview?distri=sle-micro&version=6.2&build=8.9&groupid=513

