### PR TITLE
Ignore PPTT table found, but unable to locate core

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -198,9 +198,9 @@
         "type": "bug"
     },
     "bsc#1191575": {
-        "description": "kernel: ACPI: SRAT not present|kernel: ARM_SMCCC_ARCH_WORKAROUND_1 missing from firmware|kernel: ACPI PPTT: No PPTT table found, CPU and cache topology may be inaccurate|kernel: cacheinfo: Unable to detect cache hierarchy for CPU|kernel: hrtimer: interrupt took.*ns",
+        "description": "kernel: ACPI: SRAT not present|kernel: ARM_SMCCC_ARCH_WORKAROUND_1 missing from firmware|kernel: ACPI PPTT: No PPTT table found, CPU and cache topology may be inaccurate|kernel: cacheinfo: Unable to detect cache hierarchy for CPU|kernel: hrtimer: interrupt took.*ns|kernel: ACPI PPTT: PPTT table found, but unable to locate core.*\\)",
         "products": {
-            "sle": ["15-SP4", "15-SP5"]
+            "sle": ["15-SP4", "15-SP5", "15-SP6"]
         },
         "type": "bug"
     },


### PR DESCRIPTION
In aarch64 there is a new journal entry regarding ACPI

#### Verification run

- sle-15-SP6-JeOS-for-kvm-and-xen-QR-aarch64-Build13.3-jeos-kdump@aarch64 -> https://openqa.suse.de/tests/17784408#step/journal_check/9
