### PR TITLE
Add ISCSI_ENABLED terraform variable

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -27,4 +27,5 @@ terraform:
     hana_ha_enabled: '%HA_CLUSTER%'
     hana_vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    iscsi_enabled: '%ISCSI_ENABLED%'
 

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -22,4 +22,5 @@ terraform:
     hana_ha_enabled: '%HA_CLUSTER%'
     hana_vm_size: '%PUBLIC_CLOUD_INSTANCE_TYPE%'
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    iscsi_enabled: '%ISCSI_ENABLED%'
 

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -34,6 +34,7 @@ terraform:
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    iscsi_enabled: '%ISCSI_ENABLED%'
 
 ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -34,6 +34,7 @@ terraform:
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    iscsi_enabled: '%ISCSI_ENABLED%'
 
 ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -34,6 +34,7 @@ terraform:
     hana_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     drbd_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
     netweaver_cluster_fencing_mechanism: '%FENCING_MECHANISM%'
+    iscsi_enabled: '%ISCSI_ENABLED%'
 
 ansible:
   az_storage_account_name: '%HANA_ACCOUNT%'

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -12,6 +12,7 @@
 # PUBLIC_CLOUD_INSTANCE_TYPE - VM size, sets terraform 'vm_size' parameter
 # USE_SAPCONF - (true/false) set 'false' to use saptune
 # FENCING_MECHANISM - (sbd/native) choose fencing mechanism
+# ISCSI_ENABLED - (true/false) choose if to deploy iscsi server
 # QESAP_SCC_NO_REGISTER - define variable in openqa to skip SCC registration via ANSIBLE
 # HANA_MEDIA - Hana install media directory
 # HANA_ACCOUNT - Azure Storage name
@@ -81,6 +82,7 @@ sub run {
     die "HA cluster needs at least 2 nodes. Check 'NODE_COUNT' parameter." if ($ha_enabled && (get_var('NODE_COUNT') <= 1));
 
     set_var('FENCING_MECHANISM', 'native') unless ($ha_enabled);
+    set_var('ISCSI_ENABLED', check_var('FENCING_MECHANISM', 'sbd') ? 'true' : 'false');
     set_var_output('ANSIBLE_REMOTE_PYTHON', '/usr/bin/python3');
 
     # Within the qe-sap-deployment terraform code, in each differend CSP implementation,


### PR DESCRIPTION
Add a new terraform variable named iscsi_enabled. It is controlled by a openQA variable using the same name. For the moment the value is derived by FENCING_MECHANISM. This is an intermediate commit, in a next one it will be possible to remove FENCING_MECHIANISM and all the terraform variables controlled by that.

Ticket: https://jira.suse.com/browse/TEAM-10410

# Verification run:
## HanaSR

### Azure
sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-06-16T02:03:20Z-hanasr_azure_test_sbd az_Standard_E4s_v3 
 -  http://openqaworker15.qa.suse.cz/tests/329790 :green_circle:  

1.  Job has `FENCING_MECHANISM:sbd` variable, and no ISCSI_ENABLED variable (job triggered with no modification in the JobGroup)
2. conf.yaml http://openqaworker15.qa.suse.cz/tests/329790/file/deploy_qesap_terraform-sles4sap_azure_generic.yaml has terraform variable `iscsi_enabled: true` near to all 3 legacy variables `*_cluster_fencing_mechanism: sbd`
3. Terraform is deploying th eiscsi server http://openqaworker15.qa.suse.cz/tests/329790/logfile?filename=deploy_qesap_terraform-terraform.apply.log.txt#line-108
4. Ansible inventory.yaml http://openqaworker15.qa.suse.cz/tests/329790/logfile?filename=serial_terminal.txt#line-2819 : has iscsi server, still have `use_sbd` (will be dropper soon on qe-sap-deployment side)

 -  http://openqaworker15.qa.suse.cz/tests/329888 :green_circle: 


sle-15-SP4-Azure-SAP-BYOS-Incidents-x86_64-Build Rule-SAPHanaSR-ScaleUp-PerfOpt az_Standard_E4s_v3
 - http://openqaworker15.qa.suse.cz/tests/330870 :green_circle: `FENCING_MECHANISM=sbd` 

NATIVE sle-15-SP4-Azure-SAP-BYOS-Incidents-x86_64-Build SAPHanaSR-ScaleUp-PerfOpt-msi az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/330871 :green_circle: Job has `FENCING_MECHANISM	native`, http://openqaworker15.qa.suse.cz/tests/330871/file/deploy_qesap_terraform-sles4sap_azure_generic.yaml has `iscsi_enabled: 'false'` and no `use_sbd`. http://openqaworker15.qa.suse.cz/tests/330871/file/deploy_qesap_terraform-hana_vars.yaml has no `use_sbd`. Failure is in cloning a too old job, and repo is gone.

## mr_test
sle-15-SP6-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build sles4sap_gnome_saptune_delete_rename az_Standard_E4s_v3 
- http://openqaworker15.qa.suse.cz/tests/329887 :green_circle: 

sle-15-SP4-Azure-SAP-PAYG-Incidents-saptune-x86_64-Build sles4sap_gnome_saptune_delete_rename az_Standard_E4s_v3
 -  http://openqaworker15.qa.suse.cz/tests/330872 :green_circle: 
