### PR TITLE
Add 'Kill ASCS with takeover' test variant

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1813,7 +1813,11 @@ sub crm_resource_meta_set {
         croak("Mandatory argument '$arg' missing.") unless $arg;
     }
     my $action = $args{argument_value} ? 'set' : 'delete';
-    assert_script_run("crm resource meta $args{resource} $action $args{meta_argument}");
+    my $cmd = "crm resource meta $args{resource} $action $args{meta_argument}";
+    $cmd .= " $args{argument_value}" if $action eq 'set';
+
+    assert_script_run($cmd);
+    record_info('CRM meta set', "CRM meta set: $cmd");
 }
 
 1;

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -618,6 +618,7 @@ subtest '[crm_resource_meta_set] Set value' => sub {
     my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
     my @calls;
     $hacluster->redefine(assert_script_run => sub { @calls = @_; return; });
+    $hacluster->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     crm_resource_meta_set(resource => 'Hogwarts', meta_argument => 'RoomOfRequirement', argument_value => 'enter');
     note("\n  -->  " . join("\n  -->  ", @calls));
@@ -625,12 +626,14 @@ subtest '[crm_resource_meta_set] Set value' => sub {
     ok((grep /resource meta Hogwarts/, @calls), 'Call "meta" option');
     ok((grep /set/, @calls), 'Specify "set" action');
     ok((grep /RoomOfRequirement/, @calls), 'Specify meta-arg name');
+    ok((grep /enter/, @calls), 'Specify meta-arg value');
 };
 
 subtest '[crm_resource_meta_set] Delete meta-argument' => sub {
     my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
     my @calls;
     $hacluster->redefine(assert_script_run => sub { @calls = @_; return; });
+    $hacluster->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     crm_resource_meta_set(resource => 'Hogwarts', meta_argument => 'RoomOfRequirement');
     note("\n  -->  " . join("\n  -->  ", @calls));

--- a/tests/sles4sap/redirection_tests/ensa2_schedule_sapinstance_tests.pm
+++ b/tests/sles4sap/redirection_tests/ensa2_schedule_sapinstance_tests.pm
@@ -43,12 +43,42 @@ sub run {
     disconnect_target_from_serial();
 
     # Define test scenarios
+    # %scenarios = {
+    # 'TestModule_A' => { # This is a name this test module was scheduled under using C<loadtest(name=>'TestModule_A')> .
+    #                     # It is the name visible on the openQA web UI.. It is the name visible on the openQA web UI.
+    #     description => 'First test scheduled using "loadtest()".',
+    #     forced_takeover => true/false
+    #         # B<true> sets cluster parameter B<migration_threshold>  to `1` so the takeover happens without
+    #         # prior attempt to restart the resource first.
+    #     crm_resource_name => 'rsc_sap_QES_ASCS01' # CRM resource name used for ASCS/ERS instance
+    # }
+    # 'TestModule_B' => { # This is a name this test module was scheduled under using C<loadtest(name=>'TestModule_A')>
+    #     description => 'Second test scheduled using "loadtest()".',
+    #     forced_takeover => true,
+    #     crm_resource_name => 'rsc_sap_QES_ERS02' # CRM resource name used for ASCS/ERS instance
+    # }
+    # };
+
     my %scenarios = (
         'Kill_sapinstance_ASCS' => {
             description => 'Test kills SAP instance ASCS process using "kill -9" command.
             Process must be restarted by cluster on original node without failover.',
             crm_resource_name => $ascs_resource,
             forced_takeover => undef
+        },
+        # Moves ASCS resource from Node_A to Node_B
+        'Kill_sapinstance_ASCS-takeover' => {
+            description => 'Test kills SAP instance ASCS process using "kill -9" command.
+                Failover must take place and resource will be moved to another node.',
+            crm_resource_name => $ascs_resource,
+            forced_takeover => 'true'
+        },
+        # Returns ASCS resource from Node_B to Node_A using same method (Resource location is detected on module level)
+        'Recover_sapinstance_ASCS' => {
+            description => 'ASCS resource will be moved to original place.
+                Sapinstance process will be killed triggering failover.',
+            crm_resource_name => $ascs_resource,
+            forced_takeover => 'true'
         },
         'Kill_sapinstance_ERS' => {
             description => 'Test kills SAP instance ERS process using "kill -9" command.
@@ -61,6 +91,8 @@ sub run {
     # Schedule all tests using `loadtest` call
     for my $test_name (
         'Kill_sapinstance_ASCS',
+        'Kill_sapinstance_ASCS-takeover',
+        'Recover_sapinstance_ASCS',
         'Kill_sapinstance_ERS'
       )
     {


### PR DESCRIPTION
This PR adds test variant of 'Kill sapinstance ASCS' with takeover taking in place. 
New variant forces cluster to migrate failing resource immediately to the other 
node instead of retrying to start it locally. 

**Ticket:** https://jira.suse.com/browse/TEAM-10324

**Verification run:** 
Takeover: https://mordor.suse.cz/tests/2147#step/Kill_sapinstance_ASCS-takeover/1
Recovery: https://mordor.suse.cz/tests/2147#step/Recover_sapinstance_ASCS/1
  
