### PR TITLE
Adjust openjdk-fips test for SLE15-SP7

### DIFF
--- a/tests/fips/openjdk/openjdk_fips.pm
+++ b/tests/fips/openjdk/openjdk_fips.pm
@@ -19,20 +19,22 @@ use openjdktest;
 use registration qw(add_suseconnect_product);
 use version_utils qw(is_sle is_sled is_rt);
 
+sub get_java_versions {
+    # on newer version we need legacy module for openjdk 11, but is not available
+    # on SLERT/SLED, can't test openjdk 11. On 15-SP7 17 is also in legacy module
+    return '21' if (is_rt || is_sled) && is_sle('>=15-SP7');
+    return '11 17 21' if (is_sle '>=15-SP6');
+    return '17 21' if ((is_rt || is_sled) && is_sle('>=15-SP6'));
+    return '11 17';
+}
+
 sub run {
     my $self = @_;
 
-    my @java_versions = qw(11 17);
-    if (is_sle '>=15-SP6') {
-        push @java_versions, 21;
-        # on newer version we need legacy module for openjdk 11, but
-        # is not available on SLERT, can't test openjdk 11
-        if (is_rt || is_sled) {
-            shift @java_versions;
-        } else {
-            add_suseconnect_product 'sle-module-legacy';
-        }
-    }
+    my @java_versions = split(' ', get_java_versions);
+
+    # SLED and SLERT do not have legacy module
+    add_suseconnect_product 'sle-module-legacy' unless (is_sle('>=15-SP6') && (is_rt || is_sled));
 
     foreach my $version (@java_versions) {
         configure_java_version $version;


### PR DESCRIPTION
Adjusting the test for SLE15-SP7, in SLERT and SLED there is no Legacy module, so testing only the one in Base 

- Related ticket: https://progress.opensuse.org/issues/184171
- Verification run:
  - https://openqa.suse.de/tests/18222729 (Desktop)
  - https://openqa.suse.de/tests/18222730 (DVD-Update)