### PR TITLE
Force ipv6 in wget_ipv6 test

### DIFF
--- a/tests/console/wget_ipv6.pm
+++ b/tests/console/wget_ipv6.pm
@@ -23,7 +23,7 @@ sub run {
     zypper_call 'in wget';
     select_console 'user-console';
     assert_script_run('rpm -q wget');
-    assert_script_run('wget -O- -q www3.zq1.de/test.txt');
+    assert_script_run('wget -O- -6 -q www3.zq1.de/test.txt');
 }
 
 1;


### PR DESCRIPTION
Given the points in https://bugzilla.suse.com/show_bug.cgi?id=1240730, we should add `-6` in order to force ipv6 stack in wget.

#### Verification runs
 - sle-15-SP7-JeOS-for-kvm-and-xen-s390x-Build3.22-jeos-extratest@s390x-kvm -> https://openqa.suse.de/tests/17673133
 - sle-16.0-Minimal-VM-for-kvm-and-xen-s390x-Build23.1-minimalvm-extratest@s390x-kvm -> https://openqa.suse.de/tests/17673144