### PR TITLE
armnn: skip TensorFlow Lite backend on Tumbleweed

### DIFF
--- a/tests/ai_ml/armnn.pm
+++ b/tests/ai_ml/armnn.pm
@@ -91,13 +91,17 @@ sub run {
     armnn_get_images;
 
     # Test TensorFlow Lite backend
-    record_info('TF Lite', "TensorFlow Lite backend");
-    armnn_tf_lite_test_prepare;
-    # Run with default backend, if no specific backend required
-    armnn_tf_lite_test_run if !defined($armnn_backends);
-    # Run with explicit backend, if requested
-    armnn_tf_lite_test_run(backend => $_) for split(/,/, $armnn_backends);
-    cleanup_model_folder;
+    if (is_tumbleweed) {
+        record_info('Skip TensorFlow Lite', "TensorFlow Lite has been removed from Tumbleweed");
+    } else {
+        record_info('TF Lite', "TensorFlow Lite backend");
+        armnn_tf_lite_test_prepare;
+        # Run with default backend, if no specific backend required
+        armnn_tf_lite_test_run if !defined($armnn_backends);
+        # Run with explicit backend, if requested
+        armnn_tf_lite_test_run(backend => $_) for split(/,/, $armnn_backends);
+        cleanup_model_folder;
+    }
 
     # Test ONNX backend
     if (is_tumbleweed) {


### PR DESCRIPTION
- Verification run: https://openqa.opensuse.org/tests/5043859
