### PR TITLE
Add test cases for deploying x11 related containers using helm

### DIFF
--- a/data/x11/helm_chart/kiosk_values.yaml
+++ b/data/x11/helm_chart/kiosk_values.yaml
@@ -1,0 +1,24 @@
+# Default values for kiosk.
+# This is a YAML-formatted file.
+X11:
+  image:
+    repository: registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/xorg
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: notaskbar
+pulseaudio:
+  image:
+    repository: registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/pulseaudio
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "17.0"
+workload:
+  # Page to load if using firefox as the workload
+  url: "https://freesound.org/people/kevp888/sounds/796468/"
+  # Additional environment variables to passthrough into the workload
+  env: []
+  # These can be used to provide a custom workload
+  image:
+    repository: registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/firefox-esr
+    pullPolicy: Always
+    tag: "128.11"

--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -169,11 +169,20 @@ sub install_kubectl {
 }
 
 =head2 install_helm
-Installs helm from our repositories
+Installs helm from our upstream or repositories
 =cut
 
 sub install_helm {
-    zypper_call("in helm");
+    if (get_var('HELM_INSTALL_UPSTREAM')) {
+        assert_script_run("curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3");
+        assert_script_run("chmod 700 get_helm.sh");
+        assert_script_run("./get_helm.sh");
+    } elsif (is_transactional) {
+        trup_call("pkg install helm");
+        check_reboot_changes;
+    } else {
+        zypper_call("in helm");
+    }
     record_info('helm', script_output("helm version"));
 }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2149,6 +2149,13 @@ sub load_x11_remote {
     elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_client')) {
         loadtest 'microos/workloads/x11-container/x11_client';
     }
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_helm_server')) {
+        loadtest 'transactional/host_config';
+        loadtest 'microos/workloads/x11-container/x11_helm_server';
+    }
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_helm_client')) {
+        loadtest 'microos/workloads/x11-container/x11_helm_client';
+    }
 }
 
 
