### PR TITLE
Create a lib about IBSm

### DIFF
--- a/lib/sles4sap/ibsm.pm
+++ b/lib/sles4sap/ibsm.pm
@@ -1,0 +1,80 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Utility functions to interact with the IBS Mirror
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+## no critic (RequireFilenameMatchesPackage);
+
+=encoding utf8
+
+=head1 NAME
+
+    IBS Mirror utilities lib
+
+=head1 COPYRIGHT
+
+    Copyright 2025 SUSE LLC
+    SPDX-License-Identifier: FSFAP
+
+=head1 AUTHORS
+
+    QE SAP <qe-sap@suse.de>
+
+=cut
+
+package sles4sap::ibsm;
+
+use strict;
+use warnings;
+use Carp qw(croak);
+use Exporter 'import';
+use testapi;
+
+our @EXPORT = qw(
+  ibsm_calculate_address_range
+);
+
+=head1 DESCRIPTION
+
+    Package with common methods allowing the SUT to interact with IBSm
+
+=head2 Methods
+
+
+=head3 ibsm_calculate_address_range
+
+Calculate a main range that can be used in Azure for vnet or in AWS for vpc.
+Also calculate a secondary range within the main one for Azure subnet address ranges.
+The format is 10.ip2.ip3.0/21 and /24 respectively.
+ip2 and ip3 are calculated using the slot number as seed.
+
+=over
+
+=item B<SLOT> - integer to be used as seed in calculating addresses
+
+=back
+
+=cut
+
+sub ibsm_calculate_address_range {
+    my %args = @_;
+    croak 'Missing mandatory slot argument' unless $args{slot};
+    die "Invalid 'slot' argument - valid values are 1-8192" if ($args{slot} > 8192 || $args{slot} < 1);
+    my $offset = ($args{slot} - 1) * 8;
+
+    # addresses are of the form 10.ip2.ip3.0/21 and /24 respectively
+    #ip2 gets incremented when it is >=256
+    my $ip2 = int($offset / 256);
+    #ip3 gets incremented by 8 until it's >=256, then it resets
+    my $ip3 = $offset % 256;
+
+    return (
+        main_address_range => sprintf("10.%d.%d.0/21", $ip2, $ip3),
+        subnet_address_range => sprintf("10.%d.%d.0/24", $ip2, $ip3),
+    );
+}
+
+1;

--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -9,7 +9,6 @@ package sles4sap::ipaddr2;
 use strict;
 use warnings FATAL => 'all';
 use testapi;
-use sles4sap::qesap::qesapdeployment qw (qesap_calculate_address_range qesap_az_vnet_peering qesap_az_clean_old_peerings);
 use Carp qw( croak );
 use Exporter qw(import);
 use Mojo::JSON qw( decode_json );
@@ -18,6 +17,8 @@ use sles4sap::azure_cli;
 use publiccloud::utils qw( get_ssh_private_key_path register_addon);
 use utils qw( write_sut_file ssh_fully_patch_system);
 use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
+use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering qesap_az_clean_old_peerings);
+use sles4sap::ibsm;
 
 
 =head1 SYNOPSIS
