### PR TITLE
Redesign lib/hacluster.pm

### DIFF
--- a/lib/haclusterbasetest.pm
+++ b/lib/haclusterbasetest.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Base class for HA Cluster tests
+
+package haclusterbasetest;
+
+use Mojo::Base 'opensusebasetest';
+use strict;
+use warnings;
+use utils;
+use testapi;
+use isotovideo;
+use hacluster qw(ha_export_logs);
+use Utils::Logging qw(export_logs);
+use version_utils 'is_sle';
+use x11utils qw(ensure_unlocked_desktop);
+
+our $prev_console;
+
+sub pre_run_hook {
+    my ($self) = @_;
+    # perl -c will give a "only used once" message
+    # here and this makes the travis ci tests fail.
+    1 if defined $testapi::selected_console;
+    $prev_console = $testapi::selected_console;
+    record_info(__PACKAGE__ . ':' . 'pre_run_hook' . ' ' . "prev_console=$prev_console");
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    record_info(__PACKAGE__ . ':' . 'post_run_hook' . ' ' . "prev_console=$prev_console");
+
+    return unless ($prev_console);
+    select_console($prev_console, await_console => 0);
+    if ($prev_console eq 'x11') {
+        ensure_unlocked_desktop;
+    }
+    else {
+        $self->clear_and_verify_console;
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    record_info(__PACKAGE__ . ':' . 'post_fail_hook');
+
+    # Save a screenshot before trying further measures which might fail
+    save_screenshot;
+
+    # Try to save logs as a last resort
+    ha_export_logs;
+    export_logs;
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/ha/await_upgrade_or_update.pm
+++ b/tests/ha/await_upgrade_or_update.pm
@@ -6,7 +6,7 @@
 # Summary: Wait for all nodes which are allowed to upgrade or update before.
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -7,7 +7,7 @@
 # Summary: Check cluster status *after* reboot
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/check_cluster_integrity.pm
+++ b/tests/ha/check_cluster_integrity.pm
@@ -7,7 +7,7 @@
 # Summary: Check cluster integrity
 # Maintainer: QE-SAP <qe-sap@suse.de>, Christian Lanig <clanig@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -7,7 +7,7 @@
 # Summary: cluster-md tests
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use version_utils 'is_sle';

--- a/tests/ha/clvmd_lvmlockd.pm
+++ b/tests/ha/clvmd_lvmlockd.pm
@@ -7,7 +7,7 @@
 # Summary: Configure clvmd or lvmlockd
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use version_utils 'is_sle';

--- a/tests/ha/ctdb.pm
+++ b/tests/ha/ctdb.pm
@@ -7,7 +7,7 @@
 # Summary: Test ctdb resource agent
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/dlm.pm
+++ b/tests/ha/dlm.pm
@@ -7,7 +7,7 @@
 # Summary: Configure DLM in cluster configuration
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -11,7 +11,7 @@
 # Check multistate status
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use version_utils 'is_sle';

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -7,7 +7,7 @@
 # Summary: Create filesystem and check content
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use utils qw(zypper_call write_sut_file);

--- a/tests/ha/firewall_disable.pm
+++ b/tests/ha/firewall_disable.pm
@@ -6,7 +6,7 @@
 # Summary: Disable firewall in HA tests if needed
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/graceful_shutdown.pm
+++ b/tests/ha/graceful_shutdown.pm
@@ -7,7 +7,7 @@
 # Summary: shutdown a cluster gracefully and start it up again using "crm cluster" commands
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -7,7 +7,7 @@
 # Summary: Create HA cluster using crm cluster init
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -7,7 +7,7 @@
 # Summary: Add node to existing cluster
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/ha_sle15_workarounds.pm
+++ b/tests/ha/ha_sle15_workarounds.pm
@@ -7,7 +7,7 @@
 #          Should be removed after SLE15 will be released!
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use version_utils 'is_sle';

--- a/tests/ha/haproxy.pm
+++ b/tests/ha/haproxy.pm
@@ -7,7 +7,7 @@
 # Summary: Test haproxy resource agent
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -7,7 +7,7 @@
 # Summary: check HAWK GUI with the a python+selenium script and firefox
 # Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -7,7 +7,7 @@
 # Summary: Configure iSCSI target for HA tests
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use Utils::Backends qw(is_remote_backend);

--- a/tests/ha/iscsi_client_setup.pm
+++ b/tests/ha/iscsi_client_setup.pm
@@ -7,7 +7,7 @@
 # Summary: Configure iSCSI target for HA tests
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use Utils::Backends qw(is_remote_backend);

--- a/tests/ha/migrate_clvmd_to_lvmlockd.pm
+++ b/tests/ha/migrate_clvmd_to_lvmlockd.pm
@@ -7,7 +7,7 @@
 # Summary: Workarounds after upgrade from cluster with clvmd into lvmlockd only systems
 # Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use utils qw(zypper_call systemctl zypper_enable_install_dvd);

--- a/tests/ha/pacemaker_cts_cluster_exerciser.pm
+++ b/tests/ha/pacemaker_cts_cluster_exerciser.pm
@@ -8,7 +8,7 @@
 # cluster.
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use Mojo::JSON 'encode_json';

--- a/tests/ha/pacemaker_cts_regression.pm
+++ b/tests/ha/pacemaker_cts_regression.pm
@@ -7,7 +7,7 @@
 # Summary: Execute regression tests with pacemaker-cts
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/priority_fencing_delay.pm
+++ b/tests/ha/priority_fencing_delay.pm
@@ -7,7 +7,7 @@
 # The node with the master resource must always win the fencing match
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/remove_node.pm
+++ b/tests/ha/remove_node.pm
@@ -7,7 +7,7 @@
 # Summary: Remove a node both by its hostname and ip address
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/remove_rsc.pm
+++ b/tests/ha/remove_rsc.pm
@@ -7,7 +7,7 @@
 # Summary: Remove all the resources except stonith/sbd
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/sbd.pm
+++ b/tests/ha/sbd.pm
@@ -7,7 +7,7 @@
 # Summary: Add stonith sbd resource
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/upgrade_from_sle11sp4_workarounds.pm
+++ b/tests/ha/upgrade_from_sle11sp4_workarounds.pm
@@ -7,7 +7,7 @@
 # Summary: Add some workarounds after upgrade from a SLE11-SP4
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use utils 'systemctl';

--- a/tests/ha/vg.pm
+++ b/tests/ha/vg.pm
@@ -7,7 +7,7 @@
 # Summary: Create clustered LVM in HA tests
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use version_utils 'is_sle';

--- a/tests/ha/wait_barriers.pm
+++ b/tests/ha/wait_barriers.pm
@@ -6,7 +6,7 @@
 # Summary: Wait for support server to initialize the barriers
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/wait_others_upgraded_or_updated.pm
+++ b/tests/ha/wait_others_upgraded_or_updated.pm
@@ -6,7 +6,7 @@
 # Summary: Wait for all nodes which are allowed to upgrade or update after.
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/watchdog.pm
+++ b/tests/ha/watchdog.pm
@@ -6,7 +6,7 @@
 # Summary: Configure software watchdog
 # Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/yast_cluster_init.pm
+++ b/tests/ha/yast_cluster_init.pm
@@ -7,7 +7,7 @@
 # Summary: Deploy a cluster with YaST
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;

--- a/tests/ha/yast_cluster_join.pm
+++ b/tests/ha/yast_cluster_join.pm
@@ -7,7 +7,7 @@
 # Summary: Join a cluster deployed by YaST
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
-use base 'opensusebasetest';
+use base 'haclusterbasetest';
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION
Redesign lib/hacluster.pm, it includes: 
- create a new base test class named `haclusterbasetest`
- move all the four test module interfaces (`*_hook()` and `test_flags()`) to the new `haclusterbasetest` class
- add `use haclusterbasetest` for all related `test modules` which have `use hacluser;`
- do not touch the `test modules` which have `use hacluser qw($functions_list);`
- copy `libclusterbaseclass:pre_run_hook()` to class `lib/sles4sap.pm` as `lib/sles4sap.pm` imported it from package `lib/libcluster.pm` in the past otherwise test case will failed
  
  
**Related ticket:** 
[TEAM-10413 - Redesign lib/hacluster.pm](https://jira.suse.com/browse/TEAM-10413)
  
  
**Note:** 
-  `record_info(__PACKAGE__ . ':' . 'xxx_hook');` lines are for easy debugging/review purpose,  they could be deleted in the end. 
  
  
**Check code and figure out all the files need to be updated and figure out what kind of VRs should be done:** 

Do `# grep -r hacluster | grep use | grep -v 'qw('` and got the outputs:

1. Lib file `lib/sles4sap_publiccloud.pm`: 

	This lib file first `use hacluster;` then `use sles4sap`; (the hooks are redefined by `lib/sles4sap.pm`, so remove the `test module interfaces` from hacluster is safe.
  
3. Test `modules` which `use hacluster` and `use base 'opensusebasetest';` ( need to change `use base 'opensusebasetest` to `use base 'haclusterbasetest';`)

	tests/ha/remove_rsc.pm:use hacluster; (no **VR** as I did not find a job to clone)
	tests/ha/sbd.pm:use hacluster; (no VR as I did not find a job to clone)
	tests/ha/yast_cluster_init.pm:use hacluster; (no **VR** as I did not find a job to clone)
	tests/ha/yast_cluster_join.pm:use hacluster; (no **VR** as I did not find a job to clone)
	tests/ha/upgrade_from_sle11sp4_workarounds.pm:use hacluster; (no **VR** as I did not find a job to clone)
	tests/ha/pacemaker_cts_regression.pm:use hacluster; (**VR**: ha_pacemaker_cts_regression job_id=18404456)
	tests/ha/check_cluster_integrity.pm:use hacluster; (**VR**: qam_ha_rolling_upgrade_migration job_id=18403913,18404455)
	tests/ha/wait_others_upgraded_or_updated.pm:use hacluster; (**VR**: qam_ha_rolling_upgrade_migration job_id=18403913,18404455)
	tests/ha/await_upgrade_or_update.pm:use hacluster; (**VR**: qam_ha_rolling_upgrade_migration job_id=18403913,18404455)
	tests/ha/pacemaker_cts_cluster_exerciser.pm:use hacluster; (**VR**: pacemaker_cts_client job_id=18405509)
	tests/ha/migrate_clvmd_to_lvmlockd.pm:use hacluster; (**VR**: migration_offline_scc_verify_sle12sp5_ha_alpha_xxx job_id=18404954)
	tests/ha/iscsi_client.pm:use hacluster; (**VR**: ha_cluster_crash_test job_id=18394923)
	tests/ha/watchdog.pm:use hacluster; (**VR**: ha_cluster_crash_test job_id=18394923)
	tests/ha/ha_cluster_join.pm:use hacluster; (**VR**: ha_cluster_crash_test job_id=18394923)
	tests/ha/wait_barriers.pm:use hacluster; (**VR**: ha_cluster_crash_test job_id=18394923)
	tests/ha/iscsi_client_setup.pm:use hacluster; (**VR**: ha_cluster_crash_test job_id=18394923)
	tests/ha/ha_cluster_init.pm:use hacluster; (**VR**: ha_cluster_crash_test job_id=18394923)
	tests/ha/cluster_md.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/firewall_disable.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/ha_sle15_workarounds.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/vg.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/filesystem.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/ctdb.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/haproxy.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/remove_node.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/check_after_reboot.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/dlm.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/clvmd_lvmlockd.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/drbd_passive.pm:use hacluster; (**VR**: qam_2nodes job_id=18396103)
	tests/ha/hawk_gui.pm:use hacluster; (**VR**: qam_ha_hawk_haproxy job_id=18396156)
	tests/ha/graceful_shutdown.pm:use hacluster; (**VR**: hacluster-ha_alpha_node01 job_id=18404976)
	tests/ha/priority_fencing_delay.pm:use hacluster; (**VR**: qam_ha_priority_fencing_xxx job_id=18403851)

4. Test `modules` which `use base 'sles4sap'` and `use hacluster`: 
Now they use the `hooks` in `lib\sles4sap.pm` but not the `hooks` in `lib/hacluserbasetest.pm`. 
**NOTE**: though we did not touch the code of these test modules but they need do VRs)

	tests/sles4sap/ensa/ensa2_cluster_connector_setup.pm:use hacluster; (**VR**: sles4sap_ensa_ascs_node job_id=18405627)
	tests/sles4sap/ensa/ensa2_web_methods_checks.pm:use hacluster; (**VR**: sles4sap_ensa_ascs_node job_id=18405627)
	tests/sles4sap/ensa/netweaver_swpm_installation.pm:use hacluster; (**VR**: sles4sap_ensa_ascs_node job_id=18405627)
	tests/sles4sap/ensa/ensa_filesystems.pm:use hacluster; (**VR**: sles4sap_ensa_ascs_node job_id=18405627)
	tests/sles4sap/netweaver_network.pm:use hacluster; (**VR**: sles4sap_ensa_ascs_node job_id=18405627)
	tests/sles4sap/netweaver_nfs_setup.pm:use hacluster; (**VR**: sles4sap_ensa_ascs_node job_id=18405627)
	tests/sles4sap/sap_suse_cluster_connector.pm:use hacluster; (**VR**: sles4sap_ensa_ascs_node job_id=18405627)
	tests/sles4sap/netweaver_test_systemd.pm:use hacluster; (**VR**: sles4sap_scc_textmode_netweaver_systemd job_id=18407838)
	tests/sles4sap/netweaver_patch.pm:use hacluster; (**VR**: sles4sap_scc_textmode_netweaver_systemd job_id=18407838)
	tests/sles4sap/netweaver_cluster.pm:use hacluster; (**VR**: sles4sap_nw_node01 job_id=18407991)
	tests/sles4sap/netweaver_filesystems.pm:use hacluster; (**VR**: sles4sap_nw_node01 job_id=18407991)
	tests/sles4sap/hana_cluster.pm:use hacluster; (**VR**: SAPHanaSR_ScaleUp_PerfOpt_WMP_node01 job_id=18407995)
	tests/sles4sap/netweaver_install.pm:use hacluster; (**VR**: qam-sles4sap_scc_gnome_netweave job_id=18406393)

6. Test `modules` which `use parent 'sles4sap::sap_deployment_automation_framework::basetest';` and `use hacluster`

	tests/sles4sap/redirection_tests/ensa2_kill_sapinstance.pm:use hacluster; (**VR**: SDAF_PRD_ensa2_scenarios_sbd job_id=18417014)
	tests/sles4sap/redirection_tests/ensa2_schedule_sapinstance_tests.pm:use hacluster; (**VR**: SDAF_PRD_ensa2_scenarios_sbd job_id=18417014)

Do `# grep -r -s hacluster | grep use | grep qw | grep hook`
	lib/sles4sap.pm:use hacluster qw(xxx pre_run_hook xxx);
	Remove importing `pre_run_hook` here and copy `pre_run_hook()` from `lib/libhaclusterbasetest.pm`.

Do `# grep -r -s hacluster | grep use | grep qw | grep test_flags`
	(nothing todo)

**VRs:** (all are as expected)

**1. VRs for code changes of sdaf:**
15-SP6 Azure SDAF_PRD_ensa2_scenarios_sbd
    https://openqa.suse.de/tests/18417014#step/Kill_sapinstance_ASCS/386 (not execute hacluserbasetes post_run_hook as expected)
    https://openqa.suse.de/tests/18417014#step/ensa2_schedule_sapinstance_tests/24 (not execute hacluserbasetes post_run_hook as expected)

15-SP3 x86_64 qam-SAPHanaSR_ScaleUp_PerfOpt_WMP_node01
http://openqa.suse.de/tests/18407995#step/hana_cluster/174 (used the hooks of `sles4sap` as expected)

**2. VRs for code changes of sles4sap:**
sle16.0 x86_64 sles4sap_nw_node01 
http://openqa.suse.de/tests/18407991#step/netweaver_cluster/201 (the failure is known) (used the hooks of `sles4sap` as expected)

sle16.0 x86_64 sles4sap_scc_textmode_netweaver_systemd http://openqa.suse.de/tests/18407838#step/netweaver_test_systemd/9 (used the hooks of `sles4sap` as expected)

15-SP5 x86_64 qam-sles4sap_scc_gnome_netweave 
http://openqa.suse.de/tests/18406393#step/netweaver_install/117 (used the hooks of `sles4sap` as expected)
  
15-SP7 x86_64 sles4sap_ensa_ascs_node 
http://openqa.suse.de/tests/18405627#step/sap_suse_cluster_connector/323 (used the hooks of `sles4sap` as expected)

**3. VRs for code changes of test modules:**
sle16.0 x86_64 pacemaker_cts_client 
http://openqa.suse.de/tests/18405509#step/pacemaker_cts_cluster_exerciser/39 (the hooks are executed as expected as before)
  
15-SP7 aarch64 hacluster-ha_alpha_node01 
https://openqa.suse.de/tests/18404976#step/drbd_passive/90 (though failed but the libhacluserbasetest:post_fail_hook was executed as expected)
rerun: https://openqa.suse.de/tests/18405499#step/drbd_passive/90  (as expected and the failure is known)
  
15-SP7 s390x migration_offline_scc_verify_sle12sp5_ha_alpha_xxx
https://openqa.suse.de/tests/18404954#step/migrate_clvmd_to_lvmlockd/1 (the hooks are executed as expected as before)
  
sle16 x86_64 ha_cluster_crash_test (results are as expected)
https://openqa.suse.de/tests/18394923#step/ha_cluster_join/1 (executed `haclusterbasetest:pre_run_hook` as expected as before)
https://openqa.suse.de/tests/18394923#step/ha_cluster_join/23 (executed `haclusterbasetest:post_run_hook` as expected as before)
https://openqa.suse.de/tests/18394923#step/ha_cluster_crash_test/1 (*NOT* execute `haclusterbasetest:*_hook` as expected as before)

12-SP5 x86_64 qam_2nodes_xxx 
http://openqa.suse.de/tests/18396103#step/remove_node/46 (the hooks are executed as expected as before)
 
15-SP7 x86_64 qam_ha_hawk_haproxy_xxx 
http://openqa.suse.de/tests/18396158#step/check_hawk/1 (no hook is executed as expected as before)
http://openqa.suse.de/tests/18396156#step/hawk_gui/1 (hooks are executed as expected as before)
  
15-SP6 x86_64 qam_ha_priority_fencing_xxx
https://openqa.suse.de/tests/18403851#step/priority_fencing_delay/1 (hooks are executed as expected as before)
  
15-SP6 qam_ha_rolling_upgrade_migration_xxx 
http://openqa.suse.de/tests/18403913#step/drbd_passive/4 (failed due to infra issue, but verified post_fail_hook is executed as expected)
https://openqa.suse.de/tests/18404455#step/wait_others_upgraded_or_updated/1 (hooks are executed as expected as before)

sle16.0 ppc64le ha_pacemaker_cts_regression
https://openqa.suse.de/tests/18404456#step/pacemaker_cts_regression/1 (hooks are executed as expected as before)
