### PR TITLE
bats/podman: Update SKIP for podman 5.5.0

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -62,10 +62,10 @@ podman:
     - 25942
     - 26017
     BATS_SKIP:
-    BATS_SKIP_ROOT_LOCAL:
+    BATS_SKIP_ROOT_LOCAL: 200-pod
     BATS_SKIP_ROOT_REMOTE:
     BATS_SKIP_USER_LOCAL: 252-quadlet 505-networking-pasta
-    BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
+    BATS_SKIP_USER_REMOTE: 505-networking-pasta
   sle-15-SP6:
     BATS_PATCHES:
     - 21875


### PR DESCRIPTION
130-kill is now passing: https://openqa.opensuse.org/tests/5078602#step/podman/376
200-pod is giving us trouble.
