### PR TITLE
Remove registry suse login

### DIFF
--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -79,10 +79,6 @@ sub run {
     reset_container_network_if_needed($runtime);
 
     scc_apply_docker_image_credentials() if (get_var('SCC_DOCKER_IMAGE') && $runtime eq 'docker');
-    if (get_var('LTSS_TEST_ISSUES')) {
-        my $regcode = get_var('SCC_REGCODE_LTSS');
-        assert_script_run qq[echo $regcode | $runtime login -u "regcode" --password-stdin registry.suse.com];
-    }
     # Running podman as root with docker installed may be problematic as netavark uses nftables
     # while docker still uses iptables.
     # Use workaround suggested in:


### PR DESCRIPTION
We do not need login to registry as we do not test LTSS containers. Not all of them are enabled for download

