### PR TITLE
Avoid calling PC post_run_hook for SLES4SAP tests

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -214,6 +214,10 @@ sub post_fail_hook {
 
 sub post_run_hook {
     my ($self) = @_;
+    if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
+        # SAP/HA Public Cloud test case uses its own cleanup procedure (for example: loadtest qesap_cleanup.pm)
+        return;
+    }
     $self->finalize() unless $self->{finalize_called};
 }
 


### PR DESCRIPTION
Avoid calling PC post_fail_hook for the SLES4SAP tests to fix PC mr_test test module ssh_interactive_end has ERROR when doing "terraform destroy":   
do not run  post_run_hook which includes tear down.

TEAM-10315 - [PC][mr_test] Test module ssh_interactive_end has ERROR when doing "terraform destroy"

- Related ticket: https://jira.suse.com/browse/TEAM-10315
- Verification run:   
15-SP6 Azure mr_test: https://openqa.suse.de/tests/17631778#step/ssh_interactive_end/15 :green_circle: 
15-SP7 Azure mr_test: https://openqa.suse.de/tests/17631668#step/ssh_interactive_end/15 :green_circle: 
15-SP7 EC2 mr_test: https://openqa.suse.de/tests/17631775#step/ssh_interactive_end/15 :green_circle: 
15-SP7 GCE mr_test: https://openqa.suse.de/tests/17631777#step/ssh_interactive_end/15 :green_circle: 
15-SP7 Azure -publiccloud_containers: https://openqa.suse.de/tests/17632029#step/ssh_interactive_end/223 :green_circle: 
