### PR TITLE
microos: reboot again after ejecting cd on older Micro < 6.0

### DIFF
--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -48,6 +48,8 @@ sub run {
         wait_serial('reboot: Restarting system', 240) or die "SelfInstall image has not rebooted as expected";
         # Avoid booting into selfinstall again
         eject_cd() unless $no_cd;
+        # Reboot again to avoid potential race conditions
+        send_key 'ctrl-alt-delete' unless $no_cd;
         microos_login;
     } elsif (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
         wait_serial('The initial configuration', 180) or die "jeos-firstboot has not been reached";


### PR DESCRIPTION
Micro < 6.0 does an actual reboot to properly handle firstboot configuration. We already eject the disc once detecting that the reboot occurred, but it might be too late.

So, ensure we reboot again just in case.

Note: I'm not sure if there is a better way to that, please advice, thanks :smile: 

- Related ticket: https://progress.opensuse.org/issues/185239
- Verification run: https://openqa.suse.de/tests/18316537