### PR TITLE
Drop syststat service description check in sles4sap/sapconf

### DIFF
--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -107,8 +107,7 @@ sub run {
 
     verify_sapconf_service('sapconf.service', 'sapconf') unless ($default_profile eq 'saptune');
     verify_sapconf_service('uuidd.socket', 'UUID daemon activation socket');
-    verify_sapconf_service('sysstat.service', 'Write information about system start to sysstat log')
-      if is_sle('15+');
+    verify_sapconf_service('sysstat.service', '') if is_sle('15+');
 
     my $sapconf_bin = is_sle('<15') ? 'sapconf' : '/usr/lib/sapconf/sapconf';
     if (is_sle('<15')) {


### PR DESCRIPTION
The `sles4sap/sapconf` test module checks the status of related services. These include `sapconf`, `systat` and `uuidd.socket`. Recently the description of `sapconf` has changed leading to the test failure. Since `sapconf` is nearing EOL, this commit drops the check for `sysstat`'s description, but keeps everything else intact.

- Related ticket: https://jira.suse.com/browse/TEAM-10357
- Needles: N/A
- Verification run: https://openqaworker15.qa.suse.cz/tests/324117 :green_circle: 
