### PR TITLE
Automate unattended for iSCSI and use it for /home

### DIFF
--- a/data/yam/agama/auto/lib/iscsi.libsonnet
+++ b/data/yam/agama/auto/lib/iscsi.libsonnet
@@ -1,0 +1,14 @@
+{
+  iscsi():: {
+    initiator: 'iqn.1996-04.de.suse:01:972154f2547d',
+    targets: [
+      {
+        address: '10.145.10.3',
+        port: 3260,
+        name: 'iqn.2016-02.openqa.de:for.openqa',
+        interface: 'default',
+        startup: 'onboot',
+      },
+    ],
+  },
+}

--- a/data/yam/agama/auto/lib/storage.libsonnet
+++ b/data/yam/agama/auto/lib/storage.libsonnet
@@ -23,13 +23,13 @@ local resize() = {
         {
           search: '/dev/vda3',
           filesystem: { path: 'swap' },
-          size: '1 GiB'
+          size: '1 GiB',
         },
         {
           filesystem: { path: '/home' },
           encryption: {
-            luks2: { password: 'nots3cr3t' }
-          }
+            luks2: { password: 'nots3cr3t' },
+          },
         },
       ],
     },
@@ -182,7 +182,52 @@ local raid(level='raid0', uefi=false) = {
     },
   ],
 };
+
+local home_on_iscsi() = {
+  boot: {
+    configure: true,
+  },
+  drives: [
+    {
+      search: '/dev/sda',
+      partitions: [
+        {
+          search: '*',
+          delete: true,
+        },
+        {
+          filesystem: {
+            path: '/home',
+            type: 'xfs',
+          },
+        },
+      ],
+    },
+    {
+      search: '/dev/vda',
+      partitions: [
+        {
+          search: '*',
+          delete: true,
+        },
+        {
+          filesystem: {
+            path: '/',
+            type: 'btrfs',
+          },
+          size: '20 GiB',
+        },
+        {
+          filesystem: { path: 'swap' },
+          size: '1 GiB',
+        },
+      ],
+    },
+  ],
+};
+
 {
+  home_on_iscsi: home_on_iscsi(),
   lvm: lvm(false),
   lvm_encrypted: lvm(true),
   lvm_tpm_fde: lvm(true, 'tpmFde'),

--- a/data/yam/agama/auto/template.libsonnet
+++ b/data/yam/agama/auto/template.libsonnet
@@ -1,6 +1,7 @@
 local base_lib = import 'lib/base.libsonnet';
 local addons_lib = import 'lib/addons.libsonnet';
 local dasd_lib = import 'lib/dasd.libsonnet';
+local iscsi_lib = import 'lib/iscsi.libsonnet';
 local scripts_post_lib = import 'lib/scripts_post.libsonnet';
 local scripts_post_partitioning_lib = import 'lib/scripts_post_partitioning.libsonnet';
 local scripts_pre_lib = import 'lib/scripts_pre.libsonnet';
@@ -12,6 +13,7 @@ function(bootloader=false,
          dasd=false,
          extra_repositories=false,
          files=false,
+         iscsi=false,
          localization='',
          packages='',
          patterns='',
@@ -28,6 +30,7 @@ function(bootloader=false,
   [if bootloader == true then 'bootloader']: base_lib['bootloader'],
   [if dasd == true then 'dasd']: dasd_lib.dasd(),
   [if files == true then 'files']: base_lib['files'],
+  [if iscsi == true then 'iscsi']: iscsi_lib.iscsi(),
   [if localization == true then 'localization']: base_lib['localization'],
   [if patterns != '' || packages != '' || extra_repositories then 'software']: std.prune({
     patterns: if patterns != '' then std.split(patterns, ','),
@@ -49,6 +52,7 @@ function(bootloader=false,
     [if scripts_pre != '' then 'pre']: [ scripts_pre_lib[x] for x in std.split(scripts_pre, ',') ],
   },
   [if std.startsWith(storage, 'raid') then 'storage']: storage_lib[storage],
+  [if storage == 'home_on_iscsi' then 'storage']: storage_lib.home_on_iscsi,
   [if storage == 'lvm' then 'storage']: storage_lib['lvm'],
   [if storage == 'lvm_encrypted' then 'storage']: storage_lib['lvm_encrypted'],
   [if storage == 'lvm_tpm_fde' then 'storage']: storage_lib['lvm_tpm_fde'],

--- a/schedule/yam/agama_iscsi_activate_unattended.yaml
+++ b/schedule/yam/agama_iscsi_activate_unattended.yaml
@@ -1,0 +1,10 @@
+---
+name: agama_iscsi_activate_unattended
+description: >
+  Installation where Agama activates iSCSI disk and use it for a non-root partition.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_partition_table


### PR DESCRIPTION
##
### Automate unattended for iSCSI and use it for /home

- Related ticket: https://progress.opensuse.org/issues/183140
- Related MR: 
   - [MR#514](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/514)
- Needles: N/A
- Verification run: 
  - [__sles_iscsi_activation_non_root_unattended__](https://openqa.suse.de/tests/overview?arch=&flavor=agama-installer&machine=&test=&modules=&module_re=&group_glob=&not_group_glob=&comment=&build=hjluo%2Fos-autoinst-distri-opensuse%23activating_iSCSI&distri=sle&version=16.0#)

## 