### PR TITLE
Schedule openSUSE repos test as early as possible

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1210,6 +1210,7 @@ sub load_consoletests {
             loadtest "console/installation_snapshots" unless get_var('FLAVOR') =~ /OpenStack-Cloud/;
         }
     }
+    loadtest "console/opensuse_repos";
     loadtest "console/zypper_lr";
     # Enable installation repo from the usb, unless we boot from USB, but don't use it
     # for the installation, like in case of LiveCDs and when using http/smb/ftp mirror

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1210,7 +1210,7 @@ sub load_consoletests {
             loadtest "console/installation_snapshots" unless get_var('FLAVOR') =~ /OpenStack-Cloud/;
         }
     }
-    loadtest "console/opensuse_repos";
+    loadtest "console/opensuse_repos" if is_opensuse && !(is_staging);
     loadtest "console/zypper_lr";
     # Enable installation repo from the usb, unless we boot from USB, but don't use it
     # for the installation, like in case of LiveCDs and when using http/smb/ftp mirror

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1234,6 +1234,8 @@ sub load_consoletests {
         }
         loadtest "console/zypper_ref";
     }
+    loadtest "console/zypper_in";
+    loadtest "console/zypper_log";
     if (is_jeos) {
         loadtest "jeos/glibc_locale";
         loadtest "jeos/kiwi_templates" unless (is_leap('<15.2') || is_staging);
@@ -1264,8 +1266,6 @@ sub load_consoletests {
     loadtest "console/glibc_tunables";
     load_system_update_tests(console_updates => 1);
     loadtest "console/console_reboot" if is_jeos;
-    loadtest "console/zypper_in";
-    loadtest "console/zypper_log";
     if (!get_var("LIVETEST")) {
         loadtest "console/yast2_i" unless (is_sle("16+") || is_leap("16.0+"));
         loadtest "console/yast2_bootloader" unless ((is_sle("16+") || is_leap("16.0+")) || is_bootloader_sdboot || is_bootloader_grub2_bls);

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -81,10 +81,6 @@ conditional_schedule:
                 - console/kdump_and_crash
                 - console/ansible
                 - console/libgit2
-    opensuse_repos:
-        DISTRI:
-            opensuse:
-                - console/opensuse_repos
     validate_packages_and_patterns:
         DISTRI:
             sle:
@@ -196,7 +192,6 @@ schedule:
     - console/aaa_base
     - console/osinfo_db
     - '{{opensuse_tests}}'
-    - '{{opensuse_repos}}'
     - '{{leap_tests}}'
     - '{{tumbleweed_tests}}'
     - console/journalctl

--- a/schedule/functional/leap16/agama_create_hdd_gnome_leap.yaml
+++ b/schedule/functional/leap16/agama_create_hdd_gnome_leap.yaml
@@ -16,6 +16,7 @@ schedule:
     - update/zypper_clear_repos
     - console/zypper_ar
     - console/zypper_ref
+    - console/opensuse_repos
     - console/hostname
     - console/force_scheduled_tasks
     - console/check_selinux_fails

--- a/schedule/functional/leap16/agama_create_hdd_textmode_leap.yaml
+++ b/schedule/functional/leap16/agama_create_hdd_textmode_leap.yaml
@@ -15,6 +15,7 @@ schedule:
     - update/zypper_clear_repos
     - console/zypper_ar
     - console/zypper_ref
+    - console/opensuse_repos
     - console/hostname
     - console/force_scheduled_tasks
     - console/check_selinux_fails

--- a/t/data/test_schedule.out
+++ b/t/data/test_schedule.out
@@ -27,11 +27,11 @@ tests/console/textinfo.pm
 tests/console/hostname.pm
 tests/console/zypper_lr.pm
 tests/console/zypper_ref.pm
+tests/console/zypper_in.pm
+tests/console/zypper_log.pm
 tests/console/yast2_lan.pm
 tests/console/curl_https.pm
 tests/console/glibc_tunables.pm
-tests/console/zypper_in.pm
-tests/console/zypper_log.pm
 tests/console/yast2_i.pm
 tests/console/yast2_bootloader.pm
 tests/console/vim.pm


### PR DESCRIPTION
The openSUSE repos test is now updated to also remove the zypper service, so that https://progress.opensuse.org/issues/185863 doesn't happen

The test schedule has been updated to include the test by default, wherever console tests are being ran.

VR: 
- Leap 16 https://openqa.opensuse.org/tests/5177407
- Tumbleweed on aarch64 https://openqa.opensuse.org/tests/5177408
- Jeos x86 https://openqa.opensuse.org/tests/5177409
