### PR TITLE
Fix race condition in xfs fs creation in ensa2 test

### DIFF
--- a/tests/sles4sap/ensa/ensa_filesystems.pm
+++ b/tests/sles4sap/ensa/ensa_filesystems.pm
@@ -12,7 +12,7 @@ use strict;
 use warnings;
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(systemctl file_content_replace);
+use utils qw(systemctl file_content_replace script_retry);
 use hacluster;
 use lockapi;
 
@@ -42,21 +42,21 @@ sub run {
         # cache and the disk’s hardware cache may delay this. When using serial
         # we hit this limitation, to avoid that we run partprobe and parted again.
         script_run('partprobe');
-        script_run('partprobe -s');
         assert_script_run("parted -s $lun_path mklabel gpt");
         script_run('partprobe');
-        script_run('partprobe -s');
         assert_script_run("parted -s $lun_path mkpart primary 0% 50%");
         script_run('partprobe');
-        script_run('partprobe -s');
         assert_script_run("parted -s $lun_path mkpart primary 50% 100%");
         script_run('partprobe');
         script_run('partprobe -s');
         assert_script_run("parted -s $lun_path --list");
 
         # Format the partitions
-        assert_script_run("mkfs.xfs $lun_path-part1");
-        assert_script_run("mkfs.xfs $lun_path-part2");
+        script_retry("mkfs.xfs $lun_path-part1", delay => 5, retry => 3);
+        script_run('partprobe');
+        script_retry("mkfs.xfs $lun_path-part2", delay => 5, retry => 3);
+        script_run('partprobe');
+        assert_script_run("fdisk -l");
         assert_script_run("mount -t xfs $lun_path-part1 $sap_dir/$instance_dir");
         assert_script_run("chmod 777 $sap_dir/$instance_dir");
     }


### PR DESCRIPTION
As described in commit 6be0607, the serial terminal is too fast and by the time it reaches mkfs.xfs, the partition table is not ready.

Because I could not find a way to force a sync, I added a script_retry that will cut down on the amount of failures.

- Related Ticket: TEAM-10321
- Verification run:
- - OSD
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-1&groupid=615
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-2&groupid=615
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-3&groupid=615
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-4&groupid=615
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-5&groupid=615
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-6&groupid=615
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-8&groupid=615
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-9&groupid=615
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=ensavr-10&groupid=615

- - prg8
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-1&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-2&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-3&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-4&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-5&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-6&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-7&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-8&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-9&groupid=1
https://qesapworker-prg8.qa.suse.cz/tests/overview?distri=sle&version=15-SP6&build=ensavr-10&groupid=1
