### PR TITLE
bats: mkdir should not fail

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -269,7 +269,7 @@ sub bats_post_hook {
     select_serial_terminal;
 
     my $log_dir = "/tmp/logs/";
-    assert_script_run "mkdir -p $log_dir";
+    assert_script_run "mkdir -p $log_dir || true";
     assert_script_run "cd $log_dir";
 
     script_run "rm -rf $test_dir";


### PR DESCRIPTION
For some stupid reason there's a stupid timeout for a stupid mkdir:
https://openqa.suse.de/tests/17989702/logfile?filename=serial_terminal.txt#line-1455
