### PR TITLE
console: Fail assertion when curl doesn't return HTTP 200

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -40,6 +40,7 @@ sub run {
     zypper_call "in $apache2";
     zypper_call "in apache2-utils" if is_jeos;
     zypper_call "in policycoreutils-python-utils" if (is_jeos && has_selinux);
+    assert_script_run 'restorecon -Rv /srv/www' if (has_selinux);
     systemctl 'enable apache2';    # Note: The systemd service is always apache2, not apache2-tls13.
     systemctl 'restart apache2';    # apache2 could be already running from previous test runs
     systemctl 'status apache2';


### PR DESCRIPTION
Use `curl --fail` to make the assertion fail if we don't get HTTP 200 to avoid false positive when grepping "index".

- Related ticket: https://progress.opensuse.org/issues/185353
- Failing test: https://openqa.suse.de/tests/18308858#step/apache/2
- Verification runs:
  - first commit: https://openqa.suse.de/tests/18352008#step/apache/2
  - second commit: https://openqa.suse.de/tests/18352120