### PR TITLE
Report SELinux AVCs after each HA & SAP test module

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -19,7 +19,7 @@ use lockapi;
 use isotovideo;
 use maintenance_smelt qw(get_incident_packages);
 use x11utils qw(ensure_unlocked_desktop);
-use Utils::Logging qw(export_logs);
+use Utils::Logging qw(export_logs record_avc_selinux_alerts);
 use network_utils qw(iface);
 use Carp qw(croak);
 use Data::Dumper;
@@ -1098,6 +1098,7 @@ sub pre_run_hook {
 sub post_run_hook {
     my ($self) = @_;
 
+    record_avc_selinux_alerts() if is_sle('16+');
     return unless ($prev_console);
     select_console($prev_console, await_console => 0);
     if ($prev_console eq 'x11') {

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -26,7 +26,7 @@ use version_utils qw(is_sle has_selinux);
 use utils qw(zypper_call);
 use Digest::MD5 qw(md5_hex);
 use Utils::Systemd qw(systemctl);
-use Utils::Logging qw(save_and_upload_log);
+use Utils::Logging qw(save_and_upload_log record_avc_selinux_alerts);
 use Carp qw(croak);
 
 our @EXPORT = qw(
@@ -1487,6 +1487,7 @@ sub modify_selinux_setenforce {
 sub post_run_hook {
     my ($self) = @_;
 
+    record_avc_selinux_alerts() if is_sle('16+');
     return unless ($prev_console);
     select_console($prev_console, await_console => 0);
     ensure_unlocked_desktop if ($prev_console eq 'x11');

--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -14,6 +14,7 @@ use testapi;
 use lockapi;
 use hacluster qw(get_cluster_name ha_export_logs);
 use version_utils 'is_sle';
+use Utils::Logging qw(record_avc_selinux_alerts);
 
 sub run {
     my $cluster_name = get_cluster_name;
@@ -39,6 +40,10 @@ sub run {
             title => 'segfault?'
         );
     }
+}
+
+sub post_run_hook {
+    record_avc_selinux_alerts() if is_sle('16+');
 }
 
 # Specific test_flags for this test module


### PR DESCRIPTION
This commit adds a call to `Utils::Logging::record_avc_selinux_alerts` in the `post_run_hook` of HA and SLES for SAP tests so the AVC alerts are collected and reported at the end of each module's run.

- Related Ticket: https://jira.suse.com/browse/TEAM-10408
- Needles: N/A

### Verification runs

Check at the end of each HA or SLES for SAP test module that the command `ausearch -m avc -r` was executed.

Exceptions are `ha/check_hawk` and `ha/ha_cluster_crash_test` which are not running the `post_run_hook` from `lib/hacluster`.

- HANA: http://mango.qe.nue2.suse.org/tests/6745 :green_circle: 
- NetWeaver ASCS: http://mango.qe.nue2.suse.org/tests/6744 :green_circle: 
- ASE: http://mango.qe.nue2.suse.org/tests/6743 :green_circle: 
- Pacemaker CTS cluster test: [node](http://mango.qe.nue2.suse.org/tests/6751), [node2](http://mango.qe.nue2.suse.org/tests/6752) & [client](http://mango.qe.nue2.suse.org/tests/6750) :green_circle: 
- 3 node cluster (failure in `ha/check_logs` in one of the nodes is expected): [node1](http://mango.qe.nue2.suse.org/tests/6770), [node2](http://mango.qe.nue2.suse.org/tests/6772), [node3](http://mango.qe.nue2.suse.org/tests/6771)
- 15-SP7 qnetd regression: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&build=VR4PR22279 :green_circle: 
