### PR TITLE
bats/podman: Re-enable 161-volume-quotas test

### DIFF
--- a/data/containers/bats/patches/podman/25858.patch
+++ b/data/containers/bats/patches/podman/25858.patch
@@ -1,0 +1,60 @@
+From 857b536507eb4561532f64dd220529218c50637b Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Fri, 11 Apr 2025 18:34:42 +0200
+Subject: [PATCH] test/system: add prefetch users to use cache image
+
+When using a custom --root it will not have the image present and as
+such cause a pull. We can however use our own local cache if present to
+avoid the pull if we give the right podman options via
+_PODMAN_TEST_OPTS.
+
+I saw the volume quota test fail during the pull in openQA thus I
+noticed this issue.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/161-volume-quotas.bats | 9 ++++++++-
+ test/system/520-checkpoint.bats    | 8 +++++---
+ 2 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/test/system/161-volume-quotas.bats b/test/system/161-volume-quotas.bats
+index 8019499509..6fcf4dfd00 100644
+--- a/test/system/161-volume-quotas.bats
++++ b/test/system/161-volume-quotas.bats
+@@ -61,8 +61,15 @@ function teardown() {
+     vol_two="testvol2"
+     run_podman $safe_opts volume create --opt o=size=4m $vol_two
+ 
++    # prefetch image to avoid registry pulls because this is using a
++    # unique root which does not have the image already present.
++    # _PODMAN_TEST_OPTS is used to overwrite the podman options to
++    # make the function aware of the custom --root.
++    _PODMAN_TEST_OPTS="$safe_opts --storage-driver $(podman_storage_driver)" _prefetch $IMAGE
++
+     ctrname="testctr"
+-    run_podman $safe_opts run -d --name=$ctrname -i -v $vol_one:/one -v $vol_two:/two $IMAGE top
++    # pull never to ensure the prefetch works correctly
++    run_podman $safe_opts run -d --pull=never --name=$ctrname -i -v $vol_one:/one -v $vol_two:/two $IMAGE top
+ 
+     run_podman $safe_opts exec $ctrname dd if=/dev/zero of=/one/oneMB bs=1M count=1
+     run_podman 1 $safe_opts exec $ctrname dd if=/dev/zero of=/one/twoMB bs=1M count=1
+diff --git a/test/system/520-checkpoint.bats b/test/system/520-checkpoint.bats
+index 5113f6785e..a581f1bf47 100644
+--- a/test/system/520-checkpoint.bats
++++ b/test/system/520-checkpoint.bats
+@@ -134,10 +134,12 @@ function setup() {
+ @test "podman checkpoint --export, with volumes" {
+     skip_if_remote "Test uses --root/--runroot, which are N/A over remote"
+ 
+-    # To avoid network pull, copy $IMAGE straight to temp root
+     local p_opts="$(podman_isolation_opts ${PODMAN_TMPDIR}) --events-backend file"
+-    run_podman         save -o $PODMAN_TMPDIR/image.tar $IMAGE
+-    run_podman $p_opts load -i $PODMAN_TMPDIR/image.tar
++    # prefetch image to avoid registry pulls because this is using a
++    # unique root which does not have the image already present.
++    # _PODMAN_TEST_OPTS is used to overwrite the podman options to
++    # make the function aware of the custom --root.
++    _PODMAN_TEST_OPTS="$p_opts --storage-driver $(podman_storage_driver)" _prefetch $IMAGE
+ 
+     # Create a volume, find unused network port, and create a webserv container
+     volname=v-$(safename)

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -53,6 +53,7 @@ podman:
   # Note on patches:
   # https://github.com/containers/podman/pull/21875 is needed for 060-mount
   # https://github.com/containers/podman/pull/25792 is needed for 080-pause
+  # https://github.com/containers/podman/pull/25858 is needed for 161-volume-quotas
   # https://github.com/containers/podman/pull/25918 is needed for 195-run-namespaces
   # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
@@ -69,6 +70,7 @@ podman:
   sle-16.0:
     BATS_PATCHES:
     - 25792
+    - 25858
     - 25918
     - 25942
     - 26017

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -84,8 +84,6 @@ sub run {
     # Patch tests
     run_command "sed -i 's/^PODMAN_RUNTIME=/&$oci_runtime/' test/system/helpers.bash";
     run_command "rm -f contrib/systemd/system/podman-kube@.service.in";
-    # This test needs xfs & lots of space and fails on 16.0 RC1
-    run_command "rm -f test/system/161-volume-quotas.bats";
     # This test is flaky and will fail if system is "full"
     run_command "rm -f test/system/320-system-df.bats";
     # This tests needs criu, available only on Tumbleweed


### PR DESCRIPTION
Re-enable [161-volume-quotas](https://github.com/containers/podman/blob/main/test/system/161-volume-quotas.bats) test as it helped uncover https://bugzilla.suse.com/show_bug.cgi?id=1244500

Also incorporate https://github.com/containers/podman/pull/25858 to make it faster on SLE 16.0.

Verification runs:
- Tumbleweed: https://openqa.opensuse.org/tests/5101219
- SLE 16.0: https://openqa.suse.de/tests/18040019 (failed due to the above bug).