### PR TITLE
ha: Detect service status more robustly

### DIFF
--- a/tests/ha/graceful_shutdown.pm
+++ b/tests/ha/graceful_shutdown.pm
@@ -43,7 +43,7 @@ sub run {
 
     # confirm cluster suite is started (only needed for logging purposes)
     record_info('corosync', 'check if corosync is started');
-    validate_script_output_retry("systemctl --no-pager -l status corosync", sub { m/Started Corosync Cluster Engine/i });
+    validate_script_output_retry("systemctl --no-pager -l status corosync", sub { m/Active: active \(running\)/i });
     record_info('pacemaker', 'check if pacemaker is started');
     validate_script_output_retry("systemctl --no-pager -l status pacemaker", sub { m/Active: active \(running\)/i });
     record_info('crm_mon', 'check crm_mon output');


### PR DESCRIPTION
The changed line should be looking like this:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/86118dd28bdc5fa9d90204afa51171eed7e33f1d/tests/ha/graceful_shutdown.pm#L48

The more robust way to check for service status is to check the `Active:` section instead of the `log` section, because the log section only shows 10 lines by default and the status message may not show sometimes.

- Related ticket: https://jira.suse.com/browse/TEAM-10361
- Needles: none
- Verification run:
https://openqa.suse.de/tests/17998865#step/graceful_shutdown/41
https://openqa.suse.de/tests/17998980#step/graceful_shutdown/41
https://openqa.suse.de/tests/17998977
https://openqa.suse.de/tests/17998975
https://openqa.suse.de/tests/17998967
https://openqa.suse.de/tests/17998965
https://openqa.suse.de/tests/17998963
https://openqa.suse.de/tests/17998959
https://openqa.suse.de/tests/17998956

