### PR TITLE
bats: Incorporate upstream patches into osado

### DIFF
--- a/data/containers/bats/patches/netavark/1191.patch
+++ b/data/containers/bats/patches/netavark/1191.patch
@@ -1,0 +1,43 @@
+From 3902d992a0abf0e204f1da718c55283d4b812d77 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Thu, 6 Mar 2025 14:54:00 +0100
+Subject: [PATCH] test/001-basic: Make commit test optional
+
+Some distros like openSUSE & Debian don't build netavark from git,
+so the commit information won't be available.
+
+Make this test conditional when NETAVARK_UPSTREAM is set.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ .cirrus.yml         | 1 +
+ test/001-basic.bats | 4 +++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/.cirrus.yml b/.cirrus.yml
+index 74389fdb2..79610a8a7 100644
+--- a/.cirrus.yml
++++ b/.cirrus.yml
+@@ -22,6 +22,7 @@ env:
+     AARDVARK_DNS_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_DNS_BRANCH}"
+     FEDORA_NETAVARK_AARCH64_AMI: "fedora-netavark-aws-arm64-${IMAGE_SUFFIX}"
+     EC2_INST_TYPE: "t4g.xlarge"
++    NETAVARK_UPSTREAM: "1"
+ 
+ 
+ gcp_credentials: ENCRYPTED[d6efdb7d6d4c61e3831df2193ca6348bb02f26cd931695f69d41930b1965f7dab72a838ca0902f6ed8cde66c7deddae2]
+diff --git a/test/001-basic.bats b/test/001-basic.bats
+index bc30a1703..f74220dfe 100644
+--- a/test/001-basic.bats
++++ b/test/001-basic.bats
+@@ -12,7 +12,9 @@ load helpers
+     run_netavark version
+     json="$output"
+     assert_json "$json" ".version" =~ "^1\.[0-9]+\.[0-9]+(-rc[0-9]|-dev)?" "correct version"
+-    assert_json "$json" ".commit" =~ "[0-9a-f]{40}" "shows commit sha"
++    if [ -n "$NETAVARK_UPSTREAM" ]; then
++        assert_json "$json" ".commit" =~ "[0-9a-f]{40}" "shows commit sha"
++    fi
+     assert_json "$json" ".build_time" =~ "20.*" "show build date"
+     assert_json "$json" ".target" =~ ".*" "contains target string"
+ }

--- a/data/containers/bats/patches/podman/21875.patch
+++ b/data/containers/bats/patches/podman/21875.patch
@@ -1,0 +1,38 @@
+From 99b2f369db2a3a033041696c26d9ecf92df25b6c Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 29 Feb 2024 13:39:58 +0100
+Subject: [PATCH] test/system: fix mount external container test
+
+Checking for the mountdir is not relevent, a recent c/storage change[1] no
+longer deletes the mount point directory so the check will cause a false
+positive. findmnt exits 1 when the given path is not a mountpoint so
+let's use that to check.
+
+[1] https://github.com/containers/storage/pull/1828/commits/3f2e81abb38926d9b908528412c25fa2e199b6b9
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/060-mount.bats | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/test/system/060-mount.bats b/test/system/060-mount.bats
+index fbc925a47c..070dba5eb9 100644
+--- a/test/system/060-mount.bats
++++ b/test/system/060-mount.bats
+@@ -249,13 +249,10 @@ EOF
+     reported_mountpoint=$(echo "$output" | awk '{print $2}')
+     is "$reported_mountpoint" "$mount_path" "mountpoint reported by 'podman mount'"
+ 
+-    # umount, and make sure files are gone
++    # umount, and make sure mountpoint no longer exists
+     run_podman umount $external_cid
+-    if [ -d "$mount_path" ]; then
+-        # Under VFS, mountpoint always exists even despite umount
+-        if [[ "$(podman_storage_driver)" != "vfs" ]]; then
+-            die "'podman umount' did not umount $mount_path"
+-        fi
++    if findmnt "$mount_path" >/dev/null ; then
++        die "'podman umount' did not umount $mount_path"
+     fi
+     buildah rm $external_cid
+ }

