### PR TITLE
Implement check for specific USB devices on SUT

### DIFF
--- a/lib/usb.pm
+++ b/lib/usb.pm
@@ -1,0 +1,97 @@
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package usb;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT = qw(
+  list_usb_devices
+  check_usb_devices
+);
+
+=head1 SYNOPSIS
+
+Utils for working with USB devices.
+
+=cut
+
+=head2 list_usb_devices
+
+ list_usb_devices();
+
+Returns an array of hashes with the following information about all detected
+USB devices:
+- C<bus>: System bus number
+- C<device>: Device number on the bus
+- C<vendor>: Vendor ID
+- C<product>: Vendor-specific product ID
+- C<name>: Human-readable description returned by the device
+
+=cut
+
+sub list_usb_devices {
+    my @errors;
+    my @ret;
+    my $lsusb = script_output('lsusb');
+
+    for my $line (split /\n/, $lsusb) {
+        if ($line !~ m/^Bus (\d+) Device (\d+): ID ([0-9a-fA-F]+):([0-9a-fA-F]+) (.*)$/) {
+            push @errors, $line;
+            next;
+        }
+
+        push @ret, {
+            bus => $1,
+            device => $2,
+            vendor => $3,
+            product => $4,
+            name => $5
+        };
+    }
+
+    if (@errors) {
+        record_info('lsusb error', "Unrecognized data in lsusb output:\n" . join("\n", @errors), result => 'fail');
+    }
+
+    return \@ret;
+}
+
+=head2
+
+ check_usb_devices();
+
+Check that all devices listed in C<REQUIRED_USB_DEVICES> job setting are
+connected to the test machine. The variable must contain a comma-separated
+list of vendor:product IDs.
+
+=cut
+
+sub check_usb_devices {
+    my %devmap;
+    my @missing;
+    my $checklist = get_var('REQUIRED_USB_DEVICES');
+    my $devlist = list_usb_devices;
+
+    return unless $checklist;
+
+    for my $item (@$devlist) {
+        $devmap{"$$item{vendor}:$$item{product}"} = $item;
+    }
+
+    for my $dev (split /,/, $checklist) {
+        push @missing, $dev unless defined($devmap{$dev});
+    }
+
+    record_info('Missing USB devices',
+        "The following USB devices are missing:\n" . join("\n", @missing),
+        result => 'fail') if @missing;
+    return wantarray ? @missing : (scalar @missing);
+}
+
+1;

--- a/tests/kernel/usb_drive.pm
+++ b/tests/kernel/usb_drive.pm
@@ -13,11 +13,13 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use usb;
 
 sub run {
     my ($self) = @_;
 
     select_serial_terminal;
+    check_usb_devices;
 
     my $lun = script_output 'lsscsi -t -v | awk -F" " \'/usb/ {split($2,a,/[\/]/); print a[6]}\'';
     die "no usb storage device connected" if $lun eq "";

--- a/tests/kernel/usb_nic.pm
+++ b/tests/kernel/usb_nic.pm
@@ -14,11 +14,13 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use network_utils 'is_wicked_used';
+use usb;
 
 sub run {
     my ($self) = @_;
 
     select_serial_terminal;
+    check_usb_devices;
 
     my $usb_net_devs = script_output('readlink /sys/class/net/* | grep usb', proceed_on_failure => 1);
     die "no USB network interfaces found" unless $usb_net_devs ne "";


### PR DESCRIPTION
Add a new library for working with USB devices which currently provides helper functions for reading a list of USB devices and checking device presence against `REQUIRED_USB_DEVICES` job setting. These functions are used by `usb_drive` and `usb_nic` kernel tests.

- Related ticket: https://progress.opensuse.org/issues/185398
- Needles: N/A
- Verification runs: 
  - SLE-16, expected devices present: https://openqa.suse.de/tests/18408278
  - SLE-16, one device missing: https://openqa.suse.de/tests/18408277
  - SLE-16, `REQUIRED_USB_DEVICES` not set: https://openqa.suse.de/tests/18408279
  - SLE-15SP5, expected devices present: https://openqa.suse.de/tests/18408282
  
Note: None of the test modules are supposed to fail because of any missing devices alone.