### PR TITLE
Move AWS related qesap functions

### DIFF
--- a/lib/sles4sap/qesap/qesap_aws.pm
+++ b/lib/sles4sap/qesap/qesap_aws.pm
@@ -1,0 +1,482 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Functions relate to AWS to use qe-sap-deployment project
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+## no critic (RequireFilenameMatchesPackage);
+
+=encoding utf8
+
+=head1 NAME
+
+    AWS related functions for the qe-sap-deployment test lib
+
+=head1 COPYRIGHT
+
+    Copyright 2025 SUSE LLC
+    SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+    QE SAP <qe-sap@suse.de>
+
+=cut
+
+package sles4sap::qesap::qesap_aws;
+
+use strict;
+use warnings;
+use Carp qw(croak);
+use Mojo::JSON qw(decode_json);
+use Exporter 'import';
+use testapi;
+
+our @EXPORT = qw(
+  qesap_aws_get_vpc_id
+  qesap_aws_delete_transit_gateway_vpc_attachment
+  qesap_aws_get_transit_gateway_vpc_attachment
+  qesap_aws_add_route_to_tgw
+  qesap_aws_get_mirror_tg
+  qesap_aws_get_vpc_workspace
+  qesap_aws_get_routing
+  qesap_aws_vnet_peering
+  qesap_aws_create_credentials
+  qesap_aws_create_config
+);
+
+=head1 DESCRIPTION
+
+    Package with AWS related methods for qe-sap-deployment
+
+=head2 Methods
+
+=head3 qesap_aws_get_region_subnets
+
+Return a list of subnets. Return a single subnet for each region.
+
+=over
+
+=item B<VPC_ID> - VPC ID of resource to filter list of subnets
+
+=back
+=cut
+
+sub qesap_aws_get_region_subnets {
+    my (%args) = @_;
+    croak 'Missing mandatory vpc_id argument' unless $args{vpc_id};
+
+    my $cmd = join(' ', 'aws ec2 describe-subnets',
+        '--filters', "\"Name=vpc-id,Values=$args{vpc_id}\"",
+        '--query "Subnets[].{AZ:AvailabilityZone,SI:SubnetId}"',
+        '--output json');
+
+    my $describe_vpcs = decode_json(script_output($cmd));
+    my %seen = ();
+    my @uniq = ();
+    foreach (@{$describe_vpcs}) {
+        push(@uniq, $_->{SI}) unless $seen{$_->{AZ}}++;
+    }
+    return @uniq;
+}
+
+=head3 qesap_aws_create_credentials
+
+    Creates a AWS credentials file as required by QE-SAP Terraform deployment code.
+
+=over
+
+=item B<KEY> - value for the aws_access_key_id
+
+=item B<SECRET> - value for the aws_secret_access_key
+
+=item B<CONF_TRGT> - qesap_conf_trgt value in the output of qesap_get_file_paths
+
+=back
+=cut
+
+sub qesap_aws_create_credentials {
+    my (%args) = @_;
+    foreach (qw(key secret conf_trgt)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+
+    my $credfile = script_output q|awk -F ' ' '/aws_credentials/ {print $2}' | . $args{conf_trgt};
+    save_tmp_file('credentials', "[default]\naws_access_key_id = $args{key}\naws_secret_access_key = $args{secret}\n");
+    assert_script_run 'mkdir -p ~/.aws';
+    assert_script_run 'curl ' . autoinst_url . "/files/credentials -o $credfile";
+    assert_script_run "cp $credfile ~/.aws/credentials";
+}
+
+=head3 qesap_aws_create_config
+
+    Creates a AWS configuration file in ~/.aws/config
+    as required by the QE-SAP Terraform & Ansible deployment code.
+    Content is mostly (only) about region.
+
+=over
+
+=item B<REGION> - cloud region as usually provided by PUBLIC_CLOUD_REGION
+
+=back
+=cut
+
+sub qesap_aws_create_config {
+    my (%args) = @_;
+    croak "Missing mandatory region argument" unless $args{region};
+
+    save_tmp_file('config', "[default]\nregion = $args{region}\n");
+    assert_script_run 'mkdir -p ~/.aws';
+    assert_script_run 'curl ' . autoinst_url . "/files/config -o ~/.aws/config";
+}
+
+=head3 qesap_aws_get_vpc_id
+
+    Get the vpc_id of a given instance in the cluster.
+    This function looks for the cluster using the aws describe-instances
+    and filtering by terraform deployment_name value, that qe-sap-deployment
+    is kind to use as tag for each resource.
+
+=cut
+
+=over
+
+=item B<RESOURCE_GROUP> - value of the workspace tag configured in qe-sap-deployment, usually it is the deployment name
+
+=back
+=cut
+
+sub qesap_aws_get_vpc_id {
+    my (%args) = @_;
+    croak 'Missing mandatory resource_group argument' unless $args{resource_group};
+
+    # tag names has to be aligned to
+    # https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/aws/infrastructure.tf
+    my $cmd = join(' ', 'aws ec2 describe-instances',
+        '--region', get_required_var('PUBLIC_CLOUD_REGION'),
+        '--filters',
+        '"Name=tag-key,Values=workspace"',
+        "\"Name=tag-value,Values=$args{resource_group}\"",
+        '--query',
+        # the two 0 index result in select only the vpc of vmhana01
+        # that is always equal to the one used by vmhana02
+        "'Reservations[0].Instances[0].VpcId'",
+        '--output text');
+    return script_output($cmd);
+}
+
+=head3 qesap_aws_get_transit_gateway_vpc_attachment
+    Ged a description of one or more transit-gateway-attachments
+    Function support optional arguments that are translated to filters:
+     - transit_gateway_attach_id
+     - name
+
+    Example:
+      qesap_aws_get_transit_gateway_vpc_attachment(name => 'SOMETHING')
+
+      Result internally in aws cli to be called like
+
+      aws ec2 describe-transit-gateway-attachments --filter='Name=tag:Name,Values=SOMETHING
+
+    Only one filter mode is supported at any time.
+
+    Returns a HASH reference to the decoded JSON returned by the AWS command or undef on failure.
+=cut
+
+sub qesap_aws_get_transit_gateway_vpc_attachment {
+    my (%args) = @_;
+    my $filter = '';
+    if ($args{transit_gateway_attach_id}) {
+        $filter = "--filter='Name=transit-gateway-attachment-id,Values=$args{transit_gateway_attach_id}'";
+    }
+    elsif ($args{name}) {
+        $filter = "--filter='Name=tag:Name,Values=$args{name}'";
+    }
+    my $cmd = join(' ', 'aws ec2 describe-transit-gateway-attachments',
+        $filter,
+        '--query "TransitGatewayAttachments[]"');
+    return decode_json(script_output($cmd));
+}
+
+=head3 qesap_aws_create_transit_gateway_vpc_attachment
+
+    Call create-transit-gateway-vpc-attachment and
+    wait until Transit Gateway Attachment is available.
+
+    Return 1 (true) if properly managed to create the transit-gateway-vpc-attachment
+    Return 0 (false) if create-transit-gateway-vpc-attachment fails or
+                  the gateway does not become active before the timeout
+
+=over
+
+=item B<TRANSIT_GATEWAY_ID> - ID of the target Transit gateway (IBS Mirror)
+
+=item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
+
+=item B<SUBNET_ID_LIST> - List of subnet to connect (SUT HANA cluster)
+
+=item B<NAME> - Prefix for the Tag Name of transit-gateway-vpc-attachment
+
+=item B<TIMEOUT> - default is 5 mins
+
+=back
+=cut
+
+sub qesap_aws_create_transit_gateway_vpc_attachment {
+    my (%args) = @_;
+    foreach (qw(transit_gateway_id vpc_id subnet_id_list name))
+    { croak "Missing mandatory $_ argument" unless $args{$_}; }
+    $args{timeout} //= bmwqemu::scale_timeout(300);
+
+    my $cmd = join(' ', 'aws ec2 create-transit-gateway-vpc-attachment',
+        '--transit-gateway-id', $args{transit_gateway_id},
+        '--vpc-id', $args{vpc_id},
+        '--subnet-ids', join(' ', @{$args{subnet_id_list}}),
+        '--tag-specifications',
+        '"ResourceType=transit-gateway-attachment,Tags=[{Key=Name,Value=' . $args{name} . '-tga}]"',
+        '--output json');
+    my $describe_tgva = decode_json(script_output($cmd));
+    return 0 unless $describe_tgva;
+
+    my $transit_gateway_attachment_id = $describe_tgva->{TransitGatewayVpcAttachment}->{TransitGatewayAttachmentId};
+    my $res;
+    my $state = 'none';
+    my $duration;
+    my $start_time = time();
+    while ((($duration = time() - $start_time) < $args{timeout}) && ($state !~ m/available/)) {
+        sleep 5;
+        $res = qesap_aws_get_transit_gateway_vpc_attachment(
+            transit_gateway_attach_id => $transit_gateway_attachment_id);
+        $state = $res->[0]->{State};
+    }
+    return $duration < $args{timeout};
+}
+
+=head3 qesap_aws_delete_transit_gateway_vpc_attachment
+
+    Call delete-transit-gateway-vpc-attachment and
+    wait until Transit Gateway Attachment is deleted.
+
+    Return 1 (true) if properly managed to delete the transit-gateway-vpc-attachment
+    Return 0 (false) if delete-transit-gateway-vpc-attachment fails or
+         the gateway does not become inactive before the timeout
+
+=over
+
+=item B<NAME> - Prefix for the Tag Name of transit-gateway-vpc-attachment
+
+=item B<TIMEOUT> - default is 5 mins
+
+=back
+=cut
+
+sub qesap_aws_delete_transit_gateway_vpc_attachment {
+    my (%args) = @_;
+    croak 'Missing mandatory name argument' unless $args{name};
+    $args{timeout} //= bmwqemu::scale_timeout(300);
+
+    my $res = qesap_aws_get_transit_gateway_vpc_attachment(
+        name => $args{name});
+    # Here [0] suppose that only one of them match 'name'
+    my $transit_gateway_attachment_id = $res->[0]->{TransitGatewayAttachmentId};
+    return 0 unless $transit_gateway_attachment_id;
+
+    my $cmd = join(' ', 'aws ec2 delete-transit-gateway-vpc-attachment',
+        '--transit-gateway-attachment-id', $transit_gateway_attachment_id);
+    script_run($cmd);
+
+    my $state = 'none';
+    my $duration;
+    my $start_time = time();
+    while ((($duration = time() - $start_time) < $args{timeout}) && ($state !~ m/deleted/)) {
+        sleep 5;
+        $res = qesap_aws_get_transit_gateway_vpc_attachment(
+            transit_gateway_attach_id => $transit_gateway_attachment_id);
+        $state = $res->[0]->{State};
+    }
+    return $duration < $args{timeout};
+}
+
+=head3 qesap_aws_add_route_to_tgw
+    Adding the route to the transit gateway to the routing table in refhost VPC
+
+=over
+
+=item B<RTABLE_ID> - Routing table ID
+
+=item B<TARGET_IP_NET> - Target IP network to be added to the Routing table eg. 192.168.11.0/16
+
+=item B<TRANSIT_GATEWAY_ID> - ID of the target Transit gateway (IBS Mirror)
+
+=back
+=cut
+
+sub qesap_aws_add_route_to_tgw {
+    my (%args) = @_;
+    foreach (qw(rtable_id target_ip_net trans_gw_id)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+
+    my $cmd = join(' ',
+        'aws ec2 create-route',
+        '--route-table-id', $args{rtable_id},
+        '--destination-cidr-block', $args{target_ip_net},
+        '--transit-gateway-id', $args{trans_gw_id},
+        '--output text');
+    script_run($cmd);
+}
+
+=head3 qesap_aws_filter_query
+
+    Generic function to compose a aws cli command with:
+      - `aws ec2` something
+      - use both `filter` and `query`
+      - has text output
+
+=cut
+
+sub qesap_aws_filter_query {
+    my (%args) = @_;
+    foreach (qw(cmd filter query)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+
+    my $cmd = join(' ', 'aws ec2', $args{cmd},
+        '--filters', $args{filter},
+        '--query', $args{query},
+        '--output text');
+    return script_output($cmd);
+}
+
+=head3 qesap_aws_get_mirror_tg
+
+    Return the Transient Gateway ID of the IBS Mirror
+
+=over
+
+=item B<MIRROR_TAG> - Value of Project tag applied to the IBS Mirror
+
+=back
+=cut
+
+sub qesap_aws_get_mirror_tg {
+    my (%args) = @_;
+    croak "Missing mandatory $_ argument" unless $args{mirror_tag};
+    return qesap_aws_filter_query(
+        cmd => 'describe-transit-gateways',
+        filter => '"Name=tag-key,Values=Project" "Name=tag-value,Values=' . $args{mirror_tag} . '"',
+        query => '"TransitGateways[].TransitGatewayId"'
+    );
+}
+
+=head3 qesap_aws_get_vpc_workspace
+
+    Get the VPC tag workspace defined in
+    https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/aws/infrastructure.tf
+
+=over
+
+=item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
+
+=back
+=cut
+
+sub qesap_aws_get_vpc_workspace {
+    my (%args) = @_;
+    croak 'Missing mandatory vpc_id argument' unless $args{vpc_id};
+
+    return qesap_aws_filter_query(
+        cmd => 'describe-vpcs',
+        filter => "\"Name=vpc-id,Values=$args{vpc_id}\"",
+        query => '"Vpcs[*].Tags[?Key==\`workspace\`].Value"'
+    );
+}
+
+=head3 qesap_aws_get_routing
+
+    Get the Routing table: searching Routing Table with external connection
+    and get the RouteTableId
+
+=over
+
+=item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
+
+=back
+=cut
+
+sub qesap_aws_get_routing {
+    my (%args) = @_;
+    croak 'Missing mandatory vpc_id argument' unless $args{vpc_id};
+
+    return qesap_aws_filter_query(
+        cmd => 'describe-route-tables',
+        filter => "\"Name=vpc-id,Values=$args{vpc_id}\"",
+        query => '"RouteTables[?Routes[?GatewayId!=\`local\`]].RouteTableId"'
+    );
+}
+
+=head3 qesap_aws_vnet_peering
+
+    Create a pair of network peering between
+    the two provided deployments.
+
+    Return 1 (true) if the overall peering procedure completes successfully
+
+=over
+
+=item B<TARGET_IP> - Target IP network to be added to the Routing table eg. 192.168.11.0/16
+
+=item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
+
+=item B<MIRROR_TAG> - Value of Project tag applied to the IBS Mirror
+
+=back
+=cut
+
+sub qesap_aws_vnet_peering {
+    my (%args) = @_;
+    foreach (qw(target_ip vpc_id mirror_tag)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+
+    my $trans_gw_id = qesap_aws_get_mirror_tg(mirror_tag => $args{mirror_tag});
+    unless ($trans_gw_id) {
+        record_info('AWS PEERING', 'Empty trans_gw_id');
+        return 0;
+    }
+
+    # For qe-sap-deployment this one match or contain the Terraform deloyment_name
+    my $vpc_tag_name = qesap_aws_get_vpc_workspace(vpc_id => $args{vpc_id});
+    unless ($vpc_tag_name) {
+        record_info('AWS PEERING', 'Empty vpc_tag_name');
+        return 0;
+    }
+
+    my @vpc_subnets_list = qesap_aws_get_region_subnets(vpc_id => $args{vpc_id});
+    unless (@vpc_subnets_list) {
+        record_info('AWS PEERING', 'Empty vpc_subnets_list');
+        return 0;
+    }
+
+    my $rtable_id = qesap_aws_get_routing(vpc_id => $args{vpc_id});
+    unless ($rtable_id) {
+        record_info('AWS PEERING', 'Empty rtable_id');
+        return 0;
+    }
+
+    # Setting up the peering
+    # Attaching the VPC to the Transit Gateway
+    my $attach = qesap_aws_create_transit_gateway_vpc_attachment(
+        transit_gateway_id => $trans_gw_id,
+        vpc_id => $args{vpc_id},
+        subnet_id_list => \@vpc_subnets_list,
+        name => $vpc_tag_name);
+    unless ($attach) {
+        record_info('AWS PEERING', 'VPC attach failure');
+        return 0;
+    }
+
+    qesap_aws_add_route_to_tgw(
+        rtable_id => $rtable_id,
+        target_ip_net => $args{target_ip},
+        trans_gw_id => $trans_gw_id);
+
+    record_info('AWS PEERING SUCCESS');
+    return 1;
+}
+
+1;

--- a/lib/sles4sap/qesap/qesapdeployment.pm
+++ b/lib/sles4sap/qesap/qesapdeployment.pm
@@ -16,7 +16,7 @@
 
 =head1 COPYRIGHT
 
-    Copyright 2022 SUSE LLC
+    Copyright 2025 SUSE LLC
     SPDX-License-Identifier: FSFAP
 
 =head1 AUTHORS
@@ -32,15 +32,17 @@ use warnings;
 use Carp qw(croak);
 use Mojo::JSON qw(decode_json);
 use YAML::PP;
-use utils qw(file_content_replace);
-use version_utils 'is_sle';
-use publiccloud::utils qw(get_credentials);
-use sles4sap::azure_cli;
-use mmapi 'get_current_job_id';
-use testapi;
 use Exporter 'import';
 use Scalar::Util 'looks_like_number';
 use File::Basename;
+use utils qw(file_content_replace);
+use version_utils 'is_sle';
+use publiccloud::utils qw(get_credentials);
+use sles4sap::qesap::qesap_aws;
+use sles4sap::azure_cli;
+use mmapi 'get_current_job_id';
+use testapi;
+
 
 my @log_files = ();
 
@@ -77,16 +79,6 @@ our @EXPORT = qw(
   qesap_cluster_logs
   qesap_upload_crm_report
   qesap_supportconfig_logs
-  qesap_aws_get_region_subnets
-  qesap_aws_get_vpc_id
-  qesap_aws_create_transit_gateway_vpc_attachment
-  qesap_aws_delete_transit_gateway_vpc_attachment
-  qesap_aws_get_transit_gateway_vpc_attachment
-  qesap_aws_add_route_to_tgw
-  qesap_aws_get_mirror_tg
-  qesap_aws_get_vpc_workspace
-  qesap_aws_get_routing
-  qesap_aws_vnet_peering
   qesap_add_server_to_hosts
   qesap_calculate_deployment_name
   qesap_export_instances
@@ -109,7 +101,7 @@ our @EXPORT = qw(
 
 =head1 DESCRIPTION
 
-    Package with common methods and default or constant  values for qe-sap-deployment
+    Package with common methods and default or constant values for qe-sap-deployment
 
 =head2 Methods
 
@@ -561,7 +553,7 @@ sub qesap_execute {
         logname => 'somefile.txt'
         [, verbose => 1, cmd_options => '--parallel 3', timeout => 1200, retries => 5, destroy => 1] );
 
-    Execute 'qesap.py ... terraform' and eventually retry for some specific errors.
+    Execute 'qesap.py ... teraform' and eventually retry for some specific errors.
     Test returns execution result in same format of qesap_execute.
 
 =over
@@ -781,6 +773,7 @@ sub qesap_get_ansible_roles_dir {
 sub qesap_prepare_env {
     my (%args) = @_;
     croak "Missing mandatory argument 'provider'" unless $args{provider};
+    croak "Missing mandatory argument 'region' when 'provider' is EC2" if (($args{provider} eq 'EC2') && !$args{region});
 
     my $variables = $args{openqa_variables} ? $args{openqa_variables} : qesap_get_variables();
     my $provider_folder = lc $args{provider};
@@ -818,8 +811,11 @@ sub qesap_prepare_env {
 
     if ($args{provider} eq 'EC2') {
         my $data = get_credentials('aws.json');
-        qesap_create_aws_config();
-        qesap_create_aws_credentials($data->{access_key_id}, $data->{secret_access_key});
+        qesap_aws_create_config(region => $args{region});
+        qesap_aws_create_credentials(
+            conf_trgt => $paths{qesap_conf_trgt},
+            key => $data->{access_key_id},
+            secret => $data->{secret_access_key});
     }
 
     push(@log_files, $hana_media) if (script_run("test -e $hana_media") == 0);
@@ -1156,37 +1152,6 @@ sub qesap_ansible_reg_module {
       "\"value\":\"$reg_args[1]\"}]'";
 }
 
-=head3 qesap_create_aws_credentials
-
-    Creates a AWS credentials file as required by QE-SAP Terraform deployment code.
-=cut
-
-sub qesap_create_aws_credentials {
-    my ($key, $secret) = @_;
-    my %paths = qesap_get_file_paths();
-    my $credfile = script_output q|awk -F ' ' '/aws_credentials/ {print $2}' | . $paths{qesap_conf_trgt};
-    save_tmp_file('credentials', "[default]\naws_access_key_id = $key\naws_secret_access_key = $secret\n");
-    assert_script_run 'mkdir -p ~/.aws';
-    assert_script_run 'curl ' . autoinst_url . "/files/credentials -o $credfile";
-    assert_script_run "cp $credfile ~/.aws/credentials";
-}
-
-=head3 qesap_create_aws_config
-
-    Creates a AWS configuration file in ~/.aws
-    as required by the QE-SAP Terraform & Ansible deployment code.
-=cut
-
-sub qesap_create_aws_config {
-    my %paths = qesap_get_file_paths();
-    my $region = script_output q|awk -F ' ' '/aws_region/ {print $2}' | . $paths{qesap_conf_trgt};
-    $region = get_required_var('PUBLIC_CLOUD_REGION') if ($region =~ /^["']?%.+%["']?$/);
-    $region =~ s/[\"\']//g;
-    save_tmp_file('config', "[default]\nregion = $region\n");
-    assert_script_run 'mkdir -p ~/.aws';
-    assert_script_run 'curl ' . autoinst_url . "/files/config -o ~/.aws/config";
-}
-
 =head3 qesap_remote_hana_public_ips
 
     Return a list of the public IP addresses of the systems
@@ -1483,228 +1448,6 @@ sub qesap_calculate_deployment_name {
     return $prefix ? $prefix . $id : $id;
 }
 
-=head3 qesap_aws_get_region_subnets
-
-Return a list of subnets. Return a single subnet for each region.
-
-=over
-
-=item B<VPC_ID> - VPC ID of resource to filter list of subnets
-
-=back
-=cut
-
-sub qesap_aws_get_region_subnets {
-    my (%args) = @_;
-    croak 'Missing mandatory vpc_id argument' unless $args{vpc_id};
-
-    my $cmd = join(' ', 'aws ec2 describe-subnets',
-        '--filters', "\"Name=vpc-id,Values=$args{vpc_id}\"",
-        '--query "Subnets[].{AZ:AvailabilityZone,SI:SubnetId}"',
-        '--output json');
-
-    my $describe_vpcs = decode_json(script_output($cmd));
-    my %seen = ();
-    my @uniq = ();
-    foreach (@{$describe_vpcs}) {
-        push(@uniq, $_->{SI}) unless $seen{$_->{AZ}}++;
-    }
-    return @uniq;
-}
-
-=head3 qesap_aws_get_vpc_id
-
-    Get the vpc_id of a given instance in the cluster.
-    This function looks for the cluster using the aws describe-instances
-    and filtering by terraform deployment_name value, that qe-sap-deployment
-    is kind to use as tag for each resource.
-
-=cut
-
-=over
-
-=item B<RESOURCE_GROUP> - resource group name to query
-
-=back
-=cut
-
-sub qesap_aws_get_vpc_id {
-    my (%args) = @_;
-    croak 'Missing mandatory resource_group argument' unless $args{resource_group};
-
-    # tag names has to be aligned to
-    # https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/aws/infrastructure.tf
-    my $cmd = join(' ', 'aws ec2 describe-instances',
-        '--region', get_required_var('PUBLIC_CLOUD_REGION'),
-        '--filters',
-        '"Name=tag-key,Values=workspace"',
-        "\"Name=tag-value,Values=$args{resource_group}\"",
-        '--query',
-        # the two 0 index result in select only the vpc of vmhana01
-        # that is always equal to the one used by vmhana02
-        "'Reservations[0].Instances[0].VpcId'",
-        '--output text');
-    return script_output($cmd);
-}
-
-=head3 qesap_aws_get_transit_gateway_vpc_attachment
-    Ged a description of one or more transit-gateway-attachments
-    Function support optional arguments that are translated to filters:
-     - transit_gateway_attach_id
-     - name
-
-    Example:
-      qesap_aws_get_transit_gateway_vpc_attachment(name => 'SOMETHING')
-
-      Result internally in aws cli to be called like
-
-      aws ec2 describe-transit-gateway-attachments --filter='Name=tag:Name,Values=SOMETHING
-
-    Only one filter mode is supported at any time.
-
-    Returns a HASH reference to the decoded JSON returned by the AWS command or undef on failure.
-=cut
-
-sub qesap_aws_get_transit_gateway_vpc_attachment {
-    my (%args) = @_;
-    my $filter = '';
-    if ($args{transit_gateway_attach_id}) {
-        $filter = "--filter='Name=transit-gateway-attachment-id,Values=$args{transit_gateway_attach_id}'";
-    }
-    elsif ($args{name}) {
-        $filter = "--filter='Name=tag:Name,Values=$args{name}'";
-    }
-    my $cmd = join(' ', 'aws ec2 describe-transit-gateway-attachments',
-        $filter,
-        '--query "TransitGatewayAttachments[]"');
-    return decode_json(script_output($cmd));
-}
-
-=head3 qesap_aws_create_transit_gateway_vpc_attachment
-
-    Call create-transit-gateway-vpc-attachment and
-    wait until Transit Gateway Attachment is available.
-
-    Return 1 (true) if properly managed to create the transit-gateway-vpc-attachment
-    Return 0 (false) if create-transit-gateway-vpc-attachment fails or
-                  the gateway does not become active before the timeout
-
-=over
-
-=item B<TRANSIT_GATEWAY_ID> - ID of the target Transit gateway (IBS Mirror)
-
-=item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
-
-=item B<SUBNET_ID_LIST> - List of subnet to connect (SUT HANA cluster)
-
-=item B<NAME> - Prefix for the Tag Name of transit-gateway-vpc-attachment
-
-=item B<TIMEOUT> - default is 5 mins
-
-=back
-=cut
-
-sub qesap_aws_create_transit_gateway_vpc_attachment {
-    my (%args) = @_;
-    foreach (qw(transit_gateway_id vpc_id subnet_id_list name)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-    $args{timeout} //= bmwqemu::scale_timeout(300);
-
-    my $cmd = join(' ', 'aws ec2 create-transit-gateway-vpc-attachment',
-        '--transit-gateway-id', $args{transit_gateway_id},
-        '--vpc-id', $args{vpc_id},
-        '--subnet-ids', join(' ', @{$args{subnet_id_list}}),
-        '--tag-specifications',
-        '"ResourceType=transit-gateway-attachment,Tags=[{Key=Name,Value=' . $args{name} . '-tga}]"',
-        '--output json');
-    my $describe_tgva = decode_json(script_output($cmd));
-    return 0 unless $describe_tgva;
-
-    my $transit_gateway_attachment_id = $describe_tgva->{TransitGatewayVpcAttachment}->{TransitGatewayAttachmentId};
-    my $res;
-    my $state = 'none';
-    my $duration;
-    my $start_time = time();
-    while ((($duration = time() - $start_time) < $args{timeout}) && ($state !~ m/available/)) {
-        sleep 5;
-        $res = qesap_aws_get_transit_gateway_vpc_attachment(
-            transit_gateway_attach_id => $transit_gateway_attachment_id);
-        $state = $res->[0]->{State};
-    }
-    return $duration < $args{timeout};
-}
-
-=head3 qesap_aws_delete_transit_gateway_vpc_attachment
-
-    Call delete-transit-gateway-vpc-attachment and
-    wait until Transit Gateway Attachment is deleted.
-
-    Return 1 (true) if properly managed to delete the transit-gateway-vpc-attachment
-    Return 0 (false) if delete-transit-gateway-vpc-attachment fails or
-         the gateway does not become inactive before the timeout
-
-=over
-
-=item B<NAME> - Prefix for the Tag Name of transit-gateway-vpc-attachment
-
-=item B<TIMEOUT> - default is 5 mins
-
-=back
-=cut
-
-sub qesap_aws_delete_transit_gateway_vpc_attachment {
-    my (%args) = @_;
-    croak 'Missing mandatory name argument' unless $args{name};
-    $args{timeout} //= bmwqemu::scale_timeout(300);
-
-    my $res = qesap_aws_get_transit_gateway_vpc_attachment(
-        name => $args{name});
-    # Here [0] suppose that only one of them match 'name'
-    my $transit_gateway_attachment_id = $res->[0]->{TransitGatewayAttachmentId};
-    return 0 unless $transit_gateway_attachment_id;
-
-    my $cmd = join(' ', 'aws ec2 delete-transit-gateway-vpc-attachment',
-        '--transit-gateway-attachment-id', $transit_gateway_attachment_id);
-    script_run($cmd);
-
-    my $state = 'none';
-    my $duration;
-    my $start_time = time();
-    while ((($duration = time() - $start_time) < $args{timeout}) && ($state !~ m/deleted/)) {
-        sleep 5;
-        $res = qesap_aws_get_transit_gateway_vpc_attachment(
-            transit_gateway_attach_id => $transit_gateway_attachment_id);
-        $state = $res->[0]->{State};
-    }
-    return $duration < $args{timeout};
-}
-
-=head3 qesap_aws_add_route_to_tgw
-    Adding the route to the transit gateway to the routing table in refhost VPC
-
-=over
-
-=item B<RTABLE_ID> - Routing table ID
-
-=item B<TARGET_IP_NET> - Target IP network to be added to the Routing table eg. 192.168.11.0/16
-
-=item B<TRANSIT_GATEWAY_ID> - ID of the target Transit gateway (IBS Mirror)
-
-=back
-=cut
-
-sub qesap_aws_add_route_to_tgw {
-    my (%args) = @_;
-    foreach (qw(rtable_id target_ip_net trans_gw_id)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-
-    my $cmd = join(' ',
-        'aws ec2 create-route',
-        '--route-table-id', $args{rtable_id},
-        '--destination-cidr-block', $args{target_ip_net},
-        '--transit-gateway-id', $args{trans_gw_id},
-        '--output text');
-    script_run($cmd);
-}
-
 =head3 qesap_aws_filter_query
 
     Generic function to compose a aws cli command with:
@@ -1723,141 +1466,6 @@ sub qesap_aws_filter_query {
         '--query', $args{query},
         '--output text');
     return script_output($cmd);
-}
-
-=head3 qesap_aws_get_mirror_tg
-
-    Return the Transient Gateway ID of the IBS Mirror
-
-=over
-
-=item B<MIRROR_TAG> - Value of Project tag applied to the IBS Mirror
-
-=back
-=cut
-
-sub qesap_aws_get_mirror_tg {
-    my (%args) = @_;
-    croak "Missing mandatory $_ argument" unless $args{mirror_tag};
-    return qesap_aws_filter_query(
-        cmd => 'describe-transit-gateways',
-        filter => '"Name=tag-key,Values=Project" "Name=tag-value,Values=' . $args{mirror_tag} . '"',
-        query => '"TransitGateways[].TransitGatewayId"'
-    );
-}
-
-=head3 qesap_aws_get_vpc_workspace
-
-    Get the VPC tag workspace defined in
-    https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/aws/infrastructure.tf
-
-=over
-
-=item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
-
-=back
-=cut
-
-sub qesap_aws_get_vpc_workspace {
-    my (%args) = @_;
-    croak 'Missing mandatory vpc_id argument' unless $args{vpc_id};
-
-    return qesap_aws_filter_query(
-        cmd => 'describe-vpcs',
-        filter => "\"Name=vpc-id,Values=$args{vpc_id}\"",
-        query => '"Vpcs[*].Tags[?Key==\`workspace\`].Value"'
-    );
-}
-
-=head3 qesap_aws_get_routing
-
-    Get the Routing table: searching Routing Table with external connection
-    and get the RouteTableId
-
-=over
-
-=item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
-
-=back
-=cut
-
-sub qesap_aws_get_routing {
-    my (%args) = @_;
-    croak 'Missing mandatory vpc_id argument' unless $args{vpc_id};
-
-    return qesap_aws_filter_query(
-        cmd => 'describe-route-tables',
-        filter => "\"Name=vpc-id,Values=$args{vpc_id}\"",
-        query => '"RouteTables[?Routes[?GatewayId!=\`local\`]].RouteTableId"'
-    );
-}
-
-=head3 qesap_aws_vnet_peering
-
-    Create a pair of network peering between
-    the two provided deployments.
-
-    Return 1 (true) if the overall peering procedure completes successfully
-
-=over
-
-=item B<TARGET_IP> - Target IP network to be added to the Routing table eg. 192.168.11.0/16
-
-=item B<VPC_ID> - VPC ID of resource to be attached (SUT HANA cluster)
-
-=item B<MIRROR_TAG> - Value of Project tag applied to the IBS Mirror
-
-=back
-=cut
-
-sub qesap_aws_vnet_peering {
-    my (%args) = @_;
-    foreach (qw(target_ip vpc_id mirror_tag)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-
-    my $trans_gw_id = qesap_aws_get_mirror_tg(mirror_tag => $args{mirror_tag});
-    unless ($trans_gw_id) {
-        record_info('AWS PEERING', 'Empty trans_gw_id');
-        return 0;
-    }
-
-    # For qe-sap-deployment this one match or contain the Terraform deloyment_name
-    my $vpc_tag_name = qesap_aws_get_vpc_workspace(vpc_id => $args{vpc_id});
-    unless ($vpc_tag_name) {
-        record_info('AWS PEERING', 'Empty vpc_tag_name');
-        return 0;
-    }
-
-    my @vpc_subnets_list = qesap_aws_get_region_subnets(vpc_id => $args{vpc_id});
-    unless (@vpc_subnets_list) {
-        record_info('AWS PEERING', 'Empty vpc_subnets_list');
-        return 0;
-    }
-
-    my $rtable_id = qesap_aws_get_routing(vpc_id => $args{vpc_id});
-    unless ($rtable_id) {
-        record_info('AWS PEERING', 'Empty rtable_id');
-        return 0;
-    }
-
-    # Setting up the peering
-    # Attaching the VPC to the Transit Gateway
-    my $attach = qesap_aws_create_transit_gateway_vpc_attachment(
-        transit_gateway_id => $trans_gw_id,
-        vpc_id => $args{vpc_id},
-        subnet_id_list => \@vpc_subnets_list,
-        name => $vpc_tag_name);
-    unless ($attach) {
-        record_info('AWS PEERING', 'VPC attach failure');
-        return 0;
-    }
-
-    qesap_aws_add_route_to_tgw(
-        rtable_id => $rtable_id,
-        target_ip_net => $args{target_ip},
-        trans_gw_id => $trans_gw_id);
-
-    record_info('AWS PEERING SUCCESS');
-    return 1;
 }
 
 =head3 qesap_add_server_to_hosts

--- a/t/16_qesap_aws.t
+++ b/t/16_qesap_aws.t
@@ -10,11 +10,10 @@ use List::Util qw(any none);
 use Data::Dumper;
 
 use testapi 'set_var';
-use sles4sap::qesap::qesapdeployment;
-set_var('QESAP_CONFIG_FILE', 'MARLIN');
+use sles4sap::qesap::qesap_aws;
 
 subtest '[qesap_aws_get_vpc_id]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     my @soft_failure;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'FISHERMAN'; });
@@ -36,146 +35,8 @@ subtest '[qesap_aws_vnet_peering] died args' => sub {
     dies_ok { qesap_aws_vnet_peering(target_ip => 'OCEAN', vpc_id => 'OCEAN') } "Expected die for missing mirror_tag";
 };
 
-subtest '[qesap_aws_get_region_subnets]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
-    my @calls;
-    my @outputs;
-    my @result;
-    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    $qesap->redefine(script_output => sub { push @calls, $_[0];
-            return pop @outputs if ($_[0] =~ /aws ec2 describe-subnets/); });
-    push @outputs, '[
-    {
-        "AZ": "eu-central-1a",
-        "SI": "subnet-00000000000000000"
-    },
-    {
-        "AZ": "eu-central-1b",
-        "SI": "subnet-11111111111111111"
-    }]';
-
-    @result = qesap_aws_get_region_subnets(vpc_id => 'WHALE');
-
-    note("\n  C-->  " . join("\n  C-->  ", @calls));
-    ok((any { /aws ec2 describe-subnets --filters.*WHALE/ } @calls), 'Composition of describe-subnets command');
-    ok((any { /subnet-00000000000000000/ } @result), 'Subnet subnet-00000000000000000 for eu-central-1a');
-    ok((any { /subnet-11111111111111111/ } @result), 'Subnet subnet-11111111111111111 for eu-central-1b');
-
-    # Filter for duplicated regions
-    push @outputs, '[
-    {
-        "AZ": "eu-central-1a",
-        "SI": "subnet-00000000000000000"
-    },
-    {
-        "AZ": "eu-central-1a",
-        "SI": "subnet-22222222222222222"
-    },
-    {
-        "AZ": "eu-central-1b",
-        "SI": "subnet-11111111111111111"
-    }]';
-    @result = qesap_aws_get_region_subnets(vpc_id => 'WHALE');
-    ok((any { /subnet-00000000000000000/ } @result), 'Subnet subnet-00000000000000000 for eu-central-1a');
-    ok((any { /subnet-11111111111111111/ } @result), 'Subnet subnet-11111111111111111 for eu-central-1b');
-    ok((none { /subnet-22222222222222222/ } @result), 'Subnet subnet-22222222222222222 is duplicate for eu-central-1a');
-
-    push @outputs, '[
-    {
-        "AZ": "eu-central-1a",
-        "SI": "subnet-00000000000000000"
-    },
-    {
-        "AZ": "eu-central-1b",
-        "SI": "subnet-11111111111111111"
-    },
-    {
-        "AZ": "eu-central-1b",
-        "SI": "subnet-22222222222222222"
-    },
-    {
-        "AZ": "eu-central-1a",
-        "SI": "subnet-33333333333333333"
-    }]';
-    @result = qesap_aws_get_region_subnets(vpc_id => 'WHALE');
-    ok((any { /subnet-00000000000000000/ } @result), 'Subnet subnet-00000000000000000 for eu-central-1a');
-    ok((any { /subnet-11111111111111111/ } @result), 'Subnet subnet-11111111111111111 for eu-central-1b');
-    ok((none { /subnet-22222222222222222/ } @result), 'Subnet subnet-22222222222222222 is duplicate for eu-central-1b');
-    ok((none { /subnet-33333333333333333/ } @result), 'Subnet subnet-33333333333333333 is duplicate for eu-central-1a');
-};
-
-subtest '[qesap_aws_create_transit_gateway_vpc_attachment]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
-    my @calls;
-    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
-            my @tga_status = ({State => 'available'});
-            return \@tga_status;
-    });
-    $qesap->redefine(script_output => sub { push @calls, $_[0];
-            return '{
-    "TransitGatewayVpcAttachment": {
-        "TransitGatewayAttachmentId": "tgw-attach-00000000000000000",
-        "TransitGatewayId": "tgw-00000000000000000",
-        "State": "pending",
-        "Tags": [
-            {
-                "Key": "Name",
-                "Value": "WHALE-tga"
-            }
-        ]
-    }
-}' if ($_[0] =~ /aws ec2 create-transit-gateway-vpc-attachment/);
-    });
-    my @subnets = ('subnet-00000000000000000', 'subnet-11111111111111111');
-
-    my $res = qesap_aws_create_transit_gateway_vpc_attachment(
-        transit_gateway_id => 'tgw-00000000000000000',
-        vpc_id => 'vpc-00000000000000000',
-        subnet_id_list => \@subnets,
-        name => 'WHALE');
-
-    note("\n  C-->  " . join("\n  C-->  ", @calls));
-    ok $res, 'Creation of transit gateway vpc attachment is fine.';
-};
-
-subtest '[qesap_aws_create_transit_gateway_vpc_attachment] timeout' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
-    my @calls;
-    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
-            my @tga_status = ({State => 'never_ready'});
-            return \@tga_status;
-    });
-    $qesap->redefine(script_output => sub { push @calls, $_[0];
-            return '{
-    "TransitGatewayVpcAttachment": {
-        "TransitGatewayAttachmentId": "tgw-attach-00000000000000000",
-        "TransitGatewayId": "tgw-00000000000000000",
-        "State": "pending",
-        "Tags": [
-            {
-                "Key": "Name",
-                "Value": "WHALE-tga"
-            }
-        ]
-    }
-}' if ($_[0] =~ /aws ec2 create-transit-gateway-vpc-attachment/);
-    });
-    my @subnets = ('subnet-00000000000000000', 'subnet-11111111111111111');
-
-    my $res = qesap_aws_create_transit_gateway_vpc_attachment(
-        transit_gateway_id => 'tgw-00000000000000000',
-        vpc_id => 'vpc-00000000000000000',
-        subnet_id_list => \@subnets,
-        name => 'WHALE');
-
-    note("\n  C-->  " . join("\n  C-->  ", @calls));
-    ok !$res, 'Creation of transit gateway vpc attachment timeout.';
-};
-
 subtest '[qesap_aws_delete_transit_gateway_vpc_attachment]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
@@ -192,7 +53,7 @@ subtest '[qesap_aws_delete_transit_gateway_vpc_attachment]' => sub {
 };
 
 subtest '[qesap_aws_delete_transit_gateway_vpc_attachment] timeout' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
@@ -209,7 +70,7 @@ subtest '[qesap_aws_delete_transit_gateway_vpc_attachment] timeout' => sub {
 };
 
 subtest '[qesap_aws_get_transit_gateway_vpc_attachment] no filters' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_output => sub { push @calls, $_[0];
@@ -224,7 +85,7 @@ subtest '[qesap_aws_get_transit_gateway_vpc_attachment] no filters' => sub {
 };
 
 subtest '[qesap_aws_get_transit_gateway_vpc_attachment] return multiple tga' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_output => sub { push @calls, $_[0];
@@ -242,7 +103,7 @@ subtest '[qesap_aws_get_transit_gateway_vpc_attachment] return multiple tga' => 
 };
 
 subtest '[qesap_aws_get_transit_gateway_vpc_attachment] transit_gateway_attach_id filter' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_output => sub { push @calls, $_[0];
@@ -270,7 +131,7 @@ subtest '[qesap_aws_get_transit_gateway_vpc_attachment] transit_gateway_attach_i
 };
 
 subtest '[qesap_aws_get_transit_gateway_vpc_attachment] name filter' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(script_output => sub { push @calls, $_[0];
@@ -299,7 +160,7 @@ subtest '[qesap_aws_get_transit_gateway_vpc_attachment] name filter' => sub {
 };
 
 subtest '[qesap_aws_add_route_to_tgw]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(script_run => sub { push @calls, $_[0]; });
 
@@ -316,7 +177,7 @@ subtest '[qesap_aws_add_route_to_tgw]' => sub {
 };
 
 subtest '[qesap_aws_get_mirror_tg]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'tgw-00deadbeef00'; });
 
@@ -328,7 +189,7 @@ subtest '[qesap_aws_get_mirror_tg]' => sub {
 };
 
 subtest '[qesap_aws_get_vpc_workspace]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'VPC_TAG_NAME'; });
 
@@ -340,7 +201,7 @@ subtest '[qesap_aws_get_vpc_workspace]' => sub {
 };
 
 subtest '[qesap_aws_get_routing]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'rtb-00deadbeef00'; });
 
@@ -352,12 +213,40 @@ subtest '[qesap_aws_get_routing]' => sub {
 };
 
 subtest '[qesap_aws_vnet_peering]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_aws_get_mirror_tg => sub { return 'tgw-00deadbeef00'; });
-    $qesap->redefine(qesap_aws_get_region_subnets => sub { return ('subnet-00000000000000000', 'subnet-11111111111111111'); });
-    $qesap->redefine(qesap_aws_create_transit_gateway_vpc_attachment => sub { return (1 == 1); });
+    my @describe_subnet_out;
+    $qesap->redefine(script_output => sub { push @calls, $_[0];
+            return '[
+    {
+        "AZ": "eu-central-1a",
+        "SI": "subnet-00000000000000000"
+    },
+    {
+        "AZ": "eu-central-1b",
+        "SI": "subnet-11111111111111111"
+    }]' if ($_[0] =~ /aws ec2 describe-subnets/);
+            return '{
+    "TransitGatewayVpcAttachment": {
+        "TransitGatewayAttachmentId": "tgw-attach-00000000000000000",
+        "TransitGatewayId": "tgw-00000000000000000",
+        "State": "pending",
+        "Tags": [
+            {
+                "Key": "Name",
+                "Value": "WHALE-tga"
+            }
+        ]
+    }
+}' if ($_[0] =~ /aws ec2 create-transit-gateway-vpc-attachment/);
+    });
+
+    $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
+            my @tga_status = ({State => 'available'});
+            return \@tga_status;
+    });
     $qesap->redefine(qesap_aws_add_route_to_tgw => sub { push @calls, 'qesap_aws_add_route_to_tgw'; return; });
     $qesap->redefine(qesap_aws_get_routing => sub { return 'rtb-00deadbeef00'; });
     $qesap->redefine(qesap_aws_get_vpc_workspace => sub { return 'VPC_TAG_NAME'; });
@@ -368,19 +257,81 @@ subtest '[qesap_aws_vnet_peering]' => sub {
     ok((any { /qesap_aws_add_route_to_tgw/ } @calls), 'qesap_aws_add_route_to_tgw called');
 };
 
+subtest '[qesap_aws_vnet_peering] qesap_aws_create_transit_gateway_vpc_attachment timeout' => sub {
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
+    my @calls;
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $qesap->redefine(qesap_aws_get_mirror_tg => sub { return 'tgw-00deadbeef00'; });
+    my @describe_subnet_out;
+    $qesap->redefine(script_output => sub { push @calls, $_[0];
+            return '[
+    {
+        "AZ": "eu-central-1a",
+        "SI": "subnet-00000000000000000"
+    },
+    {
+        "AZ": "eu-central-1b",
+        "SI": "subnet-11111111111111111"
+    }]' if ($_[0] =~ /aws ec2 describe-subnets/);
+            return '{
+    "TransitGatewayVpcAttachment": {
+        "TransitGatewayAttachmentId": "tgw-attach-00000000000000000",
+        "TransitGatewayId": "tgw-00000000000000000",
+        "State": "pending",
+        "Tags": [
+            {
+                "Key": "Name",
+                "Value": "WHALE-tga"
+            }
+        ]
+    }
+}' if ($_[0] =~ /aws ec2 create-transit-gateway-vpc-attachment/);
+    });
+
+    $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
+            my @tga_status = ({State => 'never_ready'});
+            return \@tga_status;
+    });
+    $qesap->redefine(qesap_aws_add_route_to_tgw => sub { push @calls, 'qesap_aws_add_route_to_tgw'; return; });
+    $qesap->redefine(qesap_aws_get_routing => sub { return 'rtb-00deadbeef00'; });
+    $qesap->redefine(qesap_aws_get_vpc_workspace => sub { return 'VPC_TAG_NAME'; });
+
+    my $res = qesap_aws_vnet_peering(target_ip => '10.0.0.1/28', vpc_id => 'PLANKTON', mirror_tag => 'BLUE');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok !$res, 'Creation of transit gateway vpc attachment timeout.';
+};
+
 subtest '[qesap_aws_vnet_peering] died when aws does not return expected output' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my $tgw_return;
     $qesap->redefine(qesap_aws_get_mirror_tg => sub { return $tgw_return; });
     my $vpc_name;
     $qesap->redefine(qesap_aws_get_vpc_workspace => sub { return $vpc_name; });
