### PR TITLE
jeos: Validate that SELinux is in enforcing mode

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -132,8 +132,8 @@ sub verify_partition_label {
 
 sub verify_selinux {
     if (has_selinux_by_default) {
-        # SELinux is default, should be enabled
-        validate_script_output("sestatus", sub { m/SELinux status:.*enabled/ });
+        # SELinux is default, should be enabled and in enforcing mode
+        validate_script_output('sestatus', sub { m/SELinux status: .*enabled/ && m/Current mode: .*enforcing/ }, fail_message => 'SELinux is NOT enabled and set to enforcing');
     } else {
         # SELinux is not default, but might be supported
         my $selinux_supported = script_run("grep -qw selinux /sys/kernel/security/lsm") == 0;


### PR DESCRIPTION
Validate that SELinux is in enforcing mode.

Do the same procedure done in [selinux_setup](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/security/selinux/selinux_setup.pm#L72).

- Related ticket: https://progress.opensuse.org/issues/182351