### PR TITLE
Add ip=dhcp in kernel parameter on powerVM

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -131,7 +131,7 @@ sub enter_netboot_parameters {
     }
     my $ntlm_p = get_var('NTLM_AUTH_INSTALL') ? $ntlm_auth::ntlm_proxy : '';
     if (is_agama) {
-        type_string_slow "linux $mntpoint/linux root=live:http://" . get_var('OPENQA_HOSTNAME') . "/assets/iso/" . get_var('ISO') . " live.password=$testapi::password console=hvc0";
+        type_string_slow "linux $mntpoint/linux root=live:http://" . get_var('OPENQA_HOSTNAME') . "/assets/iso/" . get_var('ISO') . " live.password=$testapi::password console=hvc0 ip=dhcp";
         # inst.auto and inst.install_url are defined in below function
         specific_bootmenu_params;
         type_string_slow " " . get_var('EXTRABOOTPARAMS') . " " if (get_var('EXTRABOOTPARAMS'));


### PR DESCRIPTION
As https://bugzilla.suse.com/show_bug.cgi?id=1241969#c36, we need add ip=dhcp in kernel parameter on powerVM.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17631747#step/boot_agama/26