### PR TITLE
Fix grub_test for Leap 16 on aarch64 to boot from hard disk

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -338,6 +338,9 @@ sub handle_uefi_boot_disk_workaround {
     wait_screen_change { send_key 'ret' };
     # Device selection: HD or CDROM
     send_key_until_needlematch 'tianocore-select_HD', 'down';
+    if (get_var('USBBOOT')){
+        send_key 'down';
+    }
     wait_screen_change { send_key 'ret' };
     # cycle to last entry by going up in the next steps
     # <EFI>


### PR DESCRIPTION
test fails in grub_test - Boot wrong device

- Related ticket: https://progress.opensuse.org/issues/182369
- Verification run: [gnome-agama@aarch64](https://openqa.opensuse.org/tests/5133287), [kde-agama@aarch64](https://openqa.opensuse.org/tests/5133201)
