### PR TITLE
Adjust the cleanup part of the git test

### DIFF
--- a/tests/console/git.pm
+++ b/tests/console/git.pm
@@ -58,7 +58,7 @@ sub run {
     assert_script_run("cd ~;git clone -q https://github.com/os-autoinst/os-autoinst-distri-example");
 
     # clean up
-    assert_script_run("rm -rf ~/.ssh ~/repos ~/os-autoinst*");
+    assert_script_run("rm -rf ~/repos ~/os-autoinst*");
 }
 
 1;


### PR DESCRIPTION
Do not cleanup ~/.ssh at the end of the git test.

Fix poo#168199

Related ticket: https://progress.opensuse.org/issues/168199

Verification run:
- 15-SP7 x86_64: https://openqa.suse.de/tests/17767748
