### PR TITLE
ipxe_install: Set bootscript to HDD if requested for Agama installer

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -357,6 +357,7 @@ sub run {
         assert_screen([qw(load-linux-kernel load-initrd)], 240);
         record_info("Installing", "Please check the expected product is being installed");
         assert_screen('agama-installer-live-root', 400);
+        set_bootscript_hdd if get_var('IPXE_SET_HDD_BOOTSCRIPT');
         return;
     }
 


### PR DESCRIPTION
Some machines need the iPXE bootscript to be set to HDD. This logic was
missing in the Agama installation workflow.

Failure: https://openqa.suse.de/tests/18050432#step/grub_test/6  system booted installer again.

- Related ticket: https://progress.opensuse.org/issues/183980
- Needles: none
- Verification run:  https://openqa.suse.de/tests/18050595#step/first_boot/1 (will fail later in kdump, which is bsc#1244215)
