### PR TITLE
containers: Add use strict & warnings

### DIFF
--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -7,6 +7,8 @@
 # Maintainer: qac team <qa-c@suse.de>
 
 package containers::basetest;
+use strict;
+use warnings;
 use containers::docker;
 use containers::podman;
 use containers::containerd_crictl;

--- a/lib/containers/containerd_crictl.pm
+++ b/lib/containers/containerd_crictl.pm
@@ -7,6 +7,8 @@
 # Maintainer: qac team <qa-c@suse.de>
 
 package containers::containerd_crictl;
+use strict;
+use warnings;
 use Mojo::Base 'containers::engine';
 use testapi;
 use containers::common 'install_containerd_when_needed';

--- a/lib/containers/containerd_nerdctl.pm
+++ b/lib/containers/containerd_nerdctl.pm
@@ -7,6 +7,8 @@
 # Maintainer: qac team <qa-c@suse.de>
 
 package containers::containerd_nerdctl;
+use strict;
+use warnings;
 use Mojo::Base 'containers::engine';
 use testapi;
 use containers::common 'install_containerd_when_needed';

--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -7,6 +7,8 @@
 # Maintainer: qac team <qa-c@suse.de>
 
 package containers::docker;
+use strict;
+use warnings;
 use Mojo::Base 'containers::engine';
 use testapi;
 use containers::utils qw(registry_url);

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -7,6 +7,8 @@
 # Maintainer: qac team <qa-c@suse.de>
 
 package containers::engine;
+use strict;
+use warnings;
 use Mojo::Base -base;
 use testapi;
 use Carp 'croak';

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -7,6 +7,8 @@
 # Maintainer: qac team <qa-c@suse.de>
 
 package containers::podman;
+use strict;
+use warnings;
 use Mojo::Base 'containers::engine';
 use testapi;
 use containers::utils qw(registry_url);

--- a/tests/containers/apptainer.pm
+++ b/tests/containers/apptainer.pm
@@ -7,6 +7,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use utils qw(zypper_call);

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -7,6 +7,8 @@
 # Summary: Upstream aardvark-dns integration tests
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -7,6 +7,8 @@
 # Summary: Upstream buildah integration tests
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -7,6 +7,8 @@
 # Summary: Upstream netavark integration tests
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -7,6 +7,8 @@
 # Summary: Upstream podman integration tests
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -7,6 +7,8 @@
 # Summary: Upstream runc integration tests
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -7,6 +7,8 @@
 # Summary: Upstream skopeo integration tests
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/bci_collect_stats.pm
+++ b/tests/containers/bci_collect_stats.pm
@@ -9,6 +9,8 @@
 # Maintainer: QE-C team <qa-c@suse.de>
 
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use utils qw(script_retry);
 use db_utils qw(push_image_data_to_db);

--- a/tests/containers/bci_logs.pm
+++ b/tests/containers/bci_logs.pm
@@ -12,6 +12,8 @@
 #   be used by OpenQA to represent the results in "External results"
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'opensusebasetest';
 use XML::LibXML;
 use testapi;

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -19,6 +19,8 @@
 #   repository defined by BCI_TESTS_REPO.
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use XML::LibXML;
 use utils qw(zypper_call script_retry);

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -14,6 +14,8 @@
 #   in the variable BCI_TEST_ENVS.
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use XML::LibXML;
 use testapi;

--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -11,6 +11,8 @@
 # Summary: Checks if the container version for the test run is still up-to-date
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use utils qw(zypper_call script_retry);
 use version_utils;

--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -14,6 +14,8 @@
 # - cleanup system (images, containers)
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal qw(select_serial_terminal select_user_serial_terminal);

--- a/tests/containers/charts/privateregistry.pm
+++ b/tests/containers/charts/privateregistry.pm
@@ -12,6 +12,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use File::Basename qw(dirname);
 use testapi;

--- a/tests/containers/charts/rmt.pm
+++ b/tests/containers/charts/rmt.pm
@@ -12,6 +12,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use File::Basename qw(dirname);
 use testapi;

--- a/tests/containers/compose.pm
+++ b/tests/containers/compose.pm
@@ -17,6 +17,8 @@
 # Maintainer: QE-C team <qa-c@suse.de>
 
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal select_user_serial_terminal);

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -7,6 +7,8 @@
 # Summary: Print and save diffs between two containers using container-diff tool
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -24,6 +24,8 @@
 # - test networking outside of host
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/containerd_crictl.pm
+++ b/tests/containers/containerd_crictl.pm
@@ -7,6 +7,8 @@
 # Summary: Test containerd with crictl installation and usage
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use serial_terminal 'select_serial_terminal';
 use containers::utils 'runtime_smoke_tests';

--- a/tests/containers/containerd_nerdctl.pm
+++ b/tests/containers/containerd_nerdctl.pm
@@ -7,6 +7,8 @@
 # Summary: Test containerd with nerdctl installation and usage
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use serial_terminal 'select_serial_terminal';
 use containers::utils 'runtime_smoke_tests';

--- a/tests/containers/ecs_anywhere.pm
+++ b/tests/containers/ecs_anywhere.pm
@@ -11,6 +11,8 @@
 # Summary: Create VM in EC2 using aws binary
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use registration;
 use testapi;

--- a/tests/containers/firewall.pm
+++ b/tests/containers/firewall.pm
@@ -7,6 +7,8 @@
 # Summary: Test podman or docker with enabled firewall
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -14,6 +14,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -9,6 +9,8 @@
 # - import SUSE CA certificates
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -8,6 +8,8 @@
 # This module is unified to run independented the host os.
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -7,6 +7,8 @@
 # Maintainer: QE-C team <qa-c@suse.de>
 
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use utils;

