### PR TITLE
Add workaround for bsc#1245220

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -221,7 +221,10 @@ sub register_addons_in_pc {
     my ($instance) = @_;
     my @addons = split(/,/, get_var('SCC_ADDONS', ''));
     my $remote = $instance->username . '@' . $instance->public_ip;
-    $instance->ssh_script_retry(cmd => "sudo zypper -n --gpg-auto-import-keys ref", timeout => 300, retry => 3, delay => 120);
+    # Workaround for bsc#1245220
+    my $env = is_sle("=15-SP3") ? "ZYPP_CURL2=1" : "";
+    my $cmd = "sudo $env zypper -n --gpg-auto-import-keys ref";
+    $instance->ssh_script_retry(cmd => $cmd, timeout => 300, retry => 3, delay => 120);
     for my $addon (@addons) {
         next if ($addon =~ /^\s+$/);
         register_addon($remote, $addon);


### PR DESCRIPTION
Adds ZYPP_CURL2=1 env variable as suggested in
https://bugzilla.suse.com/show_bug.cgi?id=1245220#c9.

- Related ticket: https://progress.opensuse.org/issues/185047
- Verification run: https://duck-norris.qe.suse.de/tests/14888
