### PR TITLE
Use OBS repo for ca-certificates-suse

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 SUSE LLC
+# Copyright 2015-2025 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package utils;
@@ -2417,12 +2417,7 @@ This functions checks if ca-certificates-suse is installed and if it is not it a
 sub ensure_ca_certificates_suse_installed {
     return unless is_sle || is_sle_micro;
     if (script_run('rpm -qi ca-certificates-suse') == 1) {
-        my $host_version = get_var("HOST_VERSION") ? 'HOST_VERSION' : 'VERSION';
-        my $distversion = 'SLE_' . get_required_var($host_version) =~ s/-SP/_SP/r;    # 15 -> 15, 15-SP1 -> 15_SP1
-        my $exit = script_run("curl -fkIL http://download.suse.de/ibs/SUSE:/CA/$distversion/SUSE:CA.repo >/dev/null 2>&1");
-        $distversion = 'SLE-Factory' if ($exit != 0);
-        diag "CA folder: $distversion";
-        zypper_call("ar --refresh http://download.suse.de/ibs/SUSE:/CA/$distversion/SUSE:CA.repo");
+        zypper_call("ar --refresh https://download.opensuse.org/repositories/SUSE:/CA/openSUSE_Tumbleweed/SUSE:CA.repo");
         if (is_sle_micro) {
             transactional::trup_call('--continue pkg install ca-certificates-suse');
         } else {


### PR DESCRIPTION
Use OBS repo for ca-certificates-suse.  I've been using the OBS repo on 15-SP4+ without issues.

- Related ticket: https://progress.opensuse.org/issues/180143
- Verification runs:
  - opensuse-Tumbleweed-BCI-x86_64-Build20250627-bci_minimal_podman@64bit -> https://openqa.opensuse.org/tests/5138545
  - sle-15-SP3-BCI-Updates-x86_64-Build9.46_base-fips-image-bci-base-fips_15.3_on_SLES_15-SP3_podman@64bit -> https://openqa.suse.de/tests/18247916
 