### PR TITLE
Wait longer for az_vm_wait_running in ipaddr2

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -856,7 +856,11 @@ Get the VM state until status looks like:
   "VM running"
 ]
 
-or reach timeout. Polling frequency is dynamically calculated based on the timeout
+or reach timeout.
+
+Polling frequency is dynamically calculated based on the timeout.
+
+It returns the total ammount of time spent waiting or function kills the test on timeout.
 
 =over
 
@@ -891,10 +895,10 @@ sub az_vm_wait_running {
         # Expected return is
         # [ "PowerState/running", "VM running" ]
         $count = grep(/running/, @$res);
-        return if ($count eq 2);
+        return (time() - $start_time) if ($count eq 2);
         sleep $sleep_time;
     }
-    die "VM not running after " . (time() - $start_time) . "seconds";
+    die "VM not running after " . (time() - $start_time) . " seconds";
 }
 
 =head2 az_vm_openport

--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -436,9 +436,12 @@ sub ipaddr2_infra_deploy {
         port => '80');
 
     foreach (1 .. 2) {
-        az_vm_wait_running(
+        my $wt = az_vm_wait_running(
             resource_group => $rg,
-            name => ipaddr2_get_internal_vm_name(id => $_));
+            name => ipaddr2_get_internal_vm_name(id => $_),
+            timeout => 600
+        );
+        record_info('VM RUNNING', "VM $_ takes $wt seconds to reach the Running state.");
     }
 }
 

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -387,11 +387,12 @@ subtest '[az_vm_wait_running] running at first try' => sub {
     my @calls;
     $azcli->redefine(script_output => sub { push @calls, $_[0]; return '["PowerState/running","VM running"]'; });
 
-    az_vm_wait_running(resource_group => 'Arlecchino',
+    my $wt = az_vm_wait_running(resource_group => 'Arlecchino',
         name => 'Truffaldino');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((scalar @calls == 1), 'Calls az cli only once if return is running');
+    ok($wt eq 0), "WT:$wt is 0 as expected, as getting the Running state at first attempt.";
 };
 
 subtest '[az_vm_wait_running] running at second try' => sub {
@@ -406,11 +407,13 @@ subtest '[az_vm_wait_running] running at second try' => sub {
             }
             return '["PowerState/running","VM running"]'; });
 
-    az_vm_wait_running(resource_group => 'Arlecchino',
+    my $wt = az_vm_wait_running(resource_group => 'Arlecchino',
         name => 'Truffaldino');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
+    note("--> WT:$wt");
     ok((scalar @calls == 2), 'Calls az cli twice if return is not running');
+    ok($wt > 0), "WT:$wt is greate than 0 as expected.";
 };
 
 subtest '[az_vm_wait_running] never running default timeout' => sub {

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -15,8 +15,9 @@ subtest '[ipaddr2_infra_deploy]' => sub {
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
-    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return 300; });
     $ipaddr2->redefine(ipaddr2_cloudinit_create => sub { return '/tmp/Faggin'; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
@@ -46,7 +47,8 @@ subtest '[ipaddr2_infra_deploy] cloudinit_profile' => sub {
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
     $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
-    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return 300; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
@@ -77,7 +79,8 @@ subtest '[ipaddr2_infra_deploy] no cloud-init' => sub {
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
     $ipaddr2->redefine(data_url => sub { return '/Faggin'; });
-    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return 300; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });
@@ -106,7 +109,8 @@ subtest '[ipaddr2_infra_deploy] diagnostic' => sub {
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
     $ipaddr2->redefine(write_sut_file => sub { return; });
     $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
-    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return 300; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
@@ -127,7 +131,8 @@ subtest '[ipaddr2_infra_deploy] disable trusted launch' => sub {
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
     $ipaddr2->redefine(write_sut_file => sub { return; });
     $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
-    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return 300; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(assert_script_run => sub {
@@ -146,8 +151,9 @@ subtest '[ipaddr2_infra_deploy] with .vhd' => sub {
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
-    $ipaddr2->redefine(az_vm_wait_running => sub { return; });
+    $ipaddr2->redefine(az_vm_wait_running => sub { return 300; });
     $ipaddr2->redefine(ipaddr2_cloudinit_create => sub { return '/tmp/Faggin'; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(assert_script_run => sub { push @calls, ['azure_cli', $_[0]]; return; });


### PR DESCRIPTION
Double the timeout for VM boot from 300 to 600 in ipaddr2 tests. This is an attempt to mitigate test side issues happening recently on various images. The PR also add a `record_info` to print the boot time.

Related ticket: https://jira.suse.com/browse/TEAM-10404

# Verification run:

sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test_cloud_init
 - http://openqaworker15.qa.suse.cz/tests/328246 :green_heart: 
 - http://openqaworker15.qa.suse.cz/tests/328247 :red_circle: it does not reach the Running state in time http://openqaworker15.qa.suse.cz/tests/328247/logfile?filename=serial_terminal.txt#line-1354

sle-15-SP4-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_4_PAYG-ipaddr2_azure_test_rootless
- http://openqaworker15.qa.suse.cz/tests/328248 :yellow_circle: VM1 takes 32sec VM2 takes 594 secs, just below the timeout of 600 http://openqaworker15.qa.suse.cz/tests/328248#step/deploy/361
