### PR TITLE
Stablize br0 setup on SLES16 host

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -42,7 +42,7 @@
     <guest_storage_backing_format/>
     <guest_storage_others>driver.name=qemu,target.dev=vda,target.bus=virtio,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>bridge</guest_network_type>
-    <guest_network_mode>bridge</guest_network_mode>
+    <guest_network_mode>host</guest_network_mode>
     <guest_network_device/>
     <guest_network_others/>
     <guest_netaddr/>

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -1262,14 +1262,14 @@ sub config_guest_network_bridge_device {
         my $_detect_inactive_route = '';
         if ($self->{guest_network_mode} ne 'host') {
             virt_autotest::virtual_network_utils::write_network_bridge_device_config(ipaddr => $_bridge_network, name => $_bridge_device, bootproto => 'static', bridge_type => 'master', backup_folder => $_host_params{common_log_folder});
-            my $_ret = virt_autotest::virtual_network_utils::activate_network_bridge_device(bridge_device => $_bridge_device, network_mode => $self->{guest_network_mode});
+            my $_ret = virt_autotest::virtual_network_utils::activate_network_bridge_device(bridge_device => $_bridge_device, network_mode => $self->{guest_network_mode}, reconsole_counter => $_host_params{reconsole_counter});
             $self->record_guest_installation_result('FAILED') if ($_ret != 0);
         }
         else {
             my $_host_default_network_interface = script_output("ip route show default | grep -i dhcp | grep -vE br[[:digit:]]+ | head -1 | awk \'{print \$5}\'");
             virt_autotest::virtual_network_utils::write_network_bridge_device_config(ipaddr => $_bridge_network, name => $_bridge_device, bootproto => 'dhcp', bridge_type => 'master', bridge_port => $_host_default_network_interface, backup_folder => $_host_params{common_log_folder});
             virt_autotest::virtual_network_utils::write_network_bridge_device_config(ipaddr => '', name => $_host_default_network_interface, bootproto => 'none', bridge_type => 'slave', bridge_port => $_bridge_device, backup_folder => $_host_params{common_log_folder});
-            my $_ret = virt_autotest::virtual_network_utils::activate_network_bridge_device(host_device => $_host_default_network_interface, bridge_device => $_bridge_device, network_mode => $self->{guest_network_mode});
+            my $_ret = virt_autotest::virtual_network_utils::activate_network_bridge_device(host_device => $_host_default_network_interface, bridge_device => $_bridge_device, network_mode => $self->{guest_network_mode}, reconsole_counter => $_host_params{reconsole_counter});
             $self->record_guest_installation_result('FAILED') if ($_ret != 0);
         }
     }

--- a/lib/guest_installation_and_configuration_metadata.pm
+++ b/lib/guest_installation_and_configuration_metadata.pm
@@ -270,7 +270,8 @@ our %_host_params = (
     'ssh_key_file' => get_var('GUEST_SSH_KEYFILE', '/root/.ssh/id_rsa'),    # SSH key file used for guest installation and login
     'ssh_public_key' => '',    # Public key used for ssh login to guest
     'ssh_private_key' => '',    # Private key used for ssh login to guest
-    'ssh_command' => ''    # SSH command used for ssh login, for example, "ssh -vvv -i identity_file username"
+    'ssh_command' => '',    # SSH command used for ssh login, for example, "ssh -vvv -i identity_file username"
+    'reconsole_counter' => get_var('RESELECT_CONSOLE_COUNTER', 180)    # Reselect disconnected console if condition triggered in counter
 );
 
 # Global data structure %guest_network_matrix to specify network devices to be

--- a/lib/parallel_guest_migration_metadata.pm
+++ b/lib/parallel_guest_migration_metadata.pm
@@ -98,7 +98,8 @@ our %_host_params = (
     'source_imgpath' => get_var('SOURCE_IMAGE_PATH', '/var/lib/libvirt/images'),    # The folder in which guest assets are stored
     'target_imgpath' => get_var('TARGET_IMAGE_PATH', '/var/lib/libvirt/images'),    # The folder to which NFS share should be mounted
     'use_storage_pool' => get_var('USE_STORAGE_POOL', ''),    # Whether use libvirt storage pool (1 or 0)
-    'storage_pool_name' => get_var('STORAGE_POOL_NAME', 'libvirt_guest_migration')    # libvirt storage pool name
+    'storage_pool_name' => get_var('STORAGE_POOL_NAME', 'libvirt_guest_migration'),    # libvirt storage pool name
+    'reconsole_counter' => get_var('RESELECT_CONSOLE_COUNTER', 180)    # Reselect disconnected console if condition triggered in counter
 );
 
 our %_guest_params = (

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -667,6 +667,7 @@ sub activate_network_bridge_device {
     $args{network_mode} //= 'bridge';
     $args{host_device} //= '';
     $args{bridge_device} //= '';
+    $args{reconsole_counter} //= 180;
     die("Bridge device name must be given otherwise activation can not be done.") if (!$args{bridge_device});
 
     my $ret = 1;
@@ -693,14 +694,13 @@ sub activate_network_bridge_device {
     }
     else {
         if (is_networkmanager) {
-            script_retry("nmcli connection up $args{bridge_device}", timeout => 60, delay => 15, retry => 3, die => 0);
-            script_retry("nmcli connection up $args{host_device}", timeout => 60, delay => 15, retry => 3, die => 0);
+            enter_cmd("nmcli connection up $args{bridge_device}");
         }
         else {
             script_retry("systemctl restart network", timeout => 60, delay => 15, retry => 3, die => 0);
         }
-        type_string("reset\n");
-        select_console('root-ssh') if (!(check_screen('text-logged-in-root')));
+        virt_autotest::utils::reselect_openqa_console(address => get_required_var('SUT_IP'), counter => $args{reconsole_counter});
+        script_retry("nmcli connection up $args{host_device}", timeout => 60, delay => 15, retry => 3, die => 0) if is_networkmanager;
         $detect_active_route = script_output("ip route show default | grep -i $args{bridge_device}", proceed_on_failure => 1);
         $detect_inactive_route = script_output("ip route show default | grep -i $args{host_device}", proceed_on_failure => 1);
     }


### PR DESCRIPTION
* **New** subroutine ```reselect_openqa_console``` in ```lib/virt_autotest/utils.pm``` to do actual console reconnecting if it is lost due to operation like altering network configuration. 

* **Calling** ```reselect_openqa_console``` in module ```lib/guest_installation_and_configuration_base.pm``` after activating br0 to ensure 'root-ssh' console is always present. 

* **And** test suite level setting ```RESELECT_CONSOLE_COUNTER``` can be used to specify customized value of timeout when detecting whether concerned console is lost.

* **Verification Runs:**
  * [console reconnected after being considered lost](http://10.200.140.9/tests/1259#step/unified_guest_installation/431)
  * [console is not lost during detecting period](http://10.200.140.9/tests/1268)
  * [MU 15-SP7 KVM source](https://openqa.oqa.prg2.suse.org/tests/18604766)
  * [MU 15-SP7 KVM destination](https://openqa.oqa.prg2.suse.org/tests/18604765)
  * [MU 15-SP7 Xen source](https://openqa.oqa.prg2.suse.org/tests/18604768)
  * [MU 15-SP7 Xen destination](https://openqa.oqa.prg2.suse.org/tests/18604769)
  * [SLE16 uefi guest](https://openqa.suse.de/tests/18604780)
  * [SL Micro 6.2 on SL Micro 6.2](https://openqa.suse.de/tests/18612758)