### PR TITLE
Ignore messages about missing /dev/log or logger in journal

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -888,5 +888,13 @@
             "sle": ["16.0"]
         },
         "type": "ignore"
+    },
+    "dracut-no-logger": {
+        "description": "No '\/dev\/log' or 'logger' included for syslog logging",
+        "products": {
+            "opensuse": ["Tumbleweed"],
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
See discussion in obs: https://build.opensuse.org/request/show/1279057#comment-2147525
VR: https://openqa.opensuse.org/tests/5069656#step/journal_check/20