--- a/data/containers/bats/patches/podman/25792.patch
+++ b/data/containers/bats/patches/podman/25792.patch
@@ -1,0 +1,69 @@
+From b213f4a0fd3b62f2df02198ce1cc5d09b7ca163f Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Fri, 4 Apr 2025 09:49:08 +0200
+Subject: [PATCH] test: Fix expected output for pause/unpause with runc
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/system/080-pause.bats | 26 ++++++++++++++++++++++----
+ 1 file changed, 22 insertions(+), 4 deletions(-)
+
+diff --git a/test/system/080-pause.bats b/test/system/080-pause.bats
+index 99e2a847f2..bfa76063b4 100644
+--- a/test/system/080-pause.bats
++++ b/test/system/080-pause.bats
+@@ -23,8 +23,12 @@ load helpers.systemd
+     # time to write a new post-restart time value. Pause by CID, unpause
+     # by name, just to exercise code paths. While paused, check 'ps'
+     # and 'inspect', then check again after restarting.
++    expect=""
++    if is_rootless && ! is_remote && [[ "$(podman_runtime)" = "runc" ]]; then
++        expect=".*warning .*runc pause may fail if you don't have the full access to cgroups"
++    fi
+     run_podman --noout pause $cid
+-    is "$output" "" "output should be empty"
++    is "$output" "$expect" "podman pause output"
+     run_podman inspect --format '{{.State.Status}}' $cid
+     is "$output" "paused" "podman inspect .State.Status"
+     sleep 3
+@@ -80,8 +84,13 @@ load helpers.systemd
+     run_podman pause $cid
+     run_podman inspect --format '{{.State.Status}}' $cid
+     is "$output" "paused" "podman inspect .State.Status"
++
++    expect="$cid"
++    if is_rootless && ! is_remote && [[ "$(podman_runtime)" = "runc" ]]; then
++        expect=".*warning .*runc resume may fail if you don't have the full access to cgroups.*$cid"
++    fi
+     run_podman unpause --all
+-    is "$output" "$cid" "podman unpause output"
++    is "$output" "$expect" "podman unpause output"
+     run_podman ps --format '{{.ID}} {{.Names}} {{.Status}}'
+     is "$output" "${cid:0:12} $cname Up.*" "podman ps on resumed container"
+ 
+@@ -113,14 +122,23 @@ load helpers.systemd
+     run -0 systemctl status $cid-*.timer
+     assert "$output" =~ "active" "service should be running"
+ 
++    expect=""
++    runtime=$(podman_runtime)
++    if [[ $runtime = "runc" ]] && is_rootless && ! is_remote; then
++        expect=".*warning .*runc pause may fail if you don't have the full access to cgroups"
++    fi
+     run_podman --noout pause $ctrname
+-    assert "$output" == "" "output should be empty"
++    is "$output" "$expect" "podman pause output"
+ 
+     run -0 systemctl status $cid-*.{service,timer}
+     assert "$output" == "" "service should not be running"
+ 
++    expect=""
++    if [[ $runtime = "runc" ]] && is_rootless && ! is_remote; then
++        expect=".*warning .*runc resume may fail if you don't have the full access to cgroups.*$cid"
++    fi
+     run_podman --noout unpause $ctrname
+-    assert "$output" == "" "output should be empty"
++    is "$output" "$expect" "podman unpause output"
+ 
+     run_podman healthcheck run $ctrname
+     is "$output" "" "output from 'podman healthcheck run'"

