### PR TITLE
bats/buildah: Update BATS_SKIP for runc 1.2.x

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -21,26 +21,26 @@ buildah:
   sle-15-SP7:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud namespaces
-    BATS_SKIP_ROOT: run
+    BATS_SKIP: bud run
+    BATS_SKIP_ROOT: from
     BATS_SKIP_USER:
   sle-15-SP6:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud namespaces
-    BATS_SKIP_ROOT: run
+    BATS_SKIP: bud run
+    BATS_SKIP_ROOT: from namespaces
     BATS_SKIP_USER:
   sle-15-SP5:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud namespaces
-    BATS_SKIP_ROOT: run
+    BATS_SKIP: bud run
+    BATS_SKIP_ROOT: from
     BATS_SKIP_USER:
   sle-15-SP4:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud namespaces
-    BATS_SKIP_ROOT: run
+    BATS_SKIP: bud run
+    BATS_SKIP_ROOT: from
     BATS_SKIP_USER:
 netavark:
   # Note on patches:


### PR DESCRIPTION
buildah: Update BATS_SKIP for runc 1.2.x

```
# 15-SP4
$ susebats notok  https://openqa.suse.de/tests/18199921
    BATS_SKIP: bud run
    BATS_SKIP_ROOT: from
    BATS_SKIP_USER:
# 15-SP5
$ susebats notok  https://openqa.suse.de/tests/18199977
    BATS_SKIP: bud run
    BATS_SKIP_ROOT: from namespaces
    BATS_SKIP_USER:
# 15-SP6
$ susebats notok  https://openqa.suse.de/tests/18199907
    BATS_SKIP: bud run
    BATS_SKIP_ROOT: from
    BATS_SKIP_USER:
# 15-SP7
$ susebats notok  https://openqa.suse.de/tests/18199826
    BATS_SKIP: bud run
    BATS_SKIP_ROOT: from
    BATS_SKIP_USER:
```
