### PR TITLE
Use openSUSE Leap 15.6 for SLES in zypper_extend test

### DIFF
--- a/tests/console/zypper_extend.pm
+++ b/tests/console/zypper_extend.pm
@@ -90,15 +90,12 @@ sub run {
     zypper_call "rm --clean-deps cmake";
 
     my $repo_version;
-    my $package_to_install;
+    my $package_to_install = "funny-manpages";
     if (is_opensuse) {
         my $string = (is_leap) ? 'Leap_' : '';
         $repo_version = "openSUSE_$string" . get_var('VERSION');
-        $package_to_install = "funny-manpages";
     } elsif (is_sle) {
-        my $major_version = substr(get_var('VERSION'), 0, 2);
-        $repo_version = "SLE_$major_version";
-        $package_to_install = "rar";
+        $repo_version = "openSUSE_Leap_15.6";
     } else {
         die "Unknown distribution";
     }


### PR DESCRIPTION
The packman repository aren't as consistant as it is for Leap and the
convenient test package funny-manpages is not available, for SLE it is
more convenient to keep using Leap repo than branching per-arch

Failure: https://openqa.suse.de/tests/18426048#step/zypper_extend/78
VR: https://openqa.suse.de/tests/18428466
