### PR TITLE
containers: Enable docker-compose test on SLEM 6.0

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -107,7 +107,8 @@ sub load_container_engine_privileged_mode {
 sub load_compose_tests {
     my ($run_args) = @_;
     return if (is_staging);
-    return unless (is_tumbleweed || is_sle('>=16.0') || is_sle_micro('>=6.1'));
+    my $min_slem_version = ($run_args->{runtime} eq "podman") ? "6.1" : "6.0";
+    return unless (is_tumbleweed || is_sle('>=16.0') || is_sle_micro(">=$min_slem_version"));
     loadtest('containers/compose', run_args => $run_args, name => $run_args->{runtime} . "_compose");
 }
 


### PR DESCRIPTION
Enable docker-compose test on SLEM 6.0. 

The current filter avoids SLEM 6.0 because the podman version (4.9.5) doesn't play nice with docker-compose on all architectures.  But it's too broad and prevents us from testing docker-compose with docker.  This closes the gap with docker-compose tests on supported products (except SLES 12.5):

```
$ susepkg -p any docker-compose | grep -v bp
SLES/12.5 docker-compose 1.17.0-2.1
SLES/16.0 docker-compose 2.33.1-160000.1.4
SL-Micro/6.0 docker-compose 2.24.5-1.4
SL-Micro/6.1 docker-compose 2.24.5-slfo.1.1_1.2
SL-Micro/6.2 docker-compose 2.33.1-160000.1.4
openSUSE_Tumbleweed docker-compose 2.37.0-1.1
```

- Verification run: https://openqa.suse.de/tests/18039575
