### PR TITLE
Update copyright year and fix typo in EAL4 security tests

### DIFF
--- a/lib/eal4_test.pm
+++ b/lib/eal4_test.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2022 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Base module for EAL4 test cases

--- a/tests/security/eal4/dbus_fuzzer.pm
+++ b/tests/security/eal4/dbus_fuzzer.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2022 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Run 'DBus fuzzer' test case of EAL4 test suite
@@ -83,7 +83,7 @@ sub run {
         # Check the test result
         my $filter_output = script_output("grep -B 1 -i 'exit status' $log_file");
 
-        my $exit_code = $filter_output =~ /Exit status:\s+(\d)/ ? $1 : 'unknow';
+        my $exit_code = $filter_output =~ /Exit status:\s+(\d)/ ? $1 : 'unknown';
 
         # Test case pass (0) or passed but there was a memory leak (3). See poo#154105
         next if ($exit_code == 0 || $exit_code == 3);

--- a/tests/security/eal4/dbus_services_exposure.pm
+++ b/tests/security/eal4/dbus_services_exposure.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2022-2024 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Run 'DBus services exposure' test case of EAL4 test suite


### PR DESCRIPTION
- Update copyright notices from 2022/2022-2024 to 2025
- Fix typo: 'unknow' -> 'unknown' in dbus_fuzzer.pm exit code handling

Ticket: https://progress.opensuse.org/issues/182588