### PR TITLE
Rename x11_client/server to x11_podman_client/server

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2143,11 +2143,11 @@ sub load_x11_remote {
         loadtest 'x11/remote_desktop/windows_network_setup';
         loadtest 'x11/remote_desktop/windows_server_setup';
     }
-    elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_server')) {
-        loadtest 'microos/workloads/x11-container/x11_server';
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_podman_server')) {
+        loadtest 'microos/workloads/x11-container/x11_podman_server';
     }
-    elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_client')) {
-        loadtest 'microos/workloads/x11-container/x11_client';
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_podman_client')) {
+        loadtest 'microos/workloads/x11-container/x11_podman_client';
     }
     elsif (check_var('REMOTE_DESKTOP_TYPE', 'x11_helm_server')) {
         loadtest 'transactional/host_config';
@@ -2189,7 +2189,7 @@ sub load_common_x11 {
     elsif (check_var('REGRESSION', 'remote')) {
         if (check_var("REMOTE_DESKTOP_TYPE", "win_client") || check_var('REMOTE_DESKTOP_TYPE', "win_server")) {
             loadtest "x11/remote_desktop/windows_client_boot";
-        } elsif (check_var("REMOTE_DESKTOP_TYPE", "x11_server") || check_var("REMOTE_DESKTOP_TYPE", "x11_helm_server")) {
+        } elsif (check_var("REMOTE_DESKTOP_TYPE", "x11_podman_server") || check_var("REMOTE_DESKTOP_TYPE", "x11_helm_server")) {
             loadtest 'microos/disk_boot';
         }
         else {

--- a/tests/microos/workloads/x11-container/x11_podman_client.pm
+++ b/tests/microos/workloads/x11-container/x11_podman_client.pm
@@ -47,7 +47,7 @@ sub run {
     my $opts = "-e DISPLAY=:0 -e XAUTHORITY=/home/user/xauthority/.xauth -e PULSE_SERVER=/var/run/pulse/native -v xauthority:/home/user/xauthority:rw -v pasocket:/var/run/pulse/ -v xsocket:/tmp/.X11-unix:rw";
     # pulseaudio image url and firefox kiosk url are joined together by a space
     # split the string by space
-    my ($pacontainerpath, $ffcontainerpath) = split(/\s+/, get_var("CONTAINER_IMAGE_TO_TEST", 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/pulseaudio:latest registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/firefox-esr:latest'));
+    my ($pacontainerpath, $ffcontainerpath) = split(/\s+/, get_var("CONTAINER_IMAGE_TO_TEST", 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/pulseaudio:17 registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/firefox-esr:esr'));
     # start pulseaudio container
     enter_cmd("podman pull $pacontainerpath --tls-verify=false", 300);
     assert_screen("podman-pa-pull-done");

--- a/tests/microos/workloads/x11-container/x11_podman_server.pm
+++ b/tests/microos/workloads/x11-container/x11_podman_server.pm
@@ -53,7 +53,7 @@ sub run {
     x11_preparation();
 
     # start X11 container
-    my $containerpath = get_var('CONTAINER_IMAGE_TO_TEST', 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/xorg:latest');
+    my $containerpath = get_var('CONTAINER_IMAGE_TO_TEST', 'registry.suse.de/suse/sle-15-sp6/update/cr/totest/images/suse/kiosk/xorg:notaskbar');
     assert_script_run("podman pull $containerpath --tls-verify=false", 300);
     assert_script_run("podman run --privileged -d --pod wallboard-pod -e XAUTHORITY=/home/user/xauthority/.xauth -v xauthority:/home/user/xauthority:rw -v xsocket:/tmp/.X11-unix:rw -v /run/udev/data:/run/udev/data:rw --name x11-init-container --security-opt=no-new-privileges $containerpath");
     # verify the x11 server container started


### PR DESCRIPTION
Rename x11_client/server to x11_podman/server to keep consistent with deploying with kubernetes with helm scenario

Update tags for x11, pulseaudio and firefox kiosk containers since the previous used 'latest' tag is not available now

- Related ticket: https://progress.opensuse.org/issues/174418
- Needles: N/A
- Verification run: 
>  x11_podman_server https://openqa.suse.de/tests/18262817#
>  x11_podman_client https://openqa.suse.de/tests/18262819#
