### PR TITLE
[WIP] reject external dhcp offers for kea tests

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -112,6 +112,7 @@ sub run {
     my $bci_devel_repo = get_var('BCI_DEVEL_REPO');
     my $bci_tests_repo = get_var('BCI_TESTS_REPO', 'https://github.com/SUSE/BCI-tests.git');
     my $bci_tests_branch = get_var('BCI_TESTS_BRANCH', '');    # Keep BCI_TESTS_BRANCH for backwards compatibility.
+    my $reject_dhcp_offers_from = get_var('BCI_KEA_TESTS_REJECT_DHCP_OFFERS_FROM', '');
     if ($bci_tests_repo =~ m/(.*)#(.*)/) {
         $bci_tests_repo = $1;
         $bci_tests_branch = $2;
@@ -139,6 +140,9 @@ sub run {
     assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard $bci_tests_branch");
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
     assert_script_run("export CONTAINER_RUNTIME=$engine");
+    if ($reject_dhcp_offers_from) {
+        assert_script_run("export REJECT_DHCP_OFFERS_FROM=$reject_dhcp_offers_from");
+    }
     if ($os_version) {
         script_run("export OS_VERSION=$os_version");
         validate_script_output('echo $OS_VERSION', sub { m/$os_version/ });

--- a/variables.md
+++ b/variables.md
@@ -37,6 +37,7 @@ BCI_TARGET | string | ibs-cr | Container project to be tested. `ibs-cr` is the C
 BCI_SKIP | boolean | false | Switch to disable BCI test runs. Necessary for fine-granular test disablement
 BCI_PREPARE | boolean | false | Launch the bci_prepare step again. Useful to re-initialize the BCI-Test repo when using a different BCI_TESTS_REPO
 BCI_VIRTUALENV | boolean | false | Use a virtualenv for pip dependencies in BCI tests
+BCI_KEA_TESTS_REJECT_DHCP_OFFERS_FROM | string | | Ignore DHCP offers from external server for kea tests, e.g. `172.25.0.2,172.25.0.5,192.168.1.1`
 BCI_OS_VERSION | string | | Set the environment variable OS_VERSION to this value, if present
 BOOTLOADER | string | grub2 | Which bootloader is used by the image or will be selected during installation, e.g. `grub2`, `grub2-bls`, `systemd-boot`
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.


### PR DESCRIPTION
External DHCP servers in the newtork can fail the kea tests as the testing 
client might be receiving ip from external servers. To ignore the external 
dhcp offers, `BCI_KEA_TESTS_REJECT_DHCP_OFFERS_FROM` has to be 
taken from the job settings and exported.

Ongoing work in Bci tests: https://github.com/SUSE/BCI-tests/pull/831
(This PR cannot be merged befor the above)


- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1242552

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
