### PR TITLE
Export OS_PRETTY_NAME

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -136,6 +136,8 @@ sub run {
     reset_container_network_if_needed($engine);
 
     assert_script_run('source bci/bin/activate') if ($bci_virtualenv);
+    assert_script_run("source /etc/os-release");
+    assert_script_run('export OS_PRETTY_NAME=$PRETTY_NAME');
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard $bci_tests_branch");


### PR DESCRIPTION
Export the OS_PRETTY_NAME setting, as it is required by BCI-Tests.

- Related failure: https://openqa.suse.de/tests/18082593#step/_root_BCI-tests_base_/6
- Related PR: https://github.com/SUSE/BCI-tests/pull/852
- Verification run: https://duck-norris.qe.suse.de/tests/14876
