### PR TITLE
Replace repos in Microos for bonding tests

### DIFF
--- a/schedule/functional/extra_tests_network_bonding.yaml
+++ b/schedule/functional/extra_tests_network_bonding.yaml
@@ -7,6 +7,9 @@ conditional_schedule:
     DISTRI:
       'microos':
         - microos/disk_boot
+        - update/zypper_clear_repos
+        - console/zypper_ar
+        - console/zypper_ref
       'sle-micro':
         - microos/disk_boot
       'opensuse':


### PR DESCRIPTION
The test schedule doesn't add the required modules to ensure that the to-test snapshot is what's actually being tested.
[current](https://openqa.opensuse.org/tests/5173845#step/network_bonding_setup/106) failure shows an error fixed in the
to be tested snapshot.

VR: https://openqa.opensuse.org/tests/5174711 and https://openqa.opensuse.org/tests/5174710
