### PR TITLE
Adapt installation console to tty2 instead of tty7

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -483,9 +483,9 @@ sub init_consoles {
             || (get_var('BACKEND', '') =~ /generalhw/ && get_var('GENERAL_HW_VNC_IP'))
             || is_svirt_except_s390x))
     {
-        my $tty = is_agama() ? 8 : 2;
-        $self->add_console('install-shell', 'tty-console', {tty => $tty});
-        $self->add_console('installation', 'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
+        $self->add_console('install-shell', 'tty-console', {tty => is_agama() ? 8 : 2});
+        $self->add_console('installation', 'tty-console', {tty =>
+                  check_var('VIDEOMODE', 'text') ? 1 : is_agama() && get_var('AGAMA_DEV') ? 2 : 7});
         $self->add_console('install-shell2', 'tty-console', {tty => 9});
         # On SLE15 X is running on tty2 see bsc#1054782
         $self->add_console('root-console', 'tty-console', {tty => get_root_console_tty});

--- a/tests/yam/agama/validate_headless.pm
+++ b/tests/yam/agama/validate_headless.pm
@@ -11,7 +11,7 @@ use testapi qw(assert_script_run select_console);
 use utils qw(systemctl);
 
 sub run {
-    select_console 'root-console';
+    select_console 'install-shell';
 
     # verify we are not in graphic target.
     systemctl('is-active graphical.target', expect_false => 1);


### PR DESCRIPTION
We have added an installation tty console definition in case it is Agama.
In addition we have added config load and minor error check in jsonnet command.

- Related ticket: https://progress.opensuse.org/issues/184141
- Needles: N/A
- Verification run:
  - x86_64_dev: https://openqa.suse.de/tests/18150174
  - x86_64_prod: https://openqa.suse.de/tests/18150363
  - aarch64_dev: https://openqa.suse.de/tests/18150082
  - aarch64_prod: https://openqa.suse.de/tests/18150153
  - s390x-kvm_dev: https://openqa.suse.de/tests/18150078
  - s390x-kvm_prod: https://openqa.suse.de/tests/18150079
  - ppc64le_dev: https://openqa.suse.de/tests/18150080
  - ppc64le_prod: https://openqa.suse.de/tests/18150081
  - headless_dev: https://openqa.suse.de/tests/18150295
  - headless_prod: https://openqa.suse.de/tests/18150294