--- a/data/containers/bats/patches/podman/25918.patch
+++ b/data/containers/bats/patches/podman/25918.patch
@@ -1,0 +1,29 @@
+From a7a7304c6ff104fe6a6097ca6adbc89b4fdd84c3 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Thu, 17 Apr 2025 17:18:49 +0200
+Subject: [PATCH] test: Fix expected output for runc on namespaces
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/system/195-run-namespaces.bats | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/test/system/195-run-namespaces.bats b/test/system/195-run-namespaces.bats
+index dffe815dc0..599ae7eeb3 100644
+--- a/test/system/195-run-namespaces.bats
++++ b/test/system/195-run-namespaces.bats
+@@ -38,7 +38,13 @@ uts    | uts
+             run_podman logs $cname
+             con1_ns="$output"
+ 
+-            assert "$con1_ns" == "$con2_ns" "($name) namespace matches (type: $type)"
++            if [[ "$option" = "pid" ]] && is_rootless && ! is_remote && [[ "$(podman_runtime)" = "runc" ]]; then
++                # Replace "pid:[1234567]" with "pid:\[1234567\]"
++                con1_ns_esc="${con1_ns//[\[\]]/\\&}"
++                assert "$con2_ns" =~ "${con1_ns_esc}.*warning .*" "($name) namespace matches (type: $type)"
++            else
++                assert "$con1_ns" == "$con2_ns" "($name) namespace matches (type: $type)"
++            fi
+             local matcher="=="
+             if [[ "$type" != "host" ]]; then
+                 matcher="!="

