### PR TITLE
Allow avc_selinux_alerts to be used in X11base or anywhere else

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -393,7 +393,7 @@ sub record_avc_selinux_alerts {
         return;
     }
 
-    my @logged = split(/\n/, script_output('ausearch -m avc,user_avc,selinux_err,user_selinux_err', timeout => 300, proceed_on_failure => 1));
+    my @logged = split(/\n/, script_output('ausearch -m avc,user_avc,selinux_err,user_selinux_err -r', timeout => 300, proceed_on_failure => 1));
 
     # no new messages are registered
     if (scalar @logged <= $avc_record{start}) {

--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -393,7 +393,7 @@ sub record_avc_selinux_alerts {
         return;
     }
 
-    my @logged = split(/\n/, script_output('ausearch -m avc -r', timeout => 300, proceed_on_failure => 1));
+    my @logged = split(/\n/, script_output('ausearch -m avc,user_avc,selinux_err,user_selinux_err', timeout => 300, proceed_on_failure => 1));
 
     # no new messages are registered
     if (scalar @logged <= $avc_record{start}) {

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -19,7 +19,7 @@ use version_utils qw(is_sle is_leap is_tumbleweed);
 use x11utils qw(select_user_gnome start_root_shell_in_xterm handle_gnome_activities);
 use POSIX 'strftime';
 use mm_network;
-use Utils::Logging qw(export_healthcheck_basic select_log_console export_logs_basic export_logs_desktop);
+use Utils::Logging qw(export_healthcheck_basic select_log_console export_logs_basic export_logs_desktop record_avc_selinux_alerts);
 use serial_terminal 'select_serial_terminal';
 
 sub post_run_hook {
@@ -33,6 +33,7 @@ sub post_fail_hook {
     select_serial_terminal();
     export_healthcheck_basic;
     export_logs_basic;
+    record_avc_selinux_alerts;
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
     export_logs_desktop;
     select_log_console;


### PR DESCRIPTION
VRs:
- X11 test failing https://openqa.opensuse.org/tests/5062171#step/vnc_two_passwords/166
- Tumbleweed console: https://openqa.opensuse.org/tests/5062354#step/snapper_zypp/92
- 15-sp5 console: https://openqa.suse.de/tests/17702102
- 12-sp5 No audit.log: https://openqa.suse.de/tests/17702180#step/arping/74
- 15-sp5 New AVC: https://openqa.suse.de/tests/17702182#step/openvswitch/120
- https://openqa.suse.de/tests/17702415
- https://openqa.opensuse.org/tests/5064686#step/snapper_zypp/96

Cherry-picked from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22070
- **Move avc_selinux_alerts to Utils::Logging**
- **Collect selinux alerts also on X11 post_fail_hook**

I'm also tempted also cherry pick this commit to upload auditd.log from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22070/commits/c8a635345fe47cae4c73fc92102636edd1a811ce
