### PR TITLE
containers: Skip flaky 3rd party image tests on public cloud

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -133,7 +133,7 @@ sub load_host_tests_podman {
     load_container_engine_test($run_args);
     # In Public Cloud we don't have internal resources
     load_image_test($run_args) unless is_public_cloud;
-    load_3rd_party_image_test($run_args) unless is_staging;
+    load_3rd_party_image_test($run_args) unless (is_staging || is_public_cloud);
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
     # podman artifact needs podman 5.4.0


### PR DESCRIPTION
Skip flaky 3rd party image tests on public cloud.

When these images fail we must restart lots of tests that only increase our cloud bills.

Related ticket: https://progress.opensuse.org/issues/179566