### PR TITLE
Add ip_cidr_range to GCP HanaSR

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -11,8 +11,6 @@ apiver: 3
 terraform:
   variables:
     # GENERAL VARIABLES #
-    vnet_address_range: "%MAIN_ADDRESS_RANGE%"
-    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
     az_region: '%PUBLIC_CLOUD_REGION%'
     deployment_name: '%QESAP_DEPLOYMENT_NAME%'
     admin_user: 'cloudadmin'
@@ -22,6 +20,8 @@ terraform:
     # IBSM PEERING VARIABLES
     ibsm_rg: '%IBSM_RG%'
     ibsm_vnet_name: '%IBSM_VNET%'
+    vnet_address_range: "%MAIN_ADDRESS_RANGE%"
+    subnet_address_range: "%SUBNET_ADDRESS_RANGE%"
 
     # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
@@ -23,6 +23,7 @@ terraform:
     ibsm_vpc_name: '%IBSM_VPC_NAME%'
     ibsm_subnet_name: '%IBSM_SUBNET_NAME%'
     ibsm_subnet_region: '%IBSM_SUBNET_REGION%'
+    ip_cidr_range: '%MAIN_ADDRESS_RANGE%'
 
     # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'


### PR DESCRIPTION
Add ip_cidr_range terraform variable to the conf.yaml used by HanaSR.


- Related ticket: https://jira.suse.com/browse/TEAM-10231

# Verification run:

 - sle-15-SP6-HanaSr-Gcp-Byos-x86_64-Build15-SP6_2025-05-07T02:03:20Z-hanasr_gcp_test_peering@gce_n1_highmem_32 -> http://openqaworker15.qa.suse.cz/tests/323600