### PR TITLE
Make systemd-boot new default bootloader in MicroOS

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -910,5 +910,12 @@
             "sle": ["16.0"]
         },
         "type": "ignore"
+    },
+    "boo#1245786": {
+        "description": "Failed to start Update import-pubring.gpg with keys from rpmdb",
+        "products": {
+            "microos":  ["Tumbleweed"]
+        },
+        "type": "bug"
     }
 }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -868,8 +868,7 @@ sub get_bootloader {
 
     return 'grub2' if !check_var('UEFI', 1);
     return 'grub2' if is_upgrade;
-    return 'systemd-boot' if check_var("VERSION", "Staging:F") && is_microos
-      && !(get_var('FLAVOR', '') =~ /(Image-ContainerHost|JeOS-for-kvm-and-xen|JeOS-for-OpenStack-Cloud)$/);
+    return 'systemd-boot' if is_microos && !(get_var('FLAVOR', '') =~ /(Image-ContainerHost|JeOS-for-kvm-and-xen|JeOS-for-OpenStack-Cloud)$/);
     return 'grub2';
 }
 

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -207,8 +207,7 @@ subtest 'bootloader_tests' => sub {
     ok get_default_bootloader eq 'grub2', "Microos non UEFI is grub2";
 
     set_var('UEFI', '1');
-    set_var('VERSION', 'Staging:F');
-    ok get_default_bootloader eq 'systemd-boot', "Microos on UEFI in Staging:F is systemd-boot";
+    ok get_default_bootloader eq 'systemd-boot', "Microos on UEFI is systemd-boot";
 
     set_var('UPGRADE', 1);
     ok get_default_bootloader eq 'grub2', "Old Microos UEFI is grub2";


### PR DESCRIPTION
Ticket https://progress.opensuse.org/issues/184861

VR: https://openqa.opensuse.org/tests/overview?distri=microos&version=Tumbleweed&build=20250703-systemd-boot&groupid=1

Follows #[22351](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22351)