### PR TITLE
containers/compose: Add workaround for docker-compose with podman

### DIFF
--- a/tests/containers/compose.pm
+++ b/tests/containers/compose.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2017-2024 SUSE LLC
+# Copyright 2017-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: docker-compose
@@ -72,7 +72,13 @@ sub run {
 
     my $engine = $self->containers_factory($runtime);
 
-    install_packages('docker-compose');
+    my @pkgs = ('docker-compose');
+    # Work-around for https://bugzilla.suse.com/show_bug.cgi?id=1244448
+    # docker-compose package pulls all docker dependencies when used with podman
+    # Note: When `CONTAINER_RUNTIMES=podman,docker` we don't care and it allows
+    # us to test how both runtimes behave when installed together.
+    push @pkgs, 'podman-docker' if check_var("CONTAINER_RUNTIMES", "podman");
+    install_packages(@pkgs);
 
     validate_script_output("$runtime compose version", qr/version 2/);
 


### PR DESCRIPTION
When testing podman alone, install podman-docker in the compose module for testing docker-compose with podman.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1244448
- Verification runs:
  - SLE 16.0 podman: https://openqa.suse.de/tests/18246710
  - JeOS podman & docker: https://openqa.opensuse.org/tests/5138320