### PR TITLE
Add network parameters to Agama installation

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -32,6 +32,8 @@ sub prepare_boot_params {
     push @params, 'console=tty' . (is_x86_64 ? 'S0' : 'AMA0'), 'console=tty';
     push @params, 'kernel.softlockup_panic=1';
     push @params, "live.password=$testapi::password";
+    push @params, 'ip=dhcp';
+    push @params, 'rd.neednet';
 
     # override default boot params
     if (get_var('BOOTPARAMS')) {


### PR DESCRIPTION
A new [Agama feature](https://jira.suse.com/browse/AGM-147) make our interfaces in openQA not to get an IP, therefore failing in most cases due to not resolving the network.
To be consistent with the previous behavior, we need to add some new parameters in the boot process. 

Related: 
- https://trello.com/c/P6oGGmjH/4745-ui-handle-persistent-non-persistent-network-connections
- https://github.com/agama-project/agama/pull/2279
- https://github.com/agama-project/agama/pull/2291
- https://bugzilla.suse.com/show_bug.cgi?id=1241224


VR: hdd creation: https://openqa.suse.de/tests/17908933
child job: https://openqa.suse.de/tests/17908969