### PR TITLE
Fix for sysm related failures in MU

### DIFF
--- a/lib/Installation/ModuleRegistration/ModuleRegistrationPage.pm
+++ b/lib/Installation/ModuleRegistration/ModuleRegistrationPage.pm
@@ -41,6 +41,7 @@ sub init {
     $self->{rct_item_ltss} = 'SLES-LTSS';
     $self->{rct_item_live} = 'sle-module-live-patching';
     $self->{rct_item_phub} = 'PackageHub';
+    $self->{rct_item_sysm} = 'sle-module-systems-management';
     return $self;
 }
 


### PR DESCRIPTION
Problem cause: SCC_ADDONS has 'sysm' but there was no mapping for 'sysm' to the full module name. So by default the first one in the list got selected and due to recent changes in SCC the first one moved from "base" to "ha". But the HA module needs an own registration code which caused the failures e.g.
https://openqa.suse.de/tests/18109900#step/add_additional_products/1

- Verification run: https://openqa.suse.de/tests/18114997