@@ -2182,7 +2189,7 @@ sub load_common_x11 {
     elsif (check_var('REGRESSION', 'remote')) {
         if (check_var("REMOTE_DESKTOP_TYPE", "win_client") || check_var('REMOTE_DESKTOP_TYPE', "win_server")) {
             loadtest "x11/remote_desktop/windows_client_boot";
-        } elsif (check_var("REMOTE_DESKTOP_TYPE", "x11_server")) {
+        } elsif (check_var("REMOTE_DESKTOP_TYPE", "x11_server") || check_var("REMOTE_DESKTOP_TYPE", "x11_helm_server")) {
             loadtest 'microos/disk_boot';
         }
         else {

--- a/tests/microos/workloads/x11-container/x11_helm_client.pm
+++ b/tests/microos/workloads/x11-container/x11_helm_client.pm
@@ -1,0 +1,69 @@
+# SUSE"s openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Deploy X11, pulseaudio, firefox kiosk
+#          with Kubernetes Using Helm
+# Maintainer: Grace Wang <grace.wang@suse.com>
+
+use warnings;
+use strict;
+use testapi;
+use lockapi;
+use base 'x11test';
+use mmapi;
+use mm_tests;
+use x11utils 'turn_off_gnome_screensaver';
+
+# MM network check: try to ping the gateway, and the server
+sub ensure_server_reachable {
+    assert_script_run('ping -c 1 10.0.2.2');
+    assert_script_run('ping -c 1 10.0.2.101');
+}
+
+sub run {
+    my $self = shift;
+    my $helm_server = "10.0.2.101";
+
+    # Setup static NETWORK
+    $self->configure_static_ip_nm('10.0.2.102/24');
+
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver;
+
+    mutex_wait("x11_helm_server_ready");
+    ensure_server_reachable();
+
+    # ssh login to the x11 helm server
+    enter_cmd('ssh root@10.0.2.101');
+    assert_screen 'ssh-login', 60;
+    enter_cmd "yes";
+    assert_screen 'password-prompt', 60;
+    type_password();
+    send_key "ret";
+    assert_screen 'ssh-login-ok';
+
+    # Check if pulseaudio service is running
+    enter_cmd "export pod_name=`kubectl get pods -n kiosk -o name | cut -d '/' -f 2`";
+    enter_cmd "echo \$pod_name";
+    enter_cmd("kubectl exec \$pod_name -c pulseaudio -n kiosk -- sh -c 'ps aux'");
+    assert_screen("pa-service-running-helm");
+    # Check the audio can be played fine from the code level
+    enter_cmd("kubectl exec \$pod_name -c pulseaudio -n kiosk -- sh -c 'pactl list sink-inputs'");
+    assert_screen("firefox-container-playing-audio");
+
+    # Uninstall the release
+    enter_cmd("helm uninstall kiosk --namespace kiosk");
+    assert_screen("release-uninstalled");
+
+    # Stop ssh
+    enter_cmd "exit";
+
+    # Exit xterm
+    send_key "alt-f4";
+    assert_screen 'generic-desktop';
+}
+
+1;
+

--- a/tests/microos/workloads/x11-container/x11_helm_server.pm
+++ b/tests/microos/workloads/x11-container/x11_helm_server.pm
@@ -1,0 +1,75 @@
+# SUSE"s openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Deploy X11, pulseaudio, firefox kiosk
+#          with Kubernetes Using Helm
+# Maintainer: Grace Wang <grace.wang@suse.com>
+
+use base 'consoletest';
+use warnings;
+use strict;
+use testapi;
+use lockapi;
+use mmapi;
+use utils;
+use mm_network 'setup_static_mm_network';
+use containers::k8s;
+use transactional;
+
+# MM network check: try to ping the gateway, the client and the internet
+sub ensure_client_reachable {
+    assert_script_run('ping -c 1 10.0.2.2');
+    assert_script_run('ping -c 1 10.0.2.102');
+    assert_script_run('curl conncheck.opensuse.org');
+}
+
+sub run {
+    my ($self) = @_;
+    my $release_name = "kiosk";
+    my $namespace = "kiosk";
+    my $helm_values = "kiosk_values.yaml";
+    my $helm_chart = get_required_var("HELM_CHART");
+    select_console 'root-console';
+    set_hostname(get_var('HOSTNAME') // 'server');
+    setup_static_mm_network('10.0.2.101/24');
+    ensure_client_reachable();
+
+    # Permit ssh login as root
+    assert_script_run("echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf");
+    assert_script_run("systemctl restart sshd");
+
+    # Install the package SUSE certificate
+    enter_trup_shell;
+    zypper_call("ar --refresh https://download.opensuse.org/repositories/SUSE:/CA/openSUSE_Tumbleweed/SUSE:CA.repo");
+    zypper_call("--gpg-auto-import-keys ref");
+    zypper_call("install -y ca-certificates-suse");
+    exit_trup_shell;
+    check_reboot_changes;
+
+
+    # # Install helm
+    install_k3s();
+    set_var('HELM_INSTALL_UPSTREAM', 1);
+    install_helm();
+
+    # Get the kiosk_values.yaml
+    assert_script_run("curl " . autoinst_url("/data/x11/helm_chart/$helm_values") . " -o $helm_values", 60);
+    # Deploy using Helm
+    assert_script_run("helm install -n $namespace --create-namespace -f $helm_values $release_name $helm_chart", timeout => 100);
+
+    # Verify the firefox kiosk container started
+    assert_screen("firefox_kiosk", 300);
+    assert_and_click("firefox_play_audio");
+    # Enable loop play to ensure the "pactl list sink-inputs" can get a verbose list for each active audio stream
+    assert_and_click("firefox_loop_play");
+
+    # Notify that the server is ready
+    mutex_create("x11_helm_server_ready");
+
+    wait_for_children();
+}
+
+1;
+

--- a/variables.md
+++ b/variables.md
@@ -514,3 +514,11 @@ AGAMA | boolean | 0 | Agama installation support
 AGAMA_LIVE_ISO_URL | string | | The url of agama live iso to pass as kernel's command-line parameter. Example of usage "root=live:http://agama.iso"
 INST_AUTO | string | | The auto-installation is started by passing `inst.auto=<url>` on the kernel's command line
 INST_INSTALL_URL | string | | This will support using 'inst.install_url' boot parameter for overriding the default installation repositories. You can use multiple URLs separated by comma: inst.install_url=https://example.com/1,https://example.com/2
+
+### Remote desktop specific variables
+Following variables are relevant for remote desktop testing
+But "x11_helm_server" and "x11_helm_client" are used to test deploy X11, pulseaudio, firefox kiosk with Kubernetes Using Helm
+
+Variable        | Type      | Default value | Details
+---             | ---       | ---           | ---
+REMOTE_DESKTOP_TYPE | string | | This variable mainly used for remote desktop testing or other testing that uses multi machines.


### PR DESCRIPTION
Deploy below containers using helm:
X11, pulseaudio and firefox kiosk

Verify if pulseaudio is running from client side
Verify if audio can be played fine from code level

- Related ticket: https://progress.opensuse.org/issues/174418
- Needles: already added when debugging on osd
- Verification run (updated on Jun 28): 
> x11_helm_server  https://openqa.suse.de/tests/18232826
> x11_helm_client  https://openqa.suse.de/tests/18232827
