### PR TITLE
Enable test failure when AVC records are found

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -388,6 +388,7 @@ List AVCs that have been recorded during a runtime of a test module that execute
 =cut
 
 sub record_avc_selinux_alerts {
+    my $self = shift;
 
     if ((current_console() !~ /root|log/) || (script_run('test -f /var/log/audit/audit.log') != 0)) {
         return;
@@ -397,6 +398,7 @@ sub record_avc_selinux_alerts {
 
     # no new messages are registered
     if (scalar @logged <= $avc_record{start}) {
+        record_info('AVC', "AVCs were not found");
         return;
     }
 
@@ -404,7 +406,15 @@ sub record_avc_selinux_alerts {
     my @avc = @logged[$avc_record{start} .. $avc_record{end}];
     $avc_record{start} = $avc_record{end} + 1;
 
-    record_info('AVC', join("\n", @avc));
+    if (@avc) {
+        my $is_test_fail = get_var('AVC_FAIL_TEST', 1);
+        if ($is_test_fail) {
+            record_info('AVC', join("\n", @avc), result => 'fail');
+            $self->result('fail');
+        } else {
+            record_info('AVC', join("\n", @avc), result => 'softfail');
+        }
+    }
 }
 
 1;

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -30,7 +30,7 @@ sub post_run_hook {
     # start next test in home directory
     enter_cmd "cd";
 
-    record_avc_selinux_alerts();
+    $self->record_avc_selinux_alerts();
     # clear screen to make screen content ready for next test
     $self->clear_and_verify_console;
 }
@@ -44,7 +44,7 @@ Method executed when run() finishes and the module has result => 'fail'
 sub post_fail_hook {
     my ($self) = @_;
     return if get_var('NOLOGS');
-    record_avc_selinux_alerts();
+    $self->record_avc_selinux_alerts();
     $self->SUPER::post_fail_hook;
     # at this point the instance is shutdown
     return if (is_public_cloud() || is_openstack());

--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -38,4 +38,12 @@ sub containers_factory {
     return $engine;
 }
 
+sub post_fail_hook {
+    shift->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    shift->SUPER::post_run_hook;
+}
+
 1;

--- a/lib/installbasetest.pm
+++ b/lib/installbasetest.pm
@@ -5,6 +5,11 @@ use warnings;
 
 # All steps in the installation are 'fatal'.
 
+# Overwrite default post_run_hook
+sub post_run_hook {
+    ;
+}
+
 sub test_flags {
     return {fatal => 1};
 }

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -23,6 +23,10 @@ sub test_flags {
     return {fatal => 1};
 }
 
+sub post_run_hook {
+    ;
+}
+
 sub post_fail_hook {
     my ($self) = shift;
     check_bsc1215132();


### PR DESCRIPTION
After each test module, we should look for recorded AVC's if the system runs with SELinux.


- Related ticket: https://progress.opensuse.org/issues/xyz

#### Verification runs

- [microos-image](http://kepler.suse.cz/tests/24991#)
- [tw-cloud + cloudinit](http://kepler.suse.cz/tests/24983)
- [podman - avc fail](http://kepler.suse.cz/tests/24986#step/rootless_podman/239)
- [tw](http://kepler.suse.cz/tests/24982)
- [6.2 selfinstall](http://kepler.suse.cz/tests/24989)
- [microos container host - avc fail](http://kepler.suse.cz/tests/24980#step/rootless_podman/229)
- [minimal-vm](http://kepler.suse.cz/tests/24987)
- [6.2](http://kepler.suse.cz/tests/24992#live)
 - sle-micro-6.2-Default-qcow-s390x-Build13.17-default@s390x-kvm -> https://openqa.suse.de/tests/18190764
- sle-16.0-Minimal-VM-for-kvm-and-xen-s390x-Build26.11-minimalvm-extratest@s390x-kvm -> https://openqa.suse.de/tests/18191424#details4
