### PR TITLE
Make vncviewer console able to show up on the top

### DIFF
--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -17,7 +17,16 @@ sub run {
     x11_start_program('xterm');
     become_root;
     script_run('virt-install --name TESTING --osinfo detect=on,require=off --memory 512 --disk none --boot cdrom --graphics vnc &', 0);
-    wait_still_screen(15);
+    save_screenshot;
+    # Choose either of the two options to turn off the pop up
+    if (check_screen('allow-inhibiting-shortcuts', 10)) {
+        send_key('left');
+        send_key('ret');
+    }
+    wait_still_screen;
+    # Close or at least deactivate the current window in case it would cover vncviewer later
+    send_key 'alt-f4';
+    wait_still_screen;
     x11_start_program('vncviewer :0', target_match => 'virtman-gnome_virt-install', match_timeout => 100);
     # closing all windows
     send_key 'alt-f4' for (0 .. 2);


### PR DESCRIPTION
It fixs 2 problems:

1. Shortcuts were inhibited at `virt-viewer` console. It made `send_key` not work in the test.
2. The `vncviewer` console was covered by `virt-viewer` console.

- Related ticket: https://progress.opensuse.org/issues/183383
- Needles: https://openqa.opensuse.org/tests/5111491#step/virt_install/22
- Verification run: 
3 consecutive passed runs on virt_install module in https://openqa.opensuse.org/tests/5111492#next_previous
