### PR TITLE
Add quiet kernel option to container tests

### DIFF
--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -240,10 +240,10 @@ sub cleanup_system_host {
     if ($self->runtime eq 'podman') {
         # retry because on older hosts there can be remnants that take some time before they are cleaned
         $self->_engine_script_retry("rm --force --all", timeout => 120, retry => 3, delay => 60);
-        $self->_engine_script_run("system prune -f --external", 300);
+        $self->_engine_script_run("system prune -f --external", timeout => 300);
     }
-    $self->_engine_script_run("volume prune -f", 300);
-    $self->_engine_script_run("system prune -a -f", 300);
+    $self->_engine_script_run("volume prune -f", timeout => 300);
+    $self->_engine_script_run("system prune -a -f", timeout => 300);
 }
 
 1;

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -297,6 +297,8 @@ sub load_container_tests {
             # Note: bci_version_check requires jq.
             loadtest 'containers/bci_version_check' if (get_var('CONTAINER_IMAGE_TO_TEST') && get_var('CONTAINER_IMAGE_BUILD'));
         }
+    } elsif (is_tumbleweed && get_var('FLAVOR', '') =~ /dvd|net/i) {
+        loadtest 'containers/host_configuration';
     }
 
     if (get_var('CONTAINER_SLEM_RANCHER')) {


### PR DESCRIPTION
Tumbleweed's DVD|NET flavors remove the `quiet` kernel paramater from the image. Due to this, the console is polluted by container engines and block AVC or log retrievals.


#### Verification runs

* [opensuse-Tumbleweed-DVD-x86_64-Build20250709-containers_image](http://kepler.suse.cz/tests/25073#)
* [opensuse-Tumbleweed-DVD-x86_64-Build20250709-container_host_docker_apparmor](http://kepler.suse.cz/tests/25074#live)
* [opensuse-Tumbleweed-DVD-x86_64-Build20250709-container_host_docker_selinux + AVC_FAIL_ON_DENIALS=1](http://kepler.suse.cz/tests/25075)
