### PR TITLE
nvidia: Add kernel bare metal schedules

### DIFF
--- a/schedule/kernel/nvidia-micro.yaml
+++ b/schedule/kernel/nvidia-micro.yaml
@@ -1,0 +1,9 @@
+---
+name: nvidia-micro
+schedule:
+- installation/bootloader_start
+- microos/install_image
+- transactional/host_config
+- console/suseconnect_scc
+- transactional/install_updates
+- kernel/nvidia

--- a/schedule/kernel/nvidia-sle.yaml
+++ b/schedule/kernel/nvidia-sle.yaml
@@ -1,0 +1,32 @@
+---
+name: nvidia-sle
+schedule:
+- autoyast/prepare_profile
+- installation/bootloader_start
+- autoyast/installation
+- autoyast/console
+- autoyast/login
+- autoyast/wicked
+- autoyast/repos
+- autoyast/clone
+- autoyast/logs
+- console/yast2_vnc
+- console/force_scheduled_tasks
+- shutdown/grub_set_bootargs
+- autoyast/autoyast_reboot
+- installation/handle_reboot
+- installation/first_boot
+- qa_automation/patch_and_reboot
+- kernel/nvidia
+- console/system_prepare
+- console/check_network
+- console/system_state
+- console/prepare_test_data
+- console/consoletest_setup
+- locale/keymap_or_locale
+- console/textinfo
+- console/hostname
+- console/consoletest_finish
+- locale/keymap_or_locale_x11
+- x11/glxgears
+- shutdown/shutdown

--- a/tests/kernel/nvidia.pm
+++ b/tests/kernel/nvidia.pm
@@ -20,10 +20,10 @@ sub run
 
     select_serial_terminal();
 
-    nvidia_utils::install(reboot => 1);
+    nvidia_utils::install(variant => "cuda", reboot => 1);
     nvidia_utils::validate();
 
-    nvidia_utils::install(variant => "cuda", reboot => 1);
+    nvidia_utils::install(reboot => 1);
     nvidia_utils::validate();
 }
 


### PR DESCRIPTION
All previous dependencies were done and we can schedule Nvidia tests.

Related PRs:
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22153
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22177
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22158
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22191
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22196

- Related ticket: https://progress.opensuse.org/issues/182873, https://progress.opensuse.org/issues/182459
- Needles: none
- Verification run: 
SLE:  https://openqa.suse.de/tests/17875575
SL Micro: https://openqa.suse.de/tests/17880920
