### PR TITLE
Fix BATS_SKIP for SLE 16.0

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -53,6 +53,8 @@ podman:
   # https://github.com/containers/podman/pull/25918 is needed for 195-run-namespaces
   # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
+  # 080-pause fails due to missing fix in runc identified in
+  # https://github.com/containers/podman/pull/25792
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - https://github.com/containers/podman/pull/25918.patch
@@ -85,10 +87,10 @@ podman:
     - https://github.com/containers/podman/pull/25942.patch
     - https://github.com/containers/podman/pull/26017.patch
     BATS_SKIP: ''
-    BATS_SKIP_ROOT_LOCAL: 200-pod 520-checkpoint
+    BATS_SKIP_ROOT_LOCAL: 520-checkpoint
     BATS_SKIP_ROOT_REMOTE: 520-checkpoint
     BATS_SKIP_USER_LOCAL: 080-pause 505-networking-pasta
-    BATS_SKIP_USER_REMOTE: 505-networking-pasta
+    BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
 runc:
   opensuse-Tumbleweed:
     BATS_SKIP: ''


### PR DESCRIPTION
Fix BATS_SKIP for SLE 16.0

```
$ susebats notok https://openqa.suse.de/tests/17770078
    BATS_SKIP: ''
    BATS_SKIP_ROOT_LOCAL: 520-checkpoint
    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
    BATS_SKIP_USER_LOCAL: 080-pause 505-networking-pasta
    BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
```
