### PR TITLE
Increase timeout for redis test

### DIFF
--- a/tests/console/redis.pm
+++ b/tests/console/redis.pm
@@ -100,7 +100,7 @@ sub cleanup_redis {
     }
     assert_script_run($killall_redis_server_cmd);
     assert_script_run($remove_test_db_file_cmd);
-    assert_script_run("find / -type f -name 'dump.rdb' -print -exec rm -f {} + || true");
+    assert_script_run("find / -type f -name 'dump.rdb' -print -exec rm -f {} + || true", timeout => 180);
 }
 
 sub upload_redis_logs {


### PR DESCRIPTION
https://progress.opensuse.org/issues/184819

- Verification run: http://openqa.suse.de/tests/18293804#step/redis/69

The test module took `1m 26s`. then it makes sense to increase the timeout.