### PR TITLE
bats: Record OCI runtime version

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -115,7 +115,7 @@ sub configure_oci_runtime {
     }
     run_command "mkdir -p /etc/containers/containers.conf.d";
     run_command 'echo -e "[engine]\nruntime=\"' . $oci_runtime . '\"" >> /etc/containers/containers.conf.d/engine.conf';
-    record_info("OCI runtime", $oci_runtime);
+    record_info("OCI runtime", script_output("$oci_runtime --version"));
 }
 
 sub switch_to_root {


### PR DESCRIPTION
Record OCI runtime version to avoid looking at the package list to get this information.