### PR TITLE
Skip EFI verification module

### DIFF
--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -276,6 +276,9 @@ sub restore_prev_config {
 }
 
 sub run {
+    # the module does not work with encrypted drives
+    # it needs to exit as it can be loaded via yaml schedule
+    return if get_var('FLAVOR', '') =~ /encrypt/i;
     my $self = shift;
     select_serial_terminal;
     is_efi_boot or die "Image did not boot in UEFI mode!\n";


### PR DESCRIPTION
This module can be loaded by yaml schedule, therefore it has return in case of encrypted images. The test module needs to be update in order to work with them.

- Verification run: http://kepler.suse.cz/tests/24909#