### PR TITLE
containers: Skip IPv6 in isolation test on s390x

### DIFF
--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -57,7 +57,7 @@ sub run {
     script_run "echo 0 > /etc/docker/suse-secrets-enable";
 
     my @ip_versions = (4);
-    push @ip_versions, 6 unless (is_hyperv || is_vmware);
+    push @ip_versions, 6 unless (is_hyperv || is_s390x || is_vmware);
 
     my %ip_addr;
     for my $ip_version (@ip_versions) {


### PR DESCRIPTION
Skip IPv6 in isolation test on s390x

Failing tests:
- docker: https://openqa.suse.de/tests/17760514#step/docker_isolation/103
- podman: https://openqa.suse.de/tests/17760517#step/podman_isolation/69