### PR TITLE
Fail test in case of AVCs

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -30,7 +30,7 @@ sub post_run_hook {
     # start next test in home directory
     enter_cmd "cd";
 
-    record_avc_selinux_alerts();
+    $self->record_avc_selinux_alerts();
     # clear screen to make screen content ready for next test
     $self->clear_and_verify_console;
 }
@@ -44,7 +44,7 @@ Method executed when run() finishes and the module has result => 'fail'
 sub post_fail_hook {
     my ($self) = @_;
     return if get_var('NOLOGS');
-    record_avc_selinux_alerts();
+    $self->record_avc_selinux_alerts();
     $self->SUPER::post_fail_hook;
     # at this point the instance is shutdown
     return if (is_public_cloud() || is_openstack());

--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -14,6 +14,8 @@ use containers::podman;
 use containers::containerd_crictl;
 use containers::containerd_nerdctl;
 use Mojo::Base 'opensusebasetest';
+use testapi;
+use Utils::Logging qw(record_avc_selinux_alerts);
 
 sub containers_factory {
     my ($self, $runtime) = @_;
@@ -36,6 +38,22 @@ sub containers_factory {
     }
     $engine->init();
     return $engine;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    return if get_var('NOLOGS');
+
+    select_console('log-console');
+
+    $self->record_avc_selinux_alerts;
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    select_console('log-console');
+
+    shift->record_avc_selinux_alerts;
 }
 
 1;

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1098,7 +1098,6 @@ sub pre_run_hook {
 sub post_run_hook {
     my ($self) = @_;
 
-    record_avc_selinux_alerts() if is_sle('16+');
     return unless ($prev_console);
     select_console($prev_console, await_console => 0);
     if ($prev_console eq 'x11') {

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -144,6 +144,8 @@ sub load_host_tests_podman {
     loadtest 'containers/podman_netavark' unless (is_staging || is_ppc64le);
     loadtest('containers/skopeo', run_args => $run_args, name => $run_args->{runtime} . "_skopeo") unless (is_sle('<15') || is_sle_micro('<5.5'));
     loadtest 'containers/podman_quadlet' unless (is_staging || is_leap("<16") || is_sle("<16") || is_sle_micro("<6.1"));
+    load_secret_tests($run_args);
+    load_volume_tests($run_args);
     # https://github.com/containers/podman/issues/5732#issuecomment-610222293
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
@@ -152,8 +154,6 @@ sub load_host_tests_podman {
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects
     load_buildah_tests($run_args) unless (is_sle('<15') || is_sle_micro || is_microos || is_leap_micro || is_staging);
-    load_secret_tests($run_args);
-    load_volume_tests($run_args);
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
     loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_public_cloud || is_transactional);

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -1487,7 +1487,7 @@ sub modify_selinux_setenforce {
 sub post_run_hook {
     my ($self) = @_;
 
-    record_avc_selinux_alerts() if is_sle('16+');
+    $self->record_avc_selinux_alerts() if is_sle('16+');
     return unless ($prev_console);
     select_console($prev_console, await_console => 0);
     ensure_unlocked_desktop if ($prev_console eq 'x11');

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -33,7 +33,7 @@ sub post_fail_hook {
     select_serial_terminal();
     export_healthcheck_basic;
     export_logs_basic;
-    record_avc_selinux_alerts;
+    shift->record_avc_selinux_alerts;
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
     export_logs_desktop;
     select_log_console;

--- a/tests/console/perl_bootloader.pm
+++ b/tests/console/perl_bootloader.pm
@@ -17,6 +17,7 @@ use package_utils;
 use power_action_utils 'power_action';
 use version_utils qw(is_sle is_leap is_sle_micro is_leap_micro check_version is_transactional);
 use Utils::Backends 'is_pvm';
+use Utils::Logging qw(record_avc_selinux_alerts);
 use transactional;
 
 sub run {
@@ -89,6 +90,11 @@ sub post_fail_hook {
     my ($self) = @_;
     $self->SUPER::post_fail_hook;
     upload_logs('/var/log/pbl.log');
+}
+
+sub post_run_hook {
+    select_console('log-console');
+    shift->record_avc_selinux_alerts;
 }
 
 1;

--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -43,7 +43,7 @@ sub run {
 }
 
 sub post_run_hook {
-    record_avc_selinux_alerts() if is_sle('16+');
+    shift->record_avc_selinux_alerts() if is_sle('16+');
 }
 
 # Specific test_flags for this test module

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -95,7 +95,7 @@ sub post_run_hook {
     my $node_to_fence = get_var('NODE_TO_FENCE', undef);
     # If NODE_TO_FENCE is undef, then the module fences first node only, otherwise check for the hostname
     if ((defined $node_to_fence && (get_hostname ne $node_to_fence)) || (!defined $node_to_fence && !check_var('HA_CLUSTER_INIT', 'yes'))) {
-        record_avc_selinux_alerts() if is_sle('16+');
+        $self->record_avc_selinux_alerts() if is_sle('16+');
     }
 }
 

--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -179,7 +179,7 @@ sub run {
 # But collect SELinux AVCs on node 1 and server
 sub post_run_hook {
     my ($self) = @_;
-    record_avc_selinux_alerts() if (is_sle('16+') && !is_node(2));
+    $self->record_avc_selinux_alerts() if (is_sle('16+') && !is_node(2));
 }
 
 1;

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -21,6 +21,7 @@ use Utils::Backends;
 use jeos qw(expect_mount_by_uuid);
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);
 use serial_terminal 'prepare_serial_console';
+use Utils::Logging qw(record_avc_selinux_alerts);
 
 my $user_created = 0;
 
@@ -433,6 +434,10 @@ sub run {
     verify_bsc if is_jeos;
     verify_partition_label;
     verify_selinux;
+}
+
+sub post_run_hook {
+    shift->record_avc_selinux_alerts;
 }
 
 sub test_flags {


### PR DESCRIPTION
Check for AVCs and in case there any found, mark the test as failed if `AVC_FAIL_ON_DENIALS` is set.
It is expected this test will run on most of the user space tests and SELinux supported products, but for now run this code only in consoletests and container tests.

I had to re-arrange `rootless_podman` as after failure consequent tests were not recovering well from the openQA taken snapshot

- ticket: https://progress.opensuse.org/issues/182384

##### Verification runs

###### AVC_FAIL_ON_DENIALS=0

- [sle-16.0-Minimal-VM-for-kvm-and-xen](http://kepler.suse.cz/tests/25038)

###### AVC_FAIL_ON_DENIALS=1

- [microos-Tumbleweed-MicroOS-Image-ContainerHost](http://kepler.suse.cz/tests/25051#)
- [microos-Tumbleweed-MicroOS-Image](http://kepler.suse.cz/tests/25046#)
- [sle-16.0-Minimal-VM-for-kvm-and-xen](http://kepler.suse.cz/tests/25050#step/apache/2)
- [sle-16.0-Online-x86_64-Build106.5-podman_tests](http://kepler.suse.cz/tests/25052#step/rootless_podman/233)
- [sle-16.0-Minimal-VM-for-kvm-and-xen](http://kepler.suse.cz/tests/25039#step/docker_isolation/199)
- [microos-Tumbleweed-MicroOS-Image-sdboot](http://kepler.suse.cz/tests/25041)

