### PR TITLE
WIP: ssh_keyscan_fips: new test for ssh-keyscan under FIPS

### DIFF
--- a/schedule/security/fips/fips_env_mode_textmode_extra.yaml
+++ b/schedule/security/fips/fips_env_mode_textmode_extra.yaml
@@ -10,6 +10,7 @@ schedule:
     - console/aide_check
     - console/gpg
     - console/journald_fss
+    - fips/openssh/ssh_keyscan_fips
     - console/git
     - console/clamav
     - console/openvswitch_ssl

--- a/tests/fips/openssh/ssh_keyscan_fips.pm
+++ b/tests/fips/openssh/ssh_keyscan_fips.pm
@@ -1,0 +1,42 @@
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Summary: The test is meant to run on FIPS enabled systems.
+#
+#          On SLE<16 it reconfigures ssh to workaround the issue:
+#          https://bugzilla.suse.com/show_bug.cgi?id=1208797 .
+#
+#          Following that it will run ssh-keyscan.
+#
+# Maintainer: QE Security <none@suse.de>
+
+use base "consoletest";
+use strict;
+use testapi;
+use warnings;
+use utils qw(systemctl);
+use version_utils qw(is_sle);
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+
+    # Prepare directories just in case
+    assert_script_run("mkdir -p ~/.ssh && chmod 700 ~/.ssh && touch ~/.ssh/known_hosts");
+
+    # Config changes as a workaround on SLE<16 OS versions
+    if (is_sle('<16')) {
+        my $ssh_config = <<EOF;
+MACs -umac*
+Ciphers -chacha20*
+KexAlgorithms -curve25519*,-chacha20*
+EOF
+        script_output("echo '$ssh_config' >> /etc/ssh/sshd_config");
+        systemctl("restart sshd");
+    }
+
+    # Perform the test
+    assert_script_run("ssh-keyscan -H localhost > ~/.ssh/known_hosts");
+}
+
+1;


### PR DESCRIPTION
Adding a new test for ssh-keyscan under FIPS .
Schedule the test right before 'git' as a workaround for bz#1208797.

Related ticket: https://progress.opensuse.org/issues/183533

VRs:
15-SP4     : https://openqa.suse.de/tests/18088151
15-SP5     : https://openqa.suse.de/tests/18088153

15-SP4 uefi: https://openqa.suse.de/tests/18088152
15-SP5 uefi: https://openqa.suse.de/tests/18087556  

