### PR TITLE
Add parameters to fix s390x kvm network issue

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -38,6 +38,8 @@ sub set_svirt_domain_elements {
                   "/assets/repo/" . get_required_var('REPO_0') . "/LiveOS/squashfs.img" :
                   "/assets/iso/" . get_required_var('ISO'));
             $cmdline .= " live.password=$testapi::password";
+            $cmdline .= " ip=dhcp";
+            $cmdline .= " rd.neednet";
         } else {
             $cmdline .= "install=$repo";
             $cmdline .= remote_install_bootmenu_params;


### PR DESCRIPTION
No network issue after SLE16 installation on s390x kvm.
Failed job: https://openqa.suse.de/tests/17886668#step/validate_base_product/2

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17916377#details
