### PR TITLE
bats: Install specific ncat version from upstream

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -16,10 +16,9 @@ use testapi;
 use utils;
 use strict;
 use warnings;
-use version_utils qw(is_sle is_tumbleweed);
+use version_utils qw(is_sle);
 use serial_terminal qw(select_user_serial_terminal select_serial_terminal);
 use registration qw(add_suseconnect_product get_addon_fullname);
-use Utils::Architectures 'is_aarch64';
 use bootloader_setup 'add_grub_cmdline_settings';
 use power_action_utils 'power_action';
 use List::MoreUtils qw(uniq);
@@ -58,23 +57,10 @@ sub run_command {
 }
 
 sub install_ncat {
-    return if (script_run("rpm -q ncat") == 0);
-
-    my $version = "SLE_15";
-    if (is_sle('<15-SP6')) {
-        $version = get_required_var("VERSION");
-        $version =~ s/-/_/g;
-        $version = "SLE_" . $version;
-    } elsif (is_tumbleweed || is_sle('>=16')) {
-        $version = "openSUSE_Factory";
-        $version .= "_ARM" if (is_aarch64);
-    }
-
-    my $repo = "https://download.opensuse.org/repositories/network:/utilities/$version/network:utilities.repo";
+    my $version = get_var("NCAT_VERSION", "7.95-3");
 
     my @cmds = (
-        "zypper addrepo $repo",
-        "zypper --gpg-auto-import-keys -n install ncat",
+        "rpm -vhU https://nmap.org/dist/ncat-$version.x86_64.rpm",
         "ln -sf /usr/bin/ncat /usr/bin/nc"
     );
     foreach my $cmd (@cmds) {


### PR DESCRIPTION
The newer ncat from Nmap 7.96 introduces some changes that may be breaking upstream netavark tests on TW & SLES:
https://nmap.org/changelog.html

This PR introduces `NCAT_VERSION` which defaults to the previous 7.95 version and installs it from upstream, since our repos got the newest version.

This may be reverted if the tests are patched and the patches can be applied in older versioned tags.

- Failing test: https://openqa.suse.de/tests/17641825
- Verification run: https://openqa.suse.de/tests/17647842