### PR TITLE
git: Delete .ssh first before generating ssh key

### DIFF
--- a/tests/console/git.pm
+++ b/tests/console/git.pm
@@ -40,6 +40,7 @@ sub run {
     assert_script_run("cd ~/repos;git clone --bare qa1 qa0");
 
     # Prepare ssh
+    assert_script_run('rm -rf ~/.ssh');
     assert_script_run("mkdir -p ~/.ssh && chmod 700 ~/.ssh && touch ~/.ssh/known_hosts");
     assert_script_run("ssh-keyscan -H localhost >> ~/.ssh/known_hosts");
     assert_script_run("ssh-keygen -q -trsa -b4096 -f ~/.ssh/id_rsa -N ''");


### PR DESCRIPTION
/root/.ssh/id_rsa already exists.
Overwrite (y/n)?

- Related ticket: 3203380dd972d11ecb4975c7e2f88d5aa4380d03
- Verification run:
https://openqa.suse.de/tests/17730209
https://openqa.suse.de/tests/17730214
