### PR TITLE
xfstests: Add kernel-default-extra to rdma dependency

### DIFF
--- a/lib/rdma.pm
+++ b/lib/rdma.pm
@@ -38,6 +38,7 @@ sub install_rdma_dependency {
       librdmacm-utils
       infiniband-diags
       libibverbs-utils
+      kernel-default-extra
     );
     my $packages = join(' ', @deps);
     script_run('zypper --gpg-auto-import-keys ref');


### PR DESCRIPTION
Add 1 more dependency in rdma test. 

- Related ticket: https://progress.opensuse.org/issues/184327
