### PR TITLE
Add udevadm settle to wait for partition changes

### DIFF
--- a/tests/sles4sap/ensa/ensa_filesystems.pm
+++ b/tests/sles4sap/ensa/ensa_filesystems.pm
@@ -40,25 +40,25 @@ sub run {
         # From the manual: changes will *probably* be made to the disk
         # immediately after typing a command. However, the operating system’s
         # cache and the disk’s hardware cache may delay this. When using serial
-        # we hit this limitation, to avoid that we run partprobe and parted again.
-        script_run('partprobe');
+        # we hit this limitation, to avoid that we run udevadm settle and parted again.
+        assert_script_run("udevadm settle --timeout=$default_timeout", $default_timeout + 5);
         assert_script_run("parted -s $lun_path mklabel gpt");
-        script_run('partprobe');
+        assert_script_run("udevadm settle --timeout=$default_timeout", $default_timeout + 5);
         assert_script_run("parted -s $lun_path mkpart primary 0% 50%");
-        script_run('partprobe');
+        assert_script_run("udevadm settle --timeout=$default_timeout", $default_timeout + 5);
         assert_script_run("parted -s $lun_path mkpart primary 50% 100%");
-        script_run('partprobe');
-        script_run('partprobe -s');
+        assert_script_run("udevadm settle --timeout=$default_timeout", $default_timeout + 5);
         assert_script_run("parted -s $lun_path --list");
 
         # Format the partitions
         script_retry("mkfs.xfs $lun_path-part1", delay => 5, retry => 3);
-        script_run('partprobe');
+        assert_script_run("udevadm settle --timeout=$default_timeout", $default_timeout + 5);
         script_retry("mkfs.xfs $lun_path-part2", delay => 5, retry => 3);
-        script_run('partprobe');
+        assert_script_run("udevadm settle --timeout=$default_timeout", $default_timeout + 5);
         assert_script_run("fdisk -l");
         assert_script_run("mount -t xfs $lun_path-part1 $sap_dir/$instance_dir");
         assert_script_run("chmod 777 $sap_dir/$instance_dir");
+        assert_script_run("udevadm settle --timeout=$default_timeout", $default_timeout + 5);
     }
 
     # ENSA needs to wait for partitioning being done
@@ -66,9 +66,10 @@ sub run {
 
     if ($instance_type eq 'ERS') {
         my $lun_path = get_lun;    # ERS removes lun from the list.
-        assert_script_run("partprobe; fdisk -l $lun_path");
+        assert_script_run("fdisk -l $lun_path");
         assert_script_run("mkdir -p $sap_dir/$instance_dir");
-        assert_script_run("mount -t xfs $lun_path-part2 $sap_dir/$instance_dir");
+        script_run('partprobe');
+        script_retry("mount -t xfs $lun_path-part2 $sap_dir/$instance_dir", delay => 10, retry => 3);
         assert_script_run("chmod 777 $sap_dir/$instance_dir");
     }
     record_info('Block devices', assert_script_run('lsblk'));


### PR DESCRIPTION
After a discussion in research, it was suggested that `udev settle` would work unlike `partprobe` that we have been using until now. Apart from that I put the mount behind another retry.

- Related Ticket: TEAM-10390
- Verification run: https://qesapworker-prg8.qa.suse.cz/group_overview/1?limit_builds=20
