### PR TITLE
Manually installing openssl-3 should not be needed anymore

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -37,8 +37,6 @@ sub enable_fips {
     my $self = shift;
 
     if (is_sle('>=15-SP4') || is_jeos || is_tumbleweed) {
-        # bsc#1239509
-        zypper_call('in openssl-3') if is_sle('>=16');
         assert_script_run("fips-mode-setup --enable");
         $self->reboot_and_select_serial_term;
     } else {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/181931
- Bug: https://bugzilla.opensuse.org/show_bug.cgi?id=1239509
- Verification run: https://openqa.suse.de/tests/17605494 (HDD creation) -> https://openqa.suse.de/tests/17606063 (where ssh starting would fail in consoletest_setup if openssl-3 would not be installed)
