### PR TITLE
bci: Allow dnf to resolve dependencies on CentOS

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -120,7 +120,7 @@ sub run {
         assert_script_run("pip3 --quiet install tox", timeout => 600);
     } elsif ($host_distri =~ /centos|rhel/) {
         foreach my $pkg (@packages) {
-            script_retry("dnf install -y $pkg", timeout => 300);
+            script_retry("dnf install -y --allowerasing $pkg", timeout => 300);
         }
         activate_virtual_env if ($bci_virtualenv);
         assert_script_run('pip3 --quiet install --upgrade pip', timeout => 600);


### PR DESCRIPTION
Allow dnf to resolve dependencies on CentOS.

Just follow suggestion from dnf in failed test:
`(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
`
- Related ticket: https://progress.opensuse.org/issues/185419
- Failing test: https://openqa.suse.de/tests/18373503#step/bci_prepare/48
- Verification run: https://openqa.suse.de/tests/18384923