### PR TITLE
Add ha_barriers_ready mutex creation also in ensa_barriers

### DIFF
--- a/tests/sles4sap/ensa/ensa_barriers.pm
+++ b/tests/sles4sap/ensa/ensa_barriers.pm
@@ -74,6 +74,11 @@ sub run {
     create_general_ha_barriers();
     create_ensa_only_barriers();
 
+    # Create a final mutex to signal all jobs that barriers are ready to use
+    # It must be used with mutex_wait() before any barrier_wait() calls in the jobs
+    # Taken from ha/barriers_init
+    mutex_create('ha_barriers_ready');
+
     # Wait for all children to start
     # Children are server/test suites that use the PARALLEL_WITH variable
     wait_for_children_to_start();


### PR DESCRIPTION
Commit 5693fd7e70b8584c4447328f77c476122c790b38 which added a mutex to signal when barriers are ready to use, failed to also add the mutex to the test module `sles4sap/ensa/ensa_barriers` which is used in the ENSA2 scenario to create the barriers instead of the usual `ha/barrier_init`. This commit fixes the issue.

- Related PR: #21988
- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
