### PR TITLE
WIP: Adjust strongswan tests for 6.0+ versions

### DIFF
--- a/data/strongswan/ipsec.conf.temp
+++ b/data/strongswan/ipsec.conf.temp
@@ -13,4 +13,4 @@ conn host-host
     left=%LOCAL_IP%
     leftcert=%HOST_CERT_PEM%
     right=%REMOTE_IP%
-    rightid="C=CN, O=SUSEQA, CN=%HOST%"
+    rightid="C=DE, O=SUSEQA, CN=%HOST%"

--- a/data/strongswan/swanctl.conf.temp
+++ b/data/strongswan/swanctl.conf.temp
@@ -1,0 +1,18 @@
+connections {
+  host-host {
+    remote_addrs = %REMOTE_IP%
+    local {
+      auth = pubkey
+      certs = %HOST_CERT_PEM%
+    }
+    remote {
+      auth = pubkey
+      id = "C=DE, O=SUSEQA, CN=%HOST%"
+    }
+    children {
+      host-host {
+        start_action = trap
+      }
+    }
+  }
+}

--- a/tests/fips/strongswan/strongswan_client.pm
+++ b/tests/fips/strongswan/strongswan_client.pm
@@ -1,13 +1,13 @@
 # strongswan test
 #
-# Copyright 2022 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Package: strongswan
 # Summary: FIPS: strongswan_client
 #          In fips mode, testing strongswan
 #
-# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Maintainer: QE Security <none@suse.de>
 # Tags: poo#108620, tc#1769974
 
 use base 'consoletest';
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use utils;
 use lockapi;
+use version_utils qw(package_version_cmp is_sle);
 
 sub run {
     my $self = shift;
@@ -23,58 +24,83 @@ sub run {
 
     # Install runtime dependencies
     zypper_call("in strongswan strongswan-hmac tcpdump wget");
+    zypper_call 'in strongswan-mysql strongswan-sqlite wget' if is_sle('>=16');
 
     my $remote_ip = get_var('SERVER_IP', '10.0.2.101');
     my $local_ip = get_var('CLIENT_IP', '10.0.2.102');
 
-    # Configure ipsec.conf
-    my $ipsec_conf_temp = 'ipsec.conf.temp';
-    my $ipsec_conf = '/etc/ipsec.conf';
-    my $ipsec_conf_backup = '/etc/ipsec.conf.backup';
-    my $ipsec_dir = '/etc/ipsec.d';
-    my $server_work_dir = '/root/strongswan';
+    my ($conf, $conf_temp, $conf_backup) = '';
 
-    # Workaround for bsc#1184144
-    record_info('The next two steps are workaround for bsc#1184144');
-    assert_script_run('mv /usr/lib/systemd/system/strongswan.service /usr/lib/systemd/system/strongswan-swanctl.service');
-    assert_script_run('cp /usr/lib/systemd/system/strongswan-starter.service /usr/lib/systemd/system/strongswan.service');
+    my $version = script_output("rpm -q --qf '%{version}' strongswan");
+
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        # Configure ipsec.conf
+        $conf = '/etc/ipsec.conf';
+        $conf_temp = 'ipsec.conf.temp';
+        $conf_backup = '/etc/ipsec.conf.bak';
+    } else {
+        # Configure swanctl.conf
+        $conf = '/etc/swanctl/swanctl.conf';
+        $conf_temp = 'swanctl.conf.temp';
+        $conf_backup = '/etc/swanctl/swanctl.conf.bak';
+    }
+
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        # Workaround for bsc#1184144
+        record_info('The next two steps are workaround for bsc#1184144');
+        assert_script_run('mv /usr/lib/systemd/system/strongswan.service /usr/lib/systemd/system/strongswan-swanctl.service');
+        assert_script_run('cp /usr/lib/systemd/system/strongswan-starter.service /usr/lib/systemd/system/strongswan.service');
+    }
 
     # Download the template of ipsec.conf
-    assert_script_run("wget --quiet " . data_url("strongswan/$ipsec_conf_temp"));
+    assert_script_run("wget --quiet " . data_url("strongswan/$conf_temp"));
 
     # Replace the vars %VARS% with correct value
