### PR TITLE
Improve log collection fo vnc_two_passwords test

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -258,6 +258,7 @@ sub run {
 }
 
 sub post_fail_hook {
+    my $self = @_;
     # Normally this test fails on X11, but in the odd chance it doesn't
     # avoid killing the testsuite by sending ctrl+c in serial terminal
     send_key "ctrl-c" unless is_serial_terminal();
@@ -266,7 +267,7 @@ sub post_fail_hook {
     upload_logs('/tmp/xev_log', failok => 1);
     upload_logs("/home/testuser/.local/state/tigervnc/susetest$display.log", failok => 1) unless $curr_vers < 0;
     upload_logs("/home/testuser/.vnc/susetest$display.log", failok => 1) if $curr_vers < 0;
-
+    $self->SUPER::post_fail_hook;
     clean;
 }
 

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -261,7 +261,7 @@ sub post_fail_hook {
     my $self = @_;
     # Normally this test fails on X11, but in the odd chance it doesn't
     # avoid killing the testsuite by sending ctrl+c in serial terminal
-    send_key "ctrl-c" unless is_serial_terminal();
+    send_key "ctrl-c" unless testapi::is_serial_terminal();
     select_console 'log-console';
     # xev seems to hang, send control-c to ensure that we can actually type
     upload_logs('/tmp/xev_log', failok => 1);

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -258,12 +258,15 @@ sub run {
 }
 
 sub post_fail_hook {
+    # Normally this test fails on X11, but in the odd chance it doesn't
+    # avoid killing the testsuite by sending ctrl+c in serial terminal
+    send_key "ctrl-c" unless is_serial_terminal();
     select_console 'log-console';
     # xev seems to hang, send control-c to ensure that we can actually type
-    send_key "ctrl-c";
     upload_logs('/tmp/xev_log', failok => 1);
     upload_logs("/home/testuser/.local/state/tigervnc/susetest$display.log", failok => 1) unless $curr_vers < 0;
     upload_logs("/home/testuser/.vnc/susetest$display.log", failok => 1) if $curr_vers < 0;
+
     clean;
 }
 


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/5057494#step/vnc_two_passwords/56
VR: https://openqa.opensuse.org/tests/5059817

- **Send ctrl+c properly in a valid console**
- **Use parent class's post_fail_hook to collect logs**
