### PR TITLE
Enable long URLs in s390x zVM

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -90,10 +90,11 @@ sub prepare_parmfile {
     }
     else {
         if (get_var('AGAMA')) {
-            $params .= " root=live:ftp://" . get_var('REPO_HOST', 'openqa') . '/' .
-              ((get_var('FLAVOR') eq "Full") ?
-                  get_required_var('REPO_0') . "/LiveOS/squashfs.img" :
-                  get_var('REPO_999'));
+            my $host = "ftp://" . get_var('REPO_HOST', 'openqa');
+            my $root_line = " root=live:" . ((get_var('FLAVOR') eq "Full") ?
+                  shorten_url($host . '/' . get_required_var('REPO_0') . "/LiveOS/squashfs.img") :
+                  $host . '/' . get_var('REPO_999'));
+            $params .= $root_line;
         }
         else {
             $params .= " install=" . $instsrc . $repo . " ";


### PR DESCRIPTION
We need to merge this short code to short URL from root:live line.

- Related ticket: https://progress.opensuse.org/issues/181313
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18013317
