### PR TITLE
Save/restore Agama settings during installation

### DIFF
--- a/tests/yam/migration/restore_upgrade_env.pm
+++ b/tests/yam/migration/restore_upgrade_env.pm
@@ -14,9 +14,11 @@ use migration 'reset_consoles_tty';
 
 sub run {
     # Restore the original value of the variables
-    foreach my $var (qw(VERSION SCC_ADDONS)) {
-        set_var($var, get_var($var . "_ENV"));
-        record_info($var, $var . '=' . get_var($var));
+    foreach my $var (qw(AGAMA SCC_ADDONS VERSION)) {
+        if (get_var($var . "_ENV")) {
+            set_var($var, get_var($var . "_ENV"));
+            record_info($var, $var . '=' . get_var($var));
+        }
     }
 
     # tty assignation might differ between product versions

--- a/tests/yam/migration/setup_upgrade_env.pm
+++ b/tests/yam/migration/setup_upgrade_env.pm
@@ -22,14 +22,23 @@ sub run {
             get_var('SCC_ADDONS')));
 
     # Save the original value of the variables in order to restore it later if needed
-    set_var('VERSION_ENV', get_var('VERSION'));
-    set_var('SCC_ADDONS_ENV', get_var('SCC_ADDONS'));
+    foreach my $var (qw(AGAMA SCC_ADDONS VERSION)) {
+        set_var($var . "_ENV", get_var($var)) if (get_var($var));
+    }
 
     # Change variables to the other version that we want to migrate from/to
-    set_var('VERSION', $version);
-    record_info('VERSION', 'VERSION=' . get_var('VERSION'));
-    set_var('SCC_ADDONS', $scc_addons);
-    record_info('SCC_ADDONS', 'SCC_ADDONS=' . get_var('SCC_ADDONS'));
+    my $agama = '0';
+    my %vars_to_set = (
+        VERSION => $version,
+        SCC_ADDONS => $scc_addons,
+        AGAMA => $agama
+    );
+    while (my ($var_name, $var_value) = each %vars_to_set) {
+        if (get_var($var_name)) {
+            set_var($var_name, $var_value);
+            record_info($var_name, "$var_name=" . get_var($var_name));
+        }
+    }
 
     # tty assignation might differ between product versions
     reset_consoles_tty();


### PR DESCRIPTION
Failed job: https://openqa.suse.de/tests/18148231#  During 15SP7 installation, we need set AGAMA=0, then restore it after installation to avoid it affect installation of 15SP7.


- Related ticket: https://progress.opensuse.org/issues/178987 
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18164464#
  https://openqa.suse.de/tests/18164443#step/setup_upgrade_env/2 migration from 15SP5 to 15SP7
  https://openqa.suse.de/tests/18164442#step/setup_upgrade_env/1 migration from 15SP6 to 15SP7