-    assert_script_run("sed -i 's/%LOCAL_IP%/$local_ip/' $ipsec_conf_temp");
-    assert_script_run("sed -i 's/%REMOTE_IP%/$remote_ip/' $ipsec_conf_temp");
-    assert_script_run("sed -i 's/%HOST_CERT_PEM%/host2.cert.pem/' $ipsec_conf_temp");
-    assert_script_run("sed -i 's/%HOST%/host1/' $ipsec_conf_temp");
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        # only in ipsec.conf
+        assert_script_run("sed -i 's/%LOCAL_IP%/$local_ip/' $conf_temp");
+    }
+    assert_script_run("sed -i 's/%REMOTE_IP%/$remote_ip/' $conf_temp");
+    assert_script_run("sed -i 's/%HOST_CERT_PEM%/host2.cert.pem/' $conf_temp");
+    assert_script_run("sed -i 's/%HOST%/host1/' $conf_temp");
 
-    # Replace ipsec.conf with the template file
-    assert_script_run("cp $ipsec_conf $ipsec_conf_backup");
-    assert_script_run("cp $ipsec_conf_temp $ipsec_conf");
+    # Create a backup of the appropriate config file
+    # and replace it with the filled-in template file
+    assert_script_run("cp $conf $conf_backup");
+    assert_script_run("cp $conf_temp $conf");
 
-    # Edit /etc/ipsec.secrets
-    assert_script_run('echo ": RSA host2.pem" >> /etc/ipsec.secrets');
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        # Edit /etc/ipsec.secrets
+        assert_script_run('echo ": RSA host2.pem" >> /etc/ipsec.secrets');
+    }
 
     mutex_create('STRONGSWAN_HOST2_UP');
+
+    # for > v6.0 strongSwan will only start if the secrets are present
+    mutex_wait('STRONGSWAN_HOST1_SECRETS_COPIED');
+
     mutex_wait('STRONGSWAN_HOST1_SERVER_START');
 
-    systemctl 'start strongswan';
+    systemctl 'restart strongswan';
 
-    # Establish the ipsec tunnel
-    assert_script_run('ipsec up host-host');
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        # establish the ipsec tunnel
+        assert_script_run('ipsec up host-host');
+    } else {
+        #  establish a connection with swanctl
+        assert_script_run("swanctl --initiate --child host-host");
+    }
 
     mutex_create('STRONGSWAN_HOST2_START');
-
     systemctl 'is-active strongswan';
 
-    validate_script_output('ipsec status', sub { m/Routed Connections/ && m/host-host\{\d\}:\s+$local_ip\/32\s===\s$remote_ip\/32/ && m/Security Associations.*1 up/ });
-
-    validate_script_output('ipsec statusall', sub { m/host-host\[\d\]: IKEv2 SPIs/ && m/host-host\[\d\]: IKE proposal/ });
-
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        validate_script_output('ipsec status', sub { m/Routed Connections/ && m/host-host\{\d\}:\s+$local_ip\/32\s===\s$remote_ip\/32/ && m/Security Associations.*1 up/ });
+        validate_script_output('ipsec statusall', sub { m/host-host\[\d\]: IKEv2 SPIs/ && m/host-host\[\d\]: IKE proposal/ });
+    }
     mutex_wait('TCPDUMP_READY');
 
     assert_script_run("ping -c 5 $remote_ip");
-
     mutex_create('PING_DONE');
 }
 

--- a/tests/fips/strongswan/strongswan_server.pm
+++ b/tests/fips/strongswan/strongswan_server.pm
@@ -1,13 +1,13 @@
 # openssl fips test
 #
-# Copyright 2022 SUSE LLC
+# Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Package: strongswan
 # Summary: FIPS: strongswan_server
 #          In fips mode, testing strongswan
 #
-# Maintainer: Liu Xiaojing <xiaojing.liu@suse.com>
+# Maintainer: QE Security <none@suse.de>
 # Tags: poo#108620, tc#1769974, poo#111581
 
 use base 'consoletest';
