### PR TITLE
bats/podman: Add back libcriu2 dependency

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -356,9 +356,11 @@ sub bats_tests {
     push @commands, $cmd;
     my $ret = script_run $cmd, 7000;
 
-    $skip_tests = get_var($skip_tests, $settings->{$skip_tests});
-    my @skip_tests = split(/\s+/, get_var('BATS_SKIP', $settings->{BATS_SKIP}) . " " . $skip_tests);
-    patch_logfile($log_file, @skip_tests);
+    unless (get_var("BATS_TESTS")) {
+        $skip_tests = get_var($skip_tests, $settings->{$skip_tests});
+        my @skip_tests = split(/\s+/, get_var('BATS_SKIP', $settings->{BATS_SKIP}) . " " . $skip_tests);
+        patch_logfile($log_file, @skip_tests);
+    }
 
     parse_extra_log(TAP => $log_file);
 

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -50,7 +50,7 @@ sub run {
 
     my @pkgs = qw(aardvark-dns apache2-utils buildah catatonit glibc-devel-static go1.24 gpg2 jq libgpgme-devel
       libseccomp-devel make netavark openssl podman podman-remote python3-PyYAML skopeo socat sudo systemd-container xfsprogs);
-    push @pkgs, qw(criu) if is_tumbleweed;
+    push @pkgs, qw(criu libcriu2) if is_tumbleweed;
     # Needed for podman machine
     if (is_x86_64) {
         push @pkgs, "qemu-x86";


### PR DESCRIPTION
Add back libcriu2 dependency to solve an issue with `520-checkpoint` test when `OCI_RUNTIME=crun`:

> could not load `libcriu.so.2`

https://openqa.opensuse.org/tests/5085670/file/podman-bats-root-local.tap

- Verification run: https://openqa.opensuse.org/tests/5085708