### PR TITLE
Allow ltss containers to be downloaded

### DIFF
--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -77,7 +77,10 @@ sub run {
     reset_container_network_if_needed($runtime);
 
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE') && $runtime eq 'docker');
-
+    if (get_var('LTSS_TEST_ISSUES')) {
+        my $regcode = get_var('SCC_REGCODE_LTSS');
+        assert_script_run qq[echo $regcode | $runtime login -u "regcode" --password-stdin registry.suse.com];
+    }
     # Running podman as root with docker installed may be problematic as netavark uses nftables
     # while docker still uses iptables.
     # Use workaround suggested in:


### PR DESCRIPTION
Prior to pulling a released ltss container, the test needs to log in the container engine to registry.suse.com. This can be done by using the already registered credentials in `/etc/zypp/credentials.d/SCCcredentials` or by simply using the LTSS regcode that we already have present in the tests and should work also for non-suse hosts if required.

- ticket: https://progress.opensuse.org/issues/181652
- Verification run: http://kepler.suse.cz/tests/24696#step/image_docker/80
