### PR TITLE
aa_prepare: Replace nscd with samba

### DIFF
--- a/tests/security/apparmor/aa_prepare.pm
+++ b/tests/security/apparmor/aa_prepare.pm
@@ -24,7 +24,7 @@ sub run {
     zypper_call 'in -t pattern apparmor';
     if (is_jeos) {
         record_info 'JeOS', 'Some packages needed by the tests are not pre-installed by default in JeOS.';
-        zypper_call 'in apparmor-utils screen nscd netpbm';
+        zypper_call('in apparmor-utils samba screen netpbm');
     }
     services::apparmor::start_service;
     services::apparmor::enable_service;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/176154 https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21925
`aa-notify -l` is failing because of https://bugzilla.opensuse.org/show_bug.cgi?id=1216660
- Verification run: https://openqa.opensuse.org/tests/5109674
