### PR TITLE
SDAF orphaned peering cleanup

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -27,6 +27,7 @@ our @EXPORT = qw(
   az_group_create
   az_group_name_get
   az_group_delete
+  az_group_exists
   az_network_vnet_create
   az_network_vnet_get
   az_network_vnet_subnet_update
@@ -1816,4 +1817,25 @@ sub az_keyvault_secret_show {
 
     return decode_json(script_output(join(' ', @az_cmd))) if $args{output} eq 'json';
     return script_output(join(' ', @az_cmd));
+}
+
+=head2 az_group_exists
+
+    az_group_exists(resource_group=>'resource group name' [, quiet=>'pssst!']);
+
+Check if specified resource group exists. Returns B<true> or B<false>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<quiet> Turn off verbosity if defined
+
+=back
+=cut
+
+sub az_group_exists {
+    my (%args) = @_;
+    croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
+    return script_output("az group exists --resource-group $args{resource_group}", quiet => $args{quiet});
 }

--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -14,8 +14,7 @@ use warnings;
 use testapi;
 use Exporter qw(import);
 use sles4sap::sap_deployment_automation_framework::deployment qw(sdaf_cleanup az_login load_os_env_variables $output_log_file);
-use sles4sap::sap_deployment_automation_framework::deployment_connector
-  qw(find_deployer_resources destroy_deployer_vm get_deployer_vm_name find_deployment_id get_deployer_ip destroy_orphaned_resources);
+use sles4sap::sap_deployment_automation_framework::deployment_connector;
 use sles4sap::console_redirection;
 
 our @EXPORT = qw(full_cleanup $serial_regexp_playbook);
@@ -93,6 +92,7 @@ sub full_cleanup {
     # Resource retention time can be controlled by OpenQA parameter: SDAF_DEPLOYER_VM_RETENTION_SEC
     record_info('Remove orphans', 'Cleaning up orphaned resources');
     destroy_orphaned_resources();
+    destroy_orphaned_peerings();
 }
 
 sub post_fail_hook {

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -1065,4 +1065,16 @@ subtest '[az_keyvault_secret_show] Calling with "name" and "vault_name" argument
     is $result, 'SUper$ecretStuffAnD_even_m0re_secret$tuFF', 'Decode JSON output';
 };
 
+subtest '[az_group_exists] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return; });
+
+    az_group_exists(resource_group => 'Pantalone');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az group exists/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+};
+
 done_testing;


### PR DESCRIPTION
After unclean deployment teardown, there are peerings left in `disconnected` state. This PR extends cleanup routine to search for orphaned peerings and destroy them if their respective deployment does not exist anymore.

### Ticket: https://jira.suse.com/browse/TEAM-10340

### Verification run: 
  Failure mocked with `die` to speed up process:  https://openqaworker15.qa.suse.cz/tests/331008#step/configure_deployer/536

  Full HanaSR run:  https://openqaworker15.qa.suse.cz/tests/331011#step/cleanup/253
