### PR TITLE
Move SELinux set to permissive from hana_test to library

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -22,7 +22,7 @@ use x11utils qw(ensure_unlocked_desktop);
 use power_action_utils qw(power_action);
 use Utils::Backends;
 use registration qw(add_suseconnect_product);
-use version_utils qw(is_sle);
+use version_utils qw(is_sle has_selinux);
 use utils qw(zypper_call);
 use Digest::MD5 qw(md5_hex);
 use Utils::Systemd qw(systemctl);
@@ -566,8 +566,19 @@ and threads that it can create.
 =cut
 
 sub test_pids_max {
+    my ($self) = @_;
     # UserTasksMax should be set to "infinity" in /etc/systemd/logind.conf.d/sap.conf
     my $uid = script_output "id -u $sapadmin";
+
+    # In SLES 16 this test fails with SELinux in enforcing mode. Query current
+    # mode, change to permissive and then rollback after test finishes
+    my $selinux_mode = 'Enforcing';
+    if (has_selinux) {
+        $selinux_mode = script_output q@echo "|$(getenforce)|"@;
+        $selinux_mode =~ /\|(\w+)\|/;
+        $selinux_mode = $1 // 'Enforcing';
+        $self->modify_selinux_setenforce('selinux_mode' => 'Permissive');
+    }
 
     # push the command to SUT by write_sut_file API instead of typing string
     # it is not stable to type long string especially when high load on worker
@@ -609,6 +620,7 @@ systemd-run --slice user -qt su - $sapadmin -c 'ulimit -u' -s /bin/bash | tail -
     my $rc2 = script_run "bash -eox pipefail /root/test_script.sh";
 
     record_soft_failure "bsc#1031355" if ($rc1 or $rc2);
+    $self->modify_selinux_setenforce('selinux_mode' => $selinux_mode) if has_selinux;
 }
 
 =head2 test_forkbomb

--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -12,7 +12,6 @@ use strict;
 use warnings;
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use version_utils qw(has_selinux);
 
 sub test_python3 {
     my ($self) = @_;
@@ -63,17 +62,7 @@ sub run {
     my $sapadm = $self->set_sap_info($sid, $instance_id);
 
     # Test PIDs max, as SAP has some prerequisites on this and change for SAP user
-    # In SLES 16 this test fails with SELinux in enforcing mode. Query current
-    # mode, change to permisisive and then rollback after test finishes
-    my $selinux_mode = 'Enforcing';
-    if (has_selinux) {
-        $selinux_mode = script_output q@echo "|$(getenforce)|"@;
-        $selinux_mode =~ /\|(\w+)\|/;
-        $selinux_mode = $1 // 'Enforcing';
-        $self->modify_selinux_setenforce('selinux_mode' => 'Permissive');
-    }
     $self->test_pids_max unless get_var('CLUSTER_NAME');
-    $self->modify_selinux_setenforce('selinux_mode' => $selinux_mode) if has_selinux;
     $self->user_change;
 
     assert_script_run "HDB info";


### PR DESCRIPTION
The `test_pids_max` test from `lib/sles4sap.pm` does not work with SELinux configured to `Enforcing` mode. Commit
36fc991d6074c7a92b7a77409b28eaa4e3d3738e added code in the test module `sles4sap/hana_test` to temporarily set SELinux to `Permissive` mode before executing the test, and then reverting the change. However, `test_pids_max` is also called from other modules (for example, from `sles4sap/netweaver_test_instance`), so this commit moves the temporary SELinux changes to the `test_pids_max` method itself to avoid duplicating code in the test modules.

- Related ticket: N/A
- Needles: N/A
- Verification run: [HANA](http://mango.qe.nue2.suse.org/tests/6725), [NW](http://mango.qe.nue2.suse.org/tests/6722)
