### PR TITLE
Add kdump over NFS test

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -21,7 +21,7 @@ use virt_autotest::utils 'is_xen_host';
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump
   activate_kdump activate_kdump_cli activate_kdump_without_yast activate_kdump_transactional
   kdump_is_active do_kdump configure_service check_function
-  full_kdump_check deactivate_kdump_cli);
+  full_kdump_check deactivate_kdump_cli configure_kdump_with_nfs only_check_kdump);
 
 sub determine_kernel_debuginfo_package {
     # Using the provided capabilities of the currently active kernel, get the
@@ -519,6 +519,14 @@ sub full_kdump_check {
     if ($stage eq 'after') {
         check_ssh_files();
     }
+}
+
+sub configure_kdump_with_nfs {
+    record_info("configure_kdump_with_nfs: implement");
+}
+
+sub only_check_kdump {
+    record_info("only_check_kdump: implement");
 }
 
 1;

--- a/schedule/storage/nfstest.yaml
+++ b/schedule/storage/nfstest.yaml
@@ -14,11 +14,11 @@ conditional_schedule:
     ROLE:
       nfs_server:
         - kernel/nfs_server
+        - kernel/kdump_over_nfs
       nfs_client:
         - kernel/nfs_client
+        - kernel/kdump_over_nfs
 schedule:
   - boot/boot_to_desktop
   - kernel/before_nfs_test
   - '{{nfstest}}'
-  - kernel/nfs_stress_ng
-  - kernel/nfstest

--- a/tests/kernel/kdump_over_nfs.pm
+++ b/tests/kernel/kdump_over_nfs.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Configure and run kdump over NFS
+# Maintainer: QE Kernel <kernel-qa@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use kdump_utils;
+use lockapi;
+
+sub run {
+    my ($self) = @_;
+    my $role = get_required_var('ROLE');
+
+    select_console('root-console');
+
+    if ($role eq 'nfs_client') {
+        configure_service(test_type => 'function', yast_interface => 'cli');
+        configure_kdump_with_nfs;
+    }
+
+    barrier_wait("KDUMP_PROVISIONED");
+
+    if ($role eq 'nfs_client') {
+        do_kdump;
+    }
+
+    barrier_wait("KDUMP_TRIGGERED");
+
+    if ($role eq 'nfs_server') {
+        only_check_kdump;
+    }
+
+
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    script_run 'ls -lah /boot/';
+    script_run 'tar -cvJf /tmp/crash_saved.tar.xz -C /var/crash .';
+    upload_logs '/tmp/crash_saved.tar.xz';
+
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/kernel/nfs_barriers.pm
+++ b/tests/kernel/nfs_barriers.pm
@@ -21,6 +21,10 @@ sub run {
     barrier_create("NFS_STRESS_NG_END", $nodes);
     barrier_create("NFS_NFSTEST_START", $nodes);
     barrier_create("NFS_NFSTEST_END", $nodes);
+    if (check_var('KDUMP_OVER_NFS', '1')) {
+        barrier_create("KDUMP_PROVISIONED", $nodes);
+        barrier_create("KDUMP_TRIGGERED", $nodes);
+    }
     record_info("barriers initializoped");
 }
 


### PR DESCRIPTION
The patch is introducing KDUMP check over NFS where NFS multimachine tests are re-used, KDUMP is configured for writing to the mounted NFS share and then all is checked on the nfs server side - if the dump is there and if it is readable etc.

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
