### PR TITLE
cc_eal4: use boot_disk instead of boot_to_desktop

### DIFF
--- a/schedule/security/cc_eal4.yaml
+++ b/schedule/security/cc_eal4.yaml
@@ -3,7 +3,7 @@ description: >
     This is for EAL4 tests
 schedule:
     - installation/bootloader_start
-    - boot/boot_to_desktop
+    - security/boot_disk
     - security/eal4/setup_eal4_env
     - '{{disable_root_ssh}}'
     - security/eal4/accessible_network_interface


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/183860
VR: https://openqa.suse.de/tests/18079608