### PR TITLE
Wait for start of filesystem resource

### DIFF
--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -139,7 +139,7 @@ EDITOR='sed -ie \"\$ a order order_$fs_rsc Mandatory: vg_$resource $fs_rsc\"\' c
         rsc_cleanup $fs_rsc if defined($clean_flag) && $clean_flag == 'cleanup';
 
         # Wait to get Filesystem running on all nodes (if applicable)
-        sleep 5;
+        wait_until_resources_started;
     }
     else {
         diag 'Wait until Filesystem resource is added...';


### PR DESCRIPTION
Get rid of `sleep` and provide a proper wait for cluster resources

- Related ticket: https://jira.suse.com/browse/TEAM-10344
- Needles: n/a
- Verification runs:
  - https://openqa.suse.de/tests/17625510
  - https://openqa.suse.de/tests/17625511
  - https://openqa.suse.de/tests/17625512
  - https://openqa.suse.de/tests/17625513
  - https://openqa.suse.de/tests/17625503#step/filesystem/76
  - https://openqa.suse.de/tests/17625504
  - https://openqa.suse.de/tests/17625505
  - https://openqa.suse.de/tests/17625506
  - https://openqa.suse.de/tests/17625507#step/filesystem/76
  - https://openqa.suse.de/tests/17625508
  - https://openqa.suse.de/tests/17625509

x86_64 test now passes the filesystem step, which is the ticket acceptance criteria; subsequent failure will be triaged and addressed in a separate task. 

