### PR TITLE
Clean auditlog in SLE16 on s390x

### DIFF
--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -56,6 +56,14 @@ sub run {
     if (is_sle('>=16')) {
         select_serial_terminal;
         validate_script_output("sestatus", sub { m/.*Current\ mode:\ .*enforcing/sx });
+
+        # After update, clean the audit log to make suere there aren't any leftovers that were already fixed
+        # see poo181403
+        if (is_sle('>=16.0') && is_s390x) {
+            assert_script_run 'tar czf /tmp/audit_before.tgz /var/log/audit';
+            upload_logs '/tmp/audit_before.tgz';
+            assert_script_run 'rm -f /var/log/audit/* /tmp/audit_before.tgz';
+        }
         return 1;
     }
 


### PR DESCRIPTION
Cleanout previos logs before doing the tests.

- Related ticket: https://progress.opensuse.org/issues/181403
- Verification run: 
  - https://openqa.suse.de/tests/17881202  