### PR TITLE
Use serial terminal instead of root console in eal4

### DIFF
--- a/schedule/security/cc_eal4.yaml
+++ b/schedule/security/cc_eal4.yaml
@@ -3,7 +3,7 @@ description: >
     This is for EAL4 tests
 schedule:
     - installation/bootloader_start
-    - security/boot_disk
+    - boot/boot_to_desktop
     - security/eal4/setup_eal4_env
     - '{{disable_root_ssh}}'
     - security/eal4/accessible_network_interface

--- a/tests/security/eal4/accessible_network_interface.pm
+++ b/tests/security/eal4/accessible_network_interface.pm
@@ -14,11 +14,12 @@ use testapi;
 use utils;
 use eal4_test;
 use Data::Dumper;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     # The result of 'lsof -i -P' likes:
     #   COMMAND    PID     USER   FD   TYPE DEVICE SIZE/OFF NODE NAME

--- a/tests/security/eal4/check_processor_vulnerability_mitigations.pm
+++ b/tests/security/eal4/check_processor_vulnerability_mitigations.pm
@@ -14,11 +14,12 @@ use testapi;
 use utils;
 use eal4_test;
 use Utils::Architectures;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     my $script = 'spectre-meltdown-checker.sh';
     my $log_file = 'spectre-meltdown-checker.log';

--- a/tests/security/eal4/check_undocumented_security_programs.pm
+++ b/tests/security/eal4/check_undocumented_security_programs.pm
@@ -12,11 +12,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     # The programs are defined by the FSP and corresponding man pages
     my $known_programs = {

--- a/tests/security/eal4/chrony_pid_file.pm
+++ b/tests/security/eal4/chrony_pid_file.pm
@@ -12,11 +12,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     # The chrony pid file does not exist is the expected result
     if (script_run('find / -name "*chrony*" | grep \'\\.pid\'') == 0) {

--- a/tests/security/eal4/dbus_fuzzer.pm
+++ b/tests/security/eal4/dbus_fuzzer.pm
@@ -15,11 +15,12 @@ use utils;
 use eal4_test;
 use Mojo::Util 'trim';
 use Data::Dumper;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     # Install the required packages
     zypper_call('in glib2-devel libffi-devel');

--- a/tests/security/eal4/dbus_services_exposure.pm
+++ b/tests/security/eal4/dbus_services_exposure.pm
@@ -16,6 +16,7 @@ use eal4_test;
 use Data::Dumper;
 use version_utils 'is_sle';
 use Utils::Architectures 'is_s390x';
+use serial_terminal 'select_serial_terminal';
 
 # List of known safe processes that can have DBus services
 my @allowed_processes = qw(
@@ -73,7 +74,7 @@ sub is_dynamic_name {
 
 sub run {
     my ($self) = shift;
-    select_console 'root-console';
+    select_serial_terminal;
 
     # Run the test
     my $output_dbus_send = script_output('/bin/dbus-send --system --print-reply --dest=org.freedesktop.DBus --type=method_call /org/freedesktop/DBUS org.freedesktop.DBus.ListNames');

--- a/tests/security/eal4/drng_test_preparation.pm
+++ b/tests/security/eal4/drng_test_preparation.pm
@@ -13,17 +13,18 @@ use warnings;
 use testapi;
 use utils;
 use eal4_test;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     # Install the required packages
     zypper_call('in libopenssl-devel libgcrypt-devel');
 
     my $test_dir = '/root/eval/drng';
-    # Complile gather_random_data
+    # Compile gather_random_data
     my $exe_file = 'gather_random_data';
     assert_script_run("cd $eal4_test::code_dir");
     assert_script_run("gcc -o $exe_file -lcrypto -lssl -lgcrypt gather_random_data.c");

--- a/tests/security/eal4/kvm_check.pm
+++ b/tests/security/eal4/kvm_check.pm
@@ -12,11 +12,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     # Install the required packages
     zypper_call('in libvirt');

--- a/tests/security/eal4/netlink_message.pm
+++ b/tests/security/eal4/netlink_message.pm
@@ -12,11 +12,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     # Complile
     assert_script_run('cd /usr/local/eal4/pentest/netlink');

--- a/tests/security/eal4/permission_settings.pm
+++ b/tests/security/eal4/permission_settings.pm
@@ -12,11 +12,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     my $output = script_output('find -L /etc -perm -g+w,o+w');
 

--- a/tests/security/eal4/setup_eal4_env.pm
+++ b/tests/security/eal4/setup_eal4_env.pm
@@ -13,11 +13,12 @@ use warnings;
 use testapi;
 use utils;
 use eal4_test;
+use serial_terminal 'select_serial_terminal';
 
 sub run {
     my ($self) = shift;
 
-    select_console 'root-console';
+    select_serial_terminal;
 
     zypper_call('in wget gcc make curl');
 

--- a/tests/security/eal4/syscall_thrasher.pm
+++ b/tests/security/eal4/syscall_thrasher.pm
@@ -13,6 +13,12 @@ use warnings;
 use testapi;
 use utils;
 use Utils::Architectures 'is_s390x';
+use serial_terminal 'select_serial_terminal';
+
+use constant {
+    USER_TERMINAL => 0,
+    ROOT_TERMINAL => 1,
+};
 
 my $log_file = '/tmp/syscalls_output.log';
 
@@ -26,7 +32,7 @@ sub run {
         return;
     }
 
-    select_console 'root-console';
+    select_serial_terminal ROOT_TERMINAL;
 
     my $exe_file = 'thrash';
     assert_script_run('cd /usr/local/eal4');
@@ -35,7 +41,7 @@ sub run {
     assert_script_run("chmod 755 $exe_file");
 
     # The test needs to run by non-root
-    select_console 'user-console';
+    select_serial_terminal USER_TERMINAL;
 
     my $test_dir = 'test_syscall_thrasher';
     assert_script_run("mkdir -p $test_dir");


### PR DESCRIPTION
With this change, the testsuite runs 2x faster on most platform

- Related ticket: https://progress.opensuse.org/issues/183134
- Needles: no
- Verification runs:
  - https://openqa.suse.de/tests/17974011
  - https://openqa.suse.de/tests/17974012
  - https://openqa.suse.de/tests/17974013
  - https://openqa.suse.de/tests/17974014
  - https://openqa.suse.de/tests/17974660
  - https://openqa.suse.de/tests/17974156
  - https://openqa.suse.de/tests/17974158
  - https://openqa.suse.de/tests/17974159
  - https://openqa.suse.de/tests/17974160
  - https://openqa.suse.de/tests/17974161
  - https://openqa.suse.de/tests/17974162
  - https://openqa.suse.de/tests/17974163
  - https://openqa.suse.de/tests/17974164
  - https://openqa.suse.de/tests/17974165
  - https://openqa.suse.de/tests/17974166
  - https://openqa.suse.de/tests/17974167
  - https://openqa.suse.de/tests/17975177
  - https://openqa.suse.de/tests/17975209
  - https://openqa.suse.de/tests/17976740
  - https://openqa.suse.de/tests/17976739
