### PR TITLE
Hotfix helm.pm overwriting finalize subroutine

### DIFF
--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -144,8 +144,8 @@ sub test_flags {
     return {milestone => 1};
 }
 
-sub _cleanup {
-    # Skip baseclass _cleanup subroutine as it's not applicable in this test module.
+sub finalize {
+    # Skip baseclass finalize subroutine as it's not applicable in this test module.
 }
 
 1;


### PR DESCRIPTION
The `helm.pm` uses `publiccloud::basetest` which defines `finalize` subroutine.
But as `helm.pm` runs sometimes also outside of public cloud this subroutine needs to be overwrited.

- Related pull request: #21892 
