### PR TITLE
xfstests: Remove mount process in some nfs version

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -423,17 +423,10 @@ sub setup_nfs_client {
     elsif ($nfsversion =~ 'pnfs') {
         script_run('mount -t nfs4 -o vers=4.1,minorversion=1 localhost:/opt/export/test /opt/nfs/test');
         record_info('pNFS_checkpoint', script_output('cat /proc/self/mountstats | grep pnfs', proceed_on_failure => 1));
+        record_info('/etc/exports', script_output('cat /etc/exports', proceed_on_failure => 1));
+        record_info('nfsstat -m', script_output('nfsstat -m', proceed_on_failure => 1));
+        script_run('umount /opt/nfs/test');
     }
-    elsif ($nfsversion =~ '4') {
-        script_run("mount -t nfs4 -o vers=$nfsversion localhost:/opt/export/test /opt/nfs/test");
-    }
-    else {
-        script_run("mount -t nfs -o vers=$nfsversion localhost:/opt/export/test /opt/nfs/test");
-    }
-    record_info('/etc/exports', script_output('cat /etc/exports', proceed_on_failure => 1));
-    record_info('nfsstat -m', script_output('nfsstat -m', proceed_on_failure => 1));
-    script_run('umount /opt/nfs/test');
-
     # There's a graceful time we need to wait before using the NFS server
     my $gracetime = script_output('cat /proc/fs/nfsd/nfsv4gracetime;');
     sleep($gracetime * 2);


### PR DESCRIPTION
Remove the checking mount after grace time setting in some nfs versions, and keep it only in pnfs, because it cause some test run out of time during the mount. This added by commit ee2db125d2428b5c67549568c1cbdd0de6894e38 which adding pnfs test, and adding checking point. So only keep the checking point in pnfs will not cause problem for other NFS tests.

- Related ticket: https://progress.opensuse.org/issues/181241
- Verification run: 
- v4.1 server: https://openqa.suse.de/tests/17783143
- v4.0 server: https://openqa.suse.de/tests/17783153
- v3.0 server: https://openqa.suse.de/tests/17783209