### PR TITLE
kselftests: Add timeout option

### DIFF
--- a/tests/kernel/run_kselftests.pm
+++ b/tests/kernel/run_kselftests.pm
@@ -76,6 +76,7 @@ sub run
     my $kselftest_git = get_var('KSELFTEST_FROM_GIT', 0);
     my $kselftests_suite = get_required_var('KSELFTESTS_SUITE');
     my @kselftests_suite = split(',', $kselftests_suite);
+    my $timeout = get_var('KSELFTEST_TIMEOUT', 45);
 
     if (get_var('KSELFTEST_FROM_GIT')) {
         prepare_kselftests_from_git();
@@ -85,7 +86,7 @@ sub run
             assert_script_run("cd ./tools/testing/selftests/kselftest_install");
             #required by the TAP openQA parser
             assert_script_run("echo t/$i.t .. > $i.tap");
-            assert_script_run("./run_kselftest.sh -c $i >> $i.tap", 7200);
+            assert_script_run("./run_kselftest.sh -o $timeout -c $i >> $i.tap", 7200);
             parse_extra_log(TAP => "$i.tap");
             assert_script_run("cd -");
         }
@@ -94,7 +95,7 @@ sub run
 
         foreach my $i (@kselftests_suite) {
             assert_script_run("echo t/$i.t .. > $i.tap");
-            assert_script_run("/usr/share/kselftests/run_kselftest.sh -c $i >> $i.tap", 7200);
+            assert_script_run("/usr/share/kselftests/run_kselftest.sh -o $timeout -c $i >> $i.tap", 7200);
             parse_extra_log(TAP => "$i.tap");
         }
     }


### PR DESCRIPTION
45s is a default value in the kselftests thus this is kept. However at times, this might be not enough which might be also SUT-dependent. For instance the cgroup tests for mem ctl fail if there is lower number of CPUs and setting higher number of CPUs results in the cpu tests to fail as the default 45s timeout isn't sufficient. This patch allows to set --override-timeout value to the given tests

- Related ticket: https://progress.opensuse.org/issues/184108
- Verification run: https://openqa.suse.de/tests/18183821
We have this where cpu tests pass:
When fixing kmem we set CPU to 16 and we get cpu tests failing:
https://openqa.suse.de/tests/18201023

CPU=16 and timeout set to 300 we get cpu tests passing again: **https://openqa.suse.de/tests/18204132**
