### PR TITLE
Adopt get_image_id in ipaddr2 test

### DIFF
--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -49,9 +49,9 @@ sub run {
         # This section is only needed by Azure tests using images uploaded
         # with publiccloud_upload_img. This is because qe-sap-deployment
         # is still not able to use images from Azure Gallery
-        $os = $self->{provider}->get_blob_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
+        $os = $provider->get_blob_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
     } else {
-        $os = get_required_var('CLUSTER_OS_VER');
+        $os = $provider->get_image_id();
     }
 
     my %cloudinit_args;


### PR DESCRIPTION
Get the OS catalog image name from PC lib and so from PUBLIC_CLOUD_IMAGE_ID. Stop using custom CLUSTER_OS_VER.

Related: https://jira.suse.com/browse/TEAM-9961

# Verification run:

 - sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless -> https://openqa.suse.de/tests/18405511 :green_circle: it fails as expected https://openqa.suse.de/tests/18405511#step/deploy/74

 - sle-15-SP6-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-ipaddr2_azure_test_rootless explicitly setting  PUBLIC_CLOUD_IMAGE_ID=suse:sles-sap-15-sp6:gen2:latest  -> https://openqa.suse.de/tests/18405512 :green_circle:  `az vm create` get the catalog image set in the variable
