### PR TITLE
Enable multi-arch tests on buildah

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -5,9 +5,9 @@ aardvark-dns:
     BATS_SKIP: 100-basic-name-resolution 200-two-networks 300-three-networks
 buildah:
   opensuse-Tumbleweed:
-    BATS_SKIP: bud sbom
-    BATS_SKIP_ROOT: from
-    BATS_SKIP_USER: run
+    BATS_SKIP: sbom
+    BATS_SKIP_ROOT:
+    BATS_SKIP_USER: bud run
   sle-16.0:
     BATS_SKIP: bud run sbom
     BATS_SKIP_ROOT: from

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -12,8 +12,8 @@ use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
+use version_utils qw(is_sle is_tumbleweed);
 use containers::bats;
-
 
 sub run_tests {
     my %params = @_;
@@ -50,6 +50,7 @@ sub run {
     select_serial_terminal;
 
     my @pkgs = qw(buildah docker git-daemon glibc-devel-static go1.24 jq libgpgme-devel libseccomp-devel make openssl podman selinux-tools);
+    push @pkgs, "qemu-linux-user" if (is_tumbleweed || is_sle('>=15-SP6'));
 
     $self->bats_setup(@pkgs);
 


### PR DESCRIPTION
Enable multi-arch testing on buildah upstream tests.  This is achieved just by installing the `qemu-linux-user` package which is available on SLES 15-SP6+ & Tumbleweed.

Verification runs:
- Tumbleweed: https://openqa.opensuse.org/tests/5099363
- SLE 16.0: https://openqa.suse.de/tests/18031667
- SLES 15-SP7: https://openqa.suse.de/tests/18031666
- SLES 15-SP6: https://openqa.suse.de/tests/18031665 (transient network failure)

```
# Tumbleweed
$ susebats notok  https://openqa.opensuse.org/tests/5099363
    BATS_SKIP: sbom
    BATS_SKIP_ROOT:
    BATS_SKIP_USER: bud run
```