@@ -25,12 +25,14 @@ sub run {
     zypper_call 'in strongswan strongswan-hmac tcpdump';
     zypper_call 'in strongswan-mysql strongswan-sqlite wget' if is_sle('>=16');
 
+    my ($version, $conf, $conf_temp, $conf_backup, $conf_dir) = '';
+    my ($ca_cert_dir, $priv_dir, $cert_dir, $ipsec) = '';
+
     my $test_dir = '/root/strongswan';
     my $ca_pem = 'ca.pem';
     my $ca_cert_pem = 'ca.cert.pem';
     my $host1_cert_pem = 'host1.cert.pem';
     my $host2_cert_pem = 'host2.cert.pem';
-    my $ipsec_dir = '/etc/ipsec.d';
     my $local_ip = get_var('SERVER_IP', '10.0.2.101');
     my $remote_ip = get_var('CLIENT_IP', '10.0.2.102');
 
@@ -51,55 +53,81 @@ sub run {
     assert_script_run('openssl pkeyutl -kdf HKDF -kdflen 48 -pkeyopt md:SHA256 -pkeyopt key:ff -pkeyopt salt:ff -pkeyopt mode:EXTRACT_AND_EXPAND -hexdump');
     assert_script_run('openssl pkeyutl -kdf HKDF -kdflen 48 -pkeyopt md:SHA256 -pkeyopt info:ff -pkeyopt key:ff -pkeyopt mode:EXPAND_ONLY -hexdump');
 
-    # Workaround for bsc#1184144
-    record_info('The next two steps are workaround for bsc#1184144');
-    assert_script_run('mv /usr/lib/systemd/system/strongswan.service /usr/lib/systemd/system/strongswan-swanctl.service');
-    assert_script_run('cp /usr/lib/systemd/system/strongswan-starter.service /usr/lib/systemd/system/strongswan.service');
+    $version = script_output("rpm -q --qf '%{version}' strongswan");
+
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        # Workaround for bsc#1184144
+        record_info('The next two steps are workaround for bsc#1184144');
+        assert_script_run('mv /usr/lib/systemd/system/strongswan.service /usr/lib/systemd/system/strongswan-swanctl.service');
+        assert_script_run('cp /usr/lib/systemd/system/strongswan-starter.service /usr/lib/systemd/system/strongswan.service');
+        $ipsec = 'ipsec';
+        $conf = '/etc/ipsec.conf';
+        $conf_temp = 'ipsec.conf.temp';
+        $conf_backup = '/etc/ipsec.conf.bak';
+        $conf_dir = '/etc/ipsec.d';
+        $ca_cert_dir = "$conf_dir/cacerts";
+        $cert_dir = "$conf_dir/certs";
+        $priv_dir = "$conf_dir/private";
+    } else {
+        $conf_dir = '/etc/swanctl';
+        $conf = "$conf_dir/swanctl.conf";
+        $conf_temp = 'swanctl.conf.temp';
+        $conf_backup = "$conf_dir/swanctl.conf.bak";
+        $ca_cert_dir = "$conf_dir/x509ca";
+        $cert_dir = "$conf_dir/x509";
+        $priv_dir = "$conf_dir/private";
+    }
 
     # Create private CA key and self-signed certificate
     assert_script_run("mkdir $test_dir && cd $test_dir");
     assert_script_run("pki --gen --type rsa --size 2048 --outform pem > $ca_pem");
-    assert_script_run("ipsec pki --self --in $ca_pem --dn \"C=CN, O=SUSEQA, CN=CA\" --ca --outform pem > $ca_cert_pem");
+    assert_script_run("$ipsec pki --self --in $ca_pem --dn \"C=DE, O=SUSEQA, CN=CA\" --ca --outform pem > $ca_cert_pem");
 
     # Generate key and certificate for the hosts
     for my $host (qw(host1 host2)) {
         assert_script_run("pki --gen --type rsa --size 2048 --outform pem > $host.pem");
-        assert_script_run("pki --pub --in $host.pem | ipsec pki --issue --cacert $ca_cert_pem --cakey $ca_pem --dn \"C=CN, O=SUSEQA, CN=$host\" --outform pem > $host.cert.pem");
+        assert_script_run("pki --pub --in $host.pem | $ipsec pki --issue --cacert $ca_cert_pem --cakey $ca_pem --dn \"C=DE, O=SUSEQA, CN=$host\" --outform pem > $host.cert.pem");
     }
 
     # Copy the keys and certificates to specific directories
-    assert_script_run("cp -pv $ca_cert_pem $ipsec_dir/cacerts");
-    assert_script_run("cp -pv $host1_cert_pem $host2_cert_pem $ipsec_dir/certs");
-    assert_script_run("cp -pv host1.pem $ipsec_dir/private");
-
-    my $ipsec_conf_temp = 'ipsec.conf.temp';
-    my $ipsec_conf = '/etc/ipsec.conf';
-    my $ipsec_conf_backup = '/etc/ipsec.conf.backup';
+    assert_script_run("mkdir -p $conf_dir $ca_cert_dir $cert_dir $priv_dir");
+    assert_script_run("cp -pv $ca_cert_pem $ca_cert_dir");
+    assert_script_run("cp -pv $host1_cert_pem $host2_cert_pem $cert_dir");
+    assert_script_run("cp -pv host1.pem $priv_dir");
 
     # Download the template of ipsec.conf
-    assert_script_run("wget --quiet " . data_url("strongswan/$ipsec_conf_temp"));
+    assert_script_run("wget --quiet " . data_url("strongswan/$conf_temp"));
 
     # Replace the vars %VARS% with correct value
-    assert_script_run("sed -i 's/%LOCAL_IP%/$local_ip/' $ipsec_conf_temp");
-    assert_script_run("sed -i 's/%REMOTE_IP%/$remote_ip/' $ipsec_conf_temp");
-    assert_script_run("sed -i 's/%HOST_CERT_PEM%/$host1_cert_pem/' $ipsec_conf_temp");
-    assert_script_run("sed -i 's/%HOST%/host2/' $ipsec_conf_temp");
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        # only in ipsec.conf
+        assert_script_run("sed -i 's/%LOCAL_IP%/$local_ip/' $conf_temp");
+    }
+    assert_script_run("sed -i 's/%REMOTE_IP%/$remote_ip/' $conf_temp");
+    assert_script_run("sed -i 's/%HOST_CERT_PEM%/$host1_cert_pem/' $conf_temp");
+    assert_script_run("sed -i 's/%HOST%/host2/' $conf_temp");
 
