### PR TITLE
bats/buildah: Nuke sbom test

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -9,13 +9,13 @@ buildah:
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: sbom
+    BATS_SKIP:
     BATS_SKIP_ROOT:
     BATS_SKIP_USER:
   sle-16.0:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud run sbom
+    BATS_SKIP: bud run
     BATS_SKIP_ROOT: from
     BATS_SKIP_USER:
   sle-15-SP7:

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -162,10 +162,12 @@ Complete list found in [skip.yaml](data/containers/bats/skip.yaml)
 | tests | reason |
 | --- | --- |
 | [from] & [run] | https://github.com/containers/buildah/issues/6071 |
+| [sbom] | https://github.com/containers/buildah/issues/5617 |
 | others | Waiting for runc 1.2.x |
 
 [from]: https://github.com/containers/buildah/blob/main/tests/from.bats
 [run]: https://github.com/containers/buildah/blob/main/tests/run.bats
+[sbom]: https://github.com/containers/buildah/blob/main/tests/sbom.bats
 
 ### podman
 

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -93,6 +93,8 @@ sub run {
 
     # Patch mkdir to always use -p
     run_command "sed -i 's/ mkdir /& -p /' tests/*.bats tests/helpers.bash";
+    # This test is flaky and depends on 3rd party images
+    run_command "rm -f tests/sbom.bats";
 
     # Compile helpers used by the tests
     my $helpers = script_output 'echo $(grep ^all: Makefile | grep -o "bin/[a-z]*" | grep -v bin/buildah)';


### PR DESCRIPTION
The [sbom](https://github.com/containers/buildah/blob/main/tests/sbom.bats) test is flaky as it uses 3rd party images and wastes resources.
