### PR TITLE
Move test from 'ppc-emu' workers to power10 kvm workers

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -49,6 +49,7 @@ sub load_config_tests {
 }
 
 sub load_boot_from_disk_tests {
+    loadtest 'microos/disk_boot' if (check_var('MACHINE', 'ppc64le-p10-virtio') && !check_var('FIRST_BOOT_CONFIG', 'wizard'));
     return if is_ppc64le && get_var('MACHINE') !~ /ppc64le-emu/i && !(is_sle_micro('=5.5') && check_var('FLAVOR', 'Container-Image-Updates'));
     # add additional image handling module for svirt workers
     if (is_s390x()) {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/184729

- Verification run: https://openqa.suse.de/tests/18408032

**Please ignore the failed module, it is known issue**

Changes for job group:

https://gitlab.suse.de/qe-core/qa-sle-functional-userspace/-/merge_requests/285