### PR TITLE
Replace 'agama profile import' with 'agama config load'

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -804,6 +804,7 @@ sub generate_json_profile {
     diag "jsonnet @profile_options $profile_path";
     record_info("JSONNET Command", "jsonnet @profile_options $profile_path");
     my $profile_content = `jsonnet @profile_options $profile_path`;
+    die "Error generating jsonnet profile" if ($? != 0);
     record_info("Profile", $profile_content);
 
     save_tmp_file($profile_name, $profile_content);

--- a/tests/yam/agama/import_agama_profile.pm
+++ b/tests/yam/agama/import_agama_profile.pm
@@ -7,7 +7,7 @@
 use base Yam::Agama::patch_agama_base;
 use strict;
 use warnings;
-use testapi qw(assert_script_run data_url get_required_var select_console script_run);
+use testapi qw(assert_script_run data_url get_required_var select_console script_run get_var);
 use autoyast qw(expand_agama_profile generate_json_profile);
 
 sub run {
@@ -17,7 +17,12 @@ sub run {
       expand_agama_profile($profile);
 
     select_console 'install-shell';
-    assert_script_run("agama profile import $profile_url", timeout => 300);
+
+    # Workaround to import profile in each Agama version
+    my $command = script_run('agama config load --help | grep URL_OR_PATH') == '0' ?
+      "agama config load $profile_url" : "agama profile import $profile_url";
+
+    assert_script_run($command, timeout => 300);
 }
 
 1;


### PR DESCRIPTION
We have added a condition to 

- Related ticket: https://progress.opensuse.org/issues/184004
- Needles: N/A
- Verification run: 
  - x86_64 - 97.3/prod: https://openqa.suse.de/tests/18115174
  - x86_64 - 14.8/dev: https://openqa.suse.de/tests/18115181
  - aarch64 - 97.3/prod: https://openqa.suse.de/tests/18115173
  - aarch64 - 14.8/dev: https://openqa.suse.de/tests/18115180
  - s390x-kvm - 97.3/prod: https://openqa.suse.de/tests/18112463
  - s390x-kvm - 14.8/dev: https://openqa.suse.de/tests/18115787
  - ppc64le-hmc - 97.3/prod: https://openqa.suse.de/tests/18115168
  - ppc64le-hmc - 14.8/dev: https://openqa.suse.de/tests/18115179
