### PR TITLE
Add workaround to install B1 on unsupported sles

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -133,6 +133,24 @@ undef by default. Test modules testing for SAP ASE should set this property befo
 
 has ASE_RESPONSE_FILE => undef;
 
+=head2 b1_workaround_os_version
+
+    $self->b1_workaround_os_version()
+
+This is a simple workaround to  allow SAP Business One to be installed on
+versions that the_
+installer reports as "unsupported OS" by changing VERSION_ID on /etc/os-release.
+
+=cut
+
+sub b1_workaround_os_version {
+    my $origin_os = script_output(q@grep VERSION_ID /etc/os-release | cut -d '"' -f2@);
+    if (get_var('B1_WORKAROUND')) {
+        record_info("Enabling Business One workaround as SLES" . get_var('B1_WORKAROUND'));
+        file_content_replace("/etc/os-release", $origin_os => get_var('B1_WORKAROUND'));
+    }
+}
+
 =head2 download_hana_assets_from_server
 
     $self->download_hana_assets_from_server()

--- a/tests/sles4sap/bone_install.pm
+++ b/tests/sles4sap/bone_install.pm
@@ -50,7 +50,6 @@ sub run {
     # Download xml config
     my $b1_cfg = "bone.cfg";
     my $hostname = script_output 'hostname';
-    my $local_url = "http://10.100.103.247:8000/";
     my $admin_id = "ndbadm";
 
     assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/$b1_cfg -o /tmp/$b1_cfg";
@@ -58,6 +57,10 @@ sub run {
     # change some default values
     file_content_replace("/tmp/$b1_cfg", '%SERVER%' => $hostname, '%INSTANCE%' => $instid, '%TENANT_DB%' => $sid, '%PASSWORD%' => $sles4sap::instance_password);
 
+    # initial workaround for 15-SP7 and b1 installer 2502
+    $self->b1_workaround_os_version;
+
+    # Install
     assert_script_run "$install_bin -i silent -f /tmp/$b1_cfg --debug", $tout;
 
     # Upload installations logs

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -59,6 +59,9 @@ sub run {
     my $wiz_name = (is_sle('15-SP5+') and get_var('BONE')) ? "bone-installation-wizard" : "sap-installation-wizard";
     my $wizard_package_version = script_output("rpm -q --qf '%{VERSION}\n' $wiz_name");
 
+    # initial workaround for 15-SP7 and b1 installer 2502
+    $self->b1_workaround_os_version;
+
     # start wizard
     if (check_var('DESKTOP', 'textmode')) {
         script_run "yast2 sap-installation-wizard; echo yast2-sap-installation-wizard-status-\$? > /dev/$serialdev", 0;


### PR DESCRIPTION
This workaround enables B1 instalation on unsupported sles version by changing the VERSION_ID to one which is homologated by SAP. Requires previous manual testing to ensure compatibility.
In order to enable the workaround, add B1_WORKAROUND=<supported_sle> (ex. 15.6) n jobgroup.

Fixes: TEAM-10276

VR:
15-SP7:
http://10.100.103.247/tests/1158
http://10.100.103.247/tests/1152

15-SP6:
http://10.100.103.247/tests/1184
http://10.100.103.247/tests/1185