### PR TITLE
Add IDPF to GCE Terraform

### DIFF
--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -29,6 +29,7 @@ data "external" "gce_cred" {
 
 locals {
   zone = "${var.region}-${var.availability_zone}"
+  use_idpf = startswith(lower(var.type), "c3") || startswith(lower(var.type), "x4")
 }
 
 variable "cred_file" {
@@ -165,6 +166,7 @@ resource "google_compute_instance" "openqa" {
     subnetwork = "tf-subnetwork"
     access_config {}
     stack_type = var.stack_type
+    nic_type = local.use_idpf ? "IDPF" : null
   }
   can_ip_forward = true
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/182741
- Verification run: 
* [europe-west4 yielding NetworkInterface NicType can only be set to IDPF on instances with IDPF GuestOsFeature., invalid](https://openqa.suse.de/tests/17875576#step/prepare_instance/124)
* [us-central1 successful run without IDPF](https://openqa.suse.de/tests/17884056)
* [us-central1 successful run with IDPF](https://openqa.suse.de/tests/17882516)
* [us-central1 non baremetal run](https://openqa.suse.de/tests/17885088)