### PR TITLE
Unify sdaf uploaded logs file name

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -1260,11 +1260,11 @@ sub sdaf_upload_logs {
     upload_logs("$crm_cfg_log");
 
     # Upload zypper log
-    upload_logs('/var/log/zypper.log', log_name => "upload_logs-${hostname}_zypper.log");
+    upload_logs('/var/log/zypper.log', log_name => "$autotest::current_test->{name}-${hostname}_zypper.log");
 
     # Generate the packages list
     script_run "rpm -qa > $packages_list";
-    upload_logs("$packages_list", log_name => "${hostname}_${packages_list}", failok => 1);
+    upload_logs("$packages_list", failok => 1);
 
     # iSCSI devices and their real paths
     script_run "ls -l /dev/disk/by-path/ > $iscsi_devs";

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -626,6 +626,9 @@ subtest '[sdaf_upload_logs]' => sub {
     $ms_sdaf->redefine(script_output => sub { return 'log_file'; });
     $ms_sdaf->redefine(upload_logs => sub { return; });
 
+    my $basetest = Test::MockModule->new('basetest');
+    $autotest::current_test = new basetest;
+
     set_var('SUPPORTCONGFIG', undef);
     ok sdaf_upload_logs(hostname => $arguments{hostname}, sap_sid => $arguments{sap_sid});
 


### PR DESCRIPTION
Unify sdaf uploaded logs file name.

- Related ticket: no
- Verification run: https://openqaworker15.qa.suse.cz/tests/330274#downloads (the names are `upload_logs-${hostname}_xxx.xxx` now)
