### PR TITLE
Reorganize IpAddr2 test modules and sequence

### DIFF
--- a/schedule/sles4sap/cloud-components/ipaddr2.yml
+++ b/schedule/sles4sap/cloud-components/ipaddr2.yml
@@ -9,7 +9,9 @@ schedule:
     - '{{validate_repos}}'
     - sles4sap/ipaddr2/deploy
     - sles4sap/ipaddr2/configure
-    - '{{patch_system}}'
+    - sles4sap/ipaddr2/registration
+    - '{{ibsm_peering}}'
+    - sles4sap/ipaddr2/patch_system
     - sles4sap/ipaddr2/cluster_create
     - sles4sap/ipaddr2/sanity_os
     - sles4sap/ipaddr2/sanity_cluster
@@ -20,9 +22,7 @@ conditional_schedule:
         IS_MAINTENANCE:
             1:
                 - publiccloud/validate_repos
-    patch_system:
+    ibsm_peering:
         IS_MAINTENANCE:
             1:
                 - sles4sap/ipaddr2/network_peering
-                - sles4sap/ipaddr2/registration
-                - sles4sap/ipaddr2/patch_system

--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -2,7 +2,57 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Create cluster
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+ipaddr2/cluster_create.pm - Create the Pacemaker cluster for the ipaddr2 test
+
+=head1 DESCRIPTION
+
+This module is responsible for setting up the Pacemaker cluster on the two
+SUT (System Under Test) virtual machines.
+
+Its primary tasks are:
+
+- If cloud-init was disabled (B<IPADDR2_CLOUDINIT> is 0), it installs the nginx web server
+  on both SUT nodes.
+  This step is necessary because without cloud-init, the web server would not
+  have been pre-installed.
+- Initializes and configures the Pacemaker cluster across the two SUT nodes,
+  preparing them for high-availability resource management.
+
+=head1 VARIABLES
+
+=over 4
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Specifies the public cloud provider. This module currently only supports 'AZURE'.
+
+=item B<IPADDR2_CLOUDINIT>
+
+A flag that determines if the nginx web server needs to be installed by this module.
+If set to 0, this module will handle the installation. If enabled (1), it assumes
+cloud-init has already installed it.
+
+=item B<IPADDR2_NGINX_EXTREPO>
+
+An external repository URL for the nginx package. This is only used if B<IPADDR2_CLOUDINIT>
+is disabled and nginx is not available in the default system repositories.
+
+=item B<IPADDR2_ROOTLESS>
+
+A flag passed to the cluster creation function to determine the configuration context,
+for example, if the cluster is set up by a non-root user.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use strict;
 use warnings;
@@ -11,6 +61,7 @@ use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
+  ipaddr2_configure_web_server
   ipaddr2_bastion_pubip
   ipaddr2_cluster_create
   ipaddr2_deployment_logs
