### PR TITLE
Validate RMT URI in validate_repos

### DIFF
--- a/test_data/yam/agama_rmt.yaml
+++ b/test_data/yam/agama_rmt.yaml
@@ -2,13 +2,19 @@
 repos:
   - name: SLE-Product-SLES-16.0
     alias: SUSE_Linux_Enterprise_Server_%ARCH%:SLE-Product-SLES-16.0
+    Autorefresh: 'On'
     enabled: 'Yes'
     filter: name
+    URI: http://migration-rmt2.qe.nue2.suse.org/repo/SUSE/Products/SLE-Product-SLES/16.0/%ARCH%/product/
   - name: SLE-Product-SLES-16.0-Debug
     alias: SUSE_Linux_Enterprise_Server_%ARCH%:SLE-Product-SLES-16.0-Debug
+    Autorefresh: 'On'
     enabled: 'No'
     filter: name
+    URI: http://migration-rmt2.qe.nue2.suse.org/repo/SUSE/Products/SLE-Product-SLES/16.0/%ARCH%/product_debug/
   - name: SLE-Product-SLES-16.0-Source
     alias: SUSE_Linux_Enterprise_Server_%ARCH%:SLE-Product-SLES-16.0-Source
+    Autorefresh: 'On'
     enabled: 'No'
     filter: name
+    URI: http://migration-rmt2.qe.nue2.suse.org/repo/SUSE/Products/SLE-Product-SLES/16.0/%ARCH%/product_source/


### PR DESCRIPTION
##
### Validate RMT URI in validate_repos

##
### Adapt rmt validate_repos test data

- Related ticket: https://progress.opensuse.org/issues/182996
- Related info: [**repo list**](https://openqa.suse.de/tests/17921840#step/validate_repos/12)
- Related MR: [**MR#473**](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/473)
- Needles: N/A
- Verification run: [**VR**](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=hjluo_sles_rmt_unattended_dev&modules=&module_re=&group_glob=&not_group_glob=&comment=&distri=sle&version=agama-10.0&build=hjluo%2Fos-autoinst-distri-opensuse%23rmt_validate_URI#)

##
