### PR TITLE
Adapt test data for new module of systems management

### DIFF
--- a/test_data/yast/skip_registration/default_repos.yaml
+++ b/test_data/yast/skip_registration/default_repos.yaml
@@ -15,8 +15,18 @@ repos:
     uri: cd:/\?devices=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_cd0
     enabled: 'No'
     filter: name
+  - name: sle-module-python3
+    alias: Python-3
+    uri: cd:/\?devices=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_cd0
+    enabled: 'No'
+    filter: name
+  - name: sle-module-systems-management
+    alias: Systems-Management
+    uri: cd:/\?devices=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_cd0
+    enabled: 'No'
+    filter: name
   - name: SLES
-    nr: 3
+    nr: 4
     alias: SLES
     uri: cd:/\?devices=/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_cd0
     enabled: 'No'


### PR DESCRIPTION
A new module of systems management is added to 15SP7, and it is seleceted in Full media installation, adapt the test data for checking the repo list for the added module.

- Related ticket: https://progress.opensuse.org/issues/181958
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/17631999#step/validate_repos/21
