### PR TITLE
bats/buildah: Update BATS_SKIP for 16.0

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -15,8 +15,8 @@ buildah:
   sle-16.0:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud run
-    BATS_SKIP_ROOT: from
+    BATS_SKIP:
+    BATS_SKIP_ROOT: bud
     BATS_SKIP_USER:
   sle-15-SP7:
     BATS_PATCHES:


### PR DESCRIPTION
Update BATS_SKIP for 16.0

These subtests are passing in latest build for SLE 16.0 Build106.5:
- bud: https://openqa.suse.de/tests/18230629#step/buildah/326
- run: https://openqa.suse.de/tests/18230629#step/buildah/330
- from: https://openqa.suse.de/tests/18230629#step/buildah/412
- run (root): https://openqa.suse.de/tests/18230629#step/buildah/330

```
$ susebats notok https://openqa.suse.de/tests/18230629
    BATS_SKIP:
    BATS_SKIP_ROOT: bud
    BATS_SKIP_USER:
```
