### PR TITLE
bats: Use write_sut_file instead of echo

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -189,7 +189,7 @@ Options=bind
 EOF
 
     assert_script_run "mkdir -p /etc/systemd/system/tmp.mount.d/";
-    assert_script_run "echo '$override_conf' > /etc/systemd/system/tmp.mount.d/override.conf";
+    write_sut_file('/etc/systemd/system/tmp.mount.d/override.conf', $override_conf);
 }
 
 sub bats_setup {


### PR DESCRIPTION
Use write_sut_file instead of echo

- Failing test: https://openqa.suse.de/tests/17991429#step/podman/105
- Verification run: https://openqa.suse.de/tests/17991436/logfile?filename=serial_terminal.txt
