### PR TITLE
PC: cloud-init status may return 0 or 2

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -662,8 +662,8 @@ sub check_cloudinit() {
     my ($self) = @_;
 
     # cloud-init status
-    $self->ssh_script_retry(cmd => "sudo cloud-init status", timeout => 90, retry => 12, delay => 15);
-    $self->ssh_script_retry(cmd => "sudo cloud-init status --long", timeout => 90, retry => 12, delay => 15);
+    $self->ssh_script_retry(cmd => 'sudo cloud-init status; R=$?; if [[ $R -eq 0 || $R -eq 2 ]]; then true; else sh -c "exit $R"; fi', timeout => 90, retry => 12, delay => 15);
+    $self->ssh_script_run(cmd => 'sudo cloud-init status --long', timeout => 90);
 
     # cloud-id
     my $cloud_id = (is_azure) ? 'azure' : 'aws';


### PR DESCRIPTION
- Related ticket: [poo#184876](https://progress.opensuse.org/issues/184876)
- Verification run:
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=12-SP5) of sle-12-SP5-EC2-Updates.x86_64	  [username@64bit](https://pdostal-server.suse.cz/tests/9130)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP3) of sle-15-SP3-Azure-BYOS-Updates.x86_64	  [username@64bit](https://pdostal-server.suse.cz/tests/9129)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP6) of sle-15-SP6-EC2-BYOS-Updates.x86_64	  [username@64bit](https://pdostal-server.suse.cz/tests/9128)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	  [username@64bit](https://pdostal-server.suse.cz/tests/9127)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=16.0) of sle-16.0-Azure-BYOS.x86_64	  [username@az_Standard_D2s_v4](https://pdostal-server.suse.cz/tests/9126)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=16.0) of sle-16.0-EC2-BYOS.aarch64	  [username@ec2_a1.medium](https://pdostal-server.suse.cz/tests/9125)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP4) of sle-15-SP4-GCE-BYOS-Updates.aarch64	  [username@64bit](https://pdostal-server.suse.cz/tests/9124)	
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=16.0) of sle-16.0-GCE-BYOS.x86_64	  [username@gce_n2d_standard_2_confidential](https://pdostal-server.suse.cz/tests/9123)	