### PR TITLE
Force ipv6 in wget|curl

### DIFF
--- a/tests/console/curl_ipv6.pm
+++ b/tests/console/curl_ipv6.pm
@@ -19,7 +19,7 @@ use warnings;
 
 sub run {
     select_console 'user-console';
-    assert_script_run('curl www3.zq1.de/test.txt');
+    assert_script_run('curl -6 www3.zq1.de/test.txt');
     assert_script_run('rpm -q curl libcurl4');
 }
 

--- a/tests/console/wget_ipv6.pm
+++ b/tests/console/wget_ipv6.pm
@@ -23,7 +23,7 @@ sub run {
     zypper_call 'in wget';
     select_console 'user-console';
     assert_script_run('rpm -q wget');
-    assert_script_run('wget -O- -q www3.zq1.de/test.txt');
+    assert_script_run('wget -O- -6 -q www3.zq1.de/test.txt');
 }
 
 1;


### PR DESCRIPTION
Force ipv6 as curl can default to ipv4 in case of ipv6 is not working.

Resurrect https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22050
