### PR TITLE
Added GRUB stop and minor modifications

### DIFF
--- a/data/yam/agama/auto/scripts_ssh_pub_key.jsonnet
+++ b/data/yam/agama/auto/scripts_ssh_pub_key.jsonnet
@@ -1,4 +1,7 @@
 {
+  bootloader: {
+    stopOnBootMenu: true,
+  },
   root: {
     sshPublicKey: 'fake public key to enable sshd and open firewall',
   },

--- a/data/yam/agama/auto/sles_lvm_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_lvm_ssh_pub_key_ppc64le.jsonnet
@@ -1,4 +1,7 @@
 {
+  bootloader: {
+    stopOnBootMenu: true,
+  },
   product: {
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE}}',
@@ -48,7 +51,7 @@
           done
         |||,
       },
-    ],    
+    ],
     post: [
       {
         name: 'enable root login',

--- a/data/yam/agama/auto/sles_root_filesystem_ext4_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_ext4_ppc64le.jsonnet
@@ -1,4 +1,7 @@
 {
+  bootloader: {
+    stopOnBootMenu: true,
+  },
   product: {
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE}}',

--- a/data/yam/agama/auto/sles_root_filesystem_ext4_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_ext4_ssh_pub_key_ppc64le.jsonnet
@@ -1,4 +1,7 @@
 {
+  bootloader: {
+    stopOnBootMenu: true,
+  },
   product: {
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE}}',

--- a/data/yam/agama/auto/sles_root_filesystem_xfs_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_xfs_ppc64le.jsonnet
@@ -1,4 +1,7 @@
 {
+  bootloader: {
+    stopOnBootMenu: true,
+  },
   product: {
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE}}',
@@ -37,7 +40,7 @@
           done
         |||,
       },
-    ],    
+    ],
     post: [
       {
         name: 'enable root login',

--- a/data/yam/agama/auto/sles_root_filesystem_xfs_ssh_pub_key_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_root_filesystem_xfs_ssh_pub_key_ppc64le.jsonnet
@@ -1,4 +1,7 @@
 {
+  bootloader: {
+    stopOnBootMenu: true,
+  },
   product: {
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE}}',
@@ -38,7 +41,7 @@
           done
         |||,
       },
-    ],    
+    ],
     post: [
       {
         name: 'enable root login',

--- a/data/yam/agama/auto/sles_sap_default_ppc64le.jsonnet
+++ b/data/yam/agama/auto/sles_sap_default_ppc64le.jsonnet
@@ -1,4 +1,7 @@
 {
+  bootloader: {
+    stopOnBootMenu: true,
+  },
   product: {
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE_SLES4SAP}}',
@@ -24,7 +27,7 @@
         ],
       },
     ],
-  },  
+  },
   scripts: {
     pre: [
       {
@@ -38,7 +41,7 @@
           done
         |||,
       },
-    ],    
+    ],
     post: [
       {
         name: 'enable root login',

--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -8,7 +8,7 @@ schedule:
   - yam/agama/agama
   - installation/grub_test
   - installation/first_boot
-  - console/validate_repos
   - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname
+  - console/validate_repos

--- a/schedule/yam/agama_auto.yaml
+++ b/schedule/yam/agama_auto.yaml
@@ -7,7 +7,7 @@ schedule:
   - yam/agama/agama_auto
   - installation/grub_test
   - installation/first_boot
-  - console/validate_repos
   - yam/validate/validate_base_product
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname
+  - console/validate_repos


### PR DESCRIPTION
We have added the option `stopOnBootMenu` on different profiles for ppc64le tests, this will avoid the error that GRUB goes to fast.
We included a minor change of validate_repos order in the schedule.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