--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -7,6 +7,8 @@
 # Summary: Test container network isolation
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal select_user_serial_terminal);

--- a/tests/containers/multi_runtime.pm
+++ b/tests/containers/multi_runtime.pm
@@ -8,6 +8,8 @@
 # - check if firewalld doesn't break either
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(containers::basetest);
 use testapi;
 use serial_terminal qw(select_serial_terminal select_user_serial_terminal);

--- a/tests/containers/openshift_image.pm
+++ b/tests/containers/openshift_image.pm
@@ -7,6 +7,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/openshift_setup.pm
+++ b/tests/containers/openshift_setup.pm
@@ -13,6 +13,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/podman_artifact.pm
+++ b/tests/containers/podman_artifact.pm
@@ -7,6 +7,8 @@
 # Summary: Test podman artifact
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/podman_bci_systemd.pm
+++ b/tests/containers/podman_bci_systemd.pm
@@ -7,6 +7,8 @@
 # Summary: Test podman with systemd
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/podman_ipv6.pm
+++ b/tests/containers/podman_ipv6.pm
@@ -7,6 +7,8 @@
 # Summary: Test podman IPv6
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -7,6 +7,8 @@
 # Summary: Test podman netavark network backend
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/podman_network_cni.pm
+++ b/tests/containers/podman_network_cni.pm
@@ -7,6 +7,8 @@
 # Summary: Test podman network
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use utils qw(script_retry);

--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -10,6 +10,8 @@
 # - Clean up pods using hello-kubic.yaml
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use utils qw(script_retry);

--- a/tests/containers/podman_quadlet.pm
+++ b/tests/containers/podman_quadlet.pm
@@ -7,6 +7,8 @@
 # Summary: Smoke test for builtin podman tool called quadlet
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(containers::basetest);
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/podman_remote.pm
+++ b/tests/containers/podman_remote.pm
@@ -7,6 +7,8 @@
 # Summary: Test podman-remote functionality
 # Maintainer: qe-c <qe-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use utils qw(script_retry systemctl zypper_call);

--- a/tests/containers/prepare_hpvs.pm
+++ b/tests/containers/prepare_hpvs.pm
@@ -12,6 +12,8 @@
 #   A smoke test that BCI containers can run in IBM's Hyper Protect Platform
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use utils qw(script_retry file_content_replace);
 use version_utils;

--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -7,6 +7,8 @@
 # Summary: Test container runtime privileged mode
 # Maintainer: qa-c@suse.de
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/push_container_image_to_pc.pm
+++ b/tests/containers/push_container_image_to_pc.pm
@@ -7,6 +7,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'publiccloud::k8sbasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/realtime.pm
+++ b/tests/containers/realtime.pm
@@ -7,6 +7,8 @@
 # Summary: Test RT workload in a container
 # Maintainer: qa-c@suse.de
 
+use strict;
+use warnings;
 use Mojo::Base qw(containers::basetest);
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -14,6 +14,8 @@
 # - images can be deleted
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -14,6 +14,8 @@
 #   * container is launched with keep-id of the user who run the container
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -15,6 +15,8 @@
 # - Restore /etc/zypp/credentials.d/ credentials
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/run_container_in_k8s.pm
+++ b/tests/containers/run_container_in_k8s.pm
@@ -7,6 +7,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'publiccloud::k8sbasetest';
 use testapi;
 use containers::k8s qw(apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log);

--- a/tests/containers/seccomp.pm
+++ b/tests/containers/seccomp.pm
@@ -8,6 +8,8 @@
 # Maintainer: QE-C team <qa-c@suse.de>
 
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -7,6 +7,8 @@
 # Summary: Test the `secret` subcommand for Podman
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/skopeo.pm
+++ b/tests/containers/skopeo.pm
@@ -7,6 +7,8 @@
 # Summary: Test basic skopeo commands.
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';    # used in select_serial_terminal

--- a/tests/containers/slem_rancher.pm
+++ b/tests/containers/slem_rancher.pm
@@ -10,6 +10,8 @@
 #
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/suma_containers.pm
+++ b/tests/containers/suma_containers.pm
@@ -23,6 +23,8 @@
 #
 # Maintainer: Maurizio Galli <maurizio.galli@suse.com>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/testenv_prepare.pm
+++ b/tests/containers/testenv_prepare.pm
@@ -13,6 +13,8 @@
 # Verify the connections between 2 created within the pod
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/testenv_validation.pm
+++ b/tests/containers/testenv_validation.pm
@@ -7,6 +7,8 @@
 # Summary: Verify Pod and containers within pods are still running after upgrade
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/third_party_images.pm
+++ b/tests/containers/third_party_images.pm
@@ -8,6 +8,8 @@
 #          Log the test results in docker-3rd_party_images_log.txt
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/update_host.pm
+++ b/tests/containers/update_host.pm
@@ -11,6 +11,8 @@
 # Summary: Update host system
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base qw(consoletest);
 use utils qw(zypper_call script_retry);
 use version_utils qw(get_os_release);

--- a/tests/containers/validate_btrfs.pm
+++ b/tests/containers/validate_btrfs.pm
@@ -13,6 +13,8 @@
 # continue when the docker partition is fulled up.
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';

--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -7,6 +7,8 @@
 # Summary: Test podman network
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);


### PR DESCRIPTION
Add `use strict;` & `use warnings;` to every Perl file.

Automated with:
`find lib/containers/ tests/containers/ -name \*.pm -exec grep -L 'use strict' {} + | while read f ; do perl -i -pe 'BEGIN { $inserted = 0 } if (!$inserted && /^use\b/) { print "use strict;\nuse warnings;\n"; $inserted = 1 }'  $f ; done`

Missing only `podmansh.pm` til we schedule it again.

- Related ticket: https://progress.opensuse.org/issues/183644

