### PR TITLE
Remove SYSTEM_ROLE: textmode from ReaR

### DIFF
--- a/schedule/ha/rear/rear_backup_16.yaml
+++ b/schedule/ha/rear/rear_backup_16.yaml
@@ -7,7 +7,6 @@ vars:
   INSTALLONLY: '1'
   SCC_ADDONS: 'ha'
   SCC_REGISTER: 'installation'
-  SYSTEM_ROLE: 'textmode'
   HOSTNAME: 'reartest'
   AGAMA_PRODUCT_ID: SLES
   INST_AUTO: ha/agama/sles_ha_default.jsonnet


### PR DESCRIPTION
Leave the ReaR backup test to run with SYSTEM_ROLE:default in test with Agama for 16.0.

- Related ticket: https://jira.suse.com/browse/TEAM-10463

# Verification run:

https://openqa.suse.de/tests/18264831 :green_circle:  triggered with `AGAMA=1` on the command line and using dev JoGroup definition. Failure is later and due to a known issue.