### PR TITLE
Revert "Fix secureboot handling"

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1140,7 +1140,20 @@ sub tianocore_disable_secureboot {
     my $neelle_sb_change_state = $revert ? 'tianocore-devicemanager-sb-conf-enabled' : 'tianocore-devicemanager-sb-conf-attempt-sb';
     my $neelle_sb_config_state = $revert ? 'tianocore-secureboot-enabled' : 'tianocore-secureboot-not-enabled';
 
-    tianocore_enter_menu;
+    assert_screen 'grub2';
+    send_key 'c';
+    sleep 5;
+    enter_cmd "exit";
+
+    # There might be a boot menu before the mainmenu.
+    # Wait until the main menu appears and move to the EFI firmware setup, if the boot menu is present
+    while (!check_screen('tianocore-mainmenu')) {
+        wait_still_screen();
+        if (check_screen('tianocore-bootmenu')) {
+            send_key_until_needlematch("tianocore-bootmenu-EFI-fimware-selected", 'down', 6, 1);
+            send_key "ret";
+        }
+    }
 
     assert_screen 'tianocore-mainmenu';
     # Select 'Boot manager' entry

--- a/lib/security/secureboot.pm
+++ b/lib/security/secureboot.pm
@@ -20,10 +20,12 @@ use version_utils qw(is_sle);
 our @EXPORT = qw(handle_secureboot);
 
 sub handle_secureboot {
-    my ($self, $sb_opt) = @_;
+    my ($self, $sb_state, $sb_opt) = @_;
     my $boot_method = ((is_aarch64 && is_sle('>=16')) ? 'wait_boot_past_bootloader' : 'wait_boot');
 
     record_info('bsc#1189988:', 'Disabling Secure Boot due to known IMA fix mode issue');
+    $self->wait_grub(bootloader_time => 200);
+
     if (defined $sb_opt && $sb_opt eq 're_enable') {
         $self->tianocore_disable_secureboot('re_enable');
     } else {

--- a/tests/security/ima/evm_protection_digital_signatures.pm
+++ b/tests/security/ima/evm_protection_digital_signatures.pm
@@ -15,7 +15,6 @@ use utils;
 use bootloader_setup qw(replace_grub_cmdline_settings tianocore_disable_secureboot);
 use power_action_utils 'power_action';
 use security::config;
-use security::secureboot qw(handle_secureboot);
 
 
 sub run {
@@ -67,7 +66,9 @@ sub run {
 
         # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
         power_action('reboot', textmode => 1);
-        handle_secureboot($self, 're_enable');
+        $self->wait_grub(bootloader_time => 200);
+        $self->tianocore_disable_secureboot('re_enable');
+        $self->wait_boot(textmode => 1);
         select_serial_terminal;
 
         my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -14,7 +14,6 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(replace_grub_cmdline_settings tianocore_disable_secureboot);
 use power_action_utils 'power_action';
-use security::secureboot qw(handle_secureboot);
 
 sub run {
     my ($self) = @_;
@@ -44,7 +43,9 @@ sub run {
 
     # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
     power_action('reboot', textmode => 1);
-    handle_secureboot($self, 're_enable');
+    $self->wait_grub(bootloader_time => 200);
+    $self->tianocore_disable_secureboot('re_enable');
+    $self->wait_boot(textmode => 1);
     select_serial_terminal;
     my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);
     die "$sample_app should not have permission to run" if ($ret !~ "\Q$sample_app\E: *Permission denied");

--- a/tests/security/ima/evm_setup.pm
+++ b/tests/security/ima/evm_setup.pm
@@ -43,6 +43,7 @@ sub run {
 
     record_info("bsc#1189988: ", "We need disable secureboot with ima fix mode");
     power_action("reboot", textmode => 1);
+    $self->wait_grub(bootloader_time => 200);
     $self->tianocore_disable_secureboot;
     $self->wait_boot(textmode => 1);
     select_serial_terminal;

--- a/tests/security/ima/ima_appraisal_digital_signatures.pm
+++ b/tests/security/ima/ima_appraisal_digital_signatures.pm
@@ -28,8 +28,9 @@ sub run {
     my $cert_der = '/root/certs/ima_cert.der';
 
     add_grub_cmdline_settings("ima_appraise=fix", update_grub => 1);
+    my $sb_state = script_output('mokutil --sb-state');
     power_action("reboot", textmode => 1);
-    handle_secureboot($self);
+    handle_secureboot($self, $sb_state);
     select_serial_terminal;
 
     my @sign_cmd = (
@@ -64,7 +65,7 @@ sub run {
 
         replace_grub_cmdline_settings('ima_appraise=fix', '', update_grub => 1);
         power_action('reboot', textmode => 1);
-        handle_secureboot($self, 're_enable');
+        handle_secureboot($self, $sb_state, 're_enable');
 
         select_serial_terminal;
         assert_script_run "dmesg | grep IMA:.*completed";

--- a/tests/security/ima/ima_appraisal_hashes.pm
+++ b/tests/security/ima/ima_appraisal_hashes.pm
@@ -28,8 +28,9 @@ sub run {
     my $tcb_cmdline = ($kver lt 4.13) ? 'ima_appraise_tcb' : 'ima_policy=appraise_tcb';
 
     add_grub_cmdline_settings("ima_appraise=fix $tcb_cmdline", update_grub => 1);
+    my $sb_state = script_output('mokutil --sb-state');
     power_action("reboot", textmode => 1);
-    handle_secureboot($self);
+    handle_secureboot($self, $sb_state);
     select_serial_terminal;
 
     my $findret = script_output("find / -fstype $fstype -type f -uid 0 -exec sh -c \"< '{}'\" \\;", 900, proceed_on_failure => 1);
@@ -52,7 +53,7 @@ sub run {
 
     # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
     power_action('reboot', textmode => 1);
-    handle_secureboot($self, 're_enable');
+    handle_secureboot($self, $sb_state, 're_enable');
     select_serial_terminal;
 
     my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);


### PR DESCRIPTION
This reverts commit 8b84b48214bef951d40ea138312bc535772f9f69.

This commit changed how `tianocore_disable_secureboot` can be used and broke other places.
It's not actually necessary, as the issue it was meant to fix (https://progress.opensuse.org/issues/185455) was already fixed by af7e8231396292dfe779f31736874b15f854e972, but the linked job had a hardcoded CASEDIR=https://github.com/dzedro/os-autoinst-distri-opensuse.git#magic

- Related ticket: https://progress.opensuse.org/issues/185521
- Verification run: http://10.168.5.231/tests/1808
