### PR TITLE
bats: No need for PackageHub

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -140,8 +140,6 @@ sub enable_modules {
     add_suseconnect_product(get_addon_fullname('desktop'));
     add_suseconnect_product(get_addon_fullname('sdk'));
     add_suseconnect_product(get_addon_fullname('python3')) if is_sle('>=15-SP4');
-    # Needed for libcriu2
-    add_suseconnect_product(get_addon_fullname('phub'));
 }
 
 sub patch_logfile {


### PR DESCRIPTION
Drop PackageHub for SLE as we don't install libcriu2.