### PR TITLE
Add unattended support for DASD

### DIFF
--- a/data/yam/agama/auto/lib/dasd.libsonnet
+++ b/data/yam/agama/auto/lib/dasd.libsonnet
@@ -1,0 +1,11 @@
+{
+  dasd():: {
+    devices: [
+      {
+        channel: '0.0.0150',
+        format: true,
+        state: 'active',
+      },
+    ],
+  },
+}

--- a/data/yam/agama/auto/template.libsonnet
+++ b/data/yam/agama/auto/template.libsonnet
@@ -5,8 +5,10 @@ local scripts_post_partitioning_lib = import 'lib/scripts_post_partitioning.libs
 local scripts_pre_lib = import 'lib/scripts_pre.libsonnet';
 local storage_lib = import 'lib/storage.libsonnet';
 local security_lib = import 'lib/security.libsonnet';
+local dasd_lib = import 'lib/dasd.libsonnet';
 
 function(bootloader=false,
+         dasd=false,
          localization='',
          packages='',
          patterns='',
@@ -22,6 +24,7 @@ function(bootloader=false,
          storage='',
          user=true) {
   [if bootloader == true then 'bootloader']: base_lib['bootloader'],
+  [if dasd == true then 'dasd']: dasd_lib.dasd(),
   [if localization == true then 'localization']: base_lib['localization'],
   [if patterns != '' || packages != '' then 'software']: std.prune({
     patterns: if patterns != '' then std.split(patterns, ','),


### PR DESCRIPTION
##

### Add unattended support for DASD, test it in sles_lvm_unattended


- Related ticket: Quick PR to run lvm on top of DASD
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18078176
- MR: 
  - We need to overwite `+FORMAT_DASD=false` to let it skip format_dasd at bootup.

##