### PR TITLE
containers: Use script_retry to pull image to avoid timeout issues

### DIFF
--- a/tests/containers/seccomp.pm
+++ b/tests/containers/seccomp.pm
@@ -34,6 +34,8 @@ sub run {
 
     assert_script_run('curl ' . data_url("containers/$runtime-seccomp.json") . " -o $policy");
 
+    script_retry("$runtime pull $image", timeout => 300, delay => 60, retry => 3);
+
     # Verify ls works with that policy
     validate_script_output "$runtime run --rm --security-opt seccomp=$policy $image ls", qr/proc/;
     # Verify it fails if syscalls needed to get directory entries get denied


### PR DESCRIPTION
Use script_retry to pull image to avoid timeout issues

- Failing test: https://openqa.suse.de/tests/17906958#step/podman_seccomp/40