### PR TITLE
Fix: add check to re-check the connectivity and unknow as output

### DIFF
--- a/tests/yam/validate/validate_connectivity.pm
+++ b/tests/yam/validate/validate_connectivity.pm
@@ -17,8 +17,8 @@ sub run {
     select_console 'root-console';
     my $ip_address_show = script_output("ip address show");
     record_info("ip address show", $ip_address_show);
-    my $connectivity = check_var('INST_COPY_NETWORK', '0') ? 'none' : 'full';
-    validate_script_output("nmcli networking connectivity", sub { m/\b$connectivity\b/ });
+    my $connectivity = check_var('INST_COPY_NETWORK', '0') ? 'none|unknown' : 'full';
+    validate_script_output("nmcli networking connectivity check", sub { m/\b$connectivity\b/ });
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [poo#184043](https://progress.opensuse.org/issues/184043)
- Verification run: [overview](https://openqa.suse.de/tests/overview?build=issues-184043)
- Related [MR#524](https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/524) to merge first

Add "check" to refresh the status and "unknown" as output
