### PR TITLE
Install dhcpcd near to rear29a

### DIFF
--- a/tests/ha/rear_backup.pm
+++ b/tests/ha/rear_backup.pm
@@ -53,6 +53,12 @@ sub run {
         my $backup_rc = script_run($rear_cmd, timeout => $timeout);
         die 'Unexpected error in mkbackup command' unless defined $backup_rc;
         unless ($backup_rc == 0) {
+            # Check for bsc#1245306
+            if (is_sle('>=16') && (zypper_call('se -i dhcpcd', exitcode => [0, 104]) == 104)) {
+                record_soft_failure('bsc#1245306 - Rear29a: DHCP is enabled but no DHCP client binary was found');
+                zypper_call 'in dhcpcd';
+            }
+
             # Check for bsc#1180946
             my $var_rc = script_run("grep 'MODULES[[:blank:]]*=' $local_conf");
             die 'Unexpected error in grep command' unless defined $var_rc;


### PR DESCRIPTION
Soft fail for bsc#1245306. Adjust the schedule.


- Related ticket: https://jira.suse.com/browse/TEAM-10314

# Verification run:

https://openqa.suse.de/tests/18265973 :yellow_circle:  as expected :-)
