### PR TITLE
Allow remote installations with different bootloaders

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -190,7 +190,8 @@ sub load_remote_controller_tests {
     loadtest 'installation/user_settings_root';
     loadtest 'installation/resolve_dependency_issues';
     loadtest 'installation/installation_overview';
-    loadtest 'installation/disable_grub_timeout';
+    loadtest 'installation/disable_grub_timeout' if is_bootloader_grub2;
+    loadtest 'installation/configure_bls' if is_bootloader_sdboot || is_bootloader_grub2_bls;
     loadtest 'installation/start_install';
     loadtest 'installation/await_install';
     loadtest 'installation/reboot_after_installation';

--- a/tests/support_server/login.pm
+++ b/tests/support_server/login.pm
@@ -6,23 +6,40 @@
 
 use strict;
 use warnings;
-use base 'basetest';
 use base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_desktop_installed is_tumbleweed);
+use version_utils qw(is_desktop_installed is_tumbleweed is_bootloader_grub2);
 
 sub run {
     my ($self) = @_;
     my $timeout = (is_tumbleweed) ? 180 : 80;
+
+    $self->override_default_bootloader unless is_bootloader_grub2;
+
     # we have some tests that waits for dvd boot menu timeout and boot from hdd
     # - the timeout here must cover it
     $self->wait_boot(bootloader_time => $timeout, textmode => !is_desktop_installed);
 
+    $self->restore_default_bootloader if is_bootloader_grub2 && $self->{bootloader_overriden};
+
     # the supportserver image can be different version than the currently tested system
     # so try to login without use of needles
     select_serial_terminal;
+}
+
+sub override_default_bootloader {
+    my ($self) = @_;
+    $self->{bootloader_overriden} = 1;
+    $self->{bootloader} = get_var('BOOTLOADER');
+    set_var('BOOTLOADER', 'grub2');
+}
+
+sub restore_default_bootloader {
+    my ($self) = @_;
+    $self->{bootloader_overriden} = 0;
+    set_var('BOOTLOADER', $self->{bootloader});
 }
 
 sub test_flags {
@@ -30,4 +47,3 @@ sub test_flags {
 }
 
 1;
-


### PR DESCRIPTION
In https://openqa.opensuse.org/tests/5160456#step/login/6 the system is expecting systemd-boot when in reality
it should be grub2.

Additionally there's the change in the test schedule to avoid disabling grub timeout when actually the screen is different

Ticket: https://progress.opensuse.org/issues/184861 and https://progress.opensuse.org/issues/185395#note-3

VR: 
- With override: https://openqa.opensuse.org/tests/5163274
- Without override: https://openqa.opensuse.org/tests/5163278