### PR TITLE
Fix storage show entrypted disk popup after run encrypt job

### DIFF
--- a/data/yam/agama/auto/lib/scripts_pre.libsonnet
+++ b/data/yam/agama/auto/lib/scripts_pre.libsonnet
@@ -21,4 +21,26 @@
       done
     |||
   },
+  ibft_answers: {
+    name: 'ibft_test_answers',
+    content: |||
+      #!/usr/bin/env bash
+      cat > /tmp/ibft_answers.json <<EOF
+      {
+        "answers": [
+         {
+           "class":"storage.commit_error",
+           "answer": "yes"
+         },
+         {
+           "class": "storage.luks_activation",
+           "answer": "skip"
+         }
+        ]
+      }
+      EOF
+      agama questions answers /tmp/ibft_answers.json
+      agama questions mode non-interactive
+    |||
+  },
 }


### PR DESCRIPTION
##
###

- Related ticket: 
  - this is to fix:
     -  https://openqa.suse.de/tests/17519646#step/agama_auto/1
     - https://openqa.suse.de/tests/17586275#step/boot_agama/18
     
- Needles: N/A
- Verification run: 
   - [**VR**](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=hjluo%2Fos-autoinst-distri-opensuse%23fix_storage_luks)

##

