### PR TITLE
There are two versions of python installed on sle15sp7

### DIFF
--- a/lib/python_version_utils.pm
+++ b/lib/python_version_utils.pm
@@ -27,13 +27,12 @@ our @EXPORT = qw(
 
 =head2 get_system_python_version
 
-returns a string with the system's current default python version, for example 'python311'
+returns a string with the system's current python versions, for example 'python3 python311'
 =cut
 
 sub get_system_python_version() {
-    my @system_python_version = script_output(qq[zypper se --installed-only --provides '/usr/bin/python3' | awk -F '|' '/python3[0-9]*/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq]);
-    die "There are many python3 versions installed " if (scalar(@system_python_version) > 1);
-    return $system_python_version[0];
+    my $system_python_version = script_output(qq[zypper se --installed-only --provides '/usr/bin/python3' | awk -F '|' '/python3[0-9]*/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq | awk '{printf "%s ", \$0}']);
+    return $system_python_version;
 }
 
 =head2 get_available_python_versions


### PR DESCRIPTION
There are two versions of python installed on sle15sp7

- Related ticket: https://progress.opensuse.org/issues/183062
- Verification run: https://openqa.suse.de/tests/17834347#step/python3_new_version_check/9
  sle15sp6: https://openqa.suse.de/tests/17834395#step/python3_new_version_check/9
   There are two versions of python installed on sle15sp7 is expected behavior.
  https://suse.slack.com/archives/C02CBSCBNAF/p1748331443617299
  