### PR TITLE
Handle conflicts in zdup

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -133,17 +133,21 @@ sub run {
                 my @lines = split /\n/, $out;
                 foreach my $package_name (keys %conflict_solutions) {
                     last if $conflict_solved;
+                    record_info $package_name;
                     my $regex = $conflict_solutions{$package_name};
                     foreach my $line (@lines) {
+                        last if $conflict_solved;
                         if ($line =~ /$regex/) {
-                            record_info "$package_name";
                             send_key $1;
+                            wait_still_screen 1;
                             send_key 'ret';
                             $conflict_solved = 1;
+                            save_screenshot;
                             last;
                         }
                     }
                 }
+                record_info "Debug: $conflict_solved";
                 # if we found a conflict and solved it, keep looping
                 next if $conflict_solved;
 

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -147,9 +147,12 @@ sub run {
                         }
                     }
                 }
-                record_info "Debug: $conflict_solved";
-                # if we found a conflict and solved it, keep looping
-                next if $conflict_solved;
+                # if we found a conflict and solved it, keep looping, update $out too
+                if ($conflict_solved) {
+                    save_screenshot;
+                    $out = wait_serial([$zypper_dup_continue, $zypper_dup_conflict, $zypper_dup_error], 120);
+                    next;
+                }
 
                 $self->result('fail');
                 save_screenshot;


### PR DESCRIPTION
In the rare ocassions that there's a conflict during an upgrade, we have
to know which option to choose for a given conflict and avoid failing
the test in case we have an uknown conflict

Failure: https://openqa.opensuse.org/tests/5079365#step/zdup/11
VR: 
- with conflict https://openqa.opensuse.org/tests/5082020#step/zdup/457
- without conflict https://openqa.opensuse.org/tests/5082022#step/zdup/213

