### PR TITLE
Revert "bats/podman: Drop 25918 patch on newer podman 5.5.0"

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -58,6 +58,7 @@ podman:
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
   opensuse-Tumbleweed:
     BATS_PATCHES:
+    - 25918
     - 25942
     - 26017
     BATS_SKIP:


### PR DESCRIPTION
No need to drop 25918 patch as `git apply -3 --ours` works beautifully.  Only `patch` fails.

- Verification run: https://openqa.opensuse.org/tests/5075418#step/podman/216