### PR TITLE
nvidia_utils: Uninstall nvidia packages safely

### DIFF
--- a/lib/nvidia_utils.pm
+++ b/lib/nvidia_utils.pm
@@ -58,7 +58,7 @@ sub install
 
     # Make sure to remove the other variant first
     my $remove_variant = script_run("rpm -q $variant_std") ? $variant_cuda : $variant_std;
-    zypper_call("remove --clean-deps ${remove_variant}");
+    zypper_call("remove --clean-deps ${remove_variant}", exitcode => [0, 104]);
 
     # Install driver and compute utils which packages `nvidia-smi`
     zypper_call("install -l $variant");


### PR DESCRIPTION
When removing a package that isn't installed, zypper will return exit code 104. Accept that as success.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17906867
