### PR TITLE
Setup rules for sleperf when selinux enforcing and handling SELinux status in post installation

### DIFF
--- a/data/autoyast_hanaperf/agama-config.jsonnet
+++ b/data/autoyast_hanaperf/agama-config.jsonnet
@@ -71,12 +71,6 @@
           echo -e "[main]\nno-auto-default=type:ethernet" > /etc/NetworkManager/conf.d/disable_auto.conf
           echo -e "[connection]\nid=nic0\nuuid=$(uuidgen)\ntype=ethernet\n[ethernet]\nmac-address={{SUT_NETDEVICE}}\n[ipv4]\nmethod=auto\n" > /etc/NetworkManager/system-connections/nic0.nmconnection
           chmod 0600 /etc/NetworkManager/system-connections/nic0.nmconnection
-          # Workaround to set SELinux as permissive
-          cp /boot/grub2/grub.cfg /boot/grub2/grub.cfg.orig
-          cp /etc/default/grub /etc/default/grub.orig
-          sed -e "s/selinux=1 enforcing=1/ /g" -i /boot/grub2/grub.cfg
-          sed -e "s/selinux=1 enforcing=1/ /g" -i /etc/default/grub
-          sed -e "s/SELINUX=enforcing/SELINUX=permissive/g" -i /etc/selinux/config
         |||,
       },
     ],


### PR DESCRIPTION
The PR will apply for some changes as following:
1. Remove SELinux hardcode in agama.json
2. Setup SELinux rules for SLEperf framework
3. Enable a parameter to control SELinux mode: `HANAPERF_SELINUX_SETENFORCE`, the default value is Enforcing.

- Related ticket: https://jira.suse.com/browse/TEAM-10379
- Needles: N/A
- Verification run:
https://openqa.suse.de/tests/17971567 ==> verify `HANAPERF_SELINUX_SETENFORCE=Permissive`
https://openqa.suse.de/tests/17971568 ==> verify default behaviors 



