### PR TITLE
Set up br0 with virt-bridge-setup tool

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -82,8 +82,8 @@
           ssh_config_file="/etc/ssh/ssh_config.d/01-virt-test.conf"
           echo -e "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null" > $ssh_config_file
         |||
-     },
-     {
+      },
+      {
         name: "Setup_root_ssh_keys",
         chroot: true,
         content: |||
@@ -94,7 +94,16 @@
           chmod 600 /root/.ssh/id_rsa
           echo '{{_SECRET_RSA_PUB_KEY}}' > /root/.ssh/id_rsa.pub
         |||
-     }
-    ]
+      }
+    ],
+    init: [
+      {
+        name: "Setup_br0",
+        content: |||
+          #!/usr/bin/env bash
+          nohup virt-bridge-setup -m --stp no -d
+        |||
+      }
+    ]  
   }
 }

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -272,9 +272,11 @@ sub run {
     $self->login_to_console;
 
     config_ssh_client if get_var('VIRT_AUTOTEST') and !is_agama and !get_var('AUTOYAST') and !is_s390x;
-    # Provide a screenshot to check if the kernel parameters are correct before tests begin
-    script_run("cat /proc/cmdline") if !is_s390x;
-    save_screenshot;
+    # To check if the environment are correct before tests begin
+    unless (is_s390x) {
+        record_info('Kernel parameters', script_output('cat /proc/cmdline'));
+        record_info('NIC', script_output('ip a'));
+    }
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Set up br0 in agama where ssh reconnection is not required.

doc: https://github.com/aginies/virt-bridge-setup
ticket: https://progress.opensuse.org/issues/169900

Verification run: 
https://openqa.suse.de/tests/18350545#step/login_console/28
https://openqa.suse.de/tests/18358861#step/login_console/28
