### PR TITLE
SLE16 cont host aarch64 login screen missing fixed

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -914,10 +914,10 @@ sub wait_boot {
         $self->handle_pxeboot(bootloader_time => $bootloader_time, pxemenu => 'pxe-custom-kernel', pxeselect => 'pxe-custom-kernel-selected');
     }
     # When no bounce back on power KVM, we need skip bootloader process and go ahead when 'displaymanager' matched.
-    elsif (get_var('OFW') && (check_screen('displaymanager', 5))) {
+    elsif (get_var('OFW') && (check_screen('displaymanager', 10))) {
     }
-    # SLE-16 boot on ppc64le results too quick to be captured, from grub2 to login prompt
-    elsif (get_var('OFW') && is_sle('16+') && is_ppc64le && (check_screen('linux-login', 10))) {
+    # SLE-16 on ppc64le/aarch64 sometime results too quick to be captured, from grub2 to login prompt
+    elsif (is_sle('16+') && (is_aarch64 || (is_ppc64le && get_var('OFW'))) && (check_screen('linux-login', 30))) {
     }
     elsif (is_bootloader_grub2) {
         assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600) if (uses_qa_net_hardware() || get_var("PXEBOOT"));


### PR DESCRIPTION

Stall issue noted in [SLE 16 container host](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=113.1&groupid=630) last build on aarch64 test [create_hdd](
https://openqa.suse.de/tests/18308304#step/install_updates/17). Problem due to unexpected login screen.
Fixed adding the check screen and tuning the timeout. 

Verification run on aarch64: 
  - https://openqa.suse.de/tests/18314764

Non-regression VR on ppc64le:
  - https://openqa.suse.de/tests/18314770