### PR TITLE
libgpiod: skip test if v1.x

### DIFF
--- a/tests/console/libgpiod.pm
+++ b/tests/console/libgpiod.pm
@@ -17,6 +17,11 @@ use Utils::Architectures;
 use version_utils qw(is_sle is_leap);
 
 sub run {
+    # Test designed for libgpiod v2.x, so only Tumbleweed and Leap >= 16.0
+    if (is_leap('<16.0')) {
+        record_info('SKIP', 'Do not test libgpiod v1.x');
+        return;
+    }
     select_console 'root-console';
 
     # Install libgpiod tools


### PR DESCRIPTION
Follow-up https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22447
- Verification run: https://openqa.opensuse.org/tests/5144157#step/libgpiod/1