### PR TITLE
Increase timeout for drive re-encryption

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -304,7 +304,7 @@ sub run {
         type_password;
         send_key "ret";
         # Disk encryption is gonna take time
-        assert_screen 're-encrypt-finished', 600 unless is_sle_micro('>=6.2');
+        assert_screen 're-encrypt-finished', 720 unless is_sle_micro('>=6.2');
     }
 
     if (is_tumbleweed || is_microos || is_sle_micro('>6.0') || is_leap_micro('>6.0') || is_sle('>=16')) {


### PR DESCRIPTION
Currently the test is taking longer than expected. Let's try a TO increase

- ticket: https://progress.opensuse.org/issues/183254
