### PR TITLE
SLE16 ppc64le containers host fix with power10

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -910,7 +910,7 @@ sub wait_boot {
     elsif (get_var('OFW') && (check_screen('displaymanager', 5))) {
     }
     # SLE-16 boot on ppc64le results too quick to be captured, from grub2 to login prompt
-    elsif (get_var('OFW') && is_sle('16+') && check_var('MACHINE', 'ppc64le-emu') && (check_screen('linux-login', 10))) {
+    elsif (get_var('OFW') && is_sle('16+') && is_ppc64le && (check_screen('linux-login', 10))) {
     }
     elsif (is_bootloader_grub2) {
         assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600) if (uses_qa_net_hardware() || get_var("PXEBOOT"));


### PR DESCRIPTION
The event previously occurred for machine `ppc64le-emu` and fixed in [PR22281](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22281#discussion_r2135222973), in last sle16 build is also occurring for `power10` workers, `machine=ppc64le`: but actual condition on 'pppc64le-emu' excludes it, skipping the check, so that the screenshot is no more detected and tests fail.

Extending the condition to select **ppc64le** `architecture`, together with the specific screen, makes the tests pass again.

- Related ticket: https://progress.opensuse.org/issues/[184693](https://progress.opensuse.org/issues/184693)

- Verification run: https://openqa.suse.de/tests/18256029
