### PR TITLE
Add more tests which are running on sle15sp7 but not on sle16 yet

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -139,6 +139,8 @@ Set serial terminal prompt to given string.
 sub set_serial_prompt {
     $serial_term_prompt = shift // '';
 
+    # Some (older) versions of bash don't take changes to the terminal during runtime into account. Re-exec it.
+    enter_cmd('export PAGER=cat TERM=dumb; stty cols 2048; exec $SHELL') if (is_sle('>=16') && is_s390x);
     die "Invalid prompt string '$serial_term_prompt'"
       unless $serial_term_prompt =~ s/\s*$//r;
     enter_cmd(qq/PS1="$serial_term_prompt"/);

--- a/schedule/functional/sle16/extra_tests_textmode.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode.yaml
@@ -18,6 +18,14 @@ conditional_schedule:
                 - network/snmp
             aarch64:
                 - network/snmp
+    wpa_supplicant:
+        ARCH:
+            x86_64:
+                - console/wpa_supplicant
+    prepare_systemd_and_testsuite:
+        ARCH:
+            x86_64:
+                - systemd_testsuite/prepare_systemd_and_testsuite
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
@@ -88,6 +96,12 @@ schedule:
     - console/firewalld
     - console/nftables
     - console/aaa_base
+    - console/vmstat
+    - console/libjpeg_turbo
+    - console/libgit2
+    - network/cifs
+    - '{{wpa_supplicant}}'
+    - '{{prepare_systemd_and_testsuite}}'
     - console/osinfo_db
     - console/journalctl
     - console/tar

--- a/schedule/functional/sle16/extra_tests_textmode2.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode2.yaml
@@ -1,0 +1,34 @@
+name:           extra_tests_textmode2
+description:    >
+    Maintainer: qe-core.
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - console/system_prepare
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - locale/keymap_or_locale
+    - console/force_scheduled_tasks
+    - console/textinfo
+    - console/hostname
+    - console/installation_snapshots
+    - console/zypper_lr
+    - console/zypper_ref
+    - console/systemd_wo_udev
+    - console/curl_https
+    - console/ansible
+    - console/glibc_sanity
+    - console/glibc_tunables
+    - console/zypper_in
+    - console/zypper_log
+    - console/vim
+    - console/firewall_enabled
+    - console/sshd
+    - console/ssh_cleanup
+    - console/mtab
+    - console/zypper_lifecycle
+    - console/nginx
+    - console/orphaned_packages_check
+    - console/consoletest_finish
+    - console/zypper_log_packages
+    - shutdown/shutdown

--- a/tests/console/btrfs_balance.pm
+++ b/tests/console/btrfs_balance.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub percent_usage {
     my @output = split "\n", script_output("df --local --sync --output=pcent /mnt/raid");
@@ -67,6 +68,10 @@ sub run {
     # raid volume should be almost full, because data
     # is still only on one disk and filesystem is not balanced
     config_balance_parameters();
+    record_info("INFO", script_output("btrfs filesystem usage -b /mnt/raid/"));
+    record_info("INFO", script_output("btrfs ins dump-tree /dev/vdc"));
+    script_run('btrfs balance start -d /mnt/raid/', timeout => 120) if (is_sle('>=16.0'));
+    record_info("INFO", script_output("btrfs filesystem usage -b /mnt/raid/"));
     # try at most N times to rebalance filesystem
     my $retries = 0;
     for (;;) {

--- a/tests/console/libgit2.pm
+++ b/tests/console/libgit2.pm
@@ -24,12 +24,12 @@ my $python_sub_version;
 
 sub run {
     # Package 'pygit2' requires PackageHub is available
-    return if (!is_phub_ready() && is_sle);
+    return if (!is_phub_ready() && is_sle('<16'));
 
     select_serial_terminal;
     return if (is_sle('<15-sp6') || is_leap('<15.6'));
 
-    if (is_sle) {
+    if (is_sle('<16')) {
         add_suseconnect_product('sle-module-desktop-applications');
         add_suseconnect_product('sle-module-development-tools');
         add_suseconnect_product('sle-module-python3');

--- a/tests/console/wpa_supplicant.pm
+++ b/tests/console/wpa_supplicant.pm
@@ -27,13 +27,14 @@ use strict;
 use warnings;
 use utils;
 use registration 'is_phub_ready';
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
     select_serial_terminal;
 
     # Package 'hostapd' requires PackageHub is available
-    return unless is_phub_ready();
+    return if (!is_phub_ready() && is_sle('<16'));
 
     zypper_call 'in wpa_supplicant hostapd iw dnsmasq unzip dhcp-client';
     assert_script_run 'cd $(mktemp -d)';

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -74,6 +74,7 @@ sub run {
     zypper_call('in curl') if (script_run('rpm -qi curl') == 1);
     # force reinstall release notes, package must not come from expected SLE-Product repo e.g. GMC
     zypper_call('in -f release-notes*');
+    zypper_call('in zypper-lifecycle-plugin') if (is_sle('>=16'));
 
     select_user_serial_terminal;
     my $overview = script_output('zypper lifecycle', 600);
@@ -100,7 +101,7 @@ sub run {
 
     die "Got malformed repo list:\nOutput: '$output'" unless $base_repos;
 
-    $output = script_output 'echo $(for repo in ' . $base_repos . ' ; do zypper -n -x se -t package -i -s -r $repo ; done | grep name= | head -n 1 )', 300;
+    $output = script_output 'echo $(for repo in ' . $base_repos . ' ; do zypper -n -x se -t package -i -s -r $repo ; done | grep name= | head -n 1 )', 600;
     # Parse package name
     if ($output =~ /name="(?<package>[^"]+)"/) {
         $package = $+{package};

--- a/tests/network/cifs.pm
+++ b/tests/network/cifs.pm
@@ -46,13 +46,13 @@ sub setup_local_server() {
 
 sub run {
     # Package 'samba-client' requires PackageHub is available
-    return if (!is_phub_ready() && is_sle);
+    return if (!is_phub_ready() && is_sle('<16'));
 
     my $smb_domain = get_var("CIFS_TEST_DOMAIN") // "currywurst";
     # The test host is only available from the internal openqa.suse.de
     my $smb_remote = get_var("CIFS_TEST_REMOTE", is_opensuse ? "local" : "currywurst.qe.suse.de");
     select_serial_terminal;
-    add_suseconnect_product(get_addon_fullname('phub')) if is_sle;    # samba-client requires package hub
+    add_suseconnect_product(get_addon_fullname('phub')) if is_sle('<16');    # samba-client requires package hub
 
     # Use local samba server, if defined or if defined SMB server is not accessible
     my $is_local = $smb_remote eq 'local';

--- a/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
+++ b/tests/systemd_testsuite/prepare_systemd_and_testsuite.pm
@@ -48,9 +48,9 @@ sub run {
 
     select_serial_terminal();
     # Package requires PackageHub is available
-    return if (!is_phub_ready() && is_sle);
+    return if (!is_phub_ready() && is_sle('<16'));
 
-    if (is_sle) {
+    if (is_sle("<16")) {
         add_suseconnect_product(get_addon_fullname('legacy'));
         add_suseconnect_product(get_addon_fullname('desktop'));
         add_suseconnect_product(get_addon_fullname('sdk'));
@@ -58,6 +58,9 @@ sub run {
         add_suseconnect_product(get_addon_fullname('python3'));
         my $repo = sprintf('http://download.suse.de/download/ibs/SUSE:/SLE-%s:/GA/standard/',
             get_var('VERSION'));
+        zypper_call("ar $repo systemd-tests");
+    } else {
+        my $repo = get_var('SYSTEMD_TESTS_REPO');
         zypper_call("ar $repo systemd-tests");
     }
 


### PR DESCRIPTION
Add more tests which are running on sle15sp7 but not on sle16 yet

- Related ticket: https://progress.opensuse.org/issues/181166
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=89.2&groupid=220
   Failed jobs have known bugs.
- Related MR: https://gitlab.suse.de/qe-core/qa-sle-functional-userspace/-/merge_requests/273
- Verified on s390x zypper_lifecycle: https://openqa.suse.de/tests/17948060#step/zypper_lifecycle/61
