### PR TITLE
Add tests for TPM+PIN enrollment

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1113,11 +1113,11 @@ without LVM configuration (cr_swap,cr_home etc).
 
 sub need_unlock_after_bootloader {
     my $is_enc_cc_s390x = check_var('SYSTEM_ROLE', 'Common_Criteria') && check_var('FULL_LVM_ENCRYPT', '1') && is_s390x;
-
+    my $method = get_var('FDE_UNLOCK_METHOD', 'TPM');
     my $need_unlock_after_bootloader = is_leap('<15.6') || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || (!get_var('LVM', '0') && !get_var('FULL_LVM_ENCRYPT', '0')) || $is_enc_cc_s390x;
     return 0 if is_boot_encrypted && !$need_unlock_after_bootloader;
     # MicroOS with sdboot or grub2-bls supports automatic TPM based unlocking (as long as no additional PIN is set).
-    return 0 if is_microos && (is_bootloader_sdboot || is_bootloader_grub2_bls) && get_var('QEMUTPM') && check_var('FDE_UNLOCK_METHOD', 'TPM');
+    return 0 if is_microos && (is_bootloader_sdboot || is_bootloader_grub2_bls) && get_var('QEMUTPM') && $method eq 'TPM';
     return 1;
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -374,6 +374,14 @@ sub unlock_if_encrypted {
         handle_grub_zvm($console);
         unlock_zvm_disk($console);
     }
+    elsif (check_var('FDE_UNLOCK_METHOD', 'TPM_PIN')) {
+        assert_screen("encrypted-disk-tpm-pin-prompt", 200);
+        my $pin = get_var('FDE_UNLOCK_TPM_PIN', $password);
+        type_password $pin;
+        save_screenshot;
+        send_key "ret";
+        wait_still_screen 15;
+    }
     else {
         assert_screen("encrypted-disk-password-prompt", 200);
         type_password $password;
@@ -1108,8 +1116,8 @@ sub need_unlock_after_bootloader {
 
     my $need_unlock_after_bootloader = is_leap('<15.6') || is_sle('<15-sp6') || is_leap_micro || is_sle_micro || (!get_var('LVM', '0') && !get_var('FULL_LVM_ENCRYPT', '0')) || $is_enc_cc_s390x;
     return 0 if is_boot_encrypted && !$need_unlock_after_bootloader;
-    # MicroOS with sdboot supports automatic TPM based unlocking.
-    return 0 if is_microos && (is_bootloader_sdboot || is_bootloader_grub2_bls) && get_var('QEMUTPM');
+    # MicroOS with sdboot or grub2-bls supports automatic TPM based unlocking (as long as no additional PIN is set).
+    return 0 if is_microos && (is_bootloader_sdboot || is_bootloader_grub2_bls) && get_var('QEMUTPM') && check_var('FDE_UNLOCK_METHOD', 'TPM');
     return 1;
 }
 

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -299,7 +299,7 @@ sub run {
                 type_password $pin;
                 send_key 'ret';
             } else {
-                # We need to explicitly press 'Done' since we chose not to use any TPM-based unlocking method despite a TPM being available, hence we deliberately left options unused.
+# We need to explicitly press 'Done' since we chose not to use any TPM-based unlocking method despite a TPM being available, hence we deliberately left options unused.
                 send_key_until_needlematch 'jeos-fde-option-done', 'down' unless check_screen('jeos-fde-option-done', 1);
                 send_key 'ret';
             }

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -283,8 +283,13 @@ sub run {
 
         # The following options are only shown when a TPM device is available
         if (get_var('QEMUTPM')) {
+            my $method = get_var('FDE_UNLOCK_METHOD', 'TPM');
+
             # Allow either enrolling tpm with or without pin, not both, hence we want to choose between these options
-            if (check_var('FDE_UNLOCK_METHOD', 'TPM_PIN')) {
+            if ($method eq 'TPM') {
+                send_key_until_needlematch 'jeos-fde-option-enroll-tpm', 'down' unless check_screen('jeos-fde-option-enroll-tpm', 1);
+                send_key 'ret';
+            } elsif ($method eq 'TPM_PIN') {
                 my $pin = get_var('FDE_UNLOCK_TPM_PIN', $testapi::password);
                 send_key_until_needlematch 'jeos-fde-option-enroll-tpm-pin', 'down' unless check_screen('jeos-fde-option-enroll-tpm-pin', 1);
                 send_key "ret";
@@ -293,11 +298,8 @@ sub run {
                 wait_still_screen 2;
                 type_password $pin;
                 send_key 'ret';
-            } elsif (check_var('FDE_UNLOCK_METHOD', 'TPM')) {
-                send_key_until_needlematch 'jeos-fde-option-enroll-tpm', 'down' unless check_screen('jeos-fde-option-enroll-tpm', 1);
-                send_key 'ret';
             } else {
-# We need to explicitly press 'Done' since we chose not to use any TPM-based unlocking method despite a TPM being available, hence we deliberately left options unused.
+                # We need to explicitly press 'Done' since we chose not to use any TPM-based unlocking method despite a TPM being available, hence we deliberately left options unused.
                 send_key_until_needlematch 'jeos-fde-option-done', 'down' unless check_screen('jeos-fde-option-done', 1);
                 send_key 'ret';
             }

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -281,12 +281,27 @@ sub run {
         send_key_until_needlematch 'jeos-fde-option-enroll-root-pw', 'down' unless check_screen('jeos-fde-option-enroll-root-pw', 1);
         send_key 'ret';
 
+        # The following options are only shown when a TPM device is available
         if (get_var('QEMUTPM')) {
-            send_key_until_needlematch 'jeos-fde-option-enroll-tpm', 'down' unless check_screen('jeos-fde-option-enroll-tpm', 1);
-            send_key 'ret';
+            # Allow either enrolling tpm with or without pin, not both, hence we want to choose between these options
+            if (check_var('FDE_UNLOCK_METHOD', 'TPM_PIN')) {
+                my $pin = get_var('FDE_UNLOCK_TPM_PIN', $testapi::password);
+                send_key_until_needlematch 'jeos-fde-option-enroll-tpm-pin', 'down' unless check_screen('jeos-fde-option-enroll-tpm-pin', 1);
+                send_key "ret";
+                type_password $pin;
+                send_key "ret";
+                wait_still_screen 2;
+                type_password $pin;
+                send_key 'ret';
+            } elsif (check_var('FDE_UNLOCK_METHOD', 'TPM')) {
+                send_key_until_needlematch 'jeos-fde-option-enroll-tpm', 'down' unless check_screen('jeos-fde-option-enroll-tpm', 1);
+                send_key 'ret';
+            } else {
+# We need to explicitly press 'Done' since we chose not to use any TPM-based unlocking method despite a TPM being available, hence we deliberately left options unused.
+                send_key_until_needlematch 'jeos-fde-option-done', 'down' unless check_screen('jeos-fde-option-done', 1);
+                send_key 'ret';
+            }
         }
-
-        # All options used up, so no need to press 'Done' explicitly anymore.
 
         # Continues below to verify that /etc/issue shows the recovery key
     }

--- a/variables.md
+++ b/variables.md
@@ -84,6 +84,8 @@ EXTRABOOTPARAMS_LINE_OFFSET | integer | | Line offset for `linux` line in grub w
 EXTRABOOTPARAMS_DELETE_CHARACTERS | string | | Characters to delete from boot prompt.
 EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET | string | | If specified, go back with the cursor until this needle is matched to delete characters from there. Needs EXTRABOOTPARAMS_BOOT_LOCAL and should be combined with EXTRABOOTPARAMS_DELETE_CHARACTERS.
 EXTRATEST | boolean | false | Enables execution of extra tests, see `load_extra_tests`
+FDE_UNLOCK_METHOD | string | TPM_PIN | Chooses a unlocking method for full disc encryption. Currently, only "TPM" and "TPM_PIN" are supported values. Support for "FIDO2" is planned.
+FDE_UNLOCK_TPM_PIN | string | | Defines a PIN for use with the TPM_PIN method for FDE. Uses default password if undefined. Ignored if "FDE_UNLOCK_METHOD" is not set to "TPM_PIN".
 FIRST_BOOT_CONFIG | string | combustion+ignition | The method used for initial configuration of MicroOS images. Possible values are: `combustion`, `ignition`, `combustion+ignition` and `wizard`. For ignition/combustion, the job needs to have a matching HDD attached.
 FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DVD`, `Krypton`, `Argon`, `Gnome-Live`, `DVD`, `Rescue-CD`, etc.
 FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only.

--- a/variables.md
+++ b/variables.md
@@ -84,7 +84,7 @@ EXTRABOOTPARAMS_LINE_OFFSET | integer | | Line offset for `linux` line in grub w
 EXTRABOOTPARAMS_DELETE_CHARACTERS | string | | Characters to delete from boot prompt.
 EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET | string | | If specified, go back with the cursor until this needle is matched to delete characters from there. Needs EXTRABOOTPARAMS_BOOT_LOCAL and should be combined with EXTRABOOTPARAMS_DELETE_CHARACTERS.
 EXTRATEST | boolean | false | Enables execution of extra tests, see `load_extra_tests`
-FDE_UNLOCK_METHOD | string | TPM_PIN | Chooses a unlocking method for full disc encryption. Currently, only "TPM" and "TPM_PIN" are supported values. Support for "FIDO2" is planned.
+FDE_UNLOCK_METHOD | string | TPM_PIN | Chooses a unlocking method for full disc encryption. Currently, only "TPM" and "TPM_PIN" are supported values. Support for "FIDO2" is planned. Defaults to "TPM" if undefined.
 FDE_UNLOCK_TPM_PIN | string | | Defines a PIN for use with the TPM_PIN method for FDE. Uses default password if undefined. Ignored if "FDE_UNLOCK_METHOD" is not set to "TPM_PIN".
 FIRST_BOOT_CONFIG | string | combustion+ignition | The method used for initial configuration of MicroOS images. Possible values are: `combustion`, `ignition`, `combustion+ignition` and `wizard`. For ignition/combustion, the job needs to have a matching HDD attached.
 FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DVD`, `Krypton`, `Argon`, `Gnome-Live`, `DVD`, `Rescue-CD`, etc.


### PR DESCRIPTION
This PR adds tests for enrolling the TPM+PIN unlocking method in MicroOS as well as the necessary variables to configure these tests.

Using the variable `FDE_UNLOCK_METHOD`, the unlocking method can be set to `TPM` or `TPM_PIN`, respectively, with `TPM` being the default behaviour if this variable is not set.

Using the variable `FDE_UNLOCK_TPM_PIN` in conjunction with `FDE_UNLOCK_METHOD` being set to `TPM_PIN`, a separate PIN can be defined for the TPM+PIN method. If not set, the default password will be used as PIN instead.

- Related ticket:
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/836 https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/837
- Verification run: http://localhost/tests/52#step/ansible/31
