### PR TITLE
cron: Schedule cron test later

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -24,9 +24,7 @@ schedule:
   - console/command_not_found
   - console/openssl_alpn
   - console/autoyast_removed
-  - console/cron
   - console/syslog
-  - console/mta
   - console/check_default_network_manager
   - console/git
   - console/cups
@@ -36,7 +34,9 @@ schedule:
   - console/perf
   - console/sysctl
   - console/sysstat
+  - console/mta
   - console/cpio
+  - console/cron
   - console/tar
   - console/ruby
   - '{{version_specific}}'


### PR DESCRIPTION
Due to time syncing cron can be inactive

- Related ticket: https://progress.opensuse.org/issues/185737
- Verification run:
https://openqa.suse.de/tests/18438749
https://openqa.suse.de/tests/18438748