--- a/data/containers/bats/patches/podman/25942.patch
+++ b/data/containers/bats/patches/podman/25942.patch
@@ -1,0 +1,125 @@
+From bf7dcd5619b9600d7fdf93da16c8d0258e58f896 Mon Sep 17 00:00:00 2001
+From: rcmadhankumar <madhankumar.chellamuthu@suse.com>
+Date: Thu, 17 Apr 2025 18:23:57 +0530
+Subject: [PATCH] Fix: Remove appending rw as the default mount option
+
+The backstory for this is that runc 1.2 (opencontainers/runc#3967)
+fixed a long-standing bug in our mount flag handling (a bug that crun
+still has). Before runc 1.2, when dealing with locked mount flags that
+user namespaced containers cannot clear, trying to explicitly clearing
+locked flags (like rw clearing MS_RDONLY) would silently ignore the rw
+flag in most cases and would result in a read-only mount. This is
+obviously not what the user expects.
+
+What runc 1.2 did is that it made it so that passing clearing flags
+like rw would always result in an attempt to clear the flag (which was
+not the case before), and would (in all cases) explicitly return an
+error if we try to clear locking flags. (This also let us finally fix a
+bunch of other long-standing issues with locked mount flags causing
+seemingly spurious errors).
+
+The problem is that podman sets rw on all mounts by default (even if
+the user doesn't specify anything). This is actually a no-op in
+runc 1.1 and crun because of a bug in how clearing flags were handled
+(rw is the absence of MS_RDONLY but until runc 1.2 we didn't correctly
+track clearing flags like that, meaning that rw would literally be
+handled as if it were not set at all by users) but in runc 1.2 leads to
+unfortunate breakages and a subtle change in behaviour (before, a ro
+mount being bind-mounted into a container would also be ro -- though
+due to the above bug even setting rw explicitly would result in ro in
+most cases -- but with runc 1.2 the mount will always be rw even if
+the user didn't explicitly request it which most users would find
+surprising). By the way, this "always set rw" behaviour is a departure
+from Docker and it is not necesssary.
+
+Signed-off-by: rcmadhankumar <madhankumar.chellamuthu@suse.com>
+---
+ pkg/util/mount_opts.go                       | 3 ---
+ pkg/util/utils_test.go                       | 4 ++--
+ test/e2e/play_kube_test.go                   | 2 +-
+ test/python/docker/compat/test_containers.py | 4 ++--
+ test/system/252-quadlet.bats                 | 2 +-
+ 5 files changed, 6 insertions(+), 9 deletions(-)
+
+diff --git a/pkg/util/mount_opts.go b/pkg/util/mount_opts.go
+index c9a773093e..4e37fd74a0 100644
+--- a/pkg/util/mount_opts.go
++++ b/pkg/util/mount_opts.go
+@@ -191,9 +191,6 @@ func processOptionsInternal(options []string, isTmpfs bool, sourcePath string, g
+ 		newOptions = append(newOptions, opt)
+ 	}
+ 
+-	if !foundWrite {
+-		newOptions = append(newOptions, "rw")
+-	}
+ 	if !foundProp {
+ 		if recursiveBind {
+ 			newOptions = append(newOptions, "rprivate")
+diff --git a/pkg/util/utils_test.go b/pkg/util/utils_test.go
+index b582b51ecc..524f1f0250 100644
+--- a/pkg/util/utils_test.go
++++ b/pkg/util/utils_test.go
+@@ -802,13 +802,13 @@ func TestProcessOptions(t *testing.T) {
+ 		{
+ 			name:       "default bind mount",
+ 			sourcePath: "/path/to/source",
+-			expected:   []string{"nodev", "nosuid", "rbind", "rprivate", "rw"},
++			expected:   []string{"nodev", "nosuid", "rbind", "rprivate"},
+ 		},
+ 		{
+ 			name:       "default bind mount with bind",
+ 			sourcePath: "/path/to/source",
+ 			options:    []string{"bind"},
+-			expected:   []string{"nodev", "nosuid", "bind", "private", "rw"},
++			expected:   []string{"nodev", "nosuid", "bind", "private"},
+ 		},
+ 	}
+ 
+diff --git a/test/e2e/play_kube_test.go b/test/e2e/play_kube_test.go
+index 98f8e0e1d6..6902d51178 100644
+--- a/test/e2e/play_kube_test.go
++++ b/test/e2e/play_kube_test.go
+@@ -5818,7 +5818,7 @@ spec:
+ 		podmanTest.PodmanExitCleanly("kube", "play", outputFile)
+ 
+ 		inspectCtr2 := podmanTest.PodmanExitCleanly("inspect", "-f", "'{{ .HostConfig.Binds }}'", ctrNameInKubePod)
+-		Expect(inspectCtr2.OutputToString()).To(ContainSubstring(":" + vol1 + ":rw"))
++		Expect(inspectCtr2.OutputToString()).To(ContainSubstring(":" + vol1))
+ 
+ 		inspectCtr1 := podmanTest.PodmanExitCleanly("inspect", "-f", "'{{ .HostConfig.Binds }}'", ctr1)
+ 		Expect(inspectCtr2.OutputToString()).To(Equal(inspectCtr1.OutputToString()))
+diff --git a/test/python/docker/compat/test_containers.py b/test/python/docker/compat/test_containers.py
+index cb2c5f340b..138372fafd 100644
+--- a/test/python/docker/compat/test_containers.py
++++ b/test/python/docker/compat/test_containers.py
+@@ -265,7 +265,7 @@ def test_build_pull(self):
+                 has_tried_pull = True
+         self.assertFalse(has_tried_pull, "the build process has tried tried to pull the base image")
+ 
+-    def test_mount_rw_by_default(self):
++    def test_mount_options_by_default(self):
+         ctr: Optional[Container] = None
+         vol: Optional[Volume] = None
+ 
+@@ -282,7 +282,7 @@ def test_mount_rw_by_default(self):
+             ctr_inspect = self.docker.api.inspect_container(ctr.id)
+             binds: List[str] = ctr_inspect["HostConfig"]["Binds"]
+             self.assertEqual(len(binds), 1)
+-            self.assertEqual(binds[0], "test-volume:/vol-mnt:rw,rprivate,nosuid,nodev,rbind")
++            self.assertEqual(binds[0], "test-volume:/vol-mnt:rprivate,nosuid,nodev,rbind")
+         finally:
+             if ctr is not None:
+                 ctr.remove()
+diff --git a/test/system/252-quadlet.bats b/test/system/252-quadlet.bats
+index 38da54e592..6a7cf884de 100644
+--- a/test/system/252-quadlet.bats
++++ b/test/system/252-quadlet.bats
+@@ -988,7 +988,7 @@ EOF
+     service_setup $QUADLET_SERVICE_NAME
+ 
+     run_podman container inspect  --format '{{index .HostConfig.Tmpfs "/tmpfs1"}}' $QUADLET_CONTAINER_NAME
+-    is "$output" "rw,rprivate,nosuid,nodev,tmpcopyup" "regular tmpfs mount"
++    is "$output" "rprivate,nosuid,nodev,tmpcopyup" "regular tmpfs mount"
+ 
+     run_podman container inspect  --format '{{index .HostConfig.Tmpfs "/tmpfs2"}}' $QUADLET_CONTAINER_NAME
+     is "$output" "ro,rprivate,nosuid,nodev,tmpcopyup" "read-only tmpfs mount"

--- a/data/containers/bats/patches/podman/26017.patch
+++ b/data/containers/bats/patches/podman/26017.patch
@@ -1,0 +1,28 @@
+From 42c3a958e36696581fc17a08ea5026b78ecfea82 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Tue, 29 Apr 2025 15:21:11 +0200
+Subject: [PATCH] test: Fix for runc error message
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/system/030-run.bats | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/test/system/030-run.bats b/test/system/030-run.bats
+index bed44e6850..84ca7ff1c4 100644
+--- a/test/system/030-run.bats
++++ b/test/system/030-run.bats
+@@ -77,7 +77,12 @@ echo $rand        |   0 | $rand
+     echo "$content" > $PODMAN_TMPDIR/tempfile
+ 
+     run_podman run --rm -i --preserve-fds=2 $IMAGE sh -c "cat <&4" 4<$PODMAN_TMPDIR/tempfile
+-    is "$output" "$content" "container read input from fd 4"
++
++    if [[ "$(podman_runtime)" = "runc" ]]; then
++        assert "$output" =~ "${content}(.* error .* already been removed.*)?"
++    else
++        is "$output" "$content" "container read input from fd 4"
++    fi
+ }
+ 
+ # 'run --preserve-fd' passes a list of additional file descriptors into the container

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -33,19 +33,19 @@ netavark:
     BATS_SKIP: ''
   sle-15-SP5:
     BATS_PATCHES:
-    - https://github.com/containers/netavark/pull/1191.patch
+    - 1191
     BATS_SKIP: 250-bridge-nftables
   sle-15-SP6:
     BATS_PATCHES:
-    - https://github.com/containers/netavark/pull/1191.patch
+    - 1191
     BATS_SKIP: 250-bridge-nftables
   sle-15-SP7:
     BATS_PATCHES:
-    - https://github.com/containers/netavark/pull/1191.patch
+    - 1191
     BATS_SKIP: 250-bridge-nftables
   sle-16.0:
     BATS_PATCHES:
-    - https://github.com/containers/netavark/pull/1191.patch
+    - 1191
     BATS_SKIP: ''
 podman:
   # Note on patches:
@@ -56,9 +56,9 @@ podman:
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
   opensuse-Tumbleweed:
     BATS_PATCHES:
-    - https://github.com/containers/podman/pull/25918.patch
-    - https://github.com/containers/podman/pull/25942.patch
-    - https://github.com/containers/podman/pull/26017.patch
+    - 25918
+    - 25942
+    - 26017
     BATS_SKIP: ''
     BATS_SKIP_ROOT_LOCAL:
     BATS_SKIP_ROOT_REMOTE:
@@ -66,8 +66,8 @@ podman:
     BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
   sle-15-SP6:
     BATS_PATCHES:
-    - https://github.com/containers/podman/pull/21875.patch
-    - https://github.com/containers/podman/pull/25792.patch
+    - 21875
+    - 25792
     BATS_SKIP: ''
     BATS_SKIP_ROOT_LOCAL:
     BATS_SKIP_ROOT_REMOTE:
@@ -75,8 +75,8 @@ podman:
     BATS_SKIP_USER_REMOTE:
   sle-15-SP7:
     BATS_PATCHES:
-    - https://github.com/containers/podman/pull/21875.patch
-    - https://github.com/containers/podman/pull/25792.patch
+    - 21875
+    - 25792
     BATS_SKIP: ''
     BATS_SKIP_ROOT_LOCAL:
     BATS_SKIP_ROOT_REMOTE:
@@ -84,10 +84,10 @@ podman:
     BATS_SKIP_USER_REMOTE:
   sle-16.0:
     BATS_PATCHES:
-    - https://github.com/containers/podman/pull/25792.patch
-    - https://github.com/containers/podman/pull/25918.patch
-    - https://github.com/containers/podman/pull/25942.patch
-    - https://github.com/containers/podman/pull/26017.patch
+    - 25792
+    - 25918
+    - 25942
+    - 26017
     BATS_SKIP: ''
     BATS_SKIP_ROOT_LOCAL: 520-checkpoint
     BATS_SKIP_ROOT_REMOTE: 520-checkpoint

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -8,19 +8,19 @@ buildah:
     BATS_SKIP_USER: add basic commit copy overlay rmi squash
   sle-15-SP4:
     BATS_SKIP: bud namespaces run
-    BATS_SKIP_ROOT: ''
+    BATS_SKIP_ROOT:
     BATS_SKIP_USER: add basic commit copy overlay rmi sbom squash
   sle-15-SP5:
     BATS_SKIP: bud namespaces run
-    BATS_SKIP_ROOT: ''
+    BATS_SKIP_ROOT:
     BATS_SKIP_USER: add basic commit copy overlay rmi sbom squash
   sle-15-SP6:
     BATS_SKIP: bud namespaces run
-    BATS_SKIP_ROOT: ''
+    BATS_SKIP_ROOT:
     BATS_SKIP_USER: add basic commit copy overlay rmi sbom squash
   sle-15-SP7:
     BATS_SKIP: bud namespaces run
-    BATS_SKIP_ROOT: ''
+    BATS_SKIP_ROOT:
     BATS_SKIP_USER: add basic commit copy overlay rmi sbom squash
   sle-16.0:
     BATS_SKIP: bud run sbom
@@ -30,7 +30,7 @@ netavark:
   # Note on patches:
   # https://github.com/containers/netavark/pull/1191 is needed for 001-basic
   opensuse-Tumbleweed:
-    BATS_SKIP: ''
+    BATS_SKIP:
   sle-15-SP5:
     BATS_PATCHES:
     - 1191
@@ -46,7 +46,7 @@ netavark:
   sle-16.0:
     BATS_PATCHES:
     - 1191
-    BATS_SKIP: ''
+    BATS_SKIP:
 podman:
   # Note on patches:
   # https://github.com/containers/podman/pull/21875 is needed for 060-mount
@@ -59,7 +59,7 @@ podman:
     - 25918
     - 25942
     - 26017
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL:
     BATS_SKIP_ROOT_REMOTE:
     BATS_SKIP_USER_LOCAL: 252-quadlet 505-networking-pasta
@@ -68,7 +68,7 @@ podman:
     BATS_PATCHES:
     - 21875
     - 25792
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL:
     BATS_SKIP_ROOT_REMOTE:
     BATS_SKIP_USER_LOCAL:
@@ -77,7 +77,7 @@ podman:
     BATS_PATCHES:
     - 21875
     - 25792
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL:
     BATS_SKIP_ROOT_REMOTE:
     BATS_SKIP_USER_LOCAL:
@@ -88,59 +88,59 @@ podman:
     - 25918
     - 25942
     - 26017
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL: 520-checkpoint
     BATS_SKIP_ROOT_REMOTE: 520-checkpoint
     BATS_SKIP_USER_LOCAL: 505-networking-pasta
     BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
 runc:
   opensuse-Tumbleweed:
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT: cgroups checkpoint
-    BATS_SKIP_USER: ''
+    BATS_SKIP_USER:
   sle-15-SP4:
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT: cgroups
     BATS_SKIP_USER: run userns
   sle-15-SP5:
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT: cgroups
     BATS_SKIP_USER: run userns
   sle-15-SP6:
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT: cgroups
     BATS_SKIP_USER: run userns
   sle-15-SP7:
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT: cgroups
     BATS_SKIP_USER: run userns
   sle-16.0:
-    BATS_SKIP: ''
+    BATS_SKIP:
     BATS_SKIP_ROOT: cgroups
-    BATS_SKIP_USER: ''
+    BATS_SKIP_USER:
 skopeo:
   opensuse-Tumbleweed:
-    BATS_SKIP: ''
-    BATS_SKIP_ROOT: ''
-    BATS_SKIP_USER: ''
+    BATS_SKIP:
+    BATS_SKIP_ROOT:
+    BATS_SKIP_USER:
   sle-15-SP4:
-    BATS_SKIP: ''
-    BATS_SKIP_ROOT: ''
-    BATS_SKIP_USER: ''
+    BATS_SKIP:
+    BATS_SKIP_ROOT:
+    BATS_SKIP_USER:
   sle-15-SP5:
-    BATS_SKIP: ''
-    BATS_SKIP_ROOT: ''
-    BATS_SKIP_USER: ''
+    BATS_SKIP:
+    BATS_SKIP_ROOT:
+    BATS_SKIP_USER:
   sle-15-SP6:
-    BATS_SKIP: ''
-    BATS_SKIP_ROOT: ''
-    BATS_SKIP_USER: ''
+    BATS_SKIP:
+    BATS_SKIP_ROOT:
+    BATS_SKIP_USER:
   sle-15-SP7:
-    BATS_SKIP: ''
-    BATS_SKIP_ROOT: ''
-    BATS_SKIP_USER: ''
+    BATS_SKIP:
+    BATS_SKIP_ROOT:
+    BATS_SKIP_USER:
   sle-16.0:
-    BATS_SKIP: ''
-    BATS_SKIP_ROOT: ''
-    BATS_SKIP_USER: ''
+    BATS_SKIP:
+    BATS_SKIP_ROOT:
+    BATS_SKIP_USER:
 

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -380,7 +380,12 @@ sub bats_patches {
     foreach my $patch (@patches) {
         my $url = ($patch =~ /^\d+$/) ? "https://github.com/$github_org/$package/pull/$patch.patch" : $patch;
         record_info("patch", $url);
-        run_command "curl $curl_opts -O $url", timeout => 900;
+        if ($patch =~ /^\d+$/) {
+            push @commands, "curl $curl_opts -O $url";
+            assert_script_run "curl -O " . data_url("containers/bats/patches/$package/$patch.patch");
+        } else {
+            run_command "curl $curl_opts -O $url", timeout => 900;
+        }
         run_command "git apply -3 --ours " . basename($url);
     }
 }

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -83,8 +83,6 @@ sub install_ncat {
 }
 
 sub install_bats {
-    return if (script_run("command -v bats") == 0);
-
     my $bats_version = get_var("BATS_VERSION", "1.11.1");
 
     run_command "curl $curl_opts https://github.com/bats-core/bats-core/archive/refs/tags/v$bats_version.tar.gz | tar -zxf -";

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -16,7 +16,7 @@ The tests rely on some variables:
 
 | variable | description |
 | --- | --- |
-| `BATS_PACKAGE` | `aardvark` `buildah` `netavark` `podman` `runc` `skopeo` |
+| `BATS_PACKAGE` | `aardvark-dns` `buildah` `netavark` `podman` `runc` `skopeo` |
 | `BATS_PATCHES` | List of github PR id's containing upstream test patches |
 | `BATS_TESTS` | Run only the specified tests |
 | `BATS_REPO` | Repo & branch in the form `[<GITHUB_ORG>]#<BRANCH>` |


### PR DESCRIPTION
Incorporate upstream patches into osado.  This helps us avoid issues with secondary-rate limits in github.  We'll only use osado when the patch ID is numeric.

- Verification run: https://openqa.suse.de/tests/17790665
