### PR TITLE
containers: Test registry package only on supported products

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -172,11 +172,8 @@ sub load_host_tests_docker {
         loadtest 'containers/zypper_docker' if (is_sle("<15-SP6") || is_leap("<15.6"));
         loadtest 'containers/docker_runc';
     }
-    unless (check_var('BETA', 1) || is_sle_micro || is_microos || is_leap_micro || is_staging) {
-        # These tests use packages from Package Hub, so they are applicable
-        # to maintenance jobs or new products after Beta release
-        # PackageHub is not available in SLE Micro | MicroOS
-        loadtest 'containers/registry' if (is_x86_64 || is_sle('>=15-sp4'));
+    unless (is_staging || is_transactional || is_sle(">=16.0") || is_sle("<15-sp4")) {
+        loadtest 'containers/registry';
     }
     # Skip this test on docker-stable due to https://bugzilla.opensuse.org/show_bug.cgi?id=1239596
     unless (is_transactional || is_public_cloud || is_sle('<15-SP4') || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright 2009-2013 Bernhard M. Wiedemann
-# Copyright 2012-2024 SUSE LLC
+# Copyright 2012-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: docker-distribution-registry | distribution-registry
@@ -18,7 +18,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_sle is_tumbleweed is_leap);
+use version_utils qw(is_sle is_tumbleweed);
 use registration;
 use containers::common;
 use containers::utils;
@@ -74,17 +74,7 @@ sub run {
 
     # Install and check that it's running
     my $pkg = 'distribution-registry';
-    if (is_sle(">=15-SP4")) {
-        activate_containers_module;
-    } elsif (is_sle("<=15")) {
-        record_info("SKIP", "docker-distribution-registry is not available on this version of SLE");
-        return;
-    } elsif (is_sle(">15")) {
-        add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
-        $pkg = 'docker-distribution-registry';
-    } elsif (is_leap("<15.4")) {
-        $pkg = 'docker-distribution-registry';
-    }
+    activate_containers_module if is_sle(">=15-SP4");
 
     zypper_call "se -v $pkg";
     zypper_call "in $pkg";
@@ -101,11 +91,9 @@ sub run {
     $docker->cleanup_system_host();
 
     # Run podman tests
-    if (is_leap('15.1+') || is_tumbleweed || is_sle("15-sp1+")) {
-        my $podman = $self->containers_factory('podman');
-        registry_push_pull(image => $image, runtime => $podman);
-        $podman->cleanup_system_host();
-    }
+    my $podman = $self->containers_factory('podman');
+    registry_push_pull(image => $image, runtime => $podman);
+    $podman->cleanup_system_host();
 }
 
 1;


### PR DESCRIPTION
Limit the registry test to the products where the `distribution-registry` package is officially distributed and drop the dependency on PackageHub, which fails now for 15-SP3 and may introduce subtle bugs in the rest of the test modules.

```
$ susepkg -p any distribution-registry 
SLES/15.4 distribution-registry 2.8.3-150400.9.24.1
SLES/15.5 distribution-registry 2.8.3-150400.9.24.1
SLES/15.6 distribution-registry 2.8.3-150400.9.24.1
SLES/15.7 distribution-registry 2.8.3-150400.9.24.1
openSUSE_Leap/15.6 distribution-registry 2.8.3-150400.9.24.1
openSUSE_Tumbleweed distribution-registry 2.8.3-2.2
```

- Failing test: https://openqa.suse.de/tests/17931222#step/registry/14
- Verification runs:
  - SLE 15-SP3 GCE: https://openqa.suse.de/tests/17935400
