### PR TITLE
Use OSD on non-openSUSE tests

### DIFF
--- a/tests/microos/networking.pm
+++ b/tests/microos/networking.pm
@@ -10,6 +10,8 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use utils;
+use version_utils;
 
 sub run {
     # check the network configuration
@@ -21,8 +23,9 @@ sub run {
     assert_script_run 'ping -c 1 ::1';
 
     # curl
-    assert_script_run 'curl -L openqa.opensuse.org';    # openQA Networking (required for mirrors)
-    assert_script_run 'curl -L github.com';    # Required for kubeadm (behind the scenes)
+    my $openqa = is_opensuse ? "openqa.opensuse.org" : "openqa.suse.de";
+    script_retry("curl -Lf --HEAD $openqa", retry => 5, delay => 60);    # openQA Networking (required for mirrors)
+    script_retry("curl -Lf --HEAD github.com", retry => 5, delay => 60);    # Required for kubeadm (behind the scenes)
 
 }
 


### PR DESCRIPTION
Avoid putting additional load on O3 for OSD test runs. Also avoid that OSD test runs would fail, if O3 is down.

- Related failure: https://openqa.suse.de/tests/17729695#step/networking/16
- Verification run: https://openqa.suse.de/tests/17732175
