### PR TITLE
Add some debug info for agama install failure

### DIFF
--- a/tests/installation/agama_reboot.pm
+++ b/tests/installation/agama_reboot.pm
@@ -55,6 +55,9 @@ sub verify_agama_auto_install_done_cmdline {
         sleep 20;
         $timeout = $timeout - 20;
     }
+    # Add some debug info for quick check for tester before investigating full agama logs
+    # See https://progress.opensuse.org/issues/182258
+    record_info('debug info', script_output('journalctl --no-pager -u agama -n 100'));
     die "Install phase is not done, please check agama logs";
 }
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/182258


- [Verification run](https://openqa.suse.de/tests/17673413#step/agama_reboot/16)

Now it can show us that the installation is not done yet, and some packages are in the queue, then tester can try to increase the timeout for `AGAMA_INSTALL_TIMEOUT`