### PR TITLE
Move HOSTNAME for rear away from the schedule.

### DIFF
--- a/schedule/ha/rear/rear_backup_16.yaml
+++ b/schedule/ha/rear/rear_backup_16.yaml
@@ -7,7 +7,6 @@ vars:
   INSTALLONLY: '1'
   SCC_ADDONS: 'ha'
   SCC_REGISTER: 'installation'
-  HOSTNAME: 'reartest'
   AGAMA_PRODUCT_ID: SLES
   INST_AUTO: ha/agama/sles_ha_default.jsonnet
 schedule:


### PR DESCRIPTION
Move HOSTNAME variable from the schedule to the JobGroup


- Related Ticket: https://jira.suse.com/browse/TEAM-10463 

# Verification run:

## rear_restore_backup_textmode

- https://openqa.suse.de/tests/18280542#dependencies  :green_circle:  and   https://openqa.suse.de/tests/18280543 :green_circle: 

## rear_restore_backup_textmode_scsi
- https://openqa.suse.de/tests/18280545#dependencies  :green_circle:   and   https://openqa.suse.de/tests/18280546
