### PR TITLE
Fix install_qatestset.pm disable service issue and nmconnection name changes 

### DIFF
--- a/data/autoyast_hanaperf/agama-config.jsonnet
+++ b/data/autoyast_hanaperf/agama-config.jsonnet
@@ -65,8 +65,9 @@
         content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
-          # Workaround for NetworkManager to make sure the expected NIC up only
+          # Workaround for bsc#1235024 NetworkManager to make sure the expected NIC up only
           rm -f /etc/NetworkManager/system-connections/default_connection.nmconnection
+          rm -f /etc/NetworkManager/system-connections/Wired*nmconnection
           echo -e "[main]\nno-auto-default=type:ethernet" > /etc/NetworkManager/conf.d/disable_auto.conf
           echo -e "[connection]\nid=nic0\nuuid=$(uuidgen)\ntype=ethernet\n[ethernet]\nmac-address={{SUT_NETDEVICE}}\n[ipv4]\nmethod=auto\n" > /etc/NetworkManager/system-connections/nic0.nmconnection
           chmod 0600 /etc/NetworkManager/system-connections/nic0.nmconnection

--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -81,8 +81,8 @@ sub setup_environment {
         my $qaset_kernel_tag = get_var('QASET_KERNEL_TAG', '');
         if (is_sle("16+")) {
             # HANA perf does not use /usr/share/qa/qaset/bin/deploy_hana_perf.sh in SLE16
-            # Disable service
-            assert_script_run('systemctl disable qaperf.service chronyd.service firewalld.service');
+            # Disable and stop service
+            assert_script_run('systemctl disable qaperf.service chronyd.service firewalld.service --now');
             # sync time
             assert_script_run("chronyd -q 'server ntp1.suse.de iburst'");
             # set static hostname


### PR DESCRIPTION
1. Fix install_qatestset.pm disable service issue: stop service as well
2. Remove Wired*nmconnection in agama.json for bsc#1235024 workaround

- Related ticket: https://jira.suse.com/browse/TEAM-10293
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17598238, https://openqa.suse.de/tests/17598241, http://openqa.qa2.suse.asia/tests/84710, http://openqa.qa2.suse.asia/tests/84711, http://openqa.qa2.suse.asia/tests/84769
