### PR TITLE
virt_autotest Enable UEFI and secure boot test work for sle16

### DIFF
--- a/schedule/virt_autotest/sle16_guest_installation.yaml
+++ b/schedule/virt_autotest/sle16_guest_installation.yaml
@@ -7,3 +7,5 @@ schedule:
     - virt_autotest/login_console
     - virt_autotest/prepare_non_transactional_server
     - virt_autotest/unified_guest_installation
+    - virt_autotest/set_config_as_glue
+    - virt_autotest/uefi_guest_verification


### PR DESCRIPTION
Enable UEFI and secure boot test work for sle16
Add uefi_guest_verification 

- Related ticket: https://progress.opensuse.org/issues/178699
- Verification run:
[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/17564778#) PASS
