### PR TITLE
Fix undefined value as array

### DIFF
--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -493,7 +493,7 @@ sub setup_dhcp_server_network {
     my $subnet = $args{subnet} // '/24';
     my $gateway = $args{gateway} // '10.0.2.2';
     my @nics = @{$args{nics}};
-    my @dns = @{$args{dns}};
+    my @dns = @{$args{dns} || []};
 
     my $nic0 = $nics[0];
 


### PR DESCRIPTION
Can't use an undefined value as an ARRAY reference.

Fixes https://openqa.suse.de/tests/18278052#step/network_bonding_setup/40

* Verification run: https://openqa.suse.de/tests/18278272 (unrelated failure)