### PR TITLE
Stop firewall before disabling it in wicked tests

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -191,7 +191,8 @@ EOT
     # Disable firewall by default.
     # Tests which need firewall, should explicit enable it
     if (script_run('systemctl is-active -q ' . opensusebasetest::firewall) == 0) {
-        systemctl("disable --now " . opensusebasetest::firewall);
+        systemctl("stop " . opensusebasetest::firewall);
+        systemctl("disable " . opensusebasetest::firewall);
     }
     record_info('PKG', script_output(q(rpm -qa 'wicked*' --qf '%{NAME}\n' | sort | uniq | xargs rpm -qi)));
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/182003


- Verification run:
[sle12](http://openqa.suse.de/tests/17622116#dependencies)
[sle15](http://openqa.suse.de/tests/17622133#dependencies)