### PR TITLE
fips: Increase timeout for fips-mode-setup

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -37,7 +37,7 @@ sub enable_fips {
     my $self = shift;
 
     if (is_sle('>=15-SP4') || is_jeos || is_tumbleweed) {
-        assert_script_run("fips-mode-setup --enable");
+        assert_script_run("fips-mode-setup --enable", timeout => 120);
         $self->reboot_and_select_serial_term;
     } else {
         # on SL Micro 6.0+ we only need to reboot, no need to manually change grub.


### PR DESCRIPTION
 Increase timeout for fips-mode-setup

- Failing test: https://openqa.suse.de/tests/17710544#step/fips_setup/7
- Verification run: https://openqa.suse.de/tests/17711418