### PR TITLE
Skip hook calls in 3rd party hosts

### DIFF
--- a/lib/containers/basetest.pm
+++ b/lib/containers/basetest.pm
@@ -42,6 +42,7 @@ sub containers_factory {
 
 sub post_fail_hook {
     my ($self) = @_;
+    # post_{fail|run}_hooks are not working with 3rd party hosts
     return if get_var('NOLOGS');
 
     select_console('log-console');
@@ -51,6 +52,8 @@ sub post_fail_hook {
 }
 
 sub post_run_hook {
+    # post_{fail|run}_hooks are not working with 3rd party hosts
+    return if get_var('NOLOGS');
     select_console('log-console');
 
     shift->record_avc_selinux_alerts;


### PR DESCRIPTION
Log gathering is not reliable on non {open,}SUSE hosts.

- failure: https://openqa.opensuse.org/tests/5163147#step/host_configuration/37

#### Verification runs

* [opensuse-Tumbleweed-NET-x86_64-Build20250709-containers_tw_image_on_ubuntu_host@64bit](http://kepler.suse.cz/tests/25081)
* [opensuse-Tumbleweed-NET-x86_64-Build20250709-containers_tw_image_on_centos_host@64bit](http://kepler.suse.cz/tests/25082)
* [opensuse-Tumbleweed-DVD-x86_64-Build20250709-container_host_docker_selinux@64bit](http://kepler.suse.cz/tests/25078#)
* [opensuse-Tumbleweed-DVD-x86_64-Build20250709-container_host_podman_selinux@64bit](http://kepler.suse.cz/tests/25076)
