### PR TITLE
update_kernel: Check kernel package before installing livepatch

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -334,6 +334,7 @@ sub prepare_kgraft {
         zypper_call("rm " . $pversion);
     }
 
+    check_kernel_package($kernel_name);
     power_action('reboot', textmode => 1);
     reconnect_mgmt_console if is_pvm || get_var('LTP_BAREMETAL');
 


### PR DESCRIPTION
Check that the correct kernel for livepatching is installed before rebooting to install the livepatch itself.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  -  https://openqa.suse.de/tests/17751854 (expected to fail on `kernel-rt_debug`)
  - https://openqa.suse.de/tests/17751861 (expected to pass)