### PR TITLE
NFS mm: Add SP6 and SP7 to include stress_ng

### DIFF
--- a/schedule/storage/nfs.yaml
+++ b/schedule/storage/nfs.yaml
@@ -18,6 +18,10 @@ conditional_schedule:
     VERSION:
       Tumbleweed:
         - kernel/nfs_stress_ng
+      15-SP7:
+        - kernel/nfs_stress_ng
+      15-SP6:
+        - kernel/nfs_stress_ng
 schedule:
   - boot/boot_to_desktop
   - kernel/before_nfs_test


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
