### PR TITLE
Add condition to check if pygit exsited

### DIFF
--- a/tests/console/libgit2.pm
+++ b/tests/console/libgit2.pm
@@ -37,6 +37,7 @@ sub run {
 
     # Install the latest pygit2
     my @pygit2_versions = split(/\n/, script_output(qq[zypper se '/^python3[0-9]{1,2}-pygit2\$/' | awk -F '|' '/python3[0-9][1,2]/ {gsub(" ", ""); print \$2}' | uniq]));
+    die 'Cannot find any verisons of pygit2' unless (@pygit2_versions);
     record_info("Available versions", "All available new pygit2 versions are: @pygit2_versions");
     record_info("The latest version is:", "$pygit2_versions[$#pygit2_versions]");
 


### PR DESCRIPTION
Add condition to check if pygit exsited

- Related ticket: https://progress.opensuse.org/issues/183842
- Verification run: https://openqa.suse.de/tests/18042950#step/libgit2/10
  pygit2 will be added at https://build.suse.de/request/show/377542
