### PR TITLE
Collect apache logs in post fail hook

### DIFF
--- a/tests/security/libserf/libserf.pm
+++ b/tests/security/libserf/libserf.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi;
 use utils;
 use Utils::Architectures;
+use Utils::Logging qw(tar_and_upload_log);
 
 sub run {
     my ($self) = @_;
@@ -119,6 +120,13 @@ EOF
 
     # Clean up
     assert_script_run('cd && rm -rf mytestproj');
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    select_console('log-console');
+    tar_and_upload_log('/var/log/apache2', '/tmp/apache-logs.tar.bz2');
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=security_misc_o3&version=Tumbleweed#step/libserf/46
VR: pending

Related see also: https://bugzilla.opensuse.org/show_bug.cgi?id=1239177
