### PR TITLE
containers: Skip podman-docker installation on SLEM 6.1

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -107,6 +107,8 @@ sub load_container_engine_privileged_mode {
 sub load_compose_tests {
     my ($run_args) = @_;
     return if (is_staging);
+    # SLEM 6.0 has podman 4.9.5 while SLEM 6.1 has podman 5.2.5
+    # podman with docker-compose needs podman 5.x
     my $min_slem_version = ($run_args->{runtime} eq "podman") ? "6.1" : "6.0";
     return unless (is_tumbleweed || is_sle('>=16.0') || is_sle_micro(">=$min_slem_version"));
     loadtest('containers/compose', run_args => $run_args, name => $run_args->{runtime} . "_compose");


### PR DESCRIPTION
Skip **podman-docker** installation on SLEM 6.1

We didn't test this package before.  We added it to test docker-compose with podman to avoid pulling all docker dependencies, as suggested in [bsc#1244448](https://bugzilla.suse.com/show_bug.cgi?id=1244448).  Now the test for SLEM 6.1 will pull all docker dependencies.  This shouldn't be a problem being the second to last module.

This may be a bug with podman-docker on SLEM 6.1 or a defect in podman 5.2.x.  SLEM 6.1 happens to be the only SUSE product using podman 5.2.x.  The rest uses either 4.9.5 or 5.4.2.

- Failed test: https://openqa.suse.de/tests/18301042#step/podman_compose/84
- Verification run: https://openqa.suse.de/tests/18312614