### PR TITLE
Remove network isolation functionality from BCI tests

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -25,7 +25,6 @@ use Mojo::Base qw(consoletest);
 use XML::LibXML;
 use utils qw(zypper_call script_retry);
 use version_utils qw(get_os_release is_sle is_opensuse);
-use network_utils qw(is_running_in_isolated_network);
 use db_utils qw(push_image_data_to_db);
 use containers::common;
 use testapi;
@@ -109,7 +108,7 @@ sub run {
     my @packages = packages_to_install($version, $sp, $host_distri);
     if ($host_distri eq 'ubuntu') {
         # Sometimes, the host doesn't get an IP automatically via dhcp, we need force it just in case
-        assert_script_run("dhclient -v") unless is_running_in_isolated_network();
+        assert_script_run("dhclient -v");
         # This command prevents a prompt that asks for services to be restarted
         # causing a delay of 5min on each package install
         script_run('export DEBIAN_FRONTEND=noninteractive');

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -61,6 +61,7 @@ sub run_tox_cmd {
     my $bci_reruns = get_var('BCI_RERUNS', 3);
     my $bci_reruns_delay = get_var('BCI_RERUNS_DELAY', 10);
     my $tox_out = "tox_$env.txt";
+    assert_script_run("export USE_MACVLAN_DUMMY=1");
     my $cmd = "tox -e $env -- -rxX -n auto";
     $cmd .= " -k \"$bci_marker\"" if $bci_marker;
     $cmd .= " --reruns $bci_reruns --reruns-delay $bci_reruns_delay";

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -14,53 +14,18 @@ use warnings;
 use Mojo::Base qw(consoletest);
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use network_utils qw(get_nics cidr_to_netmask is_nm_used is_wicked_used delete_all_existing_connections set_nics_link_speed_duplex check_connectivity_to_host_with_retry set_resolv set_nic_dhcp_auto reload_connections_until_all_ips_assigned setup_dhcp_server_network is_running_in_isolated_network get_default_dns);
 use main_containers qw(is_suse_host);
 use utils;
-use version_utils qw(check_os_release get_os_release is_sle is_sle_micro is_transactional is_bootloader_grub2);
+use version_utils qw(check_os_release get_os_release is_sle is_sle_micro is_bootloader_grub2);
 use containers::common;
 use containers::utils qw(reset_container_network_if_needed);
 use containers::k8s qw(install_k3s);
-use transactional qw(trup_call process_reboot);
 use bootloader_setup qw(add_grub_cmdline_settings);
 use power_action_utils qw(power_action);
-
-sub setup_networking_in_isolated_network {
-    my ($self, $nics_ref) = @_;
-    my @nics = @$nics_ref;
-    my $nic0 = $nics[0];
-
-    my $server_ip = "10.0.2.101";
-    my $subnet = "/24";
-    my $gateway = "10.0.2.2";
-    my $dns_string = get_var("DNS", get_default_dns());
-    my @dns = ($dns_string ne "") ? split(",", $dns_string) : ();
-
-    setup_dhcp_server_network(
-        server_ip => $server_ip,
-        subnet => $subnet,
-        gateway => $gateway,
-        nics => \@nics,
-        dns => \@dns
-    );
-
-    set_resolv(nameservers => \@dns);
-
-    install_packages("ethtool") if is_suse_host();
-
-    # NICVLAN does not autonegotiate link speed and duplex, so we need to set it manually
-    set_nics_link_speed_duplex({
-            nics => \@nics,
-            speed => 1000,
-            duplex => 'full',
-            autoneg => 'off'
-    });
-}
 
 sub run {
     my ($self) = @_;
     select_serial_terminal;
-    setup_networking_in_isolated_network($self, [get_nics([])]) if is_running_in_isolated_network();
 
     my $interface;
     my $update_timeout = 2400;    # aarch64 takes sometimes 20-30 minutes for completion
@@ -91,11 +56,11 @@ sub run {
         set_var('NOLOGS', 1);
         if ($host_distri eq 'ubuntu') {
             # Sometimes, the host doesn't get an IP automatically via dhcp, we need force it just in case
-            assert_script_run("dhclient -v") unless is_running_in_isolated_network();
+            assert_script_run("dhclient -v");
             script_retry("apt-get update -qq -y", timeout => $update_timeout);
         } elsif ($host_distri eq 'centos') {
             # dhclient is no longer available in CentOS 10
-            script_run("dhclient -v") unless is_running_in_isolated_network();
+            script_run("dhclient -v");
             script_retry("dnf update -q -y --nobest", timeout => $update_timeout);
         } elsif ($host_distri eq 'rhel') {
             script_retry("dnf update -q -y", timeout => $update_timeout);


### PR DESCRIPTION
Removing network isolation functionality from BCI tests in favor of https://github.com/SUSE/BCI-tests/pull/875

- Related ticket: https://progress.opensuse.org/issues/184375
- Verification run:  https://openqa.suse.de/tests/18405630
https://openqa.suse.de/tests/18409398

Ubuntu:
https://openqa.suse.de/tests/18409398
https://openqa.suse.de/tests/18409399

CentOS:
https://openqa.suse.de/tests/18409441
https://openqa.suse.de/tests/18409442