### PR TITLE
wickedbase: record new AVC messages

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -203,7 +203,7 @@ sub valgrind_cmd {
 
     valgrind_enable()
 
-Modify all systemd service units, to enable valgrind for all binarys which where 
+Modify all systemd service units, to enable valgrind for all binarys which where
 specified via WICKED_VALGRIND.
 
 =cut
@@ -694,7 +694,7 @@ sub upload_wicked_logs {
   do_barrier_create(<barrier_postfix> [, <test_name>] )
 
 Create a barier which can be later used to syncronize the wicked tests for SUT and REF.
-This function can be called statically. In this case the C<test_name> parameter is 
+This function can be called statically. In this case the C<test_name> parameter is
 mandatory.
 
 =cut


### PR DESCRIPTION
This is useful for debugging issues like [bsc#1243291](https://bugzilla.suse.com/show_bug.cgi?id=1243291)

- Verification run: 
  - https://openqa.suse.de/tests/18081551 (SLE-15-SP7)
  -  http://openqa.wicked.suse.de/tests/289809#step/t12_teaming_random/15 (tumbleweed)