### PR TITLE
Test our registry image instead of deprecated registry package

### DIFF
--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -18,7 +18,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_sle is_tumbleweed is_leap);
+use version_utils qw(is_sle is_tumbleweed);
 use registration;
 use containers::common;
 use containers::utils;
@@ -58,7 +58,7 @@ sub registry_push_pull {
     assert_script_run $engine->runtime . " images | grep 'localhost:5000/$image'", 60;
 
     # podman artifact needs podman 5.4.0
-    if ($engine->runtime eq "podman" && (is_tumbleweed) {
+    if ($engine->runtime eq "podman" && (is_tumbleweed || is_sle('>=16.0'))) {
         my $artifact = "localhost:5000/testing-artifact";
         assert_script_run "podman artifact add $artifact /etc/passwd";
         assert_script_run "podman artifact push $artifact";


### PR DESCRIPTION
~The `distribution-registry` & `docker-distribution-registry` packages are not official and are only available on PackageHub, but this is now also failing.~  The correct way to setup a registry is by using our registry image.

Also extend the `podman artifact` test to SLE 16.0 since it now has podman 5.4.x

- Failing test: https://openqa.suse.de/tests/17931222#step/registry/14
- Verification runs:
  - SLE 15-SP3 GCE: https://openqa.suse.de/tests/17935400