### PR TITLE
Add TPM FDE YAML schedule with shutdown

### DIFF
--- a/schedule/security/agama_tpm_fde_unattended.yaml
+++ b/schedule/security/agama_tpm_fde_unattended.yaml
@@ -1,0 +1,17 @@
+---
+name: Agama unattended lvm with TPM FDE
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm
+  - console/validate_encrypt
+  - yam/validate/validate_tpm_fde
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown
+test_data:
+  crypttab:
+    num_devices_encrypted: 1
+  <<: !include test_data/yast/encryption/default_enc_luks2.yaml


### PR DESCRIPTION
Add YAML for QE Security TPM FDE tests for hdd creation

- Related ticket: https://progress.opensuse.org/issues/176691
- Verification run: 
  - https://openqa.suse.de/tests/17563625
  - https://openqa.suse.de/tests/17563669 