### PR TITLE
Change dracut --list-modules to search for modules instead of command line

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -23,7 +23,7 @@ sub run {
 
     validate_script_output("lsinitrd", sub { m/Image:(.*\n)+( ?)Version: dracut(-|\d+|\.|\+|\w+)+(\n( ?))+( ?)Arguments(.*\n)+( ?)dracut modules:(\w+|-|\d+|\n|( ?))+\=+\n(l|d|r|w|x|-|( ?))+\s+\d+ root\s+root(.*\n)+( ?)\=+/ });
     assert_script_run("dracut -f", 180);
-    assert_script_run("dracut --list-modules");
+    validate_script_output("dracut --list-modules", sub { m/systemd/ });
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(bootloader_time => 200);

--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -23,7 +23,7 @@ sub run {
 
     validate_script_output("lsinitrd", sub { m/Image:(.*\n)+( ?)Version: dracut(-|\d+|\.|\+|\w+)+(\n( ?))+( ?)Arguments(.*\n)+( ?)dracut modules:(\w+|-|\d+|\n|( ?))+\=+\n(l|d|r|w|x|-|( ?))+\s+\d+ root\s+root(.*\n)+( ?)\=+/ });
     assert_script_run("dracut -f", 180);
-    validate_script_output("dracut --list-modules 2>&1", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
+    assert_script_run("dracut --list-modules");
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(bootloader_time => 200);


### PR DESCRIPTION
This follows up #22337 dracut is now less verbose, and the check with the `validate_script_output` is mostly checking that the command line has any output

VR: https://openqa.opensuse.org/tests/5109617#step/dracut/20
Ticket: https://progress.opensuse.org/issues/183926
