### PR TITLE
Replace hardcoded 'eth0' with network_utils::iface() function

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -20,6 +20,7 @@ use isotovideo;
 use maintenance_smelt qw(get_incident_packages);
 use x11utils qw(ensure_unlocked_desktop);
 use Utils::Logging qw(export_logs);
+use network_utils qw(iface);
 use Carp qw(croak);
 use Data::Dumper;
 
@@ -288,7 +289,7 @@ Returns the IP address of SUT or 0 if the address cannot be determined. Special 
 =cut
 
 sub get_my_ip {
-    my $netdevice = get_var('SUT_NETDEVICE', 'eth0');
+    my $netdevice = get_var('SUT_NETDEVICE', iface());
     my $node_ip = script_output "ip -4 addr show dev $netdevice | sed -rne '/inet/s/[[:blank:]]*inet ([0-9\\.]*).*/\\1/p'";
     return _just_the_ip($node_ip);
 }

--- a/tests/ha/ctdb.pm
+++ b/tests/ha/ctdb.pm
@@ -14,8 +14,9 @@ use testapi;
 use lockapi;
 use hacluster;
 use serial_terminal qw(select_serial_terminal);
-use version_utils 'is_sle';
+use version_utils qw(is_sle);
 use utils qw(systemctl file_content_replace zypper_call);
+use network_utils qw(iface);
 
 sub run {
     # Exit of this module if we are in a maintenance update not related to samba
@@ -36,6 +37,7 @@ sub run {
         my $nmb_rsc = 'nmb';
         my $smb_rsc = 'smb';
         my $ip_rsc = 'vip';
+        my $iface = iface();
         my @node_list;
 
         foreach my $node (1 .. get_node_number) {
@@ -72,7 +74,7 @@ sub run {
             assert_script_run "crm configure property maintenance-mode=true";
 
             # Create vip resource
-            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $ip_rsc IPaddr2 params ip='$vip_ip' nic='eth0' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $ip_rsc IPaddr2 params ip='$vip_ip' nic='$iface' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
 
             # Add ctdb, nmb, smb, group, clone and order resources
             assert_script_run "EDITOR=\"sed -ie '\$ a primitive $ctdb_rsc CTDB params ctdb_manages_winbind=false ctdb_manages_samba=false ctdb_recovery_lock='$ctdb_folder/ctdb.lock' ctdb_socket='$ctdb_socket''\" crm configure edit";

--- a/tests/ha/haproxy.pm
+++ b/tests/ha/haproxy.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use lockapi;
 use utils qw(zypper_call systemctl);
+use network_utils qw(iface);
 use hacluster;
 
 sub run {
@@ -25,6 +26,7 @@ sub run {
     my $apache_file = '/srv/www/htdocs/index.html';
     my $vip_ip = '10.0.2.30';
     my $vip_rsc = 'vip_haproxy';
+    my $iface = iface();
     my $node_01 = choose_node(1);
     my $node_02 = choose_node(2);
     my $node_01_ip = get_ip($node_01);
@@ -72,7 +74,7 @@ sub run {
 
     if (is_node(1)) {
         # Create vip resource
-        assert_script_run "EDITOR=\"sed -ie '\$ a primitive $vip_rsc IPaddr2 params ip='$vip_ip' nic='eth0' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
+        assert_script_run "EDITOR=\"sed -ie '\$ a primitive $vip_rsc IPaddr2 params ip='$vip_ip' nic='$iface' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
 
         # Just to be sure that vip resource is started
         sleep 5;

--- a/tests/ha/remove_node.pm
+++ b/tests/ha/remove_node.pm
@@ -13,12 +13,13 @@ use warnings;
 use testapi;
 use lockapi;
 use hacluster;
-use version_utils 'is_sle';
+use version_utils qw(is_sle);
+use network_utils qw(iface);
 
 sub remove_state_join {
     my ($method, $cluster_name, $node_01, $node_02) = @_;
     my $remove_cmd = 'crm cluster remove -y -c';
-    my $join_cmd = 'crm cluster join -y -i ' . get_var('SUT_NETDEVICE', 'eth0') . ' -c';
+    my $join_cmd = 'crm cluster join -y -i ' . get_var('SUT_NETDEVICE', iface()) . ' -c';
     my $remove_timeout = bmwqemu::scale_timeout(60);
     my $timer = bmwqemu::scale_timeout(5);
 


### PR DESCRIPTION
Some HA modules as well as one line in `lib/hacluster` default to `eth0` when the tests do not get a network interface name set in the setting **SUT_NETDEVICE**. This is good enough for SLES 12 & 15 where SUTs have rules allowing for persistently named network interfaces, but breaks tests in SLES 16 where this is more dynamic.

This commit replace the default `eth0` values in HA modules and `lib/hacluster` for a call to `network_utils::iface()` which should return the first interface in the SUT different than `lo`.

- Related ticket: https://jira.suse.com/browse/TEAM-10345
- Needles: N/A

### Verification runs

- Diskless SBD / 16.0 / x86_64: http://mango.qe.nue2.suse.org/tests/6639, http://mango.qe.nue2.suse.org/tests/6637 & http://mango.qe.nue2.suse.org/tests/6640 :green_circle: 
- Diskless SBD / 16.0 / aarch64: TBA
- CTDB / 15-SP7 / x86_64: http://mango.qe.nue2.suse.org/tests/6645 & http://mango.qe.nue2.suse.org/tests/6647 :green_circle: 
- Diskless SBD / 15-SP7 / x86_64: http://mango.qe.nue2.suse.org/tests/6644, http://mango.qe.nue2.suse.org/tests/6642 & http://mango.qe.nue2.suse.org/tests/6641 :green_circle: 
- HAWK /15-SP7 / x86_64: TBA
- CTDB / 12-SP5 / x86_64: TBA
- CTDB / 15-SP3 / x86_64: TBA
