### PR TITLE
usr_sbin_nscd: Don't schedule on TW

### DIFF
--- a/schedule/security/apparmor_profile.yaml
+++ b/schedule/security/apparmor_profile.yaml
@@ -10,7 +10,7 @@ schedule:
     - security/apparmor_profile/apache2_changehat
     - security/apparmor_profile/usr_sbin_dovecot
     - security/apparmor_profile/usr_sbin_traceroute
-    - security/apparmor_profile/usr_sbin_nscd
+    - '{{is_sle}}'
     - security/apparmor_profile/mailserver_setup
     - security/apparmor_profile/usr_lib_dovecot
 conditional_schedule:
@@ -18,3 +18,7 @@ conditional_schedule:
         TEST:
             mau-apparmor_profile:
                 - security/apparmor/aa_prepare
+    is_sle:
+        DISTRI:
+            sle:
+                - security/apparmor_profile/usr_sbin_nscd


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/176154
- Verification run:
https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=jpupava_apparmorp o3
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=jpupava_apparmorp sle