### PR TITLE
Add qesap regression terraform peering for AWS

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
@@ -1,0 +1,54 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+provider: 'aws'
+apiver: 3
+terraform:
+  variables:
+    aws_region: '%REGION%'
+    deployment_name: '%DEPLOYMENTNAME%'
+    os_image: '%OS_VER%'
+    os_owner: '%OS_OWNER%'
+    public_key: '%SLES4SAP_PUBSSHKEY%'
+    aws_credentials: '/root/amazon_credentials'
+    hana_instancetype: '%HANA_INSTANCE_TYPE%'
+    hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    vpc_address_range: '%MAIN_ADDRESS_RANGE%'
+    ibsm_project_tag: '%IBSM_PRJ_TAG%'
+ansible:
+  roles_path: '%ANSIBLE_ROLES%'
+  az_storage_account_name: '%HANA_ACCOUNT%'
+  az_container_name:  '%HANA_CONTAINER%'
+  az_key_name: '%HANA_KEYNAME%'
+  hana_media:
+    - '%HANA_SAR%'
+    - '%HANA_CLIENT_SAR%'
+    - '%HANA_SAPCAR%'
+  hana_vars:
+    sap_hana_install_install_execution_mode: '%HANA_INSTALL_MODE%'
+    sap_hana_install_software_directory: '/hana/shared/install'
+    sap_hana_install_master_password: 'DoNotUseThisPassw0rd'
+    sap_hana_install_sid: 'HQ0'
+    sap_hana_install_instance_number: '00'
+    sap_domain: 'qe-test.example.com'
+    primary_site: 'goofy'
+    secondary_site: 'miky'
+    use_sap_hana_sr_angi: '%USE_SR_ANGI%'
+  create:
+    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+    - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'
+    - fully-patch-system.yaml
+    - pre-cluster.yaml
+    - sap-hana-preconfigure.yaml
+    - sap-hana-storage.yaml
+    - sap-hana-download-media.yaml
+    - sap-hana-install.yaml
+    - sap-hana-system-replication.yaml
+    - sap-hana-system-replication-hooks.yaml
+    - sap-hana-cluster.yaml
+  destroy:
+    - deregister.yaml

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -115,16 +115,19 @@ sub run {
         $variables{IBSM_VNET} = get_var('QESAPDEPLOY_IBSM_VNET', '');
         $variables{IBSM_RG} = get_var('QESAPDEPLOY_IBSM_RG', '');
     }
+    elsif ($provider_setting eq 'EC2') {
+        $variables{IBSM_PRJ_TAG} = get_var('QESAPDEPLOY_IBSM_PRJ_TAG', '');
+    }
     elsif ($provider_setting eq 'GCE') {
         $variables{IBSM_VPC_NAME} = get_var('QESAPDEPLOY_IBSM_VPC_NAME', '');
         $variables{IBSM_SUBNET_NAME} = get_var('QESAPDEPLOY_IBSM_SUBNET_NAME', '');
         $variables{IBSM_SUBNET_REGION} = get_var('QESAPDEPLOY_IBSM_SUBNET_REGION', '');
     }
 
