### PR TITLE
Check firewalld state and presence in JeOS

### DIFF
--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -21,19 +21,24 @@ use Utils::Architectures;
 
 sub run {
     my ($self) = @_;
+    select_serial_terminal;
+
     if ($self->firewall eq 'firewalld') {
+        # Useful to show the firewalld package version
+        # *firewall-cmd --version* returns the version only if FW is running
+        my $is_not_present = script_run('rpm -q firewalld');
         if (is_jeos && get_var('FLAVOR', '') =~ /cloud/i) {
-            script_run('rpm -q firewalld') or die "Firewalld is pre-installed on Minimal-VM cloud images";
+            record_info('No FW', 'MinimalVM\'s cloud image should have no firewall preinstalled');
+            $is_not_present or die "Firewalld is pre-installed on Minimal-VM cloud images";
             return;
         }
-        assert_script_run("firewall-cmd --version", fail_message => "firewall-cmd is not present");
-        if (script_output('firewall-cmd --state', timeout => 60, proceed_on_failure => 1) !~ /running/) {
+        if (script_output('firewall-cmd --state', timeout => 60, proceed_on_failure => 1) !~ /^running/) {
             if (is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/) {
                 # In case of upgrades from SFW2-based distros (Leap < 15.0 to TW) we end up without any firewall
                 record_soft_failure "boo#1144543 - Migration from SFW2 to firewalld: no firewall enabled";
                 return;
-            } elsif (is_jeos && is_vmware) {
-                record_info('No FW', 'MinimalVM\'s VMWare image has firewalld disabled');
+            } elsif (is_jeos && is_vmware && is_sle('<16.0')) {
+                record_info('FW disabled', 'MinimalVM\'s VMWare image has firewalld disabled');
             } else {
                 die "firewall-cmd is not running";
             }


### PR DESCRIPTION
MinimalVM/JeOS has image specific setup in terms of firewall

1) VMWare -> package is pre-installed, FW disabled 
2) Cloud -> package is NOT pre-installed
3) Others -> FW is running

`firewall-cmd --version` shows the version only if firewalld is
 running at that moment.

#### Verification runs

* [opensuse-Tumbleweed-NET-x86_64-Build20250506-minimalx](http://kepler.suse.cz/tests/24722#step/firewall_enabled/11)
* [15-SP7-JeOS-for-OpenStack-Cloud-x86_64-Build3.17-jeos-cloud-init](http://kepler.suse.cz/tests/24718#step/firewall_enabled/3)
* [sle-15-SP7-JeOS-for-OpenStack-Cloud-x86_64-Build3.17-jeos-wizard](http://kepler.suse.cz/tests/24719#step/firewall_enabled/3)
* [sle-15-SP7-JeOS-for-kvm-and-xen](http://kepler.suse.cz/tests/24720#step/firewall_enabled/1)
* [sle-15-SP3-JeOS-for-kvm-and-xen-Updates](http://kepler.suse.cz/tests/24721#step/firewall_enabled/1)
* [sle-15-SP7-JeOS-for-OpenStack-Cloud-s390x](https://openqa.suse.de/tests/17610053#step/firewall_enabled/3)
* [15-SP7-JeOS-for-OpenStack-Cloud-aarch64](https://openqa.suse.de/tests/17610036#step/firewall_enabled/3)
* [15-SP7-JeOS-for-MS-HyperV-x86_64](https://openqa.suse.de/tests/17610035)
* [sle-16.0-Minimal-VM-for-VMware](https://openqa.suse.de/tests/17610037)
* [sle-15-SP7-JeOS-for-VMware](https://openqa.suse.de/tests/17610042#step/firewall_enabled/2)