### PR TITLE
elemental3: add system extensions and RKE2 test

### DIFF
--- a/data/elemental3/config.sh
+++ b/data/elemental3/config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -xe
+
+# Setting root passwd
+echo "%TEST_PASSWORD%" | passwd root --stdin
+
+# Allow root ssh access (for testing purposes only!)
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/root_access.conf
+systemctl enable sshd
+
+# Add kubectl access/command
+ln -s /var/lib/rancher/rke2/bin/kubectl /root/bin/
+echo "export KUBECONFIG=/etc/rancher/rke2/rke2.yaml" > /root/.profile

--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -15,20 +15,33 @@ use warnings;
 use testapi;
 use transactional qw(trup_call);
 use serial_terminal qw(select_serial_terminal);
-use utils qw(zypper_call);
+use Mojo::File qw(path);
+use utils qw(file_content_replace zypper_call);
 
 sub run {
     select_serial_terminal;
 
+    # Variables
     my $arch = get_required_var('ARCH');
     my $build = get_required_var('BUILD');
     my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
     my $repo_to_test = get_required_var('REPO_TO_TEST');
+    my $rootpwd = get_required_var('TEST_PASSWORD');
+    my @sysexts = split(',', get_required_var('SYSEXTS'));
     my $img_filename = "elemental-$build-$arch";
-    my $shared = '/var/shared';
+    my $shared_dir = '/root/shared';
+    my $config_file = "$shared_dir/config.sh";
+    my $sysext_root = "$shared_dir/sysexts";
+    my $sysext_dir = "$sysext_root/etc/extensions";
+    my $overlay = "$shared_dir/sysexts.tar.gz";
 
-    # Create shared directory
-    assert_script_run("mkdir -p $shared");
+    # Set SELinux in permissive mode, as there is an issue with setfiles
+    # It will be removed as soon as the issue will be fixed
+    assert_script_run("setenforce Permissive");
+    validate_script_output("sestatus | grep 'Current mode:'", sub { m/permissive/ });
+
+    # Create directories
+    assert_script_run("mkdir -p $sysext_dir");
 
     # Add Unified Core repository and install Elemental package
     trup_call("run zypper addrepo --check --refresh $repo_to_test elemental");
@@ -36,15 +49,31 @@ sub run {
     trup_call("--continue pkg install elemental3-toolkit");
     trup_call("apply");
 
+    # OS configuration script
+    assert_script_run('curl ' . data_url('elemental3/' . path($config_file)->basename) . ' -o ' . $config_file);
+    file_content_replace($config_file, '%TEST_PASSWORD%' => $rootpwd);
+    assert_script_run("chmod 755 $config_file");
+
+    # Get the system extensions
+    foreach my $sysext (@sysexts) {
+        assert_script_run('curl ' . $sysext . " -o $sysext_dir/" . path($sysext)->basename, 300);
+    }
+
+    # Package the system extensions
+    assert_script_run("tar cvaf $overlay -C $sysext_root .");
+
     # Create a raw image and mount it as a loop device (forced to 20GB to allow enough space for creating active partition)
-    assert_script_run("qemu-img create -f raw $shared/$img_filename.raw 20G");
-    my $device = script_output("losetup --find --show $shared/$img_filename.raw");
+    assert_script_run("qemu-img create -f raw $shared_dir/$img_filename.raw 10G");
+    my $device = script_output("losetup --find --show $shared_dir/$img_filename.raw");
+
+    # Generate RAW image
+    record_info('QCOW2', 'Generate and upload QCOW2 image');
+    assert_script_run("elemental3-toolkit --debug install --os-image $image --overlay tar://$overlay --config $config_file --target $device", 240);
 
     # Generate and upload QCOW2 image
-    record_info('QCOW2', 'Generate and upload QCOW2 image');
-    assert_script_run("elemental3-toolkit --debug install --os-image $image --target $device", 300);
-    assert_script_run("qemu-img convert -f raw -O qcow2 $shared/$img_filename.raw $shared/$img_filename.qcow2");
-    upload_asset("$shared/$img_filename.qcow2", 1);
+    assert_script_run("losetup -d $device");
+    assert_script_run("qemu-img convert -c -p -f raw -O qcow2 $shared_dir/$img_filename.raw $shared_dir/$img_filename.qcow2", 240);
+    upload_asset("$shared_dir/$img_filename.qcow2", 1);
 }
 
 sub test_flags {

--- a/tests/elemental3/test_image.pm
+++ b/tests/elemental3/test_image.pm
@@ -13,20 +13,103 @@ use power_action_utils qw(power_action);
 use serial_terminal qw(select_serial_terminal);
 use Utils::Architectures;
 
+=head2 wait_kubectl_cmd
+
+ wait_kubectl_cmd();
+
+Wait for kubectl command to be available.
+
+=cut
+
+sub wait_kubectl_cmd {
+    my $starttime = time;
+    my $ret = undef;
+    my $timeout = 240;
+
+    while ($ret = script_run('which kubectl', ($timeout / 10))) {
+        my $timerun = time - $starttime;
+        if ($timerun < $timeout) {
+            sleep 5;
+        }
+        else {
+            die "kubectl command did not appear within $timeout seconds!";
+        }
+    }
+
+    # Return the command status
+    die 'Check did not return a defined value!' unless defined $ret;
+    return $ret;
+}
+
+=head2 wait_k8s_running
+
+ wait_k8s_running(regex);
+
+Checks for up to B<$timeout> seconds whether K8s cluster is running.
+Returns 0 if cluster is running or croaks on timeout.
+
+=cut
+
+sub wait_k8s_running {
+    my ($regex) = shift;
+    my $starttime = time;
+    my $ret = undef;
+    my $timeout = 300;
+    my $chk_cmd = 'kubectl get pod -A 2>&1';
+
+    while ($ret = script_run("! ($chk_cmd | grep -E -i -v -q '$regex')", ($timeout / 10))) {
+        my $timerun = time - $starttime;
+        if ($timerun < $timeout) {
+            sleep 10;
+        }
+        else {
+            record_info('RKE2 status', script_output("$chk_cmd"));
+            die "K8s cluster did not start within $timeout seconds!";
+        }
+    }
+
+    # Return the command status
+    die 'Check did not return a defined value!' unless defined $ret;
+    return $ret;
+}
+
 sub run {
     my ($self) = @_;
+    my $rootpwd = get_required_var('TEST_PASSWORD');
+    $testapi::password = $rootpwd;    # Set default root password
 
     # For HDD image boot
     if (check_var('IMAGE_TYPE', 'disk')) {
         # Wait for GRUB and select default entry
-        $self->wait_grub();
+        $self->wait_grub(bootloader_time => 300);
         send_key('ret', wait_screen_change => 1);
         wait_still_screen(timeout => 120);
         save_screenshot();
     }
 
-    # Wait for login screen
-    assert_screen('linux-login');
+    # No GUI, easier and quicker to use the serial console
+    select_serial_terminal();
+
+    # Record boot
+    record_info('OS boot', 'Successfully booted!');
+
+    # Wait for kubectl command to be available
+    wait_kubectl_cmd();
+
+    # Wait a bit for all processes to be launched
+    sleep(60);
+
+    # Check RKE2 status
+    wait_k8s_running('status.*restarts|running|completed');
+
+    # Record RKE2 status (we want all, stderr as well)
+    record_info('RKE2 status', script_output('kubectl get pod -A 2>&1'));
+
+    # Record RKE2 version/node
+    record_info('RKE2 version/node', script_output('kubectl version; kubectl get nodes'));
+
+    # Check toolkit version
+    record_info('Toolkit version', script_output('elemental3-toolkit version'));
 }
 
 sub test_flags {


### PR DESCRIPTION
Elemental3 (Unified Core) packages RKE2 as part of the OS image with `systemd-sysext`. This PR adds a basic test to validate that RKE2 is up and running.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - [generate_image](https://openqa.suse.de/tests/17933856) :white_check_mark:
  - [test_image](https://openqa.suse.de/tests/17934242) :white_check_mark: