### PR TITLE
Add publiccloud_multi_module flag to PC NVIDIA

### DIFF
--- a/tests/publiccloud/nvidia.pm
+++ b/tests/publiccloud/nvidia.pm
@@ -25,4 +25,10 @@ sub run
     nvidia_utils::validate();
 }
 
+sub test_flags {
+    return {
+        publiccloud_multi_module => 1
+    };
+}
+
 1;


### PR DESCRIPTION
Right now we are getting `ERROR: (gcloud.compute.instances.get-serial-port-output) Could not fetch serial port output: The resource 'projects/30mnullm' was not found`. The reason is because `TFM DESTROY` is called twice

- Related ticket: https://progress.opensuse.org/issues/183389
- Verification run:
[VR with intentionally provoked issue to prove absence of `Could not fetch serial port output: The resource 'projects/30mnullm'`](https://openqa.suse.de/tests/18018355/logfile?filename=serial_terminal.txt)
[Normal VR with code changes](https://openqa.suse.de/tests/18018352)
