### PR TITLE
Remove virt-bridge-setup from agama host installation

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -95,15 +95,6 @@
           echo '{{_SECRET_RSA_PUB_KEY}}' > /root/.ssh/id_rsa.pub
         |||
       }
-    ],
-    init: [
-      {
-        name: "Setup_br0",
-        content: |||
-          #!/usr/bin/env bash
-          nohup virt-bridge-setup -m --stp no -d
-        |||
-      }
-    ]  
+    ]
   }
 }


### PR DESCRIPTION
virt-bridge-setup seems to having prblem. We need remove it to make our tests pass for RC2. I'll re-open the bug later.

Related ticket: https://progress.opensuse.org/issues/185443

Verification run: 
https://openqa.suse.de/tests/18379819
https://openqa.suse.de/tests/18379981

@alice-suse @guoxuguang @waynechen55 @RoyCai7 @martinsmarcelo 
