### PR TITLE
Sectors do not change after migration

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -36,7 +36,7 @@ sub run {
     # Verify that there is no unpartitioned space left
     # 0 sectors is default and expected value in most of the images
     my $left_sectors = 0;
-    if ((is_sle_micro("6.2+") || is_leap_micro("6.2+")) && is_aarch64 && !(get_var('FLAVOR', '') =~ /qcow/i)) {
+    if ((is_sle_micro("6.2+") || is_leap_micro("6.2+")) && is_aarch64 && !(get_var('FLAVOR', '') =~ /qcow/i) && !check_var('FROM_VERSION', '6.1')) {
         $left_sectors = 4062;
     } elsif ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow|SelfInstall/) {
         $left_sectors = 2048;


### PR DESCRIPTION
The partition layout is untouched so free sectors check should expect the same values as in the previous version after migration

#### Verification runs

 - sle-micro-6.2-Default-aarch64-Build13.4-slem_migration_6.1_to_6.2@aarch64 -> https://openqa.suse.de/tests/18095739
 - sle-micro-6.2-Default-x86_64-Build13.4-slem_migration_6.1_to_6.2@64bit -> https://openqa.suse.de/tests/18095740
