### PR TITLE
containers: Temporarily exclude rootless_docker test on PC

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -184,7 +184,8 @@ sub load_host_tests_docker {
     # The docker-rootless-extras package is only available on SLES 15-SP4+
     # while the docker-stable-rootless-extras is available on SLES 16.0+
     if (is_tumbleweed || is_leap || is_sle && (is_sle('>=16') || is_sle('>=15-SP4') && !check_var("CONTAINERS_DOCKER_FLAVOUR", "stable"))) {
-        loadtest 'containers/rootless_docker';
+        # Public Cloud repos have unmatching versions of the docker & extras packages
+        loadtest 'containers/rootless_docker' unless (is_public_cloud);
     }
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {


### PR DESCRIPTION
Temporarily exclude rootless_docker test on PC until repo issues are fixed.

> the to be installed docker-rootless-extras-27.5.1_ce-150000.218.1.noarch requires 'docker = 27.5.1_ce', but this requirement cannot be provided