### PR TITLE
Use tmux for SLES16

### DIFF
--- a/tests/console/command_not_found.pm
+++ b/tests/console/command_not_found.pm
@@ -21,7 +21,7 @@ use registration qw(add_suseconnect_product remove_suseconnect_product);
 # test for regression of bug http://bugzilla.suse.com/show_bug.cgi?id=952496
 sub run {
     my ($self) = @_;
-    my $not_installed_pkg = 'iftop';
+    my $not_installed_pkg = is_sle(">=16.0") ? 'tmux' : 'iftop';    # iftop is not available on SLES16
 
     select_console 'root-console';
     zypper_call("rm $not_installed_pkg") if (script_run("which $not_installed_pkg") == 0);


### PR DESCRIPTION
Use tmux as a test package on SLES16 because iftop is not available there.

- Related failure: https://openqa.suse.de/tests/18011882#step/command_not_found/1
- Verification run: https://openqa.suse.de/tests/18029923#step/command_not_found/25
