### PR TITLE
containers: No need to disable SUSE secrets anymore

### DIFF
--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -25,7 +25,6 @@ use containers::docker;
 use containers::container_images;
 use Utils::Architectures;
 use containers::common qw(install_docker_when_needed);
-use version_utils qw(is_sle);
 
 sub run {
     my ($self) = @_;
@@ -38,8 +37,6 @@ sub run {
 
     my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
     install_packages("$pkg_name-rootless-extras");
-
-    assert_script_run("echo 0 > /etc/docker/suse-secrets-enable") if is_sle;
 
     my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
 
@@ -87,7 +84,6 @@ sub post_run_hook {
     my $self = shift;
     cleanup();
     select_serial_terminal();
-    script_run "rm -f /etc/docker/suse-secrets-enable" if is_sle;
     $self->SUPER::post_run_hook;
 }
 
@@ -95,7 +91,6 @@ sub post_fail_hook {
     my $self = shift;
     cleanup();
     select_serial_terminal();
-    script_run "rm -f /etc/docker/suse-secrets-enable" if is_sle;
     save_and_upload_log('cat /etc/{subuid,subgid}', "/tmp/permissions.txt");
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1240150 is fixed so no need to apply the workaround to disable SUSE secrets.

- Verification runs (SLE 16.0):
  - docker:  https://openqa.suse.de/tests/18263750
  - docker-stable: https://openqa.suse.de/tests/18263751

TODO in a follow-up PR:
- Schedule the test on SLE-15:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/lib/main_containers.pm#L182