### PR TITLE
containers: Enhance buildah cleanup

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -75,7 +75,8 @@ sub run_tests {
 
     record_info('Test', "Cleanup");
     assert_script_run("buildah rm $container");
-    assert_script_run("buildah rmi newimage $image");
+    assert_script_run("buildah rmi -f newimage $image");
+    assert_script_run("buildah rmi -af");
     assert_script_run("rm -f /tmp/script.sh");
 
     if (!get_var("OCI_RUNTIME")) {


### PR DESCRIPTION
Enhance buildah cleanup:
- Run with `-f` flag
- Also test `buildah rmi -af`.

---

- Related ticket: https://progress.opensuse.org/issues/181844
- Failing test: https://openqa.opensuse.org/tests/5043615#step/buildah_podman/217
- Verification run: https://openqa.opensuse.org/tests/5044290