### PR TITLE
Increase bare metal compatibility of SLE 15 maintenance autoyast profile

### DIFF
--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -213,6 +213,9 @@
   <bootloader>
     <global>
       <timeout config:type="integer">45</timeout>
+      % if ($check_var->('BACKEND', 'ipmi')) {
+      <terminal>console</terminal>
+      % }
     </global>
   </bootloader>
   <general>

--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -231,6 +231,9 @@
   </general>
   <partitioning config:type="list">
   <drive>
+    % if (my $disk_wwn = $get_var->('INSTALL_DISK_WWN')) {
+    <device>/dev/disk/by-id/<%= $disk_wwn %></device>
+    % }
     <initialize config:type="boolean">true</initialize>
     <use>all</use>
     </drive>


### PR DESCRIPTION
Installer sometimes chooses the wrong installation disk on hardware with
unconfigured RAID controllers. There is already an existing
INSTALL_DISK_WWN variable for this purpose, and we need to add it to
the SLE 15 autoyast maintenance profile.

Bare metal servers can have issues correctly displaying the GRUB menu over
IPMI console. We need to set the terminal to 'console' in order to disable
GRUB graphics.

Broken GRUB menu: https://openqa.suse.de/tests/17861253#step/installation/8

- Related ticket: https://progress.opensuse.org/issues/183023
- Needles: none
- Verification run: 
Problematic Nvidia worker: https://openqa.suse.de/tests/17866584#step/handle_reboot/2
