### PR TITLE
sle-micro 6.2 aarch64 tiny fixes

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -123,7 +123,7 @@ sub verify_partition_label {
     # The RPi firmware needs MBR. s390x images also use MBR.
     # Note: JeOS-for-RaspberryPi means "kiwi-templates-Minimal" and JeOS-for-RPi means "community JeOS".
     # In sle-micro the raw aarch64 images are used for RPi, hence they have contain `dos`
-    if (is_s390x || get_var('FLAVOR', '') =~ /JeOS-for-RaspberryPi/ || check_var('FLAVOR', 'JeOS-for-RPi') || (is_sle_micro && is_aarch64 && get_var('FLAVOR', '') =~ /(^Base$|^Default$)/)) {
+    if (is_s390x || get_var('FLAVOR', '') =~ /JeOS-for-RaspberryPi/ || check_var('FLAVOR', 'JeOS-for-RPi') || (is_sle_micro("<6.2") && is_aarch64 && get_var('FLAVOR', '') =~ /(^Base$|^Default$)/)) {
         $label = 'dos';
     }
 

--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -34,16 +34,14 @@ sub run {
     die 'GPT has errors' if script_output("sfdisk --list-free /dev/$disk 2>&1 >/dev/null", proceed_on_failure => 0) ne '';
 
     # Verify that there is no unpartitioned space left
+    # 0 sectors is default and expected value in most of the images
     my $left_sectors = 0;
-    if ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow|SelfInstall/) {
+    if ((is_sle_micro("6.2+") || is_leap_micro("6.2+")) && is_aarch64 && !(get_var('FLAVOR', '') =~ /qcow/i)) {
+        $left_sectors = 4062;
+    } elsif ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow|SelfInstall/) {
         $left_sectors = 2048;
-    } elsif ((is_sle_micro("6.0+") or is_leap_micro("6.0+")) && is_aarch64) {
-        $left_sectors = 0 if (get_var("HDD_1") =~ /qcow2/);
-        $left_sectors = 4062 if (get_var("ISO") =~ /SelfInstall/);
-        record_soft_failure "bsc#1220722: no unpartitioned space left on aarch64";
     } elsif (is_sle_micro("6.0+") && get_required_var('FLAVOR') =~ /ppc-4096/) {
         $left_sectors = 1792;
-        record_soft_failure "bsc#1220722: no unpartitioned space left on aarch64";
     }
 
     validate_script_output("sfdisk --list-free /dev/$disk", qr/Unpartitioned space .* $left_sectors sectors/);


### PR DESCRIPTION
The gpt table has replaced dos in Default/Base flavors as we have a
dedicated RPi image.
The new .*64kb images have more sectors left unpartitioned as expected
by the tests

- failures: https://openqa.suse.de/tests/17972425#step/firstrun/83 and
  https://openqa.suse.de/tests/17994364#step/image_checks/10

#### Verification runs

* [64kb](https://openqa.suse.de/tests/17999868#step/image_checks/10)
* [sle-micro-6.2-Base-qcow-aarch64-Build12.6-default@aarch64](https://openqa.suse.de/tests/18002153#step/image_checks/10)
* [sle-micro-6.1-Base-qcow-Updates-aarch64-Build63.1-slem_image_default@aarch64](https://openqa.suse.de/tests/18002138](https://openqa.suse.de/tests/18002138#step/image_checks/10))
* [sle-micro-5.5-Default-Updates-aarch64-Build20250608-1-slem_image_default@aarch64](https://openqa.suse.de/tests/18002114#step/image_checks/10)
* [sle-micro-6.2-Base-aarch64](https://openqa.suse.de/tests/18011251#step/image_checks/10)