### PR TITLE
bats/buildah: Fix BATS_SKIP for 15-SP4

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -39,8 +39,8 @@ buildah:
   sle-15-SP4:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP:
-    BATS_SKIP_ROOT: bud run
+    BATS_SKIP: bud
+    BATS_SKIP_ROOT: run
     BATS_SKIP_USER:
 netavark:
   # Note on patches:


### PR DESCRIPTION
Fix BATS_SKIP for 15-SP4

```
 susebats notok  https://openqa.suse.de/tests/18282929
    BATS_SKIP: bud
    BATS_SKIP_ROOT: run
    BATS_SKIP_USER:

```