### PR TITLE
Match uefi boot manager before exiting qemu

### DIFF
--- a/tests/qemu/qemu.pm
+++ b/tests/qemu/qemu.pm
@@ -84,7 +84,11 @@ sub run {
         assert_script_run 'dd if=/usr/share/qemu/qemu-uefi-aarch64.bin of=flash0.img conv=notrunc';
         assert_script_run 'dd if=/dev/zero of=flash1.img bs=1M count=64';
         enter_cmd "qemu-system-aarch64 -M virt,usb=off -cpu cortex-a57 -nographic -pflash flash0.img -pflash flash1.img";
-        assert_screen ['qemu-uefi-shell', 'qemu-no-bootable-device'], 600;
+        assert_screen([qw(qemu-enter-boot-manager qemu-uefi-shell)], 600);
+        if (match_has_tag('qemu-enter-boot-manager')) {
+            send_key('e');
+            assert_screen('qemu-uefi-boot-manager');
+        }
     }
     else {
         die sprintf("Test case is missing support for %s architecture", get_var('ARCH'));


### PR DESCRIPTION
* **For** recent builds, uefi shell has been removed from ovmf pacakge for security and size saving purpose. Empty qemu machine can only shows "no bootable device" and enter into boot manager which does not provide anything to boot. 

* **Match** needle [qemu-enter-boot-manager](https://openqa.suse.de/tests/18011344#step/qemu/10) and then [qemu-uefi-boot-manager](https://openqa.suse.de/tests/18011344#step/qemu/11) before exiting qemu is necessary for the test run to continue.

* **Verification Runs:**
  * [sle-micro-6.2-Default-aarch64-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18011344)
  * [ sle-micro-6.2-Default-SelfInstall-aarch64-Build12.6-slem_installation_virt](https://openqa.suse.de/tests/18011394)
  * [ sle-micro-6.2-Default-qcow-aarch64-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18011397)
  * [x86_64-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18023943)
  * [x86_64-Build12.6-slem_installation_virt](https://openqa.suse.de/tests/18023944)
  * [x86_64-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18023946)
  * [ppc-4096-ppc64le-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18023948)
  * [ppc-512-ppc64le-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18023949)
  * [s390x-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18023950)
  * [qcow-x86_64-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18023952)
  * [Build11.2 sle-micro-6.2-Default-aarch64-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18024032)
  * [Build11.2 sle-micro-6.2-Default-SelfInstall-aarch64-Build12.6-slem_installation_virt](https://openqa.suse.de/tests/18024033)
  * [Build11.2 sle-micro-6.2-Default-qcow-aarch64-Build12.6-slem_virtualization](https://openqa.suse.de/tests/18024035)