### PR TITLE
Allow controlling terraform binary in qesap

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -7,6 +7,7 @@
 provider: 'aws'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     aws_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
@@ -7,6 +7,7 @@
 provider: 'aws'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     aws_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
@@ -7,6 +7,7 @@
 provider: 'aws'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     aws_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -7,6 +7,7 @@
 provider: 'aws'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     aws_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -7,6 +7,7 @@
 provider: 'azure'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     az_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -7,6 +7,7 @@
 provider: 'azure'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     az_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -7,6 +7,7 @@
 provider: 'azure'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     az_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_peering.yaml
@@ -7,6 +7,7 @@
 provider: 'azure'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     az_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
@@ -7,6 +7,7 @@
 provider: 'azure'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     az_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -7,6 +7,7 @@
 provider: 'azure'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     az_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf_no_reg.yaml
@@ -7,6 +7,7 @@
 provider: 'azure'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     az_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -7,6 +7,7 @@
 provider: 'azure'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     az_region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -7,6 +7,7 @@
 provider: 'gcp'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     project: 'ei-sle-qa-sap-8469'
     region: '%REGION%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
@@ -7,6 +7,7 @@
 provider: 'gcp'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     project: 'ei-sle-qa-sap-8469'
     region: '%REGION%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
@@ -7,6 +7,7 @@
 provider: 'gcp'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     project: 'ei-sle-qa-sap-8469'
     region: '%REGION%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -7,6 +7,7 @@
 provider: 'gcp'
 apiver: 3
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     project: 'ei-sle-qa-sap-8469'
     region: '%REGION%'

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -30,6 +30,12 @@ sub run {
     }
 
     my %variables;
+    $variables{TERRAFORM_RUNNER} = get_var('QESAPDEPLOY_TERRAFORM_RUNNER', 'terraform');
+    script_run(join(' ',
+            'which', $variables{TERRAFORM_RUNNER}, '&&',
+            $variables{TERRAFORM_RUNNER}, '--version', '||',
+            'echo', "\"'" . $variables{TERRAFORM_RUNNER} . "' tool not available in the path\""));
+
     $variables{REGION} = $provider->provider_client->region;
     $variables{DEPLOYMENTNAME} = qesap_calculate_deployment_name('qesapval');
     if (get_var('QESAPDEPLOY_CLUSTER_OS_VER')) {


### PR DESCRIPTION
Allow to control which binary to use for the terraform deployment in all qesap regression tests. It is possible to specify the binary via QESAPDEPLOY_TERRAFORM_RUNNER variable.
This allow to run the deployment with openTofu.


- Related ticket: https://jira.suse.com/browse/TEAM-10409
# Verification run:

## publiccloud_tools_0074.qcow2 image
Old, currently used image, not containing openTofu binary

With `QESAPDEPLOY_TERRAFORM_RUNNER	terraform`  https://openqaworker15.qa.suse.cz/tests/329028 :green_circle: 

Without `QESAPDEPLOY_TERRAFORM_RUNNER` https://openqaworker15.qa.suse.cz/tests/329026 :green_circle: correctly fall bask to terraform https://openqaworker15.qa.suse.cz/tests/329026/logfile?filename=serial_terminal.txt#line-85

Without `QESAPDEPLOY_TERRAFORM_RUNNER` sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test
- http://openqaworker15.qa.suse.cz/tests/329205

## publiccloud_tools_0086.qcow2 image
New image containing openTofu binary

### Terraform runner
Without `QESAPDEPLOY_TERRAFORM_RUNNER`, default to `terraform` 
- https://openqaworker15.qa.suse.cz/tests/329019 :green_circle:   The terraform binary is found https://openqaworker15.qa.suse.cz/tests/329019/logfile?filename=serial_terminal.txt#line-83
- https://openqaworker15.qa.suse.cz/tests/329027 :green_circle: 

With `QESAPDEPLOY_TERRAFORM_RUNNER	/usr/local/bin/terraform` 
- https://openqaworker15.qa.suse.cz/tests/329029 :green_circle: 
- https://openqaworker15.qa.suse.cz/tests/329025 :green_circle: 


 Without `QESAPDEPLOY_TERRAFORM_RUNNER` sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test
- http://openqaworker15.qa.suse.cz/tests/329204

### openTofu runner

#### Azure
`QESAPDEPLOY_TERRAFORM_RUNNER	tofu` (just the name of the binary, no absolute path)
- https://openqaworker15.qa.suse.cz/tests/329020 :green_circle: tool is on the PATH https://openqaworker15.qa.suse.cz/tests/329020/logfile?filename=serial_terminal.txt#line-83 and deployment in Azure (with peering to IBSm) runs fine https://openqaworker15.qa.suse.cz/tests/329020/logfile?filename=deploy-terraform.apply.log.txt
- https://openqaworker15.qa.suse.cz/tests/329023 :green_circle: https://openqaworker15.qa.suse.cz/tests/329023/logfile?filename=serial_terminal.txt#line-83

With `QESAPDEPLOY_TERRAFORM_RUNNER	/usr/local/bin/tofu` https://openqaworker15.qa.suse.cz/tests/329024 :green_circle: 

#### GCP
 - sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6_PAYG-qesap_gcp_ibsmirror_peering_test -> http://openqaworker15.qa.suse.cz/tests/329191 :green_circle: 

#### AWS
sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test 
 - http://openqaworker15.qa.suse.cz/tests/329192 :green_circle: Terraform part is fine, fails in Ansible registration
 - http://openqaworker15.qa.suse.cz/tests/329199