### PR TITLE
containers: Enable docker-buildx test in SLEM 6.x

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -191,7 +191,7 @@ sub load_host_tests_docker {
     load_volume_tests($run_args);
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
-    loadtest('containers/buildx', run_args => $run_args, name => $run_args->{runtime} . "_buildx") if (is_tumbleweed || is_sle('>=16.0') || is_leap('>16.0'));
+    loadtest('containers/buildx', run_args => $run_args, name => $run_args->{runtime} . "_buildx") unless (is_sle('<15') || is_sle_micro('<6.0'));
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {
         loadtest 'containers/validate_btrfs';


### PR DESCRIPTION
Enable docker-buildx test in SLEM 6.x

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1239683
- Verification runs:
  - docker SLEM 6.0: https://openqa.suse.de/tests/17917692