### PR TITLE
bats: Install CA repo to use with BATS_TEST_REPOS

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -207,8 +207,13 @@ sub bats_setup {
 
     push @commands, "### RUN AS root";
 
-    foreach my $repo (split(/\s+/, get_var("BATS_TEST_REPOS", ""))) {
-        run_command "zypper addrepo $repo";
+    if (get_var("BATS_TEST_REPOS", "")) {
+        run_command "zypper addrepo --refresh http://download.opensuse.org/repositories/SUSE:/CA/openSUSE_Tumbleweed/SUSE:CA.repo";
+        run_command "zypper --gpg-auto-import-keys -n install ca-certificates-suse";
+
+        foreach my $repo (split(/\s+/, get_var("BATS_TEST_REPOS", ""))) {
+            run_command "zypper addrepo $repo";
+        }
     }
 
     foreach my $pkg (split(/\s+/, get_var("BATS_TEST_PACKAGES", ""))) {


### PR DESCRIPTION
Install CA repo to use with `BATS_TEST_REPOS`.  This is needed when testing updates from IBS.

Verification runs:
- 15-SP4: https://openqa.suse.de/tests/18206571 `BATS_TEST_REPOS=https://download.suse.de/ibs/home:/danishprakash:/branches:/SUSE:/SLE-15-SP4:/Update/standard/home:danishprakash:branches:SUSE:SLE-15-SP4:Update.repo`

- 15-SP5: https://openqa.suse.de/tests/18206570 `BATS_TEST_REPOS=https://download.suse.de/ibs/home:/danishprakash:/branches:/SUSE:/SLE-15-SP5:/Update/standard/home:danishprakash:branches:SUSE:SLE-15-SP5:Update.repo`