### PR TITLE
Enable QDevice/QNetd with Diskless SBD Test Scenario on ppc64le

### DIFF
--- a/schedule/ha/bv/pvm_ha_qdevice_node.yaml
+++ b/schedule/ha/bv/pvm_ha_qdevice_node.yaml
@@ -1,0 +1,62 @@
+name:           pvm_ha_qdevice_node
+description:    >
+  Create a 2 nodes cluster with qdevice/qnetd
+
+  Schedule for qdevice/qnetd test cluster nodes. Use HA_CLUSTER_INIT setting
+  in the job group so the schedule loads the tests for a node running
+  ha-cluster-init or for nodes running ha-cluster-join. Cluster nodes must be
+  run along a support server and a qnetd server. Some settings are defined
+  here in the schedule, while others are required outside the schedule.
+
+  The following settings must be defined outside of the schedule, either in
+  the job group yaml configuration or in a test suite.
+
+  CLUSTER_NAME defining a name for the cluster test, for example qdevice. Only
+  use characters permitted by DNS in this name
+  HA_CLUSTER_INIT set to yes on the node that does ha-cluster-init, and to
+  no on the nodes that do ha-cluster-join
+  HA_CLUSTER_JOIN set to the hostname of the node that runs ha-cluster-init
+  HOSTNAME set to the name of the node hostname
+  YAML_SCHEDULE set to schedule/ha/bv/pvm_ha_qdevice_node.yaml
+vars:
+  DESKTOP: textmode
+  HA_CLUSTER: "1"
+  # Number of nodes. This setting must match CLUSTER_INFOS in the support server job
+  NUM_NODES: "2"
+  QDEVICE: "1"
+  # qdevice test role is client in the cluster nodes and qnetd_server in the server
+  QDEVICE_TEST_ROLE: client
+schedule:
+  - '{{barrier_init}}'
+  - installation/bootloader
+  - installation/agama_reboot
+  - installation/first_boot
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/ha_sle15_workarounds
+  - ha/firewall_disable
+  - ha/iscsi_client
+  - ha/iscsi_client_setup
+  - ha/setup_hosts_and_luns
+  - ha/watchdog
+  - '{{cluster_setup}}'
+  - ha/qnetd
+  - '{{boot}}'
+  - ha/check_after_reboot
+conditional_schedule:
+  barrier_init:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/barrier_init
+  cluster_setup:
+    HA_CLUSTER_INIT:
+      yes:
+        - ha/ha_cluster_init
+      no:
+        - ha/ha_cluster_join
+  boot:
+    HA_CLUSTER_INIT:
+      no:
+        - boot/boot_to_desktop

--- a/schedule/ha/bv/pvm_ha_qnetd_server.yaml
+++ b/schedule/ha/bv/pvm_ha_qnetd_server.yaml
@@ -1,0 +1,35 @@
+name:           pvm_ha_qnetd_server
+description:    >
+  Create a qnetd server for testing qnet/device (corosync quorum feature)
+
+  This schedule corresponds to the job that provides the qnetd server for the
+  qnetd/qdevice multi-machine cluster test.  It must be scheduled PARALLEL_WITH
+  the cluster nodes. Some
+  settings are defined here in the schedule, while others are required outside
+  of it.
+
+  The following settings must be defined outside of the schedule, either in
+  the job group yaml configuration or in a test suite.
+
+  CLUSTER_NAME defining a name for the cluster test, for example qdevice. Only
+  use characters permitted by DNS in this name
+  SLE_PRODUCT with the product being tested
+  YAML_SCHEDULE set to schedule/ha/bv/pvm_ha_qnetd_server.yaml
+vars:
+  DESKTOP: textmode
+  HA_CLUSTER: "1"
+  HOSTNAME: "%CLUSTER_NAME%-node03"
+  # Number of nodes. This setting is required here and in the support server job
+  NUM_NODES: "2"
+  # qdevice test role is qnetd_server here and client in the cluster nodes
+  QDEVICE_TEST_ROLE: qnetd_server
+schedule:
+  - installation/bootloader
+  - installation/agama_reboot
+  - installation/first_boot
+  - console/system_prepare
+  - console/consoletest_setup
+  - console/check_os_release
+  - console/hostname
+  - ha/firewall_disable
+  - ha/qnetd


### PR DESCRIPTION
This PR adds QDevice/QNetd with Diskless SBD Test Scenario on ppc64le on SLE16.

The new schedule file is based on `schedule/ha/bv/ha_qdevice_node.yaml` and `schedule/ha/bv/ha_qnetd_server.yaml`.

- Related ticket: https://jira.suse.com/browse/TEAM-10289
- Needles: none
- Verification run: https://openqa.suse.de/tests/18362621 (The ticket specifies that the job does not need to pass -- create a ticket for future fixup is enough.)
