### PR TITLE
containers/buildah: Use cowsay instead of python3

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -41,8 +41,8 @@ sub run_tests {
     # network failure
     if ($runtime eq 'podman') {
         record_info('Test', "Install random package in the container");
-        assert_script_run("buildah run $container -- zypper in -y python3", timeout => 300);
-        assert_script_run("buildah run $container -- python3 --version");
+        assert_script_run("buildah run $container -- zypper in -y cowsay", timeout => 300);
+        assert_script_run("buildah run $container -- cowsay hello world");
     }
 
     record_info('Test', "Add environment variable to the container");


### PR DESCRIPTION
Use cowsay instead of python3 because python3 is a meta-package that may fail.

- Related ticket: https://progress.opensuse.org/issues/184843
- Failing test: https://openqa.suse.de/tests/18241780#step/buildah_podman/112
- Verification run: https://openqa.suse.de/tests/18248921#step/buildah_podman/115

```
 _____________
< hello world >
 -------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```
