### PR TITLE
Replace HEAD with head

### DIFF
--- a/tests/microos/networking.pm
+++ b/tests/microos/networking.pm
@@ -24,8 +24,8 @@ sub run {
 
     # curl
     my $openqa = is_opensuse ? "openqa.opensuse.org" : "openqa.suse.de";
-    script_retry("curl -Lf --HEAD $openqa", retry => 5, delay => 60);    # openQA Networking (required for mirrors)
-    script_retry("curl -Lf --HEAD github.com", retry => 5, delay => 60);    # Required for kubeadm (behind the scenes)
+    script_retry("curl -Lf --head $openqa", retry => 5, delay => 60);    # openQA Networking (required for mirrors)
+    script_retry("curl -Lf --head github.com", retry => 5, delay => 60);    # Required for kubeadm (behind the scenes)
 
 }
 


### PR DESCRIPTION
s/--HEAD/--head/g because the correct parameter is --head for curl.

- Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22118
- Related failure: https://openqa.suse.de/tests/17739745#step/networking/27
- Verification run: https://openqa.suse.de/tests/17740645
