### PR TITLE
Adapt rmt validate_repos test data

### DIFF
--- a/test_data/yam/agama_rmt.yaml
+++ b/test_data/yam/agama_rmt.yaml
@@ -1,6 +1,14 @@
 ---
 repos:
-  - name: SLE-Product-SLES-%VERSION%
-    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%
+  - name: SLE-Product-SLES-16.0
+    alias: SUSE_Linux_Enterprise_Server_%ARCH%:SLE-Product-SLES-16.0
     enabled: 'Yes'
+    filter: name
+  - name: SLE-Product-SLES-16.0-Debug
+    alias: SUSE_Linux_Enterprise_Server_%ARCH%:SLE-Product-SLES-16.0-Debug
+    enabled: 'No'
+    filter: name
+  - name: SLE-Product-SLES-16.0-Source
+    alias: SUSE_Linux_Enterprise_Server_%ARCH%:SLE-Product-SLES-16.0-Source
+    enabled: 'No'
     filter: name


### PR DESCRIPTION
##
### Adapt rmt validate_repos test data

- Related ticket: https://progress.opensuse.org/issues/182996
- Related info: [**repo list**](https://openqa.suse.de/tests/17921840#step/validate_repos/12)
- Needles: N/A
- Verification run: [**VR**](https://openqa.suse.de/tests/overview?distri=sle&version=agama-10.0&build=hjluo%2Fos-autoinst-distri-opensuse%23rmt_test_data)

>[!TIP]
> VR PASSED for dev 7.12.

##


