### PR TITLE
Add kdump over NFS test

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -256,6 +256,7 @@ sub determine_crash_memory {
 
 # Activate kdump using command line tools
 sub activate_kdump_cli {
+    set_kdump_config('KDUMP_SAVEDIR', get_var('KDUMP_SAVEDIR')) if get_var('KDUMP_SAVEDIR');
     if (is_sle('16+')) {
         # Enable fadump in configuration file if requested
         set_kdump_config("KDUMP_FADUMP", "true") if get_var('FADUMP');

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -565,9 +565,10 @@ Value for the configuration option.
 
 sub set_kdump_config {
     my ($option, $value) = @_;
+    my $escaped_value = quotemeta($value);
 
     record_info("SET CONFIG", "$option=\"$value\"");
-    my $command = "sed -i 's/^$option=.*/$option=\"$value\"/' /etc/sysconfig/kdump";
+    my $command = "sed -i 's/^$option=.*/$option=\"$escaped_value\"/' /etc/sysconfig/kdump";
 
     assert_script_run($command);
 }

--- a/schedule/storage/nfs.yaml
+++ b/schedule/storage/nfs.yaml
@@ -13,8 +13,10 @@ conditional_schedule:
     ROLE:
       nfs_server:
         - kernel/nfs_server
+        - kernel/kdump_over_nfs
       nfs_client:
         - kernel/nfs_client
+        - kernel/kdump_over_nfs
     VERSION:
       Tumbleweed:
         - kernel/nfs_stress_ng

--- a/tests/kernel/kdump_over_nfs.pm
+++ b/tests/kernel/kdump_over_nfs.pm
@@ -1,0 +1,54 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Configure and run kdump over NFS.
+# The test is configuring - on the nfs client side - the kdump with
+# KDUMP_SAVEDIR set to NFS share. Then the actual crash is triggered,
+# still on the NFS client side and once the reboot happens, the nfs share,
+# set as the target in the KDUMP_SAVEDIR, is mounted and the crash files
+# are checked
+#
+# Maintainer: QE Kernel <kernel-qa@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use kdump_utils;
+use lockapi;
+use power_action_utils 'power_action';
+
+sub run {
+    my ($self) = @_;
+    my $role = get_required_var('ROLE');
+    my $nfs_server = get_var('NFS_SERVER', 'server-node00');
+
+    get_required_var('KDUMP_SAVEDIR');
+
+    select_console('root-console');
+
+    if ($role eq 'nfs_client') {
+        assert_script_run("mkdir -p /var/crash");
+        assert_script_run("echo \"$nfs_server:/nfs/shared_nfs3 /var/crash nfs nfsvers=3,sync,nofail,x-systemd.automount 0 0\" >> /etc/fstab");
+        assert_script_run("mount -a");
+
+        configure_service(test_type => 'function', yast_interface => 'cli');
+        check_function(test_type => 'function');
+    }
+    barrier_wait("KDUMP_MULTIMACHINE");
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    script_run 'ls -lah /boot/';
+    script_run 'tar -cvJf /tmp/crash_saved.tar.xz -C /var/crash .';
+    upload_logs '/tmp/crash_saved.tar.xz';
+
+    $self->SUPER::post_fail_hook;
+}
+
+1;

--- a/tests/kernel/kdump_over_nfs.pm
+++ b/tests/kernel/kdump_over_nfs.pm
@@ -30,6 +30,14 @@ sub run {
 
     select_console('root-console');
 
+    #Specific wicked workaround for SLE15 - allow connection from all hosts
+    if ($role eq 'nfs_server') {
+        assert_script_run("echo '/nfs/shared_nfs3 10.0.2.0/24(rw,sync,no_subtree_check,no_root_squash)' > /etc/exports");
+        assert_script_run("exportfs -ra");
+    }
+
+    barrier_wait('KDUMP_WICKED_TEMP');
+
     if ($role eq 'nfs_client') {
         assert_script_run("mkdir -p /var/crash");
         assert_script_run("echo \"$nfs_server:/nfs/shared_nfs3 /var/crash nfs nfsvers=3,sync,nofail,x-systemd.automount 0 0\" >> /etc/fstab");

--- a/tests/kernel/nfs_barriers.pm
+++ b/tests/kernel/nfs_barriers.pm
@@ -21,6 +21,9 @@ sub run {
     barrier_create("NFS_STRESS_NG_END", $nodes);
     barrier_create("NFS_NFSTEST_START", $nodes);
     barrier_create("NFS_NFSTEST_END", $nodes);
+    if (check_var('KDUMP_OVER_NFS', '1')) {
+        barrier_create("KDUMP_MULTIMACHINE", $nodes);
+    }
     record_info("barriers initializoped");
 }
 

--- a/tests/kernel/nfs_barriers.pm
+++ b/tests/kernel/nfs_barriers.pm
@@ -22,6 +22,7 @@ sub run {
     barrier_create("NFS_NFSTEST_START", $nodes);
     barrier_create("NFS_NFSTEST_END", $nodes);
     if (check_var('KDUMP_OVER_NFS', '1')) {
+        barrier_create("KDUMP_WICKED_TEMP", $nodes);
         barrier_create("KDUMP_MULTIMACHINE", $nodes);
     }
     record_info("barriers initializoped");


### PR DESCRIPTION
The patch is introducing KDUMP check over NFS where NFS multimachine tests are re-used, KDUMP is configured for writing to the mounted NFS share and then all is checked on the nfs server side - if the dump is there and if it is readable etc.

We need client and the server to wait for each other. Thus I think using get_required_var('ROLE') helps and is also simple - one module to do barrier_wait() on both client and the server side.

Then the actual test is happening on the client side only using check_function()

- Related ticket: https://progress.opensuse.org/issues/57254
- Verification run:
* SLE16:
https://openqa.suse.de/tests/18139970
https://openqa.suse.de/tests/18139971
https://openqa.suse.de/tests/18139969

* TW x86_64:
https://openqa.opensuse.org/tests/5119273
https://openqa.opensuse.org/tests/5119271
https://openqa.opensuse.org/tests/5119272

* TW arm:
https://openqa.opensuse.org/tests/5119292
https://openqa.opensuse.org/tests/5119290
https://openqa.opensuse.org/tests/5119291

* SLE15SP7:
https://openqa.suse.de/tests/18139709
https://openqa.suse.de/tests/18139710
https://openqa.suse.de/tests/18139711

Also this a proposal for the next steps: https://progress.opensuse.org/issues/184312