### PR TITLE
Create a new dedicated Rear schedule for 16

### DIFF
--- a/schedule/ha/rear/rear_backup_16.yaml
+++ b/schedule/ha/rear/rear_backup_16.yaml
@@ -1,0 +1,23 @@
+---
+name: rear_backup
+description: >
+  Generate backup files for ReaR tests for SLES 16.
+vars:
+  DESKTOP: 'textmode'
+  INSTALLONLY: '1'
+  SCC_ADDONS: 'ha'
+  SCC_REGISTER: 'installation'
+  SYSTEM_ROLE: 'textmode'
+  HOSTNAME: 'reartest'
+  AGAMA_PRODUCT_ID: SLES
+  INST_AUTO: ha/agama/sles_ha_default.jsonnet
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - boot/boot_to_desktop
+  - installation/first_boot
+  - console/system_prepare
+  - console/hostname
+  - console/consoletest_setup
+  - ha/rear_backup
+  - console/scc_deregistration


### PR DESCRIPTION
Create a new backup schedule that can be used to test Rear feature on 16.
The new schedule is derived from the rear_backup.yaml in the same folder.
Functional and important changes, that are 16 specific, are about using Agama. This version of the schedule also move schedule specific settings to the schedule file from the JobGroup file.

- Related ticket: https://jira.suse.com/browse/TEAM-10314

- Verification run:
https://openqa.suse.de/tests/18183542#step/rear_backup/22 fails in package installation, in rear specific test module. But image boot is fine.
