### PR TITLE
bats: Make it possible to bypass BATS_PATCHES

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -356,7 +356,7 @@ sub bats_tests {
 }
 
 sub bats_patches {
-    return if get_var("BATS_URL");
+    return if (get_var("BATS_URL") || check_var("BATS_PATCHES", "none"));
 
     my $github_org = ($package eq "runc") ? "opencontainers" : "containers";
 


### PR DESCRIPTION
Make it possible to bypass BATS_PATCHES.  We can't set it to an empty string because we're fetching those from skip.yaml otherwise.

Make it an undocumented feature for now.  We may need it for podman 5.5 to skip the current set of patches.

Skipping VR being such an obvious change.