### PR TITLE
Removed unrequired inst.register_url boot parameter

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -776,7 +776,7 @@ sub registration_bootloader_cmdline {
     set_var('SCC_URL', 'https://scc.suse.com') unless get_var('SCC_URL');
     my $cmdline = '';
     if (my $url = get_var('SMT_URL') || get_var('SCC_URL')) {
-        $cmdline .= is_agama ? " inst.register_url=$url" : " regurl=$url";
+        $cmdline .= (is_agama && !check_var('SCC_URL', 'https://scc.suse.com')) ? " inst.register_url=$url" : " regurl=$url";
         $cmdline .= " regcert=$url" if get_var('SCC_CERT');
     }
     return $cmdline;


### PR DESCRIPTION
We detected a problem with `inst.register_url` parameter in remote systems that made Agama UI present an error at registration time. We decided to remove the parameter from default params. Now, it should be explicitly included.
I presume that there is no dependency of this parameter outside of QE-YAM scope but in this case we could revert and provide another solution.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - ppc64le-hmc: https://openqa.suse.de/tests/18450675
  - s390x-kvm: https://openqa.suse.de/tests/18450678
  - s390x-zvm: https://openqa.suse.de/tests/18450615#
