### PR TITLE
slem: Avoid re-encrypt-finished on SLEM 6.2+

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -304,7 +304,7 @@ sub run {
         type_password;
         send_key "ret";
         # Disk encryption is gonna take time
-        assert_screen 're-encrypt-finished', 600;
+        assert_screen 're-encrypt-finished', 600 unless is_sle_micro('>=6.2');
     }
 
     if (is_tumbleweed || is_microos || is_sle_micro('>6.0') || is_leap_micro('>6.0') || is_sle('>=16')) {


### PR DESCRIPTION
Fix SLEM 6.2 test.

- Failing test: https://openqa.suse.de/tests/17883366#step/firstrun/19
- Related ticket: https://jira.suse.com/browse/SMO-570
- Verification run: https://openqa.suse.de/tests/17909403