### PR TITLE
containers: Re-enable busybox image on s390x/ppc64le

### DIFF
--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
 use containers::common qw(install_packages);
 use utils;
-use Utils::Architectures qw(is_ppc64le is_s390x);
+use Utils::Architectures qw(is_s390x);
 use Utils::Backends qw(is_hyperv);
 use version_utils qw(is_vmware);
 
@@ -22,8 +22,7 @@ my $network = "test_isolated_network";
 sub test_ip_version {
     my ($ip_version, $ip_addr) = @_;
 
-    # ppc64le & s390x is using an older BusyBox image with https://bugzilla.suse.com/show_bug.cgi?id=1239176
-    my $image = (is_ppc64le || is_s390x) ? 'registry.opensuse.org/opensuse/toolbox' : 'registry.opensuse.org/opensuse/busybox';
+    my $image = 'registry.opensuse.org/opensuse/busybox';
     script_retry("$runtime pull $image", timeout => 300, delay => 60, retry => 3);
 
     # Test that containers can't access the host

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -13,7 +13,6 @@ use serial_terminal qw(select_serial_terminal);
 use version_utils qw(package_version_cmp is_transactional is_jeos is_leap is_sle_micro is_leap_micro is_sle is_microos is_public_cloud is_vmware);
 use containers::common qw(install_packages);
 use Utils::Systemd qw(systemctl);
-use Utils::Architectures qw(is_s390x);
 use main_common qw(is_updates_tests);
 use publiccloud::utils qw(is_gce);
 
@@ -235,12 +234,9 @@ sub run {
             assert_script_run("podman container inspect $ctr2->{name} --format {{.NetworkSettings.Networks.$net1->{name}.IPAddress}}");
         }
 
-        # NOTE: Remove condition when https://bugzilla.suse.com/show_bug.cgi?id=1239176 is fixed
-        unless (is_s390x) {
-            assert_script_run("podman run --network $net1->{name} -td --name $ctr1->{name} --ip 192.168.64.129 $ctr2->{image}");
-            assert_script_run("podman exec $ctr2->{name} ip addr show eth0");
-            assert_script_run("podman exec $ctr1->{name} ping -c4 192.168.64.128");
-        }
+        assert_script_run("podman run --network $net1->{name} -td --name $ctr1->{name} --ip 192.168.64.129 $ctr2->{image}");
+        assert_script_run("podman exec $ctr2->{name} ip addr show eth0");
+        assert_script_run("podman exec $ctr1->{name} ping -c4 192.168.64.128");
     }
 
     remove_subtest_setup;


### PR DESCRIPTION
Re-enable busybox image on s390x & ppc64le.  I manually checked the busybox image on these architectures and rootless ping works.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1239176
- Verification runs:
  - s390x: https://openqa.suse.de/tests/17858467


