### PR TITLE
Use proper known_hosts in kirk call for PC LTP

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -175,7 +175,7 @@ sub run {
     $sut .= ':host=' . $instance->public_ip;
     $sut .= ':reset_cmd=\'' . $reset_cmd . '\'';
     $sut .= ':hostkey_policy=missing';
-    $sut .= ':known_hosts=/dev/null';
+    $sut .= ':known_hosts=~/.ssh/known_hosts';
 
     my $cmd = 'python3.11 kirk ';
     $cmd .= "--framework ltp ";


### PR DESCRIPTION
Current implementation results in [silent fail](https://openqa.suse.de/tests/17609387#step/run_ltp/82 )
- Verification run: [https://openqa.suse.de/tests/17608588](https://openqa.suse.de/tests/17608588#step/run_ltp/82)
