### PR TITLE
Wipe existed disks on  powerVM for Autoyast scenarios in Agama

### DIFF
--- a/data/yam/agama/auto/autoyast_supported.xml
+++ b/data/yam/agama/auto/autoyast_supported.xml
@@ -101,6 +101,15 @@ systemLog:
     </user>
   </users>
   <scripts>
+    <pre-scripts config:type="list">
+      <script>
+        <filename>pre.sh</filename>
+        <source><![CDATA[
+#!/usr/bin/env bash
+agama questions mode non-interactive
+]]></source>
+      </script>
+    </pre-scripts>
     <chroot-scripts config:type="list">
       <script>
         <file_name>post.sh</file_name>


### PR DESCRIPTION
We have added the plain script to wipe the disk, the main problem is to retrieve the output of the script.
Currently, Agama can't fetch pre-scripts output. We could include the output to a temporal file to check after the test.

- Related ticket: https://progress.opensuse.org/issues/181355
- Needles: N/A
- Verification run:
  - With this branch:
    - 1: https://openqa.suse.de/tests/17634237
    - 2: https://openqa.suse.de/tests/17634238
    - 3: https://openqa.suse.de/tests/17634239
    - 4: https://openqa.suse.de/tests/17634240
    - 5: https://openqa.suse.de/tests/17634241
    - 6: https://openqa.suse.de/tests/17634242
    - 7: https://openqa.suse.de/tests/17634243
    - 8: https://openqa.suse.de/tests/17634244
    - 9: https://openqa.suse.de/tests/17634245
    - 10: https://openqa.suse.de/tests/17634246
    - 11: https://openqa.suse.de/tests/17634247
    - 12: https://openqa.suse.de/tests/17634248
    - 13: https://openqa.suse.de/tests/17634249
    - 14: https://openqa.suse.de/tests/17634250
    - 15: https://openqa.suse.de/tests/17634251
    - 16: https://openqa.suse.de/tests/17634252
    - 17: https://openqa.suse.de/tests/17634253
    - 18: https://openqa.suse.de/tests/17634254
    - 19: https://openqa.suse.de/tests/17634255
    - 20: https://openqa.suse.de/tests/17634256
  - With master branch:
    - 1: https://openqa.suse.de/tests/17624169
    - 2: https://openqa.suse.de/tests/17624170
    - 3: https://openqa.suse.de/tests/17624172
    - 4: https://openqa.suse.de/tests/17624173
    - 5: https://openqa.suse.de/tests/17624174
    - 6: https://openqa.suse.de/tests/17624175
    - 7: https://openqa.suse.de/tests/17624176
    - 8: https://openqa.suse.de/tests/17624177
    - 9: https://openqa.suse.de/tests/17624178
    - 10: https://openqa.suse.de/tests/17624179
    - 11: https://openqa.suse.de/tests/17624180
    - 12: https://openqa.suse.de/tests/17624181
    - 13: https://openqa.suse.de/tests/17624182
    - 14: https://openqa.suse.de/tests/17624183
    - 15: https://openqa.suse.de/tests/17624184
    - 16: https://openqa.suse.de/tests/17624185
    - 17: https://openqa.suse.de/tests/17624186
    - 18: https://openqa.suse.de/tests/17624187
    - 19: https://openqa.suse.de/tests/17624188
    - 20:  https://openqa.suse.de/tests/17624189


OLD TESTING:
    - 1: https://openqa.suse.de/tests/17624144
    - 2: https://openqa.suse.de/tests/17624145 FAILED, restart: https://openqa.suse.de/tests/17625848
    - 3: https://openqa.suse.de/tests/17624146 FAILED, restart: https://openqa.suse.de/tests/17625849
    - 4: https://openqa.suse.de/tests/17624147
    - 5: https://openqa.suse.de/tests/17624148 FAILED, restarted: https://openqa.suse.de/tests/17625850
    - 6: https://openqa.suse.de/tests/17624149
    - 7: https://openqa.suse.de/tests/17624150 FAILED, restarted: https://openqa.suse.de/tests/17625851
    - 8: https://openqa.suse.de/tests/17624151 FAILED, restarted: https://openqa.suse.de/tests/17625852
    - 9: https://openqa.suse.de/tests/17624152
    - 10: https://openqa.suse.de/tests/17624153
    - 11: https://openqa.suse.de/tests/17624154
    - 12: https://openqa.suse.de/tests/17624157
    - 13: https://openqa.suse.de/tests/17624158
    - 14: https://openqa.suse.de/tests/17624159
    - 15: https://openqa.suse.de/tests/17624160
    - 16: https://openqa.suse.de/tests/17624161
    - 17: https://openqa.suse.de/tests/17624162
    - 18: https://openqa.suse.de/tests/17624163
    - 19: https://openqa.suse.de/tests/17624165
    - 20: https://openqa.suse.de/tests/17624166
We have detected some errors related to GPT definition 
![image](https://github.com/user-attachments/assets/e9831961-c6f6-4bc1-8cf1-434b9f27ab56)
