### PR TITLE
NVIDIA: Move reusable code from Public Cloud into a new library

### DIFF
--- a/lib/nvidia_utils.pm
+++ b/lib/nvidia_utils.pm
@@ -1,0 +1,76 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: NVIDIA helper functions
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package nvidia_utils;
+
+use Exporter;
+use testapi;
+use strict;
+use warnings;
+use utils;
+
+our @EXPORT = qw(
+  install
+  validate
+);
+
+=head2 install
+
+ install([ variant => 'cuda' ]);
+
+Install the NVIDIA driver and the compute utils, making sure to remove
+any conflicting variant first. Also, it tries to add the relevant
+repositories to grab the packages from, defined by the job through
+NVIDIA_REPO and NVIDIA_CUDA_REPO.
+
+=cut
+
+sub install
+{
+    my %args = @_;
+    my $variant_std = 'nvidia-open-driver-G06-signed-kmp-default';
+    my $variant_cuda = 'nvidia-open-driver-G06-signed-cuda-kmp-default';
+    my $variant = $args{variant} eq "cuda" ? $variant_cuda : $variant_std;
+
+    zypper_ar(get_required_var('NVIDIA_REPO'), name => 'nvidia', no_gpg_check => 1, priority => 90);
+    zypper_ar(get_required_var('NVIDIA_CUDA_REPO'), name => 'cuda', no_gpg_check => 1, priority => 90);
+
+    # Make sure to remove the other variant first
+    my $remove_variant = script_run("rpm -q $variant_std") ? $variant_cuda : $variant_std;
+    zypper_call("remove --clean-deps ${remove_variant}");
+
+    # Install driver and compute utils which packages `nvidia-smi`
+    zypper_call("install -l $variant");
+    my $version = script_output("rpm -qa --queryformat '%{VERSION}\n' $variant | cut -d '_' -f1 | sort -u | tail -n 1");
+    record_info("NVIDIA Version", $version);
+    zypper_call("install -l nvidia-compute-utils-G06 == $version");
+}
+
+=head2 validate
+
+ validate();
+
+Do basic testing of the NVIDIA driver: check the GPU name,
+make sure the module is loaded and log `nvidia-smi` output.
+
+=cut
+
+sub validate
+{
+    # Check card name
+    if (my $gpu = get_var("NVIDIA_EXPECTED_GPU_REGEX")) {
+        validate_script_output("hwinfo --gfxcard", sub { /$gpu/mg });
+    }
+    # Check loaded modules
+    assert_script_run("lsmod | grep nvidia", fail_message => "NVIDIA module not loaded");
+    # Check driver works
+    my $smi_output = script_output("nvidia-smi");
+    record_info("NVIDIA SMI", $smi_output);
+}
+
+1;

--- a/tests/publiccloud/nvidia.pm
+++ b/tests/publiccloud/nvidia.pm
@@ -3,117 +3,26 @@
 # Copyright @ SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Opensource Nvidia test
+# Summary: NVIDIA open source driver test
 # Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use registration;
 use testapi;
 use utils;
-use publiccloud::utils;
+use nvidia_utils;
 
