### PR TITLE
Fix incorrect DB data collection

### DIFF
--- a/lib/sles4sap/sap_host_agent.pm
+++ b/lib/sles4sap/sap_host_agent.pm
@@ -14,7 +14,6 @@ use Carp qw(croak);
 use Exporter qw(import);
 
 our @EXPORT = qw(
-  saphostctrl_list_databases
   parse_instance_name
   saphostctrl_list_instances
 );
@@ -28,55 +27,6 @@ data about instances and performing various operations. Keep in mind that comman
 B<root> or B<sidadm>.
 
 =cut
-
-=head2 saphostctrl_list_databases
-
-    saphostctrl_list_databases([as_root=>1]);
-
-Uses C<saphostctrl> to get list of all databases residing on host. Returns parsed output as B<ARRAYREF>.
-Data for each DB is contained in a B<HASH>
-Example:
-$VAR1 = {
-          'Hostname' => 'qesdhdb01l029',
-          'Release' => '2.00.075.00.1702888292',
-          'Vendor' => 'HDB', # HDB = SAP hana database (not SID)
-          'Type' => 'hdb', # type of hana DB - hdb, mdc (multitenant), systemdb
-          'Instance name' => 'PRD00'
-        };
-$VAR2 = {
-          'Hostname' => 'qesdhdb01l029',
-          'Type' => 'hdb',
-          'Release' => '2.00.075.00.1702888292',
-          'Instance name' => 'QAS01',
-          'Vendor' => 'HDB'
-        };
-
-=over
-
-=item * B<as_root>: Execute command using sudo. Default: false
-
-=back
-=cut
-
-sub saphostctrl_list_databases {
-    my (%args) = @_;
-    assert_script_run("[ -f $saphostctrl ]");
-
-    # command returns data for each DB in new line = one array entry for each DB
-    my $sudo = $args{as_root} ? 'sudo' : '';
-    my $cmd = join(' ', $sudo, $saphostctrl, '-function', 'ListDatabases', '| grep Instance');
-    my @output = split("\n", script_output($cmd, timeout => 180));
-
-    # create hash with data from each array entry
-    @output = map { { split(/,\s|:\s/, $_) } } @output;
-
-    my @result;
-    # change hash keys to lower case and replace spaces with underscore
-    for my $entry (@output) {
-        push(@result, {map { lc($_ =~ s/\s/_/gr) => $entry->{$_} } keys %$entry});
-    }
-    return (\@result);
-}
 
 =head2 parse_instance_name
 

--- a/t/31_sap_host_agent.t
+++ b/t/31_sap_host_agent.t
@@ -7,47 +7,6 @@ use Test::MockModule;
 use testapi;
 use sles4sap::sap_host_agent;
 
