### PR TITLE
containers: Remove workaround for bsc#1240150

### DIFF
--- a/tests/containers/isolation.pm
+++ b/tests/containers/isolation.pm
@@ -16,7 +16,7 @@ use containers::common qw(install_packages);
 use utils;
 use Utils::Architectures qw(is_s390x);
 use Utils::Backends qw(is_hyperv);
-use version_utils qw(is_sle is_vmware);
+use version_utils qw(is_vmware);
 
 my $runtime;
 my $network = "test_isolated_network";
@@ -52,9 +52,6 @@ sub run {
         push @packages, "$base-rootless-extras";
     }
     install_packages(@packages);
-
-    # Workaround for https://bugzilla.suse.com/show_bug.cgi?id=1240150
-    script_run "echo 0 > /etc/docker/suse-secrets-enable" if is_sle('<15-SP6');
 
     my @ip_versions = (4);
     push @ip_versions, 6 unless (is_hyperv || is_s390x || is_vmware);
@@ -106,7 +103,6 @@ sub cleanup() {
     select_serial_terminal;
     script_run "$runtime network rm $network";
     $runtime->cleanup_system_host();
-    script_run "rm -f /etc/docker/suse-secrets-enable" if is_sle('<15-SP6');
 }
 
 sub post_fail_hook {

--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -25,7 +25,6 @@ use containers::docker;
 use containers::container_images;
 use Utils::Architectures;
 use containers::common qw(install_docker_when_needed);
-use version_utils qw(is_sle);
 
 sub run {
     my ($self) = @_;
@@ -38,9 +37,6 @@ sub run {
 
     my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
     install_packages("$pkg_name-rootless-extras");
-
-    # Workaround for https://bugzilla.suse.com/show_bug.cgi?id=1240150
-    assert_script_run "echo 0 > /etc/docker/suse-secrets-enable" if is_sle('<15-SP6');
 
     my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
 
@@ -87,7 +83,6 @@ sub post_run_hook {
     my $self = shift;
     cleanup();
     select_serial_terminal();
-    script_run "rm -f /etc/docker/suse-secrets-enable" if is_sle('<15-SP6');
     $self->SUPER::post_run_hook;
 }
 
@@ -95,7 +90,6 @@ sub post_fail_hook {
     my $self = shift;
     cleanup();
     select_serial_terminal();
-    script_run "rm -f /etc/docker/suse-secrets-enable" if is_sle('<15-SP6');
     save_and_upload_log('cat /etc/{subuid,subgid}', "/tmp/permissions.txt");
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Remove workaround for https://bugzilla.suse.com/show_bug.cgi?id=1240150

docker 28 is finally available on SLES 15-SP4 & 15-SP5.

Verification runs:
- SLES 15-SP4: https://openqa.suse.de/tests/18452429
- SLES 15-SP5: https://openqa.suse.de/tests/18452430