### PR TITLE
update_kernel: Lock out kernel-rt_debug

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -501,6 +501,7 @@ sub run {
     my $incident_id = undef;
 
     add_extra_customer_repositories;
+    zypper_call('al kernel-rt_debug') if check_var('SLE_PRODUCT', 'slert');
 
     if (get_var('KERNEL_VERSION')) {
         my $kver = get_var('KERNEL_VERSION');


### PR DESCRIPTION
SLERT module metadata now pulls `kernel-rt_debug` package as a dependency through the RT pattern. This triggers kernel flavor checks during update installation. Lock the debug package out to ensure only `kernel-rt` updates will be installed.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18175156
