### PR TITLE
Fix SDAF retaining deployment option

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -212,6 +212,8 @@ Deployment ID returned from both jobs: 123456 - because it matches with existing
 
 sub find_deployment_id {
     my (%args) = @_;
+    # For reusing already deployed infrastructure - check function description
+    return get_var('SDAF_DEPLOYMENT_ID') if get_var('SDAF_DEPLOYMENT_ID');
     $args{deployer_resource_group} //= get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
 
     # Lists VMs in cloud which contain 'deployment_id' tag and displays only tag values => list of all deployments


### PR DESCRIPTION
With PR#22208 retaining deployment remained broken and test would ignore
 OpenQA setting 'SDAF_DEPLOYMENT_ID'. This PR fixes the issue.

Ticket: https://jira.suse.com/browse/TEAM-10319
Verification run: 
  Retain deployment: https://openqaworker15.qa.suse.cz/tests/329072#dependencies
  Reuse deployment 329072: https://openqaworker15.qa.suse.cz/tests/329188#live
