### PR TITLE
Always do a zypper ref before installing anything

### DIFF
--- a/tests/security/postgresql_ssl/postgresql_ssl_client.pm
+++ b/tests/security/postgresql_ssl/postgresql_ssl_client.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2022 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: The client side of postgresql ssl connection test.
@@ -24,6 +24,7 @@ sub run {
     select_console 'root-console';
 
     # Install runtime dependencies
+    zypper_call("ref");
     zypper_call("in iputils");
 
     # We don't run setup_multimachine in s390x, but we need to know the server and client's

--- a/tests/security/postgresql_ssl/postgresql_ssl_server.pm
+++ b/tests/security/postgresql_ssl/postgresql_ssl_server.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2022 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: The server side of postgresql ssl connection test.
@@ -34,6 +34,7 @@ sub run {
     systemctl("stop firewalld");
 
     # Install postgresql
+    zypper_call("ref");
     zypper_call('in postgresql-server');
     systemctl('start postgresql');
 


### PR DESCRIPTION
zypper could not find a suitable version of postgresql-server. The reason as it turned out was that the repo was outdated
on the SUT. Fix is always easy in this situations: zypper ref before zypper in.

- Related ticket: https://progress.opensuse.org/issues/182504
- Verification run server part: https://openqa.suse.de/tests/17702468
- Verification run client part: https://openqa.suse.de/tests/17702469

The VR shows that I did a zypper ref before letting the test continue. This solved the problem. However I was not able to clone the job and do a regular VR with my CASEDIR, because the repo of the referenced upgrade has already vanished.. So OpenQA refused to clone the job....
