### PR TITLE
Fix sporadic issue with ASCS kill sapoinstance tests

### DIFF
--- a/tests/sles4sap/redirection_tests/ensa2_kill_sapinstance.pm
+++ b/tests/sles4sap/redirection_tests/ensa2_kill_sapinstance.pm
@@ -142,10 +142,12 @@ sub run {
     $fail_count = crm_wait_failcount(crm_resource => $resource_name);
     record_info("Fail count: $fail_count", "Fail count is $fail_count");
 
+    wait_for_idle_cluster();
     record_info('Refresh', 'Refreshing resources using "crm resource refresh"');
     assert_script_run('crm resource refresh');
     wait_until_resources_started();
     wait_for_idle_cluster();
+
     record_info('Cluster check', 'Checking state of cluster resources');
     check_cluster_state();
 


### PR DESCRIPTION
Test variants 'Kill sapinstance ASCS' contain currently a sporadic issue
 with ASCS resource kill process does not reach expected state. Test 
 only waits for failcount to appear instead of stabilizing before 
 further actions. This PR corrects this behavior.

Ticket: https://jira.suse.com/browse/TEAM-10495

Verification run:
1st round:
15SP4: https://openqaworker15.qa.suse.cz/tests/334110#
15SP5: https://openqaworker15.qa.suse.cz/tests/334113#
15SP6: https://openqaworker15.qa.suse.cz/tests/334116#

2nd round
15SP4: https://openqaworker15.qa.suse.cz/tests/334267#
15SP5: https://openqaworker15.qa.suse.cz/tests/334270#
15SP6: https://openqaworker15.qa.suse.cz/tests/334278#