### PR TITLE
Fix 16 ppc64le ha_cluster_crash_test timed out

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -85,7 +85,8 @@ sub run {
     }
 
     # bsc#997263 - VMware screen resolution defaults to 800x600 and longer GRUB_TIMEOUT for better needle detection
-    if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+    # Also for HA ha_cluster_crash_test test cases
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware') || check_var('CLUSTER_NAME', 'crashtest')) {
         #change_grub_config('=.*', '=1024x768x32', 'GFXMODE=');
         #change_grub_config('=.*', '=1024x768x32', 'GFXPAYLOAD_LINUX=');
         change_grub_config('=.*', '=30', 'GRUB_TIMEOUT=');

--- a/tests/ha/ha_cluster_crash_test.pm
+++ b/tests/ha/ha_cluster_crash_test.pm
@@ -31,7 +31,9 @@ use hacluster qw(check_cluster_state
   wait_until_resources_started
   prepare_console_for_fencing
 );
-use utils qw(zypper_call);
+use utils qw(zypper_call reconnect_mgmt_console);
+use Utils::Backends 'is_pvm';
+use version_utils qw(is_sle);
 use Mojo::JSON qw(encode_json);
 
 our $dir_log = '/var/lib/crmsh/crash_test/';
@@ -73,7 +75,11 @@ sub run {
         my $cmd = "crm cluster crash_test --$check --force";
         record_info($check, "Executing $cmd");
         if ($check eq 'split-brain-iptables') {
-            enter_cmd $cmd;
+            # iptables is not installed in SLE 16 by default
+            zypper_call 'in iptables' if is_sle('>=16');
+            # Wait for a moment and save the screen shot for debugging purpose
+            enter_cmd $cmd, wait_still_screen => 10;
+            save_screenshot();
             $cmd_fails = 0;
         }
         else { $cmd_fails = script_run("timeout 20 $cmd"); }
@@ -83,6 +89,7 @@ sub run {
         my $loop_count = bmwqemu::scale_timeout(15);    # Wait 1 minute (15*4) maximum, can be scaled with SCALE_TIMEOUT
         while (1) {
             last if ($loop_count-- <= 0);
+            reconnect_mgmt_console if (is_pvm && ($check ne 'kill-pacemakerd'));
             if (check_screen('grub2', 0, no_wait => 1)) {
                 # Wait for boot and reconnect to root console
                 $self->wait_boot;


### PR DESCRIPTION
Fix 16 ppc64le ha_cluster_crash_test timed out failure.
-  Set `GRUB_TIMEOUT=30` for needles match when doing reboot (default `8s` is too short and will introduce sporadic needles mismatch failure)
- Added `save_screenshot` for `enter_cmd split-brain-iptables ...`
- Added `zypper_call "in iptables" if is_sle('>=16');`
- Added `reconnect_mgmt_console` for pvm
- Added retry for nodes check as there are sporadic issues like https://openqa.suse.de/tests/17896658#step/ha_cluster_init/41

TEAM-10374 - [16][ppc64le] after resolving TEAM-10288, ha_cluster_crash_test_x failed on ha_cluster_crash_test


- Related ticket: https://jira.suse.com/browse/TEAM-10374
- Verification run: 
https://openqa.suse.de/tests/17898083  (passed)
https://openqa.suse.de/tests/17898099#step/ha_cluster_crash_test/156 (passed, and the `save_screenshot` of `split-brain-iptables`)