### PR TITLE
buildah/bats: Update BATS_SKIP for runc 1.2

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -21,26 +21,26 @@ buildah:
   sle-15-SP7:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud namespaces
-    BATS_SKIP_ROOT: run
+    BATS_SKIP:
+    BATS_SKIP_ROOT: bud run
     BATS_SKIP_USER:
   sle-15-SP6:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud namespaces
-    BATS_SKIP_ROOT: run
+    BATS_SKIP:
+    BATS_SKIP_ROOT: bud namespaces run
     BATS_SKIP_USER:
   sle-15-SP5:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud namespaces
+    BATS_SKIP: bud
     BATS_SKIP_ROOT: run
     BATS_SKIP_USER:
   sle-15-SP4:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud namespaces
-    BATS_SKIP_ROOT: run
+    BATS_SKIP:
+    BATS_SKIP_ROOT: bud run
     BATS_SKIP_USER:
 netavark:
   # Note on patches:

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -161,9 +161,7 @@ Complete list found in [skip.yaml](data/containers/bats/skip.yaml)
 
 | tests | reason |
 | --- | --- |
-| [from] & [run] | https://github.com/containers/buildah/issues/6071 |
 | [sbom] | https://github.com/containers/buildah/issues/5617 |
-| others | Waiting for runc 1.2.x |
 
 [from]: https://github.com/containers/buildah/blob/main/tests/from.bats
 [run]: https://github.com/containers/buildah/blob/main/tests/run.bats


### PR DESCRIPTION
Update BATS_SKIP for runc 1.2. 

```
# 15-SP7
$ susebats notok https://openqa.suse.de/tests/18259892
    BATS_SKIP:
    BATS_SKIP_ROOT: bud run
    BATS_SKIP_USER:
# 15-SP6
$ susebats notok https://openqa.suse.de/tests/18259624
    BATS_SKIP:
    BATS_SKIP_ROOT: bud namespaces run
    BATS_SKIP_USER:
# 15-SP5
$ susebats notok https://openqa.suse.de/tests/18259716
    BATS_SKIP: bud
    BATS_SKIP_ROOT: run
    BATS_SKIP_USER:
# 15-SP4
$ susebats notok https://openqa.suse.de/tests/18259892
    BATS_SKIP:
    BATS_SKIP_ROOT: bud run
    BATS_SKIP_USER:
```