### PR TITLE
bats: Fix grep "not ok" for podman

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -345,10 +345,8 @@ sub bats_tests {
     my $ret = script_run $cmd, 7000;
 
     $skip_tests = get_var($skip_tests, $settings->{$skip_tests});
-    unless (@tests) {
-        my @skip_tests = split(/\s+/, get_var('BATS_SKIP', $settings->{BATS_SKIP}) . " " . $skip_tests);
-        patch_logfile($log_file, @skip_tests);
-    }
+    my @skip_tests = split(/\s+/, get_var('BATS_SKIP', $settings->{BATS_SKIP}) . " " . $skip_tests);
+    patch_logfile($log_file, @skip_tests);
 
     parse_extra_log(TAP => $log_file);
 


### PR DESCRIPTION
Fix `record_info` issue for podman tests in remote mode where the test name can't be fetched and we need the test number instead.  This wrongly shows up as PASS: https://openqa.opensuse.org/tests/5063175#step/podman/360

- Verification run: https://openqa.opensuse.org/tests/5064760