### PR TITLE
Add mutex to signal when HA barriers are ready to use

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -190,6 +190,10 @@ sub run {
     # Children are server/test suites that use the PARALLEL_WITH variable
     wait_for_children_to_start;
 
+    # Create a final mutex to signal all jobs that barriers are ready to use
+    # It must be used with mutex_wait() before any barrier_wait() calls in the jobs
+    mutex_create('ha_barriers_ready');
+
     # Finish early if running in node 1 instead of supportserver
     return if is_not_supportserver_scenario;
 

--- a/tests/ha/wait_barriers.pm
+++ b/tests/ha/wait_barriers.pm
@@ -16,6 +16,8 @@ use lockapi;
 sub run {
     my $cluster_name = get_cluster_name;
 
+    diag 'Waiting for barriers creation';
+    mutex_wait 'ha_barriers_ready';
     diag "Waiting for barrier $cluster_name...";
     barrier_wait("BARRIER_HA_$cluster_name");
 }


### PR DESCRIPTION
Currently, HA modules rely on barriers to sync test steps among nodes, they do so by calling `barrier_wait()` API without checking whether the barriers have been created. This can lead to unexpected failures when jobs other than the parent job run first and attempt to call `barrier_wait()` on a barrier which has not been created. In those cases, tests will fail on a call to `bmwqemu::mydie()` as part of the `_try_lock()` function in `lockapi`.

To avoid such failures, this commit introduces a new mutex called `ha_barriers_ready` which is created at the end of the `ha/barrier_init` test module after all the necessary barriers have been created. The mutex is used in the `ha/wait_barriers` module before the call to `barrier_wait()` with a call to `mutex_wait()` which will block the process until the mutex is created and unlocked.

- Related ticket: N/A
- Needles: N/A
- Test failure: https://openqa.suse.de/tests/17580208#step/wait_barriers/3

### Verification run

* [support server](http://mango.qe.nue2.suse.org/tests/6631), [node1](http://mango.qe.nue2.suse.org/tests/6630) & [node2](http://mango.qe.nue2.suse.org/tests/6629)
* For the VRs, a `sleep 300` was added at the start of `ha/barrier_init` in the support server to force node 1 and 2 jobs to run `ha/wait_barriers` before the barriers were ready.
* The `sleep 300` can be seen here: http://mango.qe.nue2.suse.org/tests/6631#step/barrier_init/1
* With the new mutex, it can be seen the cluster node jobs wait approximately that time in `ha/wait_barriers`: [node1](http://mango.qe.nue2.suse.org/tests/6630#step/wait_barriers/1) and [node2](http://mango.qe.nue2.suse.org/tests/6629#step/wait_barriers/1)
* After that, there's the calls to `barrier_wait`: [node1](http://mango.qe.nue2.suse.org/tests/6630#step/wait_barriers/2) and [node2](http://mango.qe.nue2.suse.org/tests/6629#step/wait_barriers/2)
* Without the `mutex_wait`, this happens: http://mango.qe.nue2.suse.org/tests/6626#step/wait_barriers/4
  * Related support server job with the `sleep 300` is: http://mango.qe.nue2.suse.org/tests/6628#step/barrier_init/1
