### PR TITLE
Fix wrong unicast opt for sle16

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -56,7 +56,8 @@ sub run {
     my $corosync_conf = '/etc/corosync/corosync.conf';
     my $sbd_device = get_lun;
     my $sbd_cfg = '/etc/sysconfig/sbd';
-    my $unicast_opt = get_var("HA_UNICAST") ? '-u' : '';
+    my $unicast_arg = is_sle('>=16') ? '--transport udpu' : '-u';
+    my $unicast_opt = get_var("HA_UNICAST") ? $unicast_arg : '';
     my $quorum_policy = 'stop';
     my $fencing_opt = "-s \"$sbd_device\"";
     my $qdevice_opt = '';


### PR DESCRIPTION
Older version of crmsh used `-u` for Unicast, but in the newer version used in sle 16 this opt was changed to `--transport udpu`. This pr take this case into account.

- Related ticket: https://jira.suse.com/browse/TEAM-10359
- Verification run: https://openqa.suse.de/tests/17951305#step/ha_cluster_init/24 (fails later for other reason)
