### PR TITLE
Fix container-suseconnect test

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -89,59 +89,6 @@ sub build_and_run_image {
     assert_script_run("$runtime rm myapp");
 }
 
-# Build a sle container image using zypper_docker
-sub build_with_zypper_docker {
-    my %args = @_;
-    my $image = $args{image};
-    my $runtime = $args{runtime};
-    my $derived_image = "zypper_docker_derived";
-
-    my $distri = $args{distri} //= get_required_var("DISTRI");
-    my $version = $args{version} //= get_required_var("VERSION");
-
-    die 'Argument $image not provided!' unless $image;
-    die 'Argument $runtime not provided!' unless $runtime;
-
-    my ($host_version, $host_sp, $host_id) = get_os_release();
-    my ($image_version, $image_sp, $image_id) = get_os_release("$runtime run $image");
-
-    # The zypper-docker works only on openSUSE or on SLE based image on SLE host
-    unless (($host_id =~ 'sles' && $image_id =~ 'sles') || $image_id =~ 'opensuse') {
-        record_info 'Warning!', 'The zypper-docker only works for openSUSE based images and SLE based images on SLE host.';
-        return;
-    }
-
-    if ($distri eq 'sle') {
-        my $pretty_version = $version =~ s/-SP/ SP/r;
-        my $betaversion = get_var('BETA') ? '\s\([^)]+\)' : '';
-        validate_script_output("$runtime run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'",
-            sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
-    } else {
-        $version =~ s/^Jump://i;
-        validate_script_output qq{$runtime container run --entrypoint '/bin/bash' --rm $image -c 'cat /etc/os-release'}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
-    }
-
-    zypper_call("in zypper-docker") if (script_run("which zypper-docker") != 0);
-
-    my $log = "/tmp/zypper-docker-list-updates.log";
-    my $zypper_docker = 'zypper-docker --gpg-auto-import-keys';
-    my $rc = script_retry("$zypper_docker list-updates $image | tee $log", timeout => 300, retry => 3, delay => 60);
-    return if script_run("grep 'No updates found.' $log");
-
-    script_retry("$zypper_docker up $image $derived_image", timeout => 300, retry => 3, delay => 60);
-
-    # If zypper-docker list-updates lists no updates then derived image was successfully updated
-    validate_script_output_retry("$zypper_docker list-updates $derived_image", qr/No updates found/, timeout => 300, retry => 3, delay => 60);
-
-    my $local_images_list = script_output("$runtime image ls");
-    die("$runtime $derived_image not found") unless ($local_images_list =~ $derived_image);
-
-    record_info("Testing derived", "Derived image: $derived_image");
-    test_opensuse_based_image(image => $derived_image, runtime => $runtime, version => $version);
-
-    assert_script_run("docker rmi -f $derived_image");
-}
-
 sub test_opensuse_based_image {
     my %args = @_;
     my $image = $args{image};
@@ -167,17 +114,15 @@ sub test_opensuse_based_image {
             my $pretty_version = $version =~ s/-SP/ SP/r;
             my $betaversion = $beta ? '\s\([^)]+\)' : '';
             record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
-            # zypper-docker changes the layout of the image (Note: We may have images without 'grep')
             validate_script_output("$runtime run --entrypoint /bin/bash $image -c 'cat /etc/os-release' | grep PRETTY_NAME | cut -d= -f2",
                 sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
 
             # SUSEConnect zypper service is supported only on SLE based image on SLE host
             unless (is_unreleased_sle) {
-                # we set --entrypoint specifically to the zypper plugin to avoid bsc#1192941
-                my $plugin = '/usr/lib/zypp/plugins/services/container-suseconnect-zypp';
-                validate_script_output("$runtime run --entrypoint $plugin -i $image -v", sub { m/container-suseconnect version .*/ }, timeout => 180);
-                validate_script_output_retry("$runtime run --entrypoint $plugin -i $image lp", sub { m/.*All available products.*/ }, retry => 5, delay => 60, timeout => 300);
-                validate_script_output_retry("$runtime run --entrypoint $plugin -i $image lm", sub { m/.*All available modules.*/ }, retry => 5, delay => 60, timeout => 300);
+                my $cmd = "container-suseconnect";
+                validate_script_output("$runtime run --rm -i $image $cmd --version", sub { m/^\d+\.\d+/ }, timeout => 180);
+                validate_script_output_retry("$runtime run --rm -i $image $cmd lp", sub { m/.*All available products.*/ }, retry => 5, delay => 60, timeout => 300);
+                validate_script_output_retry("$runtime run --rm -i $image $cmd lm", sub { m/.*All available modules.*/ }, retry => 5, delay => 60, timeout => 300);
             }
         } else {
             record_info "non-SLE host", "This host ($host_id) does not support zypper service";
@@ -193,10 +138,6 @@ sub test_opensuse_based_image {
         # that are not the same version as the host, so we skip this test.
         test_zypper_on_container($runtime, $image);
         build_and_run_image(base => $image, runtime => $runtime);
-        # zypper-docker package has been excluded from sle starting with 15-SP6
-        if (is_sle('<15-SP6') && $runtime->runtime eq 'docker' && script_run('zypper -q se zypper-docker') == 0) {
-            build_with_zypper_docker(image => $image, runtime => $runtime, version => $version);
-        }
     }
 }
 
@@ -207,13 +148,6 @@ sub test_zypper_on_container {
     die 'Argument $image not provided!' unless $image;
     die 'Argument $runtime not provided!' unless $runtime;
 
-    # Check for bsc#1192941, which affects the docker runtime only - this is just check not softfailure as this won't be fixed.
-    # bsc#1192941 states that the entrypoint of a derived image is set in a way, that program arguments are not passed anymore
-    # we run 'zypper ls' on a container, and if we detect the zypper usage message, we know that the 'ls' parameter was ignored
-    if ($runtime->runtime eq 'docker') {
-        my $zypper_output = script_output_retry("docker run --rm -ti $image zypper ls", timeout => 270, delay => 60, retry => 3);
-        record_info('bsc#1192941', 'bsc#1192941 - zypper-docker entrypoint confuses program arguments') if ($zypper_output =~ /Usage:/);
-    }
     validate_script_output_retry("$runtime run -i --entrypoint '' $image zypper lr -s", sub { m/.*Alias.*Name.*Enabled.*GPG.*Refresh.*Service/ }, timeout => 180);
     assert_script_run("$runtime run -t -d --name 'refreshed' --entrypoint '' $image bash", timeout => 300);
     script_retry("$runtime exec refreshed zypper -nv --gpg-auto-import-keys ref", timeout => 600, retry => 3, delay => 120);

--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -102,7 +102,7 @@ sub test_opensuse_based_image {
     die 'Argument $runtime not provided!' unless $runtime;
 
     my ($host_version, $host_sp, $host_id) = get_os_release();
-    my ($image_version, $image_sp, $image_id) = get_os_release("$runtime run --entrypoint '' $image");
+    my ($image_version, $image_sp, $image_id) = get_os_release("$runtime run --rm --entrypoint '' $image");
 
     record_info "Host", "Host has '$host_version', '$host_sp', '$host_id' in /etc/os-release";
     record_info "Image", "Image has '$image_version', '$image_sp', '$image_id' in /etc/os-release";
@@ -114,7 +114,7 @@ sub test_opensuse_based_image {
             my $pretty_version = $version =~ s/-SP/ SP/r;
             my $betaversion = $beta ? '\s\([^)]+\)' : '';
             record_info "Validating", "Validating That $image has $pretty_version on /etc/os-release";
-            validate_script_output("$runtime run --entrypoint /bin/bash $image -c 'cat /etc/os-release' | grep PRETTY_NAME | cut -d= -f2",
+            validate_script_output("$runtime run --rm --entrypoint /bin/bash $image -c 'cat /etc/os-release' | grep PRETTY_NAME | cut -d= -f2",
                 sub { /"SUSE Linux Enterprise Server ${pretty_version}${betaversion}"/ });
 
             # SUSEConnect zypper service is supported only on SLE based image on SLE host
@@ -148,7 +148,7 @@ sub test_zypper_on_container {
     die 'Argument $image not provided!' unless $image;
     die 'Argument $runtime not provided!' unless $runtime;
 
-    validate_script_output_retry("$runtime run -i --entrypoint '' $image zypper lr -s", sub { m/.*Alias.*Name.*Enabled.*GPG.*Refresh.*Service/ }, timeout => 180);
+    validate_script_output_retry("$runtime run --rm -i --entrypoint '' $image zypper lr -s", sub { m/.*Alias.*Name.*Enabled.*GPG.*Refresh.*Service/ }, timeout => 180);
     assert_script_run("$runtime run -t -d --name 'refreshed' --entrypoint '' $image bash", timeout => 300);
     script_retry("$runtime exec refreshed zypper -nv --gpg-auto-import-keys ref", timeout => 600, retry => 3, delay => 120);
     assert_script_run("$runtime commit refreshed refreshed-image", timeout => 120);


### PR DESCRIPTION
Fix container-suseconnect test

- Call `container-suseconnect` directly as customers would do instead of calling a plugin directly.
- Remove all code related to `zypper-docker` which is no longer maintained.
- Add missing `--rm` option to ephemeral container runs.

Related discussion: https://suse.slack.com/archives/C02DR0C5XUY/p1750153948868519

Supersedes https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22388

Failing tests:
- https://openqa.suse.de/tests/18108940

Verification runs:
- 15-SP3:
  - docker: https://openqa.suse.de/tests/18112478
  - podman: https://openqa.suse.de/tests/18112479
- 15-SP4:
  - docker: https://openqa.suse.de/tests/18112480
  - podman: https://openqa.suse.de/tests/18112481
- 15-SP5:
  - docker: https://openqa.suse.de/tests/18112482
  - podman: https://openqa.suse.de/tests/18112483
- 15-SP6:
  - docker: https://openqa.suse.de/tests/18112484
  - podman: https://openqa.suse.de/tests/18112485
- 15-SP7:
  - docker: https://openqa.suse.de/tests/18112486
  - podman: https://openqa.suse.de/tests/18112487