### PR TITLE
Generalize ipaddr2_scc_addon usage

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -2132,6 +2132,8 @@ Register addons on SUT
 
 =over
 
+=item B<scc_addons> - List of scc addons as usually provided by SCC_ADDONS variable
+
 =item B<bastion_ip> - Public IP address of the bastion. Calculated if not provided.
                       Providing it as an argument is recommended in order
                       to avoid having to query Azure to get it.
@@ -2142,9 +2144,10 @@ Register addons on SUT
 
 sub ipaddr2_scc_addons {
     my (%args) = @_;
+    croak 'Missing mandatory argument < scc_addons >' unless $args{scc_addons};
     $args{bastion_pubip} //= ipaddr2_bastion_pubip();
     my $host_ip = ipaddr2_bastion_ssh_addr(bastion_ip => $args{bastion_pubip});
-    my @addons = split(/,/, get_var('SCC_ADDONS', ''));
+    my @addons = split(/,/, $args{scc_addons});
 
     foreach my $id (1 .. 2) {
         # Register through an external library function register_addon.

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -1001,4 +1001,37 @@ subtest '[ipaddr2_network_peering_create]' => sub {
     ok $create_peering, "qesap_az_vnet_peering called";
 };
 
+subtest '[ipaddr2_scc_addons] no args' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    dies_ok { ipaddr2_scc_addons() } "die if no scc_addons argument is provided";
+    dies_ok { ipaddr2_scc_addons(scc_addons => '') } "die if empty scc_addons argument is provided";
+};
+
+subtest '[ipaddr2_scc_addons] one addon' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my (@remotes, @addons);
+    $ipaddr2->redefine(register_addon => sub {
+            my ($remote, $addon) = @_;
+            push @remotes, $remote;
+            push @addons, $addon;
+    });
+    my ($exp, $act);
+    # Here there are 2 test coded:
+    #  - one for SCC_ADDONS with value for a single addon
+    #  - one for SCC_ADDONS with string containing two addons
+    foreach ('123', '456,789') {
+        ipaddr2_scc_addons(scc_addons => $_);
+        note("\n  REMOTE[$_] -->  " . join("\n  REMOTE[$_] -->  ", @remotes));
+        note("\n  ADDON[$_] -->  " . join("\n  ADDON[$_] -->  ", @addons));
+        $act = scalar @remotes;
+        $exp = (1 + ($_ =~ tr/,//)) * 2;
+        ok $act eq $exp, "Expected remotes to have $exp elements but it has $act .";
+        @remotes = ();
+        @addons = ();
+    }
+    ok 1;
+};
+
 done_testing;

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -22,6 +22,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_cloudinit_logs
   ipaddr2_scc_check
   ipaddr2_scc_register
+  ipaddr2_scc_addons
   ipaddr2_refresh_repo
   ipaddr2_azure_resource_group
 );
@@ -60,15 +61,19 @@ sub run {
                     bastion_ip => $bastion_ip,
                     id => $_);
                 record_info('is_registered', "$is_registered");
-                # Only perform registration if it is no
-                # So test can be programmatically configured not to perform
-                # any registration, by not providing SCC_REGCODE_SLES4SAP variable.
-                # But even if it is, registration is only performed if image
-                # at this test moment is not registered.
+                # Conditionally register the SLES for SAP instance.
+                # Registration is attempted only if the instance is not currently registered and a
+                # registration code ('SCC_REGCODE_SLES4SAP') is available.
                 ipaddr2_scc_register(
                     bastion_ip => $bastion_ip,
                     id => $_,
                     scc_code => get_required_var('SCC_REGCODE_SLES4SAP')) if ($is_registered ne 1);
+
+                # Optionally register addons
+                ipaddr2_scc_addons(
+                    bastion_pubip => $bastion_pubip,
+                    scc_addons => get_required_var('SCC_ADDONS')
+                ) if (get_var('SCC_ADDONS'));
             }
         }
         record_info("TEST STAGE", "Install the web server");

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -56,6 +56,9 @@ sub run {
 
     my %cloudinit_args;
     $cloudinit_args{scc_code} = get_required_var('SCC_REGCODE_SLES4SAP') if ($os =~ /byos/i);
+
+    die "SCC_ADDONS registration is not implemented via cloudinit script yet"
+      if (get_var('SCC_ADDONS') && !check_var('IPADDR2_CLOUDINIT', 0));
     $cloudinit_args{external_repo} = get_var('IPADDR2_NGINX_EXTREPO') if get_var('IPADDR2_NGINX_EXTREPO');
     my %deployment = (
         os => $os,

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -30,7 +30,10 @@ sub run {
     my $bastion_pubip = ipaddr2_bastion_pubip();
 
     # Addons registration
-    ipaddr2_scc_addons(bastion_pubip => $bastion_pubip);
+    ipaddr2_scc_addons(
+        bastion_pubip => $bastion_pubip,
+        scc_addons => get_required_var('SCC_ADDONS')
+    ) if (get_var('SCC_ADDONS'));
 
     foreach my $id (1 .. 2) {
         # refresh repo


### PR DESCRIPTION
Change the API to read SCC_ADDONS variable at test module level. Only run the function when SCC_ADDONS is defined.
Add unit testing.


- Related ticket: https://progress.opensuse.org/issues/xyz

# Verification run:

