### PR TITLE
Add UEFI bootmenu

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1137,8 +1137,20 @@ sub tianocore_disable_secureboot {
 
     assert_screen 'grub2';
     send_key 'c';
-    sleep 2;
+    sleep 5;
     enter_cmd "exit";
+
+    # There might be a boot menu before the mainmenu.
+    # Wait until the main menu appears and move to the EFI firmware setup, if the boot menu is present
+    while (!check_screen('tianocore-mainmenu')) {
+        wait_still_screen();
+        if (check_screen('tianocore-bootmenu')) {
+            send_key 'down';
+            assert_screen 'tianocore-bootmenu-EFI-fimware-selected';
+            send_key 'ret';
+        }
+    }
+
     assert_screen 'tianocore-mainmenu';
     # Select 'Boot manager' entry
     send_key_until_needlematch('tianocore-devicemanager', 'down', 6, 5);


### PR DESCRIPTION
Adds ability to navigate from the bootmenu to the mainmenu as required in some UEFI systems.

**REQUIRED NEEDLES TO BE ALSO MERGE (link below)**

- Related ticket: https://progress.opensuse.org/issues/184837
- Related failure: https://openqa.suse.de/tests/18246090#step/bootloader_uefi/4
- Needles: [SLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/merge_requests/1688) | [openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/843)
- Verification run: https://duck-norris.qe.suse.de/tests/14884#step/bootloader_uefi/13 (cancelled after relevant part)
