### PR TITLE
Allow to pass extra CPU kernel options in specific tests

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -208,6 +208,8 @@ sub set_bootscript_agama_cmdline_extra {
     $cmdline_extra .= ' ' . get_var('EXTRA_PXE_CMDLINE', '');
     $cmdline_extra .= ' ' . get_var('EXTRABOOTPARAMS', '');
     $cmdline_extra .= ' ' . get_var('AGAMA_NETWORK_PARAMS', '');
+    # Pass specific CPU parameters for a particular type of tests
+    $cmdline_extra .= ' ' . get_var('CPU_BOOTPARAMS', '') if get_var('ALLOW_CPU_BOOTPARAMS', '');
 
     return $cmdline_extra;
 }


### PR DESCRIPTION
Specific CPU kernel options are required in bootscripts in some of our tests(with SR-IOV capability), for example, `intel_iommu=on` for Ethernet PCI passthrough test and vGPU passthrough tests. I can't find other better places than 
ipxe_install.pm to support this feature.

usage:
    # For example, to pass a parameter for a Kvm test on a bare-metal machine with Intel CPUs,
    # To place CPU_BOOTPARAMS in workers.ini for Intel machines and put ALLOW_CPU_BOOTPARAMS in a KVM testsuite

- Related ticket: https://progress.opensuse.org/issues/178702
- Verification run: https://openqa.suse.de/tests/18200856#step/login_console/27
