### PR TITLE
Increase expected leftover sectors in sle-micro

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -37,6 +37,8 @@ sub run {
     # 0 sectors is default and expected value in most of the images
     my $left_sectors = 0;
     if ((is_sle_micro("6.2+") || is_leap_micro("6.2+")) && is_aarch64 && !(get_var('FLAVOR', '') =~ /qcow/i) && !check_var('FROM_VERSION', '6.1')) {
+        $left_sectors = 6144;
+    } elsif ((is_sle_micro("=6.1") || is_leap_micro("=6.1") || check_var('FROM_VERSION', '6.1')) && is_aarch64 && (get_var('FLAVOR', '') =~ /selfinstall/i)) {
         $left_sectors = 4062;
     } elsif ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow|SelfInstall/) {
         $left_sectors = 2048;


### PR DESCRIPTION
Re-introduce expected leftover settings for sle micro 6.1. `.*-64kb` flavors increased expected leftover sectors to 6144

#### Verification runs
 - sle-micro-6.2-Base-64kb-aarch64-Build15.14-default@aarch64 -> https://openqa.suse.de/tests/18382651
 - sle-micro-6.1-Base-SelfInstall-aarch64-Build26.83-default@aarch64 -> https://openqa.suse.de/tests/18382653
 - sle-micro-6.2-Default-aarch64-Build15.14-slem_migration_6.1_to_6.2@aarch64 -> https://openqa.suse.de/tests/18383162
