### PR TITLE
Convert qesap conf to apiver:4

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws.yaml
@@ -6,7 +6,7 @@
 # Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
 #          Deploy on AWS, two node HANA cluster with cloud native fencing.
 provider: 'aws'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -38,16 +38,17 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_fencing.yaml
@@ -5,7 +5,7 @@
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
 provider: 'aws'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -41,16 +41,17 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
@@ -7,7 +7,7 @@
 #          Deploy on AWS, two node HANA cluster with cloud native fencing.
 #          Deployment create a network peering the the IBSm
 provider: 'aws'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -41,17 +41,18 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml
+      - sap-hana-storage.yaml
+       - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_sapconf.yaml
@@ -7,7 +7,7 @@
 #          Deploy on AWS, two node HANA cluster with cloud native fencing.
 #          System uses sapconf
 provider: 'aws'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -39,16 +39,17 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_sapconf=true
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_sapconf=true
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure.yaml
@@ -7,7 +7,7 @@
 #          Deploy on Azure, two node HANA cluster and a iscsi server VM.
 #          The two HANA nodes cluster is using sbd.
 provider: 'azure'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -38,17 +38,18 @@ ansible:
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
     use_sbd: true
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
-    - cluster_sbd_prep.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+      - cluster_sbd_prep.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_msi.yaml
@@ -6,7 +6,7 @@
 # Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
 #          Deploy on Azure, two node HANA cluster with cloud native MSI fencing.
 provider: 'azure'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -41,16 +41,17 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml -e azure_identity_management=%AZURE_NATIVE_FENCING_AIM%
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml -e azure_identity_management=%AZURE_NATIVE_FENCING_AIM%
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_fencing_spn.yaml
@@ -6,7 +6,7 @@
 # Summary: conf.yaml template for qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
 #          Deploy on Azure, two node HANA cluster with cloud native SPN fencing.
 provider: 'azure'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -41,16 +41,17 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml -e azure_identity_management=%AZURE_NATIVE_FENCING_AIM% -e spn_application_id=%AZURE_NATIVE_FENCING_APP_ID% -e spn_application_password=%AZURE_NATIVE_FENCING_APP_PASSWORD%
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml -e azure_identity_management=%AZURE_NATIVE_FENCING_AIM% -e spn_application_id=%AZURE_NATIVE_FENCING_APP_ID% -e spn_application_password=%AZURE_NATIVE_FENCING_APP_PASSWORD%
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_peering.yaml
@@ -7,7 +7,7 @@
 #          Deploy on Azure, two node HANA cluster and a iscsi server VM.
 #          The two HANA nodes cluster is using sbd.
 provider: 'azure'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -42,18 +42,19 @@ ansible:
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
     use_sbd: true
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
-    - cluster_sbd_prep.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+      - cluster_sbd_prep.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_roles.yaml
@@ -7,7 +7,7 @@
 #          Deploy on Azure, two node HANA cluster and a iscsi server VM.
 #          The two HANA nodes cluster is using sbd.
 provider: 'azure'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -38,17 +38,18 @@ ansible:
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
     use_sbd: true
-  create:
-    - registration_role.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_reboottimeout=900
-    - cluster_sbd_prep.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - registration_role.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com'
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_reboottimeout=900
+      - cluster_sbd_prep.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_sapconf.yaml
@@ -8,7 +8,7 @@
 #          The two HANA nodes cluster is using sbd.
 #          System uses sapconf
 provider: 'azure'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -39,17 +39,18 @@ ansible:
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
     use_sbd: true
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_sapconf=true -e use_reboottimeout=900
-    - cluster_sbd_prep.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_sapconf=true -e use_reboottimeout=900
+      - cluster_sbd_prep.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_azure_uri.yaml
@@ -8,7 +8,7 @@
 #          Allow using OS image not from the catalog.
 #          The two HANA nodes cluster is using sbd.
 provider: 'azure'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -39,17 +39,18 @@ ansible:
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
     use_sbd: true
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_sapconf=%USE_SAPCONF%
-    - cluster_sbd_prep.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_sapconf=%USE_SAPCONF%
+      - cluster_sbd_prep.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -7,7 +7,7 @@
 #          Deploy on GCP, two node HANA cluster with cloud native fencing.
 #          System uses saptune
 provider: 'gcp'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -40,16 +40,17 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
@@ -5,7 +5,7 @@
 # Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Generic yaml template for use with qe-sap-deployment project: https://github.com/SUSE/qe-sap-deployment
 provider: 'gcp'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -41,16 +41,17 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
@@ -7,7 +7,7 @@
 #          Deploy on GCP, two node HANA cluster with cloud native fencing.
 #          Deployment create a network peering the the IBSm
 provider: 'gcp'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -44,17 +44,18 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - ibsm.yaml -e ibsm_ip='%IBSM_IP%' -e download_hostname='%DOWNLOAD_HOSTNAME%' -e repos='%REPOS%'
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -7,7 +7,7 @@
 #          Deploy on GCP, two node HANA cluster with cloud native fencing.
 #          System uses sapconf
 provider: 'gcp'
-apiver: 3
+apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
@@ -40,16 +40,17 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
     use_sap_hana_sr_angi: '%USE_SR_ANGI%'
-  create:
-    - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
-    - fully-patch-system.yaml
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_sapconf=true
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - %REGISTRATION_PLAYBOOK%.yaml -e reg_code='%SCC_REGCODE_SLES4SAP%' -e email_address='testing@suse.com' %REG_ARGS%
+      - fully-patch-system.yaml
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_sapconf=true
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    destroy:
+      - deregister.yaml


### PR DESCRIPTION
Convert all the qe-sap-deployment conf.yaml files for the qesap regression to use apiver_4 format.

- Related ticket: [TEAM-10427](https://jira.suse.com/browse/TEAM-10427)


# Verification run:

## Azure

### qesap_azure.yaml
 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test -> http://openqaworker15.qa.suse.cz/tests/329381 :green_circle: 

### qesap_azure_fencing_msi.yaml
 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test_msi -> http://openqaworker15.qa.suse.cz/tests/329382 :green_circle: 


## AWS 

### qesap_aws.yaml
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_r48xlarge_test@64bit -> http://openqaworker15.qa.suse.cz/tests/329427 :green_circle: 

## GCP

### qesap_gcp.yaml
 sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6_PAYG-qesap_gcp_angi_test
 -  http://openqaworker15.qa.suse.cz/tests/329410 :green_circle: deployment was ok
 - http://openqaworker15.qa.suse.cz/tests/329428  :green_circle: 

