### PR TITLE
Extend wait_grub timeout for Elemental3

### DIFF
--- a/tests/elemental3/test_image.pm
+++ b/tests/elemental3/test_image.pm
@@ -19,7 +19,7 @@ sub run {
     # For HDD image boot
     if (check_var('IMAGE_TYPE', 'disk')) {
         # Wait for GRUB and select default entry
-        $self->wait_grub();
+        $self->wait_grub(bootloader_time => 300);
         send_key('ret', wait_screen_change => 1);
         wait_still_screen(timeout => 120);
         save_screenshot();


### PR DESCRIPTION
On aarch64 it can time more time to reach Grub prompt.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17750989

**NOTE:** the test still fails but for another reason, the purpose of this PR is to let more time and be able to quickly see where is the issue, as well as workaround slow workers.