### PR TITLE
blktests: Block section requires longer timeout

### DIFF
--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -54,7 +54,7 @@ sub run {
 
     $exclude = join(' ', map { "--exclude=$_" } split(/,/, $exclude // ''));
     foreach my $i (@tests) {
-        script_run("./check --quick=$quick $exclude $i", 480);
+        script_run("./check --quick=$quick $exclude $i", 1200);
     }
 
     script_run('wget --quiet ' . data_url('kernel/post_process') . ' -O post_process');


### PR DESCRIPTION
Some of the block tests run longer tests using fio and as such require longer time to finish

- Related ticket: https://progress.opensuse.org/issues/185881
- Verification run: https://openqa.suse.de/tests/18448473
