### PR TITLE
Revert "Force ipv6 in wget_ipv6 test"

### DIFF
--- a/tests/console/wget_ipv6.pm
+++ b/tests/console/wget_ipv6.pm
@@ -23,7 +23,7 @@ sub run {
     zypper_call 'in wget';
     select_console 'user-console';
     assert_script_run('rpm -q wget');
-    assert_script_run('wget -O- -6 -q www3.zq1.de/test.txt');
+    assert_script_run('wget -O- -q www3.zq1.de/test.txt');
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#22050

I need to check o3 again. Locally it worked maybe we need to make a worker config change