### PR TITLE
wsl/distro_install: AArch64 images also show the firstrun window

### DIFF
--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -72,7 +72,7 @@ sub run {
         $self->close_powershell;
         $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
         assert_and_click 'wsl-suse-startup-search';
-        if (check_var('DISTRI', 'sle')) {
+        if (check_var('DISTRI', 'sle') || is_aarch64) {
             assert_and_click("welcome_to_wsl", timeout => 120);
             send_key "alt-f4";
         }
@@ -82,7 +82,7 @@ sub run {
             cmd => "wsl --install --distribution $WSL_version",
             timeout => 300,
         );
-        if (check_var('DISTRI', 'sle')) {
+        if (check_var('DISTRI', 'sle') || is_aarch64) {
             assert_and_click("welcome_to_wsl", timeout => 120);
             send_key "alt-f4";
         }


### PR DESCRIPTION
This window should actually appear everywhere meanwhile, but for some reason that's not the case. So just add aarch64 explicitly for now.

- Verification run:
* https://openqa.opensuse.org/tests/5103460
* https://openqa.opensuse.org/tests/5103461
