### PR TITLE
Added HA and SAP repo validation data files

### DIFF
--- a/schedule/yam/agama_extensions_and_patterns.yaml
+++ b/schedule/yam/agama_extensions_and_patterns.yaml
@@ -10,3 +10,4 @@ schedule:
   - installation/first_boot
   - yam/validate/validate_registered_addons
   - yam/validate/validate_installed_patterns
+  - console/validate_repos

--- a/schedule/yam/agama_extensions_and_patterns_unattended.yaml
+++ b/schedule/yam/agama_extensions_and_patterns_unattended.yaml
@@ -9,3 +9,4 @@ schedule:
   - installation/first_boot
   - yam/validate/validate_registered_addons
   - yam/validate/validate_installed_patterns
+  - console/validate_repos

--- a/test_data/yam/agama_ha.yaml
+++ b/test_data/yam/agama_ha.yaml
@@ -1,0 +1,33 @@
+---
+os_release_name: SLES
+repos:
+  - name: SLE-Product-HA-%VERSION%
+    alias: SUSE_Linux_Enterprise_High_Availability_Extension_%VERSION%_%ARCH%:SLE-Product-HA-%VERSION%
+    uri: http://openqa.suse.de/assets/repo/SLES-HA-%VERSION%-%ARCH%-Build%BUILD%/
+    enabled: 'Yes'
+    filter: name
+  - name: SLE-Product-HA-%VERSION%-Debug
+    alias: SUSE_Linux_Enterprise_High_Availability_Extension_%VERSION%_%ARCH%:SLE-Product-HA-%VERSION%-Debug
+    uri: http://openqa.suse.de/assets/repo/SLES-HA-%VERSION%-%ARCH%-Debug-Build%BUILD%/
+    enabled: 'No'
+    filter: name
+  - name: SLE-Product-HA-%VERSION%-Source
+    alias: SUSE_Linux_Enterprise_High_Availability_Extension_%VERSION%_%ARCH%:SLE-Product-HA-%VERSION%-Source
+    uri: http://openqa.suse.de/assets/repo/SLES-HA-%VERSION%-%ARCH%-Source-Build%BUILD%/
+    enabled: 'No'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Build%BUILD%/
+    enabled: 'Yes'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%-Debug
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%-Debug
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Debug-Build%BUILD%/
+    enabled: 'No'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%-Source
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%-Source
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Source-Build%BUILD%/
+    enabled: 'No'
+    filter: name

--- a/test_data/yam/agama_sap.yaml
+++ b/test_data/yam/agama_sap.yaml
@@ -1,2 +1,18 @@
 ---
 os_release_name: SLES_SAP
+repos:
+  - name: SLE-Product-SLES_SAP-%VERSION%
+    alias: SUSE_Linux_Enterprise_Server_for_SAP_Applications_%VERSION%_%ARCH%:SLE-Product-SLES_SAP-%VERSION%
+    uri: http://openqa.suse.de/assets/repo/SLES-SAP-%VERSION%-%ARCH%-Build%BUILD%/
+    enabled: 'Yes'
+    filter: name
+  - name: SLE-Product-SLES_SAP-%VERSION%-Debug
+    alias: SUSE_Linux_Enterprise_Server_for_SAP_Applications_%VERSION%_%ARCH%:SLE-Product-SLES_SAP-%VERSION%-Debug
+    uri: http://openqa.suse.de/assets/repo/SLES-SAP-%VERSION%-%ARCH%-Debug-Build%BUILD%/
+    enabled: 'No'
+    filter: name
+  - name: SLE-Product-SLES_SAP-%VERSION%-Source
+    alias: SUSE_Linux_Enterprise_Server_for_SAP_Applications_%VERSION%_%ARCH%:SLE-Product-SLES_SAP-%VERSION%-Source
+    uri: http://openqa.suse.de/assets/repo/SLES-SAP-%VERSION%-%ARCH%-Source-Build%BUILD%/
+    enabled: 'No'
+    filter: name


### PR DESCRIPTION
In this PR we have added the SAP and HA repository definition to use in `validate_repos` validation step.

- Related ticket: https://progress.opensuse.org/issues/180956
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/456
- Needles: N/A
- Verification run:
  - sles_sap_default: https://openqa.suse.de/tests/17885097
  - sles_ha_unattended: https://openqa.suse.de/tests/17885204#
