### PR TITLE
Fix the 15-SP2 sriov test issue

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2577,14 +2577,28 @@ sub load_hypervisor_tests {
     );
 
     for my $test (keys %virt_features) {
+        print "Processing feature: $test\n";
         next if $test eq 'ENABLE_SNAPSHOTS';
+        print "Skipping ENABLE_SNAPSHOTS\n";
+
         my $feature = $virt_features{$test};
         my $modules = $feature->{modules};
         my $hypervisor = $feature->{hypervisor};
+
+        print "Feature: $test\n";
+        print "  Modules: @$modules\n";
+        print "  Hypervisor: $hypervisor\n";
+
         # The LTSS for SUSE 15-SP1 has ended. Due to a bug (bsc#1230913), also skip 15-SP2.
         if ($test eq 'ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH') {
-            next unless is_sle('>=15-sp3');
+            print "Checking version for ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH\n";
+            unless (is_sle('>=15-sp3')) {
+                print "Skipping ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH due to version <= 15-SP2\n";
+                next;
+            }
         }
+
+        print "Calling check_and_load_mu_virt_features for $test\n";
         check_and_load_mu_virt_features($test, $modules, $hypervisor);
     }
     # Load ENABLE_SNAPSHOTS at the end


### PR DESCRIPTION
Expected result:
```
>=15-sp3, require to execute sriov test.
<15-sp3, do not execute sriov test.
```


- Related ticket: https://progress.opensuse.org/issues/167018
- Needles: n/a
- Verification run: 
[15-SP2 with current branch](https://openqa.oqa.prg2.suse.org/tests/17710612#details)
[15-SP2 with master branch](https://openqa.oqa.prg2.suse.org/tests/17710680#details) still have sriov test even though version=15-SP2
[15-SP6 with current branch](https://openqa.oqa.prg2.suse.org/tests/17710626#details)
