### PR TITLE
kea: Change kea log path

### DIFF
--- a/data/network_bonding/kea-dhcp4.conf
+++ b/data/network_bonding/kea-dhcp4.conf
@@ -29,7 +29,7 @@
         "name": "kea-dhcp4",
         "output_options": [
           {
-            "output": "/var/log/kea.log"
+            "output": "/var/log/kea/kea.log"
           }
         ],
         "severity": "INFO",

--- a/tests/network/kea_server.pm
+++ b/tests/network/kea_server.pm
@@ -46,20 +46,15 @@ sub run {
     my $lease_file = '/var/lib/kea/kea-leases4.csv';
     record_info("Lease file", script_output("cat $lease_file"));
     die("Lease file only has header, no lease assigned") if script_output("wc -l < $lease_file") < 2;
-
-    unless (is_sle('>=16') || is_tumbleweed) {
-        my $dhcp_log = script_output("grep -E 'DHCP(DISCOVER|OFFER|REQUEST|ACK)' /var/log/kea.log");
-        record_info("DHCP handshake", $dhcp_log);
-        assert_script_run("grep -Pz '(?s)(?=.*DHCPDISCOVER)(?=.*DHCPOFFER)(?=.*DHCPREQUEST)(?=.*DHCPACK)' /var/log/kea.log", fail_message => "Missing one or more DHCP handshake keywords in kea log");
-    } else {
-        record_soft_failure("bsc#1243797 - kea is not logging in kea.log");
-    }
+    my $dhcp_log = script_output("grep -E 'DHCP(DISCOVER|OFFER|REQUEST|ACK)' /var/log/kea/kea.log");
+    record_info("DHCP handshake", $dhcp_log);
+    assert_script_run("grep -Pz '(?s)(?=.*DHCPDISCOVER)(?=.*DHCPOFFER)(?=.*DHCPREQUEST)(?=.*DHCPACK)' /var/log/kea/kea.log", fail_message => "Missing one or more DHCP handshake keywords in kea log");
 }
 
 sub post_fail_hook {
     my ($self) = shift;
     $self->SUPER::post_fail_hook;
-    upload_logs('/var/log/kea.log');
+    upload_logs('/var/log/kea/kea.log');
 }
 
 1;


### PR DESCRIPTION
Removed the soft-fail for bsc#1243797 and changed the log path in the config file.

- Related:
  - progress ticket: https://progress.opensuse.org/issues/182975
  - bug ticket: https://bugzilla.suse.com/show_bug.cgi?id=1243797
- Verification run: 
  - sle: https://openqa.suse.de/tests/overview?build=cedvid%2Fos-autoinst-distri-opensuse%2322244
  - TW: https://openqa.opensuse.org/tests/5087966
