### PR TITLE
bats/buildah: Update BATS_SKIP

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -22,13 +22,13 @@ buildah:
     BATS_PATCHES:
     - 6226
     BATS_SKIP:
-    BATS_SKIP_ROOT: bud copy run
+    BATS_SKIP_ROOT: bud namespaces run
     BATS_SKIP_USER:
   sle-15-SP6:
     BATS_PATCHES:
     - 6226
     BATS_SKIP:
-    BATS_SKIP_ROOT: bud run
+    BATS_SKIP_ROOT: bud namespaces run
     BATS_SKIP_USER:
   sle-15-SP5:
     BATS_PATCHES:


### PR DESCRIPTION
Update BATS_SKIP for buildah with runc 1.2
