### PR TITLE
Dont check realtime sysfs entry

### DIFF
--- a/tests/rt/rt_is_realtime.pm
+++ b/tests/rt/rt_is_realtime.pm
@@ -12,6 +12,7 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Logging qw(export_logs_basic upload_coredumps);
+use version_utils qw(is_sle_micro);
 
 sub run {
     select_serial_terminal;
@@ -20,7 +21,9 @@ sub run {
     # display running RT processes, expected to see FF - SCHED_FIFO or RR - SCHED_RR processes
     validate_script_output("ps -e -o pid,start_time,pri,cls,command", sub { m/FF|RR/ });
     # is realtime ?
-    validate_script_output("cat /sys/kernel/realtime", sub { m/1/ });
+    if (!is_sle_micro('=6.2')) {
+        validate_script_output("cat /sys/kernel/realtime", sub { m/1/ });
+    }
     # check kernel in procfs
     validate_script_output("cat /proc/sys/kernel/osrelease", sub { m/rt/ });
     # period over which real-time task bandwidth enforcement is measured


### PR DESCRIPTION
The realtime sysfs entry is gone, at least in sle micro 6.2 for now.

- Verification run: http://kepler.suse.cz/tests/24705#step/rt_is_realtime/1
