### PR TITLE
containers: Extend the rootless docker test to SLES 15-SP4 & Leap

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -181,7 +181,11 @@ sub load_host_tests_docker {
     load_volume_tests($run_args);
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
-    loadtest 'containers/rootless_docker' if (is_tumbleweed || is_sle('>=16.0'));
+    # The docker-rootless-extras package is only available on SLES 15-SP4+
+    # while the docker-stable-rootless-extras is available on SLES 16.0+
+    if (is_tumbleweed || is_leap || is_sle && (is_sle('>=16') || is_sle('>=15-SP4') && !check_var("CONTAINERS_DOCKER_FLAVOUR", "stable"))) {
+        loadtest 'containers/rootless_docker';
+    }
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {
         loadtest 'containers/validate_btrfs';


### PR DESCRIPTION
Extend the rootless docker test to SLES 15-SP4 & Leap

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1240150
- Verification runs:
  - 15-SP4 docker x86_64: https://openqa.suse.de/tests/18316649
  - 15-SP4 docker cgroupsv2 s390x: https://openqa.suse.de/tests/18317009
  - 15-SP7 docker: https://openqa.suse.de/tests/18317267
- Verification runs (verify module is not scheduled):
  - 12-SP5 docker: https://openqa.suse.de/tests/18317239
  - 12-SP5 docker-stable: https://openqa.suse.de/tests/18317252
  - 15-SP2 docker: https://openqa.suse.de/tests/18317262
