### PR TITLE
Enhance BATS documentation

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -58,6 +58,7 @@ podman:
   # https://github.com/containers/podman/pull/25340 is needed for 030-run
   # https://github.com/containers/podman/pull/25350 is needed for 030-run
   # https://github.com/containers/podman/pull/25718 is needed for 030-run
+  # https://github.com/containers/podman/pull/25918 is needed for 195-run-namespaces
   # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
   opensuse-Tumbleweed:

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -1,12 +1,14 @@
 
 This directory contains [BATS framework](https://github.com/bats-core/bats-core) tests for the following packages:
 
-- [aardvark](https://github.com/containers/aardvark-dns/tree/main/test)
-- [buildah](https://github.com/containers/buildah/tree/main/tests)
-- [netavark](https://github.com/containers/netavark/tree/main/test)
-- [podman](https://github.com/containers/podman/tree/main/test/system)
-- [runc](https://github.com/opencontainers/runc/tree/main/tests/integration)
-- [skopeo](https://github.com/containers/skopeo/tree/main/systemtest)
+| package | tests |
+| --- | --- |
+| [aardvark-dns](aardvark.pm) | https://github.com/containers/aardvark-dns/tree/main/test |
+| [buildah](buildah.pm) | https://github.com/containers/buildah/tree/main/tests |
+| [netavark](netavark.pm) | https://github.com/containers/netavark/tree/main/test |
+| [podman](podman.pm) | https://github.com/containers/podman/tree/main/test/system |
+| [runc](runc.pm) | https://github.com/opencontainers/runc/tree/main/tests/integration |
+| [skopeo](skopeo.pm) | https://github.com/containers/skopeo/tree/main/systemtest |
 
 Library code is found in [lib/containers/bats.pm](../../../lib/containers/bats.pm)
 

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -31,7 +31,7 @@ NOTES
 
 ### Summary of the `BATS_SKIP` variables
 
-These are defined for each product in [data/containers/bats/skip.yaml](skip.yaml)
+These are defined in [skip.yaml](data/containers/bats/skip.yaml)
 
 | variable | description | aardvark | buildah | netavark | podman | runc | skopeo |
 |---|---|:---:|:---:|:---:|:---:|:---:|:---:|


### PR DESCRIPTION
- Fix skip.yaml link
- Add missing comment
- Enhance it a bit

VR: 
https://github.com/ricardobranco777/os-autoinst-distri-opensuse/blob/bats_docu/tests/containers/bats/README.md
