### PR TITLE
Change fencing selection in qesap regression

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -3,7 +3,8 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on AWS, two node HANA cluster with cloud native fencing.
 provider: 'aws'
 apiver: 3
 terraform:
@@ -18,7 +19,6 @@ terraform:
     hana_instancetype: '%HANA_INSTANCE_TYPE%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
-    vpc_address_range: '%MAIN_ADDRESS_RANGE%'
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
@@ -3,7 +3,9 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on AWS, two node HANA cluster with cloud native fencing.
+#          Deployment create a network peering the the IBSm
 provider: 'aws'
 apiver: 3
 terraform:

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -3,7 +3,9 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on AWS, two node HANA cluster with cloud native fencing.
+#          System uses sapconf
 provider: 'aws'
 apiver: 3
 terraform:

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -3,7 +3,9 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on Azure, two node HANA cluster and a iscsi server VM.
+#          The two HANA nodes cluster is using sbd.
 provider: 'azure'
 apiver: 3
 terraform:
@@ -15,8 +17,7 @@ terraform:
     public_key: '%SLES4SAP_PUBSSHKEY%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
-    vnet_address_range: '%MAIN_ADDRESS_RANGE%'
-    subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
+    iscsi_enabled: true
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
@@ -36,6 +37,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
+    use_sbd: true
   create:
     - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
     - fully-patch-system.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -3,7 +3,8 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on Azure, two node HANA cluster with cloud native MSI fencing.
 provider: 'azure'
 apiver: 3
 terraform:
@@ -17,9 +18,10 @@ terraform:
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     vnet_address_range: '%MAIN_ADDRESS_RANGE%'
     subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
-    hana_cluster_fencing_mechanism: '%FENCING%'
-    drbd_cluster_fencing_mechanism: '%FENCING%'
-    netweaver_cluster_fencing_mechanism: '%FENCING%'
+    hana_cluster_fencing_mechanism: 'native'
+    drbd_cluster_fencing_mechanism: 'native'
+    netweaver_cluster_fencing_mechanism: 'native'
+    iscsi_enabled: false
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -3,7 +3,8 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on Azure, two node HANA cluster with cloud native SPN fencing.
 provider: 'azure'
 apiver: 3
 terraform:
@@ -17,9 +18,10 @@ terraform:
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     vnet_address_range: '%MAIN_ADDRESS_RANGE%'
     subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
-    hana_cluster_fencing_mechanism: '%FENCING%'
-    drbd_cluster_fencing_mechanism: '%FENCING%'
-    netweaver_cluster_fencing_mechanism: '%FENCING%'
+    hana_cluster_fencing_mechanism: 'native'
+    drbd_cluster_fencing_mechanism: 'native'
+    netweaver_cluster_fencing_mechanism: 'native'
+    iscsi_enabled: false
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_peering.yaml
@@ -3,7 +3,9 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on Azure, two node HANA cluster and a iscsi server VM.
+#          The two HANA nodes cluster is using sbd.
 provider: 'azure'
 apiver: 3
 terraform:
@@ -15,6 +17,7 @@ terraform:
     public_key: '%SLES4SAP_PUBSSHKEY%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_enabled: true
     vnet_address_range: '%MAIN_ADDRESS_RANGE%'
     subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
     ibsm_rg: '%IBSM_RG%'
@@ -38,6 +41,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
+    use_sbd: true
   create:
     - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
     - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
@@ -3,7 +3,9 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on Azure, two node HANA cluster and a iscsi server VM.
+#          The two HANA nodes cluster is using sbd.
 provider: 'azure'
 apiver: 3
 terraform:
@@ -15,8 +17,7 @@ terraform:
     public_key: '%SLES4SAP_PUBSSHKEY%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
-    vnet_address_range: '%MAIN_ADDRESS_RANGE%'
-    subnet_address_range: '%SUBNET_ADDRESS_RANGE%'
+    iscsi_enabled: true
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
@@ -36,6 +37,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
+    use_sbd: true
   create:
     - registration_role.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
     - fully-patch-system.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -3,7 +3,10 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on Azure, two node HANA cluster and a iscsi server VM.
+#          The two HANA nodes cluster is using sbd.
+#          System uses sapconf
 provider: 'azure'
 apiver: 3
 terraform:
@@ -15,6 +18,7 @@ terraform:
     public_key: '%SLES4SAP_PUBSSHKEY%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_enabled: true
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
@@ -34,6 +38,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
+    use_sbd: true
   create:
     - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
     - fully-patch-system.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -3,7 +3,10 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on Azure, two node HANA cluster plus a iscsi server VM.
+#          Allow using OS image not from the catalog.
+#          The two HANA nodes cluster is using sbd.
 provider: 'azure'
 apiver: 3
 terraform:
