### PR TITLE
Removed version from addons jsonnet library

### DIFF
--- a/data/yam/agama/auto/lib/addons.libsonnet
+++ b/data/yam/agama/auto/lib/addons.libsonnet
@@ -1,7 +1,6 @@
 {
   addon_ha(reg_code=''):: {
     id: 'sle-ha',
-    registrationCode: reg_code,
-    version: '16.0',
+    registrationCode: reg_code
   }
 }


### PR DESCRIPTION
We don't require to set the SLE version in the addons section of jsonnet template.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