-
-
     if (($provider_setting eq 'AZURE' && get_var('QESAPDEPLOY_IBSM_VNET') && get_var('QESAPDEPLOY_IBSM_RG')) ||
-        ($provider_setting eq 'GCE' && get_var('QESAPDEPLOY_IBSM_VPC_NAME') && get_var('QESAPDEPLOY_IBSM_SUBNET_NAME') && get_var('QESAPDEPLOY_IBSM_SUBNET_REGION'))) {
+        ($provider_setting eq 'EC2' && get_var('QESAPDEPLOY_IBSM_PRJ_TAG')) ||
+        ($provider_setting eq 'GCE' && get_var('QESAPDEPLOY_IBSM_VPC_NAME') && get_var('QESAPDEPLOY_IBSM_SUBNET_NAME') && get_var('QESAPDEPLOY_IBSM_SUBNET_REGION'))
+    ) {
         $variables{IBSM_IP} = get_required_var('QESAPDEPLOY_IBSM_IP');
         $variables{DOWNLOAD_HOSTNAME} = get_required_var('QESAPDEPLOY_DOWNLOAD_HOSTNAME');
         $variables{REPOS} = join(',', get_test_repos());

--- a/tests/sles4sap/qesapdeployment/destroy.pm
+++ b/tests/sles4sap/qesapdeployment/destroy.pm
@@ -15,10 +15,6 @@ use sles4sap::qesap::qesap_aws;
 sub run {
     select_serial_terminal;
 
-    if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2') && get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE')) {
-        my $deployment_name = qesap_calculate_deployment_name('qesapval');
-        qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
-    }
     my @ansible_ret = qesap_execute(
         cmd => 'ansible',
         cmd_options => '-d',

--- a/tests/sles4sap/qesapdeployment/test_mirror.pm
+++ b/tests/sles4sap/qesapdeployment/test_mirror.pm
@@ -17,23 +17,13 @@ sub run {
     my $provider_setting = get_required_var('PUBLIC_CLOUD_PROVIDER');
 
     if (($provider_setting eq 'AZURE' && get_var('QESAPDEPLOY_IBSM_VNET') && get_var('QESAPDEPLOY_IBSM_RG')) ||
+        ($provider_setting eq 'EC2' && get_var('QESAPDEPLOY_IBSM_PRJ_TAG')) ||
         ($provider_setting eq 'GCE' && get_var('QESAPDEPLOY_IBSM_VPC_NAME') && get_var('QESAPDEPLOY_IBSM_SUBNET_NAME') && get_var('QESAPDEPLOY_IBSM_SUBNET_REGION'))) {
         my @remote_cmd = (
             'ping -c3 ' . get_required_var('QESAPDEPLOY_DOWNLOAD_HOSTNAME'),
             'zypper -n ref -s -f',
             'zypper -n lr');
         qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 300) for @remote_cmd;
-    }
-    elsif ($provider_setting eq 'EC2') {
-        if (get_var("QESAPDEPLOY_IBSMIRROR_IP_RANGE")) {
-            my $deployment_name = qesap_calculate_deployment_name('qesapval');
-            my $vpc_id = qesap_aws_get_vpc_id(resource_group => $deployment_name);
-            die "No vpc_id in this deployment" if $vpc_id eq 'None';
-            my $ibs_mirror_target_ip = get_var('QESAPDEPLOY_IBSMIRROR_IP_RANGE');
-            die 'Error in network peering setup.' if !qesap_aws_vnet_peering(target_ip => $ibs_mirror_target_ip, vpc_id => $vpc_id, mirror_tag => get_var('QESAPDEPLOY_IBSM_PRJ_TAG', 'IBS Mirror'));
-            qesap_add_server_to_hosts(name => 'download.suse.de', ip => get_required_var('QESAPDEPLOY_IBSM_IP'));
-            die 'Error in network peering delete.' if !qesap_aws_delete_transit_gateway_vpc_attachment(name => $deployment_name . '*');
-        }
     }
 }
 


### PR DESCRIPTION
Add conf.yaml for qesap regression test to do network peering to IBSm.

- Related ticket: https://jira.suse.com/browse/TEAM-9886

# Verification run:
 sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test
 -  http://openqaworker15.qa.suse.cz/tests/324419 :red_circle: Failure is in `[sap-hana-download-media](https://openqaworker15.qa.suse.cz/tests/324419#step/sap-hana-download-media/1)` so not easy to find a relation to th ecode in the PR
 -  http://openqaworker15.qa.suse.cz/tests/324510 :green_circle: overall deployment fails due to AWS disk issue, but peering is correctly created and destroyed by terraform https://openqaworker15.qa.suse.cz/tests/324510/logfile?filename=serial_terminal.txt#line-22985