### PR TITLE
kernel_kexec: Record `find` output

### DIFF
--- a/tests/kernel/kernel_kexec.pm
+++ b/tests/kernel/kernel_kexec.pm
@@ -18,7 +18,10 @@ sub run {
     # clear console to prevent linux-login to match before reboot
     clear_console;
     # Copy kernel image and rename it
-    my $kernel_orig = script_output('find /boot -maxdepth 1 -name "*$(uname -r)" | grep -iP "image|vmlinu"', 600);
+    my $find_output = script_output('find /boot -maxdepth 1 -name "*$(uname -r)"', 600);
+    record_info('Find output', $find_output);
+    my @filtered = grep { /image|vmlinu/i } split /\n/, $find_output;
+    my $kernel_orig = $filtered[0];
     (my $kernel_new = $kernel_orig) =~ s/-default$/-kexec/;
     assert_script_run("cp $kernel_orig $kernel_new");
 


### PR DESCRIPTION
For the ongoing investigation of a sporadic issue, we need to record the output of the `find` command.

- Related ticket: https://progress.opensuse.org/issues/184097
- Verification run: https://openqa.suse.de/tests/18364442