@@ -28,6 +79,19 @@ sub run {
     select_serial_terminal;
 
     my $bastion_ip = ipaddr2_bastion_pubip();
+
+    # Check if cloudinit is active or not. In case it is,
+    # registration was eventually there and no need to per performed here.
+    if (check_var('IPADDR2_CLOUDINIT', 0)) {
+        record_info("TEST STAGE", "Install the web server");
+        my %web_install_args;
+        $web_install_args{external_repo} = get_var('IPADDR2_NGINX_EXTREPO') if get_var('IPADDR2_NGINX_EXTREPO');
+        $web_install_args{bastion_ip} = $bastion_ip;
+        foreach (1 .. 2) {
+            $web_install_args{id} = $_;
+            ipaddr2_configure_web_server(%web_install_args);
+        }
+    }
 
     record_info("TEST STAGE", "Init and configure the Pacemaker cluster");
     ipaddr2_cluster_create(bastion_ip => $bastion_ip, rootless => get_var('IPADDR2_ROOTLESS', '0'));

--- a/tests/sles4sap/ipaddr2/patch_system.pm
+++ b/tests/sles4sap/ipaddr2/patch_system.pm
@@ -4,6 +4,31 @@
 # Summary: zypper patch and reboot
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
+=head1 NAME
+
+ipaddr2/patch_system.pm - Apply system patches to the SUT for the ipaddr2 test
+
+=head1 DESCRIPTION
+
+This module performs a standard system update on both SUT (System Under Test)
+virtual machines.
+
+It executes `zypper patch` to install all available patches and then reboots
+the systems to ensure that all updates, including any kernel updates, are
+correctly applied and active. This step helps ensure the SUTs are in a
+consistent and up-to-date state for subsequent tests.
+
+=head1 VARIABLES
+
+This module does not require any specific configuration variables for its core functionality.
+It assumes that the system repositories are already configured and accessible.
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
+
 use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -4,22 +4,71 @@
 # Summary: Registration SUT
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
+=head1 NAME
+
+ipaddr2/registration.pm - Perform SUT registration for the ipaddr2 test
+
+=head1 DESCRIPTION
+
+This module handles the registration of the SUT (System Under Test) VMs
+for the ipaddr2 test.
+Its behavior depends on whether cloud-init was used for the initial setup.
+
+If cloud-init is disabled (B<IPADDR2_CLOUDINIT> is 0), this module will:
+- Check the registration status
+- If the image is Not Registered: register the two SUT VMs
+  with the SUSE Customer Center (SCC) using the provided registration code.
+- Register any specified add-on products.
+
+After registration (or if cloud-init was enabled), it refreshes the software repositories
+for both SUT VMs and lists them for logging purposes.
+
+=head1 VARIABLES
+
+=over 4
+
+=item B<IPADDR2_CLOUDINIT>
+
+Controls whether this module performs the registration. Defaults to enabled (1) in the overall test flow.
+If set to 0, this module handles the full registration process.
+If enabled (not 0), this module skips the registration steps and only refreshes the repositories,
+assuming registration was handled by cloud-init during deployment.
+
+=item B<SCC_REGCODE_SLES4SAP>
+
+SUSE Customer Center registration code for SLES for SAP.
+Required if B<IPADDR2_CLOUDINIT> is set to 0 and the OS image is a BYOS (Bring Your Own Subscription) type.
+
+=item B<SCC_ADDONS>
+
+A comma-separated list of SUSE Customer Center addons to register.
+Each selected addon will require its own registration code in a dedicated variable.
+This is used only when B<IPADDR2_CLOUDINIT> is set to 0.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
+
 use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use publiccloud::utils;
-use sles4sap::qesap::qesapdeployment qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_logs
   ipaddr2_cloudinit_logs
   ipaddr2_infra_destroy
   ipaddr2_scc_addons
+  ipaddr2_scc_check
+  ipaddr2_scc_register
   ipaddr2_refresh_repo
   ipaddr2_ssh_internal
   ipaddr2_bastion_pubip
-  ipaddr2_azure_resource_group
 );
 
 sub run {
@@ -27,26 +76,48 @@ sub run {
 
     select_serial_terminal;
 
-    my $bastion_pubip = ipaddr2_bastion_pubip();
+    my $bastion_ip = ipaddr2_bastion_pubip();
 
-    # Addons registration
-    ipaddr2_scc_addons(
-        bastion_ip => $bastion_pubip,
-        scc_addons => get_required_var('SCC_ADDONS')
-    ) if (get_var('SCC_ADDONS'));
+    # Check if cloudinit is active or not. In case it is,
+    # registration was eventually performed by the cloudinit script
+    # and no need to be performed here.
+    if (check_var('IPADDR2_CLOUDINIT', 0)) {
+        # Check if reg code is provided or not, PAYG does not need it
+        if (get_var('SCC_REGCODE_SLES4SAP')) {
+            foreach (1 .. 2) {
+                # Check if somehow the image is already registered or not
+                my $is_registered = ipaddr2_scc_check(
+                    bastion_ip => $bastion_ip,
+                    id => $_);
+                record_info('is_registered', "$is_registered");
+                # Conditionally register the SLES for SAP instance.
+                # Registration is attempted only if the instance is not currently registered and a
+                # registration code ('SCC_REGCODE_SLES4SAP') is available.
+                ipaddr2_scc_register(
+                    bastion_ip => $bastion_ip,
+                    id => $_,
+                    scc_code => get_required_var('SCC_REGCODE_SLES4SAP')) if ($is_registered ne 1);
+            }
+        }
+        # Optionally register addons
+        ipaddr2_scc_addons(
+            bastion_ip => $bastion_ip,
+            scc_addons => get_required_var('SCC_ADDONS')
+        ) if (get_var('SCC_ADDONS'));
+    }
 
     foreach my $id (1 .. 2) {
         # refresh repo
-        ipaddr2_refresh_repo(id => $id, bastion_pubip => $bastion_pubip);
+        ipaddr2_refresh_repo(id => $id, bastion_ip => $bastion_ip);
 
         # record repo lr
         ipaddr2_ssh_internal(id => $id,
             cmd => "sudo zypper lr",
-            bastion_ip => $bastion_pubip);
+            bastion_ip => $bastion_ip);
         # record repo ls
         ipaddr2_ssh_internal(id => $id,
             cmd => "sudo zypper ls",
-            bastion_ip => $bastion_pubip);
+            bastion_ip => $bastion_ip);
     }
 }
 
@@ -58,9 +129,6 @@ sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
     ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    if (my $ibsm_rg = get_var('IBSM_RG')) {
-        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
-    }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Reorganize how configuration steps are distributed across test modules. All registration steps are moved to test module named registration. Test module named configure only deal with ssh connection configuration. Web server installation is moved to cluster_create. The most important motivation of all these changes is in the YAML_SCHEDULE: now the difference between schedule for maintenance and non maintenance is minimal. Adopt POD documentation in IpAddr2 test modules.
Fix a bug for ipaddr2_refresh_repo.

- Related ticket:

# Verification run:

## Regression schedule
sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5
 - ipaddr2_azure_test -> https://openqaworker15.qa.suse.cz/tests/332682 :green_circle: 
   - `SUSEConnect -s` https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-2510
   - `registercloudguest --force-new -r "***"`  https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-2519
   - `zypper ref` https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-2537
   - `zypper lr` https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-2566
   - `zypper ls` https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-2622
   - one more `zypper ref` https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-2743
   - `zypper patch` https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-2789
   - `zypper in nginx socat` https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-3913
   - `crm cluster init` https://openqaworker15.qa.suse.cz/tests/332682/logfile?filename=serial_terminal.txt#line-4035
   - ...

 - ipaddr2_azure_test_cloud_init -> http://openqaworker15.qa.suse.cz/tests/332684

sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5
 - ipaddr2_azure_test_root -> http://openqaworker15.qa.suse.cz/tests/332685
 - ipaddr2_azure_test_rootless -> http://openqaworker15.qa.suse.cz/tests/332686

## Maintenance schedule

https://openqaworker15.qa.suse.cz/tests/332683 :green_circle: 