### PR TITLE
Schedule tests for sle16 maintenance staging

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -28,7 +28,7 @@ use constant ZYPPER_STATUS_COL => 5;
 sub capture_state {
     my ($state, $y2logs) = @_;
     if ($y2logs) {    #save y2logs if needed
-        upload_y2logs(file => "/tmp/y2logs_$state.tar.xz");
+        upload_y2logs(file => "/tmp/y2logs_$state.tar.xz") unless is_sle('>=16');
     }
     #upload ip status
     script_run("ip a | tee /tmp/ip_a_$state.log");
@@ -123,7 +123,9 @@ sub add_test_repositories {
 
     # refresh repositories, inf 106 is accepted because repositories with test
     # can be removed before test start
-    zypper_call('ref', timeout => 1400, exitcode => [0, 106]);
+    # For sle16 staging tests, PR should be untrusted key
+    my $import_key = is_sle('>=16') ? '--gpg-auto-import-keys' : '';
+    zypper_call("$import_key ref", timeout => 1400, exitcode => [0, 106]);
 
     # return the count of repos-1 because counter is increased also on last cycle
     return --$counter;

--- a/schedule/qam/16/create_hdd_textmode_staging.yaml
+++ b/schedule/qam/16/create_hdd_textmode_staging.yaml
@@ -1,0 +1,17 @@
+name:  agama-create-hdd-textmode-staging
+description:    >
+    Install sle16 via agama auto and publish qcow2 images
+
+schedule:
+    - yam/agama/boot_agama
+    - yam/agama/agama_auto
+    - installation/grub_test
+    - installation/first_boot
+    - console/system_prepare
+    - qam-minimal/install_update
+    - qam-minimal/update_minimal
+    - console/hostname
+    - console/force_scheduled_tasks
+    - shutdown/grub_set_bootargs
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -40,7 +40,7 @@ sub run {
     }
     zypper_call('rr 15-SP4-TERADATA-Updates') if get_var('MACHINE') =~ /uefi/ && get_var('FLAVOR') =~ /TERADATA/;
     # yast2-logs for save_y2logs is on 15-SP4 not installed with minimal base system pattern
-    if (is_sle('>=15-SP4')) {
+    if (is_sle('>=15-SP4') && is_sle('<16')) {
         zypper_call('in yast2-logs');
     }
     # do zypper update bsc#1165180


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/182918

- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=%3A155%3Ajq&groupid=656