### PR TITLE
Rename agama_create_swtpm_hdd

### DIFF
--- a/schedule/security/sle16/agama_fde_tpm_installation.yaml
+++ b/schedule/security/sle16/agama_fde_tpm_installation.yaml
@@ -8,7 +8,6 @@ schedule:
   - console/validate_lvm
   - console/validate_encrypt
   - yam/validate/validate_tpm_fde
-  - security/create_swtpm_hdd/build_hdd
 test_data:
   crypttab:
     num_devices_encrypted: 1


### PR DESCRIPTION
Rename agama_create_swtpm_hdd to agama_fde_tpm_installation and put it under sle16 folder.

Ticket: https://progress.opensuse.org/issues/182348

VRs: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=91.1&groupid=431