-    my @subnets;
-    $qesap->redefine(qesap_aws_get_region_subnets => sub { return @subnets; });
+    my $describe_subnet_out;
+    $qesap->redefine(script_output => sub { push @calls, $_[0];
+            return $describe_subnet_out if ($_[0] =~ /aws ec2 describe-subnets/);
+            return '{
+    "TransitGatewayVpcAttachment": {
+        "TransitGatewayAttachmentId": "tgw-attach-00000000000000000",
+        "TransitGatewayId": "tgw-00000000000000000",
+        "State": "pending",
+        "Tags": [
+            {
+                "Key": "Name",
+                "Value": "WHALE-tga"
+            }
+        ]
+    }}' if ($_[0] =~ /aws ec2 create-transit-gateway-vpc-attachment/);
+    });
+    $qesap->redefine(qesap_aws_get_transit_gateway_vpc_attachment => sub {
+            my @tga_status = ({State => 'available'});
+            return \@tga_status;
+    });
     my $routing_id;
     $qesap->redefine(qesap_aws_get_routing => sub { return $routing_id; });
-    $qesap->redefine(qesap_aws_create_transit_gateway_vpc_attachment => sub { return (1 == 1); });
     $qesap->redefine(qesap_aws_add_route_to_tgw => sub { push @calls, 'qesap_aws_add_route_to_tgw'; return; });
 
     my $res;
