### PR TITLE
Fix BATS_SKIP for Tumbleweed

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -58,7 +58,6 @@ podman:
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
   opensuse-Tumbleweed:
     BATS_PATCHES:
-    - 25918
     - 25942
     - 26017
     BATS_SKIP:

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -98,7 +98,7 @@ podman:
 runc:
   opensuse-Tumbleweed:
     BATS_SKIP:
-    BATS_SKIP_ROOT: cgroups checkpoint
+    BATS_SKIP_ROOT: cgroups
     BATS_SKIP_USER:
   sle-15-SP4:
     BATS_SKIP:

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -165,10 +165,8 @@ NOTES
 | test | reason |
 | --- | --- |
 | [cgroups] | `io.bfq.weight: operation not supported` |
-| [checkpoint] | https://github.com/checkpoint-restore/criu/issues/2650 |
 
 [cgroups]: https://github.com/opencontainers/runc/blob/main/tests/integration/cgroups.bats
-[checkpoint]: https://github.com/opencontainers/runc/blob/main/tests/integration/checkpoint.bats
 
 ## Tools
 


### PR DESCRIPTION

- `checkpoint` test now passing in Tumbleweed: https://openqa.opensuse.org/tests/5074929#step/runc/262
- Drop patch not needed on podman 5.5.0