### PR TITLE
Force user removal during cleanup in pam_faillock test

### DIFF
--- a/tests/security/pam/pam_faillock.pm
+++ b/tests/security/pam/pam_faillock.pm
@@ -97,7 +97,7 @@ EOF
     # Clean up
     assert_script_run('mv /etc/pam.d/common-auth.back /etc/pam.d/common-auth');
     assert_script_run('mv /etc/pam.d/common-password.back /etc/pam.d/common-password');
-    assert_script_run("userdel -r $user_name");
+    assert_script_run("userdel -r -f $user_name");
 }
 
 sub test_flags {


### PR DESCRIPTION
During the cleanup of the pam_faillock test the "userdel" command failed, because the user still had an active session. This session was the running test itself. It is safe to use the force flag here to remove the user, since this is where the test ends and there is no other test who would need that user. 

### Related ticket

- https://progress.opensuse.org/issues/185518

### Verification runs

SLE 16

- x86_64:  https://openqa.suse.de/tests/18398279
- aarch64: https://openqa.suse.de/tests/18398273
- s390x:   https://openqa.suse.de/tests/18398239

SLE 15-SP7

- x86_64:  https://openqa.suse.de/tests/18398240
- aarch64: https://openqa.suse.de/tests/18398243
- s390x:   https://openqa.suse.de/tests/18398241
