### PR TITLE
bats: Introduce BATS_TEST_PACKAGES variable

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -202,6 +202,10 @@ sub bats_setup {
         run_command "zypper addrepo $repo";
     }
 
+    foreach my $pkg (split(/\s+/, get_var("BATS_TEST_PACKAGES", ""))) {
+        run_command "zypper --gpg-auto-import-keys --no-gpg-checks -n install $pkg";
+    }
+
     install_bats;
 
     enable_modules if is_sle;

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -18,6 +18,7 @@ The tests rely on some variables:
 | --- | --- |
 | `BATS_PACKAGE` | `aardvark-dns` `buildah` `netavark` `podman` `runc` `skopeo` |
 | `BATS_PATCHES` | List of github PR id's containing upstream test patches |
+| `BATS_TEST_PACKAGES` | List of optional package URL's |
 | `BATS_TEST_REPOS` | List of optional test repositories |
 | `BATS_TESTS` | Run only the specified tests |
 | `BATS_REPO` | Repo & branch in the form `[<GITHUB_ORG>]#<BRANCH>` |
@@ -29,6 +30,8 @@ The tests rely on some variables:
 NOTES
 - `BATS_REPO` can be `SUSE#branch` or a tag `v1.2.3`
 - `BATS_PATCHES` can contain full URL's like `https://github.com/containers/podman/pull/25918.patch`
+- `BATS_TEST_PACKAGES` may be used to test candidate kernels (KOTD, PTF, etc) and other packages.
+- `BATS_TEST_REPOS` may be used to test candidate packages outside the usual maintenance workflow.
 
 ### Summary of the `BATS_SKIP` variables
 


### PR DESCRIPTION
Introduce BATS_TEST_PACKAGES variable to be able to test emergency PTF's, kernel KOTD's, etc.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1244500#c5
- Verification runs:
  - https://openqa.suse.de/tests/18044414
  - https://openqa.suse.de/tests/18044406 (`BATS_TEST_PACKAGES=https://kerncvs.suse.de/kerneltest/suse/5e50d7e/kernel-default-6.12.0-160000.67.1.g5e50d7e.x86_64.rpm`)