-    # Replace ipsec.conf with the template file
-    assert_script_run("cp $ipsec_conf $ipsec_conf_backup");
-    assert_script_run("cp $ipsec_conf_temp $ipsec_conf");
+    # Create a backup of the appropriate config file
+    # and replace it with the filled-in template file
+    assert_script_run("cp $conf $conf_backup");
+    assert_script_run("cp $conf_temp $conf");
 
     my $children = get_children();
     mutex_wait('STRONGSWAN_HOST2_UP', (keys %$children)[0]);
 
-    # Copy the keys and certificates to the second host
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no ca.cert.pem root\@$remote_ip:$ipsec_dir/cacerts/");
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no host1.cert.pem root\@$remote_ip:$ipsec_dir/certs/");
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no host2.cert.pem root\@$remote_ip:$ipsec_dir/certs/");
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no host2.pem root\@$remote_ip:$ipsec_dir/private/");
+    # Prepare dirs and copy the keys, certificates to the second host
+    exec_and_insert_password("ssh -o StrictHostKeyChecking=no root\@$remote_ip \"mkdir -p $conf_dir $ca_cert_dir $cert_dir $priv_dir\"");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no ca.cert.pem root\@$remote_ip:$ca_cert_dir/");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no host1.cert.pem root\@$remote_ip:$cert_dir/");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no host2.cert.pem root\@$remote_ip:$cert_dir/");
+    exec_and_insert_password("scp -o StrictHostKeyChecking=no host2.pem root\@$remote_ip:$priv_dir/");
 
-    # Edit /etc/ipsec.secrets
-    assert_script_run('echo ": RSA host1.pem" >> /etc/ipsec.secrets');
+    mutex_create('STRONGSWAN_HOST1_SECRETS_COPIED');
+
+    if (package_version_cmp($version, '6.0.0') < 0) {
+        # Edit /etc/ipsec.secrets
+        assert_script_run('echo ": RSA host1.pem" >> /etc/ipsec.secrets');
+    }
 
     systemctl 'start strongswan';
 
@@ -114,10 +142,13 @@ sub run {
     my $net_device = script_output("ip route | awk '/default/ {print \$5}'");
     my $pid = background_script_run("tcpdump -n -i $net_device -e \"esp\" -vv > $tcpdump_log_file 2>&1");
     mutex_create('TCPDUMP_READY');
+
     mutex_wait('PING_DONE', (keys %$children)[0]);
+
     assert_script_run("kill -15 $pid");
 
     my $num = script_output("cat $tcpdump_log_file | grep '$remote_ip > $local_ip: ESP' | wc -l");
+
     if ($num == 5) {
         record_info('tcpdump result is correct');
     }


### PR DESCRIPTION
Strongswan tests (server and client sides) were adapted for the changes introduced in >=v6.0. 

Related ticket: https://progress.opensuse.org/issues/178840

Verification runs - server sides: 

- SLE16 x86_64: https://openqa.suse.de/tests/17922324
- SLE16 aarch64: https://openqa.suse.de/tests/17922334

- SLE 15 SP7 x86_64: 
- SLE 15 SP6 x86_64:

(Client sides can be checked out as well via clicking "Dependencies".)