### PR TITLE
bats: No need ignore some more tests

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -74,16 +74,16 @@ podman:
     BATS_PATCHES:
     - https://github.com/containers/podman/pull/21875.patch
     BATS_SKIP: ''
-    BATS_SKIP_ROOT_LOCAL: 520-checkpoint
-    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
+    BATS_SKIP_ROOT_LOCAL:
+    BATS_SKIP_ROOT_REMOTE:
     BATS_SKIP_USER_LOCAL: 080-pause
     BATS_SKIP_USER_REMOTE: ''
   sle-15-SP7:
     BATS_PATCHES:
     - https://github.com/containers/podman/pull/21875.patch
     BATS_SKIP: ''
-    BATS_SKIP_ROOT_LOCAL: 520-checkpoint
-    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
+    BATS_SKIP_ROOT_LOCAL:
+    BATS_SKIP_ROOT_REMOTE:
     BATS_SKIP_USER_LOCAL: 080-pause
     BATS_SKIP_USER_REMOTE: ''
   sle-16.0:
@@ -99,7 +99,7 @@ podman:
     - https://github.com/containers/podman/pull/26017.patch
     BATS_SKIP: 125-import
     BATS_SKIP_ROOT_LOCAL: 520-checkpoint
-    BATS_SKIP_ROOT_REMOTE: 090-events 520-checkpoint
+    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
     BATS_SKIP_USER_LOCAL: 080-pause 505-networking-pasta
     BATS_SKIP_USER_REMOTE: 505-networking-pasta
 runc:


### PR DESCRIPTION
These tests are passing:

- 090-events:
  - 16.0:
    - https://openqa.suse.de/tests/17726011#step/podman/526
- 520-checkpoint:
  - 15-SP5:
    - https://openqa.suse.de/tests/17728953#step/podman/412
    - https://openqa.suse.de/tests/17728953#step/podman/476
  - 15-SP6:
    - https://openqa.suse.de/tests/17730373#step/podman/412
    - https://openqa.suse.de/tests/17730373#step/podman/476

Confirmed with:

```
# 16.0
$ susebats notok https://openqa.suse.de/tests/17726011
    BATS_SKIP: 125-import
    BATS_SKIP_ROOT_LOCAL: 520-checkpoint
    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
    BATS_SKIP_USER_LOCAL: 080-pause 505-networking-pasta
    BATS_SKIP_USER_REMOTE: 505-networking-pasta
# 15-SP5
$ susebats notok https://openqa.suse.de/tests/17728953
    BATS_SKIP: ''
    BATS_SKIP_ROOT_LOCAL: ''
    BATS_SKIP_ROOT_REMOTE: ''
    BATS_SKIP_USER_LOCAL: 080-pause
    BATS_SKIP_USER_REMOTE: ''
# 15-SP6
$ susebats notok https://openqa.suse.de/tests/17730373
    BATS_SKIP: ''
    BATS_SKIP_ROOT_LOCAL: ''
    BATS_SKIP_ROOT_REMOTE: ''
    BATS_SKIP_USER_LOCAL: 080-pause
    BATS_SKIP_USER_REMOTE: ''
```
