### PR TITLE
Enable docker-compose tests on SLE 16.0, SLEM 6.x, and arches other than x86_64 & aarch64

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -108,9 +108,6 @@ sub load_compose_tests {
     my ($run_args) = @_;
     return if (is_staging);
     return unless (is_tumbleweed || is_microos);
-    # compose is only available on these arches:
-    # https://github.com/containers/podman/issues/21757
-    return unless (is_aarch64 || is_x86_64);
     loadtest('containers/compose', run_args => $run_args, name => $run_args->{runtime} . "_compose");
 }
 

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -107,7 +107,7 @@ sub load_container_engine_privileged_mode {
 sub load_compose_tests {
     my ($run_args) = @_;
     return if (is_staging);
-    return unless (is_tumbleweed || is_microos);
+    return unless (is_tumbleweed || is_sle('>=16.0') || is_sle_micro('>=6.0'));
     loadtest('containers/compose', run_args => $run_args, name => $run_args->{runtime} . "_compose");
 }
 


### PR DESCRIPTION
This PR:
- Re-enables docker-compose tests on arches other than x86_64 & aarch64 since https://github.com/containers/podman/issues/21757 is closed.
- Extend the Tumbleweed test to SLE 16.0 & SLEM 6.x

Verification runs (docker):
- Tumbleweed ppc64le: https://openqa.opensuse.org/tests/5085517
- SLEM 6.0 s390x: https://openqa.suse.de/tests/17922271
- SLE 16.0 s390x: https://openqa.suse.de/tests/17922272
- SLE 16.0 s390x (podman): https://openqa.suse.de/tests/17922279
