### PR TITLE
Use handle_secureboot on all IMA/EVM tests

### DIFF
--- a/lib/security/secureboot.pm
+++ b/lib/security/secureboot.pm
@@ -14,25 +14,75 @@ use warnings;
 use testapi;
 use Exporter 'import';
 use Utils::Architectures 'is_aarch64';
-use bootloader_setup qw(tianocore_disable_secureboot);
+use bootloader_setup qw(tianocore_disable_secureboot tianocore_enter_menu);
 use version_utils qw(is_sle);
 
 our @EXPORT = qw(handle_secureboot);
 
+#
+# _set_secure_boot_aarch64(enable => $bool)
+#
+# Private helper function to handle Secure Boot toggling in Tianocore firmware
+# for SLE >= 16 on aarch64. This replaces the original 'tianocore_disable_secureboot'.
+#
+# Arguments:
+#   'enable': A boolean value. If true, it enables Secure Boot. If false, it disables it.
+#
+sub _set_secure_boot_aarch64 {
+    my ($self, %args) = @_;
+    my $enable = $args{enable} // 0;    # Default to disabling
+
+    my $needle_sb_current_state = $enable ? 'tianocore-secureboot-not-enabled' : 'tianocore-secureboot-enabled';
+    my $needle_sb_target_state = $enable ? 'tianocore-devicemanager-sb-conf-enabled' : 'tianocore-devicemanager-sb-conf-disabled';
+    my $needle_sb_conf_attempt = $enable ? 'tianocore-devicemanager-sb-conf-disabled' : 'tianocore-devicemanager-sb-conf-attempt-sb';
+
+    tianocore_enter_menu;
+
+    # Navigate from the main menu to the Secure Boot configuration
+    assert_screen 'tianocore-mainmenu';
+    send_key_until_needlematch('tianocore-devicemanager', 'down', 10, 5);
+    send_key 'ret';
+    send_key_until_needlematch('tianocore-devicemanager-sb-conf', 'down', 10, 5);
+    send_key 'ret';
+    send_key_until_needlematch($needle_sb_conf_attempt, 'down', 6, 5);
+    send_key 'spc';
+    assert_screen 'tianocore-devicemanager-sb-conf-changed';
+    send_key 'ret';
+    assert_screen($enable ? 'tianocore-devicemanager-sb-conf-enabled' : 'tianocore-devicemanager-sb-conf-disabled');
+    send_key 'f10';
+    assert_screen 'tianocore-bootmanager-save-changes';
+    send_key 'Y';
+    send_key_until_needlematch 'tianocore-devicemanager', 'esc';
+    send_key_until_needlematch 'tianocore-mainmenu-reset', 'down';
+    send_key 'ret';
+}
+
+#
+# handle_secureboot($action)
+#
+# Main public function to enable or disable Secure Boot.
+#
+# Arguments:
+#   $action: A string, either 'enable' or 'disable'. Defaults to 'disable'.
+#
 sub handle_secureboot {
-    my ($self, $sb_state, $sb_opt) = @_;
-    my $boot_method = ((is_aarch64 && is_sle('>=16')) ? 'wait_boot_past_bootloader' : 'wait_boot');
+    my ($self, $action) = @_;
+    $action //= 'disable';    # Default action is to disable
 
-    record_info('bsc#1189988:', 'Disabling Secure Boot due to known IMA fix mode issue');
-    $self->wait_grub(bootloader_time => 200);
+    my $enable_flag = ($action eq 'enable');
 
-    if (defined $sb_opt && $sb_opt eq 're_enable') {
-        $self->tianocore_disable_secureboot('re_enable');
+    if (is_sle('>=16') && is_aarch64) {
+        record_info('SecureBoot', "Calling aarch64-specific handler to $action Secure Boot (bsc#1189988)");
+        _set_secure_boot_aarch64($self, enable => $enable_flag);
+        $self->wait_boot_past_bootloader(textmode => 1);
     } else {
-        $self->tianocore_disable_secureboot;
+        record_info('SecureBoot', "Calling standard handler to $action Secure Boot (bsc#1189988)");
+        $self->wait_grub(bootloader_time => 200);
+        # The original tianocore_disable_secureboot uses 're_enable' to enable.
+        my $legacy_action = $enable_flag ? 're_enable' : undef;
+        $self->tianocore_disable_secureboot($legacy_action);
+        $self->wait_boot(textmode => 1);
     }
-
-    $self->$boot_method(textmode => 1);
 }
 
 1;

--- a/tests/security/ima/evm_protection_digital_signatures.pm
+++ b/tests/security/ima/evm_protection_digital_signatures.pm
@@ -12,10 +12,10 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use bootloader_setup qw(replace_grub_cmdline_settings tianocore_disable_secureboot);
+use bootloader_setup qw(replace_grub_cmdline_settings);
 use power_action_utils 'power_action';
 use security::config;
-
+use security::secureboot qw(handle_secureboot);
 
 sub run {
     my ($self) = @_;
@@ -66,9 +66,7 @@ sub run {
 
         # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
         power_action('reboot', textmode => 1);
-        $self->wait_grub(bootloader_time => 200);
-        $self->tianocore_disable_secureboot('re_enable');
-        $self->wait_boot(textmode => 1);
+        handle_secureboot($self, 're_enable');
         select_serial_terminal;
 
         my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -12,8 +12,9 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use bootloader_setup qw(replace_grub_cmdline_settings tianocore_disable_secureboot);
+use bootloader_setup qw(replace_grub_cmdline_settings);
 use power_action_utils 'power_action';
+use security::secureboot qw(handle_secureboot);
 
 sub run {
     my ($self) = @_;
@@ -43,9 +44,7 @@ sub run {
 
     # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
     power_action('reboot', textmode => 1);
-    $self->wait_grub(bootloader_time => 200);
-    $self->tianocore_disable_secureboot('re_enable');
-    $self->wait_boot(textmode => 1);
+    handle_secureboot($self, 're_enable');
     select_serial_terminal;
     my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);
     die "$sample_app should not have permission to run" if ($ret !~ "\Q$sample_app\E: *Permission denied");

--- a/tests/security/ima/evm_setup.pm
+++ b/tests/security/ima/evm_setup.pm
@@ -14,8 +14,9 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings tianocore_disable_secureboot);
+use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
 use power_action_utils 'power_action';
+use security::secureboot qw(handle_secureboot);
 
 sub run {
     my ($self) = @_;
@@ -43,9 +44,7 @@ sub run {
 
     record_info("bsc#1189988: ", "We need disable secureboot with ima fix mode");
     power_action("reboot", textmode => 1);
-    $self->wait_grub(bootloader_time => 200);
-    $self->tianocore_disable_secureboot;
-    $self->wait_boot(textmode => 1);
+    handle_secureboot($self);
     select_serial_terminal;
 
     validate_script_output "cat /sys/kernel/security/evm", sub { m/^1$/ };

--- a/tests/security/ima/ima_appraisal_digital_signatures.pm
+++ b/tests/security/ima/ima_appraisal_digital_signatures.pm
@@ -28,9 +28,8 @@ sub run {
     my $cert_der = '/root/certs/ima_cert.der';
 
     add_grub_cmdline_settings("ima_appraise=fix", update_grub => 1);
-    my $sb_state = script_output('mokutil --sb-state');
     power_action("reboot", textmode => 1);
-    handle_secureboot($self, $sb_state);
+    handle_secureboot($self, 'disable');
     select_serial_terminal;
 
     my @sign_cmd = (
@@ -65,7 +64,7 @@ sub run {
 
         replace_grub_cmdline_settings('ima_appraise=fix', '', update_grub => 1);
         power_action('reboot', textmode => 1);
-        handle_secureboot($self, $sb_state, 're_enable');
+        handle_secureboot($self, 'enable');
 
         select_serial_terminal;
         assert_script_run "dmesg | grep IMA:.*completed";

--- a/tests/security/ima/ima_appraisal_hashes.pm
+++ b/tests/security/ima/ima_appraisal_hashes.pm
@@ -28,9 +28,8 @@ sub run {
     my $tcb_cmdline = ($kver lt 4.13) ? 'ima_appraise_tcb' : 'ima_policy=appraise_tcb';
 
     add_grub_cmdline_settings("ima_appraise=fix $tcb_cmdline", update_grub => 1);
-    my $sb_state = script_output('mokutil --sb-state');
     power_action("reboot", textmode => 1);
-    handle_secureboot($self, $sb_state);
+    handle_secureboot($self, 'disable');
     select_serial_terminal;
 
     my $findret = script_output("find / -fstype $fstype -type f -uid 0 -exec sh -c \"< '{}'\" \\;", 900, proceed_on_failure => 1);
@@ -53,7 +52,7 @@ sub run {
 
     # We need re-enable the secureboot after removing "ima_appraise=fix" kernel parameter
     power_action('reboot', textmode => 1);
-    handle_secureboot($self, $sb_state, 're_enable');
+    handle_secureboot($self, 'enable');
     select_serial_terminal;
 
     my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);

--- a/tests/security/ima/ima_kernel_cmdline_hash.pm
+++ b/tests/security/ima/ima_kernel_cmdline_hash.pm
@@ -13,7 +13,8 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
 use power_action_utils "power_action";
-use version_utils;
+use version_utils qw(is_sle is_leap);
+use Utils::Architectures qw(is_aarch64);
 
 sub run {
     my ($self) = @_;
@@ -64,7 +65,8 @@ sub run {
 
         # Reboot to make settings work
         power_action('reboot', textmode => 1);
-        $self->wait_boot;
+        my $boot_method = ((is_aarch64 && is_sle('>=16')) ? 'wait_boot_past_bootloader' : 'wait_boot');
+        $self->$boot_method;
         select_serial_terminal;
 
         my $meas_tmpfile = "/tmp/ascii_runtime_measurements-$ima_hash";

--- a/tests/security/ima/ima_kernel_cmdline_template.pm
+++ b/tests/security/ima/ima_kernel_cmdline_template.pm
@@ -13,6 +13,8 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
 use power_action_utils "power_action";
+use version_utils qw(is_sle);
+use Utils::Architectures qw(is_aarch64);
 
 sub run {
     my ($self) = @_;
@@ -57,7 +59,8 @@ sub run {
 
         # Reboot to make settings work
         power_action('reboot', textmode => 1);
-        $self->wait_boot;
+        my $boot_method = ((is_aarch64 && is_sle('>=16')) ? 'wait_boot_past_bootloader' : 'wait_boot');
+        $self->$boot_method;
         select_serial_terminal;
 
         my $meas_tmpfile = "/tmp/ascii_runtime_measurements-" . @$k{name};

--- a/tests/security/ima/ima_measure_critical_data.pm
+++ b/tests/security/ima/ima_measure_critical_data.pm
@@ -17,6 +17,8 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use power_action_utils 'power_action';
 use bootloader_setup 'add_grub_cmdline_settings';
+use version_utils qw(is_sle);
+use Utils::Architectures qw(is_aarch64);
 
 sub run {
     my ($self) = @_;
@@ -33,7 +35,8 @@ sub run {
 
     # Reboot to make settings work
     power_action('reboot', textmode => 1);
-    $self->wait_boot;
+    my $boot_method = ((is_aarch64 && is_sle('>=16')) ? 'wait_boot_past_bootloader' : 'wait_boot');
+    $self->$boot_method;
     select_serial_terminal;
 
     # Default template ima-buf should be used

--- a/tests/security/ima/ima_measurement.pm
+++ b/tests/security/ima/ima_measurement.pm
@@ -13,6 +13,8 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup 'add_grub_cmdline_settings';
 use power_action_utils "power_action";
+use version_utils qw(is_sle);
+use Utils::Architectures qw(is_aarch64);
 
 sub run {
     my ($self) = @_;
@@ -26,7 +28,8 @@ sub run {
 
     # Reboot to make settings work
     power_action('reboot', textmode => 1);
-    $self->wait_boot;
+    my $boot_method = ((is_aarch64 && is_sle('>=16')) ? 'wait_boot_past_bootloader' : 'wait_boot');
+    $self->$boot_method;
     select_serial_terminal;
 
     # Upload files for reference before test dies

--- a/tests/security/ima/ima_measurement_audit.pm
+++ b/tests/security/ima/ima_measurement_audit.pm
@@ -13,7 +13,8 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
 use power_action_utils "power_action";
-use version_utils;
+use version_utils qw(is_sle);
+use Utils::Architectures qw(is_aarch64);
 
 sub run {
     my ($self) = @_;
@@ -32,7 +33,8 @@ sub run {
 
         # Reboot to make settings work
         power_action('reboot', textmode => 1);
-        $self->wait_boot;
+        my $boot_method = ((is_aarch64 && is_sle('>=16')) ? 'wait_boot_past_bootloader' : 'wait_boot');
+        $self->$boot_method;
         select_serial_terminal;
 
         # Clear audit log

--- a/tests/security/ima/ima_setup.pm
+++ b/tests/security/ima/ima_setup.pm
@@ -14,6 +14,8 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup 'add_grub_cmdline_settings';
 use power_action_utils "power_action";
+use version_utils qw(is_sle);
+use Utils::Architectures qw(is_aarch64);
 
 sub run {
     my ($self) = @_;
@@ -36,7 +38,8 @@ sub run {
 
     # Reboot to make settings work
     power_action('reboot', textmode => 1);
-    $self->wait_boot;
+    my $boot_method = ((is_aarch64 && is_sle('>=16')) ? 'wait_boot_past_bootloader' : 'wait_boot');
+    $self->$boot_method;
     select_serial_terminal;
 }
 


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/185632
VRs: [16.0](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=116.2&groupid=431), [15-SP6](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=20250713-1&groupid=431), [15-SP4](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=20250713-1&groupid=431)