### PR TITLE
Check agama installation if agama installer banner not shown

### DIFF
--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -133,16 +133,16 @@ sub monitor_concurrent_guest_installations {
     my $_monitor_start_time = time();
     while (time() - $_monitor_start_time <= 7200) {
         foreach (keys %guest_instances) {
-            if ($guest_instances{$_}->{guest_installation_result} eq '') {
+            if (!($guest_instances{$_}->is_guest_installation_done)) {
                 $guest_instances{$_}->attach_guest_installation_screen if (($_guest_installations_not_the_last ne 0) or ($guest_instances{$_}->{guest_installation_attached} ne 'true'));
                 $guest_instances{$_}->monitor_guest_installation;
-                if ($guest_instances{$_}->{guest_installation_result} eq '') {
+                if (!($guest_instances{$_}->is_guest_installation_done)) {
                     $_guest_installations_not_the_last = 0 if ($_guest_installations_left eq 1);
                     $guest_instances{$_}->detach_guest_installation_screen if ($_guest_installations_not_the_last ne 0);
                 }
             }
             my $_current_guest_instance = $_;
-            if ((!(grep { $_ eq $_current_guest_instance } @guest_installations_done)) and ($guest_instances{$_}->{guest_installation_result} ne '')) {
+            if ((!(grep { $_ eq $_current_guest_instance } @guest_installations_done)) and ($guest_instances{$_}->is_guest_installation_done)) {
                 push(@guest_installations_done, $_);
                 $_guest_installations_left = scalar(keys %guest_instances) - scalar(@guest_installations_done);
                 $guest_instances{$_}->collect_guest_installation_logs_via_ssh if ($guest_instances{$_}->{guest_installation_result} ne 'PASSED');


### PR DESCRIPTION
* **After** guest installation console is re-attached, agama installer might not be shown. For agama installation, it is a bit different because agama installer shell is not a fully-fledged environment and guest needs to be rebooted after installation finishes. 

* **So** it is necesary to still check agama installation progression in the subroutine ```check_guest_installation_result_via_ssh``` and add a new subroutine ```is_guest_installation_done```.

* **Record** agama install phase result as ```AGAMA_INSTALL_PHASE_DONE``` to better facilitate determining guest installation result.

* **Use** ```is_guest_installation_done``` also in ```lib/concurrent_guest_installations.pm```.  

* **Verification Runs:**
  * [verification run with br0  issue fixed after open guest console without agama installer banner](http://10.200.140.9/tests/1248#step/unified_guest_installation/1192)
  * [verification run with br123](http://10.200.140.9/tests/1249)
  * [uefi guest](https://openqa.suse.de/tests/18577164)
  * [sev-es guest](https://openqa.suse.de/tests/18577163)
  * [sles15sp6 on SL Micro 6.2](https://openqa.suse.de/tests/18577180)
  * [SL Micro 6.2 on SL Micro 6.2](https://openqa.suse.de/tests/18577919)

