### PR TITLE
Revert "Exclude journal_remote on 15-SP7 until it's added"

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -48,8 +48,7 @@ conditional_schedule:
         - console/golang
         - console/redis
         - console/ansible
-        # https://bugzilla.suse.com/show_bug.cgi?id=1243259
-        # - qe-core/systemd/journal_remote
+        - qe-core/systemd/journal_remote
         - '{{arch_specific}}'
       15-SP6:
         - console/openssl_nodejs


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#22120

Fixed https://bugzilla.suse.com/show_bug.cgi?id=1243259