### PR TITLE
Generate IPv6 EUI-64 address

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -605,7 +605,7 @@ sub load_jeos_openstack_tests {
     loadtest "jeos/record_machine_id";
     loadtest "console/system_prepare" if is_sle;
     loadtest "console/force_scheduled_tasks";
-    loadtest "jeos/grub2_gfxmode";
+    loadtest "jeos/host_config";
     loadtest "jeos/build_key";
     loadtest "console/prjconf_excluded_rpms";
     unless (get_var('CI_VERIFICATION')) {
@@ -647,7 +647,7 @@ sub load_jeos_tests {
     loadtest "jeos/record_machine_id";
     loadtest "console/force_scheduled_tasks";
     # this test case also disables grub timeout
-    loadtest "jeos/grub2_gfxmode" unless (is_bootloader_sdboot || is_bootloader_grub2_bls);
+    loadtest "jeos/host_config" unless (is_bootloader_sdboot || is_bootloader_grub2_bls);
     unless (get_var('INSTALL_LTP') || get_var('SYSTEMD_TESTSUITE')) {
         # jeos/diskusage as of now works only with BTRFS
         loadtest "jeos/diskusage" if get_var('FILESYSTEM', 'btrfs') =~ /btrfs/;

--- a/schedule/jeos/sle/jeos-base+sdk+desktop.yaml
+++ b/schedule/jeos/sle/jeos-base+sdk+desktop.yaml
@@ -22,7 +22,7 @@ schedule:
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc

--- a/schedule/jeos/sle/jeos-extratest-sle12.yaml
+++ b/schedule/jeos/sle/jeos-extratest-sle12.yaml
@@ -25,7 +25,7 @@ schedule:
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc

--- a/schedule/jeos/sle/jeos-extratest.yaml
+++ b/schedule/jeos/sle/jeos-extratest.yaml
@@ -30,7 +30,7 @@ schedule:
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc

--- a/schedule/jeos/sle/jeos-fs_stress.yaml
+++ b/schedule/jeos/sle/jeos-fs_stress.yaml
@@ -22,7 +22,7 @@ schedule:
     - jeos/firstrun
     - jeos/record_machine_id
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc

--- a/schedule/jeos/sle/jeos-ltp.yaml
+++ b/schedule/jeos/sle/jeos-ltp.yaml
@@ -11,7 +11,7 @@ schedule:
   - jeos/record_machine_id
   - console/system_prepare
   - console/force_scheduled_tasks
-  - jeos/grub2_gfxmode
+  - jeos/host_config
   - jeos/diskusage
   - jeos/build_key
   - console/suseconnect_scc

--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -53,7 +53,7 @@ schedule:
     - jeos/image_info
     - jeos/record_machine_id
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/prjconf_excluded_rpms

--- a/schedule/jeos/sle/jeos12sp5-main.yaml
+++ b/schedule/jeos/sle/jeos12sp5-main.yaml
@@ -30,7 +30,7 @@ schedule:
     - jeos/firstrun
     - jeos/record_machine_id
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/prjconf_excluded_rpms

--- a/schedule/jeos/sle/jeos15sp1-main.yaml
+++ b/schedule/jeos/sle/jeos15sp1-main.yaml
@@ -41,7 +41,7 @@ schedule:
     # - jeos/image_info
     - jeos/record_machine_id
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/prjconf_excluded_rpms

--- a/schedule/jeos/sle/minimalvm-extratest.yaml
+++ b/schedule/jeos/sle/minimalvm-extratest.yaml
@@ -30,7 +30,7 @@ schedule:
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc

--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -49,7 +49,7 @@ schedule:
     - jeos/image_info
     - jeos/record_machine_id
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/prjconf_excluded_rpms

--- a/schedule/jeos/sle/minimalvm-toolchains.yaml
+++ b/schedule/jeos/sle/minimalvm-toolchains.yaml
@@ -22,7 +22,7 @@ schedule:
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
-    - jeos/grub2_gfxmode
+    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc


### PR DESCRIPTION
s390x z/KVM has a different networking setup than other openQA workers. In this particular case, we need to force eui64 address assignment.

- Verification run: https://openqa.suse.de/tests/18100322#
