### PR TITLE
Check resource location directly in module

### DIFF
--- a/tests/sles4sap/redirection_tests/ensa2_schedule_sapinstance_tests.pm
+++ b/tests/sles4sap/redirection_tests/ensa2_schedule_sapinstance_tests.pm
@@ -28,18 +28,16 @@ sub run {
     # Merge data into one hash. Resource location from redirection data is relative and can change
     my %redirection_data = map { %{$run_args->{redirection_data}{$_}} } ('nw_ascs', 'nw_ers');
     # Connect to any of the ENSA2 cluster nodes to collect current data
-    my $connect_ip = $redirection_data{(keys(%redirection_data))[0]}{ip_address};
-    my $connect_user = $redirection_data{(keys(%redirection_data))[0]}{ssh_user};
-
     select_serial_terminal();
-    connect_target_to_serial(destination_ip => $connect_ip, ssh_user => $connect_user, switch_root => 1);
+    connect_target_to_serial(
+        destination_ip => $redirection_data{(keys(%redirection_data))[0]}{ip_address},
+        ssh_user => $redirection_data{(keys(%redirection_data))[0]}{ssh_user},
+        switch_root => 1);
 
     # Collect current 'SAPInstance' resources location
     my @instance_resources = @{crm_resources_by_class(primitive_class => 'ocf:heartbeat:SAPInstance')};
     my $ascs_resource = (grep(/SCS/, @instance_resources))[0];
-    my $ascs_location = crm_resource_locate(crm_resource => $ascs_resource);
     my $ers_resource = (grep(/ERS/, @instance_resources))[0];
-    my $ers_location = crm_resource_locate(crm_resource => $ers_resource);
 
     # Disconnect from ASCS
     disconnect_target_from_serial();
@@ -47,27 +45,28 @@ sub run {
     # Define test scenarios
     my %scenarios = (
         'Kill_sapinstance_ASCS' => {
-            description => 'Test kills SAP instance ASCS process using "kill -9" command. Process must be restarted by cluster on original node without failover',
-            connect_ip => $redirection_data{$ascs_location}{ip_address},
-            connect_user => $redirection_data{$ascs_location}{ssh_user},
-            crm_resource_name => $ascs_resource
+            description => 'Test kills SAP instance ASCS process using "kill -9" command.
+            Process must be restarted by cluster on original node without failover.',
+            crm_resource_name => $ascs_resource,
+            forced_takeover => undef
         },
         'Kill_sapinstance_ERS' => {
-            description => 'Test kills SAP instance ERS process using "kill -9" command. Process must be restarted by cluster on original node without failover',
-            connect_ip => $redirection_data{$ers_location}{ip_address},
-            connect_user => $redirection_data{$ers_location}{ssh_user},
-            crm_resource_name => $ers_resource
+            description => 'Test kills SAP instance ERS process using "kill -9" command.
+                Process must be restarted by cluster on original node without failover',
+            crm_resource_name => $ers_resource,
+            forced_takeover => undef
         }
     );
 
-    loadtest('sles4sap/redirection_tests/ensa2_kill_sapinstance',
-        name => 'Kill_sapinstance_ASCS',
-        run_args => $run_args, @_);
-
-    loadtest('sles4sap/redirection_tests/ensa2_kill_sapinstance',
-        name => 'Kill_sapinstance_ERS',
-        run_args => $run_args, @_);
-
+    # Schedule all tests using `loadtest` call
+    for my $test_name (
+        'Kill_sapinstance_ASCS',
+        'Kill_sapinstance_ERS'
+      )
+    {
+        loadtest('sles4sap/redirection_tests/ensa2_kill_sapinstance', name => $test_name, run_args => $run_args, @_);
+        record_info('LOAD TEST', "Scheduling test: $test_name\nDescription:\n$scenarios{$test_name}{description}");
+    }
     $run_args->{scenarios} = \%scenarios;
 }
 


### PR DESCRIPTION
Resource location is currently checked during test module load. This causes failure if location changes during test run. This PR moves location check to test module level from scheduling.

Ticket: https://jira.suse.com/browse/TEAM-10424

Verification runs: 
Standard deployment: https://mordor.suse.cz/tests/2114
S4Hana based test: https://mordor.suse.cz/tests/2110
