### PR TITLE
bats/podman: Remove libcriu2 dependency

### DIFF
--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -48,7 +48,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(aardvark-dns apache2-utils buildah catatonit git-core glibc-devel-static go1.24 gpg2 jq libcriu2 libgpgme-devel
+    my @pkgs = qw(aardvark-dns apache2-utils buildah catatonit git-core glibc-devel-static go1.24 gpg2 jq libgpgme-devel
       libseccomp-devel make netavark openssl podman podman-remote python3-PyYAML skopeo socat sudo systemd-container xfsprogs);
     push @pkgs, qw(criu) if is_tumbleweed;
     # Needed for podman machine


### PR DESCRIPTION
Remove libcriu2 dependency as it should be pulled by criu on Tumbleweed.  We ignore the `520-checkpoint` test on SLES.

- Failing test: https://openqa.suse.de/tests/17635333#step/podman/61
