### PR TITLE
Add modern WSL installation method from MSStore.

### DIFF
--- a/lib/wsl.pm
+++ b/lib/wsl.pm
@@ -10,7 +10,7 @@ use Mojo::Base qw(Exporter);
 use testapi;
 use version_utils qw(is_sle);
 
-our @EXPORT = qw(is_sut_reg is_fake_scc_url_needed);
+our @EXPORT = qw(is_sut_reg is_fake_scc_url_needed wsl_choose_sles register_via_scc wsl_firstboot_refocus);
 
 sub is_sut_reg {
     return is_sle && get_var('SCC_REGISTER') =~ /^yast$/i;
@@ -20,4 +20,39 @@ sub is_fake_scc_url_needed {
     return is_sut_reg && get_var('BETA', 0) && get_var('SCC_URL');
 }
 
+# WSL jeos-firstboot requires to choose from sled or sles version.
+sub wsl_choose_sles {
+    assert_screen 'wsl-sled-or-sles';
+    wait_screen_change { type_string "SLES", max_interval => 125, wait_screen_change => 2 };
+    send_key 'ret';
+}
+
+# Register via SCC using jeos-firstboot
+sub register_via_scc {
+    assert_screen 'wsl-registration', 120;
+
+    unless (is_sut_reg) {
+        wait_screen_change(sub { send_key 'alt-s' }, 10);
+        assert_screen 'wsl-skip-registration-warning';
+        send_key 'ret';
+        assert_screen 'wsl-skip-registration-checked';
+        send_key 'alt-n';
+        return;
+    }
+
+    my $reg_code = get_required_var('SCC_REGCODE');
+    wait_screen_change(sub { send_key 'down' }, 10);
+    wait_screen_change { type_string $reg_code, max_interval => 125, wait_screen_change => 2 };
+    send_key 'ret';
+}
+
+# In WSL, the new process of installing, appears in an already maximized window,
+# but sometimes it loses focus. So I created another needle to check if
+# the window is already maximized and click somewhere else to bring it to focus.
+sub wsl_firstboot_refocus {
+    assert_screen(['window-max', 'window-minimize']);
+    assert_and_click 'window-max' if match_has_tag 'window-max';
+    assert_and_click 'window-minimize' if match_has_tag 'window-minimize';
+    wait_still_screen stilltime => 3, timeout => 10;
+}
 1;

--- a/schedule/wsl/wsl_main.yaml
+++ b/schedule/wsl/wsl_main.yaml
@@ -1,7 +1,7 @@
 ---
 name: wsl_main.yaml
-description:  >
-      WSL smoke test on Windows 10 image
+description: >
+  WSL smoke test on Windows 10 image
 
 conditional_schedule:
   enable_systemd:
@@ -12,11 +12,19 @@ conditional_schedule:
     ARCH:
       'aarch64':
         - wsl/wsl_install
+  # Different modules used for legacy and modern wsl installations.
+  # Legacy is yast-firstboot and modern is jeos-firstboot.
+  wsl_firstrun:
+    WSL_FIRSTBOOT:
+      'jeos':
+        - jeos/firstrun
+      'yast':
+        - wsl/firstrun
 
 schedule:
   - wsl/boot_windows
   - '{{wsl_install}}'
   - wsl/distro_install
-  - wsl/firstrun
+  - '{{wsl_firstrun}}'
   - '{{enable_systemd}}'
   - wsl/smoke_test


### PR DESCRIPTION
WSL installation from Microsoft Store now has two installation methods. 

Legacy, which installs using yast-firstboot and Modern, which installs using jeos-firstboot. Both installation methods have to be tested. This PR is accompanied by a qac-openqa-yaml PR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2265

- Related ticket: https://progress.opensuse.org/issues/180704

Verification runs:

SLES:

Win 10 Legacy: https://openqa.suse.de/tests/18462324
Win 10 Modern: https://openqa.suse.de/tests/18462703
Win 11 Legacy: https://openqa.suse.de/tests/18462702
Win 11 Modern: https://openqa.suse.de/tests/18462708

There is an issue regarding wsl installation in windows 10 for TW and Leap https://progress.opensuse.org/issues/185959 , therefore, for the time being I will propose merging SLES test code which is already working as expected.



