### PR TITLE
Fix DNS race condition with wicked

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -31,13 +31,14 @@ sub setup_networking_in_isolated_network {
     my $subnet = "/24";
     my $gateway = "10.0.2.2";
     my $dns_string = get_var("DNS", get_default_dns());
-    my @dns = defined($dns_string) && $dns_string ne "" ? split(",", $dns_string) : ();
+    my @dns = ($dns_string ne "") ? split(",", $dns_string) : ();
 
     setup_dhcp_server_network(
         server_ip => $server_ip,
         subnet => $subnet,
         gateway => $gateway,
-        nics => \@nics
+        nics => \@nics,
+        dns => \@dns
     );
 
     set_resolv(nameservers => \@dns);


### PR DESCRIPTION
When using wicked, we must not override the `resolv.conf` file without also setting `NETCONFIG_DNS_STATIC_SERVERS`.

- Related ticket: https://progress.opensuse.org/issues/184375
- Related failure: https://openqa.suse.de/tests/18265291#step/host_configuration/84
- Verification run: https://openqa.suse.de/tests/18266366
