### PR TITLE
Update Availability Zone in case of change

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -596,7 +596,10 @@ sub terraform_apply {
             $tf_apply_output = script_output('cat tf_apply_output', proceed_on_failure => 1);
             record_info("TFM apply output", $tf_apply_output);
             record_info("TFM apply exit code", $ret);
-            last if $ret == 0;
+            if ($ret == 0) {
+                $self->provider_client->availability_zone($az);
+                last;
+            }
         }
     }
 


### PR DESCRIPTION


In case of failure to create VM in defined AZ test logic tries to loop over
other AZ in same region and create VM in them. In case of success we need also to reset AZ
which defined in the provider_client. So any logic will get into correct AZ.
