### PR TITLE
Don't use PlainText password in unattend.xml

### DIFF
--- a/data/wsl/Autounattend_Arm64.xml
+++ b/data/wsl/Autounattend_Arm64.xml
@@ -378,8 +378,8 @@
             <Name>Bernhard M. Wiedeman</Name>
             <Group>Administrators</Group>
             <Password>
-              <Value>nots3cr3t</Value>
-              <PlainText>true</PlainText>
+              <Value>bgBvAHQAcwAzAGMAcgAzAHQA</Value>
+              <PlainText>false</PlainText>
             </Password>
           </LocalAccount>
         </LocalAccounts>

--- a/data/wsl/Autounattend_UEFI.xml
+++ b/data/wsl/Autounattend_UEFI.xml
@@ -413,8 +413,8 @@
             <Name>Bernhard M. Wiedeman</Name>
             <Group>Administrators</Group>
             <Password>
-              <Value>nots3cr3t</Value>
-              <PlainText>true</PlainText>
+              <Value>bgBvAHQAcwAzAGMAcgAzAHQA</Value>
+              <PlainText>false</PlainText>
             </Password>
           </LocalAccount>
         </LocalAccounts>


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/173938

