### PR TITLE
Add missing include for qesap_aws

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -27,6 +27,7 @@ use serial_terminal qw(serial_term_prompt);
 use version_utils qw(check_version is_sle);
 use hacluster;
 use sles4sap::qesap::qesapdeployment;
+use sles4sap::qesap::qesap_aws;
 use publiccloud::utils;
 use publiccloud::provider;
 use publiccloud::ssh_interactive qw(select_host_console);


### PR DESCRIPTION
Fix regression introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21993


- Related ticket: https://jira.suse.com/browse/TEAM-10370

 # Verification run:
sle-15-SP6-EC2-SAP-BYOS-Incidents-x86_64-Build SAPHanaSR-ScaleUp-PerfOpt-native-stop
 -  http://openqaworker15.qa.suse.cz/tests/324509 :green_circle: https://openqaworker15.qa.suse.cz/tests/324509/logfile?filename=autoinst-log.txt&filter=qesap_aws_delete_transit_gateway_vpc_attachment#line-44738