### PR TITLE
Update Google GPG key in chrome

### DIFF
--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -19,8 +19,7 @@ sub install_google_repo_key {
     become_root;
     assert_script_run "rpm --import https://dl.google.com/linux/linux_signing_key.pub";
     # validate it's properly installed
-    script_run "rpm -qi gpg-pubkey-d38b4796-*";
-    assert_screen 'google-key-installed';
+    assert_script_run "rpm -qi gpg-pubkey-d38b4796-*";
 }
 
 sub avoid_async_keyring_popups {

--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -19,7 +19,7 @@ sub install_google_repo_key {
     become_root;
     assert_script_run "rpm --import https://dl.google.com/linux/linux_signing_key.pub";
     # validate it's properly installed
-    script_run "rpm -qi gpg-pubkey-7fac5991-*";
+    script_run "rpm -qi gpg-pubkey-d38b4796-*";
     assert_screen 'google-key-installed';
 }
 


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/182555 and https://progress.opensuse.org/issues/182540

From: https://www.google.de/linuxrepositories/
> NOTE: From early 2023 onward, all Linux RPM packages are signed with periodically rotated subkeys of the 0xD38B4796 signing key. The 0x7FAC5991 signing key is obsoleted by this change. 


- Leap: https://openqa.opensuse.org/tests/5064503
- TW: https://openqa.opensuse.org/tests/5064502#step/chrome/10
