### PR TITLE
Handle new shortcut to enable disk encryption in Tumbleweed

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/PartitioningSchemePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/PartitioningSchemePage.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings FATAL => 'all';
 use testapi;
 use parent 'Installation::WizardPage';
+use version_utils;
 
 use constant {
     PARTITIONING_SCHEME_PAGE => 'inst-partitioning-scheme',
@@ -31,7 +32,10 @@ sub press_next {
 
 sub select_enable_disk_encryption_checkbox {
     assert_screen(PARTITIONING_SCHEME_PAGE);
-    send_key('alt-a');
+    # after https://build.opensuse.org/request/show/1277719 there's a new control
+    # Authentication, which takes the 'alt-a' change is currently in Staging:F
+    my $shortcut = ((!is_sle || !is_leap) && check_var("VERSION", "Staging:F")) ? 'alt-d' : 'alt-a';
+    send_key($shortcut);
 }
 
 sub enter_password {

--- a/lib/Installation/Partitioner/LibstorageNG/PartitioningSchemePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/PartitioningSchemePage.pm
@@ -34,7 +34,7 @@ sub select_enable_disk_encryption_checkbox {
     assert_screen(PARTITIONING_SCHEME_PAGE);
     # after https://build.opensuse.org/request/show/1277719 there's a new control
     # Authentication, which takes the 'alt-a' change is currently in Staging:F
-    my $shortcut = ((!is_sle || !is_leap) && check_var("VERSION", "Staging:F")) ? 'alt-d' : 'alt-a';
+    my $shortcut = (is_tumbleweed && check_var("VERSION", "Staging:F")) ? 'alt-d' : 'alt-a';
     send_key($shortcut);
 }
 


### PR DESCRIPTION
There's a new control in the guided partitioning scheme screen, it takes over `alt-a` for now this is confined to Staging:F

Failure: https://openqa.opensuse.org/tests/5124162#step/encrypt_lvm/6
VR: https://openqa.opensuse.org/tests/5126411 

(failure on VR already reported as https://bugzilla.opensuse.org/show_bug.cgi?id=1245247)

See also #22351
