### PR TITLE
cron mta: Run systemctl is active with script_retry

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -24,7 +24,9 @@ schedule:
   - console/command_not_found
   - console/openssl_alpn
   - console/autoyast_removed
+  - console/cron
   - console/syslog
+  - console/mta
   - console/check_default_network_manager
   - console/git
   - console/cups
@@ -34,9 +36,7 @@ schedule:
   - console/perf
   - console/sysctl
   - console/sysstat
-  - console/mta
   - console/cpio
-  - console/cron
   - console/tar
   - console/ruby
   - '{{version_specific}}'

--- a/tests/console/cron.pm
+++ b/tests/console/cron.pm
@@ -32,7 +32,7 @@ sub run {
     # check if cronie is installed, enabled and running
     assert_script_run 'rpm -q cronie';
     systemctl 'is-enabled cron';
-    systemctl 'is-active cron';
+    script_retry 'systemctl is-active cron', retry => 3, delay => 10;
     systemctl 'status cron';
 }
 

--- a/tests/console/mta.pm
+++ b/tests/console/mta.pm
@@ -28,7 +28,7 @@ sub run {
         # check if postfix is installed, enabled and running
         assert_script_run 'rpm -q postfix';
         systemctl 'is-enabled postfix';
-        systemctl 'is-active postfix';
+        script_retry 'systemctl is-active postfix', retry => 3, delay => 10;
         systemctl 'status postfix';
     } else {
         # Install and start postfix on Public Cloud


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/185737
- Verification run:
https://openqa.suse.de/tests/overview?distri=sle&build=jpupava_et1