### PR TITLE
Use correct tty in agama_reboot

### DIFF
--- a/tests/installation/agama_reboot.pm
+++ b/tests/installation/agama_reboot.pm
@@ -39,11 +39,6 @@ sub upload_agama_logs {
     upload_logs('/tmp/agama_config.txt');
 }
 
-sub get_agama_install_console_tty {
-    # get_x11_console_tty would otherwise autodetermine 2
-    return 7;
-}
-
 sub verify_agama_auto_install_done_cmdline {
     # for some remote workers, there is no vnc access to the install console,
     # so we need to make sure the installation has completed from command line.
@@ -85,7 +80,6 @@ sub run {
     }
 
     assert_screen('agama-congratulations');
-    console('installation')->set_tty(get_agama_install_console_tty());
     upload_agama_logs();
     select_console('installation', await_console => 0);
     # make sure newly booted system does not expect we're still logged in console


### PR DESCRIPTION
According to `init_consoles` the correct tty for agama installer is 2, this PR avoids overwriting that default.

This change is needed after the switch to latest version of agama

Failure: https://openqa.opensuse.org/tests/5157600/#step/agama_reboot/21
VR: https://openqa.opensuse.org/tests/5157934

https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/8e15ace766f07ca5f3df9263cd49aefd237112b1/lib/susedistribution.pm#L488