@@ -15,6 +18,7 @@ terraform:
     public_key: '%SLES4SAP_PUBSSHKEY%'
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
+    iscsi_enabled: true
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'
@@ -34,6 +38,7 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
+    use_sbd: true
   create:
     - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
     - fully-patch-system.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -3,7 +3,9 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on GCP, two node HANA cluster with cloud native fencing.
+#          System uses saptune
 provider: 'gcp'
 apiver: 3
 terraform:
@@ -19,7 +21,6 @@ terraform:
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     hana_data_disk_type: '%HANA_DATA_DISK_TYPE%'
     hana_log_disk_type: '%HANA_LOG_DISK_TYPE%'
-
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
@@ -3,7 +3,9 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on GCP, two node HANA cluster with cloud native fencing.
+#          Deployment create a network peering the the IBSm
 provider: 'gcp'
 apiver: 3
 terraform:

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -3,7 +3,9 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 # Maintainer: QE-SAP <qe-sap@suse.de>
-# Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+# Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
+#          Deploy on GCP, two node HANA cluster with cloud native fencing.
+#          System uses sapconf
 provider: 'gcp'
 apiver: 3
 terraform:
@@ -19,7 +21,6 @@ terraform:
     iscsi_remote_python: '%ANSIBLE_REMOTE_PYTHON%'
     hana_data_disk_type: '%HANA_DATA_DISK_TYPE%'
     hana_log_disk_type: '%HANA_LOG_DISK_TYPE%'
-
 ansible:
   roles_path: '%ANSIBLE_ROLES%'
   az_storage_account_name: '%HANA_ACCOUNT%'


### PR DESCRIPTION
Change all the conf.yaml used for qesap regression tests. Introduce a new terraform variable in Azure conf file to select if to deploy or not the iscsi VM.
Improve the description of all the files, reflecting the deployed scenario.
Remove terraform variables about the private IP ranges for files not deploying any network peering.
Remove two not used files.

This PR is created in advance to some next qe-sap-deployment side changes that will:
- decouple terraform and ansible about iscsi and fencing mechanism, removing some terraform variables, and adding ansible use_sbd
- make native fencing default in Azure like AWS and GCP already did

Ticket: https://jira.suse.com/browse/TEAM-10410

# Verification run:


## Azure

### qesap_azure.yaml

sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test

- http://openqaworker15.qa.suse.cz/tests/329207 :green_circle: Changes are visible in generated conf.yaml https://openqaworker15.qa.suse.cz/tests/329207/file/configure-qesap_azure.yaml. The (not yet used) new variable `iscsi_enabled` is visible in https://openqaworker15.qa.suse.cz/tests/329207/file/configure-terraform.tfvars . Inventory still have `use_sbd` https://openqaworker15.qa.suse.cz/tests/329207/file/deploy-inventory.yaml but now it is also available in https://openqaworker15.qa.suse.cz/tests/329207/file/configure-hana_vars.yaml . Iscsi server is deployed as before. 

### qesap_azure_fencing_msi.yaml
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test_msi
- http://openqaworker15.qa.suse.cz/tests/329246 :green_circle: 

### qesap_azure_fencing_spn.yaml
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test_spn
- http://openqaworker15.qa.suse.cz/tests/329247 :green_circle: 

### qesap_azure_peering.yaml
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_ibsmirror_peering_test
- http://openqaworker15.qa.suse.cz/tests/329248  :green_circle: 

## AWS 

### qesap_aws.yaml

sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_r48xlarge_test
-  http://openqaworker15.qa.suse.cz/tests/329193
-  http://openqaworker15.qa.suse.cz/tests/329233 :green_circle: No more `vpc_address_range` in https://openqaworker15.qa.suse.cz/tests/329233/file/configure-qesap_aws.yaml and so no more in https://openqaworker15.qa.suse.cz/tests/329233/file/configure-terraform.tfvars . Terraform execution is ok, using default private IP ranges https://openqaworker15.qa.suse.cz/tests/329233/logfile?filename=serial_terminal.txt#line-1350
```
DEBUG    OUTPUT: hana_ip = [
DEBUG    OUTPUT:   "10.0.32.4",
DEBUG    OUTPUT:   "10.0.64.5",
DEBUG    OUTPUT: ]
``` 
And Ansible is ok too with them.

### qesap_aws_sapconf.yaml

sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_sapconf_test
- http://openqaworker15.qa.suse.cz/tests/329206
- http://openqaworker15.qa.suse.cz/tests/329234


### qesap_aws_peering.yaml

sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test
- http://openqaworker15.qa.suse.cz/tests/329198
- http://openqaworker15.qa.suse.cz/tests/329235


## GCP

### qesap_gcp.yaml

 - sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6_PAYG-qesap_gcp_angi_test@64bit -> http://openqaworker15.qa.suse.cz/tests/329249

### qesap_gcp_peering.yaml
 - sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6_PAYG-qesap_gcp_ibsmirror_peering_test@64bit -> http://openqaworker15.qa.suse.cz/tests/329251