### PR TITLE
Revert "Handle new shortcut to enable disk encryption in Tumbleweed"

### DIFF
--- a/lib/Installation/Partitioner/LibstorageNG/PartitioningSchemePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/PartitioningSchemePage.pm
@@ -13,7 +13,6 @@ use strict;
 use warnings FATAL => 'all';
 use testapi;
 use parent 'Installation::WizardPage';
-use version_utils;
 
 use constant {
     PARTITIONING_SCHEME_PAGE => 'inst-partitioning-scheme',
@@ -32,10 +31,7 @@ sub press_next {
 
 sub select_enable_disk_encryption_checkbox {
     assert_screen(PARTITIONING_SCHEME_PAGE);
-    # after https://build.opensuse.org/request/show/1277719 there's a new control
-    # Authentication, which takes the 'alt-a' change is currently in Staging:F
-    my $shortcut = (is_tumbleweed && check_var("VERSION", "Staging:F")) ? 'alt-d' : 'alt-a';
-    send_key($shortcut);
+    send_key('alt-a');
 }
 
 sub enter_password {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#22441

See https://progress.opensuse.org/issues/184861#note-1