### PR TITLE
Remove RT check in sysfs

### DIFF
--- a/tests/containers/realtime.pm
+++ b/tests/containers/realtime.pm
@@ -17,7 +17,6 @@ sub test_schedule {
     my ($is_rt, $runtime, $container) = @_;
 
     assert_script_run("$runtime exec $container chrt -m");
-    validate_script_output("$runtime exec $container cat /sys/kernel/realtime", qr/^1$/);
     assert_script_run("$runtime exec $container test -f /proc/sys/kernel/sched_rt_period_us");
     assert_script_run("$runtime exec $container test -f /proc/sys/kernel/sched_rt_runtime_us");
 


### PR DESCRIPTION
As mentioned in https://bugzilla.suse.com/show_bug.cgi?id=1242130, the sysfs kernel flag has been deprecated.

- Verification run: http://kepler.suse.cz/tests/24706#
