### PR TITLE
bats/buildah: Drop last SELinux hack

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -331,7 +331,7 @@ sub bats_tests {
 
     my $tmp_dir = script_output "mktemp -du -p /var/tmp test.XXXXXX";
     run_command "mkdir -p $tmp_dir";
-    selinux_hack $tmp_dir if ($package =~ /buildah|podman/);
+    selinux_hack $tmp_dir if ($package eq "podman");
 
     $env{BATS_TMPDIR} = $tmp_dir;
     $env{TMPDIR} = $tmp_dir if ($package eq "buildah");


### PR DESCRIPTION
- Drop last SELinux hack.
- Re-enable sbom subtest but ignore its failure.

Verification runs:
- SLE 16.0: https://openqa.opensuse.org/tests/5158436
- Tumbleweed: https://openqa.suse.de/tests/18369046