### PR TITLE
bind: Fix TFAIL variable

### DIFF
--- a/tests/console/bind.pm
+++ b/tests/console/bind.pm
@@ -101,13 +101,13 @@ sub run {
         for (1 .. 3) {
             eval {
                 if (package_version_cmp($bind_version, '9.18.33') <= 0) {
-                    assert_script_run 'TFAIL=$(awk -F: -e \'/^R:.*:FAIL/ {print$2}\' /tmp/test-suite.txt; echo $TFAIL)';
+                    assert_script_run 'TFAIL=$(awk -F: -e \'/^R:.*:FAIL/ {print$2}\' /tmp/test-suite.txt); echo $TFAIL';
                 }
                 elsif (package_version_cmp($bind_version, '9.20.9') < 0) {
-                    assert_script_run 'TFAIL=$(awk \'/^FAIL:/ {print$2}\' /tmp/test-suite.txt; echo $TFAIL)';
+                    assert_script_run 'TFAIL=$(awk \'/^FAIL:/ {print$2}\' /tmp/test-suite.txt); echo $TFAIL';
                 }
                 else {
-                    assert_script_run 'TFAIL=$(awk \'/^FAILED/ {print$2}\' /tmp/test-suite.txt; echo $TFAIL)';
+                    assert_script_run 'TFAIL=$(awk \'/^FAILED/ {print$2}\' /tmp/test-suite.txt); echo $TFAIL';
                 }
                 assert_script_run "for t in \$TFAIL; do $bind_cmd \$t; done", 2000;
             };


### PR DESCRIPTION
Print the variable after variable is populated,
now the variable was at the end empty

- Related ticket: https://openqa.suse.de/tests/18132230#step/bind/1
- Verification run: https://openqa.suse.de/tests/18133597 VR does not prove anything, retry is required