### PR TITLE
containers: Add docker version information

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -156,6 +156,7 @@ sub install_docker_when_needed {
     systemctl('status docker', timeout => 120);
     install_oci_runtime("docker") if ($host_os =~ /sle|opensuse/);
     record_info('docker', script_output('docker info'));
+    record_info('version', script_output('docker version'));
 }
 
 sub install_buildah_when_needed {

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -65,6 +65,7 @@ sub enable_docker {
     }
 
     record_info("docker info", script_output("docker info"));
+    record_info("docker version", script_output("docker version"));
 }
 
 sub run {

--- a/tests/containers/multi_runtime.pm
+++ b/tests/containers/multi_runtime.pm
@@ -97,6 +97,7 @@ sub run {
     systemctl "enable --now docker";
 
     record_info("docker root", script_output("docker info"));
+    record_info("docker version", script_output("docker version"));
     record_info("podman root", script_output("podman info"));
 
     # Needed to avoid:


### PR DESCRIPTION
`docker info` doesn't output the Golang version used, so we need `docker version` to get information like this:

```
Client: Docker Engine - Community
 Version:           28.2.2
 API version:       1.50
 Go version:        go1.24.3
 Git commit:        e6534b4
 Built:             Fri May 30 12:09:10 2025
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          28.2.2
  API version:      1.50 (minimum version 1.24)
  Go version:       go1.24.3
  Git commit:       45873be
  Built:            Fri May 30 12:07:24 2025
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.7.27
  GitCommit:        05044ec0a9a75232cad458027ca83437aae3f4da
 runc:
  Version:          1.2.5
  GitCommit:        v1.2.5-0-g59923ef
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

Verification run: not needed.
