### PR TITLE
containers: Extend rootless docker test to SLE 16.0

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -181,7 +181,6 @@ sub load_host_tests_docker {
         # PackageHub is not available in SLE Micro | MicroOS
         loadtest 'containers/registry' if (is_x86_64 || is_sle('>=15-sp4'));
     }
-    loadtest 'containers/rootless_docker' if (is_tumbleweed);
     # Skip this test on docker-stable due to https://bugzilla.opensuse.org/show_bug.cgi?id=1239596
     unless (is_transactional || is_public_cloud || is_sle('<15-SP4') || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {
         loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation");
@@ -192,6 +191,7 @@ sub load_host_tests_docker {
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
     loadtest('containers/buildx', run_args => $run_args, name => $run_args->{runtime} . "_buildx") unless (is_sle('<15') || is_sle_micro('<6.0'));
+    loadtest 'containers/rootless_docker' if (is_tumbleweed || is_sle('>=16.0'));
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {
         loadtest 'containers/validate_btrfs';

--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -23,6 +23,7 @@ use containers::docker;
 use containers::container_images;
 use Utils::Architectures;
 use containers::common qw(install_docker_when_needed);
+use version_utils qw(is_sle);
 
 sub run {
     my ($self) = @_;
@@ -36,8 +37,11 @@ sub run {
     my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
     install_packages("$pkg_name-rootless-extras");
 
+    assert_script_run("echo 0 > /etc/docker/suse-secrets-enable") if is_sle;
+
     my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
 
+    # NOTE: Remove this when 15-SP3 is EOL
     my $subuid_start = get_user_subuid($user);
     if ($subuid_start eq '') {
         record_soft_failure 'bsc#1185342 - YaST does not set up subuids/-gids for users';
@@ -81,6 +85,7 @@ sub post_run_hook {
     my $self = shift;
     cleanup();
     select_serial_terminal();
+    script_run "rm -f /etc/docker/suse-secrets-enable" if is_sle;
     $self->SUPER::post_run_hook;
 }
 
@@ -88,6 +93,7 @@ sub post_fail_hook {
     my $self = shift;
     cleanup();
     select_serial_terminal();
+    script_run "rm -f /etc/docker/suse-secrets-enable" if is_sle;
     save_and_upload_log('cat /etc/{subuid,subgid}', "/tmp/permissions.txt");
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Extend rootless docker test to SLE 16.0

I see no point in extending to SLES 15.x because the docker-stable-rootless-extras package isn't available.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1240150
- Verification runs:
  - docker: https://openqa.suse.de/tests/17918467
  - docker-stable: https://openqa.suse.de/tests/17918468