### PR TITLE
Fix podman upstream tests on SLE 16.0

### DIFF
--- a/data/containers/bats/patches/podman/25858.patch
+++ b/data/containers/bats/patches/podman/25858.patch
@@ -1,0 +1,60 @@
+From 857b536507eb4561532f64dd220529218c50637b Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Fri, 11 Apr 2025 18:34:42 +0200
+Subject: [PATCH] test/system: add prefetch users to use cache image
+
+When using a custom --root it will not have the image present and as
+such cause a pull. We can however use our own local cache if present to
+avoid the pull if we give the right podman options via
+_PODMAN_TEST_OPTS.
+
+I saw the volume quota test fail during the pull in openQA thus I
+noticed this issue.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/161-volume-quotas.bats | 9 ++++++++-
+ test/system/520-checkpoint.bats    | 8 +++++---
+ 2 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/test/system/161-volume-quotas.bats b/test/system/161-volume-quotas.bats
+index 8019499509..6fcf4dfd00 100644
+--- a/test/system/161-volume-quotas.bats
++++ b/test/system/161-volume-quotas.bats
+@@ -61,8 +61,15 @@ function teardown() {
+     vol_two="testvol2"
+     run_podman $safe_opts volume create --opt o=size=4m $vol_two
+ 
++    # prefetch image to avoid registry pulls because this is using a
++    # unique root which does not have the image already present.
++    # _PODMAN_TEST_OPTS is used to overwrite the podman options to
++    # make the function aware of the custom --root.
++    _PODMAN_TEST_OPTS="$safe_opts --storage-driver $(podman_storage_driver)" _prefetch $IMAGE
++
+     ctrname="testctr"
+-    run_podman $safe_opts run -d --name=$ctrname -i -v $vol_one:/one -v $vol_two:/two $IMAGE top
++    # pull never to ensure the prefetch works correctly
++    run_podman $safe_opts run -d --pull=never --name=$ctrname -i -v $vol_one:/one -v $vol_two:/two $IMAGE top
+ 
+     run_podman $safe_opts exec $ctrname dd if=/dev/zero of=/one/oneMB bs=1M count=1
+     run_podman 1 $safe_opts exec $ctrname dd if=/dev/zero of=/one/twoMB bs=1M count=1
+diff --git a/test/system/520-checkpoint.bats b/test/system/520-checkpoint.bats
+index 5113f6785e..a581f1bf47 100644
+--- a/test/system/520-checkpoint.bats
++++ b/test/system/520-checkpoint.bats
+@@ -134,10 +134,12 @@ function setup() {
+ @test "podman checkpoint --export, with volumes" {
+     skip_if_remote "Test uses --root/--runroot, which are N/A over remote"
+ 
+-    # To avoid network pull, copy $IMAGE straight to temp root
+     local p_opts="$(podman_isolation_opts ${PODMAN_TMPDIR}) --events-backend file"
+-    run_podman         save -o $PODMAN_TMPDIR/image.tar $IMAGE
+-    run_podman $p_opts load -i $PODMAN_TMPDIR/image.tar
++    # prefetch image to avoid registry pulls because this is using a
++    # unique root which does not have the image already present.
++    # _PODMAN_TEST_OPTS is used to overwrite the podman options to
++    # make the function aware of the custom --root.
++    _PODMAN_TEST_OPTS="$p_opts --storage-driver $(podman_storage_driver)" _prefetch $IMAGE
+ 
+     # Create a volume, find unused network port, and create a webserv container
+     volname=v-$(safename)

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -53,6 +53,7 @@ podman:
   # Note on patches:
   # https://github.com/containers/podman/pull/21875 is needed for 060-mount
   # https://github.com/containers/podman/pull/25792 is needed for 080-pause
+  # https://github.com/containers/podman/pull/25858 is needed for 161-volume-quotas
   # https://github.com/containers/podman/pull/25918 is needed for 195-run-namespaces
   # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
@@ -69,6 +70,7 @@ podman:
   sle-16.0:
     BATS_PATCHES:
     - 25792
+    - 25858
     - 25918
     - 25942
     - 26017

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -75,8 +75,8 @@ podman:
     - 25942
     - 26017
     BATS_SKIP:
-    BATS_SKIP_ROOT_LOCAL: 200-pod 520-checkpoint
-    BATS_SKIP_ROOT_REMOTE: 520-checkpoint
+    BATS_SKIP_ROOT_LOCAL: 200-pod
+    BATS_SKIP_ROOT_REMOTE:
     BATS_SKIP_USER_LOCAL: 505-networking-pasta
     BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
   sle-15-SP7:

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -354,7 +354,7 @@ sub bats_tests {
     run_command "echo $log_file .. > $log_file";
     run_command "echo '# $package $version $os_version' >> $log_file";
     push @commands, $cmd;
-    my $ret = script_run $cmd, 9000;
+    my $ret = script_run $cmd, 7000;
 
     unless (get_var("BATS_TESTS")) {
         $skip_tests = get_var($skip_tests, $settings->{$skip_tests});

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -277,6 +277,7 @@ sub bats_post_hook {
     script_run('df -h > df-h.txt');
     script_run('dmesg > dmesg.txt');
     script_run('findmnt > findmnt.txt');
+    script_run('lsmod > lsmod.txt');
     script_run('rpm -qa | sort > rpm-qa.txt');
     script_run('sysctl -a > sysctl.txt');
     script_run('systemctl > systemctl.txt');

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -65,6 +65,7 @@ sub run {
     run_command "podman system reset -f";
     run_command "modprobe ip6_tables";
     run_command "modprobe null_blk nr_devices=1 || true";
+    run_command "modprobe xfs || true";
 
     record_info("podman version", script_output("podman version"));
     record_info("podman info", script_output("podman info"));

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -86,6 +86,8 @@ sub run {
     run_command "rm -f contrib/systemd/system/podman-kube@.service.in";
     # This test is flaky and will fail if system is "full"
     run_command "rm -f test/system/320-system-df.bats";
+    # This tests needs criu, available only on Tumbleweed
+    run_command "rm -f test/system/520-checkpoint.bats" unless is_tumbleweed;
 
     # Compile helpers used by the tests
     run_command "make podman-testing || true", timeout => 600;


### PR DESCRIPTION
Fix podman upstream tests on SLE 16.0:
- Apply https://github.com/containers/podman/pull/25858
- Load missing xfs module.
- Remove `520-checkpoint` test to avoid wasting time on SLE as `criu` is not available there.
- Revert commit that needlessly increased timeout.

The problematic test was [161-volume-quotas](https://github.com/containers/podman/blob/main/test/system/161-volume-quotas.bats) that was hanging is now patched.

Failing test: https://openqa.suse.de/tests/18004420 
Verification run: https://openqa.suse.de/tests/18022664
