### PR TITLE
Read AGAMA_VERSION to detect which version of Agama is running

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -25,6 +25,16 @@ use bootloader_s390;
 use bootloader_zkvm;
 use bootloader_pvm;
 
+sub set_agama_version {
+    select_console 'install-shell';
+
+    my $info_file = script_output("cat /var/log/build/info");
+    if ($info_file =~ /^Image.version:\s+(?<major_version>\d+)\./m) {
+        set_var("AGAMA_VERSION", $+{'major_version'});
+        record_info('AGAMA_VERSION', $+{'major_version'});
+    }
+}
+
 sub prepare_boot_params {
     my @params = ();
 
@@ -71,10 +81,12 @@ sub run {
             record_info('bootloader_zkvm');
             $self->bootloader_zkvm::run();
         }
+        set_agama_version();
         return;
     }
     elsif (is_pvm_hmc()) {
         $self->bootloader_pvm::boot_pvm();
+        set_agama_version();
         return;
     }
 
@@ -96,6 +108,7 @@ sub run {
     } else {
         $agama_up_an_running->expect_is_shown();
     }
+    set_agama_version();
 }
 
 sub post_fail_hook {

--- a/tests/yam/agama/import_agama_profile.pm
+++ b/tests/yam/agama/import_agama_profile.pm
@@ -7,7 +7,7 @@
 use base Yam::Agama::patch_agama_base;
 use strict;
 use warnings;
-use testapi qw(assert_script_run data_url get_required_var select_console script_run get_var);
+use testapi qw(assert_script_run data_url get_required_var select_console script_run);
 use autoyast qw(expand_agama_profile generate_json_profile);
 
 sub run {


### PR DESCRIPTION
We have added a function to read Agama info file and extract the Image version.

- Related ticket: https://progress.opensuse.org/issues/184480
- Needles: N/A
- Verification run: 
  - x86_64-prod: https://openqa.suse.de/tests/18175435
  - x86_64-dev: https://openqa.suse.de/tests/18175420
  - aarch64: https://openqa.suse.de/tests/18175423
  - ppc64le-hmc: https://openqa.suse.de/tests/18175419
  - s390x-kvm: https://openqa.suse.de/tests/18175422
  - s390x-zvm: https://openqa.suse.de/tests/18175424
