### PR TITLE
[WIP]Remove added network parameters

### DIFF
--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -131,7 +131,7 @@ sub enter_netboot_parameters {
     }
     my $ntlm_p = get_var('NTLM_AUTH_INSTALL') ? $ntlm_auth::ntlm_proxy : '';
     if (is_agama) {
-        type_string_slow "linux $mntpoint/linux root=live:http://" . get_var('OPENQA_HOSTNAME') . "/assets/iso/" . get_var('ISO') . " live.password=$testapi::password console=hvc0 ip=dhcp";
+        type_string_slow "linux $mntpoint/linux root=live:http://" . get_var('OPENQA_HOSTNAME') . "/assets/iso/" . get_var('ISO') . " live.password=$testapi::password console=hvc0";
         # inst.auto and inst.install_url are defined in below function
         specific_bootmenu_params;
         type_string_slow " " . get_var('EXTRABOOTPARAMS') . " " if (get_var('EXTRABOOTPARAMS'));

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -38,8 +38,6 @@ sub set_svirt_domain_elements {
                   "/assets/repo/" . get_required_var('REPO_0') . "/LiveOS/squashfs.img" :
                   "/assets/iso/" . get_required_var('ISO'));
             $cmdline .= " live.password=$testapi::password";
-            $cmdline .= " ip=dhcp";
-            $cmdline .= " rd.neednet";
         } else {
             $cmdline .= "install=$repo";
             $cmdline .= remote_install_bootmenu_params;

--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -32,8 +32,6 @@ sub prepare_boot_params {
     push @params, 'console=tty' . (is_x86_64 ? 'S0' : 'AMA0'), 'console=tty';
     push @params, 'kernel.softlockup_panic=1';
     push @params, "live.password=$testapi::password";
-    push @params, 'ip=dhcp';
-    push @params, 'rd.neednet';
 
     # override default boot params
     if (get_var('BOOTPARAMS')) {


### PR DESCRIPTION
On build 96.1, we don't need to set the two network parameters any more which should be set by default. https://bugzilla.suse.com/show_bug.cgi?id=1241969#c41

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23check-without-network-parameters&distri=sle&version=16.0

Now https://openqa.suse.de/tests/17999016#step/validate_lvm/1 failed for no route issue on s390x kvm