### PR TITLE
bats: Add 25942.patch for 252-quadlet

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -58,10 +58,12 @@ podman:
   # https://github.com/containers/podman/pull/25340 is needed for 030-run
   # https://github.com/containers/podman/pull/25350 is needed for 030-run
   # https://github.com/containers/podman/pull/25718 is needed for 030-run
+  # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - https://github.com/containers/podman/pull/25918.patch
+    - https://github.com/containers/podman/pull/25942.patch
     - https://github.com/containers/podman/pull/26017.patch
     BATS_SKIP: ''
     BATS_SKIP_ROOT_LOCAL: 200-pod


### PR DESCRIPTION
Fix failure: https://openqa.opensuse.org/tests/5057864

Context:
https://suse.slack.com/archives/C02DR0C5XUY/p1747208417838939?thread_ts=1747207591.809659&cid=C02DR0C5XUY

```
# #|     FAIL: regular tmpfs mount
# #| expected: 'rw,rprivate,nosuid,nodev,tmpcopyup'
# #|   actual: 'rprivate,nosuid,nodev,tmpcopyup'
```

Fix failure: https://openqa.opensuse.org/tests/5057864
Verification run: https://openqa.opensuse.org/tests/5058358#