### PR TITLE
Publish gnome qcow2 image for sle16

### DIFF
--- a/data/agama_auto/sle_default_gnome.jsonnet
+++ b/data/agama_auto/sle_default_gnome.jsonnet
@@ -1,0 +1,44 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}'
+  },
+  software: {
+    patterns: [
+      'gnome'
+    ]
+  },
+  bootloader: {
+    stopOnBootMenu: true,
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable sshd',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          systemctl enable sshd
+        |||
+      },
+      {
+        name: 'enable gdm',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          systemctl enable gdm
+        |||
+      }
+    ]
+  }
+}

--- a/schedule/functional/sle16/agama-create-hdd-gnome.yaml
+++ b/schedule/functional/sle16/agama-create-hdd-gnome.yaml
@@ -1,0 +1,16 @@
+name:  agama-create-hdd-gnome
+description:    >
+    Install sle16 via agama auto and publish qcow2 images
+
+schedule:
+    - yam/agama/boot_agama
+    - yam/agama/agama_auto
+    - installation/grub_test
+    - yam/agama/switch_to_product
+    - installation/first_boot
+    - console/system_prepare
+    - console/hostname
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown


### PR DESCRIPTION
https://progress.opensuse.org/issues/181478

- Verification run:
[x86_64 and aarch64](https://openqa.suse.de/tests/overview?distri=sle&build=rfan0506_2&version=16.0)