### PR TITLE
Adjust sizing for SDAF

### DIFF
--- a/data/sles4sap/sap_deployment_automation_framework/custom_sizes.json
+++ b/data/sles4sap/sap_deployment_automation_framework/custom_sizes.json
@@ -10,14 +10,14 @@
           "name": "os",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 64,
           "caching": "ReadWrite"
         },
         {
           "name": "data",
           "count": 3,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 12,
           "caching": "None",
           "write_accelerator": false,
           "lun_start": 0
@@ -26,7 +26,7 @@
           "name": "log",
           "count": 1,
           "disk_type": "UltraSSD_LRS",
-          "size_gb": 128,
+          "size_gb": 16,
           "caching": "None",
           "write_accelerator": false,
           "disk_iops_read_write": 1800,
@@ -37,7 +37,7 @@
           "name": "shared",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 256,
+          "size_gb": 64,
           "caching": "ReadOnly",
           "write_accelerator": false,
           "lun_start": 6
@@ -46,7 +46,7 @@
           "name": "backup",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 256,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false,
           "lun_start": 13
@@ -55,7 +55,7 @@
           "name": "sap",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 16,
           "caching": "ReadOnly",
           "write_accelerator": false,
           "lun_start": 14
@@ -74,14 +74,14 @@
           "name": "os",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 64,
           "caching": "ReadWrite"
         },
         {
           "name": "sap",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 16,
           "caching": "ReadWrite",
           "write_accelerator": false,
           "lun_start": 0
@@ -98,14 +98,14 @@
           "name": "os",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 64,
           "caching": "ReadWrite"
         },
         {
           "name": "sap",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 16,
           "caching": "ReadWrite",
           "write_accelerator": false,
           "lun_start": 0
@@ -124,14 +124,14 @@
           "name": "os",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 64,
           "caching": "ReadWrite"
         },
         {
           "name": "sap",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 16,
           "caching": "ReadWrite",
           "write_accelerator": false,
           "lun_start": 0
@@ -150,14 +150,14 @@
           "name": "os",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 64,
           "caching": "ReadWrite"
         },
         {
           "name": "sap",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 16,
           "caching": "ReadWrite",
           "write_accelerator": false,
           "lun_start": 0
@@ -174,14 +174,14 @@
           "name": "os",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 64,
           "caching": "ReadWrite"
         },
         {
           "name": "sap",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 16,
           "caching": "ReadWrite",
           "write_accelerator": false,
           "lun_start": 0
@@ -200,14 +200,14 @@
           "name": "os",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 64,
           "caching": "ReadWrite"
         },
         {
           "name": "sap",
           "count": 1,
           "disk_type": "Premium_LRS",
-          "size_gb": 128,
+          "size_gb": 16,
           "caching": "ReadWrite",
           "write_accelerator": false,
           "lun_start": 0


### PR DESCRIPTION
This PR adjusts disk sizing used for all SDAF based deployments according official SAP sizing recommendations and our requirements.

VM: Standard_E4d_v4
Memory: 32G
Data (1,2 x mem): 36G (3x16G lun)
Log (0,5 x meme): 16G
Shared (min 1x memory): 64G
OS: 64G
/usr/sap/ : 16G (usually enough)



Ticket: https://jira.suse.com/browse/TEAM-10259
Verification run: https://openqaworker15.qa.suse.cz/tests/324520