@@ -85,7 +86,7 @@ count the private ip range and return
 sub get_private_ip_range {
     my %range = (main_address_range => '192.168.0.0/16', subnet_address_range => '192.168.0.0/24');
     if (my $worker_id = get_var("WORKER_ID")) {
-        %range = qesap_calculate_address_range(slot => $worker_id);
+        %range = ibsm_calculate_address_range(slot => $worker_id);
     }
 
     $range{priv_ip_range} = ($range{main_address_range} =~ /^(\d+\.\d+\.\d+)\./) ? $1 : '';

--- a/lib/sles4sap/qesap/qesapdeployment.pm
+++ b/lib/sles4sap/qesap/qesapdeployment.pm
@@ -84,7 +84,6 @@ our @EXPORT = qw(
   qesap_export_instances
   qesap_import_instances
   qesap_is_job_finished
-  qesap_calculate_address_range
   qesap_az_get_resource_group
   qesap_az_vnet_peering
   qesap_az_simple_peering_delete
@@ -1604,39 +1603,6 @@ sub qesap_az_get_resource_group {
     my $result = script_output($cmd, proceed_on_failure => 1);
     record_info('QESAP RG', "result:$result");
     return $result;
-}
-
-=head3 qesap_calculate_address_range
-
-Calculate a main range that can be used in Azure for vnet or in AWS for vpc.
-Also calculate a secondary range within the main one for Azure subnet address ranges.
-The format is 10.ip2.ip3.0/21 and /24 respectively.
-ip2 and ip3 are calculated using the slot number as seed.
-
-=over
-
-=item B<SLOT> - integer to be used as seed in calculating addresses
-
-=back
-
-=cut
-
-sub qesap_calculate_address_range {
-    my %args = @_;
-    croak 'Missing mandatory slot argument' unless $args{slot};
-    die "Invalid 'slot' argument - valid values are 1-8192" if ($args{slot} > 8192 || $args{slot} < 1);
-    my $offset = ($args{slot} - 1) * 8;
-
-    # addresses are of the form 10.ip2.ip3.0/21 and /24 respectively
-    #ip2 gets incremented when it is >=256
-    my $ip2 = int($offset / 256);
-    #ip3 gets incremented by 8 until it's >=256, then it resets
-    my $ip3 = $offset % 256;
-
-    return (
-        main_address_range => sprintf("10.%d.%d.0/21", $ip2, $ip3),
-        subnet_address_range => sprintf("10.%d.%d.0/24", $ip2, $ip3),
-    );
 }
 
 =head3 qesap_az_vnet_peering

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -1318,25 +1318,4 @@ subtest '[qesap_terrafom_ansible_deploy_retry] reboot timeout Ansible failures' 
     ok $qesap_execute_calls eq 3, "qesap_execute() never called (qesap_execute_calls: $qesap_execute_calls expected 3)";
 };
 
-subtest '[qesap_calculate_address_range]' => sub {
-    my %result_1 = qesap_calculate_address_range(slot => 1);
-    my %result_2 = qesap_calculate_address_range(slot => 2);
-    my %result_64 = qesap_calculate_address_range(slot => 64);
-    my %result_65 = qesap_calculate_address_range(slot => 65);
-    my %result_8192 = qesap_calculate_address_range(slot => 8192);
-
-    is($result_1{main_address_range}, "10.0.0.0/21", 'result_1 main_address_range is correct');
-    is($result_1{subnet_address_range}, "10.0.0.0/24", 'result_1 subnet_address_range is correct');
-    is($result_2{main_address_range}, "10.0.8.0/21", 'result_2 main_address_range is correct');
-    is($result_2{subnet_address_range}, "10.0.8.0/24", 'result_2 subnet_address_range is correct');
-    is($result_64{main_address_range}, "10.1.248.0/21", 'result_64 main_address_range is correct');
-    is($result_64{subnet_address_range}, "10.1.248.0/24", 'result_64 subnet_address_range is correct');
-    is($result_65{main_address_range}, "10.2.0.0/21", 'result_65 main_address_range is correct');
-    is($result_65{subnet_address_range}, "10.2.0.0/24", 'result_65 subnet_address_range is correct');
-    is($result_8192{main_address_range}, "10.255.248.0/21", 'result_8192 main_address_range is correct');
-    is($result_8192{subnet_address_range}, "10.255.248.0/24", 'result_8192 subnet_address_range is correct');
-    dies_ok { qesap_calculate_address_range(slot => 0); } "Expected die for slot < 1";
-    dies_ok { qesap_calculate_address_range(slot => 8193); } "Expected die for slot > 8192";
-};
-
 done_testing;

--- a/t/35_ibsm.t
+++ b/t/35_ibsm.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+
+
+use sles4sap::ibsm;
+
+subtest '[ibsm_calculate_address_range]' => sub {
+    my %result_1 = ibsm_calculate_address_range(slot => 1);
+    my %result_2 = ibsm_calculate_address_range(slot => 2);
+    my %result_64 = ibsm_calculate_address_range(slot => 64);
+    my %result_65 = ibsm_calculate_address_range(slot => 65);
+    my %result_8192 = ibsm_calculate_address_range(slot => 8192);
+
+    is($result_1{main_address_range}, "10.0.0.0/21", 'result_1 main_address_range is correct');
+    is($result_1{subnet_address_range}, "10.0.0.0/24", 'result_1 subnet_address_range is correct');
+    is($result_2{main_address_range}, "10.0.8.0/21", 'result_2 main_address_range is correct');
+    is($result_2{subnet_address_range}, "10.0.8.0/24", 'result_2 subnet_address_range is correct');
+    is($result_64{main_address_range}, "10.1.248.0/21", 'result_64 main_address_range is correct');
+    is($result_64{subnet_address_range}, "10.1.248.0/24", 'result_64 subnet_address_range is correct');
+    is($result_65{main_address_range}, "10.2.0.0/21", 'result_65 main_address_range is correct');
+    is($result_65{subnet_address_range}, "10.2.0.0/24", 'result_65 subnet_address_range is correct');
+    is($result_8192{main_address_range}, "10.255.248.0/21", 'result_8192 main_address_range is correct');
+    is($result_8192{subnet_address_range}, "10.255.248.0/24", 'result_8192 subnet_address_range is correct');
+    dies_ok { ibsm_calculate_address_range(slot => 0); } "Expected die for slot < 1";
+    dies_ok { ibsm_calculate_address_range(slot => 8193); } "Expected die for slot > 8192";
+};
+
+done_testing;

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -35,6 +35,7 @@ use publiccloud::utils qw(is_azure is_gce is_ec2 get_ssh_private_key_path is_byo
 use sles4sap_publiccloud;
 use sles4sap::qesap::qesapdeployment;
 use sles4sap::azure_cli;
+use sles4sap::ibsm;
 use serial_terminal 'select_serial_terminal';
 use registration qw(get_addon_fullname scc_version %ADDONS_REGCODE);
 use qam;
@@ -67,7 +68,7 @@ sub run {
 
     # *_ADDRESS_RANGE variables are not necessary needed by all the conf.yaml templates
     # but calculate them every time is "cheap"
-    my %maintenance_vars = qesap_calculate_address_range(slot => get_required_var('WORKER_ID'));
+    my %maintenance_vars = ibsm_calculate_address_range(slot => get_required_var('WORKER_ID'));
     set_var("MAIN_ADDRESS_RANGE", $maintenance_vars{main_address_range});
     set_var("SUBNET_ADDRESS_RANGE", $maintenance_vars{subnet_address_range});
 

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -14,6 +14,7 @@ use serial_terminal 'select_serial_terminal';
 use registration qw(get_addon_fullname scc_version %ADDONS_REGCODE);
 use qam 'get_test_repos';
 use sles4sap::qesap::qesapdeployment;
+use sles4sap::ibsm;
 
 sub run {
     my ($self) = @_;
@@ -99,7 +100,7 @@ sub run {
 
     # *_ADDRESS_RANGE variables are not necessary needed by all the conf.yaml templates
     # but calculate them every time is "cheap"
-    my %peering_settings = qesap_calculate_address_range(slot => get_required_var('WORKER_ID'));
+    my %peering_settings = ibsm_calculate_address_range(slot => get_required_var('WORKER_ID'));
     $variables{MAIN_ADDRESS_RANGE} = $peering_settings{main_address_range};
     if ($provider_setting eq 'AZURE') {
         $variables{SUBNET_ADDRESS_RANGE} = $peering_settings{subnet_address_range};


### PR DESCRIPTION
Create a lib where to move the function to calculate the IP addresses ranges used for SUT peering to the IBSm.

- Related ticket: https://jira.suse.com/browse/TEAM-10275

# Verification run:

 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_ibsmirror_peering_test@64bit -> http://openqaworker15.qa.suse.cz/tests/332215 :green_circle: http://10.100.103.210//tests/332215


 - sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless@64bit -> https://openqa.suse.de/tests/18397118 :green_circle: 

 - sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:39511:dtb-armv7l-SAPHanaSR-ScaleUp-PerfOpt@az_Standard_E4s_v3 -> http://openqa.suse.de/tests/18398781