### PR TITLE
Re-enable lftp on SLE16

### DIFF
--- a/schedule/security/fips/sle16/fips_ker_mode_textmode_extra.yaml
+++ b/schedule/security/fips/sle16/fips_ker_mode_textmode_extra.yaml
@@ -21,6 +21,7 @@ schedule:
     - console/apache_ssl
     - security/vsftpd/vsftpd_setup
     - security/vsftpd/vsftpd
+    - security/vsftpd/lftp
     - console/ca_certificates_mozilla
     - console/unzip
     - console/rsync


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/182792

VRs: https://openqa.suse.de/tests/overview?groupid=431&version=16.0&build=89.2&distri=sle