### PR TITLE
Restore qam gfxdrivers schedule

### DIFF
--- a/schedule/qam/common/kernel/gfxdrivers.yaml
+++ b/schedule/qam/common/kernel/gfxdrivers.yaml
@@ -1,0 +1,30 @@
+---
+name: gfxdrivers
+schedule:
+- autoyast/prepare_profile
+- installation/bootloader_start
+- autoyast/installation
+- autoyast/console
+- autoyast/login
+- autoyast/wicked
+- autoyast/repos
+- autoyast/clone
+- autoyast/logs
+- console/yast2_vnc
+- console/force_scheduled_tasks
+- autoyast/autoyast_reboot
+- kernel/update_kernel
+- console/system_prepare
+- console/check_network
+- console/system_state
+- console/prepare_test_data
+- console/consoletest_setup
+- locale/keymap_or_locale
+- console/textinfo
+- console/hostname
+- console/consoletest_finish
+- locale/keymap_or_locale_x11
+- x11/glxgears
+- kernel/usb_nic
+- kernel/usb_drive
+- shutdown/shutdown


### PR DESCRIPTION
Restore the old qam-gfxdrivers.yaml schedule file removed by 24e25d7, with a new name in qam/common/kernel/gfxdrivers.yaml.

- Related ticket: https://progress.opensuse.org/issues/184231

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>