### PR TITLE
Fix sshd configuration on SLE16 PC

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -382,14 +382,14 @@ sub prepare_ssh_tunnel {
     assert_script_run("install -o $testapi::username -g users -m 0600 ~/.ssh/* /home/$testapi::username/.ssh/");
 
     # Permit root passwordless login and TCP forwarding over SSH
-    if (is_sle('>=16')) {
-        $instance->ssh_assert_script_run(q(echo "PermitRootLogin prohibit-password" | sudo tee /etc/ssh/sshd_config.d/10-root-login.conf));
-        $instance->ssh_assert_script_run(q(echo "AllowTcpForwarding yes" | sudo tee /etc/ssh/sshd_config.d/10-tcp-forwarding.conf));
-        record_info('cat /etc/ssh/sshd_config.d/*', $instance->ssh_script_output('sudo cat /etc/ssh/sshd_config.d/*', proceed_on_failure => 1));
-    } else {
-        $instance->ssh_assert_script_run('sudo cat /etc/ssh/sshd_config');
-        $instance->ssh_assert_script_run('sudo sed -i "s/PermitRootLogin no/PermitRootLogin prohibit-password/g" /etc/ssh/sshd_config');
-        $instance->ssh_assert_script_run('sudo sed -i "/^AllowTcpForwarding/c\AllowTcpForwarding yes" /etc/ssh/sshd_config') if (is_hardened());
+    if (script_run("sudo sshd -G | grep 'permitrootlogin prohibit-password'") == 0 && script_run("sshd -G | grep 'allowtcpforwarding yes'") ne 0) {
+        if (is_sle('>=16')) {
+            $instance->ssh_assert_script_run(q(echo "PermitRootLogin prohibit-password" | sudo tee /etc/ssh/sshd_config.d/10-root-login.conf));
+            $instance->ssh_assert_script_run(q(echo "AllowTcpForwarding yes" | sudo tee /etc/ssh/sshd_config.d/10-tcp-forwarding.conf));
+        } else {
+            $instance->ssh_assert_script_run('sudo sed -i "s/PermitRootLogin no/PermitRootLogin prohibit-password/g" /etc/ssh/sshd_config');
+            $instance->ssh_assert_script_run('sudo sed -i "/^AllowTcpForwarding/c\AllowTcpForwarding yes" /etc/ssh/sshd_config') if (is_hardened());
+        }
     }
     $instance->ssh_assert_script_run('sudo systemctl reload sshd');
     record_info('sshd -G', $instance->ssh_script_output('sudo sshd -G', proceed_on_failure => 1));


### PR DESCRIPTION
- Replaces: #22504
- Related ticket: [poo#184864](https://progress.opensuse.org/issues/184864)
- Verification runs:
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=12-SP5) of sle-12-SP5-EC2-Updates.x86_64	  [username@64bit](https://pdostal-server.suse.cz/tests/9130)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP3) of sle-15-SP3-Azure-BYOS-Updates.x86_64	  [username@64bit](https://pdostal-server.suse.cz/tests/9129)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP6) of sle-15-SP6-EC2-BYOS-Updates.x86_64	  [username@64bit](https://pdostal-server.suse.cz/tests/9128)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	  [username@64bit](https://pdostal-server.suse.cz/tests/9127)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=16.0) of sle-16.0-Azure-BYOS.x86_64	  [username@az_Standard_D2s_v4](https://pdostal-server.suse.cz/tests/9126)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=16.0) of sle-16.0-EC2-BYOS.aarch64	  [username@ec2_a1.medium](https://pdostal-server.suse.cz/tests/9125)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP4) of sle-15-SP4-GCE-BYOS-Updates.aarch64	  [username@64bit](https://pdostal-server.suse.cz/tests/9124)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=16.0) of sle-16.0-GCE-BYOS.x86_64	  [username@gce_n2d_standard_2_confidential](https://pdostal-server.suse.cz/tests/9123)	