### PR TITLE
Remove AGAMA_DEV condition

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -485,7 +485,7 @@ sub init_consoles {
     {
         $self->add_console('install-shell', 'tty-console', {tty => is_agama() ? 8 : 2});
         $self->add_console('installation', 'tty-console', {tty =>
-                  check_var('VIDEOMODE', 'text') ? 1 : is_agama() && get_var('AGAMA_DEV') ? 2 : 7});
+                  check_var('VIDEOMODE', 'text') ? 1 : is_agama() ? 2 : 7});
         $self->add_console('install-shell2', 'tty-console', {tty => 9});
         # On SLE15 X is running on tty2 see bsc#1054782
         $self->add_console('root-console', 'tty-console', {tty => get_root_console_tty});


### PR DESCRIPTION
Remove AGAMA_DEV condition here [https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22382/files#diff-cdfc5d4c733095953bb02e1338918[…]0bb886a8a775280b70917e5cdb2e797R488](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22382/files#diff-cdfc5d4c733095953bb02e1338918cc890bb886a8a775280b70917e5cdb2e797R488) ,  due to the change of the console has landed in production, https://openqa.suse.de/tests/18193172#step/agama_auto/33

- Related ticket: N/A
- Needles:  N/A
- Verification run: https://openqa.suse.de/tests/18200170#live
