### PR TITLE
Add SAPHanaSR-angi test for sle16

### DIFF
--- a/data/sles4sap/angi_hana_cluster.conf
+++ b/data/sles4sap/angi_hana_cluster.conf
@@ -25,7 +25,7 @@ primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% ocf:heartbeat:IPaddr2 \
     op monitor interval=10 timeout=20 \
     params ip=%VIRTUAL_IP_ADDRESS% \
            cidr_netmask=%VIRTUAL_IP_NETMASK% \
-           nic=eth0
+           nic=%NIC%
 colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: \
     rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started \
     cln_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE%:Promoted

--- a/data/sles4sap/hana_cluster_cln.conf
+++ b/data/sles4sap/hana_cluster_cln.conf
@@ -11,7 +11,7 @@ primitive rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHana \
         op monitor interval=60 role=Promoted timeout=700 \
         op monitor interval=61 role=Unpromoted timeout=700
 primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% IPaddr2 \
-        params ip=%VIRTUAL_IP_ADDRESS% cidr_netmask=%VIRTUAL_IP_NETMASK% nic=eth0 \
+        params ip=%VIRTUAL_IP_ADDRESS% cidr_netmask=%VIRTUAL_IP_NETMASK% nic=%NIC% \
         op start timeout=20 interval=0 \
         op stop timeout=20 interval=0 \
         op monitor interval=10 timeout=20

--- a/data/sles4sap/hana_cluster_msl.conf
+++ b/data/sles4sap/hana_cluster_msl.conf
@@ -11,7 +11,7 @@ primitive rsc_SAPHanaCtl_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHana \
         op monitor interval=60 role=Master timeout=700 \
         op monitor interval=61 role=Slave timeout=700
 primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% IPaddr2 \
-        params ip=%VIRTUAL_IP_ADDRESS% cidr_netmask=%VIRTUAL_IP_NETMASK% nic=eth0 \
+        params ip=%VIRTUAL_IP_ADDRESS% cidr_netmask=%VIRTUAL_IP_NETMASK% nic=%NIC% \
         op start timeout=20 interval=0 \
         op stop timeout=20 interval=0 \
         op monitor interval=10 timeout=20

--- a/schedule/sles4sap/hana/pvm_hana_cluster_node_sle16.yaml
+++ b/schedule/sles4sap/hana/pvm_hana_cluster_node_sle16.yaml
@@ -1,0 +1,86 @@
+---
+name: pvm_hana_cluster_node_sle16
+description: >
+  HanaSR Cluster Test for pvm_hmc for sle16. Schedule for all nodes.
+
+  Some settings are required in the job group or test suite for this schedule to work.
+  HA_CLUSTER_INIT must be defined for all jobs. In one of the jobs, it must be defined
+  to 'yes', while in the rest to 'no'. This will only control the conditional scheduling
+  of ha_cluster_init or ha_cluster_join.
+
+  The other settings required in the job group are.
+
+  CLUSTER_INFOS must be defined in the parent job to the name of the cluster, number
+  of nodes and number of LUNs. Example 'hana:2:3'
+  CLUSTER_NAME must be defined for all jobs as a string.
+  HA_CLUSTER_JOIN must be defined for the rest of the jobs, and it must contain the
+  hostname of the job where HA_CLUSTER_INIT is defined to yes
+  HANA must be defined pointing to the location of the HANA installation masters
+  HOSTNAME must be defined to different hostnames for each node.
+  ISCSI_LUN_INDEX must be defined in the parent job pointing to an available LUN
+  index in the iSCSI server
+  ISCSI_SERVER must be defined in all jobs pointing to an iSCSI server
+  MAX_JOB_TIME is recommended to be defined as well to a high value (ex. 20000)
+  NFS_SUPPORT_SHARE must be defined in all jobs pointing to a NFS share used by
+  the cluster nodes to share configuration files
+  All jobs with the exception of the parent job must include a PARALLEL_WITH setting
+  referencing the parent job.
+  SLE_PRODUCT must be defined and set to sles4sap.
+  And of course, YAML_SCHEDULE must point to this file.
+vars:
+  AUTOMATED_REGISTER: 'false'
+  DESKTOP: 'textmode'
+  HA_CLUSTER: '1'
+  INSTANCE_ID: '00'
+  INSTANCE_IP_CIDR: '10.0.2.200/24'
+  INSTANCE_SID: HA1
+  INSTANCE_TYPE: HDB
+  MULTIPATH_CONFIRM: 'yes'
+schedule:
+  - '{{barrier_init}}'
+  - installation/bootloader
+  - installation/agama_reboot
+  - installation/first_boot
+  - ha/wait_barriers
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/iscsi_client_setup
+  - ha/setup_hosts_and_luns
+  - ha/watchdog
+  - sles4sap/patterns
+  - sles4sap/hana_install
+  - '{{cluster_setup}}'
+  - sles4sap/hana_cluster
+  - ha/fencing
+  - '{{boot_to_desktop}}'
+  - ha/check_after_reboot
+  - ha/fencing
+  - '{{boot_to_desktop_non_init}}'
+  - ha/check_after_reboot
+  - ha/check_logs
+conditional_schedule:
+  barrier_init:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/barrier_init
+  cluster_setup:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/ha_cluster_init
+      no:
+        - ha/ha_cluster_join
+  boot_to_desktop:
+    HA_CLUSTER_INIT:
+      yes:
+        - boot/reconnect_mgmt_console
+        - installation/first_boot
+  boot_to_desktop_non_init:
+    HA_CLUSTER_INIT:
+      no:
+        - boot/reconnect_mgmt_console
+        - installation/first_boot

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -13,6 +13,8 @@ use warnings;
 use testapi;
 use lockapi;
 use hacluster;
