### PR TITLE
Reset consoles after reboot in agama and agama_auto

### DIFF
--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -22,6 +22,7 @@ use testapi qw(
   upload_logs
   select_console
   console
+  reset_consoles
 );
 use Utils::Architectures qw(is_s390x is_ppc64le);
 use Utils::Backends qw(is_svirt);
@@ -67,6 +68,7 @@ sub run {
       power_action('reboot', keepconsole => 1, first_reboot => 1) :
       # graphical reboot
       $reboot_page->reboot();
+    reset_consoles;
 }
 
 1;

--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -20,18 +20,14 @@ sub run {
     my $reboot_page = $testapi::distri->get_reboot();
     $reboot_page->expect_is_shown();
 
-    if (!is_leap()) {
-        # While the work on Agama settles, on leap
-        # Leave log collection for the post_fail_hook
-        # see also https://progress.opensuse.org/issues/182102
-        $self->upload_agama_logs() unless is_hyperv();
-    }
+    $self->upload_agama_logs() unless is_hyperv();
 
     (is_s390x() || is_ppc64le() || is_vmware()) ?
       # reboot via console
       power_action('reboot', keepconsole => 1, first_reboot => 1) :
       # graphical reboot
       $reboot_page->reboot();
+    reset_consoles;
 }
 
 1;


### PR DESCRIPTION
We have added reset_consoles to the agama_auto to allow Leap to fetch the logs.

- Related ticket: https://progress.opensuse.org/issues/182102
- Needles: N/A
- Verification run: 
  - Leap: https://openqa.opensuse.org/tests/5073631 (error not related to current development)
  - SLES: https://openqa.suse.de/tests/17873984