-my $driver_std = "nvidia-open-driver-G06-signed-kmp-default";
-my $driver_cuda = "nvidia-open-driver-G06-signed-cuda-kmp-default";
-
-sub pre_run_hook {
-    zypper_call('addrepo -fG -p 90 ' . get_required_var('NVIDIA_REPO') . ' nvidia');
-    zypper_call('addrepo -fG -p 90 ' . get_required_var('NVIDIA_CUDA_REPO') . ' cuda');
-}
-
-sub install {
-    my ($cuda) = @_;
-    my $variant;    # Used to pin the installed driver version
-
-    # Make sure to remove the other variant first
-    if (!script_run("rpm -q $driver_cuda")) {
-        zypper_call("remove --clean-deps $driver_cuda");
-    }
-    if (!script_run("rpm -q $driver_std")) {
-        zypper_call("remove --clean-deps $driver_std");
-    }
-    if (!script_run("rpm -q nvidia-compute-utils-G06")) {
-        zypper_call("remove --clean-deps nvidia-compute-utils-G06");
-    }
-
-    if (defined $cuda) {
-        $variant = $driver_cuda;
-    } else {
-        $variant = $driver_std;
-    }
-
-    # Install driver and compute utils which packages `nvidia-smi`
-    zypper_call("install -l $variant");
-    my $version = script_output("rpm -qa --queryformat '%{VERSION}\n' $variant | cut -d '_' -f1 | sort -u | tail -n 1");
-    record_info("NVIDIA Version", $version);
-    zypper_call("install -l nvidia-compute-utils-G06 == $version");
-}
-
-sub validate {
-    # Check card name
-    if (my $gpu = get_var("NVIDIA_EXPECTED_GPU_REGEX")) {
-        validate_script_output("hwinfo --gfxcard", sub { /$gpu/mg });
-    }
-    # Check loaded modules
-    assert_script_run("lsmod | grep nvidia", fail_message => "NVIDIA module not loaded");
-    # Check driver works
-    my $smi_output = script_output("nvidia-smi");
-    record_info("NVIDIA SMI Output", $smi_output);
-}
-
-sub run {
+sub run
+{
     my ($self, $args) = @_;
 
-    install;
+    nvidia_utils::install();
     $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
-    validate;
+    nvidia_utils::validate();
 
-    install "cuda";
+    nvidia_utils::install(variant => "cuda");
     $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
-    validate;
+    nvidia_utils::validate();
 }
 
 1;
-
-=head1 Discussion
-
-Test module to run Opensource Nvidia test on publiccloud with Turing or Ampere architecture GPUs.
-To do so, Public Cloud instance is provisioned by terraform. Setting instance with required hardware
-apply on F<publiccloud/terraform/gce.tf> using the C<guest_accelerator>. If you want to provide a
-custom terraform, C<PUBLIC_CLOUD_TERRAFORM_FILE> job variable can be used to define an alternative
-file.
-
-At the moment, the test uses https://download.opensuse.org/repositories/X11:/Drivers:/Video:/Redesign/openSUSE_Leap_15.4/ repo to get the open source drivers, however it is expected to be shipping the opengpu kernel modules, so that these no longer need to be installed from a separate repository.
-
-=head1 Configuration
-
-=head2 Hardware requirement and GCE instance configuration
-
-Most of the supported GPU are listed on https://sndirsch.github.io/nvidia/2022/06/07/nvidia-opengpu.html.
-One of them which GCE provides is B<Tesla T4>. GPU is provided via the B<europe-west1-*> regions, series C<N1>
-and machine type C<n1-standard-1>.
-
-Terraform can request which GPU to use, through C<guest_accelerator> inside the C<google_compute_instance> resource.
-
-=begin txt
-
-accelerator_config {
-    type         = "NVIDIA_TESLA_T4"
-    core_count   = 1
-  }
-
-=end txt
-
-The terraform configuration creates the required block with a dynamic block which reads the variable inputs
-assigned to the C<gnu> variable. If the job variable C<PUBLIC_CLOUD_NVIDIA> is true, then the following
-parameter will be passed in the terraform plan
-
-=begin bash
-  -var 'gpu={"count":1,"type":"nvidia-tesla-t4"}'
-=end bash
-
-This gives us agility to pass any I<type> or I<count> as value.
-
-If the C<PUBLIC_CLOUD_NVIDIA> is false, the object will be null and it will return an empty list. That disables
-the C<guest_accelerator>.
-
-=cut

--- a/variables.md
+++ b/variables.md
@@ -169,9 +169,9 @@ NO_ADD_MAINT_TEST_REPOS | boolean | true |  Do not add again (and duplicate) rep
 NOAUTOLOGIN | boolean | false | Indicates disabled auto login.
 NOIMAGES |||
 NOLOGS | boolean | false | Do not collect logs if set to true. Handy during development.
-NVIDIA_REPO | string | '' | Define the external repo for nvidia driver. Used by `nvidia.pm` module.
-NVIDIA_CUDA_REPO | string | '' | Define the external repo for nvidia cuda. Used by `nvidia.pm` module.
-NVIDIA_EXPECTED_GPU_REGEX | string | '' | Define which GPU should the test expect. Used by `nvidia.pm` module.
+NVIDIA_REPO | string | '' | Define the external repo for NVIDIA driver.
+NVIDIA_CUDA_REPO | string | '' | Define the external repo for NVIDIA cuda.
+NVIDIA_EXPECTED_GPU_REGEX | string | '' | Define which GPU should the test expect.
 OCI_RUNTIME | string | '' | Define the OCI runtime to use in container tests, if set.
 OPENSHIFT_CONFIG_REPO | string | '' | Git repo of the OpenShift configuration and packages needed by tests/containers/openshift_setup.pm. 
 OPT_KERNEL_PARAMS | string | Specify optional kernel command line parameters on bootloader settings page of the installer.


### PR DESCRIPTION
A new test will be added for NVIDIA (baremetal). So in preparation for that, move the current subroutines into a new library.

- Related ticket: https://progress.opensuse.org/issues/182873
- Verification run: https://rmarliere-openqa.qe.prg2.suse.org/tests/1238