### PR TITLE
Restrict BATS patches to each package test directory

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -97,6 +97,7 @@ podman:
     BATS_PATCHES:
     - 21875
     - 25792
+    - 25942
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL:
     BATS_SKIP_ROOT_REMOTE:
@@ -106,6 +107,7 @@ podman:
     BATS_PATCHES:
     - 21875
     - 25792
+    - 25942
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL:
     BATS_SKIP_ROOT_REMOTE:


### PR DESCRIPTION
Restrict BATS patches to each package test directory.

Sometimes patches may touch other files that may not exist in older versions and `git apply` would fail.  Restrict their scope to each package test directory so the patches can be cleanly applied.

Apply https://github.com/containers/podman/pull/25942 to SLES 15-SP6+ which uses podman v4.9.5.

Failed tests:
- https://openqa.suse.de/tests/18110404
- https://openqa.suse.de/tests/18110416

Verification runs:
- SLES 15-SP6: https://openqa.suse.de/tests/18111554
- SLES 15-SP7: https://openqa.suse.de/tests/18111553
- Tumbleweed: https://openqa.opensuse.org/tests/5114221