### PR TITLE
Fix the capitalization issue

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2582,7 +2582,7 @@ sub load_hypervisor_tests {
         my $hypervisor = $feature->{hypervisor};
         # The LTSS for SUSE 15-SP1 has ended. Due to a bug (bsc#1230913), also skip 15-SP2.
         if ($test eq 'ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH') {
-            next unless is_sle('>=15-sp3');
+            next unless is_sle('>=15-SP3');
         }
         check_and_load_mu_virt_features($test, $modules, $hypervisor);
     }


### PR DESCRIPTION
The logic of is_sle(>=15-SP3) and is_sle(>=15-sp3) is different; it is case-sensitive.
The logic of is_sle(15-sp3) and is_sle(15-SP3) is the same; it is not case-sensitive.

- Related ticket: https://progress.opensuse.org/issues/167018
- Needles: N/A
- Verification run: 
[15-SP2](https://openqa.suse.de/tests/17685408)
[15-SP6](https://openqa.suse.de/tests/17682918)
