### PR TITLE
lib: Prevent 'Use of uninitialized value' in bats module

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -372,7 +372,7 @@ sub bats_tests {
 
     unless (get_var("BATS_TESTS")) {
         $skip_tests = get_var($skip_tests, $settings->{$skip_tests});
-        my @skip_tests = split(/\s+/, get_var('BATS_SKIP', $settings->{BATS_SKIP}) . " " . $skip_tests);
+        my @skip_tests = split(/\s+/, join(' ', get_var('BATS_SKIP', $settings->{BATS_SKIP}), $skip_tests));
         patch_logfile($log_file, @skip_tests);
     }
 


### PR DESCRIPTION
As observed in
https://openqa.suse.de/tests/18458486/logfile?filename=autoinst-log.txt
if BATS_SKIP is not defined there is a Perl warning about using
undefined values. This can be fixed by using join instead of a
manual string concatenation.

Related progress issue: https://progress.opensuse.org/issues/185953