### PR TITLE
Fix upload logs failure on /var/log/zypper.log

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -1260,7 +1260,7 @@ sub sdaf_upload_logs {
     upload_logs("$crm_cfg_log");
 
     # Upload zypper log
-    upload_logs('/var/log/zypper.log', log_name => "$autotest::current_test->{name}-${hostname}_zypper.log");
+    upload_logs('/var/log/zypper.log', log_name => "$autotest::current_test->{name}-${hostname}_zypper.log", failok => 1);
 
     # Generate the packages list
     script_run "rpm -qa > $packages_list";


### PR DESCRIPTION
Fix upload logs failure on uploading /var/log/zypper.log

For example: https://openqaworker15.qa.suse.cz/tests/330664#step/upload_logs/52
`curl: (26) Failed to open/read local data from file/application`

- Related ticket: No
- Verification run:No