@@ -391,22 +342,68 @@ subtest '[qesap_aws_vnet_peering] died when aws does not return expected output'
 
     $tgw_return = 'tgw-00deadbeef00';
     $vpc_name = '';
+    $describe_subnet_out = '[]';
     $res = qesap_aws_vnet_peering(target_ip => '10.0.0.1/28', vpc_id => 'PLANKTON', mirror_tag => 'BLUE');
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     ok !$res, 'Expected die for missing return from qesap_aws_get_vpc_workspace.';
 
     $vpc_name = 'VPC_TAG_NAME';
-    @subnets = ();
     $res = qesap_aws_vnet_peering(target_ip => '10.0.0.1/28', vpc_id => 'PLANKTON', mirror_tag => 'BLUE');
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     ok !$res, 'Expected die for missing return from qesap_aws_get_region_subnets.';
 
-    @subnets = ('subnet-00000000000000000', 'subnet-11111111111111111');
+    $describe_subnet_out = '[
+    {
+        "AZ": "eu-central-1a",
+        "SI": "subnet-00000000000000000"
+    },
+    {
+        "AZ": "eu-central-1b",
+        "SI": "subnet-11111111111111111"
+    }]';
     $routing_id = '';
     $res = qesap_aws_vnet_peering(target_ip => '10.0.0.1/28', vpc_id => 'PLANKTON', mirror_tag => 'BLUE');
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     ok !$res, 'Expected die for missing return from qesap_aws_get_routing.';
     $routing_id = 'rtb-00deadbeef00';
 };
