### PR TITLE
Make an empty test environment an error

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -125,10 +125,11 @@ sub run {
     }
     my $bci_target = get_var('BCI_TARGET', 'ibs-cr');
     my $version = get_required_var('VERSION');
-    my $test_envs = get_var('BCI_TEST_ENVS', '');
+    my $test_envs = get_required_var('BCI_TEST_ENVS');
     my $bci_virtualenv = get_var('BCI_VIRTUALENV', 0);
 
-    return if ($test_envs eq '-') || ($test_envs eq '');
+    die "no BCI test environment (BCI_TEST_ENVS) set" unless ($test_envs);
+    return if ($test_envs eq '-');
 
     reset_container_network_if_needed($engine);
 


### PR DESCRIPTION
An empty test environment will cause the test to fail, while still allowing the explicit '-' to just skip it.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related: https://suse.slack.com/archives/C02CGKBCGT1/p1746561629691469?thread_ts=1746550305.107349&cid=C02CGKBCGT1
- Verification runs: [Empty environment](https://openqa.suse.de/tests/17603061#step/bci_test_podman/2) (fails intentionally) | [Skip](https://openqa.suse.de/tests/17603067)
