### PR TITLE
xfstests: Update xfstests scheduler for SL Micro

### DIFF
--- a/schedule/filesystem/xfstests_micro_ppc.yaml
+++ b/schedule/filesystem/xfstests_micro_ppc.yaml
@@ -5,5 +5,9 @@ description:    >
   xfstests test suite for SLE-Micro on ppc
 schedule:
     - installation/bootloader
+    - microos/install_image
+    - transactional/host_config
+    - console/suseconnect_scc
+    - xfstests/install
     - xfstests/partition
     - xfstests/run

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -436,10 +436,6 @@ sub setup_nfs_client {
 
 sub run {
     my ($self) = @_;
-    if (is_sle_micro && is_ppc64le) {
-        record_info('INFO', 'Booting microos on ppc64le');
-        $self->wait_boot(ready_time => 1800);
-    }
     select_serial_terminal;
 
     # DO NOT set XFSTESTS_DEVICE if you don't know what's this mean


### PR DESCRIPTION
1. Run tests directly after SL Micro installation to avoid environment changes or duplication of config files
2. update partition.pm accordingly

- Related ticket: https://progress.opensuse.org/issues/185749
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18446471