### PR TITLE
Add more validations for the output of /etc/os-release

### DIFF
--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -10,6 +10,7 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - yam/validate/validate_base_product
+  - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname

--- a/schedule/yam/agama_from_usb.yaml
+++ b/schedule/yam/agama_from_usb.yaml
@@ -10,4 +10,5 @@ schedule:
   - yam/agama/agama_boot_from_hdd
   - installation/first_boot
   - yam/validate/validate_base_product
+  - yam/validate/validate_product
   - yam/validate/validate_first_user

--- a/schedule/yam/agama_ppc64le.yaml
+++ b/schedule/yam/agama_ppc64le.yaml
@@ -10,4 +10,5 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - yam/validate/validate_base_product
+  - yam/validate/validate_product
   - yam/validate/validate_first_user

--- a/schedule/yam/agama_remote_s390x.yaml
+++ b/schedule/yam/agama_remote_s390x.yaml
@@ -11,4 +11,5 @@ schedule:
   - boot/reconnect_mgmt_console
   - installation/first_boot
   - yam/validate/validate_base_product
+  - yam/validate/validate_product
   - yam/validate/validate_first_user

--- a/schedule/yam/agama_s390x.yaml
+++ b/schedule/yam/agama_s390x.yaml
@@ -10,4 +10,5 @@ schedule:
   - boot/reconnect_mgmt_console
   - installation/first_boot
   - yam/validate/validate_base_product
+  - yam/validate/validate_product
   - yam/validate/validate_first_user

--- a/schedule/yam/agama_unattended.yaml
+++ b/schedule/yam/agama_unattended.yaml
@@ -8,6 +8,7 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - yam/validate/validate_base_product
+  - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname

--- a/test_data/yam/agama_sap.yaml
+++ b/test_data/yam/agama_sap.yaml
@@ -1,5 +1,14 @@
 ---
-os_release_name: SLES_SAP
+os_release:
+  NAME: SLES
+  PRETTY_NAME: SUSE Linux Enterprise Server 16.0
+  VARIANT: Enterprise Server for SAP applications
+  VARIANT_ID: server-sap
+  VERSION_ID: 16.0
+  ID: sles
+  ID_LIKE: suse opensuse
+  CPE_NAME: cpe:/o:suse:sles:16:16.0
+  SUSE_SUPPORT_PRODUCT: SUSE Linux Enterprise Server for SAP applications
 repos:
   - name: SLE-Product-SLES_SAP-%VERSION%
     alias: SUSE_Linux_Enterprise_Server_for_SAP_Applications_%VERSION%_%ARCH%:SLE-Product-SLES_SAP-%VERSION%

--- a/test_data/yam/agama_sle.yaml
+++ b/test_data/yam/agama_sle.yaml
@@ -1,5 +1,14 @@
 ---
-os_release_name: SLES
+os_release:
+  NAME: SLES
+  PRETTY_NAME: SUSE Linux Enterprise Server 16.0
+  VARIANT: Enterprise Server
+  VARIANT_ID: server
+  VERSION_ID: 16.0
+  ID: sles
+  ID_LIKE: suse opensuse
+  CPE_NAME: cpe:/o:suse:sles:16:16.0
+  SUSE_SUPPORT_PRODUCT: SUSE Linux Enterprise Server
 repos:
   - name: SLE-Product-SLES-%VERSION%
     alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%

--- a/tests/console/validate_repos.pm
+++ b/tests/console/validate_repos.pm
@@ -13,8 +13,11 @@ use base "consoletest";
 use testapi;
 use repo_tools 'validate_repo_properties';
 use scheduler 'get_test_suite_data';
+use version_utils qw(is_agama);
 
 sub run {
+    return if (is_agama && check_var('FLAVOR', 'Full'));
+
     my $test_data = get_test_suite_data();
 
     select_console 'root-console';

--- a/tests/yam/validate/validate_product.pm
+++ b/tests/yam/validate/validate_product.pm
@@ -17,12 +17,15 @@ use scheduler 'get_test_suite_data';
 sub run {
     select_console 'root-console';
 
-    my $os_release_name_expected = get_test_suite_data()->{os_release_name};
+    my $test_data = get_test_suite_data()->{os_release};
+    my $os_release = Config::Tiny->read_string(script_output('cat /etc/os-release'))->{_};
 
-    my $os_release_output = script_output('cat /etc/os-release');
-    my $os_release_name = Config::Tiny->read_string($os_release_output)->{_}->{NAME};
-
-    assert_equals("\"" . $os_release_name_expected . "\"", $os_release_name, 'Wrong product NAME in /etc/os-release');
+    foreach my $key (keys %$test_data) {
+        my $expected = $test_data->{$key};
+        my $actual = $os_release->{$key};
+        $actual =~ s/^"|"$//g;
+        assert_equals($expected, $actual, "Mismatch for $key, expect $expected but got $actual");
+    }
 }
 
 1;


### PR DESCRIPTION
Add more validations for the output of /etc/os-release for both sles and sap default installations.

- [Related ticket](https://progress.opensuse.org/issues/185404) 
- [Verification run](https://openqa.suse.de/tests/overview?version=16.0&distri=sle&build=chcao_185404_2)
- [Related mr](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/525)
