### PR TITLE
kernel: Improve baremetal maintenance testing over IPXE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -3003,13 +3003,12 @@ sub load_kernel_baremetal_tests {
     set_var('ADDONURL', 'sdk') if (is_sle('>=12') && is_sle('<15')) && !is_released;
     loadtest "kernel/ibtests_barriers" if get_var("IBTESTS");
     loadtest "autoyast/prepare_profile" if get_var("AUTOYAST_PREPARE_PROFILE");
+    load_boot_tests();
+    get_var("AUTOYAST") ? load_ayinst_tests() : load_inst_tests();
+    load_reboot_tests();
     if (get_var('IPXE')) {
-        loadtest "installation/ipxe_install";
-        loadtest "console/suseconnect_scc";
-    } else {
-        load_boot_tests();
-        get_var("AUTOYAST") ? load_ayinst_tests() : load_inst_tests();
-        load_reboot_tests();
+        loadtest 'boot/reconnect_mgmt_console';
+        loadtest 'installation/first_boot';
     }
     # make sure we always have the toolchain installed
     loadtest "toolchain/install";

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -82,6 +82,9 @@ sub update_kernel {
     elsif (get_var('COCO')) {
         zypper_call('in kernel-devel-coco');
     }
+    elsif (get_var('KERNEL_64KB')) {
+        zypper_call('in kernel-64kb-devel');
+    }
     elsif (is_sle('12+')) {
         zypper_call('in kernel-devel');
     }
@@ -567,6 +570,11 @@ sub run {
         $self->prepare_kernel($kernel_package);
         $self->update_kernel($repo, $incident_id);
     }
+    elsif (get_var('KERNEL_64KB')) {
+        $kernel_package = 'kernel-64kb';
+        $self->prepare_kernel($kernel_package);
+        $self->update_kernel($repo, $incident_id);
+    }
     elsif (get_var('KOTD_REPO')) {
         install_kotd($repo);
     }
@@ -627,6 +635,12 @@ kernel-default-base instead. Then update kernel as in the default case.
 When COCO variable evaluates to true, the job should test the kernel-coco from
 Confidential Computing Module. Uninstall kernel-default and install kernel-coco
 instead. Then update kernel as in the default case.
+
+=head2 KERNEL_64KB
+
+When KERNEL_64KB variable evaluates to true, the job should test the kernel-64kb.
+Uninstall kernel-default and install kernel-64kb instead. Then update kernel as
+in the default case.
 
 =head2 KERNEL_VERSION
 


### PR DESCRIPTION
We need to use IPXE for bare metal maintenance testing on OSD. We never used this scenario and existing code didn't create automatic test module schedule as it should. 

IPXE support is already handled in load_boot_tests(). The previous
condition was creating a non-functional installation schedule. Since
load_reboot_tests() explicitly excludes IPXE, we need to handle the
first boot separately. 

kernel-64kb testing was using test module designed for product development. This was working fine, but we should use same approach as for other kernel flavors. kernel-64kb is fully supported by update_kernel.

There is a difference to PXE installations. We need to use autoyast, which sets higher grub timeout. Non OSD PXE jobs relies on timeout provided by PXE boot menu.  It doesn't work well with IPXE, login console was sporadically matched earlier during shutdown and test failed https://openqa.suse.de/tests/18395336#step/update_kernel/30. Variable KEEP_GRUB_TIMEOUT was removed and with 45s timeout (set by AY profile) it works fine.

This improvement covers only SLE 15 based scenarios. SLE 12 and XEN scenarios are out of the scope for now.

Wrong schedule: https://openqa.suse.de/tests/18385791

- Related ticket: none
- Needles: none
- Verification run: 
aarch64 with kernel-64kb: https://openqa.suse.de/tests/18395985
x86_64: https://openqa.suse.de/tests/18396687