### PR TITLE
containers/isolation: Remove assert when doing workaround

### DIFF
--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -54,7 +54,7 @@ sub run {
     install_packages(@packages);
 
     # Workaround for https://bugzilla.suse.com/show_bug.cgi?id=1240150
-    assert_script_run "echo 0 > /etc/docker/suse-secrets-enable" if is_sle('<15-SP6');
+    script_run "echo 0 > /etc/docker/suse-secrets-enable" if is_sle('<15-SP6');
 
     my @ip_versions = (4);
     push @ip_versions, 6 unless (is_hyperv || is_s390x || is_vmware);


### PR DESCRIPTION
Remove assert when doing workaround

It fails with podman:
https://openqa.suse.de/tests/18435485#step/podman_isolation/35