### PR TITLE
bats: Update BATS_PATCHES for 16.0

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -50,14 +50,6 @@ netavark:
 podman:
   # Note on patches:
   # https://github.com/containers/podman/pull/21875 is needed for 060-mount
-  # https://github.com/containers/podman/pull/23851 is needed for 271-tcp-cors-server
-  # https://github.com/containers/podman/pull/23854 is needed for 125-import
-  # https://github.com/containers/podman/pull/23987 is needed for 090-events
-  # https://github.com/containers/podman/pull/24068 is needed for 271-tcp-cors-server
-  # https://github.com/containers/podman/pull/25133 is needed for 410-selinux
-  # https://github.com/containers/podman/pull/25340 is needed for 030-run
-  # https://github.com/containers/podman/pull/25350 is needed for 030-run
-  # https://github.com/containers/podman/pull/25718 is needed for 030-run
   # https://github.com/containers/podman/pull/25918 is needed for 195-run-namespaces
   # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
@@ -89,17 +81,11 @@ podman:
     BATS_SKIP_USER_REMOTE: ''
   sle-16.0:
     BATS_PATCHES:
-    - https://github.com/containers/podman/pull/23851.patch
-    - https://github.com/containers/podman/pull/23854.patch
-    - https://github.com/containers/podman/pull/23987.patch
-    - https://github.com/containers/podman/pull/24068.patch
-    - https://github.com/containers/podman/pull/25133.patch
-    - https://github.com/containers/podman/pull/25340.patch
-    - https://github.com/containers/podman/pull/25350.patch
-    - https://github.com/containers/podman/pull/25718.patch
+    - https://github.com/containers/podman/pull/25918.patch
+    - https://github.com/containers/podman/pull/25942.patch
     - https://github.com/containers/podman/pull/26017.patch
-    BATS_SKIP: 125-import
-    BATS_SKIP_ROOT_LOCAL: 520-checkpoint
+    BATS_SKIP: ''
+    BATS_SKIP_ROOT_LOCAL: 200-pod 520-checkpoint
     BATS_SKIP_ROOT_REMOTE: 520-checkpoint
     BATS_SKIP_USER_LOCAL: 080-pause 505-networking-pasta
     BATS_SKIP_USER_REMOTE: 505-networking-pasta


### PR DESCRIPTION
podman in SLE 16.0 was upgraded to v5.4.2 (the same version used in Tumbleweed):
https://openqa.suse.de/tests/17760276#step/podman/149

Because of this, the patches listed in `BATS_PATCHES` fail to apply and we need to update this list to match Tumbleweed's.   

VR: https://openqa.suse.de/tests/17767770

```
$ susebats notok https://openqa.suse.de/tests/17767770
    BATS_SKIP: ''
    BATS_SKIP_ROOT_LOCAL: 200-pod 520-checkpoint
    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
    BATS_SKIP_USER_LOCAL: 080-pause 505-networking-pasta
    BATS_SKIP_USER_REMOTE: 505-networking-pasta

```