+use version_utils qw(is_sles4sap);
+use bootloader_setup qw(add_grub_cmdline_settings);
 
 sub run {
     my $cluster_name = get_cluster_name;
@@ -34,6 +36,11 @@ sub run {
         'sles4sap'->check_hanasr_attr;
         save_screenshot;
         barrier_wait("HANA_REPLICATE_STATE_${cluster_name}_NODE${node_index}");
+    }
+
+    # Modify SELinux configurtion file to take permissive mode effect after rebooting
+    if (get_var("WORKAROUND_BSC1239148") && is_sles4sap()) {
+        add_grub_cmdline_settings('enforcing=0', update_grub => 1);
     }
 
     # Fence a node with sysrq, crm node fence or by killing corosync

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -11,6 +11,7 @@ use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use lockapi;
+use network_utils qw(iface);
 use hacluster;
 use utils qw(write_sut_file systemctl file_content_replace);
 use strict;
@@ -59,6 +60,7 @@ sub run {
         my $cluster_conf = get_var('USE_SAP_HANA_SR_ANGI') ? 'angi_hana_cluster.conf' : "hana_cluster_$sles4sap::resource_alias.conf";
         assert_script_run 'curl -f -v ' . autoinst_url . "/data/sles4sap/$cluster_conf -o /tmp/$cluster_conf";
         $cluster_conf = '/tmp/' . $cluster_conf;
+        my $iface = get_var('SUT_NETDEVICE', iface());
 
         # Initiate the template
         file_content_replace($cluster_conf, '--sed-modifier' => 'g',
@@ -66,7 +68,8 @@ sub run {
             '%HDB_INSTANCE%' => $instance_id,
             '%AUTOMATED_REGISTER%' => get_required_var('AUTOMATED_REGISTER'),
             '%VIRTUAL_IP_ADDRESS%' => $virtual_ip,
-            '%VIRTUAL_IP_NETMASK%' => $virtual_netmask);
+            '%VIRTUAL_IP_NETMASK%' => $virtual_netmask,
+            '%NIC%' => $iface);
 
         foreach ($node1, $node2) {
             add_to_known_hosts($_);


### PR DESCRIPTION
1. For sle16, the netcard name is changed, so we should not hard code it in configuration file.
2. For SAPHanaSR-angi test, we need to reboot the host, so need to let the selinux=permissive take effect after rebooting

Related: https://jira.suse.com/browse/TEAM-10280

VR:
sle 16
x86: https://openqa.suse.de/tests/17712093#  (Failed on check_after_reboot)
ppc64: https://openqa.suse.de/tests/17712090# (Failed on check_after_reboot)

Because there is some modification on configuration file, so run VR on 15-sp7
15sp7:
SAPHanaSR_ScaleUp_PerfOpt_WMP_node01 x86: https://openqa.suse.de/tests/17710747# (passed)
SAPHanaSR_angi_ScaleUp_PerfOpt_node01: ppc64https://openqa.suse.de/tests/17710704# (Passed)

