### PR TITLE
MicroOS image uses grub2 instead of systemd-boot

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -868,7 +868,7 @@ sub get_bootloader {
 
     return 'grub2' if !check_var('UEFI', 1);
     return 'grub2' if is_upgrade;
-    return 'systemd-boot' if is_microos && !(get_var('FLAVOR', '') =~ /(Image-ContainerHost|JeOS-for-kvm-and-xen|JeOS-for-OpenStack-Cloud)$/);
+    return 'systemd-boot' if is_microos && !(get_var('FLAVOR', '') =~ /(MicroOS-Image|Image-ContainerHost|JeOS-for-kvm-and-xen|JeOS-for-OpenStack-Cloud)$/);
     return 'grub2';
 }
 

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -194,6 +194,10 @@ subtest 'bootloader_tests' => sub {
 
     set_var('FLAVOR', 'JeOS-for-OpenStack-Cloud');
     ok get_default_bootloader eq 'grub2', "JeOS-for-OpenStack-Cloud image is grub2";
+
+    set_var('FLAVOR', 'MicroOS-Image');
+    ok get_default_bootloader eq 'grub2', "MicroOS-Image image is grub2";
+
     set_var('FLAVOR', 'Server-DVD');
 
     set_var('UPGRADE', 1);


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/185395
VR: https://openqa.opensuse.org/tests/5157599
