### PR TITLE
Container tests on sle16 ppc on boot desktop skip grub2

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -909,6 +909,9 @@ sub wait_boot {
     # When no bounce back on power KVM, we need skip bootloader process and go ahead when 'displaymanager' matched.
     elsif (get_var('OFW') && (check_screen('displaymanager', 5))) {
     }
+    # SLE-16 boot on ppc64le results too quick to be captured, from grub2 to login prompt
+    elsif (get_var('OFW') && is_sle('16+') && check_var('MACHINE', 'ppc64le-emu') && (check_screen('linux-login', 10))) {
+    }
     elsif (is_bootloader_grub2) {
         assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600) if (uses_qa_net_hardware() || get_var("PXEBOOT"));
         $self->handle_grub(bootloader_time => $bootloader_time, in_grub => $in_grub);


### PR DESCRIPTION
Container test for SLE16 ppc64le, the check on the _grub_ menu shall be skipped, appearing and continuing too fast and the _linux-login prompt_ directly expected.

Note that these tests rely in hdd_1 image available. But fix for create_hdd_agama_containers is still ongoing, but also unrelated, so this PR is a step forward to resolve the issue impacting the tests using that image, first.

Related ticket:https://progress.opensuse.org/issues/183641

Verification run: 
 - sle-16.0-Online-ppc64le-Build94.2-docker-stable_tests@ppc64le-emu -
   https://openqa.suse.de/tests/17986608  
 - sle-16.0-Online-ppc64le-Build94.2-docker_tests@ppc64le-emu -
   https://openqa.suse.de/tests/17986609 
 - sle-16.0-Online-ppc64le-Build94.2-podman_tests@ppc64le-emu -
   https://openqa.suse.de/tests/17986610

Next VR updates in the body.