### PR TITLE
containers: De-schedule podmansh test

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -148,8 +148,6 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        # Temporarily skipped on MicroOS due to poo#181316 & SLE 16.0 due to breaking other modules
-        loadtest 'containers/podmansh' unless (is_staging || is_leap("<16") || is_sle || is_sle_micro || is_leap_micro || is_microos);
         loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects


### PR DESCRIPTION
The podmansh test should be on its own job and when it fails it prevents other modules from being tested.

- Failing test: https://openqa.opensuse.org/tests/5053726#step/podmansh/125
- Related ticket: https://progress.opensuse.org/issues/182213
- Verification run: not needed