### PR TITLE
Add code to run IBSM playbook

### DIFF
--- a/t/12_sles4sap_publiccloud.t
+++ b/t/12_sles4sap_publiccloud.t
@@ -844,6 +844,18 @@ subtest '[create_playbook_section_list] ptf' => sub {
 };
 
 
+subtest '[create_playbook_section_list] IBSm' => sub {
+    set_var('USE_SAPCONF', 'Colombo');
+    my $ansible_playbooks = create_playbook_section_list(
+        ibsm_ip => 'Giovanni',
+        download_hostname => 'Petronio',
+        repos => 'Russo');
+    set_var('USE_SAPCONF', undef);
+    note("\n  -->  " . join("\n  -->  ", @$ansible_playbooks));
+    ok((any { /.*ibsm\.yaml.*/ } @$ansible_playbooks), 'IBSm playbook is called');
+};
+
+
 subtest '[enable_replication]' => sub {
     my $self = sles4sap_publiccloud->new();
     $self->{my_instance}->{instance_id} = 'vmhana01';

--- a/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_schedule_deployment.pm
@@ -36,8 +36,6 @@ sub run {
         loadtest('sles4sap/publiccloud/qesap_terraform', name => 'deploy_qesap_terraform', run_args => $run_args, @_);
         if (check_var('IS_MAINTENANCE', 1)) {
             loadtest('sles4sap/publiccloud/clean_leftover_peerings', name => 'clean_leftover_peerings', run_args => $run_args, @_);
-            loadtest('sles4sap/publiccloud/add_server_to_hosts', name => 'add_server_to_hosts', run_args => $run_args, @_);
-            loadtest('sles4sap/publiccloud/cluster_add_repos', name => 'cluster_add_repos', run_args => $run_args, @_);
         }
         loadtest('sles4sap/publiccloud/qesap_ansible', name => 'deploy_qesap_ansible', run_args => $run_args, @_);
         loadtest('sles4sap/publiccloud/qesap_prevalidate', name => 'qesap_prevalidate', run_args => $run_args, @_);

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -36,6 +36,7 @@ use sles4sap::qesap::qesapdeployment;
 use sles4sap::azure_cli;
 use serial_terminal 'select_serial_terminal';
 use registration qw(get_addon_fullname scc_version %ADDONS_REGCODE);
+use qam;
 
 our $ha_enabled = set_var_output('HA_CLUSTER', '0') =~ /false|0/i ? 0 : 1;
 
@@ -208,6 +209,13 @@ sub run {
             $playbook_configs{registration} = 'suseconnect' if (is_byos() && $reg_mode !~ 'noreg');
         }
     }
+
+    $playbook_configs{ibsm_ip} = get_var('IBSM_IP') if get_var('IBSM_IP');
+    $playbook_configs{download_hostname} = get_var('REPO_MIRROR_HOST') if get_var('REPO_MIRROR_HOST');
+
+    my @repos = get_test_repos();
+    $playbook_configs{repos} = join(',', @repos);
+
     $ansible_playbooks = create_playbook_section_list(%playbook_configs);
 
     # Prepare QESAP deployment


### PR DESCRIPTION
Add code in HanaSR to add maintenance repos by IBSm.yaml playbook from qe-sap-deployment.


- Related ticket: https://jira.suse.com/browse/TEAM-9887

# Verification run:

## HanaSR regression without INCIDENT_REPOS
sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-06-05T02:03:19Z-hanasr_azure_test_peering az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/328270 :green_circle:  the ibsm.yaml playbook is not executed. It is expected as the variables about the REPOS are missing.

## HanaSR regression with one INCIDENT_REPOS
 sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-06-05T02:03:19Z-hanasr_azure_test_peering az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/328275 :green_circle: the IBSm playbook is properly added to the generated  [conf.yaml](https://openqaworker15.qa.suse.cz/tests/328275/file/deploy_qesap_terraform-sles4sap_azure_generic.yaml). The playbook is correctly executed https://openqaworker15.qa.suse.cz/tests/328275/logfile?filename=deploy_qesap_ansible-ansible.ibsm.log.txt 

## HanaSR used in SingleIncident (cloned from OSD)
sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:38951:google-guest-configs-SAPHanaSR-ScaleUp-PerfOpt az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/328277 :green_circle:  This test is without removing `add_server_to_hosts` and `cluster_add_repos` from the SCHEDULE
- http://openqaworker15.qa.suse.cz/tests/328433

## saptune used in SingleIncident (cloned from OSD)
 sle-15-SP6-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:38951:google-guest-configs-sles4sap_gnome_saptune_delete_rename az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/328434 :green_circle:

