### PR TITLE
containers: Restrict docker-buildx to SLE 16.0

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -187,7 +187,7 @@ sub load_host_tests_docker {
     load_volume_tests($run_args);
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
-    loadtest('containers/buildx', run_args => $run_args, name => $run_args->{runtime} . "_buildx") unless (is_sle('<15') || is_sle_micro('<6.0'));
+    loadtest('containers/buildx', run_args => $run_args, name => $run_args->{runtime} . "_buildx") unless (is_sle('<16') || is_sle_micro('<6.0'));
     loadtest 'containers/rootless_docker' if (is_tumbleweed || is_sle('>=16.0'));
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {


### PR DESCRIPTION
Don't run docker-buildx on SLES 15
