### PR TITLE
Fix YAML indentation mistake in playbook list

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_aws_peering.yaml
@@ -49,7 +49,7 @@ ansible:
       - pre-cluster.yaml
       - sap-hana-preconfigure.yaml
       - sap-hana-storage.yaml
-       - sap-hana-download-media.yaml
+      - sap-hana-download-media.yaml
       - sap-hana-install.yaml
       - sap-hana-system-replication.yaml
       - sap-hana-system-replication-hooks.yaml


### PR DESCRIPTION
Fix a small unnoticed mistake introduced by 7bd4f55 It went un-noticed but can result in wrong sequence of ansible-playbook commands generated by the qe-sap-deployment glue script.
Fix small unnoticed mistake from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22353/files#diff-1b478325352b1fad8cd201c6802a845afe72369b435483cf65c883a13c91a30aR52

It can apparently have a negative effect like: https://openqaworker15.qa.suse.cz/tests/331014/logfile?filename=deploy-qesap_exec_ansible.log.txt#line-10410


- Related ticket: [TEAM-10427](https://jira.suse.com/browse/TEAM-10427)

# Verification run: 
sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_ibsmirror_peering_test 
- http://openqaworker15.qa.suse.cz/tests/331050