### PR TITLE
Add ntp_client test for sle15SPX and sle16

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -60,7 +60,6 @@ conditional_schedule:
             opensuse:
                 - '{{sound_tests}}'
                 - console/libvorbis
-                - console/ntp_client
                 - console/gdb
                 - console/perf
                 - console/salt
@@ -127,6 +126,7 @@ schedule:
     - console/prepare_test_data
     - console/consoletest_setup
     - '{{update_repos}}'
+    - console/ntp_client
     - console/man_pages
     - console/ping
     - console/arping

--- a/schedule/functional/extra_tests_textmode_sle16.yaml
+++ b/schedule/functional/extra_tests_textmode_sle16.yaml
@@ -88,6 +88,7 @@ schedule:
     - console/prepare_test_data
     - console/consoletest_setup
     - '{{update_repos}}'
+    - console/ntp_client
     - console/man_pages
     - console/ping
     - console/arping

--- a/schedule/qam/15-SP2/qam-textmode.yaml
+++ b/schedule/qam/15-SP2/qam-textmode.yaml
@@ -26,6 +26,7 @@ schedule:
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
+- console/ntp_client
 - console/system_state
 - console/prepare_test_data
 - console/consoletest_setup

--- a/schedule/qam/15-SP3/qam-textmode.yaml
+++ b/schedule/qam/15-SP3/qam-textmode.yaml
@@ -26,6 +26,7 @@ schedule:
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
+- console/ntp_client
 - console/system_state
 - console/prepare_test_data
 - console/consoletest_setup

--- a/schedule/qam/15-SP4/qam-textmode.yaml
+++ b/schedule/qam/15-SP4/qam-textmode.yaml
@@ -26,6 +26,7 @@ schedule:
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
+- console/ntp_client
 - console/system_state
 - console/prepare_test_data
 - console/consoletest_setup

--- a/schedule/qam/15-SP5/qam-textmode.yaml
+++ b/schedule/qam/15-SP5/qam-textmode.yaml
@@ -25,6 +25,7 @@ schedule:
 - qa_automation/patch_and_reboot
 - locale/keymap_or_locale
 - console/system_prepare
+- console/ntp_client
 - console/check_network
 - console/system_state
 - console/prepare_test_data

--- a/schedule/qam/15-SP6/qam-textmode.yaml
+++ b/schedule/qam/15-SP6/qam-textmode.yaml
@@ -28,6 +28,7 @@ schedule:
 - console/check_network
 - console/system_state
 - console/prepare_test_data
+- console/ntp_client
 - console/consoletest_setup
 - console/force_scheduled_tasks
 - console/textinfo

--- a/schedule/qam/15-SP7/qam-textmode.yaml
+++ b/schedule/qam/15-SP7/qam-textmode.yaml
@@ -26,6 +26,7 @@ schedule:
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
+- console/ntp_client
 - console/system_state
 - console/prepare_test_data
 - console/consoletest_setup


### PR DESCRIPTION
Add ntp_client test for sle15SPX and sle16

- Related ticket: https://progress.opensuse.org/issues/181625
- Verification run: sle16:
https://openqa.suse.de/tests/17631582
https://openqa.suse.de/tests/17631583
https://openqa.suse.de/tests/17631584
15sp7_daily:
https://openqa.suse.de/tests/17631690
https://openqa.suse.de/tests/17631692
https://openqa.suse.de/tests/17631693
https://openqa.suse.de/tests/17631694
15sp7:
https://openqa.suse.de/tests/17631587
15sp6:
https://openqa.suse.de/tests/17631588
15sp5:
https://openqa.suse.de/tests/17631591
15sp4:
https://openqa.suse.de/tests/17631592      
15sp3:
https://openqa.suse.de/tests/17631670
15sp2:
https://openqa.suse.de/tests/17631672
