### PR TITLE
Read AGAMA_VERSION to detect which version of Agama is running

### DIFF
--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with agama.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - installation/grub_test

--- a/schedule/yam/agama_autoyast_supported_s390x.yaml
+++ b/schedule/yam/agama_autoyast_supported_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Agama installation with backwards compatibility with AutoYaST using only supported AutoYaST elements.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - boot/reconnect_mgmt_console

--- a/schedule/yam/agama_autoyast_unsupported.yaml
+++ b/schedule/yam/agama_autoyast_unsupported.yaml
@@ -4,5 +4,6 @@ description: >
   Agama abort installation using unsupported AutoYaST elements.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_check_installation_medium.yaml
+++ b/schedule/yam/agama_check_installation_medium.yaml
@@ -4,4 +4,5 @@ description: >
   Test suite triggers installation medium integrity check and verifies that is successful by checking logs.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/validate/validate_medium_integrity

--- a/schedule/yam/agama_desktop.yaml
+++ b/schedule/yam/agama_desktop.yaml
@@ -4,6 +4,7 @@ description: >
   Perform agama installation with graphical environment.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_dud.yaml
+++ b/schedule/yam/agama_dud.yaml
@@ -4,4 +4,5 @@ description: >
   Patch or extend the Live Media by pointing to so called Driver Update which currently supports only RPM packages.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/validate/validate_dud

--- a/schedule/yam/agama_extended.yaml
+++ b/schedule/yam/agama_extended.yaml
@@ -6,6 +6,7 @@ description: >
     - Install packages gvim,rpm-build via profile.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - installation/grub_test

--- a/schedule/yam/agama_extensions_and_patterns.yaml
+++ b/schedule/yam/agama_extensions_and_patterns.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with extensions and software pattern selection.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - installation/grub_test

--- a/schedule/yam/agama_extensions_and_patterns_ppc64le.yaml
+++ b/schedule/yam/agama_extensions_and_patterns_ppc64le.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with extensions and software pattern selection for ppc64le.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_extensions_and_patterns_s390x.yaml
+++ b/schedule/yam/agama_extensions_and_patterns_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with extensions and software pattern selection for s390x.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_from_usb.yaml
+++ b/schedule/yam/agama_from_usb.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with agama.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - yam/agama/agama_boot_from_hdd

--- a/schedule/yam/agama_full_disk_encryption.yaml
+++ b/schedule/yam/agama_full_disk_encryption.yaml
@@ -4,6 +4,7 @@ description: >
   Perform full disk encryption installation with agama.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_full_disk_encryption_ppc64le.yaml
+++ b/schedule/yam/agama_full_disk_encryption_ppc64le.yaml
@@ -4,6 +4,7 @@ description: >
   Perform full disk encryption installation with agama.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_full_disk_encryption_s390x.yaml
+++ b/schedule/yam/agama_full_disk_encryption_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform full disk encryption installation with agama.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_gnome.yaml
+++ b/schedule/yam/agama_gnome.yaml
@@ -4,6 +4,7 @@ description: >
   Perform desktop interactive installation
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_gnome_ppc64le.yaml
+++ b/schedule/yam/agama_gnome_ppc64le.yaml
@@ -7,6 +7,7 @@ description: >
   want to test that we can still install gnome on ppc64le.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_gnome_s390x.yaml
+++ b/schedule/yam/agama_gnome_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform desktop installation with interactive and unattended for s390x.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_headless.yaml
+++ b/schedule/yam/agama_headless.yaml
@@ -5,6 +5,7 @@ description: >
   A headless system is just boot to multi-user.target without a graphical environment.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/validate_headless
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_headless_pvm.yaml
+++ b/schedule/yam/agama_headless_pvm.yaml
@@ -5,6 +5,7 @@ description: >
   A headless system is just boot to multi-user.target without a graphical environment.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/validate_headless
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests

--- a/schedule/yam/agama_headless_s390x.yaml
+++ b/schedule/yam/agama_headless_s390x.yaml
@@ -5,6 +5,7 @@ description: >
   A headless system is just boot to multi-user.target without a graphical environment.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/validate_headless
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests

--- a/schedule/yam/agama_lvm.yaml
+++ b/schedule/yam/agama_lvm.yaml
@@ -4,6 +4,7 @@ description: >
   Perform agama installation with LVM.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_lvm_encrypted.yaml
+++ b/schedule/yam/agama_lvm_encrypted.yaml
@@ -4,6 +4,7 @@ description: >
   Installation with lvm encrypted
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_lvm_encrypted_s390x.yaml
+++ b/schedule/yam/agama_lvm_encrypted_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Installation with lvm encrypted
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_lvm_s390x.yaml
+++ b/schedule/yam/agama_lvm_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform agama installation with LVM on s390x.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_non_default_root_filesystem.yaml
+++ b/schedule/yam/agama_non_default_root_filesystem.yaml
@@ -4,6 +4,7 @@ description: >
   Perform agama unattended installation with non default root filesystem.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/agama_auto
   - installation/grub_test
   - installation/first_boot

--- a/schedule/yam/agama_non_default_root_filesystem_ppc64le.yaml
+++ b/schedule/yam/agama_non_default_root_filesystem_ppc64le.yaml
@@ -4,6 +4,7 @@ description: >
   Perform agama unattended installation with non default root filesystem.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - installation/grub_test

--- a/schedule/yam/agama_non_default_root_filesystem_s390x.yaml
+++ b/schedule/yam/agama_non_default_root_filesystem_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform agama unattended installation with non default root filesystem.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - boot/reconnect_mgmt_console

--- a/schedule/yam/agama_post_registration_ppc64le.yaml
+++ b/schedule/yam/agama_post_registration_ppc64le.yaml
@@ -4,6 +4,7 @@ description: >
   Perform Agama unattended installation with offline medium, and register the system after installation.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - installation/grub_test

--- a/schedule/yam/agama_post_registration_s390x.yaml
+++ b/schedule/yam/agama_post_registration_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform Agama unattended installation with offline medium, and register the system after installation.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - boot/reconnect_mgmt_console

--- a/schedule/yam/agama_ppc64le.yaml
+++ b/schedule/yam/agama_ppc64le.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with agama.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - installation/grub_test

--- a/schedule/yam/agama_remote_pvm.yaml
+++ b/schedule/yam/agama_remote_pvm.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with agama for powerVM worker.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_remote_s390x.yaml
+++ b/schedule/yam/agama_remote_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with agama for s390x worker.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_s390x.yaml
+++ b/schedule/yam/agama_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with agama.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - boot/reconnect_mgmt_console

--- a/schedule/yam/agama_software_patterns.yaml
+++ b/schedule/yam/agama_software_patterns.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with software pattern selection.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/schedule/yam/agama_software_patterns_s390x.yaml
+++ b/schedule/yam/agama_software_patterns_s390x.yaml
@@ -4,6 +4,7 @@ description: >
   Perform interactive installation with pattern selection for s390x.
 schedule:
   - yam/agama/boot_agama
+  - yam/agama/agama_arrange
   - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama

--- a/tests/yam/agama/agama_arrange.pm
+++ b/tests/yam/agama/agama_arrange.pm
@@ -1,0 +1,25 @@
+## Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Summary: Set AGAMA_VERSION variable from value read in info file
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base Yam::Agama::patch_agama_base;
+use strict;
+use warnings;
+use testapi;
+
+sub set_agama_version {
+    my $info_file = script_output("cat /var/log/build/info");
+    if ($info_file =~ /^Image.version:\s+(?<major_version>\d+)\./m) {
+        set_var("AGAMA_VERSION", $+{'major_version'});
+        record_info('AGAMAVERSION', $+{'major_version'});
+    }
+}
+
+sub run {
+    select_console 'install-shell';
+    set_agama_version();
+}
+
+1;


### PR DESCRIPTION
We have added a new step to retrieve the `AGAMA_VERSION` parameter, we plan to move import and patch steps into this one.

- Related ticket: https://progress.opensuse.org/issues/184480
- Needles: N/A
- Verification run: 
  - sles_default:
    - x86_64: https://openqa.suse.de/tests/18215549
    - s390x-kvm: https://openqa.suse.de/tests/18215531#
    - s390x-zvm: https://openqa.suse.de/tests/18215532#
    - ppc64le-hmc: https://openqa.suse.de/tests/18215533
    - ppc64le: https://openqa.suse.de/tests/18215534#
    - aarch64: https://openqa.suse.de/tests/18215535#
    - uefi: https://openqa.suse.de/tests/18216658#
    - uefi_usb-4G: https://openqa.suse.de/tests/18216659#
  - sles_autoyast_supported: 
    - x86_64: https://openqa.suse.de/tests/18215568#
    - s390x-kvm: https://openqa.suse.de/tests/18215569#
    - ppc64le-hmc: https://openqa.suse.de/tests/18215570#
    - aarch64: https://openqa.suse.de/tests/18215571#
  - sles_autoyast_unsupported: 
    - x86_64: https://openqa.suse.de/tests/18215572
    - s390x-kvm: https://openqa.suse.de/tests/18215573
    - ppc64le-hmc: https://openqa.suse.de/tests/18215574#
    - aarch64: https://openqa.suse.de/tests/18215575
  - sles_check_installation_medium: 
    - x86_64: https://openqa.suse.de/tests/18215714
    - aarch64: https://openqa.suse.de/tests/18215715
  - sles_default_headless:
    - x86_64: https://openqa.suse.de/tests/18215785
    - s390x-kvm: https://openqa.suse.de/tests/18215786
    - ppc64le-hmc: https://openqa.suse.de/tests/18215842
    - aarch64: https://openqa.suse.de/tests/18215843
  - sles_dud: 
    - x86_64: https://openqa.suse.de/tests/18215789
    - s390x-kvm: https://openqa.suse.de/tests/18215790
    - ppc64le-hmc: https://openqa.suse.de/tests/18215791
    - aarch64: https://openqa.suse.de/tests/18215792
  - sles_encrypted: 
    - x86_64: https://openqa.suse.de/tests/18215797#
    - s390x-kvm: https://openqa.suse.de/tests/18215798#
    - ppc64le-hmc: https://openqa.suse.de/tests/18215799
    - aarch64: https://openqa.suse.de/tests/18215800
  - sles_extended: https://openqa.suse.de/tests/18215802
  - sles_gnome:
    - x86_64: https://openqa.suse.de/tests/18215818#
    - s390x-kvm: https://openqa.suse.de/tests/18215819
    - ppc64le-hmc: https://openqa.suse.de/tests/18215820#
    - aarch64: https://openqa.suse.de/tests/18215821
  - sles_ha: 
    - x86_64: https://openqa.suse.de/tests/18215822#
    - s390x-kvm: https://openqa.suse.de/tests/18215823#
    - ppc64le-hmc: https://openqa.suse.de/tests/18215824#
    - aarch64: https://openqa.suse.de/tests/18216791#
  - sles_lvm:
    - x86_64: https://openqa.suse.de/tests/18215826#
    - s390x-kvm: https://openqa.suse.de/tests/18215827#
    - ppc64le-hmc: https://openqa.suse.de/tests/18215828#
    - aarch64: https://openqa.suse.de/tests/18215829#
  - sles_lvm_encrypted:
    - x86_64: https://openqa.suse.de/tests/18215830
    - s390x-kvm: https://openqa.suse.de/tests/18216642
    - ppc64le-hmc: https://openqa.suse.de/tests/18216641
    - aarch64: https://openqa.suse.de/tests/18215833
  - sles_sap_default: 
    - x86_64: https://openqa.suse.de/tests/18216639
    - ppc64le-hmc: https://openqa.suse.de/tests/18215836#
  -  sles_software_selection:
    - x86_64: https://openqa.suse.de/tests/18215837
    - s390x-kvm: https://openqa.suse.de/tests/18215838#
    - ppc64le-hmc: https://openqa.suse.de/tests/18215839
    - aarch64: https://openqa.suse.de/tests/18215840
  - sles_zfcp: https://openqa.suse.de/tests/18216640#
