### PR TITLE
Remove schedule of additional_fence_agent_tasks

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -999,7 +999,6 @@ sub create_playbook_section_list {
             "-e sas_token='$args{ptf_token}'",
             "-e container=$args{ptf_container}",
             "-e storage=$args{ptf_account}");
-        push @playbook_list, 'additional_fence_agent_tasks.yaml';
     }
 
     my $hana_cluster_playbook = 'sap-hana-cluster.yaml';


### PR DESCRIPTION
Motivations:
- Playbook is applying patch to Azure fence_agent that is no more needed.
- Playbook is scheduled as part of PTF feature that is generic, even if playbook is specific.

Related ticket: https://jira.suse.com/browse/TEAM-9453

- Verification run: 
sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-06-25T02:03:24Z-hanasr_azure_test_msi az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/330909