### PR TITLE
bats/buildah: Avoid SELinux hack on /tmp

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -448,7 +448,6 @@ sub bats_sources {
         run_command "curl $curl_opts -o hack/bats $hack_bats";
     } elsif ($package eq "buildah") {
         selinux_hack $test_dir;
-        selinux_hack "/tmp";
     }
 }
 


### PR DESCRIPTION
Avoid SELinux hack on /tmp on suggestion by SELinux maintainers.

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1245074

- Verification runs:
  - SLE 16.0: https://openqa.suse.de/tests/18364885
  - Tumbleweed: https://openqa.opensuse.org/tests/5158110 (failing due to transient network issues).
