### PR TITLE
Switch default bootloader for TW and Microos (in staging F)

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -37,11 +37,7 @@ sub grub_test {
     unlock_bootloader;
     # 60 due to rare slowness e.g. multipath poo#11908
     # 90 as a workaround due to the qemu backend fallout
-    if (is_bootloader_grub2_bls) {
-        assert_screen('grub2-bls', $timeout);
-    } else {
-        assert_screen('grub2', $timeout);
-    }
+    assert_screen(is_bootloader_grub2_bls ? 'grub2-bls' : 'grub2', $timeout);
     stop_grub_timeout;
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 11, 5) if get_var('XEN');

--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -9,7 +9,7 @@ use opensusebasetest qw(handle_uefi_boot_disk_workaround);
 use testapi;
 use Utils::Architectures;
 use utils;
-use version_utils qw(is_sle is_livecd);
+use version_utils qw(is_sle is_livecd is_bootloader_grub2_bls);
 use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
 use Utils::Backends;
 
@@ -37,7 +37,11 @@ sub grub_test {
     unlock_bootloader;
     # 60 due to rare slowness e.g. multipath poo#11908
     # 90 as a workaround due to the qemu backend fallout
-    assert_screen('grub2', $timeout);
+    if (is_bootloader_grub2_bls) {
+        assert_screen('grub2-bls', $timeout);
+    } else {
+        assert_screen('grub2', $timeout);
+    }
     stop_grub_timeout;
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 11, 5) if get_var('XEN');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -383,7 +383,9 @@ sub wait_grub {
     my $in_grub = $args{in_grub} // 0;
     my @tags;
     push @tags, 'bootloader-shim-import-prompt' if get_var('UEFI') && !get_var('DISABLE_SECUREBOOT');
-    push @tags, 'grub2';
+    push @tags, 'grub2-bls' if is_bootloader_grub2_bls;
+    push @tags, 'bootloader-sdboot' if is_bootloader_sdboot;
+    push @tags, 'grub2' if is_bootloader_grub2;
     push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');    # LIVETEST won't to do installation and no grub2 menu show up
     push @tags, 'bootloader' if get_var('OFW');
     push @tags, 'encrypted-disk-password-prompt-grub', 'encrypted-disk-password-prompt' if get_var('ENCRYPT');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -921,11 +921,9 @@ sub wait_boot {
         }
     } elsif (is_bootloader_sdboot) {
         assert_screen 'systemd-boot', 300;
-        save_screenshot;    # Show what's selected for booting
         send_key('ret');
     } elsif (is_bootloader_grub2_bls) {
         assert_screen('grub2-bls', 300);
-        save_screenshot;    # Show what's selected for booting
         send_key('ret');
     } else {
         die 'Unknown bootloader';

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -924,7 +924,9 @@ sub wait_boot {
         save_screenshot;    # Show what's selected for booting
         send_key('ret');
     } elsif (is_bootloader_grub2_bls) {
-        save_screenshot;
+        assert_screen('grub2-bls', 300);
+        save_screenshot;    # Show what's selected for booting
+        send_key('ret');
     } else {
         die 'Unknown bootloader';
     }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -833,7 +833,7 @@ Returns true if the SUT uses GRUB2 as bootloader
 =cut
 
 sub is_bootloader_grub2 {
-    return 0 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_tumbleweed;
+    return 0 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && (is_tumbleweed || is_microos);
     return get_var('BOOTLOADER', 'grub2') eq 'grub2';
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -842,7 +842,7 @@ Returns true if the SUT uses systemd-boot as bootloader
 =cut
 
 sub is_bootloader_sdboot {
-    # the BOOTLOADER variable proably should be set in main.pm by default
+    # the BOOTLOADER variable probably should be set in main.pm by default
     return 1 if is_staging && check_var("VERSION", "Staging:F") && is_microos;
     return get_var('BOOTLOADER', 'grub2') eq 'systemd-boot';
 }
@@ -853,7 +853,7 @@ Returns true if the SUT uses GRUB2-BLS as bootloader
 =cut
 
 sub is_bootloader_grub2_bls {
-    # the BOOTLOADER variable proably should be set in main.pm by default
+    # the BOOTLOADER variable probably should be set in main.pm by default
     return 1 if is_staging && check_var("VERSION", "Staging:F") && get_var('UEFI') && is_tumbleweed;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2-bls';
 }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -833,7 +833,7 @@ Returns true if the SUT uses GRUB2 as bootloader
 =cut
 
 sub is_bootloader_grub2 {
-    return 0 if is_staging && check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_tumbleweed;
+    return 0 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_tumbleweed;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2';
 }
 
@@ -844,7 +844,7 @@ Returns true if the SUT uses systemd-boot as bootloader
 
 sub is_bootloader_sdboot {
     # the BOOTLOADER variable probably should be set in main.pm by default
-    return 1 if is_staging && check_var("VERSION", "Staging:F") && is_microos;
+    return 1 if check_var("VERSION", "Staging:F") && is_microos;
     return get_var('BOOTLOADER', 'grub2') eq 'systemd-boot';
 }
 
@@ -855,7 +855,7 @@ Returns true if the SUT uses GRUB2-BLS as bootloader
 
 sub is_bootloader_grub2_bls {
     # the BOOTLOADER variable probably should be set in main.pm by default
-    return 1 if is_staging && check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_tumbleweed;
+    return 1 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_tumbleweed;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2-bls';
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -53,6 +53,7 @@ use constant {
           is_bootloader_grub2
           is_bootloader_sdboot
           is_bootloader_grub2_bls
+          get_default_bootloader
           is_plasma6
           requires_role_selection
           check_version
@@ -857,6 +858,18 @@ sub is_bootloader_grub2_bls {
     # the BOOTLOADER variable probably should be set in main.pm by default
     return 1 if !get_var('BOOTLOADER', 0) && check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && !is_sle && !is_leap && !is_microos;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2-bls';
+}
+
+=head2 get_default_bootloader
+
+Returns the default bootloader, can be grub2, grub2-bls or sdboot
+=cut
+
+sub get_default_bootloader {
+    return 'grub2' if is_bootloader_grub2;
+    return 'grub2-bls' if is_bootloader_grub2_bls;
+    return 'systemd-boot' if is_bootloader_sdboot;
+    die "Could not figure out bootloader";
 }
 
 =head2 is_plasma6

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -833,7 +833,7 @@ Returns true if the SUT uses GRUB2 as bootloader
 =cut
 
 sub is_bootloader_grub2 {
-    return 0 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && (is_tumbleweed || is_microos);
+    return 0 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && (!is_sle && !is_leap || is_microos);
     return get_var('BOOTLOADER', 'grub2') eq 'grub2';
 }
 
@@ -855,7 +855,7 @@ Returns true if the SUT uses GRUB2-BLS as bootloader
 
 sub is_bootloader_grub2_bls {
     # the BOOTLOADER variable probably should be set in main.pm by default
-    return 1 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_tumbleweed;
+    return 1 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && !is_sle && !is_leap;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2-bls';
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -833,6 +833,7 @@ Returns true if the SUT uses GRUB2 as bootloader
 =cut
 
 sub is_bootloader_grub2 {
+    return 0 if is_staging && check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_tumbleweed;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2';
 }
 
@@ -854,7 +855,7 @@ Returns true if the SUT uses GRUB2-BLS as bootloader
 
 sub is_bootloader_grub2_bls {
     # the BOOTLOADER variable probably should be set in main.pm by default
-    return 1 if is_staging && check_var("VERSION", "Staging:F") && get_var('UEFI') && is_tumbleweed;
+    return 1 if is_staging && check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_tumbleweed;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2-bls';
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -833,7 +833,7 @@ Returns true if the SUT uses GRUB2 as bootloader
 =cut
 
 sub is_bootloader_grub2 {
-    return 0 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && (!is_sle && !is_leap || is_microos);
+    return 0 if !get_var('BOOTLOADER', 0) && check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && (!is_sle && !is_leap || is_microos);
     return get_var('BOOTLOADER', 'grub2') eq 'grub2';
 }
 
@@ -844,7 +844,7 @@ Returns true if the SUT uses systemd-boot as bootloader
 
 sub is_bootloader_sdboot {
     # the BOOTLOADER variable probably should be set in main.pm by default
-    return 1 if check_var("VERSION", "Staging:F") && is_microos;
+    return 1 if !get_var('BOOTLOADER', 0) && check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && is_microos;
     return get_var('BOOTLOADER', 'grub2') eq 'systemd-boot';
 }
 
@@ -855,7 +855,7 @@ Returns true if the SUT uses GRUB2-BLS as bootloader
 
 sub is_bootloader_grub2_bls {
     # the BOOTLOADER variable probably should be set in main.pm by default
-    return 1 if check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && !is_sle && !is_leap;
+    return 1 if !get_var('BOOTLOADER', 0) && check_var("VERSION", "Staging:F") && check_var('UEFI', '1') && !is_sle && !is_leap && !is_microos;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2-bls';
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -842,6 +842,8 @@ Returns true if the SUT uses systemd-boot as bootloader
 =cut
 
 sub is_bootloader_sdboot {
+    # the BOOTLOADER variable proably should be set in main.pm by default
+    return 1 if is_staging && check_var("VERSION", "Staging:F") && is_microos;
     return get_var('BOOTLOADER', 'grub2') eq 'systemd-boot';
 }
 
@@ -851,6 +853,8 @@ Returns true if the SUT uses GRUB2-BLS as bootloader
 =cut
 
 sub is_bootloader_grub2_bls {
+    # the BOOTLOADER variable proably should be set in main.pm by default
+    return 1 if is_staging && check_var("VERSION", "Staging:F") && get_var('UEFI') && is_tumbleweed;
     return get_var('BOOTLOADER', 'grub2') eq 'grub2-bls';
 }
 

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -171,4 +171,38 @@ subtest 'has_selinux' => sub {
     ok !has_selinux, "check !has_selinux for Tumbleweed with SELINUX=0";
 };
 
+subtest 'bootloader_tests' => sub {
+    use version_utils qw(get_default_bootloader);
+
+    set_var('DISTRI', 'opensuse');
+    set_var('FLAVOR', 'Server-DVD');
+    set_var('VERSION', 'Tumbleweed');
+    set_var('UEFI', '0');
+    ok get_default_bootloader eq 'grub2', "Tumbleweed no UEFI is grub2";
+
+    set_var('UEFI', '1');
+    ok get_default_bootloader eq 'grub2', "Tumbleweed on UEFI is grub2";
+
+    set_var('VERSION', 'Slowroll');
+    ok get_default_bootloader eq 'grub2', "Slowroll on UEFI is grub2";
+
+    set_var('VERSION', 'Staging:F');
+    ok get_default_bootloader eq 'grub2-bls', "Tumbleweed/Staging:F on UEFI is grub2-bls";
+
+    set_var('UEFI', '0');
+    ok get_default_bootloader eq 'grub2', "Tumbleweed non UEFI is grub2";
+
+    set_var('DISTRI', 'microos');
+    ok get_default_bootloader eq 'grub2', "Microos non UEFI is grub2";
+
+    set_var('UEFI', '1');
+    ok get_default_bootloader eq 'systemd-boot', "Microos UEFI is systemd-boot";
+
+    set_var('BOOTLOADER', 'does-not-exist');
+    dies_ok { get_default_bootloader } "Bootloader variable set, non existant bootloader, causes failure";
+
+    set_var('BOOTLOADER', 'grub2');
+    ok get_default_bootloader eq 'grub2', "Forcing bootloader works";
+};
+
 done_testing;

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -115,18 +115,18 @@ sub run {
         assert_screen("bootloader-grub2-agama", $bootloader_timeout);
     }
     else {
-        assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2 bootloader-sdboot)], $bootloader_timeout);
+        assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2 grub2-bls bootloader-sdboot)], $bootloader_timeout);
     }
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";
         send_key "ret";
-        assert_screen([qw(bootloader-grub2 bootloader-sdboot)], $bootloader_timeout);
+        assert_screen([qw(bootloader-grub2 bootloader-sdboot grub2-bls)], $bootloader_timeout);
     }
     if (match_has_tag("bootloader-sdboot")) {
         return if is_bootloader_sdboot;
     }
 
