### PR TITLE
containers: Extend registry & artifact test to SLE 16.0+

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -169,7 +169,7 @@ sub load_host_tests_docker {
     load_container_engine_privileged_mode($run_args);
     # Firewall is not installed in Public Cloud, JeOS OpenStack and MicroOS but it is in SLE Micro
     load_firewall_test($run_args);
-    unless (is_staging || is_transactional || is_sle(">=16.0") || is_sle("<15-sp4")) {
+    unless (is_staging || is_transactional || is_sle("<15-sp4")) {
         loadtest 'containers/registry';
     }
     # Skip this test on docker-stable due to https://bugzilla.opensuse.org/show_bug.cgi?id=1239596

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -60,7 +60,7 @@ sub registry_push_pull {
     assert_script_run $engine->runtime . " images | grep 'localhost:5000/$image'", 60;
 
     # podman artifact needs podman 5.4.0
-    if ($engine->runtime eq "podman" && is_tumbleweed) {
+    if ($engine->runtime eq "podman" && (is_tumbleweed || is_sle('>=16.0'))) {
         my $artifact = "localhost:5000/testing-artifact";
         assert_script_run "podman artifact add $artifact /etc/passwd";
         assert_script_run "podman artifact push $artifact";
@@ -76,7 +76,7 @@ sub run {
 
     # Install and check that it's running
     my $pkg = 'distribution-registry';
-    activate_containers_module if is_sle(">=15-SP4");
+    activate_containers_module if (is_sle(">=15-SP4") && (is_sle('<16')));
 
     zypper_call "se -v $pkg";
     zypper_call "in $pkg";


### PR DESCRIPTION
This PR extends the `registry` module test to SLE 16.0+ to:
- Test **podman-artifact**(1)
- Test **distribution-registry** package

Verification run: https://openqa.suse.de/tests/18385742

Note: The registry module is weird as it's scheduled in `load_host_tests_docker` yet it also uses podman.  Fixing it is outside the scope of this PR.