### PR TITLE
Add dnsmasq test for sle15sp7 and sle16

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -127,6 +127,7 @@ schedule:
     - console/consoletest_setup
     - '{{update_repos}}'
     - console/ntp_client
+    - console/dnsmasq
     - console/man_pages
     - console/ping
     - console/arping

--- a/schedule/functional/extra_tests_textmode_sle16.yaml
+++ b/schedule/functional/extra_tests_textmode_sle16.yaml
@@ -89,6 +89,7 @@ schedule:
     - console/consoletest_setup
     - '{{update_repos}}'
     - console/ntp_client
+    - console/dnsmasq
     - console/man_pages
     - console/ping
     - console/arping


### PR DESCRIPTION
Add dnsmasq test for sle15sp7 and sle16

- Related ticket: https://progress.opensuse.org/issues/181631
- Verification run: 
 sle16:
https://openqa.suse.de/tests/17657862
https://openqa.suse.de/tests/17657866
https://openqa.suse.de/tests/17657867
sle15sp7:
https://openqa.suse.de/tests/17658479
https://openqa.suse.de/tests/17658492
https://openqa.suse.de/tests/17658493
https://openqa.suse.de/tests/17658494
TW:
https://openqa.opensuse.org/tests/5053750