-    if (match_has_tag('bootloader-grub2') && is_bootloader_grub2_bls) {
+    if (match_has_tag('grub2-bls') && is_bootloader_grub2_bls) {
         return;
     }
 

--- a/tests/installation/configure_bls.pm
+++ b/tests/installation/configure_bls.pm
@@ -50,11 +50,21 @@ sub run {
 
         send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right', 20, 2;
         assert_screen 'installation-bootloader-options';
-        # Select Timeout dropdown box and disable
-        send_key 'alt-t';
-        # "-1" does not work and "menu-force" is not accepted, so use something else for the time being as workaround
-        record_soft_failure "boo#1216366: Disabling the timeout is not possible";
-        type_string "42";
+        my $is_textmode = check_var('VIDEOMODE', 'text');
+        # changes are for now confined to Staging:F
+        if (!is_sle && !is_leap && is_staging && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
+            # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
+            # the UI doesn't accept -1 anymore, but has a checkbox to disable the timeout
+            send_key 'alt-a';
+            send_key 'spc' if $is_textmode;
+            wait_still_screen(1);
+        } else {
+            # Select Timeout dropdown box and disable
+            send_key 'alt-t';
+            # "-1" does not work and "menu-force" is not accepted, so use something else for the time being as workaround
+            record_soft_failure "boo#1216366: Disabling the timeout is not possible";
+            type_string "42";
+        }
 
         wait_still_screen(1);
         save_screenshot;

--- a/tests/installation/configure_bls.pm
+++ b/tests/installation/configure_bls.pm
@@ -18,8 +18,8 @@ sub run {
 
     # Verify Installation Settings overview is displayed as starting point
     assert_screen "installation-settings-overview-loaded", 90;
-
-    if (check_var('VIDEOMODE', 'text')) {
+    my $is_textmode = check_var('VIDEOMODE', 'text');
+    if ($is_textmode) {
         # Select section booting on Installation Settings overview on text mode
         send_key $cmd{change};
         assert_screen 'inst-overview-options';
@@ -39,8 +39,7 @@ sub run {
     send_key_until_needlematch 'inst-bootloader-systemd-boot-selected', 'down' if is_bootloader_sdboot;
     send_key_until_needlematch 'inst-bootloader-grub2-bls-selected', 'down' if is_bootloader_grub2_bls;
     send_key 'ret', wait_screen_change => 1;    # Select the option
-    # workaround focus being stolen by bootloader field
-    send_key 'alt-d' if (is_bootloader_sdboot || is_bootloader_grub2_bls);
+    send_key 'alt-d' if (is_bootloader_sdboot || is_bootloader_grub2_bls);    # workaround focus being stolen by bootloader field
 
     unless (get_var('KEEP_GRUB_TIMEOUT')) {
         assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
@@ -50,7 +49,6 @@ sub run {
 
         send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right', 20, 2;
         assert_screen 'installation-bootloader-options';
-        my $is_textmode = check_var('VIDEOMODE', 'text');
         # changes are for now confined to Staging:F
         if (!is_sle && !is_leap && is_staging && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
             # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
@@ -69,7 +67,7 @@ sub run {
         wait_still_screen(1);
         save_screenshot;
         # ncurses uses blocking modal dialog, so press return is needed
-        send_key 'ret' if check_var('VIDEOMODE', 'text');
+        send_key 'ret' if $is_textmode;
     }
 
     send_key $cmd{ok};

--- a/tests/installation/configure_bls.pm
+++ b/tests/installation/configure_bls.pm
@@ -11,7 +11,7 @@ use warnings;
 use base 'y2_installbase';
 use testapi;
 use utils;
-use version_utils qw(is_bootloader_sdboot is_bootloader_grub2_bls);
+use version_utils qw(is_bootloader_sdboot is_bootloader_grub2_bls is_sle is_leap is_staging);
 
 sub run {
     my ($self) = shift;

--- a/tests/installation/configure_bls.pm
+++ b/tests/installation/configure_bls.pm
@@ -39,6 +39,8 @@ sub run {
     send_key_until_needlematch 'inst-bootloader-systemd-boot-selected', 'down' if is_bootloader_sdboot;
     send_key_until_needlematch 'inst-bootloader-grub2-bls-selected', 'down' if is_bootloader_grub2_bls;
     send_key 'ret', wait_screen_change => 1;    # Select the option
+    # workaround focus being stolen by bootloader field
+    send_key 'alt-d' if (is_bootloader_sdboot || is_bootloader_grub2_bls);
 
     unless (get_var('KEEP_GRUB_TIMEOUT')) {
         assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);

--- a/tests/installation/configure_bls.pm
+++ b/tests/installation/configure_bls.pm
@@ -39,24 +39,23 @@ sub run {
     send_key_until_needlematch 'inst-bootloader-systemd-boot-selected', 'down' if is_bootloader_sdboot;
     send_key_until_needlematch 'inst-bootloader-grub2-bls-selected', 'down' if is_bootloader_grub2_bls;
     send_key 'ret', wait_screen_change => 1;    # Select the option
-    send_key 'alt-d' if (is_bootloader_sdboot || is_bootloader_grub2_bls);    # workaround focus being stolen by bootloader field
 
     unless (get_var('KEEP_GRUB_TIMEOUT')) {
-        assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
-        # Depending on an optional button "release notes" we need to press "tab"
-        # to go to the first tab
-        send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
+        # In the case the bootloader selected is the same we're expecting, we have to cycle
+        # through the different controls in the ui to reach the highligted tab, since pressing
+        # enter, does not move us to the 'OK' button anymore.
+        send_key_until_needlematch 'inst-bootloader-settings-first_tab_highlighted', 'tab';
 
         send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right', 20, 2;
-        assert_screen 'installation-bootloader-options';
         # changes are for now confined to Staging:F
-        if (!is_sle && !is_leap && is_staging && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
+        if (!is_sle && !is_leap && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
             # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
             # the UI doesn't accept -1 anymore, but has a checkbox to disable the timeout
             send_key 'alt-a';
             send_key 'spc' if $is_textmode;
             wait_still_screen(1);
         } else {
+            # Keep old behavior around for now
             # Select Timeout dropdown box and disable
             send_key 'alt-t';
             # "-1" does not work and "menu-force" is not accepted, so use something else for the time being as workaround

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -70,18 +70,21 @@ sub run {
 
     send_key_until_needlematch 'inst-bootloader-options-highlighted', $bsc_1208266_needed ? $bootloader_shortcut : 'right', 20, 2;
     assert_screen 'installation-bootloader-options';
-    # Select Timeout dropdown box and disable
-    send_key 'alt-t';
-    wait_still_screen(1);
+
     my $timeout = "-1";
     # SLE-12 GA only accepts positive integers in range [0,300]
     $timeout = "60" if is_sle('<12-SP1');
     $timeout = "90" if (get_var("REGRESSION", '') =~ /xen|kvm|qemu/);
-    # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
-    # the UI doesn't accept -1 anymore, but has a checkbox to disable the timeout
+
     if (!is_sle && !is_leap && is_staging && check_var("VERSION", "Staging:F") && (is_microos || is_uefi_boot)) {
+        # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
+        # the UI doesn't accept -1 anymore, but has a checkbox to disable the timeout
         send_key 'alt-a';
+        wait_still_screen(1);
     } else {
+        # Select Timeout dropdown box and disable
+        send_key 'alt-t';
+        wait_still_screen(1);
         type_string $timeout;
     }
 

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -76,7 +76,7 @@ sub run {
     $timeout = "60" if is_sle('<12-SP1');
     $timeout = "90" if (get_var("REGRESSION", '') =~ /xen|kvm|qemu/);
     # changes are for now confined to Staging:F
-    if (!is_sle && !is_leap && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
+    if (is_bootloader_grub2_bls || is_bootloader_sdboot) {
         # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
         # the UI doesn't accept -1 anymore, but has a checkbox to disable the timeout
         send_key 'alt-a';

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -76,7 +76,7 @@ sub run {
     $timeout = "60" if is_sle('<12-SP1');
     $timeout = "90" if (get_var("REGRESSION", '') =~ /xen|kvm|qemu/);
     # changes are for now confined to Staging:F
-    if (!is_sle && !is_leap && is_staging && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
+    if (!is_sle && !is_leap && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
         # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
         # the UI doesn't accept -1 anymore, but has a checkbox to disable the timeout
         send_key 'alt-a';

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -15,7 +15,7 @@ use warnings;
 use base 'y2_installbase';
 use testapi;
 use utils;
-use version_utils qw(is_sle is_leap is_upgrade is_microos is_staging);
+use version_utils qw(is_sle is_leap is_upgrade is_microos is_staging is_bootloader_sdboot is_bootloader_grub2_bls);
 use Utils::Architectures;
 
 sub run {
@@ -75,11 +75,11 @@ sub run {
     # SLE-12 GA only accepts positive integers in range [0,300]
     $timeout = "60" if is_sle('<12-SP1');
     $timeout = "90" if (get_var("REGRESSION", '') =~ /xen|kvm|qemu/);
-
-    if (!is_sle && !is_leap && is_staging && check_var("VERSION", "Staging:F") && (is_microos || is_uefi_boot)) {
+    # changes are for now confined to Staging:F
+    if (!is_sle && !is_leap && is_staging && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
         # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
         # the UI doesn't accept -1 anymore, but has a checkbox to disable the timeout
-        send_key 'alt-a';
+        wait_screen_change(sub { send_key 'alt-a'; });
         wait_still_screen(1);
     } else {
         # Select Timeout dropdown box and disable

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -79,7 +79,8 @@ sub run {
     if (!is_sle && !is_leap && is_staging && (is_bootloader_grub2_bls || is_bootloader_sdboot)) {
         # Microos and Tumbleweed are using systemd-boot and grub-bls respectively
         # the UI doesn't accept -1 anymore, but has a checkbox to disable the timeout
-        wait_screen_change(sub { send_key 'alt-a'; });
+        send_key 'alt-a';
+        send_key 'spc' if $is_textmode;
         wait_still_screen(1);
     } else {
         # Select Timeout dropdown box and disable


### PR DESCRIPTION
This is a follow up to #22187

Currently changes in the default behavior are to be confined to Staging:F.

I was tempted to replace `grub_test` with `wait_boot` but lets start small and see where we land first; systemd-bootloader is already supported in wait_grub

## Current VR: 

### non staging
- non-staging grub-bls on jeos https://openqa.opensuse.org/tests/5089995
- non-staging microos+sdboot https://openqa.opensuse.org/tests/5089996

### in staging

- minimalx with UEFI https://openqa.opensuse.org/tests/5089997
- textmode installation: https://openqa.opensuse.org/tests/5089998
- microos installation https://openqa.opensuse.org/tests/5089999

Needle changes: 
- https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/841

See also: 
    MicroOS: https://build.opensuse.org/requests/1273704
    Tumbleweed: https://build.opensuse.org/requests/1273705

### For future me
`openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org/tests/5089219 BUILD+=_foursixnine _GROUP_ID=0 CASEDIR=https://github.com/foursixnine/os-autoinst-distri-opensuse.git#$(git rev-parse --abbrev-ref HEAD) TEST+=_foursixnine NEEDLES_DIR=https://github.com/foursixnine/os-autoinst-needles-opensuse.git#newbootloaderdefault`