+
+subtest '[qesap_aws_create_config]' => sub {
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
+
+    my @calls;
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    $qesap->redefine(script_output => sub { push @calls, $_[0]; return 'SOMEOUTPUT' });
+    $qesap->redefine(save_tmp_file => sub { });
+    $qesap->redefine(autoinst_url => sub { return 'SOMEURL' });
+
+    qesap_aws_create_config(region => 'SOMEWHERE');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok((any { /mkdir.*\.aws/ } @calls), 'Create a folder in HOME for the AWS config files');
+    ok((any { /curl SOMEURL.*\.aws\/config/ } @calls), 'Place the aws config file in the right place');
+};
+
+subtest '[qesap_aws_create_credentials]' => sub {
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesap_aws', no_auto => 1);
+    my @calls;
+    my @contents;
+
+    $qesap->redefine(script_output => sub { return 'eu-central-1'; });
+    $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
+    $qesap->redefine(save_tmp_file => sub { push @contents, @_; });
+    $qesap->redefine(autoinst_url => sub { return 'http://10.0.2.2/tests/'; });
+
+    qesap_aws_create_credentials(key => 'THEKEY', secret => 'THESECRET', conf_trgt => 'SOME_CONF.YAML');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    note("\n  CONTENT-->  " . join("\n  CONTENT-->  ", @contents));
+    ok((any { qr|mkdir -p ~/\.aws| } @calls), '.aws directory initialized');
+    ok((any { qr|curl.+/files/config.+~/\.aws/config| } @calls), 'AWS Config file downloaded');
+    is $contents[0], 'credentials', "AWS credentials file: credentials is the expected value and got $contents[0]";
+    like $contents[1], qr/aws_access_key_id/, "Expected aws_access_key_id is in the config file got $contents[1]";
+    like $contents[1], qr/aws_secret_access_key/, "Expected aws_secret_access_key is in the config file got $contents[1]";
+};
+
 
 done_testing;

