### PR TITLE
bats/buildah: Ignore sbom test as root

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -13,21 +13,21 @@ buildah:
     BATS_SKIP_ROOT: from
     BATS_SKIP_USER: add basic commit copy overlay rmi squash
   sle-15-SP7:
-    BATS_SKIP: bud namespaces run
+    BATS_SKIP: bud namespaces run sbom
     BATS_SKIP_ROOT:
-    BATS_SKIP_USER: add basic commit copy overlay rmi sbom squash
+    BATS_SKIP_USER: add basic commit copy overlay rmi squash
   sle-15-SP6:
-    BATS_SKIP: bud namespaces run
+    BATS_SKIP: bud namespaces run sbom
     BATS_SKIP_ROOT:
-    BATS_SKIP_USER: add basic commit copy overlay rmi sbom squash
+    BATS_SKIP_USER: add basic commit copy overlay rmi squash
   sle-15-SP5:
-    BATS_SKIP: bud namespaces run
+    BATS_SKIP: bud namespaces run sbom
     BATS_SKIP_ROOT:
-    BATS_SKIP_USER: add basic commit copy overlay rmi sbom squash
+    BATS_SKIP_USER: add basic commit copy overlay rmi squash
   sle-15-SP4:
-    BATS_SKIP: bud namespaces run
+    BATS_SKIP: bud namespaces run sbom
     BATS_SKIP_ROOT:
-    BATS_SKIP_USER: add basic commit copy overlay rmi sbom squash
+    BATS_SKIP_USER: add basic commit copy overlay rmi squash
 netavark:
   # Note on patches:
   # https://github.com/containers/netavark/pull/1191 is needed for 001-basic


### PR DESCRIPTION
Ignore sbom test as root as we do as user.

This [test](https://github.com/containers/buildah/blob/main/tests/sbom.bats) runs the syft and trivy Docker images on the Docker Alpine image to generate a SBOM (Software Bill Of Materials) and scan for security vulnerabilities.  This may be a test issue or bug on either of these.  It makes no sense to waste time on this one.

```
# 15-SP4
$ susebats notok https://openqa.suse.de/tests/18011237
    BATS_SKIP: bud namespaces run sbom
    BATS_SKIP_ROOT: 
    BATS_SKIP_USER: add basic commit copy overlay rmi squash
# 15-SP5
$ susebats notok https://openqa.suse.de/tests/18011235
    BATS_SKIP: bud namespaces run sbom
    BATS_SKIP_ROOT: 
    BATS_SKIP_USER: add basic commit copy overlay rmi squash
# 15-SP6
$ susebats notok https://openqa.suse.de/tests/18011238
    BATS_SKIP: bud namespaces run sbom
    BATS_SKIP_ROOT: 
    BATS_SKIP_USER: add basic commit copy overlay rmi squash
# 15-SP7
$ susebats notok https://openqa.suse.de/tests/18011234
    BATS_SKIP: bud namespaces run sbom
    BATS_SKIP_ROOT: 
    BATS_SKIP_USER: add basic commit copy overlay rmi squash
```