### PR TITLE
Fix sporadic error in ensa_filesystems after moving test to serial

### DIFF
--- a/tests/sles4sap/ensa/ensa_filesystems.pm
+++ b/tests/sles4sap/ensa/ensa_filesystems.pm
@@ -37,14 +37,20 @@ sub run {
         # Create the partitions
         assert_script_run("mkdir -p $sap_dir/$instance_dir");
         assert_script_run("parted -s $lun_path --list");
-        assert_script_run("parted -s $lun_path mklabel gpt");
-        assert_script_run("parted -s $lun_path mkpart primary 0% 50%");
-        script_run('partprobe -s');
-        assert_script_run("parted -s $lun_path mkpart primary 50% 100%");
         # From the manual: changes will *probably* be made to the disk
         # immediately after typing a command. However, the operating system’s
         # cache and the disk’s hardware cache may delay this. When using serial
         # we hit this limitation, to avoid that we run partprobe and parted again.
+        script_run('partprobe');
+        script_run('partprobe -s');
+        assert_script_run("parted -s $lun_path mklabel gpt");
+        script_run('partprobe');
+        script_run('partprobe -s');
+        assert_script_run("parted -s $lun_path mkpart primary 0% 50%");
+        script_run('partprobe');
+        script_run('partprobe -s');
+        assert_script_run("parted -s $lun_path mkpart primary 50% 100%");
+        script_run('partprobe');
         script_run('partprobe -s');
         assert_script_run("parted -s $lun_path --list");
 


### PR DESCRIPTION
The serial terminal is too fast and the test moves on before the kernel syncs the updates the partition table. This intersperses the calls to parted with partprobe that will hopefully make the kernel sync them.

- Related Ticket: TEAM-10321
- Verification run: https://qesapworker-prg8.qa.suse.cz/group_overview/1 Failures are unrelated