### PR TITLE
bats: Increase timeout

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -354,7 +354,7 @@ sub bats_tests {
     run_command "echo $log_file .. > $log_file";
     run_command "echo '# $package $version $os_version' >> $log_file";
     push @commands, $cmd;
-    my $ret = script_run $cmd, 7000;
+    my $ret = script_run $cmd, 9000;
 
     unless (get_var("BATS_TESTS")) {
         $skip_tests = get_var($skip_tests, $settings->{$skip_tests});


### PR DESCRIPTION
Increase timeout for BATS tests.

Failing test: https://openqa.suse.de/tests/17986615#step/podman/450