### PR TITLE
Minor BATS fixes

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -74,16 +74,16 @@ podman:
     BATS_PATCHES:
     - https://github.com/containers/podman/pull/21875.patch
     BATS_SKIP: ''
-    BATS_SKIP_ROOT_LOCAL: ''
-    BATS_SKIP_ROOT_REMOTE: ''
+    BATS_SKIP_ROOT_LOCAL: 520-checkpoint
+    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
     BATS_SKIP_USER_LOCAL: 080-pause
     BATS_SKIP_USER_REMOTE: ''
   sle-15-SP7:
     BATS_PATCHES:
     - https://github.com/containers/podman/pull/21875.patch
     BATS_SKIP: ''
-    BATS_SKIP_ROOT_LOCAL: ''
-    BATS_SKIP_ROOT_REMOTE: ''
+    BATS_SKIP_ROOT_LOCAL: 520-checkpoint
+    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
     BATS_SKIP_USER_LOCAL: 080-pause
     BATS_SKIP_USER_REMOTE: ''
   sle-16.0:

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -140,6 +140,8 @@ sub enable_modules {
     add_suseconnect_product(get_addon_fullname('desktop'));
     add_suseconnect_product(get_addon_fullname('sdk'));
     add_suseconnect_product(get_addon_fullname('python3')) if is_sle('>=15-SP4');
+    # Needed for criu & fakeroot
+    add_suseconnect_product(get_addon_fullname('phub'));
 }
 
 sub patch_logfile {


### PR DESCRIPTION
PackageHub is still needed for fakeroot.  Also, we need to ignore `520-checkpoint` on SLES 15-SP6+ as it doesn't officialy support criu.
