### PR TITLE
install_ltp: Fix LTP build deps

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -123,7 +123,6 @@ sub install_runtime_dependencies_network {
     my @deps;
     @deps = qw(
       dhcp-client
-      dhcp-server
       diffutils
       dnsmasq
       ethtool
@@ -139,6 +138,7 @@ sub install_runtime_dependencies_network {
     zypper_call('-t in ' . join(' ', @deps));
 
     my @maybe_deps = qw(
+      dhcp-server
       telnet-server
       wireguard-tools
       xinetd


### PR DESCRIPTION
There is no  `dhcp-server` package on some products, move it to optional LTP deps for installation from git.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/17932652 (expected to fail after install_ltp finishes)
