### PR TITLE
Enable 16.0 ppc64le Cluster Crash Test Scenario

### DIFF
--- a/schedule/ha/bv/pvm_ha_crash_test_node.yaml
+++ b/schedule/ha/bv/pvm_ha_crash_test_node.yaml
@@ -1,0 +1,71 @@
+---
+name: pvm_ha_crash_test_node
+description: >
+  HA Cluster Test on ppc64le hmc_pvm backend. Schedule for all nodes.
+
+  Some settings are required in the job group or test suite for this schedule to work.
+
+  The other settings are required in the job group.
+
+  CLUSTER_NAME must be defined for all jobs as a string.
+  HA_CLUSTER_INIT must be defined to yes in the job that initializes the cluster and to
+  no in the the other cluster node jobs
+  HA_CLUSTER_JOIN must be defined for the rest of the jobs, and it must contain the
+  hostname of the job where HA_CLUSTER_INIT is defined to yes
+  HOSTNAME must be defined to different hostnames for each node.
+  MAX_JOB_TIME is recommended to be defined as well to a high value (ex. 20000)
+  All jobs with the exception of the HA_CLUSTER_INIT=yes job must include a PARALLEL_WITH setting
+  referencing the HA_CLUSTER_INIT=yes job.
+
+  CLUSTER_INFOS must be set in one of the nodes instead of the support server.
+  ISCSI_SERVER must be set in all nodes.
+  ISCSI_LUN_INDEX - must be set in all nodes,
+  tells the modules which LUN in the iSCSI server to use to avoid having multiple jobs using the same devices.
+  NFS_SUPPORT_SHARE - must be set in all nodes, a RW NFS share where the nodes will write file and share information.
+
+  SLE_PRODUCT must be defined and set accordingly.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  DESKTOP: 'textmode'
+  HA_CLUSTER: '1'
+  HDD_SCC_REGISTERED: '1'
+  # Below setting must be defined in the openQA UI because macros for %VERSION%,
+  # %ARCH% and %BUILD% are usually not defined yet when this file is being loaded
+  # HDD_1: SLE-%VERSION%-%ARCH%-Build%BUILD%-sles4sap-gnome.qcow2
+schedule:
+  - '{{barrier_init}}'
+  - installation/bootloader
+  - installation/agama_reboot
+  - installation/first_boot
+  - console/system_prepare
+  - ha/check_hae_active.py
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/iscsi_client_setup
+  - ha/setup_hosts_and_luns
+  - ha/watchdog
+  - '{{cluster_setup}}'
+  - '{{ha_cluster_crash_test}}'
+  - ha/check_logs
+  - shutdown/shutdown
+conditional_schedule:
+  barrier_init:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/barrier_init
+  cluster_setup:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/ha_cluster_init
+      no:
+        - ha/ha_cluster_join
+  ha_cluster_crash_test:
+    PREFLIGHT_CHECK:
+      1:
+        - ha/ha_cluster_crash_test

--- a/tests/ha/ha_cluster_crash_test.pm
+++ b/tests/ha/ha_cluster_crash_test.pm
@@ -155,7 +155,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 0};
+    return {milestone => 1, fatal => 1};
 }
 
 sub post_fail_hook {
@@ -171,7 +171,7 @@ sub post_fail_hook {
     ha_export_logs;
 
     # Execute the common part
-    $self->post_fail_hook;
+    $self->SUPER::post_fail_hook();
 }
 
 1;


### PR DESCRIPTION
Enable 16.0 ppc64le Cluster Crash Test Scenario

Note:
1. `schedule/ha/bv/pvm_ha_crash_test_node.yaml` is based on `schedule/ha/bv/ha_crash_test_node.yaml` and added `gama installation` and `iscsi server` related test modules.
2. Set `fatal => 1` for test module `tests/ha/ha_cluster_crash_test.pm` as if this test module failed the `barrier_wait` will no be  executed then test module `check_logs` will hang until exceeds `MAX_JOB_TIME` .  
- Related MR: https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/1007
- Related ticket: https://jira.suse.com/browse/TEAM-10288 (TEAM-10288 - [ppc64le] Enable Cluster Crash Test Scenario)
- Verification run: 
https://openqa.suse.de/tests/17710696#step/ha_cluster_crash_test/115 (Still **failed** on reboot after `crm cluster crash_test --kill-sbd --force` , I will open a new ticket to work on)