--- a/tests/sles4sap/publiccloud/network_peering.pm
+++ b/tests/sles4sap/publiccloud/network_peering.pm
@@ -9,6 +9,7 @@ use warnings;
 use base 'sles4sap_publiccloud_basetest';
 use testapi;
 use sles4sap::qesap::qesapdeployment;
+use sles4sap::qesap::qesap_aws;
 use publiccloud::utils qw(is_azure is_ec2);
 
 sub test_flags {

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -208,14 +208,14 @@ sub run {
     $ansible_playbooks = create_playbook_section_list(%playbook_configs);
 
     # Prepare QESAP deployment
-    qesap_prepare_env(provider => $provider_setting);
+    qesap_prepare_env(provider => $provider_setting, region => get_required_var('PUBLIC_CLOUD_REGION'));
     qesap_create_ansible_section(ansible_section => 'create', section_content => $ansible_playbooks) if @$ansible_playbooks;
     qesap_create_ansible_section(
         ansible_section => 'hana_vars',
         section_content => create_hana_vars_section()) if $ha_enabled;
 
     # Regenerate config files (This workaround will be replaced with full yaml generator)
-    qesap_prepare_env(provider => $provider_setting, only_configure => 1);
+    qesap_prepare_env(provider => $provider_setting, only_configure => 1, region => get_required_var('PUBLIC_CLOUD_REGION'));
 
     my %retry_args = (
         logname => 'qesap_exec_terraform.log.txt',

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -132,8 +132,8 @@ sub run {
 
     qesap_prepare_env(
         openqa_variables => \%variables,
-        provider => get_required_var('PUBLIC_CLOUD_PROVIDER')
-    );
+        provider => get_required_var('PUBLIC_CLOUD_PROVIDER'),
+        region => $provider->provider_client->region);
 }
 
 sub test_flags {

--- a/tests/sles4sap/qesapdeployment/destroy.pm
+++ b/tests/sles4sap/qesapdeployment/destroy.pm
@@ -10,6 +10,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use sles4sap::qesap::qesapdeployment;
+use sles4sap::qesap::qesap_aws;
 
 sub run {
     select_serial_terminal;

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -9,6 +9,7 @@ use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use sles4sap::qesap::qesapdeployment;
+use sles4sap::qesap::qesap_aws;
 use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
 
 sub run {


### PR DESCRIPTION
Move functions related to AWS from qesapdeploy,pm to a dedicated lib. Library is still named qesap as some of the operations are not AWS generic but related to how qe-sap-deployment terraform AWS project is designed.
Some functions have been made private and UT has been adapted accordingly to get the same coverage.

- Related ticket:  https://jira.suse.com/browse/TEAM-8439

# Verification run: 

 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_angi_test -> http://openqaworker15.qa.suse.cz/tests/323935 :green_circle: 

 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test -> http://openqaworker15.qa.suse.cz/tests/323936 :green_circle: 


 - sle-15-SP6-HanaSr-Aws-Payg-x86_64-Build15-SP6_2025-05-12T02:03:21Z-hanasr_aws_test_peering ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/324114 :green_circle: 

- Maintenance Single Incident: https://openqaworker15.qa.suse.cz/tests/324113  :green_circle: https://openqaworker15.qa.suse.cz/tests/324112 :green_circle: 

