### PR TITLE
bats/buildah: Drop SELinux hack also on test directory

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -446,8 +446,6 @@ sub bats_sources {
     if ($package eq "podman") {
         my $hack_bats = "https://raw.githubusercontent.com/containers/podman/refs/heads/main/hack/bats";
         run_command "curl $curl_opts -o hack/bats $hack_bats";
-    } elsif ($package eq "buildah") {
-        selinux_hack $test_dir;
     }
 }
 


### PR DESCRIPTION
Since the fix for https://github.com/containers/buildah/issues/6071 was merged and backported we can drop the SELinux hack also in the tests directory.

Verification runs:
- SLE 16.0: https://openqa.suse.de/tests/18367994
- Tumbleweed: https://openqa.opensuse.org/tests/5158334