### PR TITLE
Preinstall k3s on SLEM6 builds

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -45,6 +45,7 @@ sub load_config_tests {
     loadtest 'transactional/enable_selinux' if (get_var('ENABLE_SELINUX') && is_image);
     loadtest 'console/suseconnect_scc' if (get_var('SCC_REGISTER') && !is_dvd);
     loadtest 'transactional/install_updates' if (is_sle_micro && is_released);
+    loadtest 'transactional/install_k3s' if (is_sle_micro('6.0+') && (is_x86_64 || is_aarch64));
 }
 
 sub load_boot_from_disk_tests {

--- a/tests/transactional/install_k3s.pm
+++ b/tests/transactional/install_k3s.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: transactional-update
+# Summary: Installation of K3s
+#
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base qw(consoletest);
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use containers::k8s qw(install_k3s);
+
+sub run {
+    select_serial_terminal;
+
+    install_k3s();
+}
+
+sub test_flags {
+    return {no_rollback => 1, fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
Preinstalls k3s on SLEM 6.x.

- Related ticket: https://progress.opensuse.org/issues/183983
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18150170#step/install_k3s/1