### PR TITLE
Fix Elemental3 aarch64 test

### DIFF
--- a/data/elemental3/config.sh
+++ b/data/elemental3/config.sh
@@ -2,6 +2,9 @@
 
 set -xe
 
+# Disable Grub timeout
+grub2-editenv /boot/grubenv set timeout=-1
+
 # Setting root passwd
 echo "%TEST_PASSWORD%" | passwd root --stdin
 

--- a/tests/elemental3/test_image.pm
+++ b/tests/elemental3/test_image.pm
@@ -11,7 +11,7 @@ use warnings;
 use testapi;
 use power_action_utils qw(power_action);
 use serial_terminal qw(select_serial_terminal);
-use Utils::Architectures;
+use Utils::Architectures qw(is_aarch64);
 
 =head2 wait_kubectl_cmd
 
@@ -24,7 +24,9 @@ Wait for kubectl command to be available.
 sub wait_kubectl_cmd {
     my $starttime = time;
     my $ret = undef;
-    my $timeout = 240;
+
+    # Define timeouts based on the architecture
+    my $timeout = (is_aarch64) ? 480 : 240;
 
     while ($ret = script_run('which kubectl', ($timeout / 10))) {
         my $timerun = time - $starttime;
@@ -54,8 +56,10 @@ sub wait_k8s_running {
     my ($regex) = shift;
     my $starttime = time;
     my $ret = undef;
-    my $timeout = 300;
     my $chk_cmd = 'kubectl get pod -A 2>&1';
+
+    # Define timeouts based on the architecture
+    my $timeout = (is_aarch64) ? 480 : 240;
 
     while ($ret = script_run("! ($chk_cmd | grep -E -i -v -q '$regex')", ($timeout / 10))) {
         my $timerun = time - $starttime;


### PR DESCRIPTION
Some timeout need to be increased for the test to pass. Also disable GRUB timeout to ensure that the bootloader needle is correctly trapped.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - [generate_image](https://openqa.suse.de/tests/18031314) :white_check_mark:
  - [test_image](https://openqa.suse.de/tests/18031565) :x:

**NOTE:** the `test_image` test fails because of an issue with RKE2 on aarch64, this is not related to this PR. And as aarch64 binaries are recent for RKE2 and in a preview state this will check (and fix if needed) later.