### PR TITLE
Compile test executable in non-ephemeral filesystem

### DIFF
--- a/tests/security/ebpf/check_cap_bpf.pm
+++ b/tests/security/ebpf/check_cap_bpf.pm
@@ -13,7 +13,7 @@ use utils;
 
 sub run {
     my $capability = 'cap_bpf';
-    my $f_bpf_test = '/tmp/bpf_test';
+    my $f_bpf_test = '/var/tmp/bpf_test';
 
     select_console 'root-console';
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/183464
- Needles: nope
- Verification runs:

x86_64:
  - https://openqa.suse.de/tests/17924661
  - https://openqa.suse.de/tests/17924662

  - https://openqa.suse.de/tests/17924663
  - https://openqa.suse.de/tests/17924664

aarch64:
  - https://openqa.suse.de/tests/17924665
  - https://openqa.suse.de/tests/17924666

s390x:
  - https://openqa.suse.de/tests/17924667
  - https://openqa.suse.de/tests/17924668