-subtest '[saphostctrl_list_databases] Verify command compilation' => sub {
-    my $saphostctrl_output = 'Instance name: PRD00, Hostname: qesdhdb01l029, Vendor: HDB, Type: hdb, Release: 42';
-    my $mock = Test::MockModule->new('sles4sap::sap_host_agent', no_auto => 1);
-    my @calls;
-    $mock->redefine(script_output => sub { push @calls, $_[0]; return $saphostctrl_output; });
-    $mock->redefine(assert_script_run => sub { return 0; });
-
-    saphostctrl_list_databases();
-    note("\n  -->  " . join("\n  -->  ", @calls));
-    ok((grep /saphostctrl/, @calls), 'Execute "saphostctrl" binary');
-    ok((grep /-function ListDatabases/, @calls), 'Execute "ListDatabases" function');
-    ok((grep /\| grep Instance/, @calls), 'Show only "Instances" entries');
-};
-
-subtest '[saphostctrl_list_databases] Verify command compilation - executed as root' => sub {
-    my $saphostctrl_output = 'Instance name: PRD00, Hostname: qesdhdb01l029, Vendor: HDB, Type: hdb, Release: 42';
-    my $mock = Test::MockModule->new('sles4sap::sap_host_agent', no_auto => 1);
-    my @calls;
-    $mock->redefine(script_output => sub { push @calls, $_[0]; return $saphostctrl_output; });
-    $mock->redefine(assert_script_run => sub { return 0; });
-
-    saphostctrl_list_databases(as_root => 1);
-    note("\n  -->  " . join("\n  -->  ", @calls));
-    ok((grep /sudo/, @calls), 'Execute as root');
-};
-
-subtest '[saphostctrl_list_databases] Verify output' => sub {
-    my $saphostctrl_output = 'Instance name: PRD00, Hostname: qesdhdb01l029, Vendor: HDB, Type: hdb, Release: 42';
-
-    my $mock = Test::MockModule->new('sles4sap::sap_host_agent', no_auto => 1);
-    $mock->redefine(script_output => sub { return $saphostctrl_output; });
-    $mock->redefine(assert_script_run => sub { return 0; });
-
-    my @output = @{saphostctrl_list_databases()};
-    is $output[0]->{instance_name}, 'PRD00', 'Check "instance_name" value';
-    is $output[0]->{hostname}, 'qesdhdb01l029', 'Check "hostname" value';
-    is $output[0]->{vendor}, 'HDB', 'Check "vendor" value';
-    is $output[0]->{type}, 'hdb', 'Check "type" value';
-    is $output[0]->{release}, '42', 'Check "release" value';
-};
-
 subtest '[parse_instance_name] ' => sub {
     my ($sid, $id) = @{parse_instance_name('POO08')};
     is $sid, 'POO', "Return correct SID: $sid";

--- a/tests/sles4sap/redirection_tests/hana_sr_primary_failover.pm
+++ b/tests/sles4sap/redirection_tests/hana_sr_primary_failover.pm
@@ -13,7 +13,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use sles4sap::console_redirection;
 use hacluster qw(wait_for_idle_cluster wait_until_resources_started show_cluster_parameter);
-use sles4sap::sap_host_agent qw(saphostctrl_list_databases parse_instance_name);
+use sles4sap::sap_host_agent qw(saphostctrl_list_instances );
 use sles4sap::database_hana;
 use sles4sap::sapcontrol qw(sapcontrol_process_check sap_show_status_info);
 use Carp qw(croak);
@@ -54,10 +54,11 @@ sub run {
     check_node_roles(expected_primary => $expected_primary_db, expected_failover => $expected_failover_db);
 
     # Retrieve database information: DB SID and instance ID
-    my @db_data = @{(saphostctrl_list_databases())};
+    my @db_data = @{saphostctrl_list_instances(running => 'yes')};
     record_info('DB data', Dumper(@db_data));
     die('Multiple databases on one host not supported') if @db_data > 1;
-    my ($db_sid, $db_id) = @{parse_instance_name($db_data[0]->{instance_name})};
+    my $db_sid = $db_data[0]->{sap_sid};
+    my $db_id = $db_data[0]->{instance_id};
 
     # Perform failover on primary
     record_info('Failover', "Performing failover method '$failover_method' on database '$expected_primary_db'");

--- a/tests/sles4sap/redirection_tests/hana_sr_replica_failover.pm
+++ b/tests/sles4sap/redirection_tests/hana_sr_replica_failover.pm
@@ -13,7 +13,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use sles4sap::console_redirection;
 use sles4sap::database_hana;
-use sles4sap::sap_host_agent qw(saphostctrl_list_databases parse_instance_name);
+use sles4sap::sap_host_agent qw(saphostctrl_list_instances);
 use sles4sap::sapcontrol qw(sapcontrol_process_check sap_show_status_info);
 use hacluster qw(wait_for_idle_cluster wait_until_resources_started);
 use Data::Dumper;
@@ -53,10 +53,11 @@ sub run {
     my $node_roles = get_node_roles();
 
     # Retrieve database information: DB SID and instance ID
-    my @db_data = @{(saphostctrl_list_databases())};
+    my @db_data = @{saphostctrl_list_instances(running => 'yes')};
     record_info('DB data', Dumper(@db_data));
     die('Multiple databases on one host not supported') if @db_data > 1;
-    my ($db_sid, $db_id) = @{parse_instance_name($db_data[0]->{instance_name})};
+    my $db_sid = $db_data[0]->{sap_sid};
+    my $db_id = $db_data[0]->{instance_id};
 
     # Perform failover on replica
     record_info('Failover', "Performing failover method '$failover_method' on database '$expected_failover_db'");


### PR DESCRIPTION
SDAF test modules currently collects data about DB SID and DB ID from an incorrect host agent command. Tests are passing only by coincidence. This PR fixes the issue.

- Verification run: https://openqaworker15.qa.suse.cz/tests/323622#live
