### PR TITLE
Add test data for iscsi_activation_non_root

### DIFF
--- a/schedule/yam/agama_iscsi_activate_unattended.yaml
+++ b/schedule/yam/agama_iscsi_activate_unattended.yaml
@@ -8,3 +8,4 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - console/validate_partition_table
+  - console/validate_blockdevices

--- a/test_data/yam/iscsi_activation_non_root.yaml
+++ b/test_data/yam/iscsi_activation_non_root.yaml
@@ -1,0 +1,25 @@
+---
+disks:
+  - name: sda
+    table_type: gpt
+    size: 20G
+    type: disk
+    children:
+      - name: sda1
+        type: part
+        mountpoints: ["/home"]
+        size: 20G
+  - name: vda
+    table_type: gpt
+    partitions:
+      - name: vda1
+        type: part
+        size: 8M
+      - name: vda2
+        type: part
+        mountpoints: /
+        size: 20G
+      - name: vda3
+        type: part
+        mountpoints: [SWAP]
+        size: 1G


### PR DESCRIPTION
##
### Add test data for iscsi_activation_non_root

- Related ticket:
  - https://progress.opensuse.org/issues/183140
- Related MR:
  - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/523
- Needles: N/A
- Verification run: 
  - [sles_iscsi_activation_non_root_unattended](https://openqa.suse.de/tests/overview?version=16.0&distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23iscsi_partition_data)
##
