### PR TITLE
Use install-shell console during installation instead of root console

### DIFF
--- a/lib/Yam/Agama/agama_base.pm
+++ b/lib/Yam/Agama/agama_base.pm
@@ -17,7 +17,7 @@ sub post_fail_hook {
 }
 
 sub upload_agama_logs {
-    select_console 'root-console';
+    select_console 'install-shell';
 
     if (script_run("test -d /run/agama/scripts") == 0) {
         script_run("tar czvf /tmp/agama_scripts.tar.gz /run/agama/scripts/*", {timeout => 60});

--- a/lib/Yam/Agama/patch_agama_base.pm
+++ b/lib/Yam/Agama/patch_agama_base.pm
@@ -13,7 +13,7 @@ use y2_base 'save_upload_y2logs';
 
 sub post_fail_hook {
     my ($self) = @_;
-    select_console 'root-console';
+    select_console 'install-shell';
     y2_base::save_upload_y2logs($self, skip_logs_investigation => 1);
 }
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -16,7 +16,7 @@ use utils qw(
   type_string_very_slow
   zypper_call
 );
-use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_opensuse is_hyperv is_plasma6 is_public_cloud);
+use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_opensuse is_hyperv is_plasma6 is_public_cloud is_agama);
 use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop x11_start_program_xterm default_gui_terminal);
 use Utils::Backends;
 
@@ -483,7 +483,8 @@ sub init_consoles {
             || (get_var('BACKEND', '') =~ /generalhw/ && get_var('GENERAL_HW_VNC_IP'))
             || is_svirt_except_s390x))
     {
-        $self->add_console('install-shell', 'tty-console', {tty => 2});
+        my $tty = is_agama() ? 8 : 2;
+        $self->add_console('install-shell', 'tty-console', {tty => $tty});
         $self->add_console('installation', 'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
         $self->add_console('install-shell2', 'tty-console', {tty => 9});
         # On SLE15 X is running on tty2 see bsc#1054782

--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -20,12 +20,7 @@ sub run {
     my $reboot_page = $testapi::distri->get_reboot();
     $reboot_page->expect_is_shown();
 
-    if (!is_leap()) {
-        # While the work on Agama settles, on leap
-        # Leave log collection for the post_fail_hook
-        # see also https://progress.opensuse.org/issues/182102
-        $self->upload_agama_logs() unless is_hyperv();
-    }
+    $self->upload_agama_logs() unless is_hyperv();
 
     (is_s390x() || is_ppc64le() || is_vmware()) ?
       # reboot via console

--- a/tests/yam/agama/import_agama_profile.pm
+++ b/tests/yam/agama/import_agama_profile.pm
@@ -16,7 +16,7 @@ sub run {
       generate_json_profile($profile) :
       expand_agama_profile($profile);
 
-    select_console 'root-console';
+    select_console 'install-shell';
     assert_script_run("agama profile import $profile_url", timeout => 300);
 }
 

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -11,7 +11,7 @@ use warnings;
 use testapi qw(assert_script_run get_required_var select_console);
 
 sub run {
-    select_console 'root-console';
+    select_console 'install-shell';
     my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
     assert_script_run("AGAMA_TEST=" . get_required_var('AGAMA_TEST') . " yupdate patch $repo $branch", timeout => 60);
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/182102
- Needles: inst-console
- Verification run:
  - sles_default x86_64: https://openqa.suse.de/tests/18025405
  - sles_default_unattended x86_64: https://openqa.suse.de/tests/18025381
  - sles_default s390x-zvm: https://openqa.suse.de/tests/18026334
  - sles_default s390x-kvm: https://openqa.suse.de/tests/18025404
  - sles_default ppc64le-hmc: https://openqa.suse.de/tests/18025388
  - sles_default aarch64: https://openqa.suse.de/tests/18025389
  - sles_gnome x86_64: https://openqa.suse.de/tests/18025382
  - sles_gnome s390x-kvm: https://openqa.suse.de/tests/18025383
  - sles_gnome ppc64le-hmc: https://openqa.suse.de/tests/18026333
  - sles_gnome_unattended x86_64: https://openqa.suse.de/tests/18025385
  - create_hdd_gnome uefi-3G: https://openqa.opensuse.org/tests/5098347
  - create_hdd_gnome aarch64: https://openqa.opensuse.org/tests/5098355
  - create_hdd_textmode uefi-3G: https://openqa.opensuse.org/tests/5098344
  - create_hdd_textmode aarch64: https://openqa.opensuse.org/tests/5098346
