### PR TITLE
agama: Improve IPMI installation profile

### DIFF
--- a/data/agama_auto/sle_default_ipmi.jsonnet
+++ b/data/agama_auto/sle_default_ipmi.jsonnet
@@ -3,6 +3,9 @@
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE}}'
   },
+  bootloader: {
+    timeout: 45,
+  },
   user: {
     fullName: 'Bernhard M. Wiedemann',
     password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
@@ -17,11 +20,12 @@
     pre: [
       {
         name: 'wipefs',
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
               sleep 1
+              parted -s /dev/$i mklabel gpt
               sync
           done
         |||
@@ -31,9 +35,19 @@
       {
         name: 'enable root login',
         chroot: true,
-        body: |||
+        content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          systemctl enable sshd
+        |||
+      },
+      {
+        name: 'set grub terminal to console',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          sed -i 's/^GRUB_TERMINAL=.*/GRUB_TERMINAL=\"console\"/' /etc/default/grub
+          update-bootloader --refresh
         |||
       }
     ]

--- a/data/agama_auto/sle_default_ipmi_no_reg.jsonnet
+++ b/data/agama_auto/sle_default_ipmi_no_reg.jsonnet
@@ -2,6 +2,9 @@
   product: {
     id: '{{AGAMA_PRODUCT_ID}}'
   },
+  bootloader: {
+    timeout: 45,
+  },
   user: {
     fullName: 'Bernhard M. Wiedemann',
     password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
@@ -21,6 +24,7 @@
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
               sleep 1
+              parted -s /dev/$i mklabel gpt
               sync
           done
         |||
@@ -33,6 +37,16 @@
         content: |||
           #!/usr/bin/env bash
           echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          systemctl enable sshd
+        |||
+      },
+      {
+        name: 'set grub terminal to console',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          sed -i 's/^GRUB_TERMINAL=.*/GRUB_TERMINAL=\"console\"/' /etc/default/grub
+          update-bootloader --refresh
         |||
       }
     ]


### PR DESCRIPTION
This improvement to the existing IPMI profile is based on the PVM profile with additional enhancements for bare metal. There should be a bootloader timeout to ensure that the grub menu needle is matched.
We can't use an infinite timeout because some machines have console input issues and the return key is not registered. A value of 45 seconds is taken from the SLE 15 AY profile. 
We also need to set GRUB_TERMINAL to console to ensure that the grub menu is displayed properly. We do the same in SLE 15 AY profiles.


- Related ticket: https://progress.opensuse.org/issues/183146
- Needles: none
- Verification run: 
x86_64: https://openqa.suse.de/tests/18079558 (kdump fail is bsc#1244215)
aarch64: https://openqa.suse.de/tests/18079555