### PR TITLE
Split Helm functons into a utils library

### DIFF
--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -1,0 +1,74 @@
+# SUSE's openQA tests
+#
+# Copyright 2020-2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Basic functionallity for testing Helm Charts
+# Maintainer: qac team <qa-c@suse.de>
+
+package containers::helm;
+
+use testapi;
+use version_utils qw(get_os_release);
+use Utils::Architectures qw(is_ppc64le);
+use containers::k8s qw(install_kubectl install_helm);
+
+ur @EXPORT = qw(helm_supported_os helm_get_chart helm_configure_values helm_install_chart);
+
+sub helm_supported_os {
+    my ($version, $sp, $host_distri) = get_os_release;
+    # Skip HELM tests on SLES <15-SP3 and on PPC, where k3s is not available
+    return if (!($host_distri eq "sles" && $version == 15 && $sp >= 3) || is_ppc64le);
+    die "helm tests only work on k3s" unless (check_var('CONTAINER_RUNTIMES', 'k3s'));
+}
+
+sub helm_get_chart {
+    my ($helm_chart) = @_;
+    # $helm_chart should be a full URL to a helm chart
+
+    # Pull helm chart, if it is a http file
+    if ($helm_chart =~ m!^https?://!) {
+        my ($url, $path) = split(/#/, $helm_chart, 2);    # split extracted folder path, if present
+        assert_script_run("curl -sSL --retry 3 --retry-delay 30 $url | tar -zxf -");
+        $helm_chart = $path ? "./$path" : ".";
+    }
+    return $helm_chart
+}
+
+sub helm_configure_values {
+    my ($helm_values) = @_;
+    # $helm_values should be a URL to a values.yml file
+
+    # Pull helm values file if defined
+    assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
+
+    # Configure Registry, Image repository and Image tag
+    my $full_registry_path = get_var('HELM_FULL_REGISTRY_PATH');
+    my $set_options = "--set global.imageRegistry=$full_registry_path";
+    if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
+        my ($repository, $tag) = split(':', $image, 2);
+        $set_options = "--set global.imageRegistry=$full_registry_path --set app.image.repository=$repository --set app.image.tag=$tag";
+    }
+
+    # Enable debug logs
+    my $helm_options = "--debug";
+
+    # Use the provided helm values if defined
+    $helm_options = "-f myvalue.yaml $helm_options" if ($helm_values);
+    return ($set_options, $helm_options);
+}
+
+sub helm_install_chart {
+    my ($chart, $values) = @_;
+    # e.g. helm_install_chart("url to chart", "url to values")
+
+    my $helm_chart = get_helm_chart($chart);
+    my ($set_options, $helm_options) = configure_helm_values($values);
+
+    # Install the helm chart
+    script_retry("helm pull $helm_chart", timeout => 300, retry => 6, delay => 60) if ($helm_chart =~ m!^oci://!);
+    assert_script_run("helm install $set_options $release_name $helm_chart $helm_options", timeout => 300);
+    script_run("helm list");
+}
+
+1;

--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -59,7 +59,7 @@ sub helm_configure_values {
     assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
 
     # Configure Registry, Image repository and Image tag
-    my $full_registry_path = get_var('HELM_FULL_REGISTRY_PATH');
+    my $full_registry_path = get_required_var('HELM_FULL_REGISTRY_PATH');
     my $set_options = "--set global.imageRegistry=$full_registry_path";
     if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
         my ($repository, $tag) = split(':', $image, 2);

--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -44,7 +44,7 @@ sub helm_get_chart {
         assert_script_run("curl -sSL --retry 3 --retry-delay 30 $url | tar -zxf -");
         $helm_chart = $path ? "./$path" : ".";
     }
-    return $helm_chart
+    return $helm_chart;
 }
 
 =head2 helm_configure_values

--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -64,11 +64,11 @@ sub helm_configure_values {
     assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
 
     # Configure Registry, Image repository and Image tag
-    my $full_registry_path = get_var('HELM_FULL_REGISTRY_PATH'); 
+    my $full_registry_path = get_var('HELM_FULL_REGISTRY_PATH');
     my $set_options = "";
 
     if ($full_registry_path ne "") {
-        $set_options = "--set global.imageRegistry=$full_registry_path"; # Only necessary if the chart uses non-publicly available images.
+        $set_options = "--set global.imageRegistry=$full_registry_path";    # Only necessary if the chart uses non-publicly available images.
     }
 
     if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {

--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -64,11 +64,19 @@ sub helm_configure_values {
     assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
 
     # Configure Registry, Image repository and Image tag
-    my $full_registry_path = get_required_var('HELM_FULL_REGISTRY_PATH');
-    my $set_options = "--set global.imageRegistry=$full_registry_path";
+    my $full_registry_path = get_var('HELM_FULL_REGISTRY_PATH'); 
+    my $set_options = "";
+
+    if ($full_registry_path ne "") {
+        $set_options = "--set global.imageRegistry=$full_registry_path"; # Only necessary if the chart uses non-publicly available images.
+    }
+
     if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
         my ($repository, $tag) = split(':', $image, 2);
-        $set_options = "--set global.imageRegistry=$full_registry_path --set app.image.repository=$repository --set app.image.tag=$tag";
+
+        # Add space before appending if $set_options already has content
+        $set_options .= " " if $set_options ne "";
+        $set_options .= "--set app.image.repository=$repository --set app.image.tag=$tag";
     }
 
     # Enable debug logs

--- a/tests/containers/charts/privateregistry.pm
+++ b/tests/containers/charts/privateregistry.pm
@@ -33,7 +33,7 @@ sub run {
     my $helm_chart = get_required_var('HELM_CHART');
     my $helm_values = get_var('HELM_CONFIG');
 
-    helm_supported_os();
+    return unless (helm_is_supported());
 
     install_kubectl();
     install_helm();

--- a/tests/containers/charts/privateregistry.pm
+++ b/tests/containers/charts/privateregistry.pm
@@ -15,11 +15,10 @@
 use Mojo::Base 'containers::basetest';
 use File::Basename qw(dirname);
 use testapi;
-use utils;
-use version_utils qw(get_os_release is_sle);
 use serial_terminal qw(select_serial_terminal);
-use Utils::Architectures qw(is_ppc64le);
-use containers::k8s;
+use utils;
+use containers::helm;
+use containers::k8s qw(install_kubectl install_helm);
 
 our $release_name = "privateregistry";
 
@@ -31,35 +30,15 @@ sub run {
     my $test_image = "registry.suse.com/bci/bci-busybox";
     my $test_chart = "dummy_chart";
 
-    my ($version, $sp, $host_distri) = get_os_release;
-    # Skip HELM tests on SLES <15-SP3 and on PPC, where k3s is not available
-    return if (!($host_distri == "sles" && $version == 15 && $sp >= 3) || is_ppc64le);
-    die "helm tests only work on k3s" unless (check_var('CONTAINER_RUNTIMES', 'k3s'));
+    my $helm_chart = get_required_var('HELM_CHART');
+    my $helm_values = get_var('HELM_CONFIG');
+
+    helm_supported_os();
 
     install_kubectl();
     install_helm();
 
-    my $helm_chart = get_required_var('HELM_CHART');
-
-    # Pull helm chart, if it is a http file
-    if ($helm_chart =~ m!^http(s?)://!) {
-        my ($url, $path) = split(/#/, $helm_chart, 2);    # split extracted folder path, if present
-        assert_script_run("curl -sSL --retry 3 --retry-delay 30 $url | tar -zxf -");
-        $helm_chart = $path ? "./$path" : ".";
-    }
-    my $helm_values = get_var('HELM_CONFIG');
-    assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
-    my $full_registry_path = get_required_var('HELM_FULL_REGISTRY_PATH');
-    my $set_options = "--set global.imageRegistry=$full_registry_path";
-    if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
-        my ($repository, $tag) = split(':', $image, 2);
-        $set_options = "--set global.imageRegistry=$full_registry_path --set app.image.repository=$repository --set app.image.tag=$tag";
-    }
-    my $helm_options = "--debug";
-    $helm_options = "-f myvalue.yaml $helm_options" if ($helm_values);
-    script_retry("helm pull $helm_chart", timeout => 300, retry => 6, delay => 60) if ($helm_chart =~ m!^oci://!);
-    assert_script_run("helm install $set_options $release_name $helm_chart $helm_options", timeout => 300);
-    assert_script_run("helm list");
+    helm_install_chart($helm_chart, $helm_values, $release_name);
 
     # Smoketest - is everything Ready?
     foreach my $component (@private_registry_components) {

--- a/tests/containers/charts/rmt.pm
+++ b/tests/containers/charts/rmt.pm
@@ -26,7 +26,7 @@ sub run {
     my $helm_chart = get_required_var('HELM_CHART');
     my $helm_values = get_var('HELM_CONFIG');
 
-    helm_supported_os();
+    return unless (helm_is_supported());
 
     install_kubectl();
     install_helm();

--- a/tests/containers/charts/rmt.pm
+++ b/tests/containers/charts/rmt.pm
@@ -15,45 +15,25 @@
 use Mojo::Base 'containers::basetest';
 use File::Basename qw(dirname);
 use testapi;
-use utils;
-use version_utils qw(get_os_release is_sle);
 use serial_terminal qw(select_serial_terminal);
-use Utils::Architectures qw(is_ppc64le);
-use containers::k8s;
+use utils;
+use containers::helm;
+use containers::k8s qw(install_kubectl install_helm);
 
 sub run {
     my ($self) = @_;
     select_serial_terminal;
-
-    my ($version, $sp, $host_distri) = get_os_release;
-    # Skip HELM tests on SLES <15-SP3 and on PPC, where k3s is not available
-    return if (!($host_distri == "sles" && $version == 15 && $sp >= 3) || is_ppc64le);
-    die "helm tests only work on k3s" unless (check_var('CONTAINER_RUNTIMES', 'k3s'));
-
     my $helm_chart = get_required_var('HELM_CHART');
+    my $helm_values = get_var('HELM_CONFIG');
+
+    helm_supported_os();
 
     install_kubectl();
     install_helm();
 
-    # Pull helm chart, if it is a http file
-    if ($helm_chart =~ m!^http(s?)://!) {
-        my ($url, $path) = split(/#/, $helm_chart, 2);    # split extracted folder path, if present
-        assert_script_run("curl -sSL --retry 3 --retry-delay 30 $url | tar -zxf -");
-        $helm_chart = $path ? "./$path" : ".";
-    }
-    my $helm_values = get_var('HELM_CONFIG');
-    assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
-    my $set_options = "";
-    if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
-        my ($repository, $tag) = split(':', $image, 2);
-        $set_options = "--set app.image.repository=$repository --set app.image.tag=$tag";
-    }
-    my $helm_options = "--debug";
-    $helm_options = "-f myvalue.yaml $helm_options" if ($helm_values);
-    script_retry("helm pull $helm_chart", timeout => 300, retry => 6, delay => 60) if ($helm_chart =~ m!^oci://!);
-    assert_script_run("helm install $set_options rmt $helm_chart $helm_options", timeout => 300);
-    assert_script_run("helm list");
-    validate_script_output_retry("kubectl get pods", qr/rmt-app/, retry => 10, delay => 30, timeout => 120, fail_message => "rmt-app didn't became ready");
+    helm_install_chart($helm_chart, $helm_values, "rmt");
+
+    validate_script_output_retry("kubectl get pods", qr/rmt-app/, retry => 10, delay => 30, timeout => 120, fail_message => "rmt-app didn't become ready");
     my @rmts = split(' ', script_output("kubectl get pods | grep rmt-app"));
     my $rmtapp = $rmts[0];
     validate_script_output_retry("kubectl logs $rmtapp", sub { m/All repositories have already been enabled/ }, retry => 30, timeout => 60, delay => 60);

--- a/variables.md
+++ b/variables.md
@@ -56,7 +56,7 @@ CONTAINERS_NERDCTL_VERSION | string | 0.16.1 | The version of NerdCTL tool.
 CONTAINERS_DOCKER_FLAVOUR | string | | Flavour of docker to install. Valid options are `stable` or undefined (for standard docker package)
 HELM_CHART | string | | Helm chart under test. See `main_containers.pm` for supported chart types |
 HELM_CONFIG | string | | Additional configuration file for helm |
-HELM_FULL_REGISTRY_PATH | string | Full path to the helm chart within the registry, without the chart name. e.g. `my.registry.com/myteam/secret_project` | 
+HELM_FULL_REGISTRY_PATH | string | Full path to the registry images used by the helm chart. e.g. `my.registry.com/myteam/secret_project`. Only necessary when using non-publicly available container images. | 
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEPENDENCY_RESOLVER_FLAG| boolean | false      | Control whether the resolve_dependecy_issues will be scheduled or not before certain modules which need it.


### PR DESCRIPTION
We now have 2 Helm chart tests. They share a lot of basic functionality, so before it grows into a huge mess, it makes sense to split the basic functionality into a simple library.

This library holds the functions to:
- check if the current OS is an OS we are testing helm on
- get a helm chart from a URL
- configure a helm chart based on a values file from a URL
- install a helm chart with the configuration options from the previous step

In actual tests, we only really need the check for the os and the install helm chart functions.

- Verification run:
  - RMT Helm chart: https://openqa.suse.de/tests/17790666
  - PrivateRegistry: https://openqa.suse.de/tests/17790769
