### PR TITLE
WIP: Fix agama_auto expect timeout

### DIFF
--- a/lib/Yam/Agama/Pom/RebootPage.pm
+++ b/lib/Yam/Agama/Pom/RebootPage.pm
@@ -24,6 +24,8 @@ sub expect_is_shown {
     my $self = shift;
     my $timeout = 2400;
 
+    select_console('installation');
+
     while ($timeout > 0) {
         my $ret = check_screen($self->{tag_installation_complete}, 30);
         $timeout -= 30;


### PR DESCRIPTION
The `boot_agama` module switches away from the installation console. Make sure that `RebootPage::expect_is_shown()` looks for the finish screen on the right console.

Fixes #22437 

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18206418
