### PR TITLE
Update BATS settings for runc 1.2 on SLES 15-SP7

### DIFF
--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -167,8 +167,6 @@ Complete list found in [skip.yaml](data/containers/bats/skip.yaml)
 | --- | --- |
 | [sbom] | https://github.com/containers/buildah/issues/5617 |
 
-[from]: https://github.com/containers/buildah/blob/main/tests/from.bats
-[run]: https://github.com/containers/buildah/blob/main/tests/run.bats
 [sbom]: https://github.com/containers/buildah/blob/main/tests/sbom.bats
 
 ### podman


### PR DESCRIPTION
Update BATS settings for runc 1.2 on SLES 15-SP7

Verification runs:
- buildah: https://openqa.suse.de/tests/18450365
- runc: https://openqa.suse.de/tests/18450364