### PR TITLE
Change logging method in ibm cloud

### DIFF
--- a/data/containers/ibm_hpvs/workload.yaml
+++ b/data/containers/ibm_hpvs/workload.yaml
@@ -1,10 +1,10 @@
 env: |
   type: env
   logging:
-    logDNA:
-      hostname: syslog-a.eu-de.logging.cloud.ibm.com
-      ingestionKey: INGESTIONKEY
-      port: 6514
+    logRouter:
+      hostname: cfde84ec-0c6f-40bb-bcad-c970319c2f1d.ingress.eu-de.logs.cloud.ibm.com
+      iamApiKey: INGESTIONKEY
+      port: 443
 workload: |
   type: workload
   compose:


### PR DESCRIPTION
`logRouter` is the method how to store logs from instances. This is currently the only logging method used in case of HPVS containers testing.

- Verification run: http://kepler.suse.cz/tests/24704#step/prepare_hpvs/135
