### PR TITLE
PC: Fix prepare_ssh_tunnel expression

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -385,7 +385,7 @@ sub prepare_ssh_tunnel {
     assert_script_run("install -o $testapi::username -g users -m 0600 ~/.ssh/* /home/$testapi::username/.ssh/");
 
     # Permit root passwordless login and TCP forwarding over SSH
-    if ($instance->ssh_script_run("sudo sshd -G | grep -i 'permitrootlogin prohibit-password'") == 0 && $instance->ssh_script_run("sudo sshd -G | grep -i 'allowtcpforwarding yes'") ne 0) {
+    if ($instance->ssh_script_run("sudo sshd -G | grep -i 'permitrootlogin prohibit-password'") != 0 && $instance->ssh_script_run("sudo sshd -G | grep -i 'allowtcpforwarding yes'") != 0) {
         if (is_sle('>=16')) {
             $instance->ssh_assert_script_run(q(echo "PermitRootLogin prohibit-password" | sudo tee /etc/ssh/sshd_config.d/10-root-login.conf));
             $instance->ssh_assert_script_run(q(echo "AllowTcpForwarding yes" | sudo tee /etc/ssh/sshd_config.d/10-tcp-forwarding.conf));


### PR DESCRIPTION
#22520

* Verification runs:
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP6) of sle-15-SP6-EC2-BYOS-Updates.x86_64	  [username@64bit](https://pdostal-server.suse.cz/tests/9188)
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	  [username@64bit](https://pdostal-server.suse.cz/tests/9187)
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP4) of sle-15-SP4-GCE-BYOS-Updates.aarch64	  [username@64bit](https://pdostal-server.suse.cz/tests/9186)
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Hardened-Incidents.x86_64	  [username@az_Standard_E2s_v4](https://pdostal-server.suse.cz/tests/9185)
[Buildusername](https://pdostal-server.suse.cz/tests/overview?build=username&distri=sle&version=15-SP7) of sle-15-SP7-GCE-BYOS-Hardened-Incidents.x86_64	  [username@gce_n2d_standard_2_confidential](https://pdostal-server.suse.cz/tests/9182)