### PR TITLE
Collect coredumps in sle-micro tests

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -294,6 +294,7 @@ sub load_rcshell_tests {
 sub load_journal_check_tests {
     # Enclosing test cases
     loadtest 'console/journal_check';
+    loadtest 'console/coredump_collect';
     loadtest 'shutdown/shutdown';
 }
 


### PR DESCRIPTION
We are seeing a coredump in https://openqa.suse.de/tests/18015771, but there is nothing uploaded. We need to collect coredumps at the end of the test.

### Verification runs

 - [sle-micro-6.2-Default-ppc-512-ppc64le-Build12.6-ignition@ppc64le-emu](https://openqa.suse.de/tests/18026345)
 - [microos-Tumbleweed-MicroOS-Image-sdboot-x86_64-Build20250610-microos-combustion-fde@uefi](https://openqa.opensuse.org/tests/5098358)
