### PR TITLE
Minor tweaks in console tests

### DIFF
--- a/tests/console/aide_check.pm
+++ b/tests/console/aide_check.pm
@@ -31,7 +31,7 @@ sub run {
     assert_script_run "mv aide_conf /etc/aide.conf";
 
 
-    assert_script_run "mkdir /testdir";
+    assert_script_run "mkdir -p /testdir";
     assert_script_run "echo hello > /testdir/t1.log";
 
     # Initialize the database and move it to the appropriate place before using the --check command

--- a/tests/console/git.pm
+++ b/tests/console/git.pm
@@ -29,7 +29,7 @@ sub run {
 
     # Create a test repo
     zypper_call("in git-core");
-    assert_script_run("mkdir -p repos/qa1;cd repos/qa1");
+    assert_script_run("rm -rf ~/repos && mkdir -p repos/qa1;cd repos/qa1");
     assert_script_run("git init");
     assert_script_run("echo \"SUSE Test\" > README");
     assert_script_run("git config --global user.email \"$email\"");
@@ -41,9 +41,11 @@ sub run {
 
     # Prepare ssh
     assert_script_run("mkdir -p ~/.ssh && chmod 700 ~/.ssh && touch ~/.ssh/known_hosts");
+    assert_script_run("rm -rf ~/.ssh/id_rsa");
     assert_script_run("ssh-keyscan -H localhost >> ~/.ssh/known_hosts");
     assert_script_run("ssh-keygen -q -trsa -b4096 -f ~/.ssh/id_rsa -N ''");
     assert_script_run("cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys");
+
     # Clone repo via ssh
     script_run("git clone ssh://localhost:/root/repos/qa0 qa2 | tee /dev/$serialdev", 0);
 

--- a/tests/console/journald_fss.pm
+++ b/tests/console/journald_fss.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2016-2022 SUSE LLC
+# Copyright 2016-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Case 1560070  - FIPS: systemd journald FSS
@@ -32,12 +32,12 @@ sub run {
 
     assert_script_run("sed -i -e 's/^Storage/#Storage/g' -e 's/^Seal/#Seal/g' $journald_conf") if is_sle('<=15-SP5') || is_leap('<=15.5');
     assert_script_run("echo -e \"Storage=persistent\nSeal=yes\" >> $journald_conf");
-    assert_script_run("mkdir -p /var/log/journal");
+    assert_script_run("rm -rf /var/log/journal; mkdir -p /var/log/journal");
     systemctl 'restart systemd-journald.service';
 
     # Setup keys
     assert_script_run("journalctl --flush");
-    assert_script_run("journalctl --interval=30s --setup-keys | tee /tmp/key");
+    assert_script_run("journalctl --interval=30s --setup-keys --force | tee /tmp/key");
     assert_script_run("journalctl --rotate");
 
     # Verify the journal with valid verification key


### PR DESCRIPTION
Minor tweaks for console tests:

- Related tickets:
    
    https://progress.opensuse.org/issues/178342
    https://progress.opensuse.org/issues/168199

- Verification runs: 
    ppc64le: https://openqa.suse.de/tests/17712188
    x86_64 ipmi-tyrion: https://openqa.suse.de/tests/17712711
    
Please ignore the ecryptfs failure on tyrion. That is unrelated to these changes.