### PR TITLE
Add SELinux setup required by HANA

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -1049,8 +1049,8 @@ Package and upload HANA installation logs from SUT.
 
 sub upload_hana_install_log {
     my @hana_logs = qw(/var/adm/autoinstall/logs /var/tmp/hdb*);
-    push(@hana_logs, "/var/log/SAPBusinessOne/B1Installer*") if get_var('BONE');
-    script_run 'tar -Jcf /tmp/hana_install.log.tar.xz ' . join(' ', map { "'$_'" } @hana_logs);
+    push(@hana_logs, '/var/log/SAPBusinessOne/B1Installer*') if get_var('BONE');
+    script_run 'tar -Jcf /tmp/hana_install.log.tar.xz ' . join(' ', @hana_logs);
     upload_logs '/tmp/hana_install.log.tar.xz';
 }
 


### PR DESCRIPTION
On SLES for SAP 16, in order to install HANA, we need to add additional commands to configure SELinux so the HANA installation is successful without disabling SELinux. This commit adds the required commands to the `sles4sap/hana_install` test module.

- Related ticket: https://jira.suse.com/browse/TEAM-10343
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17625440 :green_circle: , https://openqa.suse.de/tests/17625536 :green_circle: , https://openqa.suse.de/tests/17625674 :green_circle: 