### PR TITLE
tests/installation/bootloader_s390.pm: Wait for z/VM and CMS to be ready

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -148,7 +148,12 @@ EO_frickin_boot_parms
     for (1 .. $max_retries) {
         eval {
             # ensure that we are in cms mode before executing qaboot
-            $s3270->sequence_3270("String(\"#cp i cms\")", "ENTER", "ENTER", "ENTER", "ENTER",);
+            $s3270->sequence_3270("String(\"#cp i cms\")", "ENTER",);
+            # Wait for z/VM to load. "z/VM" is already in the buffer, but the check for "VM READ" suffices.
+            $r = $s3270->expect_3270(buffer_ready => qr/VM READ/, output_delim => qr/VM/, timeout => 20);
+            $s3270->sequence_3270("ENTER",);
+            $r = $s3270->expect_3270(output_delim => qr/Ready;/, timeout => 20);
+            $s3270->sequence_3270("ENTER", "ENTER",);
             $r = $s3270->expect_3270(output_delim => qr/CMS/, timeout => 20);
             $s3270->sequence_3270("String(\"qaboot $repo_host $dir_with_suse_ins\")", "ENTER", "Wait(InputField)",);
             # wait for qaboot dumping us into xedit. If this fails, probably the


### PR DESCRIPTION
With newer versions of x3270, commands are now more asynchronous and e.g. ENTER does not wait for previous ones to complete. Add some explicit synchronization.

- Related ticket: https://progress.opensuse.org/issues/183110
- Verification run:

15.6 container: https://openqa.opensuse.org/tests/5099231
15.6 container again: https://openqa.opensuse.org/tests/5099242
15.5 container: https://openqa.opensuse.org/tests/5101041