### PR TITLE
bats: Update ncat version

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -71,7 +71,7 @@ sub install_git {
 }
 
 sub install_ncat {
-    my $version = get_var("NCAT_VERSION", "7.95-3");
+    my $version = get_var("NCAT_VERSION", "7.97-1");
 
     my @cmds = (
         "rpm -vhU https://nmap.org/dist/ncat-$version.x86_64.rpm",
@@ -80,6 +80,7 @@ sub install_ncat {
     foreach my $cmd (@cmds) {
         run_command $cmd;
     }
+    record_info("nc", script_output("nc --version"));
 }
 
 sub install_bats {


### PR DESCRIPTION
Update ncat version.  

Verification runs:
- TW podman: https://openqa.opensuse.org/tests/5094858 (`NCAT_VERSION=7.97-1`)
- 15-SP5 netavark: https://openqa.suse.de/tests/17993612
- 16.0 aardvard-dns: https://openqa.suse.de/tests/17993611