### PR TITLE
virt_autotest remove record_soft_failure for bsc1182886

### DIFF
--- a/tests/virt_autotest/uefi_guest_verification.pm
+++ b/tests/virt_autotest/uefi_guest_verification.pm
@@ -22,37 +22,18 @@ use utils;
 use virt_utils;
 use virt_autotest::common;
 use virt_autotest::utils;
-use version_utils qw(is_sle is_alp);
+use version_utils qw(is_sle);
 
 sub run_test {
     my $self = shift;
 
     $self->check_guest_bootloader($_) foreach (keys %virt_autotest::common::guests);
     $self->check_guest_bootcurrent($_) foreach (keys %virt_autotest::common::guests);
-    if (is_kvm_host) {
-        if (is_sle) {
-            record_soft_failure("In order to implement pm features, current kvm virtual machine uses uefi firmware that does not support PXE/HTTP boot and secureboot. bsc#1182886 UEFI virtual machine boots with trouble");
-        }
-        elsif (is_alp) {
-            # The current default uefi firmware in alp kvm container supports secure boot,
-            # but does not support PXE/HTTP boot, and pm is not well supported either.
-            $self->check_guest_secure_boot($_) foreach (keys %virt_autotest::common::guests);
-        }
-        #$self->check_guest_uefi_boot($_) foreach (keys %virt_autotest::common::guests);
+    record_soft_failure("UEFI implementation for xen fullvirt uefi virtual machine is incomplete. bsc#1184936 Xen fullvirt lacks of complete support for UEFI") if (is_xen_host);
 
-    }
-    else {
-        record_soft_failure("UEFI implementation for xen fullvirt uefi virtual machine is incomplete. bsc#1184936 Xen fullvirt lacks of complete support for UEFI");
-    }
-
-    # TODO: enable pm check for alp once default uefi firmware supports it well
     if (is_sle('>=15')) {
         $self->check_guest_pmsuspend_enabled;
-    }
-    elsif (is_alp) {
-        record_info("Skip power management check on ALP", "The uefi firmware does not support pm well.");
-    }
-    else {
+    } else {
         record_info("SLES that is eariler than 15 does not support power management functionality with uefi", "Skip check_guest_pmsuspend_enabled");
     }
     return $self;


### PR DESCRIPTION
virt_autotest remove record_soft_failure for bsc1182886

- Related ticket: https://progress.opensuse.org/issues/178699

- Verification run: 
WIP
