### PR TITLE
Add AWS peering cleanup

### DIFF
--- a/tests/sles4sap/qesapdeployment/destroy.pm
+++ b/tests/sles4sap/qesapdeployment/destroy.pm
@@ -13,6 +13,11 @@ use sles4sap::qesap::qesapdeployment;
 
 sub run {
     select_serial_terminal;
+
+    if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2') && get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE')) {
+        my $deployment_name = qesap_calculate_deployment_name('qesapval');
+        qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
+    }
     my @ansible_ret = qesap_execute(
         cmd => 'ansible',
         cmd_options => '-d',

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -28,9 +28,9 @@ sub run {
             my $deployment_name = qesap_calculate_deployment_name('qesapval');
             my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name);
             die "No vpc_id in this deployment" if $vpc_id eq 'None';
-            my $ibs_mirror_target_ip = get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE');    # '10.254.254.240/28'
+            my $ibs_mirror_target_ip = get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE');
             die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id, mirror_tag => get_var('QESAPDEPLOY_IBSM_PRJ_TAG', 'IBS Mirror'));
-            qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var("QESAPDEPLOY_IBSM_IP"));
+            qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var('QESAPDEPLOY_IBSM_IP'));
             die 'Error in network peering delete.' if !qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
         }
     }


### PR DESCRIPTION
Add peering cleanup in qesap regression test for tests that are running test_mirror and are configured to run for AWS.

- Related ticket: https://jira.suse.com/browse/TEAM-10325

# Verification run:

 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test -> http://openqaworker15.qa.suse.cz/tests/323468 :green_circle: https://openqaworker15.qa.suse.cz/tests/323468/logfile?filename=serial_terminal.txt&filter=aws%20ec2%20del
- sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test intentionally triggered without a needed variable to get a failure in test_mirror and check that cleanup works -> http://openqaworker15.qa.suse.cz/tests/323478