### PR TITLE
containers: Only print version of container-suseconnect

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -120,7 +120,7 @@ sub test_opensuse_based_image {
             # SUSEConnect zypper service is supported only on SLE based image on SLE host
             unless (is_unreleased_sle) {
                 my $cmd = "container-suseconnect";
-                validate_script_output("$runtime run --rm -i $image $cmd --version", sub { m/^\d+\.\d+/ }, timeout => 180);
+                record_info("$cmd version", script_output("$runtime run --rm -i $image $cmd --version"));
                 validate_script_output_retry("$runtime run --rm -i $image $cmd lp", sub { m/.*All available products.*/ }, retry => 5, delay => 60, timeout => 300);
                 validate_script_output_retry("$runtime run --rm -i $image $cmd lm", sub { m/.*All available modules.*/ }, retry => 5, delay => 60, timeout => 300);
             }


### PR DESCRIPTION
Only print version of `container-suseconnect`.  We're not interested in validating the output of the command, specially if it may include a harmless warning.

- Failing test: https://openqa.suse.de/tests/18112646#step/image_podman/111
- Verification run: https://openqa.suse.de/tests/18115056