### PR TITLE
Fix the testsuite and testcase name in xml results

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -625,7 +625,7 @@ EOF
                 $n_runs++;
             }
             send_key 'ctrl-c';
-            assert_script_run("sed -i 's/Tests Suite/$section/g' $junit_xml");
+            assert_script_run("sed -i 's/\\(KubeVirt Tests Suite\\|Tests Suite\\)/$section/g' $junit_xml");
             $if_case_fail = 1 if (script_output("tail -1 $test_log") eq 'FAIL');
         }
     }
@@ -664,7 +664,7 @@ sub generate_test_report {
                 <include name="*_test.xml" />
             </fileset>
             <report format="noframes" todir="$html_dir" styledir="/tmp">
-                <param name="TITLE" expression="Kubevirt Test Results"/>
+                <param name="TITLE" expression="KubeVirt Test Results"/>
             </report>
         </junitreport>
     </target>


### PR DESCRIPTION
Refer to https://openqa.suse.de/tests/17711075/file/junit-noframes.html. Generated xml result files from sle15sp7 include additional string 'KubeVirt' in testsuite and testcase name, and it's needed to be removed from xml result files before generate html reports.

- Related ticket: https://progress.opensuse.org/issues/182693
- Verification run: https://openqa.suse.de/tests/17732296/file/junit-noframes.html
