### PR TITLE
Set GRUB timeout for autoyast_supported.xml

### DIFF
--- a/data/yam/agama/auto/autoyast_supported.xml
+++ b/data/yam/agama/auto/autoyast_supported.xml
@@ -8,7 +8,7 @@
   </suse_register>
   <bootloader>
     <global>
-      <timeout config:type="integer">-1</timeout>
+      <timeout config:type="integer">20</timeout>
     </global>
   </bootloader>
   <files config:type="list">


### PR DESCRIPTION
Set GRUB timeout to avoid '-1' which wait no time for grub shown.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17820243#details
