### PR TITLE
Update x11 related containers URLs

### DIFF
--- a/tests/microos/workloads/x11-container/x11_client.pm
+++ b/tests/microos/workloads/x11-container/x11_client.pm
@@ -47,7 +47,7 @@ sub run {
     my $opts = "-e DISPLAY=:0 -e XAUTHORITY=/home/user/xauthority/.xauth -e PULSE_SERVER=/var/run/pulse/native -v xauthority:/home/user/xauthority:rw -v pasocket:/var/run/pulse/ -v xsocket:/tmp/.X11-unix:rw";
     # pulseaudio image url and firefox kiosk url are joined together by a space
     # split the string by space
-    my ($pacontainerpath, $ffcontainerpath) = split(/\s+/, get_var("CONTAINER_IMAGE_TO_TEST", 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/pulseaudio:17 registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk-firefox-esr:128.8'));
+    my ($pacontainerpath, $ffcontainerpath) = split(/\s+/, get_var("CONTAINER_IMAGE_TO_TEST", 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/pulseaudio:latest registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/firefox-esr:latest'));
     # start pulseaudio container
     enter_cmd("podman pull $pacontainerpath --tls-verify=false", 300);
     assert_screen("podman-pa-pull-done");

--- a/tests/microos/workloads/x11-container/x11_server.pm
+++ b/tests/microos/workloads/x11-container/x11_server.pm
@@ -53,7 +53,7 @@ sub run {
     x11_preparation();
 
     # start X11 container
-    my $containerpath = get_var('CONTAINER_IMAGE_TO_TEST', 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/xorg:latest');
+    my $containerpath = get_var('CONTAINER_IMAGE_TO_TEST', 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/xorg:latest');
     assert_script_run("podman pull $containerpath --tls-verify=false", 300);
     assert_script_run("podman run --privileged -d --pod wallboard-pod -e XAUTHORITY=/home/user/xauthority/.xauth -v xauthority:/home/user/xauthority:rw -v xsocket:/tmp/.X11-unix:rw -v /run/udev/data:/run/udev/data:rw --name x11-init-container --security-opt=no-new-privileges $containerpath");
     # verify the x11 server container started


### PR DESCRIPTION
Update x11, pulseaudio and firefox kiosk container URLs

- Related ticket: https://progress.opensuse.org/issues/174418
- Needles: already added when debugging on osd
- Verification run: 
> x11 container https://openqa.suse.de/tests/17686643#step/x11_server/90
> pulseaudio container: https://openqa.suse.de/tests/17686642#step/x11_client/28 
> firefox kiosk container: https://openqa.suse.de/tests/17686642#step/x11_client/30
