### PR TITLE
mau-extratests2: Don't schedule ipv6 tests on 12-SP3

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -79,13 +79,6 @@ conditional_schedule:
         - console/golang
         - console/redis
         - '{{arch_specific}}'
-      15-SP1:
-        - console/openssl_nodejs
-        - console/golang
-        - '{{arch_specific}}'
-      15:
-        - console/openssl_nodejs
-        - '{{arch_specific}}'
       12-SP5:
         - console/openssl_nodejs
         - '{{arch_specific}}'
@@ -118,9 +111,3 @@ conditional_schedule:
       15-SP2:
         - console/firewalld
         - console/lshw
-      15-SP1:
-        - console/firewalld
-        - console/lshw
-      15:
-        - console/lshw
-        - console/firewalld

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -7,8 +7,6 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/dnsmasq
-  - console/curl_ipv6
-  - console/wget_ipv6
   - console/ca_certificates_mozilla
   - console/unzip
   - console/rsync
@@ -37,6 +35,8 @@ conditional_schedule:
   version_specific:
     VERSION:
       15-SP7:
+        - console/curl_ipv6
+        - console/wget_ipv6
         - console/osinfo_db
         - console/ovn
         - console/firewalld
@@ -48,6 +48,8 @@ conditional_schedule:
         - console/valgrind
         - '{{arch_specific15_sp5plus}}'
       15-SP6:
+        - console/curl_ipv6
+        - console/wget_ipv6
         - console/osinfo_db
         - console/ovn
         - console/firewalld
@@ -59,6 +61,8 @@ conditional_schedule:
         - console/valgrind
         - '{{arch_specific15_sp5plus}}'
       15-SP5:
+        - console/curl_ipv6
+        - console/wget_ipv6
         - console/osinfo_db
         - console/ovn
         - console/firewalld
@@ -70,6 +74,8 @@ conditional_schedule:
         - console/valgrind
         - '{{arch_specific15_sp5plus}}'
       15-SP4:
+        - console/curl_ipv6
+        - console/wget_ipv6
         - console/osinfo_db
         - console/ovn
         - console/firewalld
@@ -80,6 +86,8 @@ conditional_schedule:
         - '{{arch_specific}}'
         - console/valgrind
       15-SP3:
+        - console/curl_ipv6
+        - console/wget_ipv6
         - console/osinfo_db
         - console/ovn
         - console/firewalld
@@ -90,6 +98,8 @@ conditional_schedule:
         - '{{arch_specific}}'
         - console/valgrind
       15-SP2:
+        - console/curl_ipv6
+        - console/wget_ipv6
         - console/osinfo_db
         - console/ovn
         - console/firewalld
@@ -116,6 +126,8 @@ conditional_schedule:
         - console/valgrind
         - '{{arch_specific}}'
       12-SP5:
+        - console/curl_ipv6
+        - console/wget_ipv6
         - console/osinfo_db
         - console/libgcrypt
         - console/zziplib

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -109,22 +109,6 @@ conditional_schedule:
         - console/nginx
         - '{{arch_specific}}'
         - console/valgrind
-      15-SP1:
-        - console/osinfo_db
-        - console/libgcrypt
-        - console/zziplib
-        - console/journald_fss
-        - console/nginx
-        - console/valgrind
-        - '{{arch_specific}}'
-      15:
-        - console/osinfo_db
-        - console/libgcrypt
-        - console/zziplib
-        - console/journald_fss
-        - console/nginx
-        - console/valgrind
-        - '{{arch_specific}}'
       12-SP5:
         - console/curl_ipv6
         - console/wget_ipv6
@@ -135,16 +119,10 @@ conditional_schedule:
         - console/valgrind
         - '{{arch_12sp5}}'
         - '{{arch_systemtap}}'
-      12-SP4:
-        - console/osinfo_db
-        - console/journald_fss
-        - '{{arch_specific}}'
       12-SP3:
         - console/osinfo_db
         - console/journald_fss
         - '{{arch_specific}}'
-      12-SP2:
-        - console/journald_fss
   arch_specific:
     ARCH:
       x86_64:


### PR DESCRIPTION
- Related ticket: 4895659490d1e07aa34882c1b4ac2eb58dc6c7b3
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=jpupava_ipv6
