### PR TITLE
blktests: Correct the way the exclude is passed

### DIFF
--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -52,8 +52,9 @@ sub run {
     my @tests = split(',', $tests);
     assert_script_run('cd /usr/lib/blktests');
 
+    $exclude = join(' ', map { "--exclude=$_" } split(/,/, $exclude // ''));
     foreach my $i (@tests) {
-        script_run("./check --quick=$quick --exclude=$exclude $i", 480);
+        script_run("./check --quick=$quick $exclude $i", 480);
     }
 
     script_run('wget --quiet ' . data_url('kernel/post_process') . ' -O post_process');


### PR DESCRIPTION
Exclude flag for the check file to run blktests accepts multiple files each with the flag

- Related ticket: https://progress.opensuse.org/issues/185008
- Verification run: 
multiple excludes: https://openqa.suse.de/tests/18438969
plain regression check for sle16: https://openqa.suse.de/tests/18438979
