### PR TITLE
containers: De-schedule podmansh test on SLE 16.0

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -148,7 +148,8 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro || is_leap_micro || is_microos); # Temporarily skipped on MicroOS due to poo#181316
+        # Temporarily skipped on MicroOS due to poo#181316 & SLE 16.0 due to breaking other modules
+        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle || is_sle_micro || is_leap_micro || is_microos);
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
De-schedule podmansh test on SLE 16.0

Failing tests: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=82.2&groupid=630
