### PR TITLE
Enable security_pam tests for SLE>=16

### DIFF
--- a/tests/security/pam/pam_basic_function.pm
+++ b/tests/security/pam/pam_basic_function.pm
@@ -1,4 +1,4 @@
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Basic function check for PAM, and prepare the setup for other

--- a/tests/security/pam/pam_faillock.pm
+++ b/tests/security/pam/pam_faillock.pm
@@ -1,4 +1,4 @@
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: PAM tests for faillock, the uesr login can be locked
@@ -31,8 +31,8 @@ sub run {
         assert_script_run("echo $user_name:$user_pw | chpasswd");
     }
 
-    # Package change log check on SLE: jsc#sle-20638
-    validate_script_output('rpm -q pam --changelog', sub { m/jsc#sle-20638/ }) if (is_sle);
+    # Package change log check on SLE < 16: jsc#sle-20638
+    validate_script_output('rpm -q pam --changelog', sub { m/jsc#sle-20638/ }) if (is_sle('<16'));
 
     # Basic function test, lock&unlock
     # Modify the pam configuration files
@@ -52,7 +52,7 @@ EOF
     spawn ssh $user_name\@localhost
     expect {
         {continue} { send \"yes\\r\"; exp_continue }
-    {assword} { send \"$bad_pw\\r\" }
+        {assword} { send \"$bad_pw\\r\" }
     }
     expect {
         {denied} { exp_continue }
@@ -74,7 +74,7 @@ EOF
     spawn ssh $user_name\@localhost
     expect {
         {continue} { send \"yes\\r\"; exp_continue }
-    {assword} { send \"$user_pw\\r\" }
+        {assword} { send \"$user_pw\\r\" }
     }
     expect -nocase {The account is locked due to 3 failed logins} { close; wait }'"
     );
@@ -89,7 +89,7 @@ EOF
     spawn ssh $user_name\@localhost
     expect {
         {continue} { send \"yes\\r\"; exp_continue }
-    {assword} { send \"$user_pw\\r\" }
+        {assword} { send \"$user_pw\\r\" }
     }
     expect {$user_name\@\$HOSAME} { send \"exit\\r\" }'"
     );

--- a/tests/security/pam/pam_login.pm
+++ b/tests/security/pam/pam_login.pm
@@ -1,4 +1,4 @@
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: PAM tests for login, user login should fail without authentication
@@ -14,6 +14,12 @@ use version_utils;
 
 sub run {
     select_serial_terminal;
+
+    # pam_ssh is not part of SLE16 and above
+    if (is_sle('>=16')) {
+        record_info('SKIPPING TEST', "Skipping pam_login for now as pam_ssh.so is no longer part of SLE>=16. Refactoring might be needed.");
+        return;
+    }
 
     # Define the user and password, which are already configured in previous milestone
     my $user = 'suse';

--- a/tests/security/pam/pam_mount.pm
+++ b/tests/security/pam/pam_mount.pm
@@ -1,4 +1,4 @@
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: PAM tests for pam-mount, the encrypted volume should be mounted
@@ -13,12 +13,19 @@ use testapi;
 use utils qw(zypper_call script_run_interactive enter_cmd_slow);
 use Utils::Architectures qw(is_aarch64);
 use base 'consoletest';
+use version_utils 'is_sle';
 
 sub run {
     # There is some issue with script_run_interactive script,
     # it fails to match the serial console output sometimes,
     # so switch to root-console here
     select_console 'root-console';
+
+    # pam_mount is not part of SLE16
+    if (is_sle('>=16')) {
+        record_info('SKIPPING TEST', "Skipping pam_mount test because the package is not part of SLE>=16. It is not even on the wishlist of SLE 16.");
+        return;
+    }
 
     # Install runtime dependencies
     zypper_call("in pam_mount cryptsetup");
@@ -127,4 +134,3 @@ sub post_fail_hook {
 }
 
 1;
-

--- a/tests/security/pam/pam_u2f.pm
+++ b/tests/security/pam/pam_u2f.pm
@@ -1,4 +1,4 @@
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Update pam_u2f to 1.1.1 (or later)


### PR DESCRIPTION
This PR is for enabling the existing security_pam test suite for SLE 16.

A couple of tests are skipped. These are:

- pam_login

- pam_mount

The pam_login would rely on the pam_ssh module which was removed from SLE 16.

The pam_mount test would need the pam_mount module which is not included in the distro. The package is not even on the wishlist of SLE 16. We may get it later from Factory so that test could be re-enabled at some point.

- Related ticket

  https://progress.opensuse.org/issues/183476

- Verification runs

  SLE 16

  x86_64 : https://openqa.suse.de/tests/18385728
  aarch64: https://openqa.suse.de/tests/18385729
  s390x  : FAILED -> problem with boot
  ppc64  : FAILED -> agama_create_hdd_textmode_qesec is failing

  SLE 15-SP7

  x86_64 : https://openqa.suse.de/tests/18385562
  aarch64: https://openqa.suse.de/tests/18385724
  s390x  : FAILED -> problem